### PR TITLE
[AppKit Gestures] Add a test for clicking to change selection

### DIFF
--- a/Tools/TestWebKitAPI/Helpers/cocoa/Foundation+Extras.swift
+++ b/Tools/TestWebKitAPI/Helpers/cocoa/Foundation+Extras.swift
@@ -53,3 +53,29 @@ extension AsyncSequence {
         }
     }
 }
+
+extension StringProtocol {
+    /// Finds and returns the range of the first occurrence of a given string within a given range of the String, subject to given options, using the specified locale, if any.
+    ///
+    /// - Parameters:
+    ///   - aString: The string to search for.
+    ///   - mask: A mask specifying search options.
+    ///   - searchRange: The range within the receiver for which to search for `aString`.
+    ///   - locale: The locale to use when comparing the receiver with `aString`.
+    /// - Returns: The range that `aString` is located in, represented as a quantity of UTF-16 code points.
+    public func utf16Range(
+        of aString: some StringProtocol,
+        options mask: String.CompareOptions = [],
+        range searchRange: Range<Self.Index>? = nil,
+        locale: Locale? = nil
+    ) -> Range<Int>? {
+        guard let nominalRange = range(of: aString, options: mask, range: searchRange, locale: locale) else {
+            return nil
+        }
+
+        let start = nominalRange.lowerBound.utf16Offset(in: self)
+        let end = nominalRange.upperBound.utf16Offset(in: self)
+
+        return start..<end
+    }
+}

--- a/Tools/TestWebKitAPI/Helpers/cocoa/JavaScriptMessages.swift
+++ b/Tools/TestWebKitAPI/Helpers/cocoa/JavaScriptMessages.swift
@@ -91,6 +91,27 @@ extension JavaScriptMessages {
             self.selection = selection
         }
 
+        /// A convenience initializer for a range selection.
+        ///
+        /// - Parameters:
+        ///   - container: The container the range is relative to.
+        ///   - range: The range of the selection within the container.
+        public init(in container: String, range: Range<Int>) {
+            self.selection = .range(
+                base: .init(in: container, at: range.lowerBound),
+                extent: .init(in: container, at: range.upperBound),
+            )
+        }
+
+        /// A convenience initializer for a collapsed range selection.
+        ///
+        /// - Parameters:
+        ///   - container: The container the range is relative to.
+        ///   - offset: The offset of the selection within the container.
+        public init(in container: String, offset: Int) {
+            self.selection = .collapsed(.init(in: container, at: offset))
+        }
+
         // Protocol conformance.
         // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
         public func encoded() -> [String: Any?] {

--- a/Tools/TestWebKitAPI/Scripts/process-entitlements.sh
+++ b/Tools/TestWebKitAPI/Scripts/process-entitlements.sh
@@ -57,6 +57,7 @@ function process_mac_testwebkitapi_entitlements()
 
         plistbuddy Add :com.apple.hid.manager.user-access-device bool YES
         plistbuddy Add :com.apple.private.hid.client.event-filter bool YES
+        plistbuddy Add :com.apple.private.hid.client.event-dispatch.internal bool YES
     fi
 }
 

--- a/Tools/TestWebKitAPI/Tests/WebKit/WebPage/AppKitGesturesTests.swift
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WebPage/AppKitGesturesTests.swift
@@ -24,15 +24,171 @@
 #if HAVE_APPKIT_GESTURES_SUPPORT
 
 import Foundation
-import WebKit
+@_spi(WebKitAdditions_Testing) import WebKit
 import SwiftUI
 import struct Swift.String
 import struct _Concurrency.Task
+private import struct TestWebKitAPILibrary.DOMRect
 import Testing
 private import TestWebKitAPILibrary
+private import Recap
+
+private actor Recap {
+    static let shared = Recap()
+
+    func play(events: @Sendable (_ composer: any RCPEventStreamComposer) -> Void) async {
+        let eventStream: RCPSyntheticEventStream = RCPSyntheticEventStream { composer in
+            guard let composer else {
+                preconditionFailure()
+            }
+            composer.senderProperties = ._wk_trackpadSender()
+            events(composer)
+        }
+
+        await RCPInlinePlayer.play(eventStream, options: .init())
+    }
+}
 
 @MainActor
