### PR TITLE
[JSC] DFG iterator_next should dispatch fast modes by iterator type

### DIFF
--- a/JSTests/microbenchmarks/for-of-array-map-mixed.js
+++ b/JSTests/microbenchmarks/for-of-array-map-mixed.js
@@ -1,0 +1,19 @@
+function test(iterable) {
+    let sum = 0;
+    for (const e of iterable) {
+        if (typeof e === "number")
+            sum += e;
+        else
+            sum += e[0] + e[1];
+    }
+    return sum;
+}
+noInline(test);
+
+const arr = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
+const map = new Map([[1, 10], [2, 20], [3, 30], [4, 40], [5, 50]]);
+
+for (let i = 0; i < 1e5; ++i) {
+    test(arr);
+    test(map);
+}

--- a/JSTests/microbenchmarks/for-of-array-set-mixed.js
+++ b/JSTests/microbenchmarks/for-of-array-set-mixed.js
@@ -1,0 +1,15 @@
+function test(iterable) {
+    let sum = 0;
+    for (const v of iterable)
+        sum += v;
+    return sum;
+}
+noInline(test);
+
+const arr = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
+const set = new Set([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
+
+for (let i = 0; i < 1e5; ++i) {
+    test(arr);
+    test(set);
+}

--- a/Source/JavaScriptCore/dfg/DFGByteCodeParser.cpp
+++ b/Source/JavaScriptCore/dfg/DFGByteCodeParser.cpp
@@ -11086,14 +11086,20 @@ void ByteCodeParser::handleIteratorNext(const JSInstruction* currentInstruction,
         if (!numberOfRemainingModes)
             addToGraph(CheckIsConstant, OpInfo(m_graph.freeze(JSValue())), get(bytecode.m_next));
         else {
-            Node* hasNext = addToGraph(IsEmpty, get(bytecode.m_next));
+            Node* isEmpty = addToGraph(IsEmpty, get(bytecode.m_next));
+            Node* isArrayIterator = addToGraph(IsCellWithType, OpInfo(JSArrayIteratorType), get(bytecode.m_iterator));
+            Node* andResult = addToGraph(ArithBitAnd, isEmpty, isArrayIterator);
+
+            m_exitOK = true;
+            addToGraph(ExitOK);
+
             failedBlock = allocateUntargetableBlock();
             BasicBlock* fastArrayBlock = allocateUntargetableBlock();
 
             BranchData* branchData = m_graph.m_branchData.add();
             branchData->taken = BranchTarget(fastArrayBlock);
             branchData->notTaken = BranchTarget(failedBlock);
-            addToGraph(Branch, OpInfo(branchData), hasNext);
+            addToGraph(Branch, OpInfo(branchData), andResult);
 
             m_currentBlock = fastArrayBlock;
             clearCaches();
@@ -11199,14 +11205,20 @@ void ByteCodeParser::handleIteratorNext(const JSInstruction* currentInstruction,
         if (!numberOfRemainingModes)
             addToGraph(CheckIsConstant, OpInfo(m_graph.freeze(JSValue())), get(bytecode.m_next));
         else {
-            Node* hasNext = addToGraph(IsEmpty, get(bytecode.m_next));
+            Node* isEmpty = addToGraph(IsEmpty, get(bytecode.m_next));
+            Node* isMapIterator = addToGraph(IsCellWithType, OpInfo(JSMapIteratorType), get(bytecode.m_iterator));
+            Node* andResult = addToGraph(ArithBitAnd, isEmpty, isMapIterator);
+
+            m_exitOK = true;
+            addToGraph(ExitOK);
+
             failedBlock = allocateUntargetableBlock();
             BasicBlock* fastMapBlock = allocateUntargetableBlock();
 
             BranchData* branchData = m_graph.m_branchData.add();
             branchData->taken = BranchTarget(fastMapBlock);
             branchData->notTaken = BranchTarget(failedBlock);
-            addToGraph(Branch, OpInfo(branchData), hasNext);
+            addToGraph(Branch, OpInfo(branchData), andResult);
 
             m_currentBlock = fastMapBlock;
             clearCaches();
@@ -11292,14 +11304,20 @@ void ByteCodeParser::handleIteratorNext(const JSInstruction* currentInstruction,
         if (!numberOfRemainingModes)
             addToGraph(CheckIsConstant, OpInfo(m_graph.freeze(JSValue())), get(bytecode.m_next));
         else {
-            Node* hasNext = addToGraph(IsEmpty, get(bytecode.m_next));
+            Node* isEmpty = addToGraph(IsEmpty, get(bytecode.m_next));
+            Node* isSetIterator = addToGraph(IsCellWithType, OpInfo(JSSetIteratorType), get(bytecode.m_iterator));
+            Node* andResult = addToGraph(ArithBitAnd, isEmpty, isSetIterator);
+
+            m_exitOK = true;
+            addToGraph(ExitOK);
+
             failedBlock = allocateUntargetableBlock();
             BasicBlock* fastSetBlock = allocateUntargetableBlock();
 
             BranchData* branchData = m_graph.m_branchData.add();
             branchData->taken = BranchTarget(fastSetBlock);
             branchData->notTaken = BranchTarget(failedBlock);
-            addToGraph(Branch, OpInfo(branchData), hasNext);
+            addToGraph(Branch, OpInfo(branchData), andResult);
 
             m_currentBlock = fastSetBlock;
             clearCaches();


### PR DESCRIPTION
#### 85a14b7462fd88a437cda799412e510097a66f65
<pre>
[JSC] DFG iterator_next should dispatch fast modes by iterator type
<a href="https://bugs.webkit.org/show_bug.cgi?id=313578">https://bugs.webkit.org/show_bug.cgi?id=313578</a>

Reviewed by Yusuke Suzuki.

After 312127@main, seenModes can have multiple fast modes. handleIteratorNext
branched only on IsEmpty(m_next), but m_next is empty for every fast mode, so
Map / Set iterators always fell into the FastArray block and OSR-exited on its
CheckStructure. Add IsCellWithType on the iterator to the branch condition,
matching handleIteratorOpen.

                                     ToT                     Patched

    for-of-array-map-mixed     15.6239+-0.4009     ^      5.5403+-0.0831        ^ definitely 2.8200x faster
    for-of-array-set-mixed     11.5055+-0.5032     ^      4.4497+-0.1425        ^ definitely 2.5857x faster

Tests: JSTests/microbenchmarks/for-of-array-map-mixed.js
       JSTests/microbenchmarks/for-of-array-set-mixed.js

* JSTests/microbenchmarks/for-of-array-map-mixed.js: Added.
(test):
* JSTests/microbenchmarks/for-of-array-set-mixed.js: Added.
(test):
(const.set new):
* Source/JavaScriptCore/dfg/DFGByteCodeParser.cpp:
(JSC::DFG::ByteCodeParser::handleIteratorNext):

Canonical link: <a href="https://commits.webkit.org/312309@main">https://commits.webkit.org/312309@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c96322a4c5e61003c759aa3a195a032df3c60dbf

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/159332 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/32760 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/25866 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/168162 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/113710 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/32828 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/32747 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/123449 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/86654 "1 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/162289 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/25710 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/143119 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/104116 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/24763 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/23205 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/15935 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/151382 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/134450 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/20899 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/170656 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/20165 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/16690 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/22525 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/131654 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/32449 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/27279 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/131766 "Found 1 new API test failure: TestWebKit:WebKit.Find (failure)") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35677 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/32393 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/142692 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/90518 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/26438 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/19501 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/191615 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/31904 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/98356 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/49242 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/31424 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/31697 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/31579 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->