### PR TITLE
[JSC] JSWebAssemblyTag should retain FunctionSignature types

### DIFF
--- a/JSTests/wasm/regress/wasm-tag-retains-reachable-types.js
+++ b/JSTests/wasm/regress/wasm-tag-retains-reachable-types.js
@@ -1,0 +1,47 @@
+/*
+(module
+    (type $struct (struct (field (mut i64))))
+    (type $func (func (param (ref $struct))))
+    (tag $tag (export "tag") (type $func))
+)
+*/
+const WASM_MODULE_CODE = new Uint8Array([0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00, 0x01, 0x0a, 0x02, 0x5f, 0x01, 0x7e, 0x01, 0x60, 0x01, 0x64, 0x00, 0x00, 0x0d, 0x03, 0x01, 0x00, 0x01, 0x07, 0x07, 0x01, 0x03, 0x74, 0x61, 0x67, 0x04, 0x00, 0x00, 0x1e, 0x04, 0x6e, 0x61, 0x6d, 0x65, 0x04, 0x0f, 0x02, 0x00, 0x06, 0x73, 0x74, 0x72, 0x75, 0x63, 0x74, 0x01, 0x04, 0x66, 0x75, 0x6e, 0x63, 0x0b, 0x06, 0x01, 0x00, 0x03, 0x74, 0x61, 0x67]);
+
+function createTag() {
+    const module = new WebAssembly.Module(WASM_MODULE_CODE);
+    const instance = new WebAssembly.Instance(module);
+
+    return instance.exports.tag;
+}
+
+function callTypeInformationTryCleanup() {
+    {
+        // Just an empty module
+        new WebAssembly.Module(new Uint8Array([0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00]));
+    }
+
+    gc();
+}
+
+function main() {
+    const tag = createTag();
+
+    callTypeInformationTryCleanup();
+    callTypeInformationTryCleanup();
+    callTypeInformationTryCleanup();
+    callTypeInformationTryCleanup();
+
+    try {
+        // The following should throw a type error because the argument is not the expected struct.
+        // If the struct type is not properly retained by the tag, it will instead crash in a Debug+ASan build.
+        new WebAssembly.Exception(tag, [{}]);
+        throw new Error("Expected TypeError to be thrown");
+    } catch (e) {
+        if (!(e instanceof TypeError))
+            throw new Error(`Expected TypeError, got ${e.constructor.name}`);
+        if (e.message !== "Argument value did not match the reference type")
+            throw new Error(`Expected message "Argument value did not match the reference type", got "${e.message}"`);
+    }
+}
+
+main();

--- a/Source/JavaScriptCore/wasm/WasmTag.h
+++ b/Source/JavaScriptCore/wasm/WasmTag.h
@@ -61,11 +61,13 @@ public:
 
 private:
     Tag(Ref<const TypeDefinition>&& type)
-        : m_type(WTF::move(type))
+        : m_typeDependencies(type)
+        , m_type(WTF::move(type))
     {
         ASSERT(m_type->is<FunctionSignature>());
     }
 
+    WebAssemblyGCTypeDependencies m_typeDependencies;
     const Ref<const TypeDefinition> m_type;
 };
 

--- a/Source/JavaScriptCore/wasm/WasmTypeDefinition.cpp
+++ b/Source/JavaScriptCore/wasm/WasmTypeDefinition.cpp
@@ -38,6 +38,7 @@
 #include "WebAssemblyFunctionBase.h"
 #include <wtf/CommaPrinter.h>
 #include <wtf/FastMalloc.h>
+#include <wtf/ReferenceWrapperVector.h>
 #include <wtf/StringPrintStream.h>
 #include <wtf/TZoneMallocInlines.h>
 
@@ -1219,6 +1220,55 @@ bool Type::definitelyIsWasmGCObjectOrNull() const
     if (def.is<Wasm::ArrayType>())
         return true;
     return false;
