### PR TITLE
[Site Isolation] http/tests/workers/service/postmessage-after-sw-process-crash.https.html fails

### DIFF
--- a/LayoutTests/http/tests/workers/service/resources/postmessage-after-sw-process-crash.js
+++ b/LayoutTests/http/tests/workers/service/resources/postmessage-after-sw-process-crash.js
@@ -1,8 +1,12 @@
 let serviceWorkerHasReceivedState = false;
 let worker = null;
 let remainingAttempts = 1000; // We try for 10 seconds before timing out.
+let didFinish = false;
 
 navigator.serviceWorker.addEventListener("message", async function(event) {
+    if (didFinish)
+        return;
+
     if (!serviceWorkerHasReceivedState) {
         if (!event.data) {
             log("FAIL: service worker did not receive the state");
@@ -35,6 +39,7 @@ navigator.serviceWorker.addEventListener("message", async function(event) {
     log("PASS: service worker lost the state and responded the postMessage after process termination");
     clearInterval(handle);
     finishSWTest();
+    didFinish = true;
 });
 
 async function doTest()


### PR DESCRIPTION
#### ed753c533a815317b076036a3122ce41f4e28e2a
<pre>
[Site Isolation] http/tests/workers/service/postmessage-after-sw-process-crash.https.html fails
<a href="https://bugs.webkit.org/show_bug.cgi?id=313334">https://bugs.webkit.org/show_bug.cgi?id=313334</a>

Reviewed by Anne van Kesteren.

The failure was caused by a race condition between the page receiving a message from
the service worker and ending the test vs. more messages from the service worker getting serviced.

Fixed the test by adding an early exit for when the test had logically concluded.

* LayoutTests/http/tests/workers/service/resources/postmessage-after-sw-process-crash.js:

Canonical link: <a href="https://commits.webkit.org/312052@main">https://commits.webkit.org/312052@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/00b38142d685fe5dc19d0e9d396168150a598e78

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/158771 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/32198 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/25304 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/167601 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/112856 "Built successfully") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/32265 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/32186 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/123006 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/86334 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/161729 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/25270 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/142635 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/103675 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/24326 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/22726 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/15373 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/134012 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/20415 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/170093 "Built successfully") | | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/22041 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/131192 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/31888 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/26792 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/131306 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/31833 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/142208 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/89800 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/24148 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/26004 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/19017 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/31344 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/30864 "Built successfully") | | | | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/31137 "Build is in progress. Recent messages:OS: Tahoe (26.2), Xcode: 26.2; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (warnings)") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/31018 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->