### PR TITLE
Flex container baseline should be clamped to border edge for scroll containers

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/flex-baseline-overflow-hidden-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/flex-baseline-overflow-hidden-expected.txt
@@ -1,0 +1,13 @@
+x
+x
+x
+x
+
+PASS inline-flex with overflow:hidden produces same line box height as inline-block
+PASS inline-flex with overflow:hidden does not inflate line box from overflowing content
+PASS inline-flex with overflow:scroll synthesizes baseline from container edges
+PASS inline-flex with overflow:auto synthesizes baseline from container edges
+PASS block-level flex with overflow:hidden clamps baseline for baseline alignment
+PASS block-level flex with overflow:scroll clamps baseline for baseline alignment
+PASS block-level flex with overflow:auto clamps baseline for baseline alignment
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/flex-baseline-overflow-hidden.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/flex-baseline-overflow-hidden.html
@@ -1,0 +1,129 @@
+<!DOCTYPE html>
+<title>Flex container baseline with overflow:hidden should be clamped to border edge</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<link rel="help" href="https://drafts.csswg.org/css-flexbox/#flex-baselines">
+<link rel="stylesheet" type="text/css" href="/fonts/ahem.css">
+<style>
+.container {
+  font: 10px/1 Ahem;
+}
+</style>
+
+<!-- Test: inline-flex with overflow:hidden and a tall centered child -->
+<div class="container" id="test-hidden">
+  <div style="display: inline-flex; overflow: hidden; height: 40px; align-items: center;">
+    <div style="width: 10px; height: 100px;"></div>
+  </div>
+</div>
+
+<!-- Reference: inline-block with overflow:hidden (baseline = bottom margin edge per CSS2) -->
+<div class="container" id="ref-hidden">
+  <div style="display: inline-block; overflow: hidden; height: 40px;">
+    <div style="width: 10px; height: 100px;"></div>
+  </div>
+</div>
+
+<!-- Test: overflow:scroll should also synthesize baseline -->
+<div class="container" id="test-scroll">
+  <div style="display: inline-flex; overflow: scroll; height: 40px; align-items: center;">
+    <div style="width: 10px; height: 100px;"></div>
+  </div>
+</div>
+
+<!-- Test: overflow:auto should also synthesize baseline -->
+<div class="container" id="test-auto">
+  <div style="display: inline-flex; overflow: auto; height: 40px; align-items: center;">
+    <div style="width: 10px; height: 100px;"></div>
+  </div>
+</div>
+
+<!-- Test: block-level flex with overflow:hidden as a baseline-aligned flex item -->
+<div style="display: flex; align-items: baseline; font: 10px/1 Ahem;" id="test-flex-block">
+  <div style="display: flex; overflow: hidden; height: 40px; align-items: center;">
+    <div style="width: 10px; height: 100px;"></div>
+  </div>
+  <div>x</div>
+</div>
+
+<!-- Test: block-level flex with overflow:scroll -->
+<div style="display: flex; align-items: baseline; font: 10px/1 Ahem;" id="test-flex-block-scroll">
+  <div style="display: flex; overflow: scroll; height: 40px; align-items: center;">
+    <div style="width: 10px; height: 100px;"></div>
+  </div>
+  <div>x</div>
+</div>
+
+<!-- Test: block-level flex with overflow:auto -->
+<div style="display: flex; align-items: baseline; font: 10px/1 Ahem;" id="test-flex-block-auto">
+  <div style="display: flex; overflow: auto; height: 40px; align-items: center;">
+    <div style="width: 10px; height: 100px;"></div>
+  </div>
+  <div>x</div>
+</div>
+
+<!-- Reference: same layout but without the overflowing child -->
+<div style="display: flex; align-items: baseline; font: 10px/1 Ahem;" id="ref-flex-block">
+  <div style="display: flex; overflow: hidden; height: 40px; align-items: center;">
+    <div style="width: 10px; height: 40px;"></div>
+  </div>
+  <div>x</div>
+</div>
+
+<script>
+test(function() {
+  assert_equals(
+    document.getElementById('test-hidden').offsetHeight,
+    document.getElementById('ref-hidden').offsetHeight,
+    "should match inline-block with overflow:hidden"
+  );
+}, "inline-flex with overflow:hidden produces same line box height as inline-block");
+
+test(function() {
+  assert_equals(
+    document.getElementById('test-hidden').offsetHeight,
+    42,
+    "container height should be inline-flex height plus strut descent"
+  );
+}, "inline-flex with overflow:hidden does not inflate line box from overflowing content");
+
+test(function() {
+  assert_equals(
+    document.getElementById('test-scroll').offsetHeight,
+    document.getElementById('ref-hidden').offsetHeight,
+    "should match inline-block with overflow:hidden"
+  );
+}, "inline-flex with overflow:scroll synthesizes baseline from container edges");
+
+test(function() {
+  assert_equals(
+    document.getElementById('test-auto').offsetHeight,
+    document.getElementById('ref-hidden').offsetHeight,
+    "should match inline-block with overflow:hidden"
+  );
+}, "inline-flex with overflow:auto synthesizes baseline from container edges");
+
+test(function() {
+  assert_equals(
+    document.getElementById('test-flex-block').offsetHeight,
+    document.getElementById('ref-flex-block').offsetHeight,
+    "overflowing content should not affect baseline alignment"
+  );
+}, "block-level flex with overflow:hidden clamps baseline for baseline alignment");
+
+test(function() {
+  assert_equals(
+    document.getElementById('test-flex-block-scroll').offsetHeight,
+    document.getElementById('ref-flex-block').offsetHeight,
+    "overflowing content should not affect baseline alignment"
+  );
+}, "block-level flex with overflow:scroll clamps baseline for baseline alignment");
+
+test(function() {
+  assert_equals(
+    document.getElementById('test-flex-block-auto').offsetHeight,
+    document.getElementById('ref-flex-block').offsetHeight,
+    "overflowing content should not affect baseline alignment"
+  );
+}, "block-level flex with overflow:auto clamps baseline for baseline alignment");
+</script>

