### PR TITLE
Elements with display: contents should be focusable

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-display/display-contents-focusable-001-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-display/display-contents-focusable-001-expected.txt
@@ -1,4 +1,4 @@
 Hello
 
-FAIL element with display:contents is focusable assert_equals: e is now focused expected Element node <div id="test" style="display: contents" tabindex="1">Hel... but got Element node <body><div id="test" style="display: contents" tabindex="...
+PASS element with display:contents is focusable
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-display/focus/display-contents-focus-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-display/focus/display-contents-focus-expected.txt
@@ -2,19 +2,9 @@ Testing focusability of display: contents
 
 x x
 
-FAIL button with display: contents is focusable assert_equals: Element is focusable with element.focus() expected Element node <button style="display: contents;" class="ex-focusable" d... but got Element node <body>
-
-  <!-- Dec 2023 notes for "display: contents" tes...
-FAIL div with role button, tabindex=0 and display: contents is focusable assert_equals: Element is focusable with element.focus() expected Element node <div role="button" tabindex="0" style="display: contents;... but got Element node <body>
-
-  <!-- Dec 2023 notes for "display: contents" tes...
-FAIL div with role button, tabindex=-1 and display: contents is focusable assert_equals: Element is focusable with element.focus() expected Element node <div role="button" tabindex="-1" style="display: contents... but got Element node <body>
-
-  <!-- Dec 2023 notes for "display: contents" tes...
-FAIL link with display: contents is focusable assert_equals: Element is focusable with element.focus() expected Element node <a href="#" style="display: contents;" class="ex-focusabl... but got Element node <body>
-
-  <!-- Dec 2023 notes for "display: contents" tes...
-FAIL span with role link, tabindex=0 and display: contents is focusable assert_equals: Element is focusable with element.focus() expected Element node <span role="link" tabindex="0" style="display: contents;"... but got Element node <body>
-
-  <!-- Dec 2023 notes for "display: contents" tes...
+PASS button with display: contents is focusable
+PASS div with role button, tabindex=0 and display: contents is focusable
+PASS div with role button, tabindex=-1 and display: contents is focusable
+PASS link with display: contents is focusable
+PASS span with role link, tabindex=0 and display: contents is focusable
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/rendering/non-replaced-elements/flow-content-0/slot-element-focusable.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/rendering/non-replaced-elements/flow-content-0/slot-element-focusable.tentative-expected.txt
@@ -1,4 +1,4 @@
 
 PASS slot element with display: block should be focusable
-FAIL slot element with default style should be focusable assert_equals: slot is now focused expected Element node <slot tabindex="1" style=""></slot> but got null
+PASS slot element with default style should be focusable
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/rendering/non-replaced-elements/flow-content-0/slot-element-tabbable.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/rendering/non-replaced-elements/flow-content-0/slot-element-tabbable.tentative-expected.txt
@@ -1,4 +1,4 @@
 
 PASS slot element with display: block should be focusable
-FAIL slot element with default style should be focusable assert_equals: slot is now focused expected Element node <slot tabindex="1" style=""></slot> but got null
+PASS slot element with default style should be focusable
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-canvas-element/canvas-descendants-focusability-003.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-canvas-element/canvas-descendants-focusability-003.tentative-expected.txt
@@ -4,9 +4,9 @@ PASS <section hidden="" tabindex="-1" data-focusable="false">
 PASS <div tabindex="-1" data-focusable="false">
 PASS <span tabindex="-1" data-focusable="false">
 PASS <a href="#" data-focusable="false">
-FAIL <button style="display: contents" data-focusable="true"> assert_true: Should be focused expected true got false
-FAIL <section style="display: contents" tabindex="-1" data-focusable="true"> assert_true: Should be focused expected true got false
-FAIL <div style="display: contents" tabindex="-1" data-focusable="true"> assert_true: Should be focused expected true got false
-FAIL <span style="display: contents" tabindex="-1" data-focusable="true"> assert_true: Should be focused expected true got false
-FAIL <a style="display: contents" href="#" data-focusable="true"> assert_true: Should be focused expected true got false
+PASS <button style="display: contents" data-focusable="true">
+PASS <section style="display: contents" tabindex="-1" data-focusable="true">
+PASS <div style="display: contents" tabindex="-1" data-focusable="true">
+PASS <span style="display: contents" tabindex="-1" data-focusable="true">
+PASS <a style="display: contents" href="#" data-focusable="true">
 

