### PR TITLE
CSP object-src with an empty source list should block plugin elements without a data/src attribute

### DIFF
--- a/LayoutTests/http/tests/security/contentSecurityPolicy/object-src-param-src-blocked2-expected.txt
+++ b/LayoutTests/http/tests/security/contentSecurityPolicy/object-src-param-src-blocked2-expected.txt
@@ -1,2 +1,2 @@
-CONSOLE MESSAGE: Refused to load because it does not appear in the object-src directive of the Content Security Policy.
+CONSOLE MESSAGE: Refused to load http://127.0.0.1:8000/security/contentSecurityPolicy/object-src-param-src-blocked2.html because it does not appear in the object-src directive of the Content Security Policy.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/object-src/object-src-no-url-embed-blocked-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/object-src/object-src-no-url-embed-blocked-expected.txt
@@ -1,0 +1,4 @@
+
+
+PASS Should block the embed and fire a spv
+

--- a/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/object-src/object-src-no-url-embed-blocked.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/object-src/object-src-no-url-embed-blocked.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+    <meta http-equiv="Content-Security-Policy" content="object-src 'none'; script-src 'self' 'unsafe-inline';">
+    <script src="/resources/testharness.js"></script>
+    <script src="/resources/testharnessreport.js"></script>
+</head>
+
+<body>
+    <script>
+       var t = async_test("Should block the embed and fire a spv");
+       window.addEventListener('securitypolicyviolation', t.step_func_done(function(e) {
+         assert_equals(e.violatedDirective, "object-src");
+       }));
+    </script>
+
+    <embed type="text/html">
+</body>
+
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/object-src/object-src-no-url-empty-source-list-blocked-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/object-src/object-src-no-url-empty-source-list-blocked-expected.txt
@@ -1,0 +1,4 @@
+
+
+PASS Empty object-src source list should block the object and fire a spv
+

--- a/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/object-src/object-src-no-url-empty-source-list-blocked.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/object-src/object-src-no-url-empty-source-list-blocked.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+    <meta http-equiv="Content-Security-Policy" content="object-src; script-src 'self' 'unsafe-inline';">
+    <script src="/resources/testharness.js"></script>
+    <script src="/resources/testharnessreport.js"></script>
+</head>
+
+<body>
+    <script>
+       var t = async_test("Empty object-src source list should block the object and fire a spv");
+       window.addEventListener('securitypolicyviolation', t.step_func_done(function(e) {
+         assert_equals(e.violatedDirective, "object-src");
+       }));
+    </script>
+
+    <object type="text/html"></object>
+</body>
+
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/object-src/object-src-no-url-empty-source-list-embed-blocked-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/object-src/object-src-no-url-empty-source-list-embed-blocked-expected.txt
@@ -1,0 +1,4 @@
+
+
+PASS Empty object-src source list should block the embed and fire a spv
+

--- a/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/object-src/object-src-no-url-empty-source-list-embed-blocked.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/object-src/object-src-no-url-empty-source-list-embed-blocked.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+    <meta http-equiv="Content-Security-Policy" content="object-src; script-src 'self' 'unsafe-inline';">
+    <script src="/resources/testharness.js"></script>
+    <script src="/resources/testharnessreport.js"></script>
+</head>
+
+<body>
+    <script>
+       var t = async_test("Empty object-src source list should block the embed and fire a spv");
+       window.addEventListener('securitypolicyviolation', t.step_func_done(function(e) {
+         assert_equals(e.violatedDirective, "object-src");
+       }));
+    </script>
+
+    <embed type="text/html">
+</body>
+
+</html>

--- a/Source/WebCore/page/csp/ContentSecurityPolicy.cpp
+++ b/Source/WebCore/page/csp/ContentSecurityPolicy.cpp
@@ -620,18 +620,16 @@ bool ContentSecurityPolicy::allowObjectFromSource(const URL& url, std::optional<
         }
     }
 
-    if (m_policies.isEmpty() || LegacySchemeRegistry::schemeShouldBypassContentSecurityPolicy(url.protocol()))
+    const auto& urlToCheck = url.isEmpty() ? m_protectedURL : url;
+    if (m_policies.isEmpty() || LegacySchemeRegistry::schemeShouldBypassContentSecurityPolicy(urlToCheck.protocol()))
         return true;
