### PR TITLE
Tree-counting functions should return 0 for cross-tree ::part() styling

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-values/tree-counting/tree-scoped-sibling-function-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-values/tree-counting/tree-scoped-sibling-function-expected.txt
@@ -1,4 +1,4 @@
 
-FAIL sibling-index() and sibling-count() evaluates to 0 from outer tree with ::part assert_equals: z-index should be 0 expected "0" but got "1"
+PASS sibling-index() and sibling-count() evaluates to 0 from outer tree with ::part
 PASS sibling-index() and sibling-count() evaluate as normal from inner tree
 

--- a/Source/WebCore/style/StyleBuilderState.cpp
+++ b/Source/WebCore/style/StyleBuilderState.cpp
@@ -315,6 +315,11 @@ unsigned BuilderState::siblingCount()
 
     ASSERT(element());
 
+    // https://drafts.csswg.org/css-shadow-1/#tree-scoped-name-loosely-matched
+    // "loosely-matched tree-scoped references" return 0 for cross-tree styling.
+    if (m_currentProperty && m_currentProperty->styleScopeOrdinal <= ScopeOrdinal::ContainingHost)
+        return 0;
+
     auto* parent = element()->parentElement();
     if (!parent)
         return 1;
@@ -336,6 +341,11 @@ unsigned BuilderState::siblingIndex()
     // https://drafts.csswg.org/css-values-5/#funcdef-sibling-index
 
     ASSERT(element());
+
+    // https://drafts.csswg.org/css-shadow-1/#tree-scoped-name-loosely-matched
+    // "loosely-matched tree-scoped references" return 0 for cross-tree styling.
+    if (m_currentProperty && m_currentProperty->styleScopeOrdinal <= ScopeOrdinal::ContainingHost)
+        return 0;
 
     auto* parent = element()->parentElement();
     if (!parent)


### PR DESCRIPTION
#### 1b466cc8629c7894d93d633b1e72c1b062ec3b6e
<pre>
Tree-counting functions should return 0 for cross-tree ::part() styling
<a href="https://bugs.webkit.org/show_bug.cgi?id=313315">https://bugs.webkit.org/show_bug.cgi?id=313315</a>
<a href="https://rdar.apple.com/175592607">rdar://175592607</a>

Reviewed by Antti Koivisto.

Per [1] and [2], tree-counting functions are loosely-matched tree-scoped
references. If the reference fails to match because the element is
in a descendant shadow tree from the stylesheet, the function
returns 0.

When a ::part() rule from an outer tree styles an element inside a
shadow tree, siblingIndex() and siblingCount() now check the style
scope ordinal. If the property originates from a containing host
scope, both functions return 0 instead of counting siblings in the
shadow tree.

[1] <a href="https://drafts.csswg.org/css-values-5/#tree-counting">https://drafts.csswg.org/css-values-5/#tree-counting</a>
[2] <a href="https://drafts.csswg.org/css-shadow-1/#tree-scoped-name-loosely-matched">https://drafts.csswg.org/css-shadow-1/#tree-scoped-name-loosely-matched</a>

* LayoutTests/imported/w3c/web-platform-tests/css/css-values/tree-counting/tree-scoped-sibling-function-expected.txt: Progression
* Source/WebCore/style/StyleBuilderState.cpp:
(WebCore::Style::BuilderState::siblingCount):
(WebCore::Style::BuilderState::siblingIndex):

Canonical link: <a href="https://commits.webkit.org/312544@main">https://commits.webkit.org/312544@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/de37b532dd9a04c0029ac36e1cb7b961ee664e86

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/160152 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/33622 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/26726 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/169052 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/114533 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/2792d5a2-1932-441a-a397-dccfd4be77f6) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/162021 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/33725 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/33624 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/124149 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/87075 "2 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/59c74699-79dc-45ad-8a7a-2f3e246cb873) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/163110 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/26392 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/143852 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/104750 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/1edd2c28-a9a8-4939-9575-d2a8d11af0af) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/25445 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/23940 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/16773 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/135137 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/21615 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/171527 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/17520 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/23255 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/132402 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/33298 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/28029 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/132428 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35834 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/33283 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/143410 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/91521 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/27041 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/20224 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/32792 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/99189 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/32290 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/32536 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/32440 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->