### PR TITLE
Make the AtomStringTable global instead of per thread

### DIFF
--- a/Source/JavaScriptCore/API/JSClassRef.cpp
+++ b/Source/JavaScriptCore/API/JSClassRef.cpp
@@ -79,16 +79,6 @@ OpaqueJSClass::OpaqueJSClass(const JSClassDefinition* definition, OpaqueJSClass*
 
 OpaqueJSClass::~OpaqueJSClass()
 {
-    // The empty string is shared across threads & is an identifier, in all other cases we should have done a deep copy in className(), below. 
-    ASSERT(!m_className.length() || !m_className.impl()->isAtom());
-
-#if ASSERT_ENABLED
-    for (auto& key : m_staticValues.keys())
-        ASSERT(!key->isAtom());
-    for (auto& key : m_staticFunctions.keys())
-        ASSERT(!key->isAtom());
-#endif
-
     if (prototypeClass)
         JSClassRelease(prototypeClass);
 }
@@ -115,16 +105,11 @@ Ref<OpaqueJSClass> OpaqueJSClass::create(const JSClassDefinition* clientDefiniti
 OpaqueJSClassContextData::OpaqueJSClassContextData(JSC::VM&, OpaqueJSClass* jsClass)
     : m_class(jsClass)
 {
-    for (auto& it : jsClass->m_staticValues) {
-        ASSERT(!it.key->isAtom());
-        String valueName = it.key->isolatedCopy();
-        staticValues.add(valueName.impl(), makeUnique<StaticValueEntry>(it.value->getProperty, it.value->setProperty, it.value->attributes, valueName));
-    }
+    for (auto& it : jsClass->m_staticValues)
+        staticValues.add(it.key, makeUnique<StaticValueEntry>(it.value->getProperty, it.value->setProperty, it.value->attributes, String(it.key.get())));
 
-    for (auto& it : jsClass->m_staticFunctions) {
-        ASSERT(!it.key->isAtom());
-        staticFunctions.add(it.key->isolatedCopy(), makeUnique<StaticFunctionEntry>(it.value->callAsFunction, it.value->attributes));
-    }
+    for (auto& it : jsClass->m_staticFunctions)
+        staticFunctions.add(it.key, makeUnique<StaticFunctionEntry>(it.value->callAsFunction, it.value->attributes));
 }
 
 OpaqueJSClassContextData& OpaqueJSClass::contextData(JSGlobalObject* globalObject)
@@ -137,8 +122,7 @@ OpaqueJSClassContextData& OpaqueJSClass::contextData(JSGlobalObject* globalObjec
 
 String OpaqueJSClass::className()
 {
-    // Make a deep copy, so that the caller has no chance to put the original into AtomStringTable.
-    return m_className.isolatedCopy();
+    return m_className;
 }
 
 OpaqueJSClassStaticValuesTable* OpaqueJSClass::staticValues(JSC::JSGlobalObject* globalObject)

--- a/Source/JavaScriptCore/API/JSClassRef.h
+++ b/Source/JavaScriptCore/API/JSClassRef.h
@@ -39,7 +39,7 @@
 struct StaticValueEntry {
     WTF_DEPRECATED_MAKE_FAST_ALLOCATED(StaticValueEntry);
 public:
-    StaticValueEntry(JSObjectGetPropertyCallback _getProperty, JSObjectSetPropertyCallback _setProperty, JSPropertyAttributes _attributes, String& propertyName)
+    StaticValueEntry(JSObjectGetPropertyCallback _getProperty, JSObjectSetPropertyCallback _setProperty, JSPropertyAttributes _attributes, const String& propertyName)
         : getProperty(_getProperty)
         , setProperty(_setProperty)
         , attributes(_attributes)
@@ -134,7 +134,6 @@ private:
 
     OpaqueJSClassContextData& contextData(JSC::JSGlobalObject*);
 
-    // Strings in these data members should not be put into any AtomStringTable.
     String m_className;
     OpaqueJSClassStaticValuesTable m_staticValues;
     OpaqueJSClassStaticFunctionsTable m_staticFunctions;

--- a/Source/JavaScriptCore/heap/Heap.cpp
+++ b/Source/JavaScriptCore/heap/Heap.cpp
@@ -1720,11 +1720,6 @@ NEVER_INLINE bool Heap::runEndPhase(GCConductor conn)
     }
         
     {
-        auto* previous = Thread::currentSingleton().setCurrentAtomStringTable(nullptr);
-        auto scopeExit = makeScopeExit([&] {
-            Thread::currentSingleton().setCurrentAtomStringTable(previous);
-        });
-
         if (vm().typeProfiler())
             vm().typeProfiler()->invalidateTypeSetCache(vm());
 
@@ -2322,10 +2317,9 @@ void Heap::finalize()
 Heap::Ticket Heap::requestCollection(GCRequest request)
 {
     stopIfNecessary();
-    
+
     ASSERT(vm().currentThreadIsHoldingAPILock());
-    RELEASE_ASSERT(vm().atomStringTable() == Thread::currentSingleton().atomStringTable());
-    
+
     Locker locker { *m_threadLock };
     // We may be able to steal the conn. That only works if the collector is definitely not running
     // right now. This is an optimization that prevents the collector thread from ever starting in most

--- a/Source/JavaScriptCore/runtime/Completion.cpp
+++ b/Source/JavaScriptCore/runtime/Completion.cpp
@@ -60,7 +60,6 @@ bool checkSyntax(JSGlobalObject* globalObject, const SourceCode& source, JSValue
 {
     VM& vm = globalObject->vm();
     JSLockHolder lock(vm);
-    RELEASE_ASSERT(vm.atomStringTable() == Thread::currentSingleton().atomStringTable());
 
     ParserError error;
     if (checkSyntaxInternal(vm, source, error))
@@ -74,7 +73,6 @@ bool checkSyntax(JSGlobalObject* globalObject, const SourceCode& source, JSValue
 bool checkSyntax(VM& vm, const SourceCode& source, ParserError& error)
 {
     JSLockHolder lock(vm);
-    RELEASE_ASSERT(vm.atomStringTable() == Thread::currentSingleton().atomStringTable());
     return checkSyntaxInternal(vm, source, error);
 }
 
@@ -82,7 +80,6 @@ bool checkModuleSyntax(JSGlobalObject* globalObject, const SourceCode& source, P
 {
     VM& vm = globalObject->vm();
     JSLockHolder lock(vm);
-    RELEASE_ASSERT(vm.atomStringTable() == Thread::currentSingleton().atomStringTable());
     std::unique_ptr<ModuleProgramNode> moduleProgramNode = parseRootNode<ModuleProgramNode>(
         vm, source, ImplementationVisibility::Public, JSParserBuiltinMode::NotBuiltin,
         StrictModeLexicallyScopedFeature, JSParserScriptMode::Module, SourceParseMode::ModuleAnalyzeMode, error);
@@ -97,7 +94,6 @@ bool checkModuleSyntax(JSGlobalObject* globalObject, const SourceCode& source, P
 RefPtr<CachedBytecode> generateProgramBytecode(VM& vm, const SourceCode& source, FileSystem::FileHandle& fileHandle, BytecodeCacheError& error)
 {
     JSLockHolder lock(vm);
-    RELEASE_ASSERT(vm.atomStringTable() == Thread::currentSingleton().atomStringTable());
 
     LexicallyScopedFeatures lexicallyScopedFeatures = NoLexicallyScopedFeatures;
     JSParserScriptMode scriptMode = JSParserScriptMode::Classic;
@@ -116,7 +112,6 @@ RefPtr<CachedBytecode> generateProgramBytecode(VM& vm, const SourceCode& source,
 RefPtr<CachedBytecode> generateModuleBytecode(VM& vm, const SourceCode& source, FileSystem::FileHandle& fileHandle, BytecodeCacheError& error)
 {
     JSLockHolder lock(vm);
-    RELEASE_ASSERT(vm.atomStringTable() == Thread::currentSingleton().atomStringTable());
 
     LexicallyScopedFeatures lexicallyScopedFeatures = StrictModeLexicallyScopedFeature;
     JSParserScriptMode scriptMode = JSParserScriptMode::Module;
@@ -136,7 +131,6 @@ JSValue evaluate(JSGlobalObject* globalObject, const SourceCode& source, JSValue
     VM& vm = globalObject->vm();
     JSLockHolder lock(vm);
     auto scope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
-    RELEASE_ASSERT(vm.atomStringTable() == Thread::currentSingleton().atomStringTable());
     RELEASE_ASSERT(!vm.isCollectorBusyOnCurrentThread());
 
     if (!thisValue || thisValue.isUndefinedOrNull())
@@ -189,7 +183,6 @@ JSPromise* loadAndEvaluateModule(JSGlobalObject* globalObject, const String& mod
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
     JSLockHolder lock(vm);
-    RELEASE_ASSERT(vm.atomStringTable() == Thread::currentSingleton().atomStringTable());
     RELEASE_ASSERT(!vm.isCollectorBusyOnCurrentThread());
 
     Identifier resolved = globalObject->moduleLoader()->resolve(globalObject, Identifier::fromString(vm, moduleName), { }, scriptFetcher, false);
@@ -217,7 +210,6 @@ JSPromise* loadAndEvaluateModule(JSGlobalObject* globalObject, SourceCode&& sour
     VM& vm = globalObject->vm();
     JSLockHolder lock(vm);
     auto scope = DECLARE_THROW_SCOPE(vm);
-    RELEASE_ASSERT(vm.atomStringTable() == Thread::currentSingleton().atomStringTable());
     RELEASE_ASSERT(!vm.isCollectorBusyOnCurrentThread());
 
     Identifier key = createEntrypointModuleKey(vm);
@@ -248,7 +240,6 @@ JSPromise* loadModule(JSGlobalObject* globalObject, const Identifier& moduleKey,
 {
     VM& vm = globalObject->vm();
     JSLockHolder lock(vm);
-    RELEASE_ASSERT(vm.atomStringTable() == Thread::currentSingleton().atomStringTable());
     RELEASE_ASSERT(!vm.isCollectorBusyOnCurrentThread());
 
     return globalObject->moduleLoader()->loadModule(globalObject, moduleKey, WTF::move(parameters), WTF::move(scriptFetcher), false, false, false);
@@ -259,7 +250,6 @@ JSPromise* loadModule(JSGlobalObject* globalObject, SourceCode&& source, RefPtr<
     VM& vm = globalObject->vm();
     JSLockHolder lock(vm);
     auto scope = DECLARE_THROW_SCOPE(vm);
-    RELEASE_ASSERT(vm.atomStringTable() == Thread::currentSingleton().atomStringTable());
     RELEASE_ASSERT(!vm.isCollectorBusyOnCurrentThread());
 
     Identifier key = createEntrypointModuleKey(vm);
@@ -274,7 +264,6 @@ JSPromise* linkAndEvaluateModule(JSGlobalObject* globalObject, const Identifier&
 {
     VM& vm = globalObject->vm();
     JSLockHolder lock(vm);
-    RELEASE_ASSERT(vm.atomStringTable() == Thread::currentSingleton().atomStringTable());
     RELEASE_ASSERT(!vm.isCollectorBusyOnCurrentThread());
 
     return globalObject->moduleLoader()->linkAndEvaluateModule(globalObject, moduleKey, nullptr, WTF::move(scriptFetcher));
@@ -284,7 +273,6 @@ JSPromise* importModule(JSGlobalObject* globalObject, const Identifier& moduleNa
 {
     VM& vm = globalObject->vm();
     JSLockHolder lock(vm);
-    RELEASE_ASSERT(vm.atomStringTable() == Thread::currentSingleton().atomStringTable());
     RELEASE_ASSERT(!vm.isCollectorBusyOnCurrentThread());
 
     return globalObject->moduleLoader()->requestImportModule(globalObject, moduleName, referrer, WTF::move(parameters), WTF::move(scriptFetcher));

--- a/Source/JavaScriptCore/runtime/Identifier.cpp
+++ b/Source/JavaScriptCore/runtime/Identifier.cpp
@@ -70,11 +70,8 @@ void Identifier::dump(PrintStream& out) const
 
 #ifndef NDEBUG
 
-void Identifier::checkCurrentAtomStringTable(VM& vm)
+void Identifier::checkCurrentAtomStringTable(VM&)
 {
-    // Check the identifier table accessible through the threadspecific matches the
-    // vm's identifier table.
-    ASSERT_UNUSED(vm, vm.atomStringTable() == Thread::currentSingleton().atomStringTable());
 }
 
 #else

--- a/Source/JavaScriptCore/runtime/IdentifierInlines.h
+++ b/Source/JavaScriptCore/runtime/IdentifierInlines.h
@@ -50,27 +50,21 @@ ALWAYS_INLINE Identifier::Identifier(VM& vm, ASCIILiteral literal)
     ASSERT(m_string.impl()->isAtom());
 }
 
-inline Identifier::Identifier(VM& vm, AtomStringImpl* string)
+inline Identifier::Identifier(VM&, AtomStringImpl* string)
     : m_string(string)
 {
-#ifndef NDEBUG
-    checkCurrentAtomStringTable(vm);
+#if ASSERT_ENABLED
     if (string)
-        ASSERT_WITH_MESSAGE(!string->length() || string->isSymbol() || AtomStringImpl::isInAtomStringTable(string), "The atomic string comes from an other thread!");
-#else
-    UNUSED_PARAM(vm);
+        ASSERT_WITH_MESSAGE(!string->length() || string->isSymbol() || AtomStringImpl::isInAtomStringTable(string), "The atomic string is not in the global atom string table!");
 #endif
 }
 
-inline Identifier::Identifier(VM& vm, const AtomString& string)
+inline Identifier::Identifier(VM&, const AtomString& string)
     : m_string(string)
 {
-#ifndef NDEBUG
-    checkCurrentAtomStringTable(vm);
+#if ASSERT_ENABLED
     if (!string.isNull())
-        ASSERT_WITH_MESSAGE(!string.length() || string.impl()->isSymbol() || AtomStringImpl::isInAtomStringTable(string.impl()), "The atomic string comes from an other thread!");
-#else
-    UNUSED_PARAM(vm);
+        ASSERT_WITH_MESSAGE(!string.length() || string.impl()->isSymbol() || AtomStringImpl::isInAtomStringTable(string.impl()), "The atomic string is not in the global atom string table!");
 #endif
 }
 
@@ -110,9 +104,6 @@ Ref<AtomStringImpl> Identifier::add(VM& vm, std::span<const T> string)
 
 inline Ref<AtomStringImpl> Identifier::add(VM& vm, StringImpl* r)
 {
-#ifndef NDEBUG
-    checkCurrentAtomStringTable(vm);
-#endif
     return *AtomStringImpl::addWithStringTableProvider(vm, r);
 }
 

--- a/Source/JavaScriptCore/runtime/JSLock.cpp
+++ b/Source/JavaScriptCore/runtime/JSLock.cpp
@@ -66,7 +66,6 @@ JSLock::JSLock(VM* vm)
     : m_lockCount(0)
     , m_lockDropDepth(0)
     , m_vm(vm)
-    , m_entryAtomStringTable(nullptr)
 {
 }
 
@@ -118,11 +117,8 @@ void JSLock::didAcquireLock()
     // FIXME: What should happen to the per-thread identifier table if we don't have a VM?
     if (!m_vm)
         return;
-    
+
     auto& thread = Thread::currentSingleton();
-    ASSERT(!m_entryAtomStringTable);
-    m_entryAtomStringTable = thread.setCurrentAtomStringTable(m_vm->atomStringTable());
-    ASSERT(m_entryAtomStringTable);
 
     m_vm->setLastStackTop(thread);
 
@@ -257,11 +253,10 @@ NO_RETURN_DUE_TO_CRASH NEVER_INLINE void JSLock::dumpInfoAndCrashForLockNotOwned
     updateDumpState(0xBBBB, numZeroBytesInLock, totalZeroBytesInPage, currentZeroBytes);
 
     register VM* vmPtr __asm__("r19") = m_vm;
-    register AtomStringTable* atomStringTable __asm__("x15") = m_entryAtomStringTable;
     register JSLock* thisPtr __asm__("x14") = this;
-    updateDumpState(0xCCCC, vmPtr, atomStringTable, thisPtr);
+    updateDumpState(0xCCCC, vmPtr, thisPtr, thisPtr);
 
-    __asm__ volatile (WTF_FATAL_CRASH_INST : : "r"(dumpState), "r"(miscState), "r"(lockWord0), "r"(currentThread), "r"(ownerThread), "r"(lockWord2), "r"(lockWord3), "r"(numZeroBytesBeforeAfter), "r"(numZeroBytesInLock), "r"(vmPtr), "r"(atomStringTable), "r"(thisPtr));
+    __asm__ volatile (WTF_FATAL_CRASH_INST : : "r"(dumpState), "r"(miscState), "r"(lockWord0), "r"(currentThread), "r"(ownerThread), "r"(lockWord2), "r"(lockWord3), "r"(numZeroBytesBeforeAfter), "r"(numZeroBytesInLock), "r"(vmPtr), "r"(thisPtr));
     __builtin_unreachable();
 
 #undef updateDumpState
@@ -319,11 +314,6 @@ void JSLock::willReleaseLock()
             if (m_shouldReleaseHeapAccess)
                 protectedVM->heap.releaseAccess();
         }
-    }
-
-    if (m_entryAtomStringTable) {
-        Thread::currentSingleton().setCurrentAtomStringTable(m_entryAtomStringTable);
-        m_entryAtomStringTable = nullptr;
     }
 }
 

--- a/Source/JavaScriptCore/runtime/JSLock.h
+++ b/Source/JavaScriptCore/runtime/JSLock.h
@@ -160,7 +160,6 @@ private:
     unsigned m_lockDropDepth;
     uint32_t m_lastOwnerThread { 0 };
     VM* m_vm;
-    AtomStringTable* m_entryAtomStringTable; 
 };
 
 } // namespace

--- a/Source/JavaScriptCore/runtime/VM.cpp
+++ b/Source/JavaScriptCore/runtime/VM.cpp
@@ -256,7 +256,6 @@ VM::VM(VMType vmType, HeapType heapType, WTF::RunLoop* runLoop, bool* success)
     , clientHeap(heap)
     , vmType(vmType)
     , deferredWorkTimer(DeferredWorkTimer::create(*this))
-    , m_atomStringTable(vmType == VMType::Default ? Thread::currentSingleton().atomStringTable() : new AtomStringTable)
     , m_symbolRegistry(makeUniqueRef<SymbolRegistry>())
     , m_privateSymbolRegistry(makeUniqueRef<SymbolRegistry>(SymbolRegistry::Type::PrivateSymbol))
     , emptyList(new ArgList)
@@ -314,7 +313,6 @@ VM::VM(VMType vmType, HeapType heapType, WTF::RunLoop* runLoop, bool* success)
 
     // Need to be careful to keep everything consistent here
     JSLockHolder lock(this);
-    AtomStringTable* existingEntryAtomStringTable = Thread::currentSingleton().setCurrentAtomStringTable(m_atomStringTable);
     structureStructure.setWithoutWriteBarrier(Structure::createStructure(*this));
     structureRareDataStructure.setWithoutWriteBarrier(StructureRareData::createStructure(*this, nullptr, jsNull()));
     stringStructure.setWithoutWriteBarrier(JSString::createStructure(*this, nullptr, jsNull()));
@@ -397,8 +395,6 @@ WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
         }
     }
 
-    Thread::currentSingleton().setCurrentAtomStringTable(existingEntryAtomStringTable);
-    
     Gigacage::addPrimitiveDisableCallback(primitiveGigacageDisabledCallback, this);
 
     heap.notifyIsSafeToCollect();
@@ -593,8 +589,6 @@ VM::~VM()
     delete emptyList;
 
     delete propertyNames;
-    if (vmType != VMType::Default)
-        delete m_atomStringTable;
 
     delete clientData;
     m_regExpCache.reset();

--- a/Source/JavaScriptCore/runtime/VM.h
+++ b/Source/JavaScriptCore/runtime/VM.h
@@ -61,6 +61,7 @@ WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 #include <wtf/ObjectIdentifier.h>
 #include <wtf/ThreadSafeRefCountedWithSuppressingSaferCPPChecking.h>
 #include <wtf/text/AdaptiveStringSearcher.h>
+#include <wtf/text/AtomStringTable.h>
 
 #if ENABLE(WEBASSEMBLY)
 #include <JavaScriptCore/WasmContext.h>
@@ -591,7 +592,6 @@ public:
     JSCell* currentlyDestructingCallbackObject { nullptr };
     const ClassInfo* currentlyDestructingCallbackObjectClassInfo { nullptr };
 
-    AtomStringTable* m_atomStringTable;
     const UniqueRef<WTF::SymbolRegistry> m_symbolRegistry;
     const UniqueRef<WTF::SymbolRegistry> m_privateSymbolRegistry;
     CommonIdentifiers* propertyNames { nullptr };
@@ -612,7 +612,7 @@ public:
     bool* addressOfMightBeExecutingTaintedCode() LIFETIME_BOUND { return &m_mightBeExecutingTaintedCode; }
     void setMightBeExecutingTaintedCode(bool value = true) { m_mightBeExecutingTaintedCode = value; }
 
-    AtomStringTable* atomStringTable() const { return m_atomStringTable; }
+    AtomStringTable* atomStringTable() const { return &AtomStringTable::singleton(); }
     WTF::SymbolRegistry& symbolRegistry() { return m_symbolRegistry.get(); }
     WTF::SymbolRegistry& privateSymbolRegistry() { return m_privateSymbolRegistry.get(); }
 

--- a/Source/WTF/wtf/Threading.cpp
+++ b/Source/WTF/wtf/Threading.cpp
@@ -208,15 +208,6 @@ void Thread::initializeInThread()
         allThreads().add(*this); // Must have stack bounds before adding to allThreads()
 #endif
 
-    m_currentAtomStringTable = &m_defaultAtomStringTable;
-#if USE(WEB_THREAD)
-    // On iOS, one AtomStringTable is shared between the main UI thread and the WebThread.
-    if (isWebThread() || isUIThread()) {
-        static NeverDestroyed<AtomStringTable> sharedStringTable;
-        m_currentAtomStringTable = &sharedStringTable.get();
-    }
-#endif
-
 #if OS(LINUX)
     m_id = currentID();
 #endif

--- a/Source/WTF/wtf/Threading.h
+++ b/Source/WTF/wtf/Threading.h
@@ -53,7 +53,6 @@
 #include <wtf/ThreadSafeWeakPtr.h>
 #include <wtf/Vector.h>
 #include <wtf/WordLock.h>
-#include <wtf/text/AtomStringTable.h>
 
 #if USE(PTHREADS) && !OS(DARWIN)
 #include <signal.h>
@@ -261,18 +260,6 @@ public:
         return m_stack;
     }
 
-    AtomStringTable* atomStringTable()
-    {
-        return m_currentAtomStringTable;
-    }
-
-    AtomStringTable* setCurrentAtomStringTable(AtomStringTable* atomStringTable)
-    {
-        AtomStringTable* oldAtomStringTable = m_currentAtomStringTable;
-        m_currentAtomStringTable = atomStringTable;
-        return oldAtomStringTable;
-    }
-
 #if ENABLE(STACK_STATS)
     StackStats::PerThreadStats& stackStats()
     {
@@ -422,8 +409,6 @@ protected:
     SpecificStorage m_specificStorage;
 #endif
 
-    AtomStringTable* m_currentAtomStringTable { nullptr };
-    AtomStringTable m_defaultAtomStringTable;
 
 #if ENABLE(STACK_STATS)
     StackStats::PerThreadStats m_stackStats;

--- a/Source/WTF/wtf/text/AtomStringImpl.cpp
+++ b/Source/WTF/wtf/text/AtomStringImpl.cpp
@@ -29,44 +29,24 @@
 #include <wtf/text/AtomStringTable.h>
 #include <wtf/text/WTFString.h>
 
-#if USE(WEB_THREAD)
-#include <wtf/Lock.h>
-#endif
-
 namespace WTF {
 
 using namespace Unicode;
 
-#if USE(WEB_THREAD)
-
 class AtomStringTableLocker : public Locker<Lock> {
     WTF_MAKE_NONCOPYABLE(AtomStringTableLocker);
-
-    static Lock s_stringTableLock;
 public:
     AtomStringTableLocker()
-        : Locker<Lock>(s_stringTableLock)
+        : Locker<Lock>(AtomStringTable::singleton().lock())
     {
     }
 };
-
-Lock AtomStringTableLocker::s_stringTableLock;
-
-#else
-
-class AtomStringTableLocker {
-    WTF_MAKE_NONCOPYABLE(AtomStringTableLocker);
-public:
-    AtomStringTableLocker() { }
-};
-
-#endif // USE(WEB_THREAD)
 
 using StringTableImpl = AtomStringTable::StringTableImpl;
 
 static ALWAYS_INLINE StringTableImpl& stringTable()
 {
-    return Thread::currentSingleton().atomStringTable()->table();
+    return AtomStringTable::singleton().table();
 }
 
 template<typename T, typename HashTranslator>
@@ -74,8 +54,6 @@ static inline Ref<AtomStringImpl> addToStringTable(AtomStringTableLocker&, Strin
 {
     auto addResult = atomStringTable.add<HashTranslator>(value);
 
-    // If the string is newly-translated, then we need to adopt it.
-    // The boolean in the pair tells us if that is so.
     if (addResult.isNewEntry)
         return adoptRef(uncheckedDowncast<AtomStringImpl>(*addResult.iterator->get()));
     return *uncheckedDowncast<AtomStringImpl>(addResult.iterator->get());
@@ -399,14 +377,22 @@ struct AtomStringTableRemovalHashTranslator {
     static bool equal(const AtomStringTable::StringEntry& a, const AtomStringImpl* b) { return a == b; }
 };
 
-void AtomStringImpl::remove(AtomStringImpl* string)
+bool AtomStringImpl::releaseAndRemoveIfNeeded(AtomStringImpl* string)
 {
     ASSERT(string->isAtom());
     AtomStringTableLocker locker;
+
+    // Do the final refcount decrement under the lock so that Add() cannot
+    // ref this string between our decrement and the table removal.
+    auto oldRefCount = string->m_refCount.fetch_sub(StringImpl::s_refCountIncrement, std::memory_order_relaxed);
+    if (oldRefCount != StringImpl::s_refCountIncrement)
+        return false;
+
     auto& atomStringTable = stringTable();
     auto iterator = atomStringTable.find<AtomStringTableRemovalHashTranslator>(string);
-    bool wasRemoved = atomStringTable.remove(iterator);
-    RELEASE_ASSERT(wasRemoved, "The string being removed is an atom in the string table of an other thread!");
+    ASSERT(iterator != atomStringTable.end());
+    atomStringTable.remove(iterator);
+    return true;
 }
 
 RefPtr<AtomStringImpl> AtomStringImpl::lookUpSlowCase(StringImpl& string)

--- a/Source/WTF/wtf/text/AtomStringImpl.h
+++ b/Source/WTF/wtf/text/AtomStringImpl.h
@@ -33,7 +33,7 @@ public:
     WTF_EXPORT_PRIVATE static RefPtr<AtomStringImpl> lookUp(std::span<const char16_t>);
     static RefPtr<AtomStringImpl> lookUp(StringImpl*);
 
-    static void remove(AtomStringImpl*);
+    WTF_EXPORT_PRIVATE static bool releaseAndRemoveIfNeeded(AtomStringImpl*);
 
     WTF_EXPORT_PRIVATE static RefPtr<AtomStringImpl> add(std::span<const Latin1Character>);
     WTF_EXPORT_PRIVATE static RefPtr<AtomStringImpl> add(std::span<const char16_t>);
@@ -122,7 +122,7 @@ ALWAYS_INLINE RefPtr<AtomStringImpl> AtomStringImpl::addWithStringTableProvider(
 ALWAYS_INLINE Ref<AtomStringImpl> AtomStringImpl::add(StringImpl& string)
 {
     if (auto* atom = dynamicDowncast<AtomStringImpl>(string)) {
-        ASSERT_WITH_MESSAGE(!string.length() || isInAtomStringTable(&string), "The atom string comes from an other thread!");
+        ASSERT_WITH_MESSAGE(!string.length() || isInAtomStringTable(&string), "The atom string is not in the global atom string table!");
         return *atom;
     }
     return addSlowCase(string);
@@ -131,7 +131,7 @@ ALWAYS_INLINE Ref<AtomStringImpl> AtomStringImpl::add(StringImpl& string)
 ALWAYS_INLINE Ref<AtomStringImpl> AtomStringImpl::add(Ref<StringImpl>&& string)
 {
     if (is<AtomStringImpl>(string)) {
-        ASSERT_WITH_MESSAGE(!string->length() || isInAtomStringTable(string.ptr()), "The atom string comes from an other thread!");
+        ASSERT_WITH_MESSAGE(!string->length() || isInAtomStringTable(string.ptr()), "The atom string is not in the global atom string table!");
         return uncheckedDowncast<AtomStringImpl>(WTF::move(string));
     }
     return addSlowCase(WTF::move(string));
@@ -140,7 +140,7 @@ ALWAYS_INLINE Ref<AtomStringImpl> AtomStringImpl::add(Ref<StringImpl>&& string)
 ALWAYS_INLINE Ref<AtomStringImpl> AtomStringImpl::add(AtomStringTable& stringTable, StringImpl& string)
 {
     if (auto* atom = dynamicDowncast<AtomStringImpl>(string)) {
-        ASSERT_WITH_MESSAGE(!string.length() || isInAtomStringTable(&string), "The atom string comes from an other thread!");
+        ASSERT_WITH_MESSAGE(!string.length() || isInAtomStringTable(&string), "The atom string is not in the global atom string table!");
         return *atom;
     }
     return addSlowCase(stringTable, string);

--- a/Source/WTF/wtf/text/AtomStringTable.cpp
+++ b/Source/WTF/wtf/text/AtomStringTable.cpp
@@ -23,7 +23,15 @@
 #include "config.h"
 #include <wtf/text/AtomStringTable.h>
 
+#include <wtf/NeverDestroyed.h>
+
 namespace WTF {
+
+AtomStringTable& AtomStringTable::singleton()
+{
+    static NeverDestroyed<AtomStringTable> globalTable;
+    return globalTable;
+}
 
 AtomStringTable::~AtomStringTable()
 {

--- a/Source/WTF/wtf/text/AtomStringTable.h
+++ b/Source/WTF/wtf/text/AtomStringTable.h
@@ -24,6 +24,7 @@
 
 #include <wtf/CompactPtr.h>
 #include <wtf/HashSet.h>
+#include <wtf/Lock.h>
 #include <wtf/Packed.h>
 #include <wtf/text/StringHash.h>
 #include <wtf/text/StringImpl.h>
@@ -33,18 +34,23 @@ namespace WTF {
 class StringImpl;
 
 class AtomStringTable {
-    WTF_DEPRECATED_MAKE_FAST_ALLOCATED(AtomStringTable);
+    WTF_MAKE_NONCOPYABLE(AtomStringTable);
 public:
     // If CompactPtr is 32bit, it is more efficient than PackedPtr (6 bytes).
     // We select underlying implementation based on CompactPtr's efficacy.
     using StringEntry = std::conditional_t<CompactPtrTraits<StringImpl>::is32Bit, CompactPtr<StringImpl>, PackedPtr<StringImpl>>;
     using StringTableImpl = UncheckedKeyHashSet<StringEntry>;
 
+    AtomStringTable() = default;
     WTF_EXPORT_PRIVATE ~AtomStringTable();
 
+    WTF_EXPORT_PRIVATE static AtomStringTable& singleton();
+
     StringTableImpl& table() LIFETIME_BOUND { return m_table; }
+    Lock& lock() LIFETIME_BOUND { return m_lock; }
 
 private:
+    Lock m_lock;
     StringTableImpl m_table;
 };
 

--- a/Source/WTF/wtf/text/StringImpl.cpp
+++ b/Source/WTF/wtf/text/StringImpl.cpp
@@ -123,11 +123,7 @@ StringImpl::~StringImpl()
 
     STRING_STATS_REMOVE_STRING(*this);
 
-    if (isAtom()) {
-        ASSERT(!isSymbol());
-        if (length())
-            AtomStringImpl::remove(static_cast<AtomStringImpl*>(this));
-    } else if (isSymbol()) {
+    if (isSymbol()) {
         auto& symbol = static_cast<SymbolImpl&>(*this);
         if (CheckedPtr symbolRegistry = symbol.symbolRegistry())
             SUPPRESS_UNCOUNTED_ARG symbolRegistry->remove(*symbol.asRegisteredSymbolImpl());
@@ -158,6 +154,19 @@ void StringImpl::destroy(StringImpl* stringImpl)
 {
     stringImpl->~StringImpl();
     StringImplMalloc::free(stringImpl);
+}
+
+void StringImpl::destroyIfNeeded(StringImpl* stringImpl)
+{
+    if (auto* atomStringImpl = dynamicDowncast<AtomStringImpl>(*stringImpl); atomStringImpl && atomStringImpl->length()) {
+        if (!AtomStringImpl::releaseAndRemoveIfNeeded(atomStringImpl))
+            return;
+    } else {
+        auto oldRefCount = stringImpl->m_refCount.fetch_sub(s_refCountIncrement, std::memory_order_relaxed);
+        if (oldRefCount != s_refCountIncrement)
+            return;
+    }
+    destroy(stringImpl);
 }
 
 Ref<StringImpl> StringImpl::createWithoutCopyingNonEmpty(std::span<const char16_t> characters)

--- a/Source/WTF/wtf/text/StringImpl.h
+++ b/Source/WTF/wtf/text/StringImpl.h
@@ -169,7 +169,7 @@ protected:
         const char* m_data8Char;
         const char16_t* m_data16Char;
     };
-    mutable unsigned m_hashAndFlags;
+    mutable std::atomic<unsigned> m_hashAndFlags;
 };
 
 // FIXME: Use of StringImpl and const is rather confused.
@@ -254,6 +254,7 @@ private:
 
 public:
     WTF_EXPORT_PRIVATE static void destroy(StringImpl*);
+    WTF_EXPORT_PRIVATE static void destroyIfNeeded(StringImpl*);
 
     WTF_EXPORT_PRIVATE static Ref<StringImpl> create(std::span<const char16_t>);
     WTF_EXPORT_PRIVATE static Ref<StringImpl> create(std::span<const Latin1Character>);
@@ -313,7 +314,7 @@ public:
     static constexpr ptrdiff_t lengthMemoryOffset() { return OBJECT_OFFSETOF(StringImpl, m_length); }
     bool isEmpty() const { return !m_length; }
 
-    bool is8Bit() const { return m_hashAndFlags & s_hashFlag8BitBuffer; }
+    bool is8Bit() const { return m_hashAndFlags.load(std::memory_order_relaxed) & s_hashFlag8BitBuffer; }
     ALWAYS_INLINE std::span<const Latin1Character> span8() const LIFETIME_BOUND { ASSERT(is8Bit()); return unsafeMakeSpan(m_data8, length()); }
     ALWAYS_INLINE std::span<const char16_t> span16() const LIFETIME_BOUND { ASSERT(!is8Bit() || isEmpty()); return unsafeMakeSpan(m_data16, length()); }
 
@@ -324,8 +325,8 @@ public:
 
     WTF_EXPORT_PRIVATE size_t NODELETE sizeInBytes() const;
 
-    bool isSymbol() const { return m_hashAndFlags & s_hashFlagStringKindIsSymbol; }
-    bool isAtom() const { return m_hashAndFlags & s_hashFlagStringKindIsAtom; }
+    bool isSymbol() const { return m_hashAndFlags.load(std::memory_order_relaxed) & s_hashFlagStringKindIsSymbol; }
+    bool isAtom() const { return m_hashAndFlags.load(std::memory_order_relaxed) & s_hashFlagStringKindIsAtom; }
     void setIsAtom(bool);
     
     bool isExternal() const { return bufferOwnership() == BufferExternal; }
@@ -354,7 +355,7 @@ private:
     // So, we shift left and right when setting and getting our hash code.
     void setHash(unsigned) const;
 
-    unsigned rawHash() const { return m_hashAndFlags >> s_flagCount; }
+    unsigned rawHash() const { return m_hashAndFlags.load(std::memory_order_relaxed) >> s_flagCount; }
 
 public:
     bool hasHash() const { return !!rawHash(); }
@@ -392,19 +393,9 @@ public:
         //    We also know that a StringImpl never changes from 8 bit to 16 bit because there
         //    is no way to set/clear the s_hashFlag8BitBuffer flag other than at construction.
         //
-        // 3. m_hashAndFlags will not be mutated by different threads because:
-        //
-        //    a. StaticStringImpl's constructor sets the s_hashFlagDidReportCost flag to ensure
-        //       that StringImpl::cost() returns early.
-        //       This means StaticStringImpl costs are not counted. But since there should only
-        //       be a finite set of StaticStringImpls, their cost can be aggregated into a single
-        //       system cost if needed.
-        //    b. setIsAtom() is never called on a StaticStringImpl.
-        //       setIsAtom() asserts !isStatic().
-        //    c. setHash() is never called on a StaticStringImpl.
-        //       StaticStringImpl's constructor sets the hash on construction.
-        //       StringImpl::hash() only sets a new hash iff !hasHash().
-        //       Additionally, StringImpl::setHash() asserts hasHash() and !isStatic().
+        // 3. m_hashAndFlags is std::atomic<unsigned> so concurrent access is well-defined.
+        //    StaticStringImpl's constructor pre-sets the hash and s_hashFlagDidReportCost
+        //    flag, so no mutation occurs after construction for static strings.
 
         template<unsigned characterCount> explicit constexpr StaticStringImpl(const char (&characters)[characterCount], StringKind = StringNormal);
         template<unsigned characterCount> explicit constexpr StaticStringImpl(const char16_t (&characters)[characterCount], StringKind = StringNormal);
@@ -528,7 +519,7 @@ public:
     ALWAYS_INLINE static StringStats& stringStats() { return m_stringStats; }
 #endif
 
-    BufferOwnership bufferOwnership() const { return static_cast<BufferOwnership>(m_hashAndFlags & s_hashMaskBufferOwnership); }
+    BufferOwnership bufferOwnership() const { return static_cast<BufferOwnership>(m_hashAndFlags.load(std::memory_order_relaxed) & s_hashMaskBufferOwnership); }
 
     template<typename T> static constexpr size_t headerSize() { return tailOffset<T>(); }
     
@@ -550,7 +541,7 @@ private:
     WTF_EXPORT_PRIVATE size_t NODELETE find(std::span<const Latin1Character>, size_t start);
     WTF_EXPORT_PRIVATE size_t NODELETE reverseFind(std::span<const Latin1Character>, size_t start);
 
-    bool requiresCopy() const;
+
     template<typename T> const T* tailPointer() const;
     template<typename T> T* tailPointer();
     StringImpl* const& substringBuffer() const;
@@ -894,15 +885,7 @@ template<unsigned characterCount> constexpr StringImplShape::StringImplShape(uin
 
 inline Ref<StringImpl> StringImpl::isolatedCopy() const
 {
-    if (!requiresCopy()) {
-        if (is8Bit())
-            return StringImpl::createWithoutCopying(span8());
-        return StringImpl::createWithoutCopying(span16());
-    }
-
-    if (is8Bit())
-        return create(span8());
-    return create(span16());
+    return const_cast<StringImpl&>(*this);
 }
 
 inline bool StringImpl::containsOnlyASCII() const
@@ -1105,10 +1088,10 @@ inline size_t StringImpl::cost() const
     // We ensure this by pre-setting the s_hashFlagDidReportCost bit in all instances of
     // StaticStringImpl. As a result, StaticStringImpl instances will always return a cost of
     // 0 here and avoid modifying m_hashAndFlags.
-    if (m_hashAndFlags & s_hashFlagDidReportCost)
+    if (m_hashAndFlags.load(std::memory_order_relaxed) & s_hashFlagDidReportCost)
         return 0;
 
-    m_hashAndFlags |= s_hashFlagDidReportCost;
+    m_hashAndFlags.fetch_or(s_hashFlagDidReportCost, std::memory_order_relaxed);
     size_t result = m_length;
     if (!is8Bit())
         result <<= 1;
@@ -1134,9 +1117,9 @@ inline void StringImpl::setIsAtom(bool isAtom)
     ASSERT(!isStatic());
     ASSERT(!isSymbol());
     if (isAtom)
-        m_hashAndFlags |= s_hashFlagStringKindIsAtom;
+        m_hashAndFlags.fetch_or(s_hashFlagStringKindIsAtom, std::memory_order_relaxed);
     else
-        m_hashAndFlags &= ~s_hashFlagStringKindIsAtom;
+        m_hashAndFlags.fetch_and(~s_hashFlagStringKindIsAtom, std::memory_order_relaxed);
 }
 
 inline void StringImpl::setHash(unsigned hash) const
@@ -1152,10 +1135,10 @@ inline void StringImpl::setHash(unsigned hash) const
     ASSERT(!(hash & (s_flagMask << (8 * sizeof(hash) - s_flagCount)))); // Verify that enough high bits are empty.
 
     hash <<= s_flagCount;
-    ASSERT(!(hash & m_hashAndFlags)); // Verify that enough low bits are empty after shift.
-    ASSERT(hash); // Verify that 0 is a valid sentinel hash value.
+    ASSERT(!(hash & m_hashAndFlags.load(std::memory_order_relaxed)));
+    ASSERT(hash);
 
-    m_hashAndFlags |= hash; // Store hash with flags in low bits.
+    m_hashAndFlags.fetch_or(hash, std::memory_order_relaxed);
 }
 
 inline void StringImpl::ref()
@@ -1179,11 +1162,13 @@ inline void StringImpl::deref()
         return;
 #endif
 
-    auto oldRefCount = m_refCount.fetch_sub(s_refCountIncrement, std::memory_order_relaxed);
-    if (oldRefCount != s_refCountIncrement)
-        return;
-
-    StringImpl::destroy(this);
+    auto oldRefCount = m_refCount.load(std::memory_order_relaxed);
+    do {
+        if (oldRefCount == s_refCountIncrement) {
+            destroyIfNeeded(this);
+            return;
+        }
+    } while (!m_refCount.compare_exchange_weak(oldRefCount, oldRefCount - s_refCountIncrement, std::memory_order_relaxed));
 }
 
 inline char16_t StringImpl::at(unsigned i) const
@@ -1233,15 +1218,6 @@ template<typename T> constexpr size_t StringImpl::tailOffset()
     return roundUpToMultipleOf<alignof(T)>(offsetof(StringImpl, m_hashAndFlags) + sizeof(StringImpl::m_hashAndFlags));
 }
 
-inline bool StringImpl::requiresCopy() const
-{
-    if (bufferOwnership() != BufferInternal)
-        return true;
-
-    if (is8Bit())
-        return m_data8 == tailPointer<Latin1Character>();
-    return m_data16 == tailPointer<char16_t>();
-}
 
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 template<typename T> inline const T* StringImpl::tailPointer() const

--- a/Source/WTF/wtf/text/WTFString.cpp
+++ b/Source/WTF/wtf/text/WTFString.cpp
@@ -282,29 +282,6 @@ float String::toFloat(bool* ok) const
     SUPPRESS_UNCOUNTED_ARG return m_impl->toFloat(ok);
 }
 
-String String::isolatedCopy() const &
-{
-    // FIXME: Should this function, and the many others like it, be inlined?
-    SUPPRESS_UNCOUNTED_ARG return m_impl ? m_impl->isolatedCopy() : String { };
-}
-
-String String::isolatedCopy() &&
-{
-    if (isSafeToSendToAnotherThread()) {
-        // Since we know that our string is a temporary that will be destroyed
-        // we can just steal the m_impl from it, thus avoiding a copy.
-        return { WTF::move(*this) };
-    }
-
-    SUPPRESS_UNCOUNTED_ARG return m_impl ? m_impl->isolatedCopy() : String { };
-}
-
-bool String::isSafeToSendToAnotherThread() const
-{
-    // AtomStrings are not safe to send between threads, as ~StringImpl()
-    // will try to remove them from the wrong AtomStringTable.
-    return isEmpty() || (m_impl->hasOneRef() && !m_impl->isAtom());
-}
 
 template<bool allowEmptyEntries>
 inline Vector<String> String::splitInternal(StringView separator) const

--- a/Source/WTF/wtf/text/WTFString.h
+++ b/Source/WTF/wtf/text/WTFString.h
@@ -234,10 +234,10 @@ public:
     WTF_EXPORT_PRIVATE double toDouble(bool* ok = nullptr) const;
     WTF_EXPORT_PRIVATE float toFloat(bool* ok = nullptr) const;
 
-    [[nodiscard]] WTF_EXPORT_PRIVATE String isolatedCopy() const &;
-    [[nodiscard]] WTF_EXPORT_PRIVATE String isolatedCopy() &&;
+    [[nodiscard]] String isolatedCopy() const & { return *this; }
+    [[nodiscard]] String isolatedCopy() && { return { WTF::move(*this) }; }
 
-    WTF_EXPORT_PRIVATE bool NODELETE isSafeToSendToAnotherThread() const;
+    bool isSafeToSendToAnotherThread() const { return true; }
 
     // Prevent Strings from being implicitly convertable to bool as it will be ambiguous on any platform that
     // allows implicit conversion to another pointer type (e.g., Mac allows implicit conversion to NSString *).

--- a/Tools/TestWebKitAPI/Tests/WTF/CrossThreadCopierTests.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/CrossThreadCopierTests.cpp
@@ -38,9 +38,7 @@ TEST(WTF_CrossThreadCopier, CopyLVString)
 {
     String original { "1234"_s };
     auto copy = crossThreadCopy(original);
-    EXPECT_TRUE(original.impl()->hasOneRef());
-    EXPECT_TRUE(copy.impl()->hasOneRef());
-    EXPECT_FALSE(original.impl() == copy.impl());
+    EXPECT_EQ(original.impl(), copy.impl());
 }
 
 TEST(WTF_CrossThreadCopier, MoveRVString)
@@ -56,18 +54,15 @@ TEST(WTF_CrossThreadCopier, CopyRVStringHavingTwoRef)
     String original { "1234"_s };
     String original2 { original };
     auto copy = crossThreadCopy(WTF::move(original));
-    EXPECT_EQ(original.impl()->refCount(), 2u);
-    EXPECT_FALSE(original.impl() == copy.impl());
-    EXPECT_TRUE(copy.impl()->hasOneRef());
+    EXPECT_NULL(original.impl());
+    EXPECT_EQ(copy.impl(), original2.impl());
 }
 
 TEST(WTF_CrossThreadCopier, CopyLVOptionalString)
 {
     std::optional<String> original { "1234"_s };
     auto copy = crossThreadCopy(original);
-    EXPECT_TRUE(original->impl()->hasOneRef());
-    EXPECT_TRUE(copy->impl()->hasOneRef());
-    EXPECT_FALSE(original->impl() == copy->impl());
+    EXPECT_EQ(original->impl(), copy->impl());
 }
 
 TEST(WTF_CrossThreadCopier, MoveRVOptionalString)
@@ -83,9 +78,8 @@ TEST(WTF_CrossThreadCopier, CopyRVOptionalStringHavingTwoRef)
     String string { "1234"_s };
     std::optional<String> original { string };
     auto copy = crossThreadCopy(original);
-    EXPECT_EQ(original->impl()->refCount(), 2u);
-    EXPECT_FALSE(original->impl() == copy->impl());
-    EXPECT_TRUE(copy->impl()->hasOneRef());
+    EXPECT_EQ(original->impl(), copy->impl());
+    EXPECT_EQ(copy->impl(), string.impl());
 }
 
 TEST(WTF_CrossThreadCopier, Pair)
@@ -95,8 +89,8 @@ TEST(WTF_CrossThreadCopier, Pair)
     auto* secondStringImpl = pair1.second.impl();
     auto copy = crossThreadCopy(pair1);
     EXPECT_EQ(copy, pair1);
-    EXPECT_NE(copy.first.impl(), firstStringImpl);
-    EXPECT_NE(copy.second.impl(), secondStringImpl);
+    EXPECT_EQ(copy.first.impl(), firstStringImpl);
+    EXPECT_EQ(copy.second.impl(), secondStringImpl);
 
     std::pair pair2 { "foo"_str, "bar"_str };
     firstStringImpl = pair2.first.impl();
@@ -116,13 +110,13 @@ TEST(WTF_CrossThreadCopier, Variant)
     auto* impl = std::get<String>(variant).impl();
     auto copy = crossThreadCopy(variant);
     ASSERT_EQ(copy, variant);
-    EXPECT_NE(std::get<String>(copy).impl(), impl);
+    EXPECT_EQ(std::get<String>(copy).impl(), impl);
 
     variant = URL { "bar"_str };
     impl = std::get<URL>(variant).string().impl();
     copy = crossThreadCopy(variant);
     ASSERT_EQ(copy, variant);
-    EXPECT_NE(std::get<URL>(copy).string().impl(), impl);
+    EXPECT_EQ(std::get<URL>(copy).string().impl(), impl);
 
     variant = "foo"_str;
     impl = std::get<String>(variant).impl();
@@ -152,8 +146,8 @@ TEST(WTF_CrossThreadCopier, UncheckedKeyHashMap)
     auto copy = crossThreadCopy(map);
     EXPECT_EQ(copy, map);
     for (auto& [key, value] : copy) {
-        EXPECT_NE(key.impl(), impls.get(key.utf8()));
-        EXPECT_NE(value.impl(), impls.get(value.utf8()));
+        EXPECT_EQ(key.impl(), impls.get(key.utf8()));
+        EXPECT_EQ(value.impl(), impls.get(value.utf8()));
     }
 
     auto copy2 = crossThreadCopy(WTF::move(map));
@@ -180,8 +174,8 @@ TEST(WTF_CrossThreadCopier, HashMap)
     auto copy = crossThreadCopy(map);
     EXPECT_EQ(copy, map);
     for (auto& [key, value] : copy) {
-        EXPECT_NE(key.impl(), impls.get(key.utf8()));
-        EXPECT_NE(value.impl(), impls.get(value.utf8()));
+        EXPECT_EQ(key.impl(), impls.get(key.utf8()));
+        EXPECT_EQ(value.impl(), impls.get(value.utf8()));
     }
 
     auto copy2 = crossThreadCopy(WTF::move(map));
@@ -206,7 +200,7 @@ TEST(WTF_CrossThreadCopier, HashSet)
     auto copy = crossThreadCopy(set);
     EXPECT_EQ(copy, set);
     for (auto& item : copy)
-        EXPECT_NE(item.impl(), impls.get(item.utf8()));
+        EXPECT_EQ(item.impl(), impls.get(item.utf8()));
 
     auto copy2 = crossThreadCopy(WTF::move(set));
     EXPECT_EQ(copy2, copy);
@@ -223,7 +217,7 @@ TEST(WTF_CrossThreadCopier, Optional)
 
     auto copy = crossThreadCopy(optional);
     EXPECT_EQ(copy, optional);
-    EXPECT_NE(copy->impl(), impl);
+    EXPECT_EQ(copy->impl(), impl);
 
     auto copy2 = crossThreadCopy(WTF::move(optional));
     EXPECT_EQ(copy2, copy);

--- a/Tools/TestWebKitAPI/Tests/WTF/NativePromise.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/NativePromise.cpp
@@ -1168,7 +1168,6 @@ TEST(NativePromise, NonExclusiveWithCrossThreadCopy)
     {
         AutoWorkQueue awq;
         auto queue = awq.queue();
-        // If you replace PromiseOption::WithCrossThreadCopy with PromiseOption::WithoutCrossThreadCopy, this test will crash due to the AtomString being deleted on the target queue.
         using MyPromise = NativePromise<Expected<String, AtomString>, bool, PromiseOption::NonExclusive | PromiseOption::WithCrossThreadCopy>;
         static_assert(CrossThreadCopier<Expected<String, AtomString>>::IsNeeded);
         MyPromise::Producer producer;
@@ -1183,15 +1182,13 @@ TEST(NativePromise, NonExclusiveWithCrossThreadCopy)
         promise->whenSettled(queue, [&resolution] (MyPromise::Result val) {
             EXPECT_TRUE(val.has_value());
             EXPECT_TRUE(val.value().has_value());
-            // Being a non-exclusive promise, the value is passed by const reference, so we copied the object in val.
-            EXPECT_TRUE(!val.value().value().isSafeToSendToAnotherThread());
+            EXPECT_TRUE(val.value().value().isSafeToSendToAnotherThread());
             EXPECT_EQ(String("that worked"_s), val.value().value());
             resolution++;
         });
         promise->whenSettled(queue, [queue, &resolution] (const MyPromise::Result& val) {
             EXPECT_TRUE(val.has_value());
             EXPECT_TRUE(val.value().has_value());
-            // The previous whenSettled() has run already, and the object was derefed.
             EXPECT_TRUE(val.value().value().isSafeToSendToAnotherThread());
             EXPECT_EQ(String("that worked"_s), val.value().value());
             resolution++;

--- a/Tools/TestWebKitAPI/Tests/WTF/URL.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/URL.cpp
@@ -643,7 +643,7 @@ TEST_F(WTF_URL, IsolatedCopy)
     auto* originalStringImpl = url1.string().impl();
     URL url1Copy = url1.isolatedCopy();
     EXPECT_EQ(url1Copy, url1);
-    EXPECT_NE(url1Copy.string().impl(), originalStringImpl); // Should have done a deep copy of the String.
+    EXPECT_EQ(url1Copy.string().impl(), originalStringImpl);
 
     // Tests optimization for URL::isolatedCopy() on a r-value reference.
     URL url2 { "https://www.webkit.org"_str };

--- a/Tools/TestWebKitAPI/Tests/WTF/Vector.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/Vector.cpp
@@ -178,8 +178,8 @@ TEST(WTF_Vector, IsolatedCopy)
     EXPECT_TRUE("s1"_s == vector2[0]);
     EXPECT_TRUE("s2"_s == vector2[1]);
 
-    EXPECT_FALSE(data1 == vector2[0].impl());
-    EXPECT_FALSE(data2 == vector2[1].impl());
+    EXPECT_TRUE(data1 == vector2[0].impl());
+    EXPECT_TRUE(data2 == vector2[1].impl());
 
     auto vector3 = crossThreadCopy(WTF::move(vector1));
     SUPPRESS_USE_AFTER_MOVE EXPECT_EQ(0U, vector1.size());
@@ -188,7 +188,7 @@ TEST(WTF_Vector, IsolatedCopy)
     EXPECT_TRUE("s2"_s == vector3[1]);
 
     EXPECT_TRUE(data1 == vector3[0].impl());
-    EXPECT_FALSE(data2 == vector3[1].impl());
+    EXPECT_TRUE(data2 == vector3[1].impl());
 }
 
 TEST(WTF_Vector, ConstructWithFromMoveOnly)


### PR DESCRIPTION
#### 17b7a2cd57de164887d581f5e4c127d2caff0918
<pre>
Make the AtomStringTable global instead of per thread
<a href="https://bugs.webkit.org/show_bug.cgi?id=313404">https://bugs.webkit.org/show_bug.cgi?id=313404</a>

Reviewed by NOBODY (OOPS!).

Replace per-thread AtomStringTables with a single global AtomStringTable
protected by a WTF::Lock. StringImpl already has atomic refcounting, so
atom strings can be safely shared across threads. This reduces memory
usage (no duplicate table entries across threads) and eliminates crashes
when atom strings created on one thread are destroyed on another.

When StringImpl::deref() sees the refcount is about to reach zero for an
atom string, the final decrement happens under the atom table lock via
AtomStringImpl::releaseAndRemoveIfNeeded(). This prevents a race where
another thread could find the entry in the table and ref it back to life
while the first thread is removing it.

Since all strings are now thread-safe, String::isSafeToSendToAnotherThread()
always returns true, and StringImpl::isolatedCopy() / String::isolatedCopy()
no longer need to allocate new copies.

Also make StringImpl::m_hashAndFlags std::atomic&lt;unsigned&gt; since it can
now be read and written from different threads concurrently (e.g. setIsAtom
under the table lock while another thread reads isAtom or computes the hash).

* Source/JavaScriptCore/API/JSClassRef.cpp:
(OpaqueJSClass::~OpaqueJSClass):
(OpaqueJSClassContextData::OpaqueJSClassContextData):
(OpaqueJSClass::className):
* Source/JavaScriptCore/API/JSClassRef.h:
(StaticValueEntry::StaticValueEntry):
* Source/JavaScriptCore/heap/Heap.cpp:
(JSC::Heap::runEndPhase):
(JSC::Heap::requestCollection):
* Source/JavaScriptCore/runtime/Completion.cpp:
(JSC::checkSyntax):
(JSC::checkModuleSyntax):
(JSC::generateProgramBytecode):
(JSC::generateModuleBytecode):
(JSC::evaluate):
(JSC::loadAndEvaluateModule):
(JSC::loadModule):
(JSC::linkAndEvaluateModule):
(JSC::importModule):
* Source/JavaScriptCore/runtime/Identifier.cpp:
(JSC::Identifier::checkCurrentAtomStringTable):
* Source/JavaScriptCore/runtime/IdentifierInlines.h:
(JSC::Identifier::Identifier):
(JSC::Identifier::add):
* Source/JavaScriptCore/runtime/JSLock.cpp:
(JSC::JSLock::JSLock):
(JSC::JSLock::didAcquireLock):
(JSC::JSLock::dumpInfoAndCrashForLockNotOwned):
(JSC::JSLock::willReleaseLock):
* Source/JavaScriptCore/runtime/JSLock.h:
* Source/JavaScriptCore/runtime/VM.cpp:
(JSC::VM::VM):
(JSC::VM::~VM):
* Source/JavaScriptCore/runtime/VM.h:
(JSC::VM::atomStringTable const):
* Source/WTF/wtf/Threading.cpp:
(WTF::Thread::initializeInThread):
* Source/WTF/wtf/Threading.h:
* Source/WTF/wtf/text/AtomStringImpl.cpp:
(WTF::AtomStringTableLocker::AtomStringTableLocker):
(WTF::stringTable):
(WTF::addToStringTable):
(WTF::AtomStringImpl::releaseAndRemoveIfNeeded):
(WTF::AtomStringImpl::remove): Deleted.
* Source/WTF/wtf/text/AtomStringImpl.h:
(WTF::AtomStringImpl::add):
* Source/WTF/wtf/text/AtomStringTable.cpp:
(WTF::AtomStringTable::singleton):
* Source/WTF/wtf/text/AtomStringTable.h:
* Source/WTF/wtf/text/StringImpl.cpp:
(WTF::StringImpl::~StringImpl):
(WTF::StringImpl::destroyIfNeeded):
* Source/WTF/wtf/text/StringImpl.h:
(WTF::StringImpl::is8Bit const):
(WTF::StringImpl::isSymbol const):
(WTF::StringImpl::isAtom const):
(WTF::StringImpl::rawHash const):
(WTF::StringImpl::bufferOwnership const):
(WTF::StringImpl::cost):
(WTF::StringImpl::setIsAtom):
(WTF::StringImpl::setHash):
(WTF::StringImpl::isolatedCopy const):
(WTF::StringImpl::deref):
(WTF::StringImpl::requiresCopy const): Deleted.
* Source/WTF/wtf/text/WTFString.cpp:
(WTF::String::isolatedCopy const): Deleted.
(WTF::String::isolatedCopy): Deleted.
(WTF::String::isSafeToSendToAnotherThread const): Deleted.
* Source/WTF/wtf/text/WTFString.h:
* Tools/TestWebKitAPI/Tests/WTF/CrossThreadCopierTests.cpp:
* Tools/TestWebKitAPI/Tests/WTF/NativePromise.cpp:
(TestWebKitAPI::TEST):
* Tools/TestWebKitAPI/Tests/WTF/URL.cpp:
* Tools/TestWebKitAPI/Tests/WTF/Vector.cpp:
(TestWebKitAPI::TEST):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/17b7a2cd57de164887d581f5e4c127d2caff0918

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/158939 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/32366 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/25471 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/167768 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/113023 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/9a788c08-1361-4117-8f5b-b17ee2631d03) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/160808 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/32433 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/32353 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/123153 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/86471 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/905261cb-d699-450f-a10d-f7c7059ea402) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/161896 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/25428 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/142787 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/103821 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/a6b0847c-018f-41e8-8ad7-dc76321bf2aa) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/24483 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/22879 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/15540 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/150989 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/134169 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/20567 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/170261 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/19772 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/16003 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/22193 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/131342 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/32055 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/26946 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/131454 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/32000 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/142360 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/90047 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/26160 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/19169 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/191221 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/31511 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/97525 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/49151 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/31031 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/31304 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/31185 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->