### PR TITLE
[TSan] ANGLE: bypass PoolAllocator under ThreadSanitizer

### DIFF
--- a/Source/ThirdParty/ANGLE/src/common/PoolAlloc.h
+++ b/Source/ThirdParty/ANGLE/src/common/PoolAlloc.h
@@ -14,7 +14,9 @@
 #    pragma allow_unsafe_buffers
 #endif
 
-#if !defined(NDEBUG)
+#if defined(ANGLE_WITH_ASAN) || defined(ANGLE_WITH_TSAN)
+#    define ANGLE_DISABLE_POOL_ALLOC  // Use system allocator under sanitizers for accurate detection
+#elif !defined(NDEBUG)
 #    define ANGLE_POOL_ALLOC_GUARD_BLOCKS  // define to enable guard block checking
 #endif
 
@@ -79,8 +81,8 @@ class PoolAllocator : angle::NonCopyable
     class Segment;
     std::vector<Segment> mSingleObjectSegments;  // Large objects.
 
-#if !defined(ANGLE_DISABLE_POOL_ALLOC)
     static constexpr size_t kSegmentSize = 32768;
+#if !defined(ANGLE_DISABLE_POOL_ALLOC)
     bool allocateNewPoolSegment();
 
     Span<uint8_t> mCurrentPool;  // The unused part of memory in last entry of mPoolSegments.


### PR DESCRIPTION
#### 0b5f6b72e35fdbeeaae6ac07283191659172e808
<pre>
[TSan] ANGLE: bypass PoolAllocator under ThreadSanitizer
&lt;<a href="https://bugs.webkit.org/show_bug.cgi?id=313441">https://bugs.webkit.org/show_bug.cgi?id=313441</a>&gt;
&lt;<a href="https://rdar.apple.com/176182322">rdar://176182322</a>&gt;

Reviewed by Kimmo Kinnunen.

ANGLE&apos;s translator `PoolAllocator` is a bump allocator that never
frees individual objects, so sanitizers cannot see per-object
allocation boundaries and may report false positives on recycled
pool memory (or miss real bugs in reused slots).  Under
`ANGLE_WITH_ASAN` or `ANGLE_WITH_TSAN`, define the existing
`ANGLE_DISABLE_POOL_ALLOC` macro so that `PoolAllocator::allocate()`
routes through `allocateSingleObject()`, which uses `malloc`
per-allocation.  All call sites (`POOL_ALLOCATOR_NEW_DELETE`,
`pool_allocator`, `AllocatePoolCharArray`) go through this single
entry point, so no per-file changes are needed.

Guard blocks (`ANGLE_POOL_ALLOC_GUARD_BLOCKS`) are redundant when a
sanitizer is active, since AddressSanitizer and ThreadSanitizer already
detect out-of-bounds and unsynchronized accesses, respectively.
Structure the macro choice as an `#if`/`#elif` chain so the sanitizer
branch and the debug-only guard-block branch are mutually exclusive.

Also move `kSegmentSize` outside the `ANGLE_DISABLE_POOL_ALLOC` guard
so profiling code in `PoolAlloc.cpp` that references it compiles in
both the pool-allocator and system-allocator modes.

* Source/ThirdParty/ANGLE/src/common/PoolAlloc.h:

Canonical link: <a href="https://commits.webkit.org/312740@main">https://commits.webkit.org/312740@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/515c7a1bb1e662416596d63bf9732ee08952eb19

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/160721 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/34194 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/27295 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/169624 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/115787 "Built successfully") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/34295 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/34194 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/124644 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/88007 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/163680 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/26898 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/144368 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/105241 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/25950 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/24449 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/17344 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/135644 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/22131 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/172106 "Built successfully") | | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/23771 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/132910 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/33868 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/28541 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/132923 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/33852 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/143926 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/95661 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/24482 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/27517 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/20741 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/33363 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/32862 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/33106 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/33010 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->