### PR TITLE
Remove all KVO observers before calling [m_objcObserver disconnect] in WebCore::MediaPlayerPrivateAVFoundationObjC::cancelLoad()

### DIFF
--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.mm
@@ -477,6 +477,22 @@ void MediaPlayerPrivateAVFoundationObjC::cancelLoad()
     tearDownVideoRendering();
 
     [[NSNotificationCenter defaultCenter] removeObserver:m_objcObserver];
+
+    // Remove all KVO observers BEFORE disconnecting the observer object.
+    if (m_avPlayerItem) {
+        for (NSString *keyName in itemKVOProperties())
+            [m_avPlayerItem removeObserver:m_objcObserver.get() forKeyPath:keyName];
+    }
+
+    if (m_avPlayer) {
+        for (NSString *keyName in playerKVOProperties())
+            [m_avPlayer removeObserver:m_objcObserver.get() forKeyPath:keyName];
+        setShouldObserveTimeControlStatus(false);
+    }
+
+    for (AVPlayerItemTrack *track in m_cachedTracks.get())
+        [track removeObserver:m_objcObserver.get() forKeyPath:@"enabled"];
+
     [m_objcObserver disconnect];
 
     // Tell our observer to do nothing when our cancellation of pending loading calls its completion handler.
@@ -507,21 +523,13 @@ void MediaPlayerPrivateAVFoundationObjC::cancelLoad()
         m_metadataOutput = nil;
     }
 
-    if (m_avPlayerItem) {
-        for (NSString *keyName in itemKVOProperties())
-            [m_avPlayerItem removeObserver:m_objcObserver.get() forKeyPath:keyName];
-
+    if (m_avPlayerItem)
         m_avPlayerItem = nil;
-    }
+
     if (m_avPlayer) {
         if (m_timeObserver)
             [m_avPlayer removeTimeObserver:m_timeObserver];
         m_timeObserver = nil;
-
-        for (NSString *keyName in playerKVOProperties())
-            [m_avPlayer removeObserver:m_objcObserver forKeyPath:keyName];
-
-        setShouldObserveTimeControlStatus(false);
 
         [m_avPlayer replaceCurrentItemWithPlayerItem:nil];
 #if !PLATFORM(IOS_FAMILY)
@@ -557,8 +565,6 @@ void MediaPlayerPrivateAVFoundationObjC::cancelLoad()
     m_cachedDuration = MediaTime::zeroTime();
     m_buffered.clear();
 
-    for (AVPlayerItemTrack *track in m_cachedTracks.get())
-        [track removeObserver:m_objcObserver.get() forKeyPath:@"enabled"];
     m_cachedTracks = nullptr;
     m_chapterTracks.clear();
 


### PR DESCRIPTION
#### f2a3aa2211b24b76ef86c189d19828d07576e1f6
<pre>
Remove all KVO observers before calling [m_objcObserver disconnect] in WebCore::MediaPlayerPrivateAVFoundationObjC::cancelLoad()
&lt;<a href="https://bugs.webkit.org/show_bug.cgi?id=307543">https://bugs.webkit.org/show_bug.cgi?id=307543</a>&gt;
&lt;<a href="https://rdar.apple.com/161488988">rdar://161488988</a>&gt;

Reviewed by Per Arne Vollan.

MTE detects a crash when Foundation&apos;s KVO infrastructure encounters stale
weak references in its internal hash tables while processing
`-removeObserver:forKeyPath:` calls.  The current cleanup order calls
`[m_objcObserver disconnect]` before removing KVO observers from
`m_avPlayerItem`, `m_avPlayer`, and `m_cachedTracks`.

The fix consolidates all KVO observer removal to happen before calling
`[m_objcObserver disconnect]`.  This follows the standard practice
where KVO observers are removed before invalidating the observer object.

Covered by existing tests.

* Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.mm:
(WebCore::MediaPlayerPrivateAVFoundationObjC::cancelLoad):

Originally-landed-as: 305413.290@safari-7624-branch (1c952d61fc64). <a href="https://rdar.apple.com/173969070">rdar://173969070</a>
Canonical link: <a href="https://commits.webkit.org/312223@main">https://commits.webkit.org/312223@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2c7409ae16b22f6dcc00fad99554d969e5aee272

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/159254 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/32682 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/25787 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/168084 "Built successfully") | [⏳ 🛠 win ](https://ews-build.webkit.org/#/builders/Win-Build-EWS "Waiting in queue, processing has not started yet") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/96494fa7-ff22-4d6e-9486-3ae7b779744c) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/161123 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/32750 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/32669 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/123385 "Passed tests") | [⏳ 🧪 win-tests ](https://ews-build.webkit.org/#/builders/Win-Build-EWS "Waiting in queue, processing has not started yet") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/ca482944-1395-420c-a336-465b8c431f85) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/162211 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/25649 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/143042 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/104052 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/19275604-548b-42dd-a060-93303a8c99ab) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/24702 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/23132 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/15856 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/134388 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/20822 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/170578 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/16569 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/22448 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/131579 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/32371 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/27204 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/131690 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35620 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/32315 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/142615 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/90394 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/26383 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/19424 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/31826 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/98223 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/31346 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/31619 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/31501 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->