### PR TITLE
REGRESSION(311771@main): [Tahoe] media/media-vp8-webm-with-preload.html is a flaky TEXT failure

### DIFF
--- a/LayoutTests/platform/mac-wk2/TestExpectations
+++ b/LayoutTests/platform/mac-wk2/TestExpectations
@@ -2455,6 +2455,4 @@ webkit.org/b/313278 [ Tahoe+ ] imported/w3c/web-platform-tests/css/css-images/gr
 
 webkit.org/b/313346 [ Sequoia+ Debug ] imported/w3c/web-platform-tests/webrtc/RTCRtpReceiver-audio-jitterBufferTarget-stats.https.html [ Pass Failure ]
 
-webkit.org/b/313352 [ Sequoia+ Release ] media/media-vp8-webm-with-preload.html [ Pass Failure ]
-
 webkit.org/b/313362 [ Sequoia+ ] imported/w3c/web-platform-tests/media-source/mediasource-changetype-play-implicit.html [ Pass Failure ]

--- a/Source/WebCore/platform/graphics/avfoundation/AudioVideoRendererAVFObjC.h
+++ b/Source/WebCore/platform/graphics/avfoundation/AudioVideoRendererAVFObjC.h
@@ -315,6 +315,7 @@ private:
     HashMap<TrackIdentifier, AudioTrackProperties> m_audioTracksMap;
     std::optional<RequestPromise::AutoRejectProducer> m_requestVideoPromise;
     bool m_readyToRequestVideoData { true };
+    bool m_hasEverSubmittedVideoSample { false };
 
     HashMap<TrackIdentifier, TrackType> m_trackTypes;
     HashMap<TrackIdentifier, RetainPtr<AVSampleBufferAudioRenderer>> m_audioRenderers;
@@ -341,9 +342,7 @@ private:
     VideoRendererPreferences m_preferences;
     bool m_hasProtectedVideoContent { false };
     struct RendererConfiguration {
-        bool canUseDecompressionSession { false };
-        bool isProtected { false };
-        bool hasVideoTrack { false };
+        bool isRenderingCompressedVideo { false };
         bool operator==(const RendererConfiguration&) const = default;
     };
     RendererConfiguration m_previousRendererConfiguration;

--- a/Source/WebCore/platform/graphics/avfoundation/AudioVideoRendererAVFObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/AudioVideoRendererAVFObjC.mm
@@ -252,8 +252,13 @@ void AudioVideoRendererAVFObjC::enqueueSample(TrackIdentifier trackId, Ref<Media
             return;
         }
         m_keyframeNeeded = false;
-        if (RefPtr videoRenderer = m_videoRenderer; videoRenderer && isEnabledVideoTrackId(trackId))
+        if (RefPtr videoRenderer = m_videoRenderer; videoRenderer && isEnabledVideoTrackId(trackId)) {
             videoRenderer->enqueueSample(sample, minimumUpcomingTime.value_or(sample->presentationTime()));
+            if (!m_hasEverSubmittedVideoSample) {
+                m_hasEverSubmittedVideoSample = true;
+                m_previousRendererConfiguration.isRenderingCompressedVideo = !isUsingDecompressionSession();
+            }
+        }
         break;
 
     case TrackType::Audio:
