### PR TITLE
[JSC] Walk star-export graph once when building a module namespace

### DIFF
--- a/JSTests/modules/namespace-single-walk.js
+++ b/JSTests/modules/namespace-single-walk.js
@@ -1,0 +1,44 @@
+import { shouldBe } from "./resources/assert.js";
+import * as root from "./namespace-single-walk/root.js";
+import * as conflictOnly from "./namespace-single-walk/conflict-only.js";
+import * as leafA from "./namespace-single-walk/leaf-a.js";
+
+// (1) Unique Local binding via star: fast-path Resolved.
+shouldBe(root.onlyA, "onlyA");
+shouldBe(root.onlyB, "onlyB");
+
+// (2) Same binding via two diamond paths (mid-left + mid-right both -> leaf-a): still single binding.
+shouldBe(root.shared, "shared-from-a");
+shouldBe(root.indirectTarget, "indirectTarget-a");
+
+// (3) Root local shadows star-reachable conflict.
+shouldBe(root.conflict, "conflict-root");
+shouldBe("conflict" in root, true);
+
+// (4) Without a root local, conflicting bindings are ambiguous and excluded from the namespace.
+shouldBe("conflict" in conflictOnly, false);
+shouldBe(conflictOnly.conflict, undefined);
+shouldBe(conflictOnly.onlyA, "onlyA");
+shouldBe(conflictOnly.onlyB, "onlyB");
+
+// (5) Indirect re-export through star (slowPath) resolves to leaf-a's local.
+shouldBe(root.indirect, "indirectTarget-a");
+shouldBe(conflictOnly.indirect, "indirectTarget-a");
+
+// (6) Namespace re-export (Type::Namespace) through star: fast-path Resolved.
+shouldBe(root.nsOfA, leafA);
+shouldBe(conflictOnly.nsOfA, leafA);
+
+// Namespace key set is sorted and stable across both modules where the keys overlap.
+shouldBe(Object.keys(root).join(","), "conflict,indirect,indirectTarget,nsOfA,onlyA,onlyB,shared");
+shouldBe(Object.keys(conflictOnly).join(","), "indirect,indirectTarget,nsOfA,onlyA,onlyB,shared");
+
+// (7) Mutual star cycle: visited set terminates the walk; both names visible from either side.
+const cycleA = await import("./namespace-single-walk/cycle-a.js");
+const cycleB = await import("./namespace-single-walk/cycle-b.js");
+shouldBe(cycleA.fromA, "A");
+shouldBe(cycleA.fromB, "B");
+shouldBe(cycleB.fromA, "A");
+shouldBe(cycleB.fromB, "B");
+shouldBe(Object.keys(cycleA).join(","), "fromA,fromB");
+shouldBe(Object.keys(cycleB).join(","), "fromA,fromB");

--- a/JSTests/modules/namespace-single-walk/conflict-only.js
+++ b/JSTests/modules/namespace-single-walk/conflict-only.js
@@ -1,0 +1,3 @@
+// No local; star-reachable leaf-a and leaf-b both define `conflict` -> ambiguous, excluded from namespace.
+export * from "./leaf-a.js";
+export * from "./leaf-b.js";

--- a/JSTests/modules/namespace-single-walk/cycle-a.js
+++ b/JSTests/modules/namespace-single-walk/cycle-a.js
@@ -1,0 +1,2 @@
+export const fromA = "A";
+export * from "./cycle-b.js";

--- a/JSTests/modules/namespace-single-walk/cycle-b.js
+++ b/JSTests/modules/namespace-single-walk/cycle-b.js
@@ -1,0 +1,2 @@
+export const fromB = "B";
+export * from "./cycle-a.js";

--- a/JSTests/modules/namespace-single-walk/leaf-a.js
+++ b/JSTests/modules/namespace-single-walk/leaf-a.js
@@ -1,0 +1,4 @@
+export const onlyA = "onlyA";
+export const shared = "shared-from-a";
+export const conflict = "conflict-a";
+export const indirectTarget = "indirectTarget-a";

--- a/JSTests/modules/namespace-single-walk/leaf-b.js
+++ b/JSTests/modules/namespace-single-walk/leaf-b.js
@@ -1,0 +1,4 @@
+export const onlyB = "onlyB";
+export const conflict = "conflict-b";
+export { indirectTarget as indirect } from "./leaf-a.js";
+export * as nsOfA from "./leaf-a.js";

