### PR TITLE
[JSC] Remove the overload of printInternal() for JSC::ConstraintVolatility

### DIFF
--- a/Source/JavaScriptCore/heap/ConstraintVolatility.h
+++ b/Source/JavaScriptCore/heap/ConstraintVolatility.h
@@ -25,7 +25,7 @@
 
 #pragma once
 
-#include <wtf/PrintStream.h>
+#include <cstdint>
 
 namespace JSC {
 
@@ -48,26 +48,6 @@ enum class ConstraintVolatility : uint8_t {
     // mutator resumes.
     GreyedByMarking
 };
-    
+
 } // namespace JSC
-
-namespace WTF {
-
-inline void printInternal(PrintStream& out, JSC::ConstraintVolatility volatility)
-{
-    switch (volatility) {
-    case JSC::ConstraintVolatility::SeldomGreyed:
-        out.print("SeldomGreyed");
-        return;
-    case JSC::ConstraintVolatility::GreyedByExecution:
-        out.print("GreyedByExecuction");
-        return;
-    case JSC::ConstraintVolatility::GreyedByMarking:
-        out.print("GreyedByMarking");
-        return;
-    }
-    RELEASE_ASSERT_NOT_REACHED();
-}
-
-} // namespace WTF
 


### PR DESCRIPTION
#### 5ade7c0d6d20605a9b95aabf0a00b262984c1a4e
<pre>
[JSC] Remove the overload of printInternal() for JSC::ConstraintVolatility
<a href="https://bugs.webkit.org/show_bug.cgi?id=313358">https://bugs.webkit.org/show_bug.cgi?id=313358</a>
<a href="https://rdar.apple.com/175633230">rdar://175633230</a>

Reviewed by Yusuke Suzuki.

The printInternal() overload for JSC::ConstraintVolatility is unnecessary now that magic
enums do the same thing without additional code. The overload also misspells &quot;execution&quot;.
This patch removes the overload.

Testing: no new functionality to test.

* Source/JavaScriptCore/heap/ConstraintVolatility.h:
(WTF::printInternal): Deleted.

Canonical link: <a href="https://commits.webkit.org/312152@main">https://commits.webkit.org/312152@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/47d878c3a11ec3731b599c5f112d7d94a2d6e031

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/158994 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/32421 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/25526 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/167823 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/113078 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/ca3719d6-2334-441b-a3cc-4e92ad2429e1) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/32489 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/32409 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/123193 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/86507 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/719a22af-9011-4793-a9bc-c166b4141906) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/161951 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/25467 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/142837 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/103860 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/9043e77d-6a77-4560-be63-630560650812) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/24522 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/22931 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/15595 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/151044 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/134208 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/20617 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/170316 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/19827 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/16058 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/22243 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/131383 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/32111 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/26998 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/131495 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35568 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/32055 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/142410 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/90105 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/26202 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/19219 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/191276 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/31566 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/97580 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/49165 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/31086 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/31359 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/31241 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->