### PR TITLE
[CSS Calc] sibling-index() and sibling-count() should set requiresConversionData in calc parser

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-values/tree-counting/sibling-index-linear-gradient-gcs-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-values/tree-counting/sibling-index-linear-gradient-gcs-expected.txt
@@ -1,5 +1,5 @@
 
-FAIL Check that sibling-index() is resolved in serialization of computed value of linear-gradient() assert_equals: expected "linear-gradient(rgb(255, 255, 255), rgb(0, 0, 200))" but got "linear-gradient(rgb(255, 255, 255), rgb(0, 0, 0))"
+PASS Check that sibling-index() is resolved in serialization of computed value of linear-gradient()
 FAIL Check that sibling-index() is resolved in serialization of computed value of linear-gradient() inside cross-fade() assert_equals: expected "cross-fade(linear-gradient(rgb(255, 255, 255), rgb(0, 0, 200)) 40%, rgb(0, 0, 200) 60%)" but got "none"
-FAIL Check that sibling-index() is resolved in serialization of computed value of linear-gradient() inside image-set() assert_equals: expected "image-set(linear-gradient(rgb(255, 255, 255), rgb(0, 0, 200)) 1dppx)" but got "image-set(linear-gradient(rgb(255, 255, 255), rgb(0, 0, 0)) 1dppx)"
+PASS Check that sibling-index() is resolved in serialization of computed value of linear-gradient() inside image-set()
 

--- a/Source/WebCore/css/calc/CSSCalcTree+Parser.cpp
+++ b/Source/WebCore/css/calc/CSSCalcTree+Parser.cpp
@@ -1339,6 +1339,7 @@ std::optional<TypedChild> parseCalcFunction(CSSParserTokenRange& tokens, CSSValu
             return { };
         if (state.propertyParserState.currentProperty == CSSPropertyInvalid)
             return { };
+        state.requiresConversionData = true;
         return consumeZeroArguments<SiblingCount>(tokens, depth, state);
 
     case CSSValueSiblingIndex:
@@ -1351,6 +1352,7 @@ std::optional<TypedChild> parseCalcFunction(CSSParserTokenRange& tokens, CSSValu
             return { };
         if (state.propertyParserState.currentProperty == CSSPropertyInvalid)
             return { };
+        state.requiresConversionData = true;
         return consumeZeroArguments<SiblingIndex>(tokens, depth, state);
 
     case CSSValueAnchor:


### PR DESCRIPTION
#### 49694dd2becd6eef4db80ad7e15edbebb591f727
<pre>
[CSS Calc] sibling-index() and sibling-count() should set requiresConversionData in calc parser
<a href="https://bugs.webkit.org/show_bug.cgi?id=313313">https://bugs.webkit.org/show_bug.cgi?id=313313</a>
<a href="https://rdar.apple.com/175590806">rdar://175590806</a>

Reviewed by Sam Weinig.

Mark sibling-index() and sibling-count() as requiresConversionData in the
calc parser, consistent with other functions that need runtime context to
evaluate (anchor(), random-*()). Without this flag, the calc tree may
attempt to fully simplify at parse time even though the actual value is
not available until layout.

* LayoutTests/imported/w3c/web-platform-tests/css/css-values/tree-counting/sibling-index-linear-gradient-gcs-expected.txt: Progressions
* Source/WebCore/css/calc/CSSCalcTree+Parser.cpp:
(WebCore::CSSCalc::parseCalcFunction):

Canonical link: <a href="https://commits.webkit.org/312026@main">https://commits.webkit.org/312026@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f8eb2b80dfe23e9c224ee6a49eca7c761e62b766

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/158708 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/32135 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/25241 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/167538 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/112793 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/160578 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/32202 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/32123 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/122951 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/86282 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/161666 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/25209 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/142576 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/103620 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/24266 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/22668 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/15310 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/133952 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/20356 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/170030 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/15773 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/21981 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/131137 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/31825 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/26733 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/131251 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35522 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/31770 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/142149 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/89716 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/25946 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/18958 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/31281 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/97295 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/30801 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/31074 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/30955 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->