### PR TITLE
[iOS] currentTime updates only as often as a MediaDeviceRoute updates currentPlaybackPosition

### DIFF
--- a/LayoutTests/media/wireless-playback-media-player/current-time-advances-between-position-updates-expected.txt
+++ b/LayoutTests/media/wireless-playback-media-player/current-time-advances-between-position-updates-expected.txt
@@ -1,0 +1,14 @@
+
+Test that currentTime advances past a route position update as the CMTimebase continues to run.
+
+RUN(internals.mockMediaDeviceRouteController.activateRoute(route))
+RUN(video.src = findMediaFile('video', '../content/test'))
+RUN(route.playbackRate = 1)
+RUN(route.timeRange = { start: 0, duration: 60 })
+RUN(video.play())
+RUN(route.ready = true)
+EVENT(canplaythrough)
+RUN(route.currentPlaybackPosition = 10)
+EXPECTED (video.currentTime > 10) OK
+END OF TEST
+

--- a/LayoutTests/media/wireless-playback-media-player/current-time-advances-between-position-updates.html
+++ b/LayoutTests/media/wireless-playback-media-player/current-time-advances-between-position-updates.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html><!-- webkit-test-runner [ WirelessPlaybackMediaPlayerEnabled=true ] -->
+<html>
+    <head>
+        <script src='../media-file.js'></script>
+        <script src='../video-test.js'></script>
+        <script>
+            var route;
+            var video;
+
+            async function start()
+            {
+                if (window.internals)
+                    internals.mockMediaDeviceRouteController.enabled = true;
+
+                route = internals.mockMediaDeviceRouteController.createMockMediaDeviceRoute();
+                run(`internals.mockMediaDeviceRouteController.activateRoute(route)`);
+
+                const urlPromise = new Promise((resolve) => {
+                    route.setURLCallback(async (url) => {
+                        resolve(url);
+                    });
+                });
+
+                video = document.getElementsByTagName('video')[0];
+                run(`video.src = findMediaFile('video', '../content/test')`);
+                run(`route.playbackRate = 1`);
+                run(`route.timeRange = { start: 0, duration: 60 }`);
+                run(`video.play()`);
+                await urlPromise;
+
+                const canplaythroughPromise = waitFor(video, 'canplaythrough');
+                run(`route.ready = true`);
+                await canplaythroughPromise;
+
+                run(`route.currentPlaybackPosition = 10`);
+                await waitForConditionOrTimeout('video.currentTime > 10', false, 2000);
+
+                endTest();
+            }
+        </script>
+    </head>
+    <body onload='start()'>
+        <video controls></video>
+        <p>Test that currentTime advances past a route position update as the CMTimebase continues to run.</p>
+    </body>
+</html>

--- a/LayoutTests/media/wireless-playback-media-player/current-time-resumes-after-pause-expected.txt
+++ b/LayoutTests/media/wireless-playback-media-player/current-time-resumes-after-pause-expected.txt
@@ -1,0 +1,17 @@
+
+Test that the CMTimebase resumes advancing currentTime after a pause and play.
+
+RUN(internals.mockMediaDeviceRouteController.activateRoute(route))
+RUN(video.src = findMediaFile('video', '../content/test'))
+RUN(route.playbackRate = 1)
+RUN(route.timeRange = { start: 0, duration: 60 })
+RUN(video.play())
+RUN(route.ready = true)
+EVENT(canplaythrough)
+EVENT(timeupdate)
+RUN(video.pause())
+RUN(video.play())
+EVENT(timeupdate)
+EXPECTED (video.currentTime > 0 == 'true') OK
+END OF TEST
+

--- a/LayoutTests/media/wireless-playback-media-player/current-time-resumes-after-pause.html
+++ b/LayoutTests/media/wireless-playback-media-player/current-time-resumes-after-pause.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html><!-- webkit-test-runner [ WirelessPlaybackMediaPlayerEnabled=true ] -->
+<html>
+    <head>
+        <script src='../media-file.js'></script>
+        <script src='../video-test.js'></script>
+        <script>
+            var route;
+            var video;
+
+            async function start()
+            {
+                if (window.internals)
+                    internals.mockMediaDeviceRouteController.enabled = true;
+
+                route = internals.mockMediaDeviceRouteController.createMockMediaDeviceRoute();
+                run(`internals.mockMediaDeviceRouteController.activateRoute(route)`);
+
+                const urlPromise = new Promise((resolve) => {
+                    route.setURLCallback(async (url) => {
+                        resolve(url);
+                    });
+                });
+
+                video = document.getElementsByTagName('video')[0];
+                run(`video.src = findMediaFile('video', '../content/test')`);
+                run(`route.playbackRate = 1`);
+                run(`route.timeRange = { start: 0, duration: 60 }`);
+                run(`video.play()`);
+                await urlPromise;
+
+                const canplaythroughPromise = waitFor(video, 'canplaythrough');
+                run(`route.ready = true`);
+                await canplaythroughPromise;
+
+                await waitFor(video, 'timeupdate');
+                run(`video.pause()`);
+                run(`video.play()`);
+                await waitFor(video, 'timeupdate');
+                testExpected('video.currentTime > 0', true);
+
+                endTest();
+            }
+        </script>
+    </head>
+    <body onload='start()'>
+        <video controls></video>
+        <p>Test that the CMTimebase resumes advancing currentTime after a pause and play.</p>
+    </body>
+</html>

