### PR TITLE
[TSan] GlyphPage::s_count: use std::atomic for the debug counter

### DIFF
--- a/Source/WebCore/platform/graphics/Font.cpp
+++ b/Source/WebCore/platform/graphics/Font.cpp
@@ -60,7 +60,12 @@
 
 namespace WebCore {
 
-unsigned GlyphPage::s_count = 0;
+std::atomic<unsigned> GlyphPage::s_count = 0;
+
+unsigned GlyphPage::count()
+{
+    return s_count.load(std::memory_order_relaxed);
+}
 
 const float smallCapsFontSizeMultiplier = 0.7f;
 const float emphasisMarkFontSizeMultiplier = 0.5f;

--- a/Source/WebCore/platform/graphics/GlyphPage.h
+++ b/Source/WebCore/platform/graphics/GlyphPage.h
@@ -69,10 +69,10 @@ public:
 
     ~GlyphPage()
     {
-        --s_count;
+        s_count.fetch_sub(1, std::memory_order_relaxed);
     }
 
-    static unsigned count() { return s_count; }
+    WEBCORE_EXPORT static unsigned count();
 
     static constexpr unsigned size = 16;
 
@@ -131,14 +131,14 @@ private:
     explicit GlyphPage(const Font& font)
         : m_font(font)
     {
-        ++s_count;
+        s_count.fetch_add(1, std::memory_order_relaxed);
     }
 
     SingleThreadWeakPtr<const Font> m_font;
     std::array<Glyph, size> m_glyphs { };
     WTF::BitSet<size> m_isColor;
 
-    WEBCORE_EXPORT static unsigned s_count;
+    static std::atomic<unsigned> s_count;
 };
 
 } // namespace WebCore


### PR DESCRIPTION
#### 9070da9a886a0ac7adbf068ae69b3c821f1a42f4
<pre>
[TSan] GlyphPage::s_count: use std::atomic for the debug counter
<a href="https://bugs.webkit.org/show_bug.cgi?id=313438">https://bugs.webkit.org/show_bug.cgi?id=313438</a>

Reviewed by David Kilzer.

GlyphPage instances are created and destroyed on multiple threads
(font worker, main); the static s_count debug counter is a plain
unsigned, so every ctor/dtor is a data race. Make it
std::atomic&lt;unsigned&gt; with relaxed ordering -- it&apos;s only read by
the memory-pressure logging.

Move WEBCORE_EXPORT from s_count to count() so the atomic remains
a private implementation detail. The only external consumer
(WebCoreStatistics.mm) calls the accessor, not the raw variable.

* Source/WebCore/platform/graphics/Font.cpp:
(WebCore::GlyphPage::count):
* Source/WebCore/platform/graphics/GlyphPage.h:
(WebCore::GlyphPage::~GlyphPage):
(WebCore::GlyphPage::GlyphPage):

Canonical link: <a href="https://commits.webkit.org/312118@main">https://commits.webkit.org/312118@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d474d93865f5c58fd667fc818a34a9c84bd05645

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/158990 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/32417 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/25522 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/167819 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/113074 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/9307e192-b2ef-4ce3-b231-0098c1c79a49) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/160859 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/32485 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/32405 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/123191 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/113074 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/5775ba95-e699-40a8-ba67-0c6b0b3f6ecf) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/161947 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/25474 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/142833 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/103858 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/15b0e6b4-6207-49a1-981a-d69c178319d4) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/24529 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/22926 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/15591 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/134215 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/20613 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/170312 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/16054 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/22239 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/131379 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/32107 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/26993 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/131491 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/32051 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/142406 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/90101 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/24186 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/26198 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/19215 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/31562 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/97576 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/31082 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/31355 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/31237 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->