### PR TITLE
Add AcceleratedEffectClipPath

### DIFF
--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -2368,6 +2368,8 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     platform/animation/ProgressResolutionData.h
     platform/animation/TimelineIdentifier.h
     platform/animation/TimingFunction.h
+
+    platform/animation/values/AcceleratedEffectClipPath.h
     platform/animation/values/AcceleratedEffectOffsetAnchor.h
     platform/animation/values/AcceleratedEffectOffsetDistance.h
     platform/animation/values/AcceleratedEffectOffsetPath.h

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -2484,6 +2484,7 @@ platform/animation/AcceleratedEffectStack.cpp @no-unify
 platform/animation/AcceleratedEffectValues.cpp @header:RenderStyleGetters
 platform/animation/AcceleratedTimeline.cpp
 platform/animation/TimingFunction.cpp
+platform/animation/values/AcceleratedEffectClipPath.cpp
 platform/animation/values/AcceleratedEffectOffsetAnchor.cpp
 platform/animation/values/AcceleratedEffectOffsetDistance.cpp
 platform/animation/values/AcceleratedEffectOffsetPath.cpp

--- a/Source/WebCore/platform/animation/values/AcceleratedEffectClipPath.cpp
+++ b/Source/WebCore/platform/animation/values/AcceleratedEffectClipPath.cpp
@@ -1,0 +1,108 @@
+/*
+ * Copyright (C) 2026 Igalia S.L.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "AcceleratedEffectClipPath.h"
+
+#if ENABLE(THREADED_ANIMATIONS)
+
+#include "AcceleratedEffectAnimationUtilities.h"
+#include "TransformOperationData.h"
+
+namespace WebCore {
+
+// MARK: - Path Evaluation
+
+std::optional<WebCore::Path> tryPath(const AcceleratedEffectClipPath& path, const TransformOperationData& data)
+{
+    return WTF::switchOn(path.value,
+        [](const AcceleratedEffectClipPath::None&) -> std::optional<WebCore::Path> {
+            return std::nullopt;
+        },
+        [&](const AcceleratedEffectClipPath::ReferencePath& path) -> std::optional<WebCore::Path> {
+            return tryPath(path, data);
+        },
+        [&](const AcceleratedEffectClipPath::BasicShapePath& path) -> std::optional<WebCore::Path> {
+            return tryPath(path, data);
+        },
+        [&](const AcceleratedEffectClipPath::BoxPath& path) -> std::optional<WebCore::Path> {
+            return tryPath(path, data);
+        }
+    );
+}
+
+// MARK: - Blending
+
+bool canBlend(const AcceleratedEffectClipPath& from, const AcceleratedEffectClipPath& to)
+{
+    return WTF::visit(WTF::makeVisitor(
+        []<typename T>(const T& from, const T& to)
+        {
+            return WebCore::canBlendForAcceleratedEffect(from, to);
+        },
+        [](const AcceleratedEffectClipPath::None&, const AcceleratedEffectClipPath::None&) {
+            return false;
+        },
+        [](const AcceleratedEffectClipPath::ReferencePath&, const AcceleratedEffectClipPath::ReferencePath&) {
+            return false;
+        },
+        [](const AcceleratedEffectClipPath::BoxPath&, const AcceleratedEffectClipPath::BoxPath&) {
+            return false;
+        },
+        [](const auto&, const auto&) {
+            return false;
+        }
+    ), from.value, to.value);
+}
+
+AcceleratedEffectClipPath blend(const AcceleratedEffectClipPath& from, const AcceleratedEffectClipPath& to, const BlendingContext& context)
+{
+    if (context.isDiscrete) {
+        ASSERT(!context.progress || context.progress == 1.0);
+        return context.progress ? to : from;
+    }
+
+    return WTF::visit(WTF::makeVisitor(
+        [&]<typename T>(const T& from, const T& to) -> AcceleratedEffectClipPath {
+            return { WebCore::blendForAcceleratedEffect(from, to, context) };
+        },
+        [](const AcceleratedEffectClipPath::None&, const AcceleratedEffectClipPath::None&) -> AcceleratedEffectClipPath {
+            RELEASE_ASSERT_NOT_REACHED();
+        },
+        [](const AcceleratedEffectClipPath::ReferencePath&, const AcceleratedEffectClipPath::ReferencePath&) -> AcceleratedEffectClipPath {
+            RELEASE_ASSERT_NOT_REACHED();
+        },
+        [](const AcceleratedEffectClipPath::BoxPath&, const AcceleratedEffectClipPath::BoxPath&) -> AcceleratedEffectClipPath {
+            RELEASE_ASSERT_NOT_REACHED();
+        },
+        [&](const auto&, const auto&) -> AcceleratedEffectClipPath {
+            RELEASE_ASSERT_NOT_REACHED();
+        }
+    ), from.value, to.value);
+}
+
+} // namespace WebCore
+
+#endif // ENABLE(THREADED_ANIMATIONS)

--- a/Source/WebCore/platform/animation/values/AcceleratedEffectClipPath.h
+++ b/Source/WebCore/platform/animation/values/AcceleratedEffectClipPath.h
@@ -1,0 +1,72 @@
+/*
+ * Copyright (C) 2026 Igalia S.L.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if ENABLE(THREADED_ANIMATIONS)
+
+#include <WebCore/AcceleratedEffectBasicShapePath.h>
+#include <WebCore/AcceleratedEffectBoxPath.h>
+#include <WebCore/AcceleratedEffectReferencePath.h>
+#include <optional>
+#include <wtf/Variant.h>
+
+namespace WebCore {
+
+struct BlendingContext;
+struct TransformOperationData;
+
+// <'clip-path'> = <clip-source> | [ <basic-shape> || <geometry-box> ] | none
+// https://drafts.csswg.org/css-masking/#the-clip-path
+struct AcceleratedEffectClipPath {
+    struct None {
+        constexpr bool operator==(const None&) const = default;
+    };
+    using ReferencePath = AcceleratedEffectReferencePath;
+    using BasicShapePath = AcceleratedEffectBasicShapePath;
+    using BoxPath = AcceleratedEffectBoxPath;
+
+    Variant<None, ReferencePath, BasicShapePath, BoxPath> value { None { } };
+
+    bool isNone() const { return WTF::holdsAlternative<None>(value); }
+    bool isReferencePath() const { return WTF::holdsAlternative<ReferencePath>(value); }
+    bool isBasicShapePath() const { return WTF::holdsAlternative<BasicShapePath>(value); }
+    bool isBoxPath() const { return WTF::holdsAlternative<BoxPath>(value); }
+
+    bool operator==(const AcceleratedEffectClipPath&) const = default;
+};
+
+// MARK: - Path Evaluation
+
+WEBCORE_EXPORT std::optional<WebCore::Path> tryPath(const AcceleratedEffectClipPath&, const TransformOperationData&);
+
+// MARK: - Blending
+
+bool canBlend(const AcceleratedEffectClipPath&, const AcceleratedEffectClipPath&);
+AcceleratedEffectClipPath blend(const AcceleratedEffectClipPath&, const AcceleratedEffectClipPath&, const BlendingContext&);
+
+} // namespace WebCore
+
+#endif // ENABLE(THREADED_ANIMATIONS)

--- a/Source/WebCore/style/values/masking/StyleClipPath.cpp
+++ b/Source/WebCore/style/values/masking/StyleClipPath.cpp
@@ -25,7 +25,11 @@
 #include "config.h"
 #include "StyleClipPath.h"
 
+#include "AcceleratedEffectClipPath.h"
+#include "StyleKeyword+Serialization.h"
 #include "StylePrimitiveNumericTypes+Blending.h"
+#include "StylePrimitiveNumericTypes+CSSValueCreation.h"
+#include "StylePrimitiveNumericTypes+Serialization.h"
 
 namespace WebCore {
 namespace Style {
@@ -61,6 +65,30 @@ auto Blending<ClipPath>::blend(const ClipPath& a, const ClipPath& b, const Blend
     Ref bOperation = *b.operation;
     return ClipPath { aOperation->blend(bOperation.ptr(), context) };
 }
+
+// MARK: - Evaluation
+
+#if ENABLE(THREADED_ANIMATIONS)
+
+AcceleratedEffectClipPath Evaluation<ClipPath, AcceleratedEffectClipPath>::operator()(const ClipPath& value, const TransformOperationData& data, ZoomFactor zoom)
+{
+    return WTF::switchOn(value,
+        [&](const CSS::Keyword::None&) -> AcceleratedEffectClipPath {
+            return { .value = AcceleratedEffectClipPath::None { } };
+        },
+        [&](const ReferencePath& path) -> AcceleratedEffectClipPath {
+            return { .value = evaluate<AcceleratedEffectClipPath::ReferencePath>(path, data, zoom) };
+        },
+        [&](const BasicShapePath& path) -> AcceleratedEffectClipPath {
+            return { .value = evaluate<AcceleratedEffectClipPath::BasicShapePath>(path, data, zoom) };
+        },
+        [&](const BoxPath& path) -> AcceleratedEffectClipPath {
+            return { .value = evaluate<AcceleratedEffectClipPath::BoxPath>(path, data, zoom) };
+        }
+    );
+}
+
+#endif
 
 } // namespace Style
 } // namespace WebCore

--- a/Source/WebCore/style/values/masking/StyleClipPath.h
+++ b/Source/WebCore/style/values/masking/StyleClipPath.h
@@ -30,10 +30,10 @@
 #include <WebCore/StyleValueTypes.h>
 
 namespace WebCore {
-namespace Style {
 
-struct ClipPath;
-struct OffsetPath;
+struct AcceleratedEffectClipPath;
+
+namespace Style {
 
 // <'clip-path'> = none | <url> | [ <basic-shape> || <geometry-box> ]
 struct ClipPath {
@@ -67,6 +67,7 @@ struct ClipPath {
 
 private:
     friend struct Blending<ClipPath>;
+    friend struct ToPlatform<ClipPath>;
     friend CSSBoxType referenceBox(const ClipPath&);
     friend std::optional<WebCore::Path> tryPath(const ClipPath&, const TransformOperationData&, ZoomFactor);
 
@@ -145,6 +146,14 @@ template<> struct Blending<ClipPath> {
     auto canBlend(const ClipPath&, const ClipPath&) -> bool;
     auto blend(const ClipPath&, const ClipPath&, const BlendingContext&) -> ClipPath;
 };
+
+// MARK: - Evaluation
+
+#if ENABLE(THREADED_ANIMATIONS)
+
+template<> struct Evaluation<ClipPath, AcceleratedEffectClipPath> { AcceleratedEffectClipPath operator()(const ClipPath&, const TransformOperationData&, ZoomFactor); };
+
+#endif
 
 } // namespace Style
 } // namespace WebCore

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -6496,6 +6496,13 @@ struct WebCore::AcceleratedEffectTransformOrigin {
     WebCore::FloatPoint value;
 };
 
+struct WebCore::AcceleratedEffectClipPath {
+    Variant<WebCore::AcceleratedEffectClipPath::None, WebCore::AcceleratedEffectReferencePath, WebCore::AcceleratedEffectBasicShapePath, WebCore::AcceleratedEffectBoxPath> value;
+};
+
+[Nested] struct WebCore::AcceleratedEffectClipPath::None {
+};
+
 struct WebCore::AcceleratedEffectValues {
     WebCore::AcceleratedEffectOpacity opacity;
     std::optional<WebCore::TransformOperationData> transformOperationData;


### PR DESCRIPTION
#### 4a9bb81d9f797c90e0484eb0c57deaf43bf4abcc
<pre>
Add AcceleratedEffectClipPath
<a href="https://bugs.webkit.org/show_bug.cgi?id=313417">https://bugs.webkit.org/show_bug.cgi?id=313417</a>
<a href="https://rdar.apple.com/176170699">rdar://176170699</a>

Reviewed by Sam Weinig.

Add AcceleratedEffectClipPath in preparation for bug 185816. Also make it known
for IPC and extend StyleClipPath to support evaluation and platform operations.

* Source/WebCore/Headers.cmake:
* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/platform/animation/values/AcceleratedEffectClipPath.cpp: Added.
(WebCore::tryPath):
(WebCore::canBlend):
(WebCore::blend):
* Source/WebCore/platform/animation/values/AcceleratedEffectClipPath.h: Added.
(WebCore::AcceleratedEffectClipPath::isNone const):
(WebCore::AcceleratedEffectClipPath::isReferencePath const):
(WebCore::AcceleratedEffectClipPath::isBasicShapePath const):
(WebCore::AcceleratedEffectClipPath::isBoxPath const):
* Source/WebCore/style/values/masking/StyleClipPath.cpp:
(WebCore::Style::AcceleratedEffectClipPath&gt;::operator):
* Source/WebCore/style/values/masking/StyleClipPath.h:
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:

Canonical link: <a href="https://commits.webkit.org/314436@main">https://commits.webkit.org/314436@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bf03631d27d17afe2306c53c9093014e2ed90e7b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/166144 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/39634 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/33215 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/175191 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/123399 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/168010 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/40060 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/39638 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/129136 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/123399 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/169103 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/31511 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/149277 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/109662 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/30488 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/29180 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/23332 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/140457 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/26975 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/177724 "Built successfully") | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/30626 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/28681 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/137483 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/39703 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/33325 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/137411 "Found 1 new API test failure: WebKitGTK/TestFrame:/webkit/WebKitFrame/main-frame (failure)") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37010 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/40391 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/148771 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/102994 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/32697 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/25638 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/38902 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/111976 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/38299 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/3724 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/38544 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/38442 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->