### PR TITLE
[Site Isolation] http/tests/security/XFrameOptions/x-frame-options-ignore-deny-meta-tag.html fails

### DIFF
--- a/LayoutTests/http/tests/security/XFrameOptions/x-frame-options-ignore-deny-meta-tag-expected.txt
+++ b/LayoutTests/http/tests/security/XFrameOptions/x-frame-options-ignore-deny-meta-tag-expected.txt
@@ -3,6 +3,7 @@ http://127.0.0.1:8000/security/XFrameOptions/x-frame-options-ignore-deny-meta-ta
 http://127.0.0.1:8000/security/XFrameOptions/resources/x-frame-options-deny-meta-tag-subframe.html - didReceiveResponse <NSURLResponse http://127.0.0.1:8000/security/XFrameOptions/resources/x-frame-options-deny-meta-tag-subframe.html, http status code 200>
 CONSOLE MESSAGE: The X-Frame-Option 'deny' supplied in a <meta> element was ignored. X-Frame-Options may only be provided by an HTTP header sent with the document.
 CONSOLE MESSAGE: PASS: Could read contentWindow.location.href
+http://127.0.0.1:8000/security/XFrameOptions/resources/x-frame-options-deny-meta-tag-subframe.html - didFinishLoading
 There should be content in the iframe below
 
 

--- a/LayoutTests/http/tests/security/XFrameOptions/x-frame-options-ignore-deny-meta-tag-in-body-expected.txt
+++ b/LayoutTests/http/tests/security/XFrameOptions/x-frame-options-ignore-deny-meta-tag-in-body-expected.txt
@@ -3,6 +3,7 @@ http://127.0.0.1:8000/security/XFrameOptions/x-frame-options-ignore-deny-meta-ta
 http://127.0.0.1:8000/security/XFrameOptions/resources/x-frame-options-deny-meta-tag-subframe-in-body.html - didReceiveResponse <NSURLResponse http://127.0.0.1:8000/security/XFrameOptions/resources/x-frame-options-deny-meta-tag-subframe-in-body.html, http status code 200>
 CONSOLE MESSAGE: The X-Frame-Option 'deny' supplied in a <meta> element was ignored. X-Frame-Options may only be provided by an HTTP header sent with the document.
 CONSOLE MESSAGE: PASS: Could read contentWindow.location.href
+http://127.0.0.1:8000/security/XFrameOptions/resources/x-frame-options-deny-meta-tag-subframe-in-body.html - didFinishLoading
 There should be content in the iframe below
 
 

--- a/LayoutTests/http/tests/security/XFrameOptions/x-frame-options-ignore-deny-meta-tag-in-body.html
+++ b/LayoutTests/http/tests/security/XFrameOptions/x-frame-options-ignore-deny-meta-tag-in-body.html
@@ -1,5 +1,6 @@
 <script>
     if (window.testRunner) {
+        internals.clearMemoryCache();
         testRunner.dumpAsText();
         testRunner.dumpChildFramesAsText();
         testRunner.dumpResourceLoadCallbacks();
@@ -13,7 +14,8 @@
             console.log("FAIL: Could not read contentWindow.location.href");
         else
             console.log("PASS: Could read contentWindow.location.href");
-        testRunner.notifyDone();
+
+        setTimeout(() => testRunner.notifyDone(), 0);
     }
 </script>
 

--- a/LayoutTests/http/tests/security/XFrameOptions/x-frame-options-ignore-deny-meta-tag.html
+++ b/LayoutTests/http/tests/security/XFrameOptions/x-frame-options-ignore-deny-meta-tag.html
@@ -1,5 +1,6 @@
 <script>
     if (window.testRunner) {
+        internals.clearMemoryCache();
         testRunner.dumpAsText();
         testRunner.dumpChildFramesAsText();
         testRunner.dumpResourceLoadCallbacks();
@@ -13,7 +14,8 @@
             console.log("FAIL: Could not read contentWindow.location.href");
         else
             console.log("PASS: Could read contentWindow.location.href");
-        testRunner.notifyDone();
+
+        setTimeout(() => testRunner.notifyDone(), 0);
     }
 </script>
 

