### PR TITLE
[Site Isolation] Add multi-process BackForwardCache and CachedFrame support

### DIFF
--- a/Source/WebCore/history/BackForwardCache.cpp
+++ b/Source/WebCore/history/BackForwardCache.cpp
@@ -576,7 +576,15 @@ std::unique_ptr<CachedPage> BackForwardCache::suspendPage(Page& page)
 
 std::unique_ptr<CachedPage> BackForwardCache::take(HistoryItem& item, Page* page)
 {
-    auto it = m_cachedPageMap.find(item.frameItemID());
+    auto cachedPage = take(item.frameItemID(), page);
+    if (cachedPage)
+        item.notifyChanged();
+    return cachedPage;
+}
+
+std::unique_ptr<CachedPage> BackForwardCache::take(BackForwardFrameItemIdentifier identifier, Page* page)
+{
+    auto it = m_cachedPageMap.find(identifier);
     if (it == m_cachedPageMap.end())
         return nullptr;
     if (auto* pruningReason = std::get_if<PruningReason>(&it->value)) {
@@ -586,14 +594,16 @@ std::unique_ptr<CachedPage> BackForwardCache::take(HistoryItem& item, Page* page
         return nullptr;
     }
 
-    m_items.remove(item.frameItemID());
-    auto cachedPage = std::get<UniqueRef<CachedPage>>(m_cachedPageMap.take(it));
-    item.notifyChanged();
+    if (page && &std::get<UniqueRef<CachedPage>>(it->value)->page() != page)
+        return nullptr;
 
-    RELEASE_LOG(BackForwardCache, "BackForwardCache::take item: %s, frameItem: %s, size: %u / %u", item.itemID().toString().utf8().data(), item.frameItemID().toString().utf8().data(), pageCount(), maxSize());
+    m_items.remove(identifier);
+    auto cachedPage = std::get<UniqueRef<CachedPage>>(m_cachedPageMap.take(it));
+
+    RELEASE_LOG(BackForwardCache, "BackForwardCache::take frameItemID: %s, size: %u / %u", identifier.toString().utf8().data(), pageCount(), maxSize());
 
     if (cachedPage->hasExpired() || (page && page->isResourceCachingDisabledByWebInspector())) {
-        LOG(BackForwardCache, "Not restoring page for %s from back/forward cache because cache entry has expired", item.url().string().ascii().data());
+        LOG(BackForwardCache, "Not restoring page from back/forward cache because cache entry has expired");
         logBackForwardCacheFailureDiagnosticMessage(page, DiagnosticLoggingKeys::expiredKey());
         return nullptr;
     }
@@ -632,6 +642,8 @@ CachedPage* BackForwardCache::get(HistoryItem& item, Page* page)
             logBackForwardCacheFailureDiagnosticMessage(page, pruningReasonToDiagnosticLoggingKey(pruningReason));
         return nullptr;
     }, [&](UniqueRef<CachedPage>& cachedPage) -> CachedPage* {
+        if (page && &cachedPage->page() != page)
+            return nullptr;
         if (cachedPage->hasExpired() || (page && page->isResourceCachingDisabledByWebInspector())) {
             LOG(BackForwardCache, "Not restoring page for %s from back/forward cache because cache entry has expired", item.url().string().ascii().data());
             logBackForwardCacheFailureDiagnosticMessage(page, DiagnosticLoggingKeys::expiredKey());

--- a/Source/WebCore/history/BackForwardCache.h
+++ b/Source/WebCore/history/BackForwardCache.h
@@ -62,6 +62,7 @@ public:
     WEBCORE_EXPORT void remove(HistoryItem&);
     CachedPage* get(HistoryItem&, Page*);
     std::unique_ptr<CachedPage> take(HistoryItem&, Page*);
+    WEBCORE_EXPORT std::unique_ptr<CachedPage> take(BackForwardFrameItemIdentifier, Page*);
 
     WEBCORE_EXPORT void removeAllItemsForPage(Page&);
 

--- a/Source/WebCore/history/CachedFrame.cpp
+++ b/Source/WebCore/history/CachedFrame.cpp
@@ -97,14 +97,15 @@ void CachedFrameBase::pruneDetachedChildFrames()
 void CachedFrameBase::restore()
 {
     RefPtr view = m_view;
-    ASSERT(m_document->view() == view);
 
     if (m_isMainFrame)
         view->setParentVisible(true);
 
     Ref frame = view->frame();
     RefPtr localFrame = dynamicDowncast<LocalFrame>(frame.get());
-    {
+
+    if (m_document) {
+        ASSERT(m_document->view() == view);
         Ref document = *m_document;
         Style::PostResolutionCallbackDisabler disabler(document);
         WidgetHierarchyUpdatesSuspensionScope suspendWidgetHierarchyUpdates;
@@ -124,23 +125,23 @@ void CachedFrameBase::restore()
             protect(localFrame->script())->updatePlatformScriptObjects();
             localFrame->loader().client().didRestoreFromBackForwardCache();
         }
+    }
 
-        pruneDetachedChildFrames();
+    pruneDetachedChildFrames();
 
-        // Reconstruct the FrameTree. And open the child CachedFrames in their respective FrameLoaders.
-        for (auto& childFrame : m_childFrames) {
-            ASSERT(childFrame->view()->frame().page());
-            frame->tree().appendChild(protect(protect(childFrame->view())->frame()));
-            childFrame->open();
-            if (localFrame)
-                RELEASE_ASSERT_WITH_SECURITY_IMPLICATION(m_document == localFrame->document());
-            else
-                RELEASE_ASSERT_WITH_SECURITY_IMPLICATION(!m_document);
-        }
+    // Reconstruct the FrameTree. And open the child CachedFrames in their respective FrameLoaders.
+    for (auto& childFrame : m_childFrames) {
+        ASSERT(childFrame->view()->frame().page());
+        frame->tree().appendChild(protect(protect(childFrame->view())->frame()));
+        childFrame->open();
+        if (localFrame)
+            RELEASE_ASSERT_WITH_SECURITY_IMPLICATION(m_document == localFrame->document());
+        else
+            RELEASE_ASSERT_WITH_SECURITY_IMPLICATION(!m_document);
     }
 
 #if PLATFORM(IOS_FAMILY)
-    if (m_isMainFrame && localFrame) {
+    if (m_isMainFrame && localFrame && m_document) {
         localFrame->loader().client().didRestoreFrameHierarchyForCachedFrame();
 
         if (RefPtr window = m_document->window(); window && window->scrollEventListenerCount()) {
@@ -240,6 +241,13 @@ void CachedFrame::open()
 
     if (RefPtr localFrameView = dynamicDowncast<LocalFrameView>(m_view.get()))
         localFrameView->frame().loader().open(*this);
+    else {
+        // RemoteFrame main frame in iframe process — restore() handles
+        // frame tree reconstruction and opening child CachedFrames.
+        // FIXME: Unify with the LocalFrame path by moving restore() out
+        // of FrameLoader::open() into CachedFrame::open().
+        restore();
+    }
 }
 
 void CachedFrame::clear()

--- a/Source/WebCore/loader/FrameLoader.cpp
+++ b/Source/WebCore/loader/FrameLoader.cpp
@@ -4207,7 +4207,7 @@ void FrameLoader::continueLoadAfterNavigationPolicy(const ResourceRequest& reque
 
     if (isBackForwardLoadType(type)) {
         CheckedRef diagnosticLoggingClient = protect(frame->page())->diagnosticLoggingClient();
-        if (RefPtr provisionalItem = history().provisionalItem(); provisionalItem && provisionalItem->isInBackForwardCache()) {
+        if (RefPtr provisionalItem = history().provisionalItem(); provisionalItem && BackForwardCache::singleton().get(*provisionalItem, protect(frame->page()).get())) {
             diagnosticLoggingClient->logDiagnosticMessageWithResult(DiagnosticLoggingKeys::backForwardCacheKey(), DiagnosticLoggingKeys::retrievalKey(), DiagnosticLoggingResultPass, ShouldSample::Yes);
             loadProvisionalItemFromCachedPage();
             FRAMELOADER_RELEASE_LOG(ResourceLoading, "continueLoadAfterNavigationPolicy: can't continue loading frame because it will be loaded from cache");


### PR DESCRIPTION
#### 0dad921c8a6b371e567e1a74bac3399909e0ea93
<pre>
[Site Isolation] Add multi-process BackForwardCache and CachedFrame support
<a href="https://bugs.webkit.org/show_bug.cgi?id=313507">https://bugs.webkit.org/show_bug.cgi?id=313507</a>
<a href="https://rdar.apple.com/175721231">rdar://175721231</a>

Reviewed by Sihui Liu.

Prepare BackForwardCache and CachedFrame for multi-process BFCache with
Site Isolation.

Add a new take(BackForwardFrameItemIdentifier, Page*) overload that
looks up cache entries directly by identifier rather than through a
HistoryItem. This is needed because subframe processes suspend and
restore their BFCache entries using the main frame&apos;s identifier passed
from the UIProcess, without access to the HistoryItem. The existing
take(HistoryItem&amp;, Page*) now delegates to the new overload.

Add Page ownership validation to both take() and get(). With
multi-process BFCache, a subframe process caches its Page under the
main frame&apos;s BackForwardFrameItemIdentifier via SetSubframesSuspended.
If a different Page in the same process later navigates to the same
back/forward item, the FrameLoader&apos;s BFCache lookup can find this
subframe entry instead of a cache miss. Since the subframe&apos;s CachedPage
has a RemoteFrame main frame with no DocumentLoader, restoring from it
causes a crash. The Page validation ensures each Page only finds its own
cache entries. The take() overload checks before removing from the map
so mismatched entries are preserved for their rightful owner.

In CachedFrame, restore() now null-guards m_document to support
RemoteFrame entries. In an iframe process under Site Isolation, the
Page&apos;s main frame is a RemoteFrame with no Document — the CachedFrame
stores the frame tree structure but not a Document. The child frame
reconstruction loop and pruneDetachedChildFrames() are moved outside
the m_document guard so they execute for both LocalFrame and RemoteFrame
paths. CachedFrame::open() adds a RemoteFrame branch that calls
restore() directly, since RemoteFrames have no FrameLoader to drive the
restoration.

In FrameLoader::continueLoadAfterNavigationPolicy, replace the
isInBackForwardCache() check with BackForwardCache::get(). The former
only checks if the key exists in the cache, while the latter also
validates Page ownership. Without this, the FrameLoader can take the
BFCache restoration path using a subframe&apos;s CachedPage, stalling the
navigation instead of proceeding to the normal load path that triggers
a process swap via the UIProcess.

No new tests (no behavior change for single-process BFCache).

* Source/WebCore/history/BackForwardCache.cpp:
(WebCore::BackForwardCache::addIfCacheable):
(WebCore::BackForwardCache::take):
(WebCore::BackForwardCache::get):
* Source/WebCore/history/BackForwardCache.h:
* Source/WebCore/history/CachedFrame.cpp:
(WebCore::CachedFrameBase::restore):
(WebCore::CachedFrame::open):
* Source/WebCore/loader/FrameLoader.cpp:
(WebCore::FrameLoader::continueLoadAfterNavigationPolicy):

Canonical link: <a href="https://commits.webkit.org/312248@main">https://commits.webkit.org/312248@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4395c2c7a97b9ca9fca2c088005e04a922ca3f39

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/159264 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/32692 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/25797 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/168094 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/113642 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/161133 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/32760 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/32679 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/123395 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/113642 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/162221 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/25664 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/143057 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/104062 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/24717 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/23141 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/15866 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/134404 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/20837 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/170588 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/16595 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/22463 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/131593 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/32381 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/27213 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/131705 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35636 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/32325 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/142630 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/90404 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/26397 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/19439 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/31836 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/98243 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/31356 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/31629 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/31511 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->