### PR TITLE
Re-land [Swift Testing] Make it easy to allow a WebPage to get and set selection, and to evaluate JS in general

### DIFF
--- a/Tools/TestWebKitAPI/Helpers/cocoa/JavaScriptMessages.swift
+++ b/Tools/TestWebKitAPI/Helpers/cocoa/JavaScriptMessages.swift
@@ -1,0 +1,152 @@
+// Copyright (C) 2026 Apple Inc. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+// 1. Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+// 2. Redistributions in binary form must reproduce the above copyright
+//    notice, this list of conditions and the following disclaimer in the
+//    documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+// THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+// BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+// THE POSSIBILITY OF SUCH DAMAGE.
+
+#if ENABLE_SWIFTUI
+
+public import struct Swift.String
+public import WebKit
+
+/// A collection of common useful JavaScript expressions.
+public enum JavaScriptMessages {
+}
+
+extension JavaScriptMessages {
+    /// Gets the bounding client rect of the current selection.
+    public struct SelectionBoundingClientRect: WebPage.JavaScriptExpression {
+        // Protocol conformance.
+        // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
+        public typealias Output = DOMRect
+
+        // Protocol conformance.
+        // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
+        public static var expression: String {
+            """
+            const selection = window.getSelection();
+
+            const range = selection.getRangeAt(0);
+            return range.getBoundingClientRect().toJSON();
+            """
+        }
+
+        /// Create a new `SelectionBoundingClientRect`.
+        public init() {
+        }
+
+        // Protocol conformance.
+        // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
+        public func encoded() -> [String: Any?] {
+            [:]
+        }
+    }
+}
+
+extension JavaScriptMessages {
+    /// An expression used to set the current selection in JavaScript.
+    public struct SetSelection: WebPage.JavaScriptExpression {
+        // Protocol conformance.
+        // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
+        public typealias Output = Void
+
+        // Protocol conformance.
+        // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
+        public static var expression: String {
+            """
+            if (selection.kind === "range") {
+                const baseNode = document.getElementById(selection.base.container).firstChild;
+                const extentNode = document.getElementById(selection.extent.container).firstChild;
+                getSelection().setBaseAndExtent(baseNode, selection.base.offset, extentNode, selection.extent.offset);
+            } else {
+                const node = document.getElementById(selection.position.container).firstChild;
+                getSelection().setPosition(node, selection.position.offset);
+            }
+            """
+        }
+
+        private let selection: JavaScriptSelection
+
+        /// Create a `SetSelection` expression from the given selection.
+        ///
+        /// - Parameter selection: The selection that will be set.
+        public init(_ selection: JavaScriptSelection) {
+            self.selection = selection
+        }
+
+        // Protocol conformance.
+        // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
+        public func encoded() -> [String: Any?] {
+            [
+                "selection": selection.encoded()
+            ]
+        }
+    }
+}
+
+extension JavaScriptMessages {
+    /// Gets the current selection.
+    public struct GetSelection: WebPage.JavaScriptExpression {
+        // Protocol conformance.
+        // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
+        public typealias Output = JavaScriptSelection
+
+        // Protocol conformance.
+        // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
+        public static var expression: String {
+            """
+            const selection = getSelection();
+            if (selection.isCollapsed) {
+                return {
+                    "kind": "collapsed",
+                    "position": {
+                        "container": selection.anchorNode.parentElement.id,
+                        "offset": selection.anchorOffset,
+                    },
+                };
+            } else {
+                return {
+                    "kind": "range",
+                    "base": {
+                        "container": selection.anchorNode.parentElement.id,
+                        "offset": selection.anchorOffset,
+                    },
+                    "extent": {
+                        "container": selection.focusNode.parentElement.id,
+                        "offset": selection.focusOffset,
+                    },
+                };
+            }
+            """
+        }
+
+        /// Create a new `GetSelection`.
+        public init() {
+        }
+
+        // Protocol conformance.
+        // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
+        public func encoded() -> [String: Any?] {
+            [:]
+        }
+    }
+}
+
+#endif // ENABLE_SWIFTUI

