### PR TITLE
[Site Isolation] http/tests/websocket/tests/hybi/contentextensions/upgrade.html fails

### DIFF
--- a/LayoutTests/http/tests/websocket/tests/hybi/contentextensions/upgrade-expected.txt
+++ b/LayoutTests/http/tests/websocket/tests/hybi/contentextensions/upgrade-expected.txt
@@ -1,3 +1,5 @@
 onerror
 new url: wss://127.0.0.1/websocket/tests/hybi/simple
+onclose
+new url: wss://127.0.0.1/websocket/tests/hybi/simple
 

--- a/LayoutTests/http/tests/websocket/tests/hybi/contentextensions/upgrade.html
+++ b/LayoutTests/http/tests/websocket/tests/hybi/contentextensions/upgrade.html
@@ -15,7 +15,7 @@ if (window.testRunner) {
 function endTest() {
     doLog("new url: " + ws.url);
     if (window.testRunner)
-        testRunner.notifyDone();
+        setTimeout(() => testRunner.notifyDone(), 0);
 }
 
 var ws = new WebSocket("ws://127.0.0.1/websocket/tests/hybi/simple");


### PR DESCRIPTION
#### 0c84b51517fb9c8b2a0602302afea284ddc897bd
<pre>
[Site Isolation] http/tests/websocket/tests/hybi/contentextensions/upgrade.html fails
<a href="https://bugs.webkit.org/show_bug.cgi?id=313337">https://bugs.webkit.org/show_bug.cgi?id=313337</a>

Reviewed by Anne van Kesteren.

The failure was caused by the closing of WebSocket getting logged under site isolation
because testRunner.notifyDone is asynchronous with site isolation. Fixed the test by
always delaying testRunner.notifyDone with a 0s timer to make the test output consistent
with and without site isolation.

* LayoutTests/http/tests/websocket/tests/hybi/contentextensions/upgrade-expected.txt:
* LayoutTests/http/tests/websocket/tests/hybi/contentextensions/upgrade.html:

Canonical link: <a href="https://commits.webkit.org/312044@main">https://commits.webkit.org/312044@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c615e504c267084894b8d52a48d26754c5f648d1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/158777 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/32203 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/25309 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/167606 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/112861 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/c5756120-4be8-450b-8f39-c9480f742cd9) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/32270 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/32191 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/123011 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/86340 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/bc4585e9-7e96-4fea-84e7-0be62bd8eed9) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/161734 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/25274 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/142638 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/103680 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/71c22463-8e15-4f60-b081-869a334538d4) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/24330 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/22730 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/15378 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/134016 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/20418 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/170098 "Built successfully") | | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/22044 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/131197 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/31893 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/26796 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/131311 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/31838 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/142211 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/89813 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/24140 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/26009 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/19020 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/31349 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/30869 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/31142 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/31023 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->