--- a/LayoutTests/media/wireless-playback-media-player/current-time-updates-after-rate-change-expected.txt
+++ b/LayoutTests/media/wireless-playback-media-player/current-time-updates-after-rate-change-expected.txt
@@ -1,0 +1,17 @@
+
+Test that currentTime advances at the correct rate after a playback rate change.
+
+RUN(internals.mockMediaDeviceRouteController.activateRoute(route))
+RUN(video.src = findMediaFile('video', '../content/test'))
+RUN(route.playbackRate = 1)
+RUN(route.timeRange = { start: 0, duration: 60 })
+RUN(video.play())
+RUN(route.ready = true)
+EVENT(canplaythrough)
+RUN(route.currentPlaybackPosition = 10)
+EVENT(timeupdate)
+RUN(video.playbackRate = 2)
+EXPECTED (video.currentTime > 14) OK
+EXPECTED (video.playbackRate == '2') OK
+END OF TEST
+

--- a/LayoutTests/media/wireless-playback-media-player/current-time-updates-after-rate-change.html
+++ b/LayoutTests/media/wireless-playback-media-player/current-time-updates-after-rate-change.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html><!-- webkit-test-runner [ WirelessPlaybackMediaPlayerEnabled=true ] -->
+<html>
+    <head>
+        <script src='../media-file.js'></script>
+        <script src='../video-test.js'></script>
+        <script>
+            var route;
+            var video;
+
+            async function start()
+            {
+                if (window.internals)
+                    internals.mockMediaDeviceRouteController.enabled = true;
+
+                route = internals.mockMediaDeviceRouteController.createMockMediaDeviceRoute();
+                run(`internals.mockMediaDeviceRouteController.activateRoute(route)`);
+
+                const urlPromise = new Promise((resolve) => {
+                    route.setURLCallback(async (url) => {
+                        resolve(url);
+                    });
+                });
+
+                video = document.getElementsByTagName('video')[0];
+                run(`video.src = findMediaFile('video', '../content/test')`);
+                run(`route.playbackRate = 1`);
+                run(`route.timeRange = { start: 0, duration: 60 }`);
+                run(`video.play()`);
+                await urlPromise;
+
+                const canplaythroughPromise = waitFor(video, 'canplaythrough');
+                run(`route.ready = true`);
+                await canplaythroughPromise;
+
+                run(`route.currentPlaybackPosition = 10`);
+                await waitFor(video, 'timeupdate');
+
+                run(`video.playbackRate = 2`);
+                // At 2x from ~10s, reaching 14s takes ~2s wall clock.
+                // At 1x, it would take ~4s, exceeding the 3000ms timeout.
+                await waitForConditionOrTimeout('video.currentTime > 14', false, 3000);
+                testExpected('video.playbackRate', 2);
+
+                endTest();
+            }
+        </script>
+    </head>
+    <body onload='start()'>
+        <video controls></video>
+        <p>Test that currentTime advances at the correct rate after a playback rate change.</p>
+    </body>
+</html>

--- a/LayoutTests/media/wireless-playback-media-player/current-time-updates-after-route-seek-expected.txt
+++ b/LayoutTests/media/wireless-playback-media-player/current-time-updates-after-route-seek-expected.txt
@@ -1,0 +1,15 @@
+
+Test that currentTime updates after a seek driven by the route's currentPlaybackPosition.
+
+RUN(internals.mockMediaDeviceRouteController.activateRoute(route))
+RUN(video.src = findMediaFile('video', '../content/test'))
+RUN(route.playbackRate = 1)
+RUN(route.timeRange = { start: 0, duration: 60 })
+RUN(video.play())
+RUN(route.ready = true)
+EVENT(canplaythrough)
+EVENT(timeupdate)
+RUN(route.currentPlaybackPosition = 30)
+EXPECTED (video.currentTime > 29) OK
+END OF TEST
+

