### PR TITLE
IDBTransaction/IDBRequest/IDBObjectStore retain cycle when IDBTransaction::stop() is called on a finishing transaction

### DIFF
--- a/LayoutTests/http/tests/IndexedDB/resources/commit-then-stop-frame.html
+++ b/LayoutTests/http/tests/IndexedDB/resources/commit-then-stop-frame.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<script>
+// This frame opens an IDB database, issues requests, calls commit()
+// while requests are still pending, and immediately signals the parent.
+// The parent removes this frame before events dispatch, exercising the
+// code path where IDBTransaction::stop() is called on a transaction in
+// the Committing state with non-empty m_openRequests.
+
+var dbName = "commit-then-stop-db-" + Math.random();
+var openReq = indexedDB.open(dbName, 1);
+
+openReq.onupgradeneeded = function(e) {
+    var db = e.target.result;
+    var store = db.createObjectStore("store");
+    // Seed some data so get() requests have work to do.
+    for (var i = 0; i < 10; i++)
+        store.put("value" + i, i);
+};
+
+openReq.onsuccess = function(e) {
+    var db = e.target.result;
+    var txn = db.transaction("store", "readonly");
+    var store = txn.objectStore("store");
+
+    // Issue several get requests -- these add to m_openRequests.
+    for (var i = 0; i < 10; i++)
+        store.get(i);
+
+    // Explicitly commit while requests are still pending.
+    // This transitions the transaction to Committing state before
+    // the request success events dispatch and remove themselves
+    // from m_openRequests.
+    txn.commit();
+
+    // Signal the parent immediately -- before any success events fire.
+    parent.postMessage("committed", "*");
+};
+
+openReq.onerror = function(e) {
+    parent.postMessage("error: " + e.target.error, "*");
+};
+</script>

--- a/LayoutTests/http/tests/IndexedDB/transaction-commit-pending-requests-stop-expected.txt
+++ b/LayoutTests/http/tests/IndexedDB/transaction-commit-pending-requests-stop-expected.txt
@@ -1,0 +1,3 @@
+
+PASS IDBTransaction with pending requests should not leak when committed transaction is stopped
+

--- a/LayoutTests/http/tests/IndexedDB/transaction-commit-pending-requests-stop.html
+++ b/LayoutTests/http/tests/IndexedDB/transaction-commit-pending-requests-stop.html
@@ -1,0 +1,65 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<script src="/resources/gc.js"></script>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script>
+// Regression test for IDBTransaction/IDBRequest/IDBObjectStore retain cycle.
+//
+// When IDBTransaction::stop() is called on a finishing transaction, the
+// old code returned early without clearing operation maps or request
+// sets.  TransactionOperationImpl objects hold Ref<IDBTransaction>
+// through captured lambdas, forming retain cycles that prevent
+// destruction.
+//
+// This test exercises that path by:
+//   1. Loading a single iframe that opens an IDB transaction
+//   2. The iframe calls txn.commit() while requests are still pending
+//   3. The iframe signals the parent immediately (before events dispatch)
+//   4. The parent removes the iframe, triggering stop()
+//   5. Runs many successful IDB operations to flush the event loop
+//   6. After GC, verifies IDBTransaction count returns to baseline
+
+promise_test(async (test) => {
+    assert_true(!!window.internals, "Test requires internals API");
+
+    const gcCount = 100;
+
+    // Record baseline IDBTransaction count.
+    gc();
+    await new Promise(r => setTimeout(r, 50));
+    const baseline = internals.numberOfIDBTransactions();
+
+    // Create one iframe that opens an IDB transaction, calls commit()
+    // with pending requests, and immediately signals us.
+    let frame = await new Promise((resolve, reject) => {
+        function onMessage() {
+            window.removeEventListener("message", onMessage);
+            resolve(f);
+        }
+        window.addEventListener("message", onMessage);
+        let f = document.createElement('iframe');
+        f.src = "resources/commit-then-stop-frame.html";
+        document.body.appendChild(f);
+    });
+
+    // Remove the iframe -- triggers stop() on its IDBTransaction while
+    // it is in the Committing state with non-empty m_openRequests.
+    frame.remove();
+    frame = null;
+
+    // GC repeatedly and check if IDBTransaction objects were destroyed.
+    for (let i = 0; i < gcCount; i++) {
+        gc();
+        await new Promise(r => setTimeout(r, 50));
+        if (internals.numberOfIDBTransactions() <= baseline)
+            return;
+    }
+
+    let residual = internals.numberOfIDBTransactions() - baseline;
+    assert_equals(residual, 0,
+        "IDBTransaction objects not destroyed (" + residual + " still alive after GC)");
+
+}, "IDBTransaction with pending requests should not leak when committed transaction is stopped");
+
+</script>

