### PR TITLE
Web Inspector: wire DOM tree mutation events to FrameDOMAgent for cross-origin iframes

### DIFF
--- a/LayoutTests/http/tests/site-isolation/inspector/dom/dom-mutation-events-frame-target-expected.txt
+++ b/LayoutTests/http/tests/site-isolation/inspector/dom/dom-mutation-events-frame-target-expected.txt
@@ -1,0 +1,47 @@
+Test that DOM mutation events from cross-origin iframes are correctly forwarded to the frontend under site isolation.
+
+
+
+== Running test suite: SiteIsolation.DOM.FrameDOMAgent.MutationEvents
+-- Running test case: Setup
+PASS: Should find a cross-origin frame target.
+PASS: Frame target should have a document.
+PASS: Should find #container.
+PASS: #container should have data-role='frame-root'.
+
+-- Running test case: SiteIsolation.DOM.MutationEvents.AttributeModified
+PASS: Modified node should be #container.
+PASS: Modified attribute should be 'data-role'.
+PASS: Attribute value should be 'updated-role'.
+
+-- Running test case: SiteIsolation.DOM.MutationEvents.AttributeRemoved
+PASS: Removed attribute node should be #container.
+PASS: Removed attribute should be 'data-role'.
+PASS: data-role attribute should no longer exist.
+
+-- Running test case: SiteIsolation.DOM.MutationEvents.CharacterDataModified
+PASS: Should find #text-node.
+PASS: Text node should have updated content.
+
+-- Running test case: SiteIsolation.DOM.MutationEvents.ChildNodeInserted
+PASS: Inserted node's parent should be #container.
+PASS: Inserted node should be a SPAN.
+PASS: Inserted node should have id='inserted-span'.
+PASS: Container should have one more child.
+
+-- Running test case: SiteIsolation.DOM.MutationEvents.ChildNodeRemoved
+PASS: Should find #heading before removal.
+PASS: Removed node should be #heading.
+PASS: Removed node's parent should be #container.
+PASS: Container should have one fewer child.
+
+-- Running test case: SiteIsolation.DOM.MutationEvents.InlineStyleInvalidated
+PASS: Style-invalidated node should be #container.
+PASS: Modified attribute should be 'style'.
+PASS: Style attribute should include the updated color.
+
+-- Running test case: SiteIsolation.DOM.MutationEvents.ChildNodeCountUpdated
+PASS: Should find #list.
+PASS: Count-updated node should be #list.
+PASS: #list should report one more child.
+

