### PR TITLE
[WPE][GTK] Choose Vulkan device that matches the one used by the platform display

### DIFF
--- a/Source/WebCore/platform/graphics/egl/GLContext.cpp
+++ b/Source/WebCore/platform/graphics/egl/GLContext.cpp
@@ -642,6 +642,9 @@ const GLContext::GLExtensions& GLContext::glExtensions() const
         m_glExtensions.APPLE_sync = isExtensionSupported(extensionsString, "GL_APPLE_sync");
         m_glExtensions.OES_packed_depth_stencil = isExtensionSupported(extensionsString, "GL_OES_packed_depth_stencil");
         m_glExtensions.EXT_YUV_target = isExtensionSupported(extensionsString, "GL_EXT_YUV_target");
+#if USE(VULKAN)
+        m_glExtensions.EXT_memory_object = isExtensionSupported(extensionsString, "GL_EXT_memory_object");
+#endif
     });
     return m_glExtensions;
 }

--- a/Source/WebCore/platform/graphics/egl/GLContext.h
+++ b/Source/WebCore/platform/graphics/egl/GLContext.h
@@ -102,6 +102,9 @@ public:
         bool APPLE_sync { false };
         bool OES_packed_depth_stencil { false };
         bool EXT_YUV_target { false };
+#if USE(VULKAN)
+        bool EXT_memory_object { false };
+#endif
     };
     const GLExtensions& glExtensions() const;
 

--- a/Source/WebCore/platform/graphics/egl/GLDisplay.cpp
+++ b/Source/WebCore/platform/graphics/egl/GLDisplay.cpp
@@ -26,6 +26,7 @@
 #include <array>
 #include <wtf/Locker.h>
 #include <wtf/MainThread.h>
+#include <wtf/text/CStringView.h>
 #include <wtf/text/StringView.h>
 
 #if USE(LIBEPOXY)
