### PR TITLE
Unreviewed, reverting 311500@main (61c4954ff80a)

### DIFF
--- a/Source/WebKit/GPUProcess/graphics/RemoteImageBufferGraphicsContext.cpp
+++ b/Source/WebKit/GPUProcess/graphics/RemoteImageBufferGraphicsContext.cpp
@@ -68,18 +68,13 @@ void RemoteImageBufferGraphicsContext::drawImageBuffer(RenderingResourceIdentifi
     MESSAGE_CHECK(sourceImage);
     bool selfCopy = false;
     if (sourceImage == m_imageBuffer.ptr() && sourceImage->renderingMode() == RenderingMode::Accelerated) {
-        RefPtr selfCopySourceImage = m_renderingBackend->createImageBufferForSelfCopy(sourceImage);
-        if (selfCopySourceImage) {
-            selfCopySourceImage->context().drawImageBuffer(m_imageBuffer, FloatPoint { }, { CompositeOperator::Copy });
-            sourceImage = selfCopySourceImage;
-            selfCopy = true;
-        }
+        sourceImage = sourceImage->clone();
+        sourceImage->flushDrawingContext();
+        selfCopy = true;
     }
     context().drawImageBuffer(*sourceImage, destinationRect, srcRect, options);
-    if (selfCopy) {
-        m_imageBuffer->submitDrawingCommands();
-        m_renderingBackend->returnImageBufferForSelfCopy(WTF::move(sourceImage));
-    }
+    if (selfCopy)
+        m_imageBuffer->flushDrawingContext();
 }
 
 } // namespace WebKit

--- a/Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.cpp
+++ b/Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.cpp
@@ -164,10 +164,6 @@ void RemoteRenderingBackend::workQueueUninitialize()
     // Make sure we destroy the ResourceCache on the WorkQueue since it gets populated on the WorkQueue.
     m_remoteResourceCache.releaseAllResources();
 
-    if (m_imageBufferForSelfCopyTimer)
-        m_imageBufferForSelfCopyTimer->stop();
-    m_imageBufferForSelfCopyTimer = nullptr;
-
     Ref streamConnection = m_streamConnection;
     streamConnection->stopReceivingMessages(Messages::RemoteRenderingBackend::messageReceiverName(), m_renderingBackendIdentifier.toUInt64());
     streamConnection->invalidate();
@@ -329,41 +325,6 @@ void RemoteRenderingBackend::createImageBuffer(const FloatSize& logicalSize, Ren
     }
     auto result = m_remoteImageBuffers.add(identifier, RemoteImageBuffer::create(imageBuffer.releaseNonNull(), identifier, contextIdentifier, *this));
     MESSAGE_CHECK(result.isNewEntry, "Duplicate ImageBuffers");
-}
-
-RefPtr<ImageBuffer> RemoteRenderingBackend::createImageBufferForSelfCopy(ImageBuffer* source)
-{
-    assertIsCurrent(workQueue());
-    RefPtr imageBuffer = std::exchange(m_imageBufferForSelfCopy, nullptr);
-    if (m_imageBufferForSelfCopyTimer)
-        m_imageBufferForSelfCopyTimer->stop();
-
-    if (imageBuffer
-        && imageBuffer->logicalSize().width() >= source->logicalSize().width()
-        && imageBuffer->logicalSize().height() >= source->logicalSize().height()
-        && imageBuffer->renderingMode() == source->renderingMode()
-        && imageBuffer->renderingPurpose() == source->renderingPurpose()
-        && imageBuffer->resolutionScale() == source->resolutionScale()
-        && imageBuffer->colorSpace() == source->colorSpace()
-        && imageBuffer->pixelFormat() == source->pixelFormat())
-        return imageBuffer;
-
-    return allocateImageBuffer(source->logicalSize(), source->renderingMode(), source->renderingPurpose(), source->resolutionScale(), source->colorSpace(), { source->pixelFormat() }, { });
-}
-
-void RemoteRenderingBackend::returnImageBufferForSelfCopy(RefPtr<ImageBuffer>&& buffer)
-{
-    assertIsCurrent(workQueue());
-    m_imageBufferForSelfCopy = WTF::move(buffer);
-    if (!m_imageBufferForSelfCopyTimer)
-        m_imageBufferForSelfCopyTimer = makeUnique<Timer>(*this, &RemoteRenderingBackend::cleanupImageBufferForSelfCopy);
-    m_imageBufferForSelfCopyTimer->startOneShot(200_ms);
-}
-
-void RemoteRenderingBackend::cleanupImageBufferForSelfCopy()
-{
-    assertIsCurrent(workQueue());
-    m_imageBufferForSelfCopy = nullptr;
 }
 
 void RemoteRenderingBackend::releaseImageBuffer(RenderingResourceIdentifier identifier)

