### PR TITLE
[JSC] Add String#lastIndexOf optimizations

### DIFF
--- a/JSTests/stress/string-index-of-empty.js
+++ b/JSTests/stress/string-index-of-empty.js
@@ -1,0 +1,269 @@
+// Tests for String.prototype.indexOf / lastIndexOf when base or search is empty.
+// Cross-validates against ECMA-262 reference implementations across multiple
+// string shapes (8-bit, 16-bit, rope, substring-of-rope, mixed-encoding rope).
+//
+// https://tc39.es/ecma262/#sec-string.prototype.indexof
+// https://tc39.es/ecma262/#sec-string.prototype.lastindexof
+
+function assertEq(a, b, m) {
+    if (a !== b)
+        throw new Error(m + ": expected " + b + " got " + a);
+}
+
+function specIndexOf(S, searchStr, position) {
+    // position undefined -> ToNumber(undefined) = NaN -> ToIntegerOrInfinity(NaN) = 0.
+    var numPos = +position;
+    var pos;
+    if (numPos !== numPos)
+        pos = 0;
+    else if (!isFinite(numPos))
+        pos = numPos;
+    else
+        pos = numPos < 0 ? Math.ceil(numPos) : Math.floor(numPos);
+    var len = S.length;
+    var searchLen = searchStr.length;
+    var start;
+    if (pos < 0)
+        start = 0;
+    else if (pos > len)
+        start = len;
+    else
+        start = pos;
+    // Empty search: spec's StringIndexOf returns min(start, len) = start.
+    if (searchLen === 0)
+        return start;
+    for (var i = start; i + searchLen <= len; i++) {
+        var match = true;
+        for (var j = 0; j < searchLen; j++) {
+            if (S.charCodeAt(i + j) !== searchStr.charCodeAt(j)) {
+                match = false;
+                break;
+            }
+        }
+        if (match)
+            return i;
+    }
+    return -1;
+}
+
+function specLastIndexOf(S, searchStr, position) {
+    var numPos = +position;
+    var pos;
+    if (numPos !== numPos)
+        pos = Infinity; // NaN -> +Infinity for lastIndexOf.
+    else if (numPos === 0 || !isFinite(numPos))
+        pos = numPos === -Infinity ? -Infinity : numPos;
+    else
+        pos = numPos < 0 ? Math.ceil(numPos) : Math.floor(numPos);
+    var len = S.length;
+    var searchLen = searchStr.length;
+    if (len < searchLen)
+        return -1;
+    var maxStart = len - searchLen;
+    var start;
+    if (pos < 0)
+        start = 0;
+    else if (pos > maxStart)
+        start = maxStart;
+    else
+        start = pos | 0;
+    for (var i = start; i >= 0; i--) {
+        var match = true;
+        for (var j = 0; j < searchLen; j++) {
+            if (S.charCodeAt(i + j) !== searchStr.charCodeAt(j)) {
+                match = false;
+                break;
+            }
+        }
+        if (match)
+            return i;
+    }
+    return -1;
+}
+
+function checkIndex(S, needle, pos, tag) {
+    var expected = specIndexOf(S, needle, pos);
+    var actual = pos === undefined ? S.indexOf(needle) : S.indexOf(needle, pos);
+    if (actual !== expected)
+        throw new Error("indexOf " + tag + ": S.indexOf(" + JSON.stringify(needle) + ", " + String(pos) + ") expected " + expected + " got " + actual);
+}
+
+function checkLast(S, needle, pos, tag) {
+    var expected = specLastIndexOf(S, needle, pos);
+    var actual = pos === undefined ? S.lastIndexOf(needle) : S.lastIndexOf(needle, pos);
+    if (actual !== expected)
+        throw new Error("lastIndexOf " + tag + ": S.lastIndexOf(" + JSON.stringify(needle) + ", " + String(pos) + ") expected " + expected + " got " + actual);
+}
+
+function checkBoth(S, needle, pos, tag) {
+    checkIndex(S, needle, pos, tag);
+    checkLast(S, needle, pos, tag);
+}
+
+// All fromIndex values we iterate over for each shape.
+var positions = [
+    undefined, NaN, Infinity, -Infinity,
+    -0, 0, 1,
+    -1, -2, -100, Number.MIN_SAFE_INTEGER,
+    100, (1 << 30), Number.MAX_SAFE_INTEGER,
+    0.5, 1.5, -0.5, -1.5, 1e20, -1e20,
+];
+
+function exerciseEmptyNeedle(S, tag) {
+    for (var p of positions)
+        checkBoth(S, "", p, tag + "/empty-needle/" + String(p));
+    // At every position in [0, len].
+    for (var i = 0; i <= S.length; i++)
+        checkBoth(S, "", i, tag + "/empty-needle/pos-" + i);
+}
+
+function exerciseNonEmptyNeedleOnEmpty(S, tag) {
+    // S is empty; every non-empty needle must miss.
+    for (var p of positions) {
+        checkBoth(S, "x", p, tag + "/x/" + String(p));
+        checkBoth(S, "xyz", p, tag + "/xyz/" + String(p));
+        checkBoth(S, "ア", p, tag + "/16bit/" + String(p));
+    }
+}
+
+// -------- 1. Both empty --------
+checkBoth("", "", undefined, "both-empty/default");
+for (var p of positions)
+    checkBoth("", "", p, "both-empty/" + String(p));
+
+// -------- 2. Empty base, non-empty needle --------
+exerciseNonEmptyNeedleOnEmpty("", "empty-base");
+
+// -------- 3. Non-empty base (8-bit), empty needle --------
+exerciseEmptyNeedle("a", "len1-8bit");
+exerciseEmptyNeedle("ab", "len2-8bit");
+exerciseEmptyNeedle("hello world", "basic-8bit");
+exerciseEmptyNeedle("x".repeat(257), "long-8bit"); // crosses SIMD thresholds.
+
+// -------- 4. Non-empty base (16-bit), empty needle --------
+exerciseEmptyNeedle("ア", "len1-16bit");
+exerciseEmptyNeedle("アイ", "len2-16bit");
+exerciseEmptyNeedle("ab☃cd", "short-16bit");
+exerciseEmptyNeedle("ア".repeat(257), "long-16bit");
+
+// -------- 5. Rope base (>= minLengthForRopeWalk = 296), empty needle --------
+var rope8 = "a".repeat(200) + "b".repeat(200);
+exerciseEmptyNeedle(rope8, "rope-8bit");
+
+var rope16 = "ア".repeat(200) + "イ".repeat(200);
+exerciseEmptyNeedle(rope16, "rope-16bit");
+
+// -------- 6. Mixed-encoding rope, empty needle --------
+var mixedRope = "a".repeat(200) + "ア".repeat(200);
+exerciseEmptyNeedle(mixedRope, "rope-mixed-8-16");
+
+var mixedRope2 = "ア".repeat(200) + "a".repeat(200);
+exerciseEmptyNeedle(mixedRope2, "rope-mixed-16-8");
+
+// -------- 7. Substring rope, empty needle --------
+var baseStr = "_".repeat(100) + "#" + "_".repeat(500);
+var subRope = baseStr.substring(50, 550) + "=".repeat(100); // length 600; exercises substring fiber.
+exerciseEmptyNeedle(subRope, "substring-rope");
+
+// -------- 8. Empty needle with non-empty base, non-empty needle absent --------
+// Sanity: empty needle at every position should always be min(start, len); non-empty absent needle returns -1.
+var nonEmpty = "hello world";
+for (var p of positions) {
+    checkIndex(nonEmpty, "", p, "sanity/empty-present/" + String(p));
+    checkLast(nonEmpty, "", p, "sanity/empty-present/" + String(p));
+    checkIndex(nonEmpty, "Z", p, "sanity/nonempty-absent/" + String(p));
+    checkLast(nonEmpty, "Z", p, "sanity/nonempty-absent/" + String(p));
+}
+
+// -------- 9. Empty base with position (edge clamp) --------
+checkBoth("", "", undefined, "empty/empty/default");
+checkBoth("", "", 0, "empty/empty/0");
+checkBoth("", "", 1, "empty/empty/1");
+checkBoth("", "", -1, "empty/empty/-1");
+checkBoth("", "", Infinity, "empty/empty/inf");
+checkBoth("", "x", 0, "empty/x/0");
+checkBoth("", "x", Infinity, "empty/x/inf");
+
+// -------- 10. Empty needle at the boundary around string length --------
+for (var len of [0, 1, 2, 15, 16, 17, 31, 32, 33, 255, 256, 257]) {
+    var s = "a".repeat(len);
+    for (var p of [-1, 0, 1, len - 1, len, len + 1, len * 2]) {
+        checkIndex(s, "", p, "boundary/len" + len + "/indexOf/" + p);
+        checkLast(s, "", p, "boundary/len" + len + "/lastIndexOf/" + p);
+    }
+}
+
+// -------- JIT warm-up: drive through all tiers --------
+function idxEmpty(s) { return s.indexOf(""); }
+noInline(idxEmpty);
+function lastEmpty(s) { return s.lastIndexOf(""); }
+noInline(lastEmpty);
+function idxEmptyAt(s, p) { return s.indexOf("", p); }
+noInline(idxEmptyAt);
+function lastEmptyAt(s, p) { return s.lastIndexOf("", p); }
+noInline(lastEmptyAt);
+function idxOnEmpty(needle) { return "".indexOf(needle); }
+noInline(idxOnEmpty);
+function lastOnEmpty(needle) { return "".lastIndexOf(needle); }
+noInline(lastOnEmpty);
+
+function warmEmpty() {
+    for (var i = 0; i < testLoopCount; i++) {
+        // empty needle on non-empty base
+        assertEq(idxEmpty("hello"), 0, "warm/idx/hello");
+        assertEq(idxEmpty(""), 0, "warm/idx/empty");
+        assertEq(lastEmpty("hello"), 5, "warm/last/hello");
+        assertEq(lastEmpty(""), 0, "warm/last/empty");
+
+        // empty needle at a given position
+        assertEq(idxEmptyAt("hello", 3), 3, "warm/idxAt/3");
+        assertEq(idxEmptyAt("hello", 100), 5, "warm/idxAt/big");
+        assertEq(idxEmptyAt("hello", -1), 0, "warm/idxAt/neg");
+        assertEq(lastEmptyAt("hello", 3), 3, "warm/lastAt/3");
+        assertEq(lastEmptyAt("hello", 100), 5, "warm/lastAt/big");
+        assertEq(lastEmptyAt("hello", -1), 0, "warm/lastAt/neg");
+
+        // non-empty needle on empty base
+        assertEq(idxOnEmpty("x"), -1, "warm/idxEmpty/x");
+        assertEq(idxOnEmpty(""), 0, "warm/idxEmpty/empty");
+        assertEq(lastOnEmpty("x"), -1, "warm/lastEmpty/x");
+        assertEq(lastOnEmpty(""), 0, "warm/lastEmpty/empty");
+    }
+}
+noInline(warmEmpty);
+warmEmpty();
+
+// Warm up with a 16-bit base too.
+function idxEmptyU(s) { return s.indexOf(""); }
+noInline(idxEmptyU);
+function lastEmptyU(s) { return s.lastIndexOf(""); }
+noInline(lastEmptyU);
+
+function warmEmptyU() {
+    var u = "アイ☃";
+    for (var i = 0; i < testLoopCount; i++) {
+        assertEq(idxEmptyU(u), 0, "warmU/idx");
+        assertEq(lastEmptyU(u), 3, "warmU/last");
+    }
+}
+noInline(warmEmptyU);
+warmEmptyU();
+
+// Warm up with a rope base so the rope fast paths see empty-needle traffic.
+function idxEmptyRope(s) { return s.indexOf(""); }
+noInline(idxEmptyRope);
+function lastEmptyRope(s) { return s.lastIndexOf(""); }
+noInline(lastEmptyRope);
+
+function warmEmptyRope() {
+    for (var i = 0; i < testLoopCount; i++) {
+        assertEq(idxEmptyRope(rope8), 0, "warmR/idx/8");
+        assertEq(lastEmptyRope(rope8), rope8.length, "warmR/last/8");
+        assertEq(idxEmptyRope(rope16), 0, "warmR/idx/16");
+        assertEq(lastEmptyRope(rope16), rope16.length, "warmR/last/16");
+        assertEq(idxEmptyRope(mixedRope), 0, "warmR/idx/mixed");
+        assertEq(lastEmptyRope(mixedRope), mixedRope.length, "warmR/last/mixed");
+    }
+}
+noInline(warmEmptyRope);
+warmEmptyRope();

