### PR TITLE
Move hasURLsRequiringEnhancedSecurityCheck to the UI process

### DIFF
--- a/Source/WebKit/Shared/Cocoa/EnhancedSecurityLinkUtilities.h
+++ b/Source/WebKit/Shared/Cocoa/EnhancedSecurityLinkUtilities.h
@@ -35,6 +35,7 @@ class URL;
 
 namespace WebKit {
 
+bool hasURLsRequiringEnhancedSecurityCheck();
 void isEnhancedSecurityEnabledForURL(const WTF::URL&, CompletionHandler<void(bool)>&&);
 
 } // namespace WebKit

--- a/Source/WebKit/Shared/Cocoa/EnhancedSecurityLinkUtilities.mm
+++ b/Source/WebKit/Shared/Cocoa/EnhancedSecurityLinkUtilities.mm
@@ -33,6 +33,11 @@
 #else
 namespace WebKit {
 
+bool hasURLsRequiringEnhancedSecurityCheck()
+{
+    return false;
+}
+
 void isEnhancedSecurityEnabledForURL(const WTF::URL& url, CompletionHandler<void(bool)>&& completionHandler)
 {
     completionHandler(false);

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -476,6 +476,10 @@
 #include "RemoteMediaSessionManagerProxy.h"
 #endif
 
+#if HAVE(ENHANCED_SECURITY_LINKS)
+#include "EnhancedSecurityLinkUtilities.h"
+#endif
+
 #define MESSAGE_CHECK(process, assertion) MESSAGE_CHECK_BASE(assertion, process->connection())
 #define MESSAGE_CHECK_URL(process, url) MESSAGE_CHECK_BASE(checkURLReceivedFromCurrentOrPreviousWebProcess(process, url), process->connection())
 #define MESSAGE_CHECK_URL_COROUTINE(process, url) MESSAGE_CHECK_BASE_COROUTINE(checkURLReceivedFromCurrentOrPreviousWebProcess(process, url), process->connection())
@@ -17440,6 +17444,9 @@ void WebPageProxy::beginEnhancedSecurityLinkCheck(const URL& url, API::Navigatio
             listener->didReceiveEnhancedSecurityLinkResults();
         }
     };
+
+    if (!hasURLsRequiringEnhancedSecurityCheck())
+        return completionHandler(false);
 
     if (RefPtr networkProcess = websiteDataStore().networkProcessIfExists())
         networkProcess->sendWithAsyncReply(Messages::NetworkProcess::IsEnhancedSecurityLink(url), WTF::move(completionHandler));

--- a/Tools/MiniBrowser/MiniBrowser.entitlements
+++ b/Tools/MiniBrowser/MiniBrowser.entitlements
@@ -35,6 +35,7 @@
 	<key>com.apple.security.temporary-exception.shared-preference.read-only</key>
 	<array>
 		<string>com.apple.Safari.SandboxBroker</string>
+		<string>com.apple.messages.EnhancedLinkSecurity</string>
 	</array>
 </dict>
 </plist>

--- a/Tools/MobileMiniBrowser/MobileMiniBrowser/MobileMiniBrowser.entitlements
+++ b/Tools/MobileMiniBrowser/MobileMiniBrowser/MobileMiniBrowser.entitlements
@@ -16,5 +16,9 @@
 	<array>
 		<string>EnableQuickLookSandboxResources</string>
 	</array>
+	<key>com.apple.security.exception.shared-preference.read-only</key>
+	<array>
+		<string>com.apple.messages.EnhancedLinkSecurity</string>
+	</array>
 </dict>
 </plist>


### PR DESCRIPTION
#### 3873896ae741a6b1c892ea76a575c4f856992149
<pre>
Move hasURLsRequiringEnhancedSecurityCheck to the UI process
<a href="https://bugs.webkit.org/show_bug.cgi?id=313448">https://bugs.webkit.org/show_bug.cgi?id=313448</a>
<a href="https://rdar.apple.com/175684546">rdar://175684546</a>

Reviewed by Per Arne Vollan.

We can move the hasURLsRequiringEnhancedSecurityCheck to the UI process, rather than
in the Network process. This allows avoiding the UI -&gt; Network IPC roundtrip when the
check returns false which should be the majority of cases.

Tests to follow.

* Source/WebKit/Shared/Cocoa/EnhancedSecurityLinkUtilities.h:
* Source/WebKit/Shared/Cocoa/EnhancedSecurityLinkUtilities.mm:
(WebKit::hasURLsRequiringEnhancedSecurityCheck):
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::beginEnhancedSecurityLinkCheck):
* Tools/MiniBrowser/MiniBrowser.entitlements:
* Tools/MobileMiniBrowser/MobileMiniBrowser/MobileMiniBrowser.entitlements:

Canonical link: <a href="https://commits.webkit.org/312359@main">https://commits.webkit.org/312359@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8cf293b5449f803351fe68ddf2fce1d431c95abc

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/159678 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/33145 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/26252 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/168530 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/114059 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/a4fbc434-a3f0-4d00-b1d5-8840ae770f73) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/161547 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/33250 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/33149 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/123729 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/114059 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/8d75d74e-55df-49f1-bbde-f72a4df56a5e) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/162636 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/25980 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/143421 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/104366 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/59fb8aeb-9e30-4af2-abaf-1ad71676b02a) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/25031 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/23498 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/16297 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/134723 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/21193 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/171021 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/17046 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/22845 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/131961 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/32824 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/27575 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/132035 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35732 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/32809 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/142987 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/90891 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/26658 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/19800 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/32318 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/98714 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/31815 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/32062 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/31966 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->