### PR TITLE
Cherry-pick 312139@main (5a8b1e3dcd90). https://bugs.webkit.org/show_bug.cgi?id=313305

### DIFF
--- a/Source/WebKit/UIProcess/API/wpe/qt6/WPEQtView.cpp
+++ b/Source/WebKit/UIProcess/API/wpe/qt6/WPEQtView.cpp
@@ -145,6 +145,10 @@ void WPEQtView::createWebView()
     else if (!d->m_html.isEmpty())
         webkit_web_view_load_html(d->m_webView.get(), d->m_html.toUtf8().constData(), d->m_baseUrl.toString().toUtf8().constData());
 
+    updateWpeToplevelState();
+    connect(window(), &QQuickWindow::activeChanged, this, &WPEQtView::updateWpeToplevelState);
+    connect(window(), &QQuickWindow::windowStateChanged, this, &WPEQtView::updateWpeToplevelState);
+
     Q_EMIT webViewCreated();
 }
 
@@ -621,6 +625,25 @@ void WPEQtView::invalidateSceneGraph()
 
     auto* wpeView = webkit_web_view_get_wpe_view(d->m_webView.get());
     wpe_view_qtquick_invalidate_rendering(WPE_VIEW_QTQUICK(wpeView));
+}
+
+void WPEQtView::updateWpeToplevelState()
+{
+    Q_D(WPEQtView);
+    auto* wpeView = webkit_web_view_get_wpe_view(d->m_webView.get());
+    if (auto* wpeToplevel = wpe_view_get_toplevel(wpeView)) {
+        auto active = window()->isActive();
+        auto states = window()->windowStates();
+        uint32_t toplevelState = WPE_TOPLEVEL_STATE_NONE;
+        if (states & Qt::WindowMaximized)
+            toplevelState |= WPE_TOPLEVEL_STATE_MAXIMIZED;
+        if (states & Qt::WindowFullScreen)
+            toplevelState |= WPE_TOPLEVEL_STATE_FULLSCREEN;
+        if (active)
+            toplevelState |= WPE_TOPLEVEL_STATE_ACTIVE;
+
+        wpe_toplevel_state_changed(wpeToplevel, static_cast<WPEToplevelState>(toplevelState));
+    }
 }
 
 WebKitWebView* WPEQtView::webView() const

--- a/Source/WebKit/UIProcess/API/wpe/qt6/WPEQtView.h
+++ b/Source/WebKit/UIProcess/API/wpe/qt6/WPEQtView.h
@@ -113,6 +113,7 @@ private Q_SLOTS:
     void createWebView();
     void didUpdateScene();
     void invalidateSceneGraph();
+    void updateWpeToplevelState();
 
 private:
     QSGNode* updatePaintNode(QSGNode*, UpdatePaintNodeData*) final;

--- a/Source/WebKit/UIProcess/API/wpe/qt6/WPEViewQtQuick.cpp
+++ b/Source/WebKit/UIProcess/API/wpe/qt6/WPEViewQtQuick.cpp
@@ -368,9 +368,22 @@ void wpe_view_dispatch_wheel_event(WPEViewQtQuick *view, QWheelEvent *event)
 {
     auto position = event->position().toPoint();
     auto numPixels = event->pixelDelta();
-
+    double scrollX = 0;
+    double scrollY = 0;
+    auto hasPreciseDeltas = !numPixels.isNull();
+    if (hasPreciseDeltas) {
+        scrollX = numPixels.x();
+        scrollY = numPixels.y();
+    } else {
+        // Qt gives 120 for the wheel scroll of one tick
+        // In WebEventFactoryWPE.cpp, it accepts number of ticks
+        // for wheel events and convert it to pixels.
+        auto angleDelta = event->angleDelta().toPointF() / 120;
+        scrollX = angleDelta.x();
+        scrollY = angleDelta.y();
+    }
     auto* wpeEvent = wpe_event_scroll_new(WPE_VIEW(view), WPE_INPUT_SOURCE_MOUSE, event->timestamp(),
-        modifiersFromEvent(event), numPixels.x(), numPixels.y(), FALSE, FALSE, position.x(), position.y());
+        modifiersFromEvent(event), scrollX, scrollY, hasPreciseDeltas, FALSE, position.x(), position.y());
     wpe_view_event(WPE_VIEW(view), wpeEvent);
     wpe_event_unref(wpeEvent);
 }

