### PR TITLE
[Site Isolation] animations/animation-multiple-callbacks-timestamp.html fails

### DIFF
--- a/LayoutTests/animations/animation-multiple-callbacks-timestamp.html
+++ b/LayoutTests/animations/animation-multiple-callbacks-timestamp.html
@@ -9,10 +9,12 @@
         var timestamp2 = 0;
         var currentFrame = 0;
         const MaxFrames = 10;
+        var didFinishTest = false;
 
         function doAnimation1(timestamp)
         {
             if (++currentFrame > MaxFrames) {
+                didFinishTest = true;
                 finishJSTest();
                 return;
             }
@@ -24,6 +26,9 @@
 
         function doAnimation2(timestamp)
         {
+            if (didFinishTest)
+                return;
+
             timestamp2 = timestamp;
             shouldBe("Math.round(timestamp1)", "Math.round(timestamp2)");
         }

--- a/LayoutTests/platform/ios-site-isolation/TestExpectations
+++ b/LayoutTests/platform/ios-site-isolation/TestExpectations
@@ -105,7 +105,6 @@ webrtc/peerconnection-page-cache.html [ Timeout ]
 # Tests that Text fail #
 ########################
 accessibility/link-becomes-visited.html [ Failure ]
-animations/animation-multiple-callbacks-timestamp.html [ Failure ]
 editing/execCommand/delete-no-scroll.html [ Failure ]
 editing/inserting/insert-list-then-edit-command-crash.html [ Failure ]
 editing/pasteboard/copy-text-from-uneditable-element.html [ Failure ]

--- a/LayoutTests/platform/mac-site-isolation/TestExpectations
+++ b/LayoutTests/platform/mac-site-isolation/TestExpectations
@@ -124,7 +124,6 @@ webrtc/peerconnection-page-cache.html [ Timeout ]
 # Tests that Text fail #
 ########################
 accessibility/youtube-embed-accessibility-hierarchy.html [ Failure Timeout ]
-animations/animation-multiple-callbacks-timestamp.html [ Failure ]
 editing/execCommand/delete-no-scroll.html [ Failure ]
 editing/inserting/insert-list-then-edit-command-crash.html [ Failure ]
 editing/pasteboard/copy-text-from-uneditable-element.html [ Failure ]


### PR DESCRIPTION
#### b6083e910e96b8bcb2ad1ce2571bff42dc55ff5f
<pre>
[Site Isolation] animations/animation-multiple-callbacks-timestamp.html fails
<a href="https://bugs.webkit.org/show_bug.cgi?id=313344">https://bugs.webkit.org/show_bug.cgi?id=313344</a>

Reviewed by Anne van Kesteren.

The test failure is caused by requestAnimationFrame callback getting called after
finishJSTest since testRunner.notifyDone is asynchronous under site isolation.

Fixed the test by adding an early exit in the requestAnimationFrame callback when
the test had logically finished.

* LayoutTests/animations/animation-multiple-callbacks-timestamp.html:
* LayoutTests/platform/ios-site-isolation/TestExpectations:
* LayoutTests/platform/mac-site-isolation/TestExpectations:

Canonical link: <a href="https://commits.webkit.org/312048@main">https://commits.webkit.org/312048@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f5cd071af05436d47e1a75d039cac1669e0c1a48

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/158789 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/32215 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/25321 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/167618 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/112873 "Built successfully") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/32282 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/32203 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/123022 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/86349 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/161746 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/25284 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/142648 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/103691 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/24340 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/22741 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/15390 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/134026 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/20428 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/170110 "Built successfully") | | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/22054 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/131208 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/31905 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/26807 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/131322 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/31850 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/142221 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/89828 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/24144 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/26019 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/19030 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/31361 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/30881 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/31154 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/31035 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->