+}
+
+static inline TypeHash typeHash(const TypeDefinition& typeDef)
+{
+    return TypeHash { const_cast<TypeDefinition&>(typeDef) };
+}
+
+WebAssemblyGCTypeDependencies::WebAssemblyGCTypeDependencies(const Ref<const TypeDefinition>& unexpandedType)
+{
+    WorkList work;
+    SUPPRESS_UNCHECKED_ARG work.append(unexpandedType->expand());
+    while (!work.isEmpty())
+        SUPPRESS_UNCHECKED_ARG process(work.takeLast(), work);
+    m_typeDefinitions.add(typeHash(unexpandedType));
+}
+
+inline static void appendToWorkIfNeeded(Type type, WebAssemblyGCTypeDependencies::WorkList& work)
+{
+    if (isRefWithTypeIndex(type)) {
+        SUPPRESS_UNCHECKED_LOCAL const auto& referencedType = TypeInformation::get(type.index).expand();
+        work.append(referencedType);
+    }
+}
+
+void WebAssemblyGCTypeDependencies::process(const TypeDefinition& typeDef, WorkList& work)
+{
+    if (m_typeDefinitions.contains(typeHash(typeDef)))
+        return;
+    m_typeDefinitions.add(typeHash(typeDef));
+
+    if (typeDef.is<StructType>()) {
+        SUPPRESS_UNCHECKED_LOCAL auto* structType = typeDef.as<StructType>();
+        for (unsigned i = 0; i < structType->fieldCount(); ++i)
+            process(structType->field(i), work);
+    } else if (typeDef.is<ArrayType>()) {
+        process(typeDef.as<ArrayType>()->elementType(), work);
+    } else if (typeDef.is<FunctionSignature>()) {
+        SUPPRESS_UNCHECKED_LOCAL auto* signature = typeDef.as<FunctionSignature>();
+        for (unsigned i = 0; i < signature->argumentCount(); ++i)
+            appendToWorkIfNeeded(signature->argumentType(i), work);
+        for (unsigned i = 0; i < signature->returnCount(); ++i)
+            appendToWorkIfNeeded(signature->returnType(i), work);
+    }
+}
+
+void WebAssemblyGCTypeDependencies::process(FieldType fieldType, WorkList& work)
+{
+    if (fieldType.type.is<Type>())
+        appendToWorkIfNeeded(fieldType.type.as<Type>(), work);
 }
 
 } } // namespace JSC::Wasm

--- a/Source/JavaScriptCore/wasm/WasmTypeDefinition.h
+++ b/Source/JavaScriptCore/wasm/WasmTypeDefinition.h
@@ -42,6 +42,7 @@
 #include <wtf/HashSet.h>
 #include <wtf/HashTraits.h>
 #include <wtf/Lock.h>
+#include <wtf/ReferenceWrapperVector.h>
 #include <wtf/StdLibExtras.h>
 #include <wtf/TZoneMalloc.h>
 #include <wtf/ThreadSafeRefCounted.h>
@@ -1015,6 +1016,27 @@ private:
     RefPtr<FunctionSignature> m_Void_I32AnyrefI32I32I32I32;
     RefPtr<FunctionSignature> m_Void_I32AnyrefI32I32AnyrefI32I32;
     Lock m_lock;
+};
+
+// A set of TypeDefinitions retained to prevent dangling pointers in Wasm::Types. TypeDefinitions
+// may reference other TypeDefinitions via pointers disguised as type indices stored in StructType
+// fields, ArrayType element types, or FunctionSignature parameters and return types. To prevent
+// these unmanaged pointers from dangling if a type referenced by a GC object or Wasm::Tag outlives
+// the Wasm instance it originated from, we collect a transitive closure of all TypeDefinitions
+// reachable from a root type and retain them for at least as long as the object that depends on
+// those types lives.
+
+class WebAssemblyGCTypeDependencies {
+public:
+    WebAssemblyGCTypeDependencies(const Ref<const TypeDefinition>& unexpandedType);
+
+    using WorkList = ReferenceWrapperVector<const TypeDefinition>;
+
+private:
+    void process(const TypeDefinition&, WorkList&);
+    void process(FieldType, WorkList&);
+
+    UncheckedKeyHashSet<TypeHash> m_typeDefinitions;
 };
 
 } } // namespace JSC::Wasm

