### PR TITLE
Composited overflow scrollers on iOS lose scroll gesture when sibling compositing state changes

### DIFF
--- a/LayoutTests/fast/scrolling/ios/momentum-scroll-deceleration-with-compositing-sibling-expected.txt
+++ b/LayoutTests/fast/scrolling/ios/momentum-scroll-deceleration-with-compositing-sibling-expected.txt
@@ -1,0 +1,11 @@
+Verifies that deceleration (momentum phase) continues after touch release when a sibling toggles compositing during the scroll. The test counts scroll events that fire after the touch ends.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS scrollEventsAfterRelease is >= 3
+PASS scroller.scrollLeft is >= 150
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/scrolling/ios/momentum-scroll-deceleration-with-compositing-sibling.html
+++ b/LayoutTests/fast/scrolling/ios/momentum-scroll-deceleration-with-compositing-sibling.html
@@ -1,0 +1,112 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ useFlexibleViewport=true AsyncOverflowScrollingEnabled=true AsyncFrameScrollingEnabled=true ] -->
+<html>
+<head>
+<meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no">
+<script src="../../../resources/js-test.js"></script>
+<script src="../../../resources/ui-helper.js"></script>
+<style>
+html, body {
+    width: 100%;
+    height: 100%;
+    margin: 0;
+    padding: 0;
+    overflow: hidden;
+}
+
+#container {
+    width: 100%;
+    height: 100%;
+    position: relative;
+}
+
+#below {
+    position: absolute;
+    top: 0; left: 0;
+    width: 100%; height: 100%;
+    background: #246;
+}
+
+#scroller-wrapper {
+    position: absolute;
+    bottom: 0; left: 0; right: 0;
+    height: 120px;
+    z-index: 1;
+}
+
+#scroller {
+    height: 100%;
+    overflow-x: auto;
+    overflow-y: hidden;
+    display: flex;
+}
+
+.item {
+    height: 100px;
+    min-width: 80px;
+    margin: 10px 4px;
+    background: #666;
+    flex-shrink: 0;
+}
+</style>
+</head>
+<body>
+<div id="container">
+    <div id="below"></div>
+    <div id="scroller-wrapper">
+        <div id="scroller"></div>
+    </div>
+</div>
+<p id="description"></p>
+<p id="console"></p>
+<script>
+jsTestIsAsync = true;
+
+const scroller = document.getElementById("scroller");
+const below = document.getElementById("below");
+
+for (let i = 0; i < 200; i++) {
+    const d = document.createElement("div");
+    d.className = "item";
+    scroller.appendChild(d);
+}
+
+let scrollEventsAfterRelease = 0;
+let released = false;
+
+scroller.addEventListener("scroll", () => {
+    if (Math.floor(scroller.scrollLeft / 15) % 2 === 0) {
+        below.style.willChange = "transform";
+        below.style.transform = "translateZ(0)";
+    } else {
+        below.style.willChange = "auto";
+        below.style.transform = "none";
+    }
+    if (released)
+        scrollEventsAfterRelease++;
+});
+
+addEventListener("load", async () => {
+    description("Verifies that deceleration (momentum phase) continues after touch release when a sibling toggles compositing during the scroll. The test counts scroll events that fire after the touch ends.");
+
+    if (!window.testRunner)
+        return;
+
+    await UIHelper.ensureStablePresentationUpdate();
+
+    const rect = scroller.getBoundingClientRect();
+    const startX = rect.left + rect.width * 0.85;
+    const startY = rect.top + rect.height / 2;
+    await UIHelper.dragFromPointToPoint(startX, startY, startX - 200, startY, 0.08);
+
+    released = true;
+
+    await UIHelper.waitForTargetScrollAnimationToSettle(scroller);
+
+    shouldBeGreaterThanOrEqual("scrollEventsAfterRelease", "3");
+    shouldBeGreaterThanOrEqual("scroller.scrollLeft", "150");
+
+    finishJSTest();
+});
+</script>
+</body>
+</html>

