### PR TITLE
Require cross-origin isolation for SharedArrayBuffer serialization

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/html/cross-origin-embedder-policy/cross-origin-isolated-permission.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/cross-origin-embedder-policy/cross-origin-isolated-permission.https-expected.txt
@@ -20,7 +20,7 @@ PASS dedicated worker: scheme = blob, value = *
 PASS dedicated worker: scheme = blob, value = self
 FAIL dedicated worker: scheme = blob, value = (\) assert_equals: expected false but got true
 PASS shared worker: withCoopCoep = false
-FAIL shared worker: withCoopCoep = true assert_equals: expected true but got false
+PASS shared worker: withCoopCoep = true
 PASS service worker: withCoopCoep = false
-FAIL service worker: withCoopCoep = true assert_equals: expected true but got false
+PASS service worker: withCoopCoep = true
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/infrastructure/safe-passing-of-structured-data/messagechannel.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/infrastructure/safe-passing-of-structured-data/messagechannel.any-expected.txt
@@ -132,7 +132,7 @@ PASS Serializing a non-serializable platform object fails
 PASS An object whose interface is deleted from the global must still deserialize
 PASS A subclass instance will deserialize as its closest serializable superclass
 PASS Resizable ArrayBuffer
-FAIL Growable SharedArrayBuffer assert_true: instanceof ArrayBuffer expected true got false
+PASS Growable SharedArrayBuffer
 PASS Length-tracking TypedArray
 PASS Length-tracking DataView
 PASS Serializing OOB TypedArray throws

--- a/LayoutTests/imported/w3c/web-platform-tests/html/infrastructure/safe-passing-of-structured-data/messagechannel.any.serviceworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/infrastructure/safe-passing-of-structured-data/messagechannel.any.serviceworker-expected.txt
@@ -117,7 +117,7 @@ PASS Serializing a non-serializable platform object fails
 PASS An object whose interface is deleted from the global must still deserialize
 PASS A subclass instance will deserialize as its closest serializable superclass
 PASS Resizable ArrayBuffer
-FAIL Growable SharedArrayBuffer assert_true: instanceof ArrayBuffer expected true got false
+PASS Growable SharedArrayBuffer
 PASS Length-tracking TypedArray
 PASS Length-tracking DataView
 PASS Serializing OOB TypedArray throws

--- a/LayoutTests/imported/w3c/web-platform-tests/html/infrastructure/safe-passing-of-structured-data/messagechannel.any.sharedworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/infrastructure/safe-passing-of-structured-data/messagechannel.any.sharedworker-expected.txt
@@ -117,7 +117,7 @@ PASS Serializing a non-serializable platform object fails
 PASS An object whose interface is deleted from the global must still deserialize
 PASS A subclass instance will deserialize as its closest serializable superclass
 PASS Resizable ArrayBuffer
-FAIL Growable SharedArrayBuffer assert_true: instanceof ArrayBuffer expected true got false
+PASS Growable SharedArrayBuffer
 PASS Length-tracking TypedArray
 PASS Length-tracking DataView
 PASS Serializing OOB TypedArray throws

--- a/LayoutTests/imported/w3c/web-platform-tests/html/infrastructure/safe-passing-of-structured-data/messagechannel.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/infrastructure/safe-passing-of-structured-data/messagechannel.any.worker-expected.txt
@@ -117,7 +117,7 @@ PASS Serializing a non-serializable platform object fails
 PASS An object whose interface is deleted from the global must still deserialize
 PASS A subclass instance will deserialize as its closest serializable superclass
 PASS Resizable ArrayBuffer
-FAIL Growable SharedArrayBuffer assert_true: instanceof ArrayBuffer expected true got false
+PASS Growable SharedArrayBuffer
 PASS Length-tracking TypedArray
 PASS Length-tracking DataView
 PASS Serializing OOB TypedArray throws

