### PR TITLE
Back button not enabled in JS created windows when it should be

### DIFF
--- a/Source/WebKit/UIProcess/API/Cocoa/WKBackForwardListItem.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKBackForwardListItem.mm
@@ -79,6 +79,11 @@ WK_OBJECT_DISABLE_DISABLE_KVC_IVAR_ACCESS;
     return nullptr;
 }
 
+- (NSString *)_loggingStringForTesting
+{
+    return protect(*_item)->loggingString().createNSString().autorelease();
+}
+
 - (CGPoint)_scrollPosition
 {
     Ref frameState = protect(*_item)->mainFrameState();

--- a/Source/WebKit/UIProcess/API/Cocoa/WKBackForwardListItemPrivate.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKBackForwardListItemPrivate.h
@@ -29,6 +29,7 @@
 
 // For testing only.
 - (CGImageRef)_copySnapshotForTesting WK_API_AVAILABLE(macos(10.12.3), ios(10.3));
+- (NSString *)_loggingStringForTesting WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA));
 
 @property (nonatomic) CGPoint _scrollPosition WK_API_AVAILABLE(macos(10.14.4), ios(12.2));
 @property (nonatomic, readonly) BOOL _wasCreatedByJSWithoutUserInteraction WK_API_AVAILABLE(macos(14.0), ios(17.0));

--- a/Source/WebKit/UIProcess/WebBackForwardList.cpp
+++ b/Source/WebKit/UIProcess/WebBackForwardList.cpp
@@ -587,6 +587,9 @@ std::pair<RefPtr<WebBackForwardListItem>, size_t> WebBackForwardList::itemStarti
     if (itemIndex >= m_entries.size())
         return { nullptr, 0 };
 
+    auto startingItem = itemAtIndexWithoutSkipping(startingIndex);
+    RELEASE_ASSERT(startingItem.first);
+
     auto item = itemAtIndexWithoutSkipping(itemIndex);
 
 #if PLATFORM(COCOA)
@@ -601,37 +604,27 @@ std::pair<RefPtr<WebBackForwardListItem>, size_t> WebBackForwardList::itemStarti
     // A -> A#a (no userInteraction) -> B -> B#a (no user interaction) -> B#b (no user interaction)
     // If we're on B and navigate back, we don't want to skip anything and load A#a.
     // However, if we're on A and navigate forward, we do want to skip items and end up on B#b.