--- a/LayoutTests/media/wireless-playback-media-player/current-time-updates-after-route-seek.html
+++ b/LayoutTests/media/wireless-playback-media-player/current-time-updates-after-route-seek.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html><!-- webkit-test-runner [ WirelessPlaybackMediaPlayerEnabled=true ] -->
+<html>
+    <head>
+        <script src='../media-file.js'></script>
+        <script src='../video-test.js'></script>
+        <script>
+            var route;
+            var video;
+
+            async function start()
+            {
+                if (window.internals)
+                    internals.mockMediaDeviceRouteController.enabled = true;
+
+                route = internals.mockMediaDeviceRouteController.createMockMediaDeviceRoute();
+                run(`internals.mockMediaDeviceRouteController.activateRoute(route)`);
+
+                const urlPromise = new Promise((resolve) => {
+                    route.setURLCallback(async (url) => {
+                        resolve(url);
+                    });
+                });
+
+                video = document.getElementsByTagName('video')[0];
+                run(`video.src = findMediaFile('video', '../content/test')`);
+                run(`route.playbackRate = 1`);
+                run(`route.timeRange = { start: 0, duration: 60 }`);
+                run(`video.play()`);
+                await urlPromise;
+
+                const canplaythroughPromise = waitFor(video, 'canplaythrough');
+                run(`route.ready = true`);
+                await canplaythroughPromise;
+
+                await waitFor(video, 'timeupdate');
+                run(`route.currentPlaybackPosition = 30`);
+                // The timebase re-anchors at 30, so currentTime should jump to ~30.
+                // At rate 1 from 0, reaching 29 would take 29s, far beyond the timeout.
+                await waitForConditionOrTimeout('video.currentTime > 29', false, 2000);
+
+                endTest();
+            }
+        </script>
+    </head>
+    <body onload='start()'>
+        <video controls></video>
+        <p>Test that currentTime updates after a seek driven by the route's currentPlaybackPosition.</p>
+    </body>
+</html>

--- a/LayoutTests/media/wireless-playback-media-player/current-time-updates-after-seek-expected.txt
+++ b/LayoutTests/media/wireless-playback-media-player/current-time-updates-after-seek-expected.txt
@@ -1,0 +1,16 @@
+
+Test that currentTime continues to advance after a seek.
+
+RUN(internals.mockMediaDeviceRouteController.activateRoute(route))
+RUN(video.src = findMediaFile('video', '../content/test'))
+RUN(route.playbackRate = 1)
+RUN(route.timeRange = { start: 0, duration: 60 })
+RUN(video.play())
+RUN(route.ready = true)
+EVENT(canplaythrough)
+EVENT(timeupdate)
+RUN(video.currentTime = 30)
+EVENT(seeked)
+EXPECTED (video.currentTime > 30) OK
+END OF TEST
+

--- a/LayoutTests/media/wireless-playback-media-player/current-time-updates-after-seek.html
+++ b/LayoutTests/media/wireless-playback-media-player/current-time-updates-after-seek.html
@@ -1,0 +1,48 @@
+<!DOCTYPE html><!-- webkit-test-runner [ WirelessPlaybackMediaPlayerEnabled=true ] -->
+<html>
+    <head>
+        <script src='../media-file.js'></script>
+        <script src='../video-test.js'></script>
+        <script>
+            var route;
+            var video;
+
+            async function start()
+            {
+                if (window.internals)
+                    internals.mockMediaDeviceRouteController.enabled = true;
+
+                route = internals.mockMediaDeviceRouteController.createMockMediaDeviceRoute();
+                run(`internals.mockMediaDeviceRouteController.activateRoute(route)`);
+
+                const urlPromise = new Promise((resolve) => {
+                    route.setURLCallback(async (url) => {
+                        resolve(url);
+                    });
+                });
+
+                video = document.getElementsByTagName('video')[0];
+                run(`video.src = findMediaFile('video', '../content/test')`);
+                run(`route.playbackRate = 1`);
+                run(`route.timeRange = { start: 0, duration: 60 }`);
+                run(`video.play()`);
+                await urlPromise;
+
+                const canplaythroughPromise = waitFor(video, 'canplaythrough');
+                run(`route.ready = true`);
+                await canplaythroughPromise;
+
+                await waitFor(video, 'timeupdate');
+                run(`video.currentTime = 30`);
+                await waitFor(video, 'seeked');
+                await waitForConditionOrTimeout('video.currentTime > 30', false, 2000);
+
+                endTest();
+            }
+        </script>
+    </head>
+    <body onload='start()'>
+        <video controls></video>
+        <p>Test that currentTime continues to advance after a seek.</p>
+    </body>
+</html>

