### PR TITLE
[Site Isolation] http/tests/xmlhttprequest/origin-allow-list-all.html fails

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/media-elements/track/track-element/track-data-url-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/media-elements/track/track-element/track-data-url-expected.txt
@@ -1,5 +1,5 @@
 
 FAIL track element data: URL No CORS null is not an object (evaluating 't.track.cues.length')
-FAIL track element data: URL anonymous assert_unreached: got error event Reached unreachable code
-FAIL track element data: URL use-credentials assert_unreached: got error event Reached unreachable code
+FAIL track element data: URL anonymous null is not an object (evaluating 't.track.cues.length')
+FAIL track element data: URL use-credentials null is not an object (evaluating 't.track.cues.length')
 

--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/html/semantics/embedded-content/media-elements/track/track-element/track-data-url-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/html/semantics/embedded-content/media-elements/track/track-element/track-data-url-expected.txt
@@ -1,5 +1,0 @@
-
-FAIL track element data: URL No CORS null is not an object (evaluating 't.track.cues.length')
-FAIL track element data: URL anonymous assert_unreached: got error event Reached unreachable code
-FAIL track element data: URL use-credentials assert_unreached: got error event Reached unreachable code
-

--- a/LayoutTests/platform/ios-site-isolation/TestExpectations
+++ b/LayoutTests/platform/ios-site-isolation/TestExpectations
@@ -230,8 +230,6 @@ http/tests/workers/service/client-added-to-clients-when-restored-from-page-cache
 http/tests/workers/service/client-removed-from-clients-while-in-page-cache.html [ Failure ]
 http/tests/workers/service/page-cache-service-worker-pending-promise.https.html [ Failure ]
 http/tests/workers/service/page-caching.html [ Failure ]
-http/tests/xmlhttprequest/origin-allow-list-all.html [ Failure ]
-http/tests/xmlhttprequest/origin-allow-list-ip-addresses.html [ Failure ]
 http/wpt/css/css-view-transitions/navigation/cross-origin-bfcache.html [ Failure ]
 http/wpt/css/css-view-transitions/navigation/old_vt_promises_bfcache.html [ Failure ]
 http/wpt/fetch/inspect-preflight.html [ Failure ]

--- a/LayoutTests/platform/mac-site-isolation/TestExpectations
+++ b/LayoutTests/platform/mac-site-isolation/TestExpectations
@@ -242,8 +242,6 @@ http/tests/workers/service/client-removed-from-clients-while-in-page-cache.html 
 http/tests/workers/service/page-cache-service-worker-pending-promise.https.html [ Failure ]
 http/tests/workers/service/page-caching.html [ Failure ]
 http/tests/workers/service/postmessage-after-sw-process-crash.https.html [ Failure ]
-http/tests/xmlhttprequest/origin-allow-list-all.html [ Failure ]
-http/tests/xmlhttprequest/origin-allow-list-ip-addresses.html [ Failure ]
 http/wpt/css/css-view-transitions/navigation/cross-origin-bfcache.html [ Failure ]
 http/wpt/css/css-view-transitions/navigation/old_vt_promises_bfcache.html [ Failure ]
 http/wpt/fetch/inspect-preflight.html [ Failure ]

--- a/Source/WebCore/loader/SubresourceLoader.cpp
+++ b/Source/WebCore/loader/SubresourceLoader.cpp
@@ -47,11 +47,13 @@
 #include "HTTPStatusCodes.h"
 #include "InspectorNetworkAgent.h"
 #include "LinkLoader.h"
+#include "LoaderStrategy.h"
 #include "LocalFrame.h"
 #include "LocalFrameLoaderClient.h"
 #include "Logging.h"
 #include "MemoryCache.h"
 #include "OriginAccessPatterns.h"
+#include "PlatformStrategies.h"
 #include "RemoteFrame.h"
 #include "ResourceLoadObserver.h"
 #include "ResourceTiming.h"
