### PR TITLE
Negative stroke-dashoffset renders incorrectly with odd-length stroke-dasharray

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/svg/painting/animated-dashoffset-odd-dasharray-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/painting/animated-dashoffset-odd-dasharray-expected.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<head>
+<meta charset="utf-8">
+<title>Animated stroke-dashoffset crossing zero with odd-length stroke-dasharray (reference)</title>
+</head>
+<body>
+<svg xmlns="http://www.w3.org/2000/svg" width="600" height="250">
+    <!-- Row 1: even-length equivalent dasharray="60 60", static offsets -->
+    <path d="M20,20 L580,20" stroke="black" stroke-width="6" fill="none" stroke-dasharray="60 60" stroke-dashoffset="-10"/>
+    <path d="M20,40 L580,40" stroke="black" stroke-width="6" fill="none" stroke-dasharray="60 60" stroke-dashoffset="-5"/>
+    <path d="M20,60 L580,60" stroke="black" stroke-width="6" fill="none" stroke-dasharray="60 60" stroke-dashoffset="0"/>
+    <path d="M20,80 L580,80" stroke="black" stroke-width="6" fill="none" stroke-dasharray="60 60" stroke-dashoffset="5"/>
+    <path d="M20,100 L580,100" stroke="black" stroke-width="6" fill="none" stroke-dasharray="60 60" stroke-dashoffset="10"/>
+
+    <!-- Row 2: even-length equivalent dasharray="40 20 10 40 20 10", static offsets -->
+    <path d="M20,140 L580,140" stroke="black" stroke-width="6" fill="none" stroke-dasharray="40 20 10 40 20 10" stroke-dashoffset="-10"/>
+    <path d="M20,160 L580,160" stroke="black" stroke-width="6" fill="none" stroke-dasharray="40 20 10 40 20 10" stroke-dashoffset="-5"/>
+    <path d="M20,180 L580,180" stroke="black" stroke-width="6" fill="none" stroke-dasharray="40 20 10 40 20 10" stroke-dashoffset="0"/>
+    <path d="M20,200 L580,200" stroke="black" stroke-width="6" fill="none" stroke-dasharray="40 20 10 40 20 10" stroke-dashoffset="5"/>
+    <path d="M20,220 L580,220" stroke="black" stroke-width="6" fill="none" stroke-dasharray="40 20 10 40 20 10" stroke-dashoffset="10"/>
+</svg>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/painting/animated-dashoffset-odd-dasharray-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/painting/animated-dashoffset-odd-dasharray-ref.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<head>
+<meta charset="utf-8">
+<title>Animated stroke-dashoffset crossing zero with odd-length stroke-dasharray (reference)</title>
+</head>
+<body>
+<svg xmlns="http://www.w3.org/2000/svg" width="600" height="250">
+    <!-- Row 1: even-length equivalent dasharray="60 60", static offsets -->
+    <path d="M20,20 L580,20" stroke="black" stroke-width="6" fill="none" stroke-dasharray="60 60" stroke-dashoffset="-10"/>
+    <path d="M20,40 L580,40" stroke="black" stroke-width="6" fill="none" stroke-dasharray="60 60" stroke-dashoffset="-5"/>
+    <path d="M20,60 L580,60" stroke="black" stroke-width="6" fill="none" stroke-dasharray="60 60" stroke-dashoffset="0"/>
+    <path d="M20,80 L580,80" stroke="black" stroke-width="6" fill="none" stroke-dasharray="60 60" stroke-dashoffset="5"/>
+    <path d="M20,100 L580,100" stroke="black" stroke-width="6" fill="none" stroke-dasharray="60 60" stroke-dashoffset="10"/>
+
+    <!-- Row 2: even-length equivalent dasharray="40 20 10 40 20 10", static offsets -->
+    <path d="M20,140 L580,140" stroke="black" stroke-width="6" fill="none" stroke-dasharray="40 20 10 40 20 10" stroke-dashoffset="-10"/>
+    <path d="M20,160 L580,160" stroke="black" stroke-width="6" fill="none" stroke-dasharray="40 20 10 40 20 10" stroke-dashoffset="-5"/>
+    <path d="M20,180 L580,180" stroke="black" stroke-width="6" fill="none" stroke-dasharray="40 20 10 40 20 10" stroke-dashoffset="0"/>
+    <path d="M20,200 L580,200" stroke="black" stroke-width="6" fill="none" stroke-dasharray="40 20 10 40 20 10" stroke-dashoffset="5"/>
+    <path d="M20,220 L580,220" stroke="black" stroke-width="6" fill="none" stroke-dasharray="40 20 10 40 20 10" stroke-dashoffset="10"/>
+</svg>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/painting/animated-dashoffset-odd-dasharray.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/painting/animated-dashoffset-odd-dasharray.html
@@ -1,0 +1,55 @@
+<!DOCTYPE html>
+<html class="reftest-wait">
+<head>
+<meta charset="utf-8">
+<title>Animated stroke-dashoffset crossing zero with odd-length stroke-dasharray</title>
+<link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/painting.html#StrokeDashing">
+<link rel="match" href="animated-dashoffset-odd-dasharray-ref.html">
+<meta name="assert" content="Animating stroke-dashoffset from negative to positive with an odd-length stroke-dasharray should not produce a visual jump at the zero crossing. Each row shows an animation paused at evenly spaced offsets from -10 to +10; the progression should be smooth.">
+</head>
+<body>
+<svg xmlns="http://www.w3.org/2000/svg" width="600" height="250">
+    <!-- Row 1: dasharray="60" (odd), offsets stepping from -10 to +10 -->
+    <path id="a1" d="M20,20 L580,20" stroke="black" stroke-width="6" fill="none" stroke-dasharray="60"/>
+    <path id="a2" d="M20,40 L580,40" stroke="black" stroke-width="6" fill="none" stroke-dasharray="60"/>
+    <path id="a3" d="M20,60 L580,60" stroke="black" stroke-width="6" fill="none" stroke-dasharray="60"/>
+    <path id="a4" d="M20,80 L580,80" stroke="black" stroke-width="6" fill="none" stroke-dasharray="60"/>
+    <path id="a5" d="M20,100 L580,100" stroke="black" stroke-width="6" fill="none" stroke-dasharray="60"/>
+
+    <!-- Row 2: dasharray="40 20 10" (odd), offsets stepping from -10 to +10 -->
+    <path id="b1" d="M20,140 L580,140" stroke="black" stroke-width="6" fill="none" stroke-dasharray="40 20 10"/>
+    <path id="b2" d="M20,160 L580,160" stroke="black" stroke-width="6" fill="none" stroke-dasharray="40 20 10"/>
+    <path id="b3" d="M20,180 L580,180" stroke="black" stroke-width="6" fill="none" stroke-dasharray="40 20 10"/>
+    <path id="b4" d="M20,200 L580,200" stroke="black" stroke-width="6" fill="none" stroke-dasharray="40 20 10"/>
+    <path id="b5" d="M20,220 L580,220" stroke="black" stroke-width="6" fill="none" stroke-dasharray="40 20 10"/>
+</svg>
+<script>
+window.onload = () => {
+    requestAnimationFrame(() => {
+        const offsets = [-10, -5, 0, 5, 10];
+        const groups = [
+            { ids: ['a1','a2','a3','a4','a5'], from: -60, to: 60 },
+            { ids: ['b1','b2','b3','b4','b5'], from: -60, to: 60 },
+        ];
+
+        for (const { ids, from, to } of groups) {
+            const range = to - from;
+            ids.forEach((id, i) => {
+                const el = document.getElementById(id);
+                const anim = el.animate(
+                    [{ strokeDashoffset: from + 'px' }, { strokeDashoffset: to + 'px' }],
+                    { duration: 1000, fill: 'forwards' }
+                );
+                anim.pause();
+                anim.currentTime = ((offsets[i] - from) / range) * 1000;
+            });
+        }
+
+        requestAnimationFrame(() => {
+            document.documentElement.removeAttribute('class');
+        });
+    });
+};
+</script>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/painting/negative-dashoffset-odd-dasharray-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/painting/negative-dashoffset-odd-dasharray-expected.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>Negative stroke-dashoffset with odd-length stroke-dasharray (reference)</title>
+</head>
+<body>
+<p>Each pair of lines should be identical. The odd-length dasharray (left value)
+should render the same as the equivalent even-length dasharray (right value).</p>
+<svg xmlns="http://www.w3.org/2000/svg" width="600" height="300">
+    <path d="M20,30 L280,30" stroke="black" stroke-width="8" fill="none"
+          stroke-dasharray="60 60" stroke-dashoffset="-30"/>
+    <path d="M320,30 L580,30" stroke="black" stroke-width="8" fill="none"
+          stroke-dasharray="60 60" stroke-dashoffset="-30"/>
+
+    <path d="M20,70 L280,70" stroke="black" stroke-width="8" fill="none"
+          stroke-dasharray="40 20 10 40 20 10" stroke-dashoffset="-15"/>
+    <path d="M320,70 L580,70" stroke="black" stroke-width="8" fill="none"
+          stroke-dasharray="40 20 10 40 20 10" stroke-dashoffset="-15"/>
+
+    <path d="M20,110 L280,110" stroke="black" stroke-width="8" fill="none"
+          stroke-dasharray="30 30" stroke-dashoffset="-45"/>
+    <path d="M320,110 L580,110" stroke="black" stroke-width="8" fill="none"
+          stroke-dasharray="30 30" stroke-dashoffset="-45"/>
+
+    <path d="M20,150 L280,150" stroke="black" stroke-width="8" fill="none"
+          stroke-dasharray="50 30 20 50 30 20" stroke-dashoffset="-200"/>
+    <path d="M320,150 L580,150" stroke="black" stroke-width="8" fill="none"
+          stroke-dasharray="50 30 20 50 30 20" stroke-dashoffset="-200"/>
+</svg>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/painting/negative-dashoffset-odd-dasharray-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/painting/negative-dashoffset-odd-dasharray-ref.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>Negative stroke-dashoffset with odd-length stroke-dasharray (reference)</title>
+</head>
+<body>
+<p>Each pair of lines should be identical. The odd-length dasharray (left value)
+should render the same as the equivalent even-length dasharray (right value).</p>
+<svg xmlns="http://www.w3.org/2000/svg" width="600" height="300">
+    <path d="M20,30 L280,30" stroke="black" stroke-width="8" fill="none"
+          stroke-dasharray="60 60" stroke-dashoffset="-30"/>
+    <path d="M320,30 L580,30" stroke="black" stroke-width="8" fill="none"
+          stroke-dasharray="60 60" stroke-dashoffset="-30"/>
+
+    <path d="M20,70 L280,70" stroke="black" stroke-width="8" fill="none"
+          stroke-dasharray="40 20 10 40 20 10" stroke-dashoffset="-15"/>
+    <path d="M320,70 L580,70" stroke="black" stroke-width="8" fill="none"
+          stroke-dasharray="40 20 10 40 20 10" stroke-dashoffset="-15"/>
+
+    <path d="M20,110 L280,110" stroke="black" stroke-width="8" fill="none"
+          stroke-dasharray="30 30" stroke-dashoffset="-45"/>
+    <path d="M320,110 L580,110" stroke="black" stroke-width="8" fill="none"
+          stroke-dasharray="30 30" stroke-dashoffset="-45"/>
+
+    <path d="M20,150 L280,150" stroke="black" stroke-width="8" fill="none"
+          stroke-dasharray="50 30 20 50 30 20" stroke-dashoffset="-200"/>
+    <path d="M320,150 L580,150" stroke="black" stroke-width="8" fill="none"
+          stroke-dasharray="50 30 20 50 30 20" stroke-dashoffset="-200"/>
+</svg>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/painting/negative-dashoffset-odd-dasharray.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/painting/negative-dashoffset-odd-dasharray.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>Negative stroke-dashoffset with odd-length stroke-dasharray</title>
+<link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/painting.html#StrokeDashing">
+<link rel="match" href="negative-dashoffset-odd-dasharray-ref.html">
+<meta name="assert" content="Odd-length stroke-dasharray with negative stroke-dashoffset should render identically to the equivalent even-length dasharray.">
+</head>
+<body>
+<p>Each pair of lines should be identical. The odd-length dasharray (left value)
+should render the same as the equivalent even-length dasharray (right value).</p>
+<svg xmlns="http://www.w3.org/2000/svg" width="600" height="300">
+    <!-- dasharray="60" is equivalent to dasharray="60 60" per spec -->
+    <path d="M20,30 L280,30" stroke="black" stroke-width="8" fill="none"
+          stroke-dasharray="60" stroke-dashoffset="-30"/>
+    <path d="M320,30 L580,30" stroke="black" stroke-width="8" fill="none"
+          stroke-dasharray="60 60" stroke-dashoffset="-30"/>
+
+    <!-- dasharray="40 20 10" is equivalent to dasharray="40 20 10 40 20 10" -->
+    <path d="M20,70 L280,70" stroke="black" stroke-width="8" fill="none"
+          stroke-dasharray="40 20 10" stroke-dashoffset="-15"/>
+    <path d="M320,70 L580,70" stroke="black" stroke-width="8" fill="none"
+          stroke-dasharray="40 20 10 40 20 10" stroke-dashoffset="-15"/>
+
+    <!-- dasharray="30" with large negative offset -->
+    <path d="M20,110 L280,110" stroke="black" stroke-width="8" fill="none"
+          stroke-dasharray="30" stroke-dashoffset="-45"/>
+    <path d="M320,110 L580,110" stroke="black" stroke-width="8" fill="none"
+          stroke-dasharray="30 30" stroke-dashoffset="-45"/>
+
+    <!-- dasharray="50 30 20" with offset equal to negative total length -->
+    <path d="M20,150 L280,150" stroke="black" stroke-width="8" fill="none"
+          stroke-dasharray="50 30 20" stroke-dashoffset="-200"/>
+    <path d="M320,150 L580,150" stroke="black" stroke-width="8" fill="none"
+          stroke-dasharray="50 30 20 50 30 20" stroke-dashoffset="-200"/>
+</svg>
+</body>
+</html>

