### PR TITLE
Add FileSystem::traverseDirectory() to avoid redundant lstat() per directory entry

### DIFF
--- a/Source/WTF/wtf/FileSystem.cpp
+++ b/Source/WTF/wtf/FileSystem.cpp
@@ -433,14 +433,9 @@ void deleteAllFilesModifiedSince(const String& directory, WallTime time)
         return;
     }
 
-    auto children = listDirectory(directory);
-    for (auto& child : children) {
+    traverseDirectory(directory, [&](const String& child, FileType childType) {
         auto childPath = FileSystem::pathByAppendingComponent(directory, child);
-        auto childType = fileType(childPath);
-        if (!childType)
-            continue;
-
-        switch (*childType) {
+        switch (childType) {
         case FileType::Regular: {
             if (auto modificationTime = FileSystem::fileModificationTime(childPath); modificationTime && *modificationTime >= time)
                 deleteFile(childPath);
@@ -453,7 +448,7 @@ void deleteAllFilesModifiedSince(const String& directory, WallTime time)
         case FileType::SymbolicLink:
             break;
         }
-    }
+    });
 
     FileSystem::deleteEmptyDirectory(directory);
 }
@@ -740,6 +735,32 @@ Vector<String> listDirectory(const String& path)
             fileNames.append(WTF::move(fileName));
     }
     return fileNames;
+}
+
+void traverseDirectory(const String& path, NOESCAPE const Function<void(const String&, FileType)>& function)
+{
+    std::error_code ec;
+    auto entries = std::filesystem::directory_iterator(toStdFileSystemPath(path), ec);
+    for (auto it = std::filesystem::begin(entries), end = std::filesystem::end(entries); !ec && it != end; it.increment(ec)) {
+        auto fileName = fromStdFileSystemPath(it->path().filename());
+        if (fileName.isNull())
+            continue;
+        std::error_code statusEC;
+        auto status = it->symlink_status(statusEC);
+        if (statusEC)
+            continue;
+        switch (status.type()) {
+        case std::filesystem::file_type::directory:
+            function(fileName, FileType::Directory);
+            break;
+        case std::filesystem::file_type::symlink:
+            function(fileName, FileType::SymbolicLink);
+            break;
+        default:
+            function(fileName, FileType::Regular);
+            break;
+        }
+    }
 }
 #endif
 

--- a/Source/WTF/wtf/FileSystem.h
+++ b/Source/WTF/wtf/FileSystem.h
@@ -130,6 +130,7 @@ WTF_EXPORT_PRIVATE bool setExcludedFromBackup(const String&, bool); // Returns t
 WTF_EXPORT_PRIVATE bool markPurgeable(const String&);
 
 WTF_EXPORT_PRIVATE Vector<String> listDirectory(const String& path); // Returns file names, not full paths.
+WTF_EXPORT_PRIVATE void traverseDirectory(const String& path, NOESCAPE const Function<void(const String& fileName, FileType)>&);
 
 WTF_EXPORT_PRIVATE CString fileSystemRepresentation(const String&);
 #if !PLATFORM(WIN)

--- a/Source/WTF/wtf/playstation/FileSystemPlayStation.cpp
+++ b/Source/WTF/wtf/playstation/FileSystemPlayStation.cpp
@@ -32,6 +32,7 @@
 
 #include <dirent.h>
 #include <sys/statvfs.h>
