### PR TITLE
[GLIB] Fix flaky test fast/repaint/backgroundSizeRepaint.html

### DIFF
--- a/LayoutTests/fast/repaint/backgroundSizeRepaint.html
+++ b/LayoutTests/fast/repaint/backgroundSizeRepaint.html
@@ -6,18 +6,21 @@
     div.test { width: 200px; height: 120px; border: 1px solid blue; padding: 10px; }
 </style>
     <script type="text/javascript">
-        if (window.testRunner)
+        window.addEventListener('load', async () => {
+            if (!window.testRunner)
+                return;
             testRunner.waitUntilDone();
-        function runTest()
-        {
-           document.getElementById('a').style.height = '40px';
-           document.getElementById('b').style.height = '60px';
-            if (window.testRunner)
-                testRunner.notifyDone();
-        }
+
+            document.getElementById('a').style.height = '40px';
+            document.getElementById('b').style.height = '60px';
+
+            await new Promise(requestAnimationFrame);
+
+            testRunner.notifyDone();
+        });
     </script>
 </head>
-<body onload="setTimeout(runTest, 10)">
+<body>
 <p><b>BUG ID:</b> <a href="https://bugs.webkit.org/show_bug.cgi?id=8467">Bugzilla bug 8467</a> Block with percentage background-size doesn't repaint properly when it grows</p>
 
 <p id="success" style="background-color:palegreen; padding:3px;"><b>TEST PASS:</b> 

--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -2331,8 +2331,6 @@ fast/mediastream/multi-microphone.html [ Skip ]
 
 fast/mediastream/getUserMedia-and-getVideoPlaybackQuality.html [ Skip ]
 
-webkit.org/b/208182 fast/repaint/backgroundSizeRepaint.html [ ImageOnlyFailure Pass ]
-
 #////////////////////////////////////////////////////////////////////////////////////////
 # End of Skia-related bugs
 #////////////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
#### a776836d2d8d33a2a305b0bfd09c47dd58ec8a1c
<pre>
[GLIB] Fix flaky test fast/repaint/backgroundSizeRepaint.html
<a href="https://bugs.webkit.org/show_bug.cgi?id=208182">https://bugs.webkit.org/show_bug.cgi?id=208182</a>

Reviewed by Fujii Hironori.

This test was flaky on platforms WebKitGTK and WPEWebKit.

Replace &apos;setTimeout&apos; call of 10ms delay for an async function that calls
&apos;requestAnimationFrame&apos; once the height of the targeted div elements is
adjusted.

* LayoutTests/fast/repaint/backgroundSizeRepaint.html:
* LayoutTests/platform/glib/TestExpectations:

Canonical link: <a href="https://commits.webkit.org/312038@main">https://commits.webkit.org/312038@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0cefe46a215893683e487c82d011a2beb411501b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/158799 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/32225 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/25331 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/167628 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/112883 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/32292 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/32213 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/123032 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/86359 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/161756 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/25294 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/142659 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/103701 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/24350 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/22751 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/15400 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/134036 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/20439 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/170120 "Built successfully") | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/22065 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/131218 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/31915 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/26817 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/131332 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/31860 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/142232 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/89843 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/24137 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/26029 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/19041 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/31371 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/30891 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/31164 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/31045 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->