### PR TITLE
REGRESSION (304469@main): WTR::supportedAttributes() leaks NSMutableArray

### DIFF
--- a/Tools/WebKitTestRunner/InjectedBundle/mac/AccessibilityUIElementMac.mm
+++ b/Tools/WebKitTestRunner/InjectedBundle/mac/AccessibilityUIElementMac.mm
@@ -152,7 +152,7 @@ RetainPtr<NSArray> supportedAttributes(id element)
 
     BEGIN_AX_OBJC_EXCEPTIONS
     AccessibilityUIElementMac::s_controller->executeOnAXThreadAndWait([&attributes, &element] {
-        attributes = [[element accessibilityAttributeNames] mutableCopy];
+        attributes = adoptNS([[element accessibilityAttributeNames] mutableCopy]);
         // Exposing this in tests is not valuable, so remove it to decrease test maintenance burden.
         [attributes removeObject:@"AXPerformsOwnTextStitching"];
         [attributes removeObject:@"AXPostsOwnLiveRegionAnnouncements"];


### PR DESCRIPTION
#### 9323616ae50bf49f9a525d2f472a5511f94cb696
<pre>
REGRESSION (304469@main): WTR::supportedAttributes() leaks NSMutableArray
&lt;<a href="https://bugs.webkit.org/show_bug.cgi?id=313364">https://bugs.webkit.org/show_bug.cgi?id=313364</a>&gt;
&lt;<a href="https://rdar.apple.com/175635842">rdar://175635842</a>&gt;

Reviewed by Tyler Wilcock.

Adopt the +1 retained result of `-mutableCopy` with `adoptNS()`.
Without this, assigning the raw pointer to `RetainPtr` retains it
a second time, and the `RetainPtr` destructor only releases once,
leaving the array leaked.

The leak was introduced in Bug 304071 (304469@main) which changed
`supportedAttributes()` from returning a plain `RetainPtr&lt;NSArray&gt;`
(assigned from `-accessibilityAttributeNames`, a +0 return) to a
`RetainPtr&lt;NSMutableArray&gt;` (assigned from `-mutableCopy`, a +1
return) without adding `adoptNS()`.

Test using `run-webkit-tests --leaks`.

* Tools/WebKitTestRunner/InjectedBundle/mac/AccessibilityUIElementMac.mm:
(WTR::supportedAttributes):

Canonical link: <a href="https://commits.webkit.org/312056@main">https://commits.webkit.org/312056@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ef96fc22e711154ad37659ccb5766daba683090a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/158841 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/32268 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/25373 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/167670 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/112925 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/d73b338f-b69e-46bd-8093-3f0eed9a5e82) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/160710 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/32334 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/32255 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/123066 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/86396 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/3bac2c92-f297-4d4a-8f0f-812f9813d829) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/161798 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/25336 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/142700 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/103735 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/3cfd437e-77f1-4348-8b64-1831a6e1f5a3) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/24392 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/22792 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/15442 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/134078 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/20480 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/170162 "Built successfully") | | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/22106 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/131254 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/31957 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/26859 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/131368 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/31902 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/142273 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/89902 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/24151 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/26070 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/19082 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/31413 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/30933 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/31206 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/31087 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->