### PR TITLE
Cherry-pick 311758@main (8f0fcc5ad0e2). https://bugs.webkit.org/show_bug.cgi?id=312931

### DIFF
--- a/Source/WebCore/platform/audio/gstreamer/AudioDecoderGStreamer.cpp
+++ b/Source/WebCore/platform/audio/gstreamer/AudioDecoderGStreamer.cpp
@@ -274,11 +274,11 @@ GStreamerInternalAudioDecoder::GStreamerInternalAudioDecoder(const String& codec
 
 Ref<AudioDecoder::DecodePromise> GStreamerInternalAudioDecoder::decode(std::span<const uint8_t> frameData, [[maybe_unused]] bool isKeyFrame, int64_t timestamp, std::optional<uint64_t> duration)
 {
-    GST_DEBUG_OBJECT(m_harness->element(), "Decoding%s frame", isKeyFrame ? " key" : "");
+    GST_DEBUG_OBJECT(m_harness->element(), "Decoding%s frame with size %zu bytes", isKeyFrame ? " key" : "", frameData.size_bytes());
 
     auto encodedData = wrapSpanData(frameData);
     if (!encodedData)
-        return AudioDecoder::DecodePromise::createAndReject("Empty frame"_s);
+        return AudioDecoder::DecodePromise::createAndResolve();
 
     GstSegment segment;
     gst_segment_init(&segment, GST_FORMAT_TIME);
@@ -310,6 +310,12 @@ void GStreamerInternalAudioDecoder::flush()
         return;
     }
 
+    if (!m_harness->isStarted()) {
+        GST_DEBUG_OBJECT(m_harness->element(), "Decoder hasn't started yet, nothing to flush");
+        return;
+    }
+
+    GST_DEBUG_OBJECT(m_harness->element(), "Pushing an empty buffer with discont flag");
     auto buffer = adoptGRef(gst_buffer_new());
     GST_BUFFER_FLAG_SET(buffer.get(), GST_BUFFER_FLAG_DISCONT);
     m_harness->pushBuffer(WTF::move(buffer));


### PR DESCRIPTION
#### b0e24eb7fcc8e4318915c3be760d8c7669710162
<pre>
Cherry-pick 311758@main (8f0fcc5ad0e2). <a href="https://bugs.webkit.org/show_bug.cgi?id=312931">https://bugs.webkit.org/show_bug.cgi?id=312931</a>

    [GStreamer] fast/webcodecs/resetting-audio-decoder-with-zero-size-crash.html is a constant timeout
    <a href="https://bugs.webkit.org/show_bug.cgi?id=312931">https://bugs.webkit.org/show_bug.cgi?id=312931</a>

    Reviewed by Xabier Rodriguez-Calvar.

    There is no need to flush the decoder if it hasn&apos;t started yet. After fixing that the flush promise
    still hanged because the scheduled decode task just before was a rejected promise. The decoder now
    returns a resolved promise when the encoded frame is empty.

    * LayoutTests/platform/glib/TestExpectations:
    * Source/WebCore/platform/audio/gstreamer/AudioDecoderGStreamer.cpp:
    (WebCore::GStreamerInternalAudioDecoder::decode):
    (WebCore::GStreamerInternalAudioDecoder::flush):

    Canonical link: <a href="https://commits.webkit.org/311758@main">https://commits.webkit.org/311758@main</a>

Canonical link: <a href="https://commits.webkit.org/305877.459@webkitglib/2.52">https://commits.webkit.org/305877.459@webkitglib/2.52</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d8d8fbdefe818532baf1208a05aea97cef335cd7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/159213 "Passed style check") | [❌ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/32641 "Unable to build WebKit without PR, please check manually (failure)") | [❌ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/25746 "Unable to build WebKit without PR, please check manually (failure)") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/168042 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/113297 "The change is no longer eligible for processing.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/161082 "Passed tests") | [❌ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/32709 "Unable to build WebKit without PR, please check manually (failure)") | [❌ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/32628 "Unable to build WebKit without PR, please check manually (failure)") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/123352 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/113297 "The change is no longer eligible for processing.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/162170 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/155/builds/32709 "Unable to build WebKit without PR, please check manually (failure)") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/168/builds/25746 "Unable to build WebKit without PR, please check manually (failure)") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/104019 "Passed tests") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/155/builds/32709 "Unable to build WebKit without PR, please check manually (failure)") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/156/builds/32628 "Unable to build WebKit without PR, please check manually (failure)") | [❌ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/15815 "Unable to build WebKit without PR, please check manually (failure)") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/155/builds/32709 "Unable to build WebKit without PR, please check manually (failure)") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/168/builds/25746 "Unable to build WebKit without PR, please check manually (failure)") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/170537 "Unable to build WebKit without PR, please check manually (failure)") | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/16646 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/168/builds/25746 "Unable to build WebKit without PR, please check manually (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/2/builds/170537 "Unable to build WebKit without PR, please check manually (failure)") | 
| | [❌ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/32330 "Unable to build WebKit without PR, please check manually (failure)") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/156/builds/32628 "Unable to build WebKit without PR, please check manually (failure)") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/2/builds/170537 "Unable to build WebKit without PR, please check manually (failure)") | 
| | [❌ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/32274 "Unable to build WebKit without PR, please check manually (failure)") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/168/builds/25746 "Unable to build WebKit without PR, please check manually (failure)") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/90343 "The change is no longer eligible for processing.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/24245 "Built successfully and passed tests") | [❌ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/160/builds/32274 "Unable to build WebKit without PR, please check manually (failure)") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/168/builds/25746 "Unable to build WebKit without PR, please check manually (failure)") | | 
| | [❌ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/31785 "Unable to build WebKit without PR, please check manually (failure)") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/98324 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [❌ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/31305 "Unable to build WebKit without PR, please check manually (failure)") | | | 
| | [❌ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/31578 "Unable to build WebKit without PR, please check manually (failure)") | | | 
| | [❌ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/31460 "Unable to build WebKit without PR, please check manually (failure)") | | | 
<!--EWS-Status-Bubble-End-->