### PR TITLE
Fix FileSystemDirectoryHandle's removeEntry()

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/fs/FileSystemDirectoryHandle-getDirectoryHandle.https.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/fs/FileSystemDirectoryHandle-getDirectoryHandle.https.any-expected.txt
@@ -7,8 +7,6 @@ PASS getDirectoryHandle() when a file already exists with the same name
 PASS getDirectoryHandle() with empty name
 PASS getDirectoryHandle() with "." name
 PASS getDirectoryHandle() with ".." name
-FAIL getDirectoryHandle(create=false) with a path separator when the directory exists promise_rejects_js: getDirectoryHandle() must reject names containing "\" function "function() { throw e; }" threw object "NotFoundError: The object can not be found here." ("NotFoundError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL getDirectoryHandle(create=true) with a path separator assert_unreached: Should have rejected: getDirectoryHandle(true) must reject names containing "\" Reached unreachable code
+PASS getDirectoryHandle(create=false) with a path separator when the directory exists
+PASS getDirectoryHandle(create=true) with a path separator
 

--- a/LayoutTests/imported/w3c/web-platform-tests/fs/FileSystemDirectoryHandle-getDirectoryHandle.https.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/fs/FileSystemDirectoryHandle-getDirectoryHandle.https.any.worker-expected.txt
@@ -7,8 +7,6 @@ PASS getDirectoryHandle() when a file already exists with the same name
 PASS getDirectoryHandle() with empty name
 PASS getDirectoryHandle() with "." name
 PASS getDirectoryHandle() with ".." name
-FAIL getDirectoryHandle(create=false) with a path separator when the directory exists promise_rejects_js: getDirectoryHandle() must reject names containing "\" function "function() { throw e; }" threw object "NotFoundError: The object can not be found here." ("NotFoundError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL getDirectoryHandle(create=true) with a path separator assert_unreached: Should have rejected: getDirectoryHandle(true) must reject names containing "\" Reached unreachable code
+PASS getDirectoryHandle(create=false) with a path separator when the directory exists
+PASS getDirectoryHandle(create=true) with a path separator
 

--- a/LayoutTests/imported/w3c/web-platform-tests/fs/FileSystemDirectoryHandle-getFileHandle.https.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/fs/FileSystemDirectoryHandle-getFileHandle.https.any-expected.txt
@@ -10,8 +10,6 @@ PASS getFileHandle(create=true) when a directory already exists with the same na
 PASS getFileHandle() with empty name
 PASS getFileHandle() with "." name
 PASS getFileHandle() with ".." name
-FAIL getFileHandle(create=false) with a path separator when the file exists. promise_rejects_js: getFileHandle() must reject names containing "\" function "function() { throw e; }" threw object "NotFoundError: The object can not be found here." ("NotFoundError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL getFileHandle(create=true) with a path separator assert_unreached: Should have rejected: getFileHandle(create=true) must reject names containing "\" Reached unreachable code
+PASS getFileHandle(create=false) with a path separator when the file exists.
+PASS getFileHandle(create=true) with a path separator
 

--- a/LayoutTests/imported/w3c/web-platform-tests/fs/FileSystemDirectoryHandle-getFileHandle.https.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/fs/FileSystemDirectoryHandle-getFileHandle.https.any.worker-expected.txt
@@ -10,8 +10,6 @@ PASS getFileHandle(create=true) when a directory already exists with the same na
 PASS getFileHandle() with empty name
 PASS getFileHandle() with "." name
 PASS getFileHandle() with ".." name
-FAIL getFileHandle(create=false) with a path separator when the file exists. promise_rejects_js: getFileHandle() must reject names containing "\" function "function() { throw e; }" threw object "NotFoundError: The object can not be found here." ("NotFoundError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL getFileHandle(create=true) with a path separator assert_unreached: Should have rejected: getFileHandle(create=true) must reject names containing "\" Reached unreachable code
+PASS getFileHandle(create=false) with a path separator when the file exists.
+PASS getFileHandle(create=true) with a path separator
 

