### PR TITLE
AX: In ITM, selection in an empty contenteditable is null despite being set to the beginning of the field.

### DIFF
--- a/LayoutTests/accessibility/mac/selection-text-marker-index-in-contenteditable-expected.txt
+++ b/LayoutTests/accessibility/mac/selection-text-marker-index-in-contenteditable-expected.txt
@@ -1,0 +1,20 @@
+This test verifies that selection text marker indices are correctly reported via AXSelectedTextChanged notifications on a contenteditable element.
+
+Empty contenteditable:
+target: AXRole: AXTextArea, marker index: 0
+
+Contenteditable with just a br:
+target: AXRole: AXUnknown, marker index: 0
+
+After inserting 'hello':
+target: AXRole: AXStaticText, marker index: 5
+
+After inserting line break:
+target: AXRole: AXUnknown, marker index: 6
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+
+
+

--- a/LayoutTests/accessibility/mac/selection-text-marker-index-in-contenteditable.html
+++ b/LayoutTests/accessibility/mac/selection-text-marker-index-in-contenteditable.html
@@ -1,0 +1,84 @@
+<!DOCTYPE HTML>
+<html>
+<head>
+<script src="../../resources/accessibility-helper.js"></script>
+<script src="../../resources/js-test.js"></script>
+</head>
+<body>
+
+<div contenteditable id="editor"></div>
+
+<script>
+output = "This test verifies that selection text marker indices are correctly reported via AXSelectedTextChanged notifications on a contenteditable element.\n\n";
+
+if (window.accessibilityController) {
+    window.jsTestIsAsync = true;
+
+    function retrieveSelectionInfo(editor) {
+        selectionRange = editor.selectedTextMarkerRange();
+        startMarker = editor.startTextMarkerForTextMarkerRange(selectionRange);
+        target = editor.accessibilityElementForTextMarker(startMarker);
+        markerIndex = target.indexForTextMarker(startMarker);
+        output += `target: ${target.role}, marker index: ${markerIndex}\n`;
+    }
+
+    notificationReceived = false;
+    accessibilityController.addNotificationListener((element, notification) => {
+        if (notification === "AXSelectedTextChanged")
+            notificationReceived = true;
+    });
+
+    setTimeout(async () => {
+        editor = accessibilityController.accessibleElementById("editor");
+        editorElement = document.getElementById("editor");
+
+        // Case 1: Empty contenteditable.
+        editorElement.focus();
+        notificationReceived = false;
+        selection = window.getSelection();
+        range = document.createRange();
+        range.setStart(editorElement, 0);
+        range.setEnd(editorElement, 0);
+        selection.removeAllRanges();
+        selection.addRange(range);
+        await waitFor(() => notificationReceived);
+        output += `Empty contenteditable:\n`;
+        retrieveSelectionInfo(editor);
+
+        // Case 2: Contenteditable with just a br.
+        notificationReceived = false;
+        editorElement.innerHTML = "<br>";
+        selection.removeAllRanges();
+        range = document.createRange();
+        range.setStart(editorElement, 0);
+        range.setEnd(editorElement, 0);
+        selection.addRange(range);
+        await waitFor(() => notificationReceived);
+        output += `\nContenteditable with just a br:\n`;
+        retrieveSelectionInfo(editor);
+
+        // Case 3: After inserting 'hello'.
+        notificationReceived = false;
+        editorElement.innerHTML = "";
+        editorElement.focus();
+        document.execCommand("insertText", false, "hello");
+        await waitFor(() => notificationReceived);
+        output += `\nAfter inserting 'hello':\n`;
+        retrieveSelectionInfo(editor);
+
+        // Case 4: After inserting a line break.
+        notificationReceived = false;
+        document.execCommand("insertLineBreak");
+        await waitFor(() => notificationReceived);
+        output += `\nAfter inserting line break:\n`;
+        retrieveSelectionInfo(editor);
+
+        accessibilityController.removeNotificationListener();
+        editorElement.style.visibility = "hidden";
+        debug(output);
+        finishJSTest();
+    }, 0);
+}
+</script>
+</body>
+</html>

--- a/Source/WebCore/accessibility/AXObjectCache.cpp
+++ b/Source/WebCore/accessibility/AXObjectCache.cpp
@@ -3074,25 +3074,36 @@ void AXObjectCache::onSelectedTextChanged(const VisiblePositionRange& selection,
             m_selectedTextRangeTimer.restart();
     }
 
