### PR TITLE
Unable to enter Video Viewer on youtube.com with right click on video

### DIFF
--- a/LayoutTests/media/mac/video-viewer-context-menu-item-expected.txt
+++ b/LayoutTests/media/mac/video-viewer-context-menu-item-expected.txt
@@ -1,0 +1,11 @@
+Tests that the 'Enter Viewer' context menu item respects the InWindowFullscreenEnabled setting.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS contextMenuHasEnterViewerItem() is true
+PASS contextMenuHasEnterViewerItem() is false
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/media/mac/video-viewer-context-menu-item.html
+++ b/LayoutTests/media/mac/video-viewer-context-menu-item.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="../../resources/js-test.js"></script>
+</head>
+<body>
+<video id="video" autoplay controls style="position:absolute; top:0; left:0; width:320px; height:240px"></video>
+<script>
+description("Tests that the 'Enter Viewer' context menu item respects the InWindowFullscreenEnabled setting.");
+
+function contextMenuHasEnterViewerItem() {
+    var video = document.getElementById("video");
+    var x = video.offsetLeft + video.offsetWidth / 2;
+    var y = video.offsetTop + video.offsetHeight / 2;
+    eventSender.mouseMoveTo(x, y);
+    return eventSender.contextClick().some(item => item.title === "Enter Viewer");
+}
+
+window.addEventListener("load", () => {
+    window.jsTestIsAsync = true;
+    if (!window.internals || !window.eventSender) {
+        debug("This test requires internals and eventSender.");
+        finishJSTest();
+        return;
+    }
+
+    var video = document.getElementById("video");
+
+    video.addEventListener("canplay", () => {
+        internals.settings.setInWindowFullscreenEnabled(true);
+        shouldBeTrue("contextMenuHasEnterViewerItem()");
+
+        internals.settings.setInWindowFullscreenEnabled(false);
+        shouldBeFalse("contextMenuHasEnterViewerItem()");
+
+        finishJSTest();
+    }, { once: true });
+
+    video.src = "../content/test.mp4";
+});
+</script>
+</body>
+</html>

--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -3750,11 +3750,11 @@ InWindowFullscreenEnabled:
   humanReadableDescription: "Enable In-Window Fullscreen"
   defaultValue:
     WebKitLegacy:
-      default: false
+      default: true
     WebKit:
-      default: false
+      default: true
     WebCore:
-      default: false
+      default: true
 
 InactiveMediaCaptureStreamRepromptIntervalInMinutes:
   type: double

--- a/Source/WebCore/page/ContextMenuController.cpp
+++ b/Source/WebCore/page/ContextMenuController.cpp
@@ -1204,7 +1204,8 @@ void ContextMenuController::populate()
 #endif
 #if PLATFORM(MAC) && ENABLE(VIDEO_PRESENTATION_MODE)
             appendItem(TogglePictureInPicture, m_contextMenu.get());
-            appendItem(ToggleVideoViewer, m_contextMenu.get());
+            if (frame->page() && frame->page()->settings().inWindowFullscreenEnabled())
+                appendItem(ToggleVideoViewer, m_contextMenu.get());
 #endif
             if (m_context.hitTestResult().isDownloadableMedia() && loader->client().canHandleRequest(ResourceRequest(WTF::move(mediaURL)))) {
                 appendItem(*separatorItem(), m_contextMenu.get());


### PR DESCRIPTION
#### 794fb01e34bf52d6aa55ed49043ca2b633569cf1
<pre>
Unable to enter Video Viewer on youtube.com with right click on video
<a href="https://rdar.apple.com/132061157">rdar://132061157</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=313584">https://bugs.webkit.org/show_bug.cgi?id=313584</a>

Reviewed by NOBODY (OOPS!).

Set default value of InWindowFullscreenEnabled to true, and
only show video viewer as an option in the video context menu
if the setting is enabled.

Test: media/mac/video-viewer-context-menu-item.html

* LayoutTests/media/mac/video-viewer-context-menu-item-expected.txt: Added.
* LayoutTests/media/mac/video-viewer-context-menu-item.html: Added.
* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml:
* Source/WebCore/page/ContextMenuController.cpp:
(WebCore::ContextMenuController::populate):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/794fb01e34bf52d6aa55ed49043ca2b633569cf1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/159474 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/32903 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/26010 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/168306 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/113854 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/fcc15f48-69c9-4e8b-818e-de68f41c26f3) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/161343 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/32970 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/32891 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/123564 "Found 1 new test failure: media/mac/video-viewer-context-menu-item.html (failure)") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/113854 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/f87cff2a-aa12-42e5-bc5b-c81c437d0319) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/162431 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/25824 "Found 1 new test failure: media/mac/video-viewer-context-menu-item.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/143247 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/104227 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/bfd813ba-0b63-4334-b6cf-03fbb2815e31) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/24876 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/23330 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/16077 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/151537 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/134567 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/21020 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/170798 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/20307 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/16844 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/22646 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/131772 "Found 1 new test failure: media/mac/video-viewer-context-menu-item.html (failure)") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/32591 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/27397 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/131885 "Failed to checkout and rebase branch from PR 63853") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/32535 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/142813 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/90680 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/26543 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/19627 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/191757 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/32046 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/98511 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/49269 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/31566 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/31839 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/31721 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->