### PR TITLE
[Site Isolation] http/tests/security/mixedContent/redirect-https-to-http-image-secure-cookies-UpgradeMixedContent.html fails

### DIFF
--- a/LayoutTests/platform/wk2/webarchive/loading/javascript-url-iframe-crash-expected.txt
+++ b/LayoutTests/platform/wk2/webarchive/loading/javascript-url-iframe-crash-expected.txt
@@ -2,6 +2,8 @@ main frame - willPerformClientRedirectToURL: resources/javascript-url-iframe-cra
 main frame - didFinishDocumentLoadForFrame
 main frame - didFinishLoadForFrame
 main frame - didCancelClientRedirectForFrame
+main frame - didStartProvisionalLoadForFrame
+main frame - didCommitLoadForFrame
 frame "<!--frame1-->" - didFinishDocumentLoadForFrame
 frame "<!--frame1-->" - didHandleOnloadEventsForFrame
 main frame - didFinishDocumentLoadForFrame

--- a/LayoutTests/platform/wk2/webarchive/loading/object-expected.txt
+++ b/LayoutTests/platform/wk2/webarchive/loading/object-expected.txt
@@ -2,6 +2,8 @@ main frame - willPerformClientRedirectToURL: resources/object.webarchive
 main frame - didFinishDocumentLoadForFrame
 main frame - didFinishLoadForFrame
 main frame - didCancelClientRedirectForFrame
+main frame - didStartProvisionalLoadForFrame
+main frame - didCommitLoadForFrame
 main frame - didFinishDocumentLoadForFrame
 frame "<!--frame1-->" - didStartProvisionalLoadForFrame
 frame "<!--frame1-->" - didCommitLoadForFrame

--- a/LayoutTests/platform/wk2/webarchive/loading/test-loading-top-archive-expected.txt
+++ b/LayoutTests/platform/wk2/webarchive/loading/test-loading-top-archive-expected.txt
@@ -2,6 +2,8 @@ main frame - willPerformClientRedirectToURL: resources/top.webarchive
 main frame - didFinishDocumentLoadForFrame
 main frame - didFinishLoadForFrame
 main frame - didCancelClientRedirectForFrame
+main frame - didStartProvisionalLoadForFrame
+main frame - didCommitLoadForFrame
 main frame - didFinishDocumentLoadForFrame
 main frame - didHandleOnloadEventsForFrame
 main frame - didFinishLoadForFrame

--- a/LayoutTests/platform/wk2/webarchive/loading/video-in-webarchive-expected.txt
+++ b/LayoutTests/platform/wk2/webarchive/loading/video-in-webarchive-expected.txt
@@ -2,6 +2,8 @@ main frame - willPerformClientRedirectToURL: resources/video-in-webarchive.webar
 main frame - didFinishDocumentLoadForFrame
 main frame - didFinishLoadForFrame
 main frame - didCancelClientRedirectForFrame
+main frame - didStartProvisionalLoadForFrame
+main frame - didCommitLoadForFrame
 main frame - didFinishDocumentLoadForFrame
 frame "<!--frame1-->" - didStartProvisionalLoadForFrame
 main frame - didHandleOnloadEventsForFrame

--- a/Source/WebKit/UIProcess/ProvisionalPageProxy.cpp
+++ b/Source/WebKit/UIProcess/ProvisionalPageProxy.cpp
@@ -726,6 +726,7 @@ void ProvisionalPageProxy::didReceiveMessage(IPC::Connection& connection, IPC::D
         || decoder.messageName() == Messages::WebPageProxy::ContentRuleListNotification::name()
 #endif
         || decoder.messageName() == Messages::WebPageProxy::AddMessageToConsoleForTesting::name()
+        || decoder.messageName() == Messages::WebPageProxy::HandleMessage::name()
         )
     {
         if (RefPtr page = m_page.get())


### PR DESCRIPTION
#### 65f1f3b12dbc793c17938873f57f7483a6c30a46
<pre>
[Site Isolation] http/tests/security/mixedContent/redirect-https-to-http-image-secure-cookies-UpgradeMixedContent.html fails
<a href="https://bugs.webkit.org/show_bug.cgi?id=313385">https://bugs.webkit.org/show_bug.cgi?id=313385</a>

Reviewed by Megan Gardner.

During a cross-origin process swap, ProvisionalPageProxy intercepts all IPC from the new process.
In dispatchDidCommitLoad(), the InjectedBundle&apos;s callback fires before the DidCommitLoadForFrame
IPC is sent. When an InjectedBundle sends a HandleMessage IPC (e.g. for TextOutput in WKTR) in
this moment, ProvisionalPageProxy silently drops the message instead of forwarding it to
WebPageProxy, which hands it to the API client. Only after DidCommitLoadForFrame is processed
and the process swap completes do subsequent messages (like didFinishDocumentLoadForFrame) reach
the WebPageProxy normally.

Fixed the test by forwarding HandleMessage from the ProvisionalPageProxy to the WebPageProxy,
matching the pattern already used for AddMessageToConsoleForTesting and other forwarded messages
so that TextOutput IPC from WebKitTestRunner&apos;s injected bundle won&apos;t be dropped on floor.

Test: http/tests/security/mixedContent/redirect-https-to-http-image-secure-cookies-UpgradeMixedContent.html

* LayoutTests/platform/wk2/webarchive/loading/javascript-url-iframe-crash-expected.txt:
* LayoutTests/platform/wk2/webarchive/loading/object-expected.txt:
* LayoutTests/platform/wk2/webarchive/loading/test-loading-top-archive-expected.txt:
* LayoutTests/platform/wk2/webarchive/loading/video-in-webarchive-expected.txt:
* Source/WebKit/UIProcess/ProvisionalPageProxy.cpp:
(WebKit::ProvisionalPageProxy::didReceiveMessage):

Canonical link: <a href="https://commits.webkit.org/312171@main">https://commits.webkit.org/312171@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/57d0ee99a6f311c3dedebb51dee7cb7bdf5f7c78

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/158989 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/32416 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/25521 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/167818 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/113073 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/9b2fbce1-7ec0-4b9d-b6c5-79d727583cc6) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/32484 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/32404 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/123189 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/86506 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/1a1c2503-c7ab-41aa-bd73-65e7a932a087) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/161946 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/25465 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/142843 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/103856 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/678b0961-9d59-4603-90e9-3b547ca10b75) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/24520 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/22924 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/15590 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/134206 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/20623 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/170311 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/16053 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/22249 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/131377 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/32106 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/26991 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/131489 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/32050 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/142416 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/90100 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/24219 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/26195 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/19225 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/31561 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/97575 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/31081 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/31354 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/31236 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->