### PR TITLE
Make AudioNode's ref-counting thread-safe

### DIFF
--- a/Source/WebCore/Modules/webaudio/AudioNode.cpp
+++ b/Source/WebCore/Modules/webaudio/AudioNode.cpp
@@ -663,10 +663,8 @@ void AudioNode::ref() const
 {
     ++m_normalRefCount;
 
-    {
-        Locker locker { context().graphLock() };
+    if (auto locker = context().isAudioThread() ? Locker<RecursiveLock>::tryLock(context().graphLock()) : Locker { context().graphLock() })
         const_cast<AudioNode*>(this)->unmarkNodeForDeletionIfNecessary();
-    }
 
 #if DEBUG_AUDIONODE_REFERENCES
     fprintf(stderr, "%p: %d: AudioNode::ref() %d %d\n", this, nodeType(), m_normalRefCount.load(), m_connectionRefCount.load());
@@ -675,12 +673,14 @@ void AudioNode::ref() const
 
 void AudioNode::deref() const
 {
-    ASSERT(!context().isAudioThread());
-
-    {
-        Locker locker { context().graphLock() };
-        // This is where the real deref work happens.
+    // The actual work for deref happens completely within the audio context's graph lock.
+    // In the case of the audio thread, we must use a tryLock to avoid glitches.
+    if (auto locker = context().isAudioThread() ? Locker<RecursiveLock>::tryLock(context().graphLock()) : Locker { context().graphLock() })
         derefWithLock();
+    else {
+        // We were unable to get the lock, so put this in a list to finish up later.
+        ASSERT(context().isAudioThread());
+        const_cast<BaseAudioContext&>(context()).addDeferredDeref(this);
     }
 
     // Once AudioContext::uninitialize() is called there's no more chances for deleteMarkedNodes() to get called, so we call here.

--- a/Source/WebCore/Modules/webaudio/AudioNode.h
+++ b/Source/WebCore/Modules/webaudio/AudioNode.h
@@ -105,6 +105,7 @@ public:
 
     // Can be called from main thread or context's audio thread.  It must be called while the context's graph lock is held.
     void decrementConnectionCountWithLock();
+    void derefWithLock() const;
 
     // The AudioNodeInput(s) (if any) will already have their input data available when process() is called.
     // Subclasses will take this input data and put the results in the AudioBus(s) of its AudioNodeOutput(s) (if any).
@@ -159,6 +160,8 @@ public:
 #endif
 
     bool isMarkedForDeletion() const { return m_isMarkedForDeletion; }
+    void clearIsMarkedForDeletion() { m_isMarkedForDeletion = false; }
+    bool hasReferences() const { return m_normalRefCount || m_connectionRefCount; }
 
     // tailTime() is the length of time (not counting latency time) where non-zero output may occur after continuous silent input.
     virtual double tailTime() const = 0;
@@ -213,7 +216,6 @@ protected:
 
     void markNodeForDeletionIfNecessary();
     void unmarkNodeForDeletionIfNecessary();
-    void derefWithLock() const;
 
     struct DefaultAudioNodeOptions {
         unsigned channelCount;
@@ -325,11 +327,6 @@ namespace WTF {
 template<> struct LogArgument<WebCore::AudioNode::NodeType> {
     static String toString(WebCore::AudioNode::NodeType type) { return convertEnumerationToString(type); }
 };
-
-// Make sure `protect()` returns a CheckedPtr/CheckedRef for AudioNodes instead of a RefPtr/Ref
-// since AudioNode's ref-counting is not thread-safe and protect() gets called from the AudioThread.
-inline CheckedRef<WebCore::AudioNode> protect(WebCore::AudioNode& node) { return node; }
-inline CheckedPtr<WebCore::AudioNode> protect(WebCore::AudioNode* node) { return node; }
 
 } // namespace WTF
 

--- a/Source/WebCore/Modules/webaudio/AudioNodeOutput.h
+++ b/Source/WebCore/Modules/webaudio/AudioNodeOutput.h
@@ -51,7 +51,9 @@ public:
 
     // Can be called from any thread.
     AudioNode* node() const { return m_node.get(); }
-    BaseAudioContext& context() { return protect(node())->context(); }
+    // Use CheckedPtr instead of protect() (which returns a RefPtr) to avoid the ref/deref side effects
+    // that would cause deep recursion during markNodeForDeletionIfNecessary() → disconnectAll() chains.
+    BaseAudioContext& context() { return CheckedPtr { node() }->context(); }
     
     // Causes our AudioNode to process if it hasn't already for this render quantum.
     // It returns the bus containing the processed audio for this output, returning inPlaceBus if in-place processing was possible.

--- a/Source/WebCore/Modules/webaudio/BaseAudioContext.cpp
+++ b/Source/WebCore/Modules/webaudio/BaseAudioContext.cpp
@@ -222,6 +222,10 @@ void BaseAudioContext::uninitialize()
 
     {
         Locker locker { graphLock() };
+        // Process any deferred operations from the last render quantum that couldn't be
+        // processed in handlePostRenderTasks() due to lock contention.
+        handleDeferredDecrementConnectionCounts();
+        handleDeferredDerefs();
         // This should have been called from handlePostRenderTasks() at the end of rendering.
         // However, in case of lock contention, the tryLock() call could have failed in handlePostRenderTasks(),
         // leaving nodes in m_referencedSourceNodes. Now that the audio thread is gone, make sure we deref those nodes
@@ -566,6 +570,15 @@ void BaseAudioContext::addDeferredDecrementConnectionCount(AudioNode* node)
     m_deferredBreakConnectionList.append(node);
 }
 
+void BaseAudioContext::addDeferredDeref(const AudioNode* node)
+{
+    ASSERT(isAudioThread());
+    // Heap allocations are forbidden on the audio thread for performance reasons so we need to
+    // explicitly allow the following allocation(s).
+    DisableMallocRestrictionsForCurrentThreadScope disableMallocRestrictions;
+    m_deferredDerefList.append(const_cast<AudioNode*>(node));
+}
+
 void BaseAudioContext::handlePreRenderTasks(const AudioIOPosition& outputPosition)
 {
     ASSERT(isAudioThread());
@@ -604,6 +617,7 @@ void BaseAudioContext::handlePostRenderTasks()
 
     // Take care of finishing any derefs where the tryLock() failed previously.
     handleDeferredDecrementConnectionCounts();
+    handleDeferredDerefs();
 
     // Dynamically clean up nodes which are no longer needed.
     derefFinishedSourceNodes();
@@ -622,11 +636,19 @@ void BaseAudioContext::handlePostRenderTasks()
 
 void BaseAudioContext::handleDeferredDecrementConnectionCounts()
 {
-    ASSERT(isAudioThread() && isGraphOwner());
+    ASSERT(isGraphOwner());
     for (auto& node : m_deferredBreakConnectionList)
         node->decrementConnectionCountWithLock();
-    
+
     m_deferredBreakConnectionList.clear();
+}
+
+void BaseAudioContext::handleDeferredDerefs()
+{
+    ASSERT(isGraphOwner());
+    for (auto& node : m_deferredDerefList)
+        node->derefWithLock();
+    m_deferredDerefList.clear();
 }
 
 void BaseAudioContext::addTailProcessingNode(AudioNode& node)
@@ -779,6 +801,14 @@ void BaseAudioContext::deleteMarkedNodes()
 
     while (m_nodesToDelete.size()) {
         CheckedPtr node = m_nodesToDelete.takeLast();
+
+        // A node may have been re-referenced (via ref() or incrementConnectionCount()) after being
+        // marked for deletion. This can happen when ref() on the audio thread couldn't acquire the
+        // graph lock to unmark the node. Re-check before deleting.
+        if (node->hasReferences()) {
+            node->clearIsMarkedForDeletion();
+            continue;
+        }
 
         // Before deleting the node, clear out any AudioNodeInputs from m_dirtySummingJunctions.
         unsigned numberOfInputs = node->numberOfInputs();

--- a/Source/WebCore/Modules/webaudio/BaseAudioContext.h
+++ b/Source/WebCore/Modules/webaudio/BaseAudioContext.h
@@ -206,6 +206,9 @@ public:
     // In AudioNode::decrementConnectionCount() a tryLock() is used for calling decrementConnectionCountWithLock(), but if it fails keep track here.
     void addDeferredDecrementConnectionCount(AudioNode*);
 
+    // In AudioNode::deref() a tryLock() is used for calling derefWithLock(), but if it fails keep track here.
+    void addDeferredDeref(const AudioNode*);
+
     // Only accessed when the graph lock is held.
     void markSummingJunctionDirty(AudioSummingJunction*);
     void markAudioNodeOutputDirty(AudioNodeOutput*);
@@ -274,6 +277,7 @@ private:
 
     // In the audio thread at the start of each render cycle, we'll call handleDeferredDecrementConnectionCounts().
     void handleDeferredDecrementConnectionCounts();
+    void handleDeferredDerefs();
 
     // EventTarget
     enum EventTargetInterfaceType eventTargetInterface() const final;
@@ -360,6 +364,7 @@ private:
     Vector<CheckedPtr<AudioNode>> m_renderingAutomaticPullNodes;
     // Only accessed in the audio thread.
     Vector<CheckedPtr<AudioNode>> m_deferredBreakConnectionList;
+    Vector<CheckedPtr<AudioNode>> m_deferredDerefList;
     Vector<Vector<DOMPromiseDeferred<void>>> m_stateReactions;
 
     const Ref<AudioListener> m_listener;


### PR DESCRIPTION
#### c529c6161488dfff930bef950dc71dcbfb9b5e39
<pre>
Make AudioNode&apos;s ref-counting thread-safe
<a href="https://bugs.webkit.org/show_bug.cgi?id=313409">https://bugs.webkit.org/show_bug.cgi?id=313409</a>

Reviewed by Jer Noble.

AudioNode&apos;s ref() and deref() were not safe to call from the audio thread.
deref() had ASSERT(!context().isAudioThread()) and ref() used a blocking
Locker on the graph lock. A protect() override returning CheckedPtr instead
of RefPtr existed as a workaround, but this was error-prone.

This patch makes ref() and deref() safe to call from any thread by using
the same tryLock/defer pattern already used by decrementConnectionCount():
on the audio thread, tryLock the graph lock to avoid glitches; if the lock
can&apos;t be acquired, defer the work to handlePostRenderTasks(). On the main
thread, use a blocking lock as before.

With thread-safe ref-counting, the protect() override returning CheckedPtr
is no longer needed — protect() now returns RefPtr for AudioNodes like any
other ref-counted type. AudioNodeOutput::context() is a special case that
uses CheckedPtr directly to avoid ref/deref side effects that would cause
deep recursion during markNodeForDeletionIfNecessary() → disconnectAll()
chains.

* Source/WebCore/Modules/webaudio/AudioNode.cpp:
(WebCore::AudioNode::ref const):
(WebCore::AudioNode::deref const):
* Source/WebCore/Modules/webaudio/AudioNode.h:
(WebCore::AudioNode::clearIsMarkedForDeletion):
(WebCore::AudioNode::hasReferences const):
(WTF::protect): Deleted.
* Source/WebCore/Modules/webaudio/AudioNodeOutput.h:
* Source/WebCore/Modules/webaudio/BaseAudioContext.cpp:
(WebCore::BaseAudioContext::uninitialize):
(WebCore::BaseAudioContext::addDeferredDeref):
(WebCore::BaseAudioContext::handlePostRenderTasks):
(WebCore::BaseAudioContext::handleDeferredDecrementConnectionCounts):
(WebCore::BaseAudioContext::handleDeferredDerefs):
(WebCore::BaseAudioContext::deleteMarkedNodes):
* Source/WebCore/Modules/webaudio/BaseAudioContext.h:

Canonical link: <a href="https://commits.webkit.org/312187@main">https://commits.webkit.org/312187@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/04a7ac74113c478ad238a0224bd3d752695938a0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/158929 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/32356 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/25461 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/167758 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/113013 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/8fdf6e3f-c71b-44cd-8422-c0f165db7c2f) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/160798 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/32423 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/32343 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/123138 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/86463 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/f26b5050-df98-4f64-98d9-772b437af1e0) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/161886 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/25408 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/142773 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/103806 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/235a302b-018b-4308-bb05-7c4537a97083) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/24464 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/22866 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/15530 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/134150 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/20553 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/170251 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/15993 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/22179 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/131327 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/32045 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/26933 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/131440 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35593 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/31990 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/142346 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/90035 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/26144 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/19155 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/31501 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/97515 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/31021 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/31294 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/31175 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->