--- a/Tools/TestWebKitAPI/Helpers/cocoa/JavaScriptTypes.swift
+++ b/Tools/TestWebKitAPI/Helpers/cocoa/JavaScriptTypes.swift
@@ -1,0 +1,201 @@
+// Copyright (C) 2026 Apple Inc. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+// 1. Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+// 2. Redistributions in binary form must reproduce the above copyright
+//    notice, this list of conditions and the following disclaimer in the
+//    documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+// THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+// BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+// THE POSSIBILITY OF SUCH DAMAGE.
+
+#if ENABLE_SWIFTUI
+
+public import struct Swift.String
+public import WebKit
+
+// This file contains common JS "currency" types.
+
+// MARK: JavaScriptSelection
+
+/// A type representing the JavaScript `Selection` type.
+public enum JavaScriptSelection: Sendable, Equatable {
+    /// A position relative to some DOM element within a selection.
+    public struct Position: Sendable, Equatable {
+        /// The id of the DOM element this position is relative to.
+        public let container: String
+
+        /// The offset relative to the container.
+        public let offset: Int
+
+        /// Create a new selection.
+        ///
+        /// - Parameters:
+        ///   - container: The container element for this selection.
+        ///   - offset: The offset relative to the container.
+        public init(in container: String, at offset: Int) {
+            self.container = container
+            self.offset = offset
+        }
+    }
+
+    /// A collapsed selection.
+    case collapsed(Position)
+
+    /// A selection with a range.
+    case range(base: Position, extent: Position)
+}
+
+extension JavaScriptSelection.Position: WebPage.JavaScriptEncodable {
+    // Protocol conformance.
+    // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
+    public func encoded() -> [String: Any?] {
+        [
+            "container": container,
+            "offset": offset,
+        ]
+    }
+}
+
+extension JavaScriptSelection.Position: WebPage.JavaScriptDecodable {
+    // Protocol conformance.
+    // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
+    public init?(decodedRepresentation: [String: Any?]) {
+        guard let container = decodedRepresentation["container"] as? String else {
+            return nil
+        }
+
+        guard let offset = decodedRepresentation["offset"] as? Int else {
+            return nil
+        }
+
+        self.container = container
+        self.offset = offset
+    }
+}
+
+extension JavaScriptSelection: WebPage.JavaScriptEncodable {
+    // Protocol conformance.
+    // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
+    public func encoded() -> [String: Any?] {
+        switch self {
+        case .collapsed(let position):
+            [
+                "kind": "collapsed",
+                "position": position.encoded(),
+            ]
+        case .range(let base, let extent):
+            [
+                "kind": "range",
+                "base": base.encoded(),
+                "extent": extent.encoded(),
+            ]
+        }
+    }
+}
+
+extension JavaScriptSelection: WebPage.JavaScriptDecodable {
+    // Protocol conformance.
+    // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
+    public init?(decodedRepresentation: [String: Any?]) {
+        guard let kind = decodedRepresentation["kind"] as? String else {
+            return nil
+        }
+
+        switch kind {
+        case "collapsed":
+            guard
+                let position = decodedRepresentation["position"] as? [String: Any?],
+                let decodedPosition = Position(decodedRepresentation: position)
+            else {
+                return nil
+            }
+
+            self = .collapsed(decodedPosition)
+
+        case "range":
+            guard
+                let base = decodedRepresentation["base"] as? [String: Any?],
+                let decodedBase = Position(decodedRepresentation: base)
+            else {
+                return nil
+            }
+
+            guard
+                let extent = decodedRepresentation["extent"] as? [String: Any?],
+                let decodedExtent = Position(decodedRepresentation: extent)
+            else {
+                return nil
+            }
+
+            self = .range(base: decodedBase, extent: decodedExtent)
+
+        default:
+            return nil
+        }
+    }
+}
+
+// MARK: DOMRect
+
+/// A DOMRect describes the size and position of a rectangle.
+public struct DOMRect: Sendable {
+    /// The x coordinate of the DOMRect's origin (typically the top-left corner of the rectangle).
+    public let x: Double
+
+    /// The y coordinate of the DOMRect's origin (typically the top-left corner of the rectangle).
+    public let y: Double
+
+    /// The width of the DOMRect.
+    public let width: Double
+
+    /// The height of the DOMRect.
+    public let height: Double
+}
+
+extension DOMRect: WebPage.JavaScriptDecodable {
+    // Protocol conformance.
+    // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
+    public init?(decodedRepresentation: [String: Any?]) {
+        guard let x = decodedRepresentation["x"] as? Double else {
+            return nil
+        }
+
+        guard let y = decodedRepresentation["y"] as? Double else {
+            return nil
+        }
+
+        guard let width = decodedRepresentation["width"] as? Double else {
+            return nil
+        }
+
+        guard let height = decodedRepresentation["height"] as? Double else {
+            return nil
+        }
+
+        self = .init(x: x, y: y, width: width, height: height)
+    }
+}
+
+extension CGRect {
+    /// Converts a DOMRect to a CGRect.
+    ///
+    /// - Parameter rect: The value to convert.
+    public init(_ rect: DOMRect) {
+        self = .init(x: rect.x, y: rect.y, width: rect.width, height: rect.height)
+    }
+}
+
+#endif // ENABLE_SWIFTUI

