### PR TITLE
::cue(selector) should be able to match WebVTT root object

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -570,9 +570,6 @@ http/wpt/html/cross-origin-embedder-policy/require-corp.https.html [ DumpJSConso
 http/wpt/webauthn/public-key-credential-create-failure.https.html [ DumpJSConsoleLogInStdErr ]
 http/wpt/webauthn/public-key-credential-get-failure.https.html [ DumpJSConsoleLogInStdErr ]
 
-# We need to fix our WebVTT implementation to pass most of the WebVTT rendering WPT (https://bugs.webkit.org/show_bug.cgi?id=277975).
-imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video [ ImageOnlyFailure ]
-
 # Cookie Store API tests that timeout
 imported/w3c/web-platform-tests/cookiestore/cookieStore_set_domain_parsing.tentative.sub.https.html [ Skip ]
 
@@ -608,6 +605,9 @@ webkit.org/b/290522 imported/w3c/web-platform-tests/html/canvas/offscreen/manual
 webkit.org/b/290522 imported/w3c/web-platform-tests/html/canvas/offscreen/manual/text/canvas.2d.offscreen.transferred.direction.inherit.html [ ImageOnlyFailure ]
 webkit.org/b/290522 imported/w3c/web-platform-tests/html/canvas/offscreen/manual/text/canvas.2d.offscreen.worker.direction.inherit.html [ ImageOnlyFailure ]
 
+# We need to fix our WebVTT implementation to pass most of the WebVTT rendering WPT (https://bugs.webkit.org/show_bug.cgi?id=277975).
+imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video [ ImageOnlyFailure ]
+
 # These are the WebVTT rendering WPT we are already passing.
 imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/bidi/u06E9_no_strong_dir.html [ Pass ]
 imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/dom_override_remove_cue_while_paused.html [ Pass ]
@@ -632,11 +632,16 @@ imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-mode
 imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/navigate_cue_position.html [ Pass ]
 imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/one_line_cue_plus_wrapped_cue.html [ Pass ]
 imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/size_50.html [ Pass ]
+imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/color_hex.html [ Pass ]
+imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/color_hsla.html [ Pass ]
+imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/id_color.html [ Pass ]
 
 # These WebVTT rendering WPT are flaky.
 imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/evil/non-standard-pseudo-elements.html [ ImageOnlyFailure Pass Failure ]
 imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/audio_has_no_subtitles.html [ ImageOnlyFailure Pass Failure ]
 imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/class_object/class_white-space_pre-line_wrapped.html [ Crash ImageOnlyFailure ]
+imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/white-space_normal_wrapped.html [ ImageOnlyFailure Pass Failure ]
+imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/white-space_nowrap_wrapped.html [ ImageOnlyFailure Pass Failure ]
 
 # These WebVTT rendering WPT occasionally time out.
 imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/2_tracks.html [ Skip ]

--- a/LayoutTests/media/track/vtt-cue-root-selector-expected.txt
+++ b/LayoutTests/media/track/vtt-cue-root-selector-expected.txt
@@ -1,0 +1,10 @@
+
+EVENT(canplaythrough)
+EVENT(seeked)
+Test that ::cue(:root) targets the cue element's text color.
+EXPECTED (cueStyle.color == 'rgb(0, 255, 0)') OK
+
+Test that the document :root selector does not affect the cue element background color.
+EXPECTED (cueStyle.backgroundColor != 'rgb(255, 0, 0)' == 'true') OK
+END OF TEST
+

--- a/LayoutTests/media/track/vtt-cue-root-selector.html
+++ b/LayoutTests/media/track/vtt-cue-root-selector.html
@@ -1,0 +1,58 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Test that ::cue(:root) matches the cue element but :root does not</title>
+    <script src=../media-file.js></script>
+    <script src=../video-test.js></script>
+    <style>
+    ::cue(:root) {
+        color: lime;
+    }
+    :root {
+        background-color: red;
+    }
+    </style>
+    <script>
+    if (window.testRunner)
+        testRunner.dumpAsText();
+
+    function cueElement() {
+        return internals.shadowRoot(video).querySelector('[useragentpart="cue"]');
+    }
+
+    window.addEventListener('load', function() {
+        findMediaElement();
+        video.src = findMediaFile('video', '../content/test');
+        video.textTracks[0].mode = 'showing';
+
+        waitForEvent('canplaythrough', function() {
+            video.currentTime = 0.5;
+        });
+
+        waitForEvent('seeked', function() {
+            var cue = cueElement();
+            if (!cue) {
+                consoleWrite("FAIL: Could not find cue element in shadow root.");
+                endTest();
+                return;
+            }
+
+            window.cueStyle = getComputedStyle(cue);
+            consoleWrite("Test that ::cue(:root) targets the cue element's text color.");
+            testExpected("cueStyle.color", "rgb(0, 255, 0)");
+
+            consoleWrite("");
+            consoleWrite("Test that the document :root selector does not affect the cue element background color.");
+            testExpected("cueStyle.backgroundColor != 'rgb(255, 0, 0)'", true);
+
+            endTest();
+        });
+    });
+    </script>
+</head>
+<body>
+    <video>
+        <track src="captions-webvtt/captions.vtt" kind="captions" default>
+    </video>
+</body>
+</html>

--- a/LayoutTests/media/track/vtt-cue-root-viewtransitionname-expected.txt
+++ b/LayoutTests/media/track/vtt-cue-root-viewtransitionname-expected.txt
@@ -1,0 +1,7 @@
+
+EVENT(canplaythrough)
+EVENT(seeked)
+Test that the cue element does not inherit view-transition-name from :root.
+EXPECTED (cueStyle.viewTransitionName == 'none') OK
+END OF TEST
+

--- a/LayoutTests/media/track/vtt-cue-root-viewtransitionname.html
+++ b/LayoutTests/media/track/vtt-cue-root-viewtransitionname.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Test that :root view-transition-name does not apply to the cue element</title>
+    <script src=../media-file.js></script>
+    <script src=../video-test.js></script>
+    <script>
+    if (window.testRunner)
+        testRunner.dumpAsText();
+
+    function cueElement() {
+        return internals.shadowRoot(video).querySelector('[useragentpart="cue"]');
+    }
+
+    window.addEventListener('load', function() {
+        findMediaElement();
+        video.src = findMediaFile('video', '../content/test');
+        video.textTracks[0].mode = 'showing';
+
+        waitForEvent('canplaythrough', function() {
+            video.currentTime = 0.5;
+        });
+
+        waitForEvent('seeked', function() {
+            var cue = cueElement();
+            if (!cue) {
+                consoleWrite("FAIL: Could not find cue element in shadow root.");
+                endTest();
+                return;
+            }
+
+            window.cueStyle = getComputedStyle(cue);
+            consoleWrite("Test that the cue element does not inherit view-transition-name from :root.");
+            testExpected("cueStyle.viewTransitionName", "none");
+
+            endTest();
+        });
+    });
+    </script>
+</head>
+<body>
+    <video>
+        <track src="captions-webvtt/captions.vtt" kind="captions" default>
+    </video>
+</body>
+</html>

--- a/LayoutTests/platform/gtk/TestExpectations
+++ b/LayoutTests/platform/gtk/TestExpectations
@@ -64,6 +64,8 @@ imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-mode
 imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/voice_object/voice_white-space_nowrap.html [ Pass ]
 imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/voice_object/voice_white-space_pre-wrap_wrapped.html [ Pass ]
 
+imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/not_allowed_properties.html [ ImageOnlyFailure ]
+
 #////////////////////////////////////////////////////////////////////////////////////////
 # End of PASSING tests. See below where to put expected failures.
 #////////////////////////////////////////////////////////////////////////////////////////

--- a/LayoutTests/platform/wpe/TestExpectations
+++ b/LayoutTests/platform/wpe/TestExpectations
@@ -1102,6 +1102,8 @@ webkit.org/b/287572 imported/w3c/web-platform-tests/webvtt/rendering/cues-with-v
 webkit.org/b/287572 imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/voice_object/voice_voice_attribute.html [ ImageOnlyFailure ]
 webkit.org/b/287572 imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/voice_object/voice_with_class.html [ ImageOnlyFailure ]
 webkit.org/b/287572 imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/voice_object/voice_with_class_object_specific_selector.html [ ImageOnlyFailure ]
+webkit.org/b/287572 imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/white-space_normal_wrapped.html [ ImageOnlyFailure ]
+webkit.org/b/287572 imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/white-space_nowrap_wrapped.html [ ImageOnlyFailure ]
 webkit.org/b/287572 imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/white-space_pre-line_wrapped.html [ ImageOnlyFailure ]
 webkit.org/b/287572 imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue/text-decoration_line-through.html [ ImageOnlyFailure ]
 webkit.org/b/287572 imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue/text-decoration_overline.html [ ImageOnlyFailure ]

--- a/Source/WebCore/css/SelectorChecker.cpp
+++ b/Source/WebCore/css/SelectorChecker.cpp
@@ -54,6 +54,9 @@
 #include "StyleScope.h"
 #include "Text.h"
 #include "TypedElementDescendantIteratorInlines.h"
+#if ENABLE(VIDEO)
+#include "UserAgentParts.h"
+#endif
 #include "ViewTransition.h"
 #include "ViewTransitionTypeSet.h"
 #include <wtf/NeverDestroyed.h>
@@ -1151,6 +1154,10 @@ bool SelectorChecker::checkOne(CheckingContext& checkingContext, LocalContext& c
         case CSSSelector::PseudoClass::Root:
             if (element.ptr() == element->document().documentElement())
                 return true;
+#if ENABLE(VIDEO)
+            if (element->isInUserAgentShadowTree() && element->userAgentPart() == UserAgentParts::cue())
+                return true;
+#endif
             break;
         case CSSSelector::PseudoClass::Lang:
             ASSERT(selector.langList() && !selector.langList()->isEmpty());

--- a/Source/WebCore/style/ElementRuleCollector.cpp
+++ b/Source/WebCore/style/ElementRuleCollector.cpp
@@ -57,6 +57,9 @@
 #include "StyleSheetContents.h"
 #include "StyledElement.h"
 #include "UserAgentStyle.h"
+#if ENABLE(VIDEO)
+#include "UserAgentParts.h"
+#endif
 #include <ranges>
 #include <wtf/SetForScope.h>
 
@@ -491,7 +494,7 @@ void ElementRuleCollector::collectMatchingUserAgentPartRules(const MatchRequest&
 
     auto& rules = matchRequest.ruleSet;
 #if ENABLE(VIDEO)
-    if (element().isWebVTTElement())
+    if (element().isWebVTTElement() || element().userAgentPart() == UserAgentParts::cue())
         collectMatchingRulesForList(&rules.cuePseudoRules(), matchRequest);
 #endif
     if (auto& part = element().userAgentPart(); !part.isEmpty())


### PR DESCRIPTION
#### dda914a43403e3e7806c40b6cb377c53d35721bc
<pre>
::cue(selector) should be able to match WebVTT root object
<a href="https://rdar.apple.com/175550173">rdar://175550173</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=313274">https://bugs.webkit.org/show_bug.cgi?id=313274</a>

Reviewed by Jer Noble.

Previously, ::cue(selector) rules were only matched against WebVTT
internal node objects (e.g., bold, italic, voice elements). This meant
selectors like ::cue(#foo) could never match, since the cue ID is set
on the TextTrackCueBox (useragentpart=&quot;cue&quot;), not on any child
WebVTTElement.

Extend cuePseudoRules collection to also include elements with
userAgentPart=&quot;cue&quot;, so that ::cue(selector) can match the root cue
element in addition to its children.

To make the case ::cue(:root) work, treat the TextTrackCueBox as matching
:root, per the WebVTT spec.

Added new test media/track/vtt-cue-root-selector.html that tests that ::cue(:root)
but not :root targets the cue, and media/track/vtt-cue-root-viewtransitionname.html,
which tests that the user agent styles applied on :root elements do not get applied
on the cue.

* LayoutTests/TestExpectations:
* LayoutTests/media/track/vtt-cue-root-selector-expected.txt: Added.
* LayoutTests/media/track/vtt-cue-root-selector.html: Added.
* LayoutTests/media/track/vtt-cue-root-viewtransitionname-expected.txt: Added.
* LayoutTests/media/track/vtt-cue-root-viewtransitionname.html: Added.
* LayoutTests/platform/gtk/TestExpectations:
* LayoutTests/platform/wpe/TestExpectations:
* Source/WebCore/css/SelectorChecker.cpp:
(WebCore::SelectorChecker::checkOne const):
* Source/WebCore/style/ElementRuleCollector.cpp:
(WebCore::Style::ElementRuleCollector::collectMatchingUserAgentPartRules):

Canonical link: <a href="https://commits.webkit.org/312292@main">https://commits.webkit.org/312292@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f28431729a1d0c4667cc064497a42bb74c54bd0d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/159310 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/32738 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/25843 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/168140 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/113688 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/9978ad75-2f9b-467a-9462-08f910eee5cf) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/161179 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/32806 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/32725 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/123434 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/86642 "1 flakes 1 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/c2c6664d-aabd-4e12-9b33-52abf53ec162) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/162267 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/25693 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/143090 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/104101 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/997f62aa-754e-4b6e-80eb-a6fe37a831c4) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/24746 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/23180 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/15913 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/134433 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/20870 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/170634 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/16668 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/22496 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/131633 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/32427 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/27252 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/131746 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/32371 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/142663 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/90496 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/24271 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/26427 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/19472 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/31882 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/98334 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/31402 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/31675 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/31557 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->