### PR TITLE
[WebKit][Main+SU] [73e157cc9e45c104] ASAN_SEGV | WebCore::WebAnimation::currentTime; WebCore::KeyframeEffect::applyPendingAcceleratedActions; WebCore::KeyframeEffect::applyPendingAcceleratedActions

### DIFF
--- a/LayoutTests/animations/animation-apply-pending-animation-crash-expected.txt
+++ b/LayoutTests/animations/animation-apply-pending-animation-crash-expected.txt
@@ -1,0 +1,1 @@
+This test passes if it doesn't crash.

--- a/LayoutTests/animations/animation-apply-pending-animation-crash.html
+++ b/LayoutTests/animations/animation-apply-pending-animation-crash.html
@@ -1,0 +1,18 @@
+<style>
+map {
+     backdrop-filter: blur();
+}
+</style>
+<script>
+function main() {
+     var style = document.createElement("style");
+     var animation = map.animate({ "rotate": ["360deg", "0deg", ]}, 100);
+     style.clientTop;
+     animation.currentTime = 200;
+     animation.effect = new KeyframeEffect(null, { "line-clamp": ["1", "0"]});
+}
+testRunner?.dumpAsText();
+</script>
+<body onload="main()">
+    <map id="map"/>
+<div>This test passes if it doesn't crash.</div>

--- a/Source/WebCore/animation/KeyframeEffect.cpp
+++ b/Source/WebCore/animation/KeyframeEffect.cpp
@@ -2379,6 +2379,9 @@ void KeyframeEffect::applyPendingAcceleratedActions()
     if (m_pendingAcceleratedActions.isEmpty())
         return;
 
+    if (!animation())
+        return;
+
     CheckedPtr renderer = this->renderer();
     if (!renderer || !renderer->isComposited()) {
         // The renderer may no longer be composited because the accelerated animation ended before we had a chance to update it,


### PR DESCRIPTION
#### c7e77855c8282fc00733d11c7c2ec27eba959950
<pre>
[WebKit][Main+SU] [73e157cc9e45c104] ASAN_SEGV | WebCore::WebAnimation::currentTime; WebCore::KeyframeEffect::applyPendingAcceleratedActions; WebCore::KeyframeEffect::applyPendingAcceleratedActions
<a href="https://bugs.webkit.org/show_bug.cgi?id=306595">https://bugs.webkit.org/show_bug.cgi?id=306595</a>
<a href="https://rdar.apple.com/168488307">rdar://168488307</a>

Reviewed by Antoine Quint.

KeyframeEffect::applyPendingAcceleratedActions() can be called from an
asynchronous micro task scheduled from KeyframeEffect::wasRemovedFromStack()
and, while that method keeps a reference to the effect&apos;s animation, the lambda
doesn&apos;t, so it&apos;s possible for the weak pointer that tracks it to become nullptr
before it gets called. It&apos;s safer to check if there&apos;s still an animation
before applying anything.

Test: animations/animation-apply-pending-animation-crash.html

* LayoutTests/animations/animation-apply-pending-animation-crash-expected.txt: Added.
* LayoutTests/animations/animation-apply-pending-animation-crash.html: Added.
* Source/WebCore/animation/KeyframeEffect.cpp:
(WebCore::KeyframeEffect::applyPendingAcceleratedActions):

Originally-landed-as: 305413.2@webkit-2026.1-embargoed (2e52d07ce2b7). <a href="https://rdar.apple.com/174957251">rdar://174957251</a>
Canonical link: <a href="https://commits.webkit.org/312237@main">https://commits.webkit.org/312237@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d8d91884a6de3eb4eca4f0888e58883478a65601

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/159293 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/32721 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/25826 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/168123 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/113671 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/161162 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/32789 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/32708 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/123416 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/113671 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/162250 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/25676 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/143083 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/104084 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/24729 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/23165 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/15895 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/134416 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/20863 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/170617 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/16651 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/22489 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/131619 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/32410 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/27237 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/131732 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35633 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/32354 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/142656 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/90479 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/26412 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/19465 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/31865 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/98306 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/31385 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/31658 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/31540 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->