### PR TITLE
[JSC] Remove createSuppressedError builtin

### DIFF
--- a/Source/JavaScriptCore/builtins/DisposableStackPrototype.js
+++ b/Source/JavaScriptCore/builtins/DisposableStackPrototype.js
@@ -50,13 +50,6 @@ function createDisposableResource(value, isAsync /* , method */)
     return { value, method };
 }
 
-@linkTimeConstant
-function createSuppressedError(error, suppressed)
-{
-    'use strict';
-    return new @SuppressedError(error, suppressed);
-}
-
 // https://tc39.es/proposal-explicit-resource-management/#sec-getdisposemethod
 @linkTimeConstant
 function getDisposeMethod(value)

--- a/Source/JavaScriptCore/bytecompiler/BytecodeGenerator.cpp
+++ b/Source/JavaScriptCore/bytecompiler/BytecodeGenerator.cpp
@@ -4740,7 +4740,7 @@ void BytecodeGenerator::emitUsingBodyScope(unsigned usingCount, bool hasAwaitUsi
         // Shared temporaries for the catch handler (one pair is enough across all slots).
         RefPtr<RegisterID> caughtException = newTemporary();
         RefPtr<RegisterID> caughtValue = newTemporary();
-        RefPtr<RegisterID> createSuppressedErrorFunc = newTemporary();
+        RefPtr<RegisterID> suppressedErrorCtor = newTemporary();
 
         auto emitSuppressedErrorCatch = [&](TryData* trySlotData, Label& catchLabel) {
             emitLabel(catchLabel);
@@ -4750,12 +4750,11 @@ void BytecodeGenerator::emitUsingBodyScope(unsigned usingCount, bool hasAwaitUsi
             Ref<Label> firstError = newLabel();
             emitJumpIfFalse(hasError.get(), firstError.get());
 
-            moveLinkTimeConstant(createSuppressedErrorFunc.get(), LinkTimeConstant::createSuppressedError);
+            moveLinkTimeConstant(suppressedErrorCtor.get(), LinkTimeConstant::SuppressedError);
             CallArguments seArgs(*this, nullptr, 2);
-            emitLoad(seArgs.thisRegister(), jsUndefined());
             move(seArgs.argumentRegister(0), caughtValue.get());
             move(seArgs.argumentRegister(1), pendingError.get());
-            emitCall(pendingError.get(), createSuppressedErrorFunc.get(), NoExpectedFunction, seArgs, divot, divot, divot, DebuggableCall::No);
+            emitConstruct(pendingError.get(), suppressedErrorCtor.get(), suppressedErrorCtor.get(), NoExpectedFunction, seArgs, divot, divot, divot);
             emitJump(afterCatch.get());
 
             emitLabel(firstError.get());


### PR DESCRIPTION
#### d1ec7b5323ad1afcee48029687fc907a18c7d1f1
<pre>
[JSC] Remove createSuppressedError builtin
<a href="https://bugs.webkit.org/show_bug.cgi?id=313331">https://bugs.webkit.org/show_bug.cgi?id=313331</a>
<a href="https://rdar.apple.com/175608137">rdar://175608137</a>

Reviewed by Sosuke Suzuki.

It is just caling a SuppressedError constructor. We should just call it
directly.

* Source/JavaScriptCore/builtins/DisposableStackPrototype.js:
(linkTimeConstant.createSuppressedError): Deleted.
* Source/JavaScriptCore/bytecompiler/BytecodeGenerator.cpp:
(JSC::BytecodeGenerator::emitUsingBodyScope):

Canonical link: <a href="https://commits.webkit.org/312033@main">https://commits.webkit.org/312033@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/88be76ff4d10e6c94ebf34a66b097b3c32bd789b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/158766 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/32193 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/25299 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/167596 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/112851 "Built successfully") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/32260 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/32181 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/123003 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/86330 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/161724 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/25268 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/142629 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/103672 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/24321 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/22722 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/15368 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/150816 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/134007 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/20409 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/170088 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/19600 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/15831 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/22035 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/131189 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/31883 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/26788 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/131303 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/31828 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/142202 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/89795 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/24134 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/26001 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/19011 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/191048 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/31339 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/97353 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/49116 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/30859 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/31132 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/31013 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->