--- a/LayoutTests/fast/scrolling/ios/momentum-scroll-nested-stacking-context-with-compositing-sibling-expected.txt
+++ b/LayoutTests/fast/scrolling/ios/momentum-scroll-nested-stacking-context-with-compositing-sibling-expected.txt
@@ -1,0 +1,11 @@
+Verifies momentum scroll is preserved in a nested stacking context scenario: outer z-index:0, inner z-index:2, sibling toggles compositing. The nested structure creates multiple compositing layers that must remain stable.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS scroller.scrollLeft is >= 150
+PASS toggleCount is >= 3
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/scrolling/ios/momentum-scroll-nested-stacking-context-with-compositing-sibling.html
+++ b/LayoutTests/fast/scrolling/ios/momentum-scroll-nested-stacking-context-with-compositing-sibling.html
@@ -1,0 +1,72 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ useFlexibleViewport=true AsyncOverflowScrollingEnabled=true AsyncFrameScrollingEnabled=true ] -->
+<html>
+<head>
+<meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no">
+<script src="../../../resources/js-test.js"></script>
+<script src="../../../resources/ui-helper.js"></script>
+<style>
+html, body { width: 100%; height: 100%; margin: 0; padding: 0; overflow: hidden; }
+
+#outer { position: relative; width: 100%; height: 100%; z-index: 0; }
+#sibling { position: absolute; top: 0; left: 0; width: 100%; height: 100%; background: #357; }
+#inner-wrapper { position: absolute; top: 100px; left: 0; right: 0; height: 200px; z-index: 2; }
+#scroller { height: 100%; overflow-x: auto; display: flex; background: #fff; }
+.item { height: 180px; min-width: 70px; margin: 10px 3px; background: #888; flex-shrink: 0; }
+</style>
+</head>
+<body>
+<div id="outer">
+    <div id="sibling"></div>
+    <div id="inner-wrapper">
+        <div id="scroller"></div>
+    </div>
+</div>
+<p id="description"></p>
+<p id="console"></p>
+<script>
+jsTestIsAsync = true;
+
+const scroller = document.getElementById("scroller");
+const sibling = document.getElementById("sibling");
+
+for (let i = 0; i < 200; i++) {
+    const d = document.createElement("div");
+    d.className = "item";
+    scroller.appendChild(d);
+}
+
+let toggleCount = 0;
+scroller.addEventListener("scroll", () => {
+    if (Math.floor(scroller.scrollLeft / 15) % 2 === 0) {
+        sibling.style.willChange = "transform";
+        sibling.style.transform = "translateZ(0)";
+    } else {
+        sibling.style.willChange = "auto";
+        sibling.style.transform = "none";
+    }
+    toggleCount++;
+});
+
+addEventListener("load", async () => {
+    description("Verifies momentum scroll is preserved in a nested stacking context scenario: outer z-index:0, inner z-index:2, sibling toggles compositing. The nested structure creates multiple compositing layers that must remain stable.");
+
+    if (!window.testRunner)
+        return;
+
+    await UIHelper.ensureStablePresentationUpdate();
+
+    const rect = scroller.getBoundingClientRect();
+    const startX = rect.left + rect.width * 0.75;
+    const y = rect.top + rect.height / 2;
+    await UIHelper.dragFromPointToPoint(startX, y, startX - 250, y, 0.08);
+
+    await UIHelper.waitForTargetScrollAnimationToSettle(scroller);
+
+    shouldBeGreaterThanOrEqual("scroller.scrollLeft", "150");
+    shouldBeGreaterThanOrEqual("toggleCount", "3");
+
+    finishJSTest();
+});
+</script>
+</body>
+</html>

--- a/LayoutTests/fast/scrolling/ios/momentum-scroll-vertical-with-compositing-sibling-expected.txt
+++ b/LayoutTests/fast/scrolling/ios/momentum-scroll-vertical-with-compositing-sibling-expected.txt
@@ -1,0 +1,11 @@
+Verifies vertical overflow scrolling momentum is preserved when a sibling behind the scroller toggles compositing. Same bug pattern as horizontal, exercises the vertical scroll path.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS scroller.scrollTop is >= 100
+PASS toggleCount is >= 3
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/scrolling/ios/momentum-scroll-vertical-with-compositing-sibling.html
+++ b/LayoutTests/fast/scrolling/ios/momentum-scroll-vertical-with-compositing-sibling.html
@@ -1,0 +1,69 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ useFlexibleViewport=true AsyncOverflowScrollingEnabled=true AsyncFrameScrollingEnabled=true ] -->
+<html>
+<head>
+<meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no">
+<script src="../../../resources/js-test.js"></script>
+<script src="../../../resources/ui-helper.js"></script>
+<style>
+html, body { width: 100%; height: 100%; margin: 0; padding: 0; overflow: hidden; }
+
+#container { width: 100%; height: 100%; position: relative; }
+#below { position: absolute; top: 0; left: 0; width: 100%; height: 100%; background: #246; }
+#scroller-wrapper { position: absolute; top: 50px; left: 0; right: 0; height: 150px; z-index: 1; }
+#scroller { height: 100%; overflow-y: auto; }
+#content { height: 5000px; background: repeating-linear-gradient(to bottom, #ccc 0px, #eee 100px); }
+</style>
+</head>
+<body>
+<div id="container">
+    <div id="below"></div>
+    <div id="scroller-wrapper">
+        <div id="scroller">
+            <div id="content"></div>
+        </div>
+    </div>
+</div>
+<p id="description"></p>
+<p id="console"></p>
+<script>
+jsTestIsAsync = true;
+
+const scroller = document.getElementById("scroller");
+const below = document.getElementById("below");
+
+let toggleCount = 0;
+scroller.addEventListener("scroll", () => {
+    if (Math.floor(scroller.scrollTop / 20) % 2 === 0) {
+        below.style.willChange = "transform";
+        below.style.transform = "translateZ(0)";
+    } else {
+        below.style.willChange = "auto";
+        below.style.transform = "none";
+    }
+    toggleCount++;
+});
+
+addEventListener("load", async () => {
+    description("Verifies vertical overflow scrolling momentum is preserved when a sibling behind the scroller toggles compositing. Same bug pattern as horizontal, exercises the vertical scroll path.");
+
+    if (!window.testRunner)
+        return;
+
+    await UIHelper.ensureStablePresentationUpdate();
+
+    const rect = scroller.getBoundingClientRect();
+    const x = rect.left + rect.width / 2;
+    const startY = rect.top + rect.height * 0.75;
+    const endY = rect.top + rect.height * 0.1;
+    await UIHelper.dragFromPointToPoint(x, startY, x, endY, 0.08);
+
+    await UIHelper.waitForTargetScrollAnimationToSettle(scroller);
+
+    shouldBeGreaterThanOrEqual("scroller.scrollTop", "100");
+    shouldBeGreaterThanOrEqual("toggleCount", "3");
+
+    finishJSTest();
+});
+</script>
+</body>
+</html>

