### PR TITLE
Fix crash in MediaPlayer::hasAudio() by avoiding pure virtual call from JSC GC thread

### DIFF
--- a/Source/WebCore/platform/graphics/MediaPlayer.cpp
+++ b/Source/WebCore/platform/graphics/MediaPlayer.cpp
@@ -671,12 +671,18 @@ void MediaPlayer::loadWithNextMediaEngine(const MediaPlayerFactory* current)
     if (!engine) {
         LOG(Media, "MediaPlayer::loadWithNextMediaEngine - no media engine found for type \"%s\"", contentType().raw().utf8().data());
         m_currentMediaEngine = engine.get();
-        m_private = nullptr;
+        {
+            Locker locker { m_privateLock };
+            m_private = nullptr;
+        }
     } else if (m_currentMediaEngine.get() != engine.get()) {
         m_currentMediaEngine = engine.get();
         m_attemptedEngines.add(*engine);
         RefPtr playerPrivate = engine->createMediaEnginePlayer(*this);
-        m_private = playerPrivate;
+        {
+            Locker locker { m_privateLock };
+            m_private = playerPrivate;
+        }
         if (playerPrivate) {
             protect(client())->mediaPlayerEngineUpdated();
             playerPrivate->setMessageClientForTesting(m_internalMessageClient);
@@ -716,7 +722,10 @@ void MediaPlayer::loadWithNextMediaEngine(const MediaPlayerFactory* current)
 #endif
         playerPrivate->load(m_url, m_loadOptions);
     } else {
-        m_private = NullMediaPlayerPrivate::create(*this);
+        {
+            Locker locker { m_privateLock };
+            m_private = NullMediaPlayerPrivate::create(*this);
+        }
         CheckedPtr currentMediaEngine = m_currentMediaEngine.get();
         if (!m_activeEngineIdentifier
             && installedMediaEngines().size() > 1
@@ -940,7 +949,16 @@ bool MediaPlayer::hasVideo() const
 
 bool MediaPlayer::hasAudio() const
 {
-    return protect(m_private)->hasAudio();
+    // Called from the JSC GC thread via HTMLMediaElement::virtualHasPendingActivity ->
+    // canProduceAudio. Snapshot m_private under m_privateLock so the main thread can
+    // safely reassign or null it out concurrently. All MediaPlayerPrivateInterface
+    // subclasses are ThreadSafeRefCounted, so taking a ref under the lock is safe.
+    RefPtr<MediaPlayerPrivateInterface> playerPrivate;
+    {
+        Locker locker { m_privateLock };
+        playerPrivate = m_private;
+    }
+    return playerPrivate && playerPrivate->hasAudio();
 }
 
 PlatformLayer* MediaPlayer::platformLayer() const
@@ -1508,7 +1526,10 @@ bool MediaPlayer::attemptSniffAndReload()
         protectedThis->m_loadOptions.contentType = sniffed;
         protectedThis->m_attemptedEngines.clear();
         protectedThis->m_currentMediaEngine = nullptr;
-        protectedThis->m_private = nullptr;
+        {
+            Locker locker { protectedThis->m_privateLock };
+            protectedThis->m_private = nullptr;
+        }
         protectedThis->loadWithNextMediaEngine(nullptr);
     });
     return true;

--- a/Source/WebCore/platform/graphics/MediaPlayer.h
+++ b/Source/WebCore/platform/graphics/MediaPlayer.h
@@ -51,6 +51,7 @@
 #include <wtf/CompletionHandler.h>
 #include <wtf/Function.h>
 #include <wtf/HashSet.h>
+#include <wtf/Lock.h>
 #include <wtf/Logger.h>
 #include <wtf/MediaTime.h>
 #include <wtf/TZoneMalloc.h>
@@ -886,6 +887,12 @@ private:
     bool m_shouldContinueAfterKeyNeeded { false };
 #endif
     std::atomic<bool> m_isGatheringVideoFrameMetadata { false };
+    // Guards writes to m_private (and any read off the main thread). m_private's
+    // ref()/deref() are pure virtual on MediaPlayerPrivateInterface, so callers
+    // off the main thread (notably the JSC GC thread reaching MediaPlayer::hasAudio()
+    // via HTMLMediaElement::virtualHasPendingActivity -> canProduceAudio) must take
+    // this lock to safely snapshot m_private into a local RefPtr before invoking it.
+    mutable Lock m_privateLock;
 
 #if HAVE(SPATIAL_TRACKING_LABEL)
     String m_defaultSpatialTrackingLabel;

--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.h
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.h
@@ -40,7 +40,7 @@
 #include <wtf/LoggerHelper.h>
 #include <wtf/MediaTime.h>
 #include <wtf/NativePromise.h>
-#include <wtf/RefCountedAndCanMakeWeakPtr.h>
+#include <wtf/ThreadSafeRefCounted.h>
 #include <wtf/ThreadSafeWeakPtr.h>
 #include <wtf/WeakPtr.h>
 
@@ -66,13 +66,14 @@ class VideoMediaSampleRenderer;
 class VideoTrackPrivate;
 
 class MediaPlayerPrivateMediaSourceAVFObjC
-    : public RefCountedAndCanMakeWeakPtr<MediaPlayerPrivateMediaSourceAVFObjC>
+    : public ThreadSafeRefCounted<MediaPlayerPrivateMediaSourceAVFObjC, WTF::DestructionThread::Main>
+    , public CanMakeWeakPtr<MediaPlayerPrivateMediaSourceAVFObjC>
     , public MediaPlayerPrivateInterface
     , private LoggerHelper
 {
 public:
-    void ref() const final { RefCounted::ref(); }
-    void deref() const final { RefCounted::deref(); }
+    void ref() const final { ThreadSafeRefCounted::ref(); }
+    void deref() const final { ThreadSafeRefCounted::deref(); }
 
     explicit MediaPlayerPrivateMediaSourceAVFObjC(MediaPlayer&);
     virtual ~MediaPlayerPrivateMediaSourceAVFObjC();

--- a/Source/WebCore/platform/graphics/holepunch/MediaPlayerPrivateHolePunch.h
+++ b/Source/WebCore/platform/graphics/holepunch/MediaPlayerPrivateHolePunch.h
@@ -25,9 +25,9 @@
 #include "DestinationColorSpace.h"
 #include "MediaPlayerPrivate.h"
 #include "PlatformLayer.h"
-#include <wtf/RefCounted.h>
 #include <wtf/RunLoop.h>
 #include <wtf/TZoneMalloc.h>
+#include <wtf/ThreadSafeRefCounted.h>
 #include <wtf/WeakPtr.h>
 
 namespace WebCore {
@@ -37,12 +37,12 @@ class CoordinatedPlatformLayerBufferProxy;
 class MediaPlayerPrivateHolePunch
     : public MediaPlayerPrivateInterface
     , public CanMakeWeakPtr<MediaPlayerPrivateHolePunch>
-    , public RefCounted<MediaPlayerPrivateHolePunch>
+    , public ThreadSafeRefCounted<MediaPlayerPrivateHolePunch, WTF::DestructionThread::Main>
 {
     WTF_MAKE_TZONE_ALLOCATED(MediaPlayerPrivateHolePunch);
 public:
-    void ref() const final { RefCounted::ref(); }
-    void deref() const final { RefCounted::deref(); }
+    void ref() const final { ThreadSafeRefCounted::ref(); }
+    void deref() const final { ThreadSafeRefCounted::deref(); }
 
     MediaPlayerPrivateHolePunch(MediaPlayer&);
     ~MediaPlayerPrivateHolePunch();

--- a/Source/WebCore/platform/graphics/win/MediaPlayerPrivateMediaFoundation.h
+++ b/Source/WebCore/platform/graphics/win/MediaPlayerPrivateMediaFoundation.h
@@ -41,8 +41,8 @@
 
 #include <wtf/Deque.h>
 #include <wtf/Lock.h>
-#include <wtf/RefCounted.h>
 #include <wtf/TZoneMalloc.h>
+#include <wtf/ThreadSafeRefCounted.h>
 #include <wtf/ThreadingPrimitives.h>
 #include <wtf/WeakPtr.h>
 #include <wtf/win/Win32Handle.h>
@@ -52,11 +52,11 @@ namespace WebCore {
 class MediaPlayerPrivateMediaFoundation final
     : public MediaPlayerPrivateInterface
     , public CanMakeWeakPtr<MediaPlayerPrivateMediaFoundation>
-    , public RefCounted<MediaPlayerPrivateMediaFoundation> {
+    , public ThreadSafeRefCounted<MediaPlayerPrivateMediaFoundation, WTF::DestructionThread::Main> {
     WTF_MAKE_TZONE_ALLOCATED(MediaPlayerPrivateMediaFoundation);
 public:
-    void ref() const final { RefCounted::ref(); }
-    void deref() const final { RefCounted::deref(); }
+    void ref() const final { ThreadSafeRefCounted::ref(); }
+    void deref() const final { ThreadSafeRefCounted::deref(); }
 
     explicit MediaPlayerPrivateMediaFoundation(MediaPlayer&);
     ~MediaPlayerPrivateMediaFoundation();


### PR DESCRIPTION
#### e29871d9413feb0807dd23374fbc63d5437ef046
<pre>
Fix crash in MediaPlayer::hasAudio() by avoiding pure virtual call from JSC GC thread
&lt;<a href="https://bugs.webkit.org/show_bug.cgi?id=313536">https://bugs.webkit.org/show_bug.cgi?id=313536</a>&gt;
&lt;<a href="https://rdar.apple.com/172593804">rdar://172593804</a>&gt;

Reviewed by NOBODY (OOPS!).

JSC garbage collection visits HTMLVideoElement wrappers from a non-main
thread and reaches MediaPlayer::hasAudio() via virtualHasPendingActivity
-&gt; canProduceAudio -&gt; hasAudio. The implementation called
protect(m_private)-&gt;hasAudio(), which performs a virtual ref() on
MediaPlayerPrivateInterface. That ref() is pure virtual (inherited from
WTF::AbstractRefCounted), so when the main thread concurrently dropped
the last reference to the concrete private, the GC thread&apos;s dispatch
landed on the pure-virtual slot and aborted.

Most MediaPlayerPrivateInterface subclasses are already
ThreadSafeRefCounted. Convert the remaining three
(MediaPlayerPrivateMediaSourceAVFObjC, MediaPlayerPrivateHolePunch,
MediaPlayerPrivateMediaFoundation) to
ThreadSafeRefCounted&lt;T, DestructionThread::Main&gt; so ref()/deref() are
safe from any thread. Add a Lock in MediaPlayer guarding m_private so
the main thread can reassign or null it out while another thread is
snapshotting it. In hasAudio(), take the lock only long enough to copy
m_private into a local RefPtr (which now safely bumps the ref on any
thread), release the lock, and invoke hasAudio() through the snapshot.
All four m_private write sites (loadWithNextMediaEngine and
attemptSniffAndReload) take the same lock. Other m_private accesses
remain lock-free because they run on the main thread, which is the only
writer.

No new tests; GC-thread races are not deterministically reproducible.

* Source/WebCore/platform/graphics/MediaPlayer.cpp:
(WebCore::MediaPlayer::loadWithNextMediaEngine):
(WebCore::MediaPlayer::hasAudio const):
(WebCore::MediaPlayer::attemptSniffAndReload):
* Source/WebCore/platform/graphics/MediaPlayer.h:
* Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.h:
* Source/WebCore/platform/graphics/holepunch/MediaPlayerPrivateHolePunch.h:
* Source/WebCore/platform/graphics/win/MediaPlayerPrivateMediaFoundation.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e29871d9413feb0807dd23374fbc63d5437ef046

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/159972 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/33441 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/26546 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/168849 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/114353 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/6630eec3-14fe-4b7b-9d16-38f2170a0a79) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/161841 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/33545 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/33444 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/123984 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/86964 "2 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/8dd28145-209d-4e72-a017-6e4bfcd4641c) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/162930 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/26238 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/143683 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/104600 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/f9c5b067-2307-4c75-8ecf-32dcb74635ea) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/25291 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/23768 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/16593 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/134982 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/21453 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/171332 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/17340 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/23091 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/132252 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/33118 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/27850 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/132278 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/33103 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/143248 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/91253 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/26894 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/20061 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/32612 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/99009 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/32110 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/32356 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/32260 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->