--- a/Source/WebCore/platform/graphics/cg/GraphicsContextCG.cpp
+++ b/Source/WebCore/platform/graphics/cg/GraphicsContextCG.cpp
@@ -1366,6 +1366,10 @@ void GraphicsContextCG::setLineDash(const DashArray& dashes, float dashOffset)
         float length = 0;
         for (size_t i = 0; i < dashes.size(); ++i)
             length += static_cast<float>(dashes[i]);
+        // Odd-length dash arrays are repeated to produce an even-length pattern, doubling the cycle length.
+        // Check if odd number of dash values.
+        if (dashes.size() % 2)
+            length *= 2;
         if (length)
             dashOffset = fmod(dashOffset, length) + length;
     }

--- a/Source/WebCore/platform/graphics/cg/GraphicsContextCG.cpp
+++ b/Source/WebCore/platform/graphics/cg/GraphicsContextCG.cpp
@@ -1366,6 +1366,9 @@ void GraphicsContextCG::setLineDash(const DashArray& dashes, float dashOffset)
         float length = 0;
         for (size_t i = 0; i < dashes.size(); ++i)
             length += static_cast<float>(dashes[i]);
+        // CGContextSetLineDash repeats odd-length arrays, so the effective cycle is twice the sum.
+        if (dashes.size() % 2)
+            length *= 2;
         if (length)
             dashOffset = fmod(dashOffset, length) + length;
     }


