### PR TITLE
[Site Isolation] Document::isSecureContext ignores RemoteFrame ancestors

### DIFF
--- a/LayoutTests/platform/ios-site-isolation/TestExpectations
+++ b/LayoutTests/platform/ios-site-isolation/TestExpectations
@@ -302,7 +302,6 @@ imported/w3c/web-platform-tests/navigation-api/navigation-history-entry/entries-
 imported/w3c/web-platform-tests/navigation-api/navigation-history-entry/entries-after-bfcache.html [ Failure ]
 imported/w3c/web-platform-tests/navigation-api/per-entry-events/dispose-after-bfcache.html [ Failure ]
 imported/w3c/web-platform-tests/scroll-animations/crashtests/scroll-timeline-completion-crash.html [ Failure ]
-imported/w3c/web-platform-tests/secure-contexts/basic-popup-and-iframe-tests.html [ Failure ]
 imported/w3c/web-platform-tests/service-workers/cache-storage/cross-partition.https.tentative.html [ Failure ]
 imported/w3c/web-platform-tests/service-workers/service-worker/navigation-headers.https.html [ Failure ]
 imported/w3c/web-platform-tests/service-workers/service-worker/partitioned-claim.tentative.https.html [ Failure ]

--- a/LayoutTests/platform/mac-site-isolation/TestExpectations
+++ b/LayoutTests/platform/mac-site-isolation/TestExpectations
@@ -309,7 +309,6 @@ imported/w3c/web-platform-tests/navigation-api/navigation-activation/activation-
 imported/w3c/web-platform-tests/navigation-api/navigation-history-entry/entries-after-bfcache-in-iframe.html [ Failure ]
 imported/w3c/web-platform-tests/navigation-api/navigation-history-entry/entries-after-bfcache.html [ Failure ]
 imported/w3c/web-platform-tests/navigation-api/per-entry-events/dispose-after-bfcache.html [ Failure ]
-imported/w3c/web-platform-tests/secure-contexts/basic-popup-and-iframe-tests.html [ Failure ]
 imported/w3c/web-platform-tests/service-workers/cache-storage/cross-partition.https.tentative.html [ Failure ]
 imported/w3c/web-platform-tests/service-workers/service-worker/navigation-headers.https.html [ Failure ]
 imported/w3c/web-platform-tests/service-workers/service-worker/partitioned-claim.tentative.https.html [ Failure ]

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -8428,12 +8428,14 @@ bool Document::isSecureContext() const
         return true;
 
     for (RefPtr frame = m_frame->tree().parent(); frame; frame = frame->tree().parent()) {
-        RefPtr localFrame = dynamicDowncast<LocalFrame>(frame);
-        if (!localFrame)
-            continue;
-        Ref<Document> ancestorDocument = *localFrame->document();
-        if (!isDocumentSecure(ancestorDocument))
-            return false;
+        if (RefPtr localFrame = dynamicDowncast<LocalFrame>(frame)) {
+            Ref<Document> ancestorDocument = *localFrame->document();
+            if (!isDocumentSecure(ancestorDocument))
+                return false;
+        } else if (RefPtr securityOrigin = frame->frameDocumentSecurityOrigin()) {
+            if (!securityOrigin->isPotentiallyTrustworthy())
+                return false;
+        }
     }
 
     return isDocumentSecure(*this);


### PR DESCRIPTION
#### e211768ca32eb6c0f35255de16ee01ffcda11370
<pre>
[Site Isolation] Document::isSecureContext ignores RemoteFrame ancestors
<a href="https://bugs.webkit.org/show_bug.cgi?id=313498">https://bugs.webkit.org/show_bug.cgi?id=313498</a>
<a href="https://rdar.apple.com/175714384">rdar://175714384</a>

Reviewed by Sihui Liu.

In Document::isSecureContext, WebKit walks the frame tree to check
if all of a frame&apos;s ancestors are &quot;secure&quot;. It does this to gate access to
powerful web APIs such as navigator.geolocation.

For each ancestor, we call Document::isDocumentSecure which performs
checks to see if the frame is potentially trustworthy. Below is the implementation.
It does the following:
1. If the document is sandboxed, it checks if the document&apos;s URL is trustworthy
2. Otherwise, check if the document&apos;s security origin is trustworthy.

```
static inline bool isDocumentSecure(const Document&amp; document)
{
     if (document.isSandboxed(SandboxFlag::Origin))
         return isURLPotentiallyTrustworthy(document.url());
     return document.securityOrigin().isPotentiallyTrustworthy();
}
```

With site isolation enabled, it is possible for some of the document&apos;s
ancestors to be RemoteFrames in different processes. Currently, the
code in Document::isSecureContext, only handles LocalFrames and silently
skips any RemoteFrame ancestors.

This patch handles the RemoteFrame case by adding a fallback when
an ancestor frame can&apos;t be cast to a LocalFrame. Since we can&apos;t get the
document of the RemoteFrame, we can&apos;t call Document::isDocumentSecure
like the LocalFrame case. Instead, this patch directly calls isPotentiallyTrustworthy
on the RemoteFrame&apos;s security origin. This is #2 from the description of
Document::isDocumentSecure earlier in this commit message. I chose to skip #1 since
we don&apos;t have the full URL or sandbox flags of the remote frame. Also, only checking
the RemoteFrame&apos;s security origin is more conservative since in the worst case we would
treat a frame as insecure (and block requests) where the pre site isolation case would
treat it as secure.

This patches fixes imported/w3c/web-platform-tests/secure-contexts/basic-popup-and-iframe-tests.html
with site isolation enabled.

* LayoutTests/platform/ios-site-isolation/TestExpectations:
* LayoutTests/platform/mac-site-isolation/TestExpectations:
* Source/WebCore/dom/Document.cpp:
(WebCore::Document::isSecureContext const):

Canonical link: <a href="https://commits.webkit.org/312199@main">https://commits.webkit.org/312199@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/24ad66b7baeabb23a4669e6b55051d5f0247be57

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/159107 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/32535 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/25640 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/167936 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/113191 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/160976 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/32602 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/32522 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/123257 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/86546 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/162064 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/25535 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/142929 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/103923 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/24589 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/23005 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/15709 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/134275 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/20709 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/170429 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/16171 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/22335 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/131448 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/32224 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/27074 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/131560 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35603 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/32168 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/142502 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/90218 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/26261 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/19311 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/31679 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/97693 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/31199 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/31472 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/31354 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->