### PR TITLE
[JSC] $vm.createBuiltin should throw instead of crashing when given invalid input

### DIFF
--- a/JSTests/stress/dollar-vm-create-builtin-malformed-source.js
+++ b/JSTests/stress/dollar-vm-create-builtin-malformed-source.js
@@ -1,0 +1,36 @@
+//@ requireOptions("--useDollarVM=1")
+
+function shouldThrow(fn) {
+    let threw = false;
+    try {
+        fn();
+    } catch (e) {
+        threw = true;
+        if (!(e instanceof TypeError))
+            throw new Error("expected TypeError, got " + e);
+    }
+    if (!threw)
+        throw new Error("expected to throw");
+}
+
+// rdar://175155846: BuiltinExecutables::createExecutable uses a hand-rolled parser that
+// RELEASE_ASSERTs on input that does not match the exact shape produced by the builtins
+// generator. $vm.createBuiltin must reject such input instead of crashing.
+
+// Missing space between "function" and "(".
+shouldThrow(() => $vm.createBuiltin('(function(o){return @getByIdDirectPrivate(o,"prototype")})'));
+
+// Assorted malformed shapes.
+shouldThrow(() => $vm.createBuiltin(''));
+shouldThrow(() => $vm.createBuiltin('function (){}'));
+shouldThrow(() => $vm.createBuiltin('(function )'));
+shouldThrow(() => $vm.createBuiltin('(function (xxxxxxxxxxxxxxxxxx'));
+shouldThrow(() => $vm.createBuiltin('(function (a,b)a+b)'));
+shouldThrow(() => $vm.createBuiltin('(async function(){})'));
+shouldThrow(() => $vm.createBuiltin('(function (\u{1F600}){})'));
+
+// Well-formed shapes still work.
+if (typeof $vm.createBuiltin('(function (a, b) { return a + b; })') !== "function")
+    throw new Error("well-formed builtin should produce a function");
+if (typeof $vm.createBuiltin('(async function (a) { return a; })') !== "function")
+    throw new Error("well-formed async builtin should produce a function");

--- a/Source/JavaScriptCore/tools/JSDollarVM.cpp
+++ b/Source/JavaScriptCore/tools/JSDollarVM.cpp
@@ -3453,6 +3453,25 @@ JSC_DEFINE_HOST_FUNCTION(functionCreateBuiltin, (JSGlobalObject* globalObject, C
     auto functionText = asString(callFrame->argument(0))->value(globalObject);
     RETURN_IF_EXCEPTION(scope, encodedJSValue());
 
+    // BuiltinExecutables::createExecutable uses a hand-rolled single-function parser that
+    // RELEASE_ASSERTs (and can scan past the buffer) when its input does not match the exact
+    // shape produced by the builtins generator. Real builtins always satisfy that shape; reject
+    // anything else here so fuzzer-supplied source via $vm.createBuiltin throws instead of crashing.
+    {
+        StringView view { functionText };
+        constexpr auto regularPrefix = "(function ("_s;
+        constexpr auto asyncPrefix = "(async function ("_s;
+        bool isAsync = view.length() >= strlen("(async function (){})") && view.startsWith(asyncPrefix);
+        bool isRegular = !isAsync && view.length() >= strlen("(function (){})") && view.startsWith(regularPrefix);
+        bool isValid = view.is8Bit() && (isAsync || isRegular);
+        if (isValid) {
+            unsigned afterOpenParen = isAsync ? asyncPrefix.length() : regularPrefix.length();
+            isValid = view.find(')', afterOpenParen) != notFound && view.reverseFind('}') != notFound;
+        }
+        if (!isValid)
+            return throwVMTypeError(globalObject, scope, "$vm.createBuiltin source must be an 8-bit string of the form '(function (...){...})' or '(async function (...){...})'"_s);
+    }
+
     ImplementationVisibility visibility = ImplementationVisibility::Public;
     if (callFrame->argumentCount() >= 2 && callFrame->argument(1).isString()) {
         String visibilityString = asString(callFrame->argument(1))->value(globalObject);


### PR DESCRIPTION
#### eee86c7e3491ea96e9501d7a39386b8168a9ddd8
<pre>
[JSC] $vm.createBuiltin should throw instead of crashing when given invalid input
<a href="https://bugs.webkit.org/show_bug.cgi?id=313479">https://bugs.webkit.org/show_bug.cgi?id=313479</a>
<a href="https://rdar.apple.com/175155846">rdar://175155846</a>

Reviewed by NOBODY (OOPS!).

This patch modifies $vm.createBuiltin to throw if given invalid input.
Previously, it would fail a RELEASE_ASSERT and crash.

Test: JSTests/stress/dollar-vm-create-builtin-malformed-source.js

* JSTests/stress/dollar-vm-create-builtin-malformed-source.js: Added.
(shouldThrow):
* Source/JavaScriptCore/tools/JSDollarVM.cpp:
(JSC::JSC_DEFINE_HOST_FUNCTION):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/eee86c7e3491ea96e9501d7a39386b8168a9ddd8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/159060 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/32488 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/25593 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/167889 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/113144 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/6a75543d-60f5-4a95-8796-2c86abf82f50) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/160929 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/32555 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/32475 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/123226 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/86527 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/cc2a2f52-9a5d-4aec-8353-0216df5bb402) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/162017 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/25526 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/142885 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/103893 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/733f07da-4c89-4813-a300-4c1f44b71575) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/24580 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/22977 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/15662 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/151110 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/134266 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/20665 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/170382 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/19893 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/16124 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/22291 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/131416 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/32177 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/27046 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/131528 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/32121 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/142458 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/90171 "The change is no longer eligible for processing.") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/26239 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/19267 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/191342 "Build is in progress. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled JSC") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/31632 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/97646 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/49178 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/31152 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/31425 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/31307 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->