--- a/Source/WebKit/UIProcess/API/wpe/qt6/WPEViewQtQuick.cpp
+++ b/Source/WebKit/UIProcess/API/wpe/qt6/WPEViewQtQuick.cpp
@@ -29,6 +29,7 @@
 #include "WPEQtView.h"
 
 #include <epoxy/egl.h>
+#include <wtf/SortedArrayMap.h>
 #include <wtf/glib/GRefPtr.h>
 #include <wtf/glib/GUniquePtr.h>
 #include <wtf/glib/RunLoopSourcePriority.h>
@@ -38,6 +39,9 @@
 #include <QOpenGLFunctions>
 #include <QQuickWindow>
 #include <QSGTexture>
+#include <QCursor>
+
+#include <string_view>
 
 /**
  * WPEViewQtQuick:
@@ -79,6 +83,60 @@ static gboolean wpeViewQtQuickRenderBuffer(WPEView* view, WPEBuffer* buffer, con
     return TRUE;
 }
 
+static QCursor webCursorNameToQCursor(const char* name)
+{
+    // https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/Properties/cursor
+    // https://doc.qt.io/qt-6/qcursor.html
+    // Unsupported in Qt:
+    // context-menu, cell, all-scroll, zoom-in, zoom-out
+    // Limited:
+    // vertical-text (fallback to text),
+    // no-drop (fallback to forbidden),
+    // all single-direction resizes (fallback to double-direction resizes)
+    using namespace std::literals;
+    static constexpr SortedArrayMap shapeMap { std::to_array<std::pair<std::string_view, Qt::CursorShape>>({
+        { "alias"sv, Qt::DragLinkCursor },
+        { "col-resize"sv, Qt::SplitHCursor },
+        { "copy"sv, Qt::DragCopyCursor },
+        { "crosshair"sv, Qt::CrossCursor },
+        { "default"sv, Qt::ArrowCursor },
+        { "e-resize"sv, Qt::SizeHorCursor },
+        { "ew-resize"sv, Qt::SizeHorCursor },
+        { "grab"sv, Qt::OpenHandCursor },
+        { "grabbing"sv, Qt::ClosedHandCursor },
+        { "help"sv, Qt::WhatsThisCursor },
+        { "move"sv, Qt::DragMoveCursor },
+        { "n-resize"sv, Qt::SizeVerCursor },
+        { "ne-resize"sv, Qt::SizeBDiagCursor },
+        { "nesw-resize"sv, Qt::SizeBDiagCursor },
+        { "no-drop"sv, Qt::ForbiddenCursor },
+        { "none"sv, Qt::BlankCursor },
+        { "not-allowed"sv, Qt::ForbiddenCursor },
+        { "ns-resize"sv, Qt::SizeVerCursor },
+        { "nw-resize"sv, Qt::SizeFDiagCursor },
+        { "nwse-resize"sv, Qt::SizeFDiagCursor },
+        { "pointer"sv, Qt::PointingHandCursor },
+        { "progress"sv, Qt::BusyCursor },
+        { "row-resize"sv, Qt::SplitVCursor },
+        { "s-resize"sv, Qt::SizeVerCursor },
+        { "se-resize"sv, Qt::SizeFDiagCursor },
+        { "sw-resize"sv, Qt::SizeBDiagCursor },
+        { "text"sv, Qt::IBeamCursor },
+        { "vertical-text"sv, Qt::IBeamCursor },
+        { "w-resize"sv, Qt::SizeHorCursor },
+        { "wait"sv, Qt::WaitCursor },
+    }) };
+    auto shape = shapeMap.get(std::string_view(name), Qt::ArrowCursor);
+    return QCursor(shape);
+}
+
+static void wpeViewQtQuickSetCursorFromName(WPEView* view, const char* name)
+{
+    auto* priv = WPE_VIEW_QTQUICK(view)->priv;
+    QCursor cursor = webCursorNameToQCursor(name);
+    priv->wpeQtView->setCursor(cursor);
+}
+
 static void wpe_view_qtquick_class_init(WPEViewQtQuickClass* viewQtQuickClass)
 {
     GObjectClass* objectClass = G_OBJECT_CLASS(viewQtQuickClass);
@@ -86,6 +144,7 @@ static void wpe_view_qtquick_class_init(WPEViewQtQuickClass* viewQtQuickClass)
 
     WPEViewClass* viewClass = WPE_VIEW_CLASS(viewQtQuickClass);
     viewClass->render_buffer = wpeViewQtQuickRenderBuffer;
+    viewClass->set_cursor_from_name = wpeViewQtQuickSetCursorFromName;
 }
 
 WPEView* wpe_view_qtquick_new(WPEDisplayQtQuick* display)


### PR DESCRIPTION
#### 4424f72765dad336f87c57ba96a0fc3d9fb77a07
<pre>
Cherry-pick 312139@main (5a8b1e3dcd90). <a href="https://bugs.webkit.org/show_bug.cgi?id=313305">https://bugs.webkit.org/show_bug.cgi?id=313305</a>

    Add preliminary cursor shape support for WPEQtView

    <a href="https://bugs.webkit.org/show_bug.cgi?id=313305">https://bugs.webkit.org/show_bug.cgi?id=313305</a>

    Reviewed by Claudio Saavedra.

    Add support for the stock pointer shapes that Qt supports.

    Go to
    <a href="https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/Properties/cursor">https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/Properties/cursor</a>
    and verify you can see various cursor shapes applied.

    * Source/WebKit/UIProcess/API/wpe/qt6/WPEViewQtQuick.cpp:
    (webCursorNameToQCursor): Use a SortedArrayMap to find out the cursor shape.
    (wpeViewQtQuickSetCursorFromName): Use QQuickItem::setCursor to set
    cursor shape.
    (wpe_view_qtquick_class_init): Implement set_cursor_from_name virtual method.

    Canonical link: <a href="https://commits.webkit.org/312139@main">https://commits.webkit.org/312139@main</a>

Canonical link: <a href="https://commits.webkit.org/305877.457@webkitglib/2.52">https://commits.webkit.org/305877.457@webkitglib/2.52</a>
</pre>
----------------------------------------------------------------------
#### 96e15052dfc05c51698fb3774a14f48b7325c79f
<pre>
Cherry-pick 312019@main (a3c1d3be6028). <a href="https://bugs.webkit.org/show_bug.cgi?id=313311">https://bugs.webkit.org/show_bug.cgi?id=313311</a>

    Fix wheel event handling in WPEQtView

    <a href="https://bugs.webkit.org/show_bug.cgi?id=313311">https://bugs.webkit.org/show_bug.cgi?id=313311</a>

    Reviewed by Adrian Perez de Castro.

    On some platforms QWheelEvent will not have pixelDelta. Qt recommends
    fallback to angleDelta when it is not available.

    See <a href="https://doc.qt.io/qt-6/qwheelevent.html#pixelDelta-prop">https://doc.qt.io/qt-6/qwheelevent.html#pixelDelta-prop</a>

    Also, WPEEvent for scroll expects number of ticks if and only if
    has_precise_deltas is false. This means that we should set
    has_precise_deltas to true if we have pixelDelta.

    Go to
    <a href="https://developer.mozilla.org/en-US/docs/Web/API/Element/wheel_event">https://developer.mozilla.org/en-US/docs/Web/API/Element/wheel_event</a>
    and check the wheel event is working.

    * Source/WebKit/UIProcess/API/wpe/qt6/WPEViewQtQuick.cpp:
    (wpe_view_dispatch_wheel_event): Fix wheel event handling when
    pixelDelta is not available.

    Canonical link: <a href="https://commits.webkit.org/312019@main">https://commits.webkit.org/312019@main</a>

Canonical link: <a href="https://commits.webkit.org/305877.456@webkitglib/2.52">https://commits.webkit.org/305877.456@webkitglib/2.52</a>
</pre>
----------------------------------------------------------------------
#### ef237af08badd2561f8cf7491f0b1f94b38005a5
<pre>
Cherry-pick 312021@main (71b64438bcf2). <a href="https://bugs.webkit.org/show_bug.cgi?id=312624">https://bugs.webkit.org/show_bug.cgi?id=312624</a>

    Update state of WPEToplevelQtQuick when window state changes

    <a href="https://bugs.webkit.org/show_bug.cgi?id=312624">https://bugs.webkit.org/show_bug.cgi?id=312624</a>

    Reviewed by Adrian Perez de Castro.

    The focus style is only displayed when the window is active. This
    commit updates the WPEToplevelState whenever the relevant states of
    the QQuickWindow changes.

    Open the qt-wpe-mini-browser and Tab within the page. Check that the
    focused item has focus styles.

    * Source/WebKit/UIProcess/API/wpe/qt6/WPEQtView.cpp:
    (WPEQtView::createWebView): Initialize WPEToplevelState and listen to
    signals that should make updates to it.
    (WPEQtView::updateWpeToplevelState): Convert QQuickWindow&apos;s relevant
    properties into WPEToplevelState
    * Source/WebKit/UIProcess/API/wpe/qt6/WPEQtView.h:

    Canonical link: <a href="https://commits.webkit.org/312021@main">https://commits.webkit.org/312021@main</a>

Canonical link: <a href="https://commits.webkit.org/305877.455@webkitglib/2.52">https://commits.webkit.org/305877.455@webkitglib/2.52</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e5c9e4f9f7c27045063ab306ea612126d7e57be4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/159180 "Passed style check") | [❌ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/32608 "Unable to build WebKit without PR, please check manually (failure)") | [❌ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/25713 "Unable to build WebKit without PR, please check manually (failure)") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/168009 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/113264 "The change is no longer eligible for processing.") 
| | [❌ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/32676 "Unable to build WebKit without PR, please check manually (failure)") | [❌ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/32595 "Unable to build WebKit without PR, please check manually (failure)") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/123321 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/113264 "The change is no longer eligible for processing.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/162137 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/155/builds/32676 "Unable to build WebKit without PR, please check manually (failure)") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/168/builds/25713 "Unable to build WebKit without PR, please check manually (failure)") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/103994 "Passed tests") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/155/builds/32676 "Unable to build WebKit without PR, please check manually (failure)") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/156/builds/32595 "Unable to build WebKit without PR, please check manually (failure)") | [❌ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/15782 "Unable to build WebKit without PR, please check manually (failure)") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/155/builds/32676 "Unable to build WebKit without PR, please check manually (failure)") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/168/builds/25713 "Unable to build WebKit without PR, please check manually (failure)") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/170504 "Unable to build WebKit without PR, please check manually (failure)") | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/16348 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/168/builds/25713 "Unable to build WebKit without PR, please check manually (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/2/builds/170504 "Unable to build WebKit without PR, please check manually (failure)") | 
| | [❌ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/32297 "Unable to build WebKit without PR, please check manually (failure)") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/156/builds/32595 "Unable to build WebKit without PR, please check manually (failure)") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/2/builds/170504 "Unable to build WebKit without PR, please check manually (failure)") | 
| | [❌ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/32241 "Unable to build WebKit without PR, please check manually (failure)") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/168/builds/25713 "Unable to build WebKit without PR, please check manually (failure)") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/90299 "The change is no longer eligible for processing.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/24230 "Built successfully and passed tests") | [❌ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/160/builds/32241 "Unable to build WebKit without PR, please check manually (failure)") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/168/builds/25713 "Unable to build WebKit without PR, please check manually (failure)") | | 
| | [❌ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/31752 "Unable to build WebKit without PR, please check manually (failure)") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/97966 "Failed to checkout and rebase branch from PR 63774") | | 
| | [❌ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/31272 "Unable to build WebKit without PR, please check manually (failure)") | | | 
| | [❌ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/31545 "Unable to build WebKit without PR, please check manually (failure)") | | | 
| | [❌ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/31427 "Failed to compile WebKit") | | | 
<!--EWS-Status-Bubble-End-->