### PR TITLE
UserMessageHandler.postMessage should fail if called from another frame

### DIFF
--- a/Source/WebCore/page/UserMessageHandler.cpp
+++ b/Source/WebCore/page/UserMessageHandler.cpp
@@ -28,9 +28,10 @@
 
 #if ENABLE(USER_MESSAGE_HANDLERS)
 
+#include "Document.h"
 #include "JSDOMConvertAny.h"
 #include "JSDOMPromiseDeferred.h"
-#include "LocalFrame.h"
+#include "LocalFrameInlines.h"
 #include "SerializedScriptValue.h"
 #include <JavaScriptCore/HeapCellInlines.h>
 #include <JavaScriptCore/JSCJSValue.h>
@@ -45,15 +46,35 @@ UserMessageHandler::UserMessageHandler(LocalFrame& frame, const UserMessageHandl
 
 UserMessageHandler::~UserMessageHandler() = default;
 
-ExceptionOr<void> UserMessageHandler::postMessage(JSC::JSGlobalObject& globalObject, JSC::JSValue value, Ref<DeferredPromise>&& promise)
+static bool passesSameOriginCheck(JSC::JSGlobalObject& globalObject, RefPtr<LocalFrame> frame)
+{
+    if (!frame)
+        return false;
+    RefPtr document = frame->document();
+    if (!document)
+        return false;
+    Ref frameSecurityOrigin = document->securityOrigin();
+    if (!globalObject.inherits<JSDOMGlobalObject>())
+        return false;
+    RefPtr scriptExecutionContext = uncheckedDowncast<JSDOMGlobalObject>(globalObject).scriptExecutionContext();
+    if (!scriptExecutionContext)
+        return false;
+    RefPtr securityOrigin = scriptExecutionContext->securityOrigin();
+    if (!securityOrigin)
+        return false;
+    return securityOrigin->isSameOriginAs(frameSecurityOrigin);
+}
+
+void UserMessageHandler::postMessage(JSC::JSGlobalObject& globalObject, JSC::JSValue value, Ref<DeferredPromise>&& promise)
 {
     // Check to see if the descriptor has been removed. This can happen if the host application has
     // removed the named message handler at the WebKit2 API level.
     RefPtr descriptor = m_descriptor;
-    if (!descriptor) {
-        promise->reject(Exception { ExceptionCode::InvalidAccessError });
-        return Exception { ExceptionCode::InvalidAccessError };
-    }
+    if (!descriptor)
+        return promise->reject(Exception { ExceptionCode::InvalidAccessError });
+
+    if (!passesSameOriginCheck(globalObject, m_frame.get()))
+        return promise->reject(Exception { ExceptionCode::InvalidAccessError, "Failed same-origin check."_s });
 
     descriptor->didPostMessage(*this, globalObject, value, [promise = WTF::move(promise)](JSC::JSValue result, const String& errorMessage) {
         if (errorMessage.isNull())
@@ -65,14 +86,17 @@ ExceptionOr<void> UserMessageHandler::postMessage(JSC::JSGlobalObject& globalObj
         JSC::JSLockHolder lock(globalObject);
         promise->reject<IDLAny>(JSC::createError(globalObject, errorMessage));
     });
-    return { };
 }
 
-JSC::JSValue UserMessageHandler::postLegacySynchronousMessage(JSC::JSGlobalObject& globalObject, JSC::JSValue value)
+ExceptionOr<JSC::JSValue> UserMessageHandler::postLegacySynchronousMessage(JSC::JSGlobalObject& globalObject, JSC::JSValue value)
 {
     RefPtr descriptor = m_descriptor;
     if (!descriptor)
-        return JSC::jsUndefined();
+        return Exception { ExceptionCode::InvalidAccessError };
+
+    if (!passesSameOriginCheck(globalObject, m_frame.get()))
+        return Exception { ExceptionCode::InvalidAccessError, "Failed same-origin check."_s };
+
     return descriptor->didPostLegacySynchronousMessage(*this, globalObject, value);
 }
 

--- a/Source/WebCore/page/UserMessageHandler.h
+++ b/Source/WebCore/page/UserMessageHandler.h
@@ -52,15 +52,15 @@ public:
     void ref() const final { RefCounted::ref(); }
     void deref() const final { RefCounted::deref(); }
 
-    ExceptionOr<void> postMessage(JSC::JSGlobalObject&, JSC::JSValue, Ref<DeferredPromise>&&);
-    JSC::JSValue postLegacySynchronousMessage(JSC::JSGlobalObject&, JSC::JSValue);
+    void postMessage(JSC::JSGlobalObject&, JSC::JSValue, Ref<DeferredPromise>&&);
+    ExceptionOr<JSC::JSValue> postLegacySynchronousMessage(JSC::JSGlobalObject&, JSC::JSValue);
 
-    const UserMessageHandlerDescriptor* descriptor() { return m_descriptor.get(); }
+    const UserMessageHandlerDescriptor* descriptor() const { return m_descriptor.get(); }
     void invalidateDescriptor() { m_descriptor = nullptr; }
 
 private:
     UserMessageHandler(LocalFrame&, const UserMessageHandlerDescriptor&);
-    
+
     RefPtr<const UserMessageHandlerDescriptor> m_descriptor;
 };
 

--- a/Source/WebKit/WebProcess/InjectedBundle/API/gtk/DOM/WebKitDOMDOMWindow.cpp
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/gtk/DOM/WebKitDOMDOMWindow.cpp
@@ -1086,9 +1086,7 @@ gboolean webkit_dom_dom_window_webkit_message_handlers_post_message(WebKitDOMDOM
     JSRetainPtr<JSStringRef> jsString(Adopt, JSStringCreateWithUTF8CString(message));
     JSValueRef jsStringValue = JSValueMakeString(toRef(globalObject), jsString.get());
 
-    auto result = handler->postMessage(*globalObject, toJS(globalObject, jsStringValue), adoptRef(*(promise.leakRef())));
-    if (result.hasException())
-        return FALSE;
+    handler->postMessage(*globalObject, toJS(globalObject, jsStringValue), adoptRef(*(promise.leakRef())));
 
     return TRUE;
 #else

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKWebViewEvaluateJavaScript.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKWebViewEvaluateJavaScript.mm
@@ -174,6 +174,52 @@ TEST(WKWebView, EvaluateJavaScriptErrorCases)
     TestWebKitAPI::Util::run(&isDone);
 }
 
+@interface ScriptMessageHandlerThatShouldNotReceiveAnything : NSObject <WKScriptMessageHandler>
+@end
+
+@implementation ScriptMessageHandlerThatShouldNotReceiveAnything
+- (void)userContentController:(WKUserContentController *)userContentController didReceiveScriptMessage:(WKScriptMessage *)message
+{
+    EXPECT_FALSE(true);
+}
+@end
+
+TEST(WKWebView, MessageHandlerFromIframe)
+{
+    TestWebKitAPI::HTTPServer server({
+        { "/"_s, { "<script>alert('iframe1 loaded')</script>"_s } }
+    });
+    RetainPtr handler1 = adoptNS([ScriptMessageHandlerThatShouldNotReceiveAnything new]);
+    RetainPtr handler2 = adoptNS([TestScriptMessageHandler new]);
+    RetainPtr configuration = adoptNS([WKWebViewConfiguration new]);
+    [configuration.get().userContentController addScriptMessageHandler:handler1.get() name:@"testhandler1"];
+    [configuration.get().userContentController addScriptMessageHandler:handler2.get() name:@"testhandler2"];
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+    RetainPtr html = [NSString stringWithFormat:@"<script>onload = ()=>{"
+        "var iframe1 = document.createElement('iframe');"
+        "iframe1.src = 'http://127.0.0.1:%d/';"
+        "document.body.appendChild(iframe1);"
+        "window.handler1 = iframe1.contentWindow.window.webkit.messageHandlers.testhandler1;"
+        "var iframe2 = document.createElement('iframe');"
+        "document.body.appendChild(iframe2);"
+        "window.handler2 = iframe2.contentWindow.window.webkit.messageHandlers.testhandler2;"
+        "}</script>", server.port()];
+    [webView loadHTMLString:html.get() baseURL:[NSURL URLWithString:@"http://webkit.org/"]];
+    EXPECT_WK_STREQ([webView _test_waitForAlert], "iframe1 loaded");
+
+    __block bool done { false };
+    RetainPtr js1 = @"try { await window.handler1.postMessage('should fail') } catch (e) { return 'Sending resolved with exception: ' + e }; return 'sending succeeded'";
+    [webView callAsyncJavaScript:js1.get() arguments:nil inFrame:nil inContentWorld:WKContentWorld.pageWorld completionHandler:^(id result, NSError *error) {
+        EXPECT_WK_STREQ(result, "Sending resolved with exception: InvalidAccessError: Failed same-origin check.");
+        done = true;
+    }];
+    TestWebKitAPI::Util::run(&done);
+
+    RetainPtr js2 = @"window.handler2.postMessage('should succeed')";
+    [webView evaluateJavaScript:js2.get() completionHandler:nil];
+    EXPECT_WK_STREQ([handler2 waitForMessage].body, "should succeed");
+}
+
 TEST(WKWebView, WKContentWorld)
 {
     EXPECT_NULL(WKContentWorld.pageWorld.name);


### PR DESCRIPTION
#### 795ef8a1ac92461ca5538d06c759700e9fa20540
<pre>
UserMessageHandler.postMessage should fail if called from another frame
<a href="https://bugs.webkit.org/show_bug.cgi?id=307014">https://bugs.webkit.org/show_bug.cgi?id=307014</a>
<a href="https://rdar.apple.com/168617144">rdar://168617144</a>

Reviewed by Chris Dumez.

Before this fix, a reference to the UserMessageHandler can be stored outside the
frame, then the frame can be navigated, then the stored reference can be used to
post messages that appeared to come from the navigated frame.  This adds a restriction
to make it so a UserMessageHandler can only be used by an origin that is the same
as the frame&apos;s current origin.

I considered an alternative solution where I just make sure the global objects are
the same, but that would be more of a restriction than this, and it&apos;s normal for
frames to be able to access and use each other&apos;s JS objects when they are in the same
origin, and this change is less drastic of a change.

Test: Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebViewEvaluateJavaScript.mm

* Source/WebCore/page/UserMessageHandler.cpp:
(WebCore::passesSameOriginCheck):
(WebCore::UserMessageHandler::postMessage):
(WebCore::UserMessageHandler::postLegacySynchronousMessage):
* Source/WebCore/page/UserMessageHandler.h:
(WebCore::UserMessageHandler::descriptor const):
(WebCore::UserMessageHandler::descriptor): Deleted.
* Source/WebKit/WebProcess/InjectedBundle/API/gtk/DOM/WebKitDOMDOMWindow.cpp:
(webkit_dom_dom_window_webkit_message_handlers_post_message):
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKWebViewEvaluateJavaScript.mm:
(-[ScriptMessageHandlerThatShouldNotReceiveAnything userContentController:didReceiveScriptMessage:]):
(TEST(WKWebView, MessageHandlerFromIframe)):

Originally-landed-as: 305413.250@safari-7624-branch (c4006ba4ad2a). <a href="https://rdar.apple.com/173969283">rdar://173969283</a>
Canonical link: <a href="https://commits.webkit.org/312289@main">https://commits.webkit.org/312289@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2e7df5b4c1512e8723f0580bb4680abb36795d6e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/159407 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/32835 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/25943 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/168239 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/113785 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/161276 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/32903 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/32823 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/123506 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/86693 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/162364 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/25750 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/143181 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/104170 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/24803 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/23262 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/16010 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/134490 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/20961 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/170731 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/16765 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/22587 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/131713 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/32524 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/27337 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/131826 "Passed tests") | | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/35666 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/32468 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/142754 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/90593 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/26488 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/19563 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/31979 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/98431 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/31499 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/31772 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/31654 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->