### PR TITLE
[JSC] More aligning module loader to the spec

### DIFF
--- a/Source/JavaScriptCore/jsc.cpp
+++ b/Source/JavaScriptCore/jsc.cpp
@@ -1100,22 +1100,25 @@ JSPromise* GlobalObject::moduleLoaderImportModule(JSGlobalObject* globalObject, 
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    auto* promise = JSPromise::create(vm, globalObject->promiseStructure());
-
-    auto rejectWithError = [&](JSValue error) {
-        promise->reject(vm, globalObject, error);
-        return promise;
+    auto rejectWithCaughtException = [&]() -> JSPromise* {
+        auto* promise = JSPromise::create(vm, globalObject->promiseStructure());
+        return promise->rejectWithCaughtException(globalObject, scope);
     };
 
     auto& referrer = sourceOrigin.url();
     auto specifier = moduleNameValue->value(globalObject);
-    RETURN_IF_EXCEPTION(scope, promise->rejectWithCaughtException(globalObject, scope));
+    if (scope.exception()) [[unlikely]]
+        return rejectWithCaughtException();
 
-    if (!referrer.protocolIsFile())
-        RELEASE_AND_RETURN(scope, rejectWithError(createError(globalObject, makeString("Could not resolve the referrer's path '"_s, referrer.string(), "', while trying to resolve module '"_s, specifier.data, "'."_s))));
+    if (!referrer.protocolIsFile()) [[unlikely]] {
+        auto* promise = JSPromise::create(vm, globalObject->promiseStructure());
+        promise->reject(vm, globalObject, createError(globalObject, makeString("Could not resolve the referrer's path '"_s, referrer.string(), "', while trying to resolve module '"_s, specifier.data, "'."_s)));
+        return promise;
+    }
 
-    auto result = JSC::importModule(globalObject, Identifier::fromString(vm, specifier), Identifier::fromString(vm, referrer.string()), WTF::move(fetchParams), nullptr);
-    RETURN_IF_EXCEPTION(scope, promise->rejectWithCaughtException(globalObject, scope));
+    auto* result = JSC::importModule(globalObject, Identifier::fromString(vm, specifier), Identifier::fromString(vm, referrer.string()), WTF::move(fetchParams), nullptr);
+    if (scope.exception()) [[unlikely]]
+        return rejectWithCaughtException();
 
     return result;
 }

--- a/Source/JavaScriptCore/parser/ModuleAnalyzer.cpp
+++ b/Source/JavaScriptCore/parser/ModuleAnalyzer.cpp
@@ -148,7 +148,7 @@ Expected<JSModuleRecord*, std::tuple<ErrorType, String>> ModuleAnalyzer::analyze
     for (const auto& pair : m_moduleRecord->lexicalVariables())
         exportVariable(moduleProgramNode, pair.key, pair.value);
 
-    m_moduleRecord->hasTLA(moduleProgramNode.usesAwait());
+    m_moduleRecord->setHasTLA(moduleProgramNode.usesAwait());
 
     if (Options::dumpModuleRecord()) [[unlikely]]
         m_moduleRecord->dump();

--- a/Source/JavaScriptCore/runtime/AbstractModuleRecord.cpp
+++ b/Source/JavaScriptCore/runtime/AbstractModuleRecord.cpp
@@ -995,13 +995,13 @@ unsigned AbstractModuleRecord::innerModuleEvaluation(JSGlobalObject* globalObjec
     // 4. Assert: module.[[Status]] is LINKED.
     ASSERT(module->status() == Status::Linked);
     // 5. Set module.[[Status]] to EVALUATING.
-    module->status(Status::Evaluating);
+    module->setStatus(Status::Evaluating);
     // 6. Let moduleIndex be index.
     unsigned moduleIndex = index;
     // 7. Set module.[[DFSAncestorIndex]] to index.
-    module->dfsAncestorIndex(index);
+    module->setDFSAncestorIndex(index);
     // 8. Set module.[[PendingAsyncDependencies]] to 0.
-    module->pendingAsyncDependencies(0);
+    module->setPendingAsyncDependencies(0);
     // 9. Set index to index + 1.
     ++index;
     // 10. Append module to stack.
@@ -1025,7 +1025,7 @@ unsigned AbstractModuleRecord::innerModuleEvaluation(JSGlobalObject* globalObjec
             // 11.c.iii. If requiredModule.[[Status]] is EVALUATING, then
             if (cyclic->status() == Status::Evaluating) {
                 // 11.c.iii.1. Set module.[[DFSAncestorIndex]] to min(module.[[DFSAncestorIndex]], requiredModule.[[DFSAncestorIndex]]).
-                module->dfsAncestorIndex(std::min(module->dfsAncestorIndex(), cyclic->dfsAncestorIndex()));
+                module->setDFSAncestorIndex(std::min(module->dfsAncestorIndex(), cyclic->dfsAncestorIndex()));
             // 11.c.iv. Else,
             } else {
                 // 11.c.iv.1. Set requiredModule to requiredModule.[[CycleRoot]].
@@ -1042,7 +1042,7 @@ unsigned AbstractModuleRecord::innerModuleEvaluation(JSGlobalObject* globalObjec
             // 11.c.v. If requiredModule.[[AsyncEvaluationOrder]] is an integer, then
             if (cyclic->asyncEvaluationOrder().hasOrder()) {
                 // 11.c.v.1. Set module.[[PendingAsyncDependencies]] to module.[[PendingAsyncDependencies]] + 1.
-                module->pendingAsyncDependencies(module->pendingAsyncDependencies().value() + 1);
+                module->setPendingAsyncDependencies(module->pendingAsyncDependencies().value() + 1);
                 // 11.c.v.2. Append module to requiredModule.[[AsyncParentModules]].
                 cyclic->appendAsyncParentModule(vm, module);
             }
@@ -1053,7 +1053,7 @@ unsigned AbstractModuleRecord::innerModuleEvaluation(JSGlobalObject* globalObjec
         // 12.a. Assert: module.[[AsyncEvaluationOrder]] is UNSET.
         ASSERT(module->asyncEvaluationOrder().isUnset());
         // 12.b. Set module.[[AsyncEvaluationOrder]] to IncrementModuleAsyncEvaluationCount().
-        module->asyncEvaluationOrder(vm.incrementModuleAsyncEvaluationCount());
+        module->setAsyncEvaluationOrder(vm.incrementModuleAsyncEvaluationCount());
         // 12.c. If module.[[PendingAsyncDependencies]] = 0, perform ExecuteAsyncModule(module).
         if (std::optional<int> deps = module->pendingAsyncDependencies(); deps && !*deps) {
             module->executeAsync(globalObject);
@@ -1085,14 +1085,14 @@ unsigned AbstractModuleRecord::innerModuleEvaluation(JSGlobalObject* globalObjec
             ASSERT(cyclic->asyncEvaluationOrder().hasOrder() || cyclic->asyncEvaluationOrder().isUnset());
             // 16.b.v. If requiredModule.[[AsyncEvaluationOrder]] is UNSET, set requiredModule.[[Status]] to EVALUATED.
             if (cyclic->asyncEvaluationOrder().isUnset()) {
-                cyclic->status(Status::Evaluated);
+                cyclic->setStatus(Status::Evaluated);
             // 16.b.vi. Otherwise, set requiredModule.[[Status]] to EVALUATING-ASYNC.
             } else
-                cyclic->status(Status::EvaluatingAsync);
+                cyclic->setStatus(Status::EvaluatingAsync);
             // 16.b.vii. If requiredModule and module are the same Module Record, set done to true.
             done = requiredModule == module;
             // 16.b.viii. Set requiredModule.[[CycleRoot]] to module.
-            requiredModule->cycleRoot(vm, module);
+            requiredModule->setCycleRoot(vm, module);
         } while (!done);
     }
     // 17. Return index.
@@ -1127,11 +1127,11 @@ unsigned AbstractModuleRecord::innerModuleLinking(JSGlobalObject* globalObject, 
     // 3. Assert: module.[[Status]] is UNLINKED.
     ASSERT(module->status() == Status::Unlinked);
     // 4. Set module.[[Status]] to LINKING.
-    module->status(Status::Linking);
+    module->setStatus(Status::Linking);
     // 5. Let moduleIndex be index.
     unsigned moduleIndex = index;
     // 6. Set module.[[DFSAncestorIndex]] to index.
-    module->dfsAncestorIndex(index);
+    module->setDFSAncestorIndex(index);
     // 7. Set index to index + 1.
     ++index;
     // 8. Append module to stack.
@@ -1159,7 +1159,7 @@ unsigned AbstractModuleRecord::innerModuleLinking(JSGlobalObject* globalObject, 
             // 9.c.iii. If requiredModule.[[Status]] is LINKING, then
             if (status == Status::Linking) {
                 // 9.c.iii.1. Set module.[[DFSAncestorIndex]] to min(module.[[DFSAncestorIndex]], requiredModule.[[DFSAncestorIndex]]).
-                module->dfsAncestorIndex(std::min(module->dfsAncestorIndex(), requiredCyclic->dfsAncestorIndex()));
+                module->setDFSAncestorIndex(std::min(module->dfsAncestorIndex(), requiredCyclic->dfsAncestorIndex()));
             }
         }
     }
@@ -1184,7 +1184,7 @@ unsigned AbstractModuleRecord::innerModuleLinking(JSGlobalObject* globalObject, 
             // 13.b.iii. Assert: requiredModule is a Cyclic Module Record.
             auto* cyclic = uncheckedDowncast<CyclicModuleRecord>(requiredModule);
             // 13.b.iv. Set requiredModule.[[Status]] to LINKED.
-            cyclic->status(Status::Linked);
+            cyclic->setStatus(Status::Linked);
             // 13.b.v. If requiredModule and module are the same Module Record, set done to true.
             done = requiredModule == module;
         } while (!done);
@@ -1219,17 +1219,17 @@ ScriptFetchParameters::Type AbstractModuleRecord::moduleType() const
     return ScriptFetchParameters::None;
 }
 
-void AbstractModuleRecord::cycleRoot(VM& vm, CyclicModuleRecord* newRoot)
+void AbstractModuleRecord::setCycleRoot(VM& vm, CyclicModuleRecord* newRoot)
 {
     m_cycleRoot.set(vm, this, newRoot);
 }
 
-void AbstractModuleRecord::topLevelCapability(VM& vm, JSPromise* promise)
+void AbstractModuleRecord::setTopLevelCapability(VM& vm, JSPromise* promise)
 {
     m_topLevelCapability.set(vm, this, promise);
 }
 
-void AbstractModuleRecord::hasTLA(bool has)
+void AbstractModuleRecord::setHasTLA(bool has)
 {
     m_hasTLA = has;
 }

--- a/Source/JavaScriptCore/runtime/AbstractModuleRecord.h
+++ b/Source/JavaScriptCore/runtime/AbstractModuleRecord.h
@@ -166,13 +166,13 @@ public:
     bool hasTLA() const { return m_hasTLA; }
 
     JSPromise* topLevelCapability() const { return m_topLevelCapability.get(); }
-    void cycleRoot(VM&, CyclicModuleRecord*);
-    void asyncEvaluationOrder(AsyncEvaluationOrder newOrder) { m_asyncEvaluationOrder = newOrder; }
-    void pendingAsyncDependencies(std::optional<int> newDependencies) { m_pendingAsyncDependencies = newDependencies; }
+    void setCycleRoot(VM&, CyclicModuleRecord*);
+    void setAsyncEvaluationOrder(AsyncEvaluationOrder newOrder) { m_asyncEvaluationOrder = newOrder; }
+    void setPendingAsyncDependencies(std::optional<int> newDependencies) { m_pendingAsyncDependencies = newDependencies; }
 
     void appendAsyncParentModule(VM&, AbstractModuleRecord*);
-    void topLevelCapability(VM&, JSPromise*);
-    void hasTLA(bool);
+    void setTopLevelCapability(VM&, JSPromise*);
+    void setHasTLA(bool);
 
     void dump();
 

--- a/Source/JavaScriptCore/runtime/Completion.cpp
+++ b/Source/JavaScriptCore/runtime/Completion.cpp
@@ -192,10 +192,10 @@ JSPromise* loadAndEvaluateModule(JSGlobalObject* globalObject, const String& mod
     RELEASE_ASSERT(vm.atomStringTable() == Thread::currentSingleton().atomStringTable());
     RELEASE_ASSERT(!vm.isCollectorBusyOnCurrentThread());
 
-    Identifier resolved = globalObject->moduleLoader()->resolve(globalObject, Identifier::fromString(vm, moduleName), { }, scriptFetcher, false);
+    Identifier resolved = globalObject->moduleLoader()->resolve(globalObject, Identifier::fromString(vm, moduleName), { }, scriptFetcher, /* useImportMap */ false);
     RETURN_IF_EXCEPTION(scope, nullptr);
 
-    RELEASE_AND_RETURN(scope, globalObject->moduleLoader()->loadModule(globalObject, resolved, WTF::move(parameters), WTF::move(scriptFetcher), true, false, false));
+    RELEASE_AND_RETURN(scope, globalObject->moduleLoader()->loadModule(globalObject, resolved, WTF::move(parameters), WTF::move(scriptFetcher), /* evaluate */ true, /* dynamic */ false, /* useImportMap */ false));
 }
 
 static ScriptFetchParameters::Type getSourceType(const SourceCode& source)
@@ -234,7 +234,7 @@ JSPromise* loadAndEvaluateModule(JSGlobalObject* globalObject, SourceCode&& sour
 
     AbstractModuleRecord::ModuleRequest request { WTF::move(key), ScriptFetchParameters::create(type) };
 
-    JSPromise* promise = globalObject->moduleLoader()->loadModule(globalObject, globalObject, request, graphLoadingState, WTF::move(scriptFetcher), true, false);
+    JSPromise* promise = globalObject->moduleLoader()->loadModule(globalObject, globalObject, request, graphLoadingState, WTF::move(scriptFetcher), /* evaluate */ true, /* useImportMap */ false);
     RETURN_IF_EXCEPTION(scope, rejectPromise(scope, globalObject));
 
     JSPromise* resultPromise = JSPromise::create(vm, globalObject->promiseStructure());
@@ -251,7 +251,7 @@ JSPromise* loadModule(JSGlobalObject* globalObject, const Identifier& moduleKey,
     RELEASE_ASSERT(vm.atomStringTable() == Thread::currentSingleton().atomStringTable());
     RELEASE_ASSERT(!vm.isCollectorBusyOnCurrentThread());
 
-    return globalObject->moduleLoader()->loadModule(globalObject, moduleKey, WTF::move(parameters), WTF::move(scriptFetcher), false, false, false);
+    return globalObject->moduleLoader()->loadModule(globalObject, moduleKey, WTF::move(parameters), WTF::move(scriptFetcher), /* evaluate */ false, /* dynamic */ false, /* useImportMap */ false);
 }
 
 JSPromise* loadModule(JSGlobalObject* globalObject, SourceCode&& source, RefPtr<ScriptFetcher> scriptFetcher)
@@ -267,7 +267,7 @@ JSPromise* loadModule(JSGlobalObject* globalObject, SourceCode&& source, RefPtr<
     // Insert the given source code to the ModuleLoader registry as the fetched registry entry.
     globalObject->moduleLoader()->provideFetch(globalObject, key, getSourceType(source), WTF::move(source));
     RETURN_IF_EXCEPTION(scope, rejectPromise(scope, globalObject));
-    RELEASE_AND_RETURN(scope, globalObject->moduleLoader()->loadModule(globalObject, key, nullptr, WTF::move(scriptFetcher), false, false, false));
+    RELEASE_AND_RETURN(scope, globalObject->moduleLoader()->loadModule(globalObject, key, nullptr, WTF::move(scriptFetcher), /* evaluate */ false, /* dynamic */ false, /* useImportMap */ false));
 }
 
 JSPromise* linkAndEvaluateModule(JSGlobalObject* globalObject, const Identifier& moduleKey, RefPtr<ScriptFetcher> scriptFetcher)

--- a/Source/JavaScriptCore/runtime/CyclicModuleRecord.cpp
+++ b/Source/JavaScriptCore/runtime/CyclicModuleRecord.cpp
@@ -346,7 +346,7 @@ void CyclicModuleRecord::link(JSGlobalObject* globalObject, RefPtr<ScriptFetcher
             // 4.a.i. Assert: m.[[Status]] is LINKING.
             ASSERT(m->status() == Status::Linking);
             // 4.a.ii. Set m.[[Status]] to UNLINKED.
-            m->status(Status::Unlinked);
+            m->setStatus(Status::Unlinked);
         }
         // 4.b. Assert: module.[[Status]] is UNLINKED.
         ASSERT(status() == Status::Unlinked);
@@ -396,7 +396,7 @@ JSPromise* CyclicModuleRecord::evaluate(JSGlobalObject* globalObject)
     // 6. Let capability be ! NewPromiseCapability(%Promise%).
     JSPromise* capability = JSPromise::create(vm, globalObject->promiseStructure());
     // 7. Set module.[[TopLevelCapability]] to capability.
-    module->topLevelCapability(vm, capability);
+    module->setTopLevelCapability(vm, capability);
     // 8. Let result be Completion(InnerModuleEvaluation(module, stack, 0)).
     module->innerModuleEvaluation(globalObject, stack, 0);
     // 9. If result is an abrupt completion, then
@@ -408,9 +408,9 @@ JSPromise* CyclicModuleRecord::evaluate(JSGlobalObject* globalObject)
             auto* cyclic = uncheckedDowncast<CyclicModuleRecord>(abstractRecord);
             ASSERT(cyclic->status() == Status::Evaluating);
             // 9.a.ii. Set m.[[Status]] to EVALUATED.
-            cyclic->status(Status::Evaluated);
+            cyclic->setStatus(Status::Evaluated);
             // 9.a.iii. Set m.[[EvaluationError]] to result.
-            cyclic->evaluationError(vm, exception->value());
+            cyclic->setEvaluationError(vm, exception->value());
         }
         // 9.b. Assert: module.[[Status]] is EVALUATED.
         ASSERT(module->status() == Status::Evaluated);
@@ -520,7 +520,7 @@ static void gatherAvailableAncestors(CyclicModuleRecord* module, Vector<CyclicMo
             ASSERT(m->pendingAsyncDependencies() > 0);
             // 1.a.v. Set m.[[PendingAsyncDependencies]] to m.[[PendingAsyncDependencies]] - 1.
             int newDependencies = m->pendingAsyncDependencies().value() - 1;
-            m->pendingAsyncDependencies(newDependencies);
+            m->setPendingAsyncDependencies(newDependencies);
             // 1.a.vi. If m.[[PendingAsyncDependencies]] = 0, then
             if (!newDependencies) {
                 // 1.a.vi.1. Append m to execList.
@@ -555,11 +555,11 @@ void CyclicModuleRecord::asyncExecutionRejected(JSGlobalObject* globalObject, JS
     // 4. Assert: module.[[EvaluationError]] is EMPTY.
     ASSERT(evaluationError() == nullptr);
     // 5. Set module.[[EvaluationError]] to ThrowCompletion(error).
-    evaluationError(vm, error);
+    setEvaluationError(vm, error);
     // 6. Set module.[[Status]] to EVALUATED.
-    status(CyclicModuleRecord::Status::Evaluated);
+    setStatus(CyclicModuleRecord::Status::Evaluated);
     // 7. Set module.[[AsyncEvaluationOrder]] to DONE.
-    asyncEvaluationOrder(AbstractModuleRecord::AsyncEvaluationOrder::done());
+    setAsyncEvaluationOrder(AbstractModuleRecord::AsyncEvaluationOrder::done());
     // 8. NOTE: module.[[AsyncEvaluationOrder]] is set to DONE for symmetry with AsyncModuleExecutionFulfilled. In InnerModuleEvaluation, the value of a module's [[AsyncEvaluationOrder]] internal slot is unused when its [[EvaluationError]] internal slot is not EMPTY.
     // 9. If module.[[TopLevelCapability]] is not EMPTY, then
     if (auto* topLevel = topLevelCapability()) {
@@ -598,9 +598,9 @@ void CyclicModuleRecord::asyncExecutionFulfilled(JSGlobalObject* globalObject)
     // 4. Assert: module.[[EvaluationError]] is EMPTY.
     ASSERT(evaluationError() == nullptr);
     // 5. Set module.[[AsyncEvaluationOrder]] to DONE.
-    asyncEvaluationOrder(AbstractModuleRecord::AsyncEvaluationOrder::done());
+    setAsyncEvaluationOrder(AbstractModuleRecord::AsyncEvaluationOrder::done());
     // 6. Set module.[[Status]] to EVALUATED.
-    status(CyclicModuleRecord::Status::Evaluated);
+    setStatus(CyclicModuleRecord::Status::Evaluated);
     // 7. If module.[[TopLevelCapability]] is not EMPTY, then
     if (auto* capability = topLevelCapability()) {
         // 7.a. Assert: module.[[CycleRoot]] and module are the same Module Record.
@@ -653,9 +653,9 @@ void CyclicModuleRecord::asyncExecutionFulfilled(JSGlobalObject* globalObject)
             // 12.c.iii. Else,
             } else {
                 // 12.c.iii.1. Set m.[[AsyncEvaluationOrder]] to DONE.
-                m->asyncEvaluationOrder(AbstractModuleRecord::AsyncEvaluationOrder::done());
+                m->setAsyncEvaluationOrder(AbstractModuleRecord::AsyncEvaluationOrder::done());
                 // 12.c.iii.2. Set m.[[Status]] to EVALUATED.
-                m->status(CyclicModuleRecord::Status::Evaluated);
+                m->setStatus(CyclicModuleRecord::Status::Evaluated);
                 // 12.c.iii.3. If m.[[TopLevelCapability]] is not EMPTY, then
                 if (auto* capability = m->topLevelCapability()) {
                     // 12.c.iii.3.a. Assert: m.[[CycleRoot]] and m are the same Module Record.

--- a/Source/JavaScriptCore/runtime/CyclicModuleRecord.h
+++ b/Source/JavaScriptCore/runtime/CyclicModuleRecord.h
@@ -67,9 +67,9 @@ public:
     JSValue evaluationError() const { return m_evaluationError.get(); }
     unsigned dfsAncestorIndex() const { return m_dfsAncestorIndex; }
 
-    void status(Status newStatus) { m_status = newStatus; }
-    void evaluationError(VM& vm, JSValue error) { m_evaluationError.set(vm, this, error); }
-    void dfsAncestorIndex(unsigned newIndex) { m_dfsAncestorIndex = newIndex; }
+    void setStatus(Status newStatus) { m_status = newStatus; }
+    void setEvaluationError(VM& vm, JSValue error) { m_evaluationError.set(vm, this, error); }
+    void setDFSAncestorIndex(unsigned newIndex) { m_dfsAncestorIndex = newIndex; }
 
 protected:
     CyclicModuleRecord(VM&, Structure*, const Identifier&);

--- a/Source/JavaScriptCore/runtime/JSGlobalObjectFunctions.cpp
+++ b/Source/JavaScriptCore/runtime/JSGlobalObjectFunctions.cpp
@@ -799,22 +799,27 @@ JSC_DEFINE_HOST_FUNCTION(globalFuncImportModule, (JSGlobalObject* globalObject, 
 {
     VM& vm = globalObject->vm();
 
-    auto* promise = JSPromise::create(vm, globalObject->promiseStructure());
-
     auto scope = DECLARE_THROW_SCOPE(vm);
+
+    auto rejectWithCaughtException = [&]() -> EncodedJSValue {
+        auto* promise = JSPromise::create(vm, globalObject->promiseStructure());
+        return JSValue::encode(promise->rejectWithCaughtException(globalObject, scope));
+    };
 
     auto sourceOrigin = callFrame->callerSourceOrigin(vm);
     RELEASE_ASSERT(callFrame->argumentCount() >= 1);
+
     auto* specifier = callFrame->uncheckedArgument(0).toString(globalObject);
-    RETURN_IF_EXCEPTION(scope, JSValue::encode(promise->rejectWithCaughtException(globalObject, scope)));
+    if (scope.exception()) [[unlikely]]
+        return rejectWithCaughtException();
 
     // We always specify parameters as undefined. Once dynamic import() starts accepting fetching parameters,
     // we should retrieve this from the arguments.
     JSValue parameters = callFrame->argument(1);
     auto* importPromise = globalObject->moduleLoader()->importModule(globalObject, specifier, parameters, sourceOrigin);
-    RETURN_IF_EXCEPTION(scope, JSValue::encode(promise->rejectWithCaughtException(globalObject, scope)));
+    if (scope.exception()) [[unlikely]]
+        return rejectWithCaughtException();
 
-    scope.release();
     return JSValue::encode(importPromise);
 }
 

--- a/Source/JavaScriptCore/runtime/JSMicrotask.cpp
+++ b/Source/JavaScriptCore/runtime/JSMicrotask.cpp
@@ -1238,6 +1238,9 @@ static void moduleLoadStoreError(JSGlobalObject* globalObject, ThrowScope& scope
 
 static void dynamicImportLoadSettled(JSGlobalObject* globalObject, VM& vm, ThrowScope& scope, std::span<const JSValue, maxMicrotaskArguments> arguments, uint8_t payload)
 {
+    // https://tc39.es/ecma262/#sec-ContinueDynamicImport
+    // Step-4 rejectedClosure or Step-6 linkAndEvaluateClosure
+    //
     // continueDynamicImport: loadPromise settled
     // arguments[0] = capabilityPromise
     // arguments[1] = resolution or error
@@ -1246,25 +1249,39 @@ static void dynamicImportLoadSettled(JSGlobalObject* globalObject, VM& vm, Throw
     auto* module = uncheckedDowncast<AbstractModuleRecord>(arguments[2]);
     auto status = static_cast<JSPromise::Status>(payload);
     if (status == JSPromise::Status::Fulfilled) {
-        // linkAndEvaluate logic
+        // Step-6 linkAndEvaluateClosure
+        // 6.a. Let link be Completion(module.Link()).
         module->link(globalObject, nullptr);
-        if (Exception* exception = scope.exception()) {
+
+        // 6.b. If link is an abrupt completion, then
+        if (Exception* exception = scope.exception()) [[unlikely]] {
+            // 6.b.i. Perform ! Call(promiseCapability.[[Reject]], undefined, « link.[[Value]] »).
             JSModuleLoader::attachErrorInfo(globalObject, exception, module, module->moduleKey(), module->moduleType(), JSModuleLoader::ModuleFailure::Kind::Instantiation);
             capabilityPromise->rejectWithCaughtException(globalObject, scope);
             return;
         }
+
+        // 6.c. Let evaluatePromise be module.Evaluate().
         JSPromise* evaluatePromise = module->evaluate(globalObject);
-        if (scope.exception()) {
+        if (scope.exception()) [[unlikely]] {
             capabilityPromise->rejectWithCaughtException(globalObject, scope);
             return;
         }
+
+        // 6.d-f. Perform PerformPromiseThen(evaluatePromise, onFulfilled, onRejected).
         evaluatePromise->performPromiseThenWithInternalMicrotask(vm, globalObject, InternalMicrotask::DynamicImportEvaluateSettled, capabilityPromise, module);
-    } else
+    } else {
+        // Step-4 rejectedClosure
+        // 4.a. Perform ! Call(promiseCapability.[[Reject]], undefined, « reason »).
         capabilityPromise->reject(vm, globalObject, arguments[1]);
+    }
 }
 
 static void dynamicImportEvaluateSettled(JSGlobalObject* globalObject, VM& vm, ThrowScope& scope, std::span<const JSValue, maxMicrotaskArguments> arguments, uint8_t payload)
 {
+    // https://tc39.es/ecma262/#sec-ContinueDynamicImport
+    // Step-4 rejectedClosure or Step-6.c fulfilledClosure
+    //
     // continueDynamicImport: evaluate settled
     // arguments[0] = capabilityPromise
     // arguments[1] = resolution or error
@@ -1273,17 +1290,24 @@ static void dynamicImportEvaluateSettled(JSGlobalObject* globalObject, VM& vm, T
     auto* module = uncheckedDowncast<AbstractModuleRecord>(arguments[2]);
     auto status = static_cast<JSPromise::Status>(payload);
     if (status == JSPromise::Status::Fulfilled) {
+        // 6.d.i. Let namespace be GetModuleNamespace(module).
         JSModuleNamespaceObject* moduleNamespace = module->getModuleNamespace(globalObject);
-        if (scope.exception()) {
+        if (scope.exception()) [[unlikely]] {
             capabilityPromise->rejectWithCaughtException(globalObject, scope);
             return;
         }
-        // ContinueDynamicImport https://tc39.es/ecma262/#sec-ContinueDynamicImport
-        // Step 10 resolves the promiseCapability with the namespace. However,
+
+        // 6.d.ii. Perform ! Call(promiseCapability.[[Resolve]], undefined, « namespace »).
+        // This step resolves the promiseCapability with the namespace. However,
         // capabilityPromise here is the internal statePromise from moduleLoadTopSettled,
         // not the user-visible import() promise. The actual spec-required resolve()
         // happens in importModuleNamespace. Use fulfill here to avoid unnecessary
         // thenable unwrapping on internal pipeline.
+        //
+        // FIXME: This is different from the spec while user-observable behavior is correctly
+        // aligned (as "resolve" will happen in resultPromise side from dynamic import).
+        // But ideally, this carried capabilityPromise should be the last user-observable
+        // promise and we should do "resolve" here. This requires some clean up.
         capabilityPromise->fulfill(vm, globalObject, moduleNamespace);
     } else
         capabilityPromise->reject(vm, globalObject, arguments[1]);

--- a/Source/JavaScriptCore/runtime/JSModuleLoader.cpp
+++ b/Source/JavaScriptCore/runtime/JSModuleLoader.cpp
@@ -322,7 +322,7 @@ JSArray* JSModuleLoader::dependencyKeysIfEvaluated(JSGlobalObject* globalObject,
     RETURN_IF_EXCEPTION(scope, nullptr);
 
     for (unsigned index = 0; const AbstractModuleRecord::ModuleRequest& request : requests) {
-        Identifier resolved = resolve(globalObject, request.m_specifier, ident, nullptr, true);
+        Identifier resolved = resolve(globalObject, request.m_specifier, ident, nullptr, /* useImportMap */ true);
         RETURN_IF_EXCEPTION(scope, nullptr);
         array->putDirectIndex(globalObject, index++, identifierToJSValue(vm, resolved));
         RETURN_IF_EXCEPTION(scope, nullptr);
@@ -407,7 +407,7 @@ JSPromise* JSModuleLoader::linkAndEvaluateModule(JSGlobalObject* globalObject, c
         attachErrorInfo(globalObject, scope, record, entry->key(), entry->moduleType(), ModuleFailure::Kind::Instantiation);
         entry->setInstantiationError(globalObject, exception->value());
         if (auto* cyclic = dynamicDowncast<CyclicModuleRecord>(record))
-            cyclic->evaluationError(vm, exception->value());
+            cyclic->setEvaluationError(vm, exception->value());
         return nullptr;
     }
 
@@ -432,10 +432,10 @@ JSPromise* JSModuleLoader::requestImportModule(JSGlobalObject* globalObject, con
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    Identifier resolved = resolve(globalObject, moduleName, referrer, scriptFetcher, true);
+    Identifier resolved = resolve(globalObject, moduleName, referrer, scriptFetcher, /* useImportMap */ true);
     RETURN_IF_EXCEPTION(scope, nullptr);
 
-    JSPromise* promise = loadModule(globalObject, resolved, WTF::move(parameters), WTF::move(scriptFetcher), true, true, false);
+    JSPromise* promise = loadModule(globalObject, resolved, WTF::move(parameters), WTF::move(scriptFetcher), /* evaluate */ true, /* dynamic */ true, /* useImportMap */ false);
     RETURN_IF_EXCEPTION(scope, nullptr);
 
     JSPromise* resultPromise = JSPromise::create(vm, globalObject->promiseStructure());
@@ -715,7 +715,7 @@ JSPromise* JSModuleLoader::loadModule(JSGlobalObject* globalObject, const Module
     JSPromise* promise = hostLoadImportedModule(globalObject, referrer, moduleRequest, payload, scriptFetcher, useImportMap);
     RETURN_IF_EXCEPTION(scope, nullptr);
 
-    auto* context = ModuleLoadingContext::create(vm, moduleRequest, WTF::move(scriptFetcher), evaluate, false, useImportMap);
+    auto* context = ModuleLoadingContext::create(vm, moduleRequest, WTF::move(scriptFetcher), evaluate, /* dynamic */ false, useImportMap);
     JSPromise* resultPromise = JSPromise::create(vm, globalObject->promiseStructure());
     resultPromise->markAsHandled();
 
@@ -787,7 +787,7 @@ void JSModuleLoader::innerModuleLoading(JSGlobalObject* globalObject, ModuleGrap
         state->iterateVisited([](CyclicModuleRecord* loaded) {
             // 5.b.i. If loaded.[[Status]] is NEW, set loaded.[[Status]] to UNLINKED.
             if (loaded->status() == CyclicModuleRecord::Status::New)
-                loaded->status(CyclicModuleRecord::Status::Unlinked);
+                loaded->setStatus(CyclicModuleRecord::Status::Unlinked);
         });
         // 5.c. Perform ! Call(state.[[PromiseCapability]].[[Resolve]], undefined, « undefined »).
         state->promise()->fulfill(vm, globalObject, module);


### PR DESCRIPTION
#### 8af021fef543fbd1528de3f4926720e22081c9ae
<pre>
[JSC] More aligning module loader to the spec
<a href="https://rdar.apple.com/175637978">rdar://175637978</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=313372">https://bugs.webkit.org/show_bug.cgi?id=313372</a>

Reviewed by Sosuke Suzuki.

Add more spec comments to clarify the behavior, and cleaning up coding
style for setters, boolean parameters. Also reducing some unnecessary
JSPromise creations.

* Source/JavaScriptCore/jsc.cpp:
(GlobalObject::moduleLoaderImportModule):
* Source/JavaScriptCore/parser/ModuleAnalyzer.cpp:
(JSC::ModuleAnalyzer::analyze):
* Source/JavaScriptCore/runtime/AbstractModuleRecord.cpp:
(JSC::AbstractModuleRecord::innerModuleEvaluation):
(JSC::AbstractModuleRecord::innerModuleLinking):
(JSC::AbstractModuleRecord::setCycleRoot):
(JSC::AbstractModuleRecord::setTopLevelCapability):
(JSC::AbstractModuleRecord::setHasTLA):
(JSC::AbstractModuleRecord::cycleRoot): Deleted.
(JSC::AbstractModuleRecord::topLevelCapability): Deleted.
(JSC::AbstractModuleRecord::hasTLA): Deleted.
* Source/JavaScriptCore/runtime/AbstractModuleRecord.h:
(JSC::AbstractModuleRecord::setAsyncEvaluationOrder):
(JSC::AbstractModuleRecord::setPendingAsyncDependencies):
(JSC::AbstractModuleRecord::asyncEvaluationOrder): Deleted.
(JSC::AbstractModuleRecord::pendingAsyncDependencies): Deleted.
* Source/JavaScriptCore/runtime/Completion.cpp:
(JSC::loadAndEvaluateModule):
(JSC::loadModule):
* Source/JavaScriptCore/runtime/CyclicModuleRecord.cpp:
(JSC::CyclicModuleRecord::link):
(JSC::CyclicModuleRecord::evaluate):
(JSC::gatherAvailableAncestors):
(JSC::CyclicModuleRecord::asyncExecutionRejected):
(JSC::CyclicModuleRecord::asyncExecutionFulfilled):
* Source/JavaScriptCore/runtime/CyclicModuleRecord.h:
(JSC::CyclicModuleRecord::setStatus):
(JSC::CyclicModuleRecord::setEvaluationError):
(JSC::CyclicModuleRecord::setDFSAncestorIndex):
(JSC::CyclicModuleRecord::status): Deleted.
(JSC::CyclicModuleRecord::evaluationError): Deleted.
(JSC::CyclicModuleRecord::dfsAncestorIndex): Deleted.
* Source/JavaScriptCore/runtime/JSGlobalObjectFunctions.cpp:
(JSC::JSC_DEFINE_HOST_FUNCTION):
* Source/JavaScriptCore/runtime/JSMicrotask.cpp:
(JSC::dynamicImportLoadSettled):
(JSC::dynamicImportEvaluateSettled):
* Source/JavaScriptCore/runtime/JSModuleLoader.cpp:
(JSC::JSModuleLoader::dependencyKeysIfEvaluated):
(JSC::JSModuleLoader::linkAndEvaluateModule):
(JSC::JSModuleLoader::requestImportModule):
(JSC::JSModuleLoader::loadModule):
(JSC::JSModuleLoader::innerModuleLoading):

Canonical link: <a href="https://commits.webkit.org/312220@main">https://commits.webkit.org/312220@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fa6c88f747615e3dcf3ef5259e718615d4bdc0c9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/158873 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/32300 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/25405 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/167702 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/112957 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/68bdd683-9bca-4a90-adbf-df3bd15460a8) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/32366 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/32287 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/123084 "Found 1 new test failure: accessibility/aria-owns-deep-chain-no-timeout.html (failure)") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/86413 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/2b547ad4-5e14-4fc7-b205-ea3adc3cf444) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/161830 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/25357 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/142720 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/103753 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/1af11ea7-7bd0-4231-ba1a-a84dfb3e9604) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/24413 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/22812 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/15474 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/150923 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/134099 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/20500 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/170194 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/19706 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/15937 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/22126 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/131275 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/31989 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/26879 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/131389 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/31934 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/142293 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/89941 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/24240 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/26087 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/19102 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/191154 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/31445 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/97459 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/49140 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/30965 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/31238 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/31119 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->