### PR TITLE
Create WKRBSAssertion subclass of RBSAssertion to prevent missing invalidate calls

### DIFF
--- a/Source/WebKit/UIProcess/Cocoa/ProcessAssertionCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/ProcessAssertionCocoa.mm
@@ -55,6 +55,17 @@
 using WebKit::ProcessAndUIAssertion;
 #endif
 
+@interface WKRBSAssertion : RBSAssertion
+@end
+
+@implementation WKRBSAssertion
+- (void)dealloc
+{
+    [self invalidate];
+    [super dealloc];
+}
+@end
+
 static WorkQueue& assertionsWorkQueue()
 {
     static NeverDestroyed<Ref<WorkQueue>> workQueue(WorkQueue::create("ProcessAssertion Queue"_s, WorkQueue::QOS::UserInitiated));
@@ -85,7 +96,7 @@ static bool processHasActiveRunTimeLimitation()
 
 @implementation WKProcessAssertionBackgroundTaskManager
 {
-    RetainPtr<RBSAssertion> _backgroundTask;
+    RetainPtr<WKRBSAssertion> _backgroundTask;
     std::atomic<bool> _backgroundTaskWasInvalidated;
     ThreadSafeWeakHashSet<ProcessAndUIAssertion> _assertionsNeedingBackgroundTask;
     dispatch_block_t _pendingTaskReleaseTask;
@@ -187,7 +198,7 @@ static bool processHasActiveRunTimeLimitation()
         RELEASE_LOG(ProcessSuspension, "%p - WKProcessAssertionBackgroundTaskManager: beginBackgroundTaskWithName", self);
         RBSTarget *target = [RBSTarget currentProcess];
         RBSDomainAttribute *domainAttribute = [RBSDomainAttribute attributeWithDomain:@"com.apple.common" name:@"FinishTaskInterruptable"];
-        _backgroundTask = adoptNS([[RBSAssertion alloc] initWithExplanation:@"WebKit UIProcess background task" target:target attributes:@[domainAttribute]]);
+        _backgroundTask = adoptNS([[WKRBSAssertion alloc] initWithExplanation:@"WebKit UIProcess background task" target:target attributes:@[domainAttribute]]);
         [_backgroundTask addObserver:self];
 
         _backgroundTaskWasInvalidated = false;
@@ -263,7 +274,6 @@ static bool processHasActiveRunTimeLimitation()
     }
 
     [_backgroundTask removeObserver:self];
-    [_backgroundTask invalidate];
     _backgroundTask = nullptr;
 }
 
@@ -434,7 +444,7 @@ void ProcessAssertion::init(const String& environmentIdentifier)
         target = [RBSTarget targetWithPid:m_pid environmentIdentifier:environmentIdentifier.createNSString().get()];
 
     RetainPtr domainAttribute = [RBSDomainAttribute attributeWithDomain:runningBoardDomainForAssertionType(m_assertionType).createNSString().get() name:runningBoardAssertionName.createNSString().get()];
-    m_rbsAssertion = adoptNS([[RBSAssertion alloc] initWithExplanation:m_reason.createNSString().get() target:target attributes:@[domainAttribute.get()]]);
+    m_rbsAssertion = adoptNS([[WKRBSAssertion alloc] initWithExplanation:m_reason.createNSString().get() target:target attributes:@[domainAttribute.get()]]);
 
     m_delegate = adoptNS([[WKRBSAssertionDelegate alloc] init]);
     [m_rbsAssertion addObserver:m_delegate.get()];
@@ -513,7 +523,6 @@ ProcessAssertion::~ProcessAssertion()
         m_delegate.get().prepareForInvalidationCallback = nil;
         [m_rbsAssertion removeObserver:m_delegate.get()];
         m_delegate = nil;
-        [m_rbsAssertion invalidate];
     }
 
 #if USE(EXTENSIONKIT)

--- a/Source/WebKit/UIProcess/ProcessAssertion.h
+++ b/Source/WebKit/UIProcess/ProcessAssertion.h
@@ -47,7 +47,7 @@
 #if USE(RUNNINGBOARD)
 #include <wtf/RetainPtr.h>
 
-OBJC_CLASS RBSAssertion;
+OBJC_CLASS WKRBSAssertion;
 OBJC_CLASS WKRBSAssertionDelegate;
 #endif // USE(RUNNINGBOARD)
 
@@ -121,7 +121,7 @@ private:
     const ProcessID m_pid;
     const String m_reason;
 #if USE(RUNNINGBOARD)
-    RetainPtr<RBSAssertion> m_rbsAssertion;
+    RetainPtr<WKRBSAssertion> m_rbsAssertion;
     RetainPtr<WKRBSAssertionDelegate> m_delegate;
     bool m_wasInvalidated { false };
 #endif