--- a/JSTests/stress/string-last-index-of-large-fromindex.js
+++ b/JSTests/stress/string-last-index-of-large-fromindex.js
@@ -1,0 +1,76 @@
+// ECMA-262 reference implementation for cross-validation.
+// https://tc39.es/ecma262/#sec-string.prototype.lastindexof
+function specLastIndexOf(S, searchStr, position) {
+    var numPos = +position; // ToNumber
+    var pos;
+    if (numPos !== numPos)
+        pos = Infinity;
+    else if (numPos === 0 || !isFinite(numPos))
+        pos = numPos === -Infinity ? -Infinity : numPos;
+    else
+        pos = numPos < 0 ? Math.ceil(numPos) : Math.floor(numPos);
+    var len = S.length;
+    var searchLen = searchStr.length;
+    if (len < searchLen)
+        return -1;
+    // clamp pos to [0, len - searchLen]
+    var maxStart = len - searchLen;
+    var start;
+    if (pos < 0)
+        start = 0;
+    else if (pos > maxStart)
+        start = maxStart;
+    else
+        start = pos | 0; // The issue was here for very large positive 'pos' values.
+    // Scan backward.
+    for (var i = start; i >= 0; i--) {
+        var match = true;
+        for (var j = 0; j < searchLen; j++) {
+            if (S.charCodeAt(i + j) !== searchStr.charCodeAt(j)) {
+                match = false;
+                break;
+            }
+        }
+        if (match)
+            return i;
+    }
+    return -1;
+}
+
+function assertEq(a, b, m) {
+    if (a !== b)
+        throw new Error(m + ": expected " + b + " got " + a);
+}
+
+function check(S, needle, pos, message) {
+    var expected = specLastIndexOf(S, needle, pos);
+    var actual = pos === undefined ? S.lastIndexOf(needle) : S.lastIndexOf(needle, pos);
+    if (actual !== expected)
+        throw new Error(message + ": S.lastIndexOf(" + JSON.stringify(needle) + ", " + String(pos) + ") expected " + expected + " got " + actual);
+}
+
+const largeNumber = 2**32 + 100; // Larger than max unsigned int
+const veryLargeNumber = 2**53 + 100; // Larger than MAX_SAFE_INTEGER
+
+let testString = "abcabcabc"; // length 9
+let needle = "abc"; // length 3
+
+// Test cases for large fromIndex
+check(testString, needle, testString.length, `large fromIndex: string length`);
+check(testString, needle, testString.length + 100, `large fromIndex: string length + 100`);
+check(testString, needle, Infinity, `large fromIndex: Infinity`);
+check(testString, needle, largeNumber, `large fromIndex: 2^32 + 100`);
+check(testString, needle, veryLargeNumber, `large fromIndex: 2^53 + 100`);
+
+// Test cases where fromIndex is explicitly very large and would cause wrap around
+// if not clamped properly.
+let longString = "a".repeat(1000) + "b"; // length 1001
+let shortNeedle = "b"; // length 1
+
+check(longString, shortNeedle, longString.length + 100, `very long string, large fromIndex`);
+check(longString, shortNeedle, largeNumber, `very long string, very large fromIndex`);
+check(longString, shortNeedle, veryLargeNumber, `very long string, extremely large fromIndex`);
+
+// Test with empty string and large fromIndex
+check("", "", largeNumber, `empty string, large fromIndex`);
+check("a", "", largeNumber, `single char string, empty needle, large fromIndex`);

