### PR TITLE
[CMake][Mac] WebGPU framework fails to link: missing CoreGraphics and ICU

### DIFF
--- a/Source/WebGPU/WebGPU/CMakeLists.txt
+++ b/Source/WebGPU/WebGPU/CMakeLists.txt
@@ -81,6 +81,7 @@ set_target_properties(WebGPU PROPERTIES
 find_library(METAL_FRAMEWORK Metal)
 find_library(IOSURFACE_FRAMEWORK IOSurface)
 find_library(COREFOUNDATION_FRAMEWORK CoreFoundation)
+find_library(COREGRAPHICS_FRAMEWORK CoreGraphics)
 find_library(COREVIDEO_FRAMEWORK CoreVideo)
 find_library(FOUNDATION_FRAMEWORK Foundation)
 find_library(QUARTZCORE_FRAMEWORK QuartzCore)
@@ -89,9 +90,11 @@ target_link_libraries(WebGPU PRIVATE
     ${METAL_FRAMEWORK}
     ${IOSURFACE_FRAMEWORK}
     ${COREFOUNDATION_FRAMEWORK}
+    ${COREGRAPHICS_FRAMEWORK}
     ${COREVIDEO_FRAMEWORK}
     ${FOUNDATION_FRAMEWORK}
     ${QUARTZCORE_FRAMEWORK}
+    ICU::uc
     JavaScriptCore
 )
 


### PR DESCRIPTION
#### afc2f0fb69144dda346a574b6eeac2e0082bff26
<pre>
[CMake][Mac] WebGPU framework fails to link: missing CoreGraphics and ICU
<a href="https://bugs.webkit.org/show_bug.cgi?id=313503">https://bugs.webkit.org/show_bug.cgi?id=313503</a>

Reviewed by Geoffrey Garen, BJ Burg, and Mike Wyrzykowski.

PresentationContextIOSurface.mm uses CGImageCreate / CGColorSpaceCreateWithName,
and WGSL/Lexer.cpp uses u_charType / u_stringHasBinaryProperty since 296102@main.
Add CoreGraphics and ICU::uc to the WebGPU target&apos;s link libraries.

* Source/WebGPU/WebGPU/CMakeLists.txt:

Canonical link: <a href="https://commits.webkit.org/312168@main">https://commits.webkit.org/312168@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/71f081e1359c3070205750e927a260bd84c702d7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/159123 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/32551 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/25656 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/167952 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/113207 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/32619 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/32538 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/123272 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/113207 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/162080 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/25541 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/142934 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/103938 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/24595 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/23022 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/15725 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/134281 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/170446 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/16187 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/22340 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/131465 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/32240 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/27091 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/131577 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35580 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/32184 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/142507 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/90234 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/26274 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/19316 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/31695 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/97709 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/31215 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/31488 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/31370 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->