--- a/Source/WebCore/Modules/indexeddb/IDBTransaction.cpp
+++ b/Source/WebCore/Modules/indexeddb/IDBTransaction.cpp
@@ -345,6 +345,8 @@ void IDBTransaction::stop()
     if (isVersionChange())
         m_openDBRequest = nullptr;
 
+    m_openRequests.clear();
+
     if (isFinishedOrFinishing())
         return;
 
@@ -423,6 +425,11 @@ void IDBTransaction::completeNoncursorRequest(IDBRequest& request, const IDBResu
 
     request.completeRequestAndDispatchEvent(result);
 
+    if (m_isStopped) {
+        ++m_handledRequestResultsCount;
+        return;
+    }
+
     m_currentlyCompletingRequest = request;
 }
 
@@ -431,6 +438,11 @@ void IDBTransaction::completeCursorRequest(IDBRequest& request, const IDBResultD
     ASSERT(!m_currentlyCompletingRequest);
 
     request.didOpenOrIterateCursor(result);
+
+    if (m_isStopped) {
+        ++m_handledRequestResultsCount;
+        return;
+    }
 
     m_currentlyCompletingRequest = request;
 }


### PR DESCRIPTION
#### a460a664aa29c5fe190c3a9a70b96ffd3e3802e2
<pre>
IDBTransaction/IDBRequest/IDBObjectStore retain cycle when IDBTransaction::stop() is called on a finishing transaction
&lt;<a href="https://bugs.webkit.org/show_bug.cgi?id=313353">https://bugs.webkit.org/show_bug.cgi?id=313353</a>&gt;
&lt;<a href="https://rdar.apple.com/175627928">rdar://175627928</a>&gt;

Reviewed by Sihui Liu.

Patch by Sihui Liu.

The `IDBTransaction` &lt;-&gt; `TransactionOperation` retain cycle is
normally broken by the completion loop in
`handleOperationsCompletedOnServer()`, which removes each operation
from `m_transactionOperationMap` as it completes.  The loop
processes one operation at a time, pausing via
`m_currentlyCompletingRequest` until event dispatch finishes.

After `stop()`, event dispatch is suppressed -- but the pause
mechanism is not, so the completion loop stalls permanently on the
first operation.  The remaining operations are never removed from
the map, and the retain cycle is never broken.

The pause exists to serialize event dispatch, which is pointless
once the context is stopped and events are being dropped.  Skip
setting `m_currentlyCompletingRequest` when `m_isStopped` so the
completion loop runs to completion uninterrupted.  Also clear
`m_openRequests` in `stop()` to break a separate cycle through
`Ref&lt;IDBRequest&gt;` back-references.

Test: http/tests/IndexedDB/transaction-commit-pending-requests-stop.html

* LayoutTests/http/tests/IndexedDB/resources/commit-then-stop-frame.html: Add.
* LayoutTests/http/tests/IndexedDB/transaction-commit-pending-requests-stop-expected.txt: Add.
* LayoutTests/http/tests/IndexedDB/transaction-commit-pending-requests-stop.html: Add.
* Source/WebCore/Modules/indexeddb/IDBTransaction.cpp:
(WebCore::IDBTransaction::stop):
(WebCore::IDBTransaction::completeNoncursorRequest):
(WebCore::IDBTransaction::completeCursorRequest):

Canonical link: <a href="https://commits.webkit.org/312379@main">https://commits.webkit.org/312379@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0cfdc16611d9a9d3885481849addca4eab0f237a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/159652 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/33119 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/26226 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/168503 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/114033 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/161521 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/33224 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/33123 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/123691 "Found 1 new test failure: accessibility/aria-owns-deep-chain-no-timeout.html (failure)") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/86805 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/162610 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/25954 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/143396 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/104342 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/a7a60292-801f-452f-abb4-e8c44cc7cbcb) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/25005 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/23475 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/16268 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/134697 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/21168 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/170994 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/17020 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/22802 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/131934 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/32798 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/27551 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/132011 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/32783 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/142962 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/90865 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/24308 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/26646 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/19775 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/32292 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/98688 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/31789 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/32036 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/31940 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->