### PR TITLE
Resolve SVG <use> clone style using the clone's ancestor chain

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -2521,7 +2521,6 @@ imported/w3c/web-platform-tests/svg/animations/switch-animation-02.html [ ImageO
 imported/w3c/web-platform-tests/svg/embedded/image-crossorigin.sub.html [ Skip ]
 imported/w3c/web-platform-tests/svg/embedded/image-fractional-width-vertical-fidelity.svg [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/svg/interact/scripted/tabindex-focus-flag.svg [ Skip ]
-imported/w3c/web-platform-tests/svg/linking/reftests/use-descendant-combinator-003.html [ Skip ]
 webkit.org/b/269522 imported/w3c/web-platform-tests/svg/linking/reftests/url-processing-whitespace-001.svg [ ImageOnlyFailure ]
 webkit.org/b/269522 imported/w3c/web-platform-tests/svg/linking/reftests/url-processing-whitespace-002.svg [ ImageOnlyFailure ]
 webkit.org/b/269522 imported/w3c/web-platform-tests/svg/linking/reftests/url-processing-whitespace-003.svg [ ImageOnlyFailure ]

--- a/Source/WebCore/svg/SVGElement.cpp
+++ b/Source/WebCore/svg/SVGElement.cpp
@@ -70,9 +70,9 @@
 #include "ShadowRoot.h"
 #include "StyleAdjuster.h"
 #include "StyleComputedStyle+GettersInlines.h"
+#include "StyleDocumentScope.h"
 #include "StyleExtractor.h"
 #include "StyleKeyword+Mappings.h"
-#include "StyleResolver.h"
 #include "StyleUpdate.h"
 #include "XMLNames.h"
 #include <wtf/HashMap.h>
@@ -642,13 +642,13 @@ void SVGElement::animatorWillBeDeleted(const QualifiedName& attributeName)
 
 std::optional<Style::UnadjustedStyle> SVGElement::resolveCustomStyle(const Style::ResolutionContext& resolutionContext, const Style::ComputedStyle*)
 {
-    // If the element is in a <use> tree we get the style from the definition tree.
-    if (RefPtr styleElement = this->correspondingElement()) {
-        auto styleElementResolutionContext = resolutionContext;
-        // Can't use the state since we are going to another part of the tree.
-        styleElementResolutionContext.selectorMatchingState = nullptr;
-        styleElementResolutionContext.isSVGUseTreeRoot = true;
-        return styleElement->resolveStyle(styleElementResolutionContext);
+    // If the element is in a <use> tree, resolve style using the document's
+    // resolver (for author rules) but on the clone (for correct ancestor chain).
+    if (this->correspondingElement()) {
+        auto cloneResolutionContext = resolutionContext;
+        cloneResolutionContext.selectorMatchingState = nullptr;
+        cloneResolutionContext.isSVGUseTreeRoot = true;
+        return document().styleScope().resolver().unadjustedStyleForElement(const_cast<SVGElement&>(*this), cloneResolutionContext);
     }
 
     return resolveStyle(resolutionContext);


### PR DESCRIPTION
#### 9492d6c1f2d2
<pre>
Resolve SVG &lt;use&gt; clone style using the clone&apos;s ancestor chain
<a href="https://bugs.webkit.org/show_bug.cgi?id=320107">https://bugs.webkit.org/show_bug.cgi?id=320107</a>
<a href="https://rdar.apple.com/183045538">rdar://183045538</a>

Reviewed by NOBODY (OOPS!).

Resolve &lt;use&gt; tree clones through the document resolver (for author
rules) using the clone&apos;s own shadow-tree position (for the correct
ancestor chain), instead of restyling the corresponding element in its
original location. This aligns selector scoping with SVG 2.

* LayoutTests/TestExpectations:
* Source/WebCore/svg/SVGElement.cpp:
(WebCore::SVGElement::resolveCustomStyle):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9492d6c1f2d210b3d467819a7f8aaa3bc207a636

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/176401 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/50336 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/44126 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/186000 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/138661 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/cb9f9d94-4a2d-45d4-86ea-f86f7f60d3a3) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/178264 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/51628 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/50020 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/137400 "Found 5 new test failures: imported/w3c/web-platform-tests/svg/linking/reftests/use-symbol-rendered-001.html imported/w3c/web-platform-tests/svg/styling/use-element-non-rendered-has-selector.html imported/w3c/web-platform-tests/svg/styling/use-element-non-rendered-sibling-selector.html svg/W3C-SVG-1.1/animate-elem-40-t.svg svg/animations/animated-string-class-instances.svg (failure)") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/96247 "4 flakes 2 failures") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/51517bed-7e01-4d15-ad23-eb6c3b712212) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/179357 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/40887 "Found 2 new test failures: svg/W3C-SVG-1.1/animate-elem-40-t.svg svg/animations/animated-string-class-instances.svg (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/158181 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/117875 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/657169c2-788d-485d-82e7-21eb19776bdf) 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/39536 "Found 3 new test failures: imported/w3c/web-platform-tests/svg/linking/reftests/use-symbol-rendered-001.html imported/w3c/web-platform-tests/svg/styling/use-element-non-rendered-has-selector.html imported/w3c/web-platform-tests/svg/styling/use-element-non-rendered-sibling-selector.html (failure)") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/37901 "Passed tests") | [⏳ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/JSC-Tests-WPE-EWS "Waiting to run tests") | | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/6690 "Build is in progress. Recent messages:") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/149952 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/37679 "Found 5 new test failures: imported/w3c/web-platform-tests/svg/linking/reftests/use-symbol-rendered-001.html imported/w3c/web-platform-tests/svg/styling/use-element-non-rendered-has-selector.html imported/w3c/web-platform-tests/svg/styling/use-element-non-rendered-sibling-selector.html svg/W3C-SVG-1.1/animate-elem-40-t.svg svg/animations/animated-string-class-instances.svg (failure)") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/34468 "Built successfully") | | 
| | [❌ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/42065 "Found 1 new failure in svg/SVGElement.cpp") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/42112 "Found 5 new test failures: imported/w3c/web-platform-tests/svg/linking/reftests/use-symbol-rendered-001.html imported/w3c/web-platform-tests/svg/styling/use-element-non-rendered-has-selector.html imported/w3c/web-platform-tests/svg/styling/use-element-non-rendered-sibling-selector.html svg/W3C-SVG-1.1/animate-elem-40-t.svg svg/animations/animated-string-class-instances.svg (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/188423 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/50001 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/157726 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/146448 "Found 4 new test failures: imported/w3c/web-platform-tests/svg/styling/use-element-non-rendered-has-selector.html imported/w3c/web-platform-tests/svg/styling/use-element-non-rendered-sibling-selector.html svg/W3C-SVG-1.1/animate-elem-40-t.svg svg/animations/animated-string-class-instances.svg (failure)") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/50685 "Built successfully") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/34297 "Found 5 new test failures: imported/w3c/web-platform-tests/svg/linking/reftests/use-symbol-rendered-001.html imported/w3c/web-platform-tests/svg/styling/use-element-non-rendered-has-selector.html imported/w3c/web-platform-tests/svg/styling/use-element-non-rendered-sibling-selector.html svg/W3C-SVG-1.1/animate-elem-40-t.svg svg/animations/animated-string-class-instances.svg (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/146259 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/41032 "Passed tests") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/122889 "Found 1 new failure in svg/SVGElement.cpp") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/116939 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/49189 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/12654 "") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/48591 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/48825 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/48650 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->