--- a/LayoutTests/imported/w3c/web-platform-tests/html/infrastructure/safe-passing-of-structured-data/shared-array-buffers/nested-sharedworker-success.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/infrastructure/safe-passing-of-structured-data/shared-array-buffers/nested-sharedworker-success.https-expected.txt
@@ -1,4 +1,4 @@
 
 FAIL postMessaging to a dedicated sub-worker allows them to see each others' modifications Can't find variable: Worker
-FAIL Bonus: self.crossOriginIsolated assert_true: expected true got false
+PASS Bonus: self.crossOriginIsolated
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/infrastructure/safe-passing-of-structured-data/shared-array-buffers/no-coop-coep.https.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/infrastructure/safe-passing-of-structured-data/shared-array-buffers/no-coop-coep.https.any-expected.txt
@@ -2,8 +2,8 @@
 FAIL SharedArrayBuffer constructor does not exist without COOP+COEP assert_equals: expected (undefined) undefined but got (function) function "function SharedArrayBuffer() {
     [native code]
 }"
-FAIL SharedArrayBuffer over MessageChannel without COOP+COEP assert_throws_dom: function "() => channel.port1.postMessage(sab)" did not throw
-FAIL SharedArrayBuffer over BroadcastChannel without COOP+COEP assert_throws_dom: function "() => channel.postMessage(sab)" did not throw
+PASS SharedArrayBuffer over MessageChannel without COOP+COEP
+PASS SharedArrayBuffer over BroadcastChannel without COOP+COEP
 PASS SharedArrayBuffer over postMessage() without COOP+COEP
 PASS Bonus: self.crossOriginIsolated
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/infrastructure/safe-passing-of-structured-data/shared-array-buffers/no-coop-coep.https.any.serviceworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/infrastructure/safe-passing-of-structured-data/shared-array-buffers/no-coop-coep.https.any.serviceworker-expected.txt
@@ -2,7 +2,7 @@
 FAIL SharedArrayBuffer constructor does not exist without COOP+COEP assert_equals: expected (undefined) undefined but got (function) function "function SharedArrayBuffer() {
     [native code]
 }"
-FAIL SharedArrayBuffer over MessageChannel without COOP+COEP assert_throws_dom: function "() => channel.port1.postMessage(sab)" did not throw
-FAIL SharedArrayBuffer over BroadcastChannel without COOP+COEP assert_throws_dom: function "() => channel.postMessage(sab)" did not throw
+PASS SharedArrayBuffer over MessageChannel without COOP+COEP
+PASS SharedArrayBuffer over BroadcastChannel without COOP+COEP
 PASS Bonus: self.crossOriginIsolated
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/infrastructure/safe-passing-of-structured-data/shared-array-buffers/no-coop-coep.https.any.sharedworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/infrastructure/safe-passing-of-structured-data/shared-array-buffers/no-coop-coep.https.any.sharedworker-expected.txt
@@ -2,7 +2,7 @@
 FAIL SharedArrayBuffer constructor does not exist without COOP+COEP assert_equals: expected (undefined) undefined but got (function) function "function SharedArrayBuffer() {
     [native code]
 }"
-FAIL SharedArrayBuffer over MessageChannel without COOP+COEP assert_throws_dom: function "() => channel.port1.postMessage(sab)" did not throw
-FAIL SharedArrayBuffer over BroadcastChannel without COOP+COEP assert_throws_dom: function "() => channel.postMessage(sab)" did not throw
+PASS SharedArrayBuffer over MessageChannel without COOP+COEP
+PASS SharedArrayBuffer over BroadcastChannel without COOP+COEP
 PASS Bonus: self.crossOriginIsolated
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/infrastructure/safe-passing-of-structured-data/shared-array-buffers/no-coop-coep.https.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/infrastructure/safe-passing-of-structured-data/shared-array-buffers/no-coop-coep.https.any.worker-expected.txt
@@ -2,7 +2,7 @@
 FAIL SharedArrayBuffer constructor does not exist without COOP+COEP assert_equals: expected (undefined) undefined but got (function) function "function SharedArrayBuffer() {
     [native code]
 }"
