### PR TITLE
[WTF] Fix crash in utf8ForCharacters when string ends with unpaired surrogate

### DIFF
--- a/LayoutTests/ipc/register-mdns-name-unpaired-surrogate-crash-expected.txt
+++ b/LayoutTests/ipc/register-mdns-name-unpaired-surrogate-crash-expected.txt
@@ -1,0 +1,1 @@
+This test passes if the Networking process does not crash.

--- a/LayoutTests/ipc/register-mdns-name-unpaired-surrogate-crash.html
+++ b/LayoutTests/ipc/register-mdns-name-unpaired-surrogate-crash.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html><!-- webkit-test-runner [ IPCTestingAPIEnabled=true PeerConnectionEnabled=true ] -->
+<script>
+window.testRunner?.dumpAsText();
+window.testRunner?.waitUntilDone();
+import('./coreipc.js').then(({ CoreIPC }) => {
+    // 31 three-byte BMP code points followed by an unpaired high surrogate.
+    // simdutf::utf8_length_from_utf16 over-counts the trailing surrogate, yielding
+    // a length greater than characters.size() * 3.
+    const ipAddress = '\u0800'.repeat(31) + '\uD800';
+    CoreIPC.Networking.NetworkMDNSRegister.RegisterMDNSName(0, {
+        documentIdentifier: { object: { high: 1, low: 1 }, processIdentifier: 1 },
+        ipAddress
+    });
+    setTimeout(() => window.testRunner?.notifyDone(), 100);
+}).catch(() => window.testRunner?.notifyDone());
+</script>
+<body>
+<p>This test passes if the Networking process does not crash.</p>
+</body>

--- a/Source/WTF/wtf/text/StringImpl.h
+++ b/Source/WTF/wtf/text/StringImpl.h
@@ -1477,7 +1477,7 @@ inline Expected<std::invoke_result_t<Func, std::span<const char8_t>>, UTF8Conver
         return makeUnexpected(UTF8ConversionError::OutOfMemory);
 
     size_t bufferSize = characters.size() * 3;
-    bufferVector.grow(bufferSize);
+    bufferVector.resize(bufferSize);
     auto convertedSize = utf8ForCharactersIntoBuffer(characters, mode, bufferVector);
     if (!convertedSize)
         return makeUnexpected(convertedSize.error());


### PR DESCRIPTION
#### fd0db67fd877c487e824538cd56eb569dcbdcecb
<pre>
[WTF] Fix crash in utf8ForCharacters when string ends with unpaired surrogate
<a href="https://bugs.webkit.org/show_bug.cgi?id=313333">https://bugs.webkit.org/show_bug.cgi?id=313333</a>
<a href="https://rdar.apple.com/174924192">rdar://174924192</a>

Reviewed by Yusuke Suzuki.

Replace grow with resize so the buffer is set to exactly characters.size() * 3 bytes, satisfying the assert regardless of what simdutf estimated.

Test: ipc/register-mdns-name-unpaired-surrogate-crash.html

* LayoutTests/ipc/register-mdns-name-unpaired-surrogate-crash-expected.txt: Added.
* LayoutTests/ipc/register-mdns-name-unpaired-surrogate-crash.html: Added.
* Source/WTF/wtf/text/StringImpl.h:
(WTF::StringImpl::tryGetUTF8ForCharacters):

Canonical link: <a href="https://commits.webkit.org/312057@main">https://commits.webkit.org/312057@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1c8749863bf72c686e6b45752924c7d186c9329e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/158769 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/32196 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/25302 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/167599 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/112854 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/a9eb0d08-9cc1-4e61-b2d9-fac3de10c209) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/32263 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/32184 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/123004 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/86339 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/2095f1af-5bb0-4feb-ba25-79841537ec24) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/161727 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/25266 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/142632 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/103673 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/2873472f-5abc-4c28-9c67-bb14ce52c9fb) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/24323 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/22723 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/15371 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/150819 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/134009 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/20412 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/170091 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/19603 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/15834 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/22038 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/131191 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/31886 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/26789 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/131305 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35531 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/31831 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/142205 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/89798 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/26002 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/19014 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/191051 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/31342 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/97356 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/49118 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/30862 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/31135 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/31016 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->