### PR TITLE
[JSC] DFG `iterator_open` / `iterator_next` leave dangling failedBlock when a fast-mode watchpoint is invalidated

### DIFF
--- a/JSTests/stress/iterator-dfg-fast-path-watchpoint-invalidated-array.js
+++ b/JSTests/stress/iterator-dfg-fast-path-watchpoint-invalidated-array.js
@@ -1,0 +1,33 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error('bad: ' + actual + ' vs ' + expected);
+}
+noInline(shouldBe);
+
+function sumArrayOrMap(iterable) {
+    let sum = 0;
+    for (const e of iterable) {
+        if (typeof e === "number")
+            sum += e;
+        else
+            sum += e[0] + e[1];
+    }
+    return sum;
+}
+noInline(sumArrayOrMap);
+
+let arr = [1, 2, 3, 4, 5];
+let map = new Map([[1, 10], [2, 20], [3, 30]]);
+
+for (let i = 0; i < 80; ++i) {
+    if (i & 1)
+        shouldBe(sumArrayOrMap(arr), 15);
+    else
+        shouldBe(sumArrayOrMap(map), 66);
+}
+
+let originalArrayIterator = Array.prototype[Symbol.iterator];
+Array.prototype[Symbol.iterator] = function () { return originalArrayIterator.call(this); };
+
+for (let i = 0; i < testLoopCount; ++i)
+    shouldBe(sumArrayOrMap(map), 66);

--- a/JSTests/stress/iterator-dfg-fast-path-watchpoint-invalidated-map.js
+++ b/JSTests/stress/iterator-dfg-fast-path-watchpoint-invalidated-map.js
@@ -1,0 +1,33 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error('bad: ' + actual + ' vs ' + expected);
+}
+noInline(shouldBe);
+
+function sumArrayOrMap(iterable) {
+    let sum = 0;
+    for (const e of iterable) {
+        if (typeof e === "number")
+            sum += e;
+        else
+            sum += e[0] + e[1];
+    }
+    return sum;
+}
+noInline(sumArrayOrMap);
+
+let arr = [1, 2, 3, 4, 5];
+let map = new Map([[1, 10], [2, 20], [3, 30]]);
+
+for (let i = 0; i < 80; ++i) {
+    if (i & 1)
+        shouldBe(sumArrayOrMap(arr), 15);
+    else
+        shouldBe(sumArrayOrMap(map), 66);
+}
+
+let originalMapIterator = Map.prototype[Symbol.iterator];
+Map.prototype[Symbol.iterator] = function () { return originalMapIterator.call(this); };
+
+for (let i = 0; i < testLoopCount; ++i)
+    shouldBe(sumArrayOrMap(arr), 15);

--- a/JSTests/stress/iterator-dfg-fast-path-watchpoint-invalidated-set.js
+++ b/JSTests/stress/iterator-dfg-fast-path-watchpoint-invalidated-set.js
@@ -1,0 +1,33 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error('bad: ' + actual + ' vs ' + expected);
+}
+noInline(shouldBe);
+
+function sumMapOrSet(iterable) {
+    let sum = 0;
+    for (const e of iterable) {
+        if (typeof e === "number")
+            sum += e;
+        else
+            sum += e[0] + e[1];
+    }
+    return sum;
+}
+noInline(sumMapOrSet);
+
+let map = new Map([[1, 10], [2, 20], [3, 30]]);
+let set = new Set([100, 200, 300]);
+
+for (let i = 0; i < 80; ++i) {
+    if (i & 1)
+        shouldBe(sumMapOrSet(map), 66);
+    else
+        shouldBe(sumMapOrSet(set), 600);
+}
+
+let originalSetIterator = Set.prototype[Symbol.iterator];
+Set.prototype[Symbol.iterator] = function () { return originalSetIterator.call(this); };
+
+for (let i = 0; i < testLoopCount; ++i)
+    shouldBe(sumMapOrSet(map), 66);