--- a/LayoutTests/imported/w3c/web-platform-tests/fs/FileSystemDirectoryHandle-removeEntry.https.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/fs/FileSystemDirectoryHandle-removeEntry.https.any-expected.txt
@@ -1,17 +1,15 @@
 
-FAIL removeEntry() to remove a file promise_rejects_dom: function "function() { throw e; }" threw object "TypeError: Blob loading failed" that is not a DOMException NotFoundError: property "code" is equal to undefined, expected 8
+PASS removeEntry() to remove a file
 PASS removeEntry() on an already removed file should fail
 PASS removeEntry() to remove an empty directory
-FAIL removeEntry() on a non-empty directory should fail promise_rejects_dom: function "function() { throw e; }" threw object "UnknownError: The operation failed for an unknown transient reason (e.g. out of memory)." that is not a DOMException InvalidModificationError: property "code" is equal to 0, expected 13
+PASS removeEntry() on a non-empty directory should fail
 PASS removeEntry() on a directory recursively should delete all sub-items
 PASS removeEntry() with empty name should fail
 PASS removeEntry() with "." name should fail
 PASS removeEntry() with ".." name should fail
-FAIL removeEntry() with a path separator should fail. promise_rejects_js: removeEntry() must reject names containing "\" function "function() { throw e; }" threw object "NotFoundError: The object can not be found here." ("NotFoundError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL removeEntry() while the file has an open writable fails assert_unreached: Should have rejected: undefined Reached unreachable code
-FAIL removeEntry() of a directory while a containing file has an open writable fails promise_rejects_dom: function "function() { throw e; }" threw object "UnknownError: The operation failed for an unknown transient reason (e.g. out of memory)." that is not a DOMException NoModificationAllowedError: property "code" is equal to 0, expected 7
+PASS removeEntry() with a path separator should fail.
+PASS removeEntry() while the file has an open writable fails
+PASS removeEntry() of a directory while a containing file has an open writable fails
 PASS createWritable after removeEntry succeeds but doesnt recreate the file
 PASS removeEntry() on a non-existent directory recursively should throw NotFoundError
 

--- a/LayoutTests/imported/w3c/web-platform-tests/fs/FileSystemDirectoryHandle-removeEntry.https.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/fs/FileSystemDirectoryHandle-removeEntry.https.any.worker-expected.txt
@@ -1,17 +1,15 @@
 
-FAIL removeEntry() to remove a file promise_rejects_dom: function "function() { throw e; }" threw object "TypeError: Blob loading failed" that is not a DOMException NotFoundError: property "code" is equal to undefined, expected 8
+PASS removeEntry() to remove a file
 PASS removeEntry() on an already removed file should fail
 PASS removeEntry() to remove an empty directory
-FAIL removeEntry() on a non-empty directory should fail promise_rejects_dom: function "function() { throw e; }" threw object "UnknownError: The operation failed for an unknown transient reason (e.g. out of memory)." that is not a DOMException InvalidModificationError: property "code" is equal to 0, expected 13
+PASS removeEntry() on a non-empty directory should fail
 PASS removeEntry() on a directory recursively should delete all sub-items
 PASS removeEntry() with empty name should fail
 PASS removeEntry() with "." name should fail
 PASS removeEntry() with ".." name should fail
-FAIL removeEntry() with a path separator should fail. promise_rejects_js: removeEntry() must reject names containing "\" function "function() { throw e; }" threw object "NotFoundError: The object can not be found here." ("NotFoundError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL removeEntry() while the file has an open writable fails assert_unreached: Should have rejected: undefined Reached unreachable code
-FAIL removeEntry() of a directory while a containing file has an open writable fails promise_rejects_dom: function "function() { throw e; }" threw object "UnknownError: The operation failed for an unknown transient reason (e.g. out of memory)." that is not a DOMException NoModificationAllowedError: property "code" is equal to 0, expected 7
+PASS removeEntry() with a path separator should fail.
+PASS removeEntry() while the file has an open writable fails
+PASS removeEntry() of a directory while a containing file has an open writable fails
 PASS createWritable after removeEntry succeeds but doesnt recreate the file
 PASS removeEntry() on a non-existent directory recursively should throw NotFoundError
 