--- a/LayoutTests/fast/scrolling/ios/momentum-scroll-with-compositing-sibling-toggle-expected.txt
+++ b/LayoutTests/fast/scrolling/ios/momentum-scroll-with-compositing-sibling-toggle-expected.txt
@@ -1,0 +1,11 @@
+Verifies that momentum scrolling in an overflow scroller is not interrupted when a sibling element toggles compositing state (will-change: transform) during active scroll. This requires the scroller's z-index stacking context parent to maintain stable compositing.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS scroller.scrollLeft is >= 200
+PASS toggleCount is >= 5
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/scrolling/ios/momentum-scroll-with-compositing-sibling-toggle.html
+++ b/LayoutTests/fast/scrolling/ios/momentum-scroll-with-compositing-sibling-toggle.html
@@ -1,0 +1,107 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ useFlexibleViewport=true AsyncOverflowScrollingEnabled=true AsyncFrameScrollingEnabled=true ] -->
+<html>
+<head>
+<meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no">
+<script src="../../../resources/js-test.js"></script>
+<script src="../../../resources/ui-helper.js"></script>
+<style>
+html, body {
+    width: 100%;
+    height: 100%;
+    margin: 0;
+    padding: 0;
+    overflow: hidden;
+}
+
+#container {
+    width: 100%;
+    height: 100%;
+    position: relative;
+}
+
+#below {
+    position: absolute;
+    top: 0; left: 0;
+    width: 100%; height: 100%;
+    background: #246;
+}
+
+#scroller-wrapper {
+    position: absolute;
+    bottom: 0; left: 0; right: 0;
+    height: 120px;
+    z-index: 1;
+}
+
+#scroller {
+    height: 100%;
+    overflow-x: auto;
+    overflow-y: hidden;
+    display: flex;
+}
+
+.item {
+    height: 100px;
+    min-width: 80px;
+    margin: 10px 4px;
+    background: #666;
+    flex-shrink: 0;
+}
+</style>
+</head>
+<body>
+<div id="container">
+    <div id="below"></div>
+    <div id="scroller-wrapper">
+        <div id="scroller"></div>
+    </div>
+</div>
+<p id="description"></p>
+<p id="console"></p>
+<script>
+jsTestIsAsync = true;
+
+const scroller = document.getElementById("scroller");
+const below = document.getElementById("below");
+
+for (let i = 0; i < 200; i++) {
+    const d = document.createElement("div");
+    d.className = "item";
+    scroller.appendChild(d);
+}
+
+let toggleCount = 0;
+scroller.addEventListener("scroll", () => {
+    if (Math.floor(scroller.scrollLeft / 15) % 2 === 0) {
+        below.style.willChange = "transform";
+        below.style.transform = "translateZ(0)";
+    } else {
+        below.style.willChange = "auto";
+        below.style.transform = "none";
+    }
+    toggleCount++;
+});
+
+addEventListener("load", async () => {
+    description("Verifies that momentum scrolling in an overflow scroller is not interrupted when a sibling element toggles compositing state (will-change: transform) during active scroll. This requires the scroller's z-index stacking context parent to maintain stable compositing.");
+
+    if (!window.testRunner)
+        return;
+
+    await UIHelper.ensureStablePresentationUpdate();
+
+    const rect = scroller.getBoundingClientRect();
+    const startX = rect.left + rect.width * 0.75;
+    const startY = rect.top + rect.height / 2;
+    await UIHelper.dragFromPointToPoint(startX, startY, startX - 250, startY, 0.08);
+
+    await UIHelper.waitForTargetScrollAnimationToSettle(scroller);
+
+    shouldBeGreaterThanOrEqual("scroller.scrollLeft", "200");
+    shouldBeGreaterThanOrEqual("toggleCount", "5");
+
+    finishJSTest();
+});
+</script>
+</body>
+</html>

