### PR TITLE
REGRESSION (310265@main): Gaze glow region for slider thumb is too large

### DIFF
--- a/LayoutTests/interaction-region/form-control-refresh/slider-thumb-native-interaction-region-expected.txt
+++ b/LayoutTests/interaction-region/form-control-refresh/slider-thumb-native-interaction-region-expected.txt
@@ -11,15 +11,15 @@
         (rect (0,0) width=1600 height=2094)
 
       (interaction regions [
-        (interaction (42,-10.50) width=49 height=41)
+        (interaction (54.50,2) width=24 height=16)
         (cornerRadius 8.00)
         (useContinuousCorners 1),
         (interaction (163.50,42) width=72 height=48)
         (cornerRadius 24.00)
         (useContinuousCorners 1),
-        (interaction (42,7.50) width=49 height=41)
+        (interaction (54.50,20) width=24 height=16)
         (cornerRadius 8.00)
-        (clipPath move to (36.50,20.50), add line to (16.22,27.26), add curve to (14.79,26.38) (13.68,25.04) (13.07,23.46), add curve to (12.69,22.52) (12.50,21.51) (12.50,20.50), add curve to (12.50,19.49) (12.69,18.48) (13.07,17.54), add curve to (13.70,15.95) (14.81,14.63) (16.24,13.75), close subpath),
+        (clipPath move to (24,8), add line to (3.72,14.76), add curve to (2.29,13.88) (1.18,12.54) (0.57,10.96), add curve to (0.19,10.02) (0,9.01) (0,8), add curve to (0,6.99) (0.19,5.98) (0.57,5.04), add curve to (1.20,3.45) (2.31,2.13) (3.74,1.25), close subpath),
         (interaction (163.50,96) width=72 height=48)
         (cornerRadius 24.00)
         (clipPath move to (72,24), add line to (11.17,44.28), add curve to (6.87,41.65) (3.53,37.62) (1.70,32.88), add curve to (0.58,30.06) (0,27.04) (0,24), add curve to (0,20.96) (0.58,17.94) (1.70,15.12), add curve to (3.60,10.36) (6.92,6.38) (11.22,3.74), close subpath)])

--- a/LayoutTests/interaction-region/input-type-range-region-expected.txt
+++ b/LayoutTests/interaction-region/input-type-range-region-expected.txt
@@ -12,7 +12,8 @@
         (rect (0,0) width=800 height=600)
 
       (interaction regions [
-        (interaction (42,-10.50) width=49 height=41)
+        (guard (54.50,-8) width=24 height=36),
+        (interaction (54.50,2) width=24 height=16)
         (cornerRadius 8.00)
         (useContinuousCorners 1)])
       )

--- a/Source/WebCore/rendering/cocoa/RenderThemeCocoa.mm
+++ b/Source/WebCore/rendering/cocoa/RenderThemeCocoa.mm
@@ -4767,17 +4767,6 @@ FloatSize RenderThemeCocoa::inflateRectForInteractionRegion(const RenderElement&
         return { cssBorderWidth, cssBorderWidth };
     }
 
-    // These values were chosen to match UIKit.
-    auto appearance = box.style().usedAppearance();
-    if (appearance == StyleAppearance::SliderThumbHorizontal || appearance == StyleAppearance::SliderThumbVertical) {
-        static constexpr float thumbMinDimension = 48;
-        static constexpr float thumbHitAreaExpansion = 12.5;
-        if (rect.width() < thumbMinDimension || rect.height() < thumbMinDimension) {
-            rect.inflate(thumbHitAreaExpansion);
-            return { thumbHitAreaExpansion, thumbHitAreaExpansion };
-        }
-    }
-
     return { 0, 0 };
 }
 


### PR DESCRIPTION
#### f199b1af08dbe23da50ee3d91bdf7fb6aa7a89bc
<pre>
REGRESSION (310265@main): Gaze glow region for slider thumb is too large
<a href="https://bugs.webkit.org/show_bug.cgi?id=313574">https://bugs.webkit.org/show_bug.cgi?id=313574</a>
<a href="https://rdar.apple.com/174429082">rdar://174429082</a>

Reviewed by Lily Spiniolas, Aditya Keerthi, and Abrar Rahman Protyasha.

The problem: The previous fix 310265@main <a href="https://github.com/WebKit/WebKit/pull/60950">https://github.com/WebKit/WebKit/pull/60950</a>
expanded the slider thumb&apos;s touch hit area and interaction region by 12.5pt when either
dimension is below 48pt. The touch hit area was correct and matched UIKit, but
the interaction region (the visible gaze glow highlight) was too large.

The fix: UIKit does not enlarge the gaze glow, so to match that behaviour, the
interaction region inflation for slider thumbs in inflateRectForInteractionRegion
is removed.

* LayoutTests/interaction-region/form-control-refresh/slider-thumb-native-interaction-region-expected.txt:
* LayoutTests/interaction-region/input-type-range-region-expected.txt:
* Source/WebCore/rendering/cocoa/RenderThemeCocoa.mm:
(WebCore::RenderThemeCocoa::inflateRectForInteractionRegion):

Canonical link: <a href="https://commits.webkit.org/312271@main">https://commits.webkit.org/312271@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/12efa33348018be474813e25b8386cd9e8824f2f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/159328 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/32756 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/25862 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/168158 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/113706 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/161197 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/32824 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/32743 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/123445 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/86649 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/162285 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/25712 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/143112 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/104112 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/24765 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/23199 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/15931 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/134452 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/20892 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/170652 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/16686 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/22518 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/131649 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/32445 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/27273 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/131761 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35653 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/32389 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/142685 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/90514 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/26443 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/19494 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/31900 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/98352 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/31420 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/31693 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/31575 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->