--- a/LayoutTests/http/tests/site-isolation/inspector/dom/dom-mutation-events-frame-target.html
+++ b/LayoutTests/http/tests/site-isolation/inspector/dom/dom-mutation-events-frame-target.html
@@ -1,0 +1,188 @@
+<!-- webkit-test-runner [ SiteIsolationEnabled=true ] -->
+<script src="../../../inspector/resources/inspector-test.js"></script>
+<script src="../debugger/resources/site-isolation-debugger-test-utilities.js"></script>
+<script>
+function test() {
+    let suite = InspectorTest.createAsyncSuite("SiteIsolation.DOM.FrameDOMAgent.MutationEvents");
+
+    let frameTarget = null;
+    let frameDoc = null;
+    let containerNode = null;
+
+    function evaluateInFrame(expression) {
+        return frameTarget.RuntimeAgent.evaluate.invoke({expression, objectGroup: "test"});
+    }
+
+    suite.addTestCase({
+        name: "Setup",
+        description: "Find the cross-origin frame target and expand the DOM tree.",
+        async test() {
+            let frameTargets = WI.targets.filter((t) => t.type === WI.TargetType.Frame);
+            let urlTargetMap = await fetchDocumentURLsForTargets(frameTargets);
+            let mainFrameTarget = urlTargetMap.get(WI.networkManager.mainFrame.url);
+            frameTarget = frameTargets.find((t) => t !== mainFrameTarget);
+
+            InspectorTest.expectNotNull(frameTarget, "Should find a cross-origin frame target.");
+
+            frameDoc = WI.domManager.frameTargetDocumentForTarget(frameTarget);
+            InspectorTest.expectNotNull(frameDoc, "Frame target should have a document.");
+
+            // Expand HTML > BODY > #container so mutations are visible.
+            let htmlNode = frameDoc.children.find((child) => child.nodeName() === "HTML");
+            await new Promise((resolve) => htmlNode.getChildNodes(resolve));
+
+            let bodyNode = htmlNode.children.find((child) => child.nodeName() === "BODY");
+            await new Promise((resolve) => bodyNode.getChildNodes(resolve));
+
+            containerNode = bodyNode.children.find((child) => child.getAttribute("id") === "container");
+            InspectorTest.expectNotNull(containerNode, "Should find #container.");
+            await new Promise((resolve) => containerNode.getChildNodes(resolve));
+
+            InspectorTest.expectEqual(containerNode.getAttribute("data-role"), "frame-root", "#container should have data-role='frame-root'.");
+        }
+    });
+
+    suite.addTestCase({
+        name: "SiteIsolation.DOM.MutationEvents.AttributeModified",
+        description: "Modifying an attribute in a cross-origin frame should fire attributeModified.",
+        async test() {
+            let eventPromise = WI.domManager.awaitEvent(WI.DOMManager.Event.AttributeModified);
+            evaluateInFrame("modifyAttribute()");
+
+            let event = await eventPromise;
+            let {node, name} = event.data;
+            InspectorTest.expectEqual(node, containerNode, "Modified node should be #container.");
+            InspectorTest.expectEqual(name, "data-role", "Modified attribute should be 'data-role'.");
+            InspectorTest.expectEqual(containerNode.getAttribute("data-role"), "updated-role", "Attribute value should be 'updated-role'.");
+        }
+    });
+
+    suite.addTestCase({
+        name: "SiteIsolation.DOM.MutationEvents.AttributeRemoved",
+        description: "Removing an attribute in a cross-origin frame should fire attributeRemoved.",
+        async test() {
+            let eventPromise = WI.domManager.awaitEvent(WI.DOMManager.Event.AttributeRemoved);
+            evaluateInFrame("removeAttribute()");
+
+            let event = await eventPromise;
+            let {node, name} = event.data;
+            InspectorTest.expectEqual(node, containerNode, "Removed attribute node should be #container.");
+            InspectorTest.expectEqual(name, "data-role", "Removed attribute should be 'data-role'.");
+            InspectorTest.expectEqual(containerNode.getAttribute("data-role"), undefined, "data-role attribute should no longer exist.");
+        }
+    });
+
+    suite.addTestCase({
+        name: "SiteIsolation.DOM.MutationEvents.CharacterDataModified",
+        description: "Modifying text content in a cross-origin frame should fire characterDataModified.",
+        async test() {
+            let textParagraph = containerNode.children.find((child) => child.getAttribute("id") === "text-node");
+            InspectorTest.expectNotNull(textParagraph, "Should find #text-node.");
+
+            // Expand #text-node so we can see its text child.
+            await new Promise((resolve) => textParagraph.getChildNodes(resolve));
+
+            let eventPromise = WI.domManager.awaitEvent(WI.DOMManager.Event.CharacterDataModified);
+            evaluateInFrame("modifyCharacterData()");
+
+            let event = await eventPromise;
+            let {node} = event.data;
+            InspectorTest.expectEqual(node.nodeValue(), "Updated text content.", "Text node should have updated content.");
+        }
+    });
+
+    suite.addTestCase({
+        name: "SiteIsolation.DOM.MutationEvents.ChildNodeInserted",
+        description: "Inserting a child in a cross-origin frame should fire NodeInserted.",
+        async test() {
+            let childCountBefore = containerNode.children.length;
+
+            let eventPromise = WI.domManager.awaitEvent(WI.DOMManager.Event.NodeInserted);
+            evaluateInFrame("insertChild()");
+
+            let event = await eventPromise;
+            let {node, parent} = event.data;
+            InspectorTest.expectEqual(parent, containerNode, "Inserted node's parent should be #container.");
+            InspectorTest.expectEqual(node.nodeName(), "SPAN", "Inserted node should be a SPAN.");
+            InspectorTest.expectEqual(node.getAttribute("id"), "inserted-span", "Inserted node should have id='inserted-span'.");
+            InspectorTest.expectEqual(containerNode.children.length, childCountBefore + 1, "Container should have one more child.");
+        }
+    });
+
+    suite.addTestCase({
+        name: "SiteIsolation.DOM.MutationEvents.ChildNodeRemoved",
+        description: "Removing a child from a cross-origin frame should fire NodeRemoved.",
+        async test() {
+            let headingNode = containerNode.children.find((child) => child.getAttribute("id") === "heading");
+            InspectorTest.expectNotNull(headingNode, "Should find #heading before removal.");
+
+            let childCountBefore = containerNode.children.length;
+
+            let eventPromise = WI.domManager.awaitEvent(WI.DOMManager.Event.NodeRemoved);
+            evaluateInFrame("removeChild()");
+
+            let event = await eventPromise;
+            let {node, parent} = event.data;
+            InspectorTest.expectEqual(node, headingNode, "Removed node should be #heading.");
+            InspectorTest.expectEqual(parent, containerNode, "Removed node's parent should be #container.");
+            InspectorTest.expectEqual(containerNode.children.length, childCountBefore - 1, "Container should have one fewer child.");
+        }
+    });
+
+    suite.addTestCase({
+        name: "SiteIsolation.DOM.MutationEvents.InlineStyleInvalidated",
+        description: "Modifying inline style in a cross-origin frame should fire attributeModified for 'style'.",
+        async test() {
+            let eventPromise = WI.domManager.awaitEvent(WI.DOMManager.Event.AttributeModified);
+            evaluateInFrame("modifyInlineStyle()");
+
+            let event = await eventPromise;
+            let {node, name} = event.data;
+            InspectorTest.expectEqual(node, containerNode, "Style-invalidated node should be #container.");
+            InspectorTest.expectEqual(name, "style", "Modified attribute should be 'style'.");
+            InspectorTest.expectThat(containerNode.getAttribute("style").includes("color"), "Style attribute should include the updated color.");
+        }
+    });
+
+    suite.addTestCase({
+        name: "SiteIsolation.DOM.MutationEvents.ChildNodeCountUpdated",
+        description: "Inserting a child into an unexpanded node in a cross-origin frame should fire ChildNodeCountUpdated.",
+        async test() {
+            // #list was never expanded, so the backend reports a count change rather than the inserted node.
+            let listNode = containerNode.children.find((child) => child.getAttribute("id") === "list");
+            InspectorTest.expectNotNull(listNode, "Should find #list.");
+
+            let childCountBefore = listNode.childNodeCount;
+
+            // ChildNodeCountUpdated is a manager-wide event that the page target also fires (e.g. the
+            // harness mutating its own output element while logging), so wait for the event whose node
+            // belongs to the frame target instead of the first one that arrives.
+            let eventPromise = new Promise((resolve) => {
+                WI.domManager.addEventListener(WI.DOMManager.Event.ChildNodeCountUpdated, function listener(event) {
+                    let node = event.data;
+                    if (node._owningTarget !== frameTarget || node.getAttribute("id") !== "list")
+                        return;
+                    WI.domManager.removeEventListener(WI.DOMManager.Event.ChildNodeCountUpdated, listener, null);
+                    resolve(node);
+                });
+            });
+            evaluateInFrame("insertUnexpandedChild()");
+
+            let node = await eventPromise;
+            InspectorTest.expectEqual(node.getAttribute("id"), "list", "Count-updated node should be #list.");
+            InspectorTest.expectEqual(node.childNodeCount, childCountBefore + 1, "#list should report one more child.");
+        }
+    });
+
+    // FIXME: willDestroyDOMNode is not covered here. It fires when the backend tears down a Node
+    // (on GC after detachment), which can't be triggered deterministically from script. Its frontend
+    // handler dispatches the same NodeRemoved event already exercised by ChildNodeRemoved above.
+
+    suite.runTestCasesAndFinish();
+}
+</script>
+
+<body onload="runTest()">
+<p>Test that DOM mutation events from cross-origin iframes are correctly forwarded to the frontend under site isolation.</p>
+<iframe src="http://localhost:8000/site-isolation/inspector/dom/resources/dom-mutation-frame.html"></iframe>
+</body>

