### PR TITLE
Leak due to retain cycle between LibWebRTCRtp{Sender,Receiver}TransformBackend and libwebrtc sender/receiver after RTCPeerConnection closes

### DIFF
--- a/Source/WebCore/Modules/mediastream/RTCRtpTransformBackend.h
+++ b/Source/WebCore/Modules/mediastream/RTCRtpTransformBackend.h
@@ -49,6 +49,12 @@ public:
     virtual Side side() const = 0;
 
     virtual bool requestKeyFrame(const String&) = 0;
+
+    // Invoked when the WebKit backend that owns this transform is about to be
+    // destroyed. Gives subclasses a chance to break retain cycles with the
+    // underlying libwebrtc sender/receiver (which holds a ref back via its
+    // frame_transformer_ field).
+    virtual void detachFromOwningBackend() { }
 };
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCRtpReceiverBackend.cpp
+++ b/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCRtpReceiverBackend.cpp
@@ -96,6 +96,8 @@ LibWebRTCRtpReceiverBackend::LibWebRTCRtpReceiverBackend(Ref<webrtc::RtpReceiver
 
 LibWebRTCRtpReceiverBackend::~LibWebRTCRtpReceiverBackend()
 {
+    if (RefPtr transformBackend = m_transformBackend)
+        transformBackend->detachFromOwningBackend();
     m_rtcReceiver->SetObserver(nullptr);
 }
 

--- a/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCRtpReceiverTransformBackend.cpp
+++ b/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCRtpReceiverTransformBackend.cpp
@@ -44,6 +44,11 @@ LibWebRTCRtpReceiverTransformBackend::LibWebRTCRtpReceiverTransformBackend(Ref<w
 
 LibWebRTCRtpReceiverTransformBackend::~LibWebRTCRtpReceiverTransformBackend() = default;
 
+void LibWebRTCRtpReceiverTransformBackend::detachFromOwningBackend()
+{
+    m_rtcReceiver->SetFrameTransformer(nullptr);
+}
+
 void LibWebRTCRtpReceiverTransformBackend::setTransformableFrameCallback(Callback&& callback)
 {
     setInputCallback(WTF::move(callback));

--- a/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCRtpReceiverTransformBackend.h
+++ b/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCRtpReceiverTransformBackend.h
@@ -42,6 +42,7 @@ private:
     // RTCRtpTransformBackend
     void setTransformableFrameCallback(Callback&&) final;
     bool requestKeyFrame(const String&) final;
+    void detachFromOwningBackend() final;
 
     bool m_isRegistered { false };
     const Ref<webrtc::RtpReceiverInterface> m_rtcReceiver;

--- a/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCRtpSenderBackend.cpp
+++ b/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCRtpSenderBackend.cpp
@@ -69,6 +69,8 @@ LibWebRTCRtpSenderBackend::LibWebRTCRtpSenderBackend(LibWebRTCPeerConnectionBack
 
 LibWebRTCRtpSenderBackend::~LibWebRTCRtpSenderBackend()
 {
+    if (RefPtr transformBackend = m_transformBackend)
+        transformBackend->detachFromOwningBackend();
     stopSource();
 }
 

--- a/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCRtpSenderTransformBackend.cpp
+++ b/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCRtpSenderTransformBackend.cpp
@@ -47,6 +47,11 @@ LibWebRTCRtpSenderTransformBackend::LibWebRTCRtpSenderTransformBackend(Ref<webrt
 
 LibWebRTCRtpSenderTransformBackend::~LibWebRTCRtpSenderTransformBackend() = default;
 
+void LibWebRTCRtpSenderTransformBackend::detachFromOwningBackend()
+{
+    m_rtcSender->SetFrameTransformer(nullptr);
+}
+
 void LibWebRTCRtpSenderTransformBackend::setTransformableFrameCallback(Callback&& callback)
 {
     setInputCallback(WTF::move(callback));

--- a/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCRtpSenderTransformBackend.h
+++ b/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCRtpSenderTransformBackend.h
@@ -45,6 +45,7 @@ private:
     // RTCRtpTransformBackend
     void setTransformableFrameCallback(Callback&&) final;
     bool requestKeyFrame(const String&) final;
+    void detachFromOwningBackend() final;
 
     bool m_isRegistered { false };
     const Ref<webrtc::RtpSenderInterface> m_rtcSender;


### PR DESCRIPTION
#### 0f476dfaa434c9d93e535670b7d128b2046db5bd
<pre>
Leak due to retain cycle between LibWebRTCRtp{Sender,Receiver}TransformBackend and libwebrtc sender/receiver after RTCPeerConnection closes
&lt;<a href="https://bugs.webkit.org/show_bug.cgi?id=313426">https://bugs.webkit.org/show_bug.cgi?id=313426</a>&gt;
&lt;<a href="https://rdar.apple.com/175674797">rdar://175674797</a>&gt;

Reviewed by Youenn Fablet.

Break the retain cycle between the LibWebRTC transform backend and
its underlying libwebrtc sender / receiver so the leak does not
persist after `RTCPeerConnection.close()`.

Each side needs a strong ref to the other: the WebKit backend
forwards calls to the sender / receiver, and libwebrtc&apos;s
`FrameTransformer` contract retains the registered transformer in
`frame_transformer_` for the sender&apos;s / receiver&apos;s lifetime.  Neither
side has a hook that releases first once the transform is no longer
reachable from JavaScript, so both objects stay alive indefinitely.

`LibWebRTCRtpSenderBackend` / `LibWebRTCRtpReceiverBackend` is the
sole WebKit-side owner of the transform backend; once it is being
destroyed, no WebKit code path can reach the transform backend
anymore.  That makes its destructor a safe point to break the cycle
by calling `SetFrameTransformer(nullptr)` on the libwebrtc sender /
receiver, which clears the `frame_transformer_` back-edge.  The
transform backend keeps its `const Ref` to the sender / receiver,
so no null checks are needed elsewhere.

Test: `run-webkit-tests --debug --leaks http/wpt/webrtc webrtc`

* Source/WebCore/Modules/mediastream/RTCRtpTransformBackend.h:
(WebCore::RTCRtpTransformBackend::detachFromOwningBackend): Add.
- Default no-op; libwebrtc subclasses override to break the cycle.
* Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCRtpReceiverBackend.cpp:
(WebCore::LibWebRTCRtpReceiverBackend::~LibWebRTCRtpReceiverBackend):
- Detach the transform backend before teardown to break the cycle.
* Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCRtpReceiverTransformBackend.cpp:
(WebCore::LibWebRTCRtpReceiverTransformBackend::detachFromOwningBackend): Add.
- Clear the receiver&apos;s frame transformer to break the back-edge.
* Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCRtpReceiverTransformBackend.h:
* Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCRtpSenderBackend.cpp:
(WebCore::LibWebRTCRtpSenderBackend::~LibWebRTCRtpSenderBackend):
- Detach the transform backend before teardown to break the cycle.
* Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCRtpSenderTransformBackend.cpp:
(WebCore::LibWebRTCRtpSenderTransformBackend::detachFromOwningBackend): Add.
- Clear the sender&apos;s frame transformer to break the back-edge.
* Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCRtpSenderTransformBackend.h:

Canonical link: <a href="https://commits.webkit.org/312177@main">https://commits.webkit.org/312177@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3ed68125aa5a2be63809f19405087c55e8b74cf4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/159101 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/32529 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/25634 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/167930 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/113185 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/160970 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/32596 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/32516 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/123258 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/86544 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/162058 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/25528 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/142917 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/103924 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/24582 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/23001 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/15703 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/134268 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/20697 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/170423 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/16165 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/22323 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/131455 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/32218 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/27070 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/131567 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/32162 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/142490 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/90212 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/24223 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/26260 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/19299 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/31673 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/97687 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/31193 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/31466 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/31348 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->