--- a/LayoutTests/fast/scrolling/ios/momentum-scroll-with-multiple-compositing-siblings-expected.txt
+++ b/LayoutTests/fast/scrolling/ios/momentum-scroll-with-multiple-compositing-siblings-expected.txt
@@ -1,0 +1,11 @@
+Stress test: multiple siblings rapidly toggling compositing during scroll. Each scroll event toggles a different sibling's compositing state. Momentum must be preserved.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS scroller.scrollLeft is >= 150
+PASS toggleCount is >= 5
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/scrolling/ios/momentum-scroll-with-multiple-compositing-siblings.html
+++ b/LayoutTests/fast/scrolling/ios/momentum-scroll-with-multiple-compositing-siblings.html
@@ -1,0 +1,92 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ useFlexibleViewport=true AsyncOverflowScrollingEnabled=true AsyncFrameScrollingEnabled=true ] -->
+<html>
+<head>
+<meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no">
+<script src="../../../resources/js-test.js"></script>
+<script src="../../../resources/ui-helper.js"></script>
+<style>
+html, body { width: 100%; height: 100%; margin: 0; padding: 0; overflow: hidden; }
+
+#container { width: 100%; height: 100%; position: relative; }
+
+.sibling {
+    position: absolute; top: 0; left: 0; width: 100%; height: 100%;
+}
+#sibling1 { background: rgba(200, 0, 0, 0.1); }
+#sibling2 { background: rgba(0, 200, 0, 0.1); }
+#sibling3 { background: rgba(0, 0, 200, 0.1); }
+
+#scroller-wrapper {
+    position: absolute; top: 200px; left: 0; right: 0; height: 120px;
+    z-index: 1;
+}
+
+#scroller { height: 100%; overflow-x: auto; display: flex; }
+.item { height: 100px; min-width: 60px; margin: 10px 2px; background: #444; flex-shrink: 0; }
+</style>
+</head>
+<body>
+<div id="container">
+    <div id="sibling1" class="sibling"></div>
+    <div id="sibling2" class="sibling"></div>
+    <div id="sibling3" class="sibling"></div>
+    <div id="scroller-wrapper">
+        <div id="scroller"></div>
+    </div>
+</div>
+<p id="description"></p>
+<p id="console"></p>
+<script>
+jsTestIsAsync = true;
+
+const scroller = document.getElementById("scroller");
+const siblings = [
+    document.getElementById("sibling1"),
+    document.getElementById("sibling2"),
+    document.getElementById("sibling3"),
+];
+
+for (let i = 0; i < 200; i++) {
+    const d = document.createElement("div");
+    d.className = "item";
+    scroller.appendChild(d);
+}
+
+let toggleCount = 0;
+scroller.addEventListener("scroll", () => {
+    const phase = Math.floor(scroller.scrollLeft / 10) % 6;
+    siblings.forEach((s, i) => {
+        if (phase === i * 2) {
+            s.style.willChange = "transform";
+            s.style.transform = "translateZ(0)";
+        } else {
+            s.style.willChange = "auto";
+            s.style.transform = "none";
+        }
+    });
+    toggleCount++;
+});
+
+addEventListener("load", async () => {
+    description("Stress test: multiple siblings rapidly toggling compositing during scroll. Each scroll event toggles a different sibling's compositing state. Momentum must be preserved.");
+
+    if (!window.testRunner)
+        return;
+
+    await UIHelper.ensureStablePresentationUpdate();
+
+    const rect = scroller.getBoundingClientRect();
+    const startX = rect.left + rect.width * 0.75;
+    const y = rect.top + rect.height / 2;
+    await UIHelper.dragFromPointToPoint(startX, y, startX - 250, y, 0.08);
+
+    await UIHelper.waitForTargetScrollAnimationToSettle(scroller);
+
+    shouldBeGreaterThanOrEqual("scroller.scrollLeft", "150");
+    shouldBeGreaterThanOrEqual("toggleCount", "5");
+
+    finishJSTest();
+});
+</script>
+</body>
+</html>

--- a/LayoutTests/fast/scrolling/ios/stacking-context-with-composited-descendants-expected.txt
+++ b/LayoutTests/fast/scrolling/ios/stacking-context-with-composited-descendants-expected.txt
@@ -1,0 +1,70 @@
+(GraphicsLayer
+  (anchor 0.00 0.00)
+  (bounds 800.00 680.00)
+  (children 1
+    (GraphicsLayer
+      (bounds 800.00 680.00)
+      (contentsOpaque 1)
+      (children 1
+        (GraphicsLayer
+          (bounds 800.00 680.00)
+          (children 3
+            (GraphicsLayer
+              (position 28.00 20.00)
+              (bounds 200.00 200.00)
+              (children 1
+                (GraphicsLayer
+                  (bounds 100.00 100.00)
+                  (children 1
+                    (GraphicsLayer
+                      (bounds 100.00 100.00)
+                      (children 1
+                        (GraphicsLayer
+                          (anchor 0.00 0.00)
+                          (bounds 100.00 500.00)
+                          (drawsContent 1)
+                        )
+                      )
+                    )
+                  )
+                )
+              )
+            )
+            (GraphicsLayer
+              (position 28.00 240.00)
+              (bounds 50.00 50.00)
+              (contentsOpaque 1)
+            )
+            (GraphicsLayer
+              (position 28.00 460.00)
+              (bounds 200.00 200.00)
+              (children 1
+                (GraphicsLayer
+                  (bounds 200.00 100.00)
+                  (children 1
+                    (GraphicsLayer
+                      (bounds 100.00 100.00)
+                      (children 1
+                        (GraphicsLayer
+                          (bounds 100.00 100.00)
+                          (children 1
+                            (GraphicsLayer
+                              (anchor 0.00 0.00)
+                              (bounds 100.00 500.00)
+                              (drawsContent 1)
+                            )
+                          )
+                        )
+                      )
+                    )
+                  )
+                )
+              )
+            )
+          )
+        )
+      )
+    )
+  )
+)
+

--- a/LayoutTests/fast/scrolling/ios/stacking-context-with-composited-descendants.html
+++ b/LayoutTests/fast/scrolling/ios/stacking-context-with-composited-descendants.html
@@ -1,0 +1,55 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ AsyncOverflowScrollingEnabled=true ] -->
+<html>
+<head>
+    <style>
+        .container { position: relative; width: 200px; height: 200px; margin: 20px; }
+
+        .stacking-zindex { z-index: 1; position: relative; }
+        .stacking-opacity { opacity: 0.99; }
+        .stacking-isolation { isolation: isolate; }
+
+        .composited-child { will-change: transform; width: 50px; height: 50px; background: green; }
+        .overflow-scroller { overflow: auto; width: 100px; height: 100px; }
+        .tall-content { height: 500px; background: repeating-linear-gradient(silver, white 50px); }
+    </style>
+    <script>
+        if (window.testRunner) {
+            testRunner.dumpAsText();
+            testRunner.waitUntilDone();
+        }
+
+        function doTest()
+        {
+            if (window.internals) {
+                document.getElementById('layers').innerText = window.internals.layerTreeAsText(document);
+                testRunner.notifyDone();
+            }
+        }
+        window.addEventListener('load', doTest, false);
+    </script>
+</head>
+<body>
+    <!-- Test 1: z-index stacking context with composited overflow scroller should be composited on iOS -->
+    <div class="container stacking-zindex" id="test1">
+        <div class="overflow-scroller">
+            <div class="tall-content"></div>
+        </div>
+    </div>
+
+    <!-- Test 2: z-index stacking context with only a will-change child (no scrolling) — should NOT get extra compositing -->
+    <div class="container stacking-zindex" id="test2">
+        <div class="composited-child"></div>
+    </div>
+
+    <!-- Test 3: nested stacking contexts — outer z-index wrapping inner with composited scroller -->
+    <div class="container stacking-zindex" id="test3-outer">
+        <div class="stacking-zindex" id="test3-inner" style="position: relative;">
+            <div class="overflow-scroller">
+                <div class="tall-content"></div>
+            </div>
+        </div>
+    </div>
+
+    <pre id="layers"></pre>
+</body>
+</html>