--- a/LayoutTests/http/tests/site-isolation/inspector/dom/resources/dom-mutation-frame.html
+++ b/LayoutTests/http/tests/site-isolation/inspector/dom/resources/dom-mutation-frame.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Cross-Origin DOM Mutation Frame</title>
+</head>
+<body>
+    <div id="container" class="main-content" data-role="frame-root">
+        <h1 id="heading">Cross-Origin Heading</h1>
+        <p id="text-node">Hello from cross-origin frame.</p>
+        <ul id="list"><li>One</li></ul>
+    </div>
+    <script>
+    function modifyAttribute() {
+        document.getElementById("container").setAttribute("data-role", "updated-role");
+    }
+
+    function removeAttribute() {
+        document.getElementById("container").removeAttribute("data-role");
+    }
+
+    function modifyCharacterData() {
+        document.getElementById("text-node").firstChild.data = "Updated text content.";
+    }
+
+    function insertChild() {
+        let newElement = document.createElement("span");
+        newElement.id = "inserted-span";
+        newElement.textContent = "Inserted";
+        document.getElementById("container").appendChild(newElement);
+    }
+
+    function removeChild() {
+        document.getElementById("heading").remove();
+    }
+
+    function modifyInlineStyle() {
+        document.getElementById("container").style.color = "rgb(255, 0, 0)";
+    }
+
+    function insertUnexpandedChild() {
+        let newItem = document.createElement("li");
+        newItem.textContent = "Two";
+        document.getElementById("list").appendChild(newItem);
+    }
+    </script>
+</body>
+</html>

