### PR TITLE
[libpas] Clean up Windows implementation

### DIFF
--- a/Source/WTF/wtf/win/OSAllocatorWin.cpp
+++ b/Source/WTF/wtf/win/OSAllocatorWin.cpp
@@ -98,23 +98,20 @@ void OSAllocator::commit(void* address, size_t bytes, bool writable, bool execut
 
 void OSAllocator::decommit(void* address, size_t bytes)
 {
-    // https://docs.microsoft.com/en-us/windows/win32/api/memoryapi/nf-memoryapi-virtualalloc
-    // Use MEM_RESET to purge physical pages at timing of OS's preference. This is aligned to
-    // madvise MADV_FREE / MADV_FREE_REUSABLE.
-    // https://devblogs.microsoft.com/oldnewthing/20170113-00/?p=95185
-    // > The fact that MEM_RESET does not remove the page from the working set is not actually mentioned
-    // > in the documentation for the MEM_RESET flag. Instead, it’s mentioned in the documentation for
-    // > the Offer­Virtual­Memory function, and in a sort of backhanded way
-    // So, we need VirtualUnlock call.
+    // Symmetric decommit on Windows. MEM_DECOMMIT releases both physical pages
+    // and Windows commit charge. The matching OSAllocator::commit() call must
+    // happen before any re-access; touching a decommitted page faults.
+    //
+    // Unlike POSIX, Windows has yet another metrics (commit charge), and even though
+    // there is no physical backing pages, commit charge has low hard limit.
+    //
+    // To workaround this limit, Windows is explicitly decommiting and explicitly committing.
     if (!bytes)
         return;
-    void* result = VirtualAlloc(address, bytes, MEM_RESET, PAGE_READWRITE);
+
+    bool result = VirtualFree(address, bytes, MEM_DECOMMIT);
     if (!result)
         CRASH();
-    // Calling VirtualUnlock on a range of memory that is not locked releases the pages from the
-    // process's working set.
-    // https://devblogs.microsoft.com/oldnewthing/20170317-00/?p=95755
-    VirtualUnlock(address, bytes);
 }
 
 void OSAllocator::releaseDecommitted(void* address, size_t bytes, unsigned)

--- a/Source/bmalloc/libpas/src/libpas/pas_config.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_config.h
@@ -89,6 +89,33 @@
 #define PAS_ENABLE_MTE (PAS_USE_APPLE_INTERNAL_SDK && __PAS_ARM64E && !PAS_ASAN_ENABLED)
 #endif /* PAS_ENABLE_MTE */
 
+/* PAS_USE_SYMMETRIC_PAGE_ALLOCATION controls whether pas_page_malloc_commit /
+ * pas_page_malloc_decommit use a strictly symmetric primitive pair. When set, the
+ * strict "decommit" API is expected to be paired with a matching "commit" before
+ * re-access - violating that invariant will fault. When unset, both sides use the
+ * asymmetric model, thus commit side does not need explicit calls.
+ *
+ * This is used only on Windows as asymmetric manner is better: this is driven by
+ * the actual demand access while symmetric manner is pre-committing region.
+ * However Windows has commit-charge limit while Linux / Darwin etc. do not and it is
+ * accounting memory region even if it is not having backing physical pages.
+ *
+ * The "without_mprotect" variants of the page malloc API take an explicit
+ * is_symmetric argument — they serve both symmetric callers (pas_thread_local_cache,
+ * which pairs commit/decommit via ensure_committed + a pages_committed bitvector)
+ * and asymmetric callers (pas_expendable_memory, which reads decommitted memory
+ * without a matching commit and detects the decommit via a version + zero-check
+ * scheme). The _without_mprotect name refers only to skipping PAS_MPROTECT_DECOMMITTED
+ * test-mode poisoning; symmetry is orthogonal and chosen per call site.
+ */
+#ifndef PAS_USE_SYMMETRIC_PAGE_ALLOCATION
+#if PAS_OS(WINDOWS)
+#define PAS_USE_SYMMETRIC_PAGE_ALLOCATION 1
+#else
+#define PAS_USE_SYMMETRIC_PAGE_ALLOCATION 0
+#endif
+#endif /* PAS_USE_SYMMETRIC_PAGE_ALLOCATION */
+
 #define PAS_RISCV __PAS_RISCV
 
 #define PAS_ADDRESS_BITS                 48

--- a/Source/bmalloc/libpas/src/libpas/pas_expendable_memory.c
+++ b/Source/bmalloc/libpas/src/libpas/pas_expendable_memory.c
@@ -351,6 +351,7 @@ static PAS_ALWAYS_INLINE bool scavenge_impl(pas_expendable_memory* header,
             pas_page_malloc_decommit_without_mprotect(
                 (char*)payload + index * PAS_EXPENDABLE_MEMORY_PAGE_SIZE,
                 (other_index - index) * PAS_EXPENDABLE_MEMORY_PAGE_SIZE,
+                /* is_symmetric */ false,
                 pas_may_mmap);
         }
 

--- a/Source/bmalloc/libpas/src/libpas/pas_monotonic_time.c
+++ b/Source/bmalloc/libpas/src/libpas/pas_monotonic_time.c
@@ -106,10 +106,12 @@ uint64_t pas_get_current_monotonic_time_nanoseconds(void)
         return -1;
 
     /* Convert to seconds and nanoseconds */
-    uint64_t sec = counter.QuadPart / frequency.QuadPart;
-    uint64_t nsec = (uint64_t)((counter.QuadPart % frequency.QuadPart) * 1000000000ULL / frequency.QuadPart);
+    uint64_t freq = (uint64_t)frequency.QuadPart;
+    uint64_t ticks = (uint64_t)counter.QuadPart;
+    uint64_t sec = ticks / freq;
+    uint64_t nsec = ((ticks % freq) * 1000000000ULL) / freq;
 
-    return sec * 1.0e9 + nsec;
+    return sec * 1000000000ULL + nsec;
 }
 
 #endif

