### PR TITLE
REGRESSION(309943@main): Drag-and-drop preview does not lift from correct image location

### DIFF
--- a/Source/WebKit/UIProcess/mac/WebViewImpl.mm
+++ b/Source/WebKit/UIProcess/mac/WebViewImpl.mm
@@ -4718,7 +4718,9 @@ void WebViewImpl::startDrag(const WebCore::DragItem& item, ShareableBitmap::Hand
             RefPtr page = protectedThis->page();
             RetainPtr view = protectedThis->view();
 
+            // clientDragLocation is the bottom-left of the image, but setDraggingFrame: expects a top-left origin.
             auto clientDragLocation = IntPoint(dragLocationInMainFrameCoordinates.value());
+            auto draggingFrame = NSMakeRect(clientDragLocation.x(), clientDragLocation.y() - size.height(), size.width(), size.height());
 
             bool isImageDrag = protectedThis->m_promisedImageDragData && sourceAction == WebCore::DragSourceAction::Image;
             bool canUseFilePromiseForImageDrag = isImageDrag && !protectedThis->m_promisedImageDragData->imageUTI.isEmpty();
@@ -4762,12 +4764,12 @@ void WebViewImpl::startDrag(const WebCore::DragItem& item, ShareableBitmap::Hand
                 RetainPtr context = adoptNS([[WKPromisedAttachmentContext alloc] initWithIdentifier:promisedAttachmentInfo.attachmentIdentifier.createNSString().get() fileName:fileName.get()]);
                 [provider setUserInfo:context.get()];
                 draggingItem = adoptNS([[NSDraggingItem alloc] initWithPasteboardWriter:provider.get()]);
-                [draggingItem setDraggingFrame:NSMakeRect(clientDragLocation.x(), clientDragLocation.y() - size.height(), size.width(), size.height()) contents:dragNSImage.get()];
+                [draggingItem setDraggingFrame:draggingFrame contents:dragNSImage];
             } else if (canUseFilePromiseForImageDrag) {
                 RetainPtr imageUTI = protectedThis->m_promisedImageDragData->imageUTI.createNSString();
                 RetainPtr provider = adoptNS([[NSFilePromiseProvider alloc] initWithFileType:imageUTI.get() delegate:(id<NSFilePromiseProviderDelegate>)view.get()]);
                 draggingItem = adoptNS([[NSDraggingItem alloc] initWithPasteboardWriter:provider.get()]);
-                [draggingItem setDraggingFrame:NSMakeRect(clientDragLocation.x(), clientDragLocation.y(), size.width(), size.height()) contents:dragNSImage.get()];
+                [draggingItem setDraggingFrame:draggingFrame contents:dragNSImage];
             } else {
                 protectedThis->clearPromisedImageDragData();
 
@@ -4782,7 +4784,7 @@ void WebViewImpl::startDrag(const WebCore::DragItem& item, ShareableBitmap::Hand
                 RetainPtr pasteboardItem = adoptNS([[NSPasteboardItem alloc] init]);
                 [pasteboardItem setData:[NSData data] forType:UTTypeData.identifier];
                 draggingItem = adoptNS([[NSDraggingItem alloc] initWithPasteboardWriter:pasteboardItem.get()]);
-                [draggingItem setDraggingFrame:NSMakeRect(clientDragLocation.x(), clientDragLocation.y(), size.width(), size.height()) contents:dragNSImage.get()];
+                [draggingItem setDraggingFrame:draggingFrame contents:dragNSImage];
             }
 #if HAVE(APPKIT_GESTURES_SUPPORT)
             if (RetainPtr gesture = [gestureController activeDragGestureRecognizer]) {

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/SiteIsolation.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/SiteIsolation.mm
@@ -7457,7 +7457,7 @@ TEST(SiteIsolation, DragImageLocation)
     [webView waitForNextPresentationUpdate];
     [simulator runFrom:CGPointMake(300, 300) to:CGPointMake(350, 350)];
 
-    EXPECT_EQ([simulator initialDragImageLocationInView], NSMakePoint(252, 352));
+    EXPECT_EQ([simulator initialDragImageLocationInView], NSMakePoint(252, 252));
 }
 
 TEST(SiteIsolation, MouseClickAfterIncompleteDragging)

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/mac/DragAndDropTestsMac.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/mac/DragAndDropTestsMac.mm
@@ -399,10 +399,27 @@ TEST(DragAndDropTests, DragLocationForImageInScrolledSubframe)
     [simulator runFrom:NSMakePoint(100, 100) to:NSMakePoint(200, 200)];
 
     CGPoint dragLocation = [simulator initialDragImageLocationInView];
-    EXPECT_TRUE(NSPointInRect(dragLocation, [webView bounds]));
+    EXPECT_NEAR(dragLocation.x, 0, 20);
+    EXPECT_NEAR(dragLocation.y, 0, 20);
 
     RetainPtr dragTypes = [[[simulator draggingInfo] draggingPasteboard] types];
     EXPECT_TRUE([dragTypes containsObject:UTTypePNG.identifier]);
+}
+
+TEST(DragAndDropTests, DragPreviewOriginForImage)
+{
+    RetainPtr simulator = adoptNS([[DragAndDropSimulator alloc] initWithWebViewFrame:NSMakeRect(0, 0, 400, 400)]);
+    RetainPtr webView = [simulator webView];
+    [webView synchronouslyLoadTestPageNamed:@"image-and-contenteditable"];
+
+    auto imageMidpoint = [webView getElementMidpoint:@"#source"];
+    NSPoint dragStart = imageMidpoint.value();
+    [simulator runFrom:dragStart to:NSMakePoint(dragStart.x, dragStart.y + 200)];
+
+    // A missing flipped-coordinate adjustment (rdar://175267103) would
+    // shift the preview down by the image height, placing the origin below.
+    NSPoint previewOrigin = [simulator initialDragImageLocationInView];
+    EXPECT_LT(previewOrigin.y, dragStart.y);
 }
 
 TEST(DragAndDropTests, DragEnterAndLeaveRelatedTarget)


### PR DESCRIPTION
#### a50da550f7f0ce762c4259852a2cb28d32f556b2
<pre>
REGRESSION(309943@main): Drag-and-drop preview does not lift from correct image location
<a href="https://bugs.webkit.org/show_bug.cgi?id=313371">https://bugs.webkit.org/show_bug.cgi?id=313371</a>
<a href="https://rdar.apple.com/175267103">rdar://175267103</a>

Reviewed by Richard Robinson.

The drag image offset computed in DragController compensates for flipped
coordinates elsewhere in Cocoa, and as such points to the bottom-left of
where the drag preview should be.

Later, in WebViewImpl::startDrag(), we fail to convert back from
bottom-left to top-left by subtracting the image height for the two new
drag paths (image drag with file promise and the generic fallback path).

This patch undoes the regression. We also make the mistake less easy to
do by computing the drag frame, correctly, once and using the same value
in each of the setDraggingFrame: calls.

Test: TestWebKitAPI.DragAndDropTests.DragPreviewOriginForImage

* Source/WebKit/UIProcess/mac/WebViewImpl.mm:
(WebKit::WebViewImpl::startDrag):
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/SiteIsolation.mm:
(TestWebKitAPI::(SiteIsolation, DragImageLocation)):
  The expected origin is the top-left of the draggable element rather
  than the bottom-left.

* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/mac/DragAndDropTestsMac.mm:
(TEST(DragAndDropTests, DragLocationForImageInScrolledSubframe)):
  The origin should be near the image&apos;s top-left (close to the viewport
  origin), not necessarily within the webview bounds. A pre-existing
  coordinate conversion issue (noted in <a href="https://rdar.apple.com/165119210">rdar://165119210</a>) causes a small
  offset in the test environment.

(TEST(DragAndDropTests, DragPreviewOriginForImage)):

Canonical link: <a href="https://commits.webkit.org/312186@main">https://commits.webkit.org/312186@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/47e7dad272c995c1b9ee7f173892992a6cedfee5

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/159110 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/32538 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/25643 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/167939 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/113194 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/0e4283cf-6353-48ed-9cc9-730fea8ac223) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/160979 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/32605 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/32525 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/123259 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/86549 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/b19f646b-9e1e-4f17-b1fe-34936692d766) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/162067 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/25530 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/142911 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/103925 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/64861217-e672-4570-bdcf-abad82a41eb6) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/24584 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/23008 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/15712 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/134270 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/20691 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/170432 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/16174 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/22317 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/131449 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/32227 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/27077 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/131561 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35591 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/32171 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/142484 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/90221 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/26262 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/19293 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/31682 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/97696 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/31202 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/31475 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/31357 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->