--- a/Source/JavaScriptCore/dfg/DFGByteCodeParser.cpp
+++ b/Source/JavaScriptCore/dfg/DFGByteCodeParser.cpp
@@ -10735,11 +10735,19 @@ void ByteCodeParser::handleIteratorOpen(const JSInstruction* currentInstruction,
     auto& metadata = bytecode.metadata(codeBlock);
     uint32_t seenModes = metadata.m_iterationMetadata.seenModes;
 
+    JSGlobalObject* globalObject = m_inlineStackTop->m_codeBlock->globalObjectFor(currentCodeOrigin());
+
+    if (seenModes & IterationMode::FastArray && !globalObject->arrayIteratorProtocolWatchpointSet().isStillValid())
+        seenModes &= ~static_cast<uint32_t>(IterationMode::FastArray);
+    if (seenModes & IterationMode::FastMap && !globalObject->mapIteratorProtocolWatchpointSet().isStillValid())
+        seenModes &= ~static_cast<uint32_t>(IterationMode::FastMap);
+    if (seenModes & IterationMode::FastSet && !globalObject->setIteratorProtocolWatchpointSet().isStillValid())
+        seenModes &= ~static_cast<uint32_t>(IterationMode::FastSet);
+
     unsigned numberOfRemainingModes = std::popcount(seenModes);
     ASSERT(numberOfRemainingModes <= numberOfIterationModes);
     bool generatedCase = false;
 
-    JSGlobalObject* globalObject = m_inlineStackTop->m_codeBlock->globalObjectFor(currentCodeOrigin());
     BasicBlock* failedBlock = nullptr;
     auto connectFailedBlock = [&] {
         if (failedBlock) {
@@ -10755,7 +10763,7 @@ void ByteCodeParser::handleIteratorOpen(const JSInstruction* currentInstruction,
 
     BytecodeIndex startIndex = m_currentIndex;
 
-    if (seenModes & IterationMode::FastArray && globalObject->arrayIteratorProtocolWatchpointSet().isStillValid()) {
+    if (seenModes & IterationMode::FastArray) {
         // First set up the watchpoint conditions we need for correctness.
         m_graph.watchpoints().addLazily(globalObject->arrayIteratorProtocolWatchpointSet());
 
@@ -10816,7 +10824,7 @@ void ByteCodeParser::handleIteratorOpen(const JSInstruction* currentInstruction,
 
     m_currentIndex = startIndex;
 
-    if (seenModes & IterationMode::FastMap && globalObject->mapIteratorProtocolWatchpointSet().isStillValid()) {
+    if (seenModes & IterationMode::FastMap) {
         auto& mapIteratorProtocolWatchpointSet = globalObject->mapIteratorProtocolWatchpointSet();
         m_graph.watchpoints().addLazily(mapIteratorProtocolWatchpointSet);
 
@@ -10874,7 +10882,7 @@ void ByteCodeParser::handleIteratorOpen(const JSInstruction* currentInstruction,
 
     m_currentIndex = startIndex;
 
-    if (seenModes & IterationMode::FastSet && globalObject->setIteratorProtocolWatchpointSet().isStillValid()) {
+    if (seenModes & IterationMode::FastSet) {
         auto& setIteratorProtocolWatchpointSet = globalObject->setIteratorProtocolWatchpointSet();
         m_graph.watchpoints().addLazily(setIteratorProtocolWatchpointSet);
 
@@ -10990,6 +10998,7 @@ void ByteCodeParser::handleIteratorOpen(const JSInstruction* currentInstruction,
         generatedCase = true;
     }
 
+    ASSERT(!failedBlock);
     if (!generatedCase) {
         Node* result = jsConstant(JSValue());
         addToGraph(ForceOSRExit);
@@ -11017,11 +11026,19 @@ void ByteCodeParser::handleIteratorNext(const JSInstruction* currentInstruction,
     auto& metadata = bytecode.metadata(codeBlock);
     uint32_t seenModes = metadata.m_iterationMetadata.seenModes;
 
+    JSGlobalObject* globalObject = m_inlineStackTop->m_codeBlock->globalObjectFor(currentCodeOrigin());
+
+    if (seenModes & IterationMode::FastArray && !globalObject->arrayIteratorProtocolWatchpointSet().isStillValid())
+        seenModes &= ~static_cast<uint32_t>(IterationMode::FastArray);
+    if (seenModes & IterationMode::FastMap && !globalObject->mapIteratorProtocolWatchpointSet().isStillValid())
+        seenModes &= ~static_cast<uint32_t>(IterationMode::FastMap);
+    if (seenModes & IterationMode::FastSet && !globalObject->setIteratorProtocolWatchpointSet().isStillValid())
+        seenModes &= ~static_cast<uint32_t>(IterationMode::FastSet);
+
     unsigned numberOfRemainingModes = std::popcount(seenModes);
     ASSERT(numberOfRemainingModes <= numberOfIterationModes);
     bool generatedCase = false;
 
-    JSGlobalObject* globalObject = m_inlineStackTop->m_codeBlock->globalObjectFor(currentCodeOrigin());
     BasicBlock* failedBlock = nullptr;
     auto connectFailedBlock = [&] {
         if (failedBlock) {
@@ -11037,7 +11054,7 @@ void ByteCodeParser::handleIteratorNext(const JSInstruction* currentInstruction,
 
     BytecodeIndex startIndex = m_currentIndex;
 
-    if (seenModes & IterationMode::FastArray && globalObject->arrayIteratorProtocolWatchpointSet().isStillValid()) {
+    if (seenModes & IterationMode::FastArray) {
         // First set up the watchpoint conditions we need for correctness.
         m_graph.watchpoints().addLazily(globalObject->arrayIteratorProtocolWatchpointSet());
         numberOfRemainingModes--;
@@ -11150,7 +11167,7 @@ void ByteCodeParser::handleIteratorNext(const JSInstruction* currentInstruction,
         generatedCase = true;
     }
 
-    if (seenModes & IterationMode::FastMap && globalObject->mapIteratorProtocolWatchpointSet().isStillValid()) {
+    if (seenModes & IterationMode::FastMap) {
         auto& mapIteratorProtocolWatchpointSet = globalObject->mapIteratorProtocolWatchpointSet();
         m_graph.watchpoints().addLazily(mapIteratorProtocolWatchpointSet);
         numberOfRemainingModes--;
@@ -11243,7 +11260,7 @@ void ByteCodeParser::handleIteratorNext(const JSInstruction* currentInstruction,
         generatedCase = true;
     }
 
-    if (seenModes & IterationMode::FastSet && globalObject->setIteratorProtocolWatchpointSet().isStillValid()) {
+    if (seenModes & IterationMode::FastSet) {
         auto& setIteratorProtocolWatchpointSet = globalObject->setIteratorProtocolWatchpointSet();
         m_graph.watchpoints().addLazily(setIteratorProtocolWatchpointSet);
         numberOfRemainingModes--;
@@ -11427,6 +11444,7 @@ void ByteCodeParser::handleIteratorNext(const JSInstruction* currentInstruction,
         generatedCase = true;
     }
 
+    ASSERT(!failedBlock);
     if (!generatedCase) {
         Node* result = jsConstant(JSValue());
         addToGraph(ForceOSRExit);


### PR DESCRIPTION
#### 3f4f81750dc5d4ec8208c35be8a094ac2dbf8bdc
<pre>
[JSC] DFG `iterator_open` / `iterator_next` leave dangling failedBlock when a fast-mode watchpoint is invalidated
<a href="https://bugs.webkit.org/show_bug.cgi?id=313570">https://bugs.webkit.org/show_bug.cgi?id=313570</a>

Reviewed by Yusuke Suzuki.

After 312127@main, seenModes can contain multiple fast modes. When one of
their iterator-protocol watchpoints has already fired, that case was skipped
without decrementing numberOfRemainingModes. The remaining fast mode then
allocated a failedBlock that was never connected, leaving a BasicBlock with
no terminal and crashing in Graph::determineReachability().

Mask out invalidated fast modes from seenModes up front, and drop the
redundant isStillValid() check from each case (addLazily() handles
concurrent invalidation at finalize time).

Test: JSTests/stress/iterator-dfg-fast-path-watchpoint-invalidated.js

* JSTests/stress/iterator-dfg-fast-path-watchpoint-invalidated.js: Added.
(shouldBe):
(sumArrayOrMap):
(noInline.Array.prototype.Symbol.iterator):
(noInline):
(sumMapOrSet):
(noInline.let.set new):
(noInline.Set.prototype.Symbol.iterator):
* Source/JavaScriptCore/dfg/DFGByteCodeParser.cpp:
(JSC::DFG::ByteCodeParser::handleIteratorOpen):
(JSC::DFG::ByteCodeParser::handleIteratorNext):

Canonical link: <a href="https://commits.webkit.org/312290@main">https://commits.webkit.org/312290@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/11586c97a5be4e1e9c6b9e90bcc244290182cba1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/159320 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/32748 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/25854 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/168150 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/113698 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/32816 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/32735 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/123441 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/86646 "1 flakes 1 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/162277 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/25700 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/143106 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/104108 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/24753 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/23192 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/15923 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/151370 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/134440 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/20886 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/170644 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/20153 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/16678 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/22512 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/131645 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/32437 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/27266 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/131757 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35664 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/32381 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/142679 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/90506 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/26432 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/19488 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/191603 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/31892 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/98344 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/49238 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/31412 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/31685 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/31567 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->