### PR TITLE
Make EventTarget::opaqueRoot and Node::opaqueRoot out-of-line

### DIFF
--- a/Source/WebCore/dom/EventTarget.cpp
+++ b/Source/WebCore/dom/EventTarget.cpp
@@ -83,12 +83,10 @@ EventTarget::~EventTarget()
         eventTargetData->clear();
 }
 
-#if PLATFORM(WIN)
 WebCoreOpaqueRoot EventTarget::opaqueRoot() const
 {
     return WebCoreOpaqueRoot { const_cast<EventTarget*>(this) };
 }
-#endif
 
 bool EventTarget::isPaymentRequest() const
 {

--- a/Source/WebCore/dom/EventTarget.h
+++ b/Source/WebCore/dom/EventTarget.h
@@ -97,11 +97,7 @@ public:
     virtual enum EventTargetInterfaceType NODELETE eventTargetInterface() const = 0;
     virtual ScriptExecutionContext* scriptExecutionContext() const = 0;
 
-#if PLATFORM(WIN)
     virtual WebCoreOpaqueRoot NODELETE opaqueRoot() const;
-#else
-    virtual inline WebCoreOpaqueRoot NODELETE opaqueRoot() const; // Defined in EventTargetInlines.h.
-#endif
 
     virtual bool NODELETE isPaymentRequest() const;
 

--- a/Source/WebCore/dom/EventTargetInlines.h
+++ b/Source/WebCore/dom/EventTargetInlines.h
@@ -55,13 +55,6 @@ inline void EventTarget::deref()
         derefEventTarget();
 }
 
-#if !PLATFORM(WIN)
-inline WebCoreOpaqueRoot EventTarget::opaqueRoot() const
-{
-    return WebCoreOpaqueRoot { const_cast<EventTarget*>(this) };
-}
-#endif
-
 inline bool EventTarget::hasEventListeners() const
 {
     auto* data = eventTargetData();

--- a/Source/WebCore/dom/Node.cpp
+++ b/Source/WebCore/dom/Node.cpp
@@ -1490,7 +1490,6 @@ Node& Node::shadowIncludingRoot() const
     return root;
 }
 
-#if PLATFORM(WIN)
 SUPPRESS_NODELETE WebCoreOpaqueRoot Node::opaqueRoot() const
 {
     if (isConnected()) {
@@ -1500,7 +1499,6 @@ SUPPRESS_NODELETE WebCoreOpaqueRoot Node::opaqueRoot() const
     // FIXME: Possible race?
     return traverseToOpaqueRoot();
 }
-#endif
 
 Node& Node::getRootNode(const GetRootNodeOptions& options) const
 {

--- a/Source/WebCore/dom/Node.h
+++ b/Source/WebCore/dom/Node.h
@@ -318,11 +318,7 @@ public:
     };
     Node& NODELETE getRootNode(const GetRootNodeOptions&) const;
 
-#if PLATFORM(WIN)
     WebCoreOpaqueRoot opaqueRoot() const final;
-#else
-    inline WebCoreOpaqueRoot opaqueRoot() const final;
-#endif
 
     WebCoreOpaqueRoot NODELETE traverseToOpaqueRoot() const;
 

--- a/Source/WebCore/dom/NodeInlines.h
+++ b/Source/WebCore/dom/NodeInlines.h
@@ -52,18 +52,6 @@ inline ContainerNode* Node::parentOrShadowHostNode() const
     return parentNode();
 }
 
-#if !PLATFORM(WIN)
-SUPPRESS_NODELETE inline WebCoreOpaqueRoot Node::opaqueRoot() const
-{
-    if (isConnected()) {
-        Locker locker { TreeScope::treeScopeMutationLock() };
-        return WebCoreOpaqueRoot { &treeScope().documentScope() };
-    }
-    // FIXME: Possible race?
-    return traverseToOpaqueRoot();
-}
-#endif
-
 inline Document* Node::ownerDocument() const
 {
     auto* document = &this->document();


### PR DESCRIPTION
#### 2c5822126d547e401ed5f33a2df262e5f971d89c
<pre>
Make EventTarget::opaqueRoot and Node::opaqueRoot out-of-line
<a href="https://bugs.webkit.org/show_bug.cgi?id=313519">https://bugs.webkit.org/show_bug.cgi?id=313519</a>

Reviewed by Richard Robinson.

We already had out-of-line definitions for PLATFORM(WIN). Delete the inlined version
from other platforms as perf A/B testing shows virtually no benefit.

No new tests since there should be no behavioral differences.

* Source/WebCore/dom/EventTarget.cpp:
(WebCore::EventTarget::opaqueRoot const):
* Source/WebCore/dom/EventTarget.h:
* Source/WebCore/dom/EventTargetInlines.h:
(WebCore::EventTarget::opaqueRoot const): Deleted.
* Source/WebCore/dom/Node.cpp:
(WebCore::Node::opaqueRoot const):
* Source/WebCore/dom/Node.h:
* Source/WebCore/dom/NodeInlines.h:
(WebCore::Node::opaqueRoot const): Deleted.

Canonical link: <a href="https://commits.webkit.org/312185@main">https://commits.webkit.org/312185@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/623e0db0cf81dc43ab18021d78f80dcc630cd280

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/159154 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/32582 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/25687 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/167983 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/113238 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/161023 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/32650 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/32569 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/123301 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/86573 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/162111 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/25571 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/142961 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/103967 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/24625 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/23049 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/15756 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/134311 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/20741 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/170478 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/16218 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/22367 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/131498 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/32271 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/27118 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/131610 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/32215 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/142534 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/90266 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/24227 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/26306 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/19343 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/31726 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/97740 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/31246 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/31519 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/31401 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->