### PR TITLE
CoordinatedPlatformLayer::invalidateTarget should be called before destroyed

### DIFF
--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayer.cpp
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayer.cpp
@@ -72,7 +72,13 @@ CoordinatedPlatformLayer::CoordinatedPlatformLayer(Client* client)
     ASSERT(isMainThread());
 }
 
-CoordinatedPlatformLayer::~CoordinatedPlatformLayer() = default;
+CoordinatedPlatformLayer::~CoordinatedPlatformLayer()
+{
+    ASSERT(!m_target);
+#if USE(SKIA)
+    ASSERT(!m_skiaTarget);
+#endif
+}
 
 void CoordinatedPlatformLayer::setOwner(GraphicsLayerCoordinated* owner)
 {

--- a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/CoordinatedSceneState.cpp
+++ b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/CoordinatedSceneState.cpp
@@ -46,6 +46,7 @@ CoordinatedSceneState::~CoordinatedSceneState()
 {
     ASSERT(m_layers.isEmpty());
     ASSERT(m_pendingLayers.isEmpty());
+    ASSERT(m_pendingLayersToRemove.isEmpty());
     ASSERT(m_committedLayers.isEmpty());
 }
 
@@ -71,6 +72,7 @@ void CoordinatedSceneState::removeLayer(CoordinatedPlatformLayer& layer)
 {
     ASSERT(isMainRunLoop());
     m_layers.remove(layer);
+    m_layersToRemove.add(layer);
     m_didChangeLayers = true;
 }
 
@@ -84,25 +86,32 @@ bool CoordinatedSceneState::flush()
 
     Locker pendingLayersLock { m_pendingLayersLock };
     m_pendingLayers = m_layers;
+    m_pendingLayersToRemove.addAll(WTF::move(m_layersToRemove));
+
     return true;
+}
+
+void CoordinatedSceneState::commitPendingLayers()
+{
+    ASSERT(!isMainRunLoop());
+    Locker pendingLayersLock { m_pendingLayersLock };
+    for (auto& layer : m_pendingLayersToRemove)
+        layer->invalidateTarget();
+    m_pendingLayersToRemove.clear();
+    if (!m_pendingLayers.isEmpty())
+        m_committedLayers = WTF::move(m_pendingLayers);
 }
 
 const HashSet<Ref<CoordinatedPlatformLayer>>& CoordinatedSceneState::committedLayers()
 {
-    ASSERT(!isMainRunLoop());
-    Locker pendingLayersLock { m_pendingLayersLock };
-    if (!m_pendingLayers.isEmpty()) {
-        auto removedLayers = m_committedLayers.differenceWith(m_pendingLayers);
-        m_committedLayers = WTF::move(m_pendingLayers);
-        for (auto& layer : removedLayers)
-            layer->invalidateTarget();
-    }
+    commitPendingLayers();
     return m_committedLayers;
 }
 
 void CoordinatedSceneState::invalidateCommittedLayers()
 {
     ASSERT(!isMainRunLoop());
+    commitPendingLayers();
     m_rootLayer->invalidateTarget();
     while (!m_committedLayers.isEmpty()) {
         auto layer = m_committedLayers.takeAny();
@@ -121,6 +130,7 @@ void CoordinatedSceneState::invalidate()
 
     Locker pendingLayersLock { m_pendingLayersLock };
     m_pendingLayers = { };
+    m_pendingLayersToRemove = { };
 }
 
 void CoordinatedSceneState::waitUntilPaintingComplete()

--- a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/CoordinatedSceneState.h
+++ b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/CoordinatedSceneState.h
@@ -69,10 +69,14 @@ public:
 private:
     CoordinatedSceneState();
 
+    void commitPendingLayers();
+
     const Ref<WebCore::CoordinatedPlatformLayer> m_rootLayer;
     HashSet<Ref<WebCore::CoordinatedPlatformLayer>> m_layers;
+    HashSet<Ref<WebCore::CoordinatedPlatformLayer>> m_layersToRemove;
     Lock m_pendingLayersLock;
     HashSet<Ref<WebCore::CoordinatedPlatformLayer>> m_pendingLayers WTF_GUARDED_BY_LOCK(m_pendingLayersLock);
+    HashSet<Ref<WebCore::CoordinatedPlatformLayer>> m_pendingLayersToRemove WTF_GUARDED_BY_LOCK(m_pendingLayersLock);
     std::atomic<bool> m_didChangeLayers { false };
     HashSet<Ref<WebCore::CoordinatedPlatformLayer>> m_committedLayers;
     std::atomic<unsigned> m_pendingTiles { 0 };

--- a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/LayerTreeHost.cpp
+++ b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/LayerTreeHost.cpp
@@ -104,11 +104,12 @@ LayerTreeHost::LayerTreeHost(WebPage& webPage)
 
 LayerTreeHost::~LayerTreeHost()
 {
-    m_sceneState->invalidate();
-
     m_skiaPaintingEngine = nullptr;
 
+    // ThreadedCompositor must be invalidated before invalidating CoordinatedSceneState
+    // to invalidate pending layers in the compositor thread.
     m_compositor->invalidate();
+    m_sceneState->invalidate();
 }
 
 uint64_t LayerTreeHost::surfaceID() const

--- a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/LayerTreeHostPlayStation.cpp
+++ b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/LayerTreeHostPlayStation.cpp
@@ -123,13 +123,14 @@ LayerTreeHost::~LayerTreeHost()
 
     cancelRenderingUpdate();
 
-    m_sceneState->invalidate();
-
 #if USE(SKIA)
     m_skiaPaintingEngine = nullptr;
 #endif
 
+    // ThreadedCompositor must be invalidated before invalidating CoordinatedSceneState
+    // to invalidate pending layers in the compositor thread.
     m_compositor->invalidate();
+    m_sceneState->invalidate();
 }
 
 void LayerTreeHost::setLayerTreeStateIsFrozen(bool isFrozen)


