### PR TITLE
Bounding box does not account for skinning transforms

### DIFF
--- a/Source/WebKit/GPUProcess/graphics/Model/ModelBridge.swift
+++ b/Source/WebKit/GPUProcess/graphics/Model/ModelBridge.swift
@@ -134,6 +134,7 @@ extension WKBridgeSkinningData {
     let influenceJointIndicesData: Data?
     let influenceWeightsData: Data?
     let geometryBindTransform: simd_float4x4
+    let rootJointIndicesData: Data?
 
     init(
         influencePerVertexCount: UInt8,
@@ -141,7 +142,8 @@ extension WKBridgeSkinningData {
         inverseBindPoses: Data?,
         influenceJointIndices: Data?,
         influenceWeights: Data?,
-        geometryBindTransform: simd_float4x4
+        geometryBindTransform: simd_float4x4,
+        rootJointIndices: Data?
     ) {
         self.influencePerVertexCount = influencePerVertexCount
         self.jointTransformsData = jointTransforms
@@ -149,6 +151,7 @@ extension WKBridgeSkinningData {
         self.influenceJointIndicesData = influenceJointIndices
         self.influenceWeightsData = influenceWeights
         self.geometryBindTransform = geometryBindTransform
+        self.rootJointIndicesData = rootJointIndices
     }
 }
 
@@ -684,9 +687,10 @@ extension WKBridgeSkinningData {
     var inverseBindPoses: [simd_float4x4] { inverseBindPosesData.map { decodeValues(from: $0) } ?? [] }
     var influenceJointIndices: [UInt32] { influenceJointIndicesData.map { decodeValues(from: $0) } ?? [] }
     var influenceWeights: [Float] { influenceWeightsData.map { decodeValues(from: $0) } ?? [] }
+    var rootJointIndices: [UInt32] { rootJointIndicesData.map { decodeValues(from: $0) } ?? [] }
 
     @nonobjc
-    convenience init?(_ request: _Proto_DeformationData_v1.SkinningData?) {
+    convenience init?(_ request: _Proto_DeformationData_v1.SkinningData?, rootJointIndices: [UInt32] = []) {
         guard let request else {
             return nil
         }
@@ -697,7 +701,8 @@ extension WKBridgeSkinningData {
             inverseBindPoses: toData(request.inverseBindPosesCompat()),
             influenceJointIndices: toData(request.influenceJointIndices),
             influenceWeights: toData(request.influenceWeights),
-            geometryBindTransform: request.geometryBindTransformCompat()
+            geometryBindTransform: request.geometryBindTransformCompat(),
+            rootJointIndices: rootJointIndices.isEmpty ? nil : toData(rootJointIndices)
         )
     }
 }
@@ -731,13 +736,13 @@ extension WKBridgeRenormalizationData {
 }
 extension WKBridgeDeformationData {
     @nonobjc
-    convenience init?(_ request: _Proto_DeformationData_v1?) {
+    convenience init?(_ request: _Proto_DeformationData_v1?, rootJointIndices: [UInt32] = []) {
         guard let request else {
             return nil
         }
 
         self.init(
-            skinningData: .init(request.skinningData),
+            skinningData: .init(request.skinningData, rootJointIndices: rootJointIndices),
             blendShapeData: .init(request.blendShapeData),
             renormalizationData: .init(request.renormalizationData)
         )

--- a/Source/WebKit/GPUProcess/graphics/Model/ModelTypes.h
+++ b/Source/WebKit/GPUProcess/graphics/Model/ModelTypes.h
@@ -137,9 +137,10 @@ typedef NS_ENUM(uint8_t, WKBridgeVertexSemantic) {
 @property (nonatomic, readonly, nullable) NSData *influenceJointIndicesData; // [UInt32]
 @property (nonatomic, readonly, nullable) NSData *influenceWeightsData; // [Float]
 @property (nonatomic, readonly) simd_float4x4 geometryBindTransform;
+@property (nonatomic, readonly, nullable) NSData *rootJointIndicesData; // [UInt32] indices of joints with no parent in the skeleton
 
 - (instancetype)init NS_UNAVAILABLE;
-- (instancetype)initWithInfluencePerVertexCount:(uint8_t)influencePerVertexCount jointTransforms:(nullable NSData *)jointTransforms inverseBindPoses:(nullable NSData *)inverseBindPoses influenceJointIndices:(nullable NSData *)influenceJointIndices influenceWeights:(nullable NSData *)influenceWeights geometryBindTransform:(simd_float4x4)geometryBindTransform NS_DESIGNATED_INITIALIZER;
+- (instancetype)initWithInfluencePerVertexCount:(uint8_t)influencePerVertexCount jointTransforms:(nullable NSData *)jointTransforms inverseBindPoses:(nullable NSData *)inverseBindPoses influenceJointIndices:(nullable NSData *)influenceJointIndices influenceWeights:(nullable NSData *)influenceWeights geometryBindTransform:(simd_float4x4)geometryBindTransform rootJointIndices:(nullable NSData *)rootJointIndices NS_DESIGNATED_INITIALIZER;
 
 @end
 
@@ -770,6 +771,10 @@ struct SkinningData {
     Vector<uint32_t> influenceJointIndices;
     Vector<float> influenceWeights;
     Float4x4 geometryBindTransform;
+    // Indices into jointTransforms/inverseBindPoses for joints with no parent in the
+    // skeleton hierarchy. Computed from the USD joint token paths at load time.
+    // Empty means the caller should fall back to index 0 (single-root assumption).
+    Vector<uint32_t> rootJointIndices;
 };
 
 struct BlendShapeData {

--- a/Source/WebKit/GPUProcess/graphics/Model/USDModel.swift
+++ b/Source/WebKit/GPUProcess/graphics/Model/USDModel.swift
@@ -354,6 +354,100 @@ internal func logInfo(_ info: String) {
     Logger.modelGPU.info("\(info)")
 }
 
+// Mirrors RemoteMeshProxy.cpp::computeMinAndMaxCorners: for each root joint, computes
+// the skin matrix that places the mesh in world space for AABB purposes, returning
+// one matrix per root joint. Using only root joints avoids wildly over-inflating the
+// bounds — child joints move sub-regions that stay within the local AABB extent.
+private func rootSkinMatrices(_ skinningData: WKBridgeSkinningData) -> [simd_float4x4] {
+    let jointTransforms = skinningData.jointTransforms
+    guard !jointTransforms.isEmpty else { return [] }
+    let inverseBindPoses = skinningData.inverseBindPoses
+    let geomBind = skinningData.geometryBindTransform
+    // Fall back to index 0 when rootJointIndices is empty (single-root or unknown).
+    let indices = skinningData.rootJointIndices.isEmpty ? [UInt32(0)] : skinningData.rootJointIndices
+    return indices.compactMap { idx -> simd_float4x4? in
+        let i = Int(idx)
+        guard i < jointTransforms.count else { return nil }
+        let invBind = i < inverseBindPoses.count ? inverseBindPoses[i] : matrix_identity_float4x4
+        return simd_mul(simd_mul(jointTransforms[i], invBind), geomBind)
+    }
+}
+
+// Computes root joint indices for the mesh at meshPath by reading the skeleton's
+// joint token paths from the UsdStage. A root joint is one whose parent token path
+// is not present in the skeleton's joint list.
+private func rootJointIndices(forMeshAt meshPath: String, in stage: UsdStage) -> [UInt32] {
+    let meshPrim = stage.prim(at: SdfPath(meshPath))
+    guard meshPrim.isValid else { return [] }
+
+    // Walk up the prim hierarchy to find a skel:skeleton relationship.
+    var skelPrimPath: SdfPath? = nil
+    var current: UsdPrim? = meshPrim
+    while let prim = current {
+        if let rel = prim.relationship(named: "skel:skeleton"),
+            let targets = rel.forwardedTargets, let target = targets.first
+        {
+            skelPrimPath = target
+            break
+        }
+        current = prim.parent
+    }
+
+    guard let skelPath = skelPrimPath else { return [] }
+    let skelPrim = stage.prim(at: skelPath)
+    guard skelPrim.isValid,
+        let jointsAttr = skelPrim.attribute("joints"),
+        let jointTokens: TokenArray = jointsAttr.get()
+    else { return [] }
+
+    return rootJointIndices(from: jointTokens.map(\.string))
+}
+
+// Pure string computation: returns the indices of joints whose parent path does
+// not appear in the joints array. USD requires parents before children, so root
+// joints always appear before their descendants but there can be multiple roots
+// (e.g. ["A", "A/B", "C", "C/D/E"] has roots at indices 0 and 2).
+private func rootJointIndices(from joints: [String]) -> [UInt32] {
+    let jointSet = Set(joints)
+    return joints.enumerated()
+        .compactMap { index, joint -> UInt32? in
+            var path = joint
+            while let slash = path.lastIndex(of: "/") {
+                path = String(path[..<slash])
+                if jointSet.contains(path) { return nil }
+            }
+            return UInt32(index)
+        }
+}
+
+// Transforms a local-space AABB by one or more skin matrices and returns the
+// union of the resulting world-space AABBs. Passing multiple matrices handles
+// multi-root skeletons correctly.
+private func computeSkinningAABB(
+    _ skinMatrices: [simd_float4x4],
+    _ localMin: SIMD3<Float>,
+    _ localMax: SIMD3<Float>
+) -> (SIMD3<Float>, SIMD3<Float>) {
+    let matrices = skinMatrices.isEmpty ? [matrix_identity_float4x4] : skinMatrices
+    var effectiveMin = SIMD3<Float>(repeating: .greatestFiniteMagnitude)
+    var effectiveMax = SIMD3<Float>(repeating: -.greatestFiniteMagnitude)
+    for skinMatrix in matrices {
+        for i in 0..<8 {
+            let corner = SIMD4<Float>(
+                (i & 1) != 0 ? localMax.x : localMin.x,
+                (i & 2) != 0 ? localMax.y : localMin.y,
+                (i & 4) != 0 ? localMax.z : localMin.z,
+                1
+            )
+            let transformed = simd_mul(skinMatrix, corner)
+            let p = SIMD3<Float>(transformed.x, transformed.y, transformed.z)
+            effectiveMin = simd_min(effectiveMin, p)
+            effectiveMax = simd_max(effectiveMax, p)
+        }
+    }
+    return (effectiveMin, effectiveMax)
+}
+
 @objc
 @implementation
 extension WKBridgeUSDConfiguration {
@@ -791,6 +885,7 @@ extension WKBridgeReceiver {
 
                         var deferredMeshUpdate = DeferredMeshUpdate(identifier: identifier, type: .newMesh, updatedInstances: [])
 
+                        let skinMatrices = meshData.deformationData?.skinningData.map { rootSkinMatrices($0) } ?? []
                         for (partIndex, part) in meshData.parts.enumerated() {
                             if part.materialIndex >= meshData.assignedMaterials.count {
                                 fatalError(
@@ -811,15 +906,21 @@ extension WKBridgeReceiver {
                                 )
                             )
 
+                            let (effectiveMin, effectiveMax) = computeSkinningAABB(
+                                skinMatrices,
+                                part.boundsMin,
+                                part.boundsMax
+                            )
+
                             let meshPart = try renderContext.makeMeshPart(
                                 resource: meshResource,
-                                indexOffset: meshData.parts[partIndex].indexOffset,
-                                indexCount: meshData.parts[partIndex].indexCount,
-                                primitive: meshData.parts[partIndex].topology,
+                                indexOffset: part.indexOffset,
+                                indexCount: part.indexCount,
+                                primitive: part.topology,
                                 windingOrder: .counterClockwise,
                                 bounds: .init(
-                                    boxMin: meshData.parts[partIndex].boundsMin,
-                                    boxMax: meshData.parts[partIndex].boundsMax
+                                    boxMin: effectiveMin,
+                                    boxMax: effectiveMax
                                 )
                             )
 
@@ -1028,7 +1129,8 @@ private func webUpdateTextureRequestFromUpdateTextureRequest(_ request: _Proto_T
 }
 
 private func webUpdateMeshRequestFromUpdateMeshRequest(
-    _ request: _Proto_MeshDataUpdate_v1
+    _ request: _Proto_MeshDataUpdate_v1,
+    rootJointIndices: [UInt32]
 ) -> WKBridgeUpdateMesh {
     var descriptor: WKBridgeMeshDescriptor?
     if let requestDescriptor = request.descriptor {
@@ -1045,7 +1147,7 @@ private func webUpdateMeshRequestFromUpdateMeshRequest(
         instanceTransforms: toData(request.instanceTransformsCompat()),
         instanceTransformsCount: request.instanceTransformsCompat().count,
         assignedMaterials: convert(request.assignedMaterials),
-        deformationData: .init(request.deformationData)
+        deformationData: .init(request.deformationData, rootJointIndices: rootJointIndices)
     )
 }
 
@@ -1832,6 +1934,7 @@ final class USDModelLoader {
     fileprivate var stage: UsdStage?
     fileprivate var data: Data?
     private let objcLoader: WKBridgeModelLoader
+    private var rootJointIndicesCache: [String: [UInt32]] = [:]
 
     @nonobjc
     fileprivate var time: TimeInterval = 0
@@ -1851,6 +1954,7 @@ final class USDModelLoader {
     }
 
     func loadModel(from url: Foundation.URL) {
+        rootJointIndicesCache.removeAll()
         do {
             let stage = try UsdStage.open(url)
             self.setupTimes(from: stage)
@@ -1861,6 +1965,7 @@ final class USDModelLoader {
     }
 
     func loadModel(data: Foundation.Data) -> Bool {
+        rootJointIndicesCache.removeAll()
         do {
             self.stage = try UsdStage.open(buffer: data)
             guard let stage = self.stage else {
@@ -1990,7 +2095,25 @@ final class USDModelLoader {
     }
 
     private func processMeshUpdates(_ updates: [_Proto_MeshDataUpdate_v1]) {
-        self.objcLoader.updateMesh(webRequest: updates.map { webUpdateMeshRequestFromUpdateMeshRequest($0) })
+        let stage = self.stage
+        self.objcLoader.updateMesh(
+            webRequest: updates.map { update in
+                let rootIndices: [UInt32]
+                if let stage, update.deformationData?.skinningData != nil {
+                    let path = update.id.path
+                    if let cached = rootJointIndicesCache[path] {
+                        rootIndices = cached
+                    } else {
+                        let computed = rootJointIndices(forMeshAt: path, in: stage)
+                        rootJointIndicesCache[path] = computed
+                        rootIndices = computed
+                    }
+                } else {
+                    rootIndices = []
+                }
+                return webUpdateMeshRequestFromUpdateMeshRequest(update, rootJointIndices: rootIndices)
+            }
+        )
     }
 }
 

--- a/Source/WebKit/GPUProcess/graphics/Model/WebKitMesh.mm
+++ b/Source/WebKit/GPUProcess/graphics/Model/WebKitMesh.mm
@@ -622,7 +622,7 @@ static WKBridgeSkinningData *convert(const std::optional<SkinningData>& data)
     if (!data)
         return nil;
 
-    return [WebKit::allocWKBridgeSkinningDataInstance() initWithInfluencePerVertexCount:data->influencePerVertexCount jointTransforms:convert(data->jointTransforms) inverseBindPoses:convert(data->inverseBindPoses) influenceJointIndices:convert(data->influenceJointIndices) influenceWeights:convert(data->influenceWeights) geometryBindTransform:data->geometryBindTransform];
+    return [WebKit::allocWKBridgeSkinningDataInstance() initWithInfluencePerVertexCount:data->influencePerVertexCount jointTransforms:convert(data->jointTransforms) inverseBindPoses:convert(data->inverseBindPoses) influenceJointIndices:convert(data->influenceJointIndices) influenceWeights:convert(data->influenceWeights) geometryBindTransform:data->geometryBindTransform rootJointIndices:convert(data->rootJointIndices)];
 }
 
 static WKBridgeBlendShapeData *convert(const std::optional<BlendShapeData>& data)

--- a/Source/WebKit/Shared/Model.serialization.in
+++ b/Source/WebKit/Shared/Model.serialization.in
@@ -104,6 +104,7 @@ header: <WebKit/ModelTypes.h>
     Vector<uint32_t> influenceJointIndices;
     Vector<float> influenceWeights;
     WebModel::Float4x4 geometryBindTransform;
+    Vector<uint32_t> rootJointIndices;
 };
 
 header: <WebKit/ModelTypes.h>

--- a/Source/WebKit/WebProcess/GPU/graphics/Model/RemoteMeshProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/Model/RemoteMeshProxy.cpp
@@ -70,7 +70,7 @@ static WebModel::Float4x4 makeTransformMatrix(
     return result;
 }
 
-static std::pair<simd_float4, simd_float4> computeMinAndMaxCorners(const Vector<WebModel::MeshPart>& parts, const Vector<WebModel::Float4x4>& instanceTransforms)
+static std::pair<simd_float4, simd_float4> computeMinAndMaxCorners(const Vector<WebModel::MeshPart>& parts, const Vector<WebModel::Float4x4>& instanceTransforms, const std::optional<WebModel::DeformationData>& deformationData)
 {
     simd_float4 minCorner4 = simd_make_float4(FLT_MAX, FLT_MAX, FLT_MAX, 1.f);
     simd_float4 maxCorner4 = simd_make_float4(-FLT_MAX, -FLT_MAX, -FLT_MAX, 1.f);
@@ -87,13 +87,35 @@ static std::pair<simd_float4, simd_float4> computeMinAndMaxCorners(const Vector<
         corners[6] = simd_make_float3(part.boundsMin.x, part.boundsMax.y, part.boundsMax.z);
         corners[7] = simd_make_float3(part.boundsMax.x, part.boundsMax.y, part.boundsMax.z);
 
-        for (auto& transform : instanceTransforms) {
-            for (int j = 0; j < 8; ++j) {
-                simd_float4 corner4 = simd_make_float4(corners[j].x, corners[j].y, corners[j].z, 1.f);
-                simd_float4 transformedCorner = simd_mul(transform, corner4);
+        Vector<simd_float4x4> rootSkinMatrices;
+        if (deformationData && deformationData->skinningData && !deformationData->skinningData->jointTransforms.isEmpty()) {
+            const auto& skinning = *deformationData->skinningData;
+            const simd_float4x4 geomBind = skinning.geometryBindTransform;
+            const auto& rootIndices = skinning.rootJointIndices;
+            const bool hasRootIndices = !rootIndices.isEmpty();
+            const size_t iterCount = hasRootIndices ? rootIndices.size() : 1;
+            rootSkinMatrices.reserveInitialCapacity(iterCount);
+            for (size_t r = 0; r < iterCount; ++r) {
+                uint32_t rootIdx = hasRootIndices ? rootIndices[r] : 0;
+                if (rootIdx >= skinning.jointTransforms.size())
+                    continue;
+                const simd_float4x4 invBind = (rootIdx < skinning.inverseBindPoses.size())
+                    ? static_cast<simd_float4x4>(skinning.inverseBindPoses[rootIdx])
+                    : matrix_identity_float4x4;
+                rootSkinMatrices.append(simd_mul(simd_mul(skinning.jointTransforms[rootIdx], invBind), geomBind));
+            }
+        } else
+            rootSkinMatrices.append(matrix_identity_float4x4);
 
-                minCorner4 = simd_min(transformedCorner, minCorner4);
-                maxCorner4 = simd_max(transformedCorner, maxCorner4);
+        for (auto& transform : instanceTransforms) {
+            for (const auto& skinMatrix : rootSkinMatrices) {
+                const simd_float4x4 worldTransform = simd_mul(transform, skinMatrix);
+                for (int j = 0; j < 8; ++j) {
+                    simd_float4 corner4 = simd_make_float4(corners[j].x, corners[j].y, corners[j].z, 1.f);
+                    simd_float4 transformedCorner = simd_mul(worldTransform, corner4);
+                    minCorner4 = simd_min(transformedCorner, minCorner4);
+                    maxCorner4 = simd_max(transformedCorner, maxCorner4);
+                }
             }
         }
     }
@@ -124,24 +146,21 @@ RemoteMeshProxy::~RemoteMeshProxy()
 void RemoteMeshProxy::update(Vector<WebModel::UpdateMeshDescriptor>&& descriptorArray)
 {
 #if ENABLE(GPU_PROCESS_MODEL)
-    bool anyBoundingBoxChanged = false;
-    for (auto& descriptor : descriptorArray) {
-        auto [minCorner, maxCorner] = computeMinAndMaxCorners(descriptor.parts, descriptor.instanceTransforms);
-        auto boundingBoxChanged = minCorner.x <= maxCorner.x && minCorner.y <= maxCorner.y && minCorner.z <= maxCorner.z;
-        boundingBoxChanged = boundingBoxChanged && (!simd_equal(m_minCorner, minCorner) || !simd_equal(m_maxCorner, maxCorner));
-        if (boundingBoxChanged) {
+    bool needBoundingBoxUpdate = m_minCorner.x > m_maxCorner.x;
+    if (needBoundingBoxUpdate) {
+        for (auto& descriptor : descriptorArray) {
+            auto [minCorner, maxCorner] = computeMinAndMaxCorners(descriptor.parts, descriptor.instanceTransforms, descriptor.deformationData);
             m_minCorner = simd_min(m_minCorner, minCorner);
             m_maxCorner = simd_max(m_maxCorner, maxCorner);
         }
-        anyBoundingBoxChanged = anyBoundingBoxChanged || boundingBoxChanged;
     }
 
     auto sendResult = sendWithAsyncReply(Messages::RemoteMesh::Update(WTF::move(descriptorArray)), [](auto) mutable {
     });
     UNUSED_VARIABLE(sendResult);
-    if (anyBoundingBoxChanged)
-        computeTransform();
 
+    if (needBoundingBoxUpdate)
+        computeTransform();
 #else
     UNUSED_PARAM(descriptorArray);
 #endif

--- a/Source/WebKit/WebProcess/Model/ModelInlineConverters.h
+++ b/Source/WebKit/WebProcess/Model/ModelInlineConverters.h
@@ -531,7 +531,8 @@ static std::optional<WebModel::SkinningData> convert(WKBridgeSkinningData* data)
         .inverseBindPoses = convert<WebModel::Float4x4>(data.inverseBindPosesData),
         .influenceJointIndices = convert<uint32_t>(data.influenceJointIndicesData),
         .influenceWeights = convert<float>(data.influenceWeightsData),
-        .geometryBindTransform = data.geometryBindTransform
+        .geometryBindTransform = data.geometryBindTransform,
+        .rootJointIndices = convert<uint32_t>(data.rootJointIndicesData)
     };
 }
 


### PR DESCRIPTION
#### f9fdeabc55e9440ff8cb05e1210631b266696b4f
<pre>
Bounding box does not account for skinning transforms
<a href="https://bugs.webkit.org/show_bug.cgi?id=313476">https://bugs.webkit.org/show_bug.cgi?id=313476</a>
<a href="https://rdar.apple.com/174193414">rdar://174193414</a>

Reviewed by Etienne Segonzac.

In computing the bounding box of a mesh, we considered the instance
transform but failed to consider the skinning transform. Correct this
by taking that transform into account.

Also fix constantly recomputing bounding boxes of skinned meshes
which is not compliant with the visionOS implementation.

* Source/WebKit/GPUProcess/graphics/Model/ModelBridge.swift:
(WKBridgeSkinningData.rootJointIndices):
* Source/WebKit/GPUProcess/graphics/Model/ModelTypes.h:
* Source/WebKit/GPUProcess/graphics/Model/USDModel.swift:
(rootSkinMatrices(for:)):
(rootJointIndices(forMeshAt:in:)):
(rootJointIndices(from:)):
(updateMesh(_:)):
(USDModelLoader.processMeshUpdates(_:)):
* Source/WebKit/GPUProcess/graphics/Model/WebKitMesh.mm:
(WebModel::convert):
* Source/WebKit/Shared/Model.serialization.in:
* Source/WebKit/WebProcess/GPU/graphics/Model/RemoteMeshProxy.cpp:
(WebKit::computeMinAndMaxCorners):
(WebKit::RemoteMeshProxy::update):
* Source/WebKit/WebProcess/Model/ModelInlineConverters.h:
(WebKit::convert):

Canonical link: <a href="https://commits.webkit.org/313775@main">https://commits.webkit.org/313775@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/311fbb0110a1d5b8d8b43a0ea7f16eb7e204e2ee

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/163961 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/37445 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/30664 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/172990 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/121212 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/b45cdcce-445b-4631-be10-0fc935fd0d50) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/37777 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/37445 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/127373 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/121212 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/4fc3157b-3807-46a3-8319-308c592bffcd) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/166920 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/29659 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/147402 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/107921 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/92f0b172-203a-454a-922e-05ba5fd74d85) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/28705 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/27327 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/20754 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/138606 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/175515 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/28337 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/26787 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/135683 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/37115 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/31439 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/135655 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36584 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/37900 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/146914 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/100063 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/30955 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/23770 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/36709 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/109756 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/36108 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/1810 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/36358 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/36255 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->