### PR TITLE
[WPE][Qt6] WPEViewQtQuick: fix mouse down delay on touchscreen input.

### DIFF
--- a/Source/WebKit/UIProcess/API/wpe/qt6/WPEViewQtQuick.cpp
+++ b/Source/WebKit/UIProcess/API/wpe/qt6/WPEViewQtQuick.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2024 Igalia S.L.
+ * Copyright (C) 2026 Savoir-faire Linux, Inc.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -412,28 +413,83 @@ void wpe_view_dispatch_key_release_event(WPEViewQtQuick *view, QKeyEvent *event)
 // Touch events
 void wpe_view_dispatch_touch_event(WPEViewQtQuick *view, QTouchEvent *event)
 {
-    WPEEventType eventType = WPE_EVENT_NONE;
-    switch (event->type()) {
-    case QEvent::TouchBegin:
-        eventType = WPE_EVENT_TOUCH_DOWN;
-        break;
-    case QEvent::TouchUpdate:
-        eventType = WPE_EVENT_TOUCH_MOVE;
-        break;
-    case QEvent::TouchEnd:
-        eventType = WPE_EVENT_TOUCH_UP;
-        break;
-    default:
-        RELEASE_ASSERT_NOT_REACHED();
-        break;
+    bool isTouchPad = false;
+    if (auto* device = event->device())
+        isTouchPad = (device->type() == QInputDevice::DeviceType::TouchPad);
+
+    if (isTouchPad) {
+        WPEEventType eventType = WPE_EVENT_NONE;
+        switch (event->type()) {
+        case QEvent::TouchBegin:
+            eventType = WPE_EVENT_TOUCH_DOWN;
+            break;
+        case QEvent::TouchUpdate:
+            eventType = WPE_EVENT_TOUCH_MOVE;
+            break;
+        case QEvent::TouchEnd:
+            eventType = WPE_EVENT_TOUCH_UP;
+            break;
+        case QEvent::TouchCancel:
+            return;
+        default:
+                RELEASE_ASSERT_NOT_REACHED();
+        }
+        auto modifiers = static_cast<WPEModifiers>(keyboardModifiersFromEvent(event));
+        for (auto& point : event->points()) {
+            auto position = point.position();
+            auto* wpeEvent = wpe_event_touch_new(eventType, WPE_VIEW(view), WPE_INPUT_SOURCE_TOUCHPAD, event->timestamp(), modifiers, point.id(), position.x(), position.y());
+            wpe_view_event(WPE_VIEW(view), wpeEvent);
+            wpe_event_unref(wpeEvent);
+        }
+        return;
     }
 
+    // For touchscreen, map touch points to pointer events.
+    const auto& points = event->points();
+    if (points.isEmpty())
+        return;
+
+    const auto& point = points.first();
+    auto position = point.position().toPoint();
     auto modifiers = static_cast<WPEModifiers>(keyboardModifiersFromEvent(event));
-    for (auto& point : event->points()) {
-        auto position = point.position();
-        auto* wpeEvent = wpe_event_touch_new(eventType, WPE_VIEW(view), WPE_INPUT_SOURCE_TOUCHPAD, event->timestamp(),
-            modifiers, point.id(), position.x(), position.y());
+
+    switch (event->type()) {
+    case QEvent::TouchBegin: {
+        auto pressCount = wpe_view_compute_press_count(WPE_VIEW(view), position.x(), position.y(), WPE_BUTTON_PRIMARY, event->timestamp());
+        auto* wpeEvent = wpe_event_pointer_button_new(WPE_EVENT_POINTER_DOWN, WPE_VIEW(view), WPE_INPUT_SOURCE_MOUSE, event->timestamp(), modifiers, WPE_BUTTON_PRIMARY, position.x(), position.y(), pressCount);
         wpe_view_event(WPE_VIEW(view), wpeEvent);
         wpe_event_unref(wpeEvent);
+        view->priv->lastMousePosition = position;
+        break;
+    }
+    case QEvent::TouchUpdate: {
+        auto delta = view->priv->lastMousePosition
+            ? position - view->priv->lastMousePosition.value()
+            : QPointF();
+        view->priv->lastMousePosition = position;
+        auto* wpeEvent = wpe_event_pointer_move_new(WPE_EVENT_POINTER_MOVE, WPE_VIEW(view), WPE_INPUT_SOURCE_MOUSE, event->timestamp(), modifiers, position.x(), position.y(), delta.x(), delta.y());
+        wpe_view_event(WPE_VIEW(view), wpeEvent);
+        wpe_event_unref(wpeEvent);
+        break;
+    }
+    case QEvent::TouchEnd: {
+        auto* wpeEvent = wpe_event_pointer_button_new(WPE_EVENT_POINTER_UP, WPE_VIEW(view), WPE_INPUT_SOURCE_MOUSE, event->timestamp(), modifiers, WPE_BUTTON_PRIMARY, position.x(), position.y(), 0);
+        wpe_view_event(WPE_VIEW(view), wpeEvent);
+        wpe_event_unref(wpeEvent);
+        view->priv->lastMousePosition = std::nullopt;
+        break;
+    }
+    case QEvent::TouchCancel: {
+        if (view->priv->lastMousePosition) {
+            auto pos = view->priv->lastMousePosition.value().toPoint();
+            auto* wpeEvent = wpe_event_pointer_button_new(WPE_EVENT_POINTER_UP, WPE_VIEW(view), WPE_INPUT_SOURCE_MOUSE, event->timestamp(), modifiers, WPE_BUTTON_PRIMARY, pos.x(), pos.y(), 0);
+            wpe_view_event(WPE_VIEW(view), wpeEvent);
+            wpe_event_unref(wpeEvent);
+            view->priv->lastMousePosition = std::nullopt;
+        }
+        break;
+    }
+    default:
+            RELEASE_ASSERT_NOT_REACHED();
     }
 }


### PR DESCRIPTION
<pre>
[WPE][Qt6] WPEViewQtQuick: fix touch event dispatch.
<a href="https://bugs.webkit.org/show_bug.cgi?id=313436">https://bugs.webkit.org/show_bug.cgi?id=313436</a>

Reviewed by NOBODY (OOPS!).

The touchscreen touch events were dispatched to wpe as WPE_EVENT_TOUCH_DOWN/MOVE/UP with WPE_INPUT_SOURCE_TOUCHPAD. This caused the mousedown DOM event to fire only after the touch was released, unlike a real mouse.

This commit fixes this by detecting the Qt input device type and implementing the dispatch separately for touchpad and touch screen.

</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/17693ec382f04e26f56b067cfee00671f422b1d0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/187891 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/61706 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/55436 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/198078 "Built successfully") | [⏳ 🛠 win](https://ews-build.webkit.org/#/builders/Win-Build-EWS "Waiting in queue, processing has not started yet") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/63124 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/61430 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/146704 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Build-EWS "Waiting in queue, processing has not started yet") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/190846 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/50437 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/167161 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/127222 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/49174 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/46985 "Passed tests") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/159436 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/46797 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/9189 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/54104 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/51584 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/200132 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/61304 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/156410 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/62025 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/43277 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/156050 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/50345 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/134134 "Built successfully") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/131855 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/60390 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/21784 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/59800 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/59987 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/59959 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->