### PR TITLE
[CMake] Match the Xcode build's approach to bmalloc/WTF/JSC

### DIFF
--- a/Source/WTF/WTFPrefix.h
+++ b/Source/WTF/WTFPrefix.h
@@ -23,6 +23,10 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+#if defined(HAVE_CONFIG_H) && HAVE_CONFIG_H && defined(BUILDING_WITH_CMAKE)
+#include "cmakeconfig.h"
+#endif
+
 #ifdef __cplusplus
 #include <wtf/HashSet.h>
 #include <wtf/MathExtras.h>

--- a/Source/WTF/wtf/PlatformMac.cmake
+++ b/Source/WTF/wtf/PlatformMac.cmake
@@ -140,3 +140,5 @@ list(APPEND WTF_SOURCES
     ${WTF_DERIVED_SOURCES_DIR}/mach_excServer.c
     ${WTF_DERIVED_SOURCES_DIR}/mach_excUser.c
 )
+
+ADD_WEBKIT_PREFIX_HEADERS(WTF ../WTFPrefix.h)

--- a/Source/WebGPU/WGSL/CMakeLists.txt
+++ b/Source/WebGPU/WGSL/CMakeLists.txt
@@ -213,7 +213,7 @@ target_include_directories(WGSLCore PUBLIC
     ${CMAKE_CURRENT_SOURCE_DIR}
     ${CMAKE_CURRENT_SOURCE_DIR}/AST
     ${CMAKE_CURRENT_SOURCE_DIR}/Metal)
-target_link_libraries(WGSLCore PUBLIC WebKit::WTF WebKit::bmalloc)
+target_link_libraries(WGSLCore PUBLIC WebKit::JavaScriptCore)
 add_dependencies(WGSLCore wgsl-types)
 
 if (DEVELOPER_MODE_CXX_FLAGS)

--- a/Source/WebGPU/WebGPU/CMakeLists.txt
+++ b/Source/WebGPU/WebGPU/CMakeLists.txt
@@ -92,7 +92,7 @@ target_link_libraries(WebGPU PRIVATE
     ${COREVIDEO_FRAMEWORK}
     ${FOUNDATION_FRAMEWORK}
     ${QUARTZCORE_FRAMEWORK}
-    WTF
+    JavaScriptCore
 )
 
 target_include_directories(WebGPU PRIVATE

--- a/Source/bmalloc/PlatformMac.cmake
+++ b/Source/bmalloc/PlatformMac.cmake
@@ -1,5 +1,7 @@
 add_definitions(-DBPLATFORM_MAC=1)
 
+list(APPEND bmalloc_PRIVATE_DEFINITIONS PAS_BMALLOC_HIDDEN=1)
+
 list(APPEND bmalloc_PUBLIC_HEADERS
     Configurations/module.modulemap
 )

--- a/Source/cmake/OptionsMac.cmake
+++ b/Source/cmake/OptionsMac.cmake
@@ -169,13 +169,13 @@ set(ENABLE_WEBKIT_LEGACY ON)
 set(ENABLE_WEBKIT ON)
 
 set(bmalloc_LIBRARY_TYPE OBJECT)
-# WTF must be SHARED on Mac because the Mac port builds multiple frameworks
-# (JSC, WebCore, WebKit, WebGPU) that all need WTF. OBJECT would duplicate
-# WTF's static state in each framework, causing crashes. Other ports (GTK/WPE)
-# use OBJECT because they produce a single libwebkit.so.
+# bmalloc and WTF objects are absorbed into the JavaScriptCore dylib
+# (mirrors Xcode's -force_load libWTF.a / libbmalloc.a). Downstream
+# frameworks link JavaScriptCore only; WEBKIT_FRAMEWORK's LINKED_INTO
+# tracking redirects WTF/bmalloc references there.
 # PAL must be STATIC (not OBJECT) because it has Swift CryptoKit sources and
 # OBJECT libraries don't produce .swiftmodule files.
-set(WTF_LIBRARY_TYPE SHARED)
+set(WTF_LIBRARY_TYPE OBJECT)
 set(JavaScriptCore_LIBRARY_TYPE SHARED)
 set(PAL_LIBRARY_TYPE STATIC)
 set(WebCore_LIBRARY_TYPE SHARED)


### PR DESCRIPTION
#### 723db2e10e023f979bc52d815f358866ec4fb983
<pre>
[CMake] Match the Xcode build&apos;s approach to bmalloc/WTF/JSC
<a href="https://bugs.webkit.org/show_bug.cgi?id=313477">https://bugs.webkit.org/show_bug.cgi?id=313477</a>
<a href="https://rdar.apple.com/175703628">rdar://175703628</a>

Reviewed by Yusuke Suzuki.

Make WTF a .o target rather than a .dylib. Then JavaScriptCore.dylib exports WTF
symbols to client frameworks.

This enables turning on PAS_BMALLOC_HIDDEN, which saves duplicate compilation
of bmalloc.

Also adopt the WTF prefix header.

Total build speedup is about 2s in clean or touch-one-file build.

* Source/WTF/WTFPrefix.h: Just CMake things.

* Source/WTF/wtf/PlatformMac.cmake:

* Source/WebGPU/WGSL/CMakeLists.txt: Link JavaScriptCore like we do in the
Xcode build.
* Source/WebGPU/WebGPU/CMakeLists.txt: Ditto

* Source/bmalloc/PlatformMac.cmake: Adopt PAS_BMALLOC_HIDDEN.

* Source/cmake/OptionsMac.cmake: WTF can be a .o target now, which is faster.

Canonical link: <a href="https://commits.webkit.org/312155@main">https://commits.webkit.org/312155@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/68c6c86d4cc7aa58c5481fea14f2aa2f987219ea

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/159062 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/32490 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/25595 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/167891 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/113146 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/ba5a5d58-066e-441d-ab02-dada2149a87b) 
| | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/32557 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/32477 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/123227 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/113146 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/b2f51f70-4321-4fc9-8f0e-5d60c44ae639) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/162019 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/32557 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/142890 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/103894 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/32557 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/22978 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/15664 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/151112 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/32557 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/20670 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/170384 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/19895 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/16126 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/22296 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/131417 "Passed tests") | | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/32179 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/27047 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/131529 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/32123 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/142463 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/90173 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/24211 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/164/builds/26240 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/19272 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/191344 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/31634 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/97648 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/49179 "Passed tests") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/31154 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/31427 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/31309 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->