### PR TITLE
[CMake] Add mac-tsan preset for ThreadSanitizer builds

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -209,6 +209,26 @@
             }
         },
         {
+            "name": "mac-tsan",
+            "displayName": "macOS TSan (ThreadSanitizer, RelWithDebInfo, ccache)",
+            "inherits": ["mac", "dev"],
+            "binaryDir": "WebKitBuild/cmake-mac/TSan",
+            "cacheVariables": {
+                "CMAKE_BUILD_TYPE": {
+                    "type": "STRING",
+                    "value": "RelWithDebInfo"
+                },
+                "ENABLE_SANITIZERS": {
+                    "type": "STRING",
+                    "value": "thread"
+                },
+                "ENABLE_EXPERIMENTAL_FEATURES": {
+                    "type": "BOOL",
+                    "value": "OFF"
+                }
+            }
+        },
+        {
             "name": "ios",
             "hidden": true,
             "generator": "Ninja",
@@ -365,6 +385,11 @@
             "name": "mac-asan",
             "displayName": "macOS ASan",
             "configurePreset": "mac-asan"
+        },
+        {
+            "name": "mac-tsan",
+            "displayName": "macOS TSan",
+            "configurePreset": "mac-tsan"
         },
         {
             "name": "gtk-release",

--- a/Source/cmake/OptionsCocoa.cmake
+++ b/Source/cmake/OptionsCocoa.cmake
@@ -143,6 +143,15 @@ if (ENABLE_SANITIZERS)
         add_compile_options("$<$<NOT:$<COMPILE_LANGUAGE:Swift>>:-fsanitize-address-use-after-return=never>")
         add_link_options("$<$<NOT:$<LINK_LANGUAGE:Swift>>:-fsanitize-address-use-after-return=never>")
     endif ()
+
+    # TSan: ld64 hits "too many personality routines for compact unwind" when
+    # the TSan runtime adds its own personality. Mirror Sanitizers.xcconfig
+    # (which scopes this to WebCore/WebKit/TestWebKitAPI; applying globally is
+    # harmless and avoids per-target plumbing).
+    string(FIND "${ENABLE_SANITIZERS}" "thread" _tsan_pos)
+    if (NOT _tsan_pos EQUAL -1)
+        add_link_options("-Wl,-no_compact_unwind")
+    endif ()
 endif ()
 
 add_link_options("$<$<NOT:$<CONFIG:Debug>>:-Wl,-dead_strip>")

--- a/Tools/Scripts/generate-cmake-xcode-project
+++ b/Tools/Scripts/generate-cmake-xcode-project
@@ -404,6 +404,22 @@ def asan_options(build_dir: Path) -> str:
     return ""
 
 
+def tsan_options(build_dir: Path) -> str:
+    """TSAN_OPTIONS for any process built with -fsanitize=thread.
+    Points at the in-tree suppressions file (JSC parallel-GC, JIT, allocator
+    internals -- see Tools/Scripts/tsan_suppressions.txt). second_deadlock_stack
+    gives both lock-order stacks; halt_on_error=0 lets a test surface multiple
+    races in one run."""
+    if "thread" not in read_cmake_cache(build_dir, "ENABLE_SANITIZERS"):
+        return ""
+    source_dir = Path(read_cmake_cache(build_dir, "CMAKE_HOME_DIRECTORY"))
+    supp = source_dir / "Tools" / "Scripts" / "tsan_suppressions.txt"
+    opts = "halt_on_error=0:second_deadlock_stack=1"
+    if supp.exists():
+        opts += f":suppressions={supp}"
+    return opts
+
+
 def bundle_identifier(app_path: Path, fallback_name: str) -> str:
     try:
         with (app_path / "Contents" / "Info.plist").open("rb") as f:
@@ -430,6 +446,7 @@ def generate_scheme(name: str, executable_path: Path, is_bundle: bool,
 
     framework_path = f"{build_dir}:{build_dir}/lib"
     asan = asan_options(build_dir)
+    tsan = tsan_options(build_dir)
 
     # Plain executables (jsc, testapi, ...) find their frameworks via LC_RPATH;
     # setting DYLD_FRAMEWORK_PATH on them would only redirect Xcode's injected
@@ -454,6 +471,10 @@ def generate_scheme(name: str, executable_path: Path, is_bundle: bool,
         env.append(("ASAN_OPTIONS", asan))
         if is_bundle:
             env.append(("__XPC_ASAN_OPTIONS", asan))
+    if tsan:
+        env.append(("TSAN_OPTIONS", tsan))
+        if is_bundle:
+            env.append(("__XPC_TSAN_OPTIONS", tsan))
 
     if env:
         entries = "".join(

--- a/Tools/Scripts/tsan_suppressions.txt
+++ b/Tools/Scripts/tsan_suppressions.txt
@@ -1,0 +1,47 @@
+# WebKit TSan suppressions
+# JSC parallel GC: workers access different cells in the same MarkedBlock.
+# TSan can't see that mark bits partition the block into non-overlapping work.
+race:JSC::SlotVisitor::appendSlow
+race:JSC::SlotVisitor::appendHiddenSlow
+race:JSC::SlotVisitor::appendHiddenSlowImpl
+race:JSC::SlotVisitor::markAuxiliary
+race:JSC::SlotVisitor::visitChildren
+race:JSC::SlotVisitor::setMarkedAndAppendToMarkStack
+race:JSC::SlotVisitor::donateKnownParallel
+race:JSC::SlotVisitor::hasAcknowledgedThatTheMutatorIsResumed
+race:JSC::JSObjectWithButterfly::visitChildren
+race:JSC::JSFunction::visitChildren
+race:JSC::JSGlobalObject::visitChildren
+race:JSC::UnlinkedCodeBlock::visitChildren
+race:JSC::UnlinkedFunctionExecutable::visitChildren
+race:JSC::FunctionExecutable::visitChildren
+race:JSC::JSSymbolTableObject::visitChildren
+race:JSC::Structure::visitChildren
+race:JSC::IsoCellSet::parallelNotEmptyMarkedBlockSource
+race:JSC::Heap::reportExtraMemoryVisited
+race:JSC::Heap::resumeThePeriphery
+race:JSC::MarkingConstraintSolver::runExecutionThread
+race:stop_allocator
+# JSC JIT compiler (concurrent compilation reads object state while mutator writes)
+race:JSC::JITThunks::ctiStub
+race:JSC::InlineWatchpointSet::add
+race:JSC::speculationFromValue
+race:JSC::DFG::DesiredWatchpoints::consider
+race:JSC::DFG::ByteCodeParser::parseBlock
+race:JSC::CodeBlock::valueProfilePredictionForBytecodeIndex
+race:JSC::CodeBlock::linkIncomingCall
+race:JSC::ExecutionCounter
+race:JSC::SecureARM64EHashPins::allocatePinForCurrentThreadImpl
+race:WTF::Thread::registerGCThread
+# JSC/bmalloc allocator internals
+race:jit_heap_config_specialized_local_allocator_try_allocate_small_segregated_slow
+race:pas_page_sharing_pool_add_at_index
+race:pas_thread_local_cache_stop_local_allocators_if_necessary
+# WTF parallel helpers
+race:WTF::ParallelHelperPool::Thread::poll
+# WebCore GC visitors (same parallel GC issue)
+race:WebCore::JSDOMGlobalObject::visitChildren
+race:WebCore::JSDOMWindow::visitChildren
+race:WebCore::JSDOMWindow::visitAdditionalChildrenInGCThread
+race:WebCore::JSNode::visitAdditionalChildrenInGCThread
+race:WebCore::JSEventListener::visitJSFunctionInGCThread


### PR DESCRIPTION
#### 18cae3c8d1c7a84d48a9bd658f9b7d6eee60f0ff
<pre>
[CMake] Add mac-tsan preset for ThreadSanitizer builds
<a href="https://bugs.webkit.org/show_bug.cgi?id=313433">https://bugs.webkit.org/show_bug.cgi?id=313433</a>

Reviewed by David Kilzer.

Parallel to mac-asan: ENABLE_SANITIZERS=thread, binaryDir
WebKitBuild/cmake-mac/TSan. WebKitCompilerFlags.cmake already
handles ENABLE_SANITIZERS=thread; this just exposes it as a preset
and adds the one Mac-specific link flag.

OptionsCocoa.cmake: add -Wl,-no_compact_unwind under TSan, mirroring
Configurations/Sanitizers.xcconfig (the TSan runtime&apos;s extra
personality routine overflows ld64&apos;s compact-unwind encoding on
large frameworks). The xcconfig scopes it to four targets; applying
globally is harmless and keeps the CMake side simple.

Tools/Scripts/tsan_suppressions.txt: JSC&apos;s parallel GC has worker
threads that visit different cells in the same MarkedBlock; TSan
can&apos;t see that the mark bits partition the block into
non-overlapping work and reports every visitChildren as a race. The
concurrent JIT similarly reads object state while the mutator
writes. Suppress these by symbol so real WebCore races aren&apos;t
drowned out.

Tools/Scripts/generate-cmake-xcode-project: when the build dir was
configured with ENABLE_SANITIZERS=thread, set
TSAN_OPTIONS=suppressions=&lt;abs path&gt;/Tools/Scripts/tsan_suppressions.txt
in every generated scheme&apos;s LaunchAction EnvironmentVariables, so
running from the cmake-generated Xcode project picks up the
suppressions without per-user setup.

ASan and TSan are mutually exclusive (clang rejects
-fsanitize=address,thread), so this is a separate build.

* CMakePresets.json:
* Source/cmake/OptionsCocoa.cmake:
* Tools/Scripts/generate-cmake-xcode-project:
(tsan_options):
(generate_scheme):
* Tools/Scripts/tsan_suppressions.txt: Added.

Canonical link: <a href="https://commits.webkit.org/312758@main">https://commits.webkit.org/312758@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7bb551631c5d9ff54b5198991342938066389bd7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/160916 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/34389 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/27490 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/169819 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/117176 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/7139799a-0819-4d84-a191-53e00ea743df) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/162785 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/34490 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/34389 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/124813 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/117176 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/0ec41088-8923-4da1-94e5-d86aa5104d83) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/163875 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/27071 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/144553 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/105410 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/dc0a141c-63b2-42ac-9288-47071f3d560d) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/26123 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/24626 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/17539 "Built successfully") | | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/20/builds/152972 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/135817 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/22315 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/172302 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/21754 "Built successfully and passed tests") | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/23956 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/133086 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/34063 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/28718 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/133096 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/34047 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/144110 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/95886 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/24485 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/27679 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/20926 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/193315 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/33558 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/49776 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/33057 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/33301 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/33206 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->