+private func convertToCoreGraphicsScreenCoordinates(rectInViewportCoordinates: DOMRect, window: NSWindow) -> CGRect {
+    guard let contentViewController = window.contentViewController else {
+        preconditionFailure()
+    }
+
+    guard let screen = window.screen else {
+        preconditionFailure()
+    }
+
+    let inViewportCoordinates = CGRect(rectInViewportCoordinates)
+
+    let inWindowCoordinates = CGRect(
+        x: inViewportCoordinates.origin.x,
+        y: contentViewController.view.frame.height - inViewportCoordinates.origin.y - inViewportCoordinates.size.height,
+        width: inViewportCoordinates.size.width,
+        height: inViewportCoordinates.size.height,
+    )
+
+    let inAppKitScreenCoordinates = window.convertToScreen(inWindowCoordinates)
+
+    let inCoreGraphicsScreenCoordinates = CGRect(
+        x: inAppKitScreenCoordinates.origin.x,
+        y: screen.frame.maxY - inAppKitScreenCoordinates.maxY,
+        width: inAppKitScreenCoordinates.width,
+        height: inAppKitScreenCoordinates.height,
+    )
+
+    return inCoreGraphicsScreenCoordinates
+}
+
+@MainActor
+@Suite(.serialized)
 struct AppKitGesturesTests {
+    private static let text = "Here's to the crazy ones."
+
+    private static let html = """
+        <div id="div" contenteditable style="font-size: 30px;">\(text)</div>
+        """
+
+    private let recap = Recap.shared
+    private let page = WebPage()
+    private let window: NSWindow
+
+    init() async throws {
+        try await self.page.load(html: Self.html).wait()
+
+        let contentSize = NSSize(width: 800, height: 600)
+
+        self.window = NSWindow(size: contentSize) { [page] in
+            WebView(page)
+        }
+
+        self.window.setFrameOrigin(.zero)
+        NSApp.activate(ignoringOtherApps: true)
+        self.window.makeKeyAndOrderFront(nil)
+    }
+
+    @Test
+    func doubleClickingInWordSelectsWord() async throws {
+        let crazyRange = try #require(Self.text.utf16Range(of: "crazy"))
+        let crazySelection = JavaScriptSelection.range(
+            base: .init(in: "div", at: crazyRange.lowerBound),
+            extent: .init(in: "div", at: crazyRange.upperBound)
+        )
+        try await page.callJavaScript(JavaScriptMessages.SetSelection(crazySelection))
+
+        let crazyBoundsInViewportCoordinates = try await page.callJavaScript(JavaScriptMessages.SelectionBoundingClientRect())
+
+        let crazyBoundsInScreenCoordinates = convertToCoreGraphicsScreenCoordinates(
+            rectInViewportCoordinates: crazyBoundsInViewportCoordinates,
+            window: window
+        )
+
+        let point = CGPoint(
+            x: crazyBoundsInScreenCoordinates.midX,
+            y: crazyBoundsInScreenCoordinates.midY
+        )
+
+        try await page.callJavaScript(JavaScriptMessages.SetSelection(in: "div", offset: 0))
+
+        await page.waitForNextPresentationUpdate()
+
+        // Recap requires this test to be ran within an app host.
+        guard NSApp.isActive else {
+            return
+        }
+
+        await recap.play { composer in
+            composer._wk_click(point)
+            composer.advanceTime(0.1)
+            composer._wk_click(point)
+        }
+
+        await page.waitForNextPresentationUpdate()
+
+        let newSelection = try await page.callJavaScript(JavaScriptMessages.GetSelection())
+
+        #expect(newSelection == crazySelection)
+    }
+
+    @Test(arguments: [0.1, 0.5, 0.9])
+    func clickingInWordChangesSelection(fractionOfWordToClick: Double) async throws {
+        let crazyRange = try #require(Self.text.utf16Range(of: "crazy"))
+        try await page.callJavaScript(JavaScriptMessages.SetSelection(in: "div", range: crazyRange))
+
+        let crazyBoundsInViewportCoordinates = try await page.callJavaScript(JavaScriptMessages.SelectionBoundingClientRect())
+
+        let crazyBoundsInScreenCoordinates = convertToCoreGraphicsScreenCoordinates(
+            rectInViewportCoordinates: crazyBoundsInViewportCoordinates,
+            window: window
+        )
+
+        let point = CGPoint(
+            x: crazyBoundsInScreenCoordinates.origin.x + (crazyBoundsInScreenCoordinates.size.width * fractionOfWordToClick),
+            y: crazyBoundsInScreenCoordinates.midY
+        )
+
+        try await page.callJavaScript(JavaScriptMessages.SetSelection(in: "div", offset: 0))
+
+        await page.waitForNextPresentationUpdate()
+
+        // Recap requires this test to be ran within an app host.
+        guard NSApp.isActive else {
+            return
+        }
+
+        await recap.play { composer in
+            composer._wk_click(point)
+        }
+
+        await page.waitForNextPresentationUpdate()
+
+        // This is a rough approximation of the heuristic the implementation uses.
+        let offset = fractionOfWordToClick < 0.2 ? crazyRange.lowerBound : crazyRange.upperBound
+
+        let newSelection = try await page.callJavaScript(JavaScriptMessages.GetSelection())
+        #expect(newSelection == .collapsed(.init(in: "div", at: offset)))
+    }
+
     @Test
     func clickingChangesSelection() async throws {
         let page = WebPage()
@@ -53,12 +209,8 @@ struct AppKitGesturesTests {
         window.setFrameOrigin(.zero)
         window.makeKeyAndOrderFront(nil)
 
-        let range = try #require(text.range(of: "crazy"))
-        let start = range.lowerBound.utf16Offset(in: text)
-        let end = range.upperBound.utf16Offset(in: text)
-        let crazySelection: JavaScriptSelection = .range(base: .init(in: "div", at: start), extent: .init(in: "div", at: end))
-
-        try await page.callJavaScript(JavaScriptMessages.SetSelection(crazySelection))
+        let crazyRange = try #require(text.utf16Range(of: "crazy"))
+        try await page.callJavaScript(JavaScriptMessages.SetSelection(in: "div", range: crazyRange))
 
         let crazyBoundsInViewportCoordinates = try await CGRect(page.callJavaScript(JavaScriptMessages.SelectionBoundingClientRect()))
 
@@ -71,8 +223,7 @@ struct AppKitGesturesTests {
 
         let middleOfCrazy = CGPoint(x: crazyBoundsInAppKitCoordinates.midX, y: crazyBoundsInAppKitCoordinates.midY)
 
-        let selectionAtStart: JavaScriptSelection = .collapsed(.init(in: "div", at: 0))
-        try await page.callJavaScript(JavaScriptMessages.SetSelection(selectionAtStart))
+        try await page.callJavaScript(JavaScriptMessages.SetSelection(in: "div", offset: 0))
 
         let waitForSelectionChange = """
             return await new Promise(resolve => {


### PR DESCRIPTION
#### fdf97620232c4b1891d677678421c5e296c03793
<pre>
[AppKit Gestures] Add a test for clicking to change selection
<a href="https://bugs.webkit.org/show_bug.cgi?id=313585">https://bugs.webkit.org/show_bug.cgi?id=313585</a>
<a href="https://rdar.apple.com/175798813">rdar://175798813</a>

Reviewed by Abrar Rahman Protyasha.

Add initial tests that test {double-}clicking at various points within a word to change selection.

* Tools/TestWebKitAPI/Helpers/cocoa/Foundation+Extras.swift:
* Tools/TestWebKitAPI/Helpers/cocoa/JavaScriptMessages.swift:

Add/improve some support functions.

* Tools/TestWebKitAPI/Scripts/process-entitlements.sh:

Add a new HID entitlement to allow Recap to simulate clicks and events.

* Tools/TestWebKitAPI/Tests/WebKit/WebPage/AppKitGesturesTests.swift:
(TestWebKitAPILibrary.play(_:)):
(convertToCoreGraphicsScreenCoordinates(_:window:)):
(AppKitGesturesTests.doubleClickingInWordSelectsWord):
(AppKitGesturesTests.clickingInWordChangesSelection(_:)):
(AppKitGesturesTests.clickingChangesSelection):

Canonical link: <a href="https://commits.webkit.org/312311@main">https://commits.webkit.org/312311@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5a4201f9b386320353f7fc3b7b266d6f0a0f4b1d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/159378 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/32806 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/25914 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/168210 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/113756 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/161247 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/32874 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/32794 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/123480 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/86671 "1 flakes 1 failures") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/162335 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/25735 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/143146 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/104145 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/24788 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/23237 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/15981 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/134475 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/20926 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/170702 "Built successfully") | | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/22552 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/131686 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/32495 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/27311 "Found 1 new test failure: http/tests/security/javascriptURL/xss-ALLOWED-to-javascript-url-from-javscript-url.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/131799 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/32439 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/142719 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/90564 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/24281 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/26467 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/19528 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/31950 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/31470 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/31743 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/31625 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->