### PR TITLE
Canvas descendants not in the flat tree should not be focusable

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-canvas-element/canvas-descendants-focusability-004.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-canvas-element/canvas-descendants-focusability-004.tentative-expected.txt
@@ -1,7 +1,7 @@
 
-FAIL <button data-focusable="false"> assert_true: Shouldn't be focused expected true got false
-FAIL <section tabindex="-1" data-focusable="false"> assert_true: Shouldn't be focused expected true got false
-FAIL <div tabindex="-1" data-focusable="false"> assert_true: Shouldn't be focused expected true got false
-FAIL <span tabindex="-1" data-focusable="false"> assert_true: Shouldn't be focused expected true got false
-FAIL <a href="#" data-focusable="false"> assert_true: Shouldn't be focused expected true got false
+PASS <button data-focusable="false">
+PASS <section tabindex="-1" data-focusable="false">
+PASS <div tabindex="-1" data-focusable="false">
+PASS <span tabindex="-1" data-focusable="false">
+PASS <a href="#" data-focusable="false">
 

--- a/Source/WebCore/dom/Element.cpp
+++ b/Source/WebCore/dom/Element.cpp
@@ -922,6 +922,17 @@ bool Element::isFocusable() const
         RefPtr canvas = ancestorsOfType<HTMLCanvasElement>(*this).first();
         if (canvas && !canvas->hasFocusableStyle())
             return false;
+        // When the canvas represents embedded content, descendants are not rendered
+        // but can still be focusable. Verify the element is actually in the flat tree
+        // and not excluded by shadow DOM (e.g. unslotted children of a shadow host).
+        if (CheckedPtr canvasRenderer = canvas ? canvas->renderer() : nullptr; canvasRenderer && canvasRenderer->isRenderHTMLCanvas()) {
+            for (RefPtr<const Node> node = this; node && node != canvas.get(); node = node->parentElement()) {
+                if (RefPtr parent = node->parentElement()) {
+                    if (parent->shadowRoot() && !node->assignedSlot())
+                        return false;
+                }
+            }
+        }
     }
 
     return hasFocusableStyle();

--- a/Source/WebCore/dom/Element.cpp
+++ b/Source/WebCore/dom/Element.cpp
@@ -932,10 +932,29 @@ bool Element::isFocusable() const
         return false;
 
     if (!renderer()) {
-        // Elements in canvas fallback content are not rendered, but they are allowed to be
-        // focusable as long as their canvas is displayed and visible.
-        RefPtr canvas = ancestorsOfType<HTMLCanvasElement>(*this).first();
-        if (canvas && !canvas->hasFocusableStyle())
+        // An element with no renderer may still be focusable as canvas fallback content. Per
+        // spec, that requires its nearest canvas ancestor in the flat tree to be displayed and
+        // visible, so we walk the flat tree once:
+        //
+        //   - If we reach a canvas, this element is fallback content and is focusable only if
+        //     that canvas is displayed and visible.
+        //   - If we leave the flat tree before reaching the document element (e.g. an unslotted
+        //     descendant of a shadow host), this element is not in the flat tree and so is not
+        //     focusable. This must be checked here because hasFocusableStyle() resolves a
+        //     "rendered" style even for elements outside the flat tree.
+        //   - Otherwise (e.g. inside a skipped content-visibility:auto subtree with no canvas
+        //     ancestor) we fall through to hasFocusableStyle(), preserving the scroll-on-focus
+        //     and focus-visible paths.
+        bool reachedRoot = false;
+        for (Ref ancestor : composedTreeAncestors(*this)) {
+            if (RefPtr canvas = dynamicDowncast<HTMLCanvasElement>(ancestor.get()))
+                return canvas->hasFocusableStyle() && hasFocusableStyle();
+            if (ancestor.ptr() == document().documentElement()) {
+                reachedRoot = true;
+                break;
+            }
+        }
+        if (!reachedRoot)
             return false;
     }
 


### PR DESCRIPTION
#### f858f8524aa70a0d731c2e04d4e694d63bce9ead
<pre>
Canvas descendants not in the flat tree should not be focusable
<a href="https://bugs.webkit.org/show_bug.cgi?id=313467">https://bugs.webkit.org/show_bug.cgi?id=313467</a>
<a href="https://rdar.apple.com/175699073">rdar://175699073</a>

Reviewed by NOBODY (OOPS!).

Per specification [1], an element is &quot;being used as relevant canvas
fallback content&quot; only if its nearest canvas element ancestor in the
flat tree is being rendered and represents embedded content. Elements
not assigned to a slot inside a shadow host are not in the flat tree and
should not be considered focusable canvas fallback content.

Element::isFocusable() reaches hasFocusableStyle() for elements with no
renderer, and hasFocusableStyle() resolves a &quot;rendered&quot; style even for
elements outside the flat tree -- which is what made unslotted canvas
fallback content focusable. Walk the flat tree (composed tree) once from
the element:

  - If a canvas ancestor is reached, the element is fallback content and
    is focusable only if that canvas is displayed and visible.
  - If the walk leaves the flat tree before reaching the document element
    (e.g. an unslotted descendant of a shadow host), the element is not
    in the flat tree and is not focusable.
  - Otherwise (e.g. inside a skipped content-visibility:auto subtree with
    no canvas ancestor) we fall through to hasFocusableStyle() as before,
    preserving the scroll-on-focus and focus-visible paths.

[1] <a href="https://html.spec.whatwg.org/multipage/canvas.html#being-used-as-relevant-canvas-fallback-content">https://html.spec.whatwg.org/multipage/canvas.html#being-used-as-relevant-canvas-fallback-content</a>

* LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-canvas-element/canvas-descendants-focusability-004.tentative-expected.txt: Progressions
* Source/WebCore/dom/Element.cpp:
(WebCore::Element::isFocusable const):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f858f8524aa70a0d731c2e04d4e694d63bce9ead

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/165461 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/38951 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/32532 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/174503 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/122716 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/d10f8b14-2967-4a48-93c4-e49c2070d5b3) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/167327 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/39287 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/38955 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/128631 "Found 1 new test failure: fast/text/out-of-flow-line-break-crash.html (failure)") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/90505 "1 flakes 2 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/51852a30-7cc2-4b73-9251-f2ebd722b5ff) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/168420 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/30890 "Found 3 new test failures: fast/events/touch/ios/touch-event-regions-layer-tree/mousemove-mouseup.html fast/forms/ios/drag-range-track.html fast/text/out-of-flow-line-break-crash.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/148652 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/109105 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/f0e325d5-4de7-469a-af55-f3031eb14bb6) 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/29936 "Found 2 new test failures: imported/w3c/web-platform-tests/css/css-images/gradients-with-border.html imported/w3c/web-platform-tests/css/css-images/multiple-position-color-stop-linear.html (failure)") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/28568 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/22578 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/139831 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/26350 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/177027 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/29936 "Built successfully") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/28055 "Found 1 new test failure: fast/text/out-of-flow-line-break-crash.html (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/136957 "Found 1 new test failure: fast/text/out-of-flow-line-break-crash.html (failure)") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/39020 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/32762 "Found 2 new test failures: fast/text/out-of-flow-line-break-crash.html imported/w3c/web-platform-tests/css/css-display/display-contents-svg-elements.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/136841 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/39708 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/148146 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/102087 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/32111 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/25013 "Found 1 new test failure: fast/text/out-of-flow-line-break-crash.html (failure)") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/38218 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/111292 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/37615 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/3093 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/37861 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/37759 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->