@@ -667,6 +669,11 @@ static void logResourceLoaded(LocalFrame* frame, CachedResource::Type type)
 Expected<void, String> SubresourceLoader::checkResponseCrossOriginAccessControl(const ResourceResponse& response)
 {
     if (!m_resource->isCrossOrigin() || options().mode != FetchOptions::Mode::Cors)
+        return { };
+
+    if (platformStrategies()->loaderStrategy()->havePerformedSecurityChecks(response)
+        && response.source() != ResourceResponse::Source::Unknown
+        && response.tainting() == ResourceResponse::Tainting::Basic)
         return { };
 
     if (response.source() == ResourceResponse::Source::ServiceWorker) {


### PR DESCRIPTION
#### 1fd159ccc6dfeef72c7d30b9226b5747aa7d534f
<pre>
[Site Isolation] http/tests/xmlhttprequest/origin-allow-list-all.html fails
<a href="https://bugs.webkit.org/show_bug.cgi?id=313361">https://bugs.webkit.org/show_bug.cgi?id=313361</a>

Reviewed by Chris Dumez.

Under site isolation, testRunner.addOriginAccessAllowListEntry() updates the calling WebProcess&apos;s local
SecurityPolicy::originAccessMap and the Network Process&apos;s global copy via IPC. But the iframe&apos;s WebProcess
(a separate process for localhost:8000) never receives these entries.

The Network Process correctly identifies the request as same-origin via its global allowlist and returns
the response. However, SubresourceLoader::checkResponseCrossOriginAccessControl() in the iframe&apos;s
WebProcess performs a redundant CORS header check. It uses m_resource-&gt;isCrossOrigin(), which was set at
CachedResource construction time using the WebProcess-local allowlist (empty in the iframe&apos;s process).
Since the server doesn&apos;t send Access-Control-Allow-Origin headers (the test relies on the allowlist to
bypass CORS), this check fails for the async XHR. The sync XHR works because it bypasses SubresourceLoader
entirely and trusts the Network Process when shouldPerformSecurityChecks() is true.

Fixed the test by adding an early return in SubresourceLoader::checkResponseCrossOriginAccessControl()
when havePerformedSecurityChecks(response) returns true to skip the redundant WebProcess-side CORS check
when the Network Process has already validated the response. This follows the same pattern already used
in DocumentThreadableLoader::willSendRequest and DocumentLoader::responseReceived.

Co-authored with Claude.

Tests: http/tests/xmlhttprequest/origin-allow-list-all.html
       http/tests/xmlhttprequest/origin-allow-list-ip-addresses.html

* LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/media-elements/track/track-element/track-data-url-expected.txt:
* LayoutTests/platform/glib/imported/w3c/web-platform-tests/html/semantics/embedded-content/media-elements/track/track-element/track-data-url-expected.txt: Removed.
* LayoutTests/platform/ios-site-isolation/TestExpectations:
* LayoutTests/platform/mac-site-isolation/TestExpectations:
* Source/WebCore/loader/SubresourceLoader.cpp:
(WebCore::SubresourceLoader::checkResponseCrossOriginAccessControl):

Canonical link: <a href="https://commits.webkit.org/312297@main">https://commits.webkit.org/312297@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/395547c4d138255df63fc88aca722521fda343d8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/159413 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/32841 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/25949 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/168245 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/113791 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/8fe092b9-bf1a-4f62-8e52-433bd23b0b10) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/161282 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/32909 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/32829 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/123512 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/86696 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/cd665ded-8e89-43c6-b209-8e41dbe5fede) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/162370 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/25758 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/143182 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/104176 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/24825 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/23268 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/16016 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/134498 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/20962 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/170737 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/16771 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/22588 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/131718 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/32530 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/27343 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/131831 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/32474 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/142755 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/90599 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/24274 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/26491 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/19564 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/31985 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/98437 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/31505 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/31778 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/31660 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->