### PR TITLE
[TSan] Add BitSet::concurrentGet for MarkedBlock mark-bit reads

### DIFF
--- a/Source/JavaScriptCore/heap/MarkedBlock.h
+++ b/Source/JavaScriptCore/heap/MarkedBlock.h
@@ -621,13 +621,13 @@ inline bool MarkedBlock::isMarked(HeapVersion markingVersion, const void* p)
     Dependency dependency = Dependency::loadAndFence(&header().m_markingVersion, version);
     if (version != markingVersion) [[unlikely]]
         return false;
-    return header().m_marks.get(atomNumber(p), dependency);
+    return header().m_marks.concurrentGet(atomNumber(p), dependency);
 }
 
 inline bool MarkedBlock::isMarked(const void* p, Dependency dependency)
 {
     assertMarksNotStale();
-    return header().m_marks.get(atomNumber(p), dependency);
+    return header().m_marks.concurrentGet(atomNumber(p), dependency);
 }
 
 inline bool MarkedBlock::testAndSetMarked(const void* p, Dependency dependency)

--- a/Source/WTF/wtf/BitSet.h
+++ b/Source/WTF/wtf/BitSet.h
@@ -50,7 +50,8 @@ public:
         return bitSetSize;
     }
 
-    constexpr bool get(size_t, Dependency = Dependency()) const;
+    constexpr bool get(size_t) const;
+    constexpr bool concurrentGet(size_t, Dependency = Dependency()) const;
     constexpr void set(size_t);
     constexpr void set(size_t, bool);
     constexpr bool testAndSet(size_t); // Returns the previous bit value.
@@ -162,9 +163,16 @@ private:
 };
 
 template<size_t bitSetSize, typename WordType>
-inline constexpr bool BitSet<bitSetSize, WordType>::get(size_t n, Dependency dependency) const
+inline constexpr bool BitSet<bitSetSize, WordType>::get(size_t n) const
 {
-    return !!(dependency.consume(this)->bits[n / wordSize] & (one << (n % wordSize)));
+    return !!(bits[n / wordSize] & (one << (n % wordSize)));
+}
+
+template<size_t bitSetSize, typename WordType>
+ALWAYS_INLINE constexpr bool BitSet<bitSetSize, WordType>::concurrentGet(size_t n, Dependency dependency) const
+{
+    const WordType* data = dependency.consume(&bits[n / wordSize]);
+    return !!(std::bit_cast<const Atomic<WordType>*>(data)->loadRelaxed() & (one << (n % wordSize)));
 }
 
 template<size_t bitSetSize, typename WordType>


### PR DESCRIPTION
#### 0c5600b9794df33fca2fc34c2fd6bda39bde9909
<pre>
[TSan] Add BitSet::concurrentGet for MarkedBlock mark-bit reads
<a href="https://bugs.webkit.org/show_bug.cgi?id=313435">https://bugs.webkit.org/show_bug.cgi?id=313435</a>

Reviewed by Keith Miller.

MarkedBlock::isMarked reads m_marks while concurrent GC workers may
testAndSetMarked the same word. The existing get() is a plain load;
add concurrentGet() that does a relaxed atomic load of the word so
TSan recognises the access as intentional concurrent read. No
ordering change (Dependency already provides consume ordering on
the version check); this only changes how TSan models the load.

The two MarkedBlock::isMarked overloads were the only callers passing
a Dependency to get(); now that they use concurrentGet(), drop the
unused Dependency parameter from get() so future concurrent readers
reach for concurrentGet() rather than the non-atomic path.

* Source/JavaScriptCore/heap/MarkedBlock.h:
(JSC::MarkedBlock::isMarked):
* Source/WTF/wtf/BitSet.h:
(WTF::BitSet::get const):
(WTF::BitSet::concurrentGet const):

Canonical link: <a href="https://commits.webkit.org/312852@main">https://commits.webkit.org/312852@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/527cc365460c0367148c57bf3011deedf25982e5

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/161017 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/34490 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/27591 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/169920 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/117277 "Built successfully") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/34591 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/34490 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/124897 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/88119 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/163976 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/27165 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/144635 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/105494 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/26214 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/24714 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/17640 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/153073 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/135908 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/22397 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/172403 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/21855 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/19424 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/24038 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/133176 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/34164 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/28807 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/133186 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36021 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/34148 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/144192 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/95987 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/27752 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/21010 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/193416 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/33659 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/101084 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/49811 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/33158 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/33402 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/33307 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->