--- a/LayoutTests/media/wireless-playback-media-player/timeupdate-without-position-updates-expected.txt
+++ b/LayoutTests/media/wireless-playback-media-player/timeupdate-without-position-updates-expected.txt
@@ -1,0 +1,14 @@
+
+Test that the CMTimebase drives timeupdate and advances currentTime even without route position updates.
+
+RUN(internals.mockMediaDeviceRouteController.activateRoute(route))
+RUN(video.src = findMediaFile('video', '../content/test'))
+RUN(route.playbackRate = 1)
+RUN(route.timeRange = { start: 0, duration: 60 })
+RUN(video.play())
+RUN(route.ready = true)
+EVENT(canplaythrough)
+EVENT(timeupdate)
+EXPECTED (video.currentTime > 0 == 'true') OK
+END OF TEST
+

--- a/LayoutTests/media/wireless-playback-media-player/timeupdate-without-position-updates.html
+++ b/LayoutTests/media/wireless-playback-media-player/timeupdate-without-position-updates.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html><!-- webkit-test-runner [ WirelessPlaybackMediaPlayerEnabled=true ] -->
+<html>
+    <head>
+        <script src='../media-file.js'></script>
+        <script src='../video-test.js'></script>
+        <script>
+            var route;
+            var video;
+
+            async function start()
+            {
+                if (window.internals)
+                    internals.mockMediaDeviceRouteController.enabled = true;
+
+                route = internals.mockMediaDeviceRouteController.createMockMediaDeviceRoute();
+                run(`internals.mockMediaDeviceRouteController.activateRoute(route)`);
+
+                const urlPromise = new Promise((resolve) => {
+                    route.setURLCallback(async (url) => {
+                        resolve(url);
+                    });
+                });
+
+                video = document.getElementsByTagName('video')[0];
+                run(`video.src = findMediaFile('video', '../content/test')`);
+                run(`route.playbackRate = 1`);
+                run(`route.timeRange = { start: 0, duration: 60 }`);
+                run(`video.play()`);
+                await urlPromise;
+
+                const canplaythroughPromise = waitFor(video, 'canplaythrough');
+                run(`route.ready = true`);
+                await canplaythroughPromise;
+
+                await waitFor(video, 'timeupdate');
+                testExpected('video.currentTime > 0', true);
+
+                endTest();
+            }
+        </script>
+    </head>
+    <body onload='start()'>
+        <video controls></video>
+        <p>Test that the CMTimebase drives timeupdate and advances currentTime even without route position updates.</p>
+    </body>
+</html>

