### PR TITLE
`eventTypeForEventListenerType` has incorrect mappings for `mousemove` and `mouseup`

### DIFF
--- a/LayoutTests/fast/events/touch/ios/touch-event-regions-layer-tree/mousemove-mouseup-expected.txt
+++ b/LayoutTests/fast/events/touch/ios/touch-event-regions-layer-tree/mousemove-mouseup-expected.txt
@@ -1,0 +1,9 @@
+(event region
+        (rect (0,0) width=800 height=600)
+      (touch event listener region: asynchronousDispatchRegion:
+        (rect (8,56) width=150 height=150)
+eventSpecificSynchronousDispatchRegions: eventName: mousemove eventRect:
+        (rect (8,56) width=150 height=150)
+
+      )
+    )

--- a/LayoutTests/fast/events/touch/ios/touch-event-regions-layer-tree/mousemove-mouseup.html
+++ b/LayoutTests/fast/events/touch/ios/touch-event-regions-layer-tree/mousemove-mouseup.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html><!-- webkit-test-runner [ MouseEventsSimulationEnabled=true ] -->
+<html>
+<head>
+    <script src="resources/touch-regions-helper.js"></script>
+    <style>
+        .region {
+            display: block;
+            width:150px;
+            height:150px;
+            background: blue;
+            margin-top:20px;
+        }
+    </style>
+</head>
+<body>
+    <p>Test for <a href="https://webkit.org/b/313386">https://webkit.org/b/313386</a></p>
+    <div id="mousemove_region" class="region"></div>
+    <div id="mouseup_region" class="region"></div>
+    <script>
+        mousemove_region.addEventListener("mousemove", ()=>{});
+        mouseup_region.addEventListener("mouseup", ()=>{});
+        prepareForTest();
+        window.addEventListener('load', dumpRegions, false);
+    </script>
+</body>
+</html>

--- a/Source/WebCore/rendering/EventRegion.cpp
+++ b/Source/WebCore/rendering/EventRegion.cpp
@@ -708,9 +708,9 @@ static EventTrackingRegionsEventType eventTypeForEventListenerType(EventListener
     case EventListenerRegionType::NonPassiveMouseDown:
         return EventTrackingRegionsEventType::Mousedown;
     case EventListenerRegionType::NonPassiveMouseUp:
-        return EventTrackingRegionsEventType::Mousemove;
-    case EventListenerRegionType::NonPassiveMouseMove:
         return EventTrackingRegionsEventType::Mouseup;
+    case EventListenerRegionType::NonPassiveMouseMove:
+        return EventTrackingRegionsEventType::Mousemove;
     case EventListenerRegionType::NonPassiveGestureChange:
         return EventTrackingRegionsEventType::Gesturechange;
     case EventListenerRegionType::NonPassiveGestureEnd:


### PR DESCRIPTION
#### 5a0861728608a38c536bfebbc4160e60d81b02ff
<pre>
`eventTypeForEventListenerType` has incorrect mappings for `mousemove` and `mouseup`
<a href="https://bugs.webkit.org/show_bug.cgi?id=313386">https://bugs.webkit.org/show_bug.cgi?id=313386</a>
<a href="https://rdar.apple.com/175651369">rdar://175651369</a>

Reviewed by Richard Robinson, Tim Nguyen, and Ryosuke Niwa.

Map `EventListenerRegionType::NonPassiveMouseMove` to
`EventTrackingRegionsEventType::Mousemove` and
`EventListenerRegionType::NonPassiveMouseUp` to
`EventTrackingRegionsEventType::Mouseup` instead of
vice-versa.

Added tests:
LayoutTests/fast/events/touch/ios/touch-event-regions-layer-tree/mousemove-mouseup.html

* LayoutTests/fast/events/touch/ios/touch-event-regions-layer-tree/mousemove-mouseup-expected.txt: Added.
* LayoutTests/fast/events/touch/ios/touch-event-regions-layer-tree/mousemove-mouseup.html: Added.
* Source/WebCore/rendering/EventRegion.cpp:
(WebCore::eventTypeForEventListenerType):

Canonical link: <a href="https://commits.webkit.org/312142@main">https://commits.webkit.org/312142@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b36c2991913a48d4dfdc5eb10a40937e96d845a3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/158898 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/32325 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/25430 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/167727 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/112982 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/6b8aaec9-5516-4ce1-9dd4-081063e83d9d) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/160767 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/32392 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/32312 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/123112 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/86438 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/161855 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/25381 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/142745 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/103781 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/e52184ed-cc9e-45eb-8681-2f4662713120) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/24437 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/22838 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/15499 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/134123 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/20525 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/170219 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/15962 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/22151 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/131299 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/32014 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/26905 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/131413 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35564 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/31959 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/142318 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/89983 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/26116 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/19127 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/31470 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/97484 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/30990 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/31263 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/31144 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->