### PR TITLE
Fix subtest leak in fast/selectors/has-invalidation-traversal-size.html

### DIFF
--- a/LayoutTests/fast/selectors/has-invalidation-traversal-size-expected.txt
+++ b/LayoutTests/fast/selectors/has-invalidation-traversal-size-expected.txt
@@ -1,21 +1,22 @@
 :has(> .trigger) with compound peer .c1
   Traversal count: 7
 :has(.trigger) with compound peer .c2
-  Traversal count: 14
-:has(> .trigger) without compound peer
+  Traversal count: 13
+:has(> .trigger3) without compound peer
   Traversal count: 7
 :has(> .trigger) in non-subject position with compound peer .c4
-  Traversal count: 14
-:has(+ .trigger) with compound peer .c5
-  Traversal count: 3
-:has(:is(.trigger + .other)) with compound peer .c6
   Traversal count: 7
+:has(+ .trigger) with compound peer .c5
+  Traversal count: 1
+:has(:is(.trigger + .other)) with compound peer .c6
+  Traversal count: 0
+  FAIL: unexpected color rgb(0, 0, 0)
 :has(.trigger) non-subject with scope-bounded traversal .c7
-  Traversal count: 14
+  Traversal count: 7
 :not(:has(.trigger)) inside :not() with compound peer .c8
-  Traversal count: 14
+  Traversal count: 7
 :is(:has(.trigger)) inside :is() with compound peer .c9
-  Traversal count: 14
+  Traversal count: 7
 :is(.other :has(.trigger)) inside :is() with complex selector and compound peer .c10
-  Traversal count: 14
+  Traversal count: 7
 

--- a/LayoutTests/fast/selectors/has-invalidation-traversal-size.html
+++ b/LayoutTests/fast/selectors/has-invalidation-traversal-size.html
@@ -6,8 +6,8 @@
 .c1:has(> .trigger) > .target { color: green; }
 /* Subject :has() with descendant combinator and compound peer */
 .c2:has(.trigger) > .target { color: green; }
-/* Subject :has() without compound peer */
-:has(> .trigger) > .target { color: green; }
+/* Subject :has() without compound peer (uses unique trigger3 class to avoid leaking invalidations to other subtests via shared class "trigger" key) */
+:has(> .trigger3) > .target { color: green; }
 /* :has() in non-subject position with compound peer */
 .c4:has(> .trigger) .target { color: green; }
 /* :has() with sibling combinator */
@@ -36,7 +36,7 @@ function log(message) {
     document.getElementById("log").textContent += message + "\n";
 }
 
-function makeTree(containerClass, childCount) {
+function makeTree(containerClass, childCount, wrapperClass) {
     var container = document.createElement("div");
     if (containerClass)
         container.className = containerClass;
@@ -49,12 +49,19 @@ function makeTree(containerClass, childCount) {
     var target = document.createElement("div");
     target.className = "target";
     container.appendChild(target);
-    document.getElementById("tests").appendChild(container);
+    var root = container;
+    if (wrapperClass) {
+        var wrapper = document.createElement("div");
+        wrapper.className = wrapperClass;
+        wrapper.appendChild(container);
+        root = wrapper;
+    }
+    document.getElementById("tests").appendChild(root);
     return container;
 }
 
-function runTest(description, containerClass, mutate, expectGreen) {
-    var container = makeTree(containerClass, 5);
+function runTest(description, containerClass, mutate, expectGreen, wrapperClass) {
+    var container = makeTree(containerClass, 5, wrapperClass);
     // Force initial style.
     document.body.offsetHeight;
 
@@ -75,7 +82,7 @@ function runTest(description, containerClass, mutate, expectGreen) {
     if (!passed)
         log("  FAIL: unexpected color " + color);
 
-    container.remove();
+    (container.parentNode === document.getElementById("tests") ? container : container.parentNode).remove();
 }
 
 runTest(":has(> .trigger) with compound peer .c1", "c1", function(container) {
@@ -90,9 +97,9 @@ runTest(":has(.trigger) with compound peer .c2", "c2", function(container) {
     container.firstElementChild.appendChild(trigger);
 }, true);
 
-runTest(":has(> .trigger) without compound peer", null, function(container) {
+runTest(":has(> .trigger3) without compound peer", null, function(container) {
     var trigger = document.createElement("div");
-    trigger.className = "trigger";
+    trigger.className = "trigger3";
     container.appendChild(trigger);
 }, true);
 
@@ -124,7 +131,7 @@ runTest(":not(:has(.trigger)) inside :not() with compound peer .c8", "c8", funct
     var trigger = document.createElement("div");
     trigger.className = "trigger";
     container.appendChild(trigger);
-}, true);
+}, false);
 
 runTest(":is(:has(.trigger)) inside :is() with compound peer .c9", "c9", function(container) {
     var trigger = document.createElement("div");
@@ -136,7 +143,7 @@ runTest(":is(.other :has(.trigger)) inside :is() with complex selector and compo
     var trigger = document.createElement("div");
     trigger.className = "trigger";
     container.appendChild(trigger);
-}, true);
+}, true, "other");
 </script>
 </script>
 </body>


### PR DESCRIPTION
#### d11310970d66218aeaccee0d5669453601b0acf2
<pre>
Fix subtest leak in fast/selectors/has-invalidation-traversal-size.html
<a href="https://bugs.webkit.org/show_bug.cgi?id=313422">https://bugs.webkit.org/show_bug.cgi?id=313422</a>
<a href="https://rdar.apple.com/175669416">rdar://175669416</a>

Reviewed by Alan Baradlay.

Unscoped :has(&gt; .trigger) in subtest 3 leaked to other subtests affecting their results.

* LayoutTests/fast/selectors/has-invalidation-traversal-size-expected.txt:
* LayoutTests/fast/selectors/has-invalidation-traversal-size.html:

Fix by making it use a unique trigger.
Also ensure subtest 10 tests what it is supposed to test.
Subtest 6 now fails as a bug was masked by the leak.

Canonical link: <a href="https://commits.webkit.org/312089@main">https://commits.webkit.org/312089@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/260e768e8d5f372b5650b6b730dfe84ad1186e67

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/158942 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/32369 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/25474 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/167771 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/113026 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/c46733de-6868-4bc9-a98e-d8b10b11e058) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/32436 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/32356 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/123147 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/86473 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/95be6bac-6a32-47a0-a07f-16b8a3471584) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/161899 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/25423 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/142795 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/103815 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/3473b079-f9d6-466d-9101-9719e07b1461) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/24479 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/22876 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/15543 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/134165 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/167/builds/20575 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/170264 "Built successfully") | | 
| | | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/22201 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/131335 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/32058 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/26943 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/131447 "Passed tests") | | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/35543 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/32003 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/142368 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/90052 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/26158 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/19177 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/31514 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/31034 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/31307 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/31188 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->