### PR TITLE
[GLIB] Do not resolve '-apple-system' font to default system font

### DIFF
--- a/LayoutTests/platform/glib/fast/forms/auto-fill-button/input-strong-password-auto-fill-button-expected.txt
+++ b/LayoutTests/platform/glib/fast/forms/auto-fill-button/input-strong-password-auto-fill-button-expected.txt
@@ -27,71 +27,71 @@ layer at (0,0) size 800x188
         RenderTextControl {INPUT} at (243,65) size 209x24 [bgcolor=#FAFFBD] [border: (2px inset #808080)]
 layer at (11,53) size 203x18
   RenderFlexibleBox {DIV} at (3,3) size 203x18
-    RenderBlock {DIV} at (75,0) size 128x18 [color=#000000CC]
-      RenderText {#text} at (6,0) size 122x18
-        text run at (6,0) width 122: "Strong Password"
-layer at (11,53) size 75x18
-  RenderBlock {DIV} at (0,0) size 75x18
+    RenderBlock {DIV} at (90,0) size 113x18 [color=#000000CC]
+      RenderText {#text} at (6,0) size 107x18
+        text run at (6,0) width 107: "Strong Password"
+layer at (11,53) size 90x18
+  RenderBlock {DIV} at (0,0) size 90x18
 layer at (224,53) size 203x18
   RenderFlexibleBox {DIV} at (3,3) size 203x18
-    RenderBlock {DIV} at (75,0) size 128x18 [color=#000000CC]
-      RenderText {#text} at (6,0) size 122x18
-        text run at (6,0) width 122: "Strong Password"
-layer at (224,53) size 75x18
-  RenderBlock {DIV} at (0,0) size 75x18
+    RenderBlock {DIV} at (90,0) size 113x18 [color=#000000CC]
+      RenderText {#text} at (6,0) size 107x18
+        text run at (6,0) width 107: "Strong Password"
+layer at (224,53) size 90x18
+  RenderBlock {DIV} at (0,0) size 90x18
 layer at (437,53) size 300x18
   RenderFlexibleBox {DIV} at (3,3) size 300x18
-    RenderBlock {DIV} at (172,0) size 128x18 [color=#000000CC]
-      RenderText {#text} at (6,0) size 122x18
-        text run at (6,0) width 122: "Strong Password"
-layer at (437,53) size 172x18
-  RenderBlock {DIV} at (0,0) size 172x18
-layer at (747,53) size 20x18 scrollWidth 128 scrollHeight 36
+    RenderBlock {DIV} at (187,0) size 113x18 [color=#000000CC]
+      RenderText {#text} at (6,0) size 107x18
+        text run at (6,0) width 107: "Strong Password"
+layer at (437,53) size 187x18
+  RenderBlock {DIV} at (0,0) size 187x18
+layer at (747,53) size 20x18 scrollWidth 113 scrollHeight 36
   RenderFlexibleBox {DIV} at (3,3) size 20x18
-    RenderBlock {DIV} at (0,18) size 128x18 [color=#000000CC]
-      RenderText {#text} at (6,0) size 122x18
-        text run at (6,0) width 122: "Strong Password"
+    RenderBlock {DIV} at (0,18) size 113x18 [color=#000000CC]
+      RenderText {#text} at (6,0) size 107x18
+        text run at (6,0) width 107: "Strong Password"
 layer at (747,53) size 20x18
   RenderBlock {DIV} at (0,0) size 20x18
 layer at (11,118) size 203x18
   RenderFlexibleBox {DIV} at (3,44) size 203x18
-    RenderBlock {DIV} at (75,0) size 128x18 [color=#000000CC]
-      RenderText {#text} at (6,0) size 122x18
-        text run at (6,0) width 122: "Strong Password"
-layer at (11,118) size 75x18
-  RenderBlock {DIV} at (0,0) size 75x18
-layer at (224,118) size 20x18 scrollWidth 128 scrollHeight 36
+    RenderBlock {DIV} at (90,0) size 113x18 [color=#000000CC]
+      RenderText {#text} at (6,0) size 107x18
+        text run at (6,0) width 107: "Strong Password"
+layer at (11,118) size 90x18
+  RenderBlock {DIV} at (0,0) size 90x18
+layer at (224,118) size 20x18 scrollWidth 113 scrollHeight 36
   RenderFlexibleBox {DIV} at (3,44) size 20x18
-    RenderBlock {DIV} at (0,18) size 128x18 [color=#000000CC]
-      RenderText {#text} at (6,0) size 122x18
-        text run at (6,0) width 122: "Strong Password"
+    RenderBlock {DIV} at (0,18) size 113x18 [color=#000000CC]
+      RenderText {#text} at (6,0) size 107x18
+        text run at (6,0) width 107: "Strong Password"
 layer at (224,118) size 20x18
   RenderBlock {DIV} at (0,0) size 20x18
 layer at (254,118) size 203x18
   RenderFlexibleBox {DIV} at (3,3) size 203x18
-    RenderBlock {DIV} at (75,0) size 128x18 [color=#000000CC]
-      RenderText {#text} at (6,0) size 122x18
-        text run at (6,0) width 122: "Strong Password"
-layer at (254,118) size 75x18
-  RenderBlock {DIV} at (0,0) size 75x18
-layer at (11,53) size 75x18 scrollWidth 430
-  RenderBlock {DIV} at (0,0) size 75x18 [color=#00000099]
+    RenderBlock {DIV} at (90,0) size 113x18 [color=#000000CC]
+      RenderText {#text} at (6,0) size 107x18
+        text run at (6,0) width 107: "Strong Password"
+layer at (254,118) size 90x18
+  RenderBlock {DIV} at (0,0) size 90x18
+layer at (11,53) size 90x18 scrollWidth 430
+  RenderBlock {DIV} at (0,0) size 90x18 [color=#00000099]
     RenderText {#text} at (0,0) size 430x18
       text run at (0,0) width 430: "A quick brown fox jumped over the lazy dog."
-layer at (224,53) size 75x18 scrollWidth 430
-  RenderBlock {DIV} at (0,0) size 75x18 [color=#00000099]
+layer at (224,53) size 90x18 scrollWidth 430
+  RenderBlock {DIV} at (0,0) size 90x18 [color=#00000099]
     RenderText {#text} at (0,0) size 430x18
       text run at (0,0) width 430: "A quick brown fox jumped over the lazy dog."
-layer at (437,53) size 172x18 scrollWidth 430
-  RenderBlock {DIV} at (0,0) size 172x18 [color=#00000099]
+layer at (437,53) size 187x18 scrollWidth 430
+  RenderBlock {DIV} at (0,0) size 187x18 [color=#00000099]
     RenderText {#text} at (0,0) size 430x18
       text run at (0,0) width 430: "A quick brown fox jumped over the lazy dog."
 layer at (747,53) size 20x18 scrollWidth 430
   RenderBlock {DIV} at (0,0) size 20x18 [color=#00000099]
     RenderText {#text} at (0,0) size 430x18
       text run at (0,0) width 430: "A quick brown fox jumped over the lazy dog."
-layer at (11,118) size 75x18 scrollWidth 430
-  RenderBlock {DIV} at (0,0) size 75x18 [color=#00000099]
+layer at (11,118) size 90x18 scrollWidth 430
+  RenderBlock {DIV} at (0,0) size 90x18 [color=#00000099]
     RenderText {#text} at (0,0) size 430x18
       text run at (0,0) width 430: "A quick brown fox jumped over the lazy dog."
 layer at (224,118) size 20x18 scrollWidth 430

--- a/LayoutTests/platform/glib/fast/text/system-font-features-expected.html
+++ b/LayoutTests/platform/glib/fast/text/system-font-features-expected.html
@@ -4,7 +4,7 @@
 </head>
 <body>
 This test makes sure that font features are applied to -apple-system and system-ui.
-<div style="font: 50px 'Liberation Sans';">0123456789</div>
+<div style="font: 50px 'Cantarell';">0123456789</div>
 <div style="font: 50px 'Liberation Sans';">0123456789</div>
 </body>
 </html>

--- a/LayoutTests/platform/glib/fast/text/system-font-legacy-name-expected.txt
+++ b/LayoutTests/platform/glib/fast/text/system-font-legacy-name-expected.txt
@@ -1,0 +1,10 @@
+These next three lines should be the same width
+
+This is some text
+
+This is some text
+
+This is some text
+
+FAIL: system-ui and -apple-system widths were not the same
+FAIL: system-ui and -apple-system-font widths were not the same

--- a/Source/WebCore/platform/graphics/skia/FontCacheSkia.cpp
+++ b/Source/WebCore/platform/graphics/skia/FontCacheSkia.cpp
@@ -207,9 +207,7 @@ Vector<FontSelectionCapabilities> FontCache::getFontSelectionCapabilitiesInFamil
 #if PLATFORM(GTK) || (PLATFORM(WPE) && ENABLE(WPE_PLATFORM))
 static bool isSystemUIFamilyFont(const String& family)
 {
-    return family == "-apple-system-font"_s
-        || family == "-apple-system"_s
-        || family == "-webkit-system-font"_s
+    return family == "-webkit-system-font"_s
         || family == "-webkit-system-ui"_s
         || family == "system-font"_s
         || family == "system-ui"_s
@@ -403,8 +401,16 @@ Vector<hb_feature_t> FontCache::computeFeatures(const FontDescription& fontDescr
     return features;
 }
 
+static bool isUnsupportedFamilyFont(const AtomString& family)
+{
+    return family == "-apple-system"
+        || family == "-apple-system-font";
+}
+
 std::unique_ptr<FontPlatformData> FontCache::createFontPlatformData(const FontDescription& fontDescription, const AtomString& family, const FontCreationContext& fontCreationContext, OptionSet<FontLookupOptions> options)
 {
+    if (isUnsupportedFamilyFont(family))
+        return nullptr;
     auto familyName = getFamilyNameStringFromFamily(family);
     auto skFontStyle = skiaFontStyle(fontDescription);
     auto typeface = fontManager().matchFamilyStyle(familyName.utf8().data(), skFontStyle);


### PR DESCRIPTION
#### 73d4d6d5e1fd18a8fecdf7595a0c91ce126d74cf
<pre>
[GLIB] Do not resolve &apos;-apple-system&apos; font to default system font
<a href="https://bugs.webkit.org/show_bug.cgi?id=209727">https://bugs.webkit.org/show_bug.cgi?id=209727</a>

Reviewed by Carlos Garcia Campos.

Follow-up to 312073@main.

After 312073@main, Apple system fonts such as &apos;-apple-system&apos; or
&apos;-apple-system-font&apos; are resolved to the default system&apos;s font in GLIB ports.

That change produced a regression in how pages using &apos;-apple-system&apos;
fonts are rendered in GLIB ports since, in case the font could not be
resolved, any potential fallback font stated in a page&apos;s stylesheet wouldn&apos;t
get applied.

Thus, this new patch restores the previous behaviour in which
&apos;-apple-system&apos; fonts do not map to the default system&apos;s font in GLIB
ports. In fact, now &apos;-apple-system&apos; fonts exit early to save time trying
to resolve that font.

* LayoutTests/platform/glib/fast/forms/auto-fill-button/input-strong-password-auto-fill-button-expected.txt:
* LayoutTests/platform/glib/fast/text/system-font-features-expected.html:
* LayoutTests/platform/glib/fast/text/system-font-legacy-name-expected.txt: Added.
* Source/WebCore/platform/graphics/skia/FontCacheSkia.cpp:
(WebCore::isSystemUIFamilyFont):
(WebCore::isUnsupportedFamilyFont):
(WebCore::FontCache::createFontPlatformData):

Canonical link: <a href="https://commits.webkit.org/312351@main">https://commits.webkit.org/312351@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1ba436351b6238119caa1be3a64d7aa02358a704

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/159658 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/33125 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/26232 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/168509 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/114039 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/161527 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/33230 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/33129 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/123704 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/114039 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/162616 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/25963 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/143403 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/104347 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/25014 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/23482 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/16274 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/134706 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/21175 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/171000 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/17026 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/22809 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/131939 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/32804 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/27558 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/132015 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/32789 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/142969 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/90871 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/24300 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/26649 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/19782 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/32298 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/98694 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/31795 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/32042 "Built successfully") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/31946 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->