-FAIL SharedArrayBuffer over MessageChannel without COOP+COEP assert_throws_dom: function "() => channel.port1.postMessage(sab)" did not throw
-FAIL SharedArrayBuffer over BroadcastChannel without COOP+COEP assert_throws_dom: function "() => channel.postMessage(sab)" did not throw
+PASS SharedArrayBuffer over MessageChannel without COOP+COEP
+PASS SharedArrayBuffer over BroadcastChannel without COOP+COEP
 PASS Bonus: self.crossOriginIsolated
 

--- a/LayoutTests/imported/w3c/web-platform-tests/workers/semantics/structured-clone/dedicated-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/workers/semantics/structured-clone/dedicated-expected.txt
@@ -132,7 +132,7 @@ PASS Serializing a non-serializable platform object fails
 PASS An object whose interface is deleted from the global must still deserialize
 PASS A subclass instance will deserialize as its closest serializable superclass
 PASS Resizable ArrayBuffer
-FAIL Growable SharedArrayBuffer assert_true: instanceof ArrayBuffer expected true got false
+PASS Growable SharedArrayBuffer
 PASS Length-tracking TypedArray
 PASS Length-tracking DataView
 PASS Serializing OOB TypedArray throws

--- a/LayoutTests/imported/w3c/web-platform-tests/workers/semantics/structured-clone/shared-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/workers/semantics/structured-clone/shared-expected.txt
@@ -132,7 +132,7 @@ PASS Serializing a non-serializable platform object fails
 PASS An object whose interface is deleted from the global must still deserialize
 PASS A subclass instance will deserialize as its closest serializable superclass
 PASS Resizable ArrayBuffer
-FAIL Growable SharedArrayBuffer assert_true: instanceof ArrayBuffer expected true got false
+PASS Growable SharedArrayBuffer
 PASS Length-tracking TypedArray
 PASS Length-tracking DataView
 PASS Serializing OOB TypedArray throws

--- a/LayoutTests/workers/worker-set-delete-terminate-crash-expected.txt
+++ b/LayoutTests/workers/worker-set-delete-terminate-crash-expected.txt
@@ -1,3 +1,4 @@
+CONSOLE MESSAGE: ReferenceError: Can't find variable: SharedArrayBuffer
 PASS successfullyParsed is true
 
 TEST COMPLETE

--- a/LayoutTests/workers/worker-terminate-crash-expected.txt
+++ b/LayoutTests/workers/worker-terminate-crash-expected.txt
@@ -1,3 +1,4 @@
+CONSOLE MESSAGE: ReferenceError: Can't find variable: SharedArrayBuffer
 PASS successfullyParsed is true
 
 TEST COMPLETE