@@ -1334,7 +1339,7 @@ void AudioVideoRendererAVFObjC::configureHasAvailableVideoFrameCallbackIfNeeded(
     if (videoRenderer)
         videoRenderer->setPreferences(m_preferences);
 
-    if (m_previousRendererConfiguration.hasVideoTrack) {
+    if (hasSelectedVideo()) {
         // Activating AvailableVideoFrame callback may force the use of decompression session.
         updateDisplayLayerIfNeeded();
     }
@@ -1441,10 +1446,9 @@ Ref<GenericPromise> AudioVideoRendererAVFObjC::stageVideoRenderer(WebSampleBuffe
     ASSERT(m_videoRenderer);
 
     RefPtr videoRenderer = m_videoRenderer;
+
     RendererConfiguration newConfiguration {
-        .canUseDecompressionSession = willUseDecompressionSessionIfNeeded(),
-        .isProtected = m_hasProtectedVideoContent,
-        .hasVideoTrack = m_enabledVideoTrackId.has_value()
+        .isRenderingCompressedVideo = !!renderer && !willUseDecompressionSessionIfNeeded() && m_hasEverSubmittedVideoSample
     };
     if (renderer == videoRenderer->renderer()) {
         if (std::exchange(m_previousRendererConfiguration, newConfiguration) != newConfiguration && renderer)
@@ -1471,13 +1475,9 @@ Ref<GenericPromise> AudioVideoRendererAVFObjC::stageVideoRenderer(WebSampleBuffe
         destroyVideoRenderer();
     }
 
-    bool videoTrackChangeOnly = !m_previousRendererConfiguration.hasVideoTrack && newConfiguration.hasVideoTrack;
-    bool configurationChanged = std::exchange(m_previousRendererConfiguration, newConfiguration) != newConfiguration;
-    bool hasVideoRenderer = videoRenderer && videoRenderer->renderer();
-    bool switchingFromRenderless = renderer && !hasVideoRenderer && !isUsingDecompressionSession();
-    bool flushRequired = (configurationChanged || switchingFromRenderless) && !videoTrackChangeOnly;
+    bool flushRequired = std::exchange(m_previousRendererConfiguration, newConfiguration) != newConfiguration && m_hasEverSubmittedVideoSample;
     m_readyToRequestVideoData = !flushRequired;
-    ALWAYS_LOG(LOGIDENTIFIER, "renderer: ", !!renderer, " videoTrackChangeOnly: ", videoTrackChangeOnly, " configurationChanged: ", configurationChanged, " switchingFromRenderless: ", switchingFromRenderless, " flushRequired: ", flushRequired);
+    ALWAYS_LOG(LOGIDENTIFIER, "renderer: ", !!renderer, " flushRequired: ", flushRequired);
 
     return videoRenderer->changeRenderer(renderer)->whenSettled(RunLoop::mainSingleton(), [weakThis = ThreadSafeWeakPtr { *this }, rendererToExpire = WTF::move(rendererToExpire), flushRequired]() {
         RefPtr protectedThis = weakThis.get();
@@ -1868,6 +1868,7 @@ void AudioVideoRendererAVFObjC::flushVideo()
     ALWAYS_LOG(LOGIDENTIFIER);
 
     setHasAvailableVideoFrame(false);
+    m_hasEverSubmittedVideoSample = false;
     // Flush may call immediately requestMediaDataWhenReady. Must clear m_readyToRequestVideoData before flushing renderer.
     m_readyToRequestVideoData = true;
     if (RefPtr videoRenderer = m_videoRenderer)

--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.mm
@@ -1086,16 +1086,12 @@ void MediaPlayerPrivateMediaSourceAVFObjC::cdmInstanceAttached(CDMInstance& inst
 {
     ALWAYS_LOG(LOGIDENTIFIER);
     m_renderer->setCDMInstance(&instance);
-
-    needsVideoLayerChanged();
 }
 
 void MediaPlayerPrivateMediaSourceAVFObjC::cdmInstanceDetached(CDMInstance&)
 {
     ALWAYS_LOG(LOGIDENTIFIER);
     m_renderer->setCDMInstance(nullptr);
-
-    needsVideoLayerChanged();
 }
 
 void MediaPlayerPrivateMediaSourceAVFObjC::attemptToDecryptWithInstance(CDMInstance&)

--- a/Source/WebCore/platform/graphics/avfoundation/objc/SourceBufferPrivateAVFObjC.h
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/SourceBufferPrivateAVFObjC.h
@@ -173,7 +173,7 @@ private:
 
     void setTrackChangeCallbacks(const InitializationSegment&, bool initialized);
 
-    void NODELETE maybeUpdateNeedsVideoLayer();
+    void maybeUpdateNeedsVideoLayer();
 
     void ensureWeakOnDispatcher(Function<void(SourceBufferPrivateAVFObjC&)>&&);
     void callOnMainThreadWithPlayer(Function<void(MediaPlayerPrivateMediaSourceAVFObjC&)>&&);

--- a/Source/WebCore/platform/graphics/avfoundation/objc/SourceBufferPrivateAVFObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/SourceBufferPrivateAVFObjC.mm
@@ -363,11 +363,11 @@ void SourceBufferPrivateAVFObjC::didProvideContentKeyRequestInitializationDataFo
     if (!mediaSource)
         return;
 
-#if HAVE(AVCONTENTKEYSESSION) && ENABLE(LEGACY_ENCRYPTED_MEDIA)
-    ALWAYS_LOG(LOGIDENTIFIER, "track = ", trackID);
-
     m_protectedTrackID = trackID;
     maybeUpdateNeedsVideoLayer();
+
+#if HAVE(AVCONTENTKEYSESSION) && ENABLE(LEGACY_ENCRYPTED_MEDIA)
+    ALWAYS_LOG(LOGIDENTIFIER, "track = ", trackID);
     callOnMainThreadWithPlayer([initData](auto& player) {
         player.keyNeeded(initData);
     });
@@ -401,7 +401,6 @@ void SourceBufferPrivateAVFObjC::didProvideContentKeyRequestInitializationDataFo
             protectedThis->callOnMainThreadWithPlayer([initDataType = initDataType.isolatedCopy(), initData](auto& player) {
                 player.initializationDataEncountered(initDataType, initData->tryCreateArrayBuffer());
                 player.waitingForKeyChanged();
-                player.needsVideoLayerChanged();
             });
             return;
         }
@@ -426,7 +425,12 @@ bool SourceBufferPrivateAVFObjC::needsVideoLayer() const
 void SourceBufferPrivateAVFObjC::maybeUpdateNeedsVideoLayer()
 {
     assertIsCurrent(m_dispatcher.get());
-    m_needsVideoLayer = m_protectedTrackID && isEnabledVideoTrackID(*m_protectedTrackID);
+    bool needsVideoLayer = m_protectedTrackID && isEnabledVideoTrackID(*m_protectedTrackID);
+    if (m_needsVideoLayer.exchange(needsVideoLayer) != needsVideoLayer) {
+        callOnMainThreadWithPlayer([](auto& player) {
+            player.needsVideoLayerChanged();
+        });
+    }
 }
 
 Ref<MediaPromise> SourceBufferPrivateAVFObjC::appendInternal(Ref<SharedBuffer>&& data)

--- a/Tools/TestWebKitAPI/Tests/WebCore/cocoa/AudioVideoRendererAVFObjCTests.mm
+++ b/Tools/TestWebKitAPI/Tests/WebCore/cocoa/AudioVideoRendererAVFObjCTests.mm
@@ -30,12 +30,35 @@
 #include "Helpers/PlatformUtilities.h"
 #include <WebCore/AudioVideoRendererAVFObjC.h>
 #include <WebCore/MediaPlayerEnums.h>
+#include <WebCore/MediaSampleAVFObjC.h>
 #include <WebCore/TrackInfo.h>
 #include <wtf/Logger.h>
+
+#include <pal/cf/CoreMediaSoftLink.h>
 
 using namespace WebCore;
 
 namespace TestWebKitAPI {
+
+static RetainPtr<CMSampleBufferRef> createVideoSampleBuffer()
+{
+    CVPixelBufferRef rawPixelBuffer = nullptr;
+    if (CVPixelBufferCreate(kCFAllocatorDefault, 16, 16, kCVPixelFormatType_32BGRA, nullptr, &rawPixelBuffer))
+        return nullptr;
+    RetainPtr pixelBuffer = adoptCF(rawPixelBuffer);
+
+    CMVideoFormatDescriptionRef rawFormatDescription = nullptr;
+    if (PAL::CMVideoFormatDescriptionCreateForImageBuffer(kCFAllocatorDefault, pixelBuffer.get(), &rawFormatDescription))
+        return nullptr;
+    RetainPtr formatDescription = adoptCF(rawFormatDescription);
+
+    CMSampleTimingInfo timing = { PAL::kCMTimeInvalid, PAL::kCMTimeZero, PAL::kCMTimeInvalid };
+    CMSampleBufferRef rawSampleBuffer = nullptr;
+    if (PAL::CMSampleBufferCreateForImageBuffer(kCFAllocatorDefault, pixelBuffer.get(), true, nullptr, nullptr, formatDescription.get(), &timing, &rawSampleBuffer))
+        return nullptr;
+
+    return adoptCF(rawSampleBuffer);
+}
 
 class AudioVideoRendererAVFObjCTest : public testing::Test {
 public:
@@ -43,11 +66,14 @@ public:
     {
         Ref logger = Logger::create(this);
         renderer = AudioVideoRendererAVFObjC::create(logger, 0);
-        renderer->setPreferences({ VideoRendererPreference::PrefersDecompressionSession });
+        renderer->setPreferences({ });
         renderer->notifyWhenRequiresFlushToResume([this] {
             ++flushToResumeCount;
         });
-        renderer->addTrack(TrackInfo::TrackType::Video);
+        renderer->notifyWhenErrorOccurs([this](PlatformMediaError error) {
+            ++errorCount;
+        });
+        videoTrackId = renderer->addTrack(TrackInfo::TrackType::Video);
     }
 
     void TearDown() final
@@ -55,11 +81,20 @@ public:
         renderer = nullptr;
     }
 
-    RefPtr<AudioVideoRendererAVFObjC> renderer;
+    void enqueueVideoSample()
+    {
+        RetainPtr sampleBuffer = createVideoSampleBuffer();
+        ASSERT_TRUE(sampleBuffer);
+        renderer->enqueueSample(*videoTrackId, MediaSampleAVFObjC::create(sampleBuffer.get(), 0), { });
+    }
+
+    RefPtr<AudioVideoRenderer> renderer;
+    std::optional<AudioVideoRenderer::TrackIdentifier> videoTrackId;
     int flushToResumeCount { 0 };
+    int errorCount { 0 };
 };
 
-TEST_F(AudioVideoRendererAVFObjCTest, FlushToResumeOnVisibilityRestore)
+TEST_F(AudioVideoRendererAVFObjCTest, NoFlushWithoutEnqueuedSamples)
 {
     renderer->renderingCanBeAcceleratedChanged(true);
     Util::runFor(0.1_s);
@@ -70,11 +105,67 @@ TEST_F(AudioVideoRendererAVFObjCTest, FlushToResumeOnVisibilityRestore)
     EXPECT_EQ(flushToResumeCount, 0);
 
     renderer->renderingCanBeAcceleratedChanged(true);
-    bool callbackFired = Util::waitFor([this] {
-        return flushToResumeCount > 0;
-    });
-    EXPECT_TRUE(callbackFired);
-    EXPECT_EQ(flushToResumeCount, 1);
+    Util::runFor(0.1_s);
+    EXPECT_EQ(flushToResumeCount, 0);
+}
+
+TEST_F(AudioVideoRendererAVFObjCTest, NoFlushOnRendererDestroy)
+{
+    ASSERT_TRUE(videoTrackId.has_value());
+
+    renderer->renderingCanBeAcceleratedChanged(true);
+    Util::runFor(0.1_s);
+    EXPECT_EQ(flushToResumeCount, 0);
+
+    enqueueVideoSample();
+
+    renderer->renderingCanBeAcceleratedChanged(false);
+    Util::runFor(0.1_s);
+    EXPECT_EQ(flushToResumeCount, 0);
+    EXPECT_EQ(errorCount, 0);
+}
+
+TEST_F(AudioVideoRendererAVFObjCTest, NoFlushOnProtectedContentVisibilityCycle)
+{
+    ASSERT_TRUE(videoTrackId.has_value());
+
+    renderer->setHasProtectedVideoContent(true);
+    renderer->renderingCanBeAcceleratedChanged(true);
+    Util::runFor(0.1_s);
+    EXPECT_EQ(flushToResumeCount, 0);
+
+    enqueueVideoSample();
+
+    renderer->renderingCanBeAcceleratedChanged(false);
+    Util::runFor(0.1_s);
+    EXPECT_EQ(flushToResumeCount, 0);
+
+    renderer->renderingCanBeAcceleratedChanged(true);
+    Util::runFor(0.1_s);
+    EXPECT_EQ(flushToResumeCount, 0);
+    EXPECT_EQ(errorCount, 0);
+}
+
+TEST_F(AudioVideoRendererAVFObjCTest, NoFlushWithDecompressionSessionForProtectedContent)
+{
+    ASSERT_TRUE(videoTrackId.has_value());
+
+    renderer->setPreferences({ VideoRendererPreference::PrefersDecompressionSession, VideoRendererPreference::UseDecompressionSessionForProtectedContent });
+    renderer->setHasProtectedVideoContent(true);
+    renderer->renderingCanBeAcceleratedChanged(true);
+    Util::runFor(0.1_s);
+    EXPECT_EQ(flushToResumeCount, 0);
+
+    enqueueVideoSample();
+
+    renderer->renderingCanBeAcceleratedChanged(false);
+    Util::runFor(0.1_s);
+    EXPECT_EQ(flushToResumeCount, 0);
+
+    renderer->renderingCanBeAcceleratedChanged(true);
+    Util::runFor(0.1_s);
+    EXPECT_EQ(flushToResumeCount, 0);
+    EXPECT_EQ(errorCount, 0);
 }
 
 } // namespace TestWebKitAPI


### PR DESCRIPTION
#### 70e442b8b1ce7784fc7c7c29ea6ca784e020aea3
<pre>
REGRESSION(311771@main): [Tahoe] media/media-vp8-webm-with-preload.html is a flaky TEXT failure
<a href="https://bugs.webkit.org/show_bug.cgi?id=313352">https://bugs.webkit.org/show_bug.cgi?id=313352</a>
<a href="https://rdar.apple.com/175625798">rdar://175625798</a>

Reviewed by Jer Noble.

The test expects readyState to remain at HAVE_METADATA for 500ms when
preload=&quot;metadata&quot;, but sometimes observed HAVE_ENOUGH_DATA.

The regressing commit added a switchingFromRenderless condition in
stageVideoRenderer that triggered notifyRequiresFlushToResume during
initial renderer setup, even when no video sample had ever been enqueued.
This flush caused the WebM player to re-enqueue video samples to the
renderer, accelerating the first frame decode and advancing readyState
within the test&apos;s 500ms window.

However, 311771@main only fixed the video-disappearing-on-tab-switch bug
incidentally. The real issue was that
SourceBufferPrivateAVFObjC::maybeUpdateNeedsVideoLayer did not notify
the player when m_needsVideoLayer changed, causing
setHasProtectedVideoContent to remain false even when encrypted content
was being decoded. This meant canUseDecompressionSession() incorrectly
returned true for protected content, allowing the renderer to be torn
down on tab switch. The decompression session could not handle the
protected content, leaving the renderer empty on restore.
switchingFromRenderless masked this by forcing a flush on restore.

Fixed by:

- Making maybeUpdateNeedsVideoLayer notify the player when the value
  changes, ensuring setHasProtectedVideoContent is set correctly. The
  renderer now stays during tab switch for protected content, and the
  platform callback handles the flush when needed.

- Removing redundant needsVideoLayerChanged calls from
  cdmInstanceAttached/cdmInstanceDetached (neither changes
  m_protectedTrackID or the enabled track state) and from
  didProvideContentKeyRequestInitializationDataForTrackID (now handled
  by maybeUpdateNeedsVideoLayer).

- Moving m_protectedTrackID assignment outside the LEGACY_ENCRYPTED_MEDIA
  guard so it is set for all encrypted media paths.

- Simplifying RendererConfiguration to a single isRenderingCompressedVideo
  field that captures when a flush is actually needed: when compressed
  video was being sent to the platform renderer (not using a
  decompression session) and that renderer configuration changed.

- Adding m_hasEverSubmittedVideoSample to prevent flush during initial
  renderer setup before any sample has been enqueued.

- Eliminating the switchingFromRenderless workaround and the separate
  videoTrackChangeOnly, configurationChanged, hasVideoTrack,
  canUseDecompressionSession, and isProtected tracking variables.

* LayoutTests/platform/mac-wk2/TestExpectations:
* Source/WebCore/platform/graphics/avfoundation/AudioVideoRendererAVFObjC.h:
* Source/WebCore/platform/graphics/avfoundation/AudioVideoRendererAVFObjC.mm:
(WebCore::AudioVideoRendererAVFObjC::enqueueSample):
(WebCore::AudioVideoRendererAVFObjC::configureHasAvailableVideoFrameCallbackIfNeeded):
(WebCore::AudioVideoRendererAVFObjC::stageVideoRenderer):
(WebCore::AudioVideoRendererAVFObjC::flushVideo):
* Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.mm:
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::cdmInstanceAttached):
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::cdmInstanceDetached):
* Source/WebCore/platform/graphics/avfoundation/objc/SourceBufferPrivateAVFObjC.mm:
(WebCore::SourceBufferPrivateAVFObjC::didProvideContentKeyRequestInitializationDataForTrackID):
(WebCore::SourceBufferPrivateAVFObjC::maybeUpdateNeedsVideoLayer):
* Tools/TestWebKitAPI/Tests/WebCore/cocoa/AudioVideoRendererAVFObjCTests.mm:

Canonical link: <a href="https://commits.webkit.org/312161@main">https://commits.webkit.org/312161@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/384596e86b5b2e4472249ea6086cc01f883b9f35

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/159084 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/32512 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/25617 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/167913 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/113168 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/410791e0-c6fb-4b90-a969-6ff8c9ac71e5) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/160953 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/32579 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/32499 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/123244 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/113168 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/3b240876-14a5-4a3d-92e7-7cad6de35f88) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/162041 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/25515 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/142902 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/103910 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/908e8500-b364-49d7-9188-c8e580850003) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/24569 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/22988 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/15686 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/134255 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/20682 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/170406 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/16148 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/22308 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/131433 "Passed tests") | | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/32201 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/27057 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/131545 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35576 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/32145 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/142475 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/90195 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/26249 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/19284 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/31656 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/97670 "Built successfully") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/31176 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/31449 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/31331 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->