### PR TITLE
Fix FileSystemDirectoryHandle's resolve()

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/fs/FileSystemDirectoryHandle-resolve.https.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/fs/FileSystemDirectoryHandle-resolve.https.any-expected.txt
@@ -2,5 +2,6 @@
 PASS Resolve returns empty array for same directory
 PASS Resolve returns correct path
 PASS Resolve returns correct path with non-ascii characters
-FAIL Resolve returns null when entry is not a child assert_equals: expected null but got []
+PASS Resolve returns null when entry is not a child
+PASS Resolve returns null when sibling directory name is a prefix
 

--- a/LayoutTests/imported/w3c/web-platform-tests/fs/FileSystemDirectoryHandle-resolve.https.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/fs/FileSystemDirectoryHandle-resolve.https.any.worker-expected.txt
@@ -2,5 +2,6 @@
 PASS Resolve returns empty array for same directory
 PASS Resolve returns correct path
 PASS Resolve returns correct path with non-ascii characters
-FAIL Resolve returns null when entry is not a child assert_equals: expected null but got []
+PASS Resolve returns null when entry is not a child
+PASS Resolve returns null when sibling directory name is a prefix
 

--- a/LayoutTests/imported/w3c/web-platform-tests/fs/script-tests/FileSystemDirectoryHandle-resolve.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/fs/script-tests/FileSystemDirectoryHandle-resolve.js
@@ -25,3 +25,11 @@ directory_test(async (t, root_dir) => {
 
   assert_equals(await subdir.resolve(file), null);
 }, 'Resolve returns null when entry is not a child');
+
+directory_test(async (t, root_dir) => {
+  const subdir = await createDirectory('sub', root_dir);
+  const subdir2 = await createDirectory('subdir', root_dir);
+  const file = await createEmptyFile('file-name', subdir2);
+
+  assert_equals(await subdir.resolve(file), null);
+}, 'Resolve returns null when sibling directory name is a prefix');

--- a/Source/WebCore/Modules/filesystem/FileSystemDirectoryHandle.cpp
+++ b/Source/WebCore/Modules/filesystem/FileSystemDirectoryHandle.cpp
@@ -30,6 +30,7 @@
 #include "FileSystemHandleCloseScope.h"
 #include "FileSystemStorageConnection.h"
 #include "JSDOMConvertInterface.h"
+#include "JSDOMConvertNullable.h"
 #include "JSDOMConvertSequences.h"
 #include "JSDOMConvertStrings.h"
 #include "JSDOMPromiseDeferred.h"
@@ -101,7 +102,7 @@ void FileSystemDirectoryHandle::removeEntry(const String& name, const FileSystem
     });
 }
 
-void FileSystemDirectoryHandle::resolve(const FileSystemHandle& handle, DOMPromiseDeferred<IDLSequence<IDLUSVString>>&& promise)
+void FileSystemDirectoryHandle::resolve(const FileSystemHandle& handle, DOMPromiseDeferred<IDLNullable<IDLSequence<IDLUSVString>>>&& promise)
 {
     if (isClosed())
         return promise.reject(Exception { ExceptionCode::InvalidStateError, "Handle is closed"_s });

--- a/Source/WebCore/Modules/filesystem/FileSystemDirectoryHandle.h
+++ b/Source/WebCore/Modules/filesystem/FileSystemDirectoryHandle.h
@@ -51,7 +51,7 @@ public:
     void getFileHandle(const String& name, const GetFileOptions&, DOMPromiseDeferred<IDLInterface<FileSystemFileHandle>>&&);
     void getDirectoryHandle(const String& name, const GetDirectoryOptions&, DOMPromiseDeferred<IDLInterface<FileSystemDirectoryHandle>>&&);
     void removeEntry(const String& name, const RemoveOptions&, DOMPromiseDeferred<void>&&);
-    void resolve(const FileSystemHandle&, DOMPromiseDeferred<IDLSequence<IDLUSVString>>&&);
+    void resolve(const FileSystemHandle&, DOMPromiseDeferred<IDLNullable<IDLSequence<IDLUSVString>>>&&);
 
     void getHandleNames(CompletionHandler<void(ExceptionOr<Vector<String>>&&)>&&);
     void getHandle(const String& name, CompletionHandler<void(ExceptionOr<Ref<FileSystemHandle>>&&)>&&);

--- a/Source/WebCore/Modules/filesystem/FileSystemStorageConnection.h
+++ b/Source/WebCore/Modules/filesystem/FileSystemStorageConnection.h
@@ -52,7 +52,7 @@ public:
 
     using SameEntryCallback = CompletionHandler<void(ExceptionOr<bool>&&)>;
     using GetHandleCallback = CompletionHandler<void(ExceptionOr<Ref<FileSystemHandleCloseScope>>&&)>;
-    using ResolveCallback = CompletionHandler<void(ExceptionOr<Vector<String>>&&)>;
+    using ResolveCallback = CompletionHandler<void(ExceptionOr<std::optional<Vector<String>>>&&)>;
     struct SyncAccessHandleInfo {
         FileSystemSyncAccessHandleIdentifier identifier;
         FileSystem::FileHandle file;

--- a/Source/WebCore/Modules/filesystem/WorkerFileSystemStorageConnection.cpp
+++ b/Source/WebCore/Modules/filesystem/WorkerFileSystemStorageConnection.cpp
@@ -215,7 +215,7 @@ void WorkerFileSystemStorageConnection::resolve(FileSystemHandleIdentifier ident
     });
 }
 
