### PR TITLE
[Site Isolation] http/tests/xmlhttprequest/abort-should-cancel-load.html fails

### DIFF
--- a/LayoutTests/http/tests/xmlhttprequest/abort-should-cancel-load-expected.txt
+++ b/LayoutTests/http/tests/xmlhttprequest/abort-should-cancel-load-expected.txt
@@ -1,4 +1,5 @@
 http://127.0.0.1:8000/xmlhttprequest/resources/endlessxml.py - willSendRequest <NSURLRequest URL http://127.0.0.1:8000/xmlhttprequest/resources/endlessxml.py, main document URL http://127.0.0.1:8000/xmlhttprequest/abort-should-cancel-load.html, http method GET> redirectResponse (null)
 http://127.0.0.1:8000/xmlhttprequest/resources/endlessxml.py - didFailLoadingWithError: <NSError domain NSURLErrorDomain, code -999, failing URL "http://127.0.0.1:8000/xmlhttprequest/resources/endlessxml.py">
+http://127.0.0.1:8000/xmlhttprequest/abort-should-cancel-load.html - didFinishLoading
 This tests that calling abort() on an XHR object stops the load, causing the relevant resource load delegates to be sent.
 

--- a/LayoutTests/http/tests/xmlhttprequest/abort-should-cancel-load.html
+++ b/LayoutTests/http/tests/xmlhttprequest/abort-should-cancel-load.html
@@ -13,13 +13,14 @@ function runTest() {
     document.body.appendChild(console_messages);
 
     if (window.testRunner) {
+        internals.clearMemoryCache();
         testRunner.dumpResourceLoadCallbacks();
         testRunner.waitUntilDone();
         testRunner.dumpAsText();
     }
     
     f();
-    testRunner.notifyDone();
+    setTimeout(() => testRunner.notifyDone(), 0);
 }
 
 function log(message)


### PR DESCRIPTION
#### 9bed770bc117bd3a1d80739ef89acde2fbcb3730
<pre>
[Site Isolation] http/tests/xmlhttprequest/abort-should-cancel-load.html fails
<a href="https://bugs.webkit.org/show_bug.cgi?id=313335">https://bugs.webkit.org/show_bug.cgi?id=313335</a>

Reviewed by Lily Spiniolas.

The failure was caused by the end of (main) page loading getting logged as
testRunner.notifyDone works asynchronously under site isolation.

Fixed the test by adding a 0s delay so that the logging always happens.

* LayoutTests/http/tests/xmlhttprequest/abort-should-cancel-load-expected.txt:
* LayoutTests/http/tests/xmlhttprequest/abort-should-cancel-load.html:

Canonical link: <a href="https://commits.webkit.org/312062@main">https://commits.webkit.org/312062@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6982cd90eaca49344ba27db6413eb022eb28579c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/158825 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/32251 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/25357 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/167654 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/112909 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/8ca87929-95a5-48dd-a4dd-718d1fd0bd3b) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/32318 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/32239 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/123050 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/86382 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/05e1aeab-739e-4dd6-b971-7c5f94711a5a) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/161782 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/25318 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/142684 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/103719 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/0f910df7-4469-453c-bf30-afa939439b23) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/24374 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/22774 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/15426 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/134060 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/20464 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/170146 "Built successfully") | | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/22090 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/131237 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/31941 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/26840 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/131351 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/31886 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/142257 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/89878 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/24156 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/26052 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/19066 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/31397 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/30917 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/31190 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/31071 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->