-    // As per section object-src of the Content Security Policy Level 3 spec., <http://w3c.github.io/webappsec-csp> (Editor's Draft, 29 February 2016),
-    // "If plugin content is loaded without an associated URL (perhaps an object element lacks a data attribute, but loads some default plugin based
-    // on the specified type), it MUST be blocked if object-src's value is 'none', but will otherwise be allowed".
     String sourceURL;
-    const auto& blockedURL = !preRedirectURL.isNull() ? preRedirectURL : url;
-    auto handleViolatedDirective = [checkedThis = CheckedRef { *this }, &sourceURL, sourcePosition = WTF::move(sourcePosition), &blockedURL, &url](const ContentSecurityPolicyDirective& violatedDirective) mutable {
-        String consoleMessage = consoleMessageForViolation(violatedDirective, url, "Refused to load"_s);
+    const auto& blockedURL = !preRedirectURL.isNull() ? preRedirectURL : urlToCheck;
+    auto handleViolatedDirective = [checkedThis = CheckedRef { *this }, &sourceURL, sourcePosition = WTF::move(sourcePosition), &blockedURL, &urlToCheck](const ContentSecurityPolicyDirective& violatedDirective) mutable {
+        String consoleMessage = consoleMessageForViolation(violatedDirective, urlToCheck, "Refused to load"_s);
         checkedThis->reportViolation(violatedDirective, blockedURL.string(), consoleMessage, sourceURL, StringView(), WTF::move(sourcePosition));
     };
-    return allPoliciesAllow(handleViolatedDirective, &ContentSecurityPolicyDirectiveList::violatedDirectiveForObjectSource, url, redirectResponseReceived == RedirectResponseReceived::Yes, ContentSecurityPolicySourceListDirective::ShouldAllowEmptyURLIfSourceListIsNotNone::Yes);
+    return allPoliciesAllow(handleViolatedDirective, &ContentSecurityPolicyDirectiveList::violatedDirectiveForObjectSource, urlToCheck, redirectResponseReceived == RedirectResponseReceived::Yes);
 }
 
 bool ContentSecurityPolicy::allowChildFrameFromSource(const URL& url, std::optional<TextPosition>&& sourcePosition, RedirectResponseReceived redirectResponseReceived) const

--- a/Source/WebCore/page/csp/ContentSecurityPolicyDirectiveList.cpp
+++ b/Source/WebCore/page/csp/ContentSecurityPolicyDirectiveList.cpp
@@ -84,9 +84,9 @@ static inline bool NODELETE checkNonParserInsertedScripts(ContentSecurityPolicyS
     return directive->allowNonParserInsertedScripts() && parserInserted == ParserInserted::No;
 }
 
-static inline bool checkSource(ContentSecurityPolicySourceListDirective* directive, const URL& url, bool didReceiveRedirectResponse = false, ContentSecurityPolicySourceListDirective::ShouldAllowEmptyURLIfSourceListIsNotNone shouldAllowEmptyURLIfSourceListEmpty = ContentSecurityPolicySourceListDirective::ShouldAllowEmptyURLIfSourceListIsNotNone::No)
+static inline bool checkSource(ContentSecurityPolicySourceListDirective* directive, const URL& url, bool didReceiveRedirectResponse = false)
 {
-    return !directive || directive->allows(url, didReceiveRedirectResponse, shouldAllowEmptyURLIfSourceListEmpty);
+    return !directive || directive->allows(url, didReceiveRedirectResponse);
 }
 
 static inline bool checkHashes(ContentSecurityPolicySourceListDirective* directive, const Vector<ContentSecurityPolicyHash>& hashes)
@@ -118,7 +118,7 @@ static inline bool checkFrameAncestors(ContentSecurityPolicySourceListDirective*
         if (!localFrame)
             continue;
         URL origin = urlFromOrigin(protect(protect(localFrame->document())->securityOrigin()));
-        if (!origin.isValid() || !directive->allows(origin, didReceiveRedirectResponse, ContentSecurityPolicySourceListDirective::ShouldAllowEmptyURLIfSourceListIsNotNone::No))
+        if (!origin.isValid() || !directive->allows(origin, didReceiveRedirectResponse))
             return false;
     }
     return true;
