### PR TITLE
Occasional flicker of bad layer offsets when positions are adjusted by scroll anchoring (or other programmatic scrolling)

### DIFF
--- a/Source/WebCore/PAL/pal/spi/cocoa/QuartzCoreSPI.h
+++ b/Source/WebCore/PAL/pal/spi/cocoa/QuartzCoreSPI.h
@@ -200,6 +200,7 @@ typedef enum {
 + (CATransactionPhase)currentPhase;
 + (void)synchronize;
 + (uint32_t)currentState;
++ (void)setDefaultDisableRunLoopObserverCommits:(BOOL)flag;
 @end
 
 @interface CALayerHost : CALayer

--- a/Source/WebKit/Configurations/AllowedSPI.toml
+++ b/Source/WebKit/Configurations/AllowedSPI.toml
@@ -293,7 +293,7 @@ selectors = [
 ]
 requires = ["PLATFORM_VISION"]
 
- [[staging]]
+[[staging]]
 request = "rdar://170178645"
 selectors = [
     { name = "screenCaptureWithEnvironment:", class = "BEProcessCapability" },

--- a/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeEventDispatcher.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeEventDispatcher.h
@@ -158,6 +158,8 @@ private:
 
     void didStartRubberbanding();
 
+    void updateLayerPositionsAndAnimations();
+
 #if ENABLE(MOMENTUM_EVENT_DISPATCHER)
     void handleSyntheticWheelEvent(WebCore::PageIdentifier, const WebWheelEvent&, WebCore::RectEdges<WebCore::RubberBandingBehavior> rubberBandableEdges);
     void startDisplayDidRefreshCallbacks(WebCore::PlatformDisplayID);

--- a/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeEventDispatcher.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeEventDispatcher.mm
@@ -38,6 +38,7 @@
 #import "WebEventConversion.h"
 #import "WebPageProxy.h"
 #import <QuartzCore/CALayer.h>
+#import <QuartzCore/CATransaction.h>
 #import <WebCore/PlatformWheelEvent.h>
 #import <WebCore/ScrollingCoordinatorTypes.h>
 #import <WebCore/ScrollingNodeID.h>
@@ -225,7 +226,7 @@ void RemoteLayerTreeEventDispatcher::handleWheelEvent(const WebWheelEvent& wheel
 void RemoteLayerTreeEventDispatcher::scrollingThreadHandleWheelEvent(const WebWheelEvent& webWheelEvent, RectEdges<WebCore::RubberBandingBehavior> rubberBandableEdges)
 {
     ASSERT(ScrollingThread::isCurrentThread());
-    
+
     auto continueEventHandlingOnMainThread = [protectedThis = Ref { *this }](WheelEventHandlingResult handlingResult) {
         RunLoop::mainSingleton().dispatch([protectedThis, handlingResult] {
             protectedThis->continueWheelEventHandling(handlingResult);
@@ -248,18 +249,21 @@ void RemoteLayerTreeEventDispatcher::scrollingThreadHandleWheelEvent(const WebWh
         // Wait for the web process to respond to the event, preventing the next event from being handled until we get a response or time out,
         // allowing us to know if this gesture should be come non-blocking.
         scrollingTree->waitForEventDefaultHandlingCompletion(platformWheelEvent);
+        [CATransaction flush];
         return;
     }
 
 #if ENABLE(MOMENTUM_EVENT_DISPATCHER)
     if (m_momentumEventDispatcher->handleWheelEvent(m_pageIdentifier, webWheelEvent, rubberBandableEdges)) {
         continueEventHandlingOnMainThread(WheelEventHandlingResult::handled(processingSteps));
+        [CATransaction flush];
         return;
     }
 #endif
 
     auto handlingResult = internalHandleWheelEvent(platformWheelEvent, processingSteps);
     continueEventHandlingOnMainThread(handlingResult);
+    [CATransaction flush];
 }
 
 void RemoteLayerTreeEventDispatcher::continueWheelEventHandling(WheelEventHandlingResult handlingResult)
@@ -324,6 +328,7 @@ void RemoteLayerTreeEventDispatcher::wheelEventHandlingCompleted(const PlatformW
                 protect(scrollingCoordinator->webPageProxy())->wheelEventHandlingCompleted(wasHandled || result.wasHandled);
         });
 
+        [CATransaction flush];
     });
 }
 
@@ -468,7 +473,7 @@ void RemoteLayerTreeEventDispatcher::didRefreshDisplay(PlatformDisplayID display
     }
 #endif
 
-    auto needsAnimationUpdate = false;
+    auto needsUpdateLayerPositionsAndAnimations = false;
     {
         Locker locker { m_scrollingTreeLock };
 
@@ -477,10 +482,7 @@ void RemoteLayerTreeEventDispatcher::didRefreshDisplay(PlatformDisplayID display
 
         scrollingTree->displayDidRefresh(displayID);
 
-        if (m_state != SynchronizationState::Idle) {
-            scrollingTree->tryToApplyLayerPositions();
-            needsAnimationUpdate = true;
-        }
+        needsUpdateLayerPositionsAndAnimations = m_state != SynchronizationState::Idle;
 
         switch (m_state) {
         case SynchronizationState::Idle: {
@@ -495,9 +497,22 @@ void RemoteLayerTreeEventDispatcher::didRefreshDisplay(PlatformDisplayID display
             break;
         }
     }
+
+    if (needsUpdateLayerPositionsAndAnimations)
+        updateLayerPositionsAndAnimations();
+}
+
+void RemoteLayerTreeEventDispatcher::updateLayerPositionsAndAnimations()
+{
+    if (auto scrollingTree = this->scrollingTree())
+        scrollingTree->tryToApplyLayerPositions();
+
+    // Commit scroll position changes before updating animation effects, so the
+    // render server sees a consistent scroll position + presentation modifier values.
+    [CATransaction flush];
+
 #if ENABLE(THREADED_ANIMATIONS)
-    if (needsAnimationUpdate)
-        updateAnimations();
+    updateAnimations();
 #endif
 }
 
@@ -518,12 +533,7 @@ void RemoteLayerTreeEventDispatcher::scheduleDelayedRenderingUpdateDetectionTime
 void RemoteLayerTreeEventDispatcher::delayedRenderingUpdateDetectionTimerFired()
 {
     ASSERT(ScrollingThread::isCurrentThread());
-
-    if (auto scrollingTree = this->scrollingTree())
-        scrollingTree->tryToApplyLayerPositions();
-#if ENABLE(THREADED_ANIMATIONS)
-    updateAnimations();
-#endif
+    updateLayerPositionsAndAnimations();
 }
 
 void RemoteLayerTreeEventDispatcher::waitForRenderingUpdateCompletionOrTimeout()
@@ -560,11 +570,7 @@ void RemoteLayerTreeEventDispatcher::waitForRenderingUpdateCompletionOrTimeout()
         // so we give up trying to sync with the main thread and update layers here on the scrolling thread.
         // Dispatch to allow for the scrolling thread to handle any outstanding wheel events before we commit layers.
         ScrollingThread::dispatch([protectedThis = Ref { *this }]() {
-            if (auto scrollingTree = protectedThis->scrollingTree())
-                scrollingTree->tryToApplyLayerPositions();
-#if ENABLE(THREADED_ANIMATIONS)
-            protectedThis->updateAnimations();
-#endif
+            protectedThis->updateLayerPositionsAndAnimations();
         });
         tracePoint(ScrollingThreadRenderUpdateSyncEnd, 1);
     } else
@@ -674,8 +680,10 @@ RefPtr<const RemoteAnimationTimeline> RemoteLayerTreeEventDispatcher::timeline(c
         if (auto* timeline = m_monotonicTimelineRegistry->get(timelineID))
             return timeline;
     }
+
     if (auto scrollingTree = this->scrollingTree())
         return scrollingTree->timeline(timelineID);
+
     return nullptr;
 }
 

--- a/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingTreeMac.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingTreeMac.mm
@@ -66,6 +66,8 @@ RemoteScrollingTreeMac::RemoteScrollingTreeMac(RemoteScrollingCoordinatorProxy& 
     ScrollingThread::dispatch([protectedThis = Ref { *this }]() {
         if ([CATransaction respondsToSelector:@selector(setDisableImplicitTransactionMainThreadAssert:)])
             [CATransaction setDisableImplicitTransactionMainThreadAssert:YES];
+
+        [CATransaction setDefaultDisableRunLoopObserverCommits:YES];
     });
 }
 


### PR DESCRIPTION
#### 80eaeca1f565e58a3df57b5d6b2a77cb40446dea
<pre>
Occasional flicker of bad layer offsets when positions are adjusted by scroll anchoring (or other programmatic scrolling)
<a href="https://bugs.webkit.org/show_bug.cgi?id=313486">https://bugs.webkit.org/show_bug.cgi?id=313486</a>
<a href="https://rdar.apple.com/175706332">rdar://175706332</a>

Reviewed by Abrar Rahman Protyasha.

On macOS, we process wheel events in the scrolling thread, which can happen concurrently
with the main thread receiving a RemoteLayerTreeTransaction/RemoteScrollingCoordinatorTransaction.
If the web process issued a programmatic scroll (e.g. for a scroll anchoring adjustment),
the layer tree transaction may contain new layer backing stores with the newly rendered
scroll offset, and the scrolling transaction will have nodes with RequestedScrollPositions.
To avoid flashes of incorrect content, it&apos;s essential that the new positions and backing
stores show up in the same Core Animation commit.

However there was no guarantee of that. When the main thread receives the transaction
with RequestedScrollPositions, the scrolling thread may have recently processed wheel
events, and have pending layer position updates. The main thread may then process the
RequestedScrollPositions, which modify ScrollingTreeNode `currentScrollPosition`, which
affects layer positions. Now, if the scrolling thread&apos;s CACommit happens before the
main thread, the scrolling thread commits positions affected by programmatic scrolls,
but the layer backing stores still show the old state; this is the flash of bad state.

Reduce the window of opportunity here by changing the scrolling thread to use explict
CATransaction flushing, rather than relying on automatic runloop observer-based commits,
which was the main cause of raceyness. We can&apos;t just use explict `begin`/`commit` pairs
because there are code paths that touch scrollbar layers that open implicit transactions;
those still need to get flushed.

We call `[CATransaction flush]` for any `ScrollingThread::dispatch()` that can
touch layers; the most common is the case that updates layers and animations,
and has to flush before updating animations (which uses CAPresentationModifierGroup).

Now that we have explicit flushing, we can, if necessary, use it to eliminate the
race in future.

* Source/WebCore/PAL/pal/spi/cocoa/QuartzCoreSPI.h:
* Source/WebKit/Configurations/AllowedSPI.toml: Just whitespace.
* Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeEventDispatcher.h:
* Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeEventDispatcher.mm:
(WebKit::RemoteLayerTreeEventDispatcher::scrollingThreadHandleWheelEvent):
(WebKit::RemoteLayerTreeEventDispatcher::wheelEventHandlingCompleted):
(WebKit::RemoteLayerTreeEventDispatcher::didRefreshDisplay): tryToApplyLayerPositions() doesn&apos;t
have to run with the lock held.
(WebKit::RemoteLayerTreeEventDispatcher::updateLayerPositionsAndAnimations):
(WebKit::RemoteLayerTreeEventDispatcher::delayedRenderingUpdateDetectionTimerFired):
(WebKit::RemoteLayerTreeEventDispatcher::waitForRenderingUpdateCompletionOrTimeout):
(WebKit::RemoteLayerTreeEventDispatcher::timeline):
* Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingTreeMac.mm:
(WebKit::RemoteScrollingTreeMac::RemoteScrollingTreeMac):

Canonical link: <a href="https://commits.webkit.org/312233@main">https://commits.webkit.org/312233@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6ba6be448b19c9f20cdf2b5b680bd670a05baf80

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/159308 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/32736 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/25841 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/168138 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/113686 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/123f3458-33fa-412b-81af-92418c413281) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/161177 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/32804 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/32723 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/123433 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/113686 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/a3da2611-f8a9-4f4d-a640-e78f3696f997) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/162265 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/32804 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/143084 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/104100 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/8b45e25e-5fec-4327-9c62-dc5496bc68a3) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/32804 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/23182 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk3-libwebrtc~~](https://ews-build.webkit.org/#/builders/173/builds/15911 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/32804 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/20864 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/170632 "Built successfully") | | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/16666 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/22490 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/131632 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/32425 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/27254 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/131745 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35622 "Built successfully and passed tests") | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/32369 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/142657 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/90494 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/160/builds/32369 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/19466 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/31880 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/98332 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/31400 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/31673 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/31555 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->