### PR TITLE
[Site Isolation] webarchive/loading/test-loading-archive.html fails

### DIFF
--- a/LayoutTests/platform/wk2/webarchive/loading/test-loading-archive-expected.txt
+++ b/LayoutTests/platform/wk2/webarchive/loading/test-loading-archive-expected.txt
@@ -9,4 +9,5 @@ frame "<!--frame1-->" - didHandleOnloadEventsForFrame
 main frame - didHandleOnloadEventsForFrame
 frame "<!--frame1-->" - didFinishLoadForFrame
 main frame - didFinishLoadForFrame
+resources/helloworld.webarchive - didFinishLoading
  This tests that doing a "normal load" of a webarchive (not using loadArchive) does not cause a cancelled error to be called.

--- a/LayoutTests/webarchive/loading/test-loading-archive-expected.txt
+++ b/LayoutTests/webarchive/loading/test-loading-archive-expected.txt
@@ -9,4 +9,5 @@ frame "<!--frame1-->" - didHandleOnloadEventsForFrame
 main frame - didHandleOnloadEventsForFrame
 frame "<!--frame1-->" - didFinishLoadForFrame
 main frame - didFinishLoadForFrame
+resources/helloworld.webarchive - didFinishLoading
  This tests that doing a "normal load" of a webarchive (not using loadArchive) does not cause a cancelled error to be called.

--- a/LayoutTests/webarchive/loading/test-loading-archive.html
+++ b/LayoutTests/webarchive/loading/test-loading-archive.html
@@ -10,7 +10,7 @@
         internals.setAlwaysAllowLocalWebarchive(true);
     function frameLoaded() {
         if (window.testRunner)
-            testRunner.notifyDone();
+            setTimeout(() => testRunner.notifyDone(), 0);
     }
 </script>
 <body>


### PR DESCRIPTION
#### afaad749c82ea3a5b27679b039b75b5535e2ef90
<pre>
[Site Isolation] webarchive/loading/test-loading-archive.html fails
<a href="https://bugs.webkit.org/show_bug.cgi?id=313339">https://bugs.webkit.org/show_bug.cgi?id=313339</a>

Reviewed by Anne van Kesteren.

The failure was caused by the race between testRunner.notifyDone finishing the test vs. subframe
finish loading getting logged. Fixed the test by always delaying testRunner.notifyDone with a 0s timer.

* LayoutTests/platform/wk2/webarchive/loading/test-loading-archive-expected.txt:
* LayoutTests/webarchive/loading/test-loading-archive-expected.txt:
* LayoutTests/webarchive/loading/test-loading-archive.html:

Canonical link: <a href="https://commits.webkit.org/312045@main">https://commits.webkit.org/312045@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/985c343415d5fb62b55cafb1befaa4101f9cbdcd

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/158779 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/32205 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/25311 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/167608 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/112863 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/432d535e-62d7-43c5-8577-c98435ef69b6) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/32272 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/32193 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/123013 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/86341 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/c73dea08-59d8-45fc-9754-baff71201e99) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/161736 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/25276 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/142640 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/103682 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/dd18f046-01b8-4280-be94-5c123c2fc0c5) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/24332 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/22732 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/15380 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/134018 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/20420 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/170100 "Built successfully") | | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/22046 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/131199 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/31895 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/26798 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/131313 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/31840 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/142213 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/89815 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/24141 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/26010 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/19022 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/31351 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/30871 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/31144 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/31025 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->