--- a/LayoutTests/imported/w3c/web-platform-tests/fs/resources/test-helpers.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/fs/resources/test-helpers.js
@@ -28,11 +28,6 @@ function wfsModesAreContentious(mode1, mode2) {
   return primitiveModesAreContentious('exclusive', mode1, mode2);
 }
 
-// Array of separators used to separate components in hierarchical paths.
-// Consider both '/' and '\' as path separators to ensure file names are
-// platform-agnostic.
-let kPathSeparators = ['/', '\\'];
-
 async function getFileSize(handle) {
   const file = await handle.getFile();
   return file.size;

--- a/LayoutTests/imported/w3c/web-platform-tests/fs/script-tests/FileSystemDirectoryHandle-getDirectoryHandle.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/fs/script-tests/FileSystemDirectoryHandle-getDirectoryHandle.js
@@ -89,26 +89,22 @@ directory_test(async (t, dir) => {
   const second_subdir =
       await createDirectory(second_subdir_name, /*parent=*/ first_subdir);
 
-  for (let i = 0; i < kPathSeparators.length; ++i) {
-    const path_with_separator =
-        `${first_subdir_name}${kPathSeparators[i]}${second_subdir_name}`;
-    await promise_rejects_js(
-        t, TypeError, dir.getDirectoryHandle(path_with_separator),
-        `getDirectoryHandle() must reject names containing "${
-            kPathSeparators[i]}"`);
-  }
+  const path_with_separator =
+      `${first_subdir_name}/${second_subdir_name}`;
+  await promise_rejects_js(
+      t, TypeError, dir.getDirectoryHandle(path_with_separator),
+      `getDirectoryHandle() must reject names containing "/"`);
+
 }, 'getDirectoryHandle(create=false) with a path separator when the directory exists');
 
 directory_test(async (t, dir) => {
   const subdir_name = 'subdir-name';
   const subdir = await createDirectory(subdir_name, /*parent=*/ dir);
 
-  for (let i = 0; i < kPathSeparators.length; ++i) {
-    const path_with_separator = `${subdir_name}${kPathSeparators[i]}file_name`;
-    await promise_rejects_js(
-        t, TypeError,
-        dir.getDirectoryHandle(path_with_separator, {create: true}),
-        `getDirectoryHandle(true) must reject names containing "${
-            kPathSeparators[i]}"`);
-  }
+  const path_with_separator = `${subdir_name}/file_name`;
+  await promise_rejects_js(
+      t, TypeError,
+      dir.getDirectoryHandle(path_with_separator, {create: true}),
+      `getDirectoryHandle(true) must reject names containing "/"`);
+
 }, 'getDirectoryHandle(create=true) with a path separator');

--- a/LayoutTests/imported/w3c/web-platform-tests/fs/script-tests/FileSystemDirectoryHandle-getFileHandle.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/fs/script-tests/FileSystemDirectoryHandle-getFileHandle.js
@@ -19,15 +19,10 @@ directory_test(async (t, dir) => {
   // test the ascii characters -- start after the non-character ASCII values, exclude DEL
   for (let i = 32; i < 127; i++) {
     // Path separators are disallowed
-    let disallow = false;
-    for (let j = 0; j < kPathSeparators.length; ++j) {
-      if (String.fromCharCode(i) == kPathSeparators[j]) {
-        disallow = true;
-      }
+    if (String.fromCharCode(i) == '/' || String.fromCharCode(i) == '\\') {
+      continue;
     }
-    if (!disallow) {
-      name += String.fromCharCode(i);
-    }
+    name += String.fromCharCode(i);
   }
   // Add in CR, LF, FF, Tab, Vertical Tab
   for (let i = 9; i < 14; i++) {
@@ -117,24 +112,21 @@ directory_test(async (t, dir) => {
   const file_name = 'file-name';
   await createEmptyFile(file_name, /*parent=*/ subdir);
 
-  for (let i = 0; i < kPathSeparators.length; ++i) {
-    const path_with_separator =
-        `${subdir_name}${kPathSeparators[i]}${file_name}`;
-    await promise_rejects_js(
-        t, TypeError, dir.getFileHandle(path_with_separator),
-        `getFileHandle() must reject names containing "${kPathSeparators[i]}"`);
-  }
+  const path_with_separator =
+      `${subdir_name}/${file_name}`;
+  await promise_rejects_js(
+      t, TypeError, dir.getFileHandle(path_with_separator),
+      `getFileHandle() must reject names containing "/"`);
+
 }, 'getFileHandle(create=false) with a path separator when the file exists.');
 
 directory_test(async (t, dir) => {
   const subdir_name = 'subdir-name';
   const subdir = await createDirectory(subdir_name, /*parent=*/ dir);
 
-  for (let i = 0; i < kPathSeparators.length; ++i) {
-    const path_with_separator = `${subdir_name}${kPathSeparators[i]}file_name`;
-    await promise_rejects_js(
-        t, TypeError, dir.getFileHandle(path_with_separator, {create: true}),
-        `getFileHandle(create=true) must reject names containing "${
-            kPathSeparators[i]}"`);
-  }
+  const path_with_separator = `${subdir_name}/file_name`;
+  await promise_rejects_js(
+      t, TypeError, dir.getFileHandle(path_with_separator, {create: true}),
+      `getFileHandle(create=true) must reject names containing "/"`);
+
 }, 'getFileHandle(create=true) with a path separator');

--- a/LayoutTests/imported/w3c/web-platform-tests/fs/script-tests/FileSystemDirectoryHandle-removeEntry.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/fs/script-tests/FileSystemDirectoryHandle-removeEntry.js
@@ -77,12 +77,11 @@ directory_test(async (t, root) => {
   const file_name = 'file-name';
   await createEmptyFile(file_name, dir);
 
-  for (let i = 0; i < kPathSeparators.length; ++i) {
-    const path_with_separator = `${dir_name}${kPathSeparators[i]}${file_name}`;
-    await promise_rejects_js(
-        t, TypeError, root.removeEntry(path_with_separator),
-        `removeEntry() must reject names containing "${kPathSeparators[i]}"`);
-  }
+  const path_with_separator = `${dir_name}/${file_name}`;
+  await promise_rejects_js(
+      t, TypeError, root.removeEntry(path_with_separator),
+      `removeEntry() must reject names containing "/"`);
+
 }, 'removeEntry() with a path separator should fail.');
 
 directory_test(async (t, root) => {

--- a/Source/WebKit/NetworkProcess/storage/FileSystemStorageError.h
+++ b/Source/WebKit/NetworkProcess/storage/FileSystemStorageError.h
@@ -38,6 +38,7 @@ enum class FileSystemStorageError : uint8_t {
     InvalidName,
     InvalidState,
     MissingArgument,
+    NoModificationAllowed,
     TypeMismatch,
     QuotaError,
     Unknown
@@ -62,6 +63,8 @@ inline WebCore::Exception convertToException(FileSystemStorageError error)
         return WebCore::Exception { WebCore::ExceptionCode::InvalidStateError };
     case FileSystemStorageError::MissingArgument:
         return WebCore::Exception { WebCore::ExceptionCode::TypeError, "Required argument is missing"_s };
+    case FileSystemStorageError::NoModificationAllowed:
+        return WebCore::Exception { WebCore::ExceptionCode::NoModificationAllowedError };
     case FileSystemStorageError::TypeMismatch:
         return WebCore::Exception { WebCore::ExceptionCode::TypeMismatchError, "File type is incompatible with handle type"_s };
     case FileSystemStorageError::QuotaError:

--- a/Source/WebKit/NetworkProcess/storage/FileSystemStorageError.serialization.in
+++ b/Source/WebKit/NetworkProcess/storage/FileSystemStorageError.serialization.in
@@ -30,6 +30,7 @@ enum class WebKit::FileSystemStorageError : uint8_t {
     InvalidName,
     InvalidState,
     MissingArgument,
+    NoModificationAllowed,
     TypeMismatch,
     QuotaError,
     Unknown

--- a/Source/WebKit/NetworkProcess/storage/FileSystemStorageHandle.cpp
+++ b/Source/WebKit/NetworkProcess/storage/FileSystemStorageHandle.cpp
@@ -37,11 +37,6 @@
 
 namespace WebKit {
 
-#if OS(WINDOWS)
-constexpr char pathSeparator = '\\';
-#else
-constexpr char pathSeparator = '/';
-#endif
 constexpr uint64_t defaultInitialCapacity = 1 * MB;
 constexpr uint64_t defaultMaxCapacityForExponentialGrowth = 256 * MB;
 constexpr uint64_t defaultCapacityStep = 128 * MB;
@@ -111,7 +106,7 @@ bool FileSystemStorageHandle::isSameEntry(WebCore::FileSystemHandleIdentifier id
 static bool isValidFileName(const String& directory, const String& name)
 {
     // https://fs.spec.whatwg.org/#valid-file-name
-    if (name.isEmpty() || (name == "."_s) || (name == ".."_s) || name.contains(pathSeparator))
+    if (name.isEmpty() || (name == "."_s) || (name == ".."_s) || name.contains('/') || name.contains(FileSystem::pathSeparator))
         return false;
 
     return FileSystem::pathFileName(FileSystem::pathByAppendingComponent(directory, name)) == name;
@@ -155,6 +150,13 @@ std::optional<FileSystemStorageError> FileSystemStorageHandle::removeEntry(const
     if (!FileSystem::fileExists(path))
         return FileSystemStorageError::FileNotFound;
 
+    RefPtr manager = m_manager;
+    if (!manager)
+        return FileSystemStorageError::Unknown;
+
+    if (manager->hasActiveLock(path))
+        return FileSystemStorageError::NoModificationAllowed;
+
     auto type = FileSystem::fileType(path);
     if (!type)
         return FileSystemStorageError::TypeMismatch;
@@ -167,8 +169,10 @@ std::optional<FileSystemStorageError> FileSystemStorageHandle::removeEntry(const
         break;
     case FileSystem::FileType::Directory:
         if (!deleteRecursively) {
-            if (!FileSystem::deleteEmptyDirectory(path))
-                result = FileSystemStorageError::Unknown;
+            if (!FileSystem::deleteEmptyDirectory(path)) {
+                auto entries = FileSystem::listDirectory(path);
+                result = entries.isEmpty() ? FileSystemStorageError::Unknown : FileSystemStorageError::InvalidModification;
+            }
         } else if (!FileSystem::deleteNonEmptyDirectory(path))
             result = FileSystemStorageError::Unknown;
         break;
@@ -193,10 +197,10 @@ Expected<std::optional<Vector<String>>, FileSystemStorageError> FileSystemStorag
         return { std::nullopt };
 
     auto restPath = path.substring(m_path.length());
-    if (!restPath.isEmpty() && !restPath.startsWith(pathSeparator))
+    if (!restPath.isEmpty() && !restPath.startsWith(FileSystem::pathSeparator))
         return { std::nullopt };
 
-    return { restPath.split(pathSeparator) };
+    return { restPath.split(FileSystem::pathSeparator) };
 }
 
 Expected<FileSystemSyncAccessHandleInfo, FileSystemStorageError> FileSystemStorageHandle::createSyncAccessHandle()

--- a/Source/WebKit/NetworkProcess/storage/FileSystemStorageManager.cpp
+++ b/Source/WebKit/NetworkProcess/storage/FileSystemStorageManager.cpp
@@ -29,6 +29,7 @@
 #include "FileSystemStorageError.h"
 #include "FileSystemStorageHandleRegistry.h"
 #include "WebFileSystemStorageConnectionMessages.h"
+#include <wtf/FileSystem.h>
 #include <wtf/TZoneMallocInlines.h>
 
 namespace WebKit {
@@ -202,6 +203,18 @@ bool FileSystemStorageManager::releaseLockForFile(const String& path)
     }
     m_lockMap.remove(iterator);
     return true;
+}
+
+bool FileSystemStorageManager::hasActiveLock(const String& path) const
+{
+    auto prefix = makeString(path, FileSystem::pathSeparator);
+    for (auto& [lockedPath, lock] : m_lockMap) {
+        if (lock.state == Lock::State::Open)
+            continue;
+        if (lockedPath == path || lockedPath.startsWith(prefix))
+            return true;
+    }
+    return false;
 }
 
 void FileSystemStorageManager::close()

--- a/Source/WebKit/NetworkProcess/storage/FileSystemStorageManager.h
+++ b/Source/WebKit/NetworkProcess/storage/FileSystemStorageManager.h
@@ -55,6 +55,7 @@ public:
     enum class LockType : bool { Exclusive, Shared };
     bool acquireLockForFile(const String& path, LockType);
     bool releaseLockForFile(const String& path);
+    bool hasActiveLock(const String& path) const;
     void requestSpace(uint64_t spaceRequested, CompletionHandler<void(bool)>&&);
 
 private:

--- a/Source/WebKit/NetworkProcess/storage/NetworkStorageManager.cpp
+++ b/Source/WebKit/NetworkProcess/storage/NetworkStorageManager.cpp
@@ -64,6 +64,7 @@
 #include <algorithm>
 #include <pal/crypto/CryptoDigest.h>
 #include <ranges>
+#include <wtf/FileSystem.h>
 #include <wtf/SuspendableWorkQueue.h>
 #include <wtf/TZoneMallocInlines.h>
 #include <wtf/text/Base64.h>
@@ -999,6 +1000,9 @@ void NetworkStorageManager::getFile(WebCore::FileSystemHandleIdentifier identifi
     RefPtr handle = m_fileSystemStorageHandleRegistry->getHandle(identifier);
     if (!handle)
         return completionHandler(makeUnexpected(FileSystemStorageError::Unknown));
+
+    if (!FileSystem::fileExists(handle->path()))
+        return completionHandler(makeUnexpected(FileSystemStorageError::FileNotFound));
 
     completionHandler(handle->path());
 }


### PR DESCRIPTION
#### ddc0a2f55d92a256bf40710ea3d501582cc309a6
<pre>
Fix FileSystemDirectoryHandle&apos;s removeEntry()
<a href="https://bugs.webkit.org/show_bug.cgi?id=313349">https://bugs.webkit.org/show_bug.cgi?id=313349</a>

Reviewed by Sihui Liu.

WPT identified a couple minor issues. While here we also correct
isValidFileName() to properly reject \ on Windows and update WPT to not
count \ as a path separator on all platforms:

    <a href="https://github.com/web-platform-tests/wpt/pull/59480">https://github.com/web-platform-tests/wpt/pull/59480</a>

Canonical link: <a href="https://commits.webkit.org/312193@main">https://commits.webkit.org/312193@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/67c6547fb5dd759b33e37a9adf4ae2bdbd446198

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/159149 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/32577 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/25682 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/167978 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/113233 "Built successfully") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/32645 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/32564 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/123293 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/86569 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/162106 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/25566 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/142957 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/103959 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/24620 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/23043 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/15751 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/134306 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/20737 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/170473 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/16213 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/22363 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/131487 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/32266 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/27112 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/131599 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35596 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/32210 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/142530 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/90260 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/26296 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/19339 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/31721 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/97735 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/31241 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/31514 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/31396 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->