### PR TITLE
[CoordinatedGraphics] Replace bit-shifted Change enum in CoordinatedPlatformLayer with EnumSet

### DIFF
--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayer.h
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayer.h
@@ -34,6 +34,7 @@
 #include "PlatformLayerIdentifier.h"
 #include "TextureMapperAnimation.h"
 #include "TransformationMatrix.h"
+#include <wtf/EnumSet.h>
 #include <wtf/Lock.h>
 #include <wtf/ThreadSafeRefCounted.h>
 
@@ -223,45 +224,45 @@ private:
     void flushCompositingStateOnSkiaTarget(const OptionSet<CompositionReason>&, SkiaCompositingLayer&);
 #endif
 
-    enum class Change : uint64_t {
-        Position                     = 1LLU << 0,
-        BoundsOrigin                 = 1LLU << 1,
-        AnchorPoint                  = 1LLU << 2,
-        Size                         = 1LLU << 3,
-        Transform                    = 1LLU << 4,
-        ChildrenTransform            = 1LLU << 5,
-        DrawsContent                 = 1LLU << 6,
-        MasksToBounds                = 1LLU << 7,
-        Preserves3D                  = 1LLU << 8,
-        BackfaceVisibility           = 1LLU << 9,
-        Opacity                      = 1LLU << 10,
-        BlendMode                    = 1LLU << 11,
-        Children                     = 1LLU << 12,
-        BackingStore                 = 1LLU << 13,
-        ContentsVisible              = 1LLU << 14,
-        ContentsOpaque               = 1LLU << 15,
-        ContentsRect                 = 1LLU << 16,
-        ContentsRectClipsDescendants = 1LLU << 17,
-        ContentsClippingRect         = 1LLU << 18,
-        ContentsTiling               = 1LLU << 19,
-        ContentsBuffer               = 1LLU << 20,
-        ContentsImage                = 1LLU << 21,
-        ContentsColor                = 1LLU << 22,
-        ClipPath                     = 1LLU << 23,
-        Filters                      = 1LLU << 24,
-        Mask                         = 1LLU << 25,
-        Replica                      = 1LLU << 26,
-        Backdrop                     = 1LLU << 27,
-        BackdropRect                 = 1LLU << 28,
-        BackdropRoot                 = 1LLU << 29,
-        Animations                   = 1LLU << 30,
-        DebugIndicators              = 1LLU << 31,
+    enum class Change : uint8_t {
+        AnchorPoint,
+        Animations,
+        Backdrop,
+        BackdropRect,
+        BackdropRoot,
+        BackfaceVisibility,
+        BackingStore,
+        BlendMode,
+        BoundsOrigin,
+        Children,
+        ChildrenTransform,
+        ClipPath,
+        ContentsBuffer,
+        ContentsClippingRect,
+        ContentsColor,
+        ContentsImage,
+        ContentsOpaque,
+        ContentsRect,
+        ContentsRectClipsDescendants,
+        ContentsTiling,
+        ContentsVisible,
 #if ENABLE(DAMAGE_TRACKING)
-        Damage                       = 1LLU << 32,
+        Damage,
 #endif
+        DebugIndicators,
+        DrawsContent,
+        Filters,
+        Mask,
+        MasksToBounds,
+        Opacity,
+        Position,
+        Preserves3D,
+        Replica,
 #if ENABLE(SCROLLING_THREAD)
-        ScrollingNode                = 1LLU << 33
+        ScrollingNode,
 #endif
+        Size,
+        Transform,
     };
 
     // FIXME: remove the client when a subclass is added for the WebProcess.
@@ -283,7 +284,7 @@ private:
 #endif
 
     Lock m_lock;
-    OptionSet<Change> m_pendingChanges WTF_GUARDED_BY_LOCK(m_lock);
+    EnumSet<Change> m_pendingChanges WTF_GUARDED_BY_LOCK(m_lock);
     FloatPoint m_position WTF_GUARDED_BY_LOCK(m_lock);
     FloatPoint3D m_anchorPoint WTF_GUARDED_BY_LOCK(m_lock) { 0.5f, 0.5f, 0 };
     FloatSize m_size WTF_GUARDED_BY_LOCK(m_lock);

--- a/Source/WebCore/platform/graphics/texmap/coordinated/GraphicsLayerCoordinated.cpp
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/GraphicsLayerCoordinated.cpp
@@ -390,7 +390,7 @@ void GraphicsLayerCoordinated::setContentsToPlatformLayer(PlatformLayer* content
 
     m_contentsBufferProxy = contentsLayer;
 
-    OptionSet<Change> change = { Change::ContentsBuffer };
+    EnumSet<Change> change = { Change::ContentsBuffer };
     if (m_contentsBufferProxy) {
         m_contentsBufferProxy->setTargetLayer(m_platformLayer.ptr());
         m_contentsDisplayDelegate = nullptr;
@@ -406,7 +406,7 @@ void GraphicsLayerCoordinated::setContentsDisplayDelegate(RefPtr<GraphicsLayerCo
 
     m_contentsDisplayDelegate = WTF::move(delegate);
 
-    OptionSet<Change> change = { Change::ContentsBuffer };
+    EnumSet<Change> change = { Change::ContentsBuffer };
     if (m_contentsDisplayDelegate) {
         if (m_contentsBufferProxy) {
             m_contentsBufferProxy->setTargetLayer(nullptr);
@@ -764,7 +764,7 @@ bool GraphicsLayerCoordinated::filtersCanBeComposited(const FilterOperations& fi
     return !filters.isEmpty();
 }
 
-void GraphicsLayerCoordinated::noteLayerPropertyChanged(OptionSet<Change> change, ScheduleFlush scheduleFlush)
+void GraphicsLayerCoordinated::noteLayerPropertyChanged(EnumSet<Change> change, ScheduleFlush scheduleFlush)
 {
     if (beingDestroyed())
         return;

--- a/Source/WebCore/platform/graphics/texmap/coordinated/GraphicsLayerCoordinated.h
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/GraphicsLayerCoordinated.h
@@ -30,6 +30,7 @@
 #include "GraphicsLayer.h"
 #include "GraphicsLayerTransform.h"
 #include "TextureMapperAnimation.h"
+#include <wtf/EnumSet.h>
 #include <wtf/OptionSet.h>
 
 namespace WebCore {
@@ -134,47 +135,47 @@ private:
     void setShowRepaintCounter(bool) override;
     void dumpAdditionalProperties(TextStream&, OptionSet<LayerTreeAsTextOptions>) const override;
 
-    enum class Change : uint64_t {
-        Geometry                     = 1LLU << 0,
-        Transform                    = 1LLU << 1,
-        ChildrenTransform            = 1LLU << 2,
-        DrawsContent                 = 1LLU << 3,
-        MasksToBounds                = 1LLU << 4,
-        Preserves3D                  = 1LLU << 5,
-        BackfaceVisibility           = 1LLU << 6,
-        Opacity                      = 1LLU << 7,
-        BlendMode                    = 1LLU << 8,
-        Children                     = 1LLU << 9,
-        ContentsVisible              = 1LLU << 10,
-        ContentsOpaque               = 1LLU << 11,
-        ContentsRect                 = 1LLU << 12,
-        ContentsRectClipsDescendants = 1LLU << 13,
-        ContentsClippingRect         = 1LLU << 14,
-        ContentsScale                = 1LLU << 15,
-        ContentsTiling               = 1LLU << 16,
-        ContentsBuffer               = 1LLU << 17,
-        ContentsBufferNeedsDisplay   = 1LLU << 18,
-        ContentsImage                = 1LLU << 19,
-        ContentsColor                = 1LLU << 20,
-        DirtyRegion                  = 1LLU << 21,
-        EventRegion                  = 1LLU << 22,
-        Shape                        = 1LLU << 23,
-        Filters                      = 1LLU << 24,
-        Mask                         = 1LLU << 25,
-        Replica                      = 1LLU << 26,
-        Backdrop                     = 1LLU << 27,
-        BackdropRect                 = 1LLU << 28,
-        BackdropRoot                 = 1LLU << 29,
-        Animations                   = 1LLU << 30,
-        TileCoverage                 = 1LLU << 31,
-        DebugIndicators              = 1LLU << 32,
+    enum class Change : uint8_t {
+        Animations,
+        Backdrop,
+        BackdropRect,
+        BackdropRoot,
+        BackfaceVisibility,
+        BlendMode,
+        Children,
+        ChildrenTransform,
+        ContentsBuffer,
+        ContentsBufferNeedsDisplay,
+        ContentsClippingRect,
+        ContentsColor,
+        ContentsImage,
+        ContentsOpaque,
+        ContentsRect,
+        ContentsRectClipsDescendants,
+        ContentsScale,
+        ContentsTiling,
+        ContentsVisible,
+        DebugIndicators,
+        DirtyRegion,
+        DrawsContent,
+        EventRegion,
+        Filters,
+        Geometry,
+        Mask,
+        MasksToBounds,
+        Opacity,
+        Preserves3D,
+        Replica,
 #if ENABLE(SCROLLING_THREAD)
-        ScrollingNode                = 1LLU << 33
+        ScrollingNode,
 #endif
+        Shape,
+        TileCoverage,
+        Transform,
     };
 
     enum class ScheduleFlush : bool { No, Yes };
-    void noteLayerPropertyChanged(OptionSet<Change>, ScheduleFlush);
+    void noteLayerPropertyChanged(EnumSet<Change>, ScheduleFlush);
     void setNeedsUpdateLayerTransform();
     std::pair<FloatPoint, float> computePositionRelativeToBase() const;
     void computePixelAlignmentIfNeeded(float pageScaleFactor, const FloatPoint& positionRelativeToBase, FloatPoint& adjustedPosition, FloatPoint& adjustedBoundsOrigin, FloatPoint3D& adjustedAnchorPoint, FloatSize& adjustedSize);
@@ -203,7 +204,7 @@ private:
     bool updateBackingStoreIfNeeded();
 
     const Ref<CoordinatedPlatformLayer> m_platformLayer;
-    OptionSet<Change> m_pendingChanges;
+    EnumSet<Change> m_pendingChanges;
     bool m_hasDescendantsWithPendingChanges { false };
     bool m_hasDescendantsWithPendingTilesCreation { false };
     bool m_hasDescendantsWithRunningTransformAnimations { false };


### PR DESCRIPTION
#### 70bdcef19d81fe08c3a4092400684765d71345cd
<pre>
[CoordinatedGraphics] Replace bit-shifted Change enum in CoordinatedPlatformLayer with EnumSet
<a href="https://bugs.webkit.org/show_bug.cgi?id=313406">https://bugs.webkit.org/show_bug.cgi?id=313406</a>

Reviewed by Carlos Garcia Campos.

Replace the bit-shifted OptionSet&lt;Change&gt; with an EnumSet&lt;Change&gt; backed
by sequential enum values. Sort the Change enumerators alphabetically.

No change in behavior, thus no new tests.

* Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayer.h:
* Source/WebCore/platform/graphics/texmap/coordinated/GraphicsLayerCoordinated.cpp:
(WebCore::GraphicsLayerCoordinated::setContentsToPlatformLayer):
(WebCore::GraphicsLayerCoordinated::setContentsDisplayDelegate):
(WebCore::GraphicsLayerCoordinated::noteLayerPropertyChanged):
* Source/WebCore/platform/graphics/texmap/coordinated/GraphicsLayerCoordinated.h:

Canonical link: <a href="https://commits.webkit.org/312078@main">https://commits.webkit.org/312078@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5c78580da2c9ad5a6c18e02a33eb5f9212ae320a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/158924 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/32351 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/25456 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/167753 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/113008 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/160793 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/32418 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/32338 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/123135 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/86460 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/161881 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/25407 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/142771 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/103803 "Found 1 new API test failure: WPE/TestUIClient:/webkit/WebKitWebView/usermedia-permission-requests (failure)") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/24463 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/22862 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/15525 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/134149 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/20551 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/170246 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/15988 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/22177 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/131324 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/32040 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/26929 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/131437 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35540 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/31985 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/142344 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/90030 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/26140 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/19153 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/31496 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/97510 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/31016 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/31289 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/31170 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->