--- a/Source/WebCore/PAL/pal/cf/CoreMediaSoftLink.cpp
+++ b/Source/WebCore/PAL/pal/cf/CoreMediaSoftLink.cpp
@@ -139,7 +139,7 @@ SOFT_LINK_FUNCTION_FOR_SOURCE_WITH_EXPORT(PAL, CoreMedia, CMGetAttachment, CFTyp
 SOFT_LINK_FUNCTION_FOR_SOURCE_WITH_EXPORT(PAL, CoreMedia, CMSetAttachment, void, (CMAttachmentBearerRef target, CFStringRef key, CFTypeRef value, CMAttachmentMode attachmentMode), (target, key, value, attachmentMode), PAL_EXPORT)
 SOFT_LINK_FUNCTION_FOR_SOURCE_WITH_EXPORT(PAL, CoreMedia, CMRemoveAttachment, void, (CMAttachmentBearerRef target, CFStringRef key), (target, key), PAL_EXPORT)
 
-SOFT_LINK_FUNCTION_FOR_SOURCE_WITH_EXPORT(PAL, CoreMedia, CMTimebaseCreateWithMasterClock, OSStatus, (CFAllocatorRef allocator, CMClockRef masterClock, CMTimebaseRef* timebaseOut), (allocator, masterClock, timebaseOut), PAL_EXPORT)
+SOFT_LINK_FUNCTION_FOR_SOURCE_WITH_EXPORT(PAL, CoreMedia, CMTimebaseCreateWithSourceClock, OSStatus, (CFAllocatorRef allocator, CMClockRef masterClock, CMTimebaseRef* timebaseOut), (allocator, masterClock, timebaseOut), PAL_EXPORT)
 SOFT_LINK_FUNCTION_FOR_SOURCE_WITH_EXPORT(PAL, CoreMedia, CMTimebaseGetTime, CMTime, (CMTimebaseRef timebase), (timebase), PAL_EXPORT)
 SOFT_LINK_FUNCTION_FOR_SOURCE_WITH_EXPORT(PAL, CoreMedia, CMTimebaseGetRate, Float64, (CMTimebaseRef timebase), (timebase), PAL_EXPORT)
 SOFT_LINK_FUNCTION_FOR_SOURCE_WITH_EXPORT(PAL, CoreMedia, CMTimebaseSetRate, OSStatus, (CMTimebaseRef timebase, Float64 rate), (timebase, rate), PAL_EXPORT)

--- a/Source/WebCore/PAL/pal/cf/CoreMediaSoftLink.h
+++ b/Source/WebCore/PAL/pal/cf/CoreMediaSoftLink.h
@@ -241,8 +241,8 @@ SOFT_LINK_FUNCTION_FOR_HEADER(PAL, CoreMedia, CMSetAttachment, void, (CMAttachme
 SOFT_LINK_FUNCTION_FOR_HEADER(PAL, CoreMedia, CMRemoveAttachment, void, (CMAttachmentBearerRef target, CFStringRef key), (target, key))
 #define CMRemoveAttachment softLink_CoreMedia_CMRemoveAttachment
 
-SOFT_LINK_FUNCTION_FOR_HEADER(PAL, CoreMedia, CMTimebaseCreateWithMasterClock, OSStatus, (CFAllocatorRef allocator, CMClockRef masterClock, CMTimebaseRef* timebaseOut), (allocator, masterClock, timebaseOut))
-#define CMTimebaseCreateWithMasterClock softLink_CoreMedia_CMTimebaseCreateWithMasterClock
+SOFT_LINK_FUNCTION_FOR_HEADER(PAL, CoreMedia, CMTimebaseCreateWithSourceClock, OSStatus, (CFAllocatorRef allocator, CMClockRef masterClock, CMTimebaseRef* timebaseOut), (allocator, masterClock, timebaseOut))
+#define CMTimebaseCreateWithSourceClock softLink_CoreMedia_CMTimebaseCreateWithSourceClock
 SOFT_LINK_FUNCTION_FOR_HEADER(PAL, CoreMedia, CMTimebaseGetTime, CMTime, (CMTimebaseRef timebase), (timebase))
 #define CMTimebaseGetTime softLink_CoreMedia_CMTimebaseGetTime
 SOFT_LINK_FUNCTION_FOR_HEADER(PAL, CoreMedia, CMTimebaseGetRate, Float64, (CMTimebaseRef timebase), (timebase))

--- a/Source/WebCore/platform/graphics/MediaPlayerPrivateWirelessPlayback.cpp
+++ b/Source/WebCore/platform/graphics/MediaPlayerPrivateWirelessPlayback.cpp
@@ -31,7 +31,11 @@
 #include "Logging.h"
 #include "MediaDeviceRoute.h"
 #include "MediaPlaybackTargetWirelessPlayback.h"
+#include <pal/avfoundation/MediaTimeAVFoundation.h>
+#include <wtf/BlockPtr.h>
 #include <wtf/TZoneMallocInlines.h>
+
+#include <pal/cf/CoreMediaSoftLink.h>
 
 namespace WebCore {
 
@@ -77,7 +81,10 @@ MediaPlayerPrivateWirelessPlayback::MediaPlayerPrivateWirelessPlayback(MediaPlay
 {
 }
 
-MediaPlayerPrivateWirelessPlayback::~MediaPlayerPrivateWirelessPlayback() = default;
+MediaPlayerPrivateWirelessPlayback::~MediaPlayerPrivateWirelessPlayback()
+{
+    destroyTimebase();
+}
 
 static bool supportsURL(const URL& url)
 {
@@ -100,8 +107,6 @@ void MediaPlayerPrivateWirelessPlayback::load(const URL& url, const LoadOptions&
     m_url = url;
     updateURLIfNeeded();
 }
-
-#if ENABLE(WIRELESS_PLAYBACK_TARGET)
 
 OptionSet<MediaPlaybackTargetType> MediaPlayerPrivateWirelessPlayback::playbackTargetTypes()
 {
@@ -232,6 +237,11 @@ void MediaPlayerPrivateWirelessPlayback::play()
 
     ALWAYS_LOG(LOGIDENTIFIER);
     route->setPlaying(true);
+
+    if (RetainPtr timebase = ensureTimebase()) {
+        PAL::CMTimebaseSetRate(timebase.get(), route->playbackSpeed());
+        scheduleTimebaseTimer();
+    }
 }
 
 void MediaPlayerPrivateWirelessPlayback::pause()
@@ -242,6 +252,9 @@ void MediaPlayerPrivateWirelessPlayback::pause()
 
     ALWAYS_LOG(LOGIDENTIFIER);
     route->setPlaying(false);
+
+    if (RetainPtr timebase = ensureTimebase())
+        PAL::CMTimebaseSetRate(timebase.get(), 0);
 }
 
 bool MediaPlayerPrivateWirelessPlayback::hasAudio() const
@@ -258,7 +271,6 @@ void MediaPlayerPrivateWirelessPlayback::seekToTarget(const SeekTarget& seekTarg
         return;
 
     ALWAYS_LOG(LOGIDENTIFIER, seekTarget);
-    m_pendingSeekTarget = seekTarget;
     route->setCurrentPlaybackPosition(seekTarget.time);
 }
 
@@ -291,8 +303,8 @@ MediaTime MediaPlayerPrivateWirelessPlayback::duration() const
 
 MediaTime MediaPlayerPrivateWirelessPlayback::currentTime() const
 {
-    if (RefPtr route = this->route())
-        return route->currentPlaybackPosition() ?: MediaTime::zeroTime();
+    if (m_timebase)
+        return PAL::toMediaTime(PAL::CMTimebaseGetTime(m_timebase.get()));
     return MediaTime::zeroTime();
 }
 
@@ -320,6 +332,11 @@ void MediaPlayerPrivateWirelessPlayback::setRate(float rate)
 
     ALWAYS_LOG(LOGIDENTIFIER, rate);
     route->setPlaybackSpeed(rate);
+
+    if (RetainPtr timebase = ensureTimebase()) {
+        PAL::CMTimebaseSetRate(timebase, route->playing() ? rate : 0);
+        scheduleTimebaseTimer();
+    }
 }
 
 double MediaPlayerPrivateWirelessPlayback::rate() const
@@ -420,29 +437,97 @@ void MediaPlayerPrivateWirelessPlayback::currentPlaybackPositionDidChange(MediaD
     auto currentPlaybackPosition = route.currentPlaybackPosition();
     ALWAYS_LOG(LOGIDENTIFIER, currentPlaybackPosition);
 
-    // FIXME (171121901): We don't actually know when the route finishes seeking. For now we
-    // consider the seek to have completed whenever currentPlaybackPosition changes to within
-    // 1 second of the requested playback position.
-    if (m_pendingSeekTarget) {
-        if (std::abs(currentPlaybackPosition.toFloat() - m_pendingSeekTarget->time.toFloat()) > 1)
-            return;
+    updateTimebaseTimeAndRate(currentPlaybackPosition, route.playing() ? route.playbackSpeed() : 0);
 
-        ALWAYS_LOG(LOGIDENTIFIER, "seek completed");
+    auto currentTime = this->currentTime();
 
-        if (RefPtr player = m_player.get()) {
-            player->seeked(currentPlaybackPosition);
-            player->timeChanged();
-        }
-
-        m_pendingSeekTarget = std::nullopt;
-        return;
+    if (RefPtr player = m_player.get()) {
+        player->seeked(currentTime);
+        player->timeChanged();
     }
 
     if (m_currentTimeDidChangeCallback)
-        m_currentTimeDidChangeCallback(currentPlaybackPosition);
+        m_currentTimeDidChangeCallback(currentTime);
 }
 
-#endif // ENABLE(WIRELESS_PLAYBACK_TARGET)
+CMTimebaseRef MediaPlayerPrivateWirelessPlayback::ensureTimebase()
+{
+    if (m_timebase)
+        return m_timebase.get();
+
+    CMTimebaseRef rawTimebase = nullptr;
+    OSStatus result = PAL::CMTimebaseCreateWithSourceClock(kCFAllocatorDefault, PAL::CMClockGetHostTimeClock(), &rawTimebase);
+    if (result != noErr) {
+        ERROR_LOG(LOGIDENTIFIER, "failed to create timebase with error ", result);
+        return nullptr;
+    }
+
+    m_timebase = adoptCF(rawTimebase);
+    m_timerSource = adoptOSObject(dispatch_source_create(DISPATCH_SOURCE_TYPE_TIMER, 0, 0, mainDispatchQueueSingleton()));
+
+    dispatch_source_set_event_handler(m_timerSource.get(), makeBlockPtr([weakThis = ThreadSafeWeakPtr { *this }] {
+        if (RefPtr protectedThis = weakThis.get())
+            protectedThis->timebaseTimerFired();
+    }).get());
+
+    PAL::CMTimebaseAddTimerDispatchSource(m_timebase.get(), m_timerSource.get());
+    dispatch_activate(m_timerSource.get());
+
+    if (RefPtr route = this->route())
+        updateTimebaseTimeAndRate(route->currentPlaybackPosition() ?: MediaTime::zeroTime(), route->playing() ? route->playbackSpeed() : 0);
+
+    return m_timebase.get();
+}
+
+void MediaPlayerPrivateWirelessPlayback::destroyTimebase()
+{
+    if (!m_timebase)
+        return;
+
+    PAL::CMTimebaseSetRate(m_timebase.get(), 0);
+    PAL::CMTimebaseRemoveTimerDispatchSource(m_timebase.get(), m_timerSource.get());
+    dispatch_source_cancel(m_timerSource.get());
+
+    m_timerSource = nullptr;
+    m_timebase = nullptr;
+}
+
+void MediaPlayerPrivateWirelessPlayback::updateTimebaseTimeAndRate(MediaTime currentPosition, float rate)
+{
+    RetainPtr timebase = ensureTimebase();
+    if (!timebase)
+        return;
+
+    PAL::CMTimebaseSetTime(timebase, PAL::toCMTime(currentPosition));
+    PAL::CMTimebaseSetRate(timebase, rate);
+    scheduleTimebaseTimer();
+}
+
+void MediaPlayerPrivateWirelessPlayback::scheduleTimebaseTimer()
+{
+    RetainPtr timebase = ensureTimebase();
+    if (!timebase)
+        return;
+
+    if (PAL::CMTimebaseGetEffectiveRate(timebase) <= 0)
+        return;
+
+    auto nextFireTime = PAL::CMTimeAdd(PAL::CMTimebaseGetTime(timebase), PAL::CMTimeMake(1, 10));
+    PAL::CMTimebaseSetTimerDispatchSourceNextFireTime(timebase, m_timerSource.get(), nextFireTime, 0);
+}
+
+void MediaPlayerPrivateWirelessPlayback::timebaseTimerFired()
+{
+    if (!m_currentTimeDidChangeCallback)
+        return;
+
+    auto timebase = ensureTimebase();
+    if (!timebase)
+        return;
+
+    m_currentTimeDidChangeCallback(PAL::toMediaTime(PAL::CMTimebaseGetTime(timebase)));
+    scheduleTimebaseTimer();
+}
 
 #if !RELEASE_LOG_DISABLED
 WTFLogChannel& MediaPlayerPrivateWirelessPlayback::logChannel() const

--- a/Source/WebCore/platform/graphics/MediaPlayerPrivateWirelessPlayback.h
+++ b/Source/WebCore/platform/graphics/MediaPlayerPrivateWirelessPlayback.h
@@ -34,9 +34,13 @@
 #include <wtf/LoggerHelper.h>
 #include <wtf/Ref.h>
 #include <wtf/RefCounted.h>
+#include <wtf/RetainPtr.h>
 #include <wtf/TZoneMalloc.h>
 #include <wtf/ThreadSafeWeakPtr.h>
 #include <wtf/URL.h>
+#include <wtf/darwin/DispatchOSObject.h>
+
+typedef struct OpaqueCMTimebase* CMTimebaseRef;
 
 namespace WebCore {
 
@@ -128,6 +132,12 @@ private:
     void playbackErrorDidChange(MediaDeviceRoute&) final;
     void currentPlaybackPositionDidChange(MediaDeviceRoute&) final;
 
+    CMTimebaseRef ensureTimebase();
+    void destroyTimebase();
+    void updateTimebaseTimeAndRate(MediaTime, float rate);
+    void scheduleTimebaseTimer();
+    void timebaseTimerFired();
+
 #if !RELEASE_LOG_DISABLED
     // LoggerHelper
     const Logger& logger() const final { return m_logger.get(); }
@@ -149,7 +159,8 @@ private:
     ShouldPlayToTarget m_shouldPlayToTarget { ShouldPlayToTarget::Unknown };
     RefPtr<MediaPlaybackTarget> m_playbackTarget;
     MediaPlayer::CurrentTimeDidChangeCallback m_currentTimeDidChangeCallback;
-    std::optional<SeekTarget> m_pendingSeekTarget;
+    RetainPtr<CMTimebaseRef> m_timebase;
+    OSObjectPtr<dispatch_source_t> m_timerSource;
 #if !RELEASE_LOG_DISABLED
     const Ref<const Logger> m_logger;
     const uint64_t m_logIdentifier;


### PR DESCRIPTION
#### 3b6d172541dd55e39042c9f972abafc91fe892b0
<pre>
[iOS] currentTime updates only as often as a MediaDeviceRoute updates currentPlaybackPosition
<a href="https://bugs.webkit.org/show_bug.cgi?id=313557">https://bugs.webkit.org/show_bug.cgi?id=313557</a>
<a href="https://rdar.apple.com/175774587">rdar://175774587</a>

Reviewed by Eric Carlson.

When MediaPlayerPrivateWirelessPlayback is in use, a media element&apos;s currentTime is tied to the
MediaDeviceRoute&apos;s currentPlaybackPosition, but from WebKit&apos;s perspective there is no guarantee
that currentPlaybackPosition will update at a reasonable interval during playback.

To resolve this, added a CMTimebase to MediaPlayerPrivateWirelessPlayback that is configured with
the route&apos;s playbackSpeed and currentPlaybackPosition. A timebase observer is added that fires
every 100ms (in the media timeline) to update currentTime. This interval matches the one we use in
MediaPlayerPrivateAVFoundation&apos;s periodic time observer, providing smoothed estimated time updates
during wireless playback.

While here, simplified how we handle seeks. Removed the &quot;pending seek&quot; concept from
MediaPlayerPrivateWirelessPlayback and instead assumed that a seek occurs whenever
currentPlaybackPositionDidChange is called.

Tests: media/wireless-playback-media-player/current-time-advances-between-position-updates.html
       media/wireless-playback-media-player/current-time-resumes-after-pause.html
       media/wireless-playback-media-player/current-time-updates-after-rate-change.html
       media/wireless-playback-media-player/current-time-updates-after-route-seek.html
       media/wireless-playback-media-player/current-time-updates-after-seek.html
       media/wireless-playback-media-player/timeupdate-without-position-updates.html

* LayoutTests/media/wireless-playback-media-player/current-time-advances-between-position-updates-expected.txt: Added.
* LayoutTests/media/wireless-playback-media-player/current-time-advances-between-position-updates.html: Added.
* LayoutTests/media/wireless-playback-media-player/current-time-resumes-after-pause-expected.txt: Added.
* LayoutTests/media/wireless-playback-media-player/current-time-resumes-after-pause.html: Added.
* LayoutTests/media/wireless-playback-media-player/current-time-updates-after-rate-change-expected.txt: Added.
* LayoutTests/media/wireless-playback-media-player/current-time-updates-after-rate-change.html: Added.
* LayoutTests/media/wireless-playback-media-player/current-time-updates-after-route-seek-expected.txt: Added.
* LayoutTests/media/wireless-playback-media-player/current-time-updates-after-route-seek.html: Added.
* LayoutTests/media/wireless-playback-media-player/current-time-updates-after-seek-expected.txt: Added.
* LayoutTests/media/wireless-playback-media-player/current-time-updates-after-seek.html: Added.
* LayoutTests/media/wireless-playback-media-player/timeupdate-without-position-updates-expected.txt: Added.
* LayoutTests/media/wireless-playback-media-player/timeupdate-without-position-updates.html: Added.
* Source/WebCore/PAL/pal/cf/CoreMediaSoftLink.cpp:
* Source/WebCore/PAL/pal/cf/CoreMediaSoftLink.h:
* Source/WebCore/platform/graphics/MediaPlayerPrivateWirelessPlayback.cpp:
(WebCore::MediaPlayerPrivateWirelessPlayback::~MediaPlayerPrivateWirelessPlayback):
(WebCore::MediaPlayerPrivateWirelessPlayback::play):
(WebCore::MediaPlayerPrivateWirelessPlayback::pause):
(WebCore::MediaPlayerPrivateWirelessPlayback::seekToTarget):
(WebCore::MediaPlayerPrivateWirelessPlayback::currentTime const):
(WebCore::MediaPlayerPrivateWirelessPlayback::setRate):
(WebCore::MediaPlayerPrivateWirelessPlayback::currentPlaybackPositionDidChange):
(WebCore::MediaPlayerPrivateWirelessPlayback::ensureTimebase):
(WebCore::MediaPlayerPrivateWirelessPlayback::destroyTimebase):
(WebCore::MediaPlayerPrivateWirelessPlayback::updateTimebaseTimeAndRate):
(WebCore::MediaPlayerPrivateWirelessPlayback::scheduleTimebaseTimer):
(WebCore::MediaPlayerPrivateWirelessPlayback::timebaseTimerFired):
* Source/WebCore/platform/graphics/MediaPlayerPrivateWirelessPlayback.h:

Canonical link: <a href="https://commits.webkit.org/312246@main">https://commits.webkit.org/312246@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/18ba18726af2597b36849b8966194f9a295c971f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/159269 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/32697 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/25802 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/168099 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/113647 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/9c36afda-be92-4ceb-918d-8ef3ad1d8220) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/161138 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/32765 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/32684 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/123398 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/113647 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/f1a2dce9-7608-497d-8375-35851097111d) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/162226 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/25669 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/143062 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/104065 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/24722 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/23148 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/15871 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/134409 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/20842 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/170593 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/16607 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/22468 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/131592 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/32386 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/27220 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/131704 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35635 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/32330 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/142635 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/90409 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/26400 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/19444 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/31841 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/98250 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/31361 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/31634 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/31516 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->