--- a/Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.h
+++ b/Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.h
@@ -58,7 +58,6 @@
 #include <WebCore/PixelFormat.h>
 #include <WebCore/ProcessIdentity.h>
 #include <WebCore/RenderingResourceIdentifier.h>
-#include <WebCore/Timer.h>
 #include <wtf/HashMap.h>
 #include <wtf/TZoneMalloc.h>
 #include <wtf/WeakPtr.h>
@@ -136,10 +135,6 @@ public:
     RefPtr<WebCore::ImageBuffer> allocateImageBuffer(const WebCore::FloatSize& logicalSize, WebCore::RenderingMode, WebCore::RenderingPurpose, float resolutionScale, const WebCore::DestinationColorSpace&, WebCore::ImageBufferFormat, WebCore::ImageBufferCreationContext);
 
     RemoteRenderingBackendIdentifier identifier() { return m_renderingBackendIdentifier; }
-
-    RefPtr<WebCore::ImageBuffer> createImageBufferForSelfCopy(WebCore::ImageBuffer*);
-    void returnImageBufferForSelfCopy(RefPtr<WebCore::ImageBuffer>&&);
-
 private:
     friend class RemoteImageBufferSet;
     RemoteRenderingBackend(GPUConnectionToWebProcess&, RemoteRenderingBackendIdentifier, Ref<IPC::StreamServerConnection>&&);
@@ -208,8 +203,6 @@ private:
 
     void getImageBufferResourceLimitsForTesting(CompletionHandler<void(WebCore::ImageBufferResourceLimits)>&&);
 
-    void cleanupImageBufferForSelfCopy();
-
     const Ref<IPC::StreamConnectionWorkQueue> m_workQueue;
     const Ref<IPC::StreamServerConnection> m_streamConnection;
     const Ref<GPUConnectionToWebProcess> m_gpuConnectionToWebProcess;
@@ -218,9 +211,6 @@ private:
     WebCore::ProcessIdentity m_resourceOwner;
     RemoteRenderingBackendIdentifier m_renderingBackendIdentifier;
     RefPtr<WebCore::SharedMemory> m_getPixelBufferSharedMemory;
-
-    RefPtr<WebCore::ImageBuffer> m_imageBufferForSelfCopy  WTF_GUARDED_BY_CAPABILITY(workQueue());
-    std::unique_ptr<WebCore::Timer> m_imageBufferForSelfCopyTimer  WTF_GUARDED_BY_CAPABILITY(workQueue());
 
     HashMap<WebCore::RenderingResourceIdentifier, IPC::ScopedActiveMessageReceiveQueue<RemoteImageBuffer>> m_remoteImageBuffers WTF_GUARDED_BY_CAPABILITY(workQueue());
 


### PR DESCRIPTION
#### ec1b15dbe245893c7723126917f8d0ecd0cd3d44
<pre>
Unreviewed, reverting 311500@main (61c4954ff80a)
<a href="https://bugs.webkit.org/show_bug.cgi?id=313553">https://bugs.webkit.org/show_bug.cgi?id=313553</a>
<a href="https://rdar.apple.com/175124148">rdar://175124148</a>

This appears to cause us to use purged IOSurfaces unexpectedly.

* Source/WebKit/GPUProcess/graphics/RemoteImageBufferGraphicsContext.cpp:
(WebKit::RemoteImageBufferGraphicsContext::drawImageBuffer):
* Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.cpp:
(WebKit::RemoteRenderingBackend::workQueueUninitialize):
(WebKit::RemoteRenderingBackend::createImageBufferForSelfCopy): Deleted.
(WebKit::RemoteRenderingBackend::returnImageBufferForSelfCopy): Deleted.
(WebKit::RemoteRenderingBackend::cleanupImageBufferForSelfCopy): Deleted.
* Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.h:
(WebKit::RemoteRenderingBackend::identifier):

Canonical link: <a href="https://commits.webkit.org/312230@main">https://commits.webkit.org/312230@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/18490c45c688a205bbda8302ab16a4cad0ce4689

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/159247 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/32675 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/25780 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/168077 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/113625 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/bb57d111-9a39-4edf-a60b-aa4f90a6f211) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/32743 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/32662 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/123380 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/113625 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/7d4138da-81c1-4ce1-a274-7ed1ea43371f) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/162204 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/25655 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/143030 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/104047 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/49d85fd3-1d9b-41aa-9734-8b21dbb51aeb) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/24708 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/23127 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/15849 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/134395 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/170571 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/16554 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/22436 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/131574 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/32364 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/27199 "Found 1 new test failure: http/tests/security/javascriptURL/xss-ALLOWED-to-javascript-url-from-javscript-url.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/131685 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35626 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/32308 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/142603 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/90387 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/26380 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/19412 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/31819 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/98211 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/31339 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/31612 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/31494 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->