### PR TITLE
Fix format string issue in WebExtension error handling

### DIFF
--- a/Source/WebKit/Shared/Extensions/WebExtensionUtilities.cpp
+++ b/Source/WebKit/Shared/Extensions/WebExtensionUtilities.cpp
@@ -138,69 +138,6 @@ void serializeToMultipleJSONStrings(Ref<JSON::Object> jsonObject, Function<void(
         chunkCallback(currentJSON->toJSONString());
 }
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-
-WTF_ATTRIBUTE_PRINTF(1, 0)
-static String formatString(const char* format, va_list arguments)
-{
-    va_list args;
-    va_copy(args, arguments);
-
-ALLOW_NONLITERAL_FORMAT_BEGIN
-
-#if PLATFORM(COCOA)
-    auto cfFormat = adoptCF(CFStringCreateWithCStringNoCopy(kCFAllocatorDefault, format, kCFStringEncodingUTF8, kCFAllocatorNull));
-    auto cfResult = adoptCF(CFStringCreateWithFormatAndArguments(0, 0, cfFormat.get(), args));
-    va_end(args);
-    return cfResult.get();
-#endif
-
-#if PLATFORM(WIN)
-    int len = _vscwprintf(format, args);
-    Vector<wchar_t> buffer(len + 1);
-    _vsnwprintf(buffer.data(), len + 1, format, args);
-    va_end(args);
-    return { buffer.data() };
-#else
-    char ch;
-    int result = vsnprintf(&ch, 1, format, args);
-
-    if (!result) {
-        va_end(args);
-        return emptyString();
-    }
-
-    if (result < 0) {
-        va_end(args);
-        return nullString();
-    }
-
-    Vector<char, 256> buffer;
-    buffer.grow(result + 1);
-
-    vsnprintf(buffer.mutableSpan().data(), buffer.size(), format, args);
-    va_end(args);
-
-    return StringImpl::create(buffer.subspan(0, buffer.size() - 1));
-#endif
-
-ALLOW_NONLITERAL_FORMAT_END
-}
-
-WTF_ATTRIBUTE_PRINTF(1, 0)
-static String formatString(const char* format, ...)
-{
-    va_list args;
-    va_start(args, format);
-ALLOW_NONLITERAL_FORMAT_BEGIN
-    auto result = formatString(format, args);
-ALLOW_NONLITERAL_FORMAT_END
-    va_end(args);
-    return result;
-}
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
-
 static inline String lowercaseFirst(const String& input)
 {
     return !input.isEmpty() ? makeString(input.left(1).convertToASCIILowercase(), input.substring(1, input.length())) : input;
@@ -211,22 +148,13 @@ static inline String uppercaseFirst(const String& input)
     return !input.isEmpty() ? makeString(input.left(1).convertToASCIIUppercase(), input.substring(1, input.length())) : input;
 }
 
-String toErrorString(const String& callingAPIName, const String& sourceKey, String underlyingErrorString, ...)
+String toErrorString(const String& callingAPIName, const String& sourceKey, const String& underlyingErrorString)
 {
     ASSERT(!underlyingErrorString.isEmpty());
 
-    va_list arguments;
-    va_start(arguments, underlyingErrorString);
-
-ALLOW_NONLITERAL_FORMAT_BEGIN
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-    String formattedUnderlyingErrorString = formatString(underlyingErrorString.utf8().data(), arguments).trim([](char16_t character) -> bool {
+    String formattedUnderlyingErrorString = underlyingErrorString.trim([](char16_t character) -> bool {
         return character == '.';
     });
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
-ALLOW_NONLITERAL_FORMAT_END
-
-    va_end(arguments);
 
     String source = sourceKey;
 
@@ -236,19 +164,13 @@ ALLOW_NONLITERAL_FORMAT_END
     }
 
     if (!callingAPIName.isEmpty() && !source.isEmpty())
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-        return formatString("Invalid call to %s. The '%s' value is invalid, because %s.", callingAPIName.utf8().data(), source.utf8().data(), lowercaseFirst(formattedUnderlyingErrorString).utf8().data());
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
+        return makeString("Invalid call to "_s, callingAPIName, ". The '"_s, source, "' value is invalid, because "_s, lowercaseFirst(formattedUnderlyingErrorString), "."_s);
 
     if (callingAPIName.isEmpty() && !source.isEmpty())
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-        return formatString("The '%s' value is invalid, because %s.", source.utf8().data(), lowercaseFirst(formattedUnderlyingErrorString).utf8().data());
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
+        return makeString("The '"_s, source, "' value is invalid, because "_s, lowercaseFirst(formattedUnderlyingErrorString), "."_s);
 
     if (!callingAPIName.isEmpty())
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-        return formatString("Invalid call to %s. %s.", callingAPIName.utf8().data(), uppercaseFirst(formattedUnderlyingErrorString).utf8().data());
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
+        return makeString("Invalid call to "_s, callingAPIName, ". "_s, uppercaseFirst(formattedUnderlyingErrorString), "."_s);
 
     return formattedUnderlyingErrorString;
 }

--- a/Source/WebKit/Shared/Extensions/WebExtensionUtilities.h
+++ b/Source/WebKit/Shared/Extensions/WebExtensionUtilities.h
@@ -55,13 +55,12 @@ RefPtr<JSON::Object> jsonWithLowercaseKeys(RefPtr<JSON::Object>);
 RefPtr<JSON::Object> mergeJSON(RefPtr<JSON::Object>, RefPtr<JSON::Object>);
 
 /// Returns a concatenated error string that combines the provided information into a single, descriptive message.
-String toErrorString(const String& callingAPIName, const String& sourceKey, String underlyingErrorString, ...);
+String toErrorString(const String& callingAPIName, const String& sourceKey, const String& underlyingErrorString);
 
 /// Returns an error for Expected results in CompletionHandler.
-template<typename... Args>
-std::unexpected<WebExtensionError> toWebExtensionError(const String& callingAPIName, const String& sourceKey, const String& underlyingErrorString, Args&&... args)
+inline std::unexpected<WebExtensionError> toWebExtensionError(const String& callingAPIName, const String& sourceKey, const String& underlyingErrorString)
 {
-    return makeUnexpected(toErrorString(callingAPIName, sourceKey, underlyingErrorString, std::forward<Args>(args)...));
+    return makeUnexpected(toErrorString(callingAPIName, sourceKey, underlyingErrorString));
 }
 
 /// Returns an error object that combines the provided information into a single, descriptive message.

--- a/Source/WebKit/UIProcess/Extensions/API/WebExtensionContextAPIDeclarativeNetRequest.cpp
+++ b/Source/WebKit/UIProcess/Extensions/API/WebExtensionContextAPIDeclarativeNetRequest.cpp
@@ -58,7 +58,7 @@ WebExtensionContext::DeclarativeNetRequestValidatedRulesets WebExtensionContext:
     for (auto& identifier : rulesetIdentifiers) {
         auto ruleset = extension->declarativeNetRequestRuleset(identifier);
         if (!ruleset)
-            return toWebExtensionError("declarativeNetRequest.updateEnabledRulesets()"_s, nullString(), "Failed to apply rules. Invalid ruleset id: %s."_s, identifier.utf8().data());
+            return toWebExtensionError("declarativeNetRequest.updateEnabledRulesets()"_s, nullString(), makeString("Failed to apply rules. Invalid ruleset id: "_s, identifier, "."_s));
 
         validatedRulesets.append(ruleset.value());
     }

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIDeclarativeNetRequestCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIDeclarativeNetRequestCocoa.mm
@@ -126,7 +126,7 @@ void WebExtensionContext::declarativeNetRequestUpdateEnabledRulesets(const Vecto
     }
 
     if (declarativeNetRequestEnabledRulesetCount() - rulesetIdentifiersToDisable.size() + rulesetIdentifiersToEnable.size() > webExtensionDeclarativeNetRequestMaximumNumberOfEnabledRulesets) {
-        completionHandler(toWebExtensionError(@"declarativeNetRequest.updateEnabledRulesets()", nullString(), @"The number of enabled static rulesets exceeds the limit. Only %lu rulesets can be enabled at once.", webExtensionDeclarativeNetRequestMaximumNumberOfEnabledRulesets));
+        completionHandler(toWebExtensionError(@"declarativeNetRequest.updateEnabledRulesets()", nullString(), makeString("The number of enabled static rulesets exceeds the limit. Only "_s, webExtensionDeclarativeNetRequestMaximumNumberOfEnabledRulesets, " rulesets can be enabled at once."_s)));
         return;
     }
 

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIScriptingCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIScriptingCocoa.mm
@@ -266,7 +266,7 @@ void WebExtensionContext::scriptingUpdateRegisteredScripts(const Vector<WebExten
         auto scriptID = parameters.identifier;
         RefPtr registeredScript = m_registeredScriptsMap.get(scriptID);
         if (!registeredScript) {
-            completionHandler(toWebExtensionError(apiName, nullString(), @"no existing script with ID '%@'", scriptID.createNSString().get()));
+            completionHandler(toWebExtensionError(apiName, nullString(), makeString("no existing script with ID '"_s, scriptID, "'"_s)));
             return;
         }
 
@@ -341,7 +341,7 @@ void WebExtensionContext::scriptingUnregisterContentScripts(const Vector<String>
 
     for (auto& scriptID : ids) {
         if (!m_registeredScriptsMap.contains(scriptID)) {
-            completionHandler(toWebExtensionError(apiName, nullString(), @"no script with ID '%@'", scriptID.createNSString().get()));
+            completionHandler(toWebExtensionError(apiName, nullString(), makeString("no script with ID '"_s, scriptID, "'"_s)));
             return;
         }
     }
@@ -415,7 +415,7 @@ bool WebExtensionContext::createInjectedContentForScripts(const Vector<WebExtens
         auto scriptID = parameters.identifier;
 
         if (firstTimeRegistration == FirstTimeRegistration::Yes && (m_registeredScriptsMap.contains(scriptID) || idsToAdd.contains(scriptID))) {
-            *errorMessage = toErrorString(callingAPIName, nullString(), @"duplicate ID '%@'", scriptID.createNSString().get()).createNSString().autorelease();
+            *errorMessage = toErrorString(callingAPIName, nullString(), makeString("duplicate ID '"_s, scriptID, "'"_s)).createNSString().autorelease();
             return false;
         }
 
@@ -434,7 +434,7 @@ bool WebExtensionContext::createInjectedContentForScripts(const Vector<WebExtens
         for (NSString *scriptPath in scriptPaths) {
             if (auto scriptValue = extension->resourceStringForPath(scriptPath); !scriptValue) {
                 recordErrorIfNeeded(scriptValue.error());
-                *errorMessage = toErrorString(callingAPIName, nullString(), @"invalid resource '%@'", scriptPath).createNSString().autorelease();
+                *errorMessage = toErrorString(callingAPIName, nullString(), makeString("invalid resource '"_s, String(scriptPath), "'"_s)).createNSString().autorelease();
                 return false;
             }
         }
@@ -448,7 +448,7 @@ bool WebExtensionContext::createInjectedContentForScripts(const Vector<WebExtens
         for (NSString *styleSheetPath in styleSheetPaths) {
             if (auto styleSheetValue = extension->resourceStringForPath(styleSheetPath); !styleSheetValue) {
                 recordErrorIfNeeded(styleSheetValue.error());
-                *errorMessage = toErrorString(callingAPIName, nullString(), @"invalid resource '%@'", styleSheetPath).createNSString().autorelease();
+                *errorMessage = toErrorString(callingAPIName, nullString(), makeString("invalid resource '"_s, String(styleSheetPath), "'"_s)).createNSString().autorelease();
                 return false;
             }
         }
@@ -457,13 +457,13 @@ bool WebExtensionContext::createInjectedContentForScripts(const Vector<WebExtens
         auto *matchesArray = parameters.matchPatterns ? createNSArray(parameters.matchPatterns.value()).get() : @[ ];
         for (NSString *matchPatternString in matchesArray) {
             if (!matchPatternString.length) {
-                *errorMessage = toErrorString(callingAPIName, nullString(), @"script with ID '%@' contains an empty match pattern", scriptID.createNSString().get()).createNSString().autorelease();
+                *errorMessage = toErrorString(callingAPIName, nullString(), makeString("script with ID '"_s, scriptID, "' contains an empty match pattern"_s)).createNSString().autorelease();
                 return false;
             }
 
             RefPtr matchPattern = WebExtensionMatchPattern::getOrCreate(matchPatternString);
             if (!matchPattern || !matchPattern->isSupported()) {
-                *errorMessage = toErrorString(callingAPIName, nullString(), @"script with ID '%@' has an invalid match pattern '%@'", scriptID.createNSString().get(), matchPatternString).createNSString().autorelease();
+                *errorMessage = toErrorString(callingAPIName, nullString(), makeString("script with ID '"_s, scriptID, "' has an invalid match pattern '"_s, String(matchPatternString), "'"_s)).createNSString().autorelease();
                 return false;
             }
 
@@ -474,13 +474,13 @@ bool WebExtensionContext::createInjectedContentForScripts(const Vector<WebExtens
         auto *excludeMatchesArray = parameters.excludeMatchPatterns ? createNSArray(parameters.excludeMatchPatterns.value()).get() : @[ ];
         for (NSString *matchPatternString in excludeMatchesArray) {
             if (!matchPatternString.length) {
-                *errorMessage = toErrorString(callingAPIName, nullString(), @"script with ID '%@' contains an empty exclude match pattern", scriptID.createNSString().get()).createNSString().autorelease();
+                *errorMessage = toErrorString(callingAPIName, nullString(), makeString("script with ID '"_s, scriptID, "' contains an empty exclude match pattern"_s)).createNSString().autorelease();
                 return false;
             }
 
             RefPtr matchPattern = WebExtensionMatchPattern::getOrCreate(matchPatternString);
             if (!matchPattern || !matchPattern->isSupported()) {
-                *errorMessage = toErrorString(callingAPIName, nullString(), @"script with ID '%@' has an invalid exclude match pattern '%@'", scriptID.createNSString().get(), matchPatternString).createNSString().autorelease();
+                *errorMessage = toErrorString(callingAPIName, nullString(), makeString("script with ID '"_s, scriptID, "' has an invalid exclude match pattern '"_s, String(matchPatternString), "'"_s)).createNSString().autorelease();
                 return false;
             }
 

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPITabsCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPITabsCocoa.mm
@@ -579,7 +579,7 @@ void WebExtensionContext::tabsRemove(Vector<WebExtensionTabIdentifier> tabIdenti
     auto tabs = tabIdentifiers.map([&](auto& tabIdentifier) -> RefPtr<WebExtensionTab> {
         RefPtr tab = getTab(tabIdentifier);
         if (!tab) {
-            completionHandler(toWebExtensionError(@"tabs.remove()", nullString(), @"tab '%llu' was not found", tabIdentifier.toUInt64()));
+            completionHandler(toWebExtensionError(@"tabs.remove()", nullString(), makeString("tab '"_s, tabIdentifier.toUInt64(), "' was not found"_s)));
             return nullptr;
         }
 
@@ -630,7 +630,7 @@ void WebExtensionContext::tabsExecuteScript(WebPageProxyIdentifier webPageProxyI
             RetainPtr filePath = parameters.files.value().first().createNSString();
             scriptData = sourcePairForResource(filePath.get(), *this);
             if (!scriptData) {
-                completionHandler(toWebExtensionError(apiName, nullString(), @"Invalid resource: %@", filePath.get()));
+                completionHandler(toWebExtensionError(apiName, nullString(), makeString("Invalid resource: "_s, String(filePath.get()))));
                 return;
             }
         }

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIWindowsCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIWindowsCocoa.mm
@@ -87,7 +87,7 @@ void WebExtensionContext::windowsCreate(const WebExtensionWindowParameters& crea
             if (tabParameters.identifier) {
                 RefPtr tab = getTab(tabParameters.identifier.value());
                 if (!tab) {
-                    completionHandler(toWebExtensionError(apiName, nullString(), @"tab '%llu' was not found", tabParameters.identifier.value().toUInt64()));
+                    completionHandler(toWebExtensionError(apiName, nullString(), makeString("tab '"_s, tabParameters.identifier.value().toUInt64(), "' was not found"_s)));
                     return;
                 }
 

--- a/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIActionCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIActionCocoa.mm
@@ -432,7 +432,7 @@ NSMutableDictionary *WebExtensionAPIAction::parseIconPathsDictionary(NSDictionar
 
         if (!isValidDimensionKey(key)) {
             if (outExceptionString)
-                *outExceptionString = toErrorString(nullString(), inputKey, @"'%@' is not a valid dimension", key).createNSString().autorelease();
+                *outExceptionString = toErrorString(nullString(), inputKey, makeString("'"_s, String(key), "' is not a valid dimension"_s)).createNSString().autorelease();
             return nil;
         }
 
@@ -458,7 +458,7 @@ NSMutableDictionary *WebExtensionAPIAction::parseIconImageDataDictionary(NSDicti
 
         if (!isValidDimensionKey(key)) {
             if (outExceptionString)
-                *outExceptionString = toErrorString(nullString(), inputKey, @"'%@' is not a valid dimension", key).createNSString().autorelease();
+                *outExceptionString = toErrorString(nullString(), inputKey, makeString("'"_s, String(key), "' is not a valid dimension"_s)).createNSString().autorelease();
             return nil;
         }
 

--- a/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPICookiesCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPICookiesCocoa.mm
@@ -177,7 +177,7 @@ std::optional<WebExtensionAPICookies::ParsedDetails> WebExtensionAPICookies::par
 
         url = URL { urlString };
         if (!url.isValid()) {
-            *outExceptionString = toErrorString(nullString(), urlKey, @"'%@' is not a valid URL", urlString).createNSString().autorelease();
+            *outExceptionString = toErrorString(nullString(), urlKey, makeString("'"_s, String(urlString), "' is not a valid URL"_s)).createNSString().autorelease();
             return std::nullopt;
         }
     }
@@ -191,7 +191,7 @@ std::optional<WebExtensionAPICookies::ParsedDetails> WebExtensionAPICookies::par
 
         sessionID = toImpl(storeID);
         if (!sessionID) {
-            *outExceptionString = toErrorString(nullString(), storeIdKey, @"'%@' is not a valid cookie store identifier", storeID).createNSString().autorelease();
+            *outExceptionString = toErrorString(nullString(), storeIdKey, makeString("'"_s, String(storeID), "' is not a valid cookie store identifier"_s)).createNSString().autorelease();
             return std::nullopt;
         }
     }

--- a/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIDeclarativeNetRequestCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIDeclarativeNetRequestCocoa.mm
@@ -179,7 +179,7 @@ void WebExtensionAPIDeclarativeNetRequest::updateDynamicRules(NSDictionary *opti
     for (NSDictionary *ruleDictionary in rulesToAdd) {
         if (![[_WKWebExtensionDeclarativeNetRequestRule  alloc] initWithDictionary:ruleDictionary rulesetID:dynamicRulesetID errorString:&ruleErrorString]) {
             ASSERT(ruleErrorString);
-            *outExceptionString = toErrorString(nullString(), addRulesKey, @"an error with rule at index %lu: %@", index, ruleErrorString).createNSString().autorelease();
+            *outExceptionString = toErrorString(nullString(), addRulesKey, makeString("an error with rule at index "_s, index, ": "_s, String(ruleErrorString))).createNSString().autorelease();
             return;
         }
 
@@ -250,7 +250,7 @@ void WebExtensionAPIDeclarativeNetRequest::updateSessionRules(NSDictionary *opti
     for (NSDictionary *ruleDictionary in rulesToAdd) {
         if (![[_WKWebExtensionDeclarativeNetRequestRule  alloc] initWithDictionary:ruleDictionary rulesetID:sessionRulesetID errorString:&ruleErrorString]) {
             ASSERT(ruleErrorString);
-            *outExceptionString = toErrorString(nullString(), addRulesKey, @"an error with rule at index %lu: %@", index, ruleErrorString).createNSString().autorelease();
+            *outExceptionString = toErrorString(nullString(), addRulesKey, makeString("an error with rule at index "_s, index, ": "_s, String(ruleErrorString))).createNSString().autorelease();
             return;
         }
 
@@ -346,7 +346,7 @@ void WebExtensionAPIDeclarativeNetRequest::getMatchedRules(NSDictionary *filter,
     NSNumber *tabID = objectForKey<NSNumber>(filter, getMatchedRulesTabIDKey);
     auto optionalTabIdentifier = tabID ? toWebExtensionTabIdentifier(tabID.doubleValue) : std::nullopt;
     if (tabID && !isValid(optionalTabIdentifier)) {
-        *outExceptionString = toErrorString(nullString(), getMatchedRulesTabIDKey, @"%@ is not a valid tab identifier", tabID).createNSString().autorelease();
+        *outExceptionString = toErrorString(nullString(), getMatchedRulesTabIDKey, makeString(String([tabID description]), " is not a valid tab identifier"_s)).createNSString().autorelease();
         return;
     }
 
@@ -412,7 +412,7 @@ void WebExtensionAPIDeclarativeNetRequest::setExtensionActionOptions(NSDictionar
         NSNumber *tabID = objectForKey<NSNumber>(tabUpdateDictionary, actionCountTabIDKey);
         auto tabIdentifier = toWebExtensionTabIdentifier(tabID.doubleValue);
         if (!isValid(tabIdentifier)) {
-            *outExceptionString = toErrorString(nullString(), actionCountTabIDKey, @"%@ is not a valid tab identifier", tabID).createNSString().autorelease();
+            *outExceptionString = toErrorString(nullString(), actionCountTabIDKey, makeString(String([tabID description]), " is not a valid tab identifier"_s)).createNSString().autorelease();
             return;
         }
 

--- a/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIDevToolsInspectedWindowCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIDevToolsInspectedWindowCocoa.mm
@@ -67,7 +67,7 @@ void WebExtensionAPIDevToolsInspectedWindow::eval(WebPageProxyIdentifier webPage
         frameURL = URL { url };
 
         if (!frameURL.value().isValid()) {
-            *outExceptionString = toErrorString(nullString(), frameURLKey, @"'%@' is not a valid URL", url).createNSString().autorelease();
+            *outExceptionString = toErrorString(nullString(), frameURLKey, makeString("'"_s, String(url), "' is not a valid URL"_s)).createNSString().autorelease();
             return;
         }
     }

--- a/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIMenusCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIMenusCocoa.mm
@@ -180,12 +180,12 @@ bool WebExtensionAPIMenus::parseCreateAndUpdateProperties(ForUpdate forUpdate, N
 
             RefPtr extensionContext = this->extensionContext();
             if ([context isEqualToString:@"action"] && !extensionContext->supportsManifestVersion(3)) {
-                *outExceptionString = toErrorString(nullString(), contextsKey, @"'%@' is not a valid context", context).createNSString().autorelease();
+                *outExceptionString = toErrorString(nullString(), contextsKey, makeString("'"_s, String(context), "' is not a valid context"_s)).createNSString().autorelease();
                 return false;
             }
 
             if (([context isEqualToString:@"browser_action"] || [context isEqualToString:@"page_action"]) && extensionContext->supportsManifestVersion(3)) {
-                *outExceptionString = toErrorString(nullString(), contextsKey, @"'%@' is not a valid context", context).createNSString().autorelease();
+                *outExceptionString = toErrorString(nullString(), contextsKey, makeString("'"_s, String(context), "' is not a valid context"_s)).createNSString().autorelease();
                 return false;
             }
 
@@ -197,7 +197,7 @@ bool WebExtensionAPIMenus::parseCreateAndUpdateProperties(ForUpdate forUpdate, N
         for (NSString *patternString in documentPatterns) {
             auto pattern = WebExtensionMatchPattern::getOrCreate(patternString);
             if (!pattern || !pattern->isSupported()) {
-                *outExceptionString = toErrorString(nullString(), documentURLPatternsKey, @"'%@' is not a valid pattern", patternString).createNSString().autorelease();
+                *outExceptionString = toErrorString(nullString(), documentURLPatternsKey, makeString("'"_s, String(patternString), "' is not a valid pattern"_s)).createNSString().autorelease();
                 return false;
             }
         }
@@ -211,7 +211,7 @@ bool WebExtensionAPIMenus::parseCreateAndUpdateProperties(ForUpdate forUpdate, N
 
             // Any valid pattern is allowed, not just supported schemes.
             if (!pattern || !pattern->isValid()) {
-                *outExceptionString = toErrorString(nullString(), targetURLPatternsKey, @"'%@' is not a valid pattern", patternString).createNSString().autorelease();
+                *outExceptionString = toErrorString(nullString(), targetURLPatternsKey, makeString("'"_s, String(patternString), "' is not a valid pattern"_s)).createNSString().autorelease();
                 return false;
             }
         }

--- a/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIPermissionsCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIPermissionsCocoa.mm
@@ -227,7 +227,7 @@ bool WebExtensionAPIPermissions::validatePermissionsDetails(HashSet<String>& per
 {
     for (auto& permission : permissions) {
         if (!WebExtension::supportedPermissions().contains(permission)) {
-            *outExceptionString = toErrorString(nullString(), permissionsKey, @"'%@' is not a valid permission", permission.createNSString().get()).createNSString().autorelease();
+            *outExceptionString = toErrorString(nullString(), permissionsKey, makeString("'"_s, permission, "' is not a valid permission"_s)).createNSString().autorelease();
             return false;
         }
     }
@@ -235,7 +235,7 @@ bool WebExtensionAPIPermissions::validatePermissionsDetails(HashSet<String>& per
     for (auto& origin : origins) {
         auto pattern = WebExtensionMatchPattern::getOrCreate(origin);
         if (!pattern || !pattern->isSupported()) {
-            *outExceptionString = toErrorString(nullString(), originsKey, @"'%@' is not a valid pattern", origin.createNSString().get()).createNSString().autorelease();
+            *outExceptionString = toErrorString(nullString(), originsKey, makeString("'"_s, origin, "' is not a valid pattern"_s)).createNSString().autorelease();
             return false;
         }
 

--- a/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIScriptingCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIScriptingCocoa.mm
@@ -371,7 +371,7 @@ bool WebExtensionAPIScripting::parseTargetInjectionOptions(NSDictionary *targetI
     NSNumber *tabID = targetInfo[tabIDKey];
     auto tabIdentifier = toWebExtensionTabIdentifier(tabID.doubleValue);
     if (!tabIdentifier) {
-        *outExceptionString = toErrorString(nullString(), tabIDKey, @"'%@' is not a tab identifier", tabID).createNSString().autorelease();
+        *outExceptionString = toErrorString(nullString(), tabIDKey, makeString("'"_s, String([tabID description]), "' is not a tab identifier"_s)).createNSString().autorelease();
         return false;
     }
 
@@ -382,7 +382,7 @@ bool WebExtensionAPIScripting::parseTargetInjectionOptions(NSDictionary *targetI
         for (NSString *documentIdentifier in documentIdentifiers) {
             auto parsedUUID = WTF::UUID::parse(String(documentIdentifier));
             if (!parsedUUID) {
-                *outExceptionString = toErrorString(nullString(), documentIDsKey, @"'%@' is not a document identifier", documentIdentifier).createNSString().autorelease();
+                *outExceptionString = toErrorString(nullString(), documentIDsKey, makeString("'"_s, String(documentIdentifier), "' is not a document identifier"_s)).createNSString().autorelease();
                 return false;
             }
 
@@ -397,7 +397,7 @@ bool WebExtensionAPIScripting::parseTargetInjectionOptions(NSDictionary *targetI
         for (NSNumber *frameID in frameIDs) {
             auto frameIdentifier = toWebExtensionFrameIdentifier(frameID.doubleValue);
             if (!isValid(frameIdentifier)) {
-                *outExceptionString = toErrorString(nullString(), frameIDsKey, @"'%@' is not a frame identifier", frameID).createNSString().autorelease();
+                *outExceptionString = toErrorString(nullString(), frameIDsKey, makeString("'"_s, String([frameID description]), "' is not a frame identifier"_s)).createNSString().autorelease();
                 return false;
             }
 
@@ -587,7 +587,7 @@ bool WebExtensionAPIScripting::parseRegisteredContentScripts(NSArray *scripts, F
 
         NSArray *matchPatterns = script[matchesKey];
         if (firstTimeRegistration == FirstTimeRegistration::Yes && !matchPatterns.count) {
-            *outExceptionString = toErrorString(nullString(), matchesKey, @"it must specify at least one match pattern for script with ID '%@'", script[@"id"]).createNSString().autorelease();
+            *outExceptionString = toErrorString(nullString(), matchesKey, makeString("it must specify at least one match pattern for script with ID '"_s, String(script[@"id"]), "'"_s)).createNSString().autorelease();
             return false;
         }
 

--- a/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPISidebarActionCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPISidebarActionCocoa.mm
@@ -77,19 +77,19 @@ static Variant<std::monostate, String, SidebarError> parseDetailsStringFromKey(N
 {
     RetainPtr<id> maybeValue = [dict objectForKey:key];
     if (!maybeValue && required)
-        return SidebarError { toErrorString(nullString(), @"details", [NSString stringWithFormat:@"'%@' is required", key]) };
+        return SidebarError { toErrorString(nullString(), @"details", makeString("'"_s, String(key), "' is required"_s)) };
 
     if ([maybeValue isKindOfClass:NSNull.class]) {
         if (required)
-            return SidebarError { toErrorString(nullString(), @"details", adoptNS([[NSString alloc] initWithFormat:@"'%@' is required", key]).get()) };
+            return SidebarError { toErrorString(nullString(), @"details", makeString("'"_s, String(key), "' is required"_s)) };
         return std::monostate();
     }
 
     RetainPtr nsStringValue = dynamic_objc_cast<NSString>(maybeValue.get());
     if (!nsStringValue]) {
         if (required)
-            return SidebarError { toErrorString(nullString(), @"details", adoptNS([[NSString alloc] initWithFormat:@"'%@' must be of type 'string'", key]).get()) };
-        return SidebarError { toErrorString(nullString(), @"details", adoptNS([[NSString alloc] initWithFormat:@"'%@' must be of type 'string' or 'null'", key]).get()) };
+            return SidebarError { toErrorString(nullString(), @"details", makeString("'"_s, String(key), "' must be of type 'string'"_s)) };
+        return SidebarError { toErrorString(nullString(), @"details", makeString("'"_s, String(key), "' must be of type 'string' or 'null'"_s)) };
     }
 
     return String(nsStringValue.get());

--- a/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPITabsCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPITabsCocoa.mm
@@ -218,7 +218,7 @@ bool WebExtensionAPITabs::parseTabCreateOptions(NSDictionary *options, WebExtens
         parameters.windowIdentifier = toWebExtensionWindowIdentifier(windowId.doubleValue);
 
         if (!parameters.windowIdentifier || !isValid(parameters.windowIdentifier.value())) {
-            *outExceptionString = toErrorString(nullString(), windowIdKey, @"'%@' is not a window identifier", windowId).createNSString().autorelease();
+            *outExceptionString = toErrorString(nullString(), windowIdKey, makeString("'"_s, String([windowId description]), "' is not a window identifier"_s)).createNSString().autorelease();
             return false;
         }
     }
@@ -254,7 +254,7 @@ bool WebExtensionAPITabs::parseTabUpdateOptions(NSDictionary *options, WebExtens
         parameters.url = URL { extensionContext().baseURL(), url };
 
         if (!parameters.url.value().isValid()) {
-            *outExceptionString = toErrorString(nullString(), urlKey, @"'%@' is not a valid URL", url).createNSString().autorelease();
+            *outExceptionString = toErrorString(nullString(), urlKey, makeString("'"_s, String(url), "' is not a valid URL"_s)).createNSString().autorelease();
             return false;
         }
     }
@@ -263,7 +263,7 @@ bool WebExtensionAPITabs::parseTabUpdateOptions(NSDictionary *options, WebExtens
         parameters.parentTabIdentifier = toWebExtensionTabIdentifier(openerTabId.doubleValue);
 
         if (!parameters.parentTabIdentifier || !isValid(parameters.parentTabIdentifier.value())) {
-            *outExceptionString = toErrorString(nullString(), openerTabIdKey, @"'%@' is not a tab identifier", openerTabId).createNSString().autorelease();
+            *outExceptionString = toErrorString(nullString(), openerTabIdKey, makeString("'"_s, String([openerTabId description]), "' is not a tab identifier"_s)).createNSString().autorelease();
             return false;
         }
     }
@@ -332,7 +332,7 @@ bool WebExtensionAPITabs::parseTabQueryOptions(NSDictionary *options, WebExtensi
         parameters.windowIdentifier = toWebExtensionWindowIdentifier(windowId.doubleValue);
 
         if (!parameters.windowIdentifier || !isValid(parameters.windowIdentifier.value())) {
-            *outExceptionString = toErrorString(nullString(), windowIdKey, @"'%@' is not a window identifier", windowId).createNSString().autorelease();
+            *outExceptionString = toErrorString(nullString(), windowIdKey, makeString("'"_s, String([windowId description]), "' is not a window identifier"_s)).createNSString().autorelease();
             return false;
         }
 
@@ -370,7 +370,7 @@ bool WebExtensionAPITabs::parseTabQueryOptions(NSDictionary *options, WebExtensi
         for (auto& patternString : parameters.urlPatterns.value()) {
             auto pattern = WebExtensionMatchPattern::getOrCreate(patternString);
             if (!pattern || !pattern->isSupported()) {
-                *outExceptionString = toErrorString(nullString(), urlKey, @"'%@' is not a valid pattern", patternString.createNSString().get()).createNSString().autorelease();
+                *outExceptionString = toErrorString(nullString(), urlKey, makeString("'"_s, patternString, "' is not a valid pattern"_s)).createNSString().autorelease();
                 return false;
             }
         }
@@ -471,7 +471,7 @@ bool WebExtensionAPITabs::parseSendMessageOptions(NSDictionary *options, WebExte
     if (NSNumber *frameIdentifier = options[frameIdKey]) {
         auto identifier = toWebExtensionFrameIdentifier(frameIdentifier.doubleValue);
         if (!isValid(identifier)) {
-            *outExceptionString = toErrorString(nullString(), frameIdKey, @"'%@' is not a frame identifier", frameIdentifier).createNSString().autorelease();
+            *outExceptionString = toErrorString(nullString(), frameIdKey, makeString("'"_s, String([frameIdentifier description]), "' is not a frame identifier"_s)).createNSString().autorelease();
             return false;
         }
 
@@ -481,7 +481,7 @@ bool WebExtensionAPITabs::parseSendMessageOptions(NSDictionary *options, WebExte
     if (NSString *documentIdentifier = options[documentIdKey]) {
         auto parsedUUID = WTF::UUID::parse(String(documentIdentifier));
         if (!parsedUUID) {
-            *outExceptionString = toErrorString(nullString(), documentIdKey, @"'%@' is not a document identifier", documentIdentifier).createNSString().autorelease();
+            *outExceptionString = toErrorString(nullString(), documentIdKey, makeString("'"_s, String(documentIdentifier), "' is not a document identifier"_s)).createNSString().autorelease();
             return false;
         }
 
@@ -558,7 +558,7 @@ bool WebExtensionAPITabs::parseScriptOptions(NSDictionary *options, WebExtension
     if (NSString *documentIdentifer = options[documentIdKey]) {
         auto parsedUUID = WTF::UUID::parse(String(documentIdentifer));
         if (!parsedUUID) {
-            *outExceptionString = toErrorString(nullString(), documentIdKey, @"'%@' is not a valid document identifier", documentIdentifer).createNSString().autorelease();
+            *outExceptionString = toErrorString(nullString(), documentIdKey, makeString("'"_s, String(documentIdentifer), "' is not a valid document identifier"_s)).createNSString().autorelease();
             return false;
         }
 
@@ -568,7 +568,7 @@ bool WebExtensionAPITabs::parseScriptOptions(NSDictionary *options, WebExtension
     if (NSNumber *frameID = options[frameIdKey]) {
         auto frameIdentifier = toWebExtensionFrameIdentifier(frameID.doubleValue);
         if (!isValid(frameIdentifier)) {
-            *outExceptionString = toErrorString(nullString(), frameIdKey, @"'%@' is not a frame identifier", frameID).createNSString().autorelease();
+            *outExceptionString = toErrorString(nullString(), frameIdKey, makeString("'"_s, String([frameID description]), "' is not a frame identifier"_s)).createNSString().autorelease();
             return false;
         }
 
@@ -596,7 +596,7 @@ bool isValid(std::optional<WebExtensionTabIdentifier> identifier, NSString **out
         if (isNone(identifier))
             *outExceptionString = toErrorString(nullString(), @"tabId", @"'tabs.TAB_ID_NONE' is not allowed").createNSString().autorelease();
         else if (identifier)
-            *outExceptionString = toErrorString(nullString(), @"tabId", @"'%llu' is not a tab identifier", identifier.value().toUInt64()).createNSString().autorelease();
+            *outExceptionString = toErrorString(nullString(), @"tabId", makeString("'"_s, identifier.value().toUInt64(), "' is not a tab identifier"_s)).createNSString().autorelease();
         else
             *outExceptionString = toErrorString(nullString(), @"tabId", @"it is not a tab identifier").createNSString().autorelease();
         return false;
@@ -773,7 +773,7 @@ void WebExtensionAPITabs::remove(NSObject *tabIDs, Ref<WebExtensionCallbackHandl
     if (NSNumber *tabID = dynamic_objc_cast<NSNumber>(tabIDs)) {
         auto tabIdentifer = toWebExtensionTabIdentifier(tabID.doubleValue);
         if (!isValid(tabIdentifer)) {
-            *outExceptionString = toErrorString(nullString(), @"tabIDs", @"'%@' is not a tab identifier", tabID).createNSString().autorelease();
+            *outExceptionString = toErrorString(nullString(), @"tabIDs", makeString("'"_s, String([tabID description]), "' is not a tab identifier"_s)).createNSString().autorelease();
             return;
         }
 
@@ -784,7 +784,7 @@ void WebExtensionAPITabs::remove(NSObject *tabIDs, Ref<WebExtensionCallbackHandl
         for (NSNumber *tabID in tabIDArray) {
             auto tabIdentifer = toWebExtensionTabIdentifier(tabID.doubleValue);
             if (!isValid(tabIdentifer)) {
-                *outExceptionString = toErrorString(nullString(), @"tabIDs", @"'%@' is not a tab identifier", tabID).createNSString().autorelease();
+                *outExceptionString = toErrorString(nullString(), @"tabIDs", makeString("'"_s, String([tabID description]), "' is not a tab identifier"_s)).createNSString().autorelease();
                 return;
             }
 

--- a/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIWindowsCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIWindowsCocoa.mm
@@ -275,7 +275,7 @@ bool WebExtensionAPIWindows::parseWindowCreateOptions(NSDictionary *options, Web
         tabParameters.url = URL { extensionContext().baseURL(), url };
 
         if (!tabParameters.url.value().isValid()) {
-            *outExceptionString = toErrorString(nullString(), urlKey, @"'%@' is not a valid URL", url).createNSString().autorelease();
+            *outExceptionString = toErrorString(nullString(), urlKey, makeString("'"_s, String(url), "' is not a valid URL"_s)).createNSString().autorelease();
             return false;
         }
 
@@ -289,7 +289,7 @@ bool WebExtensionAPIWindows::parseWindowCreateOptions(NSDictionary *options, Web
             tabParameters.url = URL { extensionContext().baseURL(), url };
 
             if (!tabParameters.url.value().isValid()) {
-                *outExceptionString = toErrorString(nullString(), urlKey, @"'%@' is not a valid URL", url).createNSString().autorelease();
+                *outExceptionString = toErrorString(nullString(), urlKey, makeString("'"_s, String(url), "' is not a valid URL"_s)).createNSString().autorelease();
                 return false;
             }
 
@@ -367,7 +367,7 @@ bool isValid(std::optional<WebExtensionWindowIdentifier> identifier, NSString **
         if (isNone(identifier))
             *outExceptionString = toErrorString(nullString(), @"windowId", @"'windows.WINDOW_ID_NONE' is not allowed").createNSString().autorelease();
         else if (identifier)
-            *outExceptionString = toErrorString(nullString(), @"windowId", @"'%llu' is not a window identifier", identifier.value().toUInt64()).createNSString().autorelease();
+            *outExceptionString = toErrorString(nullString(), @"windowId", makeString("'"_s, identifier.value().toUInt64(), "' is not a window identifier"_s)).createNSString().autorelease();
         else
             *outExceptionString = toErrorString(nullString(), @"windowId", @"it is not a window identifier").createNSString().autorelease();
         return false;

--- a/Source/WebKit/WebProcess/Extensions/Cocoa/_WKWebExtensionWebNavigationURLFilter.mm
+++ b/Source/WebKit/WebProcess/Extensions/Cocoa/_WKWebExtensionWebNavigationURLFilter.mm
@@ -151,7 +151,7 @@ static NSString * const portsKey = @"ports";
         ASSERT([rawValue isKindOfClass:NSString.class]);
 
         if (!(_value = [NSRegularExpression regularExpressionWithPattern:rawValue options:0 error:nil])) {
-            *outErrorMessage = toErrorString(nullString(), originAndPathMatchesKey, @"'%@' is not a valid regular expression", rawValue).createNSString().autorelease();
+            *outErrorMessage = toErrorString(nullString(), originAndPathMatchesKey, makeString("'"_s, String(rawValue), "' is not a valid regular expression"_s)).createNSString().autorelease();
             return nil;
         }
 
@@ -179,7 +179,7 @@ static NSString * const portsKey = @"ports";
             if (NSNumber *number = dynamic_objc_cast<NSNumber>(portOrRange)) {
                 NSInteger integerValue = number.integerValue;
                 if (integerValue < 0 || integerValue > maximumPortNumber) {
-                    *outErrorMessage = toErrorString(nullString(), portsKey, @"'%zd' is not a valid port", integerValue).createNSString().autorelease();
+                    *outErrorMessage = toErrorString(nullString(), portsKey, makeString("'"_s, integerValue, "' is not a valid port"_s)).createNSString().autorelease();
                     return nil;
                 }
 
@@ -193,7 +193,7 @@ static NSString * const portsKey = @"ports";
                 for (NSNumber *number in rangeArray) {
                     NSInteger integerValue = number.integerValue;
                     if (integerValue < 0 || integerValue > maximumPortNumber) {
-                        *outErrorMessage = toErrorString(nullString(), portsKey, @"'%zd' is not a valid port", integerValue).createNSString().autorelease();
+                        *outErrorMessage = toErrorString(nullString(), portsKey, makeString("'"_s, integerValue, "' is not a valid port"_s)).createNSString().autorelease();
                         return nil;
                     }
                 }
@@ -201,7 +201,7 @@ static NSString * const portsKey = @"ports";
                 NSUInteger firstPort = rangeArray[0].unsignedIntegerValue;
                 NSUInteger lastPort = rangeArray[1].unsignedIntegerValue;
                 if (firstPort >= lastPort) {
-                    *outErrorMessage = toErrorString(nullString(), portsKey, @"'%zd-%zd' is not a valid port range", firstPort, lastPort).createNSString().autorelease();
+                    *outErrorMessage = toErrorString(nullString(), portsKey, makeString("'"_s, firstPort, "-"_s, lastPort, "' is not a valid port range"_s)).createNSString().autorelease();
                     return nil;
                 }
 

--- a/Source/WebKit/WebProcess/Extensions/Cocoa/_WKWebExtensionWebRequestFilter.mm
+++ b/Source/WebKit/WebProcess/Extensions/Cocoa/_WKWebExtensionWebRequestFilter.mm
@@ -131,7 +131,7 @@ static NSArray<WKWebExtensionMatchPattern *> *toMatchPatterns(NSArray<NSString *
         WKWebExtensionMatchPattern *pattern = [[WKWebExtensionMatchPattern alloc] initWithString:rawPattern error:&error];
         if (!pattern) {
             if (outErrorMessage)
-                *outErrorMessage = toErrorString(nullString(), urlsKey, @"'%@' is an invalid match pattern. %@", rawPattern, error.localizedDescription).createNSString().autorelease();
+                *outErrorMessage = toErrorString(nullString(), urlsKey, makeString("'"_s, String(rawPattern), "' is an invalid match pattern. "_s, String(error.localizedDescription))).createNSString().autorelease();
             return nil;
         }
 
@@ -164,7 +164,7 @@ static NSNumber *toResourceType(NSString *typeString, NSString **outErrorMessage
 
     NSNumber *typeAsNumber = validTypes[typeString];
     if (!typeAsNumber) {
-        *outErrorMessage = toErrorString(nullString(), typesKey, @"'%@' is an unknown resource type", typeString).createNSString().autorelease();
+        *outErrorMessage = toErrorString(nullString(), typesKey, makeString("'"_s, String(typeString), "' is an unknown resource type"_s)).createNSString().autorelease();
         return nil;
     }
 


### PR DESCRIPTION
#### 8dea243f3d526e8521cbe3542d6fa0fa4763e735
<pre>
Fix format string issue in WebExtension error handling
&lt;<a href="https://bugs.webkit.org/show_bug.cgi?id=307732">https://bugs.webkit.org/show_bug.cgi?id=307732</a>&gt;
&lt;<a href="https://rdar.apple.com/146743429">rdar://146743429</a>&gt;

Reviewed by Timothy Hatcher.

Remove variadic formatting from `toErrorString()` entirely by changing
the function signature to accept only fixed parameters and replacing all
`formatString()` calls with safe `makeString()` concatenation.

Covered by existing tests in Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPI*.mm.

* Source/WebKit/Shared/Extensions/WebExtensionUtilities.cpp:
(WebKit::toErrorString):
(WebKit::formatString): Deleted.
* Source/WebKit/Shared/Extensions/WebExtensionUtilities.h:
(WebKit::toWebExtensionError):
* Source/WebKit/UIProcess/Extensions/API/WebExtensionContextAPIDeclarativeNetRequest.cpp:
(WebKit::WebExtensionContext::declarativeNetRequestValidateRulesetIdentifiers):
* Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIDeclarativeNetRequestCocoa.mm:
(WebKit::WebExtensionContext::declarativeNetRequestUpdateEnabledRulesets):
* Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIScriptingCocoa.mm:
(WebKit::WebExtensionContext::scriptingUpdateRegisteredScripts):
(WebKit::WebExtensionContext::scriptingUnregisterContentScripts):
(WebKit::WebExtensionContext::createInjectedContentForScripts):
* Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPITabsCocoa.mm:
(WebKit::WebExtensionContext::tabsRemove):
(WebKit::WebExtensionContext::tabsExecuteScript):
* Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIWindowsCocoa.mm:
(WebKit::WebExtensionContext::windowsCreate):
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIActionCocoa.mm:
(WebKit::WebExtensionAPIAction::parseIconPathsDictionary):
(WebKit::WebExtensionAPIAction::parseIconImageDataDictionary):
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPICookiesCocoa.mm:
(WebKit::WebExtensionAPICookies::parseCookieDetails):
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIDeclarativeNetRequestCocoa.mm:
(WebKit::WebExtensionAPIDeclarativeNetRequest::updateDynamicRules):
(WebKit::WebExtensionAPIDeclarativeNetRequest::updateSessionRules):
(WebKit::WebExtensionAPIDeclarativeNetRequest::getMatchedRules):
(WebKit::WebExtensionAPIDeclarativeNetRequest::setExtensionActionOptions):
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIDevToolsInspectedWindowCocoa.mm:
(WebKit::WebExtensionAPIDevToolsInspectedWindow::eval):
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIMenusCocoa.mm:
(WebKit::WebExtensionAPIMenus::parseCreateAndUpdateProperties):
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIPermissionsCocoa.mm:
(WebKit::WebExtensionAPIPermissions::validatePermissionsDetails):
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIScriptingCocoa.mm:
(WebKit::WebExtensionAPIScripting::parseTargetInjectionOptions):
(WebKit::WebExtensionAPIScripting::parseRegisteredContentScripts):
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPISidebarActionCocoa.mm:
(WebKit::parseDetailsStringFromKey):
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPITabsCocoa.mm:
(WebKit::WebExtensionAPITabs::parseTabCreateOptions):
(WebKit::WebExtensionAPITabs::parseTabUpdateOptions):
(WebKit::WebExtensionAPITabs::parseTabQueryOptions):
(WebKit::WebExtensionAPITabs::parseSendMessageOptions):
(WebKit::WebExtensionAPITabs::parseScriptOptions):
(WebKit::isValid):
(WebKit::WebExtensionAPITabs::remove):
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIWindowsCocoa.mm:
(WebKit::WebExtensionAPIWindows::parseWindowCreateOptions):
(WebKit::isValid):
* Source/WebKit/WebProcess/Extensions/Cocoa/_WKWebExtensionWebNavigationURLFilter.mm:
(-[_WKWebExtensionWebNavigationURLPredicate initWithTypeString:value:outErrorMessage:]):
* Source/WebKit/WebProcess/Extensions/Cocoa/_WKWebExtensionWebRequestFilter.mm:
(toResourceType):

Originally-landed-as: 305413.295@safari-7624-branch (5cbcce761278). <a href="https://rdar.apple.com/173969352">rdar://173969352</a>
Canonical link: <a href="https://commits.webkit.org/312282@main">https://commits.webkit.org/312282@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/550e94f0eaf2a23fd9ab8fee35350be4746387f2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/159405 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/32833 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/25941 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/168237 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/113783 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/161274 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/32901 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/32821 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/123503 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/86690 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/162362 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/25754 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/143175 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/104167 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/24807 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/23260 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/16008 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/134494 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/20955 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/170729 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/16763 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/22581 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/131710 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/32522 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/27335 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/131823 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35659 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/32466 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/142748 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/90591 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/26485 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/19557 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/31977 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/98429 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/31497 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/31770 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/31652 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->