### PR TITLE
[JSC] Delay intlAvailableTimeZoneIndex initialization as normal IANA case covers most of cases

### DIFF
--- a/Source/JavaScriptCore/runtime/IntlObject.cpp
+++ b/Source/JavaScriptCore/runtime/IntlObject.cpp
@@ -1997,7 +1997,7 @@ static const Vector<String>& intlAvailableTimeZones()
             int32_t length = 0;
             const char* pointer = uenum_next(enumeration.get(), &length, &status);
             ASSERT(U_SUCCESS(status));
-            String timeZone(unsafeMakeSpan(pointer, static_cast<size_t>(length)));
+            StringView timeZone(unsafeMakeSpan(pointer, static_cast<size_t>(length)));
             if (!isValidTimeZoneNameFromICUTimeZone(timeZone))
                 continue;
             // UCAL_ZONE_TYPE_CANONICAL yields CLDR canonical IDs, which lag behind the IANA
@@ -2015,7 +2015,9 @@ static const Vector<String>& intlAvailableTimeZones()
         auto end = std::unique(temporary.begin(), temporary.end());
         availableTimeZones.construct();
 
-        auto createImmortalThreadSafeString = [&](String&& string) {
+        auto createImmortalThreadSafeString = [&](String&& string) -> String {
+            if (string.impl() && string.impl()->isStatic())
+                return WTF::move(string);
             if (string.is8Bit())
                 return StringImpl::createStaticStringImpl(string.span8());
             return StringImpl::createStaticStringImpl(string.span16());
@@ -2035,10 +2037,12 @@ const String& intlTimeZoneIDToString(TimeZoneID id)
 // Index from any accepted time zone string (case-insensitive) to the
 // TimeZoneID of its IANA primary. Multiple input forms (legacy IANA Backward
 // links, UTC-equivalent aliases, the primary itself) collapse onto the same
-// TimeZoneID. Built once on first use; the time zone list is fixed by the
-// linked ICU/CLDR version, so a fixed map is safe. Stored keys must be
-// immortal so the read-only map can be shared across VM threads — same
-// requirement that intlAvailableTimeZones() satisfies via createStaticStringImpl.
+// TimeZoneID. Lazily built on first lookup that does not match a primary via
+// binary search (see intlResolveTimeZoneID / intlAvailableNamedTimeZone). The
+// time zone list is fixed by the linked ICU/CLDR version, so a fixed map is
+// safe. Stored keys must be immortal so the read-only map can be shared across
+// VM threads — same requirement that intlAvailableTimeZones() satisfies via
+// createStaticStringImpl.
 static const HashMap<String, TimeZoneID, ASCIICaseInsensitiveHash>& intlAvailableTimeZoneIndex()
 {
     static LazyNeverDestroyed<HashMap<String, TimeZoneID, ASCIICaseInsensitiveHash>> index;
@@ -2097,6 +2101,11 @@ static const HashMap<String, TimeZoneID, ASCIICaseInsensitiveHash>& intlAvailabl
 
 std::optional<TimeZoneID> intlResolveTimeZoneID(StringView name)
 {
+    const auto& primaries = intlAvailableTimeZones();
+    auto it = std::ranges::lower_bound(primaries, name, WTF::codePointCompareLessThan);
+    if (it != primaries.end() && StringView(*it) == name)
+        return static_cast<TimeZoneID>(it - primaries.begin());
+
     const auto& index = intlAvailableTimeZoneIndex();
     auto entry = index.find<ASCIICaseInsensitiveStringViewHashTranslator>(name);
     if (entry == index.end())
@@ -2106,6 +2115,11 @@ std::optional<TimeZoneID> intlResolveTimeZoneID(StringView name)
 
 std::optional<AvailableNamedTimeZone> intlAvailableNamedTimeZone(StringView name)
 {
+    const auto& primaries = intlAvailableTimeZones();
+    auto it = std::ranges::lower_bound(primaries, name, WTF::codePointCompareLessThan);
+    if (it != primaries.end() && StringView(*it) == name)
+        return AvailableNamedTimeZone { static_cast<TimeZoneID>(it - primaries.begin()), *it };
+
     const auto& index = intlAvailableTimeZoneIndex();
     auto entry = index.find<ASCIICaseInsensitiveStringViewHashTranslator>(name);
     if (entry == index.end())

--- a/Source/JavaScriptCore/runtime/VM.cpp
+++ b/Source/JavaScriptCore/runtime/VM.cpp
@@ -513,7 +513,8 @@ WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
     Config::finalize();
 
-    initializeAvailableTimeZones();
+    if (!isInMiniMode())
+        initializeAvailableTimeZones();
 
     // We must set this at the end only after the VM is fully initialized.
     WTF::storeStoreFence();


### PR DESCRIPTION
#### 3d3f4763409e6ffe73158cf837cb77580a707a60
<pre>
[JSC] Delay intlAvailableTimeZoneIndex initialization as normal IANA case covers most of cases
<a href="https://bugs.webkit.org/show_bug.cgi?id=313324">https://bugs.webkit.org/show_bug.cgi?id=313324</a>
<a href="https://rdar.apple.com/175601401">rdar://175601401</a>

Reviewed by Yijia Huang.

Since IANA primary TimeZone IDs can conver most of cases, let&apos;s just
initialize that part, and let the legacy TimeZone ID handling hashtable
initialized lazily. Also delaying initialization when minimode is enabled.

* Source/JavaScriptCore/runtime/IntlObject.cpp:
(JSC::intlAvailableTimeZones):
(JSC::intlResolveTimeZoneID):
(JSC::intlAvailableNamedTimeZone):
* Source/JavaScriptCore/runtime/VM.cpp:
(JSC::VM::VM):

Canonical link: <a href="https://commits.webkit.org/312136@main">https://commits.webkit.org/312136@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/09b3e142dfb45e4f1991cb79d5bfea6b137ed66f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/159044 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/32472 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/25577 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/167873 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/113128 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/dfa69b45-84fb-4a07-8859-14b8d2e9caa0) 
| | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/32539 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/32459 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/123219 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/113128 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/a972884d-efbd-4b31-bb18-b38c8b438f7c) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/162001 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/32539 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/142878 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/103886 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/3091f392-4c1a-45a1-ba33-9335868a3e33) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/32539 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/22965 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk3-libwebrtc~~](https://ews-build.webkit.org/#/builders/173/builds/15646 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/20/builds/151094 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/32539 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/167/builds/20658 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/170366 "Built successfully") | | 
| [  ~~🛠 🧪 jsc-debug-arm64~~](https://ews-build.webkit.org/#/builders/171/builds/19877 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/16108 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/22284 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/131410 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/32161 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/27034 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/131522 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/32105 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/142451 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/90155 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/24200 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/160/builds/32105 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/19260 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/191326 "Failed to checkout and rebase branch from PR 63605") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/31616 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/97630 "Built successfully") | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/35/builds/191326 "Failed to checkout and rebase branch from PR 63605") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/31136 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/31409 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/31291 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->