### PR TITLE
SMIL clock value parser rejects hours > 99 and accepts malformed seconds

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/svg/animations/smil-clock-value-parsing-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/animations/smil-clock-value-parsing-expected.txt
@@ -5,15 +5,15 @@ PASS SMIL clock values: out-of-range minutes/seconds validation and fractional s
 PASS SMIL clock values: out-of-range minutes/seconds validation and fractional seconds support, dur="00:01.50"
 PASS SMIL clock values: out-of-range minutes/seconds validation and fractional seconds support, dur="00:00:59.50"
 PASS SMIL clock values: out-of-range minutes/seconds validation and fractional seconds support, dur="00:59.50"
-FAIL SMIL clock values: out-of-range minutes/seconds validation and fractional seconds support, dur="101:00:01" assert_not_equals: dur="101:00:01" should be valid and animate got disallowed value 0
+PASS SMIL clock values: out-of-range minutes/seconds validation and fractional seconds support, dur="101:00:01"
 PASS SMIL clock values: out-of-range minutes/seconds validation and fractional seconds support, dur="01:99:01"
 PASS SMIL clock values: out-of-range minutes/seconds validation and fractional seconds support, dur="99:01"
 PASS SMIL clock values: out-of-range minutes/seconds validation and fractional seconds support, dur="01:30:99"
 PASS SMIL clock values: out-of-range minutes/seconds validation and fractional seconds support, dur="30:99"
 PASS SMIL clock values: out-of-range minutes/seconds validation and fractional seconds support, dur="00:59:59."
-FAIL SMIL clock values: out-of-range minutes/seconds validation and fractional seconds support, dur="00:59:9.9" assert_equals: dur="00:59:9.9" should be invalid (seconds < 10 should have a leading zero) expected 0 but got 3.3803768157958984
-FAIL SMIL clock values: out-of-range minutes/seconds validation and fractional seconds support, dur="00:59:.9" assert_equals: dur="00:59:.9" should be invalid (seconds needs to be specified) expected 0 but got 3.3889689445495605
-FAIL SMIL clock values: out-of-range minutes/seconds validation and fractional seconds support, dur="00:59:009" assert_equals: dur="00:59:009" should be invalid (seconds without fraction should be two digits) expected 0 but got 3.3812339305877686
+PASS SMIL clock values: out-of-range minutes/seconds validation and fractional seconds support, dur="00:59:9.9"
+PASS SMIL clock values: out-of-range minutes/seconds validation and fractional seconds support, dur="00:59:.9"
+PASS SMIL clock values: out-of-range minutes/seconds validation and fractional seconds support, dur="00:59:009"
 PASS SMIL clock values: out-of-range minutes/seconds validation and fractional seconds support, dur=":30:01"
 PASS SMIL clock values: out-of-range minutes/seconds validation and fractional seconds support, dur="01::01"
 PASS SMIL clock values: out-of-range minutes/seconds validation and fractional seconds support, dur="5:30"

--- a/Source/WebCore/svg/animation/SVGSMILElement.cpp
+++ b/Source/WebCore/svg/animation/SVGSMILElement.cpp
@@ -355,19 +355,39 @@ SMILTime SVGSMILElement::parseClockValue(StringView data)
     if (parse == indefiniteAtom())
         return SMILTime::indefinite();
 
+    // SMIL Seconds must be 2DIGIT ("." DIGIT+)? per the spec.
+    auto hasValidSecondsFormat = [](const StringView& seconds) {
+        if (seconds.length() < 2 || !isASCIIDigit(seconds[0]) || !isASCIIDigit(seconds[1]))
+            return false;
+        if (seconds.length() > 2 && (seconds[2] != '.' || seconds.length() < 4))
+            return false;
+        return true;
+    };
+
     double result = 0;
     size_t doublePointOne = parse.find(':');
