### PR TITLE
Cherry-pick 311939@main (9f495be6bdad). https://bugs.webkit.org/show_bug.cgi?id=313214

### DIFF
--- a/Source/cmake/WebKitCompilerFlags.cmake
+++ b/Source/cmake/WebKitCompilerFlags.cmake
@@ -385,7 +385,7 @@ if (COMPILER_IS_GCC_OR_CLANG)
 endif ()
 
 if (COMPILER_IS_GCC_OR_CLANG)
-    set(ATOMIC_TEST_SOURCE "
+    set(ATOMIC_TEST_SOURCE [=[
 #include <atomic>
 #include <optional>
 #include <stdbool.h>
@@ -480,7 +480,7 @@ int main() {
                   l) ? 0 : 1;
     return static_cast<int>(result + d.load().value());
 }
-    ")
+    ]=])
     check_cxx_source_compiles("${ATOMIC_TEST_SOURCE}" ATOMICS_ARE_BUILTIN)
     if (NOT ATOMICS_ARE_BUILTIN)
         set(CMAKE_REQUIRED_LIBRARIES atomic)


### PR DESCRIPTION
#### e24e0886d8daee7abc46f0c78fbbd2272c75407a
<pre>
Cherry-pick 311939@main (9f495be6bdad). <a href="https://bugs.webkit.org/show_bug.cgi?id=313214">https://bugs.webkit.org/show_bug.cgi?id=313214</a>

    REGRESSION(311900@main): [CMake] Use a bracket argument for ATOMIC_TEST_SOURCE
    <a href="https://bugs.webkit.org/show_bug.cgi?id=313214">https://bugs.webkit.org/show_bug.cgi?id=313214</a>

    Reviewed by Adrian Perez de Castro.

    CMake reported a warning.

    &gt; CMake Warning (dev) at Source/cmake/WebKitCompilerFlags.cmake:472:
    &gt;   Syntax Warning in cmake code at column 23
    &gt;
    &gt;   Argument not separated from preceding token by whitespace.

    * Source/cmake/WebKitCompilerFlags.cmake:

    Canonical link: <a href="https://commits.webkit.org/311939@main">https://commits.webkit.org/311939@main</a>

Canonical link: <a href="https://commits.webkit.org/305877.458@webkitglib/2.52">https://commits.webkit.org/305877.458@webkitglib/2.52</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4571b28aac550ca60d3727ae2ca6a69478482844

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/159181 "Passed style check") | [❌ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/32609 "Unable to build WebKit without PR, please check manually (failure)") | [❌ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/25714 "Unable to build WebKit without PR, please check manually (failure)") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/168010 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/113265 "The change is no longer eligible for processing.") 
| | [❌ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/32677 "Unable to build WebKit without PR, please check manually (failure)") | [❌ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/32596 "Unable to build WebKit without PR, please check manually (failure)") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/123322 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/113265 "The change is no longer eligible for processing.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/162138 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/155/builds/32677 "Unable to build WebKit without PR, please check manually (failure)") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/168/builds/25714 "Unable to build WebKit without PR, please check manually (failure)") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/103988 "Passed tests") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/155/builds/32677 "Unable to build WebKit without PR, please check manually (failure)") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/156/builds/32596 "Unable to build WebKit without PR, please check manually (failure)") | [❌ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/15783 "Unable to build WebKit without PR, please check manually (failure)") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/151231 "Built successfully and passed tests") | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/155/builds/32677 "Unable to build WebKit without PR, please check manually (failure)") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/168/builds/25714 "Unable to build WebKit without PR, please check manually (failure)") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/170505 "Unable to build WebKit without PR, please check manually (failure)") | 
| [❌ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/20014 "Found 2 new JSC stress test failures: wasm.yaml/wasm/stress/simd-exception-throwing-v128-clobbers-fp.js.wasm-graph-reg-alloc, wasm.yaml/wasm/stress/simd-exception-throwing-v128-clobbers-fp.js.wasm-simd (failure)") | | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/168/builds/25714 "Unable to build WebKit without PR, please check manually (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/2/builds/170505 "Unable to build WebKit without PR, please check manually (failure)") | 
| | [❌ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/32298 "Unable to build WebKit without PR, please check manually (failure)") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/156/builds/32596 "Unable to build WebKit without PR, please check manually (failure)") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/2/builds/170505 "Unable to build WebKit without PR, please check manually (failure)") | 
| | [❌ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/32242 "Unable to build WebKit without PR, please check manually (failure)") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/168/builds/25714 "Unable to build WebKit without PR, please check manually (failure)") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/90300 "The change is no longer eligible for processing.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/24231 "Built successfully and passed tests") | [❌ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/160/builds/32242 "Unable to build WebKit without PR, please check manually (failure)") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/168/builds/25714 "Unable to build WebKit without PR, please check manually (failure)") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/191463 "Built successfully") | 
| | [❌ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/31753 "Unable to build WebKit without PR, please check manually (failure)") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/49199 "Passed tests") | 
| | [❌ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/31273 "Unable to build WebKit without PR, please check manually (failure)") | | | 
| | [❌ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/31546 "Unable to build WebKit without PR, please check manually (failure)") | | | 
| | [❌ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/31428 "Unable to build WebKit without PR, please check manually (failure)") | | | 
<!--EWS-Status-Bubble-End-->