### PR TITLE
[git-webkit review] Inline comments sometimes missing from the review text file

### DIFF
--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/remote/git_hub.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/remote/git_hub.py
@@ -312,19 +312,71 @@ class GitHub(Scm):
                     content=comment.content,
                 )
 
-        def _diff_comments(self, pull_request, ids=False):
+        HUNK_HEADER_RE = re.compile(r'^@@ -\d+(?:,\d+)? \+(?P<new_start>\d+)(?:,\d+)? @@')
+
+        @classmethod
+        def _line_to_position_map(cls, diff_text_lines):
+            # Build a map of (file, new-file line number) -> position within the diff
+            # we fetched, matching how insert_diff_comments counts line positions.
+            # GitHub's reported comment position is computed against a diff that can
+            # differ from what 'application/vnd.github.diff' returns (e.g. base SHA
+            # vs merge base), so we translate using the line number GitHub reports
+            # for the comment instead of trusting its position.
+            result = defaultdict(dict)
+            file = None
+            count = 0
+            new_line = None
+            for line in diff_text_lines or []:
+                if line.startswith('+++ b/'):
+                    file = line.split('/', 1)[-1]
+                    count = -1
+                    new_line = None
+                elif file and line.startswith('@@'):
+                    match = cls.HUNK_HEADER_RE.match(line)
+                    if match:
+                        new_line = int(match.group('new_start')) - 1
+                elif file and new_line is not None:
+                    if line.startswith('+') or line.startswith(' '):
+                        new_line += 1
+                        result[file][new_line] = count
+                count += 1
+            return result
+
+        def _diff_comments(self, pull_request, ids=False, diff_text_lines=None):
+            if diff_text_lines is None:
+                response = self.repository.request('pulls/{}'.format(pull_request.number), headers=dict(Accept=self.repository.DIFF_HEADER))
+                if response.status_code // 100 == 2:
+                    diff_text_lines = response.text.splitlines()
+                else:
+                    diff_text_lines = []
+            line_to_position = self._line_to_position_map(diff_text_lines)
+
             comment_lines = defaultdict(lambda: defaultdict(list))
             for comment in self.repository.request('pulls/{}/comments'.format(pull_request.number)):
                 id = comment.get('id', None)
                 path = comment.get('path', None)
-                position = comment.get('position', None)
-                if comment.get('commit_id') != comment.get('original_commit_id') and position is None:
-                    continue
                 if not id or not path:
                     continue
-                position = int(position) if position else None
                 if comment.get('subject_type') == 'file':
                     position = None
+                else:
+                    line = comment.get('line')
+                    if line is None:
+                        line = comment.get('original_line')
+                    if line is not None:
+                        position = line_to_position.get(path, {}).get(int(line))
+                        if position is None:
+                            # The commented line is not present in the diff we
+                            # fetched (e.g. outdated comment on code that is no
+                            # longer in the current diff). Skip.
+                            continue
+                    else:
+                        # No line information (can happen for legacy comments or
+                        # mocked data); fall back to the reported position field.
+                        raw_position = comment.get('position', None)
+                        if comment.get('commit_id') != comment.get('original_commit_id') and raw_position is None:
+                            continue
+                        position = int(raw_position) if raw_position else None
                 if ids:
                     comment_lines[path][position].append(id)
                 else:
@@ -460,17 +512,19 @@ class GitHub(Scm):
                 )
 
         def diff(self, pull_request, comments=False):
-            def generator(repository=self.repository, pull_request=pull_request):
-                response = repository.request('pulls/{}'.format(pull_request.number), headers=dict(Accept=repository.DIFF_HEADER))
-                if response.status_code // 100 != 2:
-                    sys.stderr.write('Failed to retrieve diff of {} with status code {}\n'.format(commit, response.status_code))
-                    return
-                for line in response.text.splitlines():
+            response = self.repository.request('pulls/{}'.format(pull_request.number), headers=dict(Accept=self.repository.DIFF_HEADER))
+            if response.status_code // 100 != 2:
+                sys.stderr.write('Failed to retrieve diff of {} with status code {}\n'.format(pull_request, response.status_code))
+                return
+            diff_text_lines = response.text.splitlines()
+
+            def generator(lines=diff_text_lines):
+                for line in lines:
                     yield line
 
             comment_lines = defaultdict(lambda: defaultdict(list))
             if comments:
-                comment_lines = self._diff_comments(pull_request)
+                comment_lines = self._diff_comments(pull_request, diff_text_lines=diff_text_lines)
 
             for line in self.repository.insert_diff_comments(generator, comments=comment_lines):
                 yield line


### PR DESCRIPTION
#### 4eab3cdb1517ad95547d1307d7080ccf820e89b6
<pre>
[git-webkit review] Inline comments sometimes missing from the review text file
<a href="https://bugs.webkit.org/show_bug.cgi?id=313572">https://bugs.webkit.org/show_bug.cgi?id=313572</a>

Reviewed by Jonathan Bedard.

Problem:
  `git-webkit review` relies on the `position` field returned by GitHub&apos;s
  pull request comments API to place each inline comment in the generated
  review text file. GitHub computes `position` against its own view of the
  pull request diff, but the diff we fetch via `application/vnd.github.diff`
  is computed against the merge base and can have a different hunk layout
  (e.g. a hunk that has already landed on main is absent from our diff).
  When GitHub&apos;s `position` lands outside the range of lines in the diff we
  fetched, the count in `insert_diff_comments` never matches and the
  comment is silently dropped — it never appears in the review text file.

Solution:
  Translate comment locations ourselves using the `line` / `original_line`
  field (the new-file line number the comment applies to), which is
  unambiguous regardless of which diff was used to compute it. A new
  `_line_to_position_map` helper walks the diff we actually fetched,
  parses `@@ -a,b +c,d @@` hunk headers, and records the position within
  our diff for each new-file line. `_diff_comments` now uses that map to
  assign each comment a position that matches the diff being displayed,
  falling back to the raw `position` field only when no line number is
  reported (preserves behavior for file-level comments and legacy/mock
  data used by the existing tests).

* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/remote/git_hub.py:

Canonical link: <a href="https://commits.webkit.org/312247@main">https://commits.webkit.org/312247@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1f60fa5d9ae13a88028b399687f2fbfa888cd7bb

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/159323 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/32751 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/25857 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/168153 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/113701 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/161192 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/32819 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/32738 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/123443 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/113701 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/162280 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/25701 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/143109 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/104110 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | ⏳ 🛠 vision-apple 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/158643 "Passed tests") | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/24754 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/23195 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk3-libwebrtc~~](https://ews-build.webkit.org/#/builders/173/builds/15926 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/134441 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/20889 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/170647 "Built successfully") | | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/22515 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/131647 "Passed tests") | | 
| [❌ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/158719 "Failed buildbot checkconfig") | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/32440 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/27269 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/131759 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35639 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/32384 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/142682 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/90509 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/164/builds/26436 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/19491 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/31895 "Built successfully") | | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/31415 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/31688 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/31570 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->