### PR TITLE
Unreviewed test gardening platform/ipad/fast/viewport/viewport-overriden-by-minimum-effective-width-if-ignore-meta-viewport.html is a constant text failure

### DIFF
--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -8192,7 +8192,6 @@ http/tests/workers/service/basic-install-event-sw-fetch-third-party.html [ Failu
 http/wpt/webcodecs/videoFrame-negative-timestamp.html [ Failure ]
 imported/w3c/web-platform-tests/css/selectors/invalidation/has-with-nesting-parent-containing-hover.html [ Failure ]
 imported/w3c/web-platform-tests/uievents/mouse/mousemove_after_mouseover_target_removed.html [ Failure ]
-platform/ipad/fast/viewport/viewport-overriden-by-minimum-effective-width-if-ignore-meta-viewport.html [ Failure ]
 fast/css/accent-color/button.html [ ImageOnlyFailure ]
 fast/css/accent-color/date.html [ ImageOnlyFailure ]
 fast/css/accent-color/select.html [ ImageOnlyFailure ]

--- a/LayoutTests/platform/ipad/fast/viewport/viewport-overriden-by-minimum-effective-width-if-ignore-meta-viewport-expected.txt
+++ b/LayoutTests/platform/ipad/fast/viewport/viewport-overriden-by-minimum-effective-width-if-ignore-meta-viewport-expected.txt
@@ -9,33 +9,33 @@ square size: [81, 106]
 zoom scale: 1.00
 
 setMinimumEffectiveWidth(834.00)
-window size: [834, 1091]
-square size: [83, 109]
-zoom scale: 0.97
+window size: [824, 1078]
+square size: [82, 108]
+zoom scale: 0.98
 
 setMinimumEffectiveWidth(980.00)
-window size: [980, 1282]
-square size: [98, 128]
-zoom scale: 0.83
+window size: [968, 1267]
+square size: [97, 127]
+zoom scale: 0.84
 
 setMinimumEffectiveWidth(1024.00)
-window size: [1024, 1340]
-square size: [102, 134]
-zoom scale: 0.79
+window size: [1012, 1324]
+square size: [101, 132]
+zoom scale: 0.80
 
 setMinimumEffectiveWidth(1112.00)
-window size: [1112, 1455]
-square size: [111, 146]
-zoom scale: 0.73
+window size: [1098, 1437]
+square size: [110, 144]
+zoom scale: 0.74
 
 setMinimumEffectiveWidth(1280.00)
-window size: [1280, 1675]
-square size: [128, 168]
-zoom scale: 0.63
+window size: [1264, 1655]
+square size: [126, 165]
+zoom scale: 0.64
 
 setMinimumEffectiveWidth(1336.00)
-window size: [1336, 1748]
-square size: [134, 175]
+window size: [1320, 1727]
+square size: [132, 173]
 zoom scale: 0.61
 
 


### PR DESCRIPTION
#### 760bf5b28aca8581d2aece04b6b949897e83d815
<pre>
Unreviewed test gardening platform/ipad/fast/viewport/viewport-overriden-by-minimum-effective-width-if-ignore-meta-viewport.html is a constant text failure
<a href="https://bugs.webkit.org/show_bug.cgi?id=313582">https://bugs.webkit.org/show_bug.cgi?id=313582</a>
<a href="https://rdar.apple.com/156642371">rdar://156642371</a>

This failure is due to m_prefersHorizontalScrollingBelowDesktopViewportWidths
being true, with the introduction of stage manager support on the iPad 9th gen
(which is also the root cause of 309938@main).

Update the test expectations to reflect the current state.

* LayoutTests/platform/ios/TestExpectations:
* LayoutTests/platform/ipad/fast/viewport/viewport-overriden-by-minimum-effective-width-if-ignore-meta-viewport-expected.txt:

Canonical link: <a href="https://commits.webkit.org/312298@main">https://commits.webkit.org/312298@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/40a3404d9ef5bf6c94eccb49d34be6db735e22b2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/159349 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/32777 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/25883 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/168181 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/113727 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/37d09f5b-4de0-401a-9e72-b57f7eb5970e) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/32845 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/32764 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/123462 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/86661 "1 failures") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/b83465a1-a962-4551-bddc-5dd5e93bfc73) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/162306 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/25716 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/143133 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/104128 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/9d4cc5c1-304c-4440-9048-072a7ebb2349) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/24769 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/23215 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/15952 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/134456 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/20913 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/170673 "Built successfully") | | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/22539 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/131664 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/32466 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/27289 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/131777 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/32410 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/142706 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/90535 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/24275 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/26447 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/19515 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/31921 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/31441 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/31714 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/31596 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->