### PR TITLE
[Navigation API] intercept() wrongly succeeds for cross-subdomain navigations

### DIFF
--- a/Source/WebCore/page/Navigation.cpp
+++ b/Source/WebCore/page/Navigation.cpp
@@ -831,12 +831,11 @@ static bool documentCanHaveURLRewritten(const Document& document, const URL& tar
     const URL& documentURL = document.url();
     Ref documentOrigin = document.securityOrigin();
     auto targetOrigin = SecurityOrigin::create(targetURL);
-    bool isSameSite = documentOrigin->isSameSiteAs(targetOrigin);
-    bool isSameOrigin = documentOrigin->isSameOriginAs(targetOrigin);
 
-    // For cross-window navigation with document.domain, we need to check same-origin rather than same-site
-    // to account for document.domain modifications that make cross-origin windows same-origin-domain
-    if (!isSameSite && !isSameOrigin)
+    if (!documentOrigin->isSameOriginAs(targetOrigin))
+        return false;
+
+    if (documentURL.user() != targetURL.user() || documentURL.password() != targetURL.password())
         return false;
 
     // https://html.spec.whatwg.org/multipage/nav-history-apis.html#can-have-its-url-rewritten

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/NavigationAPI.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/NavigationAPI.mm
@@ -121,4 +121,74 @@ TEST(NavigationAPI, ReplaceStateAfterBackPreservesKey)
     EXPECT_TRUE([keyPageA isEqualToString:keyAfterReplace]);
 }
 
+TEST(NavigationAPI, InterceptFailsForDifferentSubdomain)
+{
+    HTTPServer server({
+        { "/page1"_s, { "page1"_s } },
+        { "/page2"_s, { "page2"_s } }
+    }, HTTPServer::Protocol::HttpsProxy);
+
+    RetainPtr configuration = server.httpsProxyConfiguration();
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 300, 300) configuration:configuration.get()]);
+
+    RetainPtr navigationDelegate = adoptNS([TestNavigationDelegate new]);
+    [navigationDelegate allowAnyTLSCertificate];
+    [webView setNavigationDelegate:navigationDelegate.get()];
+
+    [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://page1.example.com/page1"]]];
+    [navigationDelegate waitForDidFinishNavigation];
+
+    NSError *error = nil;
+    id result = [webView objectByCallingAsyncFunction:@"return await new Promise((resolve) => {"
+        "    navigation.addEventListener('navigate', (event) => {"
+        "       try {"
+        "           event.intercept({ handler: () => {} });"
+        "           resolve('intercept succeeded');"
+        "       } catch (e) {"
+        "           resolve('intercept failed: ' + e.name);"
+        "       }"
+        "    });"
+        "    location.href = 'https://page2.example.com/page2';"
+        "});" withArguments:nil error:&error];
+
+    EXPECT_NULL(error);
+    EXPECT_TRUE([result isKindOfClass:[NSString class]]);
+    EXPECT_TRUE([result hasPrefix:@"intercept failed"]);
+}
+
+TEST(NavigationAPI, InterceptFailsForDifferentUsernameAndPassword)
+{
+    HTTPServer server({
+        { "/page1"_s, { "page1"_s } },
+        { "/page2"_s, { "page2"_s } }
+    }, HTTPServer::Protocol::HttpsProxy);
+
+    RetainPtr configuration = server.httpsProxyConfiguration();
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 300, 300) configuration:configuration.get()]);
+
+    RetainPtr navigationDelegate = adoptNS([TestNavigationDelegate new]);
+    [navigationDelegate allowAnyTLSCertificate];
+    [webView setNavigationDelegate:navigationDelegate.get()];
+
+    [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://username1:password1@example.com/page1"]]];
+    [navigationDelegate waitForDidFinishNavigation];
+
+    NSError *error = nil;
+    id result = [webView objectByCallingAsyncFunction:@"return await new Promise((resolve) => {"
+        "    navigation.addEventListener('navigate', (event) => {"
+        "       try {"
+        "           event.intercept({ handler: () => {} });"
+        "           resolve('intercept succeeded');"
+        "       } catch (e) {"
+        "           resolve('intercept failed: ' + e.name);"
+        "       }"
+        "    });"
+        "    location.href = 'https://username2:password2@example.com/page2';"
+        "});" withArguments:nil error:&error];
+
+    EXPECT_NULL(error);
+    EXPECT_TRUE([result isKindOfClass:[NSString class]]);
+    EXPECT_TRUE([result hasPrefix:@"intercept failed"]);
+}
+
 } // namespace TestWebKitAPI