--- a/Source/WebCore/inspector/InspectorInstrumentation.cpp
+++ b/Source/WebCore/inspector/InspectorInstrumentation.cpp
@@ -161,6 +161,10 @@ void InspectorInstrumentation::willInsertDOMNodeImpl(InstrumentingAgents& instru
 
 void InspectorInstrumentation::didInsertDOMNodeImpl(InstrumentingAgents& instrumentingAgents, Node& node)
 {
+    if (RefPtr frame = node.document().frame()) {
+        if (CheckedPtr frameDOMAgent = frame->inspectorController().instrumentingAgents().persistentFrameDOMAgent())
+            frameDOMAgent->didInsertDOMNode(node);
+    }
     if (CheckedPtr domAgent = instrumentingAgents.persistentDOMAgent())
         domAgent->didInsertDOMNode(node);
 }
@@ -173,6 +177,10 @@ void InspectorInstrumentation::willRemoveDOMNodeImpl(InstrumentingAgents& instru
 
 void InspectorInstrumentation::didRemoveDOMNodeImpl(InstrumentingAgents& instrumentingAgents, Node& node)
 {
+    if (RefPtr frame = node.document().frame()) {
+        if (CheckedPtr frameDOMAgent = frame->inspectorController().instrumentingAgents().persistentFrameDOMAgent())
+            frameDOMAgent->didRemoveDOMNode(node);
+    }
     if (auto* pageDOMDebuggerAgent = instrumentingAgents.enabledPageDOMDebuggerAgent())
         pageDOMDebuggerAgent->didRemoveDOMNode(node);
     if (CheckedPtr domAgent = instrumentingAgents.persistentDOMAgent())
@@ -181,6 +189,10 @@ void InspectorInstrumentation::didRemoveDOMNodeImpl(InstrumentingAgents& instrum
 
 void InspectorInstrumentation::willDestroyDOMNodeImpl(InstrumentingAgents& instrumentingAgents, Node& node)
 {
+    if (RefPtr frame = node.document().frame()) {
+        if (CheckedPtr frameDOMAgent = frame->inspectorController().instrumentingAgents().persistentFrameDOMAgent())
+            frameDOMAgent->willDestroyDOMNode(node);
+    }
     if (auto* pageDOMDebuggerAgent = instrumentingAgents.enabledPageDOMDebuggerAgent())
         pageDOMDebuggerAgent->willDestroyDOMNode(node);
     if (CheckedPtr domAgent = instrumentingAgents.persistentDOMAgent())
@@ -219,18 +231,30 @@ void InspectorInstrumentation::willModifyDOMAttrImpl(InstrumentingAgents& instru
 {
     if (auto* pageDOMDebuggerAgent = instrumentingAgents.enabledPageDOMDebuggerAgent())
         pageDOMDebuggerAgent->willModifyDOMAttr(element);
+    if (RefPtr frame = element.document().frame()) {
+        if (CheckedPtr frameDOMAgent = frame->inspectorController().instrumentingAgents().persistentFrameDOMAgent())
+            frameDOMAgent->willModifyDOMAttr(element, oldValue, newValue);
+    }
     if (CheckedPtr domAgent = instrumentingAgents.persistentDOMAgent())
         domAgent->willModifyDOMAttr(element, oldValue, newValue);
 }
 
 void InspectorInstrumentation::didModifyDOMAttrImpl(InstrumentingAgents& instrumentingAgents, Element& element, const AtomString& name, const AtomString& value)
 {
+    if (RefPtr frame = element.document().frame()) {
+        if (CheckedPtr frameDOMAgent = frame->inspectorController().instrumentingAgents().persistentFrameDOMAgent())
+            frameDOMAgent->didModifyDOMAttr(element, name, value);
+    }
     if (CheckedPtr domAgent = instrumentingAgents.persistentDOMAgent())
         domAgent->didModifyDOMAttr(element, name, value);
 }
 
 void InspectorInstrumentation::didRemoveDOMAttrImpl(InstrumentingAgents& instrumentingAgents, Element& element, const AtomString& name)
 {
+    if (RefPtr frame = element.document().frame()) {
+        if (CheckedPtr frameDOMAgent = frame->inspectorController().instrumentingAgents().persistentFrameDOMAgent())
+            frameDOMAgent->didRemoveDOMAttr(element, name);
+    }
     if (CheckedPtr domAgent = instrumentingAgents.persistentDOMAgent())
         domAgent->didRemoveDOMAttr(element, name);
 }
@@ -243,6 +267,10 @@ void InspectorInstrumentation::willInvalidateStyleAttrImpl(InstrumentingAgents& 
 
 void InspectorInstrumentation::didInvalidateStyleAttrImpl(InstrumentingAgents& instrumentingAgents, Element& element)
 {
+    if (RefPtr frame = element.document().frame()) {
+        if (CheckedPtr frameDOMAgent = frame->inspectorController().instrumentingAgents().persistentFrameDOMAgent())
+            frameDOMAgent->didInvalidateStyleAttr(element);
+    }
     if (CheckedPtr domAgent = instrumentingAgents.persistentDOMAgent())
         domAgent->didInvalidateStyleAttr(element);
 }
@@ -356,6 +384,10 @@ bool InspectorInstrumentation::forcePseudoStateImpl(InstrumentingAgents& instrum
 
 void InspectorInstrumentation::characterDataModifiedImpl(InstrumentingAgents& instrumentingAgents, CharacterData& characterData)
 {
+    if (RefPtr frame = characterData.document().frame()) {
+        if (CheckedPtr frameDOMAgent = frame->inspectorController().instrumentingAgents().persistentFrameDOMAgent())
+            frameDOMAgent->characterDataModified(characterData);
+    }
     if (CheckedPtr domAgent = instrumentingAgents.persistentDOMAgent())
         domAgent->characterDataModified(characterData);
 }

--- a/Source/WebInspectorUI/UserInterface/Controllers/DOMManager.js
+++ b/Source/WebInspectorUI/UserInterface/Controllers/DOMManager.js
@@ -311,6 +311,122 @@ WI.DOMManager = class DOMManager extends WI.Object
         }
     }
 
+    _frameTargetAttributeModified(target, nodeId, name, value)
+    {
+        let scopedId = target.identifier + ":" + nodeId;
+        let node = this._idToDOMNode[scopedId];
+        if (!node)
+            return;
+
+        node._setAttribute(name, value);
+        this.dispatchEventToListeners(WI.DOMManager.Event.AttributeModified, {node, name});
+        node.dispatchEventToListeners(WI.DOMNode.Event.AttributeModified, {name});
+    }
+
+    _frameTargetAttributeRemoved(target, nodeId, name)
+    {
+        let scopedId = target.identifier + ":" + nodeId;
+        let node = this._idToDOMNode[scopedId];
+        if (!node)
+            return;
+
+        node._removeAttribute(name);
+        this.dispatchEventToListeners(WI.DOMManager.Event.AttributeRemoved, {node, name});
+        node.dispatchEventToListeners(WI.DOMNode.Event.AttributeRemoved, {name});
+    }
+
+    _frameTargetInlineStyleInvalidated(target, nodeIds)
+    {
+        // FIXME: https://bugs.webkit.org/show_bug.cgi?id=316416 The page-target variant 
+        // (`_inlineStyleInvalidated`) debounces and batches the `DOM.getAttributes` calls 
+        // so they run at most once per tick. Mimic that here to avoid
+        // issuing one command per invalidated node.
+        for (let nodeId of nodeIds) {
+            let scopedId = target.identifier + ":" + nodeId;
+            let node = this._idToDOMNode[scopedId];
+            if (!node)
+                continue;
+
+            target.DOMAgent.getAttributes(nodeId, (error, attributes) => {
+                if (error || !attributes)
+                    return;
+
+                let currentNode = this._idToDOMNode[scopedId];
+                if (!currentNode)
+                    return;
+
+                currentNode._setAttributesPayload(attributes);
+                this.dispatchEventToListeners(WI.DOMManager.Event.AttributeModified, {node: currentNode, name: "style"});
+                currentNode.dispatchEventToListeners(WI.DOMNode.Event.AttributeModified, {name: "style"});
+            });
+        }
+    }
+
+    _frameTargetCharacterDataModified(target, nodeId, newValue)
+    {
+        let scopedId = target.identifier + ":" + nodeId;
+        let node = this._idToDOMNode[scopedId];
+        if (!node)
+            return;
+
+        node._nodeValue = newValue;
+        this.dispatchEventToListeners(WI.DOMManager.Event.CharacterDataModified, {node});
+    }
+
+    _frameTargetChildNodeCountUpdated(target, nodeId, newValue)
+    {
+        let scopedId = target.identifier + ":" + nodeId;
+        let node = this._idToDOMNode[scopedId];
+        if (!node)
+            return;
+
+        node.childNodeCount = newValue;
+        this.dispatchEventToListeners(WI.DOMManager.Event.ChildNodeCountUpdated, node);
+    }
+
+    _frameTargetChildNodeInserted(target, parentId, prevId, payload)
+    {
+        let scopedParentId = target.identifier + ":" + parentId;
+        let parent = this._idToDOMNode[scopedParentId];
+        if (!parent)
+            return;
+
+        let scopedPrevId = prevId ? target.identifier + ":" + prevId : 0;
+        let prev = prevId ? this._idToDOMNode[scopedPrevId] : null;
+        let node = parent._insertChild(prev, payload);
+        this._idToDOMNode[node.id] = node;
+        this.dispatchEventToListeners(WI.DOMManager.Event.NodeInserted, {node, parent});
+
+        // A new iframe element may have been inserted — try to splice pending frame documents.
+        this._trySpliceUnsplicedFrameDocuments();
+    }
+
+    _frameTargetChildNodeRemoved(target, parentId, nodeId)
+    {
+        let scopedParentId = target.identifier + ":" + parentId;
+        let scopedNodeId = target.identifier + ":" + nodeId;
+        let parent = this._idToDOMNode[scopedParentId];
+        let node = this._idToDOMNode[scopedNodeId];
+        if (!parent || !node)
+            return;
+
+        parent._removeChild(node);
+        this._frameTargetUnbind(node);
+        this.dispatchEventToListeners(WI.DOMManager.Event.NodeRemoved, {node, parent});
+    }
+
+    _frameTargetWillDestroyDOMNode(target, nodeId)
+    {
+        let scopedId = target.identifier + ":" + nodeId;
+        let node = this._idToDOMNode[scopedId];
+        if (!node)
+            return;
+
+        node.markDestroyed();
+        delete this._idToDOMNode[scopedId];
+        this.dispatchEventToListeners(WI.DOMManager.Event.NodeRemoved, {node});
+    }
+
     transitionPageTarget()
     {
         this._documentUpdated();

--- a/Source/WebInspectorUI/UserInterface/Protocol/DOMObserver.js
+++ b/Source/WebInspectorUI/UserInterface/Protocol/DOMObserver.js
@@ -54,57 +54,73 @@ WI.DOMObserver = class DOMObserver extends InspectorBackend.Dispatcher
 
     attributeModified(nodeId, name, value)
     {
-        if (this._target instanceof WI.FrameTarget)
-            return; // FIXME: <https://webkit.org/b/298980> Route to frame-target handler.
+        if (this._target instanceof WI.FrameTarget) {
+            WI.domManager._frameTargetAttributeModified(this._target, nodeId, name, value);
+            return;
+        }
         WI.domManager._attributeModified(nodeId, name, value);
     }
 
     attributeRemoved(nodeId, name)
     {
-        if (this._target instanceof WI.FrameTarget)
-            return; // FIXME: <https://webkit.org/b/298980> Route to frame-target handler.
+        if (this._target instanceof WI.FrameTarget) {
+            WI.domManager._frameTargetAttributeRemoved(this._target, nodeId, name);
+            return;
+        }
         WI.domManager._attributeRemoved(nodeId, name);
     }
 
     inlineStyleInvalidated(nodeIds)
     {
-        if (this._target instanceof WI.FrameTarget)
-            return; // FIXME: <https://webkit.org/b/298980> Route to frame-target handler.
+        if (this._target instanceof WI.FrameTarget) {
+            WI.domManager._frameTargetInlineStyleInvalidated(this._target, nodeIds);
+            return;
+        }
         WI.domManager._inlineStyleInvalidated(nodeIds);
     }
 
     characterDataModified(nodeId, characterData)
     {
-        if (this._target instanceof WI.FrameTarget)
-            return; // FIXME: <https://webkit.org/b/298980> Route to frame-target handler.
+        if (this._target instanceof WI.FrameTarget) {
+            WI.domManager._frameTargetCharacterDataModified(this._target, nodeId, characterData);
+            return;
+        }
         WI.domManager._characterDataModified(nodeId, characterData);
     }
 
     childNodeCountUpdated(nodeId, childNodeCount)
     {
-        if (this._target instanceof WI.FrameTarget)
-            return; // FIXME: <https://webkit.org/b/298980> Route to frame-target handler.
+        if (this._target instanceof WI.FrameTarget) {
+            WI.domManager._frameTargetChildNodeCountUpdated(this._target, nodeId, childNodeCount);
+            return;
+        }
         WI.domManager._childNodeCountUpdated(nodeId, childNodeCount);
     }
 
     childNodeInserted(parentNodeId, previousNodeId, node)
     {
-        if (this._target instanceof WI.FrameTarget)
-            return; // FIXME: <https://webkit.org/b/298980> Route to frame-target handler.
+        if (this._target instanceof WI.FrameTarget) {
+            WI.domManager._frameTargetChildNodeInserted(this._target, parentNodeId, previousNodeId, node);
+            return;
+        }
         WI.domManager._childNodeInserted(parentNodeId, previousNodeId, node);
     }
 
     childNodeRemoved(parentNodeId, nodeId)
     {
-        if (this._target instanceof WI.FrameTarget)
-            return; // FIXME: <https://webkit.org/b/298980> Route to frame-target handler.
+        if (this._target instanceof WI.FrameTarget) {
+            WI.domManager._frameTargetChildNodeRemoved(this._target, parentNodeId, nodeId);
+            return;
+        }
         WI.domManager._childNodeRemoved(parentNodeId, nodeId);
     }
 
     willDestroyDOMNode(nodeId)
     {
-        if (this._target instanceof WI.FrameTarget)
-            return; // FIXME: <https://webkit.org/b/298980> Route to frame-target handler.
+        if (this._target instanceof WI.FrameTarget) {
+            WI.domManager._frameTargetWillDestroyDOMNode(this._target, nodeId);
+            return;
+        }
         WI.domManager.willDestroyDOMNode(nodeId);
     }
 


### PR DESCRIPTION
#### dd08cc4886525e32a953c8257b803a602e2b6ba5
<pre>
Web Inspector: wire DOM tree mutation events to FrameDOMAgent for cross-origin iframes
<a href="https://bugs.webkit.org/show_bug.cgi?id=313550">https://bugs.webkit.org/show_bug.cgi?id=313550</a>
<a href="https://rdar.apple.com/175764777">rdar://175764777</a>

Reviewed by Qianlang Chen.

The previous patch introduced FrameDOMAgent with DOM tree read support and
implemented mutation event handlers in the agent, but they were never called.
InspectorInstrumentation only routed to the page-level InspectorDOMAgent, so
cross-origin iframe DOM changes were invisible to the frontend

This patch wires 8 InspectorInstrumentation hooks to also reach FrameDOMAgent
via the node&apos;s owning frame: didInsertDOMNode, didRemoveDOMNode
willDestroyDOMNode, willModifyDOMAttr, didModifyDOMAttr, didRemoveDOMAttr,
characterDataModified, and didInvalidateStyleAttr.

On the frontend, DOMObserver&apos;s early-return guards for FrameTarget are replaced
with routing to new DOMManager frame-target handlers that resolve scoped node
IDs (targetId:nodeId) and dispatch the same events as the page-target path

The Elements panel now stays in sync with cross-origin iframe DOM changes in
real time — attribute modifications, text content changes, node
insertions/removals, and inline style invalidations all update live.

Test: http/tests/site-isolation/inspector/dom/dom-mutation-events-frame-target.html

* LayoutTests/http/tests/site-isolation/inspector/dom/dom-mutation-events-frame-target-expected.txt: Added.
* LayoutTests/http/tests/site-isolation/inspector/dom/dom-mutation-events-frame-target.html: Added.
* LayoutTests/http/tests/site-isolation/inspector/dom/resources/dom-mutation-frame.html: Added.
* Source/WebCore/inspector/InspectorInstrumentation.cpp:
(WebCore::InspectorInstrumentation::didInsertDOMNodeImpl):
(WebCore::InspectorInstrumentation::didRemoveDOMNodeImpl):
(WebCore::InspectorInstrumentation::willDestroyDOMNodeImpl):
(WebCore::InspectorInstrumentation::willModifyDOMAttrImpl):
(WebCore::InspectorInstrumentation::didModifyDOMAttrImpl):
(WebCore::InspectorInstrumentation::didRemoveDOMAttrImpl):
(WebCore::InspectorInstrumentation::didInvalidateStyleAttrImpl):
(WebCore::InspectorInstrumentation::characterDataModifiedImpl):
* Source/WebInspectorUI/UserInterface/Controllers/DOMManager.js:
(WI.DOMManager.prototype._frameTargetAttributeModified):
(WI.DOMManager.prototype._frameTargetAttributeRemoved):
(WI.DOMManager.prototype._frameTargetInlineStyleInvalidated):
(WI.DOMManager.prototype._frameTargetCharacterDataModified):
(WI.DOMManager.prototype._frameTargetChildNodeCountUpdated):
(WI.DOMManager.prototype._frameTargetChildNodeInserted):
(WI.DOMManager.prototype._frameTargetChildNodeRemoved):
(WI.DOMManager.prototype._frameTargetWillDestroyDOMNode):
* Source/WebInspectorUI/UserInterface/Protocol/DOMObserver.js:
(WI.DOMObserver.prototype.attributeModified):
(WI.DOMObserver.prototype.attributeRemoved):
(WI.DOMObserver.prototype.inlineStyleInvalidated):
(WI.DOMObserver.prototype.characterDataModified):
(WI.DOMObserver.prototype.childNodeCountUpdated):
(WI.DOMObserver.prototype.childNodeInserted):
(WI.DOMObserver.prototype.childNodeRemoved):
(WI.DOMObserver.prototype.willDestroyDOMNode):

Canonical link: <a href="https://commits.webkit.org/314740@main">https://commits.webkit.org/314740@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/84ce744c08b09230538041cf0d7dff9f02a42f46

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/166738 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/40228 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/33809 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/175786 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/123995 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/55b7a2a6-67a1-453f-85ad-3c398b3f2a3d) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/168604 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/40661 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/40236 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/129650 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/91313 "1 flakes 3 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/6e7da898-765f-4a2c-be7c-8ef3a672771e) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/169697 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/32046 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/149817 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/110175 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/8885240f-b5ea-4915-97a1-7196819d92b3) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/31022 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/29720 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/24522 "Build is in progress. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/140993 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/27514 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/178320 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/31251 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/29221 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/138012 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/40298 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/33867 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/137927 "Passed tests") | | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/37207 "The change is no longer eligible for processing.") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/40986 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/149312 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/103783 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/25429 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/33208 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/26177 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/39497 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/112571 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/38893 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/4384 "") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/39138 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/39036 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->