### PR TITLE
[GTK] Minibrowser: add user scripts via command-line options

### DIFF
--- a/Tools/MiniBrowser/gtk/main.c
+++ b/Tools/MiniBrowser/gtk/main.c
@@ -47,6 +47,8 @@
 
 static const gchar **uriArguments = NULL;
 static const gchar **ignoreHosts = NULL;
+static const gchar **userScriptsAtDocumentStart = NULL;
+static const gchar **userScriptsAtDocumentEnd = NULL;
 static WebKitAutoplayPolicy autoplayPolicy = WEBKIT_AUTOPLAY_ALLOW_WITHOUT_SOUND;
 static GdkRGBA *backgroundColor;
 static gboolean editorMode;
@@ -166,6 +168,8 @@ static const GOptionEntry commandLineOptions[] =
     { "ignore-host", 0, 0, G_OPTION_ARG_STRING_ARRAY, &ignoreHosts, "Set proxy ignore hosts", "HOSTS" },
     { "ignore-tls-errors", 0, 0, G_OPTION_ARG_NONE, &ignoreTLSErrors, "Ignore TLS errors", NULL },
     { "content-filter", 0, 0, G_OPTION_ARG_FILENAME, &contentFilter, "JSON with content filtering rules", "FILE" },
+    { "user-script-at-start", 0, 0, G_OPTION_ARG_FILENAME_ARRAY, &userScriptsAtDocumentStart, "Inject one or more user scripts at document start.", "PATH" },
+    { "user-script-at-end", 0, 0, G_OPTION_ARG_FILENAME_ARRAY, &userScriptsAtDocumentEnd, "Inject one or more user scripts at document end.", "PATH" },
     { "enable-itp", 0, 0, G_OPTION_ARG_NONE, &enableITP, "Enable Intelligent Tracking Prevention (ITP)", NULL },
 #if !GTK_CHECK_VERSION(3, 98, 0)
     { "enable-sandbox", 0, 0, G_OPTION_ARG_NONE, &enableSandbox, "Enable web process sandbox support", NULL },
@@ -786,6 +790,19 @@ static void setupDarkMode(GtkSettings *settings)
     g_signal_connect_swapped(interfaceSettings, "changed::color-scheme", G_CALLBACK(colorSchemeChanged), settings);
 }
 
+static void addUserScript(WebKitUserContentManager *userContentManager, const gchar* userScriptPath, WebKitUserScriptInjectionTime injectionTime)
+{
+    g_autoptr(GFile) file = g_file_new_for_commandline_arg(userScriptPath);
+    g_autofree gchar *source;
+    g_autoptr(GError) error = 0;
+
+    if (g_file_load_contents(file, NULL, &source, NULL, NULL, &error)) {
+        webkit_user_content_manager_add_script(userContentManager, webkit_user_script_new(source,
+            WEBKIT_USER_CONTENT_INJECT_ALL_FRAMES, injectionTime, NULL, NULL));
+    } else
+        g_printerr("Failed to load user script at path '%s': %s\n", userScriptPath, error->message);
+}
+
 static void activate(GApplication *application, WebKitSettings *webkitSettings)
 {
 #if GTK_CHECK_VERSION(3, 98, 0)
@@ -926,6 +943,15 @@ static void activate(GApplication *application, WebKitSettings *webkitSettings)
         g_clear_pointer(&saveData.filter, webkit_user_content_filter_unref);
         g_main_loop_unref(saveData.mainLoop);
         g_object_unref(contentFilterFile);
+    }
+
+    if (userScriptsAtDocumentStart) {
+        for (int i = 0; userScriptsAtDocumentStart[i]; i++)
+            addUserScript(userContentManager, userScriptsAtDocumentStart[i], WEBKIT_USER_SCRIPT_INJECT_AT_DOCUMENT_START);
+    }
+    if (userScriptsAtDocumentEnd) {
+        for (int i = 0; userScriptsAtDocumentEnd[i]; i++)
+            addUserScript(userContentManager, userScriptsAtDocumentEnd[i], WEBKIT_USER_SCRIPT_INJECT_AT_DOCUMENT_END);
     }
 
 #if GTK_CHECK_VERSION(3, 98, 0)


### PR DESCRIPTION
#### 0cef72406e97c8e823a01e2ee172cae14e298422
<pre>
[GTK] Minibrowser: add user scripts via command-line options
<a href="https://bugs.webkit.org/show_bug.cgi?id=313541">https://bugs.webkit.org/show_bug.cgi?id=313541</a>

Reviewed by Adrian Perez de Castro.

Adds two options to Minibrowser, which read one or more user scripts
from the given paths and inject them at document start and document end respectively:
  --user-script-at-start
  --user-script-at-end

These options don&apos;t allow setting allow/block lists for user scripts,
to avoid making them needlessly complex.

* Tools/MiniBrowser/gtk/main.c:
(addUserScript):
(activate):

Canonical link: <a href="https://commits.webkit.org/312353@main">https://commits.webkit.org/312353@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0127bba1e8acf41dd05ecc927429ac416fd17a57

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/159432 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/32860 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/25968 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/168264 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/113810 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/161301 "Passed tests") | [❌ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/32928 "Hash 0127bba1 for PR 63792 does not build (failure)") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/32848 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/123529 "Passed tests") | [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/86706 "Build is in progress. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Skipped layout-tests; 1 failures; Uploaded test results; 1 flakes 1 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/162389 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/155/builds/32928 "Hash 0127bba1 for PR 63792 does not build (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/143199 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/104193 "Passed tests") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/155/builds/32928 "Hash 0127bba1 for PR 63792 does not build (failure)") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/23301 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/16035 "Built successfully") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/155/builds/32928 "Hash 0127bba1 for PR 63792 does not build (failure)") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/20979 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/170756 "Built successfully") | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/22605 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/131734 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/32549 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/27358 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/131847 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35728 "Built successfully and passed tests") | [❌ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/32493 "Hash 0127bba1 for PR 63792 does not build (failure)") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/142772 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/90619 "The change is no longer eligible for processing.") | 
| | [❌ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/160/builds/32493 "Hash 0127bba1 for PR 63792 does not build (failure)") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/19581 "Passed tests") | | 
| | [❌ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/32004 "Hash 0127bba1 for PR 63792 does not build (failure)") | | | 
| | [❌ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/31524 "Hash 0127bba1 for PR 63792 does not build (failure)") | | | 
| | [❌ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/31797 "Hash 0127bba1 for PR 63792 does not build (failure)") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/31679 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->