### PR TITLE
[CMake] Add mac-dev-debug-o3 preset

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -119,6 +119,22 @@
             "inherits": ["mac-debug", "dev"]
         },
         {
+            "name": "mac-dev-debug-o3",
+            "displayName": "macOS Development (Debug O3 optimization, ccache, compile_commands)",
+            "inherits": ["mac-debug", "dev"],
+            "binaryDir": "WebKitBuild/cmake-mac/DebugO3",
+            "cacheVariables": {
+                "CMAKE_C_FLAGS_DEBUG": {
+                    "type": "STRING",
+                    "value": "-g -O3"
+                },
+                "CMAKE_CXX_FLAGS_DEBUG": {
+                    "type": "STRING",
+                    "value": "-g -O3"
+                }
+            }
+        },
+        {
             "name": "mac-dev-relwithdebinfo",
             "displayName": "macOS Development (RelWithDebInfo -- optimized + debuggable)",
             "inherits": ["mac", "dev"],
@@ -204,6 +220,11 @@
             "name": "mac-dev-debug",
             "displayName": "macOS Development Debug",
             "configurePreset": "mac-dev-debug"
+        },
+        {
+            "name": "mac-dev-debug-o3",
+            "displayName": "macOS Development Debug O3",
+            "configurePreset": "mac-dev-debug-o3"
         },
         {
             "name": "mac-dev-relwithdebinfo",


### PR DESCRIPTION
#### 042fe2f22789b5c2e1a3059c2f114b8f2616b50b
<pre>
[CMake] Add mac-dev-debug-o3 preset
<a href="https://bugs.webkit.org/show_bug.cgi?id=313323">https://bugs.webkit.org/show_bug.cgi?id=313323</a>
<a href="https://rdar.apple.com/175599536">rdar://175599536</a>

Reviewed by Yijia Huang.

Add mac-dev-debug-o3 preset, which uses Debug build but with -O3.

* CMakePresets.json:

Canonical link: <a href="https://commits.webkit.org/312129@main">https://commits.webkit.org/312129@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3fc6fe8fdf5498dbf51147c78823ffc27207095d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/158735 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/32162 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/25268 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/167565 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/112820 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/1074c890-a3f3-4a24-8295-c0c49f7d438b) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/32229 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/32150 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/122973 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/86302 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/4fad9a46-6826-4e98-942c-75db5440a3f2) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/161693 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/25238 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/142604 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/103642 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/462c89b4-1b74-43e0-b5da-318be81f757f) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/24295 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/22695 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/15337 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/133981 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/170057 "Built successfully") | | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/22010 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/131159 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/31852 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/26761 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/131273 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/31797 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/142177 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/89752 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/24196 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/25970 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/18986 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/31308 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/30828 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/31101 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/30982 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->