### PR DESCRIPTION
#### d32b6f5f3630f92c961e3b665fa3545a6d6ef6ec
<pre>
Negative stroke-dashoffset renders incorrectly with odd-length stroke-dasharray
<a href="https://bugs.webkit.org/show_bug.cgi?id=249307">https://bugs.webkit.org/show_bug.cgi?id=249307</a>
<a href="https://rdar.apple.com/103596361">rdar://103596361</a>

Reviewed by Simon Fraser.

The SVG spec says odd-length dash arrays are repeated to yield an even
number of values [1], so the full pattern cycle length is doubled. The CG
backend&apos;s negative dashoffset normalization computed the cycle length from
the raw array sum without accounting for this, producing wrong offsets and
a visible jump when animating across zero. This patch fixes the issue and
add test cases for both.

[1] <a href="https://w3c.github.io/svgwg/svg2-draft/painting.html#StrokeDashing">https://w3c.github.io/svgwg/svg2-draft/painting.html#StrokeDashing</a>

Tests: imported/w3c/web-platform-tests/svg/painting/animated-dashoffset-odd-dasharray-ref.html
       imported/w3c/web-platform-tests/svg/painting/animated-dashoffset-odd-dasharray.html
       imported/w3c/web-platform-tests/svg/painting/negative-dashoffset-odd-dasharray-ref.html
       imported/w3c/web-platform-tests/svg/painting/negative-dashoffset-odd-dasharray.html