--- a/JSTests/stress/string-last-index-of.js
+++ b/JSTests/stress/string-last-index-of.js
@@ -1,0 +1,369 @@
+// ECMA-262 reference implementation for cross-validation.
+// https://tc39.es/ecma262/#sec-string.prototype.lastindexof
+function specLastIndexOf(S, searchStr, position) {
+    var numPos = +position; // ToNumber
+    var pos;
+    if (numPos !== numPos)
+        pos = Infinity;
+    else if (numPos === 0 || !isFinite(numPos))
+        pos = numPos === -Infinity ? -Infinity : numPos;
+    else
+        pos = numPos < 0 ? Math.ceil(numPos) : Math.floor(numPos);
+    var len = S.length;
+    var searchLen = searchStr.length;
+    if (len < searchLen)
+        return -1;
+    // clamp pos to [0, len - searchLen]
+    var maxStart = len - searchLen;
+    var start;
+    if (pos < 0)
+        start = 0;
+    else if (pos > maxStart)
+        start = maxStart;
+    else
+        start = pos | 0;
+    // Scan backward.
+    for (var i = start; i >= 0; i--) {
+        var match = true;
+        for (var j = 0; j < searchLen; j++) {
+            if (S.charCodeAt(i + j) !== searchStr.charCodeAt(j)) {
+                match = false;
+                break;
+            }
+        }
+        if (match)
+            return i;
+    }
+    return -1;
+}
+
+function assertEq(a, b, m) {
+    if (a !== b)
+        throw new Error(m + ": expected " + b + " got " + a);
+}
+
+function check(S, needle, pos, message) {
+    var expected = specLastIndexOf(S, needle, pos);
+    var actual = pos === undefined ? S.lastIndexOf(needle) : S.lastIndexOf(needle, pos);
+    if (actual !== expected)
+        throw new Error(message + ": S.lastIndexOf(" + JSON.stringify(needle) + ", " + String(pos) + ") expected " + expected + " got " + actual);
+}
+
+// -------- fromIndex edge values --------
+var basic = "hello world";
+for (var p of [undefined, NaN, Infinity, -Infinity, -0, 0, 0.5, 1, 1.5, 4, 4.7, 6, 7, 10, 11, 12, -1, -100,
+               Number.MIN_SAFE_INTEGER, Number.MAX_SAFE_INTEGER,
+               1 << 30, -(1 << 30), (1 << 30) * 2, -(1 << 30) * 2]) {
+    check(basic, "o", p, "basic/o/" + String(p));
+    check(basic, "l", p, "basic/l/" + String(p));
+    check(basic, "x", p, "basic/x/" + String(p));
+    check(basic, "", p, "basic//" + String(p));
+    check(basic, "hello", p, "basic/hello/" + String(p));
+    check(basic, "world", p, "basic/world/" + String(p));
+    check(basic, "hello world", p, "basic/full/" + String(p));
+    check(basic, "hello world!", p, "basic/toolong/" + String(p));
+}
+
+// -------- Empty strings --------
+check("", "", undefined, "empty/empty");
+check("", "", 0, "empty/empty/0");
+check("", "", 999, "empty/empty/big");
+check("", "x", undefined, "empty/x");
+check("abc", "", undefined, "abc/empty");
+check("abc", "", 0, "abc/empty/0");
+check("abc", "", 1, "abc/empty/1");
+check("abc", "", 3, "abc/empty/3");
+check("abc", "", 100, "abc/empty/big");
+
+// -------- Non-integer position (ToIntegerOrInfinity truncates toward zero) --------
+check("abcdefg", "c", 2.5, "frac/2.5");
+check("abcdefg", "c", 2.9, "frac/2.9");
+check("abcdefg", "c", -0.5, "frac/-0.5");
+check("abcdefg", "c", -0.999, "frac/-0.999");
+
+// -------- Value coercion on receiver and needle --------
+assertEq(String.prototype.lastIndexOf.call(123456123, "1"), 6, "number receiver");
+assertEq("abc".lastIndexOf(undefined), -1, "undefined needle");
+assertEq("abundefinedc".lastIndexOf(undefined), 2, "undefined coerces to 'undefined'");
+assertEq("a1b".lastIndexOf(1), 1, "number needle");
+assertEq("null".lastIndexOf(null), 0, "null needle");
+
+// position via valueOf
+var counted = 0;
+var pos = { valueOf: function() { counted++; return 3; } };
+assertEq("aaaa".lastIndexOf("a", pos), 3, "valueOf position");
+assertEq(counted, 1, "valueOf called once");
+
+// Symbol needle should throw.
+try {
+    "abc".lastIndexOf(Symbol("s"));
+    throw new Error("symbol-needle should throw");
+} catch (e) {
+    if (!(e instanceof TypeError))
+        throw new Error("expected TypeError, got " + e);
+}
+
+// -------- SIMD threshold boundary (single-char, 8-bit) --------
+for (var n of [0, 1, 2, 15, 16, 17, 31, 32, 33, 47, 48, 49, 63, 64, 100, 255, 256, 257]) {
+    var s = "a".repeat(n);
+    check(s, "b", undefined, "simd8/nomatch/" + n);
+    check(s, "a", undefined, "simd8/allmatch/" + n);
+    if (n > 0) {
+        // Match at every position.
+        for (var k = 0; k < n; k++) {
+            var t = "a".repeat(k) + "X" + "a".repeat(n - k - 1);
+            check(t, "X", undefined, "simd8/pos/" + n + "/" + k);
+            check(t, "X", k, "simd8/pos/" + n + "/" + k + "/k");
+            check(t, "X", k - 1, "simd8/pos/" + n + "/" + k + "/k-1");
+            check(t, "X", k + 1, "simd8/pos/" + n + "/" + k + "/k+1");
+        }
+    }
+}
+
+// -------- SIMD threshold boundary (single-char, 16-bit) --------
+for (var n of [0, 1, 2, 15, 16, 17, 31, 32, 33, 63, 64, 100]) {
+    var s16 = "ア".repeat(n);
+    check(s16, "イ", undefined, "simd16/nomatch/" + n);
+    check(s16, "ア", undefined, "simd16/allmatch/" + n);
+    if (n > 0) {
+        for (var k of [0, 1, n >> 1, n - 2, n - 1].filter(function(i) { return i >= 0 && i < n; })) {
+            var t16 = "ア".repeat(k) + "★" + "ア".repeat(n - k - 1);
+            check(t16, "★", undefined, "simd16/pos/" + n + "/" + k);
+        }
+    }
+}
+
+// Non-Latin1 needle in 8-bit haystack must return -1.
+assertEq("abc".lastIndexOf("☃"), -1, "non-latin1 in 8bit");
+assertEq("☃abc".lastIndexOf("☃"), 0, "non-latin1 in 16bit");
+
+// -------- Rope coverage (length >= minLengthForRopeWalk = 0x128 = 296) --------
+// Helper: force a rope by concatenating pieces.
+function makeRope2(a, b) {
+    return a + b; // JSC typically lazy-concatenates into a rope.
+}
+function makeRope3(a, b, c) {
+    return (a + b) + c;
+}
+
+// Rope with single '/' in each of 3 fibers.
+var fiberA = "a".repeat(200) + "/" + "b".repeat(50);  // 251 chars, '/' at index 200
+var fiberB = "c".repeat(100) + "/" + "d".repeat(50);  // 151 chars, '/' at local 100 (global 351)
+var fiberC = "e".repeat(100) + "/" + "f".repeat(50);  // 151 chars, '/' at local 100 (global 502)
+var r3 = makeRope3(fiberA, fiberB, fiberC);
+
+check(r3, "/", undefined, "rope3/last");
+assertEq(r3.lastIndexOf("/"), 502, "rope3/last/value");
+assertEq(r3.lastIndexOf("/", 501), 351, "rope3/middle");
+assertEq(r3.lastIndexOf("/", 350), 200, "rope3/first");
+assertEq(r3.lastIndexOf("/", 199), -1, "rope3/nothing");
+assertEq(r3.lastIndexOf("Z"), -1, "rope3/missing");
+
+// Rope where needle sits at fiber boundary (last char of fiber vs first char of next).
+var boundaryA = "x".repeat(150) + "/";  // '/' at 150 (last char)
+var boundaryB = "y".repeat(150);
+var rBoundary = makeRope2(boundaryA, boundaryB);
+assertEq(rBoundary.lastIndexOf("/"), 150, "rope/boundary-last-of-A");
+assertEq(rBoundary.lastIndexOf("/", 150), 150, "rope/boundary-exact");
+assertEq(rBoundary.lastIndexOf("/", 149), -1, "rope/boundary-before");
+
+var bA2 = "x".repeat(150);
+var bB2 = "/" + "y".repeat(150);  // '/' at 150 (first of B, global 150)
+var rBoundary2 = makeRope2(bA2, bB2);
+assertEq(rBoundary2.lastIndexOf("/"), 150, "rope/boundary-first-of-B");
+
+// Nested rope → bail out through non-substring rope fiber.
+var inner = makeRope2("p".repeat(100), "q".repeat(100)); // 200 chars rope
+var outer = makeRope2(inner, "/" + "r".repeat(200));      // outer[0] is a non-substring rope
+assertEq(outer.lastIndexOf("/"), 200, "nested-rope/last");
+// '/' is in fiber[1] at local 0 → global 200. Rope walk scans fiber[1] first (reverse order),
+// finds it, returns without bailing.
+assertEq(outer.lastIndexOf("/", 199), -1, "nested-rope/before-slash");
+// Search for something only in the nested fiber → forces bailout.
+var inner2 = makeRope2("a".repeat(150), "@" + "b".repeat(49)); // '@' at local 150 inside inner
+var outer2 = makeRope2(inner2, "c".repeat(200));
+assertEq(outer2.lastIndexOf("@"), 150, "nested-rope/bailout-find");
+assertEq(outer2.lastIndexOf("@", 149), -1, "nested-rope/bailout-miss");
+assertEq(outer2.lastIndexOf("@", 150), 150, "nested-rope/bailout-exact");
+assertEq(outer2.lastIndexOf("@", 200), 150, "nested-rope/bailout-from-after");
+
+// Substring rope (fiber is a substring of a base).
+var base = "_".repeat(100) + "#" + "_".repeat(200); // '#' at 100, length 301
+var subrope = base.substring(50, 260);              // length 210, '#' at local 50
+// subrope alone may not reach minLengthForRopeWalk; combine.
+var rS = makeRope2(subrope, "=".repeat(100));       // length 310
+assertEq(rS.lastIndexOf("#"), 50, "substring-rope/find");
+assertEq(rS.lastIndexOf("#", 49), -1, "substring-rope/before");
+assertEq(rS.lastIndexOf("="), 309, "substring-rope/other-fiber");
+
+// Deep rope stress (many concatenations → multi-level rope tree).
+var deep = "";
+for (var i = 0; i < 50; i++)
+    deep = "0123456789" + deep;
+// deep has length 500, contains "/" never.
+assertEq(deep.lastIndexOf("/"), -1, "deep/nomatch");
+assertEq(deep.lastIndexOf("9"), 499, "deep/last9");
+assertEq(deep.lastIndexOf("0", 499), 490, "deep/last0");
+assertEq(deep.lastIndexOf("0"), 490, "deep/last0-nopos");
+
+// Rope with startPosition at every fiber boundary.
+var p1 = "1".repeat(100);
+var p2 = "2".repeat(100);
+var p3 = "3".repeat(100);
+var pRope = makeRope3(p1, p2, p3);
+for (var pos of [0, 50, 99, 100, 101, 150, 199, 200, 201, 250, 299]) {
+    check(pRope, "1", pos, "pRope/1/" + pos);
+    check(pRope, "2", pos, "pRope/2/" + pos);
+    check(pRope, "3", pos, "pRope/3/" + pos);
+    check(pRope, "X", pos, "pRope/X/" + pos);
+}
+
+// -------- Multi-char needle in rope with spec clamp on long needle --------
+var bigRope = makeRope3("abc".repeat(100), "xyz".repeat(100), "abc".repeat(100)); // 900 chars
+assertEq(bigRope.lastIndexOf("abc"), 897, "bigRope/abc");
+assertEq(bigRope.lastIndexOf("abc", 597), 297, "bigRope/abc/low");
+assertEq(bigRope.lastIndexOf("xyz"), 597, "bigRope/xyz");
+assertEq(bigRope.lastIndexOf("xyzabc"), 597, "bigRope/xyzabc");
+assertEq(bigRope.lastIndexOf("abcabc"), 894, "bigRope/abcabc");
+
+// -------- Empty receiver / needle combinations --------
+assertEq("".lastIndexOf("x"), -1, "empty/x");
+assertEq("".lastIndexOf(""), 0, "empty/empty/return");
+assertEq("x".lastIndexOf(""), 1, "x/empty");
+
+// -------- Spec clamp: long needle --------
+assertEq("abc".lastIndexOf("abcdef"), -1, "too-long-needle");
+assertEq("abc".lastIndexOf("abc"), 0, "exact-match");
+assertEq("abc".lastIndexOf("abc", 0), 0, "exact-match-0");
+assertEq("abc".lastIndexOf("abc", 1), 0, "exact-match-clamp");
+assertEq("abc".lastIndexOf("abc", 100), 0, "exact-match-bigpos");
+assertEq("abc".lastIndexOf("abc", -1), 0, "exact-match-negpos");
+
+// -------- JIT warm-up loop for doxbee-promise pattern --------
+function hotSlash(s) { return s.lastIndexOf("/"); }
+noInline(hotSlash);
+
+function warmSingleChar() {
+    for (var i = 0; i < testLoopCount; i++) {
+        assertEq(hotSlash("foo"), -1, "hot/foo");
+        assertEq(hotSlash("a/b"), 1, "hot/a/b");
+        assertEq(hotSlash("/"), 0, "hot/solo");
+        assertEq(hotSlash(""), -1, "hot/empty");
+        assertEq(hotSlash("//a"), 1, "hot/double");
+    }
+}
+noInline(warmSingleChar);
+warmSingleChar();
+
+// JIT warm-up for the rope fast path.
+function hotRope(r) { return r.lastIndexOf("/"); }
+noInline(hotRope);
+
+function warmRope() {
+    for (var i = 0; i < testLoopCount; i++) {
+        assertEq(hotRope(r3), 502, "hot-rope/all");
+        assertEq(hotRope(outer2), -1, "hot-rope/bailout-miss");
+        assertEq(hotRope(rBoundary), 150, "hot-rope/boundary");
+    }
+}
+noInline(warmRope);
+warmRope();
+
+// -------- Middle-fiber bailout: nested rope in the middle of a larger rope --------
+// Construct shapes where a non-substring rope fiber sits *between* already-scanned
+// higher-offset fibers and unscanned lower-offset fibers, so tryFindLastOneChar must
+// scan the tail flat fiber(s), then bail when it hits the nested rope, forcing the
+// caller to resolve and finish with reverseFind on the flat result. The exact rope
+// layout chosen by JSC is opaque, but the output must still match the reference.
+function buildMiddleBailoutRope() {
+    var tail = "t".repeat(150);                    // flat, no needle
+    var middleInner = "a".repeat(60) + "b".repeat(60); // 120 chars — candidate nested rope
+    var head = "h".repeat(100) + "#" + "g".repeat(49); // flat, needle '#' at local 100
+    return (head + middleInner) + tail;            // try to keep middle as nested rope
+}
+var mbr = buildMiddleBailoutRope();
+// '#' is at position 100 in head. Total length = 150 + 120 + 150 = 420.
+check(mbr, "#", undefined, "middle-bailout/#/any");
+check(mbr, "#", 100, "middle-bailout/#/exact");
+check(mbr, "#", 99, "middle-bailout/#/before");
+check(mbr, "#", 101, "middle-bailout/#/after");
+check(mbr, "#", 419, "middle-bailout/#/end");
+// Needle only in tail — forces bailout with a non-trivial earlier scan.
+var mbr2 = buildMiddleBailoutRope() + "Q" + "z".repeat(100); // 'Q' at position 420
+check(mbr2, "Q", undefined, "middle-bailout-append/Q/any");
+check(mbr2, "Q", 419, "middle-bailout-append/Q/before");
+check(mbr2, "Q", 420, "middle-bailout-append/Q/exact");
+// Needle only inside the nested middle — walk scans tail, bails at middle, resolves.
+function buildMiddleOnly() {
+    var tail = "z".repeat(150);
+    var middle = "m".repeat(59) + "@" + "n".repeat(60); // '@' at local 59 inside middle
+    var head = "h".repeat(150);
+    return (head + middle) + tail;
+}
+var mo = buildMiddleOnly();
+// '@' global position = 150 (head) + 59 = 209.
+check(mo, "@", undefined, "middle-only/@/any");
+check(mo, "@", 208, "middle-only/@/before");
+check(mo, "@", 209, "middle-only/@/exact");
+check(mo, "@", 210, "middle-only/@/after");
+check(mo, "@", 500, "middle-only/@/past-end");
+
+// -------- Mixed 8-bit / 16-bit rope --------
+// Build a rope whose fibers span both encodings. JSC's rope can combine 8-bit and
+// 16-bit fibers; search with each encoding of needle must behave correctly.
+var f8 = "a".repeat(200) + "X" + "a".repeat(49); // 8-bit, length 250, 'X' at 200
+var f16 = "ア".repeat(100) + "★" + "ア".repeat(49); // 16-bit, length 150, '★' at 100
+var mixed = f8 + f16; // 8-bit + 16-bit → promoted to 16-bit rope, total 400
+assertEq(mixed.length, 400, "mixed/length");
+// 'X' (Latin1) appears only in the 8-bit fiber at global index 200.
+check(mixed, "X", undefined, "mixed/X/any");
+check(mixed, "X", 199, "mixed/X/before");
+check(mixed, "X", 200, "mixed/X/exact");
+check(mixed, "X", 399, "mixed/X/past");
+// '★' (non-Latin1) appears only in the 16-bit fiber at global 250 + 100 = 350.
+check(mixed, "★", undefined, "mixed/*/any");
+check(mixed, "★", 349, "mixed/*/before");
+check(mixed, "★", 350, "mixed/*/exact");
+check(mixed, "★", 399, "mixed/*/past");
+// 'a' (Latin1) only appears in the 8-bit fiber; last 'a' at global 249.
+check(mixed, "a", undefined, "mixed/a/any");
+check(mixed, "a", 248, "mixed/a/before");
+check(mixed, "a", 249, "mixed/a/exact");
+check(mixed, "a", 399, "mixed/a/past");
+// Non-Latin1 needle that doesn't appear at all.
+check(mixed, "☃", undefined, "mixed/snow/none");
+// Latin1 needle that doesn't appear at all.
+check(mixed, "Z", undefined, "mixed/Z/none");
+
+// Reverse mixed order: 16-bit first, 8-bit second.
+var mixed2 = f16 + f8; // length 400
+check(mixed2, "X", undefined, "mixed2/X/any");
+check(mixed2, "★", undefined, "mixed2/*/any");
+check(mixed2, "a", undefined, "mixed2/a/any");
+
+// Three-fiber mixed rope.
+var mixed3 = (f8 + f16) + f8; // 250 + 150 + 250 = 650
+check(mixed3, "X", undefined, "mixed3/X/any");
+check(mixed3, "★", undefined, "mixed3/*/any");
+check(mixed3, "a", undefined, "mixed3/a/any");
+
+// JIT warm-up for middle-bailout and mixed-encoding paths.
+function hotMiddle(r) { return r.lastIndexOf("@"); }
+noInline(hotMiddle);
+function hotMixed8(r) { return r.lastIndexOf("X"); }
+noInline(hotMixed8);
+function hotMixed16(r) { return r.lastIndexOf("★"); }
+noInline(hotMixed16);
+
+function warmMiddleMixed() {
+    var expectedMiddle = mo.lastIndexOf("@");
+    var expectedMixed8 = mixed.lastIndexOf("X");
+    var expectedMixed16 = mixed.lastIndexOf("★");
+    for (var i = 0; i < testLoopCount; i++) {
+        assertEq(hotMiddle(mo), expectedMiddle, "hot-middle");
+        assertEq(hotMixed8(mixed), expectedMixed8, "hot-mixed8");
+        assertEq(hotMixed16(mixed), expectedMixed16, "hot-mixed16");
+    }
+}
+noInline(warmMiddleMixed);
+warmMiddleMixed();

