### PR TITLE
Use HTTP status codes in more places

### DIFF
--- a/Source/WebCore/Modules/fetch/FetchResponse.cpp
+++ b/Source/WebCore/Modules/fetch/FetchResponse.cpp
@@ -42,18 +42,13 @@
 #include "ScriptExecutionContext.h"
 #include <JavaScriptCore/JSCJSValueInlines.h>
 #include <JavaScriptCore/JSONObject.h>
+#include <WebCore/HTTPStatusCodes.h>
 #include <wtf/text/MakeString.h>
 #include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(FetchResponseBodyLoader);
-
-// https://fetch.spec.whatwg.org/#null-body-status
-static inline bool NODELETE isNullBodyStatus(int status)
-{
-    return status == 101 || status == 204 || status == 205 || status == 304;
-}
 
 FetchResponse::~FetchResponse() = default;
 
@@ -106,7 +101,7 @@ ExceptionOr<Ref<FetchResponse>> FetchResponse::create(ScriptExecutionContext& co
     if (bodyWithType) {
         // 6.1 If response’s status is a null body status, then throw a TypeError.
         //     (NOTE: 101 and 103 are included in null body status due to their use elsewhere. It does not affect this step.)
-        if (isNullBodyStatus(init.status))
+        if (isHttpNullBodyStatus(init.status))
             return Exception { ExceptionCode::TypeError, "Response cannot have a body with the given status."_s };
 
         // 6.2 Set response’s body to body’s body.
@@ -167,7 +162,7 @@ ExceptionOr<Ref<FetchResponse>> FetchResponse::redirect(ScriptExecutionContext& 
         return Exception { ExceptionCode::TypeError, makeString("Redirection URL '"_s, requestURL.string(), "' is invalid"_s) };
     if (requestURL.hasCredentials())
         return Exception { ExceptionCode::TypeError, "Redirection URL contains credentials"_s };
-    if (!ResourceResponse::isRedirectionStatusCode(status))
+    if (!isHttpRedirectStatus(status))
         return Exception { ExceptionCode::RangeError, makeString(status, " is not a redirection status code"_s) };
     auto redirectResponse = adoptRef(*new FetchResponse(&context, { }, FetchHeaders::create(FetchHeaders::Guard::Immutable), { }));
     redirectResponse->suspendIfNeeded();

--- a/Source/WebCore/Modules/model-element/HTMLModelElement.cpp
+++ b/Source/WebCore/Modules/model-element/HTMLModelElement.cpp
@@ -85,6 +85,7 @@
 #include "Settings.h"
 #include <JavaScriptCore/ConsoleTypes.h>
 #include <JavaScriptCore/HeapInlines.h>
+#include <WebCore/HTTPStatusCodes.h>
 #include <wtf/Seconds.h>
 #include <wtf/TZoneMallocInlines.h>
 #include <wtf/URL.h>
@@ -1294,7 +1295,7 @@ void HTMLModelElement::environmentMapResetAndReject(Exception&& exception)
 void HTMLModelElement::environmentMapResourceFinished()
 {
     int status = m_environmentMapResource->response().httpStatusCode();
-    if (m_environmentMapResource->loadFailedOrCanceled() || (status && (status < 200 || status > 299))) {
+    if (m_environmentMapResource->loadFailedOrCanceled() || !isHttpOkStatus(status)) {
         environmentMapResetAndReject(Exception { ExceptionCode::NetworkError });
 
         // sending a message with empty data to indicate resource removal

--- a/Source/WebCore/html/HTMLImageLoader.cpp
+++ b/Source/WebCore/html/HTMLImageLoader.cpp
@@ -36,6 +36,7 @@
 #include "JSDOMWindowBase.h"
 #include <JavaScriptCore/JSCInlines.h>
 #include <JavaScriptCore/JSLock.h>
+#include <WebCore/HTTPStatusCodes.h>
 
 namespace WebCore {
 
@@ -70,7 +71,7 @@ void HTMLImageLoader::dispatchLoadEvent()
 
     RefPtr image = this->image();
     bool errorOccurred = image->errorOccurred();
-    if (!errorOccurred && image->response().httpStatusCode() >= 400)
+    if (!errorOccurred && image->response().httpStatusCode() >= httpStatus400BadRequest)
         errorOccurred = is<HTMLObjectElement>(element()); // An <object> considers a 404 to be an error and should fire onerror.
     protect(element())->dispatchEvent(Event::create(errorOccurred ? eventNames().errorEvent : eventNames().loadEvent, Event::CanBubble::No, Event::IsCancelable::No));
 }
@@ -83,7 +84,7 @@ void HTMLImageLoader::notifyFinished(CachedResource&, const NetworkLoadMetrics& 
     Ref<Element> protect(element());
     ImageLoader::notifyFinished(cachedImage, metrics, loadWillContinueInAnotherProcess);
 
-    bool loadError = cachedImage->errorOccurred() || cachedImage->response().httpStatusCode() >= 400;
+    bool loadError = cachedImage->errorOccurred() || cachedImage->response().httpStatusCode() >= httpStatus400BadRequest;
     if (!loadError) {
         if (!element().isConnected()) {
             JSC::VM& vm = commonVM();

--- a/Source/WebCore/inspector/NetworkResourcesData.cpp
+++ b/Source/WebCore/inspector/NetworkResourcesData.cpp
@@ -36,6 +36,7 @@
 #include "InspectorResourceUtilities.h"
 #include "ResourceResponse.h"
 #include "TextResourceDecoder.h"
+#include <WebCore/HTTPStatusCodes.h>
 #include <wtf/TZoneMallocInlines.h>
 #include <wtf/text/Base64.h>
 
@@ -300,7 +301,7 @@ NetworkResourcesData::ResourceData const* NetworkResourcesData::dataForURL(const
     
     for (auto* resourceData : resources()) {
         // responseTimestamp is checked so that we only grab the most recent response for the URL, instead of potentionally getting a more stale response.
-        if (resourceData->url() == url && resourceData->httpStatusCode() != 304 && (!mostRecentResourceData || (resourceData->responseTimestamp() > mostRecentResourceData->responseTimestamp())))
+        if (resourceData->url() == url && resourceData->httpStatusCode() != httpStatus304NotModified && (!mostRecentResourceData || (resourceData->responseTimestamp() > mostRecentResourceData->responseTimestamp())))
             mostRecentResourceData = resourceData;
     }
     

--- a/Source/WebCore/inspector/agents/InspectorNetworkAgent.cpp
+++ b/Source/WebCore/inspector/agents/InspectorNetworkAgent.cpp
@@ -86,6 +86,7 @@
 #include <JavaScriptCore/JSCInlines.h>
 #include <JavaScriptCore/ScriptCallStack.h>
 #include <JavaScriptCore/ScriptCallStackFactory.h>
+#include <WebCore/HTTPStatusCodes.h>
 #include <wtf/JSONValues.h>
 #include <wtf/Lock.h>
 #include <wtf/RefPtr.h>
@@ -500,7 +501,7 @@ void InspectorNetworkAgent::didReceiveResponse(ResourceLoaderIdentifier identifi
     auto resourceResponse = buildObjectForResourceResponse(realResponse ? *realResponse : response, resourceLoader);
     ASSERT(resourceResponse);
 
-    bool isNotModified = response.httpStatusCode() == 304;
+    bool isNotModified = response.httpStatusCode() == httpStatus304NotModified;
 
     RefPtr<CachedResource> cachedResource;
     if (auto* subresourceLoader = dynamicDowncast<SubresourceLoader>(resourceLoader); subresourceLoader && !isNotModified)

--- a/Source/WebCore/inspector/agents/WebConsoleAgent.cpp
+++ b/Source/WebCore/inspector/agents/WebConsoleAgent.cpp
@@ -39,6 +39,7 @@
 #include <JavaScriptCore/ConsoleMessage.h>
 #include <JavaScriptCore/JSCInlines.h>
 #include <JavaScriptCore/ScriptArguments.h>
+#include <WebCore/HTTPStatusCodes.h>
 #include <wtf/CheckedRef.h>
 #include <wtf/text/MakeString.h>
 #include <wtf/text/StringBuilder.h>
@@ -76,7 +77,7 @@ void WebConsoleAgent::frameWindowDiscarded(LocalDOMWindow& window)
 
 void WebConsoleAgent::didReceiveResponse(ResourceLoaderIdentifier requestIdentifier, const ResourceResponse& response)
 {
-    if (response.httpStatusCode() >= 400) {
+    if (response.httpStatusCode() >= httpStatus400BadRequest) {
         auto message = makeString("Failed to load resource: the server responded with a status of "_s, response.httpStatusCode(), " ("_s, ScriptArguments::truncateStringForConsoleMessage(response.httpStatusText()), ')');
         addMessageToConsole(makeUnique<ConsoleMessage>(MessageSource::Network, MessageType::Log, MessageLevel::Error, message, response.url().string(), 0, 0, nullptr, requestIdentifier.toUInt64()));
     }

--- a/Source/WebCore/loader/CrossOriginAccessControl.cpp
+++ b/Source/WebCore/loader/CrossOriginAccessControl.cpp
@@ -366,7 +366,7 @@ std::optional<ResourceError> validateCrossOriginResourcePolicy(CrossOriginEmbedd
 
 std::optional<ResourceError> validateRangeRequestedFlag(const ResourceRequest& request, const ResourceResponse& response)
 {
-    if (response.isRangeRequested() && (response.httpStatusCode() == httpStatus206PartialContent || response.httpStatusCode() == httpStatus416RangeNotSatisfiable) && response.type() == ResourceResponse::Type::Opaque && !request.hasHTTPHeaderField(HTTPHeaderName::Range))
+    if (response.isRangeRequested() && isHttpRangeStatus(response.httpStatusCode()) && response.type() == ResourceResponse::Type::Opaque && !request.hasHTTPHeaderField(HTTPHeaderName::Range))
         return ResourceError({ }, 0, response.url(), { }, ResourceError::Type::General);
     return std::nullopt;
 }

--- a/Source/WebCore/loader/DocumentLoader.cpp
+++ b/Source/WebCore/loader/DocumentLoader.cpp
@@ -1197,15 +1197,16 @@ void DocumentLoader::continueAfterContentPolicy(PolicyAction policy)
     if (m_response.isInHTTPFamily()) {
         int status = m_response.httpStatusCode(); // Status may be zero when loading substitute data, in particular from a WebArchive.
         if (status) {
-            if (status < httpStatus200OK || status >= httpStatus300MultipleChoices) {
+            if (!isHttpOkStatus(status)) {
                 if (RefPtr owner = dynamicDowncast<HTMLObjectElement>(frame->ownerElement())) {
                     owner->renderFallbackContent();
                     // object elements are no longer rendered after we fallback, so don't
                     // keep trying to process data from their load
                     cancelMainResourceLoad(protect(frameLoader())->cancelledError(m_request));
                 }
-            } else if (status == httpStatus204NoContent || status == httpStatus205ResetContent) {
-                // 204/205 responses should abort navigation without changing the document.
+            } else if (isHttpNullBodyStatus(status)) {
+                // Implementing step 21 of https://fetch.spec.whatwg.org/#main-fetch.
+                // null-body responses should abort navigation without changing the document.
                 stopLoadingForPolicyChange();
                 return;
             }
@@ -1979,7 +1980,7 @@ URL DocumentLoader::urlForHistory() const
 
 bool DocumentLoader::urlForHistoryReflectsFailure() const
 {
-    return m_substituteData.isValid() || m_response.httpStatusCode() >= 400;
+    return m_substituteData.isValid() || m_response.httpStatusCode() >= httpStatus400BadRequest;
 }
 
 URL DocumentLoader::documentURL() const

--- a/Source/WebCore/loader/HistoryController.cpp
+++ b/Source/WebCore/loader/HistoryController.cpp
@@ -59,6 +59,7 @@
 #include "SharedStringHash.h"
 #include "ShouldTreatAsContinuingLoad.h"
 #include "VisitedLinkStore.h"
+#include <WebCore/HTTPStatusCodes.h>
 #include <wtf/text/CString.h>
 
 #if PLATFORM(COCOA)
@@ -874,7 +875,7 @@ void HistoryController::initializeItem(HistoryItem& item, RefPtr<DocumentLoader>
     item.setTitle(WTF::move(title.string));
     item.setOriginalURLString(originalURL.string());
 
-    if (!unreachableURL.isEmpty() || documentLoader->response().httpStatusCode() >= 400)
+    if (!unreachableURL.isEmpty() || documentLoader->response().httpStatusCode() >= httpStatus400BadRequest)
         item.setLastVisitWasFailure(true);
 
     item.setShouldOpenExternalURLsPolicy(documentLoader->shouldOpenExternalURLsPolicyToPropagate());

--- a/Source/WebCore/loader/MediaResourceLoader.cpp
+++ b/Source/WebCore/loader/MediaResourceLoader.cpp
@@ -44,6 +44,7 @@
 #include "OriginAccessPatterns.h"
 #include "SecurityOrigin.h"
 #include "Settings.h"
+#include <WebCore/HTTPStatusCodes.h>
 #include <wtf/NeverDestroyed.h>
 #include <wtf/SortedArrayMap.h>
 #include <wtf/TZoneMallocInlines.h>
@@ -239,7 +240,7 @@ bool MediaResourceLoader::verifyMediaResponse(const URL& requestURL, const Resou
         m_loadedFromOpaqueSource = LoadedFromOpaqueSource::Yes;
 
     // FIXME: We should probably implement https://html.spec.whatwg.org/multipage/media.html#verify-a-media-response
-    if (!requestURL.protocolIsInHTTPFamily() || response.httpStatusCode() != 206 || !response.contentRange().isValid() || !contextOrigin)
+    if (!requestURL.protocolIsInHTTPFamily() || response.httpStatusCode() != httpStatus206PartialContent || !response.contentRange().isValid() || !contextOrigin)
         return true;
 
     auto ensureResult = m_validationLoadInformations.ensure(requestURL, [&] () -> ValidationInformation {

--- a/Source/WebCore/loader/NetscapePlugInStreamLoader.cpp
+++ b/Source/WebCore/loader/NetscapePlugInStreamLoader.cpp
@@ -32,6 +32,7 @@
 #include "DocumentLoader.h"
 #include "LoaderStrategy.h"
 #include "PlatformStrategies.h"
+#include <WebCore/HTTPStatusCodes.h>
 #include <wtf/CompletionHandler.h>
 #include <wtf/Ref.h>
 
@@ -142,7 +143,7 @@ void NetscapePlugInStreamLoader::didReceiveResponse(ResourceResponse&& response,
             return;
 
         // Status code can be null when serving from a Web archive.
-        if (response.httpStatusCode() && (response.httpStatusCode() < 100 || response.httpStatusCode() >= 400))
+        if (response.httpStatusCode() && (response.httpStatusCode() < httpStatus100Continue || response.httpStatusCode() >= httpStatus400BadRequest))
             cancel(platformStrategies()->loaderStrategy()->fileDoesNotExistError(response));
     });
 }

--- a/Source/WebCore/loader/SubresourceLoader.cpp
+++ b/Source/WebCore/loader/SubresourceLoader.cpp
@@ -413,6 +413,7 @@ void SubresourceLoader::didReceiveResponse(ResourceResponse&& response, Completi
         }
     }
 
+    // Implementing step 20 of https://fetch.spec.whatwg.org/#concept-main-fetch.
     if (auto error = validateRangeRequestedFlag(request(), response)) {
         SUBRESOURCELOADER_RELEASE_LOG(SubResourceLoaderDidReceiveResponseCancelingLoadReceivedUnexpectedRangeResponse);
         cancel(WTF::move(*error));
@@ -470,7 +471,7 @@ void SubresourceLoader::didReceiveResponse(ResourceResponse&& response, Completi
 
     if (response.isRedirection()) {
         if (options().redirect == FetchOptions::Redirect::Follow && isLocationURLFailure(response)) {
-            // Implementing https://fetch.spec.whatwg.org/#concept-http-redirect-fetch step 3
+            // Implementing https://fetch.spec.whatwg.org/#concept-http-redirect-fetch step 5
             cancel();
             return;
         }

--- a/Source/WebCore/loader/icon/IconLoader.cpp
+++ b/Source/WebCore/loader/icon/IconLoader.cpp
@@ -38,6 +38,7 @@
 #include "Logging.h"
 #include "ResourceRequest.h"
 #include "SharedBuffer.h"
+#include <WebCore/HTTPStatusCodes.h>
 #include <wtf/text/CString.h>
 
 namespace WebCore {
@@ -117,7 +118,7 @@ void IconLoader::notifyFinished(CachedResource& resource, const NetworkLoadMetri
     // ignore the data and not try to decode the error page as an icon.
     RefPtr data = resource.resourceBuffer();
     int status = resource.response().httpStatusCode();
-    if (status && (status < 200 || status > 299))
+    if (status && !isHttpOkStatus(status))
         data = nullptr;
 
     constexpr std::array<uint8_t, 4> pdfMagicNumber { '%', 'P', 'D', 'F' };

--- a/Source/WebCore/platform/graphics/avfoundation/cf/WebCoreAVCFResourceLoader.cpp
+++ b/Source/WebCore/platform/graphics/avfoundation/cf/WebCoreAVCFResourceLoader.cpp
@@ -35,6 +35,7 @@
 #include "ResourceLoaderOptions.h"
 #include "SharedBuffer.h"
 #include <AVFoundationCF/AVFoundationCF.h>
+#include <WebCore/HTTPStatusCodes.h>
 #include <wtf/SoftLinking.h>
 #include <wtf/TZoneMallocInlines.h>
 #include <wtf/text/CString.h>
@@ -131,7 +132,7 @@ void WebCoreAVCFResourceLoader::responseReceived(CachedResource& resource, const
     CompletionHandlerCallingScope completionHandlerCaller(WTF::move(completionHandler));
 
     int status = response.httpStatusCode();
-    if (status && (status < 200 || status > 299)) {
+    if (status && !isHttpOkStatus(status)) {
         RetainPtr<CFErrorRef> error = adoptCF(CFErrorCreate(kCFAllocatorDefault, kCFErrorDomainCFNetwork, status, nullptr));
         AVCFAssetResourceLoadingRequestFinishLoadingWithError(m_avRequest.get(), error.get());
         return;

--- a/Source/WebCore/platform/graphics/avfoundation/objc/WebCoreAVFResourceLoader.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/WebCoreAVFResourceLoader.mm
@@ -39,6 +39,7 @@
 #import "SharedBuffer.h"
 #import "UTIUtilities.h"
 #import <AVFoundation/AVAssetResourceLoader.h>
+#import <WebCore/HTTPStatusCodes.h>
 #import <objc/runtime.h>
 #import <wtf/BlockObjCExceptions.h>
 #import <wtf/LoggerHelper.h>
@@ -399,7 +400,7 @@ bool WebCoreAVFResourceLoader::responseReceived(const String& mimeType, int stat
 
     ALWAYS_LOG(LOGIDENTIFIER, "status: ", status, ", range: ", contentRange.firstBytePosition(), "-", contentRange.lastBytePosition(), "/", contentRange.instanceLength(), ", expectedContentLength: ", expectedContentLength);
 
-    if (status && (status < 200 || status > 299)) {
+    if (status && !isHttpOkStatus(status)) {
         [m_avRequest finishLoadingWithError:0];
         return true;
     }

--- a/Source/WebCore/platform/graphics/gstreamer/WebKitWebSourceGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/WebKitWebSourceGStreamer.cpp
@@ -33,6 +33,7 @@
 #include "ResourceRequest.h"
 #include "ResourceResponse.h"
 #include "SecurityOrigin.h"
+#include <WebCore/HTTPStatusCodes.h>
 #include <cstdint>
 #include <wtf/Condition.h>
 #include <wtf/DataMutex.h>
@@ -1046,7 +1047,7 @@ void CachedResourceStreamingClient::responseReceived(PlatformMediaResource&, con
         && (contentLength = parseInteger<uint64_t>(response.httpHeaderField(HTTPHeaderName::ContentLength))))
         length = contentLength.value();
 
-    if (length > 0 && members->requestedPosition && response.httpStatusCode() == 206)
+    if (length > 0 && members->requestedPosition && response.httpStatusCode() == httpStatus206PartialContent)
         length += members->requestedPosition;
 
     GUniquePtr<GstStructure> httpHeaders(gst_structure_new_empty("http-headers"));
@@ -1077,7 +1078,7 @@ void CachedResourceStreamingClient::responseReceived(PlatformMediaResource&, con
     members->pendingHttpHeadersMessage = adoptGRef(gst_message_new_element(GST_OBJECT_CAST(src.get()), gst_structure_copy(httpHeaders.get())));
     members->pendingHttpHeadersEvent = adoptGRef(gst_event_new_custom(GST_EVENT_CUSTOM_DOWNSTREAM_STICKY, httpHeaders.release()));
 
-    if (response.httpStatusCode() >= 400) {
+    if (response.httpStatusCode() >= httpStatus400BadRequest) {
         GST_ELEMENT_ERROR(src.get(), RESOURCE, READ, ("R%u: Received %d HTTP error code", m_requestNumber, response.httpStatusCode()), (nullptr));
         members->doesHaveEOS = true;
         members->responseCondition.notifyOne();
@@ -1087,7 +1088,7 @@ void CachedResourceStreamingClient::responseReceived(PlatformMediaResource&, con
 
     if (members->requestedPosition) {
         // Seeking ... we expect a 206 == PARTIAL_CONTENT
-        if (response.httpStatusCode() != 206) {
+        if (response.httpStatusCode() != httpStatus206PartialContent) {
             // Range request completely failed.
             GST_ELEMENT_ERROR(src.get(), RESOURCE, READ, ("R%u: Received unexpected %d HTTP status code for range request", m_requestNumber, response.httpStatusCode()), (nullptr));
             members->doesHaveEOS = true;

--- a/Source/WebCore/platform/network/HTTPStatusCodes.h
+++ b/Source/WebCore/platform/network/HTTPStatusCodes.h
@@ -29,6 +29,8 @@ namespace WebCore {
 
 // https://www.iana.org/assignments/http-status-codes/http-status-codes.xhtml
 
+constexpr auto httpStatus100Continue = 100;
+constexpr auto httpStatus101SwitchingProtocols = 101;
 constexpr auto httpStatus103EarlyHints = 103;
 
 constexpr auto httpStatus200OK = 200;
@@ -50,8 +52,22 @@ constexpr auto httpStatus403Forbidden = 403;
 constexpr auto httpStatus407ProxyAuthenticationRequired = 407;
 constexpr auto httpStatus416RangeNotSatisfiable = 416;
 
+// https://fetch.spec.whatwg.org/#null-body-status
+ALWAYS_INLINE bool isHttpNullBodyStatus(int code) { return code == httpStatus101SwitchingProtocols || code == httpStatus103EarlyHints || code == httpStatus204NoContent || code == httpStatus205ResetContent || code == httpStatus304NotModified; }
+
+// https://fetch.spec.whatwg.org/#ok-status
+ALWAYS_INLINE bool isHttpOkStatus(int code) { return code >= httpStatus200OK && code < httpStatus300MultipleChoices; }
+
+// https://fetch.spec.whatwg.org/#range-status
+ALWAYS_INLINE bool isHttpRangeStatus(int code) { return code == httpStatus206PartialContent || code == httpStatus416RangeNotSatisfiable; }
+
+// https://fetch.spec.whatwg.org/#redirect-status
+ALWAYS_INLINE bool isHttpRedirectStatus(int code) { return code == httpStatus301MovedPermanently || code == httpStatus302Found || code == httpStatus303SeeOther || code == httpStatus307TemporaryRedirect || code == httpStatus308PermanentRedirect; }
+
 } // namespace WebCore
 
+using WebCore::httpStatus100Continue;
+using WebCore::httpStatus101SwitchingProtocols;
 using WebCore::httpStatus103EarlyHints;
 
 using WebCore::httpStatus200OK;
@@ -72,3 +88,7 @@ using WebCore::httpStatus401Unauthorized;
 using WebCore::httpStatus403Forbidden;
 using WebCore::httpStatus407ProxyAuthenticationRequired;
 using WebCore::httpStatus416RangeNotSatisfiable;
+using WebCore::isHttpNullBodyStatus;
+using WebCore::isHttpOkStatus;
+using WebCore::isHttpRangeStatus;
+using WebCore::isHttpRedirectStatus;

--- a/Source/WebCore/platform/network/ResourceResponseBase.cpp
+++ b/Source/WebCore/platform/network/ResourceResponseBase.cpp
@@ -31,6 +31,7 @@
 #include "DataURLDecoder.h"
 #include "HTTPHeaderNames.h"
 #include "HTTPParsers.h"
+#include "HTTPStatusCodes.h"
 #include "IPAddressSpace.h"
 #include "MIMETypeRegistry.h"
 #include "ParsedContentRange.h"
@@ -365,8 +366,7 @@ bool ResourceResponseBase::isNosniff() const
 
 bool ResourceResponseBase::isSuccessful() const
 {
-    int code = httpStatusCode();
-    return code >= 200 && code < 300;
+    return isHttpOkStatus(httpStatusCode());
 }
 
 int ResourceResponseBase::httpStatusCode() const
@@ -388,7 +388,7 @@ void ResourceResponseBase::setHTTPStatusCode(int statusCode)
 
 bool ResourceResponseBase::isRedirection() const
 {
-    return isRedirectionStatusCode(m_httpStatusCode);
+    return isHttpRedirectStatus(m_httpStatusCode);
 }
 
 const String& ResourceResponseBase::httpStatusText() const

--- a/Source/WebCore/platform/network/ResourceResponseBase.h
+++ b/Source/WebCore/platform/network/ResourceResponseBase.h
@@ -81,8 +81,6 @@ public:
     using Source = ResourceResponseSource;
     static constexpr unsigned bitWidthOfSource = 4;
 
-    static bool isRedirectionStatusCode(int code) { return code == 301 || code == 302 || code == 303 || code == 307 || code == 308; }
-
     using CrossThreadData = ResourceResponseData;
 
     WEBCORE_EXPORT CrossThreadData crossThreadData() const;

--- a/Source/WebCore/platform/network/curl/ResourceResponse.h
+++ b/Source/WebCore/platform/network/curl/ResourceResponse.h
@@ -26,6 +26,7 @@
 
 #pragma once
 
+#include <WebCore/HTTPStatusCodes.h>
 #include <WebCore/ResourceResponseBase.h>
 
 namespace WebCore {
@@ -51,11 +52,11 @@ public:
 
     WEBCORE_EXPORT ResourceResponse(CurlResponse&);
 
-    bool isMovedPermanently() const { return httpStatusCode() == 301; };
-    bool isFound() const { return httpStatusCode() == 302; }
-    bool isSeeOther() const { return httpStatusCode() == 303; }
-    bool isUnauthorized() const { return httpStatusCode() == 401; }
-    bool isProxyAuthenticationRequired() const { return httpStatusCode() == 407; }
+    bool isMovedPermanently() const { return httpStatusCode() == httpStatus301MovedPermanently; };
+    bool isFound() const { return httpStatusCode() == httpStatus302Found; }
+    bool isSeeOther() const { return httpStatusCode() == httpStatus303SeeOther; }
+    bool isUnauthorized() const { return httpStatusCode() == httpStatus401Unauthorized; }
+    bool isProxyAuthenticationRequired() const { return httpStatusCode() == httpStatus407ProxyAuthenticationRequired; }
 
 private:
     friend class ResourceResponseBase;

--- a/Source/WebCore/workers/WorkerFontLoadRequest.cpp
+++ b/Source/WebCore/workers/WorkerFontLoadRequest.cpp
@@ -37,6 +37,7 @@
 #include "ServiceWorker.h"
 #include "WorkerGlobalScope.h"
 #include "WorkerThreadableLoader.h"
+#include <WebCore/HTTPStatusCodes.h>
 #include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
@@ -130,7 +131,7 @@ void WorkerFontLoadRequest::setClient(FontLoadRequestClient* client)
 
 void WorkerFontLoadRequest::didReceiveResponse(ScriptExecutionContextIdentifier, std::optional<ResourceLoaderIdentifier>, const ResourceResponse& response)
 {
-    if (response.httpStatusCode() / 100 != 2 && response.httpStatusCode())
+    if (!response.isSuccessful() && response.httpStatusCode())
         m_errorOccurred = true;
 }
 

--- a/Source/WebCore/workers/WorkerScriptLoader.cpp
+++ b/Source/WebCore/workers/WorkerScriptLoader.cpp
@@ -44,6 +44,7 @@
 #include "WorkerSWClientConnection.h"
 #include "WorkerScriptLoaderClient.h"
 #include "WorkerThreadableLoader.h"
+#include <WebCore/HTTPStatusCodes.h>
 #include <wtf/Ref.h>
 #include <wtf/TZoneMallocInlines.h>
 #include <wtf/text/MakeString.h>
@@ -204,7 +205,7 @@ static ResourceError constructJavaScriptMIMETypeError(const ResourceResponse& re
 
 ResourceError WorkerScriptLoader::validateWorkerResponse(const ResourceResponse& response, Source source, FetchOptions::Destination destination)
 {
-    if (response.httpStatusCode() / 100 != 2 && response.httpStatusCode())
+    if (!response.isSuccessful() && response.httpStatusCode())
         return { errorDomainWebKitInternal, 0, response.url(), "Response is not 2xx"_s, ResourceError::Type::General };
 
     if (!isScriptAllowedByNosniff(response)) {

--- a/Source/WebCore/workers/service/background-fetch/BackgroundFetch.cpp
+++ b/Source/WebCore/workers/service/background-fetch/BackgroundFetch.cpp
@@ -36,6 +36,7 @@
 #include "RetrieveRecordsOptions.h"
 #include "SWServerRegistration.h"
 #include "WebCorePersistentCoders.h"
+#include <WebCore/HTTPStatusCodes.h>
 #include <algorithm>
 #include <wtf/TZoneMallocInlines.h>
 #include <wtf/persistence/PersistentCoders.h>
@@ -344,7 +345,7 @@ static bool validatePartialResponse(size_t rangeStart, const ResourceResponse& p
     if (!previousLastMotified.isEmpty() && previousLastMotified != partialResponse.httpHeaderField(HTTPHeaderName::LastModified))
         return false;
 
-    if (previousResponse.httpStatusCode() == 206) {
+    if (previousResponse.httpStatusCode() == httpStatus206PartialContent) {
         auto parsedPreviousContentRange = extractContentRangeValues(previousResponse);
         if (!parsedPreviousContentRange.isValid())
             return false;
@@ -357,7 +358,7 @@ static bool validatePartialResponse(size_t rangeStart, const ResourceResponse& p
 void BackgroundFetch::Record::didReceiveResponse(ResourceResponse&& response)
 {
     bool shouldClearResponseBody = false;
-    if (response.httpStatusCode() == 206) {
+    if (response.httpStatusCode() == httpStatus206PartialContent) {
         if (!validatePartialResponse(m_responseDataSize, response, m_response)) {
             didFinish(ResourceError { String { }, 0, response.url(), "Validation of partial response failed"_s, ResourceError::Type::AccessControl });
             return;
@@ -365,7 +366,7 @@ void BackgroundFetch::Record::didReceiveResponse(ResourceResponse&& response)
     } else if (m_responseDataSize)
         shouldClearResponseBody = true;
 
-    if (!m_responseDataSize || response.httpStatusCode() != 206)
+    if (!m_responseDataSize || response.httpStatusCode() != httpStatus206PartialContent)
         m_response = response;
 
     auto callbacks = std::exchange(m_responseCallbacks, { });

--- a/Source/WebKit/NetworkProcess/EarlyHintsResourceLoader.cpp
+++ b/Source/WebKit/NetworkProcess/EarlyHintsResourceLoader.cpp
@@ -31,6 +31,7 @@
 #include "PreconnectTask.h"
 #include "WebPageMessages.h"
 #include <WebCore/ContentSecurityPolicy.h>
+#include <WebCore/HTTPStatusCodes.h>
 #include <WebCore/LinkHeader.h>
 #include <WebCore/ResourceLoaderOptions.h>
 #include <WebCore/ResourceRequest.h>
@@ -65,7 +66,7 @@ void EarlyHintsResourceLoader::enqueueSecurityPolicyViolationEvent(SecurityPolic
 
 void EarlyHintsResourceLoader::handleEarlyHintsResponse(ResourceResponse&& response)
 {
-    RELEASE_ASSERT(response.httpStatusCode() == 103);
+    RELEASE_ASSERT(response.httpStatusCode() == httpStatus103EarlyHints);
 
     if (!m_loader)
         return;

--- a/Source/WebKit/NetworkProcess/soup/NetworkDataTaskSoup.cpp
+++ b/Source/WebKit/NetworkProcess/soup/NetworkDataTaskSoup.cpp
@@ -37,6 +37,7 @@
 #include "WebKitDirectoryInputStream.h"
 #include <WebCore/AuthenticationChallenge.h>
 #include <WebCore/HTTPParsers.h>
+#include <WebCore/HTTPStatusCodes.h>
 #include <WebCore/MIMETypeRegistry.h>
 #include <WebCore/NetworkStorageSession.h>
 #include <WebCore/OriginAccessPatterns.h>
@@ -796,7 +797,7 @@ void NetworkDataTaskSoup::continueHTTPRedirection()
 
     m_networkLoadMetrics.hasCrossOriginRedirect = m_networkLoadMetrics.hasCrossOriginRedirect || !SecurityOrigin::create(m_currentRequest.url())->canRequest(request.url(), WebCore::EmptyOriginAccessPatterns::singleton());
 
-    if (m_response.httpStatusCode() == 307 || m_response.httpStatusCode() == 308) {
+    if (m_response.httpStatusCode() == httpStatus307TemporaryRedirect || m_response.httpStatusCode() == httpStatus308PermanentRedirect) {
         ASSERT(m_lastHTTPMethod == request.httpMethod());
         RefPtr body = m_firstRequest.httpBody();
         if (body && !body->isEmpty() && !equalLettersIgnoringASCIICase(m_lastHTTPMethod, "get"_s))
@@ -1212,7 +1213,7 @@ void NetworkDataTaskSoup::download()
     ASSERT(m_pendingDownloadLocation);
     ASSERT(!m_response.isNull());
 
-    if (m_response.httpStatusCode() >= 400) {
+    if (m_response.httpStatusCode() >= httpStatus400BadRequest) {
         didFailDownload(downloadNetworkError(m_response.url(), m_response.httpStatusText()));
         return;
     }

--- a/Source/WebKit/WebProcess/InjectedBundle/API/glib/WebKitWebPage.cpp
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/glib/WebKitWebPage.cpp
@@ -52,6 +52,7 @@
 #include <WebCore/FrameDestructionObserver.h>
 #include <WebCore/FrameLoader.h>
 #include <WebCore/HTMLFormElement.h>
+#include <WebCore/HTTPStatusCodes.h>
 #include <WebCore/LocalFrameInlines.h>
 #include <WebCore/LocalFrameView.h>
 #include <glib/gi18n-lib.h>
@@ -327,7 +328,7 @@ private:
     void didReceiveResponseForResource(WebPage& page, WebFrame&, WebCore::ResourceLoaderIdentifier identifier, const ResourceResponse& response) override
     {
         // Post on the console as well to be consistent with the inspector.
-        if (response.httpStatusCode() >= 400) {
+        if (response.httpStatusCode() >= httpStatus400BadRequest) {
             String errorMessage = makeString("Failed to load resource: the server responded with a status of "_s, response.httpStatusCode(), " ("_s, response.httpStatusText(), ')');
             webkitWebPageDidSendConsoleMessage(m_webPage, MessageSource::Network, MessageLevel::Error, errorMessage, 0, response.url().string());
         }

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebResourceLoadObserver.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebResourceLoadObserver.cpp
@@ -35,6 +35,7 @@
 #include <WebCore/FrameDestructionObserverInlines.h>
 #include <WebCore/FrameLoader.h>
 #include <WebCore/HTMLFrameOwnerElement.h>
+#include <WebCore/HTTPStatusCodes.h>
 #include <WebCore/LocalFrameInlines.h>
 #include <WebCore/LocalFrameLoaderClient.h>
 #include <WebCore/Settings.h>
@@ -57,7 +58,7 @@ void WebResourceLoadObserver::setShouldLogUserInteraction(bool value)
 
 static bool is3xxRedirect(const ResourceResponse& response)
 {
-    return response.httpStatusCode() >= 300 && response.httpStatusCode() <= 399;
+    return response.httpStatusCode() >= httpStatus300MultipleChoices && response.httpStatusCode() < httpStatus400BadRequest;
 }
 
 WebResourceLoadObserver::WebResourceLoadObserver(ResourceLoadStatistics::IsEphemeral isEphemeral)


### PR DESCRIPTION
#### 3caec8396210f21ab36adc76f8c37091dc553bbc
<pre>
Use HTTP status codes in more places
<a href="https://bugs.webkit.org/show_bug.cgi?id=313531">https://bugs.webkit.org/show_bug.cgi?id=313531</a>

Reviewed by Anne van Kesteren.

This also introduces helper function based on concepts from
<a href="https://fetch.spec.whatwg.org/#statuses">https://fetch.spec.whatwg.org/#statuses</a>

Potential minor aligment with the fetch spec:

* Source/WebCore/Modules/fetch/FetchResponse.cpp: Replace isNullBodyStatus() with isHttpNullBodyStatus(), which includes 103 Early Hints too.
(WebCore::FetchResponse::create):
(WebCore::FetchResponse::redirect):
(WebCore::isNullBodyStatus): Deleted.
* Source/WebCore/Modules/model-element/HTMLModelElement.cpp:
(WebCore::HTMLModelElement::environmentMapResourceFinished):
* Source/WebCore/html/HTMLImageLoader.cpp:
(WebCore::HTMLImageLoader::dispatchLoadEvent):
(WebCore::HTMLImageLoader::notifyFinished):
* Source/WebCore/inspector/NetworkResourcesData.cpp:
(WebCore::NetworkResourcesData::dataForURL):
* Source/WebCore/inspector/agents/InspectorNetworkAgent.cpp:
(WebCore::InspectorNetworkAgent::didReceiveResponse):
* Source/WebCore/inspector/agents/WebConsoleAgent.cpp:
(WebCore::WebConsoleAgent::didReceiveResponse):
* Source/WebCore/loader/CrossOriginAccessControl.cpp:
(WebCore::validateRangeRequestedFlag):
* Source/WebCore/loader/DocumentLoader.cpp:
(WebCore::DocumentLoader::continueAfterContentPolicy): Use isHttpNullBodyStatus() which includes 101 Switching Protocols, 103 Early Hints and 304 Not Modified too.
(WebCore::DocumentLoader::urlForHistoryReflectsFailure const):
* Source/WebCore/loader/HistoryController.cpp:
(WebCore::HistoryController::initializeItem):
* Source/WebCore/loader/MediaResourceLoader.cpp:
(WebCore::MediaResourceLoader::verifyMediaResponse):
* Source/WebCore/loader/NetscapePlugInStreamLoader.cpp:
(WebCore::NetscapePlugInStreamLoader::didReceiveResponse):
* Source/WebCore/loader/SubresourceLoader.cpp:
(WebCore::SubresourceLoader::didReceiveResponse):
* Source/WebCore/loader/icon/IconLoader.cpp:
(WebCore::IconLoader::notifyFinished):
* Source/WebCore/platform/graphics/avfoundation/cf/WebCoreAVCFResourceLoader.cpp:
(WebCore::WebCoreAVCFResourceLoader::responseReceived):
* Source/WebCore/platform/graphics/avfoundation/objc/WebCoreAVFResourceLoader.mm:
(WebCore::WebCoreAVFResourceLoader::responseReceived):
* Source/WebCore/platform/graphics/gstreamer/WebKitWebSourceGStreamer.cpp:
(CachedResourceStreamingClient::responseReceived):
* Source/WebCore/platform/network/HTTPStatusCodes.h:
(WebCore::isHttpNullBodyStatus):
(WebCore::isHttpOkStatus):
(WebCore::isHttpRangeStatus):
(WebCore::isHttpRedirectStatus):
* Source/WebCore/platform/network/ResourceResponseBase.cpp:
(WebCore::ResourceResponseBase::isSuccessful const):
(WebCore::ResourceResponseBase::isRedirection const):
* Source/WebCore/platform/network/ResourceResponseBase.h:
(WebCore::ResourceResponseBase::isRedirectionStatusCode): Deleted.
* Source/WebCore/platform/network/curl/ResourceResponse.h:
(WebCore::ResourceResponse::isMovedPermanently const):
(WebCore::ResourceResponse::isFound const):
(WebCore::ResourceResponse::isSeeOther const):
(WebCore::ResourceResponse::isUnauthorized const):
(WebCore::ResourceResponse::isProxyAuthenticationRequired const):
* Source/WebCore/workers/WorkerFontLoadRequest.cpp:
(WebCore::WorkerFontLoadRequest::didReceiveResponse):
* Source/WebCore/workers/WorkerScriptLoader.cpp:
(WebCore::WorkerScriptLoader::validateWorkerResponse):
* Source/WebCore/workers/service/background-fetch/BackgroundFetch.cpp:
(WebCore::validatePartialResponse):
(WebCore::BackgroundFetch::Record::didReceiveResponse):
* Source/WebKit/NetworkProcess/EarlyHintsResourceLoader.cpp:
(WebKit::EarlyHintsResourceLoader::handleEarlyHintsResponse):
* Source/WebKit/NetworkProcess/soup/NetworkDataTaskSoup.cpp:
(WebKit::NetworkDataTaskSoup::continueHTTPRedirection):
(WebKit::NetworkDataTaskSoup::download):
* Source/WebKit/WebProcess/InjectedBundle/API/glib/WebKitWebPage.cpp:
* Source/WebKit/WebProcess/WebCoreSupport/WebResourceLoadObserver.cpp:
(WebKit::is3xxRedirect):

Canonical link: <a href="https://commits.webkit.org/312234@main">https://commits.webkit.org/312234@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a1c1670ed4083a418c39dd6ccd4b31e1fc4c00df

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/159218 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/32646 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/25751 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/168047 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/113595 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/161087 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/32714 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/32633 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/123357 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/86610 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/162175 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/25629 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/143015 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/104024 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/24683 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/23101 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/15820 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/134369 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/20795 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/170542 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/16427 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/22421 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/131549 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/32335 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/27171 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/131660 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35629 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/32279 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/142588 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/90351 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/26358 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/19397 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/31790 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/98057 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/31310 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/31583 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/31465 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->