--- a/Source/WebCore/bindings/js/SerializedScriptValue.cpp
+++ b/Source/WebCore/bindings/js/SerializedScriptValue.cpp
@@ -2187,11 +2187,12 @@ private:
                 
                 if (arrayBuffer->isShared()) {
                     // https://html.spec.whatwg.org/multipage/structured-data.html#structuredserializeinternal
-                    if (m_context == SerializationContext::WorkerPostMessage) {
-                        if (!JSC::Options::useSharedArrayBuffer() || m_forStorage == SerializationForStorage::Yes) {
-                            code = SerializationReturnCode::DataCloneError;
-                            return true;
-                        }
+                    if (m_forStorage == SerializationForStorage::Yes) {
+                        code = SerializationReturnCode::DataCloneError;
+                        return true;
+                    }
+                    bool isCrossOriginIsolated = ScriptExecutionContext::crossOriginMode() == CrossOriginMode::Isolated;
+                    if (m_context == SerializationContext::WorkerPostMessage && (isCrossOriginIsolated || JSC::Options::useSharedArrayBuffer())) {
                         uint32_t index = m_sharedBuffers.size();
                         ArrayBufferContents contents;
                         if (arrayBuffer->shareWith(contents)) {
@@ -2201,11 +2202,12 @@ private:
                             write(index);
                             return true;
                         }
-                    } else if (m_context != SerializationContext::WindowPostMessage || ScriptExecutionContext::crossOriginMode() != CrossOriginMode::Isolated) {
+                    }
+                    if (!isCrossOriginIsolated) {
                         code = SerializationReturnCode::DataCloneError;
                         return true;
                     }
-                    // WindowPostMessage in a cross-origin isolated context: fall through to serialize as a non-shared copy.
+                    // FIXME: For non-WorkerPostMessage contexts that are cross-origin isolated, this falls through and serializes as a non-shared copy, which is not correct per the specification.
                 }
                 
                 if (arrayBuffer->isResizableOrGrowableShared()) {

--- a/Tools/Scripts/webkitpy/layout_tests/run_webkit_tests.py
+++ b/Tools/Scripts/webkitpy/layout_tests/run_webkit_tests.py
@@ -97,8 +97,6 @@ def main(argv, stdout, stderr):
         stackSizeInBytes = int(1.5 * 1024 * 1024)
         options.additional_env_var.append('JSC_maxPerThreadStackUsage=' + str(stackSizeInBytes))
         options.additional_env_var.append('__XPC_JSC_maxPerThreadStackUsage=' + str(stackSizeInBytes))
-        options.additional_env_var.append('JSC_useSharedArrayBuffer=1')
-        options.additional_env_var.append('__XPC_JSC_useSharedArrayBuffer=1')
         options.additional_env_var.append('JSC_useRecursiveJSONParse=0')
         options.additional_env_var.append('__XPC_JSC_useRecursiveJSONParse=0')
         run_details = run(port, options, args, stderr)


### PR DESCRIPTION
#### 0ecb6b50d4d6aef46ed73ed160cf517e4ad01fbc
<pre>
Require cross-origin isolation for SharedArrayBuffer serialization
<a href="https://bugs.webkit.org/show_bug.cgi?id=313579">https://bugs.webkit.org/show_bug.cgi?id=313579</a>

Reviewed by NOBODY (OOPS!).

Per the HTML specification, StructuredSerializeInternal must throw
DataCloneError when serializing a SharedArrayBuffer if the cross-origin
isolated capability is false. WebKit only enforced this for
window.postMessage, not for workers, MessageChannel, or
BroadcastChannel.

Move the cross-origin isolation check to the top of the isShared()
block in SerializedScriptValue, before any context-specific handling.

The check was also defeated by run-webkit-tests globally setting
JSC_useSharedArrayBuffer=1 for all test processes. Remove the global
override — every internal test that needs it already sets
jscOptions=--useSharedArrayBuffer=true per-test.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0ecb6b50d4d6aef46ed73ed160cf517e4ad01fbc

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/159340 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/32768 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/25874 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/168172 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/113718 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/c1d84697-a741-4966-bdf6-edb66f275ce1) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/161209 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/32836 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/32755 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/123457 "Found 40 new test failures: http/wpt/webaudio/the-audio-api/the-audioworklet-interface/shared-array-buffer.https.html imported/w3c/web-platform-tests/IndexedDB/serialize-sharedarraybuffer-throws.https.html imported/w3c/web-platform-tests/encoding/sharedarraybuffer.https.html imported/w3c/web-platform-tests/html/infrastructure/safe-passing-of-structured-data/shared-array-buffers/broadcastchannel-success-and-failure.https.html imported/w3c/web-platform-tests/html/infrastructure/safe-passing-of-structured-data/shared-array-buffers/broadcastchannel-success.https.html imported/w3c/web-platform-tests/html/infrastructure/safe-passing-of-structured-data/shared-array-buffers/identity-not-preserved.https.html imported/w3c/web-platform-tests/html/infrastructure/safe-passing-of-structured-data/shared-array-buffers/nested-sharedworker-success.https.html imported/w3c/web-platform-tests/html/infrastructure/safe-passing-of-structured-data/shared-array-buffers/nested-worker-success.https.html imported/w3c/web-platform-tests/html/infrastructure/safe-passing-of-structured-data/shared-array-buffers/no-coop-coep.https.any.html imported/w3c/web-platform-tests/html/infrastructure/safe-passing-of-structured-data/shared-array-buffers/no-coop-coep.https.any.serviceworker.html ... (failure)") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/86657 "1 flakes 5 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/bf76c1ef-c87d-4f78-9f10-037353085829) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/162297 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/25711 "Found 5 new test failures: js/Atomics-waitasync-invocable-on-main-thread.html js/dom/webassembly-memory-shared-basic.html webaudio/dom-exceptions.html webgl/webgl-allow-shared-typed-array.html webgl/webgl-allow-shared.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/143123 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/104123 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/323db569-2f19-40c0-ac26-260df1c6efef) 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/158660 "Passed tests") | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/24764 "Found 8 new test failures: imported/w3c/web-platform-tests/html/cross-origin-embedder-policy/cross-origin-isolated-permission.https.html imported/w3c/web-platform-tests/html/infrastructure/safe-passing-of-structured-data/shared-array-buffers/nested-sharedworker-success.https.html imported/w3c/web-platform-tests/html/infrastructure/safe-passing-of-structured-data/shared-array-buffers/no-coop-coep.https.any.html imported/w3c/web-platform-tests/html/infrastructure/safe-passing-of-structured-data/shared-array-buffers/no-coop-coep.https.any.serviceworker.html imported/w3c/web-platform-tests/html/infrastructure/safe-passing-of-structured-data/shared-array-buffers/no-coop-coep.https.any.sharedworker.html imported/w3c/web-platform-tests/html/infrastructure/safe-passing-of-structured-data/shared-array-buffers/no-coop-coep.https.any.worker.html imported/w3c/web-platform-tests/html/infrastructure/safe-passing-of-structured-data/shared-array-buffers/window-serviceworker-failure.https.html imported/w3c/web-platform-tests/html/infrastructure/safe-passing-of-structured-data/shared-array-buffers/window-sharedworker-failure.https.html (failure)") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/23209 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/15943 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/134451 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/20903 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/170664 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/16698 "Built successfully") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/22529 "Found 13 new test failures: imported/w3c/web-platform-tests/html/cross-origin-embedder-policy/cross-origin-isolated-permission.https.html imported/w3c/web-platform-tests/html/infrastructure/safe-passing-of-structured-data/shared-array-buffers/nested-sharedworker-success.https.html imported/w3c/web-platform-tests/html/infrastructure/safe-passing-of-structured-data/shared-array-buffers/no-coop-coep.https.any.html imported/w3c/web-platform-tests/html/infrastructure/safe-passing-of-structured-data/shared-array-buffers/no-coop-coep.https.any.serviceworker.html imported/w3c/web-platform-tests/html/infrastructure/safe-passing-of-structured-data/shared-array-buffers/no-coop-coep.https.any.sharedworker.html imported/w3c/web-platform-tests/html/infrastructure/safe-passing-of-structured-data/shared-array-buffers/no-coop-coep.https.any.worker.html imported/w3c/web-platform-tests/html/infrastructure/safe-passing-of-structured-data/shared-array-buffers/window-serviceworker-failure.https.html imported/w3c/web-platform-tests/html/infrastructure/safe-passing-of-structured-data/shared-array-buffers/window-sharedworker-failure.https.html js/Atomics-waitasync-invocable-on-main-thread.html js/dom/webassembly-memory-shared-basic.html ... (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/131660 "Found 40 new test failures: http/wpt/webaudio/the-audio-api/the-audioworklet-interface/shared-array-buffer.https.html imported/w3c/web-platform-tests/IndexedDB/serialize-sharedarraybuffer-throws.https.html imported/w3c/web-platform-tests/encoding/sharedarraybuffer.https.html imported/w3c/web-platform-tests/html/infrastructure/safe-passing-of-structured-data/shared-array-buffers/broadcastchannel-success-and-failure.https.html imported/w3c/web-platform-tests/html/infrastructure/safe-passing-of-structured-data/shared-array-buffers/broadcastchannel-success.https.html imported/w3c/web-platform-tests/html/infrastructure/safe-passing-of-structured-data/shared-array-buffers/identity-not-preserved.https.html imported/w3c/web-platform-tests/html/infrastructure/safe-passing-of-structured-data/shared-array-buffers/nested-sharedworker-success.https.html imported/w3c/web-platform-tests/html/infrastructure/safe-passing-of-structured-data/shared-array-buffers/nested-worker-success.https.html imported/w3c/web-platform-tests/html/infrastructure/safe-passing-of-structured-data/shared-array-buffers/no-coop-coep.https.any.html imported/w3c/web-platform-tests/html/infrastructure/safe-passing-of-structured-data/shared-array-buffers/no-coop-coep.https.any.serviceworker.html ... (failure)") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/32457 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/27283 "Found 13 new test failures: imported/w3c/web-platform-tests/html/cross-origin-embedder-policy/cross-origin-isolated-permission.https.html imported/w3c/web-platform-tests/html/infrastructure/safe-passing-of-structured-data/shared-array-buffers/nested-sharedworker-success.https.html imported/w3c/web-platform-tests/html/infrastructure/safe-passing-of-structured-data/shared-array-buffers/no-coop-coep.https.any.html imported/w3c/web-platform-tests/html/infrastructure/safe-passing-of-structured-data/shared-array-buffers/no-coop-coep.https.any.serviceworker.html imported/w3c/web-platform-tests/html/infrastructure/safe-passing-of-structured-data/shared-array-buffers/no-coop-coep.https.any.sharedworker.html imported/w3c/web-platform-tests/html/infrastructure/safe-passing-of-structured-data/shared-array-buffers/no-coop-coep.https.any.worker.html imported/w3c/web-platform-tests/html/infrastructure/safe-passing-of-structured-data/shared-array-buffers/window-serviceworker-failure.https.html imported/w3c/web-platform-tests/html/infrastructure/safe-passing-of-structured-data/shared-array-buffers/window-sharedworker-failure.https.html js/Atomics-waitasync-invocable-on-main-thread.html js/dom/webassembly-memory-shared-basic.html ... (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/131773 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/32401 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/142696 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/90526 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/26442 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/19505 "Found 13 new test failures: imported/w3c/web-platform-tests/html/cross-origin-embedder-policy/cross-origin-isolated-permission.https.html imported/w3c/web-platform-tests/html/infrastructure/safe-passing-of-structured-data/shared-array-buffers/nested-sharedworker-success.https.html imported/w3c/web-platform-tests/html/infrastructure/safe-passing-of-structured-data/shared-array-buffers/no-coop-coep.https.any.html imported/w3c/web-platform-tests/html/infrastructure/safe-passing-of-structured-data/shared-array-buffers/no-coop-coep.https.any.serviceworker.html imported/w3c/web-platform-tests/html/infrastructure/safe-passing-of-structured-data/shared-array-buffers/no-coop-coep.https.any.sharedworker.html imported/w3c/web-platform-tests/html/infrastructure/safe-passing-of-structured-data/shared-array-buffers/no-coop-coep.https.any.worker.html imported/w3c/web-platform-tests/html/infrastructure/safe-passing-of-structured-data/shared-array-buffers/window-serviceworker-failure.https.html imported/w3c/web-platform-tests/html/infrastructure/safe-passing-of-structured-data/shared-array-buffers/window-sharedworker-failure.https.html js/Atomics-waitasync-invocable-on-main-thread.html js/dom/webassembly-memory-shared-basic.html ... (failure)") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/31912 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/98364 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/31432 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/31705 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/31587 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->