--- a/LayoutTests/platform/wk2/http/tests/security/XFrameOptions/x-frame-options-ignore-deny-meta-tag-expected.txt
+++ b/LayoutTests/platform/wk2/http/tests/security/XFrameOptions/x-frame-options-ignore-deny-meta-tag-expected.txt
@@ -3,6 +3,7 @@ http://127.0.0.1:8000/security/XFrameOptions/resources/x-frame-options-deny-meta
 http://127.0.0.1:8000/security/XFrameOptions/resources/x-frame-options-deny-meta-tag-subframe.html - didReceiveResponse <NSURLResponse http://127.0.0.1:8000/security/XFrameOptions/resources/x-frame-options-deny-meta-tag-subframe.html, http status code 200>
 CONSOLE MESSAGE: The X-Frame-Option 'deny' supplied in a <meta> element was ignored. X-Frame-Options may only be provided by an HTTP header sent with the document.
 CONSOLE MESSAGE: PASS: Could read contentWindow.location.href
+http://127.0.0.1:8000/security/XFrameOptions/resources/x-frame-options-deny-meta-tag-subframe.html - didFinishLoading
 There should be content in the iframe below
 
 

--- a/LayoutTests/platform/wk2/http/tests/security/XFrameOptions/x-frame-options-ignore-deny-meta-tag-in-body-expected.txt
+++ b/LayoutTests/platform/wk2/http/tests/security/XFrameOptions/x-frame-options-ignore-deny-meta-tag-in-body-expected.txt
@@ -3,6 +3,7 @@ http://127.0.0.1:8000/security/XFrameOptions/resources/x-frame-options-deny-meta
 http://127.0.0.1:8000/security/XFrameOptions/resources/x-frame-options-deny-meta-tag-subframe-in-body.html - didReceiveResponse <NSURLResponse http://127.0.0.1:8000/security/XFrameOptions/resources/x-frame-options-deny-meta-tag-subframe-in-body.html, http status code 200>
 CONSOLE MESSAGE: The X-Frame-Option 'deny' supplied in a <meta> element was ignored. X-Frame-Options may only be provided by an HTTP header sent with the document.
 CONSOLE MESSAGE: PASS: Could read contentWindow.location.href
+http://127.0.0.1:8000/security/XFrameOptions/resources/x-frame-options-deny-meta-tag-subframe-in-body.html - didFinishLoading
 There should be content in the iframe below
 
 


### PR DESCRIPTION
#### e12a52d5fbd6b8259084008795631769d05a8640
<pre>
[Site Isolation] http/tests/security/XFrameOptions/x-frame-options-ignore-deny-meta-tag.html fails
<a href="https://bugs.webkit.org/show_bug.cgi?id=313326">https://bugs.webkit.org/show_bug.cgi?id=313326</a>

Reviewed by Alan Baradlay.

The failure was caused by the race between testRunner.notifyDone finishing the test vs. subframe
finish loading getting logged. Fixed the test by always delaying testRunner.notifyDone with a 0s timer.

* LayoutTests/http/tests/security/XFrameOptions/x-frame-options-ignore-deny-meta-tag-expected.txt:
* LayoutTests/http/tests/security/XFrameOptions/x-frame-options-ignore-deny-meta-tag-in-body-expected.txt:
* LayoutTests/http/tests/security/XFrameOptions/x-frame-options-ignore-deny-meta-tag-in-body.html:
* LayoutTests/http/tests/security/XFrameOptions/x-frame-options-ignore-deny-meta-tag.html:
* LayoutTests/platform/wk2/http/tests/security/XFrameOptions/x-frame-options-ignore-deny-meta-tag-expected.txt:
* LayoutTests/platform/wk2/http/tests/security/XFrameOptions/x-frame-options-ignore-deny-meta-tag-in-body-expected.txt:

Canonical link: <a href="https://commits.webkit.org/312028@main">https://commits.webkit.org/312028@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d5317f8972ee81d187fa5a958346c3985f831800

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/158752 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/32179 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/25285 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/167582 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/112837 "Built successfully") | ⏳ 🛠 ios-apple 
| [⏳ 🧪 bindings ](https://ews-build.webkit.org/#/builders/Bindings-Tests-EWS "Waiting in queue, processing has not started yet") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/32246 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/32167 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/122989 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/86316 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/161710 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/25249 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/142619 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/103658 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/24306 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/22710 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/15354 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/133992 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/20399 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/170074 "Built successfully") | | 
| [⏳ 🛠 🧪 jsc-debug-arm64 ](https://ews-build.webkit.org/#/builders/JSC-Tests-O3-Debug-arm64-EWS "Waiting in queue, processing has not started yet") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/15817 "Build is in progress. Recent messages:") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/22025 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/131175 "Passed tests") | | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/158149 "Build is in progress. Recent messages:") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/31869 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/26776 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/131289 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/31814 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/142192 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/89776 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/24131 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/25984 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/19001 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/31325 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/30845 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/31118 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/30999 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->