### PR DESCRIPTION
#### 1d5da19bdbd9eebb6be7e160959c283fcd39a8fc
<pre>
CoordinatedPlatformLayer::invalidateTarget should be called before destroyed
<a href="https://bugs.webkit.org/show_bug.cgi?id=312775">https://bugs.webkit.org/show_bug.cgi?id=312775</a>

Reviewed by Carlos Garcia Campos.

If UseSkiaForComposition was enabled and assertions were enabled,
some layout tests were crashing because SkiaCompositingLayer was created in the
compositor thread, but destroyed in the main thread.

If ensureTarget() or ensureSkiaTarget() are called, invalidateTarget() should
be called in the compositor thread before the CoordinatedPlatformLayer is
destroyed.

The main thread adds a new layer while the compositor thread is committing. It
can create a target layer for an uncommitted layer. And, the layer can be
removed before committed. Then, invalidateTarget() wasn&apos;t called for it.

Added m_layersToRemove and m_pendingLayersToRemove to CoordinatedSceneState
class to ensure to call invalidateTarget() in the compositor thread.

CoordinatedSceneState::invalidateCommittedLayers() should call
committedLayers() to invalid pending layers.

~LayerTreeHost() should to call ThreadedCompositor::invalidate() before calling
CoordinatedSceneState::invalidate(). ThreadedCompositor::invalidate() calls
CoordinatedSceneState::invalidateCommittedLayers.
CoordinatedSceneState::invalidate() clears m_pendingLayers.

* Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayer.cpp:
(WebCore::CoordinatedPlatformLayer::~CoordinatedPlatformLayer):
* Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/CoordinatedSceneState.cpp:
(WebKit::CoordinatedSceneState::~CoordinatedSceneState):
(WebKit::CoordinatedSceneState::removeLayer):
(WebKit::CoordinatedSceneState::flush):
(WebKit::CoordinatedSceneState::commitPendingLayers):
(WebKit::CoordinatedSceneState::committedLayers):
(WebKit::CoordinatedSceneState::invalidateCommittedLayers):
(WebKit::CoordinatedSceneState::invalidate):
* Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/CoordinatedSceneState.h:
* Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/LayerTreeHost.cpp:
(WebKit::LayerTreeHost::~LayerTreeHost):
* Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/LayerTreeHostPlayStation.cpp:
(WebKit::LayerTreeHost::~LayerTreeHost):

Canonical link: <a href="https://commits.webkit.org/312071@main">https://commits.webkit.org/312071@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4fa347bd3890d859b65cb12d7e62f37de1c98385

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/158904 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/32331 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/25436 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/167733 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/112988 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/160773 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/32398 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/32318 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/123116 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/86444 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/161861 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/25387 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/142751 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/103785 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/24443 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/22844 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/15505 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/134129 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/167/builds/20531 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/170225 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/15968 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/22157 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/131304 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/32020 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/26911 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/131418 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/31965 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/142324 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/89999 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/24162 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/164/builds/26122 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/19133 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/31476 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/97490 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/30996 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/31269 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/31150 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->