--- a/Source/WebCore/rendering/RenderLayerCompositor.cpp
+++ b/Source/WebCore/rendering/RenderLayerCompositor.cpp
@@ -170,6 +170,7 @@ struct RenderLayerCompositor::CompositingState {
         childState.ancestorHasTransformAnimation = ancestorHasTransformAnimation;
         childState.ancestorAllowsBackingStoreDetachingForFixed = ancestorAllowsBackingStoreDetachingForFixed;
         childState.hasCompositedNonContainedDescendants = false;
+        childState.hasCompositedScrollableOverflowDescendants = false;
         childState.hasNotIsolatedCompositedBlendingDescendants = false; // FIXME: should this only be reset for stacking contexts?
         childState.hasBackdropFilterDescendantsWithoutRoot = false;
 #if !LOG_DISABLED
@@ -210,6 +211,11 @@ struct RenderLayerCompositor::CompositingState {
 
         hasCompositedNonContainedDescendants = computeHasCompositedNonContainedDescendants();
 
+        if (layer.isComposited() && layer.hasCompositedScrollableOverflow())
+            hasCompositedScrollableOverflowDescendants = true;
+        else
+            hasCompositedScrollableOverflowDescendants |= childState.hasCompositedScrollableOverflowDescendants;
+
         if ((layer.isComposited() && layer.hasBlendMode()) || (layer.hasNotIsolatedCompositedBlendingDescendants() && !layer.isolatesCompositedBlending()))
             hasNotIsolatedCompositedBlendingDescendants = true;
 
@@ -237,6 +243,7 @@ struct RenderLayerCompositor::CompositingState {
     bool ancestorHasTransformAnimation { false };
     bool ancestorAllowsBackingStoreDetachingForFixed { false };
     bool hasCompositedNonContainedDescendants { false };
+    bool hasCompositedScrollableOverflowDescendants { false };
     bool hasNotIsolatedCompositedBlendingDescendants { false };
     bool hasBackdropFilterDescendantsWithoutRoot { false };
 #if !LOG_DISABLED
@@ -1469,7 +1476,7 @@ void RenderLayerCompositor::computeCompositingRequirements(RenderLayer* ancestor
     // Now check for reasons to become composited that depend on the state of descendant layers.
     if (!willBeComposited && canBeComposited(layer)) {
         layer.update3DTransformedDescendantStatus();
-        auto indirectReason = computeIndirectCompositingReason(layer, currentState.subtreeIsCompositing, layer.has3DTransformedDescendant(), !!providedBackingLayer);
+        auto indirectReason = computeIndirectCompositingReason(layer, currentState.subtreeIsCompositing, layer.has3DTransformedDescendant(), !!providedBackingLayer, currentState.hasCompositedScrollableOverflowDescendants);
         if (indirectReason != IndirectCompositingReason::None) {
             layer.setIndirectCompositingReason(indirectReason);
             layerWillCompositePostDescendants();
@@ -4149,8 +4156,11 @@ bool RenderLayerCompositor::requiresCompositingForAnchorPositioning(const Render
     return !!layer.anchorScrollAdjustment();
 }
 
-IndirectCompositingReason RenderLayerCompositor::computeIndirectCompositingReason(const RenderLayer& layer, bool hasCompositedDescendants, bool has3DTransformedDescendants, bool paintsIntoProvidedBacking) const
+IndirectCompositingReason RenderLayerCompositor::computeIndirectCompositingReason(const RenderLayer& layer, bool hasCompositedDescendants, bool has3DTransformedDescendants, bool paintsIntoProvidedBacking, bool hasCompositedScrollableOverflowDescendants) const
 {
+#if !PLATFORM(IOS_FAMILY)
+    UNUSED_PARAM(hasCompositedScrollableOverflowDescendants);
+#endif
     // When a layer has composited descendants, some effects, like 2d transforms, filters, masks etc must be implemented
     // via compositing so that they also apply to those composited descendants.
     auto& renderer = layer.renderer();
@@ -4162,10 +4172,19 @@ IndirectCompositingReason RenderLayerCompositor::computeIndirectCompositingReaso
     if (has3DTransformedDescendants) {
         if (renderer.style().usedTransformStyle3D() == TransformStyle3D::Preserve3D)
             return IndirectCompositingReason::Preserve3D;
-    
+
         if (!renderer.style().perspective().isNone())
             return IndirectCompositingReason::Perspective;
     }
+
+#if PLATFORM(IOS_FAMILY)
+    // Stacking contexts with composited scrollable overflow descendants need their own compositing
+    // layer to prevent layer tree restructuring when sibling compositing state changes. Without
+    // this, composited overflow scrollers get reparented, which causes UIKit to cancel active
+    // scroll gesture recognizers.
+    if (hasCompositedScrollableOverflowDescendants && layer.isStackingContext())
+        return IndirectCompositingReason::Stacking;
+#endif
 
     // If this layer scrolls independently from the layer that it would paint into, it needs to get composited.
     if (!paintsIntoProvidedBacking && layer.hasCompositedScrollingAncestor()) {

--- a/Source/WebCore/rendering/RenderLayerCompositor.h
+++ b/Source/WebCore/rendering/RenderLayerCompositor.h
@@ -556,7 +556,7 @@ private:
     bool requiresCompositingForPosition(RenderLayerModelObject&, const RenderLayer&, RequiresCompositingData&) const;
     bool requiresCompositingForOverflowScrolling(const RenderLayer&, RequiresCompositingData&) const;
     bool NODELETE requiresCompositingForAnchorPositioning(const RenderLayer&) const;
-    IndirectCompositingReason computeIndirectCompositingReason(const RenderLayer&, bool hasCompositedDescendants, bool has3DTransformedDescendants, bool paintsIntoProvidedBacking) const;
+    IndirectCompositingReason computeIndirectCompositingReason(const RenderLayer&, bool hasCompositedDescendants, bool has3DTransformedDescendants, bool paintsIntoProvidedBacking, bool hasCompositedScrollableOverflowDescendants) const;
 
     static ScrollPositioningBehavior layerScrollBehahaviorRelativeToCompositedAncestor(const RenderLayer&, const RenderLayer& compositedAncestor);
 


### PR DESCRIPTION
#### 92b0e5b460ecd0bc52197b80f9267772f0115942
<pre>
Composited overflow scrollers on iOS lose scroll gesture when sibling compositing state changes
<a href="https://bugs.webkit.org/show_bug.cgi?id=313581">https://bugs.webkit.org/show_bug.cgi?id=313581</a>
<a href="https://rdar.apple.com/124978644">rdar://124978644</a>

Reviewed by NOBODY (OOPS!).

On iOS, when an overflow scroller lives inside a stacking context (e.g.,
z-index: 1) and a sibling element toggles compositing state (via will-change
or similar), the layer tree gets restructured: the scroller&apos;s compositing
layer is removed from its parent and re-added. UIKit interprets this as the
scroll view being removed, causing it to cancel the active scroll gesture
recognizer, which kills momentum scrolling.

Fix this by ensuring that on iOS, stacking contexts with composited
scrollable overflow descendants get their own compositing layer. This is
scoped narrowly to layers that have scrollable overflow to avoid creating
unnecessary compositing layers for stacking contexts whose descendants are
composited for non-scrolling reasons (e.g. will-change: transform).

A new hasCompositedScrollableOverflowDescendants flag is propagated through
CompositingState during the compositing requirements traversal.

Tests: fast/scrolling/ios/stacking-context-with-composited-descendants.html
       fast/scrolling/ios/momentum-scroll-with-compositing-sibling-toggle.html
       fast/scrolling/ios/momentum-scroll-deceleration-with-compositing-sibling.html
       fast/scrolling/ios/momentum-scroll-vertical-with-compositing-sibling.html
       fast/scrolling/ios/momentum-scroll-nested-stacking-context-with-compositing-sibling.html
       fast/scrolling/ios/momentum-scroll-with-multiple-compositing-siblings.html

* Source/WebCore/rendering/RenderLayerCompositor.cpp:
(WebCore::RenderLayerCompositor::CompositingState::stateForPaintOrderChildren):
(WebCore::RenderLayerCompositor::CompositingState::updateWithDescendantStateAndLayer):
(WebCore::RenderLayerCompositor::computeCompositingRequirements):
(WebCore::RenderLayerCompositor::computeIndirectCompositingReason):
* Source/WebCore/rendering/RenderLayerCompositor.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/92b0e5b460ecd0bc52197b80f9267772f0115942

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/159345 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/32773 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/25879 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/168177 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/113723 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/161214 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/32841 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/32760 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/123459 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/86658 "1 flakes 1 failures") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/162302 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/25715 "Found 60 new test failures: compositing/backing/backing-store-attachment-animating-outside-viewport.html compositing/clipping/border-radius-async-overflow-clipping-layer.html compositing/layer-creation/absolute-in-async-overflow-scroll.html compositing/layer-creation/clipping-scope/nested-scroller-overlap.html compositing/layer-creation/clipping-scope/overlap-constrained-inside-scroller.html compositing/layer-creation/clipping-scope/overlap-constrained-inside-stacking-context-scroller.html compositing/layer-creation/clipping-scope/shared-layers-in-scroller.html compositing/overflow/overflow-auto-with-touch-toggle.html compositing/overflow/overflow-auto-with-touch.html compositing/overflow/overflow-overlay-with-touch.html ... (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/143127 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/104125 "Found 11 new API test failures: TestWebKit:WebKit.ResizeWindowAfterCrash, TestWebKit:WebKit.GeolocationWatchMultiprocess, TestWebKit:WebKit2.ProvisionalURLAfterWillSendRequestCallback, TestWebKit:WebKit2TextFieldBeginAndEditEditingTest.TextFieldDidBeginAndEndEditingEventsInReadOnlyField, TestWebKit:WebKit2TextFieldBeginAndEditEditingTest.TextFieldDidBeginShouldNotBeDispatchedForAlreadyFocusedField, TestWebKit:WebKit.MouseMoveAfterCrash, TestWebKit:WebKit.EnumerateDevicesCrash, TestWebKit:WebKit2UserMessageRoundTripTest.WKURL, TestWebKit:WebKit.NewFirstVisuallyNonEmptyLayoutFails, TestWebKit:WebKit.RestoreSessionStateContainingFormData ... (failure)") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/24768 "Passed tests") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/23214 "Found 1 new API test failure: TestWebKitAPI.WKWebExtension.LoadFromChromeExtensionArchive (failure)") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/15948 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/134455 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/20907 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/170669 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/16703 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/22533 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/131663 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/32462 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/27288 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/131776 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/32406 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/142700 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/90531 "Built successfully") | | 
| | [❌ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/26446 "Found 10 new test failures: overlay-region/full-page-overflow-scrolling.html overlay-region/full-page-overflow-snapping.html overlay-region/full-page-overflow.html overlay-region/many-candidates.html overlay-region/map-small.html overlay-region/map.html overlay-region/no-merging.html overlay-region/overflow-with-proxy.html overlay-region/overlay-element-overflow.html overlay-region/split-scrollers.html (failure)") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/19509 "Passed tests") | | | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/31917 "Build is in progress. Recent messages:OS: Tahoe (26.2), Xcode: 26.2; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (warnings)") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/98369 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/31437 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/31710 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/31592 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->