--- a/Source/WebCore/dom/Element.cpp
+++ b/Source/WebCore/dom/Element.cpp
@@ -898,7 +898,7 @@ Vector<String> Element::getAttributeNames() const
 bool Element::hasFocusableStyle() const
 {
     auto isFocusableStyle = [](const RenderStyle* style) {
-        return style && style->display().doesGenerateBox()
+        return style && style->display() != Style::DisplayType::None
             && style->visibility() == Visibility::Visible && !style->effectiveInert()
             && (style->usedContentVisibility() != ContentVisibility::Hidden || style->contentVisibility() != ContentVisibility::Visible);
     };


### PR DESCRIPTION
#### 5aebc56764824da8a376265feda261d58b3c2891
<pre>
Elements with display: contents should be focusable
<a href="https://bugs.webkit.org/show_bug.cgi?id=255149">https://bugs.webkit.org/show_bug.cgi?id=255149</a>
<a href="https://rdar.apple.com/108048437">rdar://108048437</a>

Reviewed by NOBODY (OOPS!).

hasFocusableStyle() used doesGenerateBox() to determine whether an element
could be focused. This excluded elements with display: contents, since they
do not generate a box. However, the HTML specification defines a focusable
area as one that is &quot;being rendered, delegating its rendering to its
children, or being used as relevant canvas fallback content&quot; [1].

An element with display: contents is &quot;delegating its rendering to its
children&quot; [2] — it is not being rendered itself, but its children can be.
Per the spec, such elements should still be focusable.

Replace doesGenerateBox() with a check for display != None, which correctly
allows display: contents elements (and default-styled slot elements, which
also use display: contents per the rendering spec) to be focused while
still excluding display: none elements.

[1] <a href="https://html.spec.whatwg.org/multipage/interaction.html#focusable-area">https://html.spec.whatwg.org/multipage/interaction.html#focusable-area</a>
[2] <a href="https://html.spec.whatwg.org/multipage/rendering.html#delegating-its-rendering-to-its-children">https://html.spec.whatwg.org/multipage/rendering.html#delegating-its-rendering-to-its-children</a>

* LayoutTests/imported/w3c/web-platform-tests/css/css-display/display-contents-focusable-001-expected.txt: Progression
* LayoutTests/imported/w3c/web-platform-tests/css/css-display/focus/display-contents-focus-expected.txt: Ditto
* LayoutTests/imported/w3c/web-platform-tests/html/rendering/non-replaced-elements/flow-content-0/slot-element-focusable.tentative-expected.txt: Ditto
* LayoutTests/imported/w3c/web-platform-tests/html/rendering/non-replaced-elements/flow-content-0/slot-element-tabbable.tentative-expected.txt: Ditto
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-canvas-element/canvas-descendants-focusability-003.tentative-expected.txt: Ditto
* Source/WebCore/dom/Element.cpp:
(WebCore::Element::hasFocusableStyle const):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5aebc56764824da8a376265feda261d58b3c2891

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/158905 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/32332 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/25437 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/167734 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/112989 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/61bafd99-7eb1-403a-ae6e-b8e9c779921f) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/160774 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/32399 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/32319 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/123117 "Found 14 new test failures: imported/w3c/web-platform-tests/shadow-dom/focus-navigation/focus-navigation-slot-fallback-default-tabindex.html imported/w3c/web-platform-tests/shadow-dom/focus-navigation/focus-navigation-slot-shadow-in-fallback.html imported/w3c/web-platform-tests/shadow-dom/focus-navigation/focus-navigation-slot-shadow-in-slot.html imported/w3c/web-platform-tests/shadow-dom/focus-navigation/focus-navigation-slot-with-tabindex.html imported/w3c/web-platform-tests/shadow-dom/focus-navigation/focus-navigation-slots.html imported/w3c/web-platform-tests/shadow-dom/focus/focus-tabindex-order-shadow-slot-one.html imported/w3c/web-platform-tests/shadow-dom/focus/focus-tabindex-order-shadow-varying-delegatesFocus.html imported/w3c/web-platform-tests/shadow-dom/focus/focus-tabindex-order-shadow-varying-tabindex.html imported/w3c/web-platform-tests/shadow-dom/focus/focus-tabindex-order-shadow-zero-delegatesFocus.html imported/w3c/web-platform-tests/shadow-dom/focus/focus-tabindex-order-shadow-zero-host-not-set-scrollable.html ... (failure)") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/86445 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/bbbf8b5f-b2e7-47fa-a6c0-0165d433877b) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/161862 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/25388 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/142753 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/103786 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/5f74a920-29cb-462b-8ee3-84a876cb0b59) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/24444 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/22845 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/15506 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/134130 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/20533 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/170226 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/15969 "Built successfully") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/22159 "Found 14 new test failures: imported/w3c/web-platform-tests/shadow-dom/focus-navigation/focus-navigation-slot-fallback-default-tabindex.html imported/w3c/web-platform-tests/shadow-dom/focus-navigation/focus-navigation-slot-shadow-in-fallback.html imported/w3c/web-platform-tests/shadow-dom/focus-navigation/focus-navigation-slot-shadow-in-slot.html imported/w3c/web-platform-tests/shadow-dom/focus-navigation/focus-navigation-slot-with-tabindex.html imported/w3c/web-platform-tests/shadow-dom/focus-navigation/focus-navigation-slots.html imported/w3c/web-platform-tests/shadow-dom/focus/focus-tabindex-order-shadow-slot-one.html imported/w3c/web-platform-tests/shadow-dom/focus/focus-tabindex-order-shadow-varying-delegatesFocus.html imported/w3c/web-platform-tests/shadow-dom/focus/focus-tabindex-order-shadow-varying-tabindex.html imported/w3c/web-platform-tests/shadow-dom/focus/focus-tabindex-order-shadow-zero-delegatesFocus.html imported/w3c/web-platform-tests/shadow-dom/focus/focus-tabindex-order-shadow-zero-host-not-set-scrollable.html ... (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/131305 "Found 12 new test failures: imported/w3c/web-platform-tests/shadow-dom/focus-navigation/focus-navigation-slot-shadow-in-slot.html imported/w3c/web-platform-tests/shadow-dom/focus-navigation/focus-navigation-slot-with-tabindex.html imported/w3c/web-platform-tests/shadow-dom/focus-navigation/focus-navigation-slots.html imported/w3c/web-platform-tests/shadow-dom/focus/focus-tabindex-order-shadow-slot-one.html imported/w3c/web-platform-tests/shadow-dom/focus/focus-tabindex-order-shadow-varying-delegatesFocus.html imported/w3c/web-platform-tests/shadow-dom/focus/focus-tabindex-order-shadow-varying-tabindex.html imported/w3c/web-platform-tests/shadow-dom/focus/focus-tabindex-order-shadow-zero-delegatesFocus.html imported/w3c/web-platform-tests/shadow-dom/focus/focus-tabindex-order-shadow-zero-host-not-set-scrollable.html imported/w3c/web-platform-tests/shadow-dom/focus/focus-tabindex-order-shadow-zero-host-not-set.html imported/w3c/web-platform-tests/shadow-dom/focus/focus-tabindex-order-shadow-zero-host-one.html ... (failure)") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/32021 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/26912 "Found 14 new test failures: imported/w3c/web-platform-tests/shadow-dom/focus-navigation/focus-navigation-slot-fallback-default-tabindex.html imported/w3c/web-platform-tests/shadow-dom/focus-navigation/focus-navigation-slot-shadow-in-fallback.html imported/w3c/web-platform-tests/shadow-dom/focus-navigation/focus-navigation-slot-shadow-in-slot.html imported/w3c/web-platform-tests/shadow-dom/focus-navigation/focus-navigation-slot-with-tabindex.html imported/w3c/web-platform-tests/shadow-dom/focus-navigation/focus-navigation-slots.html imported/w3c/web-platform-tests/shadow-dom/focus/focus-tabindex-order-shadow-slot-one.html imported/w3c/web-platform-tests/shadow-dom/focus/focus-tabindex-order-shadow-varying-delegatesFocus.html imported/w3c/web-platform-tests/shadow-dom/focus/focus-tabindex-order-shadow-varying-tabindex.html imported/w3c/web-platform-tests/shadow-dom/focus/focus-tabindex-order-shadow-zero-delegatesFocus.html imported/w3c/web-platform-tests/shadow-dom/focus/focus-tabindex-order-shadow-zero-host-not-set-scrollable.html ... (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/131419 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/31966 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/142326 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/90000 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/26123 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/19135 "Found 14 new test failures: imported/w3c/web-platform-tests/shadow-dom/focus-navigation/focus-navigation-slot-fallback-default-tabindex.html imported/w3c/web-platform-tests/shadow-dom/focus-navigation/focus-navigation-slot-shadow-in-fallback.html imported/w3c/web-platform-tests/shadow-dom/focus-navigation/focus-navigation-slot-shadow-in-slot.html imported/w3c/web-platform-tests/shadow-dom/focus-navigation/focus-navigation-slot-with-tabindex.html imported/w3c/web-platform-tests/shadow-dom/focus-navigation/focus-navigation-slots.html imported/w3c/web-platform-tests/shadow-dom/focus/focus-tabindex-order-shadow-slot-one.html imported/w3c/web-platform-tests/shadow-dom/focus/focus-tabindex-order-shadow-varying-delegatesFocus.html imported/w3c/web-platform-tests/shadow-dom/focus/focus-tabindex-order-shadow-varying-tabindex.html imported/w3c/web-platform-tests/shadow-dom/focus/focus-tabindex-order-shadow-zero-delegatesFocus.html imported/w3c/web-platform-tests/shadow-dom/focus/focus-tabindex-order-shadow-zero-host-not-set-scrollable.html ... (failure)") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/31477 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/97491 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/30997 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/31270 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/31151 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->