-    if (direction == NavigationDirection::Backward && !currentItem()->wasCreatedByJSWithoutUserInteraction()) {
-        // The exception to the above is that if the entire list of back items is missing user interaction,
-        // they should all be ignored. For example:
-        // A (no userInteraction) -> B (no userInteraction) -> C*
-        // From the API perspective, C should be item 0, and going back is not an option.
-        // This happens e.g. with new windows that undergo a series of JS driven client redirects.
-        // See https://bugs.webkit.org/show_bug.cgi?id=310243
+    // The forward logic comes later.
+    if (direction == NavigationDirection::Backward && !startingItem.first->wasCreatedByJSWithoutUserInteraction())
+        return item;
 
-        auto itemToReturn = item;
-        do {
-            if (item.first->wasCreatedByJSWithoutUserInteraction()) {
-                if (item.second)
-                    item = itemAtIndexWithoutSkipping(item.second - 1);
-                else {
-                    // We reached the beginning of the list and still didn't find an item with user interaction,
-                    // therefore we are returning nothing.
-                    itemToReturn = { };
-                    break;
-                }
-            } else
-                break;
-        } while (true);
-
-        return itemToReturn;
+    // If every item from this point back to the start of the list was created by JS without user interaction,
+    // we ignore them all.
+    if (direction == NavigationDirection::Backward && startingItem.first->wasCreatedByJSWithoutUserInteraction()) {
+        auto innerItem = item;
+        while (innerItem.first->wasCreatedByJSWithoutUserInteraction()) {
+            if (innerItem.second)
+                innerItem = itemAtIndexWithoutSkipping(innerItem.second - 1);
+            else
+                return { };
+            ASSERT(innerItem.first);
+        }
     }
 
     // For example:
     // Yahoo -> Yahoo#a (no userInteraction) -> Google -> Google#a (no user interaction) -> Google#b (no user interaction)
     // If we are on Google#b and navigate backwards, we want to skip over Google#a and Google, to end up on Yahoo#a.
     // If we are on Yahoo#a and navigate forwards, we want to skip over Google and Google#a, to end up on Google#b.
-
     auto originalitem = item;
     while (item.first->wasCreatedByJSWithoutUserInteraction()) {
         itemIndex += delta;
@@ -897,7 +890,7 @@ FrameState* WebBackForwardList::findFrameStateInItem(WebCore::BackForwardItemIde
     return &childFrameItem->frameState();
 }
 
-String WebBackForwardList::loggingString()
+String WebBackForwardList::loggingString() const
 {
     StringBuilder builder;
 

--- a/Source/WebKit/UIProcess/WebBackForwardList.h
+++ b/Source/WebKit/UIProcess/WebBackForwardList.h
@@ -103,7 +103,7 @@ public:
     FrameState* findFrameStateInItem(WebCore::BackForwardItemIdentifier, WebCore::FrameIdentifier, uint64_t);
     void updateFrameIdentifier(WebCore::FrameIdentifier oldFrameID, WebCore::FrameIdentifier newFrameID);
 
-    String loggingString();
+    String loggingString() const;
 
 private:
     explicit WebBackForwardList(WebPageProxy&);

--- a/Source/WebKit/UIProcess/WebBackForwardList.swift
+++ b/Source/WebKit/UIProcess/WebBackForwardList.swift
@@ -699,6 +699,11 @@ final class WebBackForwardList {
             return (nil, 0)
         }
 
+        let startingItemResult = itemAtIndexWithoutSkipping(index: startingIndex)
+        guard let startingItem = startingItemResult.item else {
+            preconditionFailure("Starting item should always exist")
+        }
+
         let maybeItem = itemAtIndexWithoutSkipping(index: itemIndex)
 
         #if os(macOS) || os(iOS) || os(watchOS) || os(tvOS) || os(visionOS)
@@ -715,34 +720,26 @@ final class WebBackForwardList {
         // A -> A#a (no userInteraction) -> B -> B#a (no user interaction) -> B#b (no user interaction)
         // If we're on B and navigate back, we don't want to skip anything and load A#a.
         // However, if we're on A and navigate forward, we do want to skip items and end up on B#b.
-        // swift-format-ignore: NeverForceUnwrap
-        if direction == Direction.backward && !currentItem()!.wasCreatedByJSWithoutUserInteraction() {
-            // The exception to the above is that if the entire list of back items is missing user interaction,
-            // they should all be ignored. For example:
-            // A (no userInteraction) -> B (no userInteraction) -> C*
-            // From the API perspective, C should be item 0, and going back is not an option.
-            // This happens e.g. with new windows that undergo a series of JS driven client redirects.
-            // See https://bugs.webkit.org/show_bug.cgi?id=310243
-            let itemToReturn = maybeItem
-            var checkItem = maybeItem
-            while true {
-                guard let checkItemUnwrapped = checkItem.item, checkItemUnwrapped.wasCreatedByJSWithoutUserInteraction() else {
-                    break
-                }
-                guard checkItem.index > 0 else {
-                    // We reached the beginning of the list and still didn't find an item with user interaction,
-                    // therefore we are returning nothing.
+        // The forward logic comes later.
+        if direction == .backward && !startingItem.wasCreatedByJSWithoutUserInteraction() {
+            return maybeItem
+        }
+
+        // If every item from this point back to the start of the list was created by JS without user interaction,
+        // we ignore them all.
+        if direction == .backward && startingItem.wasCreatedByJSWithoutUserInteraction() {
+            var innerItem = maybeItem
+            while let innerItemUnwrapped = innerItem.item, innerItemUnwrapped.wasCreatedByJSWithoutUserInteraction() {
+                guard innerItem.index > 0 else {
                     return (nil, 0)
                 }
-
-                checkItem = itemAtIndexWithoutSkipping(index: checkItem.index - 1)
+                innerItem = itemAtIndexWithoutSkipping(index: innerItem.index - 1)
+                assert(innerItem.item != nil)
             }
-            return itemToReturn
         }
 
         let (definiteItem, index) = maybeItem
         guard let definiteItem else {
-            // Matches C++ by not asserting in release mode until past the above two 'if's
             preconditionFailure("Should have an item by now")
         }
         var item = (item: definiteItem, index: index)

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKBackForwardListTests.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKBackForwardListTests.mm
@@ -568,14 +568,15 @@ static void runBackForwardNavigationSkipsItemsWithoutUserGestureTest(Function<vo
     [navigationDelegate waitForDidFinishNavigationOrDidSameDocumentNavigation];
     EXPECT_FALSE(webView.get().backForwardList.currentItem._wasCreatedByJSWithoutUserInteraction);
 
-    EXPECT_EQ([webView backForwardList].backList.count, 5U);
+    // url1 -> url2 -> url2#a (no user gesture) -> url2#b (no user gesture) -> url2#c (no user gesture) -> url3 **
+    EXPECT_EQ([webView backForwardList].backList.count, 2U);
     EXPECT_EQ([webView backForwardList].forwardList.count, 0U);
 
     // We are now on url3. Let's go back.
     [webView goBack];
     [navigationDelegate waitForDidFinishNavigationOrDidSameDocumentNavigation];
 
-    // We should go back to url2#c.
+    // url1 -> url2 -> url2#a (no user gesture) -> url2#b (no user gesture) -> url2#c (no user gesture) ** -> url3
     expectedURLString = makeString(String([url2 absoluteString]), "#c"_s).createNSString();
     EXPECT_STREQ([webView URL].absoluteString.UTF8String, expectedURLString.get().UTF8String);
     EXPECT_EQ([webView backForwardList].backList.count, 1U);
@@ -586,6 +587,7 @@ static void runBackForwardNavigationSkipsItemsWithoutUserGestureTest(Function<vo
     [navigationDelegate waitForDidFinishNavigationOrDidSameDocumentNavigation];
 
     // We should have skipped over url2#b, url2#a and url2, to end up on url1.
+    // url1 ** -> url2 -> url2#a (no user gesture) -> url2#b (no user gesture) -> url2#c (no user gesture) -> url3
     EXPECT_STREQ([webView URL].absoluteString.UTF8String, [url1 absoluteString].UTF8String);
     EXPECT_EQ([webView backForwardList].backList.count, 0U);
     EXPECT_EQ([webView backForwardList].forwardList.count, 2U);
@@ -595,6 +597,7 @@ static void runBackForwardNavigationSkipsItemsWithoutUserGestureTest(Function<vo
     [navigationDelegate waitForDidFinishNavigationOrDidSameDocumentNavigation];
 
     // We should get to the latest url2 URL, that is url2#c.
+    // url1 -> url2 -> url2#a (no user gesture) -> url2#b (no user gesture) -> url2#c (no user gesture) ** -> url3
     expectedURLString = makeString(String([url2 absoluteString]), "#c"_s).createNSString();
     EXPECT_STREQ([webView URL].absoluteString.UTF8String, expectedURLString.get().UTF8String);
     EXPECT_EQ([webView backForwardList].backList.count, 1U);
@@ -606,7 +609,8 @@ static void runBackForwardNavigationSkipsItemsWithoutUserGestureTest(Function<vo
 
     // We should now be on url3.
     EXPECT_STREQ([webView URL].absoluteString.UTF8String, [url3 absoluteString].UTF8String);
-    EXPECT_EQ([webView backForwardList].backList.count, 5U);
+
+    EXPECT_EQ([webView backForwardList].backList.count, 2U);
     EXPECT_EQ([webView backForwardList].forwardList.count, 0U);
 
     // Navigating via the JS API shouldn't skip those back/forward list items.
@@ -898,14 +902,23 @@ TEST(WKBackForwardList, BackNavigationHijacking)
     [navigationDelegate waitForDidFinishNavigationOrDidSameDocumentNavigation];
     TestWebKitAPI::Util::run(&ranJS);
 
+    // At this point, the bf list is:
+    // url1 - url1` (no user gesture)*
+
     [webView loadRequest:[NSURLRequest requestWithURL:url2.get()]];
     [navigationDelegate waitForDidFinishNavigationOrDidSameDocumentNavigation];
     EXPECT_STREQ([webView URL].absoluteString.UTF8String, [url2 absoluteString].UTF8String);
+
+    // At this point, the bf list is:
+    // url1 - url1` (no user gesture) - url2*
 
     EXPECT_TRUE(webView.get().backForwardList.backItem._wasCreatedByJSWithoutUserInteraction);
     [webView goBack];
     [navigationDelegate waitForDidFinishNavigationOrDidSameDocumentNavigation];
     EXPECT_STREQ([webView URL].absoluteString.UTF8String, [url1 absoluteString].UTF8String);
+
+    // At this point, the bf list is:
+    // url1* - url1` (no user gesture) - url2
 
     TestWebKitAPI::Util::spinRunLoop(10);
     usleep(100000);
@@ -1348,6 +1361,9 @@ TEST(WKBackForwardList, ForwardSkipIteratesThroughLeadingConsecutiveJSItems)
     [webView loadRequest:[NSURLRequest requestWithURL:url2.get()]];
     [navigationDelegate waitForDidFinishNavigationOrDidSameDocumentNavigation];
 
+    // The state of the list right now is:
+    // url1 -> url1#a(JS) -> url1#b(JS) -> url2*
+
     // backList is ordered oldest-first; firstObject is url1 (the original loadRequest item).
     WKBackForwardListItem *url1Item = [webView backForwardList].backList.firstObject;
     [webView goToBackForwardListItem:url1Item];
@@ -1599,9 +1615,10 @@ TEST(WKBackForwardList, BackForwardNavigationSkipsPromiseRedirectWithoutUserInte
 
     // The history now looks like this:
     // (A) -> (B) -> C*
-    // JavaScript sees all 3, but the API back/forward list ignores those first two entries.
+    // JavaScript sees all 3, but the API back/forward list only sees (B), which is where the
+    // user presumably clicked a link to get to C.
     EXPECT_STREQ([[popupWebView stringByEvaluatingJavaScript:@"history.length"] UTF8String], "3");
-    EXPECT_EQ([popupWebView backForwardList].backList.count, 0U);
+    EXPECT_EQ([popupWebView backForwardList].backList.count, 1U);
     EXPECT_EQ([popupWebView backForwardList].forwardList.count, 0U);
     EXPECT_STREQ([popupWebView URL].absoluteString.UTF8String, server.request("/pageC"_s).URL.absoluteString.UTF8String);
 
@@ -1610,9 +1627,11 @@ TEST(WKBackForwardList, BackForwardNavigationSkipsPromiseRedirectWithoutUserInte
 
     // The history now looks like this:
     // (A) -> (B) -> C -> D*
-    // JavaScript sees all 4, the API back/forward list should see only 2.
+    // JavaScript sees all 4, the API back/forward list should see only 3.
+    // C and D because they both have a user gesture, and (B) because it's where the
+    // user presumably clicked a link to get to C.
     EXPECT_STREQ([[popupWebView stringByEvaluatingJavaScript:@"history.length"] UTF8String], "4");
-    EXPECT_EQ([popupWebView backForwardList].backList.count, 1U);
+    EXPECT_EQ([popupWebView backForwardList].backList.count, 2U);
     EXPECT_EQ([popupWebView backForwardList].forwardList.count, 0U);
     EXPECT_STREQ([popupWebView URL].absoluteString.UTF8String, server.request("/pageD"_s).URL.absoluteString.UTF8String);
 
@@ -1621,11 +1640,73 @@ TEST(WKBackForwardList, BackForwardNavigationSkipsPromiseRedirectWithoutUserInte
 
     // The history now looks like this:
     // (A) -> (B) -> C* -> D
-    EXPECT_EQ([popupWebView backForwardList].backList.count, 0U);
+    EXPECT_EQ([popupWebView backForwardList].backList.count, 1U);
     EXPECT_EQ([popupWebView backForwardList].forwardList.count, 1U);
     EXPECT_STREQ([popupWebView URL].absoluteString.UTF8String, server.request("/pageC"_s).URL.absoluteString.UTF8String);
+
+    [popupWebView goBack];
+    [navigationDelegate waitForDidFinishNavigation];
+
+    // The history now looks like this:
+    // (A) -> (B)* -> C -> D
+    EXPECT_EQ([popupWebView backForwardList].backList.count, 0U);
+    EXPECT_EQ([popupWebView backForwardList].forwardList.count, 2U);
+    EXPECT_STREQ([popupWebView URL].absoluteString.UTF8String, server.request("/pageB"_s).URL.absoluteString.UTF8String);
 
     // Attempting to goBack now should simply fail.
     auto *navigation = [popupWebView goBack];
     EXPECT_NULL(navigation);
+}
+
+TEST(WKBackForwardList, BackButtonWorksAfterUserClickFromJSCreatedPage)
+{
+    TestWebKitAPI::HTTPServer server({
+        { "/opener"_s, { "<a id='link' href='/pageA' target='_blank'>Open</a>"
+            "<script>function clickLink() { document.getElementById('link').click(); }</script>"_s } },
+        { "/pageA"_s, { "<a id='nextLink' href='/pageB'>Go to B</a>"
+            "<script>function clickNextLink() { document.getElementById('nextLink').click(); }</script>"_s } },
+        { "/pageB"_s, { "Page B"_s } },
+    }, TestWebKitAPI::HTTPServer::Protocol::Http);
+
+    RetainPtr openerWebView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectZero]);
+    [openerWebView configuration].preferences.javaScriptCanOpenWindowsAutomatically = YES;
+
+    __block RetainPtr<TestWKWebView> popupWebView;
+    __block bool popupCreated = false;
+    RetainPtr navigationDelegate = adoptNS([WKBackForwardNavigationDelegate new]);
+
+    RetainPtr uiDelegate = adoptNS([TestUIDelegate new]);
+    uiDelegate.get().createWebViewWithConfiguration = ^(WKWebViewConfiguration *configuration, WKNavigationAction *action, WKWindowFeatures *windowFeatures) {
+        popupWebView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectZero configuration:configuration]);
+        [popupWebView setNavigationDelegate:navigationDelegate.get()];
+        popupCreated = true;
+        return popupWebView.get();
+    };
+    [openerWebView setUIDelegate:uiDelegate.get()];
+
+    RetainPtr openerNavigationDelegate = adoptNS([WKBackForwardNavigationDelegate new]);
+    [openerWebView setNavigationDelegate:openerNavigationDelegate.get()];
+    [openerWebView loadRequest:server.request("/opener"_s)];
+    [openerNavigationDelegate waitForDidFinishNavigation];
+
+    [openerWebView evaluateJavaScript:@"clickLink()" completionHandler:nil];
+    TestWebKitAPI::Util::run(&popupCreated);
+    [navigationDelegate waitForDidFinishNavigation];
+
+    EXPECT_STREQ([[popupWebView stringByEvaluatingJavaScript:@"history.length"] UTF8String], "1");
+    EXPECT_EQ([popupWebView backForwardList].backList.count, 0U);
+
+    // User clicks a link on page A to navigate to page B.
+    [popupWebView evaluateJavaScript:@"clickNextLink()" completionHandler:nil];
+    [navigationDelegate waitForDidFinishNavigation];
+
+    EXPECT_STREQ([[popupWebView stringByEvaluatingJavaScript:@"history.length"] UTF8String], "2");
+    EXPECT_STREQ([popupWebView URL].absoluteString.UTF8String, server.request("/pageB"_s).URL.absoluteString.UTF8String);
+    EXPECT_EQ([popupWebView backForwardList].backList.count, 1U);
+    EXPECT_EQ([popupWebView backForwardList].forwardList.count, 0U);
+
+    [popupWebView goBack];
+    [navigationDelegate waitForDidFinishNavigation];
+
+    EXPECT_STREQ([popupWebView URL].absoluteString.UTF8String, server.request("/pageA"_s).URL.absoluteString.UTF8String);
 }


### PR DESCRIPTION
#### 608b8e3a70180aee6452e93d029920e31f56275a
<pre>
Back button not enabled in JS created windows when it should be
<a href="https://rdar.apple.com/175516150">rdar://175516150</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=313487">https://bugs.webkit.org/show_bug.cgi?id=313487</a>

Reviewed by Richard Robinson.

Say JavaScript creates a new window.
That window starts out with a session history for items the user has never interacted with.

Once the user clicks a link on that document, we push a new session history entry that *does*
have user interaction. But when analyzing the back list we notice the previous item had no
interaction, and therefore don&apos;t reveal it to the API back/forward list.

The intention is that once the user makes a new entry by interacting, a series of non-interacted-with
items in the back list are coalesced into one logical step in the list.

311615@main accidentally broke that logic if the series of interaction-free items was at the
start of the list (as in the new window case)

This PR fixes that and gives progressions on some other API tests that had some back counts wrong.

Test: Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKBackForwardListTests.mm

* Source/WebKit/UIProcess/API/Cocoa/WKBackForwardListItem.mm:
(-[WKBackForwardListItem _loggingStringForTesting]):
* Source/WebKit/UIProcess/API/Cocoa/WKBackForwardListItemPrivate.h:
* Source/WebKit/UIProcess/WebBackForwardList.cpp:
(WebKit::WebBackForwardList::itemStartingAtIndexSkippingItemsAddedByJSWithoutUserGesture const):
(WebKit::WebBackForwardList::loggingString const):
(WebKit::WebBackForwardList::loggingString): Deleted.
* Source/WebKit/UIProcess/WebBackForwardList.h:
* Source/WebKit/UIProcess/WebBackForwardList.swift:
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKBackForwardListTests.mm:
(runBackForwardNavigationSkipsItemsWithoutUserGestureTest):
(TEST(WKBackForwardList, BackNavigationHijacking)):
(TEST(WKBackForwardList, ForwardSkipIteratesThroughLeadingConsecutiveJSItems)):
(TEST(WKBackForwardList, BackForwardNavigationSkipsPromiseRedirectWithoutUserInteraction)):
(TEST(WKBackForwardList, BackButtonWorksAfterUserClickFromJSCreatedPage)):

Canonical link: <a href="https://commits.webkit.org/312249@main">https://commits.webkit.org/312249@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fbb8b23668f2f82ecffba4d4d7831c2c141902ec

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/159356 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/32784 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/25891 "Build is in progress. Recent messages:OS: Sequoia (15.7.3), Xcode: 26.2; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (warnings)") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/168188 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/113734 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/b4833503-ce6c-49c4-9df3-cb88c7c29123) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/161225 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/32852 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/32771 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/123466 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/113734 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/4a52696c-d5d9-4363-af77-85f160e93d5d) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/162313 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/32852 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/143143 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/104131 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/289dd956-f982-43c5-be37-43fb59c33d1d) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/32852 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/23226 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk3-libwebrtc~~](https://ews-build.webkit.org/#/builders/173/builds/15959 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/32852 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/167/builds/20923 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/170680 "Built successfully") | | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/16714 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/22549 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/131668 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/32473 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/27300 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/131781 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/35637 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/32417 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/142716 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/90542 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/24252 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/160/builds/32417 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/19525 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/31928 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/98380 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/31448 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/31721 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/31603 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->