### PR TITLE
[WebXR Layers] Add Cylinder layer support

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/webxr/layers/xrCylinderLayer_paramValidation.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webxr/layers/xrCylinderLayer_paramValidation.https-expected.txt
@@ -1,0 +1,4 @@
+
+PASS Ensure XRCylinderLayer init and setter parameters are validated - webgl
+PASS Ensure XRCylinderLayer init and setter parameters are validated - webgl2
+

--- a/LayoutTests/imported/w3c/web-platform-tests/webxr/layers/xrCylinderLayer_paramValidation.https.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webxr/layers/xrCylinderLayer_paramValidation.https.html
@@ -1,0 +1,86 @@
+<!DOCTYPE html>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="../resources/webxr_util.js"></script>
+<script src="../resources/webxr_test_constants.js"></script>
+
+<script>
+
+  const MAX_CENTRAL_ANGLE = 1.9 * Math.PI;
+
+  function testCylinderLayerParamValidation(xrSession, deviceController, t, { gl }) {
+    return xrSession.requestReferenceSpace('local').then((refSpace) => {
+      const binding = new XRWebGLBinding(xrSession, gl);
+      const baseInit = { space: refSpace, viewPixelWidth: 1, viewPixelHeight: 1, };
+
+      // Constructor params validation
+      t.step(() => {
+        const layer = binding.createCylinderLayer({ ...baseInit, radius: -1 });
+        assert_greater_than(layer.radius, 0, "Negative radius must be clamped to a positive value");
+      });
+
+      t.step(() => {
+        const layer = binding.createCylinderLayer({ ...baseInit, radius: 0 });
+        assert_greater_than(layer.radius, 0, "radius must be a positive value");
+      });
+
+      t.step(() => {
+	const layer = binding.createCylinderLayer({ ...baseInit, aspectRatio: -1 });
+	assert_greater_than(layer.aspectRatio, 0, "Negative aspectRatio must be clamped to a positive value");
+      });
+
+      t.step(() => {
+	const layer = binding.createCylinderLayer({ ...baseInit, aspectRatio: 0 });
+	assert_greater_than(layer.aspectRatio, 0, "aspectRatio must be a positive value");
+      });
+
+      t.step(() => {
+	const layer = binding.createCylinderLayer({ ...baseInit, centralAngle: -1 });
+	assert_greater_than(layer.centralAngle, 0, "Negative centralAngle must be clamped to a positive value");
+      });
+
+      t.step(() => {
+	const layer = binding.createCylinderLayer({ ...baseInit, centralAngle: 2 * Math.PI });
+	assert_approx_equals(layer.centralAngle, MAX_CENTRAL_ANGLE, 1e-4, "centralAngle should not exceed 1.9*pi");
+      });
+
+      // Setter validation
+      const layer = binding.createCylinderLayer({ ...baseInit });
+
+      t.step(() => {
+	layer.radius = -5;
+	assert_greater_than(layer.radius, 0, "Setting negative radius must clamp to a positive value");
+      });
+
+      t.step(() => {
+	layer.radius = 0;
+	assert_greater_than(layer.radius, 0, "Setting zero radius must clamp to a positive value");
+      });
+
+      t.step(() => {
+	layer.aspectRatio = -3;
+	assert_greater_than(layer.aspectRatio, 0, "Setting negative aspectRatio must clamp to a positive value");
+      });
+
+      t.step(() => {
+	layer.aspectRatio = 0;
+	assert_greater_than(layer.aspectRatio, 0, "Setting zero aspectRatio must clamp to a positive value");
+      });
+
+      t.step(() => {
+	layer.centralAngle = -1;
+	assert_greater_than(layer.centralAngle, 0, "Setting negative centralAngle must clamp to a positive value");
+      });
+
+      t.step(() => {
+	layer.centralAngle = 10;
+	assert_approx_equals(layer.centralAngle, MAX_CENTRAL_ANGLE, 1e-4, "Setting centralAngle must not exceed 1.9*pi");
+      });
+    });
+  }
+
+  xr_session_promise_test("Ensure XRCylinderLayer init and setter parameters are validated",
+    testCylinderLayerParamValidation, TRACKED_IMMERSIVE_DEVICE, 'immersive-vr', { requiredFeatures: ['layers'] }
+);
+
+</script>

--- a/Source/WebCore/Modules/webxr/WebXRWebGLLayer.cpp
+++ b/Source/WebCore/Modules/webxr/WebXRWebGLLayer.cpp
@@ -345,6 +345,7 @@ PlatformXR::DeviceLayer WebXRWebGLLayer::endFrame()
         .forceMonoPresentation = false,
         .quadLayerData = std::nullopt,
         .equirectLayerData = std::nullopt,
+        .cylinderLayerData = std::nullopt,
 #endif
 #endif
     };

--- a/Source/WebCore/Modules/webxr/XRCylinderLayer.cpp
+++ b/Source/WebCore/Modules/webxr/XRCylinderLayer.cpp
@@ -27,11 +27,152 @@
 #include "XRCylinderLayer.h"
 
 #if ENABLE(WEBXR_LAYERS)
+#include "EventTargetInlines.h"
+#include "Logging.h"
+#include "TransformationMatrix.h"
+#include "WebXRRigidTransform.h"
+#include "WebXRSession.h"
+#include "XRLayerBacking.h"
+#include "XRWebGLBinding.h"
+#include <wtf/Scope.h>
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
 
-XRCylinderLayer::~XRCylinderLayer() = default;
+WTF_MAKE_TZONE_ALLOCATED_IMPL(XRCylinderLayer);
 
+XRCylinderLayer::XRCylinderLayer(ScriptExecutionContext& scriptExecutionContext, WebXRSession& session, Ref<XRLayerBacking>&& backing, const XRCylinderLayerInit& init)
+    : XRCompositionLayer(&scriptExecutionContext, session, WTF::move(backing), init)
+    , m_space(init.space)
+    , m_transform((init.transform) ? init.transform : WebXRRigidTransform::create())
+{
+    // Explicitly call setters to add validation.
+    setRadius(init.radius);
+    setCentralAngle(init.centralAngle);
+    setAspectRatio(init.aspectRatio);
+
+    setIsStatic(init.isStatic);
 }
 
