### PR TITLE
[JSC] Add Map / Set fast iteration

### DIFF
--- a/JSTests/microbenchmarks/for-of-map-entries-small.js
+++ b/JSTests/microbenchmarks/for-of-map-entries-small.js
@@ -1,0 +1,14 @@
+const map = new Map();
+for (let i = 0; i < 10; ++i)
+    map.set(i, i * 2);
+
+function test(map) {
+    let sum = 0;
+    for (let [k, v] of map)
+        sum += k + v;
+    return sum;
+}
+noInline(test);
+
+for (let i = 0; i < 1e5; ++i)
+    test(map);

--- a/JSTests/microbenchmarks/for-of-map-entries.js
+++ b/JSTests/microbenchmarks/for-of-map-entries.js
@@ -1,0 +1,14 @@
+const map = new Map();
+for (let i = 0; i < 100; ++i)
+    map.set(i, i * 2);
+
+function test(map) {
+    let sum = 0;
+    for (let [k, v] of map)
+        sum += k + v;
+    return sum;
+}
+noInline(test);
+
+for (let i = 0; i < 1e4; ++i)
+    test(map);

--- a/JSTests/microbenchmarks/for-of-set-values-small.js
+++ b/JSTests/microbenchmarks/for-of-set-values-small.js
@@ -1,0 +1,14 @@
+const set = new Set();
+for (let i = 0; i < 10; ++i)
+    set.add(i);
+
+function test(set) {
+    let sum = 0;
+    for (let x of set)
+        sum += x;
+    return sum;
+}
+noInline(test);
+
+for (let i = 0; i < 1e5; ++i)
+    test(set);

--- a/JSTests/microbenchmarks/for-of-set-values.js
+++ b/JSTests/microbenchmarks/for-of-set-values.js
@@ -1,0 +1,14 @@
+const set = new Set();
+for (let i = 0; i < 100; ++i)
+    set.add(i);
+
+function test(set) {
+    let sum = 0;
+    for (let x of set)
+        sum += x;
+    return sum;
+}
+noInline(test);
+
+for (let i = 0; i < 1e4; ++i)
+    test(set);

--- a/JSTests/stress/iterator-dfg-fast-path-bad-time.js
+++ b/JSTests/stress/iterator-dfg-fast-path-bad-time.js
@@ -1,0 +1,65 @@
+// Stress the DFG iterator_next fast path for Map iteration under "having a bad time".
+// In that state, the NewArray([key, value]) pair-allocation for Map entries takes
+// the operationNewArray slow path (a C++ call under DECLARE_THROW_SCOPE). This
+// exercises NewArray's ExitsForExceptions classification: if allocation throws,
+// exception unwind must not replay the already-advanced MapIteratorNext.
+//
+// Two phases:
+//   (1) warm up with normal allocation so DFG/FTL compiles the fast NewArray path,
+//   (2) flip to bad-time (invalidates the havingABadTime watchpoint installed by
+//       FixupPhase::watchHavingABadTime on NewArray) to force recompilation through
+//       the slow allocation path.
+
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error('bad: ' + actual + ' vs ' + expected);
+}
+noInline(shouldBe);
+
+const map = new Map();
+for (let i = 0; i < 16; ++i)
+    map.set(i, i * 10);
+// 0+0 + 1+10 + ... + 15+150 = sum(0..15) + 10*sum(0..15) = 120 + 1200 = 1320
+const expectedMapSum = 1320;
+
+const set = new Set();
+for (let i = 0; i < 16; ++i)
+    set.add(i);
+const expectedSetSum = 120;
+
+function sumMapEntries(m) {
+    let total = 0;
+    for (const [k, v] of m)
+        total += k + v;
+    return total;
+}
+noInline(sumMapEntries);
+
+function sumSetValues(s) {
+    let total = 0;
+    for (const v of s)
+        total += v;
+    return total;
+}
+noInline(sumSetValues);
+
+// Phase 1: warm up with normal fast allocation.
+for (let i = 0; i < testLoopCount; ++i) {
+    shouldBe(sumMapEntries(map), expectedMapSum);
+    shouldBe(sumSetValues(set), expectedSetSum);
+}
+
+// Phase 2: trigger bad-time by installing a getter on a numeric-indexed slot
+// of Object.prototype. This fires the havingABadTime watchpoint, invalidating
+// any compiled code that relied on NewArray taking the fast inline-allocation
+// path. Subsequent runs must still iterate correctly.
+Object.defineProperty(Object.prototype, "0", {
+    get() { return "shadow"; },
+    set(v) { },
+    configurable: true,
+});
+
+for (let i = 0; i < testLoopCount; ++i) {
+    shouldBe(sumMapEntries(map), expectedMapSum);
+    shouldBe(sumSetValues(set), expectedSetSum);
+}

--- a/JSTests/stress/iterator-dfg-fast-path-mixed-modes.js
+++ b/JSTests/stress/iterator-dfg-fast-path-mixed-modes.js
@@ -1,0 +1,58 @@
+// Stress the DFG iterator_open / iterator_next fast path when a single
+// call site observes Array, Map, Set, and a Generic user-defined iterable.
+// The seenModes IterationMetadata accumulates FastArray|FastMap|FastSet|Generic,
+// and the DFG parser emits the full chained fast path. This exercises the
+// connectFailedBlock/numberOfRemainingModes bookkeeping across all four modes.
+
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error('bad: ' + actual + ' vs ' + expected);
+}
+noInline(shouldBe);
+
+function sumIterable(iterable) {
+    let sum = 0;
+    for (const entry of iterable) {
+        if (typeof entry === "number")
+            sum += entry;                   // Array / Set yields values
+        else if (Array.isArray(entry))
+            sum += entry[0] + entry[1];     // Map yields [key, value]
+        else
+            sum += entry.val;               // Generic iterator yields {val}
+    }
+    return sum;
+}
+noInline(sumIterable);
+
+const arr = [1, 2, 3, 4];
+const map = new Map([[10, 1], [20, 2], [30, 3]]);
+const set = new Set([100, 200, 300]);
+
+function makeGeneric() {
+    let i = 0;
+    return {
+        [Symbol.iterator]() { return this; },
+        next() {
+            if (i >= 4)
+                return { value: undefined, done: true };
+            return { value: { val: ++i * 1000 }, done: false };
+        }
+    };
+}
+
+const arrSum = 1 + 2 + 3 + 4;
+const mapSum = (10 + 1) + (20 + 2) + (30 + 3);
+const setSum = 100 + 200 + 300;
+const genSum = 1000 + 2000 + 3000 + 4000;
+
+for (let i = 0; i < testLoopCount; i++) {
+    const idx = i & 3;
+    if (idx === 0)
+        shouldBe(sumIterable(arr), arrSum);
+    else if (idx === 1)
+        shouldBe(sumIterable(map), mapSum);
+    else if (idx === 2)
+        shouldBe(sumIterable(set), setSum);
+    else
+        shouldBe(sumIterable(makeGeneric()), genSum);
+}

--- a/JSTests/stress/iterator-dfg-fast-path-no-generic.js
+++ b/JSTests/stress/iterator-dfg-fast-path-no-generic.js
@@ -1,0 +1,75 @@
+// Regression coverage for the op_iterator_next DFG fast path when seenModes
+// contains exactly FastArray + FastMap (no Generic). Prior to the fix, the
+// FastArray branch did not decrement numberOfRemainingModes and used a
+// `!= 1` test, so after FastMap decremented and allocated its own failedBlock,
+// the chain had a dangling failedBlock with no consumer. Same hazard for
+// FastArray + FastSet and FastArray + FastMap + FastSet (no Generic).
+//
+// Exercises all three combinations through tiered compilation so the DFG
+// parser encounters each seenModes shape in practice.
+
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error('bad: ' + actual + ' vs ' + expected);
+}
+noInline(shouldBe);
+
+function sumAny(iterable) {
+    let total = 0;
+    for (const entry of iterable) {
+        if (typeof entry === "number")
+            total += entry;                 // Array / Set
+        else
+            total += entry[0] + entry[1];   // Map entry
+    }
+    return total;
+}
+noInline(sumAny);
+
+const arr = [1, 2, 3, 4, 5];                           // 15
+const map = new Map([[1, 10], [2, 20], [3, 30]]);      // 66
+const set = new Set([100, 200, 300, 400]);             // 1000
+
+// Case 1: FastArray + FastMap (no Generic, no FastSet).
+function runArrayMap() {
+    for (let i = 0; i < testLoopCount; ++i) {
+        if (i & 1)
+            shouldBe(sumAny(arr), 15);
+        else
+            shouldBe(sumAny(map), 66);
+    }
+}
+runArrayMap();
+
+// Case 2: FastArray + FastSet (no Generic, no FastMap).
+function runArraySet() {
+    function sumArrOrSet(iter) {
+        let total = 0;
+        for (const v of iter)
+            total += v;
+        return total;
+    }
+    noInline(sumArrOrSet);
+
+    for (let i = 0; i < testLoopCount; ++i) {
+        if (i & 1)
+            shouldBe(sumArrOrSet(arr), 15);
+        else
+            shouldBe(sumArrOrSet(set), 1000);
+    }
+}
+runArraySet();
+
+// Case 3: FastArray + FastMap + FastSet, still no Generic.
+function runAllFastNoGeneric() {
+    for (let i = 0; i < testLoopCount; ++i) {
+        const idx = i % 3;
+        if (idx === 0)
+            shouldBe(sumAny(arr), 15);
+        else if (idx === 1)
+            shouldBe(sumAny(map), 66);
+        else
+            shouldBe(sumAny(set), 1000);
+    }
+}
+runAllFastNoGeneric();