+#include <wtf/Function.h>
 #include <wtf/text/MakeString.h>
 
 namespace WTF {
@@ -117,6 +118,14 @@ Vector<String> listDirectorySub(const String& path, bool fullPath)
 Vector<String> listDirectory(const String& path)
 {
     return listDirectorySub(path, false);
+}
+
+void traverseDirectory(const String& path, NOESCAPE const Function<void(const String&, FileType)>& function)
+{
+    for (auto& fileName : listDirectory(path)) {
+        auto type = fileTypePotentiallyFollowingSymLinks(pathByAppendingComponent(path, fileName), ShouldFollowSymbolicLinks::No).value_or(FileType::Regular);
+        function(fileName, type);
+    }
 }
 
 bool deleteNonEmptyDirectory(const String& path)

--- a/Source/WebCore/Modules/entriesapi/DOMFileSystem.cpp
+++ b/Source/WebCore/Modules/entriesapi/DOMFileSystem.cpp
@@ -65,13 +65,13 @@ static ExceptionOr<Vector<ListedChild>> listDirectoryWithMetadata(const String& 
     if (FileSystem::fileType(fullPath) != FileSystem::FileType::Directory)
         return Exception { ExceptionCode::NotFoundError, "Path no longer exists or is no longer a directory"_s };
 
-    auto childNames = FileSystem::listDirectory(fullPath);
-    return WTF::compactMap(WTF::move(childNames), [&](auto&& childName) -> std::optional<ListedChild> {
+    Vector<ListedChild> result;
+    FileSystem::traverseDirectory(fullPath, [&](const String& childName, FileSystem::FileType type) {
         auto childPath = FileSystem::pathByAppendingComponent(fullPath, childName);
-        if (auto fileType = fileTypeIgnoringHiddenFiles(childPath))
-            return ListedChild { WTF::move(childName), *fileType };
-        return std::nullopt;
+        if (!FileSystem::isHiddenFile(childPath))
+            result.append(ListedChild { childName, type });
     });
+    return result;
 }
 
 static ExceptionOr<Vector<Ref<FileSystemEntry>>> toFileSystemEntries(ScriptExecutionContext& context, DOMFileSystem& fileSystem, ExceptionOr<Vector<ListedChild>>&& listedChildren, const String& parentVirtualPath)

--- a/Source/WebCore/html/DirectoryFileListCreator.cpp
+++ b/Source/WebCore/html/DirectoryFileListCreator.cpp
@@ -52,21 +52,17 @@ struct FileInformation {
 static void appendDirectoryFiles(const String& directory, const String& relativePath, Vector<FileInformation>& files)
 {
     ASSERT(!isMainThread());
-    for (auto& childName : FileSystem::listDirectory(directory)) {
+    FileSystem::traverseDirectory(directory, [&](const String& childName, FileSystem::FileType fileType) {
         auto childPath = FileSystem::pathByAppendingComponent(directory, childName);
         if (FileSystem::isHiddenFile(childPath))
-            continue;
-
-        auto fileType = FileSystem::fileType(childPath);
-        if (!fileType)
-            continue;
+            return;
 
         auto childRelativePath = makeString(relativePath, '/', childName);
-        if (*fileType == FileSystem::FileType::Directory)
+        if (fileType == FileSystem::FileType::Directory)
             appendDirectoryFiles(childPath, childRelativePath, files);
-        else if (*fileType == FileSystem::FileType::Regular)
+        else if (fileType == FileSystem::FileType::Regular)
             files.append(FileInformation { childPath, childRelativePath, { } });
-    }
+    });
 }
 
 static Vector<FileInformation> gatherFileInformation(const Vector<FileChooserFileInfo>& paths)

--- a/Source/WebKit/NetworkProcess/cache/NetworkCacheFileSystem.cpp
+++ b/Source/WebKit/NetworkProcess/cache/NetworkCacheFileSystem.cpp
@@ -55,12 +55,9 @@ namespace NetworkCache {
 
 void traverseDirectory(const String& path, NOESCAPE const Function<void (const String&, DirectoryEntryType)>& function)
 {
-    auto entries = FileSystem::listDirectory(path);
-    for (auto& entry : entries) {
-        auto entryPath = FileSystem::pathByAppendingComponent(path, entry);
-        auto type = FileSystem::fileType(entryPath) == FileSystem::FileType::Directory ? DirectoryEntryType::Directory : DirectoryEntryType::File;
-        function(entry, type);
-    }
+    FileSystem::traverseDirectory(path, [&](const String& fileName, FileSystem::FileType type) {
+        function(fileName, type == FileSystem::FileType::Directory ? DirectoryEntryType::Directory : DirectoryEntryType::File);
+    });
 }
 
 FileTimes fileTimes(const String& path)


### PR DESCRIPTION
#### 7f663a4d9b7248dc94fd3e36548dcafa1de590d4
<pre>
Add FileSystem::traverseDirectory() to avoid redundant lstat() per directory entry
<a href="https://bugs.webkit.org/show_bug.cgi?id=313538">https://bugs.webkit.org/show_bug.cgi?id=313538</a>

Reviewed by Darin Adler.

FileSystem::listDirectory() uses std::filesystem::directory_iterator internally,
which caches each entry&apos;s file type from readdir&apos;s d_type field. However, it only
returns filenames, discarding the cached type. Callers that need the entry type
then call FileSystem::fileType() per entry, which does a redundant lstat() syscall
to rediscover what directory_iterator already knew.

Add FileSystem::traverseDirectory() that uses directory_iterator directly and
provides both the filename and file type to the callback, reading the type from
directory_entry::symlink_status() which uses the cached d_type without a syscall.
It also avoids materializing all filenames into an intermediate Vector.

Update the four call sites that were doing listDirectory() + fileType() per entry:
NetworkCacheFileSystem, deleteAllFilesModifiedSince, DirectoryFileListCreator,
and DOMFileSystem::listDirectoryWithMetadata.

* Source/WTF/wtf/FileSystem.cpp:
(WTF::FileSystemImpl::deleteAllFilesModifiedSince):
(WTF::FileSystemImpl::traverseDirectory):
* Source/WTF/wtf/FileSystem.h:
* Source/WTF/wtf/playstation/FileSystemPlayStation.cpp:
(WTF::FileSystemImpl::traverseDirectory):
* Source/WebCore/Modules/entriesapi/DOMFileSystem.cpp:
(WebCore::listDirectoryWithMetadata):
* Source/WebCore/html/DirectoryFileListCreator.cpp:
(WebCore::appendDirectoryFiles):
* Source/WebKit/NetworkProcess/cache/NetworkCacheFileSystem.cpp:
(WebKit::NetworkCache::traverseDirectory):

Canonical link: <a href="https://commits.webkit.org/312267@main">https://commits.webkit.org/312267@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/466ffb5db6697490835182f31624beb17224412c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/159391 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/32819 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/25927 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/168223 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/113769 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/161260 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/32887 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/32807 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/123497 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/113769 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/162348 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/25746 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/143163 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/104161 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/24799 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/23248 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/15994 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/151441 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/134486 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/20943 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/170715 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/20224 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/16749 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/22569 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/131703 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/32508 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/27323 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/131816 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35649 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/32452 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/142736 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/90577 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/26477 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/19545 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/191674 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/31963 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/98415 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/49255 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/31483 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/31756 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/31638 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->