### PR TITLE
[AppKit Gestures] Gesture recognizer driven inputs can stop working after web content process crash

### DIFF
--- a/Source/WebKit/UIProcess/mac/WKAppKitGestureController.h
+++ b/Source/WebKit/UIProcess/mac/WKAppKitGestureController.h
@@ -59,6 +59,7 @@ OBJC_CLASS NSPanGestureRecognizer;
 - (NSGestureRecognizer *)activeDragGestureRecognizer;
 - (void)setGestureDraggingSession:(NSDraggingSession *)session;
 - (void)clearGestureDragState;
+- (void)reset;
 
 #if ENABLE(TWO_PHASE_CLICKS)
 

--- a/Source/WebKit/UIProcess/mac/WKAppKitGestureController.mm
+++ b/Source/WebKit/UIProcess/mac/WKAppKitGestureController.mm
@@ -916,6 +916,16 @@ ALLOW_NEW_API_WITHOUT_GUARDS_END
     _dragGestureHasSentMouseDown = false;
 }
 
+- (void)reset
+{
+    [self clearGestureDragState];
+    [self _handleClickCancelled];
+    _mouseTrackingHasSentMouseDown = false;
+    _isMomentumActive = false;
+    _latestClickID.reset();
+    _layerTreeTransactionIdAtLastInteractionStart.reset();
+}
+
 #pragma mark - NSGestureRecognizerDelegate
 
 static BOOL isBuiltInScrollViewPanGestureRecognizer(NSGestureRecognizer *recognizer)

--- a/Source/WebKit/UIProcess/mac/WebViewImpl.mm
+++ b/Source/WebKit/UIProcess/mac/WebViewImpl.mm
@@ -1475,6 +1475,10 @@ void WebViewImpl::handleProcessSwapOrExit()
 #if ENABLE(WRITING_TOOLS)
     [m_view.get() _clearWritingToolsPreservedNodes];
 #endif
+
+#if HAVE(APPKIT_GESTURES_SUPPORT)
+    [m_appKitGestureController reset];
+#endif
 }
 
 void WebViewImpl::processWillSwap()


### PR DESCRIPTION
#### 5878eac344c57f1ce5c7de1a317388785141604a
<pre>
[AppKit Gestures] Gesture recognizer driven inputs can stop working after web content process crash
<a href="https://bugs.webkit.org/show_bug.cgi?id=313322">https://bugs.webkit.org/show_bug.cgi?id=313322</a>
<a href="https://rdar.apple.com/175599268">rdar://175599268</a>

Reviewed by Richard Robinson.

There is a bunch of local state tracked within the UI process bound
AppKit gesture controller that we fail to clear when the web content
process terminates, which would leave the controller in a stale state.
For example, if the web content process crashed during an on-going drag
gesture, it would permanently suppress mouse tracking.

To remedy this, we add a reset method that clears all process-dependent
state and have it called from WebViewImpl::handleProcessSwapOrExit().

* Source/WebKit/UIProcess/mac/WKAppKitGestureController.h:
* Source/WebKit/UIProcess/mac/WKAppKitGestureController.mm:
(-[WKAppKitGestureController reset]):
* Source/WebKit/UIProcess/mac/WebViewImpl.mm:
(WebKit::WebViewImpl::handleProcessSwapOrExit):

Canonical link: <a href="https://commits.webkit.org/312030@main">https://commits.webkit.org/312030@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ce34508f211cd20dd5c549f16afb2f531d4cb6cb

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/158734 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/32161 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/25267 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/167564 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/112819 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/a11bd87a-cc10-47da-b83c-20531833b511) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/32228 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/32149 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/122972 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/86306 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/8cdd7983-ca51-4be3-807e-ee0403df88d2) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/161692 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/25231 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/142598 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/103641 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/ca597d21-daae-4e03-a6e9-00757c670be7) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/24288 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/22694 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/15336 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/133974 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/170056 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/15799 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/22004 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/131158 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/31851 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/26760 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/131272 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/31796 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/142171 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/89751 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/24132 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/25968 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/18980 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/31307 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/97321 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/30827 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/31100 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/30981 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->