### PR TITLE
[JSC] B3 CSE asserts on struct.new_default with f32/f64 fields due to type mismatch in store-to-load forwarding

### DIFF
--- a/JSTests/wasm/stress/new_default-f32.js
+++ b/JSTests/wasm/stress/new_default-f32.js
@@ -1,0 +1,44 @@
+function instantiate(moduleBase64, importObject, compileOptions) {
+    let bytes = Uint8Array.fromBase64(moduleBase64);
+    return WebAssembly.instantiate(bytes, importObject, compileOptions);
+}
+
+(async function() {
+    /*
+        (module
+            (type (struct (field f32)))
+            (global (mut f32) f32.const 0)
+            (func (export "fn")
+                struct.new_default 0
+                struct.get 0 0
+                global.set 0
+            )
+        )
+    */
+    let { instance } = await instantiate("AGFzbQEAAAABCAJfAX0AYAAAAwIBAQYJAX0BQwAAAAALBwYBAmZuAAAKDQELAPsBAPsCAAAkAAs=");
+    let { fn } = instance.exports;
+    for (let i = 0; i < wasmTestLoopCount; ++i)
+        fn();
+})().then(async function() {
+    /*
+        (module
+            (type (array f32))
+            (global (mut f32) f32.const 0)
+            (func (export "fn")
+                i32.const 1
+                array.new_default 0
+                i32.const 0
+                array.get 0
+                global.set 0
+            )
+        )
+    */
+    let { instance } = await instantiate("AGFzbQEAAAABBwJefQBgAAADAgEBBgkBfQFDAAAAAAsHBgECZm4AAAoQAQ4AQQH7BwBBAPsLACQACw==");
+    let { fn } = instance.exports;
+    for (let i = 0; i < wasmTestLoopCount; ++i)
+        fn();
+}).catch(e => {
+    print("error:", e.constructor.name, e.message);
+    if (e.stack)
+        report(e.stack);
+});

--- a/Source/JavaScriptCore/wasm/WasmOMGIRGenerator.cpp
+++ b/Source/JavaScriptCore/wasm/WasmOMGIRGenerator.cpp
@@ -3668,10 +3668,8 @@ auto OMGIRGenerator::addArrayNewDefault(TypeSignatureIndex typeIndex, Expression
         initValue = m_currentBlock->appendNew<WasmConstRefValue>(m_proc, origin(), JSValue::encode(jsNull()));
     else if (elementType.elementSize() == 16)
         initValue = constant(V128, v128_t { });
-    else if (elementType.elementSize() <= 4)
-        initValue = constant(Int32, 0);
     else
-        initValue = constant(Int64, 0);
+        initValue = constant(toB3Type(elementType.unpacked()), 0);
 
     Value* sizeValue = get(size);
 
@@ -4029,10 +4027,8 @@ auto OMGIRGenerator::addStructNewDefault(TypeSignatureIndex typeIndex, Expressio
             initValue = m_currentBlock->appendNew<WasmConstRefValue>(m_proc, origin(), JSValue::encode(jsNull()));
         else if (typeSizeInBytes(fieldType) == 16)
             initValue = constant(V128, v128_t { });
-        else if (typeSizeInBytes(fieldType) <= 4)
-            initValue = constant(Int32, 0);
         else
-            initValue = constant(Int64, 0);
+            initValue = constant(toB3Type(fieldType.unpacked()), 0);
         // We know all the values here are not cells so we don't need a writeBarrier.
         bool needsWriteBarrier = emitStructSet(/* canTrap */ false, structNew, i, rtt, initValue);
         UNUSED_VARIABLE(needsWriteBarrier);


### PR DESCRIPTION
#### 7842f4848d8259d14f510fc671081fbeb6bff3f1
<pre>
[JSC] B3 CSE asserts on struct.new_default with f32/f64 fields due to type mismatch in store-to-load forwarding
<a href="https://bugs.webkit.org/show_bug.cgi?id=313591">https://bugs.webkit.org/show_bug.cgi?id=313591</a>
<a href="https://rdar.apple.com/175665634">rdar://175665634</a>

Reviewed by Keith Miller and Yusuke Suzuki.

The struct.new_default wasm instruction currently writes Int32(0) for f32 types.
If store-to-load forwarding occurs, B3::Value::replaceWithIdentity will fail a
RELEASE_ASSERT because the expected type is f32, not i32. This patch adjusts
OMGIRGenerator::addStructNewDefault and OMGIRGenerator::addArrayNewDefault to
create a constant of the correct type instead of defaulting to int types.

Test: JSTests/wasm/stress/new_default-f32.js

* JSTests/wasm/stress/new_default-f32.js: Added.
(instantiate):
(async let):
(then.async let):
(then):
* Source/JavaScriptCore/wasm/WasmOMGIRGenerator.cpp:
(JSC::Wasm::OMGIRGenerator::addArrayNewDefault):
(JSC::Wasm::OMGIRGenerator::addStructNewDefault):

Canonical link: <a href="https://commits.webkit.org/312557@main">https://commits.webkit.org/312557@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/064eb92372939ecbbc2c5c92c2d6d8492af57d01

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/159371 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/32799 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/25907 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/168203 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/113749 "Built successfully") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/32867 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/32787 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/123474 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/86667 "1 failures") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/162328 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/25726 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/143138 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/104139 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/24779 "Passed tests") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/23229 "Found 1 new API test failure: TestWebKitAPI.WKWebExtension.LoadFromChromeExtensionArchive (failure)") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/15974 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/151421 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/134466 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/20918 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/170695 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/20204 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/16729 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/22544 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/131679 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/32488 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/27303 "Found 1 new test failure: http/tests/security/javascriptURL/xss-ALLOWED-to-javascript-url-from-javscript-url.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/131792 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35842 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/32432 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/142711 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/90557 "The change is no longer eligible for processing.") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/26455 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/19520 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/191654 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/31943 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/98395 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/49251 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/31463 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/31736 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/31618 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->