### PR TITLE
style checker fails with PNG files

### DIFF
--- a/Tools/Scripts/webkitpy/style/checkers/png.py
+++ b/Tools/Scripts/webkitpy/style/checkers/png.py
@@ -42,7 +42,7 @@ class PNGChecker(object):
         self._fs = self._host.filesystem
         self._detector = scm or SCMDetector(self._fs, self._host.executive).detect_scm_system(self._fs.getcwd())
 
-    def check(self, inline=None):
+    def check(self, inline=None, line_numbers=None):
         errorstr = ""
         config_file_path = ""
         detection = self._detector.display_name()


### PR DESCRIPTION
#### b5484e5e0f6acf8fc3f7160e5994acad0d30073b
<pre>
style checker fails with PNG files
<a href="https://bugs.webkit.org/show_bug.cgi?id=313407">https://bugs.webkit.org/show_bug.cgi?id=313407</a>
<a href="https://rdar.apple.com/175663298">rdar://175663298</a>

Reviewed by Chris Dumez.

adding line_numbers=None to PNGChecker.check() so it matches the updated
call signature at checker.py:1263 that was introduced by 3b961212f23f
<a href="https://bugs.webkit.org/show_bug.cgi?id=312739">https://bugs.webkit.org/show_bug.cgi?id=312739</a>
<a href="https://github.com/WebKit/WebKit/pull/63090">https://github.com/WebKit/WebKit/pull/63090</a>

* Tools/Scripts/webkitpy/style/checkers/png.py:
(PNGChecker.check):

Canonical link: <a href="https://commits.webkit.org/312091@main">https://commits.webkit.org/312091@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/dcbe8894fb62cee96d3b0168f7b4df97b12e430f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/158925 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/32352 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/25457 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/167754 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/113009 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/a46b1120-025a-496b-8f85-518184d91420) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/160794 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/32419 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/32339 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/123136 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/86461 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/5783b30b-2d50-4d3b-9f59-a4143421511f) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/161882 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/25405 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/142769 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/103804 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/a8197a14-6aa4-4c45-b082-16c11162b3e7) 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/158245 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/24461 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/22863 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/15526 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/134147 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/20549 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/170247 "Built successfully") | | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/22175 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/131323 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/32041 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/26930 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/131436 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35545 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/31986 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/142342 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/90031 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/26141 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/19151 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/31497 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/31017 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/31290 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/31171 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->