@@ -131,7 +131,7 @@ static inline bool checkFrameAncestors(ContentSecurityPolicySourceListDirective*
     bool didReceiveRedirectResponse = false;
     for (auto& origin : ancestorOrigins) {
         URL originURL = urlFromOrigin(origin);
-        if (!originURL.isValid() || !directive->allows(originURL, didReceiveRedirectResponse, ContentSecurityPolicySourceListDirective::ShouldAllowEmptyURLIfSourceListIsNotNone::No))
+        if (!originURL.isValid() || !directive->allows(originURL, didReceiveRedirectResponse))
             return false;
     }
     return true;
@@ -404,12 +404,12 @@ const ContentSecurityPolicyDirective* ContentSecurityPolicyDirectiveList::violat
     return operativeDirective;
 }
 
-const ContentSecurityPolicyDirective* ContentSecurityPolicyDirectiveList::violatedDirectiveForObjectSource(const URL& url, bool didReceiveRedirectResponse, ContentSecurityPolicySourceListDirective::ShouldAllowEmptyURLIfSourceListIsNotNone shouldAllowEmptyURLIfSourceListEmpty) const
+const ContentSecurityPolicyDirective* ContentSecurityPolicyDirectiveList::violatedDirectiveForObjectSource(const URL& url, bool didReceiveRedirectResponse) const
 {
     if (url.protocolIsAbout())
         return nullptr;
     auto* operativeDirective = this->operativeDirective(m_objectSrc.get(), ContentSecurityPolicyDirectiveNames::objectSrc);
-    if (checkSource(operativeDirective, url, didReceiveRedirectResponse, shouldAllowEmptyURLIfSourceListEmpty))
+    if (checkSource(operativeDirective, url, didReceiveRedirectResponse))
         return nullptr;
     return operativeDirective;
 }

--- a/Source/WebCore/page/csp/ContentSecurityPolicyDirectiveList.h
+++ b/Source/WebCore/page/csp/ContentSecurityPolicyDirectiveList.h
@@ -72,7 +72,7 @@ public:
     const ContentSecurityPolicyDirective* violatedDirectiveForManifest(const URL&, bool didReceiveRedirectResponse) const LIFETIME_BOUND;
 #endif
     const ContentSecurityPolicyDirective* violatedDirectiveForMedia(const URL&, bool didReceiveRedirectResponse) const LIFETIME_BOUND;
-    const ContentSecurityPolicyDirective* violatedDirectiveForObjectSource(const URL&, bool didReceiveRedirectResponse, ContentSecurityPolicySourceListDirective::ShouldAllowEmptyURLIfSourceListIsNotNone) const LIFETIME_BOUND;
+    const ContentSecurityPolicyDirective* violatedDirectiveForObjectSource(const URL&, bool didReceiveRedirectResponse) const LIFETIME_BOUND;
     const ContentSecurityPolicyDirective* violatedDirectiveForPluginType(const String& type, const String& typeAttribute) const LIFETIME_BOUND;
     bool hasPluginTypesDirective() const { return !!m_pluginTypes; }
     const ContentSecurityPolicyDirective* violatedDirectiveForScript(const URL&, bool didReceiveRedirectResponse, const Vector<ResourceCryptographicDigest>&, const String&) const LIFETIME_BOUND;

--- a/Source/WebCore/page/csp/ContentSecurityPolicySourceListDirective.cpp
+++ b/Source/WebCore/page/csp/ContentSecurityPolicySourceListDirective.cpp
@@ -43,10 +43,10 @@ ContentSecurityPolicySourceListDirective::ContentSecurityPolicySourceListDirecti
     m_sourceList.parse(value);
 }
 
-bool ContentSecurityPolicySourceListDirective::allows(const URL& url, bool didReceiveRedirectResponse, ShouldAllowEmptyURLIfSourceListIsNotNone shouldAllowEmptyURLIfSourceListEmpty)
+bool ContentSecurityPolicySourceListDirective::allows(const URL& url, bool didReceiveRedirectResponse)
 {
     if (url.isEmpty())
-        return shouldAllowEmptyURLIfSourceListEmpty == ShouldAllowEmptyURLIfSourceListIsNotNone::Yes && !m_sourceList.isNone();
+        return false;
     return m_sourceList.matches(url, didReceiveRedirectResponse);
 }
 