-void WorkerFileSystemStorageConnection::didResolve(CallbackIdentifier callbackIdentifier, ExceptionOr<Vector<String>>&& result)
+void WorkerFileSystemStorageConnection::didResolve(CallbackIdentifier callbackIdentifier, ExceptionOr<std::optional<Vector<String>>>&& result)
 {
     if (auto callback = m_resolveCallbacks.take(callbackIdentifier))
         callback(WTF::move(result));

--- a/Source/WebCore/Modules/filesystem/WorkerFileSystemStorageConnection.h
+++ b/Source/WebCore/Modules/filesystem/WorkerFileSystemStorageConnection.h
@@ -52,7 +52,7 @@ public:
     using CallbackIdentifier = WorkerFileSystemStorageConnectionCallbackIdentifier;
     void didIsSameEntry(CallbackIdentifier, ExceptionOr<bool>&&);
     void didGetHandle(CallbackIdentifier, ExceptionOr<Ref<FileSystemHandleCloseScope>>&&);
-    void didResolve(CallbackIdentifier, ExceptionOr<Vector<String>>&&);
+    void didResolve(CallbackIdentifier, ExceptionOr<std::optional<Vector<String>>>&&);
     void completeStringCallback(CallbackIdentifier, ExceptionOr<String>&&);
     void didCreateSyncAccessHandle(CallbackIdentifier, ExceptionOr<FileSystemStorageConnection::SyncAccessHandleInfo>&&);
     void completeVoidCallback(CallbackIdentifier, ExceptionOr<void>&& result);

--- a/Source/WebKit/NetworkProcess/storage/FileSystemStorageHandle.cpp
+++ b/Source/WebKit/NetworkProcess/storage/FileSystemStorageHandle.cpp
@@ -179,7 +179,7 @@ std::optional<FileSystemStorageError> FileSystemStorageHandle::removeEntry(const
     return result;
 }
 
-Expected<Vector<String>, FileSystemStorageError> FileSystemStorageHandle::resolve(WebCore::FileSystemHandleIdentifier identifier)
+Expected<std::optional<Vector<String>>, FileSystemStorageError> FileSystemStorageHandle::resolve(WebCore::FileSystemHandleIdentifier identifier)
 {
     RefPtr manager = m_manager.get();
     if (!manager)
@@ -190,10 +190,13 @@ Expected<Vector<String>, FileSystemStorageError> FileSystemStorageHandle::resolv
         return makeUnexpected(FileSystemStorageError::Unknown);
 
     if (!path.startsWith(m_path))
-        return Vector<String> { };
+        return { std::nullopt };
 
     auto restPath = path.substring(m_path.length());
-    return restPath.split(pathSeparator);
+    if (!restPath.isEmpty() && !restPath.startsWith(pathSeparator))
+        return { std::nullopt };
+
+    return { restPath.split(pathSeparator) };
 }
 
 Expected<FileSystemSyncAccessHandleInfo, FileSystemStorageError> FileSystemStorageHandle::createSyncAccessHandle()

--- a/Source/WebKit/NetworkProcess/storage/FileSystemStorageHandle.h
+++ b/Source/WebKit/NetworkProcess/storage/FileSystemStorageHandle.h
@@ -66,7 +66,7 @@ public:
     Expected<WebCore::FileSystemHandleIdentifier, FileSystemStorageError> getFileHandle(IPC::Connection::UniqueID, String&& name, bool createIfNecessary);
     Expected<WebCore::FileSystemHandleIdentifier, FileSystemStorageError> getDirectoryHandle(IPC::Connection::UniqueID, String&& name, bool createIfNecessary);
     std::optional<FileSystemStorageError> removeEntry(const String& name, bool deleteRecursively);
-    Expected<Vector<String>, FileSystemStorageError> resolve(WebCore::FileSystemHandleIdentifier);
+    Expected<std::optional<Vector<String>>, FileSystemStorageError> resolve(WebCore::FileSystemHandleIdentifier);
     Expected<Vector<String>, FileSystemStorageError> getHandleNames();
     Expected<std::pair<WebCore::FileSystemHandleIdentifier, bool>, FileSystemStorageError> getHandle(IPC::Connection::UniqueID, String&& name);
     void requestNewCapacityForSyncAccessHandle(WebCore::FileSystemSyncAccessHandleIdentifier, uint64_t newCapacity, CompletionHandler<void(std::optional<uint64_t>)>&&);

--- a/Source/WebKit/NetworkProcess/storage/NetworkStorageManager.cpp
+++ b/Source/WebKit/NetworkProcess/storage/NetworkStorageManager.cpp
@@ -981,7 +981,7 @@ void NetworkStorageManager::removeEntry(WebCore::FileSystemHandleIdentifier iden
     completionHandler(handle->removeEntry(name, deleteRecursively));
 }
 
-void NetworkStorageManager::resolve(WebCore::FileSystemHandleIdentifier identifier, WebCore::FileSystemHandleIdentifier targetIdentifier, CompletionHandler<void(Expected<Vector<String>, FileSystemStorageError>)>&& completionHandler)
+void NetworkStorageManager::resolve(WebCore::FileSystemHandleIdentifier identifier, WebCore::FileSystemHandleIdentifier targetIdentifier, CompletionHandler<void(Expected<std::optional<Vector<String>>, FileSystemStorageError>)>&& completionHandler)
 {
     ASSERT(!RunLoop::isMain());
 

--- a/Source/WebKit/NetworkProcess/storage/NetworkStorageManager.h
+++ b/Source/WebKit/NetworkProcess/storage/NetworkStorageManager.h
@@ -198,7 +198,7 @@ private:
     void getFileHandle(IPC::Connection&, WebCore::FileSystemHandleIdentifier, String&& name, bool createIfNecessary, CompletionHandler<void(Expected<WebCore::FileSystemHandleIdentifier, FileSystemStorageError>)>&&);
     void getDirectoryHandle(IPC::Connection&, WebCore::FileSystemHandleIdentifier, String&& name, bool createIfNecessary, CompletionHandler<void(Expected<WebCore::FileSystemHandleIdentifier, FileSystemStorageError>)>&&);
     void removeEntry(WebCore::FileSystemHandleIdentifier, const String& name, bool deleteRecursively, CompletionHandler<void(std::optional<FileSystemStorageError>)>&&);
-    void resolve(WebCore::FileSystemHandleIdentifier, WebCore::FileSystemHandleIdentifier, CompletionHandler<void(Expected<Vector<String>, FileSystemStorageError>)>&&);
+    void resolve(WebCore::FileSystemHandleIdentifier, WebCore::FileSystemHandleIdentifier, CompletionHandler<void(Expected<std::optional<Vector<String>>, FileSystemStorageError>)>&&);
     void getFile(WebCore::FileSystemHandleIdentifier, CompletionHandler<void(Expected<String, FileSystemStorageError>)>&&);
     void createSyncAccessHandle(WebCore::FileSystemHandleIdentifier, CompletionHandler<void(Expected<FileSystemSyncAccessHandleInfo, FileSystemStorageError>)>&&);
     void closeSyncAccessHandle(WebCore::FileSystemHandleIdentifier, WebCore::FileSystemSyncAccessHandleIdentifier, CompletionHandler<void()>&&);

--- a/Source/WebKit/NetworkProcess/storage/NetworkStorageManager.messages.in
+++ b/Source/WebKit/NetworkProcess/storage/NetworkStorageManager.messages.in
@@ -39,7 +39,7 @@
     [EnabledBy=FileSystemEnabled] GetFileHandle(WebCore::FileSystemHandleIdentifier identifier, String name, bool createIfNecessary) -> (Expected<WebCore::FileSystemHandleIdentifier, WebKit::FileSystemStorageError> result)
     [EnabledBy=FileSystemEnabled] GetDirectoryHandle(WebCore::FileSystemHandleIdentifier identifier, String name, bool createIfNecessary) -> (Expected<WebCore::FileSystemHandleIdentifier, WebKit::FileSystemStorageError> result)
     [EnabledBy=FileSystemEnabled] RemoveEntry(WebCore::FileSystemHandleIdentifier identifier, String name, bool deleteRecursively) -> (std::optional<WebKit::FileSystemStorageError> result)
-    [EnabledBy=FileSystemEnabled] Resolve(WebCore::FileSystemHandleIdentifier identifier, WebCore::FileSystemHandleIdentifier targetIdentifier) -> (Expected<Vector<String>, WebKit::FileSystemStorageError> result)
+    [EnabledBy=FileSystemEnabled] Resolve(WebCore::FileSystemHandleIdentifier identifier, WebCore::FileSystemHandleIdentifier targetIdentifier) -> (Expected<std::optional<Vector<String>>, WebKit::FileSystemStorageError> result)
     [EnabledBy=FileSystemEnabled] Move(WebCore::FileSystemHandleIdentifier identifier, WebCore::FileSystemHandleIdentifier destinationIdentifier, String newName) -> (std::optional<WebKit::FileSystemStorageError> result)
     [EnabledBy=FileSystemEnabled] GetFile(WebCore::FileSystemHandleIdentifier identifier) -> (Expected<String, WebKit::FileSystemStorageError> result)
     [EnabledBy=FileSystemEnabled] CreateSyncAccessHandle(WebCore::FileSystemHandleIdentifier identifier) -> (Expected<WebKit::FileSystemSyncAccessHandleInfo, WebKit::FileSystemStorageError> result)


### PR DESCRIPTION
#### 0f86f542d97c317ab548ed2e39851277c592d8d3
<pre>
Fix FileSystemDirectoryHandle&apos;s resolve()
<a href="https://bugs.webkit.org/show_bug.cgi?id=313348">https://bugs.webkit.org/show_bug.cgi?id=313348</a>

Reviewed by Chris Dumez.

resolve() needs to return null when its argument is not a descendant of
this. When fixing this I noticed there was also a bug with sibling
directories. An additional WPT test is added for that and upstreamed
here:

    <a href="https://github.com/web-platform-tests/wpt/pull/59479">https://github.com/web-platform-tests/wpt/pull/59479</a>

Canonical link: <a href="https://commits.webkit.org/312061@main">https://commits.webkit.org/312061@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c5e6ff00120e40316bf558be86b34acbce0c93ac

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/158812 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/32238 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/25344 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/167641 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/112896 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/2bc94a64-9df5-461d-b68a-cf62dd2067b6) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/160681 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/32305 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/32226 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/123041 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/86371 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/2b3e5280-18e8-4bea-af6f-fe8e16bb15b7) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/161769 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/25308 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/142671 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/103710 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/99f6a1cc-c526-475a-a41e-5a3902af4984) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/24364 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/22764 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/15413 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/134050 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/20451 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/170133 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/15876 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/22077 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/131228 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/31928 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/26830 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/131342 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/31873 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/142244 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/89861 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/24155 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/26041 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/19053 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/31384 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/97398 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/30904 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/31177 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/31058 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->