### PR TITLE
[JSC] Split DataView construction step into a separated code path from other TypedArrays

### DIFF
--- a/JSTests/stress/create-subclass-structure-might-throw.js
+++ b/JSTests/stress/create-subclass-structure-might-throw.js
@@ -3,8 +3,14 @@ function assert(b) {
         throw new Error("bad assertion.");
 }
 
+function sameValue(a, b, testname) {
+    if (a !== b)
+        throw new Error(`${testname}: Expected ${b} but got ${a}`);
+}
+
 let targets = [Function, String, Array, Set, Map, WeakSet, WeakMap, RegExp, Number, Promise, Date, Boolean, Error, TypeError, SyntaxError, ArrayBuffer, Int32Array, Int8Array, Uint8Array, Uint8ClampedArray, Int16Array, Uint16Array, Uint32Array, Float32Array, Float64Array, DataView];
 for (let target of targets) {
+    const testname = target.name;
     let error = null;
     let called = false;
     let handler = {
@@ -23,15 +29,17 @@ for (let target of targets) {
         try {
             if (target === Promise)
                 new proxy(function() {});
+            if (target === DataView)
+                new proxy(new ArrayBuffer(64));
             else
                 new proxy;
         } catch(e) {
             threw = true;
-            assert(e === error);
+            sameValue(e, error, testname);
             error = null;
         }
-        assert(threw);
-        assert(called);
+        sameValue(threw, true, testname);
+        sameValue(called, true, testname);
         called = false;
     }
 }

--- a/Source/JavaScriptCore/runtime/JSGenericTypedArrayViewConstructorInlines.h
+++ b/Source/JavaScriptCore/runtime/JSGenericTypedArrayViewConstructorInlines.h
@@ -115,46 +115,52 @@ inline JSObject* constructGenericTypedArrayViewFromIterator(JSGlobalObject* glob
 constinit const ASCIILiteral typedArrayErrorMessageBufferIsAlreadyDetached = "Buffer is already detached"_s;
 
 template<typename ViewClass>
-inline JSObject* constructGenericTypedArrayViewWithArguments(JSGlobalObject* globalObject, Structure* structure, JSValue firstValue, size_t offset, std::optional<size_t> lengthOpt)
+inline JSObject* constructGenericTypedArrayViewWithArrayBuffer(JSGlobalObject* globalObject, Structure* structure, JSArrayBuffer* jsBuffer, size_t offset, std::optional<size_t> lengthOpt)
 {
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    // https://tc39.es/proposal-resizablearraybuffer/#sec-initializetypedarrayfromarraybuffer
-    if (JSArrayBuffer* jsBuffer = dynamicDowncast<JSArrayBuffer>(firstValue)) {
-        RefPtr<ArrayBuffer> buffer = jsBuffer->impl();
-        if (buffer->isDetached()) {
-            throwTypeError(globalObject, scope, typedArrayErrorMessageBufferIsAlreadyDetached);
-            return nullptr;
-        }
-
-        std::optional<size_t> length;
-        if (lengthOpt)
-            length = lengthOpt;
-        else {
-            size_t byteLength = buffer->byteLength();
-            if (buffer->isResizableOrGrowableShared()) {
-                if (offset > byteLength) [[unlikely]] {
-                    throwRangeError(globalObject, scope, "byteOffset exceeds source ArrayBuffer byteLength"_s);
-                    return nullptr;
-                }
-            } else {
-                if ((byteLength - offset) % ViewClass::elementSize) [[unlikely]] {
-                    throwRangeError(globalObject, scope, "ArrayBuffer length minus the byteOffset is not a multiple of the element size"_s);
-                    return nullptr;
-                }
-                length = (byteLength - offset) / ViewClass::elementSize;
-            }
-        }
-
-        RELEASE_AND_RETURN(scope, ViewClass::create(globalObject, structure, WTF::move(buffer), offset, length));
-    }
-    ASSERT(!offset && !lengthOpt);
-
-    if constexpr (ViewClass::TypedArrayStorageType == TypeDataView) {
-        throwTypeError(globalObject, scope, "Expected ArrayBuffer for the first argument."_s);
+    RefPtr<ArrayBuffer> buffer = jsBuffer->impl();
+    if (buffer->isDetached()) {
+        throwTypeError(globalObject, scope, typedArrayErrorMessageBufferIsAlreadyDetached);
         return nullptr;
     }
+
+    std::optional<size_t> length;
+    if (lengthOpt)
+        length = lengthOpt;
+    else {
+        size_t byteLength = buffer->byteLength();
+        if (buffer->isResizableOrGrowableShared()) {
+            if (offset > byteLength) [[unlikely]] {
+                throwRangeError(globalObject, scope, "byteOffset exceeds source ArrayBuffer byteLength"_s);
+                return nullptr;
+            }
+        } else {
+            if ((byteLength - offset) % ViewClass::elementSize) [[unlikely]] {
+                throwRangeError(globalObject, scope, "ArrayBuffer length minus the byteOffset is not a multiple of the element size"_s);
+                return nullptr;
+            }
+            length = (byteLength - offset) / ViewClass::elementSize;
+        }
+    }
+
+    RELEASE_AND_RETURN(scope, ViewClass::create(globalObject, structure, WTF::move(buffer), offset, length));
+}
+
+template<typename ViewClass>
+inline JSObject* constructGenericTypedArrayViewWithArguments(JSGlobalObject* globalObject, Structure* structure, JSValue firstValue, size_t offset, std::optional<size_t> lengthOpt)
+{
+    static_assert(ViewClass::TypedArrayStorageType != TypeDataView);
+
+    VM& vm = globalObject->vm();
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
+    // https://tc39.es/ecma262/#sec-initializetypedarrayfromarraybuffer
+    if (JSArrayBuffer* jsBuffer = dynamicDowncast<JSArrayBuffer>(firstValue))
+        RELEASE_AND_RETURN(scope, constructGenericTypedArrayViewWithArrayBuffer<ViewClass>(globalObject, structure, jsBuffer, offset, lengthOpt));
+
+    ASSERT(!offset && !lengthOpt);
     
     // For everything but DataView, we allow construction with any of:
     // - Another array. This creates a copy of the of that array.
@@ -247,9 +253,12 @@ inline JSObject* constructGenericTypedArrayViewWithArguments(JSGlobalObject* glo
     RELEASE_AND_RETURN(scope, ViewClass::create(globalObject, structure, length));
 }
 
+// This is equivalent to https://tc39.es/ecma262/#sec-typedarray
 template<typename ViewClass>
 ALWAYS_INLINE EncodedJSValue constructGenericTypedArrayViewImpl(JSGlobalObject* globalObject, CallFrame* callFrame)
 {
+    static_assert(ViewClass::TypedArrayStorageType != TypeDataView);
+
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
@@ -260,9 +269,6 @@ ALWAYS_INLINE EncodedJSValue constructGenericTypedArrayViewImpl(JSGlobalObject* 
     if (!argCount) {
         Structure* structure = JSC_GET_DERIVED_STRUCTURE(vm, typedArrayStructureWithTypedArrayType<ViewClass::TypedArrayStorageType>, newTarget, callFrame->jsCallee());
         RETURN_IF_EXCEPTION(scope, { });
-
-        if constexpr (ViewClass::TypedArrayStorageType == TypeDataView)
-            return throwVMTypeError(globalObject, scope, "DataView constructor requires at least one argument."_s);
 
         RELEASE_AND_RETURN(scope, JSValue::encode(ViewClass::create(globalObject, structure, 0)));
     }
@@ -275,19 +281,6 @@ ALWAYS_INLINE EncodedJSValue constructGenericTypedArrayViewImpl(JSGlobalObject* 
         if (argCount > 1) {
             offset = callFrame->uncheckedArgument(1).toIndex(globalObject, "byteOffset"_s);
             RETURN_IF_EXCEPTION(scope, { });
-
-            if constexpr (ViewClass::TypedArrayStorageType == TypeDataView) {
-                RefPtr<ArrayBuffer> buffer = arrayBuffer->impl();
-                if (buffer->isDetached()) [[unlikely]] {
-                    throwVMTypeError(globalObject, scope, typedArrayErrorMessageBufferIsAlreadyDetached);
-                    RETURN_IF_EXCEPTION(scope, { });
-                }
-
-                if (offset > buffer->byteLength()) [[unlikely]] {
-                    throwRangeError(globalObject, scope, "byteOffset exceeds source ArrayBuffer byteLength"_s);
-                    RETURN_IF_EXCEPTION(scope, { });
-                }
-            }
         }
 
         if (arrayBuffer->isResizableOrGrowableShared()) {
@@ -302,7 +295,7 @@ ALWAYS_INLINE EncodedJSValue constructGenericTypedArrayViewImpl(JSGlobalObject* 
             // If the length value is present but undefined, treat it as missing.
             JSValue lengthValue = callFrame->uncheckedArgument(2);
             if (!lengthValue.isUndefined()) {
-                length = lengthValue.toIndex(globalObject, ViewClass::TypedArrayStorageType == TypeDataView ? "byteLength"_s : "length"_s);
+                length = lengthValue.toIndex(globalObject, "length"_s);
                 RETURN_IF_EXCEPTION(scope, encodedJSValue());
             }
         }
@@ -312,6 +305,83 @@ ALWAYS_INLINE EncodedJSValue constructGenericTypedArrayViewImpl(JSGlobalObject* 
     }
 
     RELEASE_AND_RETURN(scope, JSValue::encode(constructGenericTypedArrayViewWithArguments<ViewClass>(globalObject, structure, firstValue, offset, length)));
+}
+
+static EncodedJSValue constructDataViewImpl(JSGlobalObject* globalObject, CallFrame* callFrame)
+{
+    VM& vm = globalObject->vm();
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
+    // [`DataView`][dataview] and [the other `%TypedArray%` constructors][typedarray] take almost same arguments and behave very similarly
+    // but the spec has a different abstract operation steps.
+    // It makes a difference for an order of checking their arguments and throwing errors in the detail.
+    // And its difference comes with an user observable behavior in a corner case.
+    // We should have a separate code path among them to implement the spec correctly & simply.
+    //
+    // [dataview]: https://tc39.es/ecma262/#sec-dataview-buffer-byteoffset-bytelength
+    // [typedarray]: https://tc39.es/ecma262/#sec-typedarray
+
+    size_t argCount = callFrame->argumentCount();
+    if (!argCount) [[unlikely]]
+        return throwVMTypeError(globalObject, scope, "DataView constructor requires at least one argument."_s);
+
+    ASSERT(argCount > 0);
+
+    JSValue firstValue = callFrame->uncheckedArgument(0);
+    JSArrayBuffer* arrayBuffer = dynamicDowncast<JSArrayBuffer>(firstValue);
+    if (!arrayBuffer) [[unlikely]]
+        return throwVMTypeError(globalObject, scope, "Expected ArrayBuffer for the first argument."_s);
+
+    JSObject* newTarget = asObject(callFrame->newTarget());
+    Structure* structure = nullptr;
+    if (arrayBuffer->isResizableOrGrowableShared()) {
+        structure = JSC_GET_DERIVED_STRUCTURE(vm, resizableOrGrowableSharedTypedArrayStructureWithTypedArrayType<JSDataView::TypedArrayStorageType>, newTarget, callFrame->jsCallee());
+        RETURN_IF_EXCEPTION(scope, { });
+    } else {
+        structure = JSC_GET_DERIVED_STRUCTURE(vm, typedArrayStructureWithTypedArrayType<JSDataView::TypedArrayStorageType>, newTarget, callFrame->jsCallee());
+        RETURN_IF_EXCEPTION(scope, { });
+    }
+
+    if (argCount == 1)
+        RELEASE_AND_RETURN(scope, JSValue::encode(constructGenericTypedArrayViewWithArrayBuffer<JSDataView>(globalObject, structure, arrayBuffer, 0, std::nullopt)));
+
+    ASSERT(argCount > 1);
+
+    RefPtr<ArrayBuffer> buffer = arrayBuffer->impl();
+
+    size_t offset = callFrame->uncheckedArgument(1).toIndex(globalObject, "byteOffset"_s);
+    RETURN_IF_EXCEPTION(scope, { });
+
+    if (buffer->isDetached()) [[unlikely]]
+        return throwVMTypeError(globalObject, scope, typedArrayErrorMessageBufferIsAlreadyDetached);
+
+    size_t bufferByteLength = buffer->byteLength();
+    if (offset > bufferByteLength) [[unlikely]]
+        return throwVMRangeError(globalObject, scope, "byteOffset exceeds source ArrayBuffer byteLength"_s);
+
+    if (argCount == 2)
+        RELEASE_AND_RETURN(scope, JSValue::encode(constructGenericTypedArrayViewWithArrayBuffer<JSDataView>(globalObject, structure, arrayBuffer, offset, std::nullopt)));
+
+    ASSERT(argCount > 2);
+
+    // If the length value is present but undefined, treat it as missing.
+    std::optional<size_t> length { };
+    if (JSValue lengthValue = callFrame->uncheckedArgument(2); !lengthValue.isUndefined()) [[likely]] {
+        length = lengthValue.toIndex(globalObject, "byteLength"_s);
+        RETURN_IF_EXCEPTION(scope, { });
+    }
+
+    RELEASE_AND_RETURN(scope, JSValue::encode(constructGenericTypedArrayViewWithArrayBuffer<JSDataView>(globalObject, structure, arrayBuffer, offset, length)));
+}
+
+// This is equivalent to https://tc39.es/ecma262/#sec-dataview-buffer-byteoffset-bytelength
+template<>
+ALWAYS_INLINE EncodedJSValue constructGenericTypedArrayViewImpl<JSDataView>(JSGlobalObject* globalObject, CallFrame* callFrame)
+{
+    VM& vm = globalObject->vm();
+    auto scope = DECLARE_THROW_SCOPE(vm);
+    EncodedJSValue dataview = constructDataViewImpl(globalObject, callFrame);
+    RELEASE_AND_RETURN(scope, dataview);
 }
 
 template<typename ViewClass>


### PR DESCRIPTION
#### fb077714dba8ee9670220b16b4fd3b3f6d66af23
<pre>
[JSC] Split DataView construction step into a separated code path from other TypedArrays
<a href="https://bugs.webkit.org/show_bug.cgi?id=313416">https://bugs.webkit.org/show_bug.cgi?id=313416</a>

Reviewed by Yusuke Suzuki.

`DataView` and %TypedArray%` constructors take almost same arguments and behave very similarly
but the spec has a different abstract operation steps.
It makes a difference for an order of checking their arguments and throwing errors in the detail.
And its difference comes with an user observable behavior.

- <a href="https://tc39.es/ecma262/#sec-dataview-buffer-byteoffset-bytelength">https://tc39.es/ecma262/#sec-dataview-buffer-byteoffset-bytelength</a>
- <a href="https://tc39.es/ecma262/#sec-typedarray">https://tc39.es/ecma262/#sec-typedarray</a>

Our previous implementation shares the infrastructure for both of them via C++ template and if constexpr.
But `if constexpr` branch makes a thing complex.

To prepare to resolve <a href="https://bugs.webkit.org/show_bug.cgi?id=313230">https://bugs.webkit.org/show_bug.cgi?id=313230</a>,
let&apos;s split into separate paths.

* JSTests/stress/create-subclass-structure-might-throw.js:
    By this change, `new DataView` would throw error _earlier_ if the argument count is 0 just like as `Promise`.
    This fix add the case of `DataView`.
* Source/JavaScriptCore/runtime/JSGenericTypedArrayViewConstructorInlines.h:
(JSC::constructGenericTypedArrayViewWithArrayBuffer):
    Share the part of the construction with JSArrayBuffer.
(JSC::constructGenericTypedArrayViewWithArguments):
    This removes JSDataView branches.
(JSC::constructGenericTypedArrayViewImpl):
    This removes JSDataView branches.
(JSC::constructDataViewImpl):
    To clarify the purpose, this change adds this function.
(JSC::constructGenericTypedArrayViewImpl&lt;JSDataView&gt;):
    This is a C++ template specialization to call the actual new separated implementation.
    This is useful to not change the exist code base on caller side.

Canonical link: <a href="https://commits.webkit.org/312483@main">https://commits.webkit.org/312483@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c13ec40ff975d0d399ff2c6fe53e84a3abe4f9ff

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/159921 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/33389 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/26495 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/168792 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/114302 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/33493 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/33393 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/123941 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/86931 "1 flakes 9 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/162879 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/26193 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/143637 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/104561 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/25245 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/23862 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/16542 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/151977 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/134937 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/21407 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/171278 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/20758 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/17289 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/23045 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/132206 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/33067 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/27802 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/132233 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/33052 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/143202 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/91177 "The change is no longer eligible for processing.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/24364 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/26853 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/20015 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/192205 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/32561 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/98958 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/49425 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/32058 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/32305 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/32209 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->