### PR DESCRIPTION
#### b537a57c092d669ff1e1dee094bef292cd95dd5d
<pre>
[Navigation API] intercept() wrongly succeeds for cross-subdomain navigations
<a href="https://bugs.webkit.org/show_bug.cgi?id=306050">https://bugs.webkit.org/show_bug.cgi?id=306050</a>
<a href="https://rdar.apple.com/165690775">rdar://165690775</a>

Reviewed by Alex Christensen.

Consider that we have two sites that differ in subdomain:
1. page1.example.com
2. page2.example.com

If we navigate from page1 to page2, page1 should not be able to intercept the
navigation because this is a cross-origin navigation. Our bug is that currently,
the intercept succeeds.

How it&apos;s supposed to work:

One of the steps in firing a navigate event says:
(Step 9 in <a href="https://html.spec.whatwg.org/multipage/nav-history-apis.html#inner-navigate-event-firing-algorithm)">https://html.spec.whatwg.org/multipage/nav-history-apis.html#inner-navigate-event-firing-algorithm)</a>

&quot;If document can have its URL rewritten to destination&apos;s URL, and either
destination&apos;s is same document is true or navigationType is not &quot;traverse&quot;, then
initialize event&apos;s canIntercept to true. Otherwise, initialize it to false.&quot;

One of the steps for checking if the URL can be rewritten to destination&apos;s URL is:
(<a href="https://html.spec.whatwg.org/multipage/nav-history-apis.html#can-have-its-url-rewritten)">https://html.spec.whatwg.org/multipage/nav-history-apis.html#can-have-its-url-rewritten)</a>

&quot;If targetURL and documentURL differ in their scheme, username, password, host,
or port components, then return false.&quot;

Our two URLs differ in host. so canIntercept should be set to false.

Later on, when intercept() is called, it should fail because it&apos;s steps say:
(<a href="https://html.spec.whatwg.org/multipage/nav-history-apis.html#dom-navigateevent-intercept)">https://html.spec.whatwg.org/multipage/nav-history-apis.html#dom-navigateevent-intercept)</a>

&quot;If this&apos;s canIntercept attribute was initialized to false, then throw a
&quot;SecurityError&quot; DOMException.&quot;

What&apos;s wrong:

Our issue is that the &quot;can-have-its-url-rewritten&quot; check returns true, so
canIntercept is set to true and later on the intercept succeeds. The check is
implemented incorrectly. Instead of checking if the URLS differ in scheme,
username, password, host, or port components, it simply does:

bool isSameSite = documentOrigin-&gt;isSameSiteAs(targetOrigin);
bool isSameOrigin = documentOrigin-&gt;isSameOriginAs(targetOrigin);
if (!isSameSite &amp;&amp; !isSameOrigin)
    return false;

For our two URLs, isSameSite is true, so this check doesn&apos;t return false as it
should. Also this check never compares the usernames and passwords. This means
that not only does the cross-origin check fail in the case of URLs that differ by
subdomain but it will also fail for URLs that differ in username and password.

We fix this by changing to check to follow the spec. We also add new API tests for
both the subdomain and username/password cases.

* Source/WebCore/page/Navigation.cpp:
(WebCore::documentCanHaveURLRewritten):
* Tools/TestWebKitAPI/SourcesCocoa.txt:
* Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/NavigationAPI.mm: Added.
(TestWebKitAPI::TEST(NavigationAPI, InterceptFailsForDifferentSubdomain)):
(TestWebKitAPI::TEST(NavigationAPI, InterceptFailsForDifferentUsernameAndPassword)):

Originally-landed-as: 305413.125@safari-7624-branch (67e3366c7a2c). <a href="https://rdar.apple.com/173969327">rdar://173969327</a>
Canonical link: <a href="https://commits.webkit.org/312283@main">https://commits.webkit.org/312283@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/78e8a196973154d4cbd746d672102bd5429adf07

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/159360 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/32788 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/25896 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/168192 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/113738 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/9a9c8643-8dbc-4b8e-8580-26edde9be52b) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/161229 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/32856 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/32775 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/123470 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/86665 "1 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/f042b0e9-72ae-44d0-8970-a7e136dd03b4) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/162317 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/25719 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/143151 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/104135 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/211f4c44-2f75-41b4-ae79-c26ccd500f55) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/24772 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/23222 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/15963 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/134459 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/20931 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/170684 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/16718 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/22557 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/131672 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/32477 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/27296 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/131785 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35661 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/32421 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/142724 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/90546 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/26454 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/19533 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/31932 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/98384 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/31452 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/31725 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/31607 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->