### PR TITLE
WorkerMessagingProxy objects leak after calling worker.terminate() from JavaScript

### DIFF
--- a/Source/WebCore/workers/WorkerMessagingProxy.cpp
+++ b/Source/WebCore/workers/WorkerMessagingProxy.cpp
@@ -398,8 +398,12 @@ void WorkerMessagingProxy::workerThreadCreated(DedicatedWorkerThread& workerThre
 void WorkerMessagingProxy::workerObjectDestroyed()
 {
     m_workerObject = nullptr;
-    if (!m_scriptExecutionContextIdentifier)
+    if (!m_scriptExecutionContextIdentifier) {
+        m_mayBeDestroyed = true;
+        m_queuedEarlyTasks.clear();
+        deref();
         return;
+    }
 
     ScriptExecutionContext::postTaskTo(*m_scriptExecutionContextIdentifier, [this, protectedThis = Ref { *this }](auto&) {
         m_mayBeDestroyed = true;
@@ -457,6 +461,8 @@ void WorkerMessagingProxy::workerGlobalScopeDestroyedInternal()
     m_askedToTerminate = true;
 
     m_inspectorProxy->workerTerminated();
+
+    m_queuedEarlyTasks.clear();
 
     if (RefPtr workerGlobalScope = dynamicDowncast<WorkerGlobalScope>(m_scriptExecutionContext); workerGlobalScope && m_workerThread)
         workerGlobalScope->thread()->removeChildThread(Ref { *m_workerThread });


### PR DESCRIPTION
#### 80cc99fb32cb5757aad6ff9c4f816c09d1e1dae0
<pre>
WorkerMessagingProxy objects leak after calling worker.terminate() from JavaScript
&lt;<a href="https://bugs.webkit.org/show_bug.cgi?id=313389">https://bugs.webkit.org/show_bug.cgi?id=313389</a>&gt;
&lt;<a href="https://rdar.apple.com/175652847">rdar://175652847</a>&gt;

Reviewed by Chris Dumez.

Handle the case in `workerObjectDestroyed()` where
`workerGlobalScopeDestroyedInternal()` has already run.  When
that happens, the proxy&apos;s thread, context, and identifier are
already cleaned up -- the only remaining work is releasing the
initial construction ref via `deref()`.  Without this,
`workerObjectDestroyed()` returns early on the nullopt
identifier, leaving the ref permanently held.

Also clear `m_queuedEarlyTasks` in
`workerGlobalScopeDestroyedInternal()` because tasks queued
before the worker thread is created capture `Ref { *this }`,
forming a retain cycle through the proxy&apos;s own member vector
that prevents destruction even after `deref()` is called.

The leak was introduced in Bug 22723 (254597@main) which added
the null-context early return to `workerObjectDestroyed()` and
added `m_scriptExecutionContext = nullptr` to
`workerGlobalScopeDestroyedInternal()` as part of implementing
nested dedicated workers.

Test using `run-webkit-tests --leaks` with:
- workers/worker-set-delete-terminate-crash.html
- workers/worker-terminate-crash.html

* Source/WebCore/workers/WorkerMessagingProxy.cpp:
(WebCore::WorkerMessagingProxy::workerObjectDestroyed):
(WebCore::WorkerMessagingProxy::workerGlobalScopeDestroyedInternal):

Canonical link: <a href="https://commits.webkit.org/312256@main">https://commits.webkit.org/312256@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1d4cea62692d73986ce1052fbef42e1043bda25c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/158899 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/32326 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/25431 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/167728 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/112983 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/4115b33d-279f-4ea8-9bc4-f87304f72c8b) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/160768 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/32393 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/32313 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/123111 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/86439 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/48a060d3-20d3-46f0-81c6-8b83f63ef5a7) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/161856 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/25382 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/142746 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/103780 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/1211b574-dd26-4106-a7af-a133f78cba8f) 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/158219 "Build is in progress. Recent messages:") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/24438 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/22839 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/15500 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/134124 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/20526 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/170220 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/15963 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/22152 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/131300 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/32015 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/26906 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/131414 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/31960 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/142319 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/89985 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/24255 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/26117 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/19128 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/31471 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/97485 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/30991 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/31264 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/31145 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->