### PR TITLE
[CMake] generate-cmake-xcode-project: set TSAN_OPTIONS in TSan-build schemes https://bugs.webkit.org/show_bug.cgi?id=313442

### DIFF
--- a/Tools/Scripts/generate-cmake-xcode-project
+++ b/Tools/Scripts/generate-cmake-xcode-project
@@ -404,6 +404,22 @@ def asan_options(build_dir: Path) -> str:
     return ""
 
 
+def tsan_options(build_dir: Path) -> str:
+    """TSAN_OPTIONS for any process built with -fsanitize=thread.
+    Points at the in-tree suppressions file (JSC parallel-GC, JIT, allocator
+    internals -- see Tools/Scripts/tsan_suppressions.txt). second_deadlock_stack
+    gives both lock-order stacks; halt_on_error=0 lets a test surface multiple
+    races in one run."""
+    if "thread" not in read_cmake_cache(build_dir, "ENABLE_SANITIZERS"):
+        return ""
+    source_dir = Path(read_cmake_cache(build_dir, "CMAKE_HOME_DIRECTORY"))
+    supp = source_dir / "Tools" / "Scripts" / "tsan_suppressions.txt"
+    opts = "halt_on_error=0:second_deadlock_stack=1"
+    if supp.exists():
+        opts += f":suppressions={supp}"
+    return opts
+
+
 def bundle_identifier(app_path: Path, fallback_name: str) -> str:
     try:
         with (app_path / "Contents" / "Info.plist").open("rb") as f:
@@ -430,6 +446,7 @@ def generate_scheme(name: str, executable_path: Path, is_bundle: bool,
 
     framework_path = f"{build_dir}:{build_dir}/lib"
     asan = asan_options(build_dir)
+    tsan = tsan_options(build_dir)
 
     # Plain executables (jsc, testapi, ...) find their frameworks via LC_RPATH;
     # setting DYLD_FRAMEWORK_PATH on them would only redirect Xcode's injected
@@ -454,6 +471,10 @@ def generate_scheme(name: str, executable_path: Path, is_bundle: bool,
         env.append(("ASAN_OPTIONS", asan))
         if is_bundle:
             env.append(("__XPC_ASAN_OPTIONS", asan))
+    if tsan:
+        env.append(("TSAN_OPTIONS", tsan))
+        if is_bundle:
+            env.append(("__XPC_TSAN_OPTIONS", tsan))
 
     if env:
         entries = "".join(


### PR DESCRIPTION
Reviewed by NOBODY (OOPS!).

Parallel to the existing ASAN_OPTIONS handling: when the build was
configured with ENABLE_SANITIZERS=thread, emit TSAN_OPTIONS (and
__XPC_TSAN_OPTIONS for app bundles so the XPC services inherit it)
pointing at Tools/Scripts/tsan_suppressions.txt, with
halt_on_error=0 (collect multiple races per run) and
second_deadlock_stack=1 (show both lock-order acquisition stacks).

* Tools/Scripts/generate-cmake-xcode-project:
(tsan_options):
(generate_scheme):

<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e0c4e2bbf5ad77498119f868f7e0867cfcf88cb5

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/158979 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/32406 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/25511 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/167808 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/113063 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/1c50d70c-b4fd-452c-8e84-bb11196337ca) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/160848 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/32474 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/32394 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/123179 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/86503 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/858b9682-e588-4388-a93f-8de70ff5bc14) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/161936 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/25452 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/142827 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/103847 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/6b7717b2-dba0-4a0d-b02b-7632359e2eca) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/24507 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/22913 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/15580 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/134193 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/20607 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/170301 "Built successfully") | | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/22233 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/131367 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/32096 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/26980 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/131479 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/32040 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/142400 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/90090 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/26186 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/19209 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/31551 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/31071 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/31344 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/31226 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->