+XRCylinderLayer::~XRCylinderLayer() = default;
+
+const WebXRSpace& XRCylinderLayer::space() const
+{
+    ASSERT(m_space);
+    return *m_space;
+}
+
+void XRCylinderLayer::setSpace(WebXRSpace& space)
+{
+    if (m_space == &space)
+        return;
+
+    m_space = space;
+    setNeedsRedraw(true);
+}
+
+const WebXRRigidTransform& XRCylinderLayer::transform() const
+{
+    ASSERT(m_transform);
+    return *m_transform;
+}
+
+void XRCylinderLayer::setTransform(WebXRRigidTransform& transform)
+{
+    if (m_transform == &transform)
+        return;
+
+    m_transform = transform;
+    setNeedsRedraw(true);
+}
+
+void XRCylinderLayer::setRadius(float radius)
+{
+    m_radius = std::max(std::numeric_limits<float>::epsilon(), radius);
+    setNeedsRedraw(true);
+}
+
+void XRCylinderLayer::setCentralAngle(float angle)
+{
+    // (0, 2 * pi) although specs recommend 1.9 * pi as a practical limit.
+    static constexpr float MaxCentralAngle = 1.9 * static_cast<float>(M_PI);
+
+    m_centralAngle = std::clamp(angle, std::numeric_limits<float>::epsilon(), MaxCentralAngle);
+    setNeedsRedraw(true);
+}
+
+void XRCylinderLayer::setAspectRatio(float ratio)
+{
+    m_aspectRatio = std::max(std::numeric_limits<float>::epsilon(), ratio);
+    setNeedsRedraw(true);
+}
+
+void XRCylinderLayer::startFrame(PlatformXR::FrameData& frameData)
+{
+#if PLATFORM(GTK) || PLATFORM(WPE)
+    auto it = frameData.layers.find(m_backing->handle());
+    if (it == frameData.layers.end())
+        return;
+
+    if (needsRedraw())
+        m_backing->startFrame(frameData);
+#else
+    UNUSED_PARAM(frameData);
 #endif
+}
+
+void XRCylinderLayer::recomputePose()
+{
+    auto scopeExit = makeScopeExit([&]() {
+        RELEASE_LOG_ERROR(XR, "Failed to invert space transform, using identity transform for layer pose");
+        m_poseInLocalSpace = PlatformXR::FrameData::Pose { .position = { 0, 0, 0 }, .orientation = { 0, 0, 0, 1 } };
+    });
+
+    std::optional<TransformationMatrix> spaceTransform;
+    if (m_space)
+        spaceTransform = m_space->nativeOrigin();
+    if (!spaceTransform)
+        spaceTransform = TransformationMatrix();
+    else if (!spaceTransform->isInvertible())
+        return;
+
+    auto transformInLocalSpace = m_transform ? *spaceTransform->inverse() * m_transform->rawTransform() : *spaceTransform->inverse();
+    TransformationMatrix::Decomposed4Type decomposed;
+    if (!transformInLocalSpace.decompose4(decomposed))
+        return;
+
+    scopeExit.release();
+    m_poseInLocalSpace.position = { static_cast<float>(decomposed.translateX), static_cast<float>(decomposed.translateY), static_cast<float>(decomposed.translateZ) };
+    m_poseInLocalSpace.orientation = { static_cast<float>(decomposed.quaternion.x), static_cast<float>(decomposed.quaternion.y), static_cast<float>(decomposed.quaternion.z), static_cast<float>(decomposed.quaternion.w) };
+}
+
+PlatformXR::DeviceLayer XRCylinderLayer::endFrame()
+{
+#if PLATFORM(GTK) || PLATFORM(WPE)
+    PlatformXR::DeviceLayer layerData;
+    if (needsRedraw())
+        m_backing->endFrame(layerData);
+
+    layerData.handle = m_backing->handle();
+    layerData.visible = true;
+
+    if (needsRedraw())
+        recomputePose();
+
+    fillInCommonDeviceLayerData(layerData);
+
+    layerData.cylinderLayerData = {
+        .radius = m_radius,
+        .centralAngle = m_centralAngle,
+        .aspectRatio = m_aspectRatio,
+        .poseInLocalSpace = m_poseInLocalSpace,
+    };
+    return layerData;
+#else
+    return PlatformXR::DeviceLayer { };
+#endif
+}
+
+} // namespace WebCore
+
+#endif // ENABLE(WEBXR_LAYERS)

--- a/Source/WebCore/Modules/webxr/XRCylinderLayer.h
+++ b/Source/WebCore/Modules/webxr/XRCylinderLayer.h
@@ -27,35 +27,57 @@
 
 #if ENABLE(WEBXR_LAYERS)
 
-#include "WebXRRigidTransform.h"
-#include "WebXRSpace.h"
+#include "ExceptionOr.h"
 #include "XRCompositionLayer.h"