-    if (RefPtr tree = AXIsolatedTree::treeForFrameID(m_frameID)) {
-        if (selection.isNull())
-            tree->setSelectedTextMarkerRange({ });
-        else {
-            auto startPosition = selection.start.deepEquivalent();
-            auto endPosition = selection.end.deepEquivalent();
+    RefPtr tree = AXIsolatedTree::treeForFrameID(m_frameID);
+    if (!tree)
+        return;
 
-            if (startPosition.isNull() || endPosition.isNull())
-                tree->setSelectedTextMarkerRange({ });
-            else {
-                if (RefPtr startObject = get(startPosition.anchorNode()))
-                    createIsolatedObjectIfNeeded(*startObject);
-                if (RefPtr endObject = get(endPosition.anchorNode()))
-                    createIsolatedObjectIfNeeded(*endObject);
+    AXTextMarkerRange markerRange;
+    if (!selection.isNull()) {
+        auto startPosition = selection.start.deepEquivalent();
+        auto endPosition = selection.end.deepEquivalent();
 
-                tree->setSelectedTextMarkerRange({ selection });
-            }
+        RefPtr startObject = getOrCreate(startPosition.anchorNode());
+        if (startObject)
+            createIsolatedObjectIfNeeded(*startObject);
+        RefPtr endObject = getOrCreate(endPosition.anchorNode());
+        if (endObject && endObject != startObject)
+            createIsolatedObjectIfNeeded(*endObject);
+
+        markerRange = { selection };
+        if (!markerRange && startObject) {
+            unsigned startOffset = std::max(startPosition.deprecatedEditingOffset(), 0);
+            unsigned endOffset = std::max(endPosition.deprecatedEditingOffset(), 0);
+            markerRange = { startObject->treeID(), startObject->objectID(), startOffset, endOffset };
         }
     }
+
+    if (!markerRange && object) {
+        createIsolatedObjectIfNeeded(*object);
+        markerRange = { object->treeID(), object->objectID(), 0, 0 };
+    }
+
+    tree->setSelectedTextMarkerRange(WTF::move(markerRange));
 }
 #endif // ENABLE(ACCESSIBILITY_ISOLATED_TREE)
 
@@ -4446,8 +4457,11 @@ std::optional<TextMarkerData> AXObjectCache::textMarkerDataForVisiblePosition(co
 
         if (!renderText) {
             renderText = dynamicDowncast<RenderText>(node ? node->renderer() : nullptr);
-            if (!renderText)
+            if (!renderText) {
+                if (node->renderer())
+                    return createFromRendererAndOffset(*node->renderer(), domOffset);
                 return std::nullopt;
+            }
         }
 
         auto [textBox, orderCache] = InlineIterator::firstTextBoxInLogicalOrderFor(*renderText);


### PR DESCRIPTION
#### f07b4b2fa5d8dd8f5aa45db9652d1ce74e54040b
<pre>
AX: In ITM, selection in an empty contenteditable is null despite being set to the beginning of the field.
<a href="https://bugs.webkit.org/show_bug.cgi?id=313517">https://bugs.webkit.org/show_bug.cgi?id=313517</a>
&lt;<a href="https://rdar.apple.com/problem/175728064">rdar://problem/175728064</a>&gt;

Reviewed by NOBODY (OOPS!).

In ITM, AXTextMarker creation from VisiblePosition fails for positions where
the anchor node has no RenderText (e.g., empty contenteditable divs), causing
the selected text marker range to contain null markers.

Two fixes in AXObjectCache:
1. In textMarkerDataForVisiblePosition, fall back to createFromRendererAndOffset
   when the node has a renderer but it is not a RenderText.
2. In onSelectedTextChanged, when the standard AXTextMarkerRange construction
   from VisiblePositionRange fails, fall back to creating markers directly from
   the position anchor nodes. When the selection is entirely null (empty
   contenteditable), create a collapsed range at offset 0 on the notification
   object.

Added layout test selection-text-marker-index-in-contenteditable that verifies
text marker index retrieval via AXSelectedTextChanged notifications across four
cases: empty contenteditable, br-only, after text insertion, and after line break.

* LayoutTests/accessibility/mac/selection-text-marker-index-in-contenteditable-expected.txt: Added.
* LayoutTests/accessibility/mac/selection-text-marker-index-in-contenteditable.html: Added.
* Source/WebCore/accessibility/AXObjectCache.cpp:
(WebCore::AXObjectCache::onSelectedTextChanged):
(WebCore::AXObjectCache::textMarkerDataForVisiblePosition):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f07b4b2fa5d8dd8f5aa45db9652d1ce74e54040b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/159220 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/32648 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/25753 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/168049 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/113598 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/32bfb30e-3f87-4008-83ba-810e30656224) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/161089 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/32716 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/32635 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/123359 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/86612 "Passed tests") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/bb31d014-a89f-4cdb-be5d-87ab70d64ec6) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/162177 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/25627 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/143016 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/104026 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/b5bc6630-7444-4e6f-b517-9c079eb7dff5) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/24681 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/23104 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/15822 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/134367 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/20796 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/170544 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/16465 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/22422 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/131551 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/32337 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/27174 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/131662 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/32281 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/142589 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/90352 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/26359 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/19398 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/31792 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/98093 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/31312 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/31585 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/31467 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->