-    size_t doublePointTwo = parse.find(':', doublePointOne + 1);
-    if (doublePointOne == 2 && doublePointTwo == 5 && parse.length() >= 8) {
-        auto hours = parseInteger<uint8_t>(parse.left(2));
-        auto minutes = parseInteger<uint8_t>(parse.substring(3, 2));
-        auto seconds = parseNumber(parse.substring(6));
+    size_t doublePointTwo = doublePointOne != notFound ? parse.find(':', doublePointOne + 1) : notFound;
+    if (doublePointOne != notFound && doublePointTwo != notFound) {
+        // Full-clock-value: Hours ":" Minutes ":" Seconds ("." Fraction)?
+        // Hours is DIGIT+ (one or more digits), Minutes and Seconds are 2DIGIT.
+        if (!doublePointOne || doublePointTwo != doublePointOne + 3)
+            return SMILTime::unresolved();
+        auto hours = parseInteger<unsigned>(parse.left(doublePointOne));
+        auto minutes = parseInteger<uint8_t>(parse.substring(doublePointOne + 1, 2));
+        auto secondsString = parse.substring(doublePointTwo + 1);
+        if (!hasValidSecondsFormat(secondsString))
+            return SMILTime::unresolved();
+        auto seconds = parseNumber(secondsString);
         if (!hours || !minutes || *minutes > 59 || !seconds || *seconds >= 60)
             return SMILTime::unresolved();
         result = *hours * 60 * 60 + *minutes * 60 + *seconds;
     } else if (doublePointOne == 2 && doublePointTwo == notFound && parse.length() >= 5) {
+        // Partial-clock-value: Minutes ":" Seconds ("." Fraction)?
         auto minutes = parseInteger<uint8_t>(parse.left(2));
-        auto seconds = parseNumber(parse.substring(3));
+        auto secondsString = parse.substring(3);
+        if (!hasValidSecondsFormat(secondsString))
+            return SMILTime::unresolved();
+        auto seconds = parseNumber(secondsString);
         if (!minutes || *minutes > 59 || !seconds || *seconds >= 60)
             return SMILTime::unresolved();
         result = *minutes * 60 + *seconds;


### PR DESCRIPTION
#### 39e946b43d741aff6ba3f09fb442e22510e10027
<pre>
SMIL clock value parser rejects hours &gt; 99 and accepts malformed seconds
<a href="https://bugs.webkit.org/show_bug.cgi?id=313318">https://bugs.webkit.org/show_bug.cgi?id=313318</a>
<a href="https://rdar.apple.com/175593583">rdar://175593583</a>

Reviewed by Nikolas Zimmermann.

This patch aligns WebKit with Gecko / Firefox and Blink / Chromium.

The SMIL clock value parser had two issues:

1. Hours were limited to exactly 2 digits because colon positions were
 hardcoded, rejecting valid values like &quot;101:00:01&quot;. The SMIL spec [1]
 defines Hours as DIGIT+ (one or more digits).

2. The seconds field was passed directly to parseNumber() without
 format validation, accepting malformed values like &quot;9.9&quot;, &quot;.9&quot;,
 and &quot;009&quot;. The spec [1] requires exactly 2DIGIT optionally followed
 by &quot;.&quot; and DIGIT+.

Fix by detecting Full-clock-value vs Partial-clock-value based on
colon count rather than fixed positions, using parseInteger&lt;unsigned&gt;
for variable-length hours, and adding seconds format validation.

[1] <a href="https://www.w3.org/TR/SMIL/smil-timing.html#q22">https://www.w3.org/TR/SMIL/smil-timing.html#q22</a>

* Source/WebCore/svg/animation/SVGSMILElement.cpp:
(WebCore::SVGSMILElement::parseClockValue):
* LayoutTests/imported/w3c/web-platform-tests/svg/animations/smil-clock-value-parsing-expected.txt: Progressions

Canonical link: <a href="https://commits.webkit.org/312350@main">https://commits.webkit.org/312350@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/faa88ae0e86cf3e6050523dba78edf172523307f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/159680 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/33147 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/26254 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/168533 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/114061 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/161549 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/33252 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/33151 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/123721 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/114061 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/162638 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/25982 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/143426 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/104368 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/25033 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/23501 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/16299 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/134725 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/167/builds/21198 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/171024 "Built successfully") | | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/17048 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/22832 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/131965 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/32826 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/27578 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/132037 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35725 "Built successfully and passed tests") | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/32811 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/142992 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/90893 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/160/builds/32811 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/19805 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/32320 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/98716 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/31817 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/32064 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/31968 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->