### PR TITLE
Media controls loading indicator overlaps playhead while WebKit bug attachment is loading

### DIFF
--- a/LayoutTests/media/modern-media-controls/time-control/time-control-loading-indicator-layout-expected.txt
+++ b/LayoutTests/media/modern-media-controls/time-control/time-control-loading-indicator-layout-expected.txt
@@ -1,0 +1,11 @@
+TimeControl activity indicator must occupy a flex slot when loading rather than overlapping the scrubber.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS getComputedStyle(timeControl.activityIndicator.element).position is "relative"
+PASS timeControl.activityIndicator.element.getBoundingClientRect().right <= timeControl.scrubber.element.getBoundingClientRect().left is true
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/media/modern-media-controls/time-control/time-control-loading-indicator-layout.html
+++ b/LayoutTests/media/modern-media-controls/time-control/time-control-loading-indicator-layout.html
@@ -1,0 +1,19 @@
+<script src="../../../resources/js-test.js"></script>
+<script src="../resources/media-controls-loader.js"></script>
+<body>
+<script>
+description("TimeControl activity indicator must occupy a flex slot when loading rather than overlapping the scrubber.");
+
+const timeControl = new TimeControl({ layoutTraits: new MacOSLayoutTraits(LayoutTraits.Mode.Inline) });
+document.body.appendChild(timeControl.element);
+timeControl.width = 500;
+timeControl.loading = true;
+scheduler.flushScheduledLayoutCallbacks();
+scheduler.flushScheduledLayoutCallbacks();
+
+shouldBeEqualToString("getComputedStyle(timeControl.activityIndicator.element).position", "relative");
+shouldBeTrue("timeControl.activityIndicator.element.getBoundingClientRect().right <= timeControl.scrubber.element.getBoundingClientRect().left");
+
+timeControl.element.remove();
+</script>
+</body>

--- a/Source/WebCore/Modules/modern-media-controls/controls/activity-indicator.css
+++ b/Source/WebCore/Modules/modern-media-controls/controls/activity-indicator.css
@@ -24,7 +24,7 @@
  */
 
 .activity-indicator {
-    position: absolute;
+    position: relative;
     mix-blend-mode: plus-lighter;
     width: 14px;
     height: 14px;


### PR DESCRIPTION
#### 886194c45df18442d88de9cb1839c66694ff1956
<pre>
Media controls loading indicator overlaps playhead while WebKit bug attachment is loading
<a href="https://bugs.webkit.org/show_bug.cgi?id=313471">https://bugs.webkit.org/show_bug.cgi?id=313471</a>
<a href="https://rdar.apple.com/174394222">rdar://174394222</a>

Reviewed by Jer Noble.

The activity indicator&apos;s position: absolute removed it from the flex flow
inside .time-control, so the scrubber&apos;s flex-grow reclaimed the slot it
should have occupied and put the activity indicator directly on top of the
scrubber.

This change modifies the indicator to position: relative which lets it
participate as a flex item, stopping the indicator from overlapping
with the playhead.

Test: media/modern-media-controls/time-control/time-control-loading-indicator-layout.html

* LayoutTests/media/modern-media-controls/time-control/time-control-loading-indicator-layout-expected.txt: Added.
* LayoutTests/media/modern-media-controls/time-control/time-control-loading-indicator-layout.html: Added.
* Source/WebCore/Modules/modern-media-controls/controls/activity-indicator.css:
(.activity-indicator):

Canonical link: <a href="https://commits.webkit.org/312291@main">https://commits.webkit.org/312291@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e8b41ba3c35d243b9e8ce34b60490567c55c9565

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/159051 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/32479 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/25584 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/167880 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/113135 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/160920 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/32546 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/32466 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/123223 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/86523 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/162008 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/25507 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/142882 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/103890 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/24561 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/22970 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/15653 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/134247 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/20662 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/170373 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/16115 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/22288 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/131413 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/32168 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/27039 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/131525 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35668 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/32112 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/142455 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/90162 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/26236 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/19264 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/31623 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/97637 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/31143 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/31416 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/31298 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->