### PR TITLE
[CMake][Mac] WebKitTestRunner/TestWebKitAPI/TestIPC fail to link: WTF OBJECT library brings in unresolved bmalloc

### DIFF
--- a/Tools/TestWebKitAPI/PlatformMac.cmake
+++ b/Tools/TestWebKitAPI/PlatformMac.cmake
@@ -100,6 +100,7 @@ list(APPEND TestWebKit_SOURCES
 )
 
 list(APPEND TestWebKit_PRIVATE_INCLUDE_DIRECTORIES
+    ${ICU_INCLUDE_DIRS}
     ${WTF_FRAMEWORK_HEADERS_DIR}
     ${bmalloc_FRAMEWORK_HEADERS_DIR}
     ${WebKit_FRAMEWORK_HEADERS_DIR}
@@ -130,7 +131,6 @@ list(APPEND TestWebKit_LIBRARIES
     JavaScriptCore
     WebCoreTestSupport
     WebKitLegacy
-    WTF
     ${CARBON_LIBRARY}
 )
 
@@ -152,6 +152,7 @@ list(APPEND TestIPC_SOURCES
 )
 
 list(APPEND TestIPC_PRIVATE_INCLUDE_DIRECTORIES
+    ${ICU_INCLUDE_DIRS}
     ${WTF_FRAMEWORK_HEADERS_DIR}
     ${bmalloc_FRAMEWORK_HEADERS_DIR}
     ${WEBKIT_DIR}/Platform/cocoa
@@ -166,8 +167,9 @@ list(APPEND TestIPC_LIBRARIES
     "-framework CoreServices"
     "-framework CoreVideo"
     "-framework IOSurface"
+    "-framework Security"
     "-framework UniformTypeIdentifiers"
-    WTF
+    JavaScriptCore
 )
 
 WEBKIT_ADD_TARGET_CXX_FLAGS(TestIPC -Wno-deprecated-declarations)

--- a/Tools/WebKitTestRunner/PlatformMac.cmake
+++ b/Tools/WebKitTestRunner/PlatformMac.cmake
@@ -64,7 +64,6 @@ list(APPEND WebKitTestRunner_INCLUDE_DIRECTORIES
 )
 
 list(APPEND WebKitTestRunner_LIBRARIES
-    WTF
     ${CARBON_LIBRARY}
 )
 


### PR DESCRIPTION
#### dc829e1a2e2883cbe3e903f0265351c103aed8fb
<pre>
[CMake][Mac] WebKitTestRunner/TestWebKitAPI/TestIPC fail to link: WTF OBJECT library brings in unresolved bmalloc
<a href="https://bugs.webkit.org/show_bug.cgi?id=313509">https://bugs.webkit.org/show_bug.cgi?id=313509</a>

Reviewed by Geoffrey Garen.

WTF and bmalloc are OBJECT libraries on the Mac port. Listing bare `WTF` in
a target&apos;s _LIBRARIES pulls every WTF .o onto the link line, which references
bmalloc symbols that aren&apos;t linked, and would also create a second copy of
WTF static state alongside JavaScriptCore.framework&apos;s (see the existing
TestRunnerInjectedBundle comment). These executables already get WTF symbols
via JavaScriptCore.framework, which re-exports them.

Drop `WTF` from the three _LIBRARIES lists. TestIPC additionally needs
JavaScriptCore (it previously had no direct link to it) and Security (which
rode in on WTF&apos;s INTERFACE), and both TestWebKit and TestIPC need
${ICU_INCLUDE_DIRS} for the same reason.

* Tools/TestWebKitAPI/PlatformMac.cmake:
* Tools/WebKitTestRunner/PlatformMac.cmake:

Canonical link: <a href="https://commits.webkit.org/312165@main">https://commits.webkit.org/312165@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/164583f691944384900cd9cd7e27dbe2d5f1cdfb

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/159132 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/32560 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/25665 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/167961 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/113216 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/363950f7-2f10-434e-b5e6-377e5157b0ff) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/161001 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/32628 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/32547 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/123279 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/113216 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/162089 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/25551 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/142943 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/103945 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/cf966349-8b17-4b0d-b049-c94853fee5fb) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/24605 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/23029 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk3-libwebrtc~~](https://ews-build.webkit.org/#/builders/173/builds/15734 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/134291 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/167/builds/20723 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/170456 "Built successfully") | | 
| | | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/22349 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/131472 "Build is in progress. Recent messages:") | | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/32249 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/27098 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/131584 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/32193 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/142516 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/90243 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/24216 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/26283 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/19325 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/31704 "Built successfully") | | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/31224 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/31497 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/31379 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->