### PR TITLE
[JSC] Skip redundant `resolve()` in `HostLoadImportedModule` for repeat dynamic imports

### DIFF
--- a/JSTests/modules/dynamic-import-loaded-modules-cache.js
+++ b/JSTests/modules/dynamic-import-loaded-modules-cache.js
@@ -1,0 +1,24 @@
+import { shouldBe } from "./resources/assert.js";
+
+// Repeated dynamic import() of the same specifier from the same referrer
+// must return the same Module Namespace Object (HostLoadImportedModule
+// idempotency, https://tc39.es/ecma262/#sec-HostLoadImportedModule).
+// Exercises the referrer.[[LoadedModules]] short-circuit in
+// hostLoadImportedModule for both Realm and module referrers.
+
+const first = await import("./dynamic-import-loaded-modules-cache/leaf.js");
+shouldBe(first.value, 42);
+
+for (let i = 0; i < 100; i++) {
+    const ns = await import("./dynamic-import-loaded-modules-cache/leaf.js");
+    shouldBe(ns, first);
+    shouldBe(ns.value, 42);
+}
+
+// Same module via a fresh module-referrer (re-importer.js).
+const re = await import("./dynamic-import-loaded-modules-cache/re-importer.js");
+shouldBe(re.ns, first);
+
+// Re-importing re-importer hits the cache as well.
+const re2 = await import("./dynamic-import-loaded-modules-cache/re-importer.js");
+shouldBe(re2, re);

--- a/JSTests/modules/dynamic-import-loaded-modules-cache/leaf.js
+++ b/JSTests/modules/dynamic-import-loaded-modules-cache/leaf.js
@@ -1,0 +1,1 @@
+export const value = 42;

--- a/JSTests/modules/dynamic-import-loaded-modules-cache/re-importer.js
+++ b/JSTests/modules/dynamic-import-loaded-modules-cache/re-importer.js
@@ -1,0 +1,4 @@
+// This module performs its own dynamic import of leaf.js so that the
+// LoadedModules cache check in hostLoadImportedModule is exercised with
+// a CyclicModuleRecord referrer (this module), not just the Realm.
+export const ns = await import("./leaf.js");

--- a/Source/JavaScriptCore/runtime/JSModuleLoader.cpp
+++ b/Source/JavaScriptCore/runtime/JSModuleLoader.cpp
@@ -600,10 +600,30 @@ JSPromise* JSModuleLoader::hostLoadImportedModule(JSGlobalObject* globalObject, 
     const Identifier& specifier = moduleRequest.m_specifier;
     auto type = moduleRequest.type();
 
+    ModuleMapKey moduleMapKey { specifier.impl(), type };
+
+    // HostLoadImportedModule is required to be idempotent for the same
+    // (referrer, moduleRequest) pair. referrer.[[LoadedModules]] is that cache;
+    // FinishLoadingImportedModule populates it, and innerModuleLoading consults it,
+    // but top-level loadModule (dynamic import) reaches here without checking.
+    // Consult it now so we can skip the host resolve() hook for repeat imports.
+    {
+        auto& loadedModules = record ? record->loadedModules() : m_loadedModules;
+        if (auto iter = loadedModules.find(moduleMapKey); iter != loadedModules.end()) {
+            AbstractModuleRecord* loaded = iter->value.m_module.get();
+            ModuleRegistryEntry* loadedEntry = getRegisteredMayBeNull(loaded->moduleKey(), type);
+            ASSERT(loadedEntry);
+            ASSERT(loadedEntry->record() == loaded);
+            ASSERT(loadedEntry->loadPromise());
+            finishLoadingImportedModule(globalObject, referrer, moduleRequest, payload, loaded, scriptFetcher);
+            RETURN_IF_EXCEPTION(scope, nullptr);
+            return loadedEntry->loadPromise();
+        }
+    }
+
     if (specifier.isSymbol())
         mapEntry = getRegisteredMayBeNull(specifier, type);
 
-    ModuleMapKey moduleMapKey { specifier.impl(), type };
     ResolutionMapKey resolutionKey { referrerKey.impl(), specifier.impl() };
 
     if (auto error = m_resolutionFailures.get(resolutionKey)) {


### PR DESCRIPTION
#### aeefbc27b80ad1c5c8ce432931b3b0da211b7ed6
<pre>
[JSC] Skip redundant `resolve()` in `HostLoadImportedModule` for repeat dynamic imports
<a href="https://bugs.webkit.org/show_bug.cgi?id=313564">https://bugs.webkit.org/show_bug.cgi?id=313564</a>

Reviewed by Yusuke Suzuki.

A warm dynamic import() (same specifier from the same referrer) currently
re-runs the host&apos;s moduleLoaderResolve hook even though the result is
already known. The hook can be expensive depending on the embedder, and
the spec already provides the cache to avoid it: HostLoadImportedModule
[1] is required to be idempotent for the same (referrer, moduleRequest)
pair, and FinishLoadingImportedModule [2] populates
referrer.[[LoadedModules]] for that purpose. InnerModuleLoading already
consults that cache before calling the host hook, but the top-level
loadModule() path used by dynamic import() does not.

Consult referrer.[[LoadedModules]] (the module&apos;s, or the Realm&apos;s
m_loadedModules) at the top of hostLoadImportedModule and short-circuit
to FinishLoadingImportedModule with the cached record on hit, returning
the existing registry entry&apos;s loadPromise. [[LoadedModules]] is populated
only on normal completion, so fetch / resolution failures fall through to
the existing slow path unchanged. Per the idempotency requirement, this
is unobservable.

In a local microbenchmark of 100,000 warm dynamic imports of one cached
module, per-import time drops from ~28 us to ~0.68 us. Cold loads are
unaffected since [[LoadedModules]] is empty on first call.

[1]: <a href="https://tc39.es/ecma262/#sec-HostLoadImportedModule">https://tc39.es/ecma262/#sec-HostLoadImportedModule</a>
[2]: <a href="https://tc39.es/ecma262/#sec-FinishLoadingImportedModule">https://tc39.es/ecma262/#sec-FinishLoadingImportedModule</a>

Tests: JSTests/modules/dynamic-import-loaded-modules-cache.js
       JSTests/modules/dynamic-import-loaded-modules-cache/leaf.js
       JSTests/modules/dynamic-import-loaded-modules-cache/re-importer.js

* JSTests/modules/dynamic-import-loaded-modules-cache.js: Added.
* JSTests/modules/dynamic-import-loaded-modules-cache/leaf.js: Added.
* JSTests/modules/dynamic-import-loaded-modules-cache/re-importer.js: Added.
* Source/JavaScriptCore/runtime/JSModuleLoader.cpp:
(JSC::JSModuleLoader::hostLoadImportedModule):

Canonical link: <a href="https://commits.webkit.org/317132@main">https://commits.webkit.org/317132@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/19c265d2e994a795d182d12fab5cf7065cf388fd

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/174405 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/48338 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/42119 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/183982 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/132273 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/49630 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/48020 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/135669 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/95725 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/177363 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/39105 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/156464 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/116147 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/37746 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/36113 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/32463 "Built successfully") | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/4973 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/148169 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/35956 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/186408 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/35667 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/39622 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/40310 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/144583 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/48005 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/144441 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38935 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/48684 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/32576 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/114236 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/39341 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/120632 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/211440 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/47190 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/10920 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/55094 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/46593 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/46824 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/46651 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->