### PR TITLE
The WebContent process should not prevent local file loads where the Networking process has access by extension

### DIFF
--- a/Source/WebKit/NetworkProcess/NetworkResourceLoadParameters.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkResourceLoadParameters.cpp
@@ -34,20 +34,31 @@
 namespace WebKit {
 using namespace WebCore;
 
+static bool networkProcessHasAccessViaSandboxExtension(const String& path)
+{
+#if PLATFORM(IOS_FAMILY)
+    return path.startsWith(WebProcess::singleton().containerTemporaryDirectory());
+#else
+    UNUSED_PARAM(path);
+    return false;
+#endif
+}
+
 bool NetworkResourceLoadParameters::createSandboxExtensionHandlesIfNecessary()
 {
     if (request.url().protocolIsFile()) {
+        String path = request.url().fileSystemPath();
 #if HAVE(AUDIT_TOKEN)
         if (auto networkProcessAuditToken = WebProcess::singleton().ensureNetworkProcessConnection().networkProcessAuditToken()) {
-            if (auto handle = SandboxExtension::createHandleForReadByAuditToken(request.url().fileSystemPath(), *networkProcessAuditToken))
+            if (auto handle = SandboxExtension::createHandleForReadByAuditToken(path, *networkProcessAuditToken))
                 resourceSandboxExtension = WTF::move(*handle);
         } else
 #endif
         {
-            if (auto handle = SandboxExtension::createHandle(request.url().fileSystemPath(), SandboxExtension::Type::ReadOnly))
+            if (auto handle = SandboxExtension::createHandle(path, SandboxExtension::Type::ReadOnly))
                 resourceSandboxExtension = WTF::move(*handle);
         }
-        return resourceSandboxExtension.has_value();
+        return resourceSandboxExtension.has_value() || networkProcessHasAccessViaSandboxExtension(path);
     }
     return true;
 }

--- a/Source/WebKit/Shared/WebProcessCreationParameters.h
+++ b/Source/WebKit/Shared/WebProcessCreationParameters.h
@@ -220,6 +220,7 @@ struct WebProcessCreationParameters {
     WebCore::Color focusRingColor;
     String localizedDeviceModel;
     String contentSizeCategory;
+    String containerTemporaryDirectory;
 #endif
 
 #if USE(GBM)

--- a/Source/WebKit/Shared/WebProcessCreationParameters.serialization.in
+++ b/Source/WebKit/Shared/WebProcessCreationParameters.serialization.in
@@ -168,6 +168,9 @@ using WebCore::SystemSettings::State = WebCore::SystemSettingsState;
     WebCore::Color focusRingColor;
     String localizedDeviceModel;
     String contentSizeCategory;
+    String containerTemporaryDirectory;
+#endif
+
 #endif
 
 #if USE(GBM)

--- a/Source/WebKit/UIProcess/Cocoa/WebProcessPoolCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/WebProcessPoolCocoa.mm
@@ -476,6 +476,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
     parameters.focusRingColor = RenderThemeIOS::systemFocusRingColor();
     parameters.localizedDeviceModel = localizedDeviceModel();
     parameters.contentSizeCategory = contentSizeCategory();
+    parameters.containerTemporaryDirectory = WebsiteDataStore::defaultResolvedContainerTemporaryDirectory();
 #endif
 
     parameters.mobileGestaltExtensionHandle = process.createMobileGestaltSandboxExtensionIfNeeded();

--- a/Source/WebKit/WebProcess/WebProcess.h
+++ b/Source/WebKit/WebProcess/WebProcess.h
@@ -552,6 +552,10 @@ public:
     void remoteAudioSessionConfigurationChanged(const RemoteAudioSessionConfiguration&);
 #endif
 
+#if PLATFORM(IOS_FAMILY)
+    const String& containerTemporaryDirectory() const { return m_containerTemporaryDirectory; }
+#endif
+
 private:
     WebProcess();
     ~WebProcess();
@@ -987,6 +991,9 @@ private:
 #endif
 #if ENABLE(INITIALIZE_ACCESSIBILITY_ON_DEMAND)
     bool m_shouldInitializeAccessibility { false };
+#endif
+#if PLATFORM(IOS_FAMILY)
+    String m_containerTemporaryDirectory;
 #endif
 };
 

--- a/Source/WebKit/WebProcess/cocoa/WebProcessCocoa.mm
+++ b/Source/WebKit/WebProcess/cocoa/WebProcessCocoa.mm
@@ -497,6 +497,7 @@ void WebProcess::platformInitializeWebProcess(WebProcessCreationParameters& para
     setCurrentUserInterfaceIdiom(parameters.currentUserInterfaceIdiom);
     setLocalizedDeviceModel(parameters.localizedDeviceModel);
     setContentSizeCategory(parameters.contentSizeCategory);
+    m_containerTemporaryDirectory = WTF::move(parameters.containerTemporaryDirectory);
 #if ENABLE(VIDEO_PRESENTATION_MODE)
     setSupportsPictureInPicture(parameters.supportsPictureInPicture);
 #endif


### PR DESCRIPTION
#### b0e5d5d7c7ca44794a9f74e0ada46d56bbac75cf
<pre>
The WebContent process should not prevent local file loads where the Networking process has access by extension
<a href="https://bugs.webkit.org/show_bug.cgi?id=308348">https://bugs.webkit.org/show_bug.cgi?id=308348</a>
<a href="https://rdar.apple.com/170610201">rdar://170610201</a>

Reviewed by Chris Dumez.

The UI process is granting the Networking process access to its temp directory. If the UI process is performing
a load of a local file inside that directory, the WebContent process should not block it.

* Source/WebKit/NetworkProcess/NetworkResourceLoadParameters.cpp:
(WebKit::networkProcessHasAccessByExtensions):
(WebKit::NetworkResourceLoadParameters::createSandboxExtensionHandlesIfNecessary):
* Source/WebKit/Shared/WebProcessCreationParameters.h:
* Source/WebKit/Shared/WebProcessCreationParameters.serialization.in:
* Source/WebKit/UIProcess/Cocoa/WebProcessPoolCocoa.mm:
(WebKit::WebProcessPool::platformInitializeWebProcess):
* Source/WebKit/WebProcess/WebProcess.h:
* Source/WebKit/WebProcess/cocoa/WebProcessCocoa.mm:
(WebKit::WebProcess::accessibilityFocusedUIElement):

Originally-landed-as: 305413.335@safari-7624-branch (00906723527a). <a href="https://rdar.apple.com/173969195">rdar://173969195</a>
Canonical link: <a href="https://commits.webkit.org/312287@main">https://commits.webkit.org/312287@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/10034f86166d5a86ac5ac72de269f1e995c14705

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/159406 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/32834 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/25942 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/168238 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/113784 "Built successfully") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/32902 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/32822 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/123504 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/86691 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/162363 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/25753 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/143174 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/104168 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/7d7e631e-889b-4c7e-9e86-7a1123636c97) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/24806 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/23263 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/16009 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/134493 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/170730 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/16764 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/22580 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/131711 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/32523 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/27338 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/131824 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35658 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/32467 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/142747 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/90592 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/26486 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/19556 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/31978 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/98430 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/31498 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/31771 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/31653 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->