### PR TITLE
[List Marker] Search past empty inline items when parenting list markers

### DIFF
--- a/LayoutTests/fast/lists/list-marker-with-empty-inline-before-blockquote-expected.html
+++ b/LayoutTests/fast/lists/list-marker-with-empty-inline-before-blockquote-expected.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+    body { font-family: Ahem; font-size: 16px; }
+</style>
+</head>
+<body>
+<ol>
+    <li>
+        <p>Item text</p>
+        <blockquote><p>Blockquote text</p></blockquote>
+    </li>
+</ol>
+</body>
+</html>

--- a/LayoutTests/fast/lists/list-marker-with-empty-inline-before-blockquote.html
+++ b/LayoutTests/fast/lists/list-marker-with-empty-inline-before-blockquote.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+    body { font-family: Ahem; font-size: 16px; }
+</style>
+</head>
+<body>
+<ol>
+    <li>
+        <p><a id="anchor"></a> Item text</p>
+        <blockquote><p>Blockquote text</p></blockquote>
+    </li>
+</ol>
+</body>
+</html>

--- a/Source/WebCore/rendering/updating/RenderTreeBuilderList.cpp
+++ b/Source/WebCore/rendering/updating/RenderTreeBuilderList.cpp
@@ -32,6 +32,7 @@
 #include "RenderMultiColumnFlow.h"
 #include "RenderObjectStyle.h"
 #include "RenderTable.h"
+#include "RenderText.h"
 #include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
@@ -56,9 +57,15 @@ static LineBoxParentSearchResult findParentOfEmptyOrFirstLineBox(RenderBlock& bl
             continue;
 
         if (child.isInline()) {
-            if (!is<RenderInline>(child) || !isEmptyInline(downcast<RenderInline>(child)))
-                return { &blockContainer, { }, false };
-            fallbackParent = &blockContainer;
+            // Continue searching past empty inlines (e.g., <a id="anchor"></a>) — the remaining checks below
+            // assume block-level children, and an inline falling through would falsely trigger failedDueToBlockification.
+            if (is<RenderInline>(child) && isEmptyInline(downcast<RenderInline>(child))) {
+                fallbackParent = &blockContainer;
+                continue;
+            }
+            if (is<RenderText>(child) && downcast<RenderText>(child).containsOnlyCollapsibleWhitespace())
+                continue;
+            return { &blockContainer, { }, false };
         }
 
         if (child.isFloating() || child.isOutOfFlowPositioned() || is<RenderMenuList>(child))


### PR DESCRIPTION
#### 2c1af1cba4b0334b7932780e7f2239adbac781ac
<pre>
[List Marker] Search past empty inline items when parenting list markers
<a href="https://bugs.webkit.org/show_bug.cgi?id=313568">https://bugs.webkit.org/show_bug.cgi?id=313568</a>
&lt;<a href="https://rdar.apple.com/172762578">rdar://172762578</a>&gt;

Reviewed by Alan Baradlay.

This PR fixes a bug where a list item starting with an empty inline element causes
findParentOfEmptyOrFirstLineBox to always use the blockContainer as the list marker parent.

The PR updates findParentOfEmptyOrFirstLineBox to skip empty inlines with an explicit continue
after setting the block container as the fallback parent. This way we continue iterating over
the blockContainer&apos;s other children to try and find a valid parent instead of falling through
with the assumption the child is not inline and falsely triggering failedDueToBlockification.

Also skip collapsible whitespace-only RenderText children that are not valid marker parents.

This change was added as the empty inline fix broke

imported/w3c/web-platform-tests/css/css-lists/add-inline-child-after-marker-002.html

which exposed the bug where we incorrectly parented the list marker to collapsible whitespace.

* LayoutTests/fast/lists/list-marker-with-empty-inline-before-blockquote-expected.html: Added.
* LayoutTests/fast/lists/list-marker-with-empty-inline-before-blockquote.html: Added.
* Source/WebCore/rendering/updating/RenderTreeBuilderList.cpp:
(WebCore::findParentOfEmptyOrFirstLineBox):

Canonical link: <a href="https://commits.webkit.org/312356@main">https://commits.webkit.org/312356@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d6b6a5765d829c4c982db4a1121370d9f94e99fb

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/159561 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/33028 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/26127 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/168408 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/113942 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/161430 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/33133 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/33032 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/123634 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/86768 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/162518 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/25881 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/143309 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/104286 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/24932 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/23396 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/16171 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/134623 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/21081 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/170893 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/16929 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/22714 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/131855 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/32706 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/27469 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/131944 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35731 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/32692 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/142874 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/90774 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/26590 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/19688 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/32201 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/98597 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/31698 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/31945 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/31849 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->