### PR TITLE
Resize handle doesn't work on iframe container when handle overlaps iframe

### DIFF
--- a/LayoutTests/fast/css/resize-corner-over-child-layer-expected.txt
+++ b/LayoutTests/fast/css/resize-corner-over-child-layer-expected.txt
@@ -1,0 +1,4 @@
+The resize handle should work even when a child layer with overflowing content covers it.
+
+Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet.
+PASS: container resized to 252x152

--- a/LayoutTests/fast/css/resize-corner-over-child-layer.html
+++ b/LayoutTests/fast/css/resize-corner-over-child-layer.html
@@ -1,0 +1,49 @@
+<html>
+<head>
+<style>
+div.container {
+    overflow: scroll;
+    resize: both;
+    width: 200px;
+    height: 100px;
+    border: solid 1px black;
+}
+div.child {
+    will-change: transform;
+}
+</style>
+<script>
+function test()
+{
+    if (window.testRunner)
+        testRunner.dumpAsText();
+
+    if (!window.eventSender)
+        return;
+
+    var target = document.getElementById("container");
+    var x = target.offsetLeft + target.offsetWidth - 5;
+    var y = target.offsetTop + target.offsetHeight - 5;
+    eventSender.mouseMoveTo(x, y);
+    eventSender.mouseDown();
+    eventSender.mouseMoveTo(x + 50, y + 50);
+    eventSender.mouseUp();
+
+    var result = document.getElementById("result");
+    var newWidth = target.offsetWidth;
+    var newHeight = target.offsetHeight;
+    if (newWidth > 200 && newHeight > 100)
+        result.textContent = "PASS: container resized to " + newWidth + "x" + newHeight;
+    else
+        result.textContent = "FAIL: container stayed at " + newWidth + "x" + newHeight + " (expected > 200x100)";
+}
+</script>
+</head>
+<body onload="test()">
+<p>The resize handle should work even when a child layer with overflowing content covers it.</p>
+<div id="container" class="container">
+    <div class="child">Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet.</div>
+</div>
+<p id="result"></p>
+</body>
+</html>

--- a/Source/WebCore/rendering/RenderLayer.cpp
+++ b/Source/WebCore/rendering/RenderLayer.cpp
@@ -4747,6 +4747,17 @@ RenderLayer::HitLayer RenderLayer::hitTestLayer(RenderLayer* rootLayer, RenderLa
     if (auto* rendererBox = this->renderBox(); rendererBox && !rendererBox->hitTestClipPath(hitTestLocation, toLayoutPoint(offsetFromRoot - toLayoutSize(rendererLocation()))))
         return { };
 
+    // Collect the fragments. This will compute the clip rectangles for each layer fragment.
+    LayerFragments layerFragments;
+    collectFragments(layerFragments, rootLayer, hitTestRect, IncludeCompositedPaginatedLayers, RootRelativeClipRects, { ClipRectsOption::RespectOverflowClip }, offsetFromRoot);
+
+    // The resize control is painted on top of all content, so hit-test it first.
+    LayoutPoint localPoint;
+    if (canResize() && m_scrollableArea && m_scrollableArea->hitTestResizerInFragments(layerFragments, hitTestLocation, localPoint)) {
+        renderer().updateHitTestResult(result, localPoint);
+        return { this, selfZOffset };
+    }
+
     // Begin by walking our list of positive layers from highest z-index down to the lowest z-index.
     auto hitLayer = hitTestList(positiveZOrderLayers(), rootLayer, request, result, hitTestRect, hitTestLocation, localTransformState.get(), zOffsetForDescendantsPtr, depthSortDescendants);
     if (hitLayer.layer) {
@@ -4775,16 +4786,6 @@ RenderLayer::HitLayer RenderLayer::hitTestLayer(RenderLayer* rootLayer, RenderLa
             if (!depthSortDescendants)
                 return hitLayer;
         }
-    }
-
-    // Collect the fragments. This will compute the clip rectangles for each layer fragment.
-    LayerFragments layerFragments;
-    collectFragments(layerFragments, rootLayer, hitTestRect, IncludeCompositedPaginatedLayers, RootRelativeClipRects, { ClipRectsOption::RespectOverflowClip }, offsetFromRoot);
-
-    LayoutPoint localPoint;
-    if (canResize() && m_scrollableArea && m_scrollableArea->hitTestResizerInFragments(layerFragments, hitTestLocation, localPoint)) {
-        renderer().updateHitTestResult(result, localPoint);
-        return { this, selfZOffset };
     }
 
     auto isHitCandidate = [&]() {


### PR DESCRIPTION
#### 245699fb335798e64aa1628b41febd830c6e39f3
<pre>
Resize handle doesn&apos;t work on iframe container when handle overlaps iframe
<a href="https://bugs.webkit.org/show_bug.cgi?id=312718">https://bugs.webkit.org/show_bug.cgi?id=312718</a>
&lt;<a href="https://rdar.apple.com/problem/175621855">rdar://problem/175621855</a>&gt;

Reviewed by NOBODY (OOPS!).

The resize handle is painted on top of all content, but the hit-test
checked it after child layers. When a child with its own layer (e.g.
position: relative, will-change: transform, iframe) covered the resize
corner, the child caught the click first and the resize check never ran.

The fix moves the resize hit-test before all child layer checks. This
matches paint order: last painted = first hit-tested.

Test: fast/css/resize-corner-over-child-layer.html

* LayoutTests/fast/css/resize-corner-over-child-layer-expected.txt: Added.
* LayoutTests/fast/css/resize-corner-over-child-layer.html: Added.
* Source/WebCore/rendering/RenderLayer.cpp:
(WebCore::RenderLayer::hitTestLayer):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/245699fb335798e64aa1628b41febd830c6e39f3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/158830 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/32256 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/25362 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/167659 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/112914 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/36584698-cd8e-4c02-a072-cfc78bb184f5) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/160699 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/32323 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/32244 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/123056 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/86392 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/576a3cd6-4ade-49c7-9b83-c551982dcff4) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/161787 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/25325 "Found 1 new test failure: fast/css/resize-corner-over-child-layer.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/142693 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/103725 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/c37c67d4-2056-49b4-8712-a62dac140feb) 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/24381 "Exiting early after 10 failures. 10 tests run. 1 failures") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/22782 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/15431 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/134067 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/20473 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/170151 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/15894 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/22099 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/131243 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/31946 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/26848 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/131357 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/31891 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/142266 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/89884 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/26063 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/19075 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/31402 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/97416 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/30922 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/31195 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/31076 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->