--- a/Source/bmalloc/libpas/src/libpas/pas_page_malloc.c
+++ b/Source/bmalloc/libpas/src/libpas/pas_page_malloc.c
@@ -100,6 +100,13 @@ static bool madv_zero_supported = false;
 #endif
 
 #if PAS_OS(WINDOWS)
+static void virtual_query_checked(void* ptr, MEMORY_BASIC_INFORMATION* memInfo)
+{
+    SIZE_T bytes = VirtualQuery(ptr, memInfo, sizeof(*memInfo));
+    PAS_ASSERT(bytes == sizeof(*memInfo));
+    PAS_ASSERT(memInfo->RegionSize > 0);
+}
+
 static void* virtual_alloc_with_retry(LPVOID ptr, SIZE_T size, DWORD allocation_type, DWORD protection)
 {
     void* result = VirtualAlloc(ptr, size, allocation_type, protection);
@@ -110,7 +117,7 @@ static void* virtual_alloc_with_retry(LPVOID ptr, SIZE_T size, DWORD allocation_
     if (error != ERROR_COMMITMENT_LIMIT && error != ERROR_NOT_ENOUGH_MEMORY)
         return result;
 
-    // Only retry commits
+    /* Only retry commits */
     if (!(allocation_type & MEM_COMMIT))
         return result;
 
@@ -164,9 +171,11 @@ pas_page_malloc_try_map_pages(size_t size, bool may_contain_small_or_medium)
     PAS_PROFILE(PAGE_ALLOCATION, size, may_contain_small_or_medium, PAS_VM_TAG);
     PAS_MTE_HANDLE(PAGE_ALLOCATION, size, may_contain_small_or_medium, PAS_VM_TAG);
 
-    // PAS_STATS is not currently supported on Windows, so we do not currently
-    // increment pas_stats_page_alloc_counts counters here. If that ever
-    // changes, we should call PAS_RECORD_STAT here as well.
+    /*
+     * PAS_STATS is not currently supported on Windows, so we do not currently
+     * increment pas_stats_page_alloc_counts counters here. If that ever
+     * changes, we should call PAS_RECORD_STAT here as well.
+     */
     PAS_TESTING_ASSERT(!PAS_ENABLE_STATS);
 
     return virtual_alloc_with_retry(NULL, size, MEM_COMMIT | MEM_RESERVE, PAGE_READWRITE);
@@ -351,7 +360,7 @@ void pas_page_malloc_zero_fill(void* base, size_t size)
 #endif /* PAS_OS(WINDOWS) */
 }
 
-static void commit_impl(void* ptr, size_t size, bool do_mprotect, pas_mmap_capability mmap_capability)
+static void commit_impl(void* ptr, size_t size, bool do_mprotect, bool is_symmetric, pas_mmap_capability mmap_capability)
 {
     uintptr_t base_as_int;
     uintptr_t end_as_int;
@@ -377,46 +386,60 @@ static void commit_impl(void* ptr, size_t size, bool do_mprotect, pas_mmap_capab
     }
 
 #if PAS_OS(LINUX)
+    PAS_ASSERT(!is_symmetric);
     PAS_SYSCALL(madvise(ptr, size, MADV_DODUMP));
 #elif PAS_OS(WINDOWS)
-    /* Sometimes the returned memInfo.RegionSize < size, and VirtualAlloc can't span regions
-       We loop to make sure we get the full requested range. */
-    size_t totalSeen = 0;
-    void *currentPtr = ptr;
-    while (totalSeen < size) {
-        MEMORY_BASIC_INFORMATION memInfo;
-        VirtualQuery(currentPtr, &memInfo, sizeof(memInfo));
-        PAS_ASSERT(memInfo.State != 0x10000);
-        PAS_ASSERT(memInfo.RegionSize > 0);
-        PAS_ASSERT(virtual_alloc_with_retry(currentPtr, PAS_MIN(memInfo.RegionSize, size - totalSeen), MEM_COMMIT, PAGE_READWRITE));
-        currentPtr = (void*) ((uintptr_t) currentPtr + memInfo.RegionSize);
-        totalSeen += memInfo.RegionSize;
+    if (is_symmetric) {
+        /*
+         * Symmetric: re-commit pages that the matching decommit released via
+         * MEM_DECOMMIT. Loop because the range may span multiple reservations.
+         */
+        size_t totalSeen = 0;
+        void *currentPtr = ptr;
+        while (totalSeen < size) {
+            MEMORY_BASIC_INFORMATION memInfo;
+            virtual_query_checked(currentPtr, &memInfo);
+            PAS_ASSERT(memInfo.State != 0x10000);
+            PAS_ASSERT(virtual_alloc_with_retry(currentPtr, PAS_MIN(memInfo.RegionSize, size - totalSeen), MEM_COMMIT, PAGE_READWRITE));
+            currentPtr = (void*) ((uintptr_t) currentPtr + memInfo.RegionSize);
+            totalSeen += memInfo.RegionSize;
+        }
+    } else {
+        /*
+         * Asymmetric: pages stayed committed through the matching decommit,
+         * so there's nothing to re-commit.
+         */
     }
 #elif PAS_PLATFORM(PLAYSTATION)
-    // We don't need to call madvise to map page.
+    /* We don't need to call madvise to map page. */
+    PAS_ASSERT(!is_symmetric);
 #elif PAS_OS(FREEBSD)
+    PAS_ASSERT(!is_symmetric);
     PAS_SYSCALL(madvise(ptr, size, MADV_NORMAL));
+#else
+    PAS_ASSERT(!is_symmetric);
 #endif
 }
 
 void pas_page_malloc_commit(void* ptr, size_t size, pas_mmap_capability mmap_capability)
 {
     static const bool do_mprotect = true;
-    commit_impl(ptr, size, do_mprotect, mmap_capability);
+    static const bool is_symmetric = !!PAS_USE_SYMMETRIC_PAGE_ALLOCATION;
+    commit_impl(ptr, size, do_mprotect, is_symmetric, mmap_capability);
 }
 
-void pas_page_malloc_commit_without_mprotect(void* ptr, size_t size, pas_mmap_capability mmap_capability)
+void pas_page_malloc_commit_without_mprotect(void* ptr, size_t size, bool is_symmetric, pas_mmap_capability mmap_capability)
 {
     static const bool do_mprotect = false;
-    commit_impl(ptr, size, do_mprotect, mmap_capability);
+    commit_impl(ptr, size, do_mprotect, is_symmetric, mmap_capability);
 }
 
 static void decommit_impl(void* ptr, size_t size,
-                          bool do_mprotect,
+                          bool do_mprotect, bool is_symmetric,
                           pas_mmap_capability mmap_capability)
 {
     static const bool verbose = PAS_SHOULD_LOG(PAS_LOG_OTHER);
-    
+
     uintptr_t base_as_int;
     uintptr_t end_as_int;
 
@@ -431,51 +454,70 @@ static void decommit_impl(void* ptr, size_t size,
         base_as_int == pas_round_up_to_power_of_2(base_as_int, pas_page_malloc_alignment()));
     PAS_ASSERT(
         end_as_int == pas_round_down_to_power_of_2(end_as_int, pas_page_malloc_alignment()));
-    
+
 #if PAS_OS(DARWIN)
+    PAS_ASSERT(!is_symmetric);
     if (pas_page_malloc_decommit_zero_fill && mmap_capability)
         pas_page_malloc_zero_fill(ptr, size);
     else
         PAS_SYSCALL(madvise(ptr, size, MADV_FREE_REUSABLE));
 #elif PAS_OS(FREEBSD)
+    PAS_ASSERT(!is_symmetric);
     PAS_SYSCALL(madvise(ptr, size, MADV_FREE));
 #elif PAS_OS(LINUX)
+    PAS_ASSERT(!is_symmetric);
     PAS_SYSCALL(madvise(ptr, size, MADV_DONTNEED));
     PAS_SYSCALL(madvise(ptr, size, MADV_DONTDUMP));
 #elif PAS_OS(WINDOWS)
-    // DiscardVirtualMemory returns memory to the OS faster, but fails sometimes on Windows 10
-    // Fall back to VirtualAlloc in those cases
-    DWORD ret = DiscardVirtualMemory(ptr, size);
-    if (ret) {
-        /* Sometimes the returned memInfo.RegionSize < size, and VirtualAlloc can't span regions
-        We loop to make sure we get the full requested range. */
-        size_t totalSeen = 0;
-        void *currentPtr = ptr;
-        while (totalSeen < size) {
-            MEMORY_BASIC_INFORMATION memInfo;
-            VirtualQuery(currentPtr, &memInfo, sizeof(memInfo));
-            PAS_ASSERT(VirtualAlloc(currentPtr, PAS_MIN(memInfo.RegionSize, size - totalSeen), MEM_RESET, PAGE_READWRITE));
-            PAS_ASSERT(memInfo.RegionSize > 0);
-            currentPtr = (void*) ((uintptr_t) currentPtr + memInfo.RegionSize);
-            totalSeen += memInfo.RegionSize;
-        }
-    }
-
-    // We need to decommit the region as well, otherwise commit space will never shrink
-    // However we can't decommit if do_mprotect is false - decommitting is an implicit mprotect
-    if (do_mprotect) {
+    if (is_symmetric) {
+        /*
+         * Symmetric: MEM_DECOMMIT releases both the physical backing and
+         * the Windows commit charge. The matching commit path is required
+         * before re-access; reading decommitted pages faults.
+         *
+         * This is the cost of preserving commit-charge accounting on Windows,
+         * where commit is a hard system-wide limit (RAM + pagefile).
+         */
         size_t totalSeen = 0;
         void* currentPtr = ptr;
         while (totalSeen < size) {
             MEMORY_BASIC_INFORMATION memInfo;
-            VirtualQuery(currentPtr, &memInfo, sizeof(memInfo));
+            virtual_query_checked(currentPtr, &memInfo);
             PAS_ASSERT(VirtualFree(currentPtr, PAS_MIN(memInfo.RegionSize, size - totalSeen), MEM_DECOMMIT));
-            PAS_ASSERT(memInfo.RegionSize > 0);
             currentPtr = (void*)((uintptr_t)currentPtr + memInfo.RegionSize);
             totalSeen += memInfo.RegionSize;
         }
+    } else {
+        /*
+         * Asymmetric: pages stay committed but contents are discarded.
+         * This is equivalent to madvise(MADV_DONTNEED).
+         *
+         * DiscardVirtualMemory frees physical pages immediately and removes
+         * them from the working set. On older Windows 10 builds and on ranges
+         * spanning multiple reservations it can fail, so we fall back
+         * to a per-reservation MEM_RESET loop + VirtualUnlock, which has the
+         * same effect but with lazy reclaim.
+         */
+        PAS_ASSERT(!do_mprotect);
+        if (DiscardVirtualMemory(ptr, size)) {
+            size_t totalSeen = 0;
+            void* currentPtr = ptr;
+            while (totalSeen < size) {
+                MEMORY_BASIC_INFORMATION memInfo;
+                virtual_query_checked(currentPtr, &memInfo);
+                PAS_ASSERT(VirtualAlloc(currentPtr, PAS_MIN(memInfo.RegionSize, size - totalSeen), MEM_RESET, PAGE_READWRITE));
+                currentPtr = (void*)((uintptr_t)currentPtr + memInfo.RegionSize);
+                totalSeen += memInfo.RegionSize;
+            }
+            /*
+             * MEM_RESET on its own does not remove pages from the process working set.
+             * VirtualUnlock of unlocked pages evicts them from the working set.
+             */
+            VirtualUnlock(ptr, size);
+        }
     }
 #else
+    PAS_ASSERT(!is_symmetric);
     PAS_SYSCALL(madvise(ptr, size, MADV_DONTNEED));
 #endif
 
@@ -491,13 +533,14 @@ static void decommit_impl(void* ptr, size_t size,
 void pas_page_malloc_decommit(void* ptr, size_t size, pas_mmap_capability mmap_capability)
 {
     static const bool do_mprotect = true;
-    decommit_impl(ptr, size, do_mprotect, mmap_capability);
+    static const bool is_symmetric = !!PAS_USE_SYMMETRIC_PAGE_ALLOCATION;
+    decommit_impl(ptr, size, do_mprotect, is_symmetric, mmap_capability);
 }
 
-void pas_page_malloc_decommit_without_mprotect(void* ptr, size_t size, pas_mmap_capability mmap_capability)
+void pas_page_malloc_decommit_without_mprotect(void* ptr, size_t size, bool is_symmetric, pas_mmap_capability mmap_capability)
 {
     static const bool do_mprotect = false;
-    decommit_impl(ptr, size, do_mprotect, mmap_capability);
+    decommit_impl(ptr, size, do_mprotect, is_symmetric, mmap_capability);
 }
 
 void pas_page_malloc_deallocate(void* ptr, size_t size)
@@ -514,7 +557,9 @@ void pas_page_malloc_deallocate(void* ptr, size_t size)
         return;
 
 #if PAS_OS(WINDOWS)
-    VirtualFree(ptr, size, MEM_RELEASE);
+    /* For MEM_RELEASE, the size argument to VirtualFree must be 0 — it releases the
+       entire range allocated by the original VirtualAlloc(MEM_RESERVE) call. */
+    PAS_ASSERT(VirtualFree(ptr, 0, MEM_RELEASE));
 #else
     munmap(ptr, size);
 #endif

--- a/Source/bmalloc/libpas/src/libpas/pas_page_malloc.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_page_malloc.h
@@ -74,11 +74,15 @@ PAS_API void pas_page_malloc_decommit(void* base, size_t size, pas_mmap_capabili
 /* In testing mode, we have commit/decommit mprotect the memory as a way of helping us see if we are
    accidentally reading or writing that memory. But sometimes we use commit/decommit in a way that prevents
    us from making such assertions, like if we allow some reads and writes to decommitted memory in rare
-   cases. */
+   cases.
+
+   The is_symmetric flag controls whether the OS primitive is strictly symmetric (commit/decommit must be
+   paired; reads after decommit fault) or asymmetric (reads after decommit zero-fill via the page-fault
+   handler). Only usable when PAS_USE_SYMMETRIC_PAGE_ALLOCATION is true */
 PAS_API void pas_page_malloc_commit_without_mprotect(
-    void* base, size_t size, pas_mmap_capability mmap_capability);
+    void* base, size_t size, bool is_symmetric, pas_mmap_capability mmap_capability);
 PAS_API void pas_page_malloc_decommit_without_mprotect(
-    void* base, size_t size, pas_mmap_capability mmap_capability);
+    void* base, size_t size, bool is_symmetric, pas_mmap_capability mmap_capability);
 
 PAS_END_EXTERN_C;
 

--- a/Source/bmalloc/libpas/src/libpas/pas_scavenger.c
+++ b/Source/bmalloc/libpas/src/libpas/pas_scavenger.c
@@ -129,10 +129,17 @@ static double get_time_in_milliseconds(void)
 {
 #if PAS_OS(WINDOWS)
     LARGE_INTEGER frequency, counter;
-    QueryPerformanceFrequency(&frequency);
-    QueryPerformanceCounter(&counter);
+    if (!QueryPerformanceFrequency(&frequency))
+        return 0.;
 
-    return (counter.QuadPart * 1000.) / frequency.QuadPart;
+    if (!QueryPerformanceCounter(&counter))
+        return 0.;
+
+    uint64_t freq = (uint64_t)frequency.QuadPart;
+    uint64_t ticks = (uint64_t)counter.QuadPart;
+    uint64_t sec_ms = (ticks / freq) * 1000ULL;
+    uint64_t frac_ms = ((ticks % freq) * 1000ULL) / freq;
+    return (double)(sec_ms + frac_ms);
 #else
     struct timeval current_time;
 

--- a/Source/bmalloc/libpas/src/libpas/pas_thread.c
+++ b/Source/bmalloc/libpas/src/libpas/pas_thread.c
@@ -39,9 +39,7 @@ static const bool verbose = false;
 
 int pthread_create(pthread_t* tid, const pthread_attr_t* attr, unsigned (*start)(void *), void* arg)
 {
-    PAS_UNUSED_PARAM(tid);
     PAS_UNUSED_PARAM(attr);
-    PAS_UNUSED_PARAM(arg);
 
     /* Create thread handle */
     HANDLE hThread;
@@ -54,7 +52,7 @@ int pthread_create(pthread_t* tid, const pthread_attr_t* attr, unsigned (*start)
         NULL,
         0,
         start,
-        NULL,
+        arg,
         0,
         &threadIdentifier
     );
@@ -65,13 +63,17 @@ int pthread_create(pthread_t* tid, const pthread_attr_t* attr, unsigned (*start)
         return 1;
     }
 
+    *tid = (pthread_t)hThread;
     return 0;
 }
 
 int pthread_detach(pthread_t thread)
 {
-    PAS_UNUSED_PARAM(thread);
-    /* Detach is a no-op on Windows */
+    /* _beginthreadex returns a HANDLE that must be closed; closing it while the
+       thread is still running tells the kernel to release thread resources when
+       the thread exits, which matches POSIX pthread_detach semantics. */
+    if (!CloseHandle((HANDLE)thread))
+        return 1;
     return 0;
 }
 
@@ -113,12 +115,14 @@ BOOL once_init_runner(PINIT_ONCE once_control, PVOID init_routine, PVOID* contex
 
 int pthread_once(pthread_once_t* once_control, void (*init_routine)(void))
 {
-    int result;
-    result = InitOnceExecuteOnce(*once_control, once_init_runner, init_routine, NULL);
-    if (verbose && !result)
-        pas_log("Failed to run pthread_once.\n");
-
-    return result;
+    BOOL result;
+    result = InitOnceExecuteOnce(once_control, once_init_runner, init_routine, NULL);
+    if (!result) {
+        if (verbose)
+            pas_log("Failed to run pthread_once.\n");
+        return 1;
+    }
+    return 0;
 }
 
 /* Thread Local Storage
@@ -137,10 +141,9 @@ int pthread_once(pthread_once_t* once_control, void (*init_routine)(void))
    switch to Thread Local Storage and deal with the extra complexity. */
 int pthread_key_create(pthread_key_t* key, void (*destructor)(void*))
 {
-    PAS_UNUSED_PARAM(key);
     DWORD result = FlsAlloc(destructor);
     PAS_ASSERT(result != FLS_OUT_OF_INDEXES);
-
+    *key = result;
     return 0;
 }
 
@@ -187,13 +190,26 @@ int pthread_cond_wait(pthread_cond_t* cond, pthread_mutex_t* mutex)
 int pthread_cond_timedwait(pthread_cond_t* cond, pthread_mutex_t* mutex, const struct timespec* abstime)
 {
     LARGE_INTEGER frequency, counter;
-    QueryPerformanceFrequency(&frequency);
-    QueryPerformanceCounter(&counter);
+    if (!QueryPerformanceFrequency(&frequency))
+        return 1;
 
-    uint64_t current_ms = (counter.QuadPart * 1000) / frequency.QuadPart;
-    uint64_t wait_until_ms = abstime->tv_sec * 1000 + abstime->tv_nsec / 1000000;
+    if (!QueryPerformanceCounter(&counter))
+        return 1;
 
-    return SleepConditionVariableSRW(cond, mutex, wait_until_ms - current_ms, 0);
+    uint64_t current_ms = ((uint64_t)counter.QuadPart * 1000ULL) / (uint64_t)frequency.QuadPart;
+    uint64_t wait_until_ms = (uint64_t)abstime->tv_sec * 1000ULL + (uint64_t)abstime->tv_nsec / 1000000ULL;
+
+    DWORD wait_ms;
+    if (wait_until_ms <= current_ms)
+        wait_ms = 0;
+    else {
+        uint64_t remaining = wait_until_ms - current_ms;
+        wait_ms = remaining >= (uint64_t)(INFINITE - 1) ? (INFINITE - 1) : (DWORD)remaining;
+    }
+
+    if (!SleepConditionVariableSRW(cond, mutex, wait_ms, 0))
+        return 1;
+    return 0;
 }
 
 int pthread_mutex_lock(pthread_mutex_t* mutex)

--- a/Source/bmalloc/libpas/src/libpas/pas_thread.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_thread.h
@@ -38,7 +38,7 @@
 
 /* Threads */
 
-typedef PINIT_ONCE pthread_once_t;
+typedef INIT_ONCE pthread_once_t;
 
 struct pthread_attr_t_internal { };
 typedef struct pthread_attr_t_internal * pthread_attr_t;

--- a/Source/bmalloc/libpas/src/libpas/pas_thread_local_cache.c
+++ b/Source/bmalloc/libpas/src/libpas/pas_thread_local_cache.c
@@ -119,7 +119,7 @@ static void deallocate(pas_thread_local_cache* thread_local_cache)
         thread_local_cache->allocator_index_capacity);
 
     /* If we're doing symmetric decommit, then we need to commit the memory for the TLC now. */
-    pas_page_malloc_commit_without_mprotect(begin, size, pas_may_mmap);
+    pas_page_malloc_commit_without_mprotect(begin, size, /* is_symmetric */ !!PAS_USE_SYMMETRIC_PAGE_ALLOCATION, pas_may_mmap);
     
     pas_large_utility_free_heap_deallocate(begin, size);
 }
@@ -487,12 +487,13 @@ void pas_thread_local_cache_ensure_committed(pas_thread_local_cache* thread_loca
             continue;
         
         pas_lock_assert_held(&thread_local_cache->node->scavenger_lock);
-        
+
         /* Don't attempt to do fancy things with spans for commit, since we're no longer really
            optimizing for symmetric commit anyway. */
         pas_page_malloc_commit_without_mprotect(
             (char*)thread_local_cache + (page_index << pas_page_malloc_alignment_shift()),
             pas_page_malloc_alignment(),
+            /* is_symmetric */ !!PAS_USE_SYMMETRIC_PAGE_ALLOCATION,
             pas_may_mmap);
 
         pas_bitvector_set(thread_local_cache->pages_committed, page_index, true);
@@ -927,7 +928,8 @@ static void decommit_allocator_range(pas_thread_local_cache* cache,
         pas_log("Decommitting %p...%p\n", (void*)decommit_range.begin, (void*)decommit_range.end);
 
     pas_page_malloc_decommit_without_mprotect(
-        (char*)cache + decommit_range.begin, pas_range_size(decommit_range), pas_may_mmap);
+        (char*)cache + decommit_range.begin, pas_range_size(decommit_range),
+        /* is_symmetric */ !!PAS_USE_SYMMETRIC_PAGE_ALLOCATION, pas_may_mmap);
 
     if (verbose) {
         pas_log("Num committed pages in the range we just decommitted: %zu\n",


### PR DESCRIPTION
#### 0e74ad95db8ecba2c260ccd1be4642746813b4de
<pre>
[libpas] Clean up Windows implementation
<a href="https://bugs.webkit.org/show_bug.cgi?id=313512">https://bugs.webkit.org/show_bug.cgi?id=313512</a>
<a href="https://rdar.apple.com/175725768">rdar://175725768</a>

Reviewed by Marcus Plutowski.

1. Scan libpas pthread stub on Windows and fix obvious issues.
2. We reintroduce is_symmetric flag to pas page allocation. When it is set,
   commit and decommit are paired explicitly (asymmetric protocol does not
   require explicit commit) as Windows has commit charge limit which
   does not exits on POSIX environment.

* Source/WTF/wtf/win/OSAllocatorWin.cpp:
(WTF::OSAllocator::decommit):
* Source/bmalloc/libpas/src/libpas/pas_config.h:
* Source/bmalloc/libpas/src/libpas/pas_expendable_memory.c:
(scavenge_impl):
* Source/bmalloc/libpas/src/libpas/pas_monotonic_time.c:
(pas_get_current_monotonic_time_nanoseconds):
* Source/bmalloc/libpas/src/libpas/pas_page_malloc.c:
(virtual_query_checked):
(virtual_alloc_with_retry):
(pas_page_malloc_try_map_pages):
(commit_impl):
(pas_page_malloc_commit):
(pas_page_malloc_commit_without_mprotect):
(decommit_impl):
(pas_page_malloc_decommit):
(pas_page_malloc_decommit_without_mprotect):
(pas_page_malloc_deallocate):
* Source/bmalloc/libpas/src/libpas/pas_page_malloc.h:
* Source/bmalloc/libpas/src/libpas/pas_scavenger.c:
(get_time_in_milliseconds):
* Source/bmalloc/libpas/src/libpas/pas_thread.c:
(pthread_create):
(pthread_detach):
(pthread_once):
(pthread_key_create):
(pthread_cond_timedwait):
* Source/bmalloc/libpas/src/libpas/pas_thread.h:
* Source/bmalloc/libpas/src/libpas/pas_thread_local_cache.c:
(deallocate):
(pas_thread_local_cache_ensure_committed):
(decommit_allocator_range):

Canonical link: <a href="https://commits.webkit.org/312218@main">https://commits.webkit.org/312218@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cb02a8ba04b2029b807dc92238c375cd1accae0a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/159139 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/32567 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/25672 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/167968 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/113223 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/9a21fe08-8dbc-472c-a8be-e1ef675dea19) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/32635 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/32554 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/123284 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/86563 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/162096 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/25562 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/142954 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/103950 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/b0db033a-8024-4609-864c-789c91774a5e) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/24616 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/23041 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/15741 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/151189 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/134302 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/20734 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/170463 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/19972 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/16203 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/22360 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/131477 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/32256 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/27110 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/131589 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/32200 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/142527 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/90250 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/24239 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/26300 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/19336 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/191421 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/31711 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/97725 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/49195 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/31231 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/31504 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/31386 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->