@@ -53,6 +54,19 @@ typedef EGLBoolean (EGLAPIENTRYP PFNEGLDESTROYIMAGEKHRPROC) (EGLDisplay, EGLImag
 typedef EGLImageKHR (EGLAPIENTRYP PFNEGLCREATEIMAGEKHRPROC) (EGLDisplay, EGLContext, EGLenum target, EGLClientBuffer, const EGLint* attribList);
 typedef EGLBoolean (EGLAPIENTRYP PFNEGLDESTROYIMAGEKHRPROC) (EGLDisplay, EGLImageKHR);
 #endif
+#endif
+
+// Epoxy does not yet define these macros as of version 1.5.10
+#ifndef EGL_DEVICE_TYPE_EXT
+#define EGL_DEVICE_TYPE_EXT 0x3590
+#endif
+
+#ifndef EGL_DEVICE_TYPE_CPU_EXT
+#define EGL_DEVICE_TYPE_CPU_EXT 0x3594
+#endif
+
+#ifndef EGL_RENDERER_EXT
+#define EGL_RENDERER_EXT 0x335F
 #endif
 
 namespace WebCore {
@@ -116,6 +130,53 @@ bool GLDisplay::checkVersion(int major, int minor) const
 {
     return (m_version.major > major) || ((m_version.major == major) && (m_version.minor >= minor));
 }
+
+#if USE(LIBEPOXY)
+bool GLDisplay::isSoftwareRendered() const
+{
+    if (m_display == EGL_NO_DISPLAY)
+        return false;
+
+    static const auto containsSoftwareRendererName = [](const CStringView& rendererName) {
+        static constexpr ASCIILiteral substringsToCheck[] = {
+            "llvmpipe"_s,
+            "swrast"_s,
+        };
+
+        for (const auto& substring : substringsToCheck) {
+            if (contains(rendererName.span(), substring))
+                return true;
+        }
+
+        return false;
+    };
+
+    if (GLContext::isExtensionSupported(eglQueryString(nullptr, EGL_EXTENSIONS), "EGL_EXT_device_query")) {
+        EGLDeviceEXT eglDevice;
+        if (eglQueryDisplayAttribEXT(m_display, EGL_DEVICE_EXT, reinterpret_cast<EGLAttrib*>(&eglDevice))) {
+            const char* deviceExtensionsString = eglQueryDeviceStringEXT(eglDevice, EGL_EXTENSIONS);
+            if (GLContext::isExtensionSupported(deviceExtensionsString, "EGL_EXT_device_type")) {
+                EGLAttrib deviceType;
+                if (eglQueryDeviceAttribEXT(eglDevice, EGL_DEVICE_TYPE_EXT, &deviceType))
+                    return deviceType == EGL_DEVICE_TYPE_CPU_EXT;
+            }
+
+            if (GLContext::isExtensionSupported(deviceExtensionsString, "EGL_MESA_device_software"))
+                return true;
+
+            if (GLContext::isExtensionSupported(deviceExtensionsString, "EGL_EXT_device_query_name")) {
+                if (const char* rendererName = eglQueryDeviceStringEXT(eglDevice, EGL_RENDERER_EXT))
+                    return containsSoftwareRendererName(CStringView::unsafeFromUTF8(rendererName));
+            }
+        }
+    }
+
+    if (const char* rendererName = reinterpret_cast<const char*>(glGetString(GL_RENDERER)))
+        return containsSoftwareRendererName(CStringView::unsafeFromUTF8(rendererName));
+
+    return false;
+}
+#endif // USE(LIBEPOXY)
 
 EGLImage GLDisplay::createImage(EGLContext context, EGLenum target, EGLClientBuffer clientBuffer, const Vector<EGLAttrib>& attributes) const
 {

--- a/Source/WebCore/platform/graphics/egl/GLDisplay.h
+++ b/Source/WebCore/platform/graphics/egl/GLDisplay.h
@@ -46,6 +46,10 @@ public:
     EGLDisplay eglDisplay() const { return m_display; }
     bool checkVersion(int major, int minor) const;
 
+#if USE(LIBEPOXY)
+    bool isSoftwareRendered() const;
+#endif
+
     void terminate();
 
     EGLImage createImage(EGLContext, EGLenum, EGLClientBuffer, const Vector<EGLAttrib>&) const;

--- a/Source/WebCore/platform/graphics/gbm/PlatformDisplayGBM.h
+++ b/Source/WebCore/platform/graphics/gbm/PlatformDisplayGBM.h
@@ -45,4 +45,6 @@ private:
 
 } // namespace WebCore
 
+SPECIALIZE_TYPE_TRAITS_PLATFORM_DISPLAY(PlatformDisplayGBM, GBM)
+
 #endif // USE(GBM)

--- a/Source/WebCore/platform/graphics/vulkan/VulkanTypes.cpp
+++ b/Source/WebCore/platform/graphics/vulkan/VulkanTypes.cpp
@@ -27,9 +27,33 @@
 #include "VulkanTypes.h"
 
 #if USE(VULKAN)
+#include "GLContext.h"
 #include "Logging.h"
+#include "PlatformDisplay.h"
 #include "VulkanUtilities.h"
+#include <epoxy/egl.h>
+#include <epoxy/gl.h>
+#include <sys/stat.h>
+#include <sys/sysmacros.h>
+#include <wtf/Scope.h>
 #include <wtf/text/CStringView.h>
+
+#if USE(GBM)
+#include "DRMDeviceManager.h"
+#include "GBMDevice.h"
+#include "PlatformDisplayGBM.h"
+#include <fcntl.h>
+#include <gbm.h>
+#endif
+
+#if USE(LIBDRM)
+#include <xf86drm.h>
+#endif
+
+// Epoxy does not yet define this macro as of version 1.5.10
+#ifndef EGL_DRM_RENDER_NODE_FILE_EXT
+#define EGL_DRM_RENDER_NODE_FILE_EXT 0x3377
+#endif
 
 namespace WebCore {
 namespace Vulkan {
@@ -49,6 +73,16 @@ InstanceCreateInfo::InstanceCreateInfo(const ApplicationInfo& applicationInfo, s
 
     m_inner.enabledExtensionCount = enabledExtensions.size();
     m_inner.ppEnabledExtensionNames = enabledExtensions.data();
+}
+
+std::span<const uint8_t> PhysicalDeviceIDProperties::deviceUUID() const
+{
+    return unsafeMakeSpan(m_inner.deviceUUID, VK_UUID_SIZE);
+}
+
+std::span<const uint8_t> PhysicalDeviceIDProperties::driverUUID() const
+{
+    return unsafeMakeSpan(m_inner.driverUUID, VK_UUID_SIZE);
 }
 
 void PhysicalDevice::fillProperties(PhysicalDeviceProperties& properties) const
@@ -197,6 +231,188 @@ Result<Vector<PhysicalDevice>> Instance::availableDevices() const
         return makeUnexpected(result);
 
     return devices;
+}
+
+#if USE(GBM)
+static UnixFileDescriptor drmFileDescriptorForGBMDisplay()
+{
+    auto& deviceManager = DRMDeviceManager::singleton();
+    if (!deviceManager.isInitialized())
+        return { };
+
+    // Same logic used in WebProcessGLib::initializePlatformDisplayIfNeeded() to obtain the gbm_device.
+    if (auto device = deviceManager.mainGBMDevice(DRMDeviceManager::NodeType::Render))
+        return { gbm_device_get_fd(device->device()), UnixFileDescriptor::Borrow };
+
+    const auto& device = deviceManager.mainDevice();
+    const CString& deviceNode = device.renderNode.isNull() ? device.primaryNode : device.renderNode;
+    return { open(deviceNode.data(), O_RDWR | O_CLOEXEC), UnixFileDescriptor::Adopt };
+}
+#endif // USE(GBM)
+
+#if USE(LIBDRM)
+static UnixFileDescriptor drmFileDescriptorForDisplay(const PlatformDisplay& display)
+{
+    auto eglDisplay = display.eglDisplay();
+    if (eglDisplay == EGL_NO_DISPLAY)
+        return { };
+
+    if (!GLContext::isExtensionSupported(eglQueryString(nullptr, EGL_EXTENSIONS), "EGL_EXT_device_query"))
+        return { };
+
+    EGLDeviceEXT eglDevice;
+    if (!eglQueryDisplayAttribEXT(eglDisplay, EGL_DEVICE_EXT, reinterpret_cast<EGLAttrib*>(&eglDevice)))
+        return { };
+
+    const char* deviceExtensionsString = eglQueryDeviceStringEXT(eglDevice, EGL_EXTENSIONS);
+    if (!GLContext::isExtensionSupported(deviceExtensionsString, "EGL_EXT_device_drm"))
+        return { };
+
+    // Prefer the render node path, if available; use the main device node otherwise.
+    const char* devicePath = nullptr;
+    if (GLContext::isExtensionSupported(deviceExtensionsString, "EGL_EXT_device_drm_render_node"))
+        devicePath = eglQueryDeviceStringEXT(eglDevice, EGL_DRM_RENDER_NODE_FILE_EXT);
+
+    if (!devicePath || !*devicePath)
+        devicePath = eglQueryDeviceStringEXT(eglDevice, EGL_DRM_DEVICE_FILE_EXT);
+
+    if (!devicePath || !*devicePath)
+        return { };
+
+    return { open(devicePath, O_RDWR | O_CLOEXEC), UnixFileDescriptor::Adopt };
+}
+#endif // USE(LIBDRM)
+
+Result<PhysicalDevice> Instance::deviceForDisplay(PlatformDisplay& display)
+{
+    auto devices = availableDevices();
+    if (!devices)
+        return makeUnexpected(devices.error());
+
+    //
+    // The best (exact!) match can be found by comparing the unique device and driver
+    // identifiers provided by the GL_EXT_memory_object extension, because both OpenGL
+    // and Vulkan will report the same values.
+    //
+    if (auto* context = display.sharingGLContext()) {
+        GLContext::ScopedGLContextCurrent scopedContext(*context);
+        RELEASE_LOG_DEBUG(Vulkan, "deviceForDisplay: GL_EXT_memory_object = %s", context->glExtensions().EXT_memory_object ? "yes" : "no");
+        if (context->glExtensions().EXT_memory_object) {
+            GLint deviceUUIDCount = 0;
+            glGetIntegerv(GL_NUM_DEVICE_UUIDS_EXT, &deviceUUIDCount);
+            RELEASE_LOG_DEBUG(Vulkan, "deviceForDisplay: found %d device UUIDs", deviceUUIDCount);
+            if (deviceUUIDCount == 1) {
+                std::array<GLubyte, GL_UUID_SIZE_EXT> deviceUUID;
+                glGetUnsignedBytei_vEXT(GL_DEVICE_UUID_EXT, 0, deviceUUID.data());
+
+                std::array<GLubyte, GL_UUID_SIZE_EXT> driverUUID;
+                glGetUnsignedBytei_vEXT(GL_DRIVER_UUID_EXT, 0, driverUUID.data());
+
+                auto index = devices->findIf([&deviceUUID, &driverUUID](const auto& deviceInfo) {
+                    PhysicalDeviceProperties properties;
+                    auto idProperties = properties.next<PhysicalDeviceIDProperties>();
+                    deviceInfo.fillProperties(properties);
+                    return equalSpans(std::span(deviceUUID), idProperties.deviceUUID())
+                        && equalSpans(std::span(driverUUID), idProperties.driverUUID());
+                });
+                if (index != notFound) {
+                    RELEASE_LOG_DEBUG(Vulkan, "deviceForDisplay: matched device/driver UUIDs");
+                    return devices->at(index);
+                }
+            }
+        }
+    }
+
+    //
+    // The next best option is to obtain the PCI bus vendor and device identifiers,
+    // and match those to the identifiers reported by Vulkan.
+    //
+    UnixFileDescriptor drmFileDescriptor;
+#if USE(GBM)
+    if (is<PlatformDisplayGBM>(display))
+        drmFileDescriptor = drmFileDescriptorForGBMDisplay();
+#endif
+
+    if (!drmFileDescriptor)
+        drmFileDescriptor = drmFileDescriptorForDisplay(display);
+
+#if USE(LIBDRM)
+    if (drmFileDescriptor) {
+        drmDevice* device { nullptr };
+        auto deviceScope = makeScopeExit([&device]() {
+            if (device) {
+                drmFreeDevice(&device);
+                device = nullptr;
+            }
+        });
+        if (!drmGetDevice(drmFileDescriptor.value(), &device) && device->bustype == DRM_BUS_PCI) {
+            auto index = devices->findIf([pciInfo = device->deviceinfo.pci](const auto& deviceInfo) {
+                PhysicalDeviceProperties properties;
+                deviceInfo.fillProperties(properties);
+                return pciInfo->vendor_id == properties->vendorID && pciInfo->device_id == properties->deviceID;
+            });
+            if (index != notFound) {
+                RELEASE_LOG_DEBUG(Vulkan, "deviceForDisplay: matched PCI device %04x:%04x",
+                    device->deviceinfo.pci->vendor_id, device->deviceinfo.pci->device_id);
+                return devices->at(index);
+            }
+        }
+    }
+#endif // USE(LIBDRM)
+
+    //
+    // Try to match the major+minor device numbers.
+    //
+    struct stat statBuffer;
+    if (drmFileDescriptor && !fstat(drmFileDescriptor.value(), &statBuffer)) {
+        auto index = devices->findIf([deviceID = statBuffer.st_dev](const auto& deviceInfo) {
+            PhysicalDeviceProperties properties;
+            auto drmProperties = properties.next<PhysicalDeviceDRMProperties>();
+            deviceInfo.fillProperties(properties);
+            return (major(deviceID) == drmProperties->renderMajor && minor(deviceID) == drmProperties->renderMinor)
+                || (major(deviceID) == drmProperties->primaryMajor && minor(deviceID) == drmProperties->primaryMinor);
+        });
+        if (index != notFound) {
+            RELEASE_LOG_DEBUG(Vulkan, "deviceForDisplay: matched device major=%d, minor=%d", major(statBuffer.st_dev), minor(statBuffer.st_dev));
+            return devices->at(index);
+        }
+    }
+
+    //
+    // As a last resort, try to split the list of devices in software renderers (CPU based)
+    // and hardware ones (the rest). If the resulting set has only one device of the same
+    // type as the GL display, that one must be the device to use.
+    //
+    // Note that it is better to NOT pick a device (and avoid using Vulkan) if it is not
+    // possible to be completely sure that both OpenGL and Vulkan will be using the same
+    // device. Therefore, a choice is only made if there is only a single Vulkan device.
+    // Splitting the list of devices in software-based and actual GPUs increases
+    // chances of covering single-GPU setups where swrast is also installed.
+    //
+    Vector<PhysicalDevice, 2> softwareDevices;
+    Vector<PhysicalDevice, 2> hardwareDevices;
+    for (auto& deviceInfo : *devices) {
+        PhysicalDeviceProperties properties;
+        deviceInfo.fillProperties(properties);
+        if (properties->deviceType == VK_PHYSICAL_DEVICE_TYPE_CPU)
+            softwareDevices.append(deviceInfo);
+        else
+            hardwareDevices.append(deviceInfo);
+    }
+
+    if (display.glDisplay().isSoftwareRendered()) {
+        if (softwareDevices.size() == 1) {
+            RELEASE_LOG_DEBUG(Vulkan, "deviceForDisplay: matched single software-based device");
+            return softwareDevices[0];
+        }
+    } else {
+        if (hardwareDevices.size() == 1) {
+            RELEASE_LOG_DEBUG(Vulkan, "deviceForDisplay: matched single hardware-based device");
+            return hardwareDevices[0];
+        }
+    }
+
+    return makeUnexpected(VK_ERROR_DEVICE_LOST);
 }
 
 #ifdef VK_EXT_debug_utils

--- a/Source/WebCore/platform/graphics/vulkan/VulkanTypes.h
+++ b/Source/WebCore/platform/graphics/vulkan/VulkanTypes.h
@@ -31,6 +31,9 @@
 #include <wtf/Noncopyable.h>
 
 namespace WebCore {
+
+class PlatformDisplay;
+
 namespace Vulkan {
 
 template <typename Type>
@@ -146,8 +149,22 @@ struct PhysicalDeviceProperties : Structure<VkPhysicalDeviceProperties2, VK_STRU
 struct PhysicalDeviceDRMProperties : Structure<VkPhysicalDeviceDrmPropertiesEXT, VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DRM_PROPERTIES_EXT> {
 };
 
+struct PhysicalDeviceIDProperties : Structure<VkPhysicalDeviceIDProperties, VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_ID_PROPERTIES> {
+    std::span<const uint8_t> deviceUUID() const;
+    std::span<const uint8_t> driverUUID() const;
+};
+
 struct PhysicalDevice : BaseStruct<VkPhysicalDevice> {
     void fillProperties(PhysicalDeviceProperties&) const;
+
+    PhysicalDevice() = default;
+
+    // VkPhysicalDevice instances are owned by the VkInstance and are never destroyed,
+    // which means their handles (and therefore the PhysicalDevice wrapper) can be copied.
+    PhysicalDevice(const PhysicalDevice& other)
+        : BaseStruct(const_cast<VkPhysicalDevice>(other.m_inner))
+    {
+    }
 };
 
 struct Instance : BaseStruct<VkInstance> {
@@ -186,6 +203,7 @@ struct Instance : BaseStruct<VkInstance> {
     }
 
     [[nodiscard]] Result<Vector<PhysicalDevice>> availableDevices() const;
+    [[nodiscard]] Result<PhysicalDevice> deviceForDisplay(PlatformDisplay&);
     [[nodiscard]] VkResult installDebugMessenger();
 
 private:

--- a/Source/WebCore/platform/graphics/vulkan/VulkanUtilities.cpp
+++ b/Source/WebCore/platform/graphics/vulkan/VulkanUtilities.cpp
@@ -28,6 +28,7 @@
 
 #if USE(VULKAN)
 #include "Logging.h"
+#include "PlatformDisplay.h"
 #include <wtf/RuntimeApplicationChecks.h>
 #include <wtf/StdLibExtras.h>
 #include <wtf/Vector.h>
@@ -248,26 +249,15 @@ void initializeIfNeeded()
     }
 #endif // VK_EXT_debug_utils
 
-    // TODO: For now we only enumerate devices, choose one that matches the OpenGL device in use.
-    auto devices = instance->availableDevices();
-    for (auto& deviceInfo : *devices) {
-        PhysicalDeviceProperties properties;
-        auto drmProperties = properties.next<PhysicalDeviceDRMProperties>();
-        deviceInfo.fillProperties(properties);
-
-        RELEASE_LOG(Vulkan, "=== Device: %s ===", properties->deviceName);
-        RELEASE_LOG(Vulkan, "API version: %d.%d.%d", VK_VERSION_MAJOR(properties->apiVersion),
-            VK_VERSION_MINOR(properties->apiVersion), VK_VERSION_PATCH(properties->apiVersion));
-        RELEASE_LOG(Vulkan, "Vendor ID: %#" PRIx32, properties->vendorID);
-        RELEASE_LOG(Vulkan, "Device ID: %#" PRIx32, properties->deviceID);
-
-        RELEASE_LOG(Vulkan, "DRM primary: %s", drmProperties->hasPrimary ? "yes" : "no");
-        if (drmProperties->hasPrimary)
-            RELEASE_LOG(Vulkan, "  - Node: major=%" PRIi64 ", minor=%" PRIi64, drmProperties->primaryMajor, drmProperties->primaryMinor);
-        RELEASE_LOG(Vulkan, "DRM render: %s", drmProperties->hasRender ? "yes" : "no");
-        if (drmProperties->hasRender)
-            RELEASE_LOG(Vulkan, "  - Node: major=%" PRIi64 ", minor=%" PRIi64, drmProperties->renderMajor, drmProperties->renderMinor);
+    auto device = instance->deviceForDisplay(PlatformDisplay::sharedDisplay());
+    if (!device) {
+        RELEASE_LOG_ERROR(Vulkan, "Cannot find device for EGL display: %s (%d)", Vulkan::resultString(device), device.error());
+        return;
     }
+
+    PhysicalDeviceProperties properties;
+    device->fillProperties(properties);
+    RELEASE_LOG(Vulkan, "Found device for EGL display: %s", properties->deviceName);
 
     Instance::setSharedInstance(WTF::move(*instance));
 }


### PR DESCRIPTION
#### 0024d6069a67438a676b5587fa066984cca824f6
<pre>
[WPE][GTK] Choose Vulkan device that matches the one used by the platform display
<a href="https://bugs.webkit.org/show_bug.cgi?id=313491">https://bugs.webkit.org/show_bug.cgi?id=313491</a>

Reviewed by Nikolas Zimmermann.

Add a Vulkan::Instance::deviceForDisplay() utility that can use the
following heuristics to determine which Vulkan device corresponds to
the device being used by the EGL display:

0. Use the information provided by the GL_EXT_memory_object extension
   to fetch the device and driver UUIDs, which can then be matched
   against those reported by Vulkan.

1. Try to obtain the DRM device information, and for devices with
   PCI-like busses match the vendor and device identifiers, otherwise
   match the major+minor device node numbers. There are two ways tried
   to obtain the DRM device:

     a. For GBM displays, reuse the logic from DRMDeviceManager used
        to pick the render node. If the gbm_device was not yet
        initialized, try to use the DRM device node path.

     b. Use the EGL_EXT_device_query and EGL_EXT_device_drm[_render_node]
        extensions to obtain paths to the render node or the main device
        node.

2. Split the list of Vulkan devices in &quot;software based&quot; and &quot;hardware
   based&quot;, then figure out which of these kinds the platform device is.
   If there is only one device of the same kind, then use that.

Determining whether a platform display is &quot;software based&quot; is done using
the EGL_EXT_device_query, first checking EGL_EXT_device_type when
available, then try detecting the EGL_MESA_device_software marker extension,
and finally checking for the strings &quot;llvmpipe&quot; or &quot;swrast&quot; in the renderer
name.

* Source/WebCore/platform/graphics/egl/GLContext.cpp:
(WebCore::GLContext::glExtensions const):
* Source/WebCore/platform/graphics/egl/GLContext.h:
* Source/WebCore/platform/graphics/egl/GLDisplay.cpp:
(WebCore::GLDisplay::isSoftwareRendered const):
* Source/WebCore/platform/graphics/egl/GLDisplay.h:
* Source/WebCore/platform/graphics/gbm/PlatformDisplayGBM.h:
* Source/WebCore/platform/graphics/vulkan/VulkanTypes.cpp:
(WebCore::Vulkan::PhysicalDeviceIDProperties::deviceUUID const):
(WebCore::Vulkan::PhysicalDeviceIDProperties::driverUUID const):
(WebCore::Vulkan::drmFileDescriptorForGBMDisplay):
(WebCore::Vulkan::drmFileDescriptorForDisplay):
(WebCore::Vulkan::Instance::deviceForDisplay):
* Source/WebCore/platform/graphics/vulkan/VulkanTypes.h:
(WebCore::Vulkan::PhysicalDevice::PhysicalDevice):
* Source/WebCore/platform/graphics/vulkan/VulkanUtilities.cpp:
(WebCore::Vulkan::initializeIfNeeded):

Canonical link: <a href="https://commits.webkit.org/312643@main">https://commits.webkit.org/312643@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d079d7f408ccabb1bf0f7a8fde3037bf93d8a523

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/160669 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/34142 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/27243 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/169572 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/115735 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/162538 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/34243 "Built successfully") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/156/builds/34142 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/169572 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/115735 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/163628 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/26847 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/144320 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/169572 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/25899 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/156/builds/34142 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk3-libwebrtc~~](https://ews-build.webkit.org/#/builders/173/builds/17292 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/135593 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/167/builds/22083 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/172052 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/18948 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/23723 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/172052 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [❌ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/33816 "Failed to checkout and rebase branch from PR 63754") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/156/builds/34142 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/172052 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/33800 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/143878 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/95609 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/24437 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/160/builds/33800 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/20693 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/33311 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/100560 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/32810 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/33054 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/32958 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->