--- a/Tools/Scripts/webkitpy/style/checkers/cpp.py
+++ b/Tools/Scripts/webkitpy/style/checkers/cpp.py
@@ -3722,6 +3722,26 @@ def check_objc_protocol(clean_lines, line_number, file_extension, error):
     error(line_number, 'spacing/objc-protocol', 2, "Protocol names shouldn't have a space before them.")
 
 
+def check_rbs_assertion(clean_lines, line_number, error):
+    """Looks for uses of [RBSAssertion alloc]
+
+    Before an RBSAssertion is deallocated, we must call invalidate on it.
+    This is easy to forget, and will cause a crash if forgotten. So we
+    must instead use WKRBSAssertion which automatically calls invalidate
+    before deallocation.
+
+    Args:
+      clean_lines: A CleansedLines instance containing the file.
+      line_number: The number of the line to check.
+      error: The function to call with any errors found.
+    """
+
+    line = clean_lines.elided[line_number]  # Get rid of comments and strings.
+
+    if search(r'\bRBSAssertion\s+alloc\b', line):
+        error(line_number, 'runtime/rbs_assertion', 5, 'Do not directly allocate RBSAssertion. Use WKRBSAssertion instead.')
+
+
 def check_safer_cpp(clean_lines, line_number, error):
     """Looks for safer C++ errors.
 
@@ -5069,6 +5089,7 @@ def process_line(filename, file_extension,
     check_ismainthread(filename, clean_lines, line, file_state, error)
     check_mainthreadneverdestroyed(filename, clean_lines, line, file_state, error)
     check_mainthreadlazyneverdestroyed(filename, clean_lines, line, file_state, error)
+    check_rbs_assertion(clean_lines, line, error)
 
 
 class _InlineASMState(object):
@@ -5212,6 +5233,7 @@ class CppChecker(object):
         'runtime/once_flag',
         'runtime/printf',
         'runtime/printf_format',
+        'runtime/rbs_assertion',
         'runtime/references',
         'runtime/retainptr',
         'runtime/rtti',


### PR DESCRIPTION
#### c53a7f951fa09d02d7695f80611ea2118fdcb53e
<pre>
Create WKRBSAssertion subclass of RBSAssertion to prevent missing invalidate calls
<a href="https://bugs.webkit.org/show_bug.cgi?id=313382">https://bugs.webkit.org/show_bug.cgi?id=313382</a>
<a href="https://rdar.apple.com/175648970">rdar://175648970</a>

Reviewed by Ben Nham.

RunningBoardServices requires that the client invalidate the RBSAssertion before
it is deallocated. This is subtle and easy to miss. The consequence of forgetting
to call invalidate is a crash. Recently, we had to fix such a crash that was
affecting users: <a href="https://commits.webkit.org/311649@main.">https://commits.webkit.org/311649@main.</a>

To prevent us from having to remember to always call invalidate and possibly
forgetting, we create a subclass WKRBSAssertion which automatically calls
invalidate before deallocation.

WebKit code should never allocate an RBSAssertion directly. It should only use
WKRBSAssertion.

We amend all parts of the codebase that currently create an RBSAssertion to use
this WKRBSAssertion instead. We remove explicit calls to invalidate since they
are no longer needed.

We also modify the style checker to ensure that no new code will directly create
an RBSAssertion.

There is no behavior change.

* Source/WebKit/UIProcess/Cocoa/ProcessAssertionCocoa.mm:
(-[WKRBSAssertion dealloc]):
(-[WKProcessAssertionBackgroundTaskManager _updateBackgroundTask]):
(-[WKProcessAssertionBackgroundTaskManager _releaseBackgroundTask]):
(WebKit::ProcessAssertion::init):
(WebKit::ProcessAssertion::~ProcessAssertion):
* Source/WebKit/UIProcess/ProcessAssertion.h:
* Tools/Scripts/webkitpy/style/checkers/cpp.py:
(check_rbs_assertion):
(process_line):
(CppChecker):

Canonical link: <a href="https://commits.webkit.org/312175@main">https://commits.webkit.org/312175@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6e860ecf46e6211a1d39c8a46a78f2657cd73ad2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/159165 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/32593 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/25698 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/167994 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/113249 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/161034 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/32661 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/32580 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/123309 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/113249 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/162122 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/25581 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/142968 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/103975 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | ⏳ 🛠 vision-apple 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/158485 "Passed tests") | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/24635 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/23057 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk3-libwebrtc~~](https://ews-build.webkit.org/#/builders/173/builds/15767 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/134321 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/167/builds/20748 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/170489 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/16229 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/22374 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/131503 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/32282 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/27126 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/131615 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/32226 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/142541 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/90280 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/24222 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/164/builds/26313 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/19350 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/31737 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/97751 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/31257 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/31530 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/31412 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->