--- a/Tools/TestWebKitAPI/Helpers/cocoa/WebPage+JavaScriptExpression.swift
+++ b/Tools/TestWebKitAPI/Helpers/cocoa/WebPage+JavaScriptExpression.swift
@@ -1,0 +1,121 @@
+// Copyright (C) 2026 Apple Inc. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+// 1. Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+// 2. Redistributions in binary form must reproduce the above copyright
+//    notice, this list of conditions and the following disclaimer in the
+//    documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+// THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+// BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+// THE POSSIBILITY OF SUCH DAMAGE.
+
+#if ENABLE_SWIFTUI
+
+public import WebKit
+
+extension WebPage {
+    /// A type that can encode itself to a JavaScript JSON value representation.
+    public protocol JavaScriptEncodable {
+        /// Encodes this value as a JSON value.
+        ///
+        /// - Returns: A representation of this value as encoded in JSON.
+        func encoded() -> [String: Any?]
+    }
+}
+
+extension WebPage {
+    /// A type that can decode itself from a JavaScript JSON value representation.
+    public protocol JavaScriptDecodable {
+        /// Decodes a value from a JSON value.
+        ///
+        /// - Parameter decodedRepresentation: A representation of this value as encoded in JSON.
+        init?(decodedRepresentation: [String: Any?])
+    }
+}
+
+extension WebPage {
+    /// A type that can be used by a `WebPage` to be evaluated by JavaScript.
+    public protocol JavaScriptExpression: JavaScriptEncodable {
+        /// The return type of this expression. If the expression does not return anything, this is `Void`.
+        associatedtype Output: Sendable
+
+        /// The JavaScript literal function body for this expression.
+        ///
+        /// The function body may access the properties of this type as if they were arguments to the JavaScript function.
+        static var expression: String { get }
+    }
+}
+
+extension WebPage {
+    /// An error representing a failure when evaluating JavaScript.
+    public enum JavaScriptEvaluationError: Error {
+        /// An unexpected error occurred.
+        case unexpectedResult(String)
+
+        /// The JavaScript expression returned a result when none was expected.
+        case noResult
+
+        /// The expression returned a value of an unexpected type.
+        case mismatchedType(String)
+
+        /// The JavaScript output type failed to decode.
+        case decodingFailure(String)
+    }
+}
+
+extension WebPage {
+    /// Evaluates the provided JavaScript expression.
+    ///
+    /// - Parameter expression: The expression to evaluate.
+    /// - Throws: An error if the JavaScript evaluation or decoding fails.
+    public func callJavaScript<Expression>(
+        _ expression: Expression
+    ) async throws where Expression: JavaScriptExpression, Expression.Output == Void {
+        let arguments = expression.encoded() as [String: Any]
+        let result = try await self.callJavaScript(Expression.expression, arguments: arguments)
+
+        if let result {
+            throw JavaScriptEvaluationError.unexpectedResult("expected no result, got \(result)")
+        }
+    }
+
+    /// Evaluates the provided JavaScript expression.
+    ///
+    /// - Parameter expression: The expression to evaluate.
+    /// - Returns: The result of evaluating the expression.
+    /// - Throws: An error if the JavaScript evaluation or decoding fails.
+    public func callJavaScript<Expression>(
+        _ expression: Expression
+    ) async throws -> Expression.Output where Expression: JavaScriptExpression, Expression.Output: JavaScriptDecodable {
+        let arguments = expression.encoded() as [String: Any]
+        let result = try await self.callJavaScript(Expression.expression, arguments: arguments)
+
+        guard let result else {
+            throw JavaScriptEvaluationError.noResult
+        }
+
+        guard let dictionaryResult = result as? [String: Any?] else {
+            throw JavaScriptEvaluationError.mismatchedType("expected dictionary JS result")
+        }
+
+        guard let decodedResult = Expression.Output.init(decodedRepresentation: dictionaryResult) else {
+            throw JavaScriptEvaluationError.decodingFailure("failed to decode result")
+        }
+
+        return decodedResult
+    }
+}
+
+#endif // ENABLE_SWIFTUI

