### PR TITLE
[CMake] Fix CMake -Xcc flag deduplication in native Swift target_compile_options

### DIFF
--- a/Source/WebCore/PAL/pal/CMakeLists.txt
+++ b/Source/WebCore/PAL/pal/CMakeLists.txt
@@ -113,14 +113,20 @@ if (SWIFT_REQUIRED AND NOT (PORT STREQUAL GTK OR PORT STREQUAL WPE))
         "PALSwift-Generated.h")
 
     # Also pass these options to CMake's native Swift compilation (the macro
-    # only adds them to the custom typecheck command).
+    # only adds them to the custom typecheck command). SHELL: keeps multi-token
+    # groups (-swift-version 6, -Xcc -I<path>) together; without it CMake
+    # deduplicates repeated -Xcc tokens, leaving -I paths unguarded.
+    # https://bugs.webkit.org/show_bug.cgi?id=312105
     target_compile_options(PAL PRIVATE
         "$<$<COMPILE_LANGUAGE:Swift>:-import-underlying-module>"
-        "$<$<COMPILE_LANGUAGE:Swift>:-swift-version>"
-        "$<$<COMPILE_LANGUAGE:Swift>:6>"
         "$<$<COMPILE_LANGUAGE:Swift>:-strict-memory-safety>"
-        "$<$<COMPILE_LANGUAGE:Swift>:-Xcc>"
-        "$<$<COMPILE_LANGUAGE:Swift>:-I${PAL_FRAMEWORK_HEADERS_DIR}>"
+        "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-swift-version 6>"
+        "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-Xcc -I${PAL_FRAMEWORK_HEADERS_DIR}>"
+        "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-Xcc -I${CMAKE_BINARY_DIR}/WTF/Headers>"
+        "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-Xcc -I${CMAKE_BINARY_DIR}/ICU/Headers>"
+        "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-Xcc -I${CMAKE_BINARY_DIR}/bmalloc/Headers>"
+        "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-Xcc -I${CMAKE_BINARY_DIR}>"
+        "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-Xcc -I${PAL_DERIVED_SOURCES_DIR}>"
     )
 endif ()
 

--- a/Source/cmake/WebKitMacros.cmake
+++ b/Source/cmake/WebKitMacros.cmake
@@ -646,9 +646,22 @@ macro(WEBKIT_SETUP_SWIFT_AND_GENERATE_SWIFT_CPP_INTEROP_HEADER _target _module_n
             list(APPEND _swift_options "-explicit-module-build")
         endif ()
         # We'll use these options both for mainstream cmake invocations of swiftc (here)
-        # and for our own invocation to output an interoperability .h file (later)
-        list(TRANSFORM _swift_options PREPEND "$<$<COMPILE_LANGUAGE:Swift>:" OUTPUT_VARIABLE _swift_only_options)
-        list(TRANSFORM _swift_only_options APPEND ">")
+        # and for our own invocation to output an interoperability .h file (later).
+        # target_compile_options deduplicates repeated tokens, so collapse each
+        # -Xcc <arg> into a single SHELL: entry to keep the pair together.
+        # https://bugs.webkit.org/show_bug.cgi?id=312105
+        set(_swift_only_options "")
+        set(_pending_xcc FALSE)
+        foreach (_opt IN LISTS _swift_options)
+            if (_pending_xcc)
+                list(APPEND _swift_only_options "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-Xcc ${_opt}>")
+                set(_pending_xcc FALSE)
+            elseif (_opt STREQUAL "-Xcc")
+                set(_pending_xcc TRUE)
+            else ()
+                list(APPEND _swift_only_options "$<$<COMPILE_LANGUAGE:Swift>:${_opt}>")
+            endif ()
+        endforeach ()
         target_compile_options(${_target} PRIVATE ${_swift_only_options})
 
         # cmake's Swift interop does not respect CMAKE_SHARED_LINKER_FLAGS, so let's pass
@@ -660,8 +673,9 @@ macro(WEBKIT_SETUP_SWIFT_AND_GENERATE_SWIFT_CPP_INTEROP_HEADER _target _module_n
             string(SUBSTRING ${_flag} 0 4 _prefix)
             if (${_prefix} STREQUAL "-Wl,")
                 string(SUBSTRING ${_flag} 4 -1 _shorter_flag)
-                # The following unfortunately deduplicates the -Xlinker
-                # target_compile_options(${_target} PUBLIC "$<$<COMPILE_LANGUAGE:Swift>:-Xlinker>")
+                # SHELL: keeps the -Xlinker/argument pair together; without it
+                # CMake deduplicates the repeated -Xlinker tokens.
+                # https://bugs.webkit.org/show_bug.cgi?id=312105
                 target_compile_options(${_target} PUBLIC "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-Xlinker ${_shorter_flag}>")
             endif ()
         endforeach ()


### PR DESCRIPTION
#### 8ecfbeadb8dd25228b17df9e36d9b46f27d4d847
<pre>
[CMake] Fix CMake -Xcc flag deduplication in native Swift target_compile_options
<a href="https://bugs.webkit.org/show_bug.cgi?id=312105">https://bugs.webkit.org/show_bug.cgi?id=312105</a>
<a href="https://rdar.apple.com/174612505">rdar://174612505</a>

Reviewed by BJ Burg.

CMake&apos;s target_compile_options deduplicates repeated tokens, so
&quot;-Xcc&quot; &quot;-I/a&quot; &quot;-Xcc&quot; &quot;-I/b&quot; loses the second -Xcc and routes -I/b
to swiftc instead of the Clang importer. The custom typecheck
add_custom_command is unaffected. The bug was masked on Apple ports
by -explicit-module-build.

Fix by using the SHELL: prefix (CMake 3.12+) to keep each
&quot;-Xcc &lt;arg&gt;&quot; pair grouped, mirroring the pattern already in
Source/WebKit/PlatformMac.cmake.

* Source/WebCore/PAL/pal/CMakeLists.txt:
Mirror all six -Xcc -I pairs (and -swift-version 6) to native Swift
compilation using SHELL: form; previously only one of six reached it.
* Source/cmake/WebKitMacros.cmake:
(WEBKIT_SETUP_SWIFT_AND_GENERATE_SWIFT_CPP_INTEROP_HEADER): Pair -Xcc
with its argument as a single SHELL: entry when mirroring _swift_options
to target_compile_options.

Canonical link: <a href="https://commits.webkit.org/312235@main">https://commits.webkit.org/312235@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c4c55d7d87fcd7a786fbc98b2778d4e26cd61774

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/159287 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/32715 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/25820 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/168117 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/113665 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/161156 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/32783 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/32702 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/123412 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/113665 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/552ec70a-5d38-42b2-a0f3-2ebb25f4ab3c) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/162244 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/25672 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/143075 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/104080 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/57399355-8879-4cb1-a133-c9da6132df93) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/24725 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/23162 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/15889 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/151337 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/134412 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/20855 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/170611 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/20120 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/16644 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/22481 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/131635 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/32404 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/27234 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/131723 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35631 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/32348 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/142648 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/90474 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/26408 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/19457 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/191570 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/31859 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/98293 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/49228 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/31379 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/31652 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/31534 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->