+#include "XRCylinderLayerInit.h"
+#include <wtf/Ref.h>
+#include <wtf/RefPtr.h>
 
 namespace WebCore {
 
+class WebXRRigidTransform;
+class WebXRSession;
+class WebXRSpace;
+class XRLayerBacking;
+
 // https://immersive-web.github.io/layers/#xrcylinderayertype
 class XRCylinderLayer : public XRCompositionLayer {
+    WTF_MAKE_TZONE_ALLOCATED(XRCylinderLayer);
 public:
+    static Ref<XRCylinderLayer> create(ScriptExecutionContext& scriptExecutionContext, WebXRSession& session, Ref<XRLayerBacking>&& backing, const XRCylinderLayerInit& init)
+    {
+        return adoptRef(*new XRCylinderLayer(scriptExecutionContext, session, WTF::move(backing), init));
+    }
+
     virtual ~XRCylinderLayer();
 
-    const WebXRSpace& space() const { RELEASE_ASSERT_NOT_REACHED(); }
-    [[noreturn]] void setSpace(WebXRSpace&) { RELEASE_ASSERT_NOT_REACHED(); }
-    const WebXRRigidTransform& transform() const { RELEASE_ASSERT_NOT_REACHED(); }
-    [[noreturn]] void setTransform(WebXRRigidTransform&) { RELEASE_ASSERT_NOT_REACHED(); }
+    const WebXRSpace& space() const;
+    void setSpace(WebXRSpace&);
+    const WebXRRigidTransform& transform() const;
+    void setTransform(WebXRRigidTransform&);
 
-    float radius() const { RELEASE_ASSERT_NOT_REACHED(); }
-    [[noreturn]] void setRadius(float) { RELEASE_ASSERT_NOT_REACHED(); }
-    float centralAngle() const { RELEASE_ASSERT_NOT_REACHED(); }
-    [[noreturn]] void setCentralAngle(float) { RELEASE_ASSERT_NOT_REACHED(); }
-    float aspectRatio() const { RELEASE_ASSERT_NOT_REACHED(); }
-    [[noreturn]] void setAspectRatio(float) { RELEASE_ASSERT_NOT_REACHED(); }
+    float radius() const { return m_radius; }
+    void setRadius(float);
+    float centralAngle() const { return m_centralAngle; }
+    void setCentralAngle(float);
+    float aspectRatio() const { return m_aspectRatio; }
+    void setAspectRatio(float);
 
 private:
+    XRCylinderLayer(ScriptExecutionContext&, WebXRSession&, Ref<XRLayerBacking>&&, const XRCylinderLayerInit&);
     bool isXRCylinderLayer() const final { return true; }
+    void recomputePose();
+
+    RefPtr<WebXRSpace> m_space;
+    RefPtr<WebXRRigidTransform> m_transform;
+    float m_radius;
+    float m_centralAngle;
+    float m_aspectRatio;
+    PlatformXR::FrameData::Pose m_poseInLocalSpace;
 
     // WebXRLayer.
-    [[noreturn]] void startFrame(PlatformXR::FrameData&) final { RELEASE_ASSERT_NOT_REACHED(); }
-    [[noreturn]] PlatformXR::DeviceLayer endFrame() final { RELEASE_ASSERT_NOT_REACHED(); }
+    void startFrame(PlatformXR::FrameData&) final;
+    PlatformXR::DeviceLayer endFrame() final;
 };
 
 } // namespace WebCore
@@ -65,4 +87,3 @@ SPECIALIZE_TYPE_TRAITS_BEGIN(WebCore::XRCylinderLayer)
 SPECIALIZE_TYPE_TRAITS_END()
 
 #endif // ENABLE(WEBXR_LAYERS)
-

--- a/Source/WebCore/Modules/webxr/XRWebGLBinding.cpp
+++ b/Source/WebCore/Modules/webxr/XRWebGLBinding.cpp
@@ -38,6 +38,8 @@
 #include "WebXRSession.h"
 #include "WebXRView.h"
 #include "WebXRViewport.h"
+#include "XRCylinderLayer.h"
+#include "XRCylinderLayerInit.h"
 #include "XREquirectLayer.h"
 #include "XREquirectLayerInit.h"
 #include "XRLayerLayout.h"
@@ -45,6 +47,7 @@
 #include "XRProjectionLayerInit.h"
 #include "XRQuadLayer.h"
 #include "XRQuadLayerInit.h"
+#include "XRWebGLCylinderLayerBacking.h"
 #include "XRWebGLEquirectLayerBacking.h"
 #include "XRWebGLProjectionLayerBacking.h"
 #include "XRWebGLQuadLayerBacking.h"
