### PR TITLE
NavigationTiming should only obfuscate redirect info on cross-origin redirects.

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-timing/nav2_test_redirect_xserver.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-timing/nav2_test_redirect_xserver.html
@@ -14,15 +14,27 @@
             function onload_test()
             {
                 var performanceNamespace = document.getElementById("frameContext").contentWindow.performance;
-                assert_equals(performanceNamespace.getEntriesByType("navigation")[0].type,
+                var entry = performanceNamespace.getEntriesByType("navigation")[0];
+                assert_equals(entry.type,
                     "navigate",
                     "Expected navigation type to be navigate.");
-                assert_equals(performanceNamespace.getEntriesByType("navigation")[0].redirectCount, 0,
+                assert_equals(entry.redirectCount, 0,
                     "Expected redirectCount to be 0.");
-                assert_equals(performanceNamespace.getEntriesByType("navigation")[0].redirectStart, 0,
+                assert_equals(entry.redirectStart, 0,
                     "Expected redirectStart to be 0.");
-                assert_equals(performanceNamespace.getEntriesByType("navigation")[0].redirectEnd, 0,
+                assert_equals(entry.redirectEnd, 0,
                     "Expected redirectEnd to be 0.");
+
+                // The final response's timing attributes should still be
+                // populated even after a cross-origin redirect.
+                assert_greater_than(entry.responseStart, 0,
+                    "Expected responseStart to be greater than 0.");
+                assert_greater_than_equal(entry.responseStart, entry.requestStart,
+                    "Expected responseStart to be >= requestStart.");
+                assert_greater_than_equal(entry.requestStart, entry.fetchStart,
+                    "Expected requestStart to be >= fetchStart.");
+                assert_greater_than_equal(entry.responseEnd, entry.responseStart,
+                    "Expected responseEnd to be >= responseStart.");
 
                 done();
             }

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-timing/redirect-xserver-top-level-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-timing/redirect-xserver-top-level-expected.txt
@@ -1,0 +1,8 @@
+Description
+
+This test validates that navigation timing attributes (responseStart, fetchStart, etc.) are correctly reported after a cross-origin redirect in a top-level (popup) navigation.
+
+
+PASS Popup control: navigation timing (no redirect)
+PASS Popup: navigation timing after cross-origin redirect
+

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-timing/redirect-xserver-top-level.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-timing/redirect-xserver-top-level.html
@@ -1,0 +1,79 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <title>Navigation Timing: response timing after cross-origin redirect (popup)</title>
+    <script src="/resources/testharness.js"></script>
+    <script src="/resources/testharnessreport.js"></script>
+    <script src="/common/utils.js"></script>
+    <script src="/common/dispatcher/dispatcher.js"></script>
+</head>
+<body>
+<h1>Description</h1>
+<p>This test validates that navigation timing attributes (responseStart,
+   fetchStart, etc.) are correctly reported after a cross-origin redirect
+   in a top-level (popup) navigation.</p>
+
+<script>
+    promise_test(async (t) => {
+        const uid = token();
+        const executorUrl = remoteExecutorUrl(uid);
+
+        const popup = window.open(executorUrl);
+        t.add_cleanup(() => { popup.close(); });
+
+        const rc = new RemoteContext(uid);
+        const result = await rc.execute_script(() => {
+            const entry = performance.getEntriesByType("navigation")[0];
+            return {
+                responseStart: entry ? entry.responseStart : -1,
+                responseEnd: entry ? entry.responseEnd : -1,
+                hasEntry: !!entry
+            };
+        });
+
+        assert_true(result.hasEntry, "navigation entry should exist");
+        assert_greater_than(result.responseStart, 0,
+            "responseStart should be > 0");
+        assert_greater_than_equal(result.responseEnd, result.responseStart,
+            "responseEnd should be >= responseStart");
+    }, "Popup control: navigation timing (no redirect)");
+
+    promise_test(async (t) => {
+        const uid = token();
+        const executorUrl = remoteExecutorUrl(uid);
+
+        const redirectUrl = make_absolute_url({
+            subdomain: "www",
+            path: "/common/redirect.py",
+            query: "location=" + encodeURIComponent(executorUrl.href)
+        });
+
+        const popup = window.open(redirectUrl);
+        t.add_cleanup(() => { popup.close(); });
+
+        const rc = new RemoteContext(uid);
+        const result = await rc.execute_script(() => {
+            const entry = performance.getEntriesByType("navigation")[0];
+            return {
+                responseStart: entry ? entry.responseStart : -1,
+                responseEnd: entry ? entry.responseEnd : -1,
+                fetchStart: entry ? entry.fetchStart : -1,
+                requestStart: entry ? entry.requestStart : -1,
+                hasEntry: !!entry
+            };
+        });
+
+        assert_true(result.hasEntry, "navigation entry should exist");
+        assert_greater_than(result.responseStart, 0,
+            "responseStart should be > 0 after cross-origin redirect");
+        assert_greater_than_equal(result.responseStart, result.requestStart,
+            "responseStart should be >= requestStart");
+        assert_greater_than_equal(result.requestStart, result.fetchStart,
+            "requestStart should be >= fetchStart");
+        assert_greater_than_equal(result.responseEnd, result.responseStart,
+            "responseEnd should be >= responseStart");
+    }, "Popup: navigation timing after cross-origin redirect");
+</script>
+</body>
+</html>

--- a/Source/WebCore/page/PerformanceNavigationTiming.cpp
+++ b/Source/WebCore/page/PerformanceNavigationTiming.cpp
@@ -120,8 +120,30 @@ PerformanceNavigationTiming::NavigationType PerformanceNavigationTiming::type() 
     return m_navigationType;
 }
 
+double PerformanceNavigationTiming::redirectStart() const
+{
+    // https://www.w3.org/TR/navigation-timing-2/#PerformanceResourceTiming
+    // "The redirectStart getter steps are to perform the following steps.. If this’s redirect count is 0, return 0."
+    if (m_resourceTiming.networkLoadMetrics().hasCrossOriginRedirect)
+        return 0.0;
+
+    return PerformanceResourceTiming::redirectStart();
+}
+
+double PerformanceNavigationTiming::redirectEnd() const
+{
+    // https://www.w3.org/TR/navigation-timing-2/#PerformanceResourceTiming
+    // "The redirectEnd getter steps are to perform the following steps.. If this’s redirect count is 0, return 0."
+    if (m_resourceTiming.networkLoadMetrics().hasCrossOriginRedirect)
+        return 0.0;
+
+    return PerformanceResourceTiming::redirectEnd();
+}
+
 unsigned short PerformanceNavigationTiming::redirectCount() const
 {
+    // https://html.spec.whatwg.org/#initialise-the-document-object step 15.2.
+    // Redirect count is 0 when there are cross-origin redirects.
     if (m_resourceTiming.networkLoadMetrics().hasCrossOriginRedirect)
         return 0;
 

--- a/Source/WebCore/page/PerformanceNavigationTiming.h
+++ b/Source/WebCore/page/PerformanceNavigationTiming.h
@@ -63,10 +63,17 @@ public:
     double loadEventStart() const;
     double loadEventEnd() const;
     NavigationType NODELETE type() const;
+    double redirectStart() const final;
+    double redirectEnd() const final;
     unsigned short NODELETE redirectCount() const;
 
     double NODELETE startTime() const final;
     double duration() const final;
+
+    // Navigation timing is never restricted by the TAO check; see
+    // https://fetch.spec.whatwg.org/#fetch-finale step 3.
+    // https://html.spec.whatwg.org/#initialise-the-document-object step 16.
+    bool shouldRestrictTimingForTAO() const final { return false; }
 
     DocumentEventTiming& documentEventTiming() LIFETIME_BOUND { return m_documentEventTiming; }
     DocumentLoadTiming& documentLoadTiming() LIFETIME_BOUND { return m_documentLoadTiming; }

--- a/Source/WebCore/page/PerformanceResourceTiming.cpp
+++ b/Source/WebCore/page/PerformanceResourceTiming.cpp
@@ -55,9 +55,9 @@ static double networkLoadTimeToDOMHighResTimeStamp(MonotonicTime timeOrigin, Mon
     return result.milliseconds();
 }
 
-static double fetchStart(MonotonicTime timeOrigin, const ResourceTiming& resourceTiming)
+static double fetchStart(MonotonicTime timeOrigin, const ResourceTiming& resourceTiming, bool restrictForTAO)
 {
-    if (auto fetchStart = resourceTiming.networkLoadMetrics().fetchStart; fetchStart && !resourceTiming.networkLoadMetrics().failsTAOCheck)
+    if (auto fetchStart = resourceTiming.networkLoadMetrics().fetchStart; fetchStart && !restrictForTAO)
         return networkLoadTimeToDOMHighResTimeStamp(timeOrigin, fetchStart);
 
     // fetchStart is a required property.
@@ -70,7 +70,7 @@ static double entryStartTime(MonotonicTime timeOrigin, const ResourceTiming& res
 {
     if (resourceTiming.networkLoadMetrics().failsTAOCheck
         || !resourceTiming.networkLoadMetrics().redirectCount)
-        return fetchStart(timeOrigin, resourceTiming);
+        return fetchStart(timeOrigin, resourceTiming, resourceTiming.networkLoadMetrics().failsTAOCheck);
 
     if (resourceTiming.networkLoadMetrics().redirectStart)
         return networkLoadTimeToDOMHighResTimeStamp(timeOrigin, resourceTiming.networkLoadMetrics().redirectStart);
@@ -103,7 +103,7 @@ PerformanceResourceTiming::~PerformanceResourceTiming() = default;
 
 const String& PerformanceResourceTiming::nextHopProtocol() const
 {
-    if (m_resourceTiming.networkLoadMetrics().failsTAOCheck)
+    if (shouldRestrictTimingForTAO())
         return emptyString();
 
     return m_resourceTiming.networkLoadMetrics().protocol;
@@ -111,7 +111,7 @@ const String& PerformanceResourceTiming::nextHopProtocol() const
 
 double PerformanceResourceTiming::workerStart() const
 {
-    if (m_resourceTiming.networkLoadMetrics().failsTAOCheck)
+    if (shouldRestrictTimingForTAO())
         return 0.0;
 
     return networkLoadTimeToDOMHighResTimeStamp(m_timeOrigin, m_resourceTiming.networkLoadMetrics().workerStart);
@@ -119,7 +119,7 @@ double PerformanceResourceTiming::workerStart() const
 
 double PerformanceResourceTiming::redirectStart() const
 {
-    if (m_resourceTiming.networkLoadMetrics().failsTAOCheck)
+    if (shouldRestrictTimingForTAO())
         return 0.0;
 
     if (m_resourceTiming.isLoadedFromServiceWorker())
@@ -133,7 +133,7 @@ double PerformanceResourceTiming::redirectStart() const
 
 double PerformanceResourceTiming::redirectEnd() const
 {
-    if (m_resourceTiming.networkLoadMetrics().failsTAOCheck)
+    if (shouldRestrictTimingForTAO())
         return 0.0;
 
     if (m_resourceTiming.isLoadedFromServiceWorker())
@@ -149,12 +149,12 @@ double PerformanceResourceTiming::redirectEnd() const
 
 double PerformanceResourceTiming::fetchStart() const
 {
-    return WebCore::fetchStart(m_timeOrigin, m_resourceTiming);
+    return WebCore::fetchStart(m_timeOrigin, m_resourceTiming, shouldRestrictTimingForTAO());
 }
 
 double PerformanceResourceTiming::domainLookupStart() const
 {
-    if (m_resourceTiming.networkLoadMetrics().failsTAOCheck)
+    if (shouldRestrictTimingForTAO())
         return 0.0;
 
     if (m_resourceTiming.isLoadedFromServiceWorker())
@@ -168,7 +168,7 @@ double PerformanceResourceTiming::domainLookupStart() const
 
 double PerformanceResourceTiming::domainLookupEnd() const
 {
-    if (m_resourceTiming.networkLoadMetrics().failsTAOCheck)
+    if (shouldRestrictTimingForTAO())
         return 0.0;
 
     if (m_resourceTiming.isLoadedFromServiceWorker())
@@ -182,7 +182,7 @@ double PerformanceResourceTiming::domainLookupEnd() const
 
 double PerformanceResourceTiming::connectStart() const
 {
-    if (m_resourceTiming.networkLoadMetrics().failsTAOCheck)
+    if (shouldRestrictTimingForTAO())
         return 0.0;
 
     if (m_resourceTiming.isLoadedFromServiceWorker())
@@ -196,7 +196,7 @@ double PerformanceResourceTiming::connectStart() const
 
 double PerformanceResourceTiming::connectEnd() const
 {
-    if (m_resourceTiming.networkLoadMetrics().failsTAOCheck)
+    if (shouldRestrictTimingForTAO())
         return 0.0;
 
     if (m_resourceTiming.isLoadedFromServiceWorker())
@@ -210,7 +210,7 @@ double PerformanceResourceTiming::connectEnd() const
 
 double PerformanceResourceTiming::secureConnectionStart() const
 {
-    if (m_resourceTiming.networkLoadMetrics().failsTAOCheck)
+    if (shouldRestrictTimingForTAO())
         return 0.0;
 
     if (m_resourceTiming.networkLoadMetrics().secureConnectionStart == reusedTLSConnectionSentinel)
@@ -224,7 +224,7 @@ double PerformanceResourceTiming::secureConnectionStart() const
 
 double PerformanceResourceTiming::requestStart() const
 {
-    if (m_resourceTiming.networkLoadMetrics().failsTAOCheck)
+    if (shouldRestrictTimingForTAO())
         return 0.0;
 
     // requestStart is 0 when a network request is not made.
@@ -236,7 +236,7 @@ double PerformanceResourceTiming::requestStart() const
 
 double PerformanceResourceTiming::finalResponseHeadersStart() const
 {
-    if (m_resourceTiming.networkLoadMetrics().failsTAOCheck)
+    if (shouldRestrictTimingForTAO())
         return 0.0;
 
     // Return 0 if no final response headers timing was captured.
@@ -248,7 +248,7 @@ double PerformanceResourceTiming::finalResponseHeadersStart() const
 
 double PerformanceResourceTiming::firstInterimResponseStart() const
 {
-    if (m_resourceTiming.networkLoadMetrics().failsTAOCheck)
+    if (shouldRestrictTimingForTAO())
         return 0.0;
 
     // Return 0 if no interim (1xx) response was received.
@@ -260,7 +260,7 @@ double PerformanceResourceTiming::firstInterimResponseStart() const
 
 double PerformanceResourceTiming::responseStart() const
 {
-    if (m_resourceTiming.networkLoadMetrics().failsTAOCheck)
+    if (shouldRestrictTimingForTAO())
         return 0.0;
 
     // Per https://github.com/w3c/resource-timing/pull/408:
@@ -302,7 +302,7 @@ uint64_t PerformanceResourceTiming::transferSize() const
 {
     // This is intentionally stricter than a TAO check.
     // See https://github.com/w3c/server-timing/issues/89
-    if (!m_resourceTiming.isSameOriginRequest() || m_resourceTiming.networkLoadMetrics().failsTAOCheck)
+    if (!m_resourceTiming.isSameOriginRequest() || shouldRestrictTimingForTAO())
         return 0;
 
     auto encodedBodySize = m_resourceTiming.networkLoadMetrics().responseBodyBytesReceived;
@@ -318,7 +318,7 @@ uint64_t PerformanceResourceTiming::encodedBodySize() const
 {
     // This is intentionally stricter than a TAO check.
     // See https://github.com/w3c/server-timing/issues/89
-    if (!m_resourceTiming.isSameOriginRequest() || m_resourceTiming.networkLoadMetrics().failsTAOCheck)
+    if (!m_resourceTiming.isSameOriginRequest() || shouldRestrictTimingForTAO())
         return 0;
 
     auto encodedBodySize = m_resourceTiming.networkLoadMetrics().responseBodyBytesReceived;
@@ -332,7 +332,7 @@ uint64_t PerformanceResourceTiming::decodedBodySize() const
 {
     // This is intentionally stricter than a TAO check.
     // See https://github.com/w3c/server-timing/issues/89
-    if (!m_resourceTiming.isSameOriginRequest() || m_resourceTiming.networkLoadMetrics().failsTAOCheck)
+    if (!m_resourceTiming.isSameOriginRequest() || shouldRestrictTimingForTAO())
         return 0;
 
     auto decodedBodySize = m_resourceTiming.networkLoadMetrics().responseBodyDecodedSize;

--- a/Source/WebCore/page/PerformanceResourceTiming.h
+++ b/Source/WebCore/page/PerformanceResourceTiming.h
@@ -48,11 +48,11 @@ public:
 
     const String& initiatorType() const LIFETIME_BOUND { return m_resourceTiming.initiatorType(); }
     String deliveryType() const { return m_resourceTiming.deliveryType(); }
-    const String& NODELETE nextHopProtocol() const LIFETIME_BOUND;
+    const String& nextHopProtocol() const LIFETIME_BOUND;
 
     double workerStart() const;
-    double redirectStart() const;
-    double redirectEnd() const;
+    virtual double redirectStart() const;
+    virtual double redirectEnd() const;
     double fetchStart() const;
     double domainLookupStart() const;
     double domainLookupEnd() const;
@@ -64,9 +64,9 @@ public:
     double firstInterimResponseStart() const;
     double responseStart() const;
     double responseEnd() const;
-    uint64_t NODELETE transferSize() const;
-    uint64_t NODELETE encodedBodySize() const;
-    uint64_t NODELETE decodedBodySize() const;
+    uint64_t transferSize() const;
+    uint64_t encodedBodySize() const;
+    uint64_t decodedBodySize() const;
     double workerRouterEvaluationStart() const;
     double workerCacheLookupStart() const;
     const String& NODELETE workerMatchedRouterSource() const LIFETIME_BOUND;
@@ -81,6 +81,9 @@ public:
 protected:
     PerformanceResourceTiming(MonotonicTime timeOrigin, ResourceTiming&&);
     ~PerformanceResourceTiming();
+
+    // https://fetch.spec.whatwg.org/#fetch-finale step 4.2.5.
+    virtual bool shouldRestrictTimingForTAO() const { return m_resourceTiming.networkLoadMetrics().failsTAOCheck; }
 
     bool isLoadedFromServiceWorker() const { return m_resourceTiming.isLoadedFromServiceWorker(); }
 


### PR DESCRIPTION
#### 8192619cda5813a6ba6a5bc54ac49f284002f92a
<pre>
NavigationTiming should only obfuscate redirect info on cross-origin redirects.
<a href="https://bugs.webkit.org/show_bug.cgi?id=313532">https://bugs.webkit.org/show_bug.cgi?id=313532</a>

Reviewed by NOBODY (OOPS!).

Currently NavigationTiming removes most of the timing info from navigations that went through a cross-origin redirect.
That&apos;s contrary to the spec, where only redirect related info should be removed from these entries.

This PR aligns the implementation to the spec, and adds relevant tests.

* LayoutTests/imported/w3c/web-platform-tests/navigation-timing/nav2_test_redirect_xserver.html: Added assertions.
* LayoutTests/imported/w3c/web-platform-tests/navigation-timing/redirect-xserver-top-level-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/navigation-timing/redirect-xserver-top-level.html: Added.
* Source/WebCore/page/PerformanceNavigationTiming.cpp:
(WebCore::PerformanceNavigationTiming::redirectStart const): Return 0 for cross origin.
(WebCore::PerformanceNavigationTiming::redirectEnd const): Return 0 for cross origin.
(WebCore::PerformanceNavigationTiming::redirectCount const): Return 0 for cross origin.
* Source/WebCore/page/PerformanceNavigationTiming.h: Override shouldRestrictTimingForTAO to return false.
* Source/WebCore/page/PerformanceResourceTiming.cpp:
(WebCore::fetchStart): Take shouldRestrictTimingForTAO into account.
(WebCore::entryStartTime): Take shouldRestrictTimingForTAO into account.
(WebCore::PerformanceResourceTiming::nextHopProtocol const): Take shouldRestrictTimingForTAO into account.
(WebCore::PerformanceResourceTiming::workerStart const): Take shouldRestrictTimingForTAO into account.
(WebCore::PerformanceResourceTiming::redirectStart const): Take shouldRestrictTimingForTAO into account.
(WebCore::PerformanceResourceTiming::redirectEnd const): Take shouldRestrictTimingForTAO into account.
(WebCore::PerformanceResourceTiming::fetchStart const): Take shouldRestrictTimingForTAO into account.
(WebCore::PerformanceResourceTiming::domainLookupStart const): Take shouldRestrictTimingForTAO into account.
(WebCore::PerformanceResourceTiming::domainLookupEnd const): Take shouldRestrictTimingForTAO into account.
(WebCore::PerformanceResourceTiming::connectStart const): Take shouldRestrictTimingForTAO into account.
(WebCore::PerformanceResourceTiming::connectEnd const): Take shouldRestrictTimingForTAO into account.
(WebCore::PerformanceResourceTiming::secureConnectionStart const): Take shouldRestrictTimingForTAO into account.
(WebCore::PerformanceResourceTiming::requestStart const): Take shouldRestrictTimingForTAO into account.
(WebCore::PerformanceResourceTiming::finalResponseHeadersStart const): Take shouldRestrictTimingForTAO into account.
(WebCore::PerformanceResourceTiming::firstInterimResponseStart const): Take shouldRestrictTimingForTAO into account.
(WebCore::PerformanceResourceTiming::responseStart const): Take shouldRestrictTimingForTAO into account.
(WebCore::PerformanceResourceTiming::transferSize const): Take shouldRestrictTimingForTAO into account.
(WebCore::PerformanceResourceTiming::encodedBodySize const): Take shouldRestrictTimingForTAO into account.
(WebCore::PerformanceResourceTiming::decodedBodySize const): Take shouldRestrictTimingForTAO into account.
* Source/WebCore/page/PerformanceResourceTiming.h:
(WebCore::PerformanceResourceTiming::shouldRestrictTimingForTAO const): Return the value from networkTimingInfo.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8192619cda5813a6ba6a5bc54ac49f284002f92a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/159215 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/32643 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/25748 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/168044 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/113594 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/161084 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/32711 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/32630 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/123354 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/86609 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/162172 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/25622 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/143011 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/104021 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/24676 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/23098 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/15817 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/134362 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/20791 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/170539 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/16392 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/22417 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/131546 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/32332 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/27168 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/131657 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/32276 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/142584 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/90345 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/26354 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/19393 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/31787 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/98024 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/31307 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/31580 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/31462 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->