--- a/Source/WebCore/rendering/RenderFlexibleBox.cpp
+++ b/Source/WebCore/rendering/RenderFlexibleBox.cpp
@@ -365,7 +365,11 @@ std::optional<LayoutUnit> RenderFlexibleBox::firstLineBaseline() const
         auto dominantBaseline = BaselineAlignmentState::dominantBaseline(flexboxWritingMode);
         baseline = BaselineAlignmentState::synthesizedBaseline(*baselineFlexItem, dominantBaseline, flexboxWritingMode, direction, BaselineSynthesisEdge::BorderBox);
     }
-    return (settings().subpixelInlineLayoutEnabled() ? LayoutUnit(baselineFlexItem->logicalTop()) : LayoutUnit(baselineFlexItem->logicalTop().toInt())) + *baseline;
+    auto result = (settings().subpixelInlineLayoutEnabled() ? LayoutUnit(baselineFlexItem->logicalTop()) : LayoutUnit(baselineFlexItem->logicalTop().toInt())) + *baseline;
+    // CSS Align §9.1: if a scroll container's baseline is outside its border edge, clamp to the border edge.
+    if (isHorizontalFlow() ? isScrollContainerY() : isScrollContainerX())
+        return std::max(0_lu, std::min(result, logicalHeight()));
+    return result;
 }
 
 std::optional <LayoutUnit> RenderFlexibleBox::lastLineBaseline() const
@@ -392,7 +396,11 @@ std::optional <LayoutUnit> RenderFlexibleBox::lastLineBaseline() const
         auto dominantBaseline = BaselineAlignmentState::dominantBaseline(flexboxWritingMode);
         baseline = BaselineAlignmentState::synthesizedBaseline(*baselineFlexItem, dominantBaseline, flexboxWritingMode, direction, BaselineSynthesisEdge::BorderBox);
     }
-    return (settings().subpixelInlineLayoutEnabled() ? LayoutUnit(baselineFlexItem->logicalTop()) : LayoutUnit(baselineFlexItem->logicalTop().toInt())) + *baseline;
+    auto result = (settings().subpixelInlineLayoutEnabled() ? LayoutUnit(baselineFlexItem->logicalTop()) : LayoutUnit(baselineFlexItem->logicalTop().toInt())) + *baseline;
+    // CSS Align §9.1: if a scroll container's baseline is outside its border edge, clamp to the border edge.
+    if (isHorizontalFlow() ? isScrollContainerY() : isScrollContainerX())
+        return std::max(0_lu, std::min(result, logicalHeight()));
+    return result;
 }
 
 static const StyleContentAlignmentData& NODELETE contentAlignmentNormalBehavior()


### PR DESCRIPTION
#### 21ca9215250e768565b6358f3c8ce95d2cd18808
<pre>
Flex container baseline should be clamped to border edge for scroll containers
<a href="https://bugs.webkit.org/show_bug.cgi?id=313354">https://bugs.webkit.org/show_bug.cgi?id=313354</a>
<a href="https://rdar.apple.com/175631095">rdar://175631095</a>

Reviewed by Alan Baradlay.

This patch aligns WebKi with Gecko / Firefox and Blink / Chromium.

RenderFlexibleBox::firstLineBaseline() and lastLineBaseline() derived
the container&apos;s baseline from flex item content without clamping. For
an inline-flex with overflow:hidden containing a large replaced element
(e.g. a centered 100x100 image in a 2.55em container), the synthesized
baseline of the image landed far below the container&apos;s bottom border
edge, inflating the enclosing line box height.

Per CSS Align §9.1 [1]: &quot;if the position of a scroll container&apos;s
first/last baseline is outside its border edge, that baseline&apos;s
position is clamped to the border edge.&quot; Clamp the computed baseline
to [0, logicalHeight()] when the flex container is a scroll container
on its cross axis, consistent with the existing flex item clamping in
marginBoxAscentForFlexItem().

* Source/WebCore/rendering/RenderFlexibleBox.cpp:
(WebCore::RenderFlexibleBox::firstLineBaseline const):
(WebCore::RenderFlexibleBox::lastLineBaseline const):
* LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/flex-baseline-overflow-hidden-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/flex-baseline-overflow-hidden.html: Added.

Canonical link: <a href="https://commits.webkit.org/312206@main">https://commits.webkit.org/312206@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0bb72b15f5bc75d853c717eb53574b3b2e4aae1b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/158859 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/32286 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/25391 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/167688 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/112943 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/a915c40b-aa79-4dd1-b878-9011e1ea1068) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/160728 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/32352 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/32273 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/123078 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/86406 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/d1c97b87-fc3b-4590-9fed-fc9e56163924) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/161816 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/25349 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/142713 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/103747 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/b599ffad-e034-43bc-8dac-3d37f4c41017) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/24405 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/22805 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/15460 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/134091 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/20493 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/170180 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/15923 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/22119 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/131266 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/31975 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/26872 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/131380 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35607 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/31920 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/142286 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/89927 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/26083 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/19095 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/31431 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/97445 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/30951 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/31224 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/31105 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->