--- a/Source/JavaScriptCore/builtins/MapIteratorPrototype.js
+++ b/Source/JavaScriptCore/builtins/MapIteratorPrototype.js
@@ -23,7 +23,8 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-function next() {
+function next()
+{
     "use strict";
 
     if (!@isMapIterator(this))

--- a/Source/JavaScriptCore/builtins/SetIteratorPrototype.js
+++ b/Source/JavaScriptCore/builtins/SetIteratorPrototype.js
@@ -23,7 +23,8 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-function next() {
+function next()
+{
     "use strict";
 
     if (!@isSetIterator(this))

--- a/Source/JavaScriptCore/bytecode/IterationModeMetadata.h
+++ b/Source/JavaScriptCore/bytecode/IterationModeMetadata.h
@@ -34,9 +34,11 @@ namespace JSC {
 enum class IterationMode : uint8_t {
     Generic = 1 << 0,
     FastArray = 1 << 1,
+    FastMap = 1 << 2,
+    FastSet = 1 << 3,
 };
 
-constexpr uint8_t numberOfIterationModes = 2;
+constexpr uint8_t numberOfIterationModes = 4;
 
 OVERLOAD_BITWISE_OPERATORS_FOR_ENUM_CLASS_WITH_INTERGRALS(IterationMode);
 

--- a/Source/JavaScriptCore/dfg/DFGByteCodeParser.cpp
+++ b/Source/JavaScriptCore/dfg/DFGByteCodeParser.cpp
@@ -294,6 +294,9 @@ private:
     void handleGetScope(VirtualRegister destination);
     void handleCheckTraps();
 
+    void handleIteratorOpen(const JSInstruction* pc, BytecodeIndex osrExitIndex);
+    void handleIteratorNext(const JSInstruction* pc, BytecodeIndex osrExitIndex);
+
     // Either register a watchpoint or emit a check for this condition. Returns false if the
     // condition no longer holds, and therefore no reasonable check can be emitted.
     bool check(const ObjectPropertyCondition&);
@@ -9204,412 +9207,12 @@ void ByteCodeParser::parseBlock(unsigned limit)
             NEXT_OPCODE(op_call_ignore_result);
 
         case op_iterator_open: {
-            auto bytecode = currentInstruction->as<OpIteratorOpen>();
-            auto& metadata = bytecode.metadata(codeBlock);
-            uint32_t seenModes = metadata.m_iterationMetadata.seenModes;
-
-            unsigned numberOfRemainingModes = std::popcount(seenModes);
-            ASSERT(numberOfRemainingModes <= numberOfIterationModes);
-            bool generatedCase = false;
-
-            JSGlobalObject* globalObject = m_inlineStackTop->m_codeBlock->globalObjectFor(currentCodeOrigin());
-            BasicBlock* genericBlock = nullptr;
-            BasicBlock* continuation = allocateUntargetableBlock();
-
-            BytecodeIndex startIndex = m_currentIndex;
-
-            Node* symbolIterator = get(bytecode.m_symbolIterator);
-            auto& arrayIteratorProtocolWatchpointSet = globalObject->arrayIteratorProtocolWatchpointSet();
-
-            if (seenModes & IterationMode::FastArray && arrayIteratorProtocolWatchpointSet.isStillValid()) {
-                // First set up the watchpoint conditions we need for correctness.
-                m_graph.watchpoints().addLazily(arrayIteratorProtocolWatchpointSet);
-
-                ASSERT_WITH_MESSAGE(globalObject->arrayProtoValuesFunctionConcurrently(), "The only way we could have seen FastArray is if we saw this function in the LLInt/Baseline so the iterator function should be allocated.");
-                FrozenValue* frozenSymbolIteratorFunction = m_graph.freeze(globalObject->arrayProtoValuesFunctionConcurrently());
-                numberOfRemainingModes--;
-                if (!numberOfRemainingModes) {
-                    addToGraph(CheckIsConstant, OpInfo(frozenSymbolIteratorFunction), symbolIterator);
-                    addToGraph(Check, Edge(get(bytecode.m_iterable), ArrayUse));
-                } else {
-                    BasicBlock* fastArrayBlock = allocateUntargetableBlock();
-                    genericBlock = allocateUntargetableBlock();
-
-                    Node* isKnownIterFunction = addToGraph(CompareEqPtr, OpInfo(frozenSymbolIteratorFunction), symbolIterator);
-                    Node* isArray = addToGraph(IsCellWithType, OpInfo(ArrayType), get(bytecode.m_iterable));
-
-                    BranchData* branchData = m_graph.m_branchData.add();
-                    branchData->taken = BranchTarget(fastArrayBlock);
-                    branchData->notTaken = BranchTarget(genericBlock);
-
-                    Node* andResult = addToGraph(ArithBitAnd, isArray, isKnownIterFunction);
-
-                    // We know the ArithBitAnd cannot have effects so it's ok to exit here.
-                    m_exitOK = true;
-                    addToGraph(ExitOK);
-
-                    addToGraph(Branch, OpInfo(branchData), andResult);
-                    flushForTerminal();
-
-                    m_currentBlock = fastArrayBlock;
-                    clearCaches();
-                    keepUsesOfCurrentInstructionAlive(currentInstruction, m_currentIndex.checkpoint());
-                }
-
-                Node* kindNode = jsConstant(jsNumber(static_cast<uint32_t>(IterationKind::Values)));
-                Node* next = jsConstant(JSValue());
-                Node* iterator = addToGraph(NewInternalFieldObject, OpInfo(m_graph.registerStructure(globalObject->arrayIteratorStructure())));
-                addToGraph(PutInternalField, OpInfo(static_cast<uint32_t>(JSArrayIterator::Field::IteratedObject)), iterator, get(bytecode.m_iterable));
-                addToGraph(PutInternalField, OpInfo(static_cast<uint32_t>(JSArrayIterator::Field::Kind)), iterator, kindNode);
-                set(bytecode.m_iterator, iterator);
-
-                // Set m_next to JSValue() so if we exit between here and iterator_next instruction it knows we are in the fast case.
-                set(bytecode.m_next, next);
-
-                // Do our set locals. We don't want to exit backwards so move our exit to the next bytecode.
-                m_currentIndex = nextOpcodeIndex();
-                m_exitOK = true;
-                processSetLocalQueue();
-
-                addToGraph(Jump, OpInfo(continuation));
-                generatedCase = true;
-            }
-
-            m_currentIndex = startIndex;
-
-            if (seenModes & IterationMode::Generic) {
-                ASSERT(numberOfRemainingModes);
-                if (genericBlock) {
-                    ASSERT(generatedCase);
-                    m_currentBlock = genericBlock;
-                    clearCaches();
-                    keepUsesOfCurrentInstructionAlive(currentInstruction, m_currentIndex.checkpoint());
-                } else
-                    ASSERT(!generatedCase);
-
-                Terminality terminality = handleCall<OpIteratorOpen>(currentInstruction, Call, CallMode::Regular, nextCheckpoint(), nullptr);
-                ASSERT_UNUSED(terminality, terminality == NonTerminal);
-                progressToNextCheckpoint();
-
-                Node* iterator = get(bytecode.m_iterator);
-                BasicBlock* notObjectBlock = allocateUntargetableBlock();
-                BasicBlock* isObjectBlock = allocateUntargetableBlock();
-                BranchData* branchData = m_graph.m_branchData.add();
-                branchData->taken = BranchTarget(isObjectBlock);
-                branchData->notTaken = BranchTarget(notObjectBlock);
-                addToGraph(Branch, OpInfo(branchData), addToGraph(IsObject, iterator));
-
-                {
-                    m_currentBlock = notObjectBlock;
-                    clearCaches();
-                    keepUsesOfCurrentInstructionAlive(currentInstruction, m_currentIndex.checkpoint());
-                    LazyJSValue errorString = LazyJSValue::newString(m_graph, "Iterator result interface is not an object."_s);
-                    OpInfo info = OpInfo(m_graph.m_lazyJSValues.add(errorString));
-                    Node* errorMessage = addToGraph(LazyJSConstant, info);
-                    addToGraph(ThrowStaticError, OpInfo(ErrorType::TypeError), errorMessage);
-                    flushForTerminal();
-                }
-
-                {
-                    m_currentBlock = isObjectBlock;
-                    clearCaches();
-                    keepUsesOfCurrentInstructionAlive(currentInstruction, m_currentIndex.checkpoint());
-                    SpeculatedType prediction = getPrediction();
-
-                    Node* base = get(bytecode.m_iterator);
-                    auto* nextImpl = m_vm->propertyNames->next.impl();
-                    unsigned identifierNumber = m_graph.identifiers().ensure(nextImpl);
-
-                    AccessType type = AccessType::GetById;
-
-                    GetByStatus getByStatus = GetByStatus::computeFor(
-                        m_inlineStackTop->m_profiledBlock,
-                        m_inlineStackTop->m_baselineMap, m_icContextStack,
-                        currentCodeOrigin());
-
-
-                    handleGetById(bytecode.m_next, prediction, base, CacheableIdentifier::createFromImmortalIdentifier(nextImpl), identifierNumber, getByStatus, type, nextOpcodeIndex());
-
-                    // Do our set locals. We don't want to run our get_by_id again so we move to the next bytecode.
-                    m_currentIndex = nextOpcodeIndex();
-                    m_exitOK = true;
-                    processSetLocalQueue();
-
-                    addToGraph(Jump, OpInfo(continuation));
-                }
-                generatedCase = true;
-            }
-
-            if (!generatedCase) {
-                Node* result = jsConstant(JSValue());
-                addToGraph(ForceOSRExit);
-                addToGraph(Phantom, get(bytecode.m_symbolIterator));
-                addToGraph(Phantom, get(bytecode.m_iterable));
-                set(bytecode.m_iterator, result);
-                set(bytecode.m_next, result);
-
-                m_currentIndex = nextOpcodeIndex();
-                m_exitOK = true;
-                processSetLocalQueue();
-
-                addToGraph(Jump, OpInfo(continuation));
-            }
-
-            m_currentIndex = startIndex;
-            m_currentBlock = continuation;
-            clearCaches();
-
+            handleIteratorOpen(currentInstruction, nextOpcodeIndex());
             NEXT_OPCODE(op_iterator_open);
         }
 
         case op_iterator_next: {
-            auto bytecode = currentInstruction->as<OpIteratorNext>();
-            auto& metadata = bytecode.metadata(codeBlock);
-            uint32_t seenModes = metadata.m_iterationMetadata.seenModes;
-
-            unsigned numberOfRemainingModes = std::popcount(seenModes);
-            ASSERT(numberOfRemainingModes <= numberOfIterationModes);
-            bool generatedCase = false;
-
-            BytecodeIndex startIndex = m_currentIndex;
-            JSGlobalObject* globalObject = m_inlineStackTop->m_codeBlock->globalObjectFor(currentCodeOrigin());
-            auto& arrayIteratorProtocolWatchpointSet = globalObject->arrayIteratorProtocolWatchpointSet();
-            BasicBlock* genericBlock = nullptr;
-            BasicBlock* continuation = allocateUntargetableBlock();
-
-            if (seenModes & IterationMode::FastArray && arrayIteratorProtocolWatchpointSet.isStillValid()) {
-                // First set up the watchpoint conditions we need for correctness.
-                m_graph.watchpoints().addLazily(arrayIteratorProtocolWatchpointSet);
-
-                if (numberOfRemainingModes != 1) {
-                    Node* hasNext = addToGraph(IsEmpty, get(bytecode.m_next));
-                    genericBlock = allocateUntargetableBlock();
-                    BasicBlock* fastArrayBlock = allocateUntargetableBlock();
-
-                    BranchData* branchData = m_graph.m_branchData.add();
-                    branchData->taken = BranchTarget(fastArrayBlock);
-                    branchData->notTaken = BranchTarget(genericBlock);
-                    addToGraph(Branch, OpInfo(branchData), hasNext);
-
-                    m_currentBlock = fastArrayBlock;
-                    clearCaches();
-                    keepUsesOfCurrentInstructionAlive(currentInstruction, m_currentIndex.checkpoint());
-                } else
-                    addToGraph(CheckIsConstant, OpInfo(m_graph.freeze(JSValue())), get(bytecode.m_next));
-
-                Node* iterator = get(bytecode.m_iterator);
-                addToGraph(CheckStructure, OpInfo(m_graph.addStructureSet(globalObject->arrayIteratorStructure())), iterator);
-
-                BasicBlock* isDoneBlock = allocateUntargetableBlock();
-                BasicBlock* doLoadBlock = allocateUntargetableBlock();
-
-                ArrayMode arrayMode = getArrayMode(metadata.m_iterableProfile, Array::Read);
-                auto prediction = getPredictionWithoutOSRExit(BytecodeIndex(m_currentIndex.offset(), OpIteratorNext::getValue));
-
-                {
-                    // FIXME: doneIndex is -1 so it seems like we should be able to do CompareBelow(index, length). See: https://bugs.webkit.org/show_bug.cgi?id=210927
-                    Node* doneIndex = jsConstant(jsNumber(JSArrayIterator::doneIndex));
-                    Node* index = addToGraph(GetInternalField, OpInfo(static_cast<uint32_t>(JSArrayIterator::Field::Index)), OpInfo(SpecInt32Only), iterator);
-                    Node* isDone = addToGraph(CompareStrictEq, index, doneIndex);
-
-                    Node* iterable = get(bytecode.m_iterable);
-                    Node* butterfly = addToGraph(GetButterfly, iterable);
-                    Node* length = addToGraph(GetArrayLength, OpInfo(arrayMode.asWord()), Edge(iterable), Edge(butterfly, KnownStorageUse));
-                    // GetArrayLength is pessimized prior to fixup.
-                    m_exitOK = true;
-                    addToGraph(ExitOK);
-                    Node* isOutOfBounds = addToGraph(CompareGreaterEq, Edge(index, Int32Use), Edge(length, Int32Use));
-
-                    isDone = addToGraph(ArithBitOr, isDone, isOutOfBounds);
-                    // The above compare doesn't produce effects since we know the values are booleans. We don't set UseKinds because Fixup likes to add edges.
-                    m_exitOK = true;
-                    addToGraph(ExitOK);
-
-                    BranchData* branchData = m_graph.m_branchData.add();
-                    branchData->taken = BranchTarget(isDoneBlock);
-                    branchData->notTaken = BranchTarget(doLoadBlock);
-                    addToGraph(Branch, OpInfo(branchData), isDone);
-                }
-
-                {
-                    m_currentBlock = doLoadBlock;
-                    clearCaches();
-                    keepUsesOfCurrentInstructionAlive(currentInstruction, m_currentIndex.checkpoint());
-                    Node* index = addToGraph(GetInternalField, OpInfo(static_cast<uint32_t>(JSArrayIterator::Field::Index)), OpInfo(SpecInt32Only), get(bytecode.m_iterator));
-                    Node* one = jsConstant(jsNumber(1));
-                    Node* newIndex = makeSafe(addToGraph(ArithAdd, index, one));
-                    Node* falseNode = jsConstant(jsBoolean(false));
-
-
-                    // FIXME: We could consider making this not vararg, since it only uses three child
-                    // slots.
-                    // https://bugs.webkit.org/show_bug.cgi?id=184192
-                    addVarArgChild(get(bytecode.m_iterable));
-                    addVarArgChild(index);
-                    addVarArgChild(nullptr); // Leave room for property storage.
-                    Node* getByVal = addToGraph(Node::VarArg, GetByVal, OpInfo(arrayMode.asWord()), OpInfo(prediction));
-                    set(bytecode.m_value, getByVal);
-                    set(bytecode.m_done, falseNode);
-                    addToGraph(PutInternalField, OpInfo(static_cast<uint32_t>(JSArrayIterator::Field::Index)), get(bytecode.m_iterator), newIndex);
-
-                    // Do our set locals. We don't want to run our getByVal again so we move to the next bytecode.
-                    m_currentIndex = nextOpcodeIndex();
-                    m_exitOK = true;
-                    processSetLocalQueue();
-
-                    addToGraph(Jump, OpInfo(continuation));
-                }
-
-                // Roll back the checkpoint.
-                m_currentIndex = startIndex;
-
-                {
-                    m_currentBlock = isDoneBlock;
-                    clearCaches();
-                    keepUsesOfCurrentInstructionAlive(currentInstruction, m_currentIndex.checkpoint());
-                    Node* trueNode = jsConstant(jsBoolean(true));
-                    Node* doneIndex = jsConstant(jsNumber(-1));
-                    Node* bottomNode = jsConstant(m_graph.bottomValueMatchingSpeculation(prediction));
-
-                    set(bytecode.m_value, bottomNode);
-                    set(bytecode.m_done, trueNode);
-                    addToGraph(PutInternalField, OpInfo(static_cast<uint32_t>(JSArrayIterator::Field::Index)), get(bytecode.m_iterator), doneIndex);
-
-                    // Do our set locals. We don't want to run this again so we have to move the exit origin forward.
-                    m_currentIndex = nextOpcodeIndex();
-                    m_exitOK = true;
-                    processSetLocalQueue();
-
-                    addToGraph(Jump, OpInfo(continuation));
-                }
-
-                m_currentIndex = startIndex;
-                generatedCase = true;
-            }
-
-            if (seenModes & IterationMode::Generic) {
-                if (genericBlock) {
-                    ASSERT(generatedCase);
-                    m_currentBlock = genericBlock;
-                    clearCaches();
-                    keepUsesOfCurrentInstructionAlive(currentInstruction, m_currentIndex.checkpoint());
-                } else
-                    ASSERT(!generatedCase);
-
-                // Our profiling could have been incorrect when we got here. For instance, if we LoopHint OSR enter the first time we would
-                // have seen a fast path, next will be the empty value. When that happens we need to make sure the empty value doesn't flow
-                // into the Call node since call can't handle empty values.
-                addToGraph(CheckNotEmpty, get(bytecode.m_next));
-
-                Terminality terminality = handleCall<OpIteratorNext>(currentInstruction, Call, CallMode::Regular, nextCheckpoint(), nullptr);
-                ASSERT_UNUSED(terminality, terminality == NonTerminal);
-                progressToNextCheckpoint();
-
-                BasicBlock* notObjectBlock = allocateUntargetableBlock();
-                BasicBlock* isObjectBlock = allocateUntargetableBlock();
-                BasicBlock* notDoneBlock = allocateUntargetableBlock();
-
-                Operand nextResult = Operand::tmp(OpIteratorNext::nextResult);
-                {
-                    Node* iteratorResult = get(nextResult);
-                    BranchData* branchData = m_graph.m_branchData.add();
-                    branchData->taken = BranchTarget(isObjectBlock);
-                    branchData->notTaken = BranchTarget(notObjectBlock);
-                    addToGraph(Branch, OpInfo(branchData), addToGraph(IsObject, iteratorResult));
-                }
-
-                {
-                    m_currentBlock = notObjectBlock;
-                    clearCaches();
-                    keepUsesOfCurrentInstructionAlive(currentInstruction, m_currentIndex.checkpoint());
-                    LazyJSValue errorString = LazyJSValue::newString(m_graph, "Iterator result interface is not an object."_s);
-                    OpInfo info = OpInfo(m_graph.m_lazyJSValues.add(errorString));
-                    Node* errorMessage = addToGraph(LazyJSConstant, info);
-                    addToGraph(ThrowStaticError, OpInfo(ErrorType::TypeError), errorMessage);
-                    flushForTerminal();
-                }
-
-                auto valuePredicition = getPredictionWithoutOSRExit(m_currentIndex.withCheckpoint(OpIteratorNext::getValue));
-
-                {
-                    m_exitOK = true;
-                    m_currentBlock = isObjectBlock;
-                    clearCaches();
-                    keepUsesOfCurrentInstructionAlive(currentInstruction, m_currentIndex.checkpoint());
-                    SpeculatedType prediction = getPrediction();
-
-                    Node* base = get(nextResult);
-                    auto* doneImpl = m_vm->propertyNames->done.impl();
-                    unsigned identifierNumber = m_graph.identifiers().ensure(doneImpl);
-
-                    AccessType type = AccessType::GetById;
-
-                    GetByStatus getByStatus = GetByStatus::computeFor(
-                        m_inlineStackTop->m_profiledBlock,
-                        m_inlineStackTop->m_baselineMap, m_icContextStack,
-                        currentCodeOrigin());
-
-                    handleGetById(bytecode.m_done, prediction, base, CacheableIdentifier::createFromImmortalIdentifier(doneImpl), identifierNumber, getByStatus, type, nextCheckpoint());
-                    // Set a value for m_value so we don't exit on it differing from what we expected.
-                    set(bytecode.m_value, jsConstant(m_graph.bottomValueMatchingSpeculation(valuePredicition)));
-                    progressToNextCheckpoint();
-
-                    BranchData* branchData = m_graph.m_branchData.add();
-                    branchData->taken = BranchTarget(continuation);
-                    branchData->notTaken = BranchTarget(notDoneBlock);
-                    addToGraph(Branch, OpInfo(branchData), get(bytecode.m_done));
-                }
-
-                {
-                    m_currentBlock = notDoneBlock;
-                    clearCaches();
-                    keepUsesOfCurrentInstructionAlive(currentInstruction, m_currentIndex.checkpoint());
-
-                    Node* base = get(nextResult);
-                    auto* valueImpl = m_vm->propertyNames->value.impl();
-                    unsigned identifierNumber = m_graph.identifiers().ensure(valueImpl);
-
-                    AccessType type = AccessType::GetById;
-
-                    GetByStatus getByStatus = GetByStatus::computeFor(
-                        m_inlineStackTop->m_profiledBlock,
-                        m_inlineStackTop->m_baselineMap, m_icContextStack,
-                        currentCodeOrigin());
-
-                    handleGetById(bytecode.m_value, valuePredicition, base, CacheableIdentifier::createFromImmortalIdentifier(valueImpl), identifierNumber, getByStatus, type, nextOpcodeIndex());
-
-                    // We're done, exit forwards.
-                    m_currentIndex = nextOpcodeIndex();
-                    m_exitOK = true;
-                    processSetLocalQueue();
-
-                    addToGraph(Jump, OpInfo(continuation));
-                }
-
-                generatedCase = true;
-            }
-
-            if (!generatedCase) {
-                Node* result = jsConstant(JSValue());
-                addToGraph(ForceOSRExit);
-                addToGraph(Phantom, get(bytecode.m_next));
-                addToGraph(Phantom, get(bytecode.m_iterator));
-                addToGraph(Phantom, get(bytecode.m_iterable));
-                set(bytecode.m_value, result);
-                set(bytecode.m_done, result);
-
-                // Do our set locals. We don't want to run our get by id again so we move to the next bytecode.
-                m_currentIndex = BytecodeIndex(m_currentIndex.offset() + currentInstruction->size());
-                m_exitOK = true;
-                processSetLocalQueue();
-
-                addToGraph(Jump, OpInfo(continuation));
-            }
-
-            m_currentIndex = startIndex;
-            m_currentBlock = continuation;
-            clearCaches();
-
+            handleIteratorNext(currentInstruction, nextOpcodeIndex());
             NEXT_OPCODE(op_iterator_next);
         }
 
@@ -11123,6 +10726,727 @@ void ByteCodeParser::handleCreateInternalFieldObject(const ClassInfo* classInfo,
     }
 
     set(VirtualRegister(bytecode.m_dst), addToGraph(createOp, callee));
+}
+
+void ByteCodeParser::handleIteratorOpen(const JSInstruction* currentInstruction, BytecodeIndex osrExitIndex)
+{
+    CodeBlock* codeBlock = m_inlineStackTop->m_codeBlock;
+    auto bytecode = currentInstruction->as<OpIteratorOpen>();
+    auto& metadata = bytecode.metadata(codeBlock);
+    uint32_t seenModes = metadata.m_iterationMetadata.seenModes;
+
+    unsigned numberOfRemainingModes = std::popcount(seenModes);
+    ASSERT(numberOfRemainingModes <= numberOfIterationModes);
+    bool generatedCase = false;
+
+    JSGlobalObject* globalObject = m_inlineStackTop->m_codeBlock->globalObjectFor(currentCodeOrigin());
+    BasicBlock* failedBlock = nullptr;
+    auto connectFailedBlock = [&] {
+        if (failedBlock) {
+            ASSERT(generatedCase);
+            m_currentBlock = failedBlock;
+            clearCaches();
+            keepUsesOfCurrentInstructionAlive(currentInstruction, m_currentIndex.checkpoint());
+            failedBlock = nullptr;
+        }
+    };
+
+    BasicBlock* continuation = allocateUntargetableBlock();
+
+    BytecodeIndex startIndex = m_currentIndex;
+
+    if (seenModes & IterationMode::FastArray && globalObject->arrayIteratorProtocolWatchpointSet().isStillValid()) {
+        // First set up the watchpoint conditions we need for correctness.
+        m_graph.watchpoints().addLazily(globalObject->arrayIteratorProtocolWatchpointSet());
+
+        ASSERT_WITH_MESSAGE(globalObject->arrayProtoValuesFunctionConcurrently(), "The only way we could have seen FastArray is if we saw this function in the LLInt/Baseline so the iterator function should be allocated.");
+        FrozenValue* frozenSymbolIteratorFunction = m_graph.freeze(globalObject->arrayProtoValuesFunctionConcurrently());
+        numberOfRemainingModes--;
+
+        connectFailedBlock();
+
+        Node* symbolIterator = get(bytecode.m_symbolIterator);
+
+        if (!numberOfRemainingModes) {
+            addToGraph(CheckIsConstant, OpInfo(frozenSymbolIteratorFunction), symbolIterator);
+            addToGraph(Check, Edge(get(bytecode.m_iterable), ArrayUse));
+        } else {
+            BasicBlock* fastArrayBlock = allocateUntargetableBlock();
+            failedBlock = allocateUntargetableBlock();
+
+            Node* isKnownIterFunction = addToGraph(CompareEqPtr, OpInfo(frozenSymbolIteratorFunction), symbolIterator);
+            Node* isArray = addToGraph(IsCellWithType, OpInfo(ArrayType), get(bytecode.m_iterable));
+
+            BranchData* branchData = m_graph.m_branchData.add();
+            branchData->taken = BranchTarget(fastArrayBlock);
+            branchData->notTaken = BranchTarget(failedBlock);
+
+            Node* andResult = addToGraph(ArithBitAnd, isArray, isKnownIterFunction);
+
+            // We know the ArithBitAnd cannot have effects so it's ok to exit here.
+            m_exitOK = true;
+            addToGraph(ExitOK);
+
+            addToGraph(Branch, OpInfo(branchData), andResult);
+            flushForTerminal();
+
+            m_currentBlock = fastArrayBlock;
+            clearCaches();
+            keepUsesOfCurrentInstructionAlive(currentInstruction, m_currentIndex.checkpoint());
+        }
+
+        Node* kindNode = jsConstant(jsNumber(static_cast<uint32_t>(IterationKind::Values)));
+        Node* next = jsConstant(JSValue());
+        Node* iterator = addToGraph(NewInternalFieldObject, OpInfo(m_graph.registerStructure(globalObject->arrayIteratorStructure())));
+        addToGraph(PutInternalField, OpInfo(static_cast<uint32_t>(JSArrayIterator::Field::IteratedObject)), iterator, get(bytecode.m_iterable));
+        addToGraph(PutInternalField, OpInfo(static_cast<uint32_t>(JSArrayIterator::Field::Kind)), iterator, kindNode);
+        set(bytecode.m_iterator, iterator);
+
+        // Set m_next to JSValue() so if we exit between here and iterator_next instruction it knows we are in the fast case.
+        set(bytecode.m_next, next);
+
+        // Do our set locals. We don't want to exit backwards so move our exit to the next bytecode.
+        m_currentIndex = osrExitIndex;
+        m_exitOK = true;
+        processSetLocalQueue();
+
+        addToGraph(Jump, OpInfo(continuation));
+        generatedCase = true;
+    }
+
+    m_currentIndex = startIndex;
+
+    if (seenModes & IterationMode::FastMap && globalObject->mapIteratorProtocolWatchpointSet().isStillValid()) {
+        auto& mapIteratorProtocolWatchpointSet = globalObject->mapIteratorProtocolWatchpointSet();
+        m_graph.watchpoints().addLazily(mapIteratorProtocolWatchpointSet);
+
+        ASSERT_WITH_MESSAGE(globalObject->mapProtoEntriesFunctionConcurrently(), "The only way we could have seen FastMap is if we saw this function in the LLInt/Baseline so the iterator function should be allocated.");
+        FrozenValue* frozenMapEntriesFunction = m_graph.freeze(globalObject->mapProtoEntriesFunctionConcurrently());
+        numberOfRemainingModes--;
+
+        connectFailedBlock();
+
+        Node* symbolIterator = get(bytecode.m_symbolIterator);
+
+        if (!numberOfRemainingModes) {
+            addToGraph(CheckIsConstant, OpInfo(frozenMapEntriesFunction), symbolIterator);
+            addToGraph(Check, Edge(get(bytecode.m_iterable), MapObjectUse));
+        } else {
+            BasicBlock* fastMapBlock = allocateUntargetableBlock();
+            failedBlock = allocateUntargetableBlock();
+
+            Node* isKnownIterFunction = addToGraph(CompareEqPtr, OpInfo(frozenMapEntriesFunction), symbolIterator);
+            Node* isMap = addToGraph(IsCellWithType, OpInfo(JSMapType), get(bytecode.m_iterable));
+
+            BranchData* branchData = m_graph.m_branchData.add();
+            branchData->taken = BranchTarget(fastMapBlock);
+            branchData->notTaken = BranchTarget(failedBlock);
+
+            Node* andResult = addToGraph(ArithBitAnd, isMap, isKnownIterFunction);
+
+            m_exitOK = true;
+            addToGraph(ExitOK);
+
+            addToGraph(Branch, OpInfo(branchData), andResult);
+            flushForTerminal();
+
+            m_currentBlock = fastMapBlock;
+            clearCaches();
+            keepUsesOfCurrentInstructionAlive(currentInstruction, m_currentIndex.checkpoint());
+        }
+
+        Node* kindNode = jsConstant(jsNumber(static_cast<uint32_t>(IterationKind::Entries)));
+        Node* next = jsConstant(JSValue());
+        Node* iterator = addToGraph(NewInternalFieldObject, OpInfo(m_graph.registerStructure(globalObject->mapIteratorStructure())));
+        addToGraph(PutInternalField, OpInfo(static_cast<uint32_t>(JSMapIterator::Field::IteratedObject)), iterator, get(bytecode.m_iterable));
+        addToGraph(PutInternalField, OpInfo(static_cast<uint32_t>(JSMapIterator::Field::Kind)), iterator, kindNode);
+        set(bytecode.m_iterator, iterator);
+
+        set(bytecode.m_next, next);
+
+        m_currentIndex = osrExitIndex;
+        m_exitOK = true;
+        processSetLocalQueue();
+
+        addToGraph(Jump, OpInfo(continuation));
+        generatedCase = true;
+    }
+
+    m_currentIndex = startIndex;
+
+    if (seenModes & IterationMode::FastSet && globalObject->setIteratorProtocolWatchpointSet().isStillValid()) {
+        auto& setIteratorProtocolWatchpointSet = globalObject->setIteratorProtocolWatchpointSet();
+        m_graph.watchpoints().addLazily(setIteratorProtocolWatchpointSet);
+
+        ASSERT_WITH_MESSAGE(globalObject->setProtoValuesFunctionConcurrently(), "The only way we could have seen FastSet is if we saw this function in the LLInt/Baseline so the iterator function should be allocated.");
+        FrozenValue* frozenSetValuesFunction = m_graph.freeze(globalObject->setProtoValuesFunctionConcurrently());
+        numberOfRemainingModes--;
+
+        connectFailedBlock();
+
+        Node* symbolIterator = get(bytecode.m_symbolIterator);
+
+        if (!numberOfRemainingModes) {
+            addToGraph(CheckIsConstant, OpInfo(frozenSetValuesFunction), symbolIterator);
+            addToGraph(Check, Edge(get(bytecode.m_iterable), SetObjectUse));
+        } else {
+            BasicBlock* fastSetBlock = allocateUntargetableBlock();
+            failedBlock = allocateUntargetableBlock();
+
+            Node* isKnownIterFunction = addToGraph(CompareEqPtr, OpInfo(frozenSetValuesFunction), symbolIterator);
+            Node* isSet = addToGraph(IsCellWithType, OpInfo(JSSetType), get(bytecode.m_iterable));
+
+            BranchData* branchData = m_graph.m_branchData.add();
+            branchData->taken = BranchTarget(fastSetBlock);
+            branchData->notTaken = BranchTarget(failedBlock);
+
+            Node* andResult = addToGraph(ArithBitAnd, isSet, isKnownIterFunction);
+
+            m_exitOK = true;
+            addToGraph(ExitOK);
+
+            addToGraph(Branch, OpInfo(branchData), andResult);
+            flushForTerminal();
+
+            m_currentBlock = fastSetBlock;
+            clearCaches();
+            keepUsesOfCurrentInstructionAlive(currentInstruction, m_currentIndex.checkpoint());
+        }
+
+        Node* kindNode = jsConstant(jsNumber(static_cast<uint32_t>(IterationKind::Values)));
+        Node* next = jsConstant(JSValue());
+        Node* iterator = addToGraph(NewInternalFieldObject, OpInfo(m_graph.registerStructure(globalObject->setIteratorStructure())));
+        addToGraph(PutInternalField, OpInfo(static_cast<uint32_t>(JSSetIterator::Field::IteratedObject)), iterator, get(bytecode.m_iterable));
+        addToGraph(PutInternalField, OpInfo(static_cast<uint32_t>(JSSetIterator::Field::Kind)), iterator, kindNode);
+        set(bytecode.m_iterator, iterator);
+
+        set(bytecode.m_next, next);
+
+        m_currentIndex = osrExitIndex;
+        m_exitOK = true;
+        processSetLocalQueue();
+
+        addToGraph(Jump, OpInfo(continuation));
+        generatedCase = true;
+    }
+
+    m_currentIndex = startIndex;
+
+    if (seenModes & IterationMode::Generic) {
+        ASSERT(numberOfRemainingModes);
+
+        connectFailedBlock();
+
+        Terminality terminality = handleCall<OpIteratorOpen>(currentInstruction, Call, CallMode::Regular, nextCheckpoint(), nullptr);
+        ASSERT_UNUSED(terminality, terminality == NonTerminal);
+        progressToNextCheckpoint();
+
+        Node* iterator = get(bytecode.m_iterator);
+        BasicBlock* notObjectBlock = allocateUntargetableBlock();
+        BasicBlock* isObjectBlock = allocateUntargetableBlock();
+        BranchData* branchData = m_graph.m_branchData.add();
+        branchData->taken = BranchTarget(isObjectBlock);
+        branchData->notTaken = BranchTarget(notObjectBlock);
+        addToGraph(Branch, OpInfo(branchData), addToGraph(IsObject, iterator));
+
+        {
+            m_currentBlock = notObjectBlock;
+            clearCaches();
+            keepUsesOfCurrentInstructionAlive(currentInstruction, m_currentIndex.checkpoint());
+            LazyJSValue errorString = LazyJSValue::newString(m_graph, "Iterator result interface is not an object."_s);
+            OpInfo info = OpInfo(m_graph.m_lazyJSValues.add(errorString));
+            Node* errorMessage = addToGraph(LazyJSConstant, info);
+            addToGraph(ThrowStaticError, OpInfo(ErrorType::TypeError), errorMessage);
+            flushForTerminal();
+        }
+
+        {
+            m_currentBlock = isObjectBlock;
+            clearCaches();
+            keepUsesOfCurrentInstructionAlive(currentInstruction, m_currentIndex.checkpoint());
+            SpeculatedType prediction = getPrediction();
+
+            Node* base = get(bytecode.m_iterator);
+            auto* nextImpl = m_vm->propertyNames->next.impl();
+            unsigned identifierNumber = m_graph.identifiers().ensure(nextImpl);
+
+            AccessType type = AccessType::GetById;
+
+            GetByStatus getByStatus = GetByStatus::computeFor(
+                m_inlineStackTop->m_profiledBlock,
+                m_inlineStackTop->m_baselineMap, m_icContextStack,
+                currentCodeOrigin());
+
+
+            handleGetById(bytecode.m_next, prediction, base, CacheableIdentifier::createFromImmortalIdentifier(nextImpl), identifierNumber, getByStatus, type, osrExitIndex);
+
+            // Do our set locals. We don't want to run our get_by_id again so we move to the next bytecode.
+            m_currentIndex = osrExitIndex;
+            m_exitOK = true;
+            processSetLocalQueue();
+
+            addToGraph(Jump, OpInfo(continuation));
+        }
+        generatedCase = true;
+    }
+
+    if (!generatedCase) {
+        Node* result = jsConstant(JSValue());
+        addToGraph(ForceOSRExit);
+        addToGraph(Phantom, get(bytecode.m_symbolIterator));
+        addToGraph(Phantom, get(bytecode.m_iterable));
+        set(bytecode.m_iterator, result);
+        set(bytecode.m_next, result);
+
+        m_currentIndex = osrExitIndex;
+        m_exitOK = true;
+        processSetLocalQueue();
+
+        addToGraph(Jump, OpInfo(continuation));
+    }
+
+    m_currentIndex = startIndex;
+    m_currentBlock = continuation;
+    clearCaches();
+}
+
+void ByteCodeParser::handleIteratorNext(const JSInstruction* currentInstruction, BytecodeIndex osrExitIndex)
+{
+    CodeBlock* codeBlock = m_inlineStackTop->m_codeBlock;
+    auto bytecode = currentInstruction->as<OpIteratorNext>();
+    auto& metadata = bytecode.metadata(codeBlock);
+    uint32_t seenModes = metadata.m_iterationMetadata.seenModes;
+
+    unsigned numberOfRemainingModes = std::popcount(seenModes);
+    ASSERT(numberOfRemainingModes <= numberOfIterationModes);
+    bool generatedCase = false;
+
+    JSGlobalObject* globalObject = m_inlineStackTop->m_codeBlock->globalObjectFor(currentCodeOrigin());
+    BasicBlock* failedBlock = nullptr;
+    auto connectFailedBlock = [&] {
+        if (failedBlock) {
+            ASSERT(generatedCase);
+            m_currentBlock = failedBlock;
+            clearCaches();
+            keepUsesOfCurrentInstructionAlive(currentInstruction, m_currentIndex.checkpoint());
+            failedBlock = nullptr;
+        }
+    };
+
+    BasicBlock* continuation = allocateUntargetableBlock();
+
+    BytecodeIndex startIndex = m_currentIndex;
+
+    if (seenModes & IterationMode::FastArray && globalObject->arrayIteratorProtocolWatchpointSet().isStillValid()) {
+        // First set up the watchpoint conditions we need for correctness.
+        m_graph.watchpoints().addLazily(globalObject->arrayIteratorProtocolWatchpointSet());
+        numberOfRemainingModes--;
+
+        connectFailedBlock();
+
+        if (!numberOfRemainingModes)
+            addToGraph(CheckIsConstant, OpInfo(m_graph.freeze(JSValue())), get(bytecode.m_next));
+        else {
+            Node* hasNext = addToGraph(IsEmpty, get(bytecode.m_next));
+            failedBlock = allocateUntargetableBlock();
+            BasicBlock* fastArrayBlock = allocateUntargetableBlock();
+
+            BranchData* branchData = m_graph.m_branchData.add();
+            branchData->taken = BranchTarget(fastArrayBlock);
+            branchData->notTaken = BranchTarget(failedBlock);
+            addToGraph(Branch, OpInfo(branchData), hasNext);
+
+            m_currentBlock = fastArrayBlock;
+            clearCaches();
+            keepUsesOfCurrentInstructionAlive(currentInstruction, m_currentIndex.checkpoint());
+        }
+
+        Node* iterator = get(bytecode.m_iterator);
+        addToGraph(CheckStructure, OpInfo(m_graph.addStructureSet(globalObject->arrayIteratorStructure())), iterator);
+
+        BasicBlock* isDoneBlock = allocateUntargetableBlock();
+        BasicBlock* doLoadBlock = allocateUntargetableBlock();
+
+        ArrayMode arrayMode = getArrayMode(metadata.m_iterableProfile, Array::Read);
+        auto prediction = getPredictionWithoutOSRExit(BytecodeIndex(m_currentIndex.offset(), OpIteratorNext::getValue));
+
+        {
+            // FIXME: doneIndex is -1 so it seems like we should be able to do CompareBelow(index, length). See: https://bugs.webkit.org/show_bug.cgi?id=210927
+            Node* doneIndex = jsConstant(jsNumber(JSArrayIterator::doneIndex));
+            Node* index = addToGraph(GetInternalField, OpInfo(static_cast<uint32_t>(JSArrayIterator::Field::Index)), OpInfo(SpecInt32Only), iterator);
+            Node* isDone = addToGraph(CompareStrictEq, index, doneIndex);
+
+            Node* iterable = get(bytecode.m_iterable);
+            Node* butterfly = addToGraph(GetButterfly, iterable);
+            Node* length = addToGraph(GetArrayLength, OpInfo(arrayMode.asWord()), Edge(iterable), Edge(butterfly, KnownStorageUse));
+            // GetArrayLength is pessimized prior to fixup.
+            m_exitOK = true;
+            addToGraph(ExitOK);
+            Node* isOutOfBounds = addToGraph(CompareGreaterEq, Edge(index, Int32Use), Edge(length, Int32Use));
+
+            isDone = addToGraph(ArithBitOr, isDone, isOutOfBounds);
+            // The above compare doesn't produce effects since we know the values are booleans. We don't set UseKinds because Fixup likes to add edges.
+            m_exitOK = true;
+            addToGraph(ExitOK);
+
+            BranchData* branchData = m_graph.m_branchData.add();
+            branchData->taken = BranchTarget(isDoneBlock);
+            branchData->notTaken = BranchTarget(doLoadBlock);
+            addToGraph(Branch, OpInfo(branchData), isDone);
+        }
+
+        {
+            m_currentBlock = doLoadBlock;
+            clearCaches();
+            keepUsesOfCurrentInstructionAlive(currentInstruction, m_currentIndex.checkpoint());
+            Node* index = addToGraph(GetInternalField, OpInfo(static_cast<uint32_t>(JSArrayIterator::Field::Index)), OpInfo(SpecInt32Only), get(bytecode.m_iterator));
+            Node* one = jsConstant(jsNumber(1));
+            Node* newIndex = makeSafe(addToGraph(ArithAdd, index, one));
+            Node* falseNode = jsConstant(jsBoolean(false));
+
+
+            // FIXME: We could consider making this not vararg, since it only uses three child slots.
+            // https://bugs.webkit.org/show_bug.cgi?id=184192
+            addVarArgChild(get(bytecode.m_iterable));
+            addVarArgChild(index);
+            addVarArgChild(nullptr); // Leave room for property storage.
+            Node* getByVal = addToGraph(Node::VarArg, GetByVal, OpInfo(arrayMode.asWord()), OpInfo(prediction));
+            set(bytecode.m_value, getByVal);
+            set(bytecode.m_done, falseNode);
+            addToGraph(PutInternalField, OpInfo(static_cast<uint32_t>(JSArrayIterator::Field::Index)), get(bytecode.m_iterator), newIndex);
+
+            // Do our set locals. We don't want to run our getByVal again so we move to the next bytecode.
+            m_currentIndex = osrExitIndex;
+            m_exitOK = true;
+            processSetLocalQueue();
+
+            addToGraph(Jump, OpInfo(continuation));
+        }
+
+        // Roll back the checkpoint.
+        m_currentIndex = startIndex;
+
+        {
+            m_currentBlock = isDoneBlock;
+            clearCaches();
+            keepUsesOfCurrentInstructionAlive(currentInstruction, m_currentIndex.checkpoint());
+            Node* trueNode = jsConstant(jsBoolean(true));
+            Node* doneIndex = jsConstant(jsNumber(-1));
+            Node* bottomNode = jsConstant(m_graph.bottomValueMatchingSpeculation(prediction));
+
+            set(bytecode.m_value, bottomNode);
+            set(bytecode.m_done, trueNode);
+            addToGraph(PutInternalField, OpInfo(static_cast<uint32_t>(JSArrayIterator::Field::Index)), get(bytecode.m_iterator), doneIndex);
+
+            // Do our set locals. We don't want to run this again so we have to move the exit origin forward.
+            m_currentIndex = osrExitIndex;
+            m_exitOK = true;
+            processSetLocalQueue();
+
+            addToGraph(Jump, OpInfo(continuation));
+        }
+
+        m_currentIndex = startIndex;
+        generatedCase = true;
+    }
+
+    if (seenModes & IterationMode::FastMap && globalObject->mapIteratorProtocolWatchpointSet().isStillValid()) {
+        auto& mapIteratorProtocolWatchpointSet = globalObject->mapIteratorProtocolWatchpointSet();
+        m_graph.watchpoints().addLazily(mapIteratorProtocolWatchpointSet);
+        numberOfRemainingModes--;
+
+        connectFailedBlock();
+
+        if (!numberOfRemainingModes)
+            addToGraph(CheckIsConstant, OpInfo(m_graph.freeze(JSValue())), get(bytecode.m_next));
+        else {
+            Node* hasNext = addToGraph(IsEmpty, get(bytecode.m_next));
+            failedBlock = allocateUntargetableBlock();
+            BasicBlock* fastMapBlock = allocateUntargetableBlock();
+
+            BranchData* branchData = m_graph.m_branchData.add();
+            branchData->taken = BranchTarget(fastMapBlock);
+            branchData->notTaken = BranchTarget(failedBlock);
+            addToGraph(Branch, OpInfo(branchData), hasNext);
+
+            m_currentBlock = fastMapBlock;
+            clearCaches();
+            keepUsesOfCurrentInstructionAlive(currentInstruction, m_currentIndex.checkpoint());
+        }
+
+        Node* iterator = get(bytecode.m_iterator);
+        addToGraph(CheckStructure, OpInfo(m_graph.addStructureSet(globalObject->mapIteratorStructure())), iterator);
+
+        auto prediction = getPredictionWithoutOSRExit(BytecodeIndex(m_currentIndex.offset(), OpIteratorNext::getValue));
+
+        BasicBlock* isDoneBlock = allocateUntargetableBlock();
+        BasicBlock* doLoadBlock = allocateUntargetableBlock();
+
+        {
+            // Now MapIterator status gets mutated. So we must not do OSRExit unless it is throwing an exception.
+            Node* doneNode = addToGraph(MapIteratorNext, Edge(iterator, MapIteratorObjectUse));
+
+            BranchData* branchData = m_graph.m_branchData.add();
+            branchData->taken = BranchTarget(isDoneBlock);
+            branchData->notTaken = BranchTarget(doLoadBlock);
+            addToGraph(Branch, OpInfo(branchData), doneNode);
+        }
+
+        {
+            m_currentBlock = doLoadBlock;
+            clearCaches();
+            keepUsesOfCurrentInstructionAlive(currentInstruction, m_currentIndex.checkpoint());
+
+            m_exitOK = true;
+            addToGraph(ExitOK);
+
+            Node* key = addToGraph(MapIteratorKey, OpInfo(0), OpInfo(prediction), Edge(get(bytecode.m_iterator), MapIteratorObjectUse));
+            Node* value = addToGraph(MapIteratorValue, OpInfo(0), OpInfo(prediction), Edge(get(bytecode.m_iterator), MapIteratorObjectUse));
+            Node* falseNode = jsConstant(jsBoolean(false));
+
+            addVarArgChild(key);
+            addVarArgChild(value);
+            unsigned vectorHint = 2;
+            Node* pair = addToGraph(Node::VarArg, NewArray, OpInfo(ArrayWithContiguous), OpInfo(vectorHint));
+            set(bytecode.m_value, pair);
+            set(bytecode.m_done, falseNode);
+
+            m_currentIndex = osrExitIndex;
+            m_exitOK = true;
+            processSetLocalQueue();
+
+            addToGraph(Jump, OpInfo(continuation));
+        }
+
+        // Roll back the checkpoint.
+        m_currentIndex = startIndex;
+
+        {
+            m_currentBlock = isDoneBlock;
+            clearCaches();
+            keepUsesOfCurrentInstructionAlive(currentInstruction, m_currentIndex.checkpoint());
+            Node* trueNode = jsConstant(jsBoolean(true));
+            Node* bottomNode = jsConstant(m_graph.bottomValueMatchingSpeculation(prediction));
+
+            set(bytecode.m_value, bottomNode);
+            set(bytecode.m_done, trueNode);
+
+            // Do our set locals. We don't want to run this again so we have to move the exit origin forward.
+            m_currentIndex = osrExitIndex;
+            m_exitOK = true;
+            processSetLocalQueue();
+
+            addToGraph(Jump, OpInfo(continuation));
+        }
+
+        m_currentIndex = startIndex;
+        generatedCase = true;
+    }
+
+    if (seenModes & IterationMode::FastSet && globalObject->setIteratorProtocolWatchpointSet().isStillValid()) {
+        auto& setIteratorProtocolWatchpointSet = globalObject->setIteratorProtocolWatchpointSet();
+        m_graph.watchpoints().addLazily(setIteratorProtocolWatchpointSet);
+        numberOfRemainingModes--;
+
+        connectFailedBlock();
+
+        if (!numberOfRemainingModes)
+            addToGraph(CheckIsConstant, OpInfo(m_graph.freeze(JSValue())), get(bytecode.m_next));
+        else {
+            Node* hasNext = addToGraph(IsEmpty, get(bytecode.m_next));
+            failedBlock = allocateUntargetableBlock();
+            BasicBlock* fastSetBlock = allocateUntargetableBlock();
+
+            BranchData* branchData = m_graph.m_branchData.add();
+            branchData->taken = BranchTarget(fastSetBlock);
+            branchData->notTaken = BranchTarget(failedBlock);
+            addToGraph(Branch, OpInfo(branchData), hasNext);
+
+            m_currentBlock = fastSetBlock;
+            clearCaches();
+            keepUsesOfCurrentInstructionAlive(currentInstruction, m_currentIndex.checkpoint());
+        }
+
+        Node* iterator = get(bytecode.m_iterator);
+        addToGraph(CheckStructure, OpInfo(m_graph.addStructureSet(globalObject->setIteratorStructure())), iterator);
+
+        auto prediction = getPredictionWithoutOSRExit(BytecodeIndex(m_currentIndex.offset(), OpIteratorNext::getValue));
+
+        BasicBlock* isDoneBlock = allocateUntargetableBlock();
+        BasicBlock* doLoadBlock = allocateUntargetableBlock();
+
+        {
+            // Now SetIterator status gets mutated. So we must not do OSRExit unless it is throwing an exception.
+            Node* doneNode = addToGraph(MapIteratorNext, Edge(iterator, SetIteratorObjectUse));
+
+            BranchData* branchData = m_graph.m_branchData.add();
+            branchData->taken = BranchTarget(isDoneBlock);
+            branchData->notTaken = BranchTarget(doLoadBlock);
+            addToGraph(Branch, OpInfo(branchData), doneNode);
+        }
+
+        {
+            m_currentBlock = doLoadBlock;
+            clearCaches();
+            keepUsesOfCurrentInstructionAlive(currentInstruction, m_currentIndex.checkpoint());
+
+            m_exitOK = true;
+            addToGraph(ExitOK);
+
+            Node* value = addToGraph(MapIteratorKey, OpInfo(0), OpInfo(prediction), Edge(get(bytecode.m_iterator), SetIteratorObjectUse));
+            Node* falseNode = jsConstant(jsBoolean(false));
+
+            set(bytecode.m_value, value);
+            set(bytecode.m_done, falseNode);
+
+            m_currentIndex = osrExitIndex;
+            m_exitOK = true;
+            processSetLocalQueue();
+
+            addToGraph(Jump, OpInfo(continuation));
+        }
+
+        // Roll back the checkpoint.
+        m_currentIndex = startIndex;
+
+        {
+            m_currentBlock = isDoneBlock;
+            clearCaches();
+            keepUsesOfCurrentInstructionAlive(currentInstruction, m_currentIndex.checkpoint());
+            Node* trueNode = jsConstant(jsBoolean(true));
+            Node* bottomNode = jsConstant(m_graph.bottomValueMatchingSpeculation(prediction));
+
+            set(bytecode.m_value, bottomNode);
+            set(bytecode.m_done, trueNode);
+
+            // Do our set locals. We don't want to run this again so we have to move the exit origin forward.
+            m_currentIndex = osrExitIndex;
+            m_exitOK = true;
+            processSetLocalQueue();
+
+            addToGraph(Jump, OpInfo(continuation));
+        }
+
+        m_currentIndex = startIndex;
+        generatedCase = true;
+    }
+
+    if (seenModes & IterationMode::Generic) {
+        connectFailedBlock();
+
+        // Our profiling could have been incorrect when we got here. For instance, if we LoopHint OSR enter the first time we would
+        // have seen a fast path, next will be the empty value. When that happens we need to make sure the empty value doesn't flow
+        // into the Call node since call can't handle empty values.
+        addToGraph(CheckNotEmpty, get(bytecode.m_next));
+
+        Terminality terminality = handleCall<OpIteratorNext>(currentInstruction, Call, CallMode::Regular, nextCheckpoint(), nullptr);
+        ASSERT_UNUSED(terminality, terminality == NonTerminal);
+        progressToNextCheckpoint();
+
+        BasicBlock* notObjectBlock = allocateUntargetableBlock();
+        BasicBlock* isObjectBlock = allocateUntargetableBlock();
+        BasicBlock* notDoneBlock = allocateUntargetableBlock();
+
+        Operand nextResult = Operand::tmp(OpIteratorNext::nextResult);
+        {
+            Node* iteratorResult = get(nextResult);
+            BranchData* branchData = m_graph.m_branchData.add();
+            branchData->taken = BranchTarget(isObjectBlock);
+            branchData->notTaken = BranchTarget(notObjectBlock);
+            addToGraph(Branch, OpInfo(branchData), addToGraph(IsObject, iteratorResult));
+        }
+
+        {
+            m_currentBlock = notObjectBlock;
+            clearCaches();
+            keepUsesOfCurrentInstructionAlive(currentInstruction, m_currentIndex.checkpoint());
+            LazyJSValue errorString = LazyJSValue::newString(m_graph, "Iterator result interface is not an object."_s);
+            OpInfo info = OpInfo(m_graph.m_lazyJSValues.add(errorString));
+            Node* errorMessage = addToGraph(LazyJSConstant, info);
+            addToGraph(ThrowStaticError, OpInfo(ErrorType::TypeError), errorMessage);
+            flushForTerminal();
+        }
+
+        auto valuePredicition = getPredictionWithoutOSRExit(m_currentIndex.withCheckpoint(OpIteratorNext::getValue));
+
+        {
+            m_exitOK = true;
+            m_currentBlock = isObjectBlock;
+            clearCaches();
+            keepUsesOfCurrentInstructionAlive(currentInstruction, m_currentIndex.checkpoint());
+            SpeculatedType prediction = getPrediction();
+
+            Node* base = get(nextResult);
+            auto* doneImpl = m_vm->propertyNames->done.impl();
+            unsigned identifierNumber = m_graph.identifiers().ensure(doneImpl);
+
+            AccessType type = AccessType::GetById;
+
+            GetByStatus getByStatus = GetByStatus::computeFor(
+                m_inlineStackTop->m_profiledBlock,
+                m_inlineStackTop->m_baselineMap, m_icContextStack,
+                currentCodeOrigin());
+
+            handleGetById(bytecode.m_done, prediction, base, CacheableIdentifier::createFromImmortalIdentifier(doneImpl), identifierNumber, getByStatus, type, nextCheckpoint());
+            // Set a value for m_value so we don't exit on it differing from what we expected.
+            set(bytecode.m_value, jsConstant(m_graph.bottomValueMatchingSpeculation(valuePredicition)));
+            progressToNextCheckpoint();
+
+            BranchData* branchData = m_graph.m_branchData.add();
+            branchData->taken = BranchTarget(continuation);
+            branchData->notTaken = BranchTarget(notDoneBlock);
+            addToGraph(Branch, OpInfo(branchData), get(bytecode.m_done));
+        }
+
+        {
+            m_currentBlock = notDoneBlock;
+            clearCaches();
+            keepUsesOfCurrentInstructionAlive(currentInstruction, m_currentIndex.checkpoint());
+
+            Node* base = get(nextResult);
+            auto* valueImpl = m_vm->propertyNames->value.impl();
+            unsigned identifierNumber = m_graph.identifiers().ensure(valueImpl);
+
+            AccessType type = AccessType::GetById;
+
+            GetByStatus getByStatus = GetByStatus::computeFor(
+                m_inlineStackTop->m_profiledBlock,
+                m_inlineStackTop->m_baselineMap, m_icContextStack,
+                currentCodeOrigin());
+
+            handleGetById(bytecode.m_value, valuePredicition, base, CacheableIdentifier::createFromImmortalIdentifier(valueImpl), identifierNumber, getByStatus, type, osrExitIndex);
+
+            // We're done, exit forwards.
+            m_currentIndex = osrExitIndex;
+            m_exitOK = true;
+            processSetLocalQueue();
+
+            addToGraph(Jump, OpInfo(continuation));
+        }
+
+        generatedCase = true;
+    }
+
+    if (!generatedCase) {
+        Node* result = jsConstant(JSValue());
+        addToGraph(ForceOSRExit);
+        addToGraph(Phantom, get(bytecode.m_next));
+        addToGraph(Phantom, get(bytecode.m_iterator));
+        addToGraph(Phantom, get(bytecode.m_iterable));
+        set(bytecode.m_value, result);
+        set(bytecode.m_done, result);
+
+        // Do our set locals. We don't want to run our get by id again so we move to the next bytecode.
+        m_currentIndex = BytecodeIndex(m_currentIndex.offset() + currentInstruction->size());
+        m_exitOK = true;
+        processSetLocalQueue();
+
+        addToGraph(Jump, OpInfo(continuation));
+    }
+
+    m_currentIndex = startIndex;
+    m_currentBlock = continuation;
+    clearCaches();
 }
 
 void ByteCodeParser::pruneUnreachableNodes()

--- a/Source/JavaScriptCore/dfg/DFGMayExit.cpp
+++ b/Source/JavaScriptCore/dfg/DFGMayExit.cpp
@@ -204,6 +204,7 @@ ExitMode mayExitImpl(Graph& graph, Node* node, StateType& state)
     case NewRegExp:
     case NewMap:
     case NewSet:
+    case NewArray:
     case NewArrayWithButterfly:
     case NewButterflyWithSize:
     case ToNumber:

--- a/Source/JavaScriptCore/jit/JITOperations.cpp
+++ b/Source/JavaScriptCore/jit/JITOperations.cpp
@@ -61,8 +61,10 @@ WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 #include "JSGeneratorFunction.h"
 #include "JSGlobalObjectFunctions.h"
 #include "JSLexicalEnvironment.h"
+#include "JSMapIterator.h"
 #include "JSPromise.h"
 #include "JSRemoteFunction.h"
+#include "JSSetIterator.h"
 #include "JSWithScope.h"
 #include "JumpTable.h"
 #include "LLIntEntrypoint.h"
@@ -3405,7 +3407,7 @@ JSC_DEFINE_JIT_OPERATION(operationInstanceOfCustom, size_t, (JSGlobalObject* glo
 
 #if CPU(ARM64) || CPU(X86_64)
 
-JSC_DEFINE_JIT_OPERATION(operationIteratorNextTryFast, UGPRPair, (JSGlobalObject* globalObject, JSArrayIterator* arrayIterator, JSArray* array, void* metadataPointer))
+JSC_DEFINE_JIT_OPERATION(operationIteratorNextTryFast, UGPRPair, (JSGlobalObject* globalObject, JSObject* iterator, JSCell* iterable, void* metadataPointer))
 {
     VM& vm = globalObject->vm();
     CallFrame* callFrame = DECLARE_CALL_FRAME(vm);
@@ -3413,27 +3415,54 @@ JSC_DEFINE_JIT_OPERATION(operationIteratorNextTryFast, UGPRPair, (JSGlobalObject
     auto scope = DECLARE_THROW_SCOPE(vm);
 
     auto& metadata = *std::bit_cast<OpIteratorNext::Metadata*>(metadataPointer);
-    metadata.m_iterableProfile.observeStructureID(array->structureID());
-    metadata.m_iterationMetadata.seenModes = metadata.m_iterationMetadata.seenModes | IterationMode::FastArray;
 
-    auto& indexSlot = arrayIterator->internalField(JSArrayIterator::Field::Index);
-    int64_t index = indexSlot.get().asAnyInt();
-    ASSERT(0 <= index && index <= maxSafeInteger());
+    if (auto* arrayIterator = dynamicDowncast<JSArrayIterator>(iterator)) {
+        auto* array = uncheckedDowncast<JSArray>(iterable);
+        metadata.m_iterableProfile.observeStructureID(array->structureID());
+        metadata.m_iterationMetadata.seenModes = metadata.m_iterationMetadata.seenModes | IterationMode::FastArray;
 
-    JSValue value;
-    bool done = index == JSArrayIterator::doneIndex || index >= array->length();
-    if (!done) {
-        // No need for a barrier here because we know this is a primitive.
-        indexSlot.setWithoutWriteBarrier(jsNumber(index + 1));
-        ASSERT(index == static_cast<unsigned>(index));
-        value = array->getIndex(globalObject, static_cast<unsigned>(index));
-        OPERATION_RETURN_IF_EXCEPTION(scope, makeUGPRPair(0, 0));
-    } else {
-        // No need for a barrier here because we know this is a primitive.
-        indexSlot.setWithoutWriteBarrier(jsNumber(-1));
+        auto& indexSlot = arrayIterator->internalField(JSArrayIterator::Field::Index);
+        int64_t index = indexSlot.get().asAnyInt();
+        ASSERT(0 <= index && index <= maxSafeInteger());
+
+        JSValue value;
+        bool done = index == JSArrayIterator::doneIndex || index >= array->length();
+        if (!done) {
+            // No need for a barrier here because we know this is a primitive.
+            indexSlot.setWithoutWriteBarrier(jsNumber(index + 1));
+            ASSERT(index == static_cast<unsigned>(index));
+            value = array->getIndex(globalObject, static_cast<unsigned>(index));
+            OPERATION_RETURN_IF_EXCEPTION(scope, makeUGPRPair(0, 0));
+        } else {
+            // No need for a barrier here because we know this is a primitive.
+            indexSlot.setWithoutWriteBarrier(jsNumber(-1));
+        }
+
+        OPERATION_RETURN(scope, makeUGPRPair(JSValue::encode(jsBoolean(done)), JSValue::encode(value)));
     }
 
-    OPERATION_RETURN(scope, makeUGPRPair(JSValue::encode(jsBoolean(done)), JSValue::encode(value)));
+    if (auto* mapIterator = dynamicDowncast<JSMapIterator>(iterator)) {
+        metadata.m_iterationMetadata.seenModes = metadata.m_iterationMetadata.seenModes | IterationMode::FastMap;
+        auto result = mapIterator->nextWithAdvance(vm);
+        bool done = result.key.isEmpty();
+        JSValue value;
+        if (!done) {
+            value = constructArrayPair(globalObject, result.key, result.value);
+            OPERATION_RETURN_IF_EXCEPTION(scope, makeUGPRPair(0, 0));
+        }
+        OPERATION_RETURN(scope, makeUGPRPair(JSValue::encode(jsBoolean(done)), JSValue::encode(value)));
+    }
+
+    if (auto* setIterator = dynamicDowncast<JSSetIterator>(iterator)) {
+        metadata.m_iterationMetadata.seenModes = metadata.m_iterationMetadata.seenModes | IterationMode::FastSet;
+        JSValue nextKey = setIterator->nextWithAdvance(vm);
+        bool done = nextKey.isEmpty();
+        JSValue value = done ? JSValue() : nextKey;
+        OPERATION_RETURN(scope, makeUGPRPair(JSValue::encode(jsBoolean(done)), JSValue::encode(value)));
+    }
+
+    RELEASE_ASSERT_NOT_REACHED();
+    OPERATION_RETURN(scope, makeUGPRPair(0, 0));
 }
 
 #endif

--- a/Source/JavaScriptCore/jit/JITOperations.h
+++ b/Source/JavaScriptCore/jit/JITOperations.h
@@ -412,7 +412,7 @@ JSC_DECLARE_NOEXCEPT_JIT_OPERATION(operationRetrieveAndClearExceptionIfCatchable
 JSC_DECLARE_JIT_OPERATION(operationInstanceOfCustom, size_t, (JSGlobalObject*, EncodedJSValue encodedValue, JSObject* constructor, EncodedJSValue encodedHasInstance));
 
 #if CPU(ARM64) || CPU(X86_64)
-JSC_DECLARE_JIT_OPERATION(operationIteratorNextTryFast, UGPRPair, (JSGlobalObject*, JSArrayIterator*, JSArray*, void*));
+JSC_DECLARE_JIT_OPERATION(operationIteratorNextTryFast, UGPRPair, (JSGlobalObject*, JSObject*, JSCell*, void*));
 #endif
 
 JSC_DECLARE_JIT_OPERATION(operationValueAdd, EncodedJSValue, (JSGlobalObject*, EncodedJSValue encodedOp1, EncodedJSValue encodedOp2));

--- a/Source/JavaScriptCore/runtime/CommonSlowPaths.cpp
+++ b/Source/JavaScriptCore/runtime/CommonSlowPaths.cpp
@@ -44,9 +44,13 @@
 #include "JSCellButterfly.h"
 #include "JSIteratorHelper.h"
 #include "JSLexicalEnvironment.h"
+#include "JSMap.h"
+#include "JSMapIterator.h"
 #include "JSPromise.h"
 #include "JSPromiseConstructor.h"
 #include "JSPropertyNameEnumerator.h"
+#include "JSSet.h"
+#include "JSSetIterator.h"
 #include "JSWithScope.h"
 #include "LLIntCommon.h"
 #include "LLIntExceptions.h"
@@ -809,6 +813,24 @@ ALWAYS_INLINE UGPRPair iteratorOpenTryFastImpl(VM& vm, JSGlobalObject* globalObj
         return encodeResult(pc, reinterpret_cast<void*>(static_cast<uintptr_t>(IterationMode::FastArray)));
     }
 
+    if (iterationMode == IterationMode::FastMap) {
+        metadata.m_iterationMetadata.seenModes = metadata.m_iterationMetadata.seenModes | IterationMode::FastMap;
+        GET(bytecode.m_next) = JSValue();
+        auto* map = uncheckedDowncast<JSMap>(iterable);
+        iterator = JSMapIterator::create(vm, globalObject->mapIteratorStructure(), map, IterationKind::Entries);
+        PROFILE_VALUE_IN(iterator.jsValue(), m_iteratorValueProfile);
+        return encodeResult(pc, reinterpret_cast<void*>(static_cast<uintptr_t>(IterationMode::FastMap)));
+    }
+
+    if (iterationMode == IterationMode::FastSet) {
+        metadata.m_iterationMetadata.seenModes = metadata.m_iterationMetadata.seenModes | IterationMode::FastSet;
+        GET(bytecode.m_next) = JSValue();
+        auto* set = uncheckedDowncast<JSSet>(iterable);
+        iterator = JSSetIterator::create(vm, globalObject->setIteratorStructure(), set, IterationKind::Values);
+        PROFILE_VALUE_IN(iterator.jsValue(), m_iteratorValueProfile);
+        return encodeResult(pc, reinterpret_cast<void*>(static_cast<uintptr_t>(IterationMode::FastSet)));
+    }
+
     auto validationResult = validateIterable(vm, iterable, symbolIterator);
     if (validationResult != IterableValidationResult::Valid) [[unlikely]] {
         throwTypeError(globalObject, throwScope, getIteratorErrorMessage(validationResult, iterable));
@@ -875,6 +897,35 @@ ALWAYS_INLINE UGPRPair iteratorNextTryFastImpl(VM& vm, JSGlobalObject* globalObj
             return encodeResult(pc, reinterpret_cast<void*>(IterationMode::FastArray));
         }
     }
+
+    if (auto mapIterator = dynamicDowncast<JSMapIterator>(iterator)) {
+        metadata.m_iterationMetadata.seenModes = metadata.m_iterationMetadata.seenModes | IterationMode::FastMap;
+        auto result = mapIterator->nextWithAdvance(vm);
+        bool done = result.key.isEmpty();
+        GET(bytecode.m_done) = jsBoolean(done);
+        if (!done) {
+            JSValue value = constructArrayPair(globalObject, result.key, result.value);
+            CHECK_EXCEPTION();
+            PROFILE_VALUE_IN(value, m_valueValueProfile);
+            GET(bytecode.m_value) = value;
+        } else
+            GET(bytecode.m_value) = JSValue();
+        return encodeResult(pc, reinterpret_cast<void*>(IterationMode::FastMap));
+    }
+
+    if (auto setIterator = dynamicDowncast<JSSetIterator>(iterator)) {
+        metadata.m_iterationMetadata.seenModes = metadata.m_iterationMetadata.seenModes | IterationMode::FastSet;
+        JSValue nextKey = setIterator->nextWithAdvance(vm);
+        bool done = nextKey.isEmpty();
+        GET(bytecode.m_done) = jsBoolean(done);
+        if (!done) {
+            PROFILE_VALUE_IN(nextKey, m_valueValueProfile);
+            GET(bytecode.m_value) = nextKey;
+        } else
+            GET(bytecode.m_value) = JSValue();
+        return encodeResult(pc, reinterpret_cast<void*>(IterationMode::FastSet));
+    }
+
     RELEASE_ASSERT_NOT_REACHED();
 }
 

--- a/Source/JavaScriptCore/runtime/IteratorOperations.cpp
+++ b/Source/JavaScriptCore/runtime/IteratorOperations.cpp
@@ -31,6 +31,8 @@
 #include "InterpreterInlines.h"
 #include "JSAsyncFromSyncIterator.h"
 #include "JSCInlines.h"
+#include "JSMap.h"
+#include "JSSet.h"
 #include "ObjectConstructor.h"
 #include "VMEntryScopeInlines.h"
 
@@ -426,10 +428,7 @@ ASCIILiteral getIteratorErrorMessage(IterableValidationResult result, JSValue it
 
 IterationMode getIterationMode(VM&, JSGlobalObject* globalObject, JSValue iterable, JSValue symbolIterator)
 {
-    if (!isJSArray(iterable))
-        return IterationMode::Generic;
-
-    if (!globalObject->arrayIteratorProtocolWatchpointSet().isStillValid())
+    if (!iterable.isCell()) [[unlikely]]
         return IterationMode::Generic;
 
     // This is correct because we just checked the watchpoint is still valid.
@@ -437,12 +436,39 @@ IterationMode getIterationMode(VM&, JSGlobalObject* globalObject, JSValue iterab
     if (!symbolIteratorFunction)
         return IterationMode::Generic;
 
-    // We don't want to allocate the values function just to check if it's the same as our function so we use the concurrent accessor.
-    // FIXME: This only works for arrays from the same global object as ourselves but we should be able to support any pairing.
-    if (globalObject->arrayProtoValuesFunctionConcurrently() != symbolIteratorFunction)
-        return IterationMode::Generic;
+    if (isJSArray(iterable)) {
+        if (!globalObject->arrayIteratorProtocolWatchpointSet().isStillValid())
+            return IterationMode::Generic;
 
-    return IterationMode::FastArray;
+        // We don't want to allocate the values function just to check if it's the same as our function so we use the concurrent accessor.
+        // FIXME: This only works for arrays from the same global object as ourselves but we should be able to support any pairing.
+        if (globalObject->arrayProtoValuesFunctionConcurrently() != symbolIteratorFunction)
+            return IterationMode::Generic;
+
+        return IterationMode::FastArray;
+    }
+
+    if (dynamicDowncast<JSMap>(iterable.asCell())) {
+        if (!globalObject->mapIteratorProtocolWatchpointSet().isStillValid())
+            return IterationMode::Generic;
+
+        if (globalObject->mapProtoEntriesFunctionConcurrently() != symbolIteratorFunction)
+            return IterationMode::Generic;
+
+        return IterationMode::FastMap;
+    }
+
+    if (dynamicDowncast<JSSet>(iterable.asCell())) {
+        if (!globalObject->setIteratorProtocolWatchpointSet().isStillValid())
+            return IterationMode::Generic;
+
+        if (globalObject->setProtoValuesFunctionConcurrently() != symbolIteratorFunction)
+            return IterationMode::Generic;
+
+        return IterationMode::FastSet;
+    }
+
+    return IterationMode::Generic;
 }
 
 IterationMode getIterationMode(VM&, JSGlobalObject* globalObject, JSValue iterable)

--- a/Source/JavaScriptCore/runtime/JSArray.cpp
+++ b/Source/JavaScriptCore/runtime/JSArray.cpp
@@ -2153,11 +2153,7 @@ JSArray* constructArrayPair(JSGlobalObject* globalObject, JSValue first, JSValue
     auto throwScope = DECLARE_THROW_SCOPE(vm);
     ObjectInitializationScope initializationScope(vm);
 
-    IndexingType indexingType = ArrayWithUndecided;
-    indexingType = leastUpperBoundOfIndexingTypeAndValue(indexingType, first);
-    indexingType = leastUpperBoundOfIndexingTypeAndValue(indexingType, second);
-
-    Structure* structure = globalObject->arrayStructureForIndexingTypeDuringAllocation(indexingType);
+    Structure* structure = globalObject->arrayStructureForIndexingTypeDuringAllocation(ArrayWithContiguous);
 
     JSArray* array = JSArray::tryCreateUninitializedRestricted(initializationScope, structure, 2);
     if (!array) [[unlikely]] {

--- a/Source/JavaScriptCore/runtime/JSGlobalObject.cpp
+++ b/Source/JavaScriptCore/runtime/JSGlobalObject.cpp
@@ -1137,6 +1137,14 @@ void JSGlobalObject::init(VM& vm)
         [] (const Initializer<JSFunction>& init) {
             init.set(JSFunction::create(init.vm, init.owner, 0, init.vm.propertyNames->builtinNames().valuesPublicName().string(), arrayProtoFuncValues, ImplementationVisibility::Public, ArrayValuesIntrinsic));
         });
+    m_mapProtoEntriesFunction.initLater(
+        [] (const Initializer<JSFunction>& init) {
+            init.set(JSFunction::create(init.vm, init.owner, 0, init.vm.propertyNames->builtinNames().entriesPublicName().string(), mapProtoFuncEntries, ImplementationVisibility::Public, JSMapEntriesIntrinsic));
+        });
+    m_setProtoValuesFunction.initLater(
+        [] (const Initializer<JSFunction>& init) {
+            init.set(JSFunction::create(init.vm, init.owner, 0, init.vm.propertyNames->builtinNames().valuesPublicName().string(), setProtoFuncValues, ImplementationVisibility::Public, JSSetValuesIntrinsic));
+        });
 
     m_numberProtoToStringFunction.initLater(
         [] (const Initializer<JSFunction>& init) {
@@ -2972,6 +2980,8 @@ void JSGlobalObject::visitChildrenImpl(JSCell* cell, Visitor& visitor)
     thisObject->m_objectProtoToStringFunction.visit(visitor);
     thisObject->m_arrayProtoToStringFunction.visit(visitor);
     thisObject->m_arrayProtoValuesFunction.visit(visitor);
+    thisObject->m_mapProtoEntriesFunction.visit(visitor);
+    thisObject->m_setProtoValuesFunction.visit(visitor);
     visitor.append(thisObject->m_objectProtoValueOfFunction);
     thisObject->m_numberProtoToStringFunction.visit(visitor);
     visitor.append(thisObject->m_functionProtoHasInstanceSymbolFunction);

--- a/Source/JavaScriptCore/runtime/JSGlobalObject.h
+++ b/Source/JavaScriptCore/runtime/JSGlobalObject.h
@@ -312,6 +312,8 @@ public:
     LazyProperty<JSGlobalObject, JSFunction> m_objectProtoToStringFunction;
     LazyProperty<JSGlobalObject, JSFunction> m_arrayProtoToStringFunction;
     LazyProperty<JSGlobalObject, JSFunction> m_arrayProtoValuesFunction;
+    LazyProperty<JSGlobalObject, JSFunction> m_mapProtoEntriesFunction;
+    LazyProperty<JSGlobalObject, JSFunction> m_setProtoValuesFunction;
     LazyProperty<JSGlobalObject, JSFunction> m_numberProtoToStringFunction;
     WriteBarrier<JSFunction> m_objectProtoValueOfFunction;
     WriteBarrier<JSFunction> m_functionProtoHasInstanceSymbolFunction;
@@ -775,6 +777,10 @@ public:
     JSFunction* arrayProtoToStringFunction() const LIFETIME_BOUND { return m_arrayProtoToStringFunction.get(this); }
     JSFunction* arrayProtoValuesFunction() const LIFETIME_BOUND { return m_arrayProtoValuesFunction.get(this); }
     JSFunction* arrayProtoValuesFunctionConcurrently() const LIFETIME_BOUND { return m_arrayProtoValuesFunction.getConcurrently(); }
+    JSFunction* mapProtoEntriesFunction() const LIFETIME_BOUND { return m_mapProtoEntriesFunction.get(this); }
+    JSFunction* mapProtoEntriesFunctionConcurrently() const LIFETIME_BOUND { return m_mapProtoEntriesFunction.getConcurrently(); }
+    JSFunction* setProtoValuesFunction() const LIFETIME_BOUND { return m_setProtoValuesFunction.get(this); }
+    JSFunction* setProtoValuesFunctionConcurrently() const LIFETIME_BOUND { return m_setProtoValuesFunction.getConcurrently(); }
     JSFunction* iteratorProtocolFunction() const;
     JSFunction* promiseProtoThenFunction() const;
     JSFunction* objectProtoValueOfFunction() const LIFETIME_BOUND { return m_objectProtoValueOfFunction.get(); }

--- a/Source/JavaScriptCore/runtime/MapPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/MapPrototype.cpp
@@ -48,7 +48,7 @@ static JSC_DECLARE_HOST_FUNCTION(mapProtoFuncGetOrInsert);
 static JSC_DECLARE_HOST_FUNCTION(mapProtoFuncGetOrInsertComputed);
 static JSC_DECLARE_HOST_FUNCTION(mapProtoFuncValues);
 static JSC_DECLARE_HOST_FUNCTION(mapProtoFuncKeys);
-static JSC_DECLARE_HOST_FUNCTION(mapProtoFuncEntries);
+JSC_DECLARE_HOST_FUNCTION(mapProtoFuncEntries);
 
 static JSC_DECLARE_HOST_FUNCTION(mapProtoFuncSize);
     
@@ -65,7 +65,7 @@ void MapPrototype::finishCreation(VM& vm, JSGlobalObject* globalObject)
     putDirectWithoutTransition(vm, vm.propertyNames->deleteKeyword, deleteFunc, static_cast<unsigned>(PropertyAttribute::DontEnum));
     putDirectWithoutTransition(vm, vm.propertyNames->builtinNames().deletePrivateName(), deleteFunc, static_cast<unsigned>(PropertyAttribute::DontEnum));
 
-    JSFunction* entries = JSFunction::create(vm, globalObject, 0, vm.propertyNames->builtinNames().entriesPublicName().string(), mapProtoFuncEntries, ImplementationVisibility::Public, JSMapEntriesIntrinsic);
+    JSFunction* entries = globalObject->mapProtoEntriesFunction();
     putDirectWithoutTransition(vm, vm.propertyNames->builtinNames().entriesPublicName(), entries, static_cast<unsigned>(PropertyAttribute::DontEnum));
     putDirectWithoutTransition(vm, vm.propertyNames->builtinNames().entriesPrivateName(), entries, static_cast<unsigned>(PropertyAttribute::DontEnum));
 

--- a/Source/JavaScriptCore/runtime/MapPrototype.h
+++ b/Source/JavaScriptCore/runtime/MapPrototype.h
@@ -61,4 +61,6 @@ private:
     void finishCreation(VM&, JSGlobalObject*);
 };
 
+JSC_DECLARE_HOST_FUNCTION(mapProtoFuncEntries);
+
 } // namespace JSC

--- a/Source/JavaScriptCore/runtime/SetPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/SetPrototype.cpp
@@ -45,7 +45,7 @@ static JSC_DECLARE_HOST_FUNCTION(setProtoFuncAdd);
 static JSC_DECLARE_HOST_FUNCTION(setProtoFuncClear);
 static JSC_DECLARE_HOST_FUNCTION(setProtoFuncDelete);
 static JSC_DECLARE_HOST_FUNCTION(setProtoFuncHas);
-static JSC_DECLARE_HOST_FUNCTION(setProtoFuncValues);
+JSC_DECLARE_HOST_FUNCTION(setProtoFuncValues);
 static JSC_DECLARE_HOST_FUNCTION(setProtoFuncEntries);
 static JSC_DECLARE_HOST_FUNCTION(setProtoFuncIntersection);
 static JSC_DECLARE_HOST_FUNCTION(setProtoFuncUnion);
@@ -86,7 +86,7 @@ void SetPrototype::finishCreation(VM& vm, JSGlobalObject* globalObject)
     putDirectWithoutTransition(vm, vm.propertyNames->has, hasFunc, static_cast<unsigned>(PropertyAttribute::DontEnum));
     putDirectWithoutTransition(vm, vm.propertyNames->builtinNames().hasPrivateName(), hasFunc, static_cast<unsigned>(PropertyAttribute::DontEnum));
 
-    JSFunction* values = JSFunction::create(vm, globalObject, 0, vm.propertyNames->builtinNames().valuesPublicName().string(), setProtoFuncValues, ImplementationVisibility::Public, JSSetValuesIntrinsic);
+    JSFunction* values = globalObject->setProtoValuesFunction();
     putDirectWithoutTransition(vm, vm.propertyNames->builtinNames().keysPublicName(), values, static_cast<unsigned>(PropertyAttribute::DontEnum));
     putDirectWithoutTransition(vm, vm.propertyNames->builtinNames().keysPrivateName(), values, static_cast<unsigned>(PropertyAttribute::DontEnum));
 

--- a/Source/JavaScriptCore/runtime/SetPrototype.h
+++ b/Source/JavaScriptCore/runtime/SetPrototype.h
@@ -61,4 +61,6 @@ private:
     void finishCreation(VM&, JSGlobalObject*);
 };
 
+JSC_DECLARE_HOST_FUNCTION(setProtoFuncValues);
+
 } // namespace JSC


### PR DESCRIPTION
#### 433704897995ae4b38b732d225c0e2f2eaf4f73c
<pre>
[JSC] Add Map / Set fast iteration
<a href="https://bugs.webkit.org/show_bug.cgi?id=313340">https://bugs.webkit.org/show_bug.cgi?id=313340</a>
<a href="https://rdar.apple.com/175613242">rdar://175613242</a>

Reviewed by Yijia Huang.

Previously our iterator_open / iterator_next supports JSArray. This
patch extends this fast iteration protocol to JSMap and JSSet.

1. LLInt / Baseline JIT should just simply add JSMap and JSMapIterator
   / JSSet and JSSetIterator iteration code. We extend IterationMode to
   have FastMap and FastSet. We also make constructArrayPair always
   using Contiguous (or Slow ArrayStorage when have-a-bad-time happens)
   to avoid frequent speculation failures when we inline them in DFG / FTL.
2. In DFG ByteCodeParser, we support JSMap / JSSet in iterator_open /
   iterator_next DFG nodes emission. One of the most subtle thing is OSR
   exit: MapIteratorNext changes the iterator, so after that, we cannot
   do OSR exit except for throwing an error, otherwise, OSR exit will
   advance the iterator again. We carefully emit DFG nodes which never
   does normal OSR exits, so this is fine.

                                         ToT                     Patched

    for-of-map-entries-small        7.3828+-0.1328     ^      6.4153+-0.1580        ^ definitely 1.1508x faster
    set-for-of                      1.3589+-0.0724     ^      0.6633+-0.0403        ^ definitely 2.0486x faster
    for-of-set-values               2.4183+-0.0569     ^      1.7421+-0.1980        ^ definitely 1.3881x faster
    for-of-map-entries              6.9321+-0.1456     ^      5.7206+-0.1448        ^ definitely 1.2118x faster
    map-for-of                      1.8342+-0.0780     ^      1.1539+-0.0725        ^ definitely 1.5896x faster
    for-of-set-values-small         2.5314+-0.0253     ^      1.9055+-0.0841        ^ definitely 1.3285x faster

Tests: JSTests/microbenchmarks/for-of-map-entries-small.js
       JSTests/microbenchmarks/for-of-map-entries.js
       JSTests/microbenchmarks/for-of-set-values-small.js
       JSTests/microbenchmarks/for-of-set-values.js
       JSTests/stress/iterator-dfg-fast-path-bad-time.js
       JSTests/stress/iterator-dfg-fast-path-mixed-modes.js
       JSTests/stress/iterator-dfg-fast-path-no-generic.js

* JSTests/microbenchmarks/for-of-map-entries-small.js: Added.
(test):
* JSTests/microbenchmarks/for-of-map-entries.js: Added.
(test):
* JSTests/microbenchmarks/for-of-set-values-small.js: Added.
* JSTests/microbenchmarks/for-of-set-values.js: Added.
* JSTests/stress/iterator-dfg-fast-path-bad-time.js: Added.
(shouldBe):
(sumMapEntries):
(sumSetValues):
(set add):
(set Object):
(set get for):
* JSTests/stress/iterator-dfg-fast-path-mixed-modes.js: Added.
(shouldBe):
(sumIterable):
(makeGeneric):
* JSTests/stress/iterator-dfg-fast-path-no-generic.js: Added.
(shouldBe):
(sumAny):
(runArrayMap):
(runArraySet.sumArrOrSet):
(runArraySet):
(runAllFastNoGeneric):
* Source/JavaScriptCore/builtins/MapIteratorPrototype.js:
(next):
* Source/JavaScriptCore/builtins/SetIteratorPrototype.js:
(next):
* Source/JavaScriptCore/bytecode/IterationModeMetadata.h:
* Source/JavaScriptCore/dfg/DFGByteCodeParser.cpp:
(JSC::DFG::ByteCodeParser::parseBlock):
(JSC::DFG::ByteCodeParser::handleIteratorOpen):
(JSC::DFG::ByteCodeParser::handleIteratorNext):
* Source/JavaScriptCore/dfg/DFGMayExit.cpp:
* Source/JavaScriptCore/jit/JITOperations.cpp:
(JSC::JSC_DEFINE_JIT_OPERATION):
* Source/JavaScriptCore/jit/JITOperations.h:
* Source/JavaScriptCore/runtime/CommonSlowPaths.cpp:
(JSC::iteratorOpenTryFastImpl):
(JSC::iteratorNextTryFastImpl):
* Source/JavaScriptCore/runtime/IteratorOperations.cpp:
(JSC::getIterationMode):
* Source/JavaScriptCore/runtime/JSArray.cpp:
(JSC::constructArrayPair):
* Source/JavaScriptCore/runtime/JSGlobalObject.cpp:
(JSC::JSGlobalObject::init):
(JSC::JSGlobalObject::visitChildrenImpl):
* Source/JavaScriptCore/runtime/JSGlobalObject.h:
* Source/JavaScriptCore/runtime/MapPrototype.cpp:
(JSC::MapPrototype::finishCreation):
* Source/JavaScriptCore/runtime/MapPrototype.h:
* Source/JavaScriptCore/runtime/SetPrototype.cpp:
(JSC::SetPrototype::finishCreation):
* Source/JavaScriptCore/runtime/SetPrototype.h:

Canonical link: <a href="https://commits.webkit.org/312127@main">https://commits.webkit.org/312127@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a4269d5138608959d55606d55abb7b8affc88b0b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/158796 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/32222 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/25328 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/167625 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/112880 "Built successfully") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/32289 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/32210 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/123030 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/86357 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/161753 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/25292 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/142656 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/103699 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/24348 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/22748 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/15397 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/150880 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/134034 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/20436 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/170117 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/19629 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/15860 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/22062 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/131216 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/31912 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/26814 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/131330 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/31857 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/142229 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/89840 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/24195 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/26027 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/19038 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/191077 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/31368 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/97382 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/49125 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/30888 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/31161 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/31042 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->