### PR TITLE
Introduced UnbarrieredMonotonicTime.

### DIFF
--- a/Source/WTF/WTF.xcodeproj/project.pbxproj
+++ b/Source/WTF/WTF.xcodeproj/project.pbxproj
@@ -967,6 +967,8 @@
 		FE35D09227DC5ECC009DFA5B /* StackCheck.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FE35D09127DC5ECC009DFA5B /* StackCheck.cpp */; };
 		FE499A6F2CD153B000E34F32 /* OverflowPolicy.h in Headers */ = {isa = PBXBuildFile; fileRef = FE499A6E2CD153B000E34F32 /* OverflowPolicy.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		FE499A712CD153B000E34F32 /* OverflowHandler.h in Headers */ = {isa = PBXBuildFile; fileRef = FE499A702CD153B000E34F32 /* OverflowHandler.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		FE69838C2F9F16BE004EA0A7 /* UnbarrieredMonotonicTime.h in Headers */ = {isa = PBXBuildFile; fileRef = FE69838B2F9F16BE004EA0A7 /* UnbarrieredMonotonicTime.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		FE69838E2F9F1FD0004EA0A7 /* UnbarrieredMonotonicTime.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FE69838D2F9F1FD0004EA0A7 /* UnbarrieredMonotonicTime.cpp */; };
 		FE6997E129D241630078B9C6 /* ReasonSPI.h in Headers */ = {isa = PBXBuildFile; fileRef = FE6997E029D241630078B9C6 /* ReasonSPI.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		FE7ACFEF285DC2F9007FC8E9 /* RawHex.h in Headers */ = {isa = PBXBuildFile; fileRef = FE7ACFEE285DC2F8007FC8E9 /* RawHex.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		FE9B8B1A28B1453D0088C6E1 /* CodePtr.h in Headers */ = {isa = PBXBuildFile; fileRef = FE9B8B1928B1453D0088C6E1 /* CodePtr.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -2078,6 +2080,8 @@
 		FE3842342325CC80009DD445 /* ResourceUsage.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ResourceUsage.h; sourceTree = "<group>"; };
 		FE499A6E2CD153B000E34F32 /* OverflowPolicy.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = OverflowPolicy.h; sourceTree = "<group>"; };
 		FE499A702CD153B000E34F32 /* OverflowHandler.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = OverflowHandler.h; sourceTree = "<group>"; };
+		FE69838B2F9F16BE004EA0A7 /* UnbarrieredMonotonicTime.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = UnbarrieredMonotonicTime.h; sourceTree = "<group>"; };
+		FE69838D2F9F1FD0004EA0A7 /* UnbarrieredMonotonicTime.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = UnbarrieredMonotonicTime.cpp; sourceTree = "<group>"; };
 		FE6997E029D241630078B9C6 /* ReasonSPI.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ReasonSPI.h; sourceTree = "<group>"; };
 		FE7497E4208FFCAA0003565B /* PtrTag.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PtrTag.h; sourceTree = "<group>"; };
 		FE7ACFEE285DC2F8007FC8E9 /* RawHex.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RawHex.h; sourceTree = "<group>"; };
@@ -2805,6 +2809,8 @@
 				FE03831B2ABC04F700A576A2 /* TZoneMalloc.h */,
 				FE03831A2ABC04F700A576A2 /* TZoneMallocInlines.h */,
 				E360C7642127B85B00C90F0E /* UnalignedAccess.h */,
+				FE69838D2F9F1FD0004EA0A7 /* UnbarrieredMonotonicTime.cpp */,
+				FE69838B2F9F16BE004EA0A7 /* UnbarrieredMonotonicTime.h */,
 				A8A4735C151A825B004123FF /* UnionFind.h */,
 				0FA6F39420CCACE900A03DCD /* UniqueArray.cpp */,
 				E300E521203D645F00DA79BE /* UniqueArray.h */,
@@ -3978,6 +3984,7 @@
 				FE03831D2ABC04F700A576A2 /* TZoneMalloc.h in Headers */,
 				FE03831C2ABC04F700A576A2 /* TZoneMallocInlines.h in Headers */,
 				DD3DC8C927A4BF8E007E5B61 /* UnalignedAccess.h in Headers */,
+				FE69838C2F9F16BE004EA0A7 /* UnbarrieredMonotonicTime.h in Headers */,
 				46E915222CD2E26C00C437B7 /* UnicodeExtras.h in Headers */,
 				DD28468829248DDA0009A61D /* UnifiedWebPreferences.yaml in Headers */,
 				DD3DC8A627A4BF8E007E5B61 /* UnionFind.h in Headers */,
@@ -4631,6 +4638,7 @@
 				0F66B2901DC97BAB004A1D3F /* TimeWithDynamicClockType.cpp in Sources */,
 				0F7075F51FBF53CD00489AF0 /* TimingScope.cpp in Sources */,
 				521CC6B424A27809004377D6 /* TranslatedProcess.cpp in Sources */,
+				FE69838E2F9F1FD0004EA0A7 /* UnbarrieredMonotonicTime.cpp in Sources */,
 				467DCD532CD4689A0040C644 /* UnicodeExtras.cpp in Sources */,
 				0FA6F39520CCACE900A03DCD /* UniqueArray.cpp in Sources */,
 				5CC0EE7621629F1900A1A842 /* URL.cpp in Sources */,

--- a/Source/WTF/wtf/CMakeLists.txt
+++ b/Source/WTF/wtf/CMakeLists.txt
@@ -381,6 +381,7 @@ set(WTF_PUBLIC_HEADERS
     URLParser.h
     UUID.h
     UnalignedAccess.h
+    UnbarrieredMonotonicTime.h
     UniStdExtras.h
     UnionFind.h
     UniqueArray.h
@@ -624,6 +625,7 @@ set(WTF_SOURCES
     URLHelpers.cpp
     URLParser.cpp
     UUID.cpp
+    UnbarrieredMonotonicTime.cpp
     UniqueArray.cpp
     Vector.cpp
     WTFAssertions.cpp

--- a/Source/WTF/wtf/ClockType.cpp
+++ b/Source/WTF/wtf/ClockType.cpp
@@ -48,6 +48,9 @@ void printInternal(PrintStream& out, ClockType type)
     case ClockType::ContinuousApproximate:
         out.print("ContinuousApproximate");
         return;
+    case ClockType::UnbarrieredMonotonic:
+        out.print("UnbarrieredMonotonic");
+        return;
     }
     RELEASE_ASSERT_NOT_REACHED();
 }

--- a/Source/WTF/wtf/ClockType.h
+++ b/Source/WTF/wtf/ClockType.h
@@ -37,6 +37,7 @@ enum class ClockType {
     Approximate,
     Continuous,
     ContinuousApproximate,
+    UnbarrieredMonotonic,
 };
 
 WTF_EXPORT_PRIVATE void printInternal(PrintStream&, ClockType);

--- a/Source/WTF/wtf/CurrentTime.cpp
+++ b/Source/WTF/wtf/CurrentTime.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2006-2019 Apple Inc. All rights reserved.
+ * Copyright (C) 2006-2019, 2026 Apple Inc. All rights reserved.
  * Copyright (C) 2008 Google Inc. All rights reserved.
  * Copyright (C) 2007-2009 Torch Mobile, Inc.
  * Copyright (C) 2008 Cameron Zwarich <cwzwarich@uwaterloo.ca>
@@ -37,6 +37,7 @@
 #include <wtf/ContinuousTime.h>
 #include <wtf/MathExtras.h>
 #include <wtf/MonotonicTime.h>
+#include <wtf/UnbarrieredMonotonicTime.h>
 #include <wtf/WallTime.h>
 
 #if OS(DARWIN)
@@ -320,7 +321,9 @@ MonotonicTime MonotonicTime::now()
 
 ApproximateTime ApproximateTime::now()
 {
-#if OS(DARWIN)
+#if USE(HARDWARE_UNBARRIERED_MONOTONIC_TIME)
+    return ApproximateTime(UnbarrieredMonotonicTime::now().secondsSinceEpoch().value());
+#elif OS(DARWIN)
     return fromMachApproximateTime(mach_approximate_time());
 #elif OS(LINUX)
     struct timespec ts { };
@@ -372,5 +375,12 @@ ContinuousApproximateTime ContinuousApproximateTime::now()
     return fromRawSeconds(currentTimeNow);
 #endif
 }
+
+#if !USE(HARDWARE_UNBARRIERED_MONOTONIC_TIME)
+UnbarrieredMonotonicTime UnbarrieredMonotonicTime::now()
+{
+    return UnbarrieredMonotonicTime(MonotonicTime::now().secondsSinceEpoch().value());
+}
+#endif
 
 } // namespace WTF

--- a/Source/WTF/wtf/TimeWithDynamicClockType.cpp
+++ b/Source/WTF/wtf/TimeWithDynamicClockType.cpp
@@ -45,6 +45,8 @@ TimeWithDynamicClockType TimeWithDynamicClockType::now(ClockType type)
         return ContinuousTime::now();
     case ClockType::ContinuousApproximate:
         return ContinuousApproximateTime::now();
+    case ClockType::UnbarrieredMonotonic:
+        return UnbarrieredMonotonicTime::now();
     }
     RELEASE_ASSERT_NOT_REACHED();
     return TimeWithDynamicClockType();
@@ -85,6 +87,12 @@ ContinuousApproximateTime TimeWithDynamicClockType::continuousApproximateTime() 
     return ContinuousApproximateTime::fromRawSeconds(m_value);
 }
 
+UnbarrieredMonotonicTime TimeWithDynamicClockType::unbarrieredMonotonicTime() const
+{
+    RELEASE_ASSERT(m_type == ClockType::UnbarrieredMonotonic);
+    return UnbarrieredMonotonicTime::fromRawSeconds(m_value);
+}
+
 WallTime TimeWithDynamicClockType::approximateWallTime() const
 {
     switch (m_type) {
@@ -98,6 +106,8 @@ WallTime TimeWithDynamicClockType::approximateWallTime() const
         return continuousTime().approximateWallTime();
     case ClockType::ContinuousApproximate:
         return ContinuousApproximateTime().approximateWallTime();
+    case ClockType::UnbarrieredMonotonic:
+        return unbarrieredMonotonicTime().approximateWallTime();
     }
     RELEASE_ASSERT_NOT_REACHED();
     return WallTime();
@@ -116,6 +126,8 @@ MonotonicTime TimeWithDynamicClockType::approximateMonotonicTime() const
         return continuousTime().approximateMonotonicTime();
     case ClockType::ContinuousApproximate:
         return ContinuousApproximateTime().approximateMonotonicTime();
+    case ClockType::UnbarrieredMonotonic:
+        return unbarrieredMonotonicTime().approximateMonotonicTime();
     }
     RELEASE_ASSERT_NOT_REACHED();
     return MonotonicTime();

--- a/Source/WTF/wtf/TimeWithDynamicClockType.h
+++ b/Source/WTF/wtf/TimeWithDynamicClockType.h
@@ -30,6 +30,7 @@
 #include <wtf/ContinuousApproximateTime.h>
 #include <wtf/ContinuousTime.h>
 #include <wtf/MonotonicTime.h>
+#include <wtf/UnbarrieredMonotonicTime.h>
 #include <wtf/WallTime.h>
 
 namespace WTF {
@@ -71,6 +72,12 @@ public:
     {
     }
 
+    TimeWithDynamicClockType(UnbarrieredMonotonicTime time)
+        : m_value(time.secondsSinceEpoch().value())
+        , m_type(ClockType::UnbarrieredMonotonic)
+    {
+    }
+
     static TimeWithDynamicClockType fromRawSeconds(double value, ClockType type)
     {
         TimeWithDynamicClockType result;
@@ -97,6 +104,7 @@ public:
     WTF_EXPORT_PRIVATE ApproximateTime NODELETE approximateTime() const;
     WTF_EXPORT_PRIVATE ContinuousTime NODELETE continuousTime() const;
     WTF_EXPORT_PRIVATE ContinuousApproximateTime NODELETE continuousApproximateTime() const;
+    WTF_EXPORT_PRIVATE UnbarrieredMonotonicTime NODELETE unbarrieredMonotonicTime() const;
 
     WTF_EXPORT_PRIVATE WallTime approximateWallTime() const;
     WTF_EXPORT_PRIVATE MonotonicTime approximateMonotonicTime() const;

--- a/Source/WTF/wtf/UnbarrieredMonotonicTime.cpp
+++ b/Source/WTF/wtf/UnbarrieredMonotonicTime.cpp
@@ -1,0 +1,85 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include <wtf/UnbarrieredMonotonicTime.h>
+
+#include <wtf/ContinuousTime.h>
+#include <wtf/MonotonicTime.h>
+#include <wtf/PrintStream.h>
+#include <wtf/WallTime.h>
+
+namespace WTF {
+
+#if USE(HARDWARE_UNBARRIERED_MONOTONIC_TIME)
+UnbarrieredMonotonicTime::Calibration UnbarrieredMonotonicTime::s_calibration;
+
+void UnbarrieredMonotonicTime::calibrate()
+{
+    constexpr double nanosecondsPerSecond = 1000'000'000;
+    if (!s_calibration.nanosecondsPerTick) [[unlikely]] {
+        auto readCounterFrequency = [] -> uint64_t {
+            uint64_t val;
+            __asm__ volatile("mrs %0, CNTFRQ_EL0" : "=r"(val) : : "memory");
+            return val;
+        };
+
+        auto currentTime = MonotonicTime::now();
+        s_calibration.startCntpct = readCounter();
+        s_calibration.startNanoseconds = currentTime.secondsSinceEpoch().nanoseconds();
+        uint64_t ticksPerSecond = readCounterFrequency();
+        s_calibration.nanosecondsPerTick = nanosecondsPerSecond / ticksPerSecond;
+    }
+}
+#endif
+
+WallTime UnbarrieredMonotonicTime::approximateWallTime() const
+{
+    if (isInfinity())
+        return WallTime::fromRawSeconds(m_value);
+    return *this - now() + WallTime::now();
+}
+
+MonotonicTime UnbarrieredMonotonicTime::approximateMonotonicTime() const
+{
+    if (isInfinity())
+        return MonotonicTime::fromRawSeconds(m_value);
+    return *this - now() + MonotonicTime::now();
+
+}
+
+ContinuousTime UnbarrieredMonotonicTime::approximateContinuousTime() const
+{
+    if (isInfinity())
+        return ContinuousTime::fromRawSeconds(m_value);
+    return *this - now() + ContinuousTime::now();
+}
+
+void UnbarrieredMonotonicTime::dump(PrintStream& out) const
+{
+    out.print("UnbarrieredMonotonic(", m_value, " sec)");
+}
+
+} // namespace WTF

--- a/Source/WTF/wtf/UnbarrieredMonotonicTime.h
+++ b/Source/WTF/wtf/UnbarrieredMonotonicTime.h
@@ -1,0 +1,142 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <wtf/ClockType.h>
+#include <wtf/Forward.h>
+#include <wtf/GenericTimeMixin.h>
+
+namespace WTF {
+
+class ContinuousTime;
+class WallTime;
+class PrintStream;
+
+// A fast (where available) implementation of MonotonicTime using hardware counters
+// and without barriers. Because UnbarrieredMonotonicTime does not use barriers,
+// its read of the hardware counter may be executed out of order (OoO) relative to
+// adjacent instructions on modern CPUs that support OoO execution. This is the
+// tradeoff that UnbarrieredMonotonicTime makes in order to be fast.
+//
+// Because of this potential OoO effect, the values time values read using
+// UnbarrieredMonotonicTime may be slightly off / inaccurate. For some applications,
+// this slight loss of accuracy is not consequential.
+//
+// For other applications where accuracy is important (e.g. profiling of the execution
+// time of a region of code), it is important that the HW counter is read in the right
+// order. In such a scenario, the client should apply their own barriers before/after
+// UnbarrieredMonotonicTime, or alternately, just use MonotonicTime instead.
+//
+// At present, availability would only be on OS(DARWIN) and CPU(ARM64). For all
+// other ports, UnbarrieredMonotonicTime will just forward to MonotonicTime.
+// UnbarrieredMonotonicTime is expected to have the same timer resolution as
+// MonotonicTime (unlike the coarse ApproximateTime).
+
+#if OS(DARWIN) && CPU(ARM64)
+#define USE_HARDWARE_UNBARRIERED_MONOTONIC_TIME 1
+#else
+#define USE_HARDWARE_UNBARRIERED_MONOTONIC_TIME 0
+#endif
+
+class UnbarrieredMonotonicTime final : public GenericTimeMixin<UnbarrieredMonotonicTime> {
+public:
+    static constexpr ClockType clockType = ClockType::UnbarrieredMonotonic;
+
+    // This is the epoch. So, x.secondsSinceEpoch() should be the same as x - UnbarrieredMonotonicTime().
+    constexpr UnbarrieredMonotonicTime() = default;
+
+#if USE(HARDWARE_UNBARRIERED_MONOTONIC_TIME)
+    static inline UnbarrieredMonotonicTime now();
+#else
+    WTF_EXPORT_PRIVATE static UnbarrieredMonotonicTime now();
+#endif
+
+    UnbarrieredMonotonicTime approximateUnbarrieredMonotonicTime() const { return *this; }
+    WTF_EXPORT_PRIVATE WallTime approximateWallTime() const;
+    WTF_EXPORT_PRIVATE MonotonicTime approximateMonotonicTime() const;
+    WTF_EXPORT_PRIVATE ContinuousTime approximateContinuousTime() const;
+
+    WTF_EXPORT_PRIVATE void dump(PrintStream&) const;
+
+    friend struct MarkableTraits<UnbarrieredMonotonicTime>;
+
+private:
+    friend class GenericTimeMixin<UnbarrieredMonotonicTime>;
+    constexpr UnbarrieredMonotonicTime(double rawValue)
+        : GenericTimeMixin<UnbarrieredMonotonicTime>(rawValue)
+    {
+    }
+
+#if USE(HARDWARE_UNBARRIERED_MONOTONIC_TIME)
+    struct Calibration {
+        uint64_t startCntpct;
+        double startNanoseconds;
+        double nanosecondsPerTick;
+    };
+
+    WTF_EXPORT_PRIVATE static void calibrate();
+    ALWAYS_INLINE static uint64_t readCounter();
+
+    WTF_EXPORT_PRIVATE static Calibration s_calibration;
+#endif
+};
+static_assert(sizeof(UnbarrieredMonotonicTime) == sizeof(double));
+
+#if USE(HARDWARE_UNBARRIERED_MONOTONIC_TIME)
+ALWAYS_INLINE uint64_t UnbarrieredMonotonicTime::readCounter()
+{
+    uint64_t val;
+    __asm__ volatile("mrs %0, CNTVCT_EL0" : "=r"(val) : : "memory");
+    return val;
+}
+
+inline UnbarrieredMonotonicTime UnbarrieredMonotonicTime::now()
+{
+    if (!s_calibration.nanosecondsPerTick) [[unlikely]]
+        calibrate();
+
+    constexpr double nanosecondsPerSecond = 1000'000'000;
+    double nanoseconds = (readCounter() - s_calibration.startCntpct) * s_calibration.nanosecondsPerTick + s_calibration.startNanoseconds;
+    return UnbarrieredMonotonicTime::fromRawSeconds(nanoseconds / nanosecondsPerSecond);
+}
+#endif // USE(HARDWARE_UNBARRIERED_MONOTONIC_TIME)
+
+template<>
+struct MarkableTraits<UnbarrieredMonotonicTime> {
+    static bool isEmptyValue(UnbarrieredMonotonicTime time)
+    {
+        return std::isnan(time.m_value);
+    }
+
+    static constexpr UnbarrieredMonotonicTime emptyValue()
+    {
+        return UnbarrieredMonotonicTime::nan();
+    }
+};
+
+} // namespace WTF
+
+using WTF::UnbarrieredMonotonicTime;


### PR DESCRIPTION
#### 0d7053c9c316e7b7281a24794163e2c33bf35b64
<pre>
Introduced UnbarrieredMonotonicTime.
<a href="https://bugs.webkit.org/show_bug.cgi?id=313432">https://bugs.webkit.org/show_bug.cgi?id=313432</a>
<a href="https://rdar.apple.com/175676940">rdar://175676940</a>

Reviewed by Yusuke Suzuki and Marcus Plutowski.

UnbarrieredMonotonicTime has the timer resolution of MonotonicTime, but is optimized for speed,
and does not do use any instruction barriers.  As a result, a read of UnbarrieredMonotonicTime
may be re-ordered by the CPU around adjacent instructions.  This may reduce fidelity in
accuracy for use cases like some profiling uses.  However, for clients like the Opportunistic
Task Scheduler, where we may want to sample the time more frequently, and are only concerned
about expired time in the order of milliseconds, such slight loss of fidelity in accuracy is
inconsequential.

At present, UnbarrieredMonotonicTime is only implemented with these new semantics for ARM64 +
OS(DARWIN) only, and will fall back to MonotonicTime for all other ports.

Since UnbarrieredMonotonicTime is faster than ApproximateTime (whose sole purpose is speed),
and has higher fidelity than ApproximateTime, we&apos;ll have ApproximateTime just use
UnbarrieredMonotonicTime for the ARM64 + OS(DARWIN) port.

Implementation Details
======================
On ARM64 + OS(DARWIN), UnbarrieredMonotonicTime is implemented using the CNTVCT_EL0 register [1],
and is calibrated with the CNTFRQ_EL0 [3].  According to ARM&apos;s architecture description of Generic
Timers [4], specifically on the counter (CNTPCT_EL0) and frequency [5]:

    The CNTPCT_EL0 system register reports the current system count value.
    CNTFRQ_EL0 reports the frequency of the system count.

And, CNTVCT_EL0 [1] is in sync with CNTPCT_EL0 [2]:

    The virtual count value is equal to the physical count value minus the virtual offset visible in CNTVOFF_EL2.

UnbarrieredMonotonicTime computes monotonic time by recording the value of MonotonicTime::now()
and CNTVCT_EL0 during an initial calibration, and then adding the time displacement since that
initial point.  The time displacement is computed as the counter displacement (ticks) divided by
the counter frequency (ticks / second).

Timer Resolution
================
On ARM64 + OS(DARWIN), CNTFRQ_EL0 appears to be 1 GHz, which means each tick of CNTVCT_EL0 measures
1 ns.  However, this is a virtualized value.  The actual timer resolution is expected to be based
on OS(DARWIN)&apos;s 24 MHz timer tick.  This means CNTVCT_EL0 will only increment once every 41.6667 ns.

Local microbenchmarks for timer resolution (averaged over 100000000 iterations) measured the
resolution to be:
                                M5 Max MacBook Pro       MacBook Neo
    MonotonicTime:              ~20.3 ns resolution      ~14.0 ns resolution
    ApproximateTime:            ~12157.5 ns resolution   ~23165.5 ns resolution
    UnbarrieredMonotonicTime:   ~23.5 ns resolution      ~19.6 ns resolution

The measured resolution values are subject to noise, and should not be taken literally.  However,
their orders of magnitude matches expected timer resolutions.

Timer Speed
===========
Local microbenchmarks for timer speed (averaged over 100000000 iterations) shows:
                                M5 Max MacBook Pro   MacBook Neo
    MonotonicTime:              8.68 ns/call         11.32 ns/call
    ApproximateTime:            1.44 ns/call         2.22 ns/call
    UnbarrieredMonotonicTime:   0.40 ns/call         0.41 ns/call

Timer Drift
===========
I ran a local test that runs 10000000000 iterations, with a 1s sleep every 1000000 iterations.
Each iteration samples MonotonicTime::now(), and UnbarrieredMonotonicTime::now(), and compares
the difference between them.  I ran the test for multiple hours (4+), and observed the following:

1. UnbarrieredMonotonicTime sometimes &quot;jump&quot; ahead of MonotonicTime by significant amount
   (e.g. as high as 250+ us has been ovbserved).  This is because MonotonicTime is implemented
   on top of mach_absolute_time(), and mach_absolute_time() is reading a software counter value
   that is updated by the kernel.  The jumps are presumably due to the kernel updates not firing
   in time sometimes, probably around context switches.

   The jumps are always such that UnbarrieredMonotonicTime is ahead of MonotonicTime, never in
   the opposite direction.  This makes sense since UnbarrieredMonotonicTime is based on the
   hardware counter CNTVCT_EL0, and hence will be more accurate, and not be impacted by needing
   a kernel update of the value.

2. The difference between UnbarrieredMonotonicTime and MonotonicTime always return to under 100ns
   on subsequent samples, and remain under 100ns on average if we disregard the &quot;jump&quot;s in (1).

   This confirms that (1) is due to some lag in the kernel updating mach_absolute_time, and
   mach_absolute_time eventually catches up (within 1 sample based on my observations).

   This also confirms that UnbarrieredMonotonicTime is generally in sync with MonotonicTime with
   NO observable drift.

Tested only on M5 Max MacBook Pro.

Timer Monotonicity
==================
While running the hours of Timer Drift test, the test also check for monotonicity and confirmed
that UnbarrieredMonotonicTime was never observed to go backward.

Tested on M5 Max MacBook Pro, and for a much smaller amount of time on MacBook Neo.

ref:
[1] <a href="https://developer.arm.com/documentation/ddi0601/2021-12/AArch64-Registers/CNTVCT-EL0--Counter-timer-Virtual-Count-register">https://developer.arm.com/documentation/ddi0601/2021-12/AArch64-Registers/CNTVCT-EL0--Counter-timer-Virtual-Count-register</a>
[2] <a href="https://developer.arm.com/documentation/ddi0601/2026-03/AArch64-Registers/CNTPCT-EL0--Counter-timer-Physical-Count-Register">https://developer.arm.com/documentation/ddi0601/2026-03/AArch64-Registers/CNTPCT-EL0--Counter-timer-Physical-Count-Register</a>
[3] <a href="https://developer.arm.com/documentation/ddi0601/2026-03/AArch64-Registers/CNTFRQ-EL0--Counter-timer-Frequency-Register">https://developer.arm.com/documentation/ddi0601/2026-03/AArch64-Registers/CNTFRQ-EL0--Counter-timer-Frequency-Register</a>
[4] <a href="https://developer.arm.com/documentation/102379/0104/What-is-the-Generic-Timer-">https://developer.arm.com/documentation/102379/0104/What-is-the-Generic-Timer-</a>
[5] <a href="https://developer.arm.com/documentation/102379/0104/The-processor-timers/Count-and-frequency">https://developer.arm.com/documentation/102379/0104/The-processor-timers/Count-and-frequency</a>

In addition to the above local testing, UnbarrieredMonotonicTime is also covered by existing
tests to the extent that they exercise ApproximateTime.

* Source/WTF/WTF.xcodeproj/project.pbxproj:
* Source/WTF/wtf/CMakeLists.txt:
* Source/WTF/wtf/ClockType.cpp:
(WTF::printInternal):
* Source/WTF/wtf/ClockType.h:
* Source/WTF/wtf/CurrentTime.cpp:
* Source/WTF/wtf/TimeWithDynamicClockType.cpp:
(WTF::TimeWithDynamicClockType::now):
(WTF::TimeWithDynamicClockType::unbarrieredMonotonicTime const):
(WTF::TimeWithDynamicClockType::approximateWallTime const):
(WTF::TimeWithDynamicClockType::approximateMonotonicTime const):
* Source/WTF/wtf/TimeWithDynamicClockType.h:
* Source/WTF/wtf/UnbarrieredMonotonicTime.cpp: Added.
(WTF::UnbarrieredMonotonicTime::calibrate):
(WTF::UnbarrieredMonotonicTime::approximateWallTime const):
(WTF::UnbarrieredMonotonicTime::approximateMonotonicTime const):
(WTF::UnbarrieredMonotonicTime::approximateContinuousTime const):
(WTF::UnbarrieredMonotonicTime::dump const):
* Source/WTF/wtf/UnbarrieredMonotonicTime.h: Added.
(WTF::UnbarrieredMonotonicTime::readCounter):
(WTF::UnbarrieredMonotonicTime::now):
(WTF::MarkableTraits&lt;UnbarrieredMonotonicTime&gt;::isEmptyValue):
(WTF::MarkableTraits&lt;UnbarrieredMonotonicTime&gt;::emptyValue):

Canonical link: <a href="https://commits.webkit.org/312153@main">https://commits.webkit.org/312153@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7eefda90742c3fff07d54f28b91927de4950044d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/159045 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/32473 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/25578 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/167874 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/113129 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/fca0d730-ff90-4afe-aaf9-860c31ad0eb5) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/32540 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/32460 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/123234 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/113129 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/8ea9094d-b5d6-4676-9c47-36f6d4a44c8f) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/162002 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/25502 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/142884 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/103901 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/3dcce6f9-b93a-46a5-878a-ceddd8bfb3b6) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/24556 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/22971 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/15647 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/151095 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/134242 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/20664 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/170367 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/19878 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/16109 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/22290 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/131423 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/32162 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/27040 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/131535 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/32106 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/142457 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/90156 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/24209 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/26232 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/19266 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/191327 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/31617 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/97631 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/49176 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/31137 "Built successfully") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/31410 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/31292 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->