### PR TITLE
[Site Isolation] editing/execCommand/delete-no-scroll.html fails

### DIFF
--- a/LayoutTests/editing/execCommand/delete-no-scroll-expected.txt
+++ b/LayoutTests/editing/execCommand/delete-no-scroll-expected.txt
@@ -1,3 +1,4 @@
+ALERT: SUCCESS
 Matching IE, execCommand("Delete") should not scroll the page to make selection visible.
 
 a

--- a/LayoutTests/editing/execCommand/delete-no-scroll.html
+++ b/LayoutTests/editing/execCommand/delete-no-scroll.html
@@ -25,10 +25,8 @@
     document.execCommand("Delete");
 
     var result = (document.scrollingElement.scrollTop == 1000) ? "SUCCESS" : "FAILURE";
-    if (window.testRunner) {
+    alert(result);
+    if (window.testRunner)
       testRunner.notifyDone();
-      document.write(result);
-    } else
-      alert(result);
   }
 </script>


### PR DESCRIPTION
#### 64a80d85a39351213591619886c75e6debe4f03f
<pre>
[Site Isolation] editing/execCommand/delete-no-scroll.html fails
<a href="https://bugs.webkit.org/show_bug.cgi?id=313341">https://bugs.webkit.org/show_bug.cgi?id=313341</a>

Reviewed by Anne van Kesteren.

The failure is caused by document.write after testRunner.notifyDone having an effect
only under site isolation since testRunner.notifyDone is now asynchronous.

It&apos;s arguably bug that the test doesn&apos;t tell us whether it had passed or not.
Fixed the test by always running alert and avoid calling document.write after calling
testRunner.notifyDone.

* LayoutTests/editing/execCommand/delete-no-scroll-expected.txt:
* LayoutTests/editing/execCommand/delete-no-scroll.html:

Canonical link: <a href="https://commits.webkit.org/312047@main">https://commits.webkit.org/312047@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/376d192010e18d94b909f88a0f803e5bdda54d91

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/158784 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/32210 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/25316 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/167613 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/112868 "Built successfully") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/32277 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/32198 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/123015 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/86346 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/161741 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/25280 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/142643 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/103684 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/24336 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/22735 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/15385 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/134022 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/20423 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/170105 "Built successfully") | | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/22049 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/131201 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/31900 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/26801 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/131315 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/31845 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/142216 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/89821 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/24143 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/26013 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/19025 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/31356 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/30876 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/31149 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/31030 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->