### PR TITLE
Speculative preload scanner incorrectly preloads scripts inside SVG elements

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/html/syntax/speculative-parsing/generated/document-write/svg-script-src.tentative.sub-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/syntax/speculative-parsing/generated/document-write/svg-script-src.tentative.sub-expected.txt
@@ -1,7 +1,8 @@
 
     <!-- speculative case in document.write -->
-    <svg><script src="/html/syntax/speculative-parsing/resources/stash.py?action=put&amp;uuid=1c8be3dd-771a-4d27-a399-c487e0cfe393&amp;encodingcheck=&Gbreve;"></script></svg>
+    <svg><script src="/html/syntax/speculative-parsing/resources/stash.py?action=put&amp;uuid=4e95b599-a598-41d2-a316-fe72d08c2bcb&amp;encodingcheck=&Gbreve;"></script></svg>
 
 
-FAIL Speculative parsing, document.write(): svg-script-src Unhandled rejection: assert_equals: speculative case incorrectly fetched expected "" but got "param-encodingcheck: %C4%9E\r\n"
+
+PASS Speculative parsing, document.write(): svg-script-src
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/syntax/speculative-parsing/generated/page-load/svg-script-src.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/syntax/speculative-parsing/generated/page-load/svg-script-src.tentative-expected.txt
@@ -1,4 +1,4 @@
 
 
-FAIL Speculative parsing, page load: svg-script-src Unhandled rejection: assert_equals: speculative case incorrectly fetched expected "" but got "param-encodingcheck: %C4%9E\r\nAccept: */*\r\nReferer: http://localhost:8800/html/syntax/speculative-parsing/generated/page-load/resources/svg-script-src-framed.sub.html?uuid=6710aaf0-4791-4492-839b-3996f434dc17"
+PASS Speculative parsing, page load: svg-script-src
 

--- a/Source/WebCore/html/parser/HTMLPreloadScanner.cpp
+++ b/Source/WebCore/html/parser/HTMLPreloadScanner.cpp
@@ -71,6 +71,7 @@ TokenPreloadScanner::TagId TokenPreloadScanner::tagIdFor(const HTMLToken::DataVe
         { "script"_s, TagId::Script },
         { "source"_s, TagId::Source },
         { "style"_s, TagId::Style },
+        { "svg"_s, TagId::Svg },
         { "template"_s, TagId::Template },
         { "video"_s, TagId::Video },
     }) };
@@ -97,6 +98,7 @@ ASCIILiteral TokenPreloadScanner::initiatorFor(TagId tagId)
     case TagId::Template:
     case TagId::Meta:
     case TagId::Picture:
+    case TagId::Svg:
         ASSERT_NOT_REACHED();
         return "unknown"_s;
     }
@@ -347,6 +349,7 @@ private:
         case TagId::Style:
         case TagId::Template:
         case TagId::Picture:
+        case TagId::Svg:
         case TagId::Unknown:
             break;
         }
@@ -402,6 +405,7 @@ private:
         case TagId::Base:
         case TagId::Template:
         case TagId::Picture:
+        case TagId::Svg:
             break;
         }
         ASSERT_NOT_REACHED();
@@ -488,6 +492,8 @@ void TokenPreloadScanner::scan(const HTMLToken& token, Vector<std::unique_ptr<Pr
             m_inStyle = false;
         } else if (tagId == TagId::Picture && !m_pictureSourceState.isEmpty())
             m_pictureSourceState.removeLast();
+        else if (tagId == TagId::Svg && m_foreignContentCount)
+            --m_foreignContentCount;
 
         return;
     }
@@ -524,6 +530,15 @@ void TokenPreloadScanner::scan(const HTMLToken& token, Vector<std::unique_ptr<Pr
             m_pictureSourceState.append(false);
             return;
         }
+        if (tagId == TagId::Svg) {
+            ++m_foreignContentCount;
+            return;
+        }
+
+        // In SVG foreign content, <script> uses href/xlink:href, not src.
+        // Don't speculatively preload scripts inside SVG.
+        if (m_foreignContentCount && tagId == TagId::Script)
+            return;
 
         StartTagScanner scanner(document, tagId, m_deviceScaleFactor);
         scanner.processAttributes(token.attributes(), m_pictureSourceState);

--- a/Source/WebCore/html/parser/HTMLPreloadScanner.h
+++ b/Source/WebCore/html/parser/HTMLPreloadScanner.h
@@ -61,7 +61,8 @@ private:
         Style,
         Base,
         Template,
-        Picture
+        Picture,
+        Svg
     };
 
     class StartTagScanner;
@@ -82,6 +83,7 @@ private:
     Vector<bool> m_pictureSourceState;
 
     unsigned m_templateCount { 0 };
+    unsigned m_foreignContentCount { 0 };
 };
 
 class HTMLPreloadScanner {


### PR DESCRIPTION
#### 7358b0aabcd951b98331c997fc12b4ae6f28ddf8
<pre>
Speculative preload scanner incorrectly preloads scripts inside SVG elements
<a href="https://bugs.webkit.org/show_bug.cgi?id=313589">https://bugs.webkit.org/show_bug.cgi?id=313589</a>
<a href="https://rdar.apple.com/175800116">rdar://175800116</a>

Reviewed by Chris Dumez.

This patch aligns WebKit with Gecko / Firefox.

SVG scripts use href/xlink:href, not src. The preload scanner
now tracks SVG depth via m_foreignContentCount and skips script
preloading when inside SVG foreign content.

* LayoutTests/imported/w3c/web-platform-tests/html/syntax/speculative-parsing/generated/document-write/svg-script-src.tentative.sub-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/syntax/speculative-parsing/generated/page-load/svg-script-src.tentative-expected.txt:
* Source/WebCore/html/parser/HTMLPreloadScanner.cpp:
(WebCore::TokenPreloadScanner::tagIdFor):
(WebCore::TokenPreloadScanner::initiatorFor):
(WebCore::TokenPreloadScanner::StartTagScanner::processAttribute):
(WebCore::TokenPreloadScanner::StartTagScanner::resourceType const):
(WebCore::TokenPreloadScanner::scan):
* Source/WebCore/html/parser/HTMLPreloadScanner.h:

Canonical link: <a href="https://commits.webkit.org/312327@main">https://commits.webkit.org/312327@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6a4f048378080712f02a313d68afd75bb17e163d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/159362 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/32790 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/25898 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/168194 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/113740 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/161231 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/32858 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/32778 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/123471 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/86666 "1 flakes 1 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/162319 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/25720 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/143155 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/104136 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/24773 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/23223 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/15965 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/134460 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/20935 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/170686 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/16720 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/22561 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/131673 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/32479 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/27297 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/131786 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35711 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/32423 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/142728 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/90548 "The change is no longer eligible for processing.") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/26457 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/19537 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/31934 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/98386 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/31454 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/31727 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/31609 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->