### PR TITLE
[JSC] OMG should only emit WasmBoundsCheck overflow guard for Int64 pointers

### DIFF
--- a/JSTests/wasm/stress/bounds-check-int32-offset-dirty-high-bits.js
+++ b/JSTests/wasm/stress/bounds-check-int32-offset-dirty-high-bits.js
@@ -1,0 +1,27 @@
+//@ requireOptions("--useWasmFastMemory=0")
+import { instantiate } from "../wabt-wrapper.js";
+import * as assert from "../assert.js";
+
+async function test() {
+    const instance = await instantiate(`
+        (module
+          (memory 1)
+          (func $load (param i32) (result i32)
+            (i32.load offset=4 (local.get 0)))
+          (func (export "run") (param i64) (param i32) (result i32)
+            (local $sum i32)
+            (loop $top
+              (local.set $sum
+                (i32.add (local.get $sum)
+                  (call $load (i32.wrap_i64 (local.get 0)))))
+              (local.set 1 (i32.sub (local.get 1) (i32.const 1)))
+              (br_if $top (local.get 1)))
+            (local.get $sum)))
+    `, {});
+
+    const dirty = 0xffffffff00000000n;
+    for (let i = 0; i < wasmTestLoopCount; ++i)
+        assert.eq(instance.exports.run(dirty, 100), 0);
+}
+
+await assert.asyncTest(test());

--- a/Source/JavaScriptCore/b3/B3LowerToAir.cpp
+++ b/Source/JavaScriptCore/b3/B3LowerToAir.cpp
@@ -5935,7 +5935,7 @@ private:
                 break;
             }
 
-            if (value->offset())
+            if (value->offset() && ptr->type() == Int64)
                 append(Inst(Air::WasmBoundsCheck, value, ptrPlusImm, limit, pointer));
             else
                 append(Inst(Air::WasmBoundsCheck, value, ptrPlusImm, limit));


### PR DESCRIPTION
#### 008ce40466bc0eaed001cf90db4de76edf65dc01
<pre>
[JSC] OMG should only emit WasmBoundsCheck overflow guard for Int64 pointers
<a href="https://bugs.webkit.org/show_bug.cgi?id=313332">https://bugs.webkit.org/show_bug.cgi?id=313332</a>

Reviewed by Yusuke Suzuki.

311362@main added a 3-arg Air::WasmBoundsCheck that emits a 64-bit
Below(ptrPlusImm, pointer) wrap-around guard. For memory32 the pointer
is an Int32 Tmp whose upper 32 bits are undefined, so the Branch64 can
spuriously jump to the OOB handler in BoundsChecking mode. The sum of a
zero-extended i32 and the offset cannot overflow 64 bits anyway, so
restrict the guard to Int64 pointers.

Test: JSTests/wasm/stress/bounds-check-int32-offset-dirty-high-bits.js

* JSTests/wasm/stress/bounds-check-int32-offset-dirty-high-bits.js: Added.
(async test):
* Source/JavaScriptCore/b3/B3LowerToAir.cpp:

Canonical link: <a href="https://commits.webkit.org/312035@main">https://commits.webkit.org/312035@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5f303046e4035398d868d9b51dc3a9b2167a5f55

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/158767 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/32194 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/25300 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/167597 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/112852 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/32261 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/32182 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/123001 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/86331 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/161725 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/25261 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/142627 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/103670 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/24318 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/22720 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/15369 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/150817 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/134004 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/20407 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/170089 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/19601 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/15832 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/22033 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/131186 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/31884 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/26786 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/131300 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35526 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/31829 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/142200 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/89796 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/25996 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/19009 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/191049 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/31340 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/97354 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/49117 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/30860 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/31133 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/31014 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->