* LayoutTests/imported/w3c/web-platform-tests/svg/painting/animated-dashoffset-odd-dasharray-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/svg/painting/animated-dashoffset-odd-dasharray-ref.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/svg/painting/animated-dashoffset-odd-dasharray.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/svg/painting/negative-dashoffset-odd-dasharray-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/svg/painting/negative-dashoffset-odd-dasharray-ref.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/svg/painting/negative-dashoffset-odd-dasharray.html: Added.
* Source/WebCore/platform/graphics/cg/GraphicsContextCG.cpp:
(WebCore::GraphicsContextCG::setLineDash):

Canonical link: <a href="https://commits.webkit.org/313353@main">https://commits.webkit.org/313353@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6358d36bbb47605510e5bd50c41c9941f729db6d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/162879 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/36357 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/29543 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/171817 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/119325 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/ffbe24a4-7a76-4d6c-93c7-d41a8c506e68) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/164748 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/36460 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/36359 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/126435 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/89036 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/682e0fb2-a508-43b0-a8a6-a187a1ea70f2) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/165838 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/28780 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/146362 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/107012 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/9fd1b202-df82-4c4a-a7ce-52991acad08c) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/27826 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/26360 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/19517 "Built successfully") | | 
| [⏳ 🛠 🧪 jsc ](https://ews-build.webkit.org/#/builders/JSC-Tests-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/137536 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/24091 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/174321 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/21908 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/25741 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/134745 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/36029 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/30463 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/134740 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36345 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/36074 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/145887 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/98440 "Built successfully") | | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/164/builds/29329 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/22738 "Exiting early after 60 failures. 58686 tests run. 60 failures") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/35523 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/103653 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/35024 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/35269 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/35172 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->