@@ -568,6 +571,57 @@ ExceptionOr<Ref<XREquirectLayer>> XRWebGLBinding::createEquirectLayer(ScriptExec
                 return checkSpaceResult.releaseException();
 
             Ref layer = XREquirectLayer::create(scriptExecutionContext, m_session, WTF::move(backing), init);
+            initializeCompositionLayer(layer.get());
+
+            auto layoutResult = determineLayout(init.textureType, init.layout);
+            if (layoutResult.hasException())
+                return layoutResult.releaseException();
+            auto layout = layoutResult.releaseReturnValue();
+            layer->setLayout(layout);
+            layer->setNeedsRedraw(true);
+
+            return layer;
+        },
+        [](std::monostate) {
+            ASSERT_NOT_REACHED();
+            return Exception { ExceptionCode::OperationError, "Could not get a WebGL rendering context."_s };
+        }
+    );
+}
+
+ExceptionOr<Ref<XRCylinderLayer>> XRWebGLBinding::createCylinderLayer(ScriptExecutionContext& scriptExecutionContext, const XRCylinderLayerInit& init)
+{
+    if (!m_session->supportsFeature(PlatformXR::SessionFeature::Layers))
+        return Exception { ExceptionCode::NotSupportedError, "Layers are not supported by the session."_s };
+
+    if (m_session->ended())
+        return Exception { ExceptionCode::InvalidStateError, "Cannot create a cylinder layer with an XRSession that has ended."_s };
+
+    return WTF::switchOn(m_context,
+        [&](const Ref<WebGLRenderingContextBase>& baseContext) -> ExceptionOr<Ref<XRCylinderLayer>> {
+            if (baseContext->isContextLost())
+                return Exception { ExceptionCode::InvalidStateError, "Cannot create a cylinder layer with a lost WebGL context"_s };
+
+            if (!init.space->isReferenceSpace())
+                return Exception { ExceptionCode::TypeError, "The space is not a reference space."_s };
+
+            if (downcast<WebXRReferenceSpace>(init.space)->type() == XRReferenceSpaceType::Viewer)
+                return Exception { ExceptionCode::TypeError, "Viewer space is not allowed for cylinder layers."_s };
+
+            auto validateInitResult = validateCompositionLayerInitParameters(init);
+            if (validateInitResult.hasException())
+                return validateInitResult.releaseException();
+
+            auto createBackingResult = XRWebGLCylinderLayerBacking::create(m_session, baseContext, init);
+            if (createBackingResult.hasException())
+                return createBackingResult.releaseException();
+            Ref backing = createBackingResult.releaseReturnValue();
+
+            auto checkSpaceResult = checkCanSetSpace(init.space.get(), m_session);
+            if (checkSpaceResult.hasException())
+                return checkSpaceResult.releaseException();
+
+            Ref layer = XRCylinderLayer::create(scriptExecutionContext, m_session, WTF::move(backing), init);
             initializeCompositionLayer(layer.get());
 
             auto layoutResult = determineLayout(init.textureType, init.layout);

--- a/Source/WebCore/Modules/webxr/XRWebGLBinding.h
+++ b/Source/WebCore/Modules/webxr/XRWebGLBinding.h
@@ -77,7 +77,7 @@ public:
 
     ExceptionOr<Ref<XRProjectionLayer>> createProjectionLayer(ScriptExecutionContext&, const XRProjectionLayerInit&);
     ExceptionOr<Ref<XRQuadLayer>> createQuadLayer(ScriptExecutionContext&, const XRQuadLayerInit&);
-    ExceptionOr<Ref<XRCylinderLayer>> createCylinderLayer(const XRCylinderLayerInit&) { RELEASE_ASSERT_NOT_REACHED(); }
+    ExceptionOr<Ref<XRCylinderLayer>> createCylinderLayer(ScriptExecutionContext&, const XRCylinderLayerInit&);
     ExceptionOr<Ref<XREquirectLayer>> createEquirectLayer(ScriptExecutionContext&, const XREquirectLayerInit&);
     ExceptionOr<Ref<XRCubeLayer>> createCubeLayer(const XRCubeLayerInit&) { RELEASE_ASSERT_NOT_REACHED(); }
 

--- a/Source/WebCore/Modules/webxr/XRWebGLCylinderLayerBacking.cpp
+++ b/Source/WebCore/Modules/webxr/XRWebGLCylinderLayerBacking.cpp
@@ -1,0 +1,88 @@
+/*
+ * Copyright (C) 2026 Igalia S.L. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "XRWebGLCylinderLayerBacking.h"
+
+#if ENABLE(WEBXR_LAYERS)
+
+#include "WebXRSession.h"
+#include "WebXRWebGLLayer.h"
+#include "WebXRWebGLSwapchain.h"
+#include "XRCylinderLayerInit.h"
+#include <wtf/TZoneMallocInlines.h>
+
+namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(XRWebGLCylinderLayerBacking);
+
+ExceptionOr<Ref<XRWebGLCylinderLayerBacking>> XRWebGLCylinderLayerBacking::create(WebXRSession& session, WebGLRenderingContextBase& context, const XRCylinderLayerInit& init)
+{
+    auto device = session.device();
+    if (!device)
+        return Exception { ExceptionCode::OperationError, "Cannot create a cylinder layer without a valid device."_s };
+
+    auto computeCylinderLayerData = [](const XRCylinderLayerInit& init) -> std::pair<IntSize, PlatformXR::LayerLayout> {
+        switch (init.layout) {
+        case XRLayerLayout::Mono:
+            return { IntSize { static_cast<int>(init.viewPixelWidth), static_cast<int>(init.viewPixelHeight) }, PlatformXR::LayerLayout::Mono };
+        case XRLayerLayout::Stereo:
+        case XRLayerLayout::StereoLeftRight:
+            return { IntSize { static_cast<int>(init.viewPixelWidth * 2), static_cast<int>(init.viewPixelHeight) }, PlatformXR::LayerLayout::StereoLeftRight };
+        case XRLayerLayout::StereoTopBottom:
+            return { IntSize { static_cast<int>(init.viewPixelWidth), static_cast<int>(init.viewPixelHeight * 2) }, PlatformXR::LayerLayout::StereoTopBottom };
+        default:
+        case XRLayerLayout::Default:
+            ASSERT_NOT_REACHED_WITH_MESSAGE("Default layout is not supported for non-projection Layers");
+            return { IntSize(), PlatformXR::LayerLayout::Mono };
+        };
+    };
+
+    auto [ cylinderLayerSize, cylinderLayerLayout ] = computeCylinderLayerData(init);
+
+    auto layerInfo = device->createCompositionLayer(PlatformXR::CompositionLayerType::Cylinder, cylinderLayerSize, cylinderLayerLayout);
+    if (!layerInfo)
+        return Exception { ExceptionCode::OperationError, "Unable to create a cylinder layer."_s };
+
+    auto colorSwapchain = WebXRWebGLSharedImageSwapchain::create(context, WebXRSwapchain::SwapchainTargetFlags::Color, init.colorFormat, init.clearOnAccess, layerInfo->numImages);
+    if (!colorSwapchain)
+        return Exception { ExceptionCode::OperationError, "Failed to create a WebGL swapchain."_s };
+
+    std::unique_ptr<WebXRWebGLSwapchain> depthStencilSwapchain;
+    if (init.depthFormat && init.depthFormat.value())
+        depthStencilSwapchain = XRWebGLLayerBacking::createDepthSwapchain(context, init.depthFormat.value(), cylinderLayerSize, init.clearOnAccess, layerInfo->numImages);
+
+    return adoptRef(*new XRWebGLCylinderLayerBacking(layerInfo->handle, WTF::move(colorSwapchain), WTF::move(depthStencilSwapchain), init));
+}
+
+XRWebGLCylinderLayerBacking::XRWebGLCylinderLayerBacking(PlatformXR::LayerHandle handle, std::unique_ptr<WebXRWebGLSwapchain>&& colorSwapchain, std::unique_ptr<WebXRWebGLSwapchain>&& depthSwapchain, const XRCylinderLayerInit& init)
+    : XRWebGLLayerBacking(handle, WTF::move(colorSwapchain), WTF::move(depthSwapchain))
+    , m_init(init)
+{
+}
+
+} // namespace WebCore
+
+#endif // ENABLE(WEBXR_LAYERS)

--- a/Source/WebCore/Modules/webxr/XRWebGLCylinderLayerBacking.h
+++ b/Source/WebCore/Modules/webxr/XRWebGLCylinderLayerBacking.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 Apple, Inc. All rights reserved.
+ * Copyright (C) 2026 Igalia S.L. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -23,25 +23,33 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-typedef (WebGLRenderingContext or WebGL2RenderingContext) WebXRWebGLRenderingContext;
+#pragma once
 
-// https://immersive-web.github.io/layers/#XRWebGLBindingtype
-[
-    Conditional=WEBXR_LAYERS,
-    EnabledBySetting=WebXRLayersAPIEnabled,
-    Exposed=Window
-] interface XRWebGLBinding {
-    constructor(WebXRSession session, WebXRWebGLRenderingContext context);
+#if ENABLE(WEBXR_LAYERS)
 
-    readonly attribute double nativeProjectionScaleFactor;
-    readonly attribute boolean usesDepthValues;
+#include "XRCylinderLayerInit.h"
+#include "XRWebGLLayerBacking.h"
+#include <wtf/Ref.h>
+#include <wtf/RefPtr.h>
+#include <wtf/TZoneMalloc.h>
 
-    [CallWith=CurrentScriptExecutionContext] XRProjectionLayer createProjectionLayer(optional XRProjectionLayerInit init = {});
-    [CallWith=CurrentScriptExecutionContext] XRQuadLayer createQuadLayer(optional XRQuadLayerInit init = {});
-    [CallWith=CurrentScriptExecutionContext] XRCylinderLayer createCylinderLayer(optional XRCylinderLayerInit init = {});
-    [CallWith=CurrentScriptExecutionContext] XREquirectLayer createEquirectLayer(optional XREquirectLayerInit init = {});
-    XRCubeLayer createCubeLayer(optional XRCubeLayerInit init = {});
+namespace WebCore {
 
-    XRWebGLSubImage getSubImage(XRCompositionLayer layer, WebXRFrame frame, optional XREye eye = "none");
-    XRWebGLSubImage getViewSubImage(XRProjectionLayer layer, WebXRView view);
+class WebGLRenderingContextBase;
+class WebXRWebGLSwapchain;
+class WebXRSession;
+
+class XRWebGLCylinderLayerBacking : public XRWebGLLayerBacking {
+    WTF_MAKE_TZONE_ALLOCATED(XRWebGLCylinderLayerBacking);
+public:
+    static ExceptionOr<Ref<XRWebGLCylinderLayerBacking>> create(WebXRSession&, WebGLRenderingContextBase&, const XRCylinderLayerInit&);
+
+private:
+    XRWebGLCylinderLayerBacking(PlatformXR::LayerHandle, std::unique_ptr<WebXRWebGLSwapchain>&& colorSwapchain, std::unique_ptr<WebXRWebGLSwapchain>&& depthSwapchain, const XRCylinderLayerInit&);
+
+    XRCylinderLayerInit m_init;
 };
+
+} // namespace WebCore
+
+#endif // ENABLE(WEBXR_LAYERS)

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -581,6 +581,7 @@ Modules/webxr/WebXRRay.cpp
 Modules/webxr/XRReferenceSpaceEvent.cpp
 Modules/webxr/XRSessionEvent.cpp
 Modules/webxr/XRSubImage.cpp
+Modules/webxr/XRWebGLCylinderLayerBacking.cpp
 Modules/webxr/XRWebGLEquirectLayerBacking.cpp
 Modules/webxr/XRWebGLLayerBacking.cpp
 Modules/webxr/XRWebGLProjectionLayerBacking.cpp

--- a/Source/WebCore/platform/xr/PlatformXR.h
+++ b/Source/WebCore/platform/xr/PlatformXR.h
@@ -490,6 +490,7 @@ struct FrameData {
 enum class CompositionLayerType : uint8_t {
     Quad,
     Equirect,
+    Cylinder,
 };
 
 enum class LayerLayout : uint8_t {
@@ -526,6 +527,13 @@ struct DeviceLayer {
         FrameData::Pose poseInLocalSpace;
     };
     std::optional<EquirectLayerData> equirectLayerData;
+    struct CylinderLayerData {
+        float radius;
+        float centralAngle;
+        float aspectRatio;
+        FrameData::Pose poseInLocalSpace;
+    };
+    std::optional<CylinderLayerData> cylinderLayerData;
 #endif
 };
 

--- a/Source/WebKit/Shared/XR/PlatformXR.serialization.in
+++ b/Source/WebKit/Shared/XR/PlatformXR.serialization.in
@@ -316,6 +316,14 @@ header: <WebCore/PlatformXR.h>
 };
 
 header: <WebCore/PlatformXR.h>
+[Nested] struct PlatformXR::DeviceLayer::CylinderLayerData {
+    float radius;
+    float centralAngle;
+    float aspectRatio;
+    PlatformXR::FrameData::Pose poseInLocalSpace;
+};
+
+header: <WebCore/PlatformXR.h>
 [CustomHeader] struct PlatformXR::DeviceLayer {
     PlatformXR::LayerHandle handle;
     bool visible;
@@ -326,6 +334,7 @@ header: <WebCore/PlatformXR.h>
     bool forceMonoPresentation;
     std::optional<PlatformXR::DeviceLayer::QuadLayerData> quadLayerData;
     std::optional<PlatformXR::DeviceLayer::EquirectLayerData> equirectLayerData;
+    std::optional<PlatformXR::DeviceLayer::CylinderLayerData> cylinderLayerData;
 #endif
 };
 #endif
@@ -339,6 +348,7 @@ header: <WebCore/PlatformXR.h>
 enum class PlatformXR::CompositionLayerType : uint8_t {
     Quad,
     Equirect,
+    Cylinder,
 };
 
 enum class PlatformXR::LayerLayout : uint8_t {

--- a/Source/WebKit/UIProcess/XR/openxr/OpenXRLayer.cpp
+++ b/Source/WebKit/UIProcess/XR/openxr/OpenXRLayer.cpp
@@ -699,6 +699,141 @@ Vector<XrCompositionLayerBaseHeader*> OpenXREquirectLayer::endFrame(const Platfo
 
 #endif
 
+#if defined(XR_KHR_composition_layer_cylinder)
+
+std::unique_ptr<OpenXRCylinderLayer> OpenXRCylinderLayer::create(std::unique_ptr<OpenXRSwapchain>&& swapchain, PlatformXR::LayerLayout layout)
+{
+    return std::unique_ptr<OpenXRCylinderLayer>(new OpenXRCylinderLayer(makeUniqueRefFromNonNullUniquePtr(WTF::move(swapchain)), layout));
+}
+
+OpenXRCylinderLayer::OpenXRCylinderLayer(UniqueRef<OpenXRSwapchain>&& swapchain, PlatformXR::LayerLayout layout)
+    : OpenXRCompositionLayer(WTF::move(swapchain), layout)
+{
+    m_layers.resize(layout == PlatformXR::LayerLayout::Mono ? 1 : 2);
+    m_layers.fill(createOpenXRStruct<XrCompositionLayerCylinderKHR, XR_TYPE_COMPOSITION_LAYER_CYLINDER_KHR>());
+    int xOffset = 0;
+    int yOffset = 0;
+    int subImageWidth = layout == PlatformXR::LayerLayout::StereoLeftRight ? m_swapchain->width() / 2 : m_swapchain->width();
+    int subImageHeight = layout == PlatformXR::LayerLayout::StereoTopBottom ? m_swapchain->height() / 2 : m_swapchain->height();
+    XrExtent2Di subImageExtent = { subImageWidth, subImageHeight };
+    for (auto& xrLayer : m_layers) {
+        xrLayer.subImage.swapchain = m_swapchain->swapchain();
+        xrLayer.subImage.imageRect.offset = { xOffset, yOffset };
+        xrLayer.subImage.imageRect.extent = subImageExtent;
+        xrLayer.subImage.imageArrayIndex = 0;
+
+        xOffset += layout == PlatformXR::LayerLayout::StereoLeftRight ? subImageWidth : 0;
+        yOffset += layout == PlatformXR::LayerLayout::StereoTopBottom ? subImageHeight : 0;
+    }
+}
+
+std::optional<PlatformXR::FrameData::LayerData> OpenXRCylinderLayer::startFrame()
+{
+    auto texture = m_swapchain->acquireImage();
+    if (!texture)
+        return std::nullopt;
+
+    auto addResult = m_exportedTextures.add(*texture, m_nextReusableTextureIndex);
+    bool needsExport = addResult.isNewEntry;
+
+    PlatformXR::FrameData::LayerData layerData;
+    layerData.renderingFrameIndex = m_renderingFrameIndex++;
+    layerData.textureData = {
+        .reusableTextureIndex = addResult.iterator->value,
+        .colorTexture = { },
+        .depthStencilBuffer = { },
+    };
+
+    if (!needsExport)
+        return layerData;
+    m_nextReusableTextureIndex++;
+
+    auto externalTexture = exportOpenXRTexture(*texture);
+    if (!externalTexture)
+        return std::nullopt;
+
+    layerData.textureData->colorTexture = WTF::move(externalTexture.value());
+
+    layerData.layerSetup = {
+        .physicalSize = { { { static_cast<uint16_t>(m_swapchain->width()), static_cast<uint16_t>(m_swapchain->height()) } } },
+        .viewports = { },
+        .foveationRateMapDesc = { }
+    };
+
+    return layerData;
+}
+
+Vector<XrCompositionLayerBaseHeader*> OpenXRCylinderLayer::endFrame(const PlatformXR::DeviceLayer& layer, XrSpace space, const Vector<XrView>& frameViews)
+{
+    if (!m_swapchain->acquiredTexture()) {
+        LOG_ERROR("OpenXRCylinderLayer::endFrame called without a valid acquired texture");
+        return { };
+    }
+
+#if OS(ANDROID) || USE(GBM)
+    if (needsBlitTexture()) {
+        if (!m_fbosForBlitting[0])
+            glGenFramebuffers(m_fbosForBlitting.size(), m_fbosForBlitting.data());
+        blitTexture();
+    }
+#endif
+
+    auto eyeVisibility = [](bool isLeftEye, bool isMonoPresentation) {
+        if (isMonoPresentation)
+            return XR_EYE_VISIBILITY_BOTH;
+        return isLeftEye ? XR_EYE_VISIBILITY_LEFT : XR_EYE_VISIBILITY_RIGHT;
+    };
+    auto flags = layer.blendTextureSourceAlpha ? XR_COMPOSITION_LAYER_BLEND_TEXTURE_SOURCE_ALPHA_BIT : 0;
+
+    auto isLeftEyeIndex = [layout = m_layout](int layerIndex) {
+        switch (layout) {
+        case PlatformXR::LayerLayout::Mono:
+        case PlatformXR::LayerLayout::StereoLeftRight:
+            return !layerIndex;
+        case PlatformXR::LayerLayout::StereoTopBottom:
+#if defined(XR_USE_GRAPHICS_API_OPENGL_ES) || defined(XR_USE_GRAPHICS_API_OPENGL)
+            return layerIndex == 1;
+#elif defined(XR_USE_GRAPHICS_API_VULKAN)
+            return !layerIndex;
+#endif
+        default:
+            ASSERT_NOT_REACHED_WITH_MESSAGE("Unrecognized layout for cylinder layer");
+            return false;
+        };
+    };
+
+    const auto numLayers = m_layers.size();
+    Vector<XrCompositionLayerBaseHeader*> layerHeaders;
+    layerHeaders.reserveCapacity(numLayers);
+
+    bool isMonoPresentation = layer.forceMonoPresentation || m_layout == PlatformXR::LayerLayout::Mono;
+    for (size_t i = 0; i < numLayers; ++i) {
+        if (isMonoPresentation && !isLeftEyeIndex(i))
+            continue;
+
+        auto& xrLayer = m_layers[i];
+        xrLayer.layerFlags = flags;
+        xrLayer.eyeVisibility = eyeVisibility(isLeftEyeIndex(i), isMonoPresentation);
+        xrLayer.space = space;
+
+        ASSERT(layer.cylinderLayerData);
+        auto& cylinderData = *layer.cylinderLayerData;
+        xrLayer.pose.position = { cylinderData.poseInLocalSpace.position.x(), cylinderData.poseInLocalSpace.position.y(), cylinderData.poseInLocalSpace.position.z() };
+        xrLayer.pose.orientation = { cylinderData.poseInLocalSpace.orientation.x, cylinderData.poseInLocalSpace.orientation.y, cylinderData.poseInLocalSpace.orientation.z, cylinderData.poseInLocalSpace.orientation.w };
+        xrLayer.radius = cylinderData.radius;
+        xrLayer.centralAngle = cylinderData.centralAngle;
+        xrLayer.aspectRatio = cylinderData.aspectRatio;
+
+        layerHeaders.append(reinterpret_cast<XrCompositionLayerBaseHeader*>(&xrLayer));
+    }
+
+    m_swapchain->releaseImage();
+
+    return layerHeaders;
+}
+
+#endif
+
 #endif
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/XR/openxr/OpenXRLayer.h
+++ b/Source/WebKit/UIProcess/XR/openxr/OpenXRLayer.h
@@ -91,8 +91,8 @@ public:
 private:
     explicit OpenXRLayerProjection(UniqueRef<OpenXRSwapchain>&&);
 
-    std::optional<PlatformXR::FrameData::LayerData> startFrame() final;
-    Vector<XrCompositionLayerBaseHeader*> endFrame(const PlatformXR::DeviceLayer&, XrSpace, const Vector<XrView>&) final;
+    std::optional<PlatformXR::FrameData::LayerData> startFrame() override;
+    Vector<XrCompositionLayerBaseHeader*> endFrame(const PlatformXR::DeviceLayer&, XrSpace, const Vector<XrView>&) override;
 
     XrCompositionLayerProjection m_layerProjection;
     Vector<XrCompositionLayerProjectionView> m_projectionViews;
@@ -142,6 +142,23 @@ private:
     explicit OpenXREquirectLayer(UniqueRef<OpenXRSwapchain>&&, PlatformXR::LayerLayout);
 
     Vector<XrCompositionLayerEquirect2KHR> m_layers;
+};
+#endif
+
+#if defined(XR_KHR_composition_layer_cylinder)
+class OpenXRCylinderLayer final : public OpenXRCompositionLayer {
+    WTF_MAKE_TZONE_ALLOCATED(OpenXRCylinderLayer);
+    WTF_MAKE_NONCOPYABLE(OpenXRCylinderLayer);
+public:
+    static std::unique_ptr<OpenXRCylinderLayer> create(std::unique_ptr<OpenXRSwapchain>&&, PlatformXR::LayerLayout);
+
+    std::optional<PlatformXR::FrameData::LayerData> startFrame() override;
+    Vector<XrCompositionLayerBaseHeader*> endFrame(const PlatformXR::DeviceLayer&, XrSpace, const Vector<XrView>&) override;
+
+private:
+    explicit OpenXRCylinderLayer(UniqueRef<OpenXRSwapchain>&&, PlatformXR::LayerLayout);
+
+    Vector<XrCompositionLayerCylinderKHR> m_layers;
 };
 #endif
 

--- a/Source/WebKit/UIProcess/XR/openxr/PlatformXROpenXR.cpp
+++ b/Source/WebKit/UIProcess/XR/openxr/PlatformXROpenXR.cpp
@@ -301,6 +301,11 @@ void OpenXRCoordinator::createCompositionLayer(PlatformXR::CompositionLayerType 
                     layer = OpenXREquirectLayer::create(WTF::move(swapchain), layout);
 #endif
                     break;
+                case PlatformXR::CompositionLayerType::Cylinder:
+#if defined(XR_KHR_composition_layer_cylinder)
+                    layer = OpenXRCylinderLayer::create(WTF::move(swapchain), layout);
+#endif
+                    break;
                 }
                 if (!layer) {
                     RELEASE_LOG(XR, "OpenXRCoordinator: failed to create composition layer");
@@ -323,6 +328,7 @@ void OpenXRCoordinator::createCompositionLayer(PlatformXR::CompositionLayerType 
             });
         });
 }
+
 #endif // ENABLE(WEBXR_LAYERS)
 
 void OpenXRCoordinator::startSession(WebPageProxy& page, WeakPtr<PlatformXRCoordinatorSessionEventClient>&& sessionEventClient, const WebCore::SecurityOriginData&, PlatformXR::SessionMode sessionMode, const PlatformXR::Device::FeatureList&, std::optional<WebCore::XRCanvasConfiguration>&&)
@@ -665,6 +671,10 @@ void OpenXRCoordinator::createInstance()
 #if defined(XR_KHR_composition_layer_equirect2)
     if (OpenXRExtensions::singleton().isExtensionSupported(XR_KHR_COMPOSITION_LAYER_EQUIRECT2_EXTENSION_NAME ""_span))
         extensions.append(const_cast<char*>(XR_KHR_COMPOSITION_LAYER_EQUIRECT2_EXTENSION_NAME));
+#endif
+#if defined(XR_KHR_composition_layer_cylinder)
+    if (OpenXRExtensions::singleton().isExtensionSupported(XR_KHR_COMPOSITION_LAYER_CYLINDER_EXTENSION_NAME ""_span))
+        extensions.append(const_cast<char*>(XR_KHR_COMPOSITION_LAYER_CYLINDER_EXTENSION_NAME));
 #endif
 
     XrInstanceCreateInfo createInfo = createOpenXRStruct<XrInstanceCreateInfo, XR_TYPE_INSTANCE_CREATE_INFO >();


### PR DESCRIPTION
#### 0adbbc533b6015f73f71071ed81218a2bc569c0c
<pre>
[WebXR Layers] Add Cylinder layer support
<a href="https://bugs.webkit.org/show_bug.cgi?id=313421">https://bugs.webkit.org/show_bug.cgi?id=313421</a>

Reviewed by Dan Glastonbury.

This implements the required changes to create cylinder layers on UIProcess
side and share them with the WebProcess so that web authors could use
them in their WebXR experiences. No new IPC is needed since this uses
the changes from ee9f80f3@main in which all composition layers started
using the same message to create new layers.

As in the case of other composition layers, texture arrays are not
supported yet but they&apos;ll be eventually added.

The only platform implementation supporting the cylinder layer will
initially be the OpenXR one which supports the cylinder layer via
the XR_KHR_composition_layer_cylinder extension.

Test: imported/w3c/web-platform-tests/webxr/layers/xrCylinderLayer_paramValidation.https.html

* LayoutTests/imported/w3c/web-platform-tests/webxr/layers/xrCylinderLayer_paramValidation.https-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/webxr/layers/xrCylinderLayer_paramValidation.https.html: Added.
* Source/WebCore/Modules/webxr/WebXRWebGLLayer.cpp:
(WebCore::WebXRWebGLLayer::endFrame):
* Source/WebCore/Modules/webxr/XRCylinderLayer.cpp:
(WebCore::XRCylinderLayer::XRCylinderLayer):
(WebCore::XRCylinderLayer::space const):
(WebCore::XRCylinderLayer::setSpace):
(WebCore::XRCylinderLayer::transform const):
(WebCore::XRCylinderLayer::setTransform):
(WebCore::XRCylinderLayer::setRadius):
(WebCore::XRCylinderLayer::setCentralAngle):
(WebCore::XRCylinderLayer::setAspectRatio):
(WebCore::XRCylinderLayer::startFrame):
(WebCore::XRCylinderLayer::recomputePose):
(WebCore::XRCylinderLayer::endFrame):
* Source/WebCore/Modules/webxr/XRCylinderLayer.h:
(WebCore::XRCylinderLayer::create):
(WebCore::XRCylinderLayer::radius const):
(WebCore::XRCylinderLayer::centralAngle const):
(WebCore::XRCylinderLayer::aspectRatio const):
(WebCore::XRCylinderLayer::space const): Deleted.
(WebCore::XRCylinderLayer::setSpace): Deleted.
(WebCore::XRCylinderLayer::transform const): Deleted.
(WebCore::XRCylinderLayer::setTransform): Deleted.
(WebCore::XRCylinderLayer::setRadius):
(WebCore::XRCylinderLayer::setCentralAngle):
(WebCore::XRCylinderLayer::setAspectRatio):
* Source/WebCore/Modules/webxr/XRWebGLBinding.cpp:
(WebCore::XRWebGLBinding::createEquirectLayer):
(WebCore::XRWebGLBinding::createCylinderLayer):
* Source/WebCore/Modules/webxr/XRWebGLBinding.h:
(WebCore::XRWebGLBinding::createCylinderLayer): Deleted.
* Source/WebCore/Modules/webxr/XRWebGLBinding.idl:
* Source/WebCore/Modules/webxr/XRWebGLCylinderLayerBacking.cpp: Added.
(WebCore::XRWebGLCylinderLayerBacking::create):
(WebCore::XRWebGLCylinderLayerBacking::XRWebGLCylinderLayerBacking):
* Source/WebCore/Modules/webxr/XRWebGLCylinderLayerBacking.h: Copied from Source/WebCore/Modules/webxr/XRCylinderLayer.cpp.
* Source/WebCore/Sources.txt:
* Source/WebCore/platform/xr/PlatformXR.h:
* Source/WebKit/Shared/XR/PlatformXR.serialization.in:
* Source/WebKit/UIProcess/XR/openxr/OpenXRLayer.cpp:
(WebKit::OpenXRCylinderLayer::create):
(WebKit::OpenXRCylinderLayer::OpenXRCylinderLayer):
(WebKit::OpenXRCylinderLayer::startFrame):
* Source/WebKit/UIProcess/XR/openxr/OpenXRLayer.h:
* Source/WebKit/UIProcess/XR/openxr/PlatformXROpenXR.cpp:
(WebKit::OpenXRCoordinator::createCompositionLayer):
(WebKit::OpenXRCoordinator::createInstance):

Canonical link: <a href="https://commits.webkit.org/312596@main">https://commits.webkit.org/312596@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5820e75f6948fb692a271716a384e9255c6c9e63

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/160285 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/33758 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/26859 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/169187 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/115087 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/162154 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/33859 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/33758 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/124268 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/115087 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/163243 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/26507 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/143969 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/104867 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/25560 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/24057 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/16907 "Built successfully") | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/152341 "Build is in progress. Recent messages:") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/135252 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/21732 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/171665 "Built successfully") | 
| [⏳ 🛠 🧪 jsc-debug-arm64 ](https://ews-build.webkit.org/#/builders/JSC-Tests-O3-Debug-arm64-EWS "Waiting in queue, processing has not started yet") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/18009 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/23372 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/132520 "Found 1 new test failure: media/media-sources-selection.html (failure)") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/33431 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/28151 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/132545 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35864 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/33416 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/143527 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/94576 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/27158 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/20341 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/32925 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/99671 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/32426 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/32670 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/32574 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->