--- a/Source/JavaScriptCore/dfg/DFGAbstractInterpreterInlines.h
+++ b/Source/JavaScriptCore/dfg/DFGAbstractInterpreterInlines.h
@@ -2684,6 +2684,7 @@ bool AbstractInterpreter<AbstractStateType>::executeEffects(unsigned clobberLimi
     }
         
     case StringIndexOf:
+    case StringLastIndexOf:
         setNonCellTypeForNode(node, SpecInt32Only);
         break;
 

--- a/Source/JavaScriptCore/dfg/DFGBackwardsPropagationPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGBackwardsPropagationPhase.cpp
@@ -350,7 +350,8 @@ private:
             break;
         }
 
-        case StringIndexOf: {
+        case StringIndexOf:
+        case StringLastIndexOf: {
             node->child1()->mergeFlags(NodeBytecodeUsesAsValue);
             node->child2()->mergeFlags(NodeBytecodeUsesAsValue);
             if (node->child3())

--- a/Source/JavaScriptCore/dfg/DFGByteCodeParser.cpp
+++ b/Source/JavaScriptCore/dfg/DFGByteCodeParser.cpp
@@ -3108,6 +3108,28 @@ auto ByteCodeParser::handleIntrinsicCall(Node* callee, Operand resultOperand, Ca
             return CallOptimizationResult::Inlined;
         }
 
+        case StringPrototypeLastIndexOfIntrinsic: {
+            if (argumentCountIncludingThis < 2)
+                return CallOptimizationResult::DidNothing;
+
+            if (m_inlineStackTop->m_exitProfile.hasExitSite(m_currentIndex, Uncountable) || m_inlineStackTop->m_exitProfile.hasExitSite(m_currentIndex, BadType))
+                return CallOptimizationResult::DidNothing;
+
+            insertChecks();
+            Node* thisValue = get(virtualRegisterForArgumentIncludingThis(0, registerOffset));
+            Node* search = get(virtualRegisterForArgumentIncludingThis(1, registerOffset));
+            Node* result = nullptr;
+            if (argumentCountIncludingThis == 2)
+                result = addToGraph(StringLastIndexOf, OpInfo(ArrayMode(Array::String, Array::Read).asWord()), thisValue, search);
+            else {
+                Node* index = get(virtualRegisterForArgumentIncludingThis(2, registerOffset));
+                result = addToGraph(StringLastIndexOf, OpInfo(ArrayMode(Array::String, Array::Read).asWord()), thisValue, search, index);
+            }
+
+            setResult(result);
+            return CallOptimizationResult::Inlined;
+        }
+
         case StringPrototypeStartsWithIntrinsic:
         case StringPrototypeEndsWithIntrinsic: {
             if (argumentCountIncludingThis < 2)

--- a/Source/JavaScriptCore/dfg/DFGClobberize.h
+++ b/Source/JavaScriptCore/dfg/DFGClobberize.h
@@ -236,6 +236,7 @@ void clobberize(Graph& graph, Node* node, const ReadFunctor& read, const WriteFu
     case StringCharCodeAt:
     case StringCodePointAt:
     case StringIndexOf:
+    case StringLastIndexOf:
     case StringStartsWith:
     case StringEndsWith:
     case CompareStrictEq:

--- a/Source/JavaScriptCore/dfg/DFGCloneHelper.h
+++ b/Source/JavaScriptCore/dfg/DFGCloneHelper.h
@@ -338,6 +338,7 @@ BasicBlock* CloneHelper::cloneBlock(BasicBlock* const block, const CustomizeSucc
     CLONE_STATUS(StringCodePointAt, Common) \
     CLONE_STATUS(StringFromCharCode, Common) \
     CLONE_STATUS(StringIndexOf, Common) \
+    CLONE_STATUS(StringLastIndexOf, Common) \
     CLONE_STATUS(StringStartsWith, Common) \
     CLONE_STATUS(StringEndsWith, Common) \
     CLONE_STATUS(StringLocaleCompare, Common) \

--- a/Source/JavaScriptCore/dfg/DFGDoesGC.cpp
+++ b/Source/JavaScriptCore/dfg/DFGDoesGC.cpp
@@ -483,6 +483,7 @@ bool doesGC(Graph& graph, Node* node)
     case ValueNegate:
     case DateSetTime:
     case StringIndexOf:
+    case StringLastIndexOf:
     case StringStartsWith:
     case StringEndsWith:
     case ResolvePromiseFirstResolving:

--- a/Source/JavaScriptCore/dfg/DFGFixupPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGFixupPhase.cpp
@@ -1117,7 +1117,8 @@ private:
             break;
         }
 
-        case StringIndexOf: {
+        case StringIndexOf:
+        case StringLastIndexOf: {
             fixEdge<StringUse>(node->child1());
             fixEdge<StringUse>(node->child2());
             if (node->child3())

--- a/Source/JavaScriptCore/dfg/DFGNodeType.h
+++ b/Source/JavaScriptCore/dfg/DFGNodeType.h
@@ -361,6 +361,7 @@ namespace JSC { namespace DFG {
     macro(StringReplaceRegExp, NodeResultJS | NodeMustGenerate) \
     macro(StringReplaceString, NodeResultJS | NodeMustGenerate) \
     macro(StringIndexOf, NodeResultInt32) \
+    macro(StringLastIndexOf, NodeResultInt32) \
     macro(StringStartsWith, NodeResultBoolean) \
     macro(StringEndsWith, NodeResultBoolean) \
     \

--- a/Source/JavaScriptCore/dfg/DFGOperations.cpp
+++ b/Source/JavaScriptCore/dfg/DFGOperations.cpp
@@ -3369,10 +3369,13 @@ JSC_DEFINE_JIT_OPERATION(operationStringIndexOf, UCPUStrictInt32, (JSGlobalObjec
 
     auto scope = DECLARE_THROW_SCOPE(vm);
 
+    auto otherView = argument->view(globalObject);
+    OPERATION_RETURN_IF_EXCEPTION(scope, 0);
+
+    unsigned argumentLength = otherView->length();
+
     unsigned pos = 0;
-    if (argument->length() == 1 && base->isRope() && base->length() >= JSString::minLengthForRopeWalk) {
-        auto otherView = argument->view(globalObject);
-        OPERATION_RETURN_IF_EXCEPTION(scope, 0);
+    if (argumentLength == 1 && base->isRope() && base->length() >= JSString::minLengthForRopeWalk) {
         if (auto result = base->tryFindOneChar(globalObject, otherView[0], pos)) {
             if (*result != notFound)
                 OPERATION_RETURN(scope, toUCPUStrictInt32(static_cast<int32_t>(*result)));
@@ -3382,9 +3385,6 @@ JSC_DEFINE_JIT_OPERATION(operationStringIndexOf, UCPUStrictInt32, (JSGlobalObjec
     }
 
     auto thisView = base->view(globalObject);
-    OPERATION_RETURN_IF_EXCEPTION(scope, 0);
-
-    auto otherView = argument->view(globalObject);
     OPERATION_RETURN_IF_EXCEPTION(scope, 0);
 
     size_t result = thisView->find(vm.adaptiveStringSearcherTables(), otherView, pos);
@@ -3428,17 +3428,19 @@ JSC_DEFINE_JIT_OPERATION(operationStringIndexOfWithIndex, UCPUStrictInt32, (JSGl
 
     auto scope = DECLARE_THROW_SCOPE(vm);
 
+    auto otherView = argument->view(globalObject);
+    OPERATION_RETURN_IF_EXCEPTION(scope, 0);
+
     int32_t length = base->length();
+    unsigned argumentLength = otherView->length();
     unsigned pos = 0;
     if (position >= 0)
         pos = std::min<uint32_t>(position, length);
 
-    if (static_cast<unsigned>(length) < argument->length() + pos)
+    if (static_cast<unsigned>(length) < static_cast<uint64_t>(argumentLength) + pos)
         OPERATION_RETURN(scope, toUCPUStrictInt32(-1));
 
-    if (argument->length() == 1 && base->isRope() && base->length() >= JSString::minLengthForRopeWalk) {
-        auto otherView = argument->view(globalObject);
-        OPERATION_RETURN_IF_EXCEPTION(scope, 0);
+    if (argumentLength == 1 && base->isRope() && base->length() >= JSString::minLengthForRopeWalk) {
         if (auto result = base->tryFindOneChar(globalObject, otherView[0], pos)) {
             if (*result != notFound)
                 OPERATION_RETURN(scope, toUCPUStrictInt32(static_cast<int32_t>(*result)));
@@ -3448,9 +3450,6 @@ JSC_DEFINE_JIT_OPERATION(operationStringIndexOfWithIndex, UCPUStrictInt32, (JSGl
     }
 
     auto thisView = base->view(globalObject);
-    OPERATION_RETURN_IF_EXCEPTION(scope, 0);
-
-    auto otherView = argument->view(globalObject);
     OPERATION_RETURN_IF_EXCEPTION(scope, 0);
 
     size_t result = thisView->find(vm.adaptiveStringSearcherTables(), otherView, pos);
@@ -3491,6 +3490,140 @@ JSC_DEFINE_JIT_OPERATION(operationStringIndexOfWithIndexWithOneChar, UCPUStrictI
     if (result == notFound)
         OPERATION_RETURN(scope, toUCPUStrictInt32(-1));
     OPERATION_RETURN(scope, toUCPUStrictInt32(result));
+}
+
+static ALWAYS_INLINE UCPUStrictInt32 stringLastIndexOfOneCharOperation(JSGlobalObject* globalObject, ThrowScope& scope, JSString* base, char16_t character, unsigned startPosition)
+{
+    ASSERT(base->length() >= 1);
+    ASSERT(startPosition < base->length());
+
+    if (base->isRope() && base->length() >= JSString::minLengthForRopeWalk) {
+        if (auto result = base->tryFindLastOneChar(globalObject, character, startPosition)) {
+            if (*result != notFound)
+                return toUCPUStrictInt32(static_cast<int32_t>(*result));
+            return toUCPUStrictInt32(-1);
+        }
+        // nullopt: bail out, fall through to resolve. startPosition has been narrowed.
+    }
+
+    auto thisView = base->view(globalObject);
+    RETURN_IF_EXCEPTION(scope, toUCPUStrictInt32(0));
+
+    size_t result = thisView->reverseFind(character, startPosition);
+    if (result == notFound)
+        return toUCPUStrictInt32(-1);
+    return toUCPUStrictInt32(result);
+}
+
+JSC_DEFINE_JIT_OPERATION(operationStringLastIndexOf, UCPUStrictInt32, (JSGlobalObject* globalObject, JSString* base, JSString* argument))
+{
+    VM& vm = globalObject->vm();
+    CallFrame* callFrame = DECLARE_CALL_FRAME(vm);
+    JITOperationPrologueCallFrameTracer tracer(vm, callFrame);
+
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
+    auto otherView = argument->view(globalObject);
+    OPERATION_RETURN_IF_EXCEPTION(scope, 0);
+
+    unsigned length = base->length();
+    unsigned argumentLength = otherView->length();
+    if (length < argumentLength)
+        OPERATION_RETURN(scope, toUCPUStrictInt32(-1));
+
+    unsigned startPosition = length - argumentLength;
+
+    if (argumentLength == 1)
+        OPERATION_RETURN(scope, stringLastIndexOfOneCharOperation(globalObject, scope, base, otherView[0], startPosition));
+
+    auto thisView = base->view(globalObject);
+    OPERATION_RETURN_IF_EXCEPTION(scope, 0);
+
+    size_t result;
+    if (!startPosition)
+        result = thisView->startsWith(otherView) ? 0 : notFound;
+    else
+        result = thisView->reverseFind(otherView, startPosition);
+    if (result == notFound)
+        OPERATION_RETURN(scope, toUCPUStrictInt32(-1));
+    OPERATION_RETURN(scope, toUCPUStrictInt32(result));
+}
+
+JSC_DEFINE_JIT_OPERATION(operationStringLastIndexOfWithOneChar, UCPUStrictInt32, (JSGlobalObject* globalObject, JSString* base, int32_t character))
+{
+    VM& vm = globalObject->vm();
+    CallFrame* callFrame = DECLARE_CALL_FRAME(vm);
+    JITOperationPrologueCallFrameTracer tracer(vm, callFrame);
+
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
+    unsigned length = base->length();
+    if (!length)
+        OPERATION_RETURN(scope, toUCPUStrictInt32(-1));
+
+    unsigned startPosition = length - 1;
+    OPERATION_RETURN(scope, stringLastIndexOfOneCharOperation(globalObject, scope, base, static_cast<char16_t>(character), startPosition));
+}
+
+JSC_DEFINE_JIT_OPERATION(operationStringLastIndexOfWithIndex, UCPUStrictInt32, (JSGlobalObject* globalObject, JSString* base, JSString* argument, int32_t position))
+{
+    VM& vm = globalObject->vm();
+    CallFrame* callFrame = DECLARE_CALL_FRAME(vm);
+    JITOperationPrologueCallFrameTracer tracer(vm, callFrame);
+
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
+    auto otherView = argument->view(globalObject);
+    OPERATION_RETURN_IF_EXCEPTION(scope, 0);
+
+    unsigned length = base->length();
+    unsigned argumentLength = otherView->length();
+    if (length < argumentLength)
+        OPERATION_RETURN(scope, toUCPUStrictInt32(-1));
+
+    unsigned maxStart = length - argumentLength;
+    unsigned startPosition;
+    if (position < 0)
+        startPosition = 0;
+    else
+        startPosition = std::min<uint32_t>(position, maxStart);
+
+    if (argumentLength == 1)
+        OPERATION_RETURN(scope, stringLastIndexOfOneCharOperation(globalObject, scope, base, otherView[0], startPosition));
+
+    auto thisView = base->view(globalObject);
+    OPERATION_RETURN_IF_EXCEPTION(scope, 0);
+
+    size_t result;
+    if (!startPosition)
+        result = thisView->startsWith(otherView) ? 0 : notFound;
+    else
+        result = thisView->reverseFind(otherView, startPosition);
+    if (result == notFound)
+        OPERATION_RETURN(scope, toUCPUStrictInt32(-1));
+    OPERATION_RETURN(scope, toUCPUStrictInt32(result));
+}
+
+JSC_DEFINE_JIT_OPERATION(operationStringLastIndexOfWithIndexWithOneChar, UCPUStrictInt32, (JSGlobalObject* globalObject, JSString* base, int32_t position, int32_t character))
+{
+    VM& vm = globalObject->vm();
+    CallFrame* callFrame = DECLARE_CALL_FRAME(vm);
+    JITOperationPrologueCallFrameTracer tracer(vm, callFrame);
+
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
+    unsigned length = base->length();
+    if (!length)
+        OPERATION_RETURN(scope, toUCPUStrictInt32(-1));
+
+    unsigned maxStart = length - 1;
+    unsigned startPosition;
+    if (position < 0)
+        startPosition = 0;
+    else
+        startPosition = std::min<uint32_t>(position, maxStart);
+
+    OPERATION_RETURN(scope, stringLastIndexOfOneCharOperation(globalObject, scope, base, static_cast<char16_t>(character), startPosition));
 }
 
 JSC_DEFINE_JIT_OPERATION(operationStringStartsWith, bool, (JSGlobalObject* globalObject, JSString* base, JSString* prefix))

--- a/Source/JavaScriptCore/dfg/DFGOperations.h
+++ b/Source/JavaScriptCore/dfg/DFGOperations.h
@@ -297,6 +297,10 @@ JSC_DECLARE_JIT_OPERATION(operationStringIndexOf, UCPUStrictInt32, (JSGlobalObje
 JSC_DECLARE_JIT_OPERATION(operationStringIndexOfWithOneChar, UCPUStrictInt32, (JSGlobalObject*, JSString*, int32_t));
 JSC_DECLARE_JIT_OPERATION(operationStringIndexOfWithIndex, UCPUStrictInt32, (JSGlobalObject*, JSString*, JSString*, int32_t));
 JSC_DECLARE_JIT_OPERATION(operationStringIndexOfWithIndexWithOneChar, UCPUStrictInt32, (JSGlobalObject*, JSString*, int32_t, int32_t));
+JSC_DECLARE_JIT_OPERATION(operationStringLastIndexOf, UCPUStrictInt32, (JSGlobalObject*, JSString*, JSString*));
+JSC_DECLARE_JIT_OPERATION(operationStringLastIndexOfWithOneChar, UCPUStrictInt32, (JSGlobalObject*, JSString*, int32_t));
+JSC_DECLARE_JIT_OPERATION(operationStringLastIndexOfWithIndex, UCPUStrictInt32, (JSGlobalObject*, JSString*, JSString*, int32_t));
+JSC_DECLARE_JIT_OPERATION(operationStringLastIndexOfWithIndexWithOneChar, UCPUStrictInt32, (JSGlobalObject*, JSString*, int32_t, int32_t));
 JSC_DECLARE_JIT_OPERATION(operationStringStartsWith, bool, (JSGlobalObject*, JSString*, JSString*));
 JSC_DECLARE_JIT_OPERATION(operationStringStartsWithWithIndex, bool, (JSGlobalObject*, JSString*, JSString*, int32_t));
 JSC_DECLARE_JIT_OPERATION(operationStringEndsWith, bool, (JSGlobalObject*, JSString*, JSString*));

--- a/Source/JavaScriptCore/dfg/DFGPredictionPropagationPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGPredictionPropagationPhase.cpp
@@ -1204,7 +1204,8 @@ private:
             break;
         }
 
-        case StringIndexOf: {
+        case StringIndexOf:
+        case StringLastIndexOf: {
             setPrediction(SpecInt32Only);
             break;
         }

--- a/Source/JavaScriptCore/dfg/DFGSafeToExecute.h
+++ b/Source/JavaScriptCore/dfg/DFGSafeToExecute.h
@@ -348,6 +348,7 @@ bool safeToExecute(AbstractStateType& state, Graph& graph, Node* node, bool igno
     case NumberIsFinite:
     case NumberIsSafeInteger:
     case StringIndexOf:
+    case StringLastIndexOf:
     case StringStartsWith:
     case StringEndsWith:
         return true;

--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp
@@ -17578,10 +17578,8 @@ void SpeculativeJIT::compileStringIndexOf(Node* node)
 {
     std::optional<char16_t> character;
     String searchString = node->child2()->tryGetString(m_graph);
-    if (!!searchString) {
-        if (searchString.length() == 1)
-            character = searchString.codeUnitAt(0);
-    }
+    if (!!searchString && searchString.length() == 1)
+        character = searchString.codeUnitAt(0);
 
     if (node->child3()) {
         SpeculateCellOperand base(this, node->child1());
@@ -17623,6 +17621,57 @@ void SpeculativeJIT::compileStringIndexOf(Node* node)
         callOperation(operationStringIndexOfWithOneChar, resultGPR, LinkableConstant::globalObject(*this, node), baseGPR, TrustedImm32(character.value()));
     else
         callOperation(operationStringIndexOf, resultGPR, LinkableConstant::globalObject(*this, node), baseGPR, argumentGPR);
+
+    strictInt32Result(resultGPR, node);
+}
+
+void SpeculativeJIT::compileStringLastIndexOf(Node* node)
+{
+    std::optional<char16_t> character;
+    String searchString = node->child2()->tryGetString(m_graph);
+    if (!!searchString && searchString.length() == 1)
+        character = searchString.codeUnitAt(0);
+
+    if (node->child3()) {
+        SpeculateCellOperand base(this, node->child1());
+        SpeculateCellOperand argument(this, node->child2());
+        SpeculateInt32Operand index(this, node->child3());
+
+        GPRReg baseGPR = base.gpr();
+        GPRReg argumentGPR = argument.gpr();
+        GPRReg indexGPR = index.gpr();
+
+        speculateString(node->child1(), baseGPR);
+        speculateString(node->child2(), argumentGPR);
+
+        flushRegisters();
+        GPRFlushedCallResult result(this);
+        GPRReg resultGPR = result.gpr();
+        if (character)
+            callOperation(operationStringLastIndexOfWithIndexWithOneChar, resultGPR, LinkableConstant::globalObject(*this, node), baseGPR, indexGPR, TrustedImm32(character.value()));
+        else
+            callOperation(operationStringLastIndexOfWithIndex, resultGPR, LinkableConstant::globalObject(*this, node), baseGPR, argumentGPR, indexGPR);
+
+        strictInt32Result(resultGPR, node);
+        return;
+    }
+
+    SpeculateCellOperand base(this, node->child1());
+    SpeculateCellOperand argument(this, node->child2());
+
+    GPRReg baseGPR = base.gpr();
+    GPRReg argumentGPR = argument.gpr();
+
+    speculateString(node->child1(), baseGPR);
+    speculateString(node->child2(), argumentGPR);
+
+    flushRegisters();
+    GPRFlushedCallResult result(this);
+    GPRReg resultGPR = result.gpr();
+    if (character)
+        callOperation(operationStringLastIndexOfWithOneChar, resultGPR, LinkableConstant::globalObject(*this, node), baseGPR, TrustedImm32(character.value()));
+    else
+        callOperation(operationStringLastIndexOf, resultGPR, LinkableConstant::globalObject(*this, node), baseGPR, argumentGPR);
 
     strictInt32Result(resultGPR, node);
 }

--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.h
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.h
@@ -1792,6 +1792,7 @@ public:
     void compileStringCodePointAt(Node*);
     void compileStringLocaleCompare(Node*);
     void compileStringIndexOf(Node*);
+    void compileStringLastIndexOf(Node*);
     void compileStringStartsOrEndsWith(Node*);
     void compileDateGet(Node*);
     void compileDateSet(Node*);

--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT32_64.cpp
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT32_64.cpp
@@ -3157,6 +3157,11 @@ void SpeculativeJIT::compile(Node* node)
         break;
     }
 
+    case StringLastIndexOf: {
+        compileStringLastIndexOf(node);
+        break;
+    }
+
     case StringStartsWith:
     case StringEndsWith: {
         compileStringStartsOrEndsWith(node);

--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT64.cpp
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT64.cpp
@@ -3782,6 +3782,11 @@ void SpeculativeJIT::compile(Node* node)
         break;
     }
 
+    case StringLastIndexOf: {
+        compileStringLastIndexOf(node);
+        break;
+    }
+
     case StringStartsWith:
     case StringEndsWith: {
         compileStringStartsOrEndsWith(node);

--- a/Source/JavaScriptCore/dfg/DFGStrengthReductionPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGStrengthReductionPhase.cpp
@@ -1399,6 +1399,43 @@ private:
             break;
         }
 
+        case StringLastIndexOf: {
+            Node* stringNode = m_node->child1().node();
+            String string = stringNode->tryGetString(m_graph);
+            if (!string)
+                break;
+
+            String searchString = m_node->child2()->tryGetString(m_graph);
+            if (!searchString)
+                break;
+
+            if (string.length() < searchString.length()) {
+                m_changed = true;
+                m_insertionSet.insertNode(m_nodeIndex, SpecNone, Check, m_node->origin, m_node->children.justChecks());
+                m_graph.convertToConstant(m_node, jsNumber(-1));
+                break;
+            }
+            unsigned maxStart = string.length() - searchString.length();
+            unsigned startPosition = maxStart;
+            if (m_node->child3()) {
+                if (!m_node->child3()->isInt32Constant())
+                    break;
+                int32_t pos = m_node->child3()->asInt32();
+                if (pos < 0)
+                    startPosition = 0;
+                else
+                    startPosition = std::min<unsigned>(pos, maxStart);
+            }
+
+            size_t result = string.reverseFind(searchString, startPosition);
+            int32_t indexResult = (result == notFound) ? -1 : static_cast<int32_t>(result);
+
+            m_changed = true;
+            m_insertionSet.insertNode(m_nodeIndex, SpecNone, Check, m_node->origin, m_node->children.justChecks());
+            m_graph.convertToConstant(m_node, jsNumber(indexResult));
+            break;
+        }
+
         case StringStartsWith:
         case StringEndsWith: {
             bool isStartsWith = m_node->op() == StringStartsWith;

--- a/Source/JavaScriptCore/ftl/FTLCapabilities.cpp
+++ b/Source/JavaScriptCore/ftl/FTLCapabilities.cpp
@@ -174,6 +174,7 @@ inline CapabilityLevel canCompile(Node* node)
     case StringCodePointAt:
     case StringFromCharCode:
     case StringIndexOf:
+    case StringLastIndexOf:
     case StringStartsWith:
     case StringEndsWith:
     case AllocatePropertyStorage:

--- a/Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp
+++ b/Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp
@@ -1366,6 +1366,9 @@ private:
         case StringIndexOf:
             compileStringIndexOf();
             break;
+        case StringLastIndexOf:
+            compileStringLastIndexOf();
+            break;
         case StringStartsWith:
         case StringEndsWith:
             compileStringStartsOrEndsWith();
@@ -11816,10 +11819,8 @@ IGNORE_CLANG_WARNINGS_END
     {
         std::optional<char16_t> character;
         String searchString = m_node->child2()->tryGetString(m_graph);
-        if (!!searchString) {
-            if (searchString.length() == 1)
-                character = searchString.codeUnitAt(0);
-        }
+        if (!!searchString && searchString.length() == 1)
+            character = searchString.codeUnitAt(0);
 
         LValue base = lowString(m_node->child1());
         LValue search = lowString(m_node->child2());
@@ -11836,6 +11837,30 @@ IGNORE_CLANG_WARNINGS_END
             setInt32(vmCall(Int32, operationStringIndexOfWithOneChar, weakPointer(globalObject), base, m_out.constInt32(character.value())));
         else
             setInt32(vmCall(Int32, operationStringIndexOf, weakPointer(globalObject), base, search));
+    }
+
+    void compileStringLastIndexOf()
+    {
+        std::optional<char16_t> character;
+        String searchString = m_node->child2()->tryGetString(m_graph);
+        if (!!searchString && searchString.length() == 1)
+            character = searchString.codeUnitAt(0);
+
+        LValue base = lowString(m_node->child1());
+        LValue search = lowString(m_node->child2());
+        auto* globalObject = m_graph.globalObjectFor(m_origin.semantic);
+        if (m_node->child3()) {
+            if (character)
+                setInt32(vmCall(Int32, operationStringLastIndexOfWithIndexWithOneChar, weakPointer(globalObject), base, lowInt32(m_node->child3()), m_out.constInt32(character.value())));
+            else
+                setInt32(vmCall(Int32, operationStringLastIndexOfWithIndex, weakPointer(globalObject), base, search, lowInt32(m_node->child3())));
+            return;
+        }
+
+        if (character)
+            setInt32(vmCall(Int32, operationStringLastIndexOfWithOneChar, weakPointer(globalObject), base, m_out.constInt32(character.value())));
+        else
+            setInt32(vmCall(Int32, operationStringLastIndexOf, weakPointer(globalObject), base, search));
     }
 
     void compileStringStartsOrEndsWith()

--- a/Source/JavaScriptCore/runtime/Intrinsic.h
+++ b/Source/JavaScriptCore/runtime/Intrinsic.h
@@ -122,6 +122,7 @@ namespace JSC {
     macro(StringPrototypeAtIntrinsic) \
     macro(StringPrototypeCodePointAtIntrinsic) \
     macro(StringPrototypeIndexOfIntrinsic) \
+    macro(StringPrototypeLastIndexOfIntrinsic) \
     macro(StringPrototypeIncludesIntrinsic) \
     macro(StringPrototypeStartsWithIntrinsic) \
     macro(StringPrototypeEndsWithIntrinsic) \

--- a/Source/JavaScriptCore/runtime/JSString.h
+++ b/Source/JavaScriptCore/runtime/JSString.h
@@ -283,6 +283,7 @@ public:
 
     ALWAYS_INLINE JSString* tryReplaceOneChar(JSGlobalObject*, char16_t, JSString* replacement);
     inline std::optional<size_t> tryFindOneChar(JSGlobalObject*, char16_t character, unsigned& startPosition) const;
+    inline std::optional<size_t> tryFindLastOneChar(JSGlobalObject*, char16_t character, unsigned& startPosition) const;
     ALWAYS_INLINE std::optional<char16_t> tryGetCharAt(JSGlobalObject*, unsigned index) const;
 
     bool isSubstring() const;

--- a/Source/JavaScriptCore/runtime/JSStringInlines.h
+++ b/Source/JavaScriptCore/runtime/JSStringInlines.h
@@ -221,6 +221,81 @@ std::optional<size_t> JSString::tryFindOneChar(JSGlobalObject*, char16_t charact
     return WTF::notFound;
 }
 
+std::optional<size_t> JSString::tryFindLastOneChar(JSGlobalObject*, char16_t character, unsigned& startPosition) const
+{
+    ASSERT(isRope());
+
+    // Reverse counterpart of tryFindOneChar: walk the rope structure without resolving it
+    // and return the last occurrence of `character` at or before `startPosition` (inclusive).
+    // nullopt means the rope structure is too complex to walk; in that case `startPosition`
+    // is updated to mark the latest position known not to contain the character (so the
+    // caller can resolve only the remaining prefix).
+
+    auto scanSubstring = [&](const JSRopeString* substringRope, unsigned fiberLength, unsigned offset) -> std::optional<size_t> {
+        JSString* base = substringRope->substringBase();
+        ASSERT(!base->isRope());
+        ASSERT(startPosition >= offset);
+        if (!fiberLength)
+            return std::nullopt;
+        unsigned localStart = startPosition >= offset + fiberLength ? fiberLength - 1 : startPosition - offset;
+        StringView view = StringView(base->valueInternal()).substring(substringRope->substringOffset(), fiberLength);
+        size_t result = view.reverseFind(character, localStart);
+        if (result != WTF::notFound)
+            return offset + result;
+        return std::nullopt;
+    };
+
+    if (isSubstring()) {
+        auto result = scanSubstring(static_cast<const JSRopeString*>(this), length(), 0);
+        return result ? result : std::optional<size_t>(WTF::notFound);
+    }
+
+    const JSRopeString* rope = static_cast<const JSRopeString*>(this);
+    unsigned fiberLengths[JSRopeString::s_maxInternalRopeLength] { };
+    JSString* fibers[JSRopeString::s_maxInternalRopeLength] { };
+    unsigned fiberCount = 0;
+    for (unsigned i = 0; i < JSRopeString::s_maxInternalRopeLength; ++i) {
+        JSString* fiber = rope->fiber(i);
+        if (!fiber)
+            break;
+        fibers[fiberCount] = fiber;
+        fiberLengths[fiberCount] = fiber->length();
+        ++fiberCount;
+    }
+
+    unsigned totalLength = length();
+
+    // Walk fibers in reverse order so we return the largest matching index.
+    unsigned offset = totalLength;
+    for (unsigned i = fiberCount; i-- > 0;) {
+        unsigned fiberLength = fiberLengths[i];
+        offset -= fiberLength;
+
+        if (!fiberLength)
+            continue;
+        if (offset > startPosition)
+            continue; // fiber is entirely past `startPosition`.
+
+        JSString* fiber = fibers[i];
+        if (!fiber->isRope()) {
+            unsigned localStart = startPosition >= offset + fiberLength ? fiberLength - 1 : startPosition - offset;
+            size_t result = StringView(fiber->valueInternal()).reverseFind(character, localStart);
+            if (result != WTF::notFound)
+                return offset + result;
+        } else if (fiber->isSubstring()) {
+            if (auto result = scanSubstring(static_cast<const JSRopeString*>(fiber), fiberLength, offset))
+                return result;
+        } else {
+            // Bail out but update startPosition so the caller only needs to scan
+            // [0, offset + fiberLength - 1].
+            startPosition = std::min(startPosition, offset + fiberLength - 1);
+            return std::nullopt;
+        }
+    }
+
+    return WTF::notFound;
+}
+
 ALWAYS_INLINE std::optional<char16_t> JSString::tryGetCharAt(JSGlobalObject*, unsigned index) const
 {
     ASSERT(isRope());

--- a/Source/JavaScriptCore/runtime/StringPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/StringPrototype.cpp
@@ -151,7 +151,7 @@ void StringPrototype::finishCreation(VM& vm, JSGlobalObject* globalObject)
     JSC_NATIVE_INTRINSIC_FUNCTION_WITHOUT_TRANSITION("codePointAt"_s, stringProtoFuncCodePointAt, static_cast<unsigned>(PropertyAttribute::DontEnum), 1, ImplementationVisibility::Public, StringPrototypeCodePointAtIntrinsic);
     JSC_NATIVE_INTRINSIC_FUNCTION_WITHOUT_TRANSITION("concat"_s, stringProtoFuncConcat, static_cast<unsigned>(PropertyAttribute::DontEnum), 1, ImplementationVisibility::Public, StringPrototypeConcatIntrinsic);
     JSC_NATIVE_INTRINSIC_FUNCTION_WITHOUT_TRANSITION(vm.propertyNames->builtinNames().indexOfPublicName(), stringProtoFuncIndexOf, static_cast<unsigned>(PropertyAttribute::DontEnum), 1, ImplementationVisibility::Public, StringPrototypeIndexOfIntrinsic);
-    JSC_NATIVE_FUNCTION_WITHOUT_TRANSITION("lastIndexOf"_s, stringProtoFuncLastIndexOf, static_cast<unsigned>(PropertyAttribute::DontEnum), 1, ImplementationVisibility::Public);
+    JSC_NATIVE_INTRINSIC_FUNCTION_WITHOUT_TRANSITION("lastIndexOf"_s, stringProtoFuncLastIndexOf, static_cast<unsigned>(PropertyAttribute::DontEnum), 1, ImplementationVisibility::Public, StringPrototypeLastIndexOfIntrinsic);
     JSC_NATIVE_INTRINSIC_FUNCTION_WITHOUT_TRANSITION("replace"_s, stringProtoFuncReplace, static_cast<unsigned>(PropertyAttribute::DontEnum), 2, ImplementationVisibility::Public, StringPrototypeReplaceIntrinsic);
     JSC_NATIVE_INTRINSIC_FUNCTION_WITHOUT_TRANSITION("replaceAll"_s, stringProtoFuncReplaceAll, static_cast<unsigned>(PropertyAttribute::DontEnum), 2, ImplementationVisibility::Public, StringPrototypeReplaceAllIntrinsic);
     JSC_NATIVE_FUNCTION_WITHOUT_TRANSITION("repeat"_s, stringProtoFuncRepeat, static_cast<unsigned>(PropertyAttribute::DontEnum), 1, ImplementationVisibility::Public);
@@ -630,9 +630,13 @@ JSC_DEFINE_HOST_FUNCTION(builtinStringIndexOfInternal, (JSGlobalObject* globalOb
 
 JSC_DEFINE_HOST_FUNCTION(stringProtoFuncLastIndexOf, (JSGlobalObject* globalObject, CallFrame* callFrame))
 {
+    // https://tc39.es/ecma262/#sec-string.prototype.lastindexof
+
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
+    // 1. Let thisValue be the this value.
+    // 2. Perform ? RequireObjectCoercible(thisValue).
     JSValue thisValue = callFrame->thisValue();
     if (!checkObjectCoercible(thisValue)) [[unlikely]]
         return throwVMTypeError(globalObject, scope);
@@ -640,34 +644,70 @@ JSC_DEFINE_HOST_FUNCTION(stringProtoFuncLastIndexOf, (JSGlobalObject* globalObje
     JSValue a0 = callFrame->argument(0);
     JSValue a1 = callFrame->argument(1);
 
+    // 3. Let str be ? ToString(thisValue).
     JSString* thisJSString = thisValue.toString(globalObject);
-    RETURN_IF_EXCEPTION(scope, encodedJSValue());
-    unsigned len = thisJSString->length();
+    RETURN_IF_EXCEPTION(scope, { });
+
+    // 4. Let searchStr be ? ToString(searchString).
     JSString* otherJSString = a0.toString(globalObject);
-    RETURN_IF_EXCEPTION(scope, encodedJSValue());
+    RETURN_IF_EXCEPTION(scope, { });
 
-    double dpos = a1.toIntegerPreserveNaN(globalObject);
-    RETURN_IF_EXCEPTION(scope, encodedJSValue());
-    unsigned startPosition;
-    if (dpos < 0)
-        startPosition = 0;
-    else if (!(dpos <= len)) // true for NaN
-        startPosition = len;
-    else
-        startPosition = static_cast<unsigned>(dpos);
+    auto otherView = otherJSString->view(globalObject);
+    RETURN_IF_EXCEPTION(scope, { });
 
-    if (len < otherJSString->length())
+    // 5. Let numPos be ? ToNumber(position).
+    // 6. Assert: If position is undefined, then numPos is NaN.
+    // 7. If numPos is NaN, let pos be +∞; else let pos be ! ToIntegerOrInfinity(numPos).
+    // 8. Let len be the length of str.
+    // 9. Let searchLen be the length of searchStr.
+    // 10. If len < searchLen, return -1.
+    // 11. Let start be the result of clamping pos between 0 and len - searchLen.
+    double numPos = a1.toIntegerPreserveNaN(globalObject);
+    RETURN_IF_EXCEPTION(scope, { });
+
+    unsigned len = thisJSString->length();
+    unsigned otherLen = otherView->length();
+    if (len < otherLen)
         return JSValue::encode(jsNumber(-1));
 
-    auto thisString = thisJSString->value(globalObject);
-    RETURN_IF_EXCEPTION(scope, encodedJSValue());
-    auto otherString = otherJSString->value(globalObject);
-    RETURN_IF_EXCEPTION(scope, encodedJSValue());
+    unsigned maxStart = len - otherLen;
+    unsigned startPosition;
+    if (numPos < 0)
+        startPosition = 0;
+    else if (!(numPos <= maxStart)) // true for NaN
+        startPosition = maxStart;
+    else
+        startPosition = static_cast<unsigned>(numPos);
+
+    // Now, startPosition is in [0, maxStart(len - otherLen)].
+    if (otherLen == 1) {
+        char16_t character = otherView[0];
+        if (thisJSString->isRope() && len >= JSString::minLengthForRopeWalk) {
+            if (auto result = thisJSString->tryFindLastOneChar(globalObject, character, startPosition)) {
+                if (*result != notFound)
+                    return JSValue::encode(jsNumber(*result));
+                return JSValue::encode(jsNumber(-1));
+            }
+            // nullopt: bail out, fall through to resolve. startPosition has been narrowed.
+        }
+
+        auto thisView = thisJSString->view(globalObject);
+        RETURN_IF_EXCEPTION(scope, { });
+
+        size_t result = thisView->reverseFind(character, startPosition);
+        if (result == notFound)
+            return JSValue::encode(jsNumber(-1));
+        return JSValue::encode(jsNumber(result));
+    }
+
+    auto thisView = thisJSString->view(globalObject);
+    RETURN_IF_EXCEPTION(scope, { });
+
     size_t result;
     if (!startPosition)
-        result = thisString->startsWith(otherString) ? 0 : notFound;
+        result = thisView->startsWith(otherView) ? 0 : notFound;
     else
-        result = thisString->reverseFind(otherString, startPosition);
+        result = thisView->reverseFind(otherView, startPosition);
     if (result == notFound)
         return JSValue::encode(jsNumber(-1));
     return JSValue::encode(jsNumber(result));

--- a/Source/WTF/wtf/SIMDHelpers.h
+++ b/Source/WTF/wtf/SIMDHelpers.h
@@ -477,6 +477,71 @@ ALWAYS_INLINE std::optional<uint8_t> findFirstNonZeroIndex(simde_uint64x2_t valu
 #endif
 }
 
+ALWAYS_INLINE std::optional<uint8_t> findLastNonZeroIndex(simde_uint8x16_t value)
+{
+#if CPU(X86_64)
+    auto raw = simde_uint8x16_to_m128i(value);
+    uint16_t mask = simde_mm_movemask_epi8(raw);
+    if (!mask)
+        return std::nullopt;
+    return 15 - std::countl_zero(mask);
+#else
+    if (!isNonZero(value))
+        return std::nullopt;
+    constexpr simde_uint8x16_t indexMask { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15 };
+    return simde_vmaxvq_u8(simde_vandq_u8(indexMask, value));
+#endif
+}
+
+ALWAYS_INLINE std::optional<uint8_t> findLastNonZeroIndex(simde_uint16x8_t value)
+{
+#if CPU(X86_64)
+    auto raw = simde_uint16x8_to_m128i(value);
+    uint16_t mask = simde_mm_movemask_epi8(raw);
+    if (!mask)
+        return std::nullopt;
+    return (15 - std::countl_zero(mask)) >> 1;
+#else
+    if (!isNonZero(value))
+        return std::nullopt;
+    constexpr simde_uint16x8_t indexMask { 0, 1, 2, 3, 4, 5, 6, 7 };
+    return simde_vmaxvq_u16(simde_vandq_u16(indexMask, value));
+#endif
+}
+
+ALWAYS_INLINE std::optional<uint8_t> findLastNonZeroIndex(simde_uint32x4_t value)
+{
+#if CPU(X86_64)
+    auto raw = simde_uint32x4_to_m128i(value);
+    uint16_t mask = simde_mm_movemask_epi8(raw);
+    if (!mask)
+        return std::nullopt;
+    return (15 - std::countl_zero(mask)) >> 2;
+#else
+    if (!isNonZero(value))
+        return std::nullopt;
+    constexpr simde_uint32x4_t indexMask { 0, 1, 2, 3 };
+    return simde_vmaxvq_u32(simde_vandq_u32(indexMask, value));
+#endif
+}
+
+ALWAYS_INLINE std::optional<uint8_t> findLastNonZeroIndex(simde_uint64x2_t value)
+{
+#if CPU(X86_64)
+    auto raw = simde_uint64x2_to_m128i(value);
+    uint16_t mask = simde_mm_movemask_epi8(raw);
+    if (!mask)
+        return std::nullopt;
+    return (15 - std::countl_zero(mask)) >> 3;
+#else
+    simde_uint32x2_t reducedMask = simde_vmovn_u64(value);
+    if (!simde_vget_lane_u64(simde_vreinterpret_u64_u32(reducedMask), 0))
+        return std::nullopt;
+    constexpr simde_uint32x2_t indexMask { 0, 1 };
+    return simde_vmaxv_u32(simde_vand_u32(indexMask, reducedMask));
+#endif
+}
+
 template<Latin1Character character, Latin1Character... characters>
 ALWAYS_INLINE simde_uint8x16_t equal(simde_uint8x16_t input)
 {
@@ -625,6 +690,38 @@ ALWAYS_INLINE const CharacterType* find(std::span<const CharacterType> span, con
     for (; cursor != end; ++cursor) {
         auto character = *cursor;
         if (scalarMatch(character))
+            return cursor;
+    }
+    return end;
+}
+
+template<typename CharacterType, size_t threshold = SIMD::stride<CharacterType>>
+ALWAYS_INLINE const CharacterType* reverseFind(std::span<const CharacterType> span, const auto& vectorMatch, const auto& scalarMatch)
+{
+    constexpr size_t stride = SIMD::stride<CharacterType>;
+    using UnsignedType = SameSizeUnsignedInteger<CharacterType>;
+    static_assert(threshold >= stride);
+    const auto* begin = span.data();
+    const auto* end = std::to_address(span.end());
+    if (span.size() >= threshold) {
+        size_t remaining = span.size();
+        while (remaining >= stride) {
+            remaining -= stride;
+            const auto* cursor = begin + remaining;
+            if (auto index = vectorMatch(SIMD::load(std::bit_cast<const UnsignedType*>(cursor))))
+                return cursor + index.value();
+        }
+        if (remaining) {
+            if (auto index = vectorMatch(SIMD::load(std::bit_cast<const UnsignedType*>(begin))))
+                return begin + index.value();
+        }
+        return end;
+    }
+
+    const auto* cursor = end;
+    while (cursor != begin) {
+        --cursor;
+        if (scalarMatch(*cursor))
             return cursor;
     }
     return end;

--- a/Source/WTF/wtf/text/StringCommon.h
+++ b/Source/WTF/wtf/text/StringCommon.h
@@ -721,6 +721,70 @@ SUPPRESS_NODELETE ALWAYS_INLINE const uint64_t* NODELETE find64(const uint64_t* 
     return nullptr;
 }
 
+SUPPRESS_NODELETE ALWAYS_INLINE const uint8_t* NODELETE reverseFind8(const uint8_t* pointer, uint8_t character, size_t length)
+{
+    constexpr size_t thresholdLength = 16;
+
+    size_t index = length;
+    size_t runway = length > thresholdLength ? length - thresholdLength : 0;
+    while (index > runway) {
+        --index;
+        if (pointer[index] == character)
+            return pointer + index;
+    }
+    if (!runway)
+        return nullptr;
+
+#if OS(LINUX) && defined(__GLIBC__)
+    return static_cast<const uint8_t*>(memrchr(pointer, character, runway));
+#else
+    auto charactersVector = SIMD::splat<uint8_t>(character);
+    auto vectorMatch = [&](auto value) ALWAYS_INLINE_LAMBDA {
+        auto mask = SIMD::equal(value, charactersVector);
+        return SIMD::findLastNonZeroIndex(mask);
+    };
+    auto scalarMatch = [&](auto current) ALWAYS_INLINE_LAMBDA {
+        return current == character;
+    };
+    auto* end = pointer + runway;
+    auto* cursor = SIMD::reverseFind<uint8_t>(std::span { pointer, end }, vectorMatch, scalarMatch);
+    if (cursor == end)
+        return nullptr;
+    return cursor;
+#endif
+}
+
+template<typename UnsignedType>
+SUPPRESS_NODELETE ALWAYS_INLINE const UnsignedType* NODELETE reverseFindImpl(const UnsignedType* pointer, UnsignedType character, size_t length)
+{
+    auto charactersVector = SIMD::splat<UnsignedType>(character);
+    auto vectorMatch = [&](auto value) ALWAYS_INLINE_LAMBDA {
+        auto mask = SIMD::equal(value, charactersVector);
+        return SIMD::findLastNonZeroIndex(mask);
+    };
+
+    auto scalarMatch = [&](auto current) ALWAYS_INLINE_LAMBDA {
+        return current == character;
+    };
+
+    constexpr size_t threshold = 32;
+    auto* end = pointer + length;
+    auto* cursor = SIMD::reverseFind<UnsignedType, threshold>(std::span { pointer, end }, vectorMatch, scalarMatch);
+    if (cursor == end)
+        return nullptr;
+    return cursor;
+}
+
+ALWAYS_INLINE const uint16_t* NODELETE reverseFind16(const uint16_t* pointer, uint16_t character, size_t length)
+{
+    return reverseFindImpl(pointer, character, length);
+}
+
+ALWAYS_INLINE const uint32_t* NODELETE reverseFind32(const uint32_t* pointer, uint32_t character, size_t length)
+{
+    return reverseFindImpl(pointer, character, length);
+}
+
 SUPPRESS_NODELETE ALWAYS_INLINE const double* NODELETE findNaN(const double* pointer, size_t length)
 {
     constexpr size_t scalarThreshold = 4;

--- a/Source/WTF/wtf/text/StringImpl.h
+++ b/Source/WTF/wtf/text/StringImpl.h
@@ -729,11 +729,17 @@ template<typename CharacterType> inline size_t reverseFind(std::span<const Chara
         return notFound;
     if (start >= characters.size())
         start = characters.size() - 1;
-    while (characters[start] != matchCharacter) {
-        if (!start--)
-            return notFound;
-    }
-    return start;
+    size_t searchLength = start + 1;
+    const CharacterType* result;
+    if constexpr (sizeof(CharacterType) == 1)
+        result = std::bit_cast<const CharacterType*>(reverseFind8(std::bit_cast<const uint8_t*>(characters.data()), static_cast<uint8_t>(matchCharacter), searchLength));
+    else if constexpr (sizeof(CharacterType) == 2)
+        result = std::bit_cast<const CharacterType*>(reverseFind16(std::bit_cast<const uint16_t*>(characters.data()), static_cast<uint16_t>(matchCharacter), searchLength));
+    else
+        result = std::bit_cast<const CharacterType*>(reverseFind32(std::bit_cast<const uint32_t*>(characters.data()), static_cast<uint32_t>(matchCharacter), searchLength));
+    if (!result)
+        return notFound;
+    return result - characters.data();
 }
 
 ALWAYS_INLINE size_t reverseFind(std::span<const char16_t> characters, Latin1Character matchCharacter, size_t start)


### PR DESCRIPTION
#### 5efecc395404bead4efeb1b572adeca3274f3e9a
<pre>
[JSC] Add String#lastIndexOf optimizations
<a href="https://bugs.webkit.org/show_bug.cgi?id=313583">https://bugs.webkit.org/show_bug.cgi?id=313583</a>
<a href="https://rdar.apple.com/175797508">rdar://175797508</a>

Reviewed by Keith Miller and Sosuke Suzuki.

This patch implements String.prototype.lastIndexOf optimizations.
Basically almost all of code is copy-and-paste from existing
String.prototype.indexOf (e.g. DFG / FTL node modeling). We did some
clean up of normal C function based on the latest spec document to clean
up the other part of implementations in DFG / FTL (operations).
To make it fast, we also add SIMD handling of SIMD::reverseFind.
Mostly similar to SIMD::find, but we need to change the iteration
reversed, and introducing findLastNonZeroIndex.

Test: JSTests/stress/string-last-index-of.js

* JSTests/stress/string-index-of-empty.js: Added.
(assertEq):
(specIndexOf):
(specLastIndexOf):
(checkIndex):
(checkLast):
(checkBoth):
(exerciseEmptyNeedle):
(exerciseNonEmptyNeedleOnEmpty):
(idxEmpty):
(lastEmpty):
(idxEmptyAt):
(lastEmptyAt):
(idxOnEmpty):
(lastOnEmpty):
(warmEmpty):
(idxEmptyU):
(lastEmptyU):
(warmEmptyU):
(idxEmptyRope):
(lastEmptyRope):
(warmEmptyRope):
* JSTests/stress/string-last-index-of-large-fromindex.js: Added.
(specLastIndexOf):
(assertEq):
(check):
* JSTests/stress/string-last-index-of.js: Added.
(specLastIndexOf):
(assertEq):
(check):
(pos.valueOf):
(catch):
(100.n.0.n.1.filter):
(makeRope2):
(makeRope3):
(hotSlash):
(warmSingleChar):
(hotRope):
(warmRope):
(buildMiddleBailoutRope):
(buildMiddleOnly):
(hotMiddle):
(hotMixed8):
(hotMixed16):
(warmMiddleMixed):
* Source/JavaScriptCore/dfg/DFGAbstractInterpreterInlines.h:
(JSC::DFG::AbstractInterpreter&lt;AbstractStateType&gt;::executeEffects):
* Source/JavaScriptCore/dfg/DFGBackwardsPropagationPhase.cpp:
(JSC::DFG::BackwardsPropagationPhase::propagate):
* Source/JavaScriptCore/dfg/DFGByteCodeParser.cpp:
(JSC::DFG::ByteCodeParser::handleIntrinsicCall):
* Source/JavaScriptCore/dfg/DFGClobberize.h:
(JSC::DFG::clobberize):
* Source/JavaScriptCore/dfg/DFGCloneHelper.h:
* Source/JavaScriptCore/dfg/DFGDoesGC.cpp:
(JSC::DFG::doesGC):
* Source/JavaScriptCore/dfg/DFGFixupPhase.cpp:
(JSC::DFG::FixupPhase::fixupNode):
* Source/JavaScriptCore/dfg/DFGNodeType.h:
* Source/JavaScriptCore/dfg/DFGOperations.cpp:
(JSC::DFG::JSC_DEFINE_JIT_OPERATION):
(JSC::DFG::stringLastIndexOfOneCharOperation):
* Source/JavaScriptCore/dfg/DFGOperations.h:
* Source/JavaScriptCore/dfg/DFGPredictionPropagationPhase.cpp:
* Source/JavaScriptCore/dfg/DFGSafeToExecute.h:
(JSC::DFG::safeToExecute):
* Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp:
* Source/JavaScriptCore/dfg/DFGSpeculativeJIT.h:
* Source/JavaScriptCore/dfg/DFGSpeculativeJIT32_64.cpp:
(JSC::DFG::SpeculativeJIT::compile):
* Source/JavaScriptCore/dfg/DFGSpeculativeJIT64.cpp:
(JSC::DFG::SpeculativeJIT::compile):
* Source/JavaScriptCore/dfg/DFGStrengthReductionPhase.cpp:
(JSC::DFG::StrengthReductionPhase::handleNode):
* Source/JavaScriptCore/ftl/FTLCapabilities.cpp:
(JSC::FTL::canCompile):
* Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp:
(JSC::FTL::DFG::LowerDFGToB3::compileNode):
(JSC::FTL::DFG::LowerDFGToB3::compileStringIndexOf):
(JSC::FTL::DFG::LowerDFGToB3::compileStringLastIndexOf):
* Source/JavaScriptCore/runtime/Intrinsic.h:
* Source/JavaScriptCore/runtime/JSString.h:
* Source/JavaScriptCore/runtime/JSStringInlines.h:
(JSC::JSString::tryFindLastOneChar const):
* Source/JavaScriptCore/runtime/StringPrototype.cpp:
(JSC::StringPrototype::finishCreation):
(JSC::JSC_DEFINE_HOST_FUNCTION):
* Source/WTF/wtf/SIMDHelpers.h:
(WTF::SIMD::findLastNonZeroIndex):
(WTF::SIMD::reverseFind):
* Source/WTF/wtf/text/StringCommon.h:
(WTF::reverseFind8):
(WTF::reverseFindImpl):
(WTF::reverseFind16):
(WTF::reverseFind32):
* Source/WTF/wtf/text/StringImpl.h:
(WTF::reverseFind):

Canonical link: <a href="https://commits.webkit.org/312307@main">https://commits.webkit.org/312307@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/21a956deeb645d3a4bd35f9a8c413c092f07d24a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/159520 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/159/builds/32987 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/26065 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/168358 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/113901 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/33022 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/156/builds/32940 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/168358 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/113901 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/162477 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/33022 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/168/builds/26065 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/168358 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/33022 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/156/builds/32940 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk3-libwebrtc~~](https://ews-build.webkit.org/#/builders/173/builds/16128 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/20/builds/151576 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/33022 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/168/builds/26065 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/170851 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [  ~~🛠 🧪 jsc-debug-arm64~~](https://ews-build.webkit.org/#/builders/171/builds/20357 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/16888 "Build is in progress. Recent messages:") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/26065 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/170851 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/32645 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/156/builds/32940 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/170851 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/32651 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/168/builds/26065 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/90733 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/24279 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/160/builds/32651 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/26065 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 jsc-armv7~~](https://ews-build.webkit.org/#/builders/35/builds/191804 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/32160 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/98556 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/35/builds/191804 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/31657 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/31895 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/31808 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->