### PR TITLE
[JSC] Avoid per-edge ModuleLoaderPayload allocation in graph loading

### DIFF
--- a/Source/JavaScriptCore/heap/Heap.h
+++ b/Source/JavaScriptCore/heap/Heap.h
@@ -306,7 +306,7 @@ class Heap;
     v(disposableStackSpace, cellHeapCellType, JSDisposableStack) \
     v(asyncDisposableStackSpace, cellHeapCellType, JSAsyncDisposableStack) \
     v(moduleLoaderSpace, destructibleCellHeapCellType, JSModuleLoader) \
-    v(moduleLoaderPayloadSpace, destructibleCellHeapCellType, ModuleLoaderPayload) \
+    v(moduleLoaderPayloadSpace, cellHeapCellType, ModuleLoaderPayload) \
     v(moduleGraphLoadingStateSpace, destructibleCellHeapCellType, ModuleGraphLoadingState) \
     \
     FOR_EACH_JSC_WEBASSEMBLY_DYNAMIC_ISO_SUBSPACE(v)

--- a/Source/JavaScriptCore/runtime/Completion.cpp
+++ b/Source/JavaScriptCore/runtime/Completion.cpp
@@ -234,7 +234,7 @@ JSPromise* loadAndEvaluateModule(JSGlobalObject* globalObject, SourceCode&& sour
 
     AbstractModuleRecord::ModuleRequest request { WTF::move(key), ScriptFetchParameters::create(type) };
 
-    JSPromise* promise = globalObject->moduleLoader()->loadModule(globalObject, globalObject, request, ModuleLoaderPayload::create(vm, graphLoadingState), WTF::move(scriptFetcher), true, false);
+    JSPromise* promise = globalObject->moduleLoader()->loadModule(globalObject, globalObject, request, graphLoadingState, WTF::move(scriptFetcher), true, false);
     RETURN_IF_EXCEPTION(scope, rejectPromise(scope, globalObject));
 
     JSPromise* resultPromise = JSPromise::create(vm, globalObject->promiseStructure());

--- a/Source/JavaScriptCore/runtime/JSMicrotask.cpp
+++ b/Source/JavaScriptCore/runtime/JSMicrotask.cpp
@@ -982,16 +982,17 @@ static void moduleLoadTopSettled(JSGlobalObject* globalObject, VM& vm, ThrowScop
         JSPromise* statePromise = JSPromise::create(vm, globalObject->promiseStructure());
         statePromise->markAsHandled();
         AbstractModuleRecord::ModuleRequest request { specifier, ScriptFetchParameters::create(type) };
-        ModuleLoaderPayload* modulePayload;
+        // combinedCell is the host-defined payload AND the AND-join state for loadPromise+statePromise.
+        // For dynamic import we wrap statePromise; for graph load we use the ModuleGraphLoadingState directly.
+        JSCell* combinedCell;
         JSPromise* loadPromise;
 
         if (context->dynamic()) {
-            modulePayload = ModuleLoaderPayload::create(vm, statePromise);
-            loadPromise = globalObject->moduleLoader()->loadModule(globalObject, globalObject, request, modulePayload, scriptFetcher, false, context->useImportMap());
+            combinedCell = ModuleLoaderPayload::create(vm, statePromise);
+            loadPromise = globalObject->moduleLoader()->loadModule(globalObject, globalObject, request, combinedCell, scriptFetcher, false, context->useImportMap());
         } else {
-            auto graphLoadingState = ModuleGraphLoadingState::create(vm, statePromise, scriptFetcher);
-            modulePayload = ModuleLoaderPayload::create(vm, graphLoadingState);
-            loadPromise = globalObject->moduleLoader()->loadModule(globalObject, globalObject, request, modulePayload, scriptFetcher, context->evaluate(), context->useImportMap());
+            combinedCell = ModuleGraphLoadingState::create(vm, statePromise, scriptFetcher);
+            loadPromise = globalObject->moduleLoader()->loadModule(globalObject, globalObject, request, combinedCell, scriptFetcher, context->evaluate(), context->useImportMap());
             if (scope.exception()) {
                 intermediatePromise->rejectWithCaughtException(globalObject, scope);
                 return;
@@ -1011,8 +1012,8 @@ static void moduleLoadTopSettled(JSGlobalObject* globalObject, VM& vm, ThrowScop
         JSPromise* combinedPromise = JSPromise::create(vm, globalObject->promiseStructure());
         combinedPromise->markAsHandled();
 
-        loadPromise->performPromiseThenWithInternalMicrotask(vm, globalObject, InternalMicrotask::ModuleLoadCombinedLoadSettled, combinedPromise, modulePayload);
-        statePromise->performPromiseThenWithInternalMicrotask(vm, globalObject, InternalMicrotask::ModuleLoadCombinedStateSettled, combinedPromise, modulePayload);
+        loadPromise->performPromiseThenWithInternalMicrotask(vm, globalObject, InternalMicrotask::ModuleLoadCombinedLoadSettled, combinedPromise, combinedCell);
+        statePromise->performPromiseThenWithInternalMicrotask(vm, globalObject, InternalMicrotask::ModuleLoadCombinedStateSettled, combinedPromise, combinedCell);
 
         intermediatePromise->pipeFrom(vm, combinedPromise);
     } else {
@@ -1094,21 +1095,35 @@ static void moduleLoadCombinedLoadSettled(JSGlobalObject* globalObject, VM& vm, 
     // Combined promise: load side settled
     // arguments[0] = combinedPromise
     // arguments[1] = resolution or error
-    // arguments[2] = ModuleLoaderPayload*
+    // arguments[2] = ModuleGraphLoadingState* (graph load) or ModuleLoaderPayload* (dynamic import)
     auto* combinedPromise = uncheckedDowncast<JSPromise>(arguments[0]);
-    auto* modulePayload = uncheckedDowncast<ModuleLoaderPayload>(arguments[2]);
+    auto* combinedCell = arguments[2].asCell();
+    ASSERT(isModuleLoaderHostDefinedPayload(combinedCell));
     auto status = static_cast<JSPromise::Status>(payload);
     scope.release();
-    if (status == JSPromise::Status::Fulfilled) {
-        if (modulePayload->decrementRemaining() && combinedPromise->status() == JSPromise::Status::Pending) {
-            JSValue fulfillmentValue = modulePayload->fulfillment();
+    bool fullySettled;
+    if (auto* state = dynamicDowncast<ModuleGraphLoadingState>(combinedCell))
+        fullySettled = state->decrementRemaining();
+    else
+        fullySettled = uncheckedDowncast<ModuleLoaderPayload>(combinedCell)->decrementRemaining();
+    switch (combinedPromise->status()) {
+    case JSPromise::Status::Pending: {
+        if (status == JSPromise::Status::Fulfilled) {
+            if (!fullySettled)
+                return;
+            JSValue fulfillmentValue;
+            if (auto* state = dynamicDowncast<ModuleGraphLoadingState>(combinedCell))
+                fulfillmentValue = state->fulfillment();
+            else
+                fulfillmentValue = uncheckedDowncast<ModuleLoaderPayload>(combinedCell)->fulfillment();
             ASSERT(fulfillmentValue);
             combinedPromise->fulfill(vm, globalObject, fulfillmentValue);
-        }
-    } else {
-        modulePayload->decrementRemaining();
-        if (combinedPromise->status() == JSPromise::Status::Pending)
+        } else
             combinedPromise->reject(vm, globalObject, arguments[1]);
+        return;
+    }
+    default:
+        return;
     }
 }
 
@@ -1117,21 +1132,33 @@ static void moduleLoadCombinedStateSettled(JSGlobalObject* globalObject, VM& vm,
     // Combined promise: state side settled
     // arguments[0] = combinedPromise
     // arguments[1] = resolution or error
-    // arguments[2] = ModuleLoaderPayload*
+    // arguments[2] = ModuleGraphLoadingState* (graph load) or ModuleLoaderPayload* (dynamic import)
     auto* combinedPromise = uncheckedDowncast<JSPromise>(arguments[0]);
-    auto* modulePayload = uncheckedDowncast<ModuleLoaderPayload>(arguments[2]);
+    auto* combinedCell = arguments[2].asCell();
+    ASSERT(isModuleLoaderHostDefinedPayload(combinedCell));
     auto status = static_cast<JSPromise::Status>(payload);
     scope.release();
-    if (status == JSPromise::Status::Fulfilled) {
-        if (modulePayload->decrementRemaining()) {
-            if (combinedPromise->status() == JSPromise::Status::Pending)
+    bool fullySettled;
+    if (auto* state = dynamicDowncast<ModuleGraphLoadingState>(combinedCell)) {
+        fullySettled = state->decrementRemaining();
+        if (status == JSPromise::Status::Fulfilled && !fullySettled)
+            state->setFulfillment(vm, arguments[1]);
+    } else {
+        auto* p = uncheckedDowncast<ModuleLoaderPayload>(combinedCell);
+        fullySettled = p->decrementRemaining();
+        if (status == JSPromise::Status::Fulfilled && !fullySettled)
+            p->setFulfillment(vm, arguments[1]);
+    }
+    switch (combinedPromise->status()) {
+    case JSPromise::Status::Pending:
+        if (status == JSPromise::Status::Fulfilled) {
+            if (fullySettled)
                 combinedPromise->fulfill(vm, globalObject, arguments[1]);
         } else
-            modulePayload->fulfillment(vm, arguments[1]);
-    } else {
-        modulePayload->decrementRemaining();
-        if (combinedPromise->status() == JSPromise::Status::Pending)
             combinedPromise->reject(vm, globalObject, arguments[1]);
+        return;
+    default:
+        return;
     }
 }
 

--- a/Source/JavaScriptCore/runtime/JSModuleLoader.cpp
+++ b/Source/JavaScriptCore/runtime/JSModuleLoader.cpp
@@ -577,10 +577,12 @@ AbstractModuleRecord* JSModuleLoader::maybeGetImportedModule(AbstractModuleRecor
     return nullptr;
 }
 
-JSPromise* JSModuleLoader::hostLoadImportedModule(JSGlobalObject* globalObject, const ModuleReferrer& referrer, const ModuleRequest& moduleRequest, ModuleLoaderPayload* payload, RefPtr<ScriptFetcher> scriptFetcher, bool useImportMap)
+JSPromise* JSModuleLoader::hostLoadImportedModule(JSGlobalObject* globalObject, const ModuleReferrer& referrer, const ModuleRequest& moduleRequest, JSCell* payload, RefPtr<ScriptFetcher> scriptFetcher, bool useImportMap)
 {
     // HostLoadImportedModule(referrer, moduleRequest, loadState, payload)
     // https://html.spec.whatwg.org/multipage/webappapis.html#hostloadimportedmodule
+
+    ASSERT(isModuleLoaderHostDefinedPayload(payload));
 
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
@@ -703,8 +705,10 @@ JSPromise* JSModuleLoader::hostLoadImportedModule(JSGlobalObject* globalObject, 
     return loadPromise;
 }
 
-JSPromise* JSModuleLoader::loadModule(JSGlobalObject* globalObject, const ModuleReferrer& referrer, const ModuleRequest& moduleRequest, ModuleLoaderPayload* payload, RefPtr<ScriptFetcher> scriptFetcher, bool evaluate, bool useImportMap)
+JSPromise* JSModuleLoader::loadModule(JSGlobalObject* globalObject, const ModuleReferrer& referrer, const ModuleRequest& moduleRequest, JSCell* payload, RefPtr<ScriptFetcher> scriptFetcher, bool evaluate, bool useImportMap)
 {
+    ASSERT(isModuleLoaderHostDefinedPayload(payload));
+
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
@@ -761,7 +765,7 @@ void JSModuleLoader::innerModuleLoading(JSGlobalObject* globalObject, ModuleGrap
                 // 2.d.iii. Else,
             } else {
                 // 2.d.iii.1. Perform HostLoadImportedModule(module, request, state.[[HostDefined]], state).
-                JSPromise* promise = hostLoadImportedModule(globalObject, cyclic, request, ModuleLoaderPayload::create(vm, state), state->scriptFetcher(), true);
+                JSPromise* promise = hostLoadImportedModule(globalObject, cyclic, request, state, state->scriptFetcher(), true);
                 RETURN_IF_EXCEPTION(scope, void());
                 promise->performPromiseThenWithInternalMicrotask(vm, globalObject, InternalMicrotask::ModuleGraphLoadingError, jsUndefined(), state);
                 // 2.d.iii.2. NOTE: HostLoadImportedModule will call FinishLoadingImportedModule, which re-enters the graph loading process through ContinueModuleLoading.
@@ -792,10 +796,12 @@ void JSModuleLoader::innerModuleLoading(JSGlobalObject* globalObject, ModuleGrap
     scope.release();
 }
 
-void JSModuleLoader::finishLoadingImportedModule(JSGlobalObject* globalObject, const ModuleReferrer& referrer, const ModuleRequest& moduleRequest, ModuleLoaderPayload* payload, ModuleCompletion result, RefPtr<ScriptFetcher> scriptFetcher)
+void JSModuleLoader::finishLoadingImportedModule(JSGlobalObject* globalObject, const ModuleReferrer& referrer, const ModuleRequest& moduleRequest, JSCell* payload, ModuleCompletion result, RefPtr<ScriptFetcher> scriptFetcher)
 {
     // FinishLoadingImportedModule(referrer, moduleRequest, payload, result)
     // https://tc39.es/ecma262/#sec-FinishLoadingImportedModule
+
+    ASSERT(isModuleLoaderHostDefinedPayload(payload));
 
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
@@ -831,15 +837,15 @@ void JSModuleLoader::finishLoadingImportedModule(JSGlobalObject* globalObject, c
     }
 
     // 2. If payload is a GraphLoadingState Record, then
-    if (ModuleGraphLoadingState* state = payload->getState()) {
+    if (auto* state = dynamicDowncast<ModuleGraphLoadingState>(payload)) {
         // 2.a. Perform ContinueModuleLoading(payload, result).
         continueModuleLoading(globalObject, state, result);
         RETURN_IF_EXCEPTION(scope, void());
     // 3. Else,
     } else {
-        ASSERT(payload->isPromise());
         // 3.a. Perform ContinueDynamicImport(payload, result).
-        continueDynamicImport(globalObject, payload->getPromise(), result, WTF::move(scriptFetcher));
+        auto* dynamicPayload = uncheckedDowncast<ModuleLoaderPayload>(payload);
+        continueDynamicImport(globalObject, dynamicPayload->promise(), result, WTF::move(scriptFetcher));
         RETURN_IF_EXCEPTION(scope, void());
     }
 

--- a/Source/JavaScriptCore/runtime/JSModuleLoader.h
+++ b/Source/JavaScriptCore/runtime/JSModuleLoader.h
@@ -144,10 +144,11 @@ public:
     using ModuleCompletion = Variant<AbstractModuleRecord*, Exception*>;
 
     void innerModuleLoading(JSGlobalObject*, ModuleGraphLoadingState*, AbstractModuleRecord*);
-    void finishLoadingImportedModule(JSGlobalObject*, const ModuleReferrer&, const ModuleRequest&, ModuleLoaderPayload*, ModuleCompletion result, RefPtr<ScriptFetcher>);
+    // payload is opaque to callers and is either a ModuleGraphLoadingState* (graph load) or a ModuleLoaderPayload* (top-level dynamic import).
+    void finishLoadingImportedModule(JSGlobalObject*, const ModuleReferrer&, const ModuleRequest&, JSCell* payload, ModuleCompletion result, RefPtr<ScriptFetcher>);
 
-    JSPromise* hostLoadImportedModule(JSGlobalObject*, const ModuleReferrer&, const ModuleRequest&, ModuleLoaderPayload*, RefPtr<ScriptFetcher>, bool useImportMap);
-    JSPromise* loadModule(JSGlobalObject*, const ModuleReferrer&, const ModuleRequest&, ModuleLoaderPayload*, RefPtr<ScriptFetcher>, bool evaluate, bool useImportMap);
+    JSPromise* hostLoadImportedModule(JSGlobalObject*, const ModuleReferrer&, const ModuleRequest&, JSCell* payload, RefPtr<ScriptFetcher>, bool useImportMap);
+    JSPromise* loadModule(JSGlobalObject*, const ModuleReferrer&, const ModuleRequest&, JSCell* payload, RefPtr<ScriptFetcher>, bool evaluate, bool useImportMap);
     void continueModuleLoading(JSGlobalObject*, ModuleGraphLoadingState*, ModuleCompletion result);
     void continueDynamicImport(JSGlobalObject*, JSPromise*, ModuleCompletion, RefPtr<ScriptFetcher>);
     JSPromise* loadRequestedModules(JSGlobalObject*, AbstractModuleRecord*, RefPtr<ScriptFetcher>);
@@ -180,5 +181,13 @@ private:
 
     ResolutionMap<WriteBarrier<Unknown>> m_resolutionFailures;
 };
+
+// Validates the host-defined payload threaded through HostLoadImportedModule / FinishLoadingImportedModule.
+// Spec's `payload ∈ { GraphLoadingState Record, PromiseCapability Record }` is encoded in JSC as
+// either ModuleGraphLoadingState* (graph load) or ModuleLoaderPayload* (top-level dynamic import).
+inline bool isModuleLoaderHostDefinedPayload(JSCell* cell)
+{
+    return cell->inherits<ModuleGraphLoadingState>() || cell->inherits<ModuleLoaderPayload>();
+}
 
 } // namespace JSC

--- a/Source/JavaScriptCore/runtime/ModuleGraphLoadingState.cpp
+++ b/Source/JavaScriptCore/runtime/ModuleGraphLoadingState.cpp
@@ -60,6 +60,7 @@ void ModuleGraphLoadingState::visitChildrenImpl(JSCell* cell, Visitor& visitor)
     ASSERT_GC_OBJECT_INHERITS(thisObject, info());
     Base::visitChildren(thisObject, visitor);
     visitor.append(thisObject->m_promise);
+    visitor.append(thisObject->m_fulfillment);
     Locker locker { thisObject->cellLock() };
     visitor.append(thisObject->m_visited.begin(), thisObject->m_visited.end());
 }

--- a/Source/JavaScriptCore/runtime/ModuleGraphLoadingState.h
+++ b/Source/JavaScriptCore/runtime/ModuleGraphLoadingState.h
@@ -73,6 +73,15 @@ public:
             function(barrier.get());
     }
 
+    // Combined-promise AND-join state used by top-level loadModule (mirrors ModuleLoaderPayload's same-named fields).
+    bool decrementRemaining()
+    {
+        ASSERT(m_remainingFulfillments > 0);
+        return !--m_remainingFulfillments;
+    }
+    JSValue fulfillment() const { return m_fulfillment.get(); }
+    void setFulfillment(VM& vm, JSValue value) { m_fulfillment.set(vm, this, value); }
+
 private:
     ModuleGraphLoadingState(VM&, Structure*, JSPromise*, RefPtr<ScriptFetcher>);
 
@@ -84,8 +93,11 @@ private:
     Vector<WriteBarrier<CyclicModuleRecord>, 8> m_visited;
     // Contains the same contents as m_visited, so no write barriers needed.
     UncheckedKeyHashSet<CyclicModuleRecord*> m_visitedSet;
+    // Slot used only at top-level loadModule to AND-join loadPromise and statePromise into combinedPromise.
+    WriteBarrier<Unknown> m_fulfillment;
     // [[PendingModulesCount]]
     unsigned m_pendingModulesCount { 1 };
+    uint8_t m_remainingFulfillments { 2 };
     // [[IsLoading]]
     bool m_isLoading { true };
     // [[HostDefined]]

--- a/Source/JavaScriptCore/runtime/ModuleLoaderPayload.cpp
+++ b/Source/JavaScriptCore/runtime/ModuleLoaderPayload.cpp
@@ -33,22 +33,10 @@ namespace JSC {
 
 const ClassInfo ModuleLoaderPayload::s_info = { "ModuleLoaderPayload"_s, nullptr, nullptr, nullptr, CREATE_METHOD_TABLE(ModuleLoaderPayload) };
 
-ModuleLoaderPayload::ModuleLoaderPayload(VM& vm, Structure* structure, ModuleGraphLoadingState* state)
-    : Base(vm, structure)
-    , m_payload(WriteBarrier(state, WriteBarrierEarlyInit))
-{
-}
-
 ModuleLoaderPayload::ModuleLoaderPayload(VM& vm, Structure* structure, JSPromise* promise)
     : Base(vm, structure)
-    , m_payload(WriteBarrier(promise, WriteBarrierEarlyInit))
+    , m_promise(promise, WriteBarrierEarlyInit)
 {
-}
-
-void ModuleLoaderPayload::destroy(JSCell* cell)
-{
-    SUPPRESS_MEMORY_UNSAFE_CAST auto* thisObject = static_cast<ModuleLoaderPayload*>(cell);
-    thisObject->~ModuleLoaderPayload();
 }
 
 void ModuleLoaderPayload::finishCreation(VM& vm)
@@ -63,72 +51,17 @@ void ModuleLoaderPayload::visitChildrenImpl(JSCell* cell, Visitor& visitor)
     auto* thisObject = uncheckedDowncast<ModuleLoaderPayload>(cell);
     ASSERT_GC_OBJECT_INHERITS(thisObject, info());
     Base::visitChildren(thisObject, visitor);
+    visitor.append(thisObject->m_promise);
     visitor.append(thisObject->m_fulfillment);
-    if (auto* state = std::get_if<WriteBarrier<ModuleGraphLoadingState>>(&thisObject->m_payload))
-        visitor.append(*state);
-    else {
-        ASSERT(std::holds_alternative<WriteBarrier<JSPromise>>(thisObject->m_payload));
-        visitor.append(std::get<WriteBarrier<JSPromise>>(thisObject->m_payload));
-    }
 }
 
 DEFINE_VISIT_CHILDREN(ModuleLoaderPayload);
-
-ModuleLoaderPayload* ModuleLoaderPayload::create(VM& vm, ModuleGraphLoadingState* state)
-{
-    ModuleLoaderPayload* instance = new (NotNull, allocateCell<ModuleLoaderPayload>(vm)) ModuleLoaderPayload(vm, vm.moduleLoaderPayloadStructure.get(), state);
-    instance->finishCreation(vm);
-    return instance;
-}
 
 ModuleLoaderPayload* ModuleLoaderPayload::create(VM& vm, JSPromise* promise)
 {
     ModuleLoaderPayload* instance = new (NotNull, allocateCell<ModuleLoaderPayload>(vm)) ModuleLoaderPayload(vm, vm.moduleLoaderPayloadStructure.get(), promise);
     instance->finishCreation(vm);
     return instance;
-}
-
-ModuleGraphLoadingState* ModuleLoaderPayload::getState() const
-{
-    auto option = std::get_if<WriteBarrier<ModuleGraphLoadingState>>(&m_payload);
-    return option ? option->get() : nullptr;
-}
-
-JSPromise* ModuleLoaderPayload::getPromise() const
-{
-    auto option = std::get_if<WriteBarrier<JSPromise>>(&m_payload);
-    return option ? option->get() : nullptr;
-}
-
-bool ModuleLoaderPayload::isState() const
-{
-    return std::holds_alternative<WriteBarrier<ModuleGraphLoadingState>>(m_payload);
-}
-
-bool ModuleLoaderPayload::isPromise() const
-{
-    return std::holds_alternative<WriteBarrier<JSPromise>>(m_payload);
-}
-
-JSPromise* ModuleLoaderPayload::underlyingPromise() const
-{
-    return isState() ? getState()->promise() : getPromise();
-}
-
-JSValue ModuleLoaderPayload::fulfillment() const
-{
-    return m_fulfillment.get();
-}
-
-void ModuleLoaderPayload::fulfillment(VM& vm, JSValue value)
-{
-    m_fulfillment.set(vm, this, value);
-}
-
-bool ModuleLoaderPayload::decrementRemaining()
-{
-    ASSERT(m_remainingFulfillments > 0);
-    return !--m_remainingFulfillments;
 }
 
 } // namespace JSC

--- a/Source/JavaScriptCore/runtime/ModuleLoaderPayload.h
+++ b/Source/JavaScriptCore/runtime/ModuleLoaderPayload.h
@@ -27,10 +27,12 @@
 
 #include "JSCell.h"
 #include "JSPromise.h"
-#include "ModuleGraphLoadingState.h"
 
 namespace JSC {
 
+// Wraps the dynamic-import target promise for top-level dynamic loadModule. Acts as the
+// host-defined "payload" passed back via FinishLoadingImportedModule, and additionally
+// holds the AND-join state used to combine loadPromise and statePromise.
 class ModuleLoaderPayload final : public JSCell {
     friend class LLIntOffsetsExtractor;
 public:
@@ -40,9 +42,6 @@ public:
     DECLARE_EXPORT_INFO;
     DECLARE_VISIT_CHILDREN;
 
-    static constexpr DestructionMode needsDestruction = NeedsDestruction;
-    static void destroy(JSCell*);
-
     template<typename CellType, SubspaceAccess mode>
     static GCClient::IsoSubspace* subspaceFor(VM& vm)
     {
@@ -50,29 +49,27 @@ public:
     }
 
     inline static Structure* createStructure(VM&, JSGlobalObject*, JSValue);
-    static ModuleLoaderPayload* create(VM&, ModuleGraphLoadingState*);
     static ModuleLoaderPayload* create(VM&, JSPromise*);
 
-    ModuleGraphLoadingState* getState() const;
-    JSPromise* getPromise() const;
-    bool isState() const;
-    bool isPromise() const;
-    JSPromise* underlyingPromise() const;
+    JSPromise* promise() const { return m_promise.get(); }
 
-    JSValue fulfillment() const;
-    void fulfillment(VM&, JSValue);
+    JSValue fulfillment() const { return m_fulfillment.get(); }
+    void setFulfillment(VM& vm, JSValue value) { m_fulfillment.set(vm, this, value); }
 
-    bool decrementRemaining();
+    bool decrementRemaining()
+    {
+        ASSERT(m_remainingFulfillments > 0);
+        return !--m_remainingFulfillments;
+    }
 
 private:
-    ModuleLoaderPayload(VM&, Structure*, ModuleGraphLoadingState*);
     ModuleLoaderPayload(VM&, Structure*, JSPromise*);
 
     void finishCreation(VM&);
 
-    const Variant<WriteBarrier<ModuleGraphLoadingState>, WriteBarrier<JSPromise>> m_payload;
+    WriteBarrier<JSPromise> m_promise;
     WriteBarrier<Unknown> m_fulfillment;
-    int m_remainingFulfillments { 2 };
+    uint8_t m_remainingFulfillments { 2 };
 };
 
 } // namespace JSC

--- a/Source/JavaScriptCore/runtime/ModuleLoadingContext.cpp
+++ b/Source/JavaScriptCore/runtime/ModuleLoadingContext.cpp
@@ -28,7 +28,7 @@
 
 #include "CyclicModuleRecord.h"
 #include "JSCInlines.h"
-#include "ModuleLoaderPayload.h"
+#include "JSModuleLoader.h"
 #include "ModuleRegistryEntry.h"
 #include "ProgramExecutable.h"
 
@@ -36,7 +36,7 @@ namespace JSC {
 
 const ClassInfo ModuleLoadingContext::s_info = { "ModuleLoadingContext"_s, nullptr, nullptr, nullptr, CREATE_METHOD_TABLE(ModuleLoadingContext) };
 
-ModuleLoadingContext::ModuleLoadingContext(VM& vm, Structure* structure, Step step, const JSModuleLoader::ModuleReferrer& referrer, AbstractModuleRecord::ModuleRequest&& moduleRequest, ModuleLoaderPayload* payload, ModuleRegistryEntry* entry, RefPtr<ScriptFetcher> scriptFetcher)
+ModuleLoadingContext::ModuleLoadingContext(VM& vm, Structure* structure, Step step, const JSModuleLoader::ModuleReferrer& referrer, AbstractModuleRecord::ModuleRequest&& moduleRequest, JSCell* payload, ModuleRegistryEntry* entry, RefPtr<ScriptFetcher> scriptFetcher)
     : Base(vm, structure)
     , m_step(step)
     , m_moduleRequest(WTF::move(moduleRequest))
@@ -53,8 +53,9 @@ void ModuleLoadingContext::destroy(JSCell* cell)
     thisObject->~ModuleLoadingContext();
 }
 
-ModuleLoadingContext* ModuleLoadingContext::create(VM& vm, Step step, const JSModuleLoader::ModuleReferrer& referrer, const AbstractModuleRecord::ModuleRequest& moduleRequest, ModuleLoaderPayload* payload, ModuleRegistryEntry* entry, RefPtr<ScriptFetcher> scriptFetcher)
+ModuleLoadingContext* ModuleLoadingContext::create(VM& vm, Step step, const JSModuleLoader::ModuleReferrer& referrer, const AbstractModuleRecord::ModuleRequest& moduleRequest, JSCell* payload, ModuleRegistryEntry* entry, RefPtr<ScriptFetcher> scriptFetcher)
 {
+    ASSERT(isModuleLoaderHostDefinedPayload(payload));
     AbstractModuleRecord::ModuleRequest requestCopy { moduleRequest };
     auto* context = new (NotNull, allocateCell<ModuleLoadingContext>(vm)) ModuleLoadingContext(vm, vm.moduleLoadingContextStructure.get(), step, referrer, WTF::move(requestCopy), payload, entry, WTF::move(scriptFetcher));
     context->finishCreation(vm);

--- a/Source/JavaScriptCore/runtime/ModuleLoadingContext.h
+++ b/Source/JavaScriptCore/runtime/ModuleLoadingContext.h
@@ -32,7 +32,6 @@
 
 namespace JSC {
 
-class ModuleLoaderPayload;
 class ModuleRegistryEntry;
 class ScriptFetcher;
 
@@ -61,7 +60,7 @@ public:
         Cached, // cached loadPromise settled -> finishLoading or evaluationError
     };
 
-    static ModuleLoadingContext* create(VM&, Step, const JSModuleLoader::ModuleReferrer&, const AbstractModuleRecord::ModuleRequest&, ModuleLoaderPayload*, ModuleRegistryEntry*, RefPtr<ScriptFetcher>);
+    static ModuleLoadingContext* create(VM&, Step, const JSModuleLoader::ModuleReferrer&, const AbstractModuleRecord::ModuleRequest&, JSCell* payload, ModuleRegistryEntry*, RefPtr<ScriptFetcher>);
     static ModuleLoadingContext* create(VM&, const AbstractModuleRecord::ModuleRequest&, RefPtr<ScriptFetcher>, bool evaluate, bool dynamic, bool useImportMap);
 
     Step step() const { return m_step; }
@@ -69,7 +68,7 @@ public:
 
     JSModuleLoader::ModuleReferrer referrer() const;
     const AbstractModuleRecord::ModuleRequest& moduleRequest() const { return m_moduleRequest; }
-    ModuleLoaderPayload* payload() const { return m_payload.get(); }
+    JSCell* payload() const { return m_payload.get(); }
     ModuleRegistryEntry* entry() const { return m_entry.get(); }
     ScriptFetcher* scriptFetcher() const { return m_scriptFetcher.get(); }
     AbstractModuleRecord* module() const { return m_module.get(); }
@@ -80,13 +79,13 @@ public:
     bool useImportMap() const { return m_useImportMap; }
 
 private:
-    ModuleLoadingContext(VM&, Structure*, Step, const JSModuleLoader::ModuleReferrer&, AbstractModuleRecord::ModuleRequest&&, ModuleLoaderPayload*, ModuleRegistryEntry*, RefPtr<ScriptFetcher>);
+    ModuleLoadingContext(VM&, Structure*, Step, const JSModuleLoader::ModuleReferrer&, AbstractModuleRecord::ModuleRequest&&, JSCell* payload, ModuleRegistryEntry*, RefPtr<ScriptFetcher>);
     ModuleLoadingContext(VM&, Structure*, AbstractModuleRecord::ModuleRequest&&, RefPtr<ScriptFetcher>, bool evaluate, bool dynamic, bool useImportMap);
 
     Step m_step { Step::Main };
     AbstractModuleRecord::ModuleRequest m_moduleRequest;
     const RefPtr<ScriptFetcher> m_scriptFetcher;
-    WriteBarrier<ModuleLoaderPayload> m_payload;
+    WriteBarrier<JSCell> m_payload;
     WriteBarrier<ModuleRegistryEntry> m_entry;
     WriteBarrier<Unknown> m_referrer;
     WriteBarrier<AbstractModuleRecord> m_module;


### PR DESCRIPTION
#### 78682e818cf83e6c8a17c7082beeeaa3f0777e10
<pre>
[JSC] Avoid per-edge ModuleLoaderPayload allocation in graph loading
<a href="https://bugs.webkit.org/show_bug.cgi?id=313330">https://bugs.webkit.org/show_bug.cgi?id=313330</a>

Reviewed by Yusuke Suzuki.

Every dependency edge in graph loading allocated a fresh
ModuleLoaderPayload cell to wrap the ModuleGraphLoadingState before
passing it to HostLoadImportedModule. The spec just passes the same
`state` for every edge [1]; the wrapper existed only so the spec&apos;s
`payload ∈ { GraphLoadingState, PromiseCapability }` sum [2] could be
encoded as a single C++ type.

Pass the payload as opaque JSCell* instead. finishLoadingImportedModule
dispatches with one dynamicDowncast on ModuleGraphLoadingState. The
graph-load path now passes the state directly; only top-level dynamic
import() still allocates a ModuleLoaderPayload (the PromiseCapability).

ModuleLoaderPayload is simplified: holds JSPromise* only,
DoesNotNeedDestruction, IsoSubspace moves to cellHeapCellType. The
combined-promise AND-join slots are mirrored onto ModuleGraphLoadingState
so it can serve as the third microtask argument too.

The host hook boundary is unchanged.

In a local microbenchmark loading 500 entry modules with 100 shared
leaves each (50,000 dependency edges), peak RSS dropped from 64.95 MB to
62.49 MB (-3.8%). End-to-end time was unchanged within noise; the savings
are footprint, not throughput. JSTests/microbenchmarks does not currently
include any module-loader benchmarks.

[1]: <a href="https://tc39.es/ecma262/#sec-InnerModuleLoading">https://tc39.es/ecma262/#sec-InnerModuleLoading</a>
[2]: <a href="https://tc39.es/ecma262/#sec-HostLoadImportedModule">https://tc39.es/ecma262/#sec-HostLoadImportedModule</a>

* Source/JavaScriptCore/heap/Heap.h:
* Source/JavaScriptCore/runtime/Completion.cpp:
(JSC::loadAndEvaluateModule):
* Source/JavaScriptCore/runtime/JSMicrotask.cpp:
(JSC::moduleLoadTopSettled):
(JSC::moduleLoadCombinedLoadSettled):
(JSC::moduleLoadCombinedStateSettled):
* Source/JavaScriptCore/runtime/JSModuleLoader.cpp:
(JSC::JSModuleLoader::hostLoadImportedModule):
(JSC::JSModuleLoader::loadModule):
(JSC::JSModuleLoader::innerModuleLoading):
(JSC::JSModuleLoader::finishLoadingImportedModule):
* Source/JavaScriptCore/runtime/JSModuleLoader.h:
(JSC::isModuleLoaderHostDefinedPayload):
* Source/JavaScriptCore/runtime/ModuleGraphLoadingState.cpp:
(JSC::ModuleGraphLoadingState::visitChildrenImpl):
* Source/JavaScriptCore/runtime/ModuleGraphLoadingState.h:
* Source/JavaScriptCore/runtime/ModuleLoaderPayload.cpp:
(JSC::ModuleLoaderPayload::ModuleLoaderPayload):
(JSC::ModuleLoaderPayload::visitChildrenImpl):
(JSC::ModuleLoaderPayload::destroy): Deleted.
(JSC::ModuleLoaderPayload::getState const): Deleted.
(JSC::ModuleLoaderPayload::getPromise const): Deleted.
(JSC::ModuleLoaderPayload::isState const): Deleted.
(JSC::ModuleLoaderPayload::isPromise const): Deleted.
(JSC::ModuleLoaderPayload::underlyingPromise const): Deleted.
(JSC::ModuleLoaderPayload::fulfillment const): Deleted.
(JSC::ModuleLoaderPayload::fulfillment): Deleted.
(JSC::ModuleLoaderPayload::decrementRemaining): Deleted.
* Source/JavaScriptCore/runtime/ModuleLoaderPayload.h:
* Source/JavaScriptCore/runtime/ModuleLoadingContext.cpp:
(JSC::ModuleLoadingContext::ModuleLoadingContext):
(JSC::ModuleLoadingContext::create):
* Source/JavaScriptCore/runtime/ModuleLoadingContext.h:

Canonical link: <a href="https://commits.webkit.org/312041@main">https://commits.webkit.org/312041@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c3421823398ae7643cc2c7d316b5bf0a177be700

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/158795 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/32221 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/25327 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/167624 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/112879 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/32288 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/32209 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/123028 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/86356 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/161752 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/25291 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/142655 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/103697 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/24347 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/22747 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/15396 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/150844 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/134033 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/20435 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/170116 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/19628 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/15859 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/22061 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/131213 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/31911 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/26813 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/131327 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35528 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/31856 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/142228 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/89837 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/26026 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/19037 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/191076 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/31367 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/97381 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/49124 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/30887 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/31160 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/31041 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->