--- a/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
+++ b/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
@@ -572,6 +572,7 @@
 			membershipExceptions = (
 				WebKit/WebPage/AppKitGesturesTests.swift,
 				WebKit/WebPage/EditingFontSizeTests.swift,
+				WebKit/WebPage/JavaScriptExpressionTests.swift,
 				WebKit/WebPage/URLSchemeHandlerTests.swift,
 				WebKit/WebPage/WebPageNavigationTests.swift,
 				WebKit/WebPage/WebPageTests.swift,
@@ -591,6 +592,8 @@
 				"cocoa/Foundation+Extras.swift",
 				cocoa/HTTPServer.mm,
 				cocoa/HTTPServer.swift,
+				cocoa/JavaScriptMessages.swift,
+				cocoa/JavaScriptTypes.swift,
 				cocoa/SmartListsSupport.swift,
 				cocoa/StdLibExtras.swift,
 				"cocoa/SwiftUI+Extras.swift",
@@ -603,6 +606,7 @@
 				cocoa/WebExtensionUtilities.mm,
 				"cocoa/WebPage+Extras.swift",
 				"cocoa/WebPageConfiguration+Extras.swift",
+				"cocoa/WebPage+JavaScriptExpression.swift",
 				cocoa/WebTransportServer.mm,
 				Counters.cpp,
 				GraphicsTestUtilities.cpp,
@@ -1313,6 +1317,7 @@
 			membershipExceptions = (
 				WebKit/WebPage/AppKitGesturesTests.swift,
 				WebKit/WebPage/EditingFontSizeTests.swift,
+				WebKit/WebPage/JavaScriptExpressionTests.swift,
 				WebKit/WebPage/URLSchemeHandlerTests.swift,
 				WebKit/WebPage/WebPageNavigationTests.swift,
 				WebKit/WebPage/WebPageTests.swift,

--- a/Tools/TestWebKitAPI/Tests/WebKit/WebPage/AppKitGesturesTests.swift
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WebPage/AppKitGesturesTests.swift
@@ -37,8 +37,9 @@ struct AppKitGesturesTests {
     func clickingChangesSelection() async throws {
         let page = WebPage()
 
+        let text = "Here's to the crazy ones."
         let html = """
-            <div id="div" contenteditable style="font-size: 30px;">Here's to the crazy ones.</div>
+            <div id="div" contenteditable style="font-size: 30px;">\(text)</div>
             """
 
         try await page.load(html: html).wait()
@@ -52,34 +53,14 @@ struct AppKitGesturesTests {
         window.setFrameOrigin(.zero)
         window.makeKeyAndOrderFront(nil)
 
-        let selectCrazy = """
-            const textNode = document.getElementById("div").firstChild
+        let range = try #require(text.range(of: "crazy"))
+        let start = range.lowerBound.utf16Offset(in: text)
+        let end = range.upperBound.utf16Offset(in: text)
+        let crazySelection: JavaScriptSelection = .range(base: .init(in: "div", at: start), extent: .init(in: "div", at: end))
 
-            const range = document.createRange();
-            range.setStart(textNode, 14);
-            range.setEnd(textNode, 19);
+        try await page.callJavaScript(JavaScriptMessages.SetSelection(crazySelection))
 
-            let selection = window.getSelection();
-            selection.removeAllRanges();
-            selection.addRange(range);
-            """
-
-        try await page.callJavaScript(selectCrazy)
-
-        let getSelectionBounds = """
-            const selection = window.getSelection();
-
-            const range = selection.getRangeAt(0);
-            return range.getBoundingClientRect().toJSON();
-            """
-
-        let crazyBoundsDictionary = try await #require(page.callJavaScript(getSelectionBounds) as? [String: Double])
-        let crazyBoundsInViewportCoordinates = CGRect(
-            x: crazyBoundsDictionary["x", default: 0],
-            y: crazyBoundsDictionary["y", default: 0],
-            width: crazyBoundsDictionary["width", default: 0],
-            height: crazyBoundsDictionary["height", default: 0],
-        )
+        let crazyBoundsInViewportCoordinates = try await CGRect(page.callJavaScript(JavaScriptMessages.SelectionBoundingClientRect()))
 
         let crazyBoundsInAppKitCoordinates = CGRect(
             x: crazyBoundsInViewportCoordinates.minX,
@@ -90,19 +71,8 @@ struct AppKitGesturesTests {
 
         let middleOfCrazy = CGPoint(x: crazyBoundsInAppKitCoordinates.midX, y: crazyBoundsInAppKitCoordinates.midY)
 
-        let moveSelectionToStart = """
-            const textNode = document.getElementById("div").firstChild
-
-            const range = document.createRange();
-            range.setStart(textNode, 0);
-            range.setEnd(textNode, 0);
-
-            let selection = window.getSelection();
-            selection.removeAllRanges();
-            selection.addRange(range);
-            """
-
-        try await page.callJavaScript(moveSelectionToStart)
+        let selectionAtStart: JavaScriptSelection = .collapsed(.init(in: "div", at: 0))
+        try await page.callJavaScript(JavaScriptMessages.SetSelection(selectionAtStart))
 
         let waitForSelectionChange = """
             return await new Promise(resolve => {

--- a/Tools/TestWebKitAPI/Tests/WebKit/WebPage/JavaScriptExpressionTests.swift
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WebPage/JavaScriptExpressionTests.swift
@@ -1,0 +1,170 @@
+// Copyright (C) 2026 Apple Inc. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+// 1. Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+// 2. Redistributions in binary form must reproduce the above copyright
+//    notice, this list of conditions and the following disclaimer in the
+//    documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+// THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+// BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+// THE POSSIBILITY OF SUCH DAMAGE.
+
+#if ENABLE_SWIFTUI
+
+import struct Swift.String
+import Testing
+import WebKit
+private import TestWebKitAPILibrary
+
+@MainActor
+struct JavaScriptExpressionTests {
+    private static let text = "Here's to the crazy ones."
+
+    private static let html = """
+        <div id="div" contenteditable style="font-size: 30px;">\(text)</div>
+        """
+
+    @Test
+    func setAndGetSelectionWithCollapsedPositionRoundTrip() async throws {
+        let page = WebPage()
+        try await page.load(html: Self.html).wait()
+
+        let selection: JavaScriptSelection = .collapsed(.init(in: "div", at: 5))
+
+        try await page.callJavaScript(JavaScriptMessages.SetSelection(selection))
+
+        let actualSelection = try await page.callJavaScript(JavaScriptMessages.GetSelection())
+
+        #expect(actualSelection == selection)
+    }
+
+    @Test
+    func setSelectionAppliesRangeSelection() async throws {
+        let page = WebPage()
+        try await page.load(html: Self.html).wait()
+
+        let text = Self.text
+        let range = try #require(text.range(of: "crazy"))
+        let start = range.lowerBound.utf16Offset(in: text)
+        let end = range.upperBound.utf16Offset(in: text)
+
+        try await page.callJavaScript(
+            JavaScriptMessages.SetSelection(.range(base: .init(in: "div", at: start), extent: .init(in: "div", at: end)))
+        )
+
+        let selectedText = try #require(await page.callJavaScript("return getSelection().toString();") as? String)
+        #expect(selectedText == "crazy")
+    }
+
+    @Test
+    func getSelectionReturnsCollapsedAfterCollapsedIsSet() async throws {
+        let page = WebPage()
+        try await page.load(html: Self.html).wait()
+
+        try await page.callJavaScript(
+            """
+            const node = document.getElementById("div").firstChild;
+            getSelection().setPosition(node, 3);
+            """
+        )
+
+        let actualSelection = try await page.callJavaScript(JavaScriptMessages.GetSelection())
+
+        let expectedSelection: JavaScriptSelection = .collapsed(.init(in: "div", at: 3))
+
+        #expect(actualSelection == expectedSelection)
+    }
+
+    @Test
+    func getSelectionReturnsRangeAfterRangeIsSet() async throws {
+        let page = WebPage()
+        try await page.load(html: Self.html).wait()
+
+        let text = Self.text
+        let range = try #require(text.range(of: "crazy"))
+        let start = range.lowerBound.utf16Offset(in: text)
+        let end = range.upperBound.utf16Offset(in: text)
+
+        try await page.callJavaScript(
+            """
+            const node = document.getElementById("div").firstChild;
+            getSelection().setBaseAndExtent(node, \(start), node, \(end));
+            """
+        )
+
+        let actualSelection = try await page.callJavaScript(JavaScriptMessages.GetSelection())
+
+        let expectedSelection: JavaScriptSelection = .range(
+            base: .init(in: "div", at: start),
+            extent: .init(in: "div", at: end)
+        )
+
+        #expect(actualSelection == expectedSelection)
+    }
+
+    @Test
+    func setAndGetSelectionRangeRoundTrip() async throws {
+        let page = WebPage()
+        try await page.load(html: Self.html).wait()
+
+        let selection: JavaScriptSelection = .range(
+            base: .init(in: "div", at: 10),
+            extent: .init(in: "div", at: 15)
+        )
+
+        try await page.callJavaScript(JavaScriptMessages.SetSelection(selection))
+
+        let actualSelection = try await page.callJavaScript(JavaScriptMessages.GetSelection())
+
+        #expect(actualSelection == selection)
+    }
+
+    @Test
+    func selectionBoundingClientRectReturnsNonEmptyRectForRangeSelection() async throws {
+        let page = WebPage()
+        try await page.load(html: Self.html).wait()
+
+        let text = Self.text
+        let range = try #require(text.range(of: "crazy"))
+        let start = range.lowerBound.utf16Offset(in: text)
+        let end = range.upperBound.utf16Offset(in: text)
+
+        let selection: JavaScriptSelection = .range(base: .init(in: "div", at: start), extent: .init(in: "div", at: end))
+
+        try await page.callJavaScript(JavaScriptMessages.SetSelection(selection))
+
+        let rect = try await page.callJavaScript(JavaScriptMessages.SelectionBoundingClientRect())
+
+        #expect(rect.x > 0)
+        #expect(rect.y > 0)
+        #expect(rect.width > 0)
+        #expect(rect.height > 0)
+    }
+
+    @Test
+    func selectionBoundingClientRectReturnsZeroWidthRectForCollapsedSelection() async throws {
+        let page = WebPage()
+        try await page.load(html: Self.html).wait()
+
+        try await page.callJavaScript(JavaScriptMessages.SetSelection(.collapsed(.init(in: "div", at: 0))))
+
+        let rect = try await page.callJavaScript(JavaScriptMessages.SelectionBoundingClientRect())
+
+        #expect(rect.width == 0)
+        #expect(rect.height > 0)
+    }
+}
+
+#endif // ENABLE_SWIFTUI


### PR DESCRIPTION
#### 16ecd5c842f14e9766c275ca31d97a6ae31e96bf
<pre>
Re-land [Swift Testing] Make it easy to allow a WebPage to get and set selection, and to evaluate JS in general
<a href="https://bugs.webkit.org/show_bug.cgi?id=313513">https://bugs.webkit.org/show_bug.cgi?id=313513</a>
<a href="https://rdar.apple.com/175726078">rdar://175726078</a>

Unreviewed re-land of 312070@main

* Tools/TestWebKitAPI/Helpers/cocoa/JavaScriptMessages.swift: Added.
(SelectionBoundingClientRect.expression):
(SelectionBoundingClientRect.encoded):
(SetSelection.expression):
(SetSelection.encoded):
(GetSelection.expression):
(GetSelection.encoded):
* Tools/TestWebKitAPI/Helpers/cocoa/JavaScriptTypes.swift: Added.
(JavaScriptSelection.encoded):
* Tools/TestWebKitAPI/Helpers/cocoa/WebPage+JavaScriptExpression.swift: Added.
(JavaScriptEncodable.encoded):
(JavaScriptExpression.expression):
* Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj:
* Tools/TestWebKitAPI/Tests/WebKit/WebPage/AppKitGesturesTests.swift:
(AppKitGesturesTests.clickingChangesSelection):
* Tools/TestWebKitAPI/Tests/WebKit/WebPage/JavaScriptExpressionTests.swift: Added.
(JavaScriptExpressionTests.setAndGetSelectionWithCollapsedPositionRoundTrip):
(JavaScriptExpressionTests.setSelectionAppliesRangeSelection):
(JavaScriptExpressionTests.getSelectionReturnsCollapsedAfterCollapsedIsSet):
(JavaScriptExpressionTests.getSelectionReturnsRangeAfterRangeIsSet):
(JavaScriptExpressionTests.setAndGetSelectionRangeRoundTrip):
(JavaScriptExpressionTests.selectionBoundingClientRectReturnsNonEmptyRectForRangeSelection):
(JavaScriptExpressionTests.selectionBoundingClientRectReturnsZeroWidthRectForCollapsedSelection):

Canonical link: <a href="https://commits.webkit.org/312167@main">https://commits.webkit.org/312167@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e09b1dd3d0c91680f88a0d9caba9228c77a28f80

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/159140 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/32568 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/25673 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/167969 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/113224 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/ab6512c7-2377-4fd4-b5ff-9342caf4d075) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/161009 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/32636 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/32555 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/123285 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/113224 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/9ebcc2ff-9f5b-43b0-a67b-1c3c17fd9405) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/162097 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/25557 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/142946 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/103951 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/600dff76-65e8-4b0d-80f7-3ed803ef71b8) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/24611 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/23036 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/15742 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/134297 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/20726 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/170464 "Built successfully") | | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/22352 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/131479 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/32257 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/27105 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/131591 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35579 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/32201 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/142519 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/90251 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/26295 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/19328 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/31712 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/31232 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/31505 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/31387 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->