### PR TITLE
[WTF] Use worklist for WTF::Liveness

### DIFF
--- a/Source/WTF/wtf/Liveness.h
+++ b/Source/WTF/wtf/Liveness.h
@@ -261,13 +261,15 @@ protected:
     void compute()
     {
         Adapter::prepareToCompute();
-        
+
         // The liveAtTail of each block automatically contains the LateUse's of the terminal.
-        for (unsigned blockIndex = m_cfg.numNodes(); blockIndex--;) {
+        BitVector dirtyBlocks;
+        Vector<unsigned, 64> worklist;
+        for (unsigned blockIndex = 0; blockIndex < m_cfg.numNodes(); ++blockIndex) {
             typename CFG::Node block = m_cfg.node(blockIndex);
             if (!block)
                 continue;
-            
+
             IndexVector& liveAtTail = m_liveAtTail[block];
 
             Adapter::forEachUse(
@@ -275,86 +277,78 @@ protected:
                 [&] (unsigned index) {
                     liveAtTail.append(index);
                 });
-            
+
             std::ranges::sort(liveAtTail);
             removeRepeatedElements(liveAtTail);
+            dirtyBlocks.set(blockIndex);
+            worklist.append(blockIndex);
         }
 
-        // Blocks with new live values at tail.
-        BitVector dirtyBlocks;
-        for (size_t blockIndex = m_cfg.numNodes(); blockIndex--;)
-            dirtyBlocks.set(blockIndex);
-        
         IndexVector mergeBuffer;
-        
-        bool changed;
-        do {
-            changed = false;
 
-            for (size_t blockIndex = m_cfg.numNodes(); blockIndex--;) {
-                typename CFG::Node block = m_cfg.node(blockIndex);
-                if (!block)
-                    continue;
+        while (!worklist.isEmpty()) {
+            unsigned blockIndex = worklist.takeLast();
+            bool cleared = dirtyBlocks.quickClear(blockIndex);
+            ASSERT_UNUSED(cleared, cleared);
 
-                if (!dirtyBlocks.quickClear(blockIndex))
-                    continue;
+            typename CFG::Node block = m_cfg.node(blockIndex);
+            ASSERT(block);
 
-                LocalCalc localCalc(*this, block);
-                for (size_t instIndex = Adapter::blockSize(block); instIndex--;)
-                    localCalc.execute(instIndex);
+            LocalCalc localCalc(*this, block);
+            for (size_t instIndex = Adapter::blockSize(block); instIndex--;)
+                localCalc.execute(instIndex);
 
-                // Handle the early def's of the first instruction.
-                Adapter::forEachDef(
-                    block, 0,
-                    [&] (unsigned index) {
-                        m_workset.remove(index);
-                    });
+            // Handle the early def's of the first instruction.
+            Adapter::forEachDef(
+                block, 0,
+                [&] (unsigned index) {
+                    m_workset.remove(index);
+                });
 
-                IndexVector& liveAtHead = m_liveAtHead[block];
+            IndexVector& liveAtHead = m_liveAtHead[block];
 
-                // We only care about Tmps that were discovered in this iteration. It is impossible
-                // to remove a live value from the head.
-                // We remove all the values we already knew about so that we only have to deal with
-                // what is new in LiveAtHead.
-                if (m_workset.size() == liveAtHead.size())
-                    m_workset.clear();
-                else {
-                    for (unsigned liveIndexAtHead : liveAtHead)
-                        m_workset.remove(liveIndexAtHead);
-                }
-
-                if (m_workset.isEmpty())
-                    continue;
-
-                liveAtHead.appendRange(m_workset.begin(), m_workset.end());
-                
-                m_workset.sort();
-                
-                for (typename CFG::Node predecessor : m_cfg.predecessors(block)) {
-                    IndexVector& liveAtTail = m_liveAtTail[predecessor];
-                    
-                    if (liveAtTail.isEmpty())
-                        liveAtTail = m_workset.values();
-                    else {
-                        mergeBuffer.resize(liveAtTail.size() + m_workset.size());
-                        auto iter = mergeDeduplicatedSorted(
-                            liveAtTail.begin(), liveAtTail.end(),
-                            m_workset.begin(), m_workset.end(),
-                            mergeBuffer.begin());
-                        mergeBuffer.shrink(iter - mergeBuffer.begin());
-                        
-                        if (mergeBuffer.size() == liveAtTail.size())
-                            continue;
-                    
-                        RELEASE_ASSERT(mergeBuffer.size() > liveAtTail.size());
-                        liveAtTail = mergeBuffer;
-                    }
-                    
-                    dirtyBlocks.quickSet(predecessor->index());
-                    changed = true;
-                }
+            // We only care about Tmps that were discovered in this iteration. It is impossible
+            // to remove a live value from the head.
+            // We remove all the values we already knew about so that we only have to deal with
+            // what is new in LiveAtHead.
+            if (m_workset.size() == liveAtHead.size())
+                m_workset.clear();
+            else {
+                for (unsigned liveIndexAtHead : liveAtHead)
+                    m_workset.remove(liveIndexAtHead);
             }
-        } while (changed);
+
+            if (m_workset.isEmpty())
+                continue;
+
+            liveAtHead.appendRange(m_workset.begin(), m_workset.end());
+
+            m_workset.sort();
+
+            for (typename CFG::Node predecessor : m_cfg.predecessors(block)) {
+                IndexVector& liveAtTail = m_liveAtTail[predecessor];
+
+                if (liveAtTail.isEmpty())
+                    liveAtTail = m_workset.values();
+                else {
+                    mergeBuffer.resize(liveAtTail.size() + m_workset.size());
+                    auto iter = mergeDeduplicatedSorted(
+                        liveAtTail.begin(), liveAtTail.end(),
+                        m_workset.begin(), m_workset.end(),
+                        mergeBuffer.begin());
+                    mergeBuffer.shrink(iter - mergeBuffer.begin());
+
+                    if (mergeBuffer.size() == liveAtTail.size())
+                        continue;
+
+                    RELEASE_ASSERT(mergeBuffer.size() > liveAtTail.size());
+                    std::swap(liveAtTail, mergeBuffer);
+                }
+
+                if (!dirtyBlocks.quickSet(predecessor->index()))
+                    worklist.append(predecessor->index());
+            }
+        }
     }
 
 private:


### PR DESCRIPTION
#### f69c4f5d8453d6c253fa41e5e8ce2a39b7c8f44d
<pre>
[WTF] Use worklist for WTF::Liveness
<a href="https://bugs.webkit.org/show_bug.cgi?id=313396">https://bugs.webkit.org/show_bug.cgi?id=313396</a>
<a href="https://rdar.apple.com/175655234">rdar://175655234</a>

Reviewed by Yijia Huang and Dan Hecht.

Use simple Vector&lt;&gt; for worklist instead of iterating all the blocks in
WTF::Liveness. This is effective when graph size is larger.
For example, OMG compilation time in Dart-flute-todomvc-wasm gets 3-4%
better.

                             Baseline  Inline=64  64 vs base
    Dart-flute-todomvc-wasm   1309.55    1263.44      −46.11

* Source/WTF/wtf/Liveness.h:
(WTF::Liveness::compute):

Canonical link: <a href="https://commits.webkit.org/312132@main">https://commits.webkit.org/312132@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c413db3ccf41c69b2c33aa222f554d92402323cb

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/159049 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/159/builds/32477 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/25582 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/167878 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/113133 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/32544 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/156/builds/32464 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/167878 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/113133 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/162006 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/32544 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/168/builds/25582 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/167878 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/32544 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/156/builds/32464 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk3-libwebrtc~~](https://ews-build.webkit.org/#/builders/173/builds/15651 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/20/builds/151099 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/32544 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/168/builds/25582 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/170371 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [  ~~🛠 🧪 jsc-debug-arm64~~](https://ews-build.webkit.org/#/builders/171/builds/19882 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/16113 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/25582 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/170371 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/32166 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/156/builds/32464 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/170371 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/32110 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/168/builds/25582 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/90160 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/24198 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/160/builds/32110 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/25582 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 jsc-armv7~~](https://ews-build.webkit.org/#/builders/35/builds/191331 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/31621 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/97635 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/35/builds/191331 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/31141 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/31414 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/31296 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->