### PR TITLE
setAutomaticLinkDetection not working in WebKit2

### DIFF
--- a/LayoutTests/platform/mac-wk2/TestExpectations
+++ b/LayoutTests/platform/mac-wk2/TestExpectations
@@ -808,10 +808,6 @@ webkit.org/b/161148 gamepad/gamepad-timestamp.html [ Pass Failure ]
 
 webkit.org/b/161633 [ Debug ] storage/indexeddb/objectstore-cursor.html [ Pass Timeout ]
 
-webkit.org/b/162081 editing/inserting/typing-space-to-trigger-smart-link.html [ Failure ]
-webkit.org/b/162081 editing/inserting/smart-quote-with-all-configurations.html [ Failure ]
-webkit.org/b/162081 fast/events/input-event-insert-link.html [ Failure ]
-
 webkit.org/b/161926 storage/indexeddb/index-cursor.html [ Pass Timeout ]
 
 

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -14797,6 +14797,12 @@ void WebPageProxy::setViewportSizeForCSSViewportUnits(const FloatSize& viewportS
 
 #if USE(AUTOMATIC_TEXT_REPLACEMENT)
 
+static void textCheckerStateChanged()
+{
+    for (auto& processPool : WebProcessPool::allProcessPools())
+        processPool->textCheckerStateChanged();
+}
+
 void WebPageProxy::toggleSmartInsertDelete()
 {
     if (TextChecker::isTestingMode())
@@ -14805,32 +14811,42 @@ void WebPageProxy::toggleSmartInsertDelete()
 
 void WebPageProxy::toggleAutomaticQuoteSubstitution()
 {
-    if (TextChecker::isTestingMode())
+    if (TextChecker::isTestingMode()) {
         TextChecker::setAutomaticQuoteSubstitutionEnabled(!TextChecker::state().contains(TextCheckerState::AutomaticQuoteSubstitutionEnabled));
+        textCheckerStateChanged();
+    }
 }
 
 void WebPageProxy::toggleAutomaticLinkDetection()
 {
-    if (TextChecker::isTestingMode())
+    if (TextChecker::isTestingMode()) {
         TextChecker::setAutomaticLinkDetectionEnabled(!TextChecker::state().contains(TextCheckerState::AutomaticLinkDetectionEnabled));
+        textCheckerStateChanged();
+    }
 }
 
 void WebPageProxy::toggleAutomaticDashSubstitution()
 {
-    if (TextChecker::isTestingMode())
+    if (TextChecker::isTestingMode()) {
         TextChecker::setAutomaticDashSubstitutionEnabled(!TextChecker::state().contains(TextCheckerState::AutomaticDashSubstitutionEnabled));
+        textCheckerStateChanged();
+    }
 }
 
 void WebPageProxy::toggleSmartLists()
 {
-    if (TextChecker::isTestingMode())
+    if (TextChecker::isTestingMode()) {
         TextChecker::setSmartListsEnabled(!TextChecker::state().contains(TextCheckerState::SmartListsEnabled));
+        textCheckerStateChanged();
+    }
 }
 
 void WebPageProxy::toggleAutomaticTextReplacement()
 {
-    if (TextChecker::isTestingMode())
+    if (TextChecker::isTestingMode()) {
         TextChecker::setAutomaticTextReplacementEnabled(!TextChecker::state().contains(TextCheckerState::AutomaticTextReplacementEnabled));
+        textCheckerStateChanged();
+    }
 }
 
 #endif

--- a/Source/WebKit/WebProcess/WebCoreSupport/mac/WebEditorClientMac.mm
+++ b/Source/WebKit/WebProcess/WebCoreSupport/mac/WebEditorClientMac.mm
@@ -183,6 +183,13 @@ bool WebEditorClient::substitutionsPanelIsShowing()
     return isShowing;
 }
 
+static void toggleTextCheckerState(TextCheckerState flag)
+{
+    auto state = WebProcess::singleton().textCheckerState();
+    state.set(flag, !state.contains(flag));
+    WebProcess::singleton().setTextCheckerState(state);
+}
+
 void WebEditorClient::toggleSmartInsertDelete()
 {
     if (RefPtr page = m_page.get())
@@ -199,6 +206,7 @@ bool WebEditorClient::isAutomaticQuoteSubstitutionEnabled()
 
 void WebEditorClient::toggleAutomaticQuoteSubstitution()
 {
+    toggleTextCheckerState(TextCheckerState::AutomaticQuoteSubstitutionEnabled);
     if (RefPtr page = m_page.get())
         page->send(Messages::WebPageProxy::toggleAutomaticQuoteSubstitution());
 }
@@ -210,6 +218,7 @@ bool WebEditorClient::isAutomaticLinkDetectionEnabled()
 
 void WebEditorClient::toggleAutomaticLinkDetection()
 {
+    toggleTextCheckerState(TextCheckerState::AutomaticLinkDetectionEnabled);
     if (RefPtr page = m_page.get())
         page->send(Messages::WebPageProxy::toggleAutomaticLinkDetection());
 }
@@ -224,6 +233,7 @@ bool WebEditorClient::isAutomaticDashSubstitutionEnabled()
 
 void WebEditorClient::toggleAutomaticDashSubstitution()
 {
+    toggleTextCheckerState(TextCheckerState::AutomaticDashSubstitutionEnabled);
     if (RefPtr page = m_page.get())
         page->send(Messages::WebPageProxy::toggleAutomaticDashSubstitution());
 }
@@ -238,6 +248,7 @@ bool WebEditorClient::isAutomaticTextReplacementEnabled()
 
 void WebEditorClient::toggleAutomaticTextReplacement()
 {
+    toggleTextCheckerState(TextCheckerState::AutomaticTextReplacementEnabled);
     if (RefPtr page = m_page.get())
         page->send(Messages::WebPageProxy::toggleAutomaticTextReplacement());
 }
@@ -252,6 +263,7 @@ bool WebEditorClient::isSmartListsEnabled()
 
 void WebEditorClient::toggleSmartLists()
 {
+    toggleTextCheckerState(TextCheckerState::SmartListsEnabled);
     if (RefPtr page = m_page.get())
         page->send(Messages::WebPageProxy::toggleSmartLists());
 }


### PR DESCRIPTION
#### a340e58cf59adea3a0aa46e9bb156f58c5c03a1e
<pre>
setAutomaticLinkDetection not working in WebKit2
<a href="https://bugs.webkit.org/show_bug.cgi?id=162081">https://bugs.webkit.org/show_bug.cgi?id=162081</a>

Reviewed by Wenson Hsieh.

When layout tests call internals.setAutomaticLinkDetectionEnabled(true) (or similar toggles for
smart quotes, dash substitution, etc.), the WebProcess sends an async IPC message to the UIProcess
to toggle the state. The UIProcess updates its TextChecker state, but never notifies the WebProcess
back — so the WebProcess&apos;s cached textCheckerState() remains stale. When the editing code later
checks isAutomaticLinkDetectionEnabled(), it reads the stale cache and gets false.

This PR fixes the bug by propagating the toggle from UIProcess to all the WebProcesses involved.
Also toggle the WebProcess&apos;s cached textCheckerState immediately before sending the async IPC,
so the state is correct by the time the next line of JS executes.

Tests: editing/inserting/smart-quote-with-all-configurations.html
       editing/inserting/typing-space-to-trigger-smart-link.html
       fast/events/input-event-insert-link.html [ Failure ]

* LayoutTests/platform/mac-wk2/TestExpectations:
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::textCheckerStateChanged):
(WebKit::WebPageProxy::toggleAutomaticQuoteSubstitution):
(WebKit::WebPageProxy::toggleAutomaticLinkDetection):
(WebKit::WebPageProxy::toggleAutomaticDashSubstitution):
(WebKit::WebPageProxy::toggleSmartLists):
(WebKit::WebPageProxy::toggleAutomaticTextReplacement):
* Source/WebKit/WebProcess/WebCoreSupport/mac/WebEditorClientMac.mm:
(WebKit::toggleTextCheckerState):
(WebKit::WebEditorClient::toggleAutomaticQuoteSubstitution):
(WebKit::WebEditorClient::toggleAutomaticLinkDetection):
(WebKit::WebEditorClient::toggleAutomaticDashSubstitution):
(WebKit::WebEditorClient::toggleAutomaticTextReplacement):
(WebKit::WebEditorClient::toggleSmartLists):

Canonical link: <a href="https://commits.webkit.org/312049@main">https://commits.webkit.org/312049@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/48d4083dcb6c4c5230cdcbf895069d8c9c37ec73

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/158780 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/32206 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/25312 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/167609 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/112864 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/b07a3630-6ce6-4ab9-819c-ac6d5d241a82) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/32273 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/32194 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/123014 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/86342 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/084e14ae-f929-4426-98fa-c166f5d54113) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/161737 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/25278 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/142641 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/103683 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/8f8fdd12-9427-4aba-b845-8bd60620af1b) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/24334 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/22733 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/15381 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/134020 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/20421 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/170101 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/15844 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/22047 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/131200 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/31896 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/26799 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/131314 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/31841 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/142214 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/89816 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/24145 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/26012 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/19023 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/31352 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/97366 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/30872 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/31145 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/31026 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->