--- a/JSTests/modules/namespace-single-walk/mid-left.js
+++ b/JSTests/modules/namespace-single-walk/mid-left.js
@@ -1,0 +1,2 @@
+export * from "./leaf-a.js";
+export * from "./leaf-b.js";

--- a/JSTests/modules/namespace-single-walk/mid-right.js
+++ b/JSTests/modules/namespace-single-walk/mid-right.js
@@ -1,0 +1,1 @@
+export * from "./leaf-a.js";

--- a/JSTests/modules/namespace-single-walk/root.js
+++ b/JSTests/modules/namespace-single-walk/root.js
@@ -1,0 +1,5 @@
+// Root has its own local that shadows a star-reachable conflict.
+export const conflict = "conflict-root";
+// Diamond: both mid-left and mid-right reach leaf-a, so onlyA / shared have a single binding via two paths.
+export * from "./mid-left.js";
+export * from "./mid-right.js";

--- a/Source/JavaScriptCore/runtime/AbstractModuleRecord.cpp
+++ b/Source/JavaScriptCore/runtime/AbstractModuleRecord.cpp
@@ -623,10 +623,7 @@ auto AbstractModuleRecord::resolveExportImpl(JSGlobalObject* globalObject, const
             return true;
         }
 
-        if (currentTop().moduleRecord != resolution.moduleRecord || currentTop().localName != resolution.localName)
-            return false;
-
-        return true;
+        return currentTop().isSameBinding(resolution);
     };
 
     auto cacheResolutionForQuery = [] (const ResolveQuery& query, const Resolution& resolution) {
@@ -767,36 +764,6 @@ auto AbstractModuleRecord::resolveExport(JSGlobalObject* globalObject, const Ide
     return resolveExportImpl(globalObject, ResolveQuery(this, exportName.impl()));
 }
 
-static void getExportedNames(JSGlobalObject* globalObject, AbstractModuleRecord* root, IdentifierSet& exportedNames)
-{
-    VM& vm = globalObject->vm();
-    auto scope = DECLARE_THROW_SCOPE(vm);
-
-    UncheckedKeyHashSet<AbstractModuleRecord*> exportStarSet;
-    Vector<AbstractModuleRecord*, 8> pendingModules;
-
-    pendingModules.append(root);
-
-    while (!pendingModules.isEmpty()) {
-        AbstractModuleRecord* moduleRecord = pendingModules.takeLast();
-        if (exportStarSet.contains(moduleRecord))
-            continue;
-        exportStarSet.add(moduleRecord);
-
-        for (const auto& pair : moduleRecord->exportEntries()) {
-            const AbstractModuleRecord::ExportEntry& exportEntry = pair.value;
-            if (moduleRecord == root || vm.propertyNames->defaultKeyword != exportEntry.exportName)
-                exportedNames.add(exportEntry.exportName.impl());
-        }
-
-        for (const auto& starModuleName : moduleRecord->starExportEntries()) {
-            AbstractModuleRecord* requestedModuleRecord = moduleRecord->hostResolveImportedModule(globalObject, Identifier::fromUid(vm, starModuleName.get()));
-            RETURN_IF_EXCEPTION(scope, void());
-            pendingModules.append(requestedModuleRecord);
-        }
-    }
-}
-
 JSModuleNamespaceObject* AbstractModuleRecord::getModuleNamespace(JSGlobalObject* globalObject)
 {
     VM& vm = globalObject->vm();
@@ -807,16 +774,91 @@ JSModuleNamespaceObject* AbstractModuleRecord::getModuleNamespace(JSGlobalObject
         ASSERT(cyclic->status() != CyclicModuleRecord::Status::New && cyclic->status() != CyclicModuleRecord::Status::Unlinked);
 #endif
 
-    // http://www.ecma-international.org/ecma-262/6.0/#sec-getmodulenamespace
+    // https://tc39.es/ecma262/#sec-getmodulenamespace
     if (m_moduleNamespaceObject)
         return m_moduleNamespaceObject.get();
 
-    IdentifierSet exportedNames;
-    getExportedNames(globalObject, this, exportedNames);
-    RETURN_IF_EXCEPTION(scope, nullptr);
+    // Spec performs GetExportedNames() then per-name ResolveExport(), which walks the
+    // star-export graph once per exported name (O(names * edges)). We instead walk the
+    // graph once, recording each name's unique Local/Namespace binding. Any name with
+    // exactly one such binding across the whole graph is provably Resolved (resolveSet
+    // can only turn paths into null, and merge(Resolved, null) = Resolved). Names with
+    // an Indirect entry, or with two distinct bindings, fall back to resolveExport().
+
+    Resolutions uniqueBindings;
+    IdentifierSet rootShadowedNames;
+    IdentifierSet slowPathNames;
+
+    UncheckedKeyHashSet<AbstractModuleRecord*> exportStarSet;
+    Vector<AbstractModuleRecord*, 8> pendingModules;
+    pendingModules.append(this);
+
+    while (!pendingModules.isEmpty()) {
+        AbstractModuleRecord* moduleRecord = pendingModules.takeLast();
+        if (!exportStarSet.add(moduleRecord).isNewEntry)
+            continue;
+        bool isRoot = moduleRecord == this;
+
+        for (const auto& pair : moduleRecord->exportEntries()) {
+            const ExportEntry& exportEntry = pair.value;
+            if (!isRoot && vm.propertyNames->defaultKeyword == exportEntry.exportName)
+                continue;
+            SUPPRESS_UNCOUNTED_LOCAL auto* exportName = exportEntry.exportName.impl();
+            // ResolveExport returns at root's own Local/Indirect/Namespace entry before
+            // consulting star exports, so star-reachable bindings cannot affect those names.
+            if (!isRoot && rootShadowedNames.contains(exportName))
+                continue;
+            if (slowPathNames.contains(exportName))
+                continue;
+
+            Resolution candidate;
+            switch (exportEntry.type) {
+            case ExportEntry::Type::Local:
+                candidate = { Resolution::Type::Resolved, moduleRecord, exportEntry.localName };
+                break;
+            case ExportEntry::Type::Namespace: {
+                AbstractModuleRecord* importedModuleRecord = moduleRecord->hostResolveImportedModule(globalObject, exportEntry.moduleName);
+                RETURN_IF_EXCEPTION(scope, nullptr);
+                candidate = { Resolution::Type::Resolved, importedModuleRecord, vm.propertyNames->starNamespacePrivateName };
+                break;
+            }
+            case ExportEntry::Type::Indirect:
+                if (isRoot)
+                    rootShadowedNames.add(exportName);
+                else
+                    uniqueBindings.remove(exportName);
+                slowPathNames.add(exportName);
+                continue;
+            }
+
+            if (isRoot) {
+                rootShadowedNames.add(exportName);
+                uniqueBindings.add(exportName, candidate);
+                continue;
+            }
+
+            auto addResult = uniqueBindings.add(exportName, candidate);
+            if (!addResult.isNewEntry && !addResult.iterator->value.isSameBinding(candidate)) {
+                slowPathNames.add(exportName);
+                uniqueBindings.remove(addResult.iterator);
+            }
+        }
+
+        for (const auto& starModuleName : moduleRecord->starExportEntries()) {
+            AbstractModuleRecord* requestedModuleRecord = moduleRecord->hostResolveImportedModule(globalObject, Identifier::fromUid(vm, starModuleName.get()));
+            RETURN_IF_EXCEPTION(scope, nullptr);
+            pendingModules.append(requestedModuleRecord);
+        }
+    }
 
     Vector<std::pair<Identifier, Resolution>> resolutions;
-    for (auto& name : exportedNames) {
+    resolutions.reserveInitialCapacity(uniqueBindings.size() + slowPathNames.size());
+    for (auto& pair : uniqueBindings) {
+        cacheResolution(pair.key.get(), pair.value);
+        resolutions.append({ Identifier::fromUid(vm, pair.key.get()), pair.value });
+    }
+
+    for (auto& name : slowPathNames) {
         Identifier ident = Identifier::fromUid(vm, name.get());
         const Resolution resolution = resolveExport(globalObject, ident);
         RETURN_IF_EXCEPTION(scope, nullptr);

--- a/Source/JavaScriptCore/runtime/AbstractModuleRecord.h
+++ b/Source/JavaScriptCore/runtime/AbstractModuleRecord.h
@@ -183,6 +183,8 @@ public:
         static Resolution NODELETE error();
         static Resolution NODELETE ambiguous();
 
+        bool isSameBinding(const Resolution& other) const { return moduleRecord == other.moduleRecord && localName == other.localName; }
+
         Type type;
         AbstractModuleRecord* moduleRecord;
         Identifier localName;


### PR DESCRIPTION
#### 66c577c4c2d0b9b3cc2d706ba9311240413a5e0b
<pre>
[JSC] Walk star-export graph once when building a module namespace
<a href="https://bugs.webkit.org/show_bug.cgi?id=313549">https://bugs.webkit.org/show_bug.cgi?id=313549</a>

Reviewed by Yusuke Suzuki.

GetModuleNamespace [1] currently runs GetExportedNames followed by a
ResolveExport call per name. resolveExportImpl walks the star-export
graph independently for each name, so building a namespace for a deep
barrel module costs O(names * star-edges).

Walk the graph once instead, recording each name&apos;s unique Local /
Namespace binding. A name with exactly one such binding across the whole
star-reachable graph is provably Resolved regardless of resolveSet [2]
(resolveSet only turns paths into null, and merge(Resolved, null) =
Resolved). Names with an Indirect entry, or with two or more distinct
bindings, fall back to resolveExport(). The root module&apos;s own export
entries shadow star-reachable bindings (ResolveExport returns at step
4-6 before consulting star), so a star-side conflict for a name the root
already provides never goes to the slow path.

Add Resolution::isSameBinding() and reuse it in mergeToCurrentTop.

In a local microbenchmark importing a barrel of 9000 exported names
through ~1500 star edges, namespace creation drops from 331 ms to 19 ms
(~17x). For modules without `export *` the walk visits only the root, so
behavior and cost are unchanged.

[1]: <a href="https://tc39.es/ecma262/#sec-getmodulenamespace">https://tc39.es/ecma262/#sec-getmodulenamespace</a>
[2]: <a href="https://tc39.es/ecma262/#sec-resolveexport">https://tc39.es/ecma262/#sec-resolveexport</a>

Tests: JSTests/modules/namespace-single-walk.js
       JSTests/modules/namespace-single-walk/conflict-only.js
       JSTests/modules/namespace-single-walk/cycle-a.js
       JSTests/modules/namespace-single-walk/cycle-b.js
       JSTests/modules/namespace-single-walk/leaf-a.js
       JSTests/modules/namespace-single-walk/leaf-b.js
       JSTests/modules/namespace-single-walk/mid-left.js
       JSTests/modules/namespace-single-walk/mid-right.js
       JSTests/modules/namespace-single-walk/root.js

* JSTests/modules/namespace-single-walk.js: Added.
* JSTests/modules/namespace-single-walk/conflict-only.js: Added.
* JSTests/modules/namespace-single-walk/cycle-a.js: Added.
* JSTests/modules/namespace-single-walk/cycle-b.js: Added.
* JSTests/modules/namespace-single-walk/leaf-a.js: Added.
* JSTests/modules/namespace-single-walk/leaf-b.js: Added.
* JSTests/modules/namespace-single-walk/mid-left.js: Added.
* JSTests/modules/namespace-single-walk/mid-right.js: Added.
* JSTests/modules/namespace-single-walk/root.js: Added.
* Source/JavaScriptCore/runtime/AbstractModuleRecord.cpp:
(JSC::AbstractModuleRecord::resolveExportImpl):
(JSC::AbstractModuleRecord::getModuleNamespace):
(JSC::getExportedNames): Deleted.
* Source/JavaScriptCore/runtime/AbstractModuleRecord.h:
(JSC::AbstractModuleRecord::Resolution::isSameBinding const):

Canonical link: <a href="https://commits.webkit.org/312370@main">https://commits.webkit.org/312370@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e21ac441fe64ef86e191fb24d74e2ecde2131e79

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/159488 "Build is in progress. Recent messages:OS: Tahoe (26.2), Xcode: 26.2") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/32923 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/26033 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/168324 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/113868 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/32989 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/32908 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/123584 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/86736 "1 flakes 1 failures") 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/162445 "Build is in progress. Recent messages:OS: Tahoe (26.2), Xcode: 26.2; Running apply-patch; Checked out pull request") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/25829 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/143257 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/104239 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/24882 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/23340 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/16096 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/151544 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/134573 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/21030 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/170817 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/20325 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/16856 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/22661 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/131787 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/32610 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/27416 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/131895 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35740 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/32554 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/142823 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/90701 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/26553 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/19637 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/191772 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/32064 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/98523 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/49276 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/31582 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/31858 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/31779 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->