--- a/Source/JavaScriptCore/wasm/js/WebAssemblyGCStructure.cpp
+++ b/Source/JavaScriptCore/wasm/js/WebAssemblyGCStructure.cpp
@@ -38,49 +38,11 @@
 
 namespace JSC {
 
-static inline Wasm::TypeHash typeHash(const Wasm::TypeDefinition& typeDef)
-{
-    return Wasm::TypeHash { const_cast<Wasm::TypeDefinition&>(typeDef) };
-}
-
-WebAssemblyGCStructureTypeDependencies::WebAssemblyGCStructureTypeDependencies(Ref<const Wasm::TypeDefinition>&& unexpandedType)
-{
-    WorkList work;
-    SUPPRESS_UNCHECKED_ARG work.append(unexpandedType->expand());
-    while (!work.isEmpty())
-        SUPPRESS_UNCHECKED_ARG process(work.takeLast(), work);
-    m_typeDefinitions.add(typeHash(unexpandedType));
-}
-
-void WebAssemblyGCStructureTypeDependencies::process(const Wasm::TypeDefinition& typeDef, WorkList& work)
-{
-    if (m_typeDefinitions.contains(typeHash(typeDef)))
-        return;
-    m_typeDefinitions.add(typeHash(typeDef));
-    if (typeDef.is<Wasm::StructType>()) {
-        SUPPRESS_UNCHECKED_LOCAL auto* structType = typeDef.as<Wasm::StructType>();
-        for (unsigned i = 0; i < structType->fieldCount(); ++i)
-            process(structType->field(i), work);
-    } else if (typeDef.is<Wasm::ArrayType>())
-        process(typeDef.as<Wasm::ArrayType>()->elementType(), work);
-}
-
-void WebAssemblyGCStructureTypeDependencies::process(Wasm::FieldType fieldType, WorkList& work)
-{
-    if (fieldType.type.is<Wasm::Type>()) {
-        Wasm::Type type = fieldType.type.as<Wasm::Type>();
-        if (isRefWithTypeIndex(type)) {
-            SUPPRESS_UNCHECKED_LOCAL const auto& typeDef = Wasm::TypeInformation::get(type.index).expand();
-            work.append(typeDef);
-        }
-    }
-}
-
 WebAssemblyGCStructure::WebAssemblyGCStructure(VM& vm, const TypeInfo& typeInfo, const ClassInfo* classInfo, Ref<const Wasm::TypeDefinition>&& unexpandedType, Ref<const Wasm::TypeDefinition>&& type, Ref<const Wasm::RTT>&& rtt)
     : Structure(vm, StructureVariant::WebAssemblyGC, nullptr, typeInfo, classInfo)
     , m_rtt(WTF::move(rtt))
     , m_type(WTF::move(type))
-    , m_typeDependencies(WebAssemblyGCStructureTypeDependencies { WTF::move(unexpandedType) })
+    , m_typeDependencies(unexpandedType)
 {
     setMayBePrototype(true); // Make sure that didPrototype transition does not happen.
     switch (m_rtt->kind()) {

--- a/Source/JavaScriptCore/wasm/js/WebAssemblyGCStructure.h
+++ b/Source/JavaScriptCore/wasm/js/WebAssemblyGCStructure.h
@@ -29,7 +29,6 @@
 #include <JavaScriptCore/WasmTypeDefinition.h>
 #include <JavaScriptCore/WriteBarrier.h>
 #include <wtf/Platform.h>
-#include <wtf/ReferenceWrapperVector.h>
 
 #if ENABLE(WEBASSEMBLY)
 
@@ -40,26 +39,6 @@ class UniquedStringImpl;
 } // namespace WTF
 
 namespace JSC {
-
-// A set of all TypeDefinitions a WebAssemblyGCStructure needs to keep alive.
-// The TypeDefinition retained by a structure as `m_type` may reference other
-// TypeDefinitions. Such references are stored as raw pointers in Wasm::FieldTypes. To
-// prevent these unmanaged pointers from dangling if a GC object and its structure outlive
-// the originating Wasm instance, we collect a transitive closure of all TypeDefinitions
-// reachable from the declared type of the GC object. The structure holds onto this set
-// to ensure all relevant type definitions live for at least as long as itself.
-class WebAssemblyGCStructureTypeDependencies {
-    public:
-        WebAssemblyGCStructureTypeDependencies(Ref<const Wasm::TypeDefinition>&& unexpandedType);
-
-    private:
-        using WorkList = ReferenceWrapperVector<const Wasm::TypeDefinition>;
-
-        void process(const Wasm::TypeDefinition&, WorkList&);
-        void process(Wasm::FieldType, WorkList&);
-
-        UncheckedKeyHashSet<Wasm::TypeHash> m_typeDefinitions;
-};
 
 // FIXME: It seems like almost all the fields of a Structure are useless to a wasm GC "object" since they can't have dynamic fields
 // e.g. PropertyTables, Transitions, SeenProperties, Prototype, etc.
@@ -94,7 +73,7 @@ private:
 
     const Ref<const Wasm::RTT> m_rtt;
     const Ref<const Wasm::TypeDefinition> m_type;
-    WebAssemblyGCStructureTypeDependencies m_typeDependencies;
+    Wasm::WebAssemblyGCTypeDependencies m_typeDependencies;
     std::array<WriteBarrierStructureID, inlinedDisplaySize> m_inlinedDisplay { };
 };
 


### PR DESCRIPTION
#### 20825c02cda2d46fc21745193bf2b91a382f40d2
<pre>
[JSC] JSWebAssemblyTag should retain FunctionSignature types
<a href="https://bugs.webkit.org/show_bug.cgi?id=306559">https://bugs.webkit.org/show_bug.cgi?id=306559</a>
<a href="https://rdar.apple.com/168041308">rdar://168041308</a>

Reviewed by Marcus Plutowski.

This problem is similar to the problem from a few months ago with WebAssemblyGCStructure not
retaining all TypeDefinitions it depends on. That problem was fixed by introducing
WebAssemblyGCStructureTypeDependencies which holds a transitive closure of all types reachable from
a given root type (a StructType or ArrayType). It is retained by a WebAssemblyGCStructure to ensure
all reachable TypeDefinitions stay alive for as long as the structure can reference them.

This patch adapts WebAssemblyGCStructureTypeDependencies to also ensure that a Wasm::Tag retains all
TypeDefinitions reachable from its &apos;m_type&apos; (a FunctionSignature).

Specifically:

- WebAssemblyGCStructureTypeDependencies is moved from WebAssemblyGCStructure.h/.cpp to
  WasmTypeDefinition.h/.cpp and renamed WebAssemblyGCTypeDependencies.

- The implementation is extended to traverse FunctionSignatures.

- An instance of WebAssemblyGCTypeDependencies is created and stored by Wasm::Tag constructor to
  capture all TypeDefinitions reachable from the tag&apos;s function signature.

Test: JSTests/wasm/regress/wasm-tag-retains-reachable-types.js

Originally-landed-as: 305413.237@safari-7624-branch (5c551f153c01). <a href="https://rdar.apple.com/173969088">rdar://173969088</a>
Canonical link: <a href="https://commits.webkit.org/312331@main">https://commits.webkit.org/312331@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4f35a0abe295ba4550dad46e6159734b75f7ff1e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/159527 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/32994 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/26072 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/168371 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/113908 "Built successfully") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/33046 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/32957 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/123621 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/86753 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/162484 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/25859 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/143294 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/104270 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/24912 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/23369 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/16136 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/151583 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/134603 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/21066 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/170858 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/20364 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/16895 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/22699 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/131840 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/32661 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/27445 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/131930 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/32658 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/142859 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/90740 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/24292 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/26577 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/19673 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/191811 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/32167 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/98563 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/49284 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/31664 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/31910 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/31815 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->