--- a/Source/WebCore/page/csp/ContentSecurityPolicySourceListDirective.h
+++ b/Source/WebCore/page/csp/ContentSecurityPolicySourceListDirective.h
@@ -39,8 +39,7 @@ class ContentSecurityPolicySourceListDirective : public ContentSecurityPolicyDir
 public:
     ContentSecurityPolicySourceListDirective(const ContentSecurityPolicyDirectiveList&, const String& name, const String& value);
 
-    enum class ShouldAllowEmptyURLIfSourceListIsNotNone : bool { No, Yes };
-    bool allows(const URL&, bool didReceiveRedirectResponse, ShouldAllowEmptyURLIfSourceListIsNotNone);
+    bool allows(const URL&, bool didReceiveRedirectResponse);
     bool allows(const Vector<ContentSecurityPolicyHash>&) const;
     bool containsAllHashes(const Vector<ContentSecurityPolicyHash>&) const;
     bool allowUnsafeHashes(const Vector<ContentSecurityPolicyHash>&) const;


### PR DESCRIPTION
#### c6228aba1c0fe9fe956dbd7315d585715d88328b
<pre>
CSP object-src with an empty source list should block plugin elements without a data/src attribute
<a href="https://bugs.webkit.org/show_bug.cgi?id=308775">https://bugs.webkit.org/show_bug.cgi?id=308775</a>
<a href="https://rdar.apple.com/171298717">rdar://171298717</a>

Reviewed by Brent Fulgham.

When an &lt;object&gt; or &lt;embed&gt; element has no data/src attribute, WebKit previously passed an empty URL
to the CSP check with special-case logic that only blocked for the literal &apos;none&apos; keyword. An empty
source list (object-src;) was incorrectly allowed despite being equivalent to &apos;none&apos; per CSP Level 3 §6.7.2.7.

Remove the special-case handling from §6.1.9 entirely. Instead, use the document&apos;s own URL as a fallback for source list
matching when the element has no associated URL. The document URL will naturally fail to match empty source lists
and &apos;none&apos; (blocked), but will match &apos;self&apos; or wildcard (allowed).

Tests: imported/w3c/web-platform-tests/content-security-policy/object-src/object-src-no-url-embed-blocked.html
       imported/w3c/web-platform-tests/content-security-policy/object-src/object-src-no-url-empty-source-list-blocked.html
       imported/w3c/web-platform-tests/content-security-policy/object-src/object-src-no-url-empty-source-list-embed-blocked.html

* LayoutTests/http/tests/security/contentSecurityPolicy/object-src-param-src-blocked2-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/content-security-policy/object-src/object-src-no-url-embed-blocked-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/content-security-policy/object-src/object-src-no-url-embed-blocked.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/content-security-policy/object-src/object-src-no-url-empty-source-list-blocked-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/content-security-policy/object-src/object-src-no-url-empty-source-list-blocked.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/content-security-policy/object-src/object-src-no-url-empty-source-list-embed-blocked-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/content-security-policy/object-src/object-src-no-url-empty-source-list-embed-blocked.html: Added.
* Source/WebCore/page/csp/ContentSecurityPolicy.cpp:
(WebCore::ContentSecurityPolicy::allowObjectFromSource const):
* Source/WebCore/page/csp/ContentSecurityPolicyDirectiveList.cpp:
(WebCore::checkSource):
(WebCore::checkFrameAncestors):
(WebCore::ContentSecurityPolicyDirectiveList::violatedDirectiveForObjectSource const):
* Source/WebCore/page/csp/ContentSecurityPolicyDirectiveList.h:
* Source/WebCore/page/csp/ContentSecurityPolicySourceListDirective.cpp:
(WebCore::ContentSecurityPolicySourceListDirective::allows):
* Source/WebCore/page/csp/ContentSecurityPolicySourceListDirective.h:

Canonical link: <a href="https://commits.webkit.org/312899@main">https://commits.webkit.org/312899@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4a2efef0116b3dedcd0a861eeefe2f5103b231df

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/161226 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/34699 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/27800 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/170129 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/117597 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/163095 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/34800 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/34700 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/125062 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/117597 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/164185 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/27347 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/144822 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/105659 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/26395 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/24895 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/17849 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/136089 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/22583 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/172612 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/19633 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/24224 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/133340 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/34373 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/28988 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/133349 "Passed tests") | | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/36062 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/34358 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/144378 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/96223 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/27896 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/21196 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/33868 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/101293 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/33367 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/33611 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/33516 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->