### PR TITLE
Partition InheritedRareData to reduce copy-on-write overhead from CSS zoom

### DIFF
--- a/LayoutTests/perf/style-recalc-zoom-expected.txt
+++ b/LayoutTests/perf/style-recalc-zoom-expected.txt
@@ -1,0 +1,3 @@
+Tests that per-element memory cost of zoomed elements vs unzoomed elements is below 200 bytes.
+PASS
+

--- a/LayoutTests/perf/style-recalc-zoom.html
+++ b/LayoutTests/perf/style-recalc-zoom.html
@@ -1,0 +1,71 @@
+<!DOCTYPE html>
+<html>
+<body>
+<script>
+if (window.testRunner)
+    testRunner.dumpAsText();
+
+var results = document.createElement('pre');
+document.body.appendChild(results);
+
+function log(msg) {
+    results.textContent += msg + '\n';
+}
+
+function createElements(parent, count) {
+    for (var i = 0; i < count; i++) {
+        var span = document.createElement('span');
+        parent.appendChild(span);
+    }
+}
+
+function measureCommittedBytes() {
+    if (window.GCController) {
+        GCController.collect();
+        GCController.collect();
+    }
+    if (window.internals)
+        return internals.mallocStatistics().committedVMBytes;
+    return 0;
+}
+
+var ELEMENT_COUNT = 5000;
+
+// Measure memory before creating anything.
+var before = measureCommittedBytes();
+
+// Create unzoomed elements and measure.
+var baselineContainer = document.createElement('div');
+document.body.appendChild(baselineContainer);
+createElements(baselineContainer, ELEMENT_COUNT);
+getComputedStyle(baselineContainer.lastElementChild).zoom;
+var midpoint = measureCommittedBytes();
+
+// Create zoomed elements and measure.
+var zoomedContainer = document.createElement('div');
+zoomedContainer.style.zoom = '2';
+document.body.appendChild(zoomedContainer);
+createElements(zoomedContainer, ELEMENT_COUNT);
+getComputedStyle(zoomedContainer.lastElementChild).zoom;
+var after = measureCommittedBytes();
+
+// Both containers exist simultaneously, so no memory was freed.
+var baselineCost = (midpoint - before) / ELEMENT_COUNT;
+var zoomedCost = (after - midpoint) / ELEMENT_COUNT;
+var perElementOverhead = zoomedCost - baselineCost;
+
+// With InheritedRareData partitioning, per-element zoom overhead
+// should be small (~38 bytes for the slimmed InheritedRareData copy,
+// with InheritedRareCSSData shared). Without partitioning, it would
+// be ~450 bytes per element. We use 200 bytes as the threshold.
+var THRESHOLD_BYTES_PER_ELEMENT = 200;
+
+log("Tests that per-element memory cost of zoomed elements vs unzoomed elements is below " + THRESHOLD_BYTES_PER_ELEMENT + " bytes.");
+
+if (perElementOverhead < THRESHOLD_BYTES_PER_ELEMENT)
+    log("PASS");
+else
+    log("FAIL: zoomed elements used " + Math.round(perElementOverhead) + " bytes/element more than unzoomed (threshold is " + THRESHOLD_BYTES_PER_ELEMENT + " bytes).");
+</script>
+</body>
+</html>

--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -3138,6 +3138,7 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     style/computed/data/StyleGridData.h
     style/computed/data/StyleGridItemData.h
     style/computed/data/StyleInheritedData.h
+    style/computed/data/StyleInheritedRareCSSData.h
     style/computed/data/StyleInheritedRareData.h
     style/computed/data/StyleMarqueeData.h
     style/computed/data/StyleMaskBorderData.h

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -3225,6 +3225,7 @@ style/computed/data/StyleFontData.cpp
 style/computed/data/StyleGridData.cpp
 style/computed/data/StyleGridItemData.cpp
 style/computed/data/StyleInheritedData.cpp
+style/computed/data/StyleInheritedRareCSSData.cpp
 style/computed/data/StyleInheritedRareData.cpp
 style/computed/data/StyleMarqueeData.cpp
 style/computed/data/StyleMaskBorderData.cpp

--- a/Source/WebCore/WebCore.xcodeproj/project.pbxproj
+++ b/Source/WebCore/WebCore.xcodeproj/project.pbxproj
@@ -77,6 +77,9 @@
 		029D57AA2C506F5900AD086B /* UserGestureTokenIdentifier.h in Headers */ = {isa = PBXBuildFile; fileRef = 029D57A92C506F5900AD086B /* UserGestureTokenIdentifier.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		02E536BD2984EA6800417C02 /* ScrollerPairMac.h in Headers */ = {isa = PBXBuildFile; fileRef = 024E5F7429844DBD009CC5FC /* ScrollerPairMac.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		02E536C12984ECE200417C02 /* ScrollerMac.h in Headers */ = {isa = PBXBuildFile; fileRef = 024E5F7129844DBC009CC5FC /* ScrollerMac.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		02F00913A402BD5A4A68ED65 /* UnifiedSource16-header-RenderStyleGetters.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 1B5C8E332AFA25F34506CCB0 /* UnifiedSource16-header-RenderStyleGetters.cpp */; };
+		030346BE5CD75A7829AD613F /* UnifiedSource40-header-RenderStyleGetters.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A756860D9AF6A2C15FCF7E3E /* UnifiedSource40-header-RenderStyleGetters.cpp */; };
+		043934662F229202E82AB23F /* UnifiedSource55-header-RenderStyleGetters.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3230252036F492BB47909DD0 /* UnifiedSource55-header-RenderStyleGetters.cpp */; };
 		0562F9611573F88F0031CA16 /* PlatformLayer.h in Headers */ = {isa = PBXBuildFile; fileRef = 0562F9601573F88F0031CA16 /* PlatformLayer.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		056A7AC8256C4F48002F9DDC /* ShadowRootInit.h in Headers */ = {isa = PBXBuildFile; fileRef = 054E3A33256C3BD90072C5B9 /* ShadowRootInit.h */; };
 		056A7AC8256C4F48002F9DDF /* GetHTMLOptions.h in Headers */ = {isa = PBXBuildFile; fileRef = 054E3A33256C3BD90072C5BF /* GetHTMLOptions.h */; };
@@ -90,6 +93,7 @@
 		0668E18B0ADD9624004128E0 /* PopupMenu.h in Headers */ = {isa = PBXBuildFile; fileRef = 0668E1890ADD9624004128E0 /* PopupMenu.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		066C772B0AB603B700238CC4 /* FileChooser.h in Headers */ = {isa = PBXBuildFile; fileRef = 066C772A0AB603B700238CC4 /* FileChooser.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		066C77310AB603FD00238CC4 /* RenderFileUploadControl.h in Headers */ = {isa = PBXBuildFile; fileRef = 066C772F0AB603FD00238CC4 /* RenderFileUploadControl.h */; };
+		0678848F73938361BD2B42E3 /* UnifiedSource18-header-RenderStyleGetters.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 9E3E301A4FF9CC03FB16C8B2 /* UnifiedSource18-header-RenderStyleGetters.cpp */; };
 		06E81ED70AB5D5E900C87837 /* LocalCurrentGraphicsContext.h in Headers */ = {isa = PBXBuildFile; fileRef = 06E81ED60AB5D5E900C87837 /* LocalCurrentGraphicsContext.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		06E8D41D99A712513E21EC9D /* StyleOutlineOffset.h in Headers */ = {isa = PBXBuildFile; fileRef = 52D4C867EF1213EBE219805C /* StyleOutlineOffset.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		070334D71459FFD5008D8D45 /* TrackBase.h in Headers */ = {isa = PBXBuildFile; fileRef = 070334D61459FFD5008D8D45 /* TrackBase.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -350,6 +354,7 @@
 		08F859D51463F9CD0067D933 /* SVGImageCache.h in Headers */ = {isa = PBXBuildFile; fileRef = 08F859D31463F9CD0067D933 /* SVGImageCache.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		08F859D51463F9CD0067D934 /* SVGImageForContainer.h in Headers */ = {isa = PBXBuildFile; fileRef = 08F859D31463F9CD0067D934 /* SVGImageForContainer.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		0AFDAC3D10F5448C00E1F3D2 /* PluginViewBase.h in Headers */ = {isa = PBXBuildFile; fileRef = 0AFDAC3C10F5448C00E1F3D2 /* PluginViewBase.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		0B2AA9B7DC40569673FC9868 /* UnifiedSource1-header-RenderStyleGetters.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4987053212B58BF9F79B19AD /* UnifiedSource1-header-RenderStyleGetters.cpp */; };
 		0B90561A0F2578BF0095FF6A /* DocumentThreadableLoader.h in Headers */ = {isa = PBXBuildFile; fileRef = 0B9056160F2578BE0095FF6A /* DocumentThreadableLoader.h */; settings = {ATTRIBUTES = (); }; };
 		0B90561B0F2578BF0095FF6A /* ThreadableLoader.h in Headers */ = {isa = PBXBuildFile; fileRef = 0B9056170F2578BE0095FF6A /* ThreadableLoader.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		0B90561C0F2578BF0095FF6A /* ThreadableLoaderClient.h in Headers */ = {isa = PBXBuildFile; fileRef = 0B9056180F2578BE0095FF6A /* ThreadableLoaderClient.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -528,6 +533,7 @@
 		1209CD7D2AF1B4390046C3F0 /* ScrollbarMac.h in Headers */ = {isa = PBXBuildFile; fileRef = 1209CD7C2AF1B2C30046C3F0 /* ScrollbarMac.h */; };
 		1209CD7E2AF1B9710046C3F0 /* ScrollbarMac.mm in Sources */ = {isa = PBXBuildFile; fileRef = 1209CD7B2AF1B2C20046C3F0 /* ScrollbarMac.mm */; };
 		12BB61212B64261C0048B442 /* ScrollingNodeID.h in Headers */ = {isa = PBXBuildFile; fileRef = 12BB61202B6426090048B442 /* ScrollingNodeID.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		12FE69ABC11EFD67590B4E34 /* UnifiedSource7-header-RenderStyleGetters.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 8367965ED15A1EE1FF2AD6D1 /* UnifiedSource7-header-RenderStyleGetters.cpp */; };
 		1400D7A817136EA70077CE05 /* ScriptWrappableInlines.h in Headers */ = {isa = PBXBuildFile; fileRef = 1400D7A717136EA70077CE05 /* ScriptWrappableInlines.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		14115B5209F84B7100CA4FC1 /* Node.h in Headers */ = {isa = PBXBuildFile; fileRef = 14115B5109F84B7100CA4FC1 /* Node.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		14115B7309F84CD600CA4FC1 /* JSNodeFilter.h in Headers */ = {isa = PBXBuildFile; fileRef = 14115B7109F84CD600CA4FC1 /* JSNodeFilter.h */; };
@@ -665,6 +671,7 @@
 		1ACE53EB0A8D18E70022947D /* XMLSerializer.h in Headers */ = {isa = PBXBuildFile; fileRef = 1ACE53E50A8D18E70022947D /* XMLSerializer.h */; };
 		1ACE53F70A8D19470022947D /* JSXMLSerializer.h in Headers */ = {isa = PBXBuildFile; fileRef = 1ACE53F50A8D19470022947D /* JSXMLSerializer.h */; };
 		1AD8F81B11CAB9E900E93E54 /* PlatformStrategies.h in Headers */ = {isa = PBXBuildFile; fileRef = 1AD8F81911CAB9E900E93E54 /* PlatformStrategies.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		1AD9141193F8BCCF688EE0B5 /* UnifiedSource32-header-RenderStyleGetters.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 939F8CC43E871DE5E8AB5A9F /* UnifiedSource32-header-RenderStyleGetters.cpp */; };
 		1AE00D59182DAC8D00087DD7 /* KeyedCoding.h in Headers */ = {isa = PBXBuildFile; fileRef = 1AE00D57182DAC8D00087DD7 /* KeyedCoding.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		1AE2AA1F0A1CDAB400B42B25 /* JSHTMLAreaElement.h in Headers */ = {isa = PBXBuildFile; fileRef = 1AE2AA0B0A1CDAB300B42B25 /* JSHTMLAreaElement.h */; };
 		1AE2AA230A1CDAB400B42B25 /* JSHTMLBodyElement.h in Headers */ = {isa = PBXBuildFile; fileRef = 1AE2AA0F0A1CDAB300B42B25 /* JSHTMLBodyElement.h */; };
@@ -907,23 +914,28 @@
 		1F8756B21E22C3350042C40D /* WebSQLiteDatabaseTrackerClient.h in Headers */ = {isa = PBXBuildFile; fileRef = 1F8756B11E22BEEF0042C40D /* WebSQLiteDatabaseTrackerClient.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		1F95C34D2B644B08006F7B93 /* PlaybackSessionInterfaceAVKitLegacy.h in Headers */ = {isa = PBXBuildFile; fileRef = 1F95C34C2B644AF6006F7B93 /* PlaybackSessionInterfaceAVKitLegacy.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		1F95C34F2B644B28006F7B93 /* PlaybackSessionInterfaceAVKitLegacy.mm in Sources */ = {isa = PBXBuildFile; fileRef = 1F95C34E2B644B1E006F7B93 /* PlaybackSessionInterfaceAVKitLegacy.mm */; };
+		1FAEE8330AB7627E254EF815 /* UnifiedSource21-header-RenderStyleGetters.cpp in Sources */ = {isa = PBXBuildFile; fileRef = C6331D4D1626BCDABB8516DB /* UnifiedSource21-header-RenderStyleGetters.cpp */; };
 		1FAFBF1915A5FA7400083A20 /* UTIUtilities.h in Headers */ = {isa = PBXBuildFile; fileRef = 1FAFBF1615A5FA5200083A20 /* UTIUtilities.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		1FC40FBA1655CCB90040F29E /* CGSubimageCacheWithTimer.h in Headers */ = {isa = PBXBuildFile; fileRef = 1FC40FB71655C5910040F29E /* CGSubimageCacheWithTimer.h */; };
 		1FD992F826AA24F90088E596 /* KeyboardScrollingAnimator.h in Headers */ = {isa = PBXBuildFile; fileRef = 1FD992F626AA24F80088E596 /* KeyboardScrollingAnimator.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		20D629271253690B00081543 /* InspectorInstrumentation.h in Headers */ = {isa = PBXBuildFile; fileRef = 20D629251253690B00081543 /* InspectorInstrumentation.h */; };
 		20E49C366FF6E0F3F57470B5 /* invalid-placard@3x.png in Copy Modern Media Controls Images */ = {isa = PBXBuildFile; fileRef = 714F5B081DEE5F8A0075BD17 /* invalid-placard@3x.png */; platformFilters = (ios, xros, ); };
 		2155A6B01D8EC0D400EE7B4B /* airplay-placard@2x.png in Copy Modern Media Controls Images */ = {isa = PBXBuildFile; fileRef = 71D6AA721DA4EAF700B23969 /* airplay-placard@2x.png */; platformFilters = (ios, xros, ); };
+		2156F76D3D2F5A9607AF69D9 /* UnifiedSource39-header-RenderStyleGetters.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0F76CD991B87ADACC0F2F37E /* UnifiedSource39-header-RenderStyleGetters.cpp */; };
 		225A16B50D5C11E900090295 /* WebEventRegion.h in Headers */ = {isa = PBXBuildFile; fileRef = 225A16B30D5C11E900090295 /* WebEventRegion.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		228C284510D82500009D0D0E /* ScriptWrappable.h in Headers */ = {isa = PBXBuildFile; fileRef = 228C284410D82500009D0D0E /* ScriptWrappable.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		23CED0538221E00106965803 /* Play.svg in Copy Modern Media Controls Images */ = {isa = PBXBuildFile; fileRef = DC8EA0C37B0638710AE9B150 /* Play.svg */; platformFilters = (macos, ); };
 		244447FB2ECD1F8E00EED177 /* WebTransportReliabilityMode.h in Headers */ = {isa = PBXBuildFile; fileRef = FAC3C3EF2A996700001E2EB8 /* WebTransportReliabilityMode.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		2444CEB42ECC4E7F00C09DC6 /* WebTransportConnectionInfo.h in Headers */ = {isa = PBXBuildFile; fileRef = 2444CEB32ECC4E7F00C09DC6 /* WebTransportConnectionInfo.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		2473729C9C40145602B6EED3 /* UnifiedSource15-header-RenderStyleGetters.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 01FA511EE07ED821FC38C8C0 /* UnifiedSource15-header-RenderStyleGetters.cpp */; };
+		247E90B270CFDDBA3A6D2512 /* UnifiedSource31-header-RenderStyleGetters.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4CA6FA18AEA1958D18A49C88 /* UnifiedSource31-header-RenderStyleGetters.cpp */; };
 		24D912B113CA9A1F00D21915 /* SVGAltGlyphDefElement.h in Headers */ = {isa = PBXBuildFile; fileRef = 24D912AE13CA9A1F00D21915 /* SVGAltGlyphDefElement.h */; };
 		24D912B813CA9A6900D21915 /* SVGAltGlyphItemElement.h in Headers */ = {isa = PBXBuildFile; fileRef = 24D912B513CA9A6900D21915 /* SVGAltGlyphItemElement.h */; };
 		24D912BE13CA9A9700D21915 /* SVGGlyphRefElement.h in Headers */ = {isa = PBXBuildFile; fileRef = 24D912BB13CA9A9700D21915 /* SVGGlyphRefElement.h */; };
 		2542F4DB1166C25A00E89A86 /* UserGestureIndicator.h in Headers */ = {isa = PBXBuildFile; fileRef = 2542F4D91166C25A00E89A86 /* UserGestureIndicator.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		25571903E0F329E69F62E5C4 /* invalid-placard@1x.png in Copy Modern Media Controls Images */ = {isa = PBXBuildFile; fileRef = 714F5B061DEE5F8A0075BD17 /* invalid-placard@1x.png */; platformFilters = (ios, xros, ); };
 		261CA627EA2BAE7CFD76CAD9 /* SkipBack10.svg in Copy Modern Media Controls Images */ = {isa = PBXBuildFile; fileRef = 8406E9C2A59B1E775A71B2ED /* SkipBack10.svg */; platformFilters = (ios, xros, ); };
+		25844670F1A4A11B90492C9C /* UnifiedSource12-header-RenderStyleGetters.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 1818859115E2479836298884 /* UnifiedSource12-header-RenderStyleGetters.cpp */; };
 		262391361A648CEE007251A3 /* ContentExtensionsDebugging.h in Headers */ = {isa = PBXBuildFile; fileRef = 262391351A648CEE007251A3 /* ContentExtensionsDebugging.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		262EC41A1D078FB900BA78FC /* EventTrackingRegions.h in Headers */ = {isa = PBXBuildFile; fileRef = 262EC4191D078F3D00BA78FC /* EventTrackingRegions.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		265541391489811C000DFC5D /* KeyEventCodesIOS.h in Headers */ = {isa = PBXBuildFile; fileRef = 265541371489811C000DFC5D /* KeyEventCodesIOS.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -954,6 +966,7 @@
 		26F9A83818A046AC00AEB88A /* ViewportConfiguration.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 26F9A83618A046AC00AEB88A /* ViewportConfiguration.cpp */; };
 		26F9A83918A046AC00AEB88A /* ViewportConfiguration.h in Headers */ = {isa = PBXBuildFile; fileRef = 26F9A83718A046AC00AEB88A /* ViewportConfiguration.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		27A0042F2AD3161800407880 /* ShouldNotFireMutationEventsScope.h in Headers */ = {isa = PBXBuildFile; fileRef = 27A0042E2AD3161800407880 /* ShouldNotFireMutationEventsScope.h */; };
+		27C4A656181E768DF2AB1CEB /* UnifiedSource26-header-RenderStyleGetters.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 9B1085E5B79E8A71CC22A26E /* UnifiedSource26-header-RenderStyleGetters.cpp */; };
 		27E3C808257F5E6E00C986AB /* ANGLEHeaders.h in Headers */ = {isa = PBXBuildFile; fileRef = 27E3C806257F5E6E00C986AB /* ANGLEHeaders.h */; };
 		27E7CA912D7572C600554A77 /* BoundaryPointInlines.h in Headers */ = {isa = PBXBuildFile; fileRef = 27E7CA902D7572C600554A77 /* BoundaryPointInlines.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		27E7CA932D7572DE00554A77 /* NodeInlines.h in Headers */ = {isa = PBXBuildFile; fileRef = 27E7CA922D7572DE00554A77 /* NodeInlines.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -961,6 +974,7 @@
 		27E7CA972D75735A00554A77 /* RangeBoundaryPointInlines.h in Headers */ = {isa = PBXBuildFile; fileRef = 27E7CA962D75735A00554A77 /* RangeBoundaryPointInlines.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		27E7CA9C2D75780500554A77 /* EditingInlines.h in Headers */ = {isa = PBXBuildFile; fileRef = 27E7CA9B2D75780500554A77 /* EditingInlines.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		27E818132BFB2A2400B872DA /* FragmentDirective.h in Headers */ = {isa = PBXBuildFile; fileRef = 27E818062BF5C67400B872DA /* FragmentDirective.h */; };
+		2889C1452CCD5A308A13F91D /* UnifiedSource22-header-RenderStyleGetters.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7C8F277F5B1147C3195DDAB2 /* UnifiedSource22-header-RenderStyleGetters.cpp */; };
 		2914E3081CAB5A440049966F /* AXAttachmentHelpers.h in Headers */ = {isa = PBXBuildFile; fileRef = 2914E3061CAB5A440049966F /* AXAttachmentHelpers.h */; };
 		2936BF5C21D69E4B004A8FC9 /* AXCoreObject.h in Headers */ = {isa = PBXBuildFile; fileRef = 2936BF5A21D6999E004A8FC9 /* AXCoreObject.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		29489FC712C00F0300D83F0F /* AccessibilityScrollView.h in Headers */ = {isa = PBXBuildFile; fileRef = 29489FC512C00F0300D83F0F /* AccessibilityScrollView.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -1118,83 +1132,6 @@
 		2D8B92FD203D13E1009C868F /* UnifiedSource528.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DE5F85D21FA23856006DB63B /* UnifiedSource528.cpp */; };
 		2D8B92FE203D13E1009C868F /* UnifiedSource529.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DE5F85CF1FA23850006DB63B /* UnifiedSource529.cpp */; };
 		2D8B92FF203D13E1009C868F /* UnifiedSource530.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DE5F85D31FA23859006DB63B /* UnifiedSource530.cpp */; };
-		0B2AA9B7DC40569673FC9868 /* UnifiedSource1-header-RenderStyleGetters.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4987053212B58BF9F79B19AD /* UnifiedSource1-header-RenderStyleGetters.cpp */; };
-		878F162BB63DC4D461E1BBE5 /* UnifiedSource2-header-RenderStyleGetters.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 89C20A7AC4BA0F7144DDF0B9 /* UnifiedSource2-header-RenderStyleGetters.cpp */; };
-		BC53A15AA2470A2CA012533D /* UnifiedSource3-header-RenderStyleGetters.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 004D65C61D84DB1DC5F43DBB /* UnifiedSource3-header-RenderStyleGetters.cpp */; };
-		8ACF57C9B7AF33922400D828 /* UnifiedSource4-header-RenderStyleGetters.cpp in Sources */ = {isa = PBXBuildFile; fileRef = C330BEA189D73D0667F53763 /* UnifiedSource4-header-RenderStyleGetters.cpp */; };
-		49EEC0684876C2F576B55113 /* UnifiedSource5-header-RenderStyleGetters.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 097892D45E6F50F9B2F119BB /* UnifiedSource5-header-RenderStyleGetters.cpp */; };
-		69A20BF3CD7D667D4E0A02BD /* UnifiedSource6-header-RenderStyleGetters.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 5A551F9473B2A7F6783FF6C1 /* UnifiedSource6-header-RenderStyleGetters.cpp */; };
-		12FE69ABC11EFD67590B4E34 /* UnifiedSource7-header-RenderStyleGetters.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 8367965ED15A1EE1FF2AD6D1 /* UnifiedSource7-header-RenderStyleGetters.cpp */; };
-		B483E80A399B821282389698 /* UnifiedSource8-header-RenderStyleGetters.cpp in Sources */ = {isa = PBXBuildFile; fileRef = B4059720D99B652A638A10FB /* UnifiedSource8-header-RenderStyleGetters.cpp */; };
-		C26A456A2363044F1B0A275D /* UnifiedSource9-header-RenderStyleGetters.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 8B4936F9C7F6D9A2071F9A39 /* UnifiedSource9-header-RenderStyleGetters.cpp */; };
-		3A8197679BC2C1DB5776BD49 /* UnifiedSource10-header-RenderStyleGetters.cpp in Sources */ = {isa = PBXBuildFile; fileRef = AB81B1E55657A17F362C4920 /* UnifiedSource10-header-RenderStyleGetters.cpp */; };
-		5B602FF31E893171DB3FB4A7 /* UnifiedSource11-header-RenderStyleGetters.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 25FAC750F76F755835BE4E86 /* UnifiedSource11-header-RenderStyleGetters.cpp */; };
-		25844670F1A4A11B90492C9C /* UnifiedSource12-header-RenderStyleGetters.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 1818859115E2479836298884 /* UnifiedSource12-header-RenderStyleGetters.cpp */; };
-		E7CFF32F4E8D19760A5EF406 /* UnifiedSource13-header-RenderStyleGetters.cpp in Sources */ = {isa = PBXBuildFile; fileRef = D508C53D5BA52394A72A6606 /* UnifiedSource13-header-RenderStyleGetters.cpp */; };
-		83FFC8AB79C6A41367EBD104 /* UnifiedSource14-header-RenderStyleGetters.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 6A5A653EE2BD51501F778B98 /* UnifiedSource14-header-RenderStyleGetters.cpp */; };
-		2473729C9C40145602B6EED3 /* UnifiedSource15-header-RenderStyleGetters.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 01FA511EE07ED821FC38C8C0 /* UnifiedSource15-header-RenderStyleGetters.cpp */; };
-		02F00913A402BD5A4A68ED65 /* UnifiedSource16-header-RenderStyleGetters.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 1B5C8E332AFA25F34506CCB0 /* UnifiedSource16-header-RenderStyleGetters.cpp */; };
-		68B3E8CF4B693302E132E36B /* UnifiedSource17-header-RenderStyleGetters.cpp in Sources */ = {isa = PBXBuildFile; fileRef = AEEABC16FEE73A1AE39407C0 /* UnifiedSource17-header-RenderStyleGetters.cpp */; };
-		0678848F73938361BD2B42E3 /* UnifiedSource18-header-RenderStyleGetters.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 9E3E301A4FF9CC03FB16C8B2 /* UnifiedSource18-header-RenderStyleGetters.cpp */; };
-		D669F992A34B36EDA5435687 /* UnifiedSource19-header-RenderStyleGetters.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 5250A569CD8198C008B831C9 /* UnifiedSource19-header-RenderStyleGetters.cpp */; };
-		EB08B45C5495A39E03D5A8B5 /* UnifiedSource20-header-RenderStyleGetters.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 1B721B8134C6AE9E9D34A5D7 /* UnifiedSource20-header-RenderStyleGetters.cpp */; };
-		1FAEE8330AB7627E254EF815 /* UnifiedSource21-header-RenderStyleGetters.cpp in Sources */ = {isa = PBXBuildFile; fileRef = C6331D4D1626BCDABB8516DB /* UnifiedSource21-header-RenderStyleGetters.cpp */; };
-		2889C1452CCD5A308A13F91D /* UnifiedSource22-header-RenderStyleGetters.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7C8F277F5B1147C3195DDAB2 /* UnifiedSource22-header-RenderStyleGetters.cpp */; };
-		9191194A55A2ECCF49FF73B3 /* UnifiedSource23-header-RenderStyleGetters.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 9BF8F60FC54FDA5A320BD129 /* UnifiedSource23-header-RenderStyleGetters.cpp */; };
-		3320B8F03AA379B81B48F469 /* UnifiedSource24-header-RenderStyleGetters.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 675EA032FFAF2A4098F106D8 /* UnifiedSource24-header-RenderStyleGetters.cpp */; };
-		7005AB0F1B9EA8615D741AF3 /* UnifiedSource25-header-RenderStyleGetters.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2EC5387B1B81D685AF55472D /* UnifiedSource25-header-RenderStyleGetters.cpp */; };
-		27C4A656181E768DF2AB1CEB /* UnifiedSource26-header-RenderStyleGetters.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 9B1085E5B79E8A71CC22A26E /* UnifiedSource26-header-RenderStyleGetters.cpp */; };
-		4B9C7CF384D437A4B1D3A3F1 /* UnifiedSource27-header-RenderStyleGetters.cpp in Sources */ = {isa = PBXBuildFile; fileRef = D482513BF8F4914090F55B14 /* UnifiedSource27-header-RenderStyleGetters.cpp */; };
-		B7BF4500CD301A381100C574 /* UnifiedSource28-header-RenderStyleGetters.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BAECA0A8276147146143052D /* UnifiedSource28-header-RenderStyleGetters.cpp */; };
-		78017BC280919209D3AF79BE /* UnifiedSource29-header-RenderStyleGetters.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FE824821D37F631F1A942B28 /* UnifiedSource29-header-RenderStyleGetters.cpp */; };
-		F08B6330FEDFA3CA4AA967FC /* UnifiedSource30-header-RenderStyleGetters.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BFD548E1DACEDB63C7EA23AF /* UnifiedSource30-header-RenderStyleGetters.cpp */; };
-		247E90B270CFDDBA3A6D2512 /* UnifiedSource31-header-RenderStyleGetters.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4CA6FA18AEA1958D18A49C88 /* UnifiedSource31-header-RenderStyleGetters.cpp */; };
-		1AD9141193F8BCCF688EE0B5 /* UnifiedSource32-header-RenderStyleGetters.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 939F8CC43E871DE5E8AB5A9F /* UnifiedSource32-header-RenderStyleGetters.cpp */; };
-		A8A0CCCAC9805312E1E53FC0 /* UnifiedSource33-header-RenderStyleGetters.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 5DE923E85927C51244CECFDD /* UnifiedSource33-header-RenderStyleGetters.cpp */; };
-		5C18AF9F085CE88F6F3BB442 /* UnifiedSource34-header-RenderStyleGetters.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 9E89B7DB68E9CE297AC2CD6A /* UnifiedSource34-header-RenderStyleGetters.cpp */; };
-		5F6B55EA93137C0827C91F9C /* UnifiedSource35-header-RenderStyleGetters.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7ABF02D621D7EBA2AFFD021A /* UnifiedSource35-header-RenderStyleGetters.cpp */; };
-		B847DE321D298447456B661B /* UnifiedSource36-header-RenderStyleGetters.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 75FC345681CEC46DD9AE1331 /* UnifiedSource36-header-RenderStyleGetters.cpp */; };
-		AD7DA56EADCC268C3A3815D3 /* UnifiedSource37-header-RenderStyleGetters.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 978CE10C711D6B12D9FBC9C9 /* UnifiedSource37-header-RenderStyleGetters.cpp */; };
-		8D8AB55246EA6D3E46D7E2EF /* UnifiedSource38-header-RenderStyleGetters.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BCFF63713748594F7E1BE330 /* UnifiedSource38-header-RenderStyleGetters.cpp */; };
-		2156F76D3D2F5A9607AF69D9 /* UnifiedSource39-header-RenderStyleGetters.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0F76CD991B87ADACC0F2F37E /* UnifiedSource39-header-RenderStyleGetters.cpp */; };
-		030346BE5CD75A7829AD613F /* UnifiedSource40-header-RenderStyleGetters.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A756860D9AF6A2C15FCF7E3E /* UnifiedSource40-header-RenderStyleGetters.cpp */; };
-		5B4C7CA9D949D424F9683D2F /* UnifiedSource41-header-RenderStyleGetters.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FBCE61FFFCC0A29F0D842C51 /* UnifiedSource41-header-RenderStyleGetters.cpp */; };
-		E9066AA4F09A6829ADADE430 /* UnifiedSource42-header-RenderStyleGetters.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 8C36C2A063D49F0AFB0A20E2 /* UnifiedSource42-header-RenderStyleGetters.cpp */; };
-		62CB37701D0713A0F5D51239 /* UnifiedSource43-header-RenderStyleGetters.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 47F192EF33A4783F5E6E60F0 /* UnifiedSource43-header-RenderStyleGetters.cpp */; };
-		975B87DD21C609E77AF85C24 /* UnifiedSource44-header-RenderStyleGetters.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BE1A40333AB79B5518B8B658 /* UnifiedSource44-header-RenderStyleGetters.cpp */; };
-		BFA1C0CAB43B888E8D099BB9 /* UnifiedSource45-header-RenderStyleGetters.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B4EE1CF43D75281121A19D6 /* UnifiedSource45-header-RenderStyleGetters.cpp */; };
-		F7C53A57143C6A21A7F6D91F /* UnifiedSource46-header-RenderStyleGetters.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 04CF8DB82E1A2436F374BC05 /* UnifiedSource46-header-RenderStyleGetters.cpp */; };
-		3909A604EDE89C842C9DE6FE /* UnifiedSource47-header-RenderStyleGetters.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A599F54EADD15733ED9178AE /* UnifiedSource47-header-RenderStyleGetters.cpp */; };
-		541F1CEE88912A324F8443AB /* UnifiedSource48-header-RenderStyleGetters.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DE0DF0E2DD6063156D395BC5 /* UnifiedSource48-header-RenderStyleGetters.cpp */; };
-		76363FA2270F28362356D07D /* UnifiedSource49-header-RenderStyleGetters.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 1D2E7A27D4CA429D6537A1BC /* UnifiedSource49-header-RenderStyleGetters.cpp */; };
-		CCB55ECCC1A9A69CDD08157E /* UnifiedSource50-header-RenderStyleGetters.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 636E4E69584B74FA6C92D248 /* UnifiedSource50-header-RenderStyleGetters.cpp */; };
-		3D42BC4514B0E28F44D62E77 /* UnifiedSource51-header-RenderStyleGetters.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 6D90699809046B96AE290168 /* UnifiedSource51-header-RenderStyleGetters.cpp */; };
-		97FAD817765D9157D255A70B /* UnifiedSource52-header-RenderStyleGetters.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3A0029C243BF23321C43D20D /* UnifiedSource52-header-RenderStyleGetters.cpp */; };
-		AC70233498D951EF103BFC93 /* UnifiedSource53-header-RenderStyleGetters.cpp in Sources */ = {isa = PBXBuildFile; fileRef = EBD345B9F06BCC0152D3057C /* UnifiedSource53-header-RenderStyleGetters.cpp */; };
-		FEB5079D8E50CAD92E49CE04 /* UnifiedSource54-header-RenderStyleGetters.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 73C6E6F635A4B4C36B107EAE /* UnifiedSource54-header-RenderStyleGetters.cpp */; };
-		043934662F229202E82AB23F /* UnifiedSource55-header-RenderStyleGetters.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3230252036F492BB47909DD0 /* UnifiedSource55-header-RenderStyleGetters.cpp */; };
-		8AAF3C352879D5D7368D5480 /* UnifiedSource56-header-RenderStyleGetters.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A7925FD267D4C894F38E1AD7 /* UnifiedSource56-header-RenderStyleGetters.cpp */; };
-		733212D86D36C78C04928DF8 /* UnifiedSource57-header-RenderStyleGetters.cpp in Sources */ = {isa = PBXBuildFile; fileRef = EAFEE1BA6EC72445F6539574 /* UnifiedSource57-header-RenderStyleGetters.cpp */; };
-		F1516286C621DBA3025C2F70 /* UnifiedSource58-header-RenderStyleGetters.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 61848160D68C25BF3B848B6C /* UnifiedSource58-header-RenderStyleGetters.cpp */; };
-		F01E1CB528746456B6A5B43E /* UnifiedSource59-header-RenderStyleGetters.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BD0EA2751C530E9F3689675A /* UnifiedSource59-header-RenderStyleGetters.cpp */; };
-		6DFAE524A5AFD075D7CBBD03 /* UnifiedSource60-header-RenderStyleGetters.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F2462F05A319D5DE971FCFBC /* UnifiedSource60-header-RenderStyleGetters.cpp */; };
-		AA4F2A23284FF2D478722264 /* UnifiedSource61-header-RenderStyleGetters.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3EB98985C78E4C2A4C58889D /* UnifiedSource61-header-RenderStyleGetters.cpp */; };
-		6CC4ACF49865BFF9672CDCDA /* UnifiedSource62-header-RenderStyleGetters.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 9C26E8CE9CFBE3ECA1C04907 /* UnifiedSource62-header-RenderStyleGetters.cpp */; };
-		D4729C709180E3A094B1EDEF /* UnifiedSource63-header-RenderStyleGetters.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7295D020E0F0C07C868B904C /* UnifiedSource63-header-RenderStyleGetters.cpp */; };
-		AEDB39B3CF27CEA5073F99DD /* UnifiedSource64-header-RenderStyleGetters.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7C61AFF4898CB7897BCB412E /* UnifiedSource64-header-RenderStyleGetters.cpp */; };
-		ADC0EC39614A71986AA229F3 /* UnifiedSource65-header-RenderStyleGetters.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E3BD27846EEC386B691B9101 /* UnifiedSource65-header-RenderStyleGetters.cpp */; };
-		49BE60851F2DF1533160C1B8 /* UnifiedSource66-header-RenderStyleGetters.cpp in Sources */ = {isa = PBXBuildFile; fileRef = C91C8C4B6EDB7E3196424FBE /* UnifiedSource66-header-RenderStyleGetters.cpp */; };
-		BF015D1C9196498DCDBB6D33 /* UnifiedSource67-header-RenderStyleGetters.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 886246164BC21FF991E1CACF /* UnifiedSource67-header-RenderStyleGetters.cpp */; };
-		95ED3B19C2F4830551DC70D0 /* UnifiedSource68-header-RenderStyleGetters.cpp in Sources */ = {isa = PBXBuildFile; fileRef = D8A6C642D6DAE088EF53F376 /* UnifiedSource68-header-RenderStyleGetters.cpp */; };
-		997C7BD0D5FF097D76C4E1F5 /* UnifiedSource69-header-RenderStyleGetters.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0DB768C810AA85BE70BB2E08 /* UnifiedSource69-header-RenderStyleGetters.cpp */; };
-		717794303F6CD3C40281ABF7 /* UnifiedSource70-header-RenderStyleGetters.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E6C0584B3F242E1D1673E792 /* UnifiedSource70-header-RenderStyleGetters.cpp */; };
-		8F9B85867BCC1EE38784EE83 /* UnifiedSource71-header-RenderStyleGetters.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB591C358F2E176568F6C0AA /* UnifiedSource71-header-RenderStyleGetters.cpp */; };
-		385737B57301EEAC14B22C0A /* UnifiedSource72-header-RenderStyleGetters.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F3E295464B8B3B72FA425243 /* UnifiedSource72-header-RenderStyleGetters.cpp */; };
-		A2197BB62750D9B81D25122B /* UnifiedSource73-header-RenderStyleGetters.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BAF547B3E0A08ACCDA0FD3EE /* UnifiedSource73-header-RenderStyleGetters.cpp */; };
-		839B297B463A43FE0B6E9D57 /* UnifiedSource74-header-RenderStyleGetters.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 41FF206D0243146B78FDD0FB /* UnifiedSource74-header-RenderStyleGetters.cpp */; };
-		37507F639BDABAC025966B8E /* UnifiedSource75-header-RenderStyleGetters.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 5188A7DDD00B206B110ED7A1 /* UnifiedSource75-header-RenderStyleGetters.cpp */; };
-		7E4B504918DA764A6B029140 /* UnifiedSource76-header-RenderStyleGetters.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DDD6571342E109928469E047 /* UnifiedSource76-header-RenderStyleGetters.cpp */; };
-		9995EAAA019FDD08826EB9FB /* UnifiedSource77-header-RenderStyleGetters.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 52D2ED227687272BB8AC7430 /* UnifiedSource77-header-RenderStyleGetters.cpp */; };
 		2D8FEBDD143E3EF70072502B /* CSSCrossfadeValue.h in Headers */ = {isa = PBXBuildFile; fileRef = 2D8FEBDB143E3EF70072502B /* CSSCrossfadeValue.h */; };
 		2D9066070BE141D400956998 /* RenderLayoutState.h in Headers */ = {isa = PBXBuildFile; fileRef = 2D9066050BE141D400956998 /* RenderLayoutState.h */; };
 		2D9153EF28AE0E280073A385 /* FragmentDirectiveParser.h in Headers */ = {isa = PBXBuildFile; fileRef = 445612AB270F6F3800758C97 /* FragmentDirectiveParser.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -1351,6 +1288,7 @@
 		329C0C2428BD96DE00F187D2 /* Namespace.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3227A92928BD744B00BC2697 /* Namespace.cpp */; };
 		329C0C2528BD96EB00F187D2 /* NodeName.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3227A92728BD744A00BC2697 /* NodeName.cpp */; };
 		32EAFB8D274C5EA600650557 /* FontCascadeCache.h in Headers */ = {isa = PBXBuildFile; fileRef = 32EAFB8B274C5EA500650557 /* FontCascadeCache.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		3320B8F03AA379B81B48F469 /* UnifiedSource24-header-RenderStyleGetters.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 675EA032FFAF2A4098F106D8 /* UnifiedSource24-header-RenderStyleGetters.cpp */; };
 		334408C433F8CA4C10044234 /* SVGLayerTransformUpdater.h in Headers */ = {isa = PBXBuildFile; fileRef = 3344077412D9BC4A00044234 /* SVGLayerTransformUpdater.h */; };
 		334408C433F8CA4C10044551 /* SVGLayerTransformComputation.h in Headers */ = {isa = PBXBuildFile; fileRef = 3344077412D9BC4A00044551 /* SVGLayerTransformComputation.h */; };
 		334408C433F8CA4C10A328F4 /* SVGVisitedRendererTracking.h in Headers */ = {isa = PBXBuildFile; fileRef = 3344077412D9BC4A00A328F4 /* SVGVisitedRendererTracking.h */; };
@@ -1373,6 +1311,7 @@
 		372D3E54216578AE00C5E021 /* DataURLDecoder.h in Headers */ = {isa = PBXBuildFile; fileRef = E4A007821B820EC8002C5A6E /* DataURLDecoder.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		372D3E55216578AE00C5E021 /* ScriptModuleLoader.h in Headers */ = {isa = PBXBuildFile; fileRef = E38838951BAD145F00D62EE3 /* ScriptModuleLoader.h */; };
 		372D3E57216578AE00C5E021 /* NavigatorCredentials.h in Headers */ = {isa = PBXBuildFile; fileRef = 57D846261FE895F800CA3682 /* NavigatorCredentials.h */; };
+		37507F639BDABAC025966B8E /* UnifiedSource75-header-RenderStyleGetters.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 5188A7DDD00B206B110ED7A1 /* UnifiedSource75-header-RenderStyleGetters.cpp */; };
 		375CD232119D43C800A2A859 /* Hyphenation.h in Headers */ = {isa = PBXBuildFile; fileRef = 375CD231119D43C800A2A859 /* Hyphenation.h */; };
 		3774ABA50FA21EB400AD7DE9 /* OverlapTestRequestClient.h in Headers */ = {isa = PBXBuildFile; fileRef = 3774ABA30FA21EB400AD7DE9 /* OverlapTestRequestClient.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		37919C240B7D188600A56998 /* PositionIterator.h in Headers */ = {isa = PBXBuildFile; fileRef = 37919C220B7D188600A56998 /* PositionIterator.h */; settings = {ATTRIBUTES = (); }; };
@@ -1394,6 +1333,8 @@
 		37E3524D12450C6600BAF5D9 /* InputType.h in Headers */ = {isa = PBXBuildFile; fileRef = 37E3524C12450C6600BAF5D9 /* InputType.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		37F567CE165358F400DDE92B /* PopupOpeningObserver.h in Headers */ = {isa = PBXBuildFile; fileRef = 3772B09516535856000A49CA /* PopupOpeningObserver.h */; };
 		37F818FD0D657606005E1F05 /* WebCoreURLResponse.h in Headers */ = {isa = PBXBuildFile; fileRef = 37F818FB0D657606005E1F05 /* WebCoreURLResponse.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		385737B57301EEAC14B22C0A /* UnifiedSource72-header-RenderStyleGetters.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F3E295464B8B3B72FA425243 /* UnifiedSource72-header-RenderStyleGetters.cpp */; };
+		3909A604EDE89C842C9DE6FE /* UnifiedSource47-header-RenderStyleGetters.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A599F54EADD15733ED9178AE /* UnifiedSource47-header-RenderStyleGetters.cpp */; };
 		39BA63C17652D5AA02D90D4D /* SVGComponentTransferFunctionElementInlines.h in Headers */ = {isa = PBXBuildFile; fileRef = 62370F94D69D08CA29D088BE /* SVGComponentTransferFunctionElementInlines.h */; };
 		3A0BAA3E2D0B6B2B00DE30E4 /* FileSystemWriteCloseReason.h in Headers */ = {isa = PBXBuildFile; fileRef = 3A0BAA3D2D0B6B2B00DE30E4 /* FileSystemWriteCloseReason.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		3A18A2ED2AFEAA7C00DB976C /* MarkupExclusionRule.h in Headers */ = {isa = PBXBuildFile; fileRef = 3A18A2EC2AFEAA7C00DB976C /* MarkupExclusionRule.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -1408,6 +1349,7 @@
 		3A5110F12CF79E9800CBFF42 /* FileSystemWritableFileStream.h in Headers */ = {isa = PBXBuildFile; fileRef = 3A5110EE2CF79E9800CBFF42 /* FileSystemWritableFileStream.h */; };
 		3A64EA542BFD3EB300D656A6 /* PublicSuffix.h in Headers */ = {isa = PBXBuildFile; fileRef = 3A64EA522BFD3E8000D656A6 /* PublicSuffix.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		3A7D62DA29D49EC900D57DAC /* SWRegistrationDatabase.h in Headers */ = {isa = PBXBuildFile; fileRef = 3A7D62D829D49EC800D57DAC /* SWRegistrationDatabase.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		3A8197679BC2C1DB5776BD49 /* UnifiedSource10-header-RenderStyleGetters.cpp in Sources */ = {isa = PBXBuildFile; fileRef = AB81B1E55657A17F362C4920 /* UnifiedSource10-header-RenderStyleGetters.cpp */; };
 		3ABD156A297A289300AF9D76 /* GraphicsContextGLEnums.h in Headers */ = {isa = PBXBuildFile; fileRef = 3ABD1569297A289200AF9D76 /* GraphicsContextGLEnums.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		3ABD156C297A340100AF9D76 /* GraphicsContextGLActiveInfo.h in Headers */ = {isa = PBXBuildFile; fileRef = 3ABD156B297A340000AF9D76 /* GraphicsContextGLActiveInfo.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		3AC4C04429D345D800402716 /* SWRegistrationStore.h in Headers */ = {isa = PBXBuildFile; fileRef = 3AC4C04229D345D800402716 /* SWRegistrationStore.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -1421,6 +1363,7 @@
 		3BB6B81122A7D313003A2A69 /* TabSize.h in Headers */ = {isa = PBXBuildFile; fileRef = 3BB6B80F22A7D311003A2A69 /* TabSize.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		3C244FEAA375AC633F88BE6F /* RenderLayerModelObject.h in Headers */ = {isa = PBXBuildFile; fileRef = 3C244FE4A375AC633F88BE6F /* RenderLayerModelObject.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		3C8D24EE2E25CF1A00D2A929 /* IPAddressSpace.h in Headers */ = {isa = PBXBuildFile; fileRef = 3C8D24ED2E25CF1A00D2A929 /* IPAddressSpace.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		3D42BC4514B0E28F44D62E77 /* UnifiedSource51-header-RenderStyleGetters.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 6D90699809046B96AE290168 /* UnifiedSource51-header-RenderStyleGetters.cpp */; };
 		3F42B31D1881191B00278AAC /* WebVideoFullscreenControllerAVKit.h in Headers */ = {isa = PBXBuildFile; fileRef = 3F42B31B1881191B00278AAC /* WebVideoFullscreenControllerAVKit.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		3F8020351E9E47BF00DEC61D /* CoreAudioCaptureDevice.h in Headers */ = {isa = PBXBuildFile; fileRef = 3F8020321E9E381D00DEC61D /* CoreAudioCaptureDevice.h */; };
 		3F8020371E9E47C500DEC61D /* CoreAudioCaptureDeviceManager.h in Headers */ = {isa = PBXBuildFile; fileRef = 3F8020341E9E381D00DEC61D /* CoreAudioCaptureDeviceManager.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -2013,6 +1956,7 @@
 		499B3EDD128DB50200E726C2 /* PlatformCAAnimation.h in Headers */ = {isa = PBXBuildFile; fileRef = 499B3EDC128DB50100E726C2 /* PlatformCAAnimation.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		49AE2D8F134EE50C0072920A /* CSSCalcValue.h in Headers */ = {isa = PBXBuildFile; fileRef = 49AE2D8D134EE50C0072920A /* CSSCalcValue.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		49AF2D6914435D050016A784 /* DisplayRefreshMonitor.h in Headers */ = {isa = PBXBuildFile; fileRef = 49AF2D6814435D050016A784 /* DisplayRefreshMonitor.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		49BE60851F2DF1533160C1B8 /* UnifiedSource66-header-RenderStyleGetters.cpp in Sources */ = {isa = PBXBuildFile; fileRef = C91C8C4B6EDB7E3196424FBE /* UnifiedSource66-header-RenderStyleGetters.cpp */; };
 		49C7B9941042D2D30009D447 /* JSWebGLBuffer.h in Headers */ = {isa = PBXBuildFile; fileRef = 49C7B9811042D2D30009D447 /* JSWebGLBuffer.h */; };
 		49C7B9981042D2D30009D447 /* JSWebGLFramebuffer.h in Headers */ = {isa = PBXBuildFile; fileRef = 49C7B9851042D2D30009D447 /* JSWebGLFramebuffer.h */; };
 		49C7B99C1042D2D30009D447 /* JSWebGLProgram.h in Headers */ = {isa = PBXBuildFile; fileRef = 49C7B9891042D2D30009D447 /* JSWebGLProgram.h */; };
@@ -2043,6 +1987,7 @@
 		49E912AE0EFAC906009D0CAF /* TimingFunction.h in Headers */ = {isa = PBXBuildFile; fileRef = 49E912A90EFAC906009D0CAF /* TimingFunction.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		49ECEB6E1499790D00CDD3A4 /* FilterOperation.h in Headers */ = {isa = PBXBuildFile; fileRef = 49ECEB641499790D00CDD3A4 /* FilterOperation.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		49ECEB701499790D00CDD3A4 /* FilterOperations.h in Headers */ = {isa = PBXBuildFile; fileRef = 49ECEB661499790D00CDD3A4 /* FilterOperations.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		49EEC0684876C2F576B55113 /* UnifiedSource5-header-RenderStyleGetters.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 097892D45E6F50F9B2F119BB /* UnifiedSource5-header-RenderStyleGetters.cpp */; };
 		49EED1451051969400099FAB /* JSCanvasRenderingContext2D.h in Headers */ = {isa = PBXBuildFile; fileRef = 49EED13F1051969400099FAB /* JSCanvasRenderingContext2D.h */; };
 		49EED1471051969400099FAB /* JSWebGLRenderingContext.h in Headers */ = {isa = PBXBuildFile; fileRef = 49EED1411051969400099FAB /* JSWebGLRenderingContext.h */; };
 		49F416EC2ECB878200DBFEEA /* WebGPUXRLayerBacking.h in Headers */ = {isa = PBXBuildFile; fileRef = 49F416EB2ECB878200DBFEEA /* WebGPUXRLayerBacking.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -2074,6 +2019,7 @@
 		4B6B5CC02164386400603817 /* PaintWorkletGlobalScope.h in Headers */ = {isa = PBXBuildFile; fileRef = 4B6B5CBF2164386400603817 /* PaintWorkletGlobalScope.h */; };
 		4B6E87692176D69200420E5E /* CSSPaintImageValue.h in Headers */ = {isa = PBXBuildFile; fileRef = 4B6E87682176D69200420E5E /* CSSPaintImageValue.h */; };
 		4B6FA6F40C39E48C00087011 /* SmartReplace.h in Headers */ = {isa = PBXBuildFile; fileRef = 4B6FA6F20C39E48C00087011 /* SmartReplace.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		4B9C7CF384D437A4B1D3A3F1 /* UnifiedSource27-header-RenderStyleGetters.cpp in Sources */ = {isa = PBXBuildFile; fileRef = D482513BF8F4914090F55B14 /* UnifiedSource27-header-RenderStyleGetters.cpp */; };
 		4BAE95B10B2FA9CE00AED8A0 /* EditorDeleteAction.h in Headers */ = {isa = PBXBuildFile; fileRef = 4BAE95B00B2FA9CE00AED8A0 /* EditorDeleteAction.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		4BAFD0CB2190EBD600C0AB64 /* CSSPaintSize.h in Headers */ = {isa = PBXBuildFile; fileRef = 4BAFD0CA2190EBD600C0AB64 /* CSSPaintSize.h */; };
 		4BAFD0CF2190F9B500C0AB64 /* StylePropertyMapReadOnly.h in Headers */ = {isa = PBXBuildFile; fileRef = 4BAFD0CE2190F9B400C0AB64 /* StylePropertyMapReadOnly.h */; };
@@ -2535,6 +2481,7 @@
 		53E29E5F167A8A1900586D3D /* InternalSettingsGenerated.h in Headers */ = {isa = PBXBuildFile; fileRef = 53E29E5D167A8A1900586D3D /* InternalSettingsGenerated.h */; };
 		53ED3FDE167A88E7006762E6 /* JSInternalSettingsGenerated.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 53ED3FDC167A88E7006762E6 /* JSInternalSettingsGenerated.cpp */; };
 		53ED3FDF167A88E7006762E6 /* JSInternalSettingsGenerated.h in Headers */ = {isa = PBXBuildFile; fileRef = 53ED3FDD167A88E7006762E6 /* JSInternalSettingsGenerated.h */; };
+		541F1CEE88912A324F8443AB /* UnifiedSource48-header-RenderStyleGetters.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DE0DF0E2DD6063156D395BC5 /* UnifiedSource48-header-RenderStyleGetters.cpp */; };
 		550640B02407587E00AAE045 /* ImageBufferCGBackend.h in Headers */ = {isa = PBXBuildFile; fileRef = 72BAC3AD23E1E545008D741C /* ImageBufferCGBackend.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		550A0BCA085F6039007353D6 /* QualifiedName.h in Headers */ = {isa = PBXBuildFile; fileRef = 550A0BC8085F6039007353D6 /* QualifiedName.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		5546757B1FD212A9003B10B0 /* ImageSource.h in Headers */ = {isa = PBXBuildFile; fileRef = 554675781FD1FC1A003B10B0 /* ImageSource.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -2681,7 +2628,10 @@
 		5B416B5E29C4F1F4002ECA1B /* FontSizeAdjust.h in Headers */ = {isa = PBXBuildFile; fileRef = 5B416B5D29C4F1F3002ECA1B /* FontSizeAdjust.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		5B46656325D14C0A000CFE14 /* ScrollingEffectsController.h in Headers */ = {isa = PBXBuildFile; fileRef = 5B46655F25D14C09000CFE14 /* ScrollingEffectsController.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		5B46656425D14C0A000CFE14 /* ScrollSnapAnimatorState.h in Headers */ = {isa = PBXBuildFile; fileRef = 5B46656025D14C0A000CFE14 /* ScrollSnapAnimatorState.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		5B4C7CA9D949D424F9683D2F /* UnifiedSource41-header-RenderStyleGetters.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FBCE61FFFCC0A29F0D842C51 /* UnifiedSource41-header-RenderStyleGetters.cpp */; };
+		5B602FF31E893171DB3FB4A7 /* UnifiedSource11-header-RenderStyleGetters.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 25FAC750F76F755835BE4E86 /* UnifiedSource11-header-RenderStyleGetters.cpp */; };
 		5B92C42D2716E28A00A37CC0 /* ScrollingTreeStickyNode.h in Headers */ = {isa = PBXBuildFile; fileRef = 5B92C42B2716E23300A37CC0 /* ScrollingTreeStickyNode.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		5C18AF9F085CE88F6F3BB442 /* UnifiedSource34-header-RenderStyleGetters.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 9E89B7DB68E9CE297AC2CD6A /* UnifiedSource34-header-RenderStyleGetters.cpp */; };
 		5C1B1D3F26F3978000882DA2 /* ResourceLoaderIdentifier.h in Headers */ = {isa = PBXBuildFile; fileRef = 5C1B1D3D26F3977F00882DA2 /* ResourceLoaderIdentifier.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		5C2397D72949288700BB4E10 /* RemoteFrameClient.h in Headers */ = {isa = PBXBuildFile; fileRef = 5C2397D22949213600BB4E10 /* RemoteFrameClient.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		5C2C019C27343DDE00F89D37 /* ContentExtensionStringSerialization.h in Headers */ = {isa = PBXBuildFile; fileRef = 5C2C01992734398E00F89D37 /* ContentExtensionStringSerialization.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -2750,6 +2700,7 @@
 		5EBB89311C7777FF00C65D41 /* MediaPayload.h in Headers */ = {isa = PBXBuildFile; fileRef = 5EBB892F1C7777D000C65D41 /* MediaPayload.h */; };
 		5EBB89331C77782900C65D41 /* IceCandidate.h in Headers */ = {isa = PBXBuildFile; fileRef = 5EBB89301C7777E100C65D41 /* IceCandidate.h */; };
 		5EBB89391C77C39900C65D41 /* PeerMediaDescription.h in Headers */ = {isa = PBXBuildFile; fileRef = 5EBB89381C77BDA400C65D41 /* PeerMediaDescription.h */; };
+		5F6B55EA93137C0827C91F9C /* UnifiedSource35-header-RenderStyleGetters.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7ABF02D621D7EBA2AFFD021A /* UnifiedSource35-header-RenderStyleGetters.cpp */; };
 		5FA904CA178E61F5004C8A2D /* CertificateInfo.h in Headers */ = {isa = PBXBuildFile; fileRef = 5F2DBBE8178E336900141486 /* CertificateInfo.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		5FA904CB178E61F5004C8A2E /* X509SubjectKeyIdentifier.h in Headers */ = {isa = PBXBuildFile; fileRef = 5F2DBBE9178E336900141487 /* X509SubjectKeyIdentifier.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		5FB69B4774EA7C62B71A6DF3 /* EnterFullscreen.svg in Copy Modern Media Controls Images */ = {isa = PBXBuildFile; fileRef = 5A767935AB7C8E39922B9A75 /* EnterFullscreen.svg */; platformFilters = (macos, ); };
@@ -2761,6 +2712,7 @@
 		626CDE0F1140424C001E5A68 /* SpatialNavigation.h in Headers */ = {isa = PBXBuildFile; fileRef = 626CDE0D1140424C001E5A68 /* SpatialNavigation.h */; };
 		628D214C12131ED10055DCFC /* NetworkingContext.h in Headers */ = {isa = PBXBuildFile; fileRef = 628D214B12131ED10055DCFC /* NetworkingContext.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		628D214E12131EF40055DCFC /* FrameNetworkingContext.h in Headers */ = {isa = PBXBuildFile; fileRef = 628D214D12131EF40055DCFC /* FrameNetworkingContext.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		62CB37701D0713A0F5D51239 /* UnifiedSource43-header-RenderStyleGetters.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 47F192EF33A4783F5E6E60F0 /* UnifiedSource43-header-RenderStyleGetters.cpp */; };
 		62CD325A1157E57C0063B0A7 /* CustomEvent.h in Headers */ = {isa = PBXBuildFile; fileRef = 62CD32571157E57C0063B0A7 /* CustomEvent.h */; };
 		62D1605F2F35A2FA0044D953 /* StyleOverflowClipMargin.h in Headers */ = {isa = PBXBuildFile; fileRef = 62D1605E2F35A2750044D953 /* StyleOverflowClipMargin.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		63152D191F9531EE007A5E4B /* ApplicationManifestLoader.h in Headers */ = {isa = PBXBuildFile; fileRef = 63152D171F9531EE007A5E4B /* ApplicationManifestLoader.h */; };
@@ -2814,6 +2766,8 @@
 		65DF323A09D1DE65000BE325 /* JSCanvasGradient.h in Headers */ = {isa = PBXBuildFile; fileRef = 65DF323409D1DE65000BE325 /* JSCanvasGradient.h */; };
 		65DF323C09D1DE65000BE325 /* JSCanvasPattern.h in Headers */ = {isa = PBXBuildFile; fileRef = 65DF323609D1DE65000BE325 /* JSCanvasPattern.h */; };
 		65E0E9441133C89F00B4CB10 /* JSDOMWrapper.h in Headers */ = {isa = PBXBuildFile; fileRef = 65E0E9431133C89F00B4CB10 /* JSDOMWrapper.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		68B3E8CF4B693302E132E36B /* UnifiedSource17-header-RenderStyleGetters.cpp in Sources */ = {isa = PBXBuildFile; fileRef = AEEABC16FEE73A1AE39407C0 /* UnifiedSource17-header-RenderStyleGetters.cpp */; };
+		69A20BF3CD7D667D4E0A02BD /* UnifiedSource6-header-RenderStyleGetters.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 5A551F9473B2A7F6783FF6C1 /* UnifiedSource6-header-RenderStyleGetters.cpp */; };
 		69A6CBAD1C6BE42C00B836E9 /* AccessibilitySVGObject.h in Headers */ = {isa = PBXBuildFile; fileRef = 697101081C6BE1550018C7F1 /* AccessibilitySVGObject.h */; };
 		6A22E8701F10418600F546C3 /* InspectorCanvas.h in Headers */ = {isa = PBXBuildFile; fileRef = 6A22E86F1F10418600F546C3 /* InspectorCanvas.h */; };
 		6A466D7700C459D5869FA7A8 /* PipIn-fullscreen.svg in Copy Modern Media Controls Images */ = {isa = PBXBuildFile; fileRef = 8ABE7EAB2915D1858FA1CDEE /* PipIn-fullscreen.svg */; platformFilters = (macos, ); };
@@ -2827,8 +2781,10 @@
 		6C4C96DF1AD4483500365672 /* JSReadableStreamBYOBRequest.h in Headers */ = {isa = PBXBuildFile; fileRef = 6C4C96DB1AD4483500365672 /* JSReadableStreamBYOBRequest.h */; };
 		6C4C96DF1AD4483500365A50 /* JSReadableStreamDefaultController.h in Headers */ = {isa = PBXBuildFile; fileRef = 6C4C96DB1AD4483500365A50 /* JSReadableStreamDefaultController.h */; };
 		6C638895A96CCEE50C8C946C /* CachedResourceRequestInitiatorTypes.h in Headers */ = {isa = PBXBuildFile; fileRef = 6C638893A96CCEE50C8C946C /* CachedResourceRequestInitiatorTypes.h */; };
+		6CC4ACF49865BFF9672CDCDA /* UnifiedSource62-header-RenderStyleGetters.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 9C26E8CE9CFBE3ECA1C04907 /* UnifiedSource62-header-RenderStyleGetters.cpp */; };
 		6DC9C7142F0C5BF300A93E65 /* DragEventTargetData.h in Headers */ = {isa = PBXBuildFile; fileRef = 6DC9C7132F0C5BC600A93E65 /* DragEventTargetData.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		6DD53F3D2C49D37F0049F1C5 /* IsLoggedIn.h in Headers */ = {isa = PBXBuildFile; fileRef = 6D46FE012C49C9DA00743D07 /* IsLoggedIn.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		6DFAE524A5AFD075D7CBBD03 /* UnifiedSource60-header-RenderStyleGetters.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F2462F05A319D5DE971FCFBC /* UnifiedSource60-header-RenderStyleGetters.cpp */; };
 		6E0B90692321A68D006223B2 /* WebGLCompressedTextureETC1.h in Headers */ = {isa = PBXBuildFile; fileRef = 6E0B90652321A68C006223B2 /* WebGLCompressedTextureETC1.h */; };
 		6E0E569C183BFFE600E0E8D5 /* FloatRoundedRect.h in Headers */ = {isa = PBXBuildFile; fileRef = 6E0E569A183BFFE600E0E8D5 /* FloatRoundedRect.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		6E242B2B23359405002CADD4 /* JSWebGLCompressedTextureETC1.h in Headers */ = {isa = PBXBuildFile; fileRef = 6E242B2A233593D8002CADD4 /* JSWebGLCompressedTextureETC1.h */; };
@@ -2906,6 +2862,7 @@
 		6FE7CFA22177EEF2005B1573 /* InlineItem.h in Headers */ = {isa = PBXBuildFile; fileRef = 6FE7CFA02177EEF1005B1573 /* InlineItem.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		6FF911F726487FC8002021DF /* FlexFormattingUtils.h in Headers */ = {isa = PBXBuildFile; fileRef = 6FF911F626487FC8002021DF /* FlexFormattingUtils.h */; };
 		6FFDC442212EFF1700A9CA91 /* FloatAvoider.h in Headers */ = {isa = PBXBuildFile; fileRef = 6FFDC440212EFF1600A9CA91 /* FloatAvoider.h */; };
+		7005AB0F1B9EA8615D741AF3 /* UnifiedSource25-header-RenderStyleGetters.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2EC5387B1B81D685AF55472D /* UnifiedSource25-header-RenderStyleGetters.cpp */; };
 		709A01FE1E3D0BDD006B0D4C /* ModuleFetchFailureKind.h in Headers */ = {isa = PBXBuildFile; fileRef = 709A01FD1E3D0BCC006B0D4C /* ModuleFetchFailureKind.h */; };
 		71025ECD1F99F0CE004A250C /* AnimationTimeline.h in Headers */ = {isa = PBXBuildFile; fileRef = 71025EC71F99F096004A250C /* AnimationTimeline.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		71025ED01F99F0CE004A250C /* DocumentTimeline.h in Headers */ = {isa = PBXBuildFile; fileRef = 71025EC51F99F096004A250C /* DocumentTimeline.h */; };
@@ -2974,6 +2931,7 @@
 		7173694A275E0B5E003ADA9B /* CustomEffect.h in Headers */ = {isa = PBXBuildFile; fileRef = 71A74B082759293600DE80BA /* CustomEffect.h */; };
 		7173694B275E0B6A003ADA9B /* CustomEffectCallback.h in Headers */ = {isa = PBXBuildFile; fileRef = 71A74B0A27592B3500DE80BA /* CustomEffectCallback.h */; };
 		7173694C275E0BAB003ADA9B /* CustomAnimationOptions.h in Headers */ = {isa = PBXBuildFile; fileRef = 71736947275E0B4B003ADA9B /* CustomAnimationOptions.h */; };
+		717794303F6CD3C40281ABF7 /* UnifiedSource70-header-RenderStyleGetters.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E6C0584B3F242E1D1673E792 /* UnifiedSource70-header-RenderStyleGetters.cpp */; };
 		7177AD57274295D1002F103B /* HTMLModelElementCamera.h in Headers */ = {isa = PBXBuildFile; fileRef = 7177AD5627429590002F103B /* HTMLModelElementCamera.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		7177B03E2C944B8100FC201F /* WebAnimationTime.h in Headers */ = {isa = PBXBuildFile; fileRef = 7177B03B2C944B8100FC201F /* WebAnimationTime.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		717CE23A29335E9C001463BC /* StyleOriginatedAnimationEvent.h in Headers */ = {isa = PBXBuildFile; fileRef = 717CE23829335E8D001463BC /* StyleOriginatedAnimationEvent.h */; };
@@ -3090,12 +3048,14 @@
 		72F9A6CD2D30DE880019DE4B /* ImageBufferDisplayListBackend.h in Headers */ = {isa = PBXBuildFile; fileRef = 72F9A6C92D30BE6E0019DE4B /* ImageBufferDisplayListBackend.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		72FD30AC27E3217B0023CDAC /* SourceBrush.h in Headers */ = {isa = PBXBuildFile; fileRef = 72FD30AA27E3217B0023CDAC /* SourceBrush.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		72FD88D1295E3C40006FACDC /* MenuListPart.h in Headers */ = {isa = PBXBuildFile; fileRef = 72FD88D0295D56E2006FACDC /* MenuListPart.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		733212D86D36C78C04928DF8 /* UnifiedSource57-header-RenderStyleGetters.cpp in Sources */ = {isa = PBXBuildFile; fileRef = EAFEE1BA6EC72445F6539574 /* UnifiedSource57-header-RenderStyleGetters.cpp */; };
 		7410760E2D6BDCA9000EC9C0 /* PlatformDynamicRangeLimitCocoa.h in Headers */ = {isa = PBXBuildFile; fileRef = 7410760D2D6BDB77000EC9C0 /* PlatformDynamicRangeLimitCocoa.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		74C2F53E29AC9B0B006C5F97 /* ApplePayDeferredPaymentRequest.h in Headers */ = {isa = PBXBuildFile; fileRef = 74C2F53D29AC9B0A006C5F97 /* ApplePayDeferredPaymentRequest.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		74FAB9C02F7B956700DBDF82 /* TextShapingResultAndDisplayList.h in Headers */ = {isa = PBXBuildFile; fileRef = 74FAB9BF2F7B956700DBDF82 /* TextShapingResultAndDisplayList.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		7553CFE8108F473F00EA281E /* TimelineRecordFactory.h in Headers */ = {isa = PBXBuildFile; fileRef = 7553CFE6108F473F00EA281E /* TimelineRecordFactory.h */; };
 		75793E840D0CE0B3007FC0AC /* MessageEvent.h in Headers */ = {isa = PBXBuildFile; fileRef = 75793E810D0CE0B3007FC0AC /* MessageEvent.h */; };
 		75793EC90D0CE72D007FC0AC /* JSMessageEvent.h in Headers */ = {isa = PBXBuildFile; fileRef = 75793EC70D0CE72D007FC0AC /* JSMessageEvent.h */; };
+		76363FA2270F28362356D07D /* UnifiedSource49-header-RenderStyleGetters.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 1D2E7A27D4CA429D6537A1BC /* UnifiedSource49-header-RenderStyleGetters.cpp */; };
 		7694563D1214D97C0007CBAE /* JSDOMTokenList.h in Headers */ = {isa = PBXBuildFile; fileRef = 7694563B1214D97C0007CBAE /* JSDOMTokenList.h */; };
 		76CDD2F31103DA6600680521 /* AccessibilityMenuList.h in Headers */ = {isa = PBXBuildFile; fileRef = 76CDD2ED1103DA6600680521 /* AccessibilityMenuList.h */; };
 		76CDD2F51103DA6600680521 /* AccessibilityMenuListPopup.h in Headers */ = {isa = PBXBuildFile; fileRef = 76CDD2EF1103DA6600680521 /* AccessibilityMenuListPopup.h */; };
@@ -3111,13 +3071,11 @@
 		77D510041ED4F71E00DA4C87 /* JSCredentialRequestOptions.h in Headers */ = {isa = PBXBuildFile; fileRef = 77D50FFF1ED4F70C00DA4C87 /* JSCredentialRequestOptions.h */; };
 		77D510061ED4F72500DA4C87 /* JSCredentialCreationOptions.h in Headers */ = {isa = PBXBuildFile; fileRef = 77D50FFD1ED4F70C00DA4C87 /* JSCredentialCreationOptions.h */; };
 		77D5100B1ED5E28800DA4C87 /* CredentialRequestOptions.h in Headers */ = {isa = PBXBuildFile; fileRef = 77D50FFB1ED4F16C00DA4C87 /* CredentialRequestOptions.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		FC260000000000FC00000003 /* FederatedCredentialRequestOptions.h in Headers */ = {isa = PBXBuildFile; fileRef = FC260000000000FC00000001 /* FederatedCredentialRequestOptions.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		FC260000000000DC00000003 /* IdentityCredentialRequestOptions.h in Headers */ = {isa = PBXBuildFile; fileRef = FC260000000000DC00000001 /* IdentityCredentialRequestOptions.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		FC2600000000000C00000003 /* OTPCredentialRequestOptions.h in Headers */ = {isa = PBXBuildFile; fileRef = FC2600000000000C00000001 /* OTPCredentialRequestOptions.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		77D5100D1ED5E29500DA4C87 /* CredentialCreationOptions.h in Headers */ = {isa = PBXBuildFile; fileRef = 77AAD6851ECFBD3900BFA2D1 /* CredentialCreationOptions.h */; };
 		77D510171ED6022200DA4C87 /* CredentialsContainer.h in Headers */ = {isa = PBXBuildFile; fileRef = 77D510161ED6021B00DA4C87 /* CredentialsContainer.h */; };
 		77D5101C1ED722BF00DA4C87 /* JSCredentialsContainer.h in Headers */ = {isa = PBXBuildFile; fileRef = 77D5101B1ED722B500DA4C87 /* JSCredentialsContainer.h */; };
 		77EF62F412F9DB7400C77BD2 /* JSWebGLVertexArrayObjectOES.h in Headers */ = {isa = PBXBuildFile; fileRef = 77EF62F212F9DB7400C77BD2 /* JSWebGLVertexArrayObjectOES.h */; };
+		78017BC280919209D3AF79BE /* UnifiedSource29-header-RenderStyleGetters.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FE824821D37F631F1A942B28 /* UnifiedSource29-header-RenderStyleGetters.cpp */; };
 		79AC9219109945C80021266E /* JSCompositionEvent.h in Headers */ = {isa = PBXBuildFile; fileRef = 79AC9217109945C80021266E /* JSCompositionEvent.h */; };
 		79F2F5A21091939A000D87CB /* CompositionEvent.h in Headers */ = {isa = PBXBuildFile; fileRef = 79F2F59F1091939A000D87CB /* CompositionEvent.h */; };
 		7A09CEF11F02069B00E93BDB /* FileMonitor.h in Headers */ = {isa = PBXBuildFile; fileRef = 7A09CEEC1F01CC9300E93BDB /* FileMonitor.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -3129,6 +3087,7 @@
 		7A29F57218C69514004D0F81 /* OutOfBandTextTrackPrivateAVF.h in Headers */ = {isa = PBXBuildFile; fileRef = 7A29F57118C69514004D0F81 /* OutOfBandTextTrackPrivateAVF.h */; };
 		7A4279002D8CC19000A60073 /* FontCascadeCocoaInlines.h in Headers */ = {isa = PBXBuildFile; fileRef = 7A4278FF2D8CC06500A60073 /* FontCascadeCocoaInlines.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		7A45033018DB717200377B34 /* BufferedLineReader.h in Headers */ = {isa = PBXBuildFile; fileRef = 7A45032E18DB717200377B34 /* BufferedLineReader.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		7A4D884F2FA285B8002C8D1C /* StyleInheritedRareCSSData.h in Headers */ = {isa = PBXBuildFile; fileRef = 7A4D884D2FA28596002C8D1C /* StyleInheritedRareCSSData.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		7A54858014E02D51006AE05A /* InspectorHistory.h in Headers */ = {isa = PBXBuildFile; fileRef = 7A54857E14E02D51006AE05A /* InspectorHistory.h */; };
 		7A54881714E432A1006AE05A /* DOMPatchSupport.h in Headers */ = {isa = PBXBuildFile; fileRef = 7A54881514E432A1006AE05A /* DOMPatchSupport.h */; };
 		7A5515F5191830A3009687D2 /* YouTubePluginReplacement.h in Headers */ = {isa = PBXBuildFile; fileRef = 7A5515F3191830A3009687D2 /* YouTubePluginReplacement.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -3383,6 +3342,7 @@
 		7E46F6FB1627A2CA00062223 /* JSOESElementIndexUint.h in Headers */ = {isa = PBXBuildFile; fileRef = 7E46F6F91627A2C900062223 /* JSOESElementIndexUint.h */; };
 		7E474E1E12494DC900235364 /* SQLiteDatabaseTrackerClient.h in Headers */ = {isa = PBXBuildFile; fileRef = 7E474E1B12494DC900235364 /* SQLiteDatabaseTrackerClient.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		7E474E1F12494DC900235364 /* SQLiteDatabaseTracker.h in Headers */ = {isa = PBXBuildFile; fileRef = 7E474E1C12494DC900235364 /* SQLiteDatabaseTracker.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		7E4B504918DA764A6B029140 /* UnifiedSource76-header-RenderStyleGetters.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DDD6571342E109928469E047 /* UnifiedSource76-header-RenderStyleGetters.cpp */; };
 		7E4C96DD1AD4483500365A50 /* JSFetchRequest.h in Headers */ = {isa = PBXBuildFile; fileRef = 7E4C96D91AD4483500365A50 /* JSFetchRequest.h */; };
 		7E4C96DD1AD4483500365A51 /* JSReadableStreamSource.h in Headers */ = {isa = PBXBuildFile; fileRef = 7E4C96D91AD4483500365A51 /* JSReadableStreamSource.h */; };
 		7E4C96DD1AD4483500365A52 /* JSFetchEvent.h in Headers */ = {isa = PBXBuildFile; fileRef = 7E4C96D91AD4483500365A52 /* JSFetchEvent.h */; };
@@ -3500,6 +3460,7 @@
 		839947101F50B6FA00E9D86B /* JSDOMFileSystem.h in Headers */ = {isa = PBXBuildFile; fileRef = 8399470E1F50B6F300E9D86B /* JSDOMFileSystem.h */; };
 		839A095D2524F37F00EEF328 /* WorkerOrWorkletScriptController.h in Headers */ = {isa = PBXBuildFile; fileRef = 839A095B2524F37600EEF328 /* WorkerOrWorkletScriptController.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		839AAFED1A0C0C8D00605F99 /* HTMLWBRElement.h in Headers */ = {isa = PBXBuildFile; fileRef = 839AAFEB1A0C0C8D00605F99 /* HTMLWBRElement.h */; };
+		839B297B463A43FE0B6E9D57 /* UnifiedSource74-header-RenderStyleGetters.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 41FF206D0243146B78FDD0FB /* UnifiedSource74-header-RenderStyleGetters.cpp */; };
 		839BE6D524F58762004DF50F /* IIRFilter.h in Headers */ = {isa = PBXBuildFile; fileRef = 839BE6D224F58755004DF50F /* IIRFilter.h */; };
 		839C69D02810D11D00E69BAD /* CommonAtomStrings.h in Headers */ = {isa = PBXBuildFile; fileRef = 839C69CE2810D11C00E69BAD /* CommonAtomStrings.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		83A2ABDB24D86DE000E2D73D /* DelayOptions.h in Headers */ = {isa = PBXBuildFile; fileRef = 83A2ABD824D86DC600E2D73D /* DelayOptions.h */; };
@@ -3541,6 +3502,7 @@
 		83FE7CA71DA9F1A70037237C /* UIEventInit.h in Headers */ = {isa = PBXBuildFile; fileRef = 83FE7CA41DA9F1660037237C /* UIEventInit.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		83FE7CA81DA9F1B60037237C /* EventModifierInit.h in Headers */ = {isa = PBXBuildFile; fileRef = 83FE7CA31DA9F1650037237C /* EventModifierInit.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		83FE90271E307C30003E9199 /* PerformanceMonitor.h in Headers */ = {isa = PBXBuildFile; fileRef = 83FE90261E307C1C003E9199 /* PerformanceMonitor.h */; };
+		83FFC8AB79C6A41367EBD104 /* UnifiedSource14-header-RenderStyleGetters.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 6A5A653EE2BD51501F778B98 /* UnifiedSource14-header-RenderStyleGetters.cpp */; };
 		8419D2A7120D92D000141F8F /* SVGPathByteStream.h in Headers */ = {isa = PBXBuildFile; fileRef = 8419D2A4120D92D000141F8F /* SVGPathByteStream.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		8419D2A9120D92D000141F8F /* SVGPathByteStreamBuilder.h in Headers */ = {isa = PBXBuildFile; fileRef = 8419D2A6120D92D000141F8F /* SVGPathByteStreamBuilder.h */; };
 		8419D2AD120D92FC00141F8F /* SVGPathByteStreamSource.h in Headers */ = {isa = PBXBuildFile; fileRef = 8419D2AB120D92FC00141F8F /* SVGPathByteStreamSource.h */; };
@@ -3625,6 +3587,7 @@
 		86D196DD29ACE0930083B077 /* TextManipulationItemIdentifier.h in Headers */ = {isa = PBXBuildFile; fileRef = 86D196DC29ACE0920083B077 /* TextManipulationItemIdentifier.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		86D982F7125C154000AD9E3D /* DocumentEventTiming.h in Headers */ = {isa = PBXBuildFile; fileRef = 86D982F6125C154000AD9E3D /* DocumentEventTiming.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		86EB71C0298C0A0F00C1DC77 /* PortIdentifier.h in Headers */ = {isa = PBXBuildFile; fileRef = 86EB71BF298C0A0E00C1DC77 /* PortIdentifier.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		878F162BB63DC4D461E1BBE5 /* UnifiedSource2-header-RenderStyleGetters.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 89C20A7AC4BA0F7144DDF0B9 /* UnifiedSource2-header-RenderStyleGetters.cpp */; };
 		898785F5122E1EAC003AABDA /* JSFileReaderSync.h in Headers */ = {isa = PBXBuildFile; fileRef = 898785F3122E1EAC003AABDA /* JSFileReaderSync.h */; };
 		8A00EECA2A680146006A53A2 /* EXTDepthClamp.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A00EEC72A680139006A53A2 /* EXTDepthClamp.h */; };
 		8A054533283CF17F00F498E7 /* EXTTextureNorm16.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A054532283CF13F00F498E7 /* EXTTextureNorm16.h */; };
@@ -3659,16 +3622,20 @@
 		8AA642082A672D0300A84D49 /* EXTClipControl.h in Headers */ = {isa = PBXBuildFile; fileRef = 8AA642072A672CAC00A84D49 /* EXTClipControl.h */; };
 		8AA9BACF2A73DA11001F6766 /* EXTTextureMirrorClampToEdge.h in Headers */ = {isa = PBXBuildFile; fileRef = 8AA9BACE2A73DA07001F6766 /* EXTTextureMirrorClampToEdge.h */; };
 		8AAAC5CD2840140500D08AE5 /* OESDrawBuffersIndexed.h in Headers */ = {isa = PBXBuildFile; fileRef = 8AAAC5CA284013D600D08AE5 /* OESDrawBuffersIndexed.h */; };
+		8AAF3C352879D5D7368D5480 /* UnifiedSource56-header-RenderStyleGetters.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A7925FD267D4C894F38E1AD7 /* UnifiedSource56-header-RenderStyleGetters.cpp */; };
 		8AB4BC77126FDB7100DEB727 /* IgnoreDestructiveWriteCountIncrementer.h in Headers */ = {isa = PBXBuildFile; fileRef = 8AB4BC76126FDB7100DEB727 /* IgnoreDestructiveWriteCountIncrementer.h */; };
 		8ACAA394299184E80075D05C /* EXTPolygonOffsetClamp.h in Headers */ = {isa = PBXBuildFile; fileRef = 8ACAA393299184CC0075D05C /* EXTPolygonOffsetClamp.h */; };
 		8ACAED3C28B8165700F215BA /* WebGLProvokingVertex.h in Headers */ = {isa = PBXBuildFile; fileRef = 8ACAED3B28B8160300F215BA /* WebGLProvokingVertex.h */; };
 		8ACCAD3D295A5A1C00788F5E /* CustomElementFormValue.h in Headers */ = {isa = PBXBuildFile; fileRef = 8ACCAD3C295A5A1B00788F5E /* CustomElementFormValue.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		8ACE88D7285C8FB80082C0FC /* WebGLDrawInstancedBaseVertexBaseInstance.h in Headers */ = {isa = PBXBuildFile; fileRef = 8ACE88D5285C8F660082C0FC /* WebGLDrawInstancedBaseVertexBaseInstance.h */; };
+		8ACF57C9B7AF33922400D828 /* UnifiedSource4-header-RenderStyleGetters.cpp in Sources */ = {isa = PBXBuildFile; fileRef = C330BEA189D73D0667F53763 /* UnifiedSource4-header-RenderStyleGetters.cpp */; };
 		8AE7A4442A6A6D2200614A30 /* NVShaderNoperspectiveInterpolation.h in Headers */ = {isa = PBXBuildFile; fileRef = 8AE7A4422A6A6D1600614A30 /* NVShaderNoperspectiveInterpolation.h */; };
 		8AF4E55611DC5A36000ED3DE /* PerformanceNavigation.h in Headers */ = {isa = PBXBuildFile; fileRef = 8AF4E55311DC5A36000ED3DE /* PerformanceNavigation.h */; };
 		8AF4E55C11DC5A63000ED3DE /* PerformanceTiming.h in Headers */ = {isa = PBXBuildFile; fileRef = 8AF4E55911DC5A63000ED3DE /* PerformanceTiming.h */; };
 		8B5216F72DEE4E75003BC21B /* LazyLoadModelObserver.h in Headers */ = {isa = PBXBuildFile; fileRef = 8B5216F42DEE4E75003BC21B /* LazyLoadModelObserver.h */; };
+		8D8AB55246EA6D3E46D7E2EF /* UnifiedSource38-header-RenderStyleGetters.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BCFF63713748594F7E1BE330 /* UnifiedSource38-header-RenderStyleGetters.cpp */; };
 		8E4C96DD1AD4483500365A50 /* JSFetchResponse.h in Headers */ = {isa = PBXBuildFile; fileRef = 8E4C96D91AD4483500365A50 /* JSFetchResponse.h */; };
+		8F9B85867BCC1EE38784EE83 /* UnifiedSource71-header-RenderStyleGetters.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB591C358F2E176568F6C0AA /* UnifiedSource71-header-RenderStyleGetters.cpp */; };
 		9001774112E0347800648462 /* OESStandardDerivatives.h in Headers */ = {isa = PBXBuildFile; fileRef = 9001773E12E0347800648462 /* OESStandardDerivatives.h */; };
 		9001788112E0370700648462 /* JSOESStandardDerivatives.h in Headers */ = {isa = PBXBuildFile; fileRef = 9001787F12E0370700648462 /* JSOESStandardDerivatives.h */; };
 		900C20842CAF8232002C79C5 /* URLPattern.h in Headers */ = {isa = PBXBuildFile; fileRef = 900C207A2CAF8225002C79C5 /* URLPattern.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -3691,6 +3658,7 @@
 		9175CE5C21E281ED00DF2C28 /* JSInspectorAuditDOMObject.h in Headers */ = {isa = PBXBuildFile; fileRef = 9175CE5821E281EC00DF2C28 /* JSInspectorAuditDOMObject.h */; };
 		9175CE5E21E281ED00DF2C27 /* InspectorAuditAccessibilityObject.h in Headers */ = {isa = PBXBuildFile; fileRef = 9175CE5A21E281ED00DF2C27 /* InspectorAuditAccessibilityObject.h */; };
 		9175CE5E21E281ED00DF2C28 /* JSInspectorAuditAccessibilityObject.h in Headers */ = {isa = PBXBuildFile; fileRef = 9175CE5A21E281ED00DF2C28 /* JSInspectorAuditAccessibilityObject.h */; };
+		9191194A55A2ECCF49FF73B3 /* UnifiedSource23-header-RenderStyleGetters.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 9BF8F60FC54FDA5A320BD129 /* UnifiedSource23-header-RenderStyleGetters.cpp */; };
 		91B8F0B521953D65000C2B00 /* CertificateSummary.h in Headers */ = {isa = PBXBuildFile; fileRef = 91B8F0B321953D65000C2B00 /* CertificateSummary.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		91B952241F58A58F00931DC2 /* RecordingSwizzleType.h in Headers */ = {isa = PBXBuildFile; fileRef = 91B952221F58A58000931DC2 /* RecordingSwizzleType.h */; };
 		91C487692D49EAEE0089ADF4 /* PageTimelineAgent.h in Headers */ = {isa = PBXBuildFile; fileRef = 91C487662D49EADA0089ADF4 /* PageTimelineAgent.h */; };
@@ -3996,6 +3964,7 @@
 		95EAD593266EF5CD004B9CF1 /* JSApplePayRecurringPaymentDateUnit.h in Headers */ = {isa = PBXBuildFile; fileRef = 95EAD591266EF5CC004B9CF1 /* JSApplePayRecurringPaymentDateUnit.h */; };
 		95EAD594266EF5D4004B9CF1 /* JSApplePayPaymentRequest.h in Headers */ = {isa = PBXBuildFile; fileRef = 7C6579EC1E00856600E3A27A /* JSApplePayPaymentRequest.h */; };
 		95EAD597266EF60B004B9CF1 /* JSApplePayShippingContactEditingMode.h in Headers */ = {isa = PBXBuildFile; fileRef = 95EAD595266EF609004B9CF1 /* JSApplePayShippingContactEditingMode.h */; };
+		95ED3B19C2F4830551DC70D0 /* UnifiedSource68-header-RenderStyleGetters.cpp in Sources */ = {isa = PBXBuildFile; fileRef = D8A6C642D6DAE088EF53F376 /* UnifiedSource68-header-RenderStyleGetters.cpp */; };
 		95F45D27264DFBF100D0B8B8 /* PageColorSampler.h in Headers */ = {isa = PBXBuildFile; fileRef = 95F45D26264DFBEB00D0B8B8 /* PageColorSampler.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		95FB662526D7033C0068AC67 /* ApplePayAMSUIPaymentHandler.h in Headers */ = {isa = PBXBuildFile; fileRef = 95FB662126D7033B0068AC67 /* ApplePayAMSUIPaymentHandler.h */; };
 		95FB662626D7033C0068AC67 /* ApplePayAMSUIRequest.h in Headers */ = {isa = PBXBuildFile; fileRef = 95FB662226D7033B0068AC67 /* ApplePayAMSUIRequest.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -4031,6 +4000,7 @@
 		9759E94314EF1CF80026A2DD /* TextTrackCue.h in Headers */ = {isa = PBXBuildFile; fileRef = 9759E93914EF1CF80026A2DD /* TextTrackCue.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		9759E94614EF1CF80026A2DD /* TextTrackCueList.h in Headers */ = {isa = PBXBuildFile; fileRef = 9759E93C14EF1CF80026A2DD /* TextTrackCueList.h */; };
 		9759E94914EF1D490026A2DD /* LoadableTextTrack.h in Headers */ = {isa = PBXBuildFile; fileRef = 9759E94814EF1D490026A2DD /* LoadableTextTrack.h */; };
+		975B87DD21C609E77AF85C24 /* UnifiedSource44-header-RenderStyleGetters.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BE1A40333AB79B5518B8B658 /* UnifiedSource44-header-RenderStyleGetters.cpp */; };
 		975CA28B130365F800E99AD9 /* Crypto.h in Headers */ = {isa = PBXBuildFile; fileRef = 975CA288130365F800E99AD9 /* Crypto.h */; };
 		975CA2A21303679D00E99AD9 /* JSCrypto.h in Headers */ = {isa = PBXBuildFile; fileRef = 975CA2A01303679D00E99AD9 /* JSCrypto.h */; };
 		97627B8E14FB3CEE002CDCA1 /* ContextDestructionObserver.h in Headers */ = {isa = PBXBuildFile; fileRef = 97627B8C14FB3CEE002CDCA1 /* ContextDestructionObserver.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -4099,6 +4069,7 @@
 		97C471DC12F925BD0086354B /* ContentSecurityPolicy.h in Headers */ = {isa = PBXBuildFile; fileRef = 97C471DA12F925BD0086354B /* ContentSecurityPolicy.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		97D2AD0414B823A60093DF32 /* LocalDOMWindowProperty.h in Headers */ = {isa = PBXBuildFile; fileRef = 97D2AD0214B823A60093DF32 /* LocalDOMWindowProperty.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		97DCE20210807C750057D394 /* HistoryController.h in Headers */ = {isa = PBXBuildFile; fileRef = 97DCE20010807C750057D394 /* HistoryController.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		97FAD817765D9157D255A70B /* UnifiedSource52-header-RenderStyleGetters.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3A0029C243BF23321C43D20D /* UnifiedSource52-header-RenderStyleGetters.cpp */; };
 		9831AE4A154225C900FE2644 /* ReferrerPolicy.h in Headers */ = {isa = PBXBuildFile; fileRef = 9831AE49154225A200FE2644 /* ReferrerPolicy.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		984264F112D5280A000D88A4 /* LinkLoaderClient.h in Headers */ = {isa = PBXBuildFile; fileRef = 984264EF12D5280A000D88A4 /* LinkLoaderClient.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		985BB96E13A94058007A0B69 /* LinkRelAttribute.h in Headers */ = {isa = PBXBuildFile; fileRef = 985BB96C13A94058007A0B69 /* LinkRelAttribute.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -4110,8 +4081,10 @@
 		994C603A253A277300BDF060 /* InspectorFrontendAPIDispatcher.h in Headers */ = {isa = PBXBuildFile; fileRef = 994C6037253A277200BDF060 /* InspectorFrontendAPIDispatcher.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		996E59DF1DF0128D006612B9 /* NavigatorWebDriver.h in Headers */ = {isa = PBXBuildFile; fileRef = 996E59DC1DF00D90006612B9 /* NavigatorWebDriver.h */; };
 		9990E3F071D846D88700442D /* SpinnerSprite@2x.png in Copy Modern Media Controls Images */ = {isa = PBXBuildFile; fileRef = 71D474A42462E834002F0106 /* SpinnerSprite@2x.png */; platformFilters = (watchos, ); };
+		997C7BD0D5FF097D76C4E1F5 /* UnifiedSource69-header-RenderStyleGetters.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0DB768C810AA85BE70BB2E08 /* UnifiedSource69-header-RenderStyleGetters.cpp */; };
 		9995243E2E8F0CA50093C3E0 /* InspectorNetworkIntercept.h in Headers */ = {isa = PBXBuildFile; fileRef = 9995243B2E8F0CA50093C3E0 /* InspectorNetworkIntercept.h */; };
 		999524422E8F1E420093C3E0 /* InspectorThreadableLoaderClient.h in Headers */ = {isa = PBXBuildFile; fileRef = 9995243F2E8F1E420093C3E0 /* InspectorThreadableLoaderClient.h */; };
+		9995EAAA019FDD08826EB9FB /* UnifiedSource77-header-RenderStyleGetters.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 52D2ED227687272BB8AC7430 /* UnifiedSource77-header-RenderStyleGetters.cpp */; };
 		99A5144D2D5AA7B200937177 /* AutomationInstrumentation.h in Headers */ = {isa = PBXBuildFile; fileRef = 99A5144A2D5AA74200937177 /* AutomationInstrumentation.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		99C2CC9F2E8DFD890008FCDF /* InspectorResourceUtilities.h in Headers */ = {isa = PBXBuildFile; fileRef = 99C2CC9C2E8DFD890008FCDF /* InspectorResourceUtilities.h */; };
 		99D1B2D323AC143100811CF0 /* InspectorDebuggableType.h in Headers */ = {isa = PBXBuildFile; fileRef = 99D1B2D123AC143000811CF0 /* InspectorDebuggableType.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -4398,6 +4371,7 @@
 		A1F76B551F44D2C70014C318 /* PaymentShippingOption.h in Headers */ = {isa = PBXBuildFile; fileRef = A1F76B521F44D2C70014C318 /* PaymentShippingOption.h */; };
 		A1F76B5B1F44D3B20014C318 /* PaymentComplete.h in Headers */ = {isa = PBXBuildFile; fileRef = A1F76B581F44D3B20014C318 /* PaymentComplete.h */; };
 		A1FAC4FE2F4ED86A001A00F0 /* CoreMedia.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A1FAC4FD2F4ED869001A00F0 /* CoreMedia.framework */; };
+		A2197BB62750D9B81D25122B /* UnifiedSource73-header-RenderStyleGetters.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BAF547B3E0A08ACCDA0FD3EE /* UnifiedSource73-header-RenderStyleGetters.cpp */; };
 		A31C4E4F16E02AB4002F7957 /* OESTextureHalfFloat.h in Headers */ = {isa = PBXBuildFile; fileRef = A31C4E4E16E02AB4002F7957 /* OESTextureHalfFloat.h */; };
 		A31C4E5416E02B40002F7957 /* JSOESTextureHalfFloat.h in Headers */ = {isa = PBXBuildFile; fileRef = A31C4E5316E02B40002F7957 /* JSOESTextureHalfFloat.h */; };
 		A336CF322B86492700464599 /* TrustedType.h in Headers */ = {isa = PBXBuildFile; fileRef = A32E83D82B7CD9250055FE75 /* TrustedType.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -4659,6 +4633,7 @@
 		A88DD4870B4629A300C02990 /* PathTraversalState.h in Headers */ = {isa = PBXBuildFile; fileRef = A88DD4860B4629A300C02990 /* PathTraversalState.h */; };
 		A89943280B42338800D7C802 /* BitmapImage.h in Headers */ = {isa = PBXBuildFile; fileRef = A89943260B42338700D7C802 /* BitmapImage.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		A89CCC530F44E98100B5DA10 /* ReplaceNodeWithSpanCommand.h in Headers */ = {isa = PBXBuildFile; fileRef = A89CCC510F44E98100B5DA10 /* ReplaceNodeWithSpanCommand.h */; };
+		A8A0CCCAC9805312E1E53FC0 /* UnifiedSource33-header-RenderStyleGetters.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 5DE923E85927C51244CECFDD /* UnifiedSource33-header-RenderStyleGetters.cpp */; };
 		A8C228A111D5722E00D5A7D3 /* DecodedDataDocumentParser.h in Headers */ = {isa = PBXBuildFile; fileRef = A8C2289F11D5722E00D5A7D3 /* DecodedDataDocumentParser.h */; };
 		A8C402931348B2220063F1E5 /* BidiRunList.h in Headers */ = {isa = PBXBuildFile; fileRef = A8C402921348B2220063F1E5 /* BidiRunList.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		A8C4A7FD09D563270003AC8D /* StyledElement.h in Headers */ = {isa = PBXBuildFile; fileRef = A8C4A7EB09D563270003AC8D /* StyledElement.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -4738,6 +4713,7 @@
 		AA2A5AD616A4861600975A25 /* LocalDOMWindowSpeechSynthesis.h in Headers */ = {isa = PBXBuildFile; fileRef = AA2A5AB916A485D500975A25 /* LocalDOMWindowSpeechSynthesis.h */; };
 		AA478A7F16CD70C3007D1BB4 /* WebAccessibilityObjectWrapperMac.h in Headers */ = {isa = PBXBuildFile; fileRef = AA478A7D16CD70C3007D1BB4 /* WebAccessibilityObjectWrapperMac.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		AA4C3A770B2B1679002334A2 /* InlineStyleSheetOwner.h in Headers */ = {isa = PBXBuildFile; fileRef = AA4C3A750B2B1679002334A2 /* InlineStyleSheetOwner.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		AA4F2A23284FF2D478722264 /* UnifiedSource61-header-RenderStyleGetters.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3EB98985C78E4C2A4C58889D /* UnifiedSource61-header-RenderStyleGetters.cpp */; };
 		AA5F3B8D16CC33D100455EB0 /* PlatformSpeechSynthesizerMock.h in Headers */ = {isa = PBXBuildFile; fileRef = AAE27B7516CBFC0D00623043 /* PlatformSpeechSynthesizerMock.h */; };
 		AA5F3B9116CC5BEB00455EB0 /* CoreFoundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = AA5F3B9016CC5BEB00455EB0 /* CoreFoundation.framework */; };
 		AA7FEEA716A4E6F3004C0C33 /* JSSpeechSynthesisUtterance.h in Headers */ = {isa = PBXBuildFile; fileRef = AA7FEE9F16A4E6F3004C0C33 /* JSSpeechSynthesisUtterance.h */; };
@@ -4753,6 +4729,7 @@
 		ABB5419F0ACDDFE4002820EB /* RenderListBox.h in Headers */ = {isa = PBXBuildFile; fileRef = ABB5419D0ACDDFE4002820EB /* RenderListBox.h */; };
 		ABC128770B33AA6D00C693D5 /* PopupMenuClient.h in Headers */ = {isa = PBXBuildFile; fileRef = ABC128760B33AA6D00C693D5 /* PopupMenuClient.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		ABDDFE7A0A5C6E7000A3E11D /* RenderMenuList.h in Headers */ = {isa = PBXBuildFile; fileRef = ABDDFE740A5C6E7000A3E11D /* RenderMenuList.h */; };
+		AC70233498D951EF103BFC93 /* UnifiedSource53-header-RenderStyleGetters.cpp in Sources */ = {isa = PBXBuildFile; fileRef = EBD345B9F06BCC0152D3057C /* UnifiedSource53-header-RenderStyleGetters.cpp */; };
 		AD20B18D18E9D237005A8083 /* JSNodeListCustom.h in Headers */ = {isa = PBXBuildFile; fileRef = AD20B18C18E9D216005A8083 /* JSNodeListCustom.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		AD4495F4141FC08900541EDF /* EventListenerMap.h in Headers */ = {isa = PBXBuildFile; fileRef = AD4495F2141FC08900541EDF /* EventListenerMap.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		AD49914318F0815100BF0092 /* HTMLUnknownElement.h in Headers */ = {isa = PBXBuildFile; fileRef = AD49914118F0815100BF0092 /* HTMLUnknownElement.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -4761,7 +4738,9 @@
 		AD726FED16DA1171003A4E6D /* JSCSSStyleDeclarationCustom.h in Headers */ = {isa = PBXBuildFile; fileRef = AD726FEA16D9F40B003A4E6D /* JSCSSStyleDeclarationCustom.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		AD726FEE16DA11BC003A4E6D /* JSStyleSheetCustom.h in Headers */ = {isa = PBXBuildFile; fileRef = AD726FEC16D9F4B9003A4E6D /* JSStyleSheetCustom.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		AD726FEF16DA11F5003A4E6D /* JSCSSRuleCustom.h in Headers */ = {isa = PBXBuildFile; fileRef = AD726FE916D9F40A003A4E6D /* JSCSSRuleCustom.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		AD7DA56EADCC268C3A3815D3 /* UnifiedSource37-header-RenderStyleGetters.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 978CE10C711D6B12D9FBC9C9 /* UnifiedSource37-header-RenderStyleGetters.cpp */; };
 		ADBAD6EF1BCDD95700381325 /* ResourceUsageOverlay.h in Headers */ = {isa = PBXBuildFile; fileRef = ADBAD6ED1BCDD95000381325 /* ResourceUsageOverlay.h */; };
+		ADC0EC39614A71986AA229F3 /* UnifiedSource65-header-RenderStyleGetters.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E3BD27846EEC386B691B9101 /* UnifiedSource65-header-RenderStyleGetters.cpp */; };
 		ADDA94C219687AA500453029 /* JSDocumentCustom.h in Headers */ = {isa = PBXBuildFile; fileRef = ADDA94BF19686F8000453029 /* JSDocumentCustom.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		ADDF1AD71257CC1A1133B644 /* RenderSVGPath.h in Headers */ = {isa = PBXBuildFile; fileRef = ADDF1AD51257CC1A1133B644 /* RenderSVGPath.h */; };
 		ADDF1AD71257CD9A0003A759 /* LegacyRenderSVGPath.h in Headers */ = {isa = PBXBuildFile; fileRef = ADDF1AD51257CD9A0003A759 /* LegacyRenderSVGPath.h */; };
@@ -4785,6 +4764,7 @@
 		AED243692C939A6800E8649D /* AuthenticationResponseJSON.h in Headers */ = {isa = PBXBuildFile; fileRef = AED243682C939A6800E8649D /* AuthenticationResponseJSON.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		AF53F56C6CD24319D07D951A /* SkipForward10.svg in Copy Modern Media Controls Images */ = {isa = PBXBuildFile; fileRef = D7E7E02D100D3C3969DAEB93 /* SkipForward10.svg */; platformFilters = (macos, ); };
 		B0358DEB688088BA80FD9DB4 /* Airplay.svg in Copy Modern Media Controls Images */ = {isa = PBXBuildFile; fileRef = B5072BE12210266CE7E320FC /* Airplay.svg */; platformFilters = (macos, ); };
+		AEDB39B3CF27CEA5073F99DD /* UnifiedSource64-header-RenderStyleGetters.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7C61AFF4898CB7897BCB412E /* UnifiedSource64-header-RenderStyleGetters.cpp */; };
 		B10B6980140C174000BC1C26 /* WebVTTToken.h in Headers */ = {isa = PBXBuildFile; fileRef = B10B697D140C174000BC1C26 /* WebVTTToken.h */; };
 		B10B6982140C174000BC1C26 /* WebVTTTokenizer.h in Headers */ = {isa = PBXBuildFile; fileRef = B10B697F140C174000BC1C26 /* WebVTTTokenizer.h */; };
 		B1AD4E7413A12A4600846B27 /* TextTrackLoader.h in Headers */ = {isa = PBXBuildFile; fileRef = B1AD4E7213A12A4600846B27 /* TextTrackLoader.h */; };
@@ -5035,6 +5015,7 @@
 		B2FA3E150AB75A6F000E5AC4 /* JSSVGUseElement.h in Headers */ = {isa = PBXBuildFile; fileRef = B2FA3D2D0AB75A6F000E5AC4 /* JSSVGUseElement.h */; };
 		B2FA3E170AB75A6F000E5AC4 /* JSSVGViewElement.h in Headers */ = {isa = PBXBuildFile; fileRef = B2FA3D2F0AB75A6F000E5AC4 /* JSSVGViewElement.h */; };
 		B3CFA73DA066891D4CC6D3B9 /* ExitFullscreen.svg in Copy Modern Media Controls Images */ = {isa = PBXBuildFile; fileRef = 0AD8DA712698235A6D8C759A /* ExitFullscreen.svg */; platformFilters = (ios, xros, ); };
+		B483E80A399B821282389698 /* UnifiedSource8-header-RenderStyleGetters.cpp in Sources */ = {isa = PBXBuildFile; fileRef = B4059720D99B652A638A10FB /* UnifiedSource8-header-RenderStyleGetters.cpp */; };
 		B51A2F3F17D7D3AE0072517A /* ImageQualityController.h in Headers */ = {isa = PBXBuildFile; fileRef = B51A2F3E17D7D3A40072517A /* ImageQualityController.h */; };
 		B5320D6B122A24E9002D1440 /* FontPlatformData.h in Headers */ = {isa = PBXBuildFile; fileRef = B5320D69122A24E9002D1440 /* FontPlatformData.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		B562DB6017D3CD630010AF96 /* HTMLElementTypeHelpers.h in Headers */ = {isa = PBXBuildFile; fileRef = B562DB5E17D3CD560010AF96 /* HTMLElementTypeHelpers.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -5059,6 +5040,8 @@
 		B6F2010D2EAC180400BBF4AA /* ShareableSpatialImage.h in Headers */ = {isa = PBXBuildFile; fileRef = B6F201092EAC180400BBF4AA /* ShareableSpatialImage.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		B6F201102EAC22B200BBF4AA /* ShareableSpatialImage.cpp in Sources */ = {isa = PBXBuildFile; fileRef = B6F2010A2EAC180400BBF4AA /* ShareableSpatialImage.cpp */; };
 		B71FE6DF11091CB300DAEF77 /* PrintContext.h in Headers */ = {isa = PBXBuildFile; fileRef = B776D43A1104525D00BEB0EC /* PrintContext.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		B7BF4500CD301A381100C574 /* UnifiedSource28-header-RenderStyleGetters.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BAECA0A8276147146143052D /* UnifiedSource28-header-RenderStyleGetters.cpp */; };
+		B847DE321D298447456B661B /* UnifiedSource36-header-RenderStyleGetters.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 75FC345681CEC46DD9AE1331 /* UnifiedSource36-header-RenderStyleGetters.cpp */; };
 		B8DBDB4C130B0F8A00F5CDB1 /* SetSelectionCommand.h in Headers */ = {isa = PBXBuildFile; fileRef = B8DBDB48130B0F8A00F5CDB1 /* SetSelectionCommand.h */; };
 		B8DBDB4E130B0F8A00F5CDB1 /* SpellingCorrectionCommand.h in Headers */ = {isa = PBXBuildFile; fileRef = B8DBDB4A130B0F8A00F5CDB1 /* SpellingCorrectionCommand.h */; };
 		B9CA3B402CAB1D3E00B2607C /* SpatialImageControls.h in Headers */ = {isa = PBXBuildFile; fileRef = B9CA3B3E2CAB1D3E00B2607C /* SpatialImageControls.h */; };
@@ -5321,6 +5304,7 @@
 		BC4F32BB2E89C51D00F6AEC1 /* StyleTransformFunction.h in Headers */ = {isa = PBXBuildFile; fileRef = BC4F32B92E89C51400F6AEC1 /* StyleTransformFunction.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		BC4F32CC2E8C518D00F6AEC1 /* StyleAccentColor.h in Headers */ = {isa = PBXBuildFile; fileRef = BC4F32CA2E8C518300F6AEC1 /* StyleAccentColor.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		BC51156E12B1749C00C96754 /* ScrollAnimatorMac.mm in Sources */ = {isa = PBXBuildFile; fileRef = BC51156D12B1749C00C96754 /* ScrollAnimatorMac.mm */; };
+		BC53A15AA2470A2CA012533D /* UnifiedSource3-header-RenderStyleGetters.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 004D65C61D84DB1DC5F43DBB /* UnifiedSource3-header-RenderStyleGetters.cpp */; };
 		BC53C5F50DA56B920021EB5D /* Gradient.h in Headers */ = {isa = PBXBuildFile; fileRef = BC53C5F40DA56B920021EB5D /* Gradient.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		BC53C6920DA591140021EB5D /* CSSGradientValue.h in Headers */ = {isa = PBXBuildFile; fileRef = BC53C6910DA591140021EB5D /* CSSGradientValue.h */; };
 		BC53D911114310CC000D817E /* WebCoreJSClientData.h in Headers */ = {isa = PBXBuildFile; fileRef = BC53D910114310CC000D817E /* WebCoreJSClientData.h */; };
@@ -5807,6 +5791,8 @@
 		BEAA24022C34A9E600C37BBE /* CSSNestedDeclarations.h in Headers */ = {isa = PBXBuildFile; fileRef = BEAA23FF2C34A63900C37BBE /* CSSNestedDeclarations.h */; };
 		BEF29EEB1715DD0900C4B4C9 /* AudioTrackPrivate.h in Headers */ = {isa = PBXBuildFile; fileRef = BEF29EE91715DD0900C4B4C9 /* AudioTrackPrivate.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		BEF29EEC1715DD0900C4B4C9 /* VideoTrackPrivate.h in Headers */ = {isa = PBXBuildFile; fileRef = BEF29EEA1715DD0900C4B4C9 /* VideoTrackPrivate.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		BF015D1C9196498DCDBB6D33 /* UnifiedSource67-header-RenderStyleGetters.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 886246164BC21FF991E1CACF /* UnifiedSource67-header-RenderStyleGetters.cpp */; };
+		BFA1C0CAB43B888E8D099BB9 /* UnifiedSource45-header-RenderStyleGetters.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B4EE1CF43D75281121A19D6 /* UnifiedSource45-header-RenderStyleGetters.cpp */; };
 		C0C054CB1118C8E400CE2636 /* CodeGenerator.pm in Headers */ = {isa = PBXBuildFile; fileRef = 93F8B3050A300FE100F61AB8 /* CodeGenerator.pm */; settings = {ATTRIBUTES = (Private, ); }; };
 		C0C054CC1118C8E400CE2636 /* generate-bindings.pl in Headers */ = {isa = PBXBuildFile; fileRef = 93F8B3070A300FEA00F61AB8 /* generate-bindings.pl */; settings = {ATTRIBUTES = (Private, ); }; };
 		C0C054CD1118C8E400CE2636 /* IDLParser.pm in Headers */ = {isa = PBXBuildFile; fileRef = 14813BF309EDF88E00F757E1 /* IDLParser.pm */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -5827,6 +5813,7 @@
 		C21DF2EA1D9E4E9900F5B24C /* CSSFontVariationValue.h in Headers */ = {isa = PBXBuildFile; fileRef = C21DF2E81D9E4E9900F5B24C /* CSSFontVariationValue.h */; };
 		C2458E631FE897B000594759 /* FontCacheCoreText.h in Headers */ = {isa = PBXBuildFile; fileRef = C2458E611FE8979E00594759 /* FontCacheCoreText.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		C26017A41C72DC9900F74A16 /* CSSFontFaceSet.h in Headers */ = {isa = PBXBuildFile; fileRef = C26017A21C72DC9900F74A16 /* CSSFontFaceSet.h */; };
+		C26A456A2363044F1B0A275D /* UnifiedSource9-header-RenderStyleGetters.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 8B4936F9C7F6D9A2071F9A39 /* UnifiedSource9-header-RenderStyleGetters.cpp */; };
 		C280833F1C6DC26F001451B6 /* JSFontFace.h in Headers */ = {isa = PBXBuildFile; fileRef = C280833E1C6DC22C001451B6 /* JSFontFace.h */; };
 		C2AB0AF71E6B3C6C001348C5 /* FontSelectionAlgorithm.h in Headers */ = {isa = PBXBuildFile; fileRef = C2AB0AF51E6B3C6C001348C5 /* FontSelectionAlgorithm.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		C2E1C286D0E15968C7E2B657 /* Volume2.svg in Copy Modern Media Controls Images */ = {isa = PBXBuildFile; fileRef = 565E7E6449095E4933B5F978 /* Volume2.svg */; platformFilters = (macos, ); };
@@ -5883,6 +5870,7 @@
 		CBB6B2D41CB7AE51009EDE1A /* LinkPreloadResourceClients.h in Headers */ = {isa = PBXBuildFile; fileRef = CBB6B2D21CB7ADD0009EDE1A /* LinkPreloadResourceClients.h */; };
 		CBC2D2301CE5B8A100D1880B /* ResourceTimingInformation.h in Headers */ = {isa = PBXBuildFile; fileRef = CBC2D22E1CE5B77D00D1880B /* ResourceTimingInformation.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		CC248C7C9216330FE11E8329 /* Volume2-RTL.svg in Copy Modern Media Controls Images */ = {isa = PBXBuildFile; fileRef = BBC79ECC2A4F6096D62983F5 /* Volume2-RTL.svg */; platformFilters = (ios, xros, ); };
+		CCB55ECCC1A9A69CDD08157E /* UnifiedSource50-header-RenderStyleGetters.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 636E4E69584B74FA6C92D248 /* UnifiedSource50-header-RenderStyleGetters.cpp */; };
 		CCC2B51415F613060048CDD6 /* DeviceClient.h in Headers */ = {isa = PBXBuildFile; fileRef = CCC2B51015F613060048CDD6 /* DeviceClient.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		CCC2B51615F613060048CDD6 /* DeviceController.h in Headers */ = {isa = PBXBuildFile; fileRef = CCC2B51215F613060048CDD6 /* DeviceController.h */; };
 		CD0445E12992F1740059B997 /* WebAVPlayerLayerView.h in Headers */ = {isa = PBXBuildFile; fileRef = CD0445DF2992F1740059B997 /* WebAVPlayerLayerView.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -6246,6 +6234,7 @@
 		D3F3D3641A69B1900059FC2B /* JSWebGL2RenderingContext.h in Headers */ = {isa = PBXBuildFile; fileRef = D3F3D3621A69B1900059FC2B /* JSWebGL2RenderingContext.h */; };
 		D3F3D36A1A69B7B90059FC2B /* WebGLRenderingContextBase.h in Headers */ = {isa = PBXBuildFile; fileRef = D3F3D35F1A69A5060059FC2B /* WebGLRenderingContextBase.h */; };
 		D3F3D36E1A69B7E00059FC2B /* WebGL2RenderingContext.h in Headers */ = {isa = PBXBuildFile; fileRef = D3F3D35C1A69A5060059FC2B /* WebGL2RenderingContext.h */; };
+		D4729C709180E3A094B1EDEF /* UnifiedSource63-header-RenderStyleGetters.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7295D020E0F0C07C868B904C /* UnifiedSource63-header-RenderStyleGetters.cpp */; };
 		D6022D882F5A48AE007BC32C /* ICUSearcher.h in Headers */ = {isa = PBXBuildFile; fileRef = D6022D862F5A489D007BC32C /* ICUSearcher.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		D619A308144E00BE004BC302 /* ChildListMutationScope.h in Headers */ = {isa = PBXBuildFile; fileRef = D619A306144E00BE004BC302 /* ChildListMutationScope.h */; };
 		D640B2462E30461D00EB6C49 /* NavigatorUAData.h in Headers */ = {isa = PBXBuildFile; fileRef = D640B2422E2F09F900EB6C49 /* NavigatorUAData.h */; };
@@ -6253,6 +6242,7 @@
 		D640B24F2E3058D500EB6C49 /* UADataValues.h in Headers */ = {isa = PBXBuildFile; fileRef = D640B24C2E3058C800EB6C49 /* UADataValues.h */; };
 		D6489D26166FFCF1007C031B /* JSHTMLTemplateElement.h in Headers */ = {isa = PBXBuildFile; fileRef = D6489D24166FFCF1007C031B /* JSHTMLTemplateElement.h */; };
 		D66817FB166FE6D700FA07B4 /* HTMLTemplateElement.h in Headers */ = {isa = PBXBuildFile; fileRef = D6EFC0BC1666DF7A003D291E /* HTMLTemplateElement.h */; };
+		D669F992A34B36EDA5435687 /* UnifiedSource19-header-RenderStyleGetters.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 5250A569CD8198C008B831C9 /* UnifiedSource19-header-RenderStyleGetters.cpp */; };
 		D6E082672F5A3AED009B51B0 /* CachedMatchFinder.h in Headers */ = {isa = PBXBuildFile; fileRef = D6E082652F5A3AD7009B51B0 /* CachedMatchFinder.h */; };
 		D6E276B014637455001D280A /* MutationObserverRegistration.h in Headers */ = {isa = PBXBuildFile; fileRef = D6E276AE14637455001D280A /* MutationObserverRegistration.h */; };
 		D6E528A4149A926D00EFE1F3 /* MutationObserverInterestGroup.h in Headers */ = {isa = PBXBuildFile; fileRef = D6E528A2149A926D00EFE1F3 /* MutationObserverInterestGroup.h */; };
@@ -7088,6 +7078,7 @@
 		E7C8E13724E2FBCE0027A27F /* ConstantSourceOptions.h in Headers */ = {isa = PBXBuildFile; fileRef = E7C8E13324E2FA7C0027A27F /* ConstantSourceOptions.h */; };
 		E7C8E13B24E2FE7E0027A27F /* ConstantSourceNode.h in Headers */ = {isa = PBXBuildFile; fileRef = E7C8E13824E2FE650027A27F /* ConstantSourceNode.h */; };
 		E7CF84A924C6461C00B06B90 /* OfflineAudioContextOptions.h in Headers */ = {isa = PBXBuildFile; fileRef = E7CF84A524C635F400B06B90 /* OfflineAudioContextOptions.h */; };
+		E7CFF32F4E8D19760A5EF406 /* UnifiedSource13-header-RenderStyleGetters.cpp in Sources */ = {isa = PBXBuildFile; fileRef = D508C53D5BA52394A72A6606 /* UnifiedSource13-header-RenderStyleGetters.cpp */; };
 		E7E0357224D4E196008DFEFB /* AnalyserOptions.h in Headers */ = {isa = PBXBuildFile; fileRef = E7E0357124D4E191008DFEFB /* AnalyserOptions.h */; };
 		E7FBE7C224EB2FB000A18E62 /* StereoPannerNode.h in Headers */ = {isa = PBXBuildFile; fileRef = E7FBE7C124EB2FAB00A18E62 /* StereoPannerNode.h */; };
 		E7FBE7C324EB2FB600A18E62 /* StereoPannerOptions.h in Headers */ = {isa = PBXBuildFile; fileRef = E7FBE7C024EB2FAB00A18E62 /* StereoPannerOptions.h */; };
@@ -7103,6 +7094,8 @@
 		E8BF3AE42D56005800E7ED0B /* DummyCredentialRequestCoordinatorClient.h in Headers */ = {isa = PBXBuildFile; fileRef = E8BF3AE12D56003700E7ED0B /* DummyCredentialRequestCoordinatorClient.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		E8E7BDE32D94D20E0000A163 /* DigitalCredentialsProtocols.h in Headers */ = {isa = PBXBuildFile; fileRef = E8E7BDE22D94D2020000A163 /* DigitalCredentialsProtocols.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		EAA1A5613998E1BFD9AE7992 /* Ellipsis.svg in Copy Modern Media Controls Images */ = {isa = PBXBuildFile; fileRef = 3F3FBC9A5EE8A4E8D3EDE484 /* Ellipsis.svg */; platformFilters = (ios, xros, ); };
+		E9066AA4F09A6829ADADE430 /* UnifiedSource42-header-RenderStyleGetters.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 8C36C2A063D49F0AFB0A20E2 /* UnifiedSource42-header-RenderStyleGetters.cpp */; };
+		EB08B45C5495A39E03D5A8B5 /* UnifiedSource20-header-RenderStyleGetters.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 1B721B8134C6AE9E9D34A5D7 /* UnifiedSource20-header-RenderStyleGetters.cpp */; };
 		EB0FB708270D0B1000F7810D /* PushEncryptionKeyName.h in Headers */ = {isa = PBXBuildFile; fileRef = EB0FB6FD270D0AE800F7810D /* PushEncryptionKeyName.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		EB0FB709270D0B1800F7810D /* PushSubscription.h in Headers */ = {isa = PBXBuildFile; fileRef = EB0FB707270D0AEC00F7810D /* PushSubscription.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		EB0FB70A270D0B1B00F7810D /* PushSubscriptionJSON.h in Headers */ = {isa = PBXBuildFile; fileRef = EB0FB703270D0AEB00F7810D /* PushSubscriptionJSON.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -7142,7 +7135,10 @@
 		EEE349082DE0061C00A7D4BB /* StyleScopeIdentifier.h in Headers */ = {isa = PBXBuildFile; fileRef = EEE349072DE005FC00A7D4BB /* StyleScopeIdentifier.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		EFCC6C8F20FE914400A2321B /* CanvasActivityRecord.h in Headers */ = {isa = PBXBuildFile; fileRef = EFCC6C8D20FE914000A2321B /* CanvasActivityRecord.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		EFDEE0C8177A66CA2E21B69E /* SkipBack10.svg in Copy Modern Media Controls Images */ = {isa = PBXBuildFile; fileRef = AAEC636EAA8CE308206FFC96 /* SkipBack10.svg */; platformFilters = (macos, ); };
+		F01E1CB528746456B6A5B43E /* UnifiedSource59-header-RenderStyleGetters.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BD0EA2751C530E9F3689675A /* UnifiedSource59-header-RenderStyleGetters.cpp */; };
+		F08B6330FEDFA3CA4AA967FC /* UnifiedSource30-header-RenderStyleGetters.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BFD548E1DACEDB63C7EA23AF /* UnifiedSource30-header-RenderStyleGetters.cpp */; };
 		F12171F616A8CF0B000053CA /* WebVTTElement.h in Headers */ = {isa = PBXBuildFile; fileRef = F12171F416A8BC63000053CA /* WebVTTElement.h */; };
+		F1516286C621DBA3025C2F70 /* UnifiedSource58-header-RenderStyleGetters.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 61848160D68C25BF3B848B6C /* UnifiedSource58-header-RenderStyleGetters.cpp */; };
 		F30EE46B2E721BA800935B60 /* FrameInspectorController.h in Headers */ = {isa = PBXBuildFile; fileRef = F30EE46A2E721B9D00935B60 /* FrameInspectorController.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		F32BDCD92363AACA0073B6AE /* UserGestureEmulationScope.h in Headers */ = {isa = PBXBuildFile; fileRef = F32BDCD72363AACA0073B6AE /* UserGestureEmulationScope.h */; };
 		F344C7141125B82C00F26EEE /* InspectorFrontendClient.h in Headers */ = {isa = PBXBuildFile; fileRef = F344C7121125B82C00F26EEE /* InspectorFrontendClient.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -7284,6 +7280,7 @@
 		F74D51FB56878DA0D0D76072 /* SkipBack15.svg in Copy Modern Media Controls Images */ = {isa = PBXBuildFile; fileRef = 6D8062ACD45DA8C2C6931790 /* SkipBack15.svg */; platformFilters = (macos, ); };
 		F82E4D14C2B825F989146994 /* invalid-placard@2x.png in Copy Modern Media Controls Images */ = {isa = PBXBuildFile; fileRef = 714F5B071DEE5F8A0075BD17 /* invalid-placard@2x.png */; platformFilters = (ios, xros, ); };
 		F90D7DAC804241BB436122FB /* Overflow.svg in Copy Modern Media Controls Images */ = {isa = PBXBuildFile; fileRef = DEFD54AB5967A88F8A36EBA6 /* Overflow.svg */; platformFilters = (macos, ); };
+		F7C53A57143C6A21A7F6D91F /* UnifiedSource46-header-RenderStyleGetters.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 04CF8DB82E1A2436F374BC05 /* UnifiedSource46-header-RenderStyleGetters.cpp */; };
 		F916C48E0DB510F80076CD83 /* JSXMLHttpRequestProgressEvent.h in Headers */ = {isa = PBXBuildFile; fileRef = F916C48C0DB510F80076CD83 /* JSXMLHttpRequestProgressEvent.h */; };
 		F9F0ED7A0DB50CA200D16DB9 /* XMLHttpRequestProgressEvent.h in Headers */ = {isa = PBXBuildFile; fileRef = F9F0ED770DB50CA200D16DB9 /* XMLHttpRequestProgressEvent.h */; };
 		FA0B46CE2E8C7FEB0073E9B3 /* WebTransportDatagramStats.h in Headers */ = {isa = PBXBuildFile; fileRef = FAC3C4032A996707001E2EB8 /* WebTransportDatagramStats.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -7331,6 +7328,9 @@
 		FBD6AF8815EF25C9008B7110 /* CSSBasicShapeValue.h in Headers */ = {isa = PBXBuildFile; fileRef = FBD6AF8715EF21D4008B7110 /* CSSBasicShapeValue.h */; };
 		FBDB619F16D6036500BB3394 /* ElementRuleCollector.h in Headers */ = {isa = PBXBuildFile; fileRef = FBDB619E16D6036500BB3394 /* ElementRuleCollector.h */; };
 		FBDB61A116D6037E00BB3394 /* PageRuleCollector.h in Headers */ = {isa = PBXBuildFile; fileRef = FBDB61A016D6037E00BB3394 /* PageRuleCollector.h */; };
+		FC2600000000000C00000003 /* OTPCredentialRequestOptions.h in Headers */ = {isa = PBXBuildFile; fileRef = FC2600000000000C00000001 /* OTPCredentialRequestOptions.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		FC260000000000DC00000003 /* IdentityCredentialRequestOptions.h in Headers */ = {isa = PBXBuildFile; fileRef = FC260000000000DC00000001 /* IdentityCredentialRequestOptions.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		FC260000000000FC00000003 /* FederatedCredentialRequestOptions.h in Headers */ = {isa = PBXBuildFile; fileRef = FC260000000000FC00000001 /* FederatedCredentialRequestOptions.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		FC54D05716A7673100575E4D /* CSSSupportsRule.h in Headers */ = {isa = PBXBuildFile; fileRef = FC63BDB1167AABAC00F9380F /* CSSSupportsRule.h */; };
 		FC54D05816A7676E00575E4D /* JSCSSSupportsRule.h in Headers */ = {isa = PBXBuildFile; fileRef = FC84802E167AB444008CD100 /* JSCSSSupportsRule.h */; };
 		FC9A0F75164094CF003D6B8D /* DOMCSSNamespace.h in Headers */ = {isa = PBXBuildFile; fileRef = FC9A0F72164094CF003D6B8D /* DOMCSSNamespace.h */; };
@@ -7463,6 +7463,7 @@
 		FE80DA640E9C4703000D6F75 /* JSGeolocation.h in Headers */ = {isa = PBXBuildFile; fileRef = FE80DA600E9C4703000D6F75 /* JSGeolocation.h */; };
 		FE8A674816CDD19E00930BF8 /* SQLStatement.h in Headers */ = {isa = PBXBuildFile; fileRef = FE8A674616CDD19E00930BF8 /* SQLStatement.h */; };
 		FE9E89FC16E2DC0500A908F8 /* OriginLock.h in Headers */ = {isa = PBXBuildFile; fileRef = FE9E89FA16E2DC0400A908F8 /* OriginLock.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		FEB5079D8E50CAD92E49CE04 /* UnifiedSource54-header-RenderStyleGetters.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 73C6E6F635A4B4C36B107EAE /* UnifiedSource54-header-RenderStyleGetters.cpp */; };
 		FED13D520CEA949700D89466 /* RenderThemeIOS.h in Headers */ = {isa = PBXBuildFile; fileRef = FED13D500CEA949700D89466 /* RenderThemeIOS.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		FEE1811416C319E800084849 /* SQLTransactionBackend.h in Headers */ = {isa = PBXBuildFile; fileRef = FEE1811216C319E800084849 /* SQLTransactionBackend.h */; };
 		FF945ECC161F7F3600971BC8 /* PseudoElement.h in Headers */ = {isa = PBXBuildFile; fileRef = FF945ECA161F7F3600971BC8 /* PseudoElement.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -7702,6 +7703,7 @@
 		00146288103CD1DE000B20DB /* OriginAccessEntry.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = OriginAccessEntry.cpp; sourceTree = "<group>"; };
 		00146289103CD1DE000B20DB /* OriginAccessEntry.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OriginAccessEntry.h; sourceTree = "<group>"; };
 		003F1FE911E6AB43008258D9 /* UserContentTypes.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = UserContentTypes.h; sourceTree = "<group>"; };
+		004D65C61D84DB1DC5F43DBB /* UnifiedSource3-header-RenderStyleGetters.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = "UnifiedSource3-header-RenderStyleGetters.cpp"; sourceTree = "<group>"; };
 		00B9318113BA867F0035A948 /* XMLDocumentParser.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = XMLDocumentParser.cpp; sourceTree = "<group>"; };
 		00B9318213BA867F0035A948 /* XMLDocumentParser.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = XMLDocumentParser.h; sourceTree = "<group>"; };
 		00B9318313BA867F0035A948 /* XMLDocumentParserLibxml2.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = XMLDocumentParserLibxml2.cpp; sourceTree = "<group>"; };
@@ -7711,6 +7713,7 @@
 		016F380929AA33E300167F2E /* ApplePayLaterAvailability.idl */ = {isa = PBXFileReference; lastKnownFileType = text; path = ApplePayLaterAvailability.idl; sourceTree = "<group>"; };
 		016F380D29AA36A200167F2E /* ApplePayLaterAvailability.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ApplePayLaterAvailability.h; sourceTree = "<group>"; };
 		01D22A1C2CFD73C7002DC857 /* AsyncNodeDeletionQueue.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = AsyncNodeDeletionQueue.h; sourceTree = "<group>"; };
+		01FA511EE07ED821FC38C8C0 /* UnifiedSource15-header-RenderStyleGetters.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = "UnifiedSource15-header-RenderStyleGetters.cpp"; sourceTree = "<group>"; };
 		0208E1822D213D9100BECD3D /* BackForwardFrameItemIdentifier.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = BackForwardFrameItemIdentifier.h; sourceTree = "<group>"; };
 		0223E06C2AAEBBCF00AF30FB /* HandleUserInputEventResult.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = HandleUserInputEventResult.h; sourceTree = "<group>"; };
 		0223E0732AAED62200AF30FB /* RemoteUserInputEventData.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RemoteUserInputEventData.h; sourceTree = "<group>"; };
@@ -7721,6 +7724,7 @@
 		024E5F7429844DBD009CC5FC /* ScrollerPairMac.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ScrollerPairMac.h; sourceTree = "<group>"; };
 		025F62A92DD69A8700573F15 /* AutoplayPolicy.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = AutoplayPolicy.h; sourceTree = "<group>"; };
 		029D57A92C506F5900AD086B /* UserGestureTokenIdentifier.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = UserGestureTokenIdentifier.h; sourceTree = "<group>"; };
+		04CF8DB82E1A2436F374BC05 /* UnifiedSource46-header-RenderStyleGetters.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = "UnifiedSource46-header-RenderStyleGetters.cpp"; sourceTree = "<group>"; };
 		054E3A33256C3BD90072C5B9 /* ShadowRootInit.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ShadowRootInit.h; sourceTree = "<group>"; };
 		054E3A33256C3BD90072C5BF /* GetHTMLOptions.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = GetHTMLOptions.h; sourceTree = "<group>"; };
 		054E3A35256C3BD90072C5B9 /* ShadowRootInit.idl */ = {isa = PBXFileReference; lastKnownFileType = text; path = ShadowRootInit.idl; sourceTree = "<group>"; };
@@ -8164,6 +8168,7 @@
 		08F859D31463F9CD0067D934 /* SVGImageForContainer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SVGImageForContainer.h; sourceTree = "<group>"; };
 		0AB951FD42B2EBB60ABA110D /* Volume0-RTL.svg */ = {isa = PBXFileReference; lastKnownFileType = text; path = "Volume0-RTL.svg"; sourceTree = "<group>"; };
 		0AD8DA712698235A6D8C759A /* ExitFullscreen.svg */ = {isa = PBXFileReference; lastKnownFileType = text; path = ExitFullscreen.svg; sourceTree = "<group>"; };
+		097892D45E6F50F9B2F119BB /* UnifiedSource5-header-RenderStyleGetters.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = "UnifiedSource5-header-RenderStyleGetters.cpp"; sourceTree = "<group>"; };
 		0AFDAC3C10F5448C00E1F3D2 /* PluginViewBase.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PluginViewBase.h; sourceTree = "<group>"; };
 		0B8C56D30F28627F000502E1 /* HTTPHeaderMap.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = HTTPHeaderMap.cpp; sourceTree = "<group>"; };
 		0B9056150F2578BE0095FF6A /* DocumentThreadableLoader.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = DocumentThreadableLoader.cpp; sourceTree = "<group>"; };
@@ -8231,6 +8236,7 @@
 		0DA55D9528E678F6004A6758 /* UserActivation.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = UserActivation.cpp; sourceTree = "<group>"; };
 		0DA55D9628E678F6004A6758 /* UserActivation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = UserActivation.h; sourceTree = "<group>"; };
 		0DA55D9928E6797E004A6758 /* Navigator+UserActivation.idl */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = "Navigator+UserActivation.idl"; sourceTree = "<group>"; };
+		0DB768C810AA85BE70BB2E08 /* UnifiedSource69-header-RenderStyleGetters.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = "UnifiedSource69-header-RenderStyleGetters.cpp"; sourceTree = "<group>"; };
 		0DC19CD22C543A6600104CAB /* WebXRRenderState+Layers.idl */ = {isa = PBXFileReference; lastKnownFileType = text; path = "WebXRRenderState+Layers.idl"; sourceTree = "<group>"; };
 		0DC19CD32C543A6600104CAB /* XRCompositionLayer.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = XRCompositionLayer.h; sourceTree = "<group>"; };
 		0DC19CD42C543A6600104CAB /* XRCompositionLayer.idl */ = {isa = PBXFileReference; lastKnownFileType = text; path = XRCompositionLayer.idl; sourceTree = "<group>"; };
@@ -8428,6 +8434,7 @@
 		0F73B765222B327F00805316 /* ScrollingStateScrollingNodeMac.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = ScrollingStateScrollingNodeMac.mm; sourceTree = "<group>"; };
 		0F768C2B26D03841008DBE0B /* UserMediaRequestIdentifier.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = UserMediaRequestIdentifier.h; sourceTree = "<group>"; };
 		0F768C3326D0AB39008DBE0B /* MediaKeySystemRequestIdentifier.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MediaKeySystemRequestIdentifier.h; sourceTree = "<group>"; };
+		0F76CD991B87ADACC0F2F37E /* UnifiedSource39-header-RenderStyleGetters.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = "UnifiedSource39-header-RenderStyleGetters.cpp"; sourceTree = "<group>"; };
 		0F7DF1471E2BF1A60095951B /* WebCoreJSClientData.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = WebCoreJSClientData.cpp; sourceTree = "<group>"; };
 		0F7E475125EEB79A0013F909 /* AnimationFrameRate.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = AnimationFrameRate.cpp; sourceTree = "<group>"; };
 		0F850FE21ED7C18300FB77A7 /* PerformanceLoggingClient.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PerformanceLoggingClient.h; sourceTree = "<group>"; };
@@ -8731,6 +8738,7 @@
 		15C77092100D3CA8005BA267 /* JSValidityState.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = JSValidityState.cpp; sourceTree = "<group>"; };
 		17277E4617D018CC0015535D /* JSMediaStreamTrackProcessor.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = JSMediaStreamTrackProcessor.cpp; sourceTree = "<group>"; };
 		17277E4717D018CC0015535D /* JSMediaStreamTrackProcessor.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = JSMediaStreamTrackProcessor.h; sourceTree = "<group>"; };
+		1818859115E2479836298884 /* UnifiedSource12-header-RenderStyleGetters.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = "UnifiedSource12-header-RenderStyleGetters.cpp"; sourceTree = "<group>"; };
 		185BCF260F3279CE000EA262 /* ThreadTimers.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ThreadTimers.cpp; sourceTree = "<group>"; };
 		185BCF270F3279CE000EA262 /* ThreadTimers.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ThreadTimers.h; sourceTree = "<group>"; };
 		188604B10F2E654A000B6443 /* DOMTimer.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = DOMTimer.cpp; sourceTree = "<group>"; };
@@ -9067,6 +9075,8 @@
 		1B124D8C1D380B7000ECDFB0 /* MediaSampleAVFObjC.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MediaSampleAVFObjC.h; sourceTree = "<group>"; };
 		1B124D8E1D380BB600ECDFB0 /* MediaSampleAVFObjC.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = MediaSampleAVFObjC.mm; sourceTree = "<group>"; };
 		1BBDE8612B8CB78D4514D54E /* Volume2-RTL.svg */ = {isa = PBXFileReference; lastKnownFileType = text; path = "Volume2-RTL.svg"; sourceTree = "<group>"; };
+		1B5C8E332AFA25F34506CCB0 /* UnifiedSource16-header-RenderStyleGetters.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = "UnifiedSource16-header-RenderStyleGetters.cpp"; sourceTree = "<group>"; };
+		1B721B8134C6AE9E9D34A5D7 /* UnifiedSource20-header-RenderStyleGetters.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = "UnifiedSource20-header-RenderStyleGetters.cpp"; sourceTree = "<group>"; };
 		1BE5BFC11D515715001666D9 /* MediaConstraints.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = MediaConstraints.cpp; sourceTree = "<group>"; };
 		1C0106FE192594DF008A4201 /* InlineTextBoxStyle.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = InlineTextBoxStyle.cpp; sourceTree = "<group>"; };
 		1C0106FF192594DF008A4201 /* InlineTextBoxStyle.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = InlineTextBoxStyle.h; sourceTree = "<group>"; };
@@ -9983,6 +9993,7 @@
 		1D0026A22374D62300CA6CDF /* JSPictureInPictureWindow.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = JSPictureInPictureWindow.h; sourceTree = "<group>"; };
 		1D0026A32374D62400CA6CDF /* JSPictureInPictureWindow.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = JSPictureInPictureWindow.cpp; sourceTree = "<group>"; };
 		1D2C82B6236A3F6A0055D6C5 /* PictureInPictureSupport.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = PictureInPictureSupport.h; sourceTree = "<group>"; };
+		1D2E7A27D4CA429D6537A1BC /* UnifiedSource49-header-RenderStyleGetters.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = "UnifiedSource49-header-RenderStyleGetters.cpp"; sourceTree = "<group>"; };
 		1D47658D25CCA778007AF312 /* ImageDecoderIdentifier.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ImageDecoderIdentifier.h; sourceTree = "<group>"; };
 		1DAB3113251D725C00FC9485 /* VideoLayerManager.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = VideoLayerManager.h; sourceTree = "<group>"; };
 		1DB66D37253678EA00B671B9 /* AudioOutputUnitAdaptor.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = AudioOutputUnitAdaptor.h; sourceTree = "<group>"; };
@@ -10039,6 +10050,7 @@
 		2527CC9516BF95DD009DDAC0 /* PlatformSpeechSynthesisUtterance.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = PlatformSpeechSynthesisUtterance.cpp; sourceTree = "<group>"; };
 		2542F4D81166C25A00E89A86 /* UserGestureIndicator.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = UserGestureIndicator.cpp; sourceTree = "<group>"; };
 		2542F4D91166C25A00E89A86 /* UserGestureIndicator.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = UserGestureIndicator.h; sourceTree = "<group>"; };
+		25FAC750F76F755835BE4E86 /* UnifiedSource11-header-RenderStyleGetters.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = "UnifiedSource11-header-RenderStyleGetters.cpp"; sourceTree = "<group>"; };
 		262391351A648CEE007251A3 /* ContentExtensionsDebugging.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ContentExtensionsDebugging.h; sourceTree = "<group>"; };
 		262EC4191D078F3D00BA78FC /* EventTrackingRegions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = EventTrackingRegions.h; sourceTree = "<group>"; };
 		262EC41C1D110B1F00BA78FC /* EventTrackingRegions.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = EventTrackingRegions.cpp; sourceTree = "<group>"; };
@@ -10259,6 +10271,7 @@
 		2B42359F15250F6000DBBCD8 /* LegacyRenderSVGEllipse.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = LegacyRenderSVGEllipse.cpp; sourceTree = "<group>"; };
 		2B4235A015250EF555DB5CD8 /* RenderSVGEllipse.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RenderSVGEllipse.h; sourceTree = "<group>"; };
 		2B4235A015250F6000DBBCD8 /* LegacyRenderSVGEllipse.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = LegacyRenderSVGEllipse.h; sourceTree = "<group>"; };
+		2B4EE1CF43D75281121A19D6 /* UnifiedSource45-header-RenderStyleGetters.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = "UnifiedSource45-header-RenderStyleGetters.cpp"; sourceTree = "<group>"; };
 		2B598F98286F6BF4005AF06F /* Formats.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Formats.h; sourceTree = "<group>"; };
 		2B59E5C8287B81B1004CC9FF /* DecompressionStream.js */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.javascript; path = DecompressionStream.js; sourceTree = "<group>"; };
 		2B59E5C9287B81B2004CC9FF /* DecompressionStreamDecoder.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = DecompressionStreamDecoder.h; sourceTree = "<group>"; };
@@ -10483,6 +10496,7 @@
 		2EB767551DA19B99003E23B5 /* InputEvent.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = InputEvent.cpp; sourceTree = "<group>"; };
 		2EBBC3D71B65988300F5253D /* WheelEventDeltaFilter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WheelEventDeltaFilter.h; sourceTree = "<group>"; };
 		2EC41DE21C0410A300D294FE /* RealtimeMediaSourceSupportedConstraints.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = RealtimeMediaSourceSupportedConstraints.cpp; sourceTree = "<group>"; };
+		2EC5387B1B81D685AF55472D /* UnifiedSource25-header-RenderStyleGetters.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = "UnifiedSource25-header-RenderStyleGetters.cpp"; sourceTree = "<group>"; };
 		2ECDBACE21D8903400F00ECD /* UndoManager.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = UndoManager.h; sourceTree = "<group>"; };
 		2ECDBACF21D8903400F00ECD /* UndoManager.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = UndoManager.cpp; sourceTree = "<group>"; };
 		2ECDBAD021D8903400F00ECD /* UndoManager.idl */ = {isa = PBXFileReference; lastKnownFileType = text; path = UndoManager.idl; sourceTree = "<group>"; };
@@ -10687,6 +10701,7 @@
 		3227A92A28BD744B00BC2697 /* NodeName.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = NodeName.h; sourceTree = "<group>"; };
 		3227A92B28BD744B00BC2697 /* Namespace.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Namespace.h; sourceTree = "<group>"; };
 		322B61142C50C22D00FB5440 /* ImageBufferResourceLimits.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ImageBufferResourceLimits.h; sourceTree = "<group>"; };
+		3230252036F492BB47909DD0 /* UnifiedSource55-header-RenderStyleGetters.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = "UnifiedSource55-header-RenderStyleGetters.cpp"; sourceTree = "<group>"; };
 		325905DA274DE1D7007B7B65 /* FontDatabase.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FontDatabase.h; sourceTree = "<group>"; };
 		325905DD274DE1E3007B7B65 /* FontDatabase.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = FontDatabase.cpp; sourceTree = "<group>"; };
 		325E1FDF274EFD4E00FC668A /* FontFamilySpecificationCoreTextCache.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = FontFamilySpecificationCoreTextCache.cpp; sourceTree = "<group>"; };
@@ -10780,6 +10795,7 @@
 		37E3524C12450C6600BAF5D9 /* InputType.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = InputType.h; sourceTree = "<group>"; };
 		37F818FB0D657606005E1F05 /* WebCoreURLResponse.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WebCoreURLResponse.h; sourceTree = "<group>"; };
 		37F818FC0D657606005E1F05 /* WebCoreURLResponse.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = WebCoreURLResponse.mm; sourceTree = "<group>"; };
+		3A0029C243BF23321C43D20D /* UnifiedSource52-header-RenderStyleGetters.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = "UnifiedSource52-header-RenderStyleGetters.cpp"; sourceTree = "<group>"; };
 		3A0BAA3D2D0B6B2B00DE30E4 /* FileSystemWriteCloseReason.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = FileSystemWriteCloseReason.h; sourceTree = "<group>"; };
 		3A18A2EC2AFEAA7C00DB976C /* MarkupExclusionRule.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MarkupExclusionRule.h; sourceTree = "<group>"; };
 		3A25C5122CF7E26E00DB9C39 /* FileSystemWritableFileStreamSink.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = FileSystemWritableFileStreamSink.h; sourceTree = "<group>"; };
@@ -10819,6 +10835,7 @@
 		3C8D24ED2E25CF1A00D2A929 /* IPAddressSpace.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = IPAddressSpace.h; sourceTree = "<group>"; };
 		3CE7C6702E270278005CDFD8 /* IPAddressSpace.idl */ = {isa = PBXFileReference; lastKnownFileType = text; path = IPAddressSpace.idl; sourceTree = "<group>"; };
 		3DCCA4B4BF1CEDC0C5E7B3BB /* Airplay.svg */ = {isa = PBXFileReference; lastKnownFileType = text; path = Airplay.svg; sourceTree = "<group>"; };
+		3EB98985C78E4C2A4C58889D /* UnifiedSource61-header-RenderStyleGetters.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = "UnifiedSource61-header-RenderStyleGetters.cpp"; sourceTree = "<group>"; };
 		3F3BB5821E709EE400C701F2 /* CoreAudioCaptureSource.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = CoreAudioCaptureSource.cpp; sourceTree = "<group>"; };
 		3F3BB5831E709EE400C701F2 /* CoreAudioCaptureSource.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CoreAudioCaptureSource.h; sourceTree = "<group>"; };
 		3F3FBC9A5EE8A4E8D3EDE484 /* Ellipsis.svg */ = {isa = PBXFileReference; lastKnownFileType = text; path = Ellipsis.svg; sourceTree = "<group>"; };
@@ -11550,6 +11567,7 @@
 		41FCB75D214866FE0038ADC6 /* RTCDegradationPreference.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RTCDegradationPreference.h; sourceTree = "<group>"; };
 		41FCB75F214866FF0038ADC6 /* RTCRtpCodecParameters.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RTCRtpCodecParameters.h; sourceTree = "<group>"; };
 		41FCB761214867000038ADC6 /* RTCRtpEncodingParameters.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RTCRtpEncodingParameters.h; sourceTree = "<group>"; };
+		41FF206D0243146B78FDD0FB /* UnifiedSource74-header-RenderStyleGetters.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = "UnifiedSource74-header-RenderStyleGetters.cpp"; sourceTree = "<group>"; };
 		41FFD2C027563DFF00501BBF /* AudioSampleDataConverter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AudioSampleDataConverter.h; sourceTree = "<group>"; };
 		41FFD2C227563E0000501BBF /* AudioSampleDataConverter.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = AudioSampleDataConverter.mm; sourceTree = "<group>"; };
 		421129A32EC39C0A00778FE6 /* AXLiveRegionManager.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; path = AXLiveRegionManager.h; sourceTree = "<group>"; };
@@ -12091,6 +12109,7 @@
 		475C89A32650AC3B00F3B456 /* FormattingGeometry.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FormattingGeometry.h; sourceTree = "<group>"; };
 		4786356426507A3700C5E2E0 /* BlockFormattingGeometry.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BlockFormattingGeometry.h; sourceTree = "<group>"; };
 		47C4D57C26508BCA00C7AB1F /* InlineFormattingUtils.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = InlineFormattingUtils.h; sourceTree = "<group>"; };
+		47F192EF33A4783F5E6E60F0 /* UnifiedSource43-header-RenderStyleGetters.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = "UnifiedSource43-header-RenderStyleGetters.cpp"; sourceTree = "<group>"; };
 		47F947DA26502F2F0087968C /* BlockFormattingQuirks.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BlockFormattingQuirks.h; sourceTree = "<group>"; };
 		47FA96FF2650982A00841416 /* TableFormattingGeometry.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TableFormattingGeometry.h; sourceTree = "<group>"; };
 		480A2F512CDFC1F800407331 /* AccessibilitySpinButtonPart.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = AccessibilitySpinButtonPart.h; sourceTree = "<group>"; };
@@ -12176,6 +12195,7 @@
 		4970AD802AE59BCE00AD3909 /* TransformOperationData.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TransformOperationData.h; sourceTree = "<group>"; };
 		497CDAA42CAC59BA00BC429D /* CSSAttrValue.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CSSAttrValue.h; sourceTree = "<group>"; };
 		497CDAA52CAC59BA00BC429D /* CSSAttrValue.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = CSSAttrValue.cpp; sourceTree = "<group>"; };
+		4987053212B58BF9F79B19AD /* UnifiedSource1-header-RenderStyleGetters.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = "UnifiedSource1-header-RenderStyleGetters.cpp"; sourceTree = "<group>"; };
 		4989734A2B663C6600720679 /* StyleScrollbarState.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = StyleScrollbarState.h; sourceTree = "<group>"; };
 		498EC5452CB431BE00B7DAE1 /* detailsElementShadow.css */ = {isa = PBXFileReference; lastKnownFileType = text.css; path = detailsElementShadow.css; sourceTree = "<group>"; };
 		4998AEC413F9D0EA0090B1AA /* RequestAnimationFrameCallback.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RequestAnimationFrameCallback.h; sourceTree = "<group>"; };
@@ -12391,6 +12411,7 @@
 		4C7133A5299A5E54007A4042 /* CoreTextCompositionEngine.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CoreTextCompositionEngine.h; sourceTree = "<group>"; };
 		4C96385729BF4A51003E5741 /* StyleListStyleType.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = StyleListStyleType.h; sourceTree = "<group>"; };
 		4CA012DB29A7D56700C260C6 /* counterStyles.css */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.css; path = counterStyles.css; sourceTree = "<group>"; };
+		4CA6FA18AEA1958D18A49C88 /* UnifiedSource31-header-RenderStyleGetters.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = "UnifiedSource31-header-RenderStyleGetters.cpp"; sourceTree = "<group>"; };
 		4CB808832964AF4600BC59FE /* CSSCounterStyleDescriptors.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CSSCounterStyleDescriptors.h; sourceTree = "<group>"; };
 		4CB808842964AF4700BC59FE /* CSSCounterStyleDescriptors.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = CSSCounterStyleDescriptors.cpp; sourceTree = "<group>"; };
 		4CBBE5192C5D41AF00B7786E /* TextSpacing.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = TextSpacing.cpp; sourceTree = "<group>"; };
@@ -12737,6 +12758,7 @@
 		5187E8442B79F8100053BFF5 /* MediaSourceHandle.idl */ = {isa = PBXFileReference; lastKnownFileType = text; path = MediaSourceHandle.idl; sourceTree = "<group>"; };
 		518864DE1BBAF30F00E540C9 /* UniqueIDBDatabase.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = UniqueIDBDatabase.cpp; sourceTree = "<group>"; };
 		518864DF1BBAF30F00E540C9 /* UniqueIDBDatabase.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = UniqueIDBDatabase.h; sourceTree = "<group>"; };
+		5188A7DDD00B206B110ED7A1 /* UnifiedSource75-header-RenderStyleGetters.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = "UnifiedSource75-header-RenderStyleGetters.cpp"; sourceTree = "<group>"; };
 		51895F892D123D0900E8D471 /* DocumentClasses.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = DocumentClasses.h; sourceTree = "<group>"; };
 		5189F01B10B37BD900F3C739 /* JSPopStateEvent.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = JSPopStateEvent.cpp; sourceTree = "<group>"; };
 		5189F01C10B37BD900F3C739 /* JSPopStateEvent.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = JSPopStateEvent.h; sourceTree = "<group>"; };
@@ -12951,6 +12973,7 @@
 		51FB67DA1AE6B5E400D06C5A /* ContentExtensionStyleSheet.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ContentExtensionStyleSheet.h; sourceTree = "<group>"; };
 		52131E5A1C4F15610033F802 /* VideoPresentationInterfaceMac.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = VideoPresentationInterfaceMac.mm; sourceTree = "<group>"; };
 		522373E42C4FE8E300F1FA0C /* ShouldRequireExplicitConsentForGamepadAccess.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ShouldRequireExplicitConsentForGamepadAccess.h; sourceTree = "<group>"; };
+		5250A569CD8198C008B831C9 /* UnifiedSource19-header-RenderStyleGetters.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = "UnifiedSource19-header-RenderStyleGetters.cpp"; sourceTree = "<group>"; };
 		52597BB32DC3F89300CAAF01 /* ModelPlayerAnimationState.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ModelPlayerAnimationState.h; sourceTree = "<group>"; };
 		52597BB42DC3F89300CAAF01 /* ModelPlayerAnimationState.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = ModelPlayerAnimationState.cpp; sourceTree = "<group>"; };
 		52597BB82DC412F500CAAF01 /* ModelPlayerTransformState.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ModelPlayerTransformState.h; sourceTree = "<group>"; };
@@ -12980,6 +13003,7 @@
 		52B074422846810A00511B65 /* AuthenticationExtensionsClientOutputs.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = AuthenticationExtensionsClientOutputs.cpp; sourceTree = "<group>"; };
 		52B0D4C11C57FF910077CE53 /* VideoPresentationInterfaceMac.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = VideoPresentationInterfaceMac.h; sourceTree = "<group>"; };
 		52B84CA048CEC33FFD5367B8 /* VolumeMuted-RTL.svg */ = {isa = PBXFileReference; lastKnownFileType = text; path = "VolumeMuted-RTL.svg"; sourceTree = "<group>"; };
+		52D2ED227687272BB8AC7430 /* UnifiedSource77-header-RenderStyleGetters.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = "UnifiedSource77-header-RenderStyleGetters.cpp"; sourceTree = "<group>"; };
 		52D4C867EF1213EBE219805C /* StyleOutlineOffset.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = StyleOutlineOffset.h; sourceTree = "<group>"; };
 		52D5A18D1C54590300DE34A3 /* VideoLayerManagerObjC.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = VideoLayerManagerObjC.mm; sourceTree = "<group>"; };
 		52D5A18E1C54590300DE34A3 /* VideoLayerManagerObjC.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = VideoLayerManagerObjC.h; sourceTree = "<group>"; };
@@ -13470,6 +13494,7 @@
 		59C28044138DC2410079B7E2 /* XMLErrors.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = XMLErrors.h; sourceTree = "<group>"; };
 		59D1C10311EB5DCF00B638C8 /* DeviceOrientationData.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = DeviceOrientationData.cpp; sourceTree = "<group>"; };
 		5A502612288B5CB300D4FC8A /* PlatformMediaError.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = PlatformMediaError.cpp; sourceTree = "<group>"; };
+		5A551F9473B2A7F6783FF6C1 /* UnifiedSource6-header-RenderStyleGetters.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = "UnifiedSource6-header-RenderStyleGetters.cpp"; sourceTree = "<group>"; };
 		5A574F22131DB93900471B88 /* RenderQuote.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = RenderQuote.cpp; sourceTree = "<group>"; };
 		5A574F23131DB93900471B88 /* RenderQuote.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RenderQuote.h; sourceTree = "<group>"; };
 		5A574F26131DB96D00471B88 /* StyleQuotes.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = StyleQuotes.cpp; sourceTree = "<group>"; };
@@ -13645,6 +13670,7 @@
 		5DA5E0FB102B953800088CF9 /* JSWebSocket.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = JSWebSocket.h; sourceTree = "<group>"; };
 		5DB1BC6810715A6400EFAA49 /* TransformSource.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TransformSource.h; sourceTree = "<group>"; };
 		5DB1BC6910715A6400EFAA49 /* TransformSourceLibxslt.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = TransformSourceLibxslt.cpp; sourceTree = "<group>"; };
+		5DE923E85927C51244CECFDD /* UnifiedSource33-header-RenderStyleGetters.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = "UnifiedSource33-header-RenderStyleGetters.cpp"; sourceTree = "<group>"; };
 		5DFEBAB618592B6D00C75BEB /* WebKitAvailability.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WebKitAvailability.h; sourceTree = "<group>"; };
 		5E2C434D1BCEE2E50001E2BC /* PeerConnectionBackend.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PeerConnectionBackend.h; sourceTree = "<group>"; };
 		5E2C43561BCEE30D0001E2BC /* RTCRtpReceiver.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = RTCRtpReceiver.cpp; sourceTree = "<group>"; };
@@ -13696,6 +13722,7 @@
 		5F2DBBE9178E336900141487 /* X509SubjectKeyIdentifier.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = X509SubjectKeyIdentifier.h; sourceTree = "<group>"; };
 		5FC7DC26CFE2563200B85AE5 /* JSEventTarget.h */ = {isa = PBXFileReference; fileEncoding = 30; lastKnownFileType = sourcecode.c.h; path = JSEventTarget.h; sourceTree = "<group>"; };
 		5FE1D291178FD1F3001AA3C3 /* Security.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Security.framework; path = System/Library/Frameworks/Security.framework; sourceTree = SDKROOT; };
+		61848160D68C25BF3B848B6C /* UnifiedSource58-header-RenderStyleGetters.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = "UnifiedSource58-header-RenderStyleGetters.cpp"; sourceTree = "<group>"; };
 		62370F94D69D08CA29D088BE /* SVGComponentTransferFunctionElementInlines.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SVGComponentTransferFunctionElementInlines.h; sourceTree = "<group>"; };
 		623C21962F529B1800B6094B /* StyleVisualBox.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = StyleVisualBox.h; sourceTree = "<group>"; };
 		6221921C2F558CFF00D1E520 /* StylePositionAnchor.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = StylePositionAnchor.cpp; sourceTree = "<group>"; };
@@ -13718,6 +13745,7 @@
 		6353E1E51F91743100A34208 /* CachedApplicationManifest.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = CachedApplicationManifest.cpp; sourceTree = "<group>"; };
 		6354F4C71F7AFC9400D89DF3 /* ApplicationManifestParser.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ApplicationManifestParser.h; sourceTree = "<group>"; };
 		6354F4C81F7AFC9400D89DF3 /* ApplicationManifestParser.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = ApplicationManifestParser.cpp; sourceTree = "<group>"; };
+		636E4E69584B74FA6C92D248 /* UnifiedSource50-header-RenderStyleGetters.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = "UnifiedSource50-header-RenderStyleGetters.cpp"; sourceTree = "<group>"; };
 		637B7ADE0E8767B800E32194 /* ElementRareData.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ElementRareData.h; sourceTree = "<group>"; };
 		63BD4A5D1F778E9F00438722 /* ApplicationManifest.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ApplicationManifest.h; sourceTree = "<group>"; };
 		63D7B32C0E78CD3F00F7617C /* NodeRenderStyle.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = NodeRenderStyle.h; sourceTree = "<group>"; };
@@ -13808,10 +13836,12 @@
 		668500B8273EEB7800FCCAD6 /* CSSOffsetRotateValue.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = CSSOffsetRotateValue.cpp; sourceTree = "<group>"; };
 		668500B9273EEB7800FCCAD6 /* CSSOffsetRotateValue.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CSSOffsetRotateValue.h; sourceTree = "<group>"; };
 		68751EF301A589C0625CC851 /* PipIn.svg */ = {isa = PBXFileReference; lastKnownFileType = text; path = PipIn.svg; sourceTree = "<group>"; };
+		675EA032FFAF2A4098F106D8 /* UnifiedSource24-header-RenderStyleGetters.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = "UnifiedSource24-header-RenderStyleGetters.cpp"; sourceTree = "<group>"; };
 		697101071C6BE1550018C7F1 /* AccessibilitySVGObject.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = AccessibilitySVGObject.cpp; sourceTree = "<group>"; };
 		697101081C6BE1550018C7F1 /* AccessibilitySVGObject.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AccessibilitySVGObject.h; sourceTree = "<group>"; };
 		6A22E86F1F10418600F546C3 /* InspectorCanvas.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = InspectorCanvas.h; sourceTree = "<group>"; };
 		6A22E8721F1042C400F546C3 /* InspectorCanvas.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = InspectorCanvas.cpp; sourceTree = "<group>"; };
+		6A5A653EE2BD51501F778B98 /* UnifiedSource14-header-RenderStyleGetters.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = "UnifiedSource14-header-RenderStyleGetters.cpp"; sourceTree = "<group>"; };
 		6A7279881F16C29B003F39B8 /* InspectorShaderProgram.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = InspectorShaderProgram.h; sourceTree = "<group>"; };
 		6A7279891F16C29B003F39B8 /* InspectorShaderProgram.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = InspectorShaderProgram.cpp; sourceTree = "<group>"; };
 		6B0A07F021FA4B5C00D57391 /* PrivateClickMeasurement.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PrivateClickMeasurement.h; sourceTree = "<group>"; };
@@ -13836,6 +13866,7 @@
 		6D61E3752C2E016F00F1C6AA /* NavigatorLoginStatus.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = NavigatorLoginStatus.h; sourceTree = "<group>"; };
 		6D61E3762C2E016F00F1C6AA /* NavigatorLoginStatus.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = NavigatorLoginStatus.cpp; sourceTree = "<group>"; };
 		6D8062ACD45DA8C2C6931790 /* SkipBack15.svg */ = {isa = PBXFileReference; lastKnownFileType = text; path = SkipBack15.svg; sourceTree = "<group>"; };
+		6D90699809046B96AE290168 /* UnifiedSource51-header-RenderStyleGetters.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = "UnifiedSource51-header-RenderStyleGetters.cpp"; sourceTree = "<group>"; };
 		6DC9C7132F0C5BC600A93E65 /* DragEventTargetData.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = DragEventTargetData.h; sourceTree = "<group>"; };
 		6DD53F3E2C49D4E20049F1C5 /* IsLoggedIn.idl */ = {isa = PBXFileReference; lastKnownFileType = text; path = IsLoggedIn.idl; sourceTree = "<group>"; };
 		6E0B90652321A68C006223B2 /* WebGLCompressedTextureETC1.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WebGLCompressedTextureETC1.h; sourceTree = "<group>"; };
@@ -14436,6 +14467,7 @@
 		7287A83A29879695004A50E2 /* SearchFieldResultsPart.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SearchFieldResultsPart.h; sourceTree = "<group>"; };
 		7287A83B298797E9004A50E2 /* SearchFieldResultsMac.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = SearchFieldResultsMac.mm; sourceTree = "<group>"; };
 		7287A83C298797E9004A50E2 /* SearchFieldResultsMac.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SearchFieldResultsMac.h; sourceTree = "<group>"; };
+		7295D020E0F0C07C868B904C /* UnifiedSource63-header-RenderStyleGetters.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = "UnifiedSource63-header-RenderStyleGetters.cpp"; sourceTree = "<group>"; };
 		72963B6C29510287004FF6FB /* TextAreaPart.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = TextAreaPart.h; sourceTree = "<group>"; };
 		729661A2275960A500E7DF9B /* FilterEffectGeometry.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = FilterEffectGeometry.h; sourceTree = "<group>"; };
 		7299BC6423D686A600CC6883 /* AlphaPremultiplication.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = AlphaPremultiplication.h; sourceTree = "<group>"; };
@@ -14601,6 +14633,7 @@
 		72FD88D0295D56E2006FACDC /* MenuListPart.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MenuListPart.h; sourceTree = "<group>"; };
 		72FE4046292F3D3A001D3855 /* ImageBufferContextSwitcher.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ImageBufferContextSwitcher.h; sourceTree = "<group>"; };
 		72FE4047292F3D3B001D3855 /* ImageBufferContextSwitcher.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ImageBufferContextSwitcher.cpp; sourceTree = "<group>"; };
+		73C6E6F635A4B4C36B107EAE /* UnifiedSource54-header-RenderStyleGetters.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = "UnifiedSource54-header-RenderStyleGetters.cpp"; sourceTree = "<group>"; };
 		7410760D2D6BDB77000EC9C0 /* PlatformDynamicRangeLimitCocoa.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = PlatformDynamicRangeLimitCocoa.h; sourceTree = "<group>"; };
 		746357992D7F91B200AFA625 /* PlatformDynamicRangeLimitCocoa.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = PlatformDynamicRangeLimitCocoa.mm; sourceTree = "<group>"; };
 		74C2F53D29AC9B0A006C5F97 /* ApplePayDeferredPaymentRequest.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ApplePayDeferredPaymentRequest.h; sourceTree = "<group>"; };
@@ -14614,6 +14647,7 @@
 		75793E820D0CE0B3007FC0AC /* MessageEvent.idl */ = {isa = PBXFileReference; fileEncoding = 30; lastKnownFileType = text; path = MessageEvent.idl; sourceTree = "<group>"; };
 		75793EC60D0CE72D007FC0AC /* JSMessageEvent.cpp */ = {isa = PBXFileReference; fileEncoding = 30; lastKnownFileType = sourcecode.cpp.cpp; path = JSMessageEvent.cpp; sourceTree = "<group>"; };
 		75793EC70D0CE72D007FC0AC /* JSMessageEvent.h */ = {isa = PBXFileReference; fileEncoding = 30; lastKnownFileType = sourcecode.c.h; path = JSMessageEvent.h; sourceTree = "<group>"; };
+		75FC345681CEC46DD9AE1331 /* UnifiedSource36-header-RenderStyleGetters.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = "UnifiedSource36-header-RenderStyleGetters.cpp"; sourceTree = "<group>"; };
 		7633A72413D8B33A008501B6 /* LocaleToScriptMapping.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = LocaleToScriptMapping.h; sourceTree = "<group>"; };
 		7633A72513D8B33A008501B6 /* LocaleToScriptMapping.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = LocaleToScriptMapping.cpp; sourceTree = "<group>"; };
 		7694563A1214D97C0007CBAE /* JSDOMTokenList.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = JSDOMTokenList.cpp; sourceTree = "<group>"; };
@@ -14656,12 +14690,6 @@
 		77D50FFD1ED4F70C00DA4C87 /* JSCredentialCreationOptions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = JSCredentialCreationOptions.h; sourceTree = "<group>"; };
 		77D50FFE1ED4F70C00DA4C87 /* JSCredentialRequestOptions.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = JSCredentialRequestOptions.cpp; sourceTree = "<group>"; };
 		77D50FFF1ED4F70C00DA4C87 /* JSCredentialRequestOptions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = JSCredentialRequestOptions.h; sourceTree = "<group>"; };
-		FC260000000000FC00000001 /* FederatedCredentialRequestOptions.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = FederatedCredentialRequestOptions.h; sourceTree = "<group>"; };
-		FC260000000000FC00000002 /* FederatedCredentialRequestOptions.idl */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = FederatedCredentialRequestOptions.idl; sourceTree = "<group>"; };
-		FC260000000000DC00000001 /* IdentityCredentialRequestOptions.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = IdentityCredentialRequestOptions.h; sourceTree = "<group>"; };
-		FC260000000000DC00000002 /* IdentityCredentialRequestOptions.idl */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = IdentityCredentialRequestOptions.idl; sourceTree = "<group>"; };
-		FC2600000000000C00000001 /* OTPCredentialRequestOptions.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = OTPCredentialRequestOptions.h; sourceTree = "<group>"; };
-		FC2600000000000C00000002 /* OTPCredentialRequestOptions.idl */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = OTPCredentialRequestOptions.idl; sourceTree = "<group>"; };
 		77D510161ED6021B00DA4C87 /* CredentialsContainer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CredentialsContainer.h; sourceTree = "<group>"; };
 		77D510181ED7159900DA4C87 /* CredentialsContainer.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = CredentialsContainer.cpp; sourceTree = "<group>"; };
 		77D5101A1ED722B500DA4C87 /* JSCredentialsContainer.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = JSCredentialsContainer.cpp; sourceTree = "<group>"; };
@@ -14695,6 +14723,8 @@
 		7A4278FF2D8CC06500A60073 /* FontCascadeCocoaInlines.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = FontCascadeCocoaInlines.h; sourceTree = "<group>"; };
 		7A45032D18DB717200377B34 /* BufferedLineReader.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = BufferedLineReader.cpp; sourceTree = "<group>"; };
 		7A45032E18DB717200377B34 /* BufferedLineReader.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BufferedLineReader.h; sourceTree = "<group>"; };
+		7A4D884D2FA28596002C8D1C /* StyleInheritedRareCSSData.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = StyleInheritedRareCSSData.h; sourceTree = "<group>"; };
+		7A4D884E2FA28596002C8D1C /* StyleInheritedRareCSSData.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = StyleInheritedRareCSSData.cpp; sourceTree = "<group>"; };
 		7A54857D14E02D51006AE05A /* InspectorHistory.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = InspectorHistory.cpp; sourceTree = "<group>"; };
 		7A54857E14E02D51006AE05A /* InspectorHistory.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = InspectorHistory.h; sourceTree = "<group>"; };
 		7A54881514E432A1006AE05A /* DOMPatchSupport.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = DOMPatchSupport.h; sourceTree = "<group>"; };
@@ -14762,6 +14792,7 @@
 		7ABA250D28AEF4FC005D4F6D /* ReportBody.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = ReportBody.cpp; sourceTree = "<group>"; };
 		7ABA250E28B40370005D4F6D /* ReportingClient.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ReportingClient.h; sourceTree = "<group>"; };
 		7ABB0F5F2CE7C170009A837D /* QuirksData.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = QuirksData.h; sourceTree = "<group>"; };
+		7ABF02D621D7EBA2AFFD021A /* UnifiedSource35-header-RenderStyleGetters.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = "UnifiedSource35-header-RenderStyleGetters.cpp"; sourceTree = "<group>"; };
 		7AC09F3628BFD45B004568FC /* JSReportBody.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = JSReportBody.h; sourceTree = "<group>"; };
 		7AC09F3728BFD45B004568FC /* JSReportBody.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = JSReportBody.cpp; sourceTree = "<group>"; };
 		7AC09F3828BFD45B004568FC /* JSReportingObserverCallback.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = JSReportingObserverCallback.h; sourceTree = "<group>"; };
@@ -15046,6 +15077,7 @@
 		7C6136F71710C35200FF4A57 /* InFilesCompiler.pm */ = {isa = PBXFileReference; lastKnownFileType = text.script.perl; name = InFilesCompiler.pm; path = scripts/InFilesCompiler.pm; sourceTree = "<group>"; };
 		7C6136F81710C35200FF4A57 /* InFilesParser.pm */ = {isa = PBXFileReference; lastKnownFileType = text.script.perl; name = InFilesParser.pm; path = scripts/InFilesParser.pm; sourceTree = "<group>"; };
 		7C6136F91710C35200FF4A57 /* StaticString.pm */ = {isa = PBXFileReference; lastKnownFileType = text.script.perl; name = StaticString.pm; path = scripts/StaticString.pm; sourceTree = "<group>"; };
+		7C61AFF4898CB7897BCB412E /* UnifiedSource64-header-RenderStyleGetters.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = "UnifiedSource64-header-RenderStyleGetters.cpp"; sourceTree = "<group>"; };
 		7C6522EC1E00A4C700677F22 /* ApplePayPaymentMethod.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ApplePayPaymentMethod.h; sourceTree = "<group>"; };
 		7C6522ED1E00A4C700677F22 /* ApplePayPaymentMethod.idl */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = ApplePayPaymentMethod.idl; sourceTree = "<group>"; };
 		7C6522F21E00A51700677F22 /* ApplePayPaymentPass.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ApplePayPaymentPass.h; sourceTree = "<group>"; };
@@ -15166,6 +15198,7 @@
 		7C8F22431DD3B3B900E92DA3 /* SVGAngleValue.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SVGAngleValue.h; sourceTree = "<group>"; };
 		7C8F22451DD3D1C500E92DA3 /* SVGPreserveAspectRatioValue.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = SVGPreserveAspectRatioValue.cpp; sourceTree = "<group>"; };
 		7C8F22461DD3D1C500E92DA3 /* SVGPreserveAspectRatioValue.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SVGPreserveAspectRatioValue.h; sourceTree = "<group>"; };
+		7C8F277F5B1147C3195DDAB2 /* UnifiedSource22-header-RenderStyleGetters.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = "UnifiedSource22-header-RenderStyleGetters.cpp"; sourceTree = "<group>"; };
 		7C93F3471AA6BA5E00A98BAB /* CompiledContentExtension.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = CompiledContentExtension.cpp; sourceTree = "<group>"; };
 		7C93F3481AA6BA5E00A98BAB /* CompiledContentExtension.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CompiledContentExtension.h; sourceTree = "<group>"; };
 		7C93F34B1AA6BF0700A98BAB /* ContentExtensionCompiler.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ContentExtensionCompiler.cpp; sourceTree = "<group>"; };
@@ -15471,6 +15504,7 @@
 		836589D91F54A76200DC31F4 /* JSFileSystemDirectoryReader.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = JSFileSystemDirectoryReader.h; sourceTree = "<group>"; };
 		836589DA1F54A76200DC31F4 /* JSFileSystemEntriesCallback.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = JSFileSystemEntriesCallback.cpp; sourceTree = "<group>"; };
 		836589DB1F54A76200DC31F4 /* JSFileSystemDirectoryReader.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = JSFileSystemDirectoryReader.cpp; sourceTree = "<group>"; };
+		8367965ED15A1EE1FF2AD6D1 /* UnifiedSource7-header-RenderStyleGetters.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = "UnifiedSource7-header-RenderStyleGetters.cpp"; sourceTree = "<group>"; };
 		8369E58F1AFDD0300087DF68 /* NonDocumentTypeChildNode.idl */ = {isa = PBXFileReference; lastKnownFileType = text; path = NonDocumentTypeChildNode.idl; sourceTree = "<group>"; };
 		8369FDF91FA102CA00C1FF1F /* ServiceWorkerClientType.idl */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = ServiceWorkerClientType.idl; sourceTree = "<group>"; };
 		8369FDFB1FA102CB00C1FF1F /* ServiceWorkerClientType.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ServiceWorkerClientType.h; sourceTree = "<group>"; };
@@ -15826,8 +15860,10 @@
 		86EB71BF298C0A0E00C1DC77 /* PortIdentifier.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PortIdentifier.h; sourceTree = "<group>"; };
 		888CF1844D9C26F073F5E8D5 /* Volume1.svg */ = {isa = PBXFileReference; lastKnownFileType = text; path = Volume1.svg; sourceTree = "<group>"; };
 		88C95BD3B0DF51F628589FE9 /* Play.svg */ = {isa = PBXFileReference; lastKnownFileType = text; path = Play.svg; sourceTree = "<group>"; };
+		886246164BC21FF991E1CACF /* UnifiedSource67-header-RenderStyleGetters.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = "UnifiedSource67-header-RenderStyleGetters.cpp"; sourceTree = "<group>"; };
 		898785F2122E1EAC003AABDA /* JSFileReaderSync.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = JSFileReaderSync.cpp; sourceTree = "<group>"; };
 		898785F3122E1EAC003AABDA /* JSFileReaderSync.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = JSFileReaderSync.h; sourceTree = "<group>"; };
+		89C20A7AC4BA0F7144DDF0B9 /* UnifiedSource2-header-RenderStyleGetters.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = "UnifiedSource2-header-RenderStyleGetters.cpp"; sourceTree = "<group>"; };
 		8A00EEC72A680139006A53A2 /* EXTDepthClamp.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = EXTDepthClamp.h; sourceTree = "<group>"; };
 		8A00EEC82A680139006A53A2 /* EXTDepthClamp.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = EXTDepthClamp.cpp; sourceTree = "<group>"; };
 		8A00EEC92A68013A006A53A2 /* EXTDepthClamp.idl */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = EXTDepthClamp.idl; sourceTree = "<group>"; };
@@ -15932,8 +15968,10 @@
 		8AF4E55411DC5A36000ED3DE /* PerformanceNavigation.idl */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = PerformanceNavigation.idl; sourceTree = "<group>"; };
 		8AF4E55911DC5A63000ED3DE /* PerformanceTiming.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PerformanceTiming.h; sourceTree = "<group>"; };
 		8AF4E55A11DC5A63000ED3DE /* PerformanceTiming.idl */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = PerformanceTiming.idl; sourceTree = "<group>"; };
+		8B4936F9C7F6D9A2071F9A39 /* UnifiedSource9-header-RenderStyleGetters.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = "UnifiedSource9-header-RenderStyleGetters.cpp"; sourceTree = "<group>"; };
 		8B5216F42DEE4E75003BC21B /* LazyLoadModelObserver.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = LazyLoadModelObserver.h; sourceTree = "<group>"; };
 		8B5216F52DEE4E75003BC21B /* LazyLoadModelObserver.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = LazyLoadModelObserver.cpp; sourceTree = "<group>"; };
+		8C36C2A063D49F0AFB0A20E2 /* UnifiedSource42-header-RenderStyleGetters.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = "UnifiedSource42-header-RenderStyleGetters.cpp"; sourceTree = "<group>"; };
 		8C9554043E0200000087F79C /* StyleSubstitutionResolver.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = StyleSubstitutionResolver.cpp; sourceTree = "<group>"; };
 		8D4BE1481A86E83B4B84198A /* Volume3-RTL.svg */ = {isa = PBXFileReference; lastKnownFileType = text; path = "Volume3-RTL.svg"; sourceTree = "<group>"; };
 		8E4C96D81AD4483500365A50 /* JSFetchResponse.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = JSFetchResponse.cpp; sourceTree = "<group>"; };
@@ -16271,6 +16309,7 @@
 		939C0D2325648C4E00B3211B /* SpeechRecognizer.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = SpeechRecognizer.cpp; sourceTree = "<group>"; };
 		939C0D282564E7F200B3211B /* MediaUtilities.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = MediaUtilities.cpp; sourceTree = "<group>"; };
 		939C0D292564E7F200B3211B /* MediaUtilities.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MediaUtilities.h; sourceTree = "<group>"; };
+		939F8CC43E871DE5E8AB5A9F /* UnifiedSource32-header-RenderStyleGetters.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = "UnifiedSource32-header-RenderStyleGetters.cpp"; sourceTree = "<group>"; };
 		93A0481B254954E4000AC462 /* SpeechRecognitionResultData.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SpeechRecognitionResultData.h; sourceTree = "<group>"; };
 		93A0481D254954E5000AC462 /* SpeechRecognitionConnection.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SpeechRecognitionConnection.h; sourceTree = "<group>"; };
 		93A0481F254954E6000AC462 /* SpeechRecognitionRequest.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SpeechRecognitionRequest.h; sourceTree = "<group>"; };
@@ -16672,6 +16711,7 @@
 		978AD67114130A8D00C7CAE3 /* HTMLSpanElement.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = HTMLSpanElement.cpp; sourceTree = "<group>"; };
 		978AD67214130A8D00C7CAE3 /* HTMLSpanElement.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = HTMLSpanElement.h; sourceTree = "<group>"; };
 		978AD67314130A8D00C7CAE3 /* HTMLSpanElement.idl */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = HTMLSpanElement.idl; sourceTree = "<group>"; };
+		978CE10C711D6B12D9FBC9C9 /* UnifiedSource37-header-RenderStyleGetters.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = "UnifiedSource37-header-RenderStyleGetters.cpp"; sourceTree = "<group>"; };
 		978D07BD145A0F6C0096908D /* DOMException.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = DOMException.cpp; sourceTree = "<group>"; };
 		979F43D11075E44A0000F83B /* NavigationScheduler.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = NavigationScheduler.cpp; sourceTree = "<group>"; };
 		979F43D21075E44A0000F83B /* NavigationScheduler.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = NavigationScheduler.h; sourceTree = "<group>"; };
@@ -16864,6 +16904,7 @@
 		9B0ABCA423679ACF00B45085 /* WorkerEventLoop.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WorkerEventLoop.h; sourceTree = "<group>"; };
 		9B0ABCAC236BB40A00B45085 /* TaskSource.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = TaskSource.h; sourceTree = "<group>"; };
 		9B0FE8731D9E02DF004A8ACB /* DocumentOrShadowRoot.idl */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = DocumentOrShadowRoot.idl; sourceTree = "<group>"; };
+		9B1085E5B79E8A71CC22A26E /* UnifiedSource26-header-RenderStyleGetters.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = "UnifiedSource26-header-RenderStyleGetters.cpp"; sourceTree = "<group>"; };
 		9B114E1B2D4CC41C00FD0A0D /* ElementCreationOptions.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ElementCreationOptions.h; sourceTree = "<group>"; };
 		9B114E1C2D4CC41C00FD0A0D /* ElementCreationOptions.idl */ = {isa = PBXFileReference; lastKnownFileType = text; path = ElementCreationOptions.idl; sourceTree = "<group>"; };
 		9B1229C623FE4D5F008CA751 /* MediaStrategy.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MediaStrategy.h; sourceTree = "<group>"; };
@@ -16964,16 +17005,20 @@
 		9BEA6CED2DD307EC0024B515 /* ScriptExecutionContextInlines.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ScriptExecutionContextInlines.h; sourceTree = "<group>"; };
 		9BED2CAF1F7CC06200666018 /* PasteboardCocoa.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = PasteboardCocoa.mm; sourceTree = "<group>"; };
 		9BF433761F67619B00E1FD71 /* WebContentReader.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WebContentReader.h; sourceTree = "<group>"; };
+		9BF8F60FC54FDA5A320BD129 /* UnifiedSource23-header-RenderStyleGetters.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = "UnifiedSource23-header-RenderStyleGetters.cpp"; sourceTree = "<group>"; };
 		9BF9A87E1648DD2F001C6B23 /* JSHTMLFormControlsCollection.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = JSHTMLFormControlsCollection.cpp; sourceTree = "<group>"; };
 		9BF9A87F1648DD2F001C6B23 /* JSHTMLFormControlsCollection.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = JSHTMLFormControlsCollection.h; sourceTree = "<group>"; };
+		9C26E8CE9CFBE3ECA1C04907 /* UnifiedSource62-header-RenderStyleGetters.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = "UnifiedSource62-header-RenderStyleGetters.cpp"; sourceTree = "<group>"; };
 		9D63800F1AF16E160031A15C /* StyleSelfAlignmentData.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = StyleSelfAlignmentData.h; sourceTree = "<group>"; };
 		9DAC7C561AF2CB6400437C44 /* StyleContentAlignmentData.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = StyleContentAlignmentData.h; sourceTree = "<group>"; };
+		9E3E301A4FF9CC03FB16C8B2 /* UnifiedSource18-header-RenderStyleGetters.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = "UnifiedSource18-header-RenderStyleGetters.cpp"; sourceTree = "<group>"; };
 		9E47A8222F01986A00D57716 /* FEMorphologyCoreImageApplier.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = FEMorphologyCoreImageApplier.h; sourceTree = "<group>"; };
 		9E47A8242F0198AA00D57716 /* FEMorphologyCoreImageApplier.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = FEMorphologyCoreImageApplier.mm; sourceTree = "<group>"; };
 		9E5F6AC02E441ABC001C81D8 /* SourceAlphaCoreImageApplier.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SourceAlphaCoreImageApplier.h; sourceTree = "<group>"; };
 		9E5F6AC12E441B09001C81D8 /* SourceAlphaCoreImageApplier.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = SourceAlphaCoreImageApplier.mm; sourceTree = "<group>"; };
 		9E68A6952DC9406100039106 /* FrameMemoryMonitor.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = FrameMemoryMonitor.h; sourceTree = "<group>"; };
 		9E68A6962DC9407300039106 /* FrameMemoryMonitor.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = FrameMemoryMonitor.cpp; sourceTree = "<group>"; };
+		9E89B7DB68E9CE297AC2CD6A /* UnifiedSource34-header-RenderStyleGetters.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = "UnifiedSource34-header-RenderStyleGetters.cpp"; sourceTree = "<group>"; };
 		A07D3353152B630E001B6393 /* JSWebGLShaderPrecisionFormat.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = JSWebGLShaderPrecisionFormat.cpp; sourceTree = "<group>"; };
 		A07D3354152B630E001B6393 /* JSWebGLShaderPrecisionFormat.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = JSWebGLShaderPrecisionFormat.h; sourceTree = "<group>"; };
 		A07D3357152B632D001B6393 /* WebGLShaderPrecisionFormat.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WebGLShaderPrecisionFormat.h; sourceTree = "<group>"; };
@@ -17502,6 +17547,7 @@
 		A58C59CE1E382EA90047859C /* JSPerformanceMeasure.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = JSPerformanceMeasure.cpp; sourceTree = "<group>"; };
 		A58C59CF1E382EA90047859C /* JSPerformanceMeasure.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = JSPerformanceMeasure.h; sourceTree = "<group>"; };
 		A593CF8A1840535200BFCE27 /* InspectorWebAgentBase.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = InspectorWebAgentBase.h; sourceTree = "<group>"; };
+		A599F54EADD15733ED9178AE /* UnifiedSource47-header-RenderStyleGetters.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = "UnifiedSource47-header-RenderStyleGetters.cpp"; sourceTree = "<group>"; };
 		A59C230621F29205004EC939 /* InspectorCPUProfilerAgent.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = InspectorCPUProfilerAgent.cpp; sourceTree = "<group>"; };
 		A59C230821F29206004EC939 /* InspectorCPUProfilerAgent.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = InspectorCPUProfilerAgent.h; sourceTree = "<group>"; };
 		A5A7AA42132F0ECC00D3A3C2 /* AutocapitalizeTypes.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AutocapitalizeTypes.h; sourceTree = "<group>"; };
@@ -17614,6 +17660,7 @@
 		A72763BE16689BFB002FCACB /* UserActionElementSet.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = UserActionElementSet.h; sourceTree = "<group>"; };
 		A73F95FC12C97BFE0031AAF9 /* LayoutRoundedRect.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = LayoutRoundedRect.cpp; sourceTree = "<group>"; };
 		A73F95FD12C97BFE0031AAF9 /* LayoutRoundedRect.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = LayoutRoundedRect.h; sourceTree = "<group>"; };
+		A756860D9AF6A2C15FCF7E3E /* UnifiedSource40-header-RenderStyleGetters.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = "UnifiedSource40-header-RenderStyleGetters.cpp"; sourceTree = "<group>"; };
 		A75E497410752ACB00C9B896 /* SerializedScriptValue.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SerializedScriptValue.h; sourceTree = "<group>"; };
 		A75E497510752ACB00C9B896 /* SerializedScriptValue.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = SerializedScriptValue.cpp; sourceTree = "<group>"; };
 		A75E8B800E1DE2D6007F2481 /* FEBlend.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = FEBlend.cpp; sourceTree = "<group>"; };
@@ -17646,6 +17693,7 @@
 		A784941A0B5FE507001E237A /* DataTransfer.cpp */ = {isa = PBXFileReference; fileEncoding = 30; lastKnownFileType = sourcecode.cpp.cpp; path = DataTransfer.cpp; sourceTree = "<group>"; };
 		A78FE13912366B1000ACE8D0 /* SpellChecker.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = SpellChecker.cpp; sourceTree = "<group>"; };
 		A78FE13A12366B1000ACE8D0 /* SpellChecker.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.h; fileEncoding = 4; path = SpellChecker.h; sourceTree = "<group>"; };
+		A7925FD267D4C894F38E1AD7 /* UnifiedSource56-header-RenderStyleGetters.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = "UnifiedSource56-header-RenderStyleGetters.cpp"; sourceTree = "<group>"; };
 		A79546420B5C4CB4007B438F /* DragData.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = DragData.cpp; sourceTree = "<group>"; };
 		A79BAD9D161E7F3F00C2E652 /* RuleFeature.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = RuleFeature.cpp; sourceTree = "<group>"; };
 		A79BAD9E161E7F3F00C2E652 /* RuleFeature.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RuleFeature.h; sourceTree = "<group>"; };
@@ -18144,6 +18192,7 @@
 		AB67D1A6097F3AE300F9392E /* RenderTextControl.cpp */ = {isa = PBXFileReference; fileEncoding = 30; lastKnownFileType = sourcecode.cpp.cpp; path = RenderTextControl.cpp; sourceTree = "<group>"; };
 		AB67D1A7097F3AE300F9392E /* RenderTextControl.h */ = {isa = PBXFileReference; fileEncoding = 30; lastKnownFileType = sourcecode.c.h; path = RenderTextControl.h; sourceTree = "<group>"; };
 		AB7170880B3118080017123E /* SearchPopupMenu.h */ = {isa = PBXFileReference; fileEncoding = 30; lastKnownFileType = sourcecode.c.h; path = SearchPopupMenu.h; sourceTree = "<group>"; };
+		AB81B1E55657A17F362C4920 /* UnifiedSource10-header-RenderStyleGetters.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = "UnifiedSource10-header-RenderStyleGetters.cpp"; sourceTree = "<group>"; };
 		ABAF22070C03B1C700B0BCF0 /* ChromeMac.mm */ = {isa = PBXFileReference; fileEncoding = 30; lastKnownFileType = sourcecode.cpp.objcpp; path = ChromeMac.mm; sourceTree = "<group>"; };
 		ABB5419C0ACDDFE4002820EB /* RenderListBox.cpp */ = {isa = PBXFileReference; fileEncoding = 30; lastKnownFileType = sourcecode.cpp.cpp; path = RenderListBox.cpp; sourceTree = "<group>"; };
 		ABB5419D0ACDDFE4002820EB /* RenderListBox.h */ = {isa = PBXFileReference; fileEncoding = 30; lastKnownFileType = sourcecode.c.h; path = RenderListBox.h; sourceTree = "<group>"; };
@@ -18212,6 +18261,7 @@
 		AED243682C939A6800E8649D /* AuthenticationResponseJSON.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = AuthenticationResponseJSON.h; sourceTree = "<group>"; };
 		AED2436A2C939AB600E8649D /* RegistrationResponseJSON.idl */ = {isa = PBXFileReference; lastKnownFileType = text; path = RegistrationResponseJSON.idl; sourceTree = "<group>"; };
 		AED2436B2C939AB800E8649D /* AuthenticationResponseJSON.idl */ = {isa = PBXFileReference; lastKnownFileType = text; path = AuthenticationResponseJSON.idl; sourceTree = "<group>"; };
+		AEEABC16FEE73A1AE39407C0 /* UnifiedSource17-header-RenderStyleGetters.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = "UnifiedSource17-header-RenderStyleGetters.cpp"; sourceTree = "<group>"; };
 		B10B697D140C174000BC1C26 /* WebVTTToken.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WebVTTToken.h; sourceTree = "<group>"; };
 		B10B697E140C174000BC1C26 /* WebVTTTokenizer.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = WebVTTTokenizer.cpp; sourceTree = "<group>"; };
 		B10B697F140C174000BC1C26 /* WebVTTTokenizer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WebVTTTokenizer.h; sourceTree = "<group>"; };
@@ -18824,6 +18874,7 @@
 		B2FA3D2E0AB75A6F000E5AC4 /* JSSVGViewElement.cpp */ = {isa = PBXFileReference; fileEncoding = 30; lastKnownFileType = sourcecode.cpp.cpp; path = JSSVGViewElement.cpp; sourceTree = "<group>"; };
 		B2FA3D2F0AB75A6F000E5AC4 /* JSSVGViewElement.h */ = {isa = PBXFileReference; fileEncoding = 30; lastKnownFileType = sourcecode.c.h; path = JSSVGViewElement.h; sourceTree = "<group>"; };
 		B5072BE12210266CE7E320FC /* Airplay.svg */ = {isa = PBXFileReference; lastKnownFileType = text; path = Airplay.svg; sourceTree = "<group>"; };
+		B4059720D99B652A638A10FB /* UnifiedSource8-header-RenderStyleGetters.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = "UnifiedSource8-header-RenderStyleGetters.cpp"; sourceTree = "<group>"; };
 		B50F5B800E96CD9900AD71A6 /* WebCoreObjCExtras.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = WebCoreObjCExtras.mm; sourceTree = "<group>"; };
 		B51A2F3E17D7D3A40072517A /* ImageQualityController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ImageQualityController.h; sourceTree = "<group>"; };
 		B51A2F4017D7D5DA0072517A /* ImageQualityController.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ImageQualityController.cpp; sourceTree = "<group>"; };
@@ -18894,6 +18945,9 @@
 		BA96836A2E8FDA9A0035D494 /* LoadableSpeculationRules.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = LoadableSpeculationRules.cpp; sourceTree = "<group>"; };
 		BAA6A9456E5BF7AF37452077 /* X.svg */ = {isa = PBXFileReference; lastKnownFileType = text; path = X.svg; sourceTree = "<group>"; };
 		BBC79ECC2A4F6096D62983F5 /* Volume2-RTL.svg */ = {isa = PBXFileReference; lastKnownFileType = text; path = "Volume2-RTL.svg"; sourceTree = "<group>"; };
+		BAECA0A8276147146143052D /* UnifiedSource28-header-RenderStyleGetters.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = "UnifiedSource28-header-RenderStyleGetters.cpp"; sourceTree = "<group>"; };
+		BAF547B3E0A08ACCDA0FD3EE /* UnifiedSource73-header-RenderStyleGetters.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = "UnifiedSource73-header-RenderStyleGetters.cpp"; sourceTree = "<group>"; };
+		BB591C358F2E176568F6C0AA /* UnifiedSource71-header-RenderStyleGetters.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = "UnifiedSource71-header-RenderStyleGetters.cpp"; sourceTree = "<group>"; };
 		BC000BD82C5A96850033AA75 /* CSSCalcType.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CSSCalcType.h; sourceTree = "<group>"; };
 		BC000BD92C5A9A820033AA75 /* CSSCalcType.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = CSSCalcType.cpp; sourceTree = "<group>"; };
 		BC000BDB2C5A9D4F0033AA75 /* CSSCalcTree.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CSSCalcTree.h; sourceTree = "<group>"; };
@@ -20599,6 +20653,8 @@
 		BCFEE3302DC6B2C300EC3901 /* StyleExtractor.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = StyleExtractor.h; sourceTree = "<group>"; };
 		BCFEE3322DC6B33D00EC3901 /* StyleExtractor.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = StyleExtractor.cpp; sourceTree = "<group>"; };
 		BCFEE3332DC6C4B800EC3901 /* StyleExtractorGenerated.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = StyleExtractorGenerated.cpp; sourceTree = "<group>"; };
+		BCFF63713748594F7E1BE330 /* UnifiedSource38-header-RenderStyleGetters.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = "UnifiedSource38-header-RenderStyleGetters.cpp"; sourceTree = "<group>"; };
+		BD0EA2751C530E9F3689675A /* UnifiedSource59-header-RenderStyleGetters.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = "UnifiedSource59-header-RenderStyleGetters.cpp"; sourceTree = "<group>"; };
 		BE0787A729B2279D0067473E /* TextTransform.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TextTransform.h; sourceTree = "<group>"; };
 		BE0C0A9F2AFCE8A6004B7765 /* CSSScopeRule.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = CSSScopeRule.cpp; sourceTree = "<group>"; };
 		BE0C0AA02AFCE8A7004B7765 /* CSSScopeRule.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CSSScopeRule.h; sourceTree = "<group>"; };
@@ -20607,6 +20663,7 @@
 		BE16C58F17CFE17200852C04 /* InbandGenericTextTrack.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = InbandGenericTextTrack.h; sourceTree = "<group>"; };
 		BE16C59017CFE17200852C04 /* InbandWebVTTTextTrack.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = InbandWebVTTTextTrack.cpp; sourceTree = "<group>"; };
 		BE16C59117CFE17200852C04 /* InbandWebVTTTextTrack.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = InbandWebVTTTextTrack.h; sourceTree = "<group>"; };
+		BE1A40333AB79B5518B8B658 /* UnifiedSource44-header-RenderStyleGetters.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = "UnifiedSource44-header-RenderStyleGetters.cpp"; sourceTree = "<group>"; };
 		BE20507618A458460080647E /* VTTCue.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = VTTCue.cpp; sourceTree = "<group>"; };
 		BE20507718A458460080647E /* VTTCue.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = VTTCue.h; sourceTree = "<group>"; };
 		BE20507818A458460080647E /* VTTCue.idl */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = VTTCue.idl; sourceTree = "<group>"; };
@@ -20661,6 +20718,7 @@
 		BEF29EE91715DD0900C4B4C9 /* AudioTrackPrivate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AudioTrackPrivate.h; sourceTree = "<group>"; };
 		BEF29EEA1715DD0900C4B4C9 /* VideoTrackPrivate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = VideoTrackPrivate.h; sourceTree = "<group>"; };
 		C029AAD880833E8D745FD969 /* Overflow.svg */ = {isa = PBXFileReference; lastKnownFileType = text; path = Overflow.svg; sourceTree = "<group>"; };
+		BFD548E1DACEDB63C7EA23AF /* UnifiedSource30-header-RenderStyleGetters.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = "UnifiedSource30-header-RenderStyleGetters.cpp"; sourceTree = "<group>"; };
 		C046E1AB1208A9FE00BA2CF7 /* LocalizedStrings.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = LocalizedStrings.cpp; sourceTree = "<group>"; };
 		C0493EB7244699E4009AAC80 /* AXLogger.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AXLogger.h; sourceTree = "<group>"; };
 		C05F94852AB8E1A70028AA39 /* AXCoreObject.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = AXCoreObject.cpp; sourceTree = "<group>"; };
@@ -20706,6 +20764,7 @@
 		C2F4E7881E45AEDF006D7105 /* ComplexTextController.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ComplexTextController.cpp; sourceTree = "<group>"; };
 		C2F4E7891E45AEDF006D7105 /* ComplexTextController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ComplexTextController.h; sourceTree = "<group>"; };
 		C330A22113EC196B0000B45B /* ColorChooser.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ColorChooser.h; sourceTree = "<group>"; };
+		C330BEA189D73D0667F53763 /* UnifiedSource4-header-RenderStyleGetters.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = "UnifiedSource4-header-RenderStyleGetters.cpp"; sourceTree = "<group>"; };
 		C33EE5C214FB49610002095A /* BaseClickableWithKeyInputType.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = BaseClickableWithKeyInputType.cpp; sourceTree = "<group>"; };
 		C33EE5C314FB49610002095A /* BaseClickableWithKeyInputType.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BaseClickableWithKeyInputType.h; sourceTree = "<group>"; };
 		C348612115FDE21E007A1CC9 /* InputTypeNames.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = InputTypeNames.cpp; sourceTree = "<group>"; };
@@ -20750,6 +20809,7 @@
 		C5F765B414E1D414006C899B /* PasteboardStrategy.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PasteboardStrategy.h; sourceTree = "<group>"; };
 		C5F765BA14E1ECF4006C899B /* PlatformPasteboardMac.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = PlatformPasteboardMac.mm; sourceTree = "<group>"; };
 		C60B274C7A64765244CADCAA /* Volume2.svg */ = {isa = PBXFileReference; lastKnownFileType = text; path = Volume2.svg; sourceTree = "<group>"; };
+		C6331D4D1626BCDABB8516DB /* UnifiedSource21-header-RenderStyleGetters.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = "UnifiedSource21-header-RenderStyleGetters.cpp"; sourceTree = "<group>"; };
 		C65046A8167BFB5500CC2A4D /* TemplateContentDocumentFragment.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TemplateContentDocumentFragment.h; sourceTree = "<group>"; };
 		C6A703325C9D0B6CDCBC4D78 /* JSEventTarget.cpp */ = {isa = PBXFileReference; fileEncoding = 30; lastKnownFileType = sourcecode.cpp.cpp; path = JSEventTarget.cpp; sourceTree = "<group>"; };
 		C6D74AD309AA282E000B0A52 /* ModifySelectionListLevel.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ModifySelectionListLevel.h; sourceTree = "<group>"; };
@@ -20766,6 +20826,7 @@
 		C6F0902414327D4F00685849 /* JSMutationObserver.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = JSMutationObserver.cpp; sourceTree = "<group>"; };
 		C6F0902514327D4F00685849 /* JSMutationObserver.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = JSMutationObserver.h; sourceTree = "<group>"; };
 		C6F0917E143A2BB900685849 /* JSMutationObserverCustom.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = JSMutationObserverCustom.cpp; sourceTree = "<group>"; };
+		C91C8C4B6EDB7E3196424FBE /* UnifiedSource66-header-RenderStyleGetters.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = "UnifiedSource66-header-RenderStyleGetters.cpp"; sourceTree = "<group>"; };
 		C9D467041E60C3EB008195FB /* AutoplayEvent.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = AutoplayEvent.h; sourceTree = "<group>"; };
 		CA1635DC2072E76900E7D2CE /* ReferrerPolicy.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ReferrerPolicy.cpp; sourceTree = "<group>"; };
 		CA1933D52407D6400071241A /* PerformancePaintTiming.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = PerformancePaintTiming.h; sourceTree = "<group>"; };
@@ -21542,7 +21603,9 @@
 		D3F3D3601A69A5060059FC2B /* WebGLRenderingContextBase.idl */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = WebGLRenderingContextBase.idl; sourceTree = "<group>"; };
 		D3F3D3611A69B1900059FC2B /* JSWebGL2RenderingContext.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = JSWebGL2RenderingContext.cpp; sourceTree = "<group>"; };
 		D3F3D3621A69B1900059FC2B /* JSWebGL2RenderingContext.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = JSWebGL2RenderingContext.h; sourceTree = "<group>"; };
+		D482513BF8F4914090F55B14 /* UnifiedSource27-header-RenderStyleGetters.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = "UnifiedSource27-header-RenderStyleGetters.cpp"; sourceTree = "<group>"; };
 		D4F72C653A64807A83E76FB8 /* MathMLOperatorDictionary.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = MathMLOperatorDictionary.cpp; sourceTree = "<group>"; };
+		D508C53D5BA52394A72A6606 /* UnifiedSource13-header-RenderStyleGetters.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = "UnifiedSource13-header-RenderStyleGetters.cpp"; sourceTree = "<group>"; };
 		D6022D862F5A489D007BC32C /* ICUSearcher.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ICUSearcher.h; sourceTree = "<group>"; };
 		D6022D872F5A48A5007BC32C /* ICUSearcher.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = ICUSearcher.cpp; sourceTree = "<group>"; };
 		D61496E12E428EDB00BAF335 /* UserAgentStringParser.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = UserAgentStringParser.h; sourceTree = "<group>"; };
@@ -21576,6 +21639,7 @@
 		D70AD65513E1342B005B50B4 /* RenderFragmentContainer.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = RenderFragmentContainer.cpp; sourceTree = "<group>"; };
 		D70AD65613E1342B005B50B4 /* RenderFragmentContainer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RenderFragmentContainer.h; sourceTree = "<group>"; };
 		D7E7E02D100D3C3969DAEB93 /* SkipForward10.svg */ = {isa = PBXFileReference; lastKnownFileType = text; path = SkipForward10.svg; sourceTree = "<group>"; };
+		D8A6C642D6DAE088EF53F376 /* UnifiedSource68-header-RenderStyleGetters.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = "UnifiedSource68-header-RenderStyleGetters.cpp"; sourceTree = "<group>"; };
 		D8B6152E1032495100C8554A /* Cookie.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Cookie.h; sourceTree = "<group>"; };
 		D913B53A28AC3BF2008B9648 /* PermissionQuerySource.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PermissionQuerySource.h; sourceTree = "<group>"; };
 		D92FD75E28A328C6008BB050 /* WorkerNavigator+Permissions.idl */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = "WorkerNavigator+Permissions.idl"; sourceTree = "<group>"; };
@@ -21634,6 +21698,7 @@
 		DDD517EB2A9FC5440069AF81 /* LineLayoutResult.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = LineLayoutResult.h; sourceTree = "<group>"; };
 		DDD5F55A2C703DF200E1C692 /* TextBoxTrimmer.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = TextBoxTrimmer.cpp; sourceTree = "<group>"; };
 		DDD5F55B2C703DFC00E1C692 /* TextBoxTrimmer.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = TextBoxTrimmer.h; sourceTree = "<group>"; };
+		DDD6571342E109928469E047 /* UnifiedSource76-header-RenderStyleGetters.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = "UnifiedSource76-header-RenderStyleGetters.cpp"; sourceTree = "<group>"; };
 		DDDBF6712AA8186800E07248 /* AbstractLineBuilder.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = AbstractLineBuilder.cpp; sourceTree = "<group>"; };
 		DDDFE83A2846ECD3006F1EE5 /* adwaita */ = {isa = PBXFileReference; lastKnownFileType = folder; path = adwaita; sourceTree = "<group>"; };
 		DDDFE83B2846ECD3006F1EE5 /* cocoa */ = {isa = PBXFileReference; lastKnownFileType = folder; path = cocoa; sourceTree = "<group>"; };
@@ -21645,6 +21710,7 @@
 		DDECCC1D2BABA83E0041CD3C /* RangeBasedLineBuilder.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = RangeBasedLineBuilder.cpp; sourceTree = "<group>"; };
 		DDECCC1E2BABA8480041CD3C /* RangeBasedLineBuilder.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RangeBasedLineBuilder.h; sourceTree = "<group>"; };
 		DDFCB4802917014500C799C6 /* InlineFormattingConstraints.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = InlineFormattingConstraints.h; sourceTree = "<group>"; };
+		DE0DF0E2DD6063156D395BC5 /* UnifiedSource48-header-RenderStyleGetters.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = "UnifiedSource48-header-RenderStyleGetters.cpp"; sourceTree = "<group>"; };
 		DE5F83B21FA18676006DB63A /* UnifiedSource301.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = UnifiedSource301.cpp; sourceTree = "<group>"; };
 		DE5F83B31FA18677006DB63A /* UnifiedSource355.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = UnifiedSource355.cpp; sourceTree = "<group>"; };
 		DE5F83B41FA18678006DB63A /* UnifiedSource378.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = UnifiedSource378.cpp; sourceTree = "<group>"; };
@@ -21922,83 +21988,6 @@
 		DE5F85D21FA23856006DB63B /* UnifiedSource528.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = UnifiedSource528.cpp; sourceTree = "<group>"; };
 		DE5F85D31FA23859006DB63A /* UnifiedSource480.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = UnifiedSource480.cpp; sourceTree = "<group>"; };
 		DE5F85D31FA23859006DB63B /* UnifiedSource530.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = UnifiedSource530.cpp; sourceTree = "<group>"; };
-		4987053212B58BF9F79B19AD /* UnifiedSource1-header-RenderStyleGetters.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = "UnifiedSource1-header-RenderStyleGetters.cpp"; sourceTree = "<group>"; };
-		89C20A7AC4BA0F7144DDF0B9 /* UnifiedSource2-header-RenderStyleGetters.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = "UnifiedSource2-header-RenderStyleGetters.cpp"; sourceTree = "<group>"; };
-		004D65C61D84DB1DC5F43DBB /* UnifiedSource3-header-RenderStyleGetters.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = "UnifiedSource3-header-RenderStyleGetters.cpp"; sourceTree = "<group>"; };
-		C330BEA189D73D0667F53763 /* UnifiedSource4-header-RenderStyleGetters.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = "UnifiedSource4-header-RenderStyleGetters.cpp"; sourceTree = "<group>"; };
-		097892D45E6F50F9B2F119BB /* UnifiedSource5-header-RenderStyleGetters.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = "UnifiedSource5-header-RenderStyleGetters.cpp"; sourceTree = "<group>"; };
-		5A551F9473B2A7F6783FF6C1 /* UnifiedSource6-header-RenderStyleGetters.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = "UnifiedSource6-header-RenderStyleGetters.cpp"; sourceTree = "<group>"; };
-		8367965ED15A1EE1FF2AD6D1 /* UnifiedSource7-header-RenderStyleGetters.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = "UnifiedSource7-header-RenderStyleGetters.cpp"; sourceTree = "<group>"; };
-		B4059720D99B652A638A10FB /* UnifiedSource8-header-RenderStyleGetters.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = "UnifiedSource8-header-RenderStyleGetters.cpp"; sourceTree = "<group>"; };
-		8B4936F9C7F6D9A2071F9A39 /* UnifiedSource9-header-RenderStyleGetters.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = "UnifiedSource9-header-RenderStyleGetters.cpp"; sourceTree = "<group>"; };
-		AB81B1E55657A17F362C4920 /* UnifiedSource10-header-RenderStyleGetters.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = "UnifiedSource10-header-RenderStyleGetters.cpp"; sourceTree = "<group>"; };
-		25FAC750F76F755835BE4E86 /* UnifiedSource11-header-RenderStyleGetters.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = "UnifiedSource11-header-RenderStyleGetters.cpp"; sourceTree = "<group>"; };
-		1818859115E2479836298884 /* UnifiedSource12-header-RenderStyleGetters.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = "UnifiedSource12-header-RenderStyleGetters.cpp"; sourceTree = "<group>"; };
-		D508C53D5BA52394A72A6606 /* UnifiedSource13-header-RenderStyleGetters.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = "UnifiedSource13-header-RenderStyleGetters.cpp"; sourceTree = "<group>"; };
-		6A5A653EE2BD51501F778B98 /* UnifiedSource14-header-RenderStyleGetters.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = "UnifiedSource14-header-RenderStyleGetters.cpp"; sourceTree = "<group>"; };
-		01FA511EE07ED821FC38C8C0 /* UnifiedSource15-header-RenderStyleGetters.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = "UnifiedSource15-header-RenderStyleGetters.cpp"; sourceTree = "<group>"; };
-		1B5C8E332AFA25F34506CCB0 /* UnifiedSource16-header-RenderStyleGetters.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = "UnifiedSource16-header-RenderStyleGetters.cpp"; sourceTree = "<group>"; };
-		AEEABC16FEE73A1AE39407C0 /* UnifiedSource17-header-RenderStyleGetters.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = "UnifiedSource17-header-RenderStyleGetters.cpp"; sourceTree = "<group>"; };
-		9E3E301A4FF9CC03FB16C8B2 /* UnifiedSource18-header-RenderStyleGetters.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = "UnifiedSource18-header-RenderStyleGetters.cpp"; sourceTree = "<group>"; };
-		5250A569CD8198C008B831C9 /* UnifiedSource19-header-RenderStyleGetters.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = "UnifiedSource19-header-RenderStyleGetters.cpp"; sourceTree = "<group>"; };
-		1B721B8134C6AE9E9D34A5D7 /* UnifiedSource20-header-RenderStyleGetters.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = "UnifiedSource20-header-RenderStyleGetters.cpp"; sourceTree = "<group>"; };
-		C6331D4D1626BCDABB8516DB /* UnifiedSource21-header-RenderStyleGetters.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = "UnifiedSource21-header-RenderStyleGetters.cpp"; sourceTree = "<group>"; };
-		7C8F277F5B1147C3195DDAB2 /* UnifiedSource22-header-RenderStyleGetters.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = "UnifiedSource22-header-RenderStyleGetters.cpp"; sourceTree = "<group>"; };
-		9BF8F60FC54FDA5A320BD129 /* UnifiedSource23-header-RenderStyleGetters.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = "UnifiedSource23-header-RenderStyleGetters.cpp"; sourceTree = "<group>"; };
-		675EA032FFAF2A4098F106D8 /* UnifiedSource24-header-RenderStyleGetters.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = "UnifiedSource24-header-RenderStyleGetters.cpp"; sourceTree = "<group>"; };
-		2EC5387B1B81D685AF55472D /* UnifiedSource25-header-RenderStyleGetters.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = "UnifiedSource25-header-RenderStyleGetters.cpp"; sourceTree = "<group>"; };
-		9B1085E5B79E8A71CC22A26E /* UnifiedSource26-header-RenderStyleGetters.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = "UnifiedSource26-header-RenderStyleGetters.cpp"; sourceTree = "<group>"; };
-		D482513BF8F4914090F55B14 /* UnifiedSource27-header-RenderStyleGetters.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = "UnifiedSource27-header-RenderStyleGetters.cpp"; sourceTree = "<group>"; };
-		BAECA0A8276147146143052D /* UnifiedSource28-header-RenderStyleGetters.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = "UnifiedSource28-header-RenderStyleGetters.cpp"; sourceTree = "<group>"; };
-		FE824821D37F631F1A942B28 /* UnifiedSource29-header-RenderStyleGetters.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = "UnifiedSource29-header-RenderStyleGetters.cpp"; sourceTree = "<group>"; };
-		BFD548E1DACEDB63C7EA23AF /* UnifiedSource30-header-RenderStyleGetters.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = "UnifiedSource30-header-RenderStyleGetters.cpp"; sourceTree = "<group>"; };
-		4CA6FA18AEA1958D18A49C88 /* UnifiedSource31-header-RenderStyleGetters.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = "UnifiedSource31-header-RenderStyleGetters.cpp"; sourceTree = "<group>"; };
-		939F8CC43E871DE5E8AB5A9F /* UnifiedSource32-header-RenderStyleGetters.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = "UnifiedSource32-header-RenderStyleGetters.cpp"; sourceTree = "<group>"; };
-		5DE923E85927C51244CECFDD /* UnifiedSource33-header-RenderStyleGetters.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = "UnifiedSource33-header-RenderStyleGetters.cpp"; sourceTree = "<group>"; };
-		9E89B7DB68E9CE297AC2CD6A /* UnifiedSource34-header-RenderStyleGetters.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = "UnifiedSource34-header-RenderStyleGetters.cpp"; sourceTree = "<group>"; };
-		7ABF02D621D7EBA2AFFD021A /* UnifiedSource35-header-RenderStyleGetters.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = "UnifiedSource35-header-RenderStyleGetters.cpp"; sourceTree = "<group>"; };
-		75FC345681CEC46DD9AE1331 /* UnifiedSource36-header-RenderStyleGetters.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = "UnifiedSource36-header-RenderStyleGetters.cpp"; sourceTree = "<group>"; };
-		978CE10C711D6B12D9FBC9C9 /* UnifiedSource37-header-RenderStyleGetters.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = "UnifiedSource37-header-RenderStyleGetters.cpp"; sourceTree = "<group>"; };
-		BCFF63713748594F7E1BE330 /* UnifiedSource38-header-RenderStyleGetters.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = "UnifiedSource38-header-RenderStyleGetters.cpp"; sourceTree = "<group>"; };
-		0F76CD991B87ADACC0F2F37E /* UnifiedSource39-header-RenderStyleGetters.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = "UnifiedSource39-header-RenderStyleGetters.cpp"; sourceTree = "<group>"; };
-		A756860D9AF6A2C15FCF7E3E /* UnifiedSource40-header-RenderStyleGetters.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = "UnifiedSource40-header-RenderStyleGetters.cpp"; sourceTree = "<group>"; };
-		FBCE61FFFCC0A29F0D842C51 /* UnifiedSource41-header-RenderStyleGetters.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = "UnifiedSource41-header-RenderStyleGetters.cpp"; sourceTree = "<group>"; };
-		8C36C2A063D49F0AFB0A20E2 /* UnifiedSource42-header-RenderStyleGetters.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = "UnifiedSource42-header-RenderStyleGetters.cpp"; sourceTree = "<group>"; };
-		47F192EF33A4783F5E6E60F0 /* UnifiedSource43-header-RenderStyleGetters.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = "UnifiedSource43-header-RenderStyleGetters.cpp"; sourceTree = "<group>"; };
-		BE1A40333AB79B5518B8B658 /* UnifiedSource44-header-RenderStyleGetters.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = "UnifiedSource44-header-RenderStyleGetters.cpp"; sourceTree = "<group>"; };
-		2B4EE1CF43D75281121A19D6 /* UnifiedSource45-header-RenderStyleGetters.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = "UnifiedSource45-header-RenderStyleGetters.cpp"; sourceTree = "<group>"; };
-		04CF8DB82E1A2436F374BC05 /* UnifiedSource46-header-RenderStyleGetters.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = "UnifiedSource46-header-RenderStyleGetters.cpp"; sourceTree = "<group>"; };
-		A599F54EADD15733ED9178AE /* UnifiedSource47-header-RenderStyleGetters.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = "UnifiedSource47-header-RenderStyleGetters.cpp"; sourceTree = "<group>"; };
-		DE0DF0E2DD6063156D395BC5 /* UnifiedSource48-header-RenderStyleGetters.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = "UnifiedSource48-header-RenderStyleGetters.cpp"; sourceTree = "<group>"; };
-		1D2E7A27D4CA429D6537A1BC /* UnifiedSource49-header-RenderStyleGetters.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = "UnifiedSource49-header-RenderStyleGetters.cpp"; sourceTree = "<group>"; };
-		636E4E69584B74FA6C92D248 /* UnifiedSource50-header-RenderStyleGetters.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = "UnifiedSource50-header-RenderStyleGetters.cpp"; sourceTree = "<group>"; };
-		6D90699809046B96AE290168 /* UnifiedSource51-header-RenderStyleGetters.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = "UnifiedSource51-header-RenderStyleGetters.cpp"; sourceTree = "<group>"; };
-		3A0029C243BF23321C43D20D /* UnifiedSource52-header-RenderStyleGetters.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = "UnifiedSource52-header-RenderStyleGetters.cpp"; sourceTree = "<group>"; };
-		EBD345B9F06BCC0152D3057C /* UnifiedSource53-header-RenderStyleGetters.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = "UnifiedSource53-header-RenderStyleGetters.cpp"; sourceTree = "<group>"; };
-		73C6E6F635A4B4C36B107EAE /* UnifiedSource54-header-RenderStyleGetters.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = "UnifiedSource54-header-RenderStyleGetters.cpp"; sourceTree = "<group>"; };
-		3230252036F492BB47909DD0 /* UnifiedSource55-header-RenderStyleGetters.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = "UnifiedSource55-header-RenderStyleGetters.cpp"; sourceTree = "<group>"; };
-		A7925FD267D4C894F38E1AD7 /* UnifiedSource56-header-RenderStyleGetters.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = "UnifiedSource56-header-RenderStyleGetters.cpp"; sourceTree = "<group>"; };
-		EAFEE1BA6EC72445F6539574 /* UnifiedSource57-header-RenderStyleGetters.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = "UnifiedSource57-header-RenderStyleGetters.cpp"; sourceTree = "<group>"; };
-		61848160D68C25BF3B848B6C /* UnifiedSource58-header-RenderStyleGetters.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = "UnifiedSource58-header-RenderStyleGetters.cpp"; sourceTree = "<group>"; };
-		BD0EA2751C530E9F3689675A /* UnifiedSource59-header-RenderStyleGetters.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = "UnifiedSource59-header-RenderStyleGetters.cpp"; sourceTree = "<group>"; };
-		F2462F05A319D5DE971FCFBC /* UnifiedSource60-header-RenderStyleGetters.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = "UnifiedSource60-header-RenderStyleGetters.cpp"; sourceTree = "<group>"; };
-		3EB98985C78E4C2A4C58889D /* UnifiedSource61-header-RenderStyleGetters.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = "UnifiedSource61-header-RenderStyleGetters.cpp"; sourceTree = "<group>"; };
-		9C26E8CE9CFBE3ECA1C04907 /* UnifiedSource62-header-RenderStyleGetters.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = "UnifiedSource62-header-RenderStyleGetters.cpp"; sourceTree = "<group>"; };
-		7295D020E0F0C07C868B904C /* UnifiedSource63-header-RenderStyleGetters.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = "UnifiedSource63-header-RenderStyleGetters.cpp"; sourceTree = "<group>"; };
-		7C61AFF4898CB7897BCB412E /* UnifiedSource64-header-RenderStyleGetters.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = "UnifiedSource64-header-RenderStyleGetters.cpp"; sourceTree = "<group>"; };
-		E3BD27846EEC386B691B9101 /* UnifiedSource65-header-RenderStyleGetters.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = "UnifiedSource65-header-RenderStyleGetters.cpp"; sourceTree = "<group>"; };
-		C91C8C4B6EDB7E3196424FBE /* UnifiedSource66-header-RenderStyleGetters.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = "UnifiedSource66-header-RenderStyleGetters.cpp"; sourceTree = "<group>"; };
-		886246164BC21FF991E1CACF /* UnifiedSource67-header-RenderStyleGetters.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = "UnifiedSource67-header-RenderStyleGetters.cpp"; sourceTree = "<group>"; };
-		D8A6C642D6DAE088EF53F376 /* UnifiedSource68-header-RenderStyleGetters.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = "UnifiedSource68-header-RenderStyleGetters.cpp"; sourceTree = "<group>"; };
-		0DB768C810AA85BE70BB2E08 /* UnifiedSource69-header-RenderStyleGetters.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = "UnifiedSource69-header-RenderStyleGetters.cpp"; sourceTree = "<group>"; };
-		E6C0584B3F242E1D1673E792 /* UnifiedSource70-header-RenderStyleGetters.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = "UnifiedSource70-header-RenderStyleGetters.cpp"; sourceTree = "<group>"; };
-		BB591C358F2E176568F6C0AA /* UnifiedSource71-header-RenderStyleGetters.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = "UnifiedSource71-header-RenderStyleGetters.cpp"; sourceTree = "<group>"; };
-		F3E295464B8B3B72FA425243 /* UnifiedSource72-header-RenderStyleGetters.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = "UnifiedSource72-header-RenderStyleGetters.cpp"; sourceTree = "<group>"; };
-		BAF547B3E0A08ACCDA0FD3EE /* UnifiedSource73-header-RenderStyleGetters.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = "UnifiedSource73-header-RenderStyleGetters.cpp"; sourceTree = "<group>"; };
-		41FF206D0243146B78FDD0FB /* UnifiedSource74-header-RenderStyleGetters.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = "UnifiedSource74-header-RenderStyleGetters.cpp"; sourceTree = "<group>"; };
-		5188A7DDD00B206B110ED7A1 /* UnifiedSource75-header-RenderStyleGetters.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = "UnifiedSource75-header-RenderStyleGetters.cpp"; sourceTree = "<group>"; };
-		DDD6571342E109928469E047 /* UnifiedSource76-header-RenderStyleGetters.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = "UnifiedSource76-header-RenderStyleGetters.cpp"; sourceTree = "<group>"; };
-		52D2ED227687272BB8AC7430 /* UnifiedSource77-header-RenderStyleGetters.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = "UnifiedSource77-header-RenderStyleGetters.cpp"; sourceTree = "<group>"; };
 		DE5F86321FA2AEFF006DB63A /* UnifiedSource59-nonARC.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = "UnifiedSource59-nonARC.mm"; sourceTree = "<group>"; };
 		DE5F86331FA2AF00006DB63A /* UnifiedSource54-nonARC.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = "UnifiedSource54-nonARC.mm"; sourceTree = "<group>"; };
 		DE5F86341FA2AF01006DB63A /* UnifiedSource56-nonARC.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = "UnifiedSource56-nonARC.mm"; sourceTree = "<group>"; };
@@ -22553,6 +22542,7 @@
 		E3B7C0621DC3415A001FB0B8 /* JSDocumentDOMJIT.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = JSDocumentDOMJIT.cpp; sourceTree = "<group>"; };
 		E3BBC2452383551A006EC39F /* CSSValueKey.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CSSValueKey.h; sourceTree = "<group>"; };
 		E3BC827322530221005276DE /* NodeList.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = NodeList.cpp; sourceTree = "<group>"; };
+		E3BD27846EEC386B691B9101 /* UnifiedSource65-header-RenderStyleGetters.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = "UnifiedSource65-header-RenderStyleGetters.cpp"; sourceTree = "<group>"; };
 		E3BF19E122AF2F55009C9926 /* XMLHttpRequestProgressEvent.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = XMLHttpRequestProgressEvent.cpp; sourceTree = "<group>"; };
 		E3BF19E322AF2FA5009C9926 /* OverconstrainedErrorEvent.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = OverconstrainedErrorEvent.cpp; sourceTree = "<group>"; };
 		E3BF19E422AF2FCF009C9926 /* CloseEvent.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = CloseEvent.cpp; sourceTree = "<group>"; };
@@ -22944,6 +22934,7 @@
 		E5F06AF624D4BB5600BBC4F8 /* DateTimeEditElement.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = DateTimeEditElement.cpp; sourceTree = "<group>"; };
 		E5F67D932B65CC2400CC30DE /* AttachmentAssociatedElement.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = AttachmentAssociatedElement.h; sourceTree = "<group>"; };
 		E5F67D942B65CC8F00CC30DE /* AttachmentAssociatedElement.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = AttachmentAssociatedElement.cpp; sourceTree = "<group>"; };
+		E6C0584B3F242E1D1673E792 /* UnifiedSource70-header-RenderStyleGetters.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = "UnifiedSource70-header-RenderStyleGetters.cpp"; sourceTree = "<group>"; };
 		E71467B124ABAEF100FB2F50 /* AudioNodeOptions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AudioNodeOptions.h; sourceTree = "<group>"; };
 		E71467B424ABAF0B00FB2F50 /* AudioNodeOptions.idl */ = {isa = PBXFileReference; lastKnownFileType = text; path = AudioNodeOptions.idl; sourceTree = "<group>"; };
 		E71467B524ABAF1D00FB2F50 /* PannerOptions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PannerOptions.h; sourceTree = "<group>"; };
@@ -23007,6 +22998,7 @@
 		E8FC921A285BFD5B004904B2 /* JSWindowEventHandlers+Gamepad.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = "JSWindowEventHandlers+Gamepad.cpp"; sourceTree = "<group>"; };
 		E9EC157B2C2330FD06371FAF /* PipIn.svg */ = {isa = PBXFileReference; lastKnownFileType = text; path = PipIn.svg; sourceTree = "<group>"; };
 		EA57D22ABF6F5246B50D8208 /* Volume1-RTL.svg */ = {isa = PBXFileReference; lastKnownFileType = text; path = "Volume1-RTL.svg"; sourceTree = "<group>"; };
+		EAFEE1BA6EC72445F6539574 /* UnifiedSource57-header-RenderStyleGetters.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = "UnifiedSource57-header-RenderStyleGetters.cpp"; sourceTree = "<group>"; };
 		EB081CD81696084400553730 /* TypeConversions.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = TypeConversions.h; sourceTree = "<group>"; };
 		EB081CD91696084400553730 /* TypeConversions.idl */ = {isa = PBXFileReference; lastKnownFileType = text; path = TypeConversions.idl; sourceTree = "<group>"; };
 		EB0FB6FB270D0AE600F7810D /* PushSubscriptionOptions.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = PushSubscriptionOptions.cpp; sourceTree = "<group>"; };
@@ -23053,6 +23045,7 @@
 		EBB9738027100654007732EF /* PushManager.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = PushManager.h; sourceTree = "<group>"; };
 		EBC470752D076C9D0026A5C3 /* ResourceMonitorChecker.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ResourceMonitorChecker.h; sourceTree = "<group>"; };
 		EBC470762D076C9D0026A5C3 /* ResourceMonitorChecker.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ResourceMonitorChecker.cpp; sourceTree = "<group>"; };
+		EBD345B9F06BCC0152D3057C /* UnifiedSource53-header-RenderStyleGetters.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = "UnifiedSource53-header-RenderStyleGetters.cpp"; sourceTree = "<group>"; };
 		EBDEDDFD2D64569A00F27038 /* ResourceMonitorThrottlerHolder.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ResourceMonitorThrottlerHolder.h; sourceTree = "<group>"; };
 		EBDEDDFE2D64569A00F27038 /* ResourceMonitorThrottlerHolder.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ResourceMonitorThrottlerHolder.cpp; sourceTree = "<group>"; };
 		EBE095E3277D14C700804D61 /* PushSubscriptionIdentifier.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = PushSubscriptionIdentifier.h; sourceTree = "<group>"; };
@@ -23091,6 +23084,7 @@
 		F08834402E721B33001B2348 /* AXLocalFrame.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = AXLocalFrame.cpp; sourceTree = "<group>"; };
 		F12171F316A8BC63000053CA /* WebVTTElement.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = WebVTTElement.cpp; sourceTree = "<group>"; };
 		F12171F416A8BC63000053CA /* WebVTTElement.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WebVTTElement.h; sourceTree = "<group>"; };
+		F2462F05A319D5DE971FCFBC /* UnifiedSource60-header-RenderStyleGetters.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = "UnifiedSource60-header-RenderStyleGetters.cpp"; sourceTree = "<group>"; };
 		F30EE46A2E721B9D00935B60 /* FrameInspectorController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = FrameInspectorController.h; sourceTree = "<group>"; };
 		F30EE46C2E721BAC00935B60 /* FrameInspectorController.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = FrameInspectorController.cpp; sourceTree = "<group>"; };
 		F32BDCD52363AAC90073B6AE /* UserGestureEmulationScope.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = UserGestureEmulationScope.cpp; sourceTree = "<group>"; };
@@ -23102,6 +23096,7 @@
 		F3ABFE0B130E9DA000E7F7D1 /* InstrumentingAgents.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = InstrumentingAgents.h; sourceTree = "<group>"; };
 		F3D461461161D53200CA0D09 /* JSErrorHandler.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = JSErrorHandler.cpp; sourceTree = "<group>"; };
 		F3D461471161D53200CA0D09 /* JSErrorHandler.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = JSErrorHandler.h; sourceTree = "<group>"; };
+		F3E295464B8B3B72FA425243 /* UnifiedSource72-header-RenderStyleGetters.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = "UnifiedSource72-header-RenderStyleGetters.cpp"; sourceTree = "<group>"; };
 		F3EB1F2E2F43B92600725B79 /* FrameConsoleAgent.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = FrameConsoleAgent.h; sourceTree = "<group>"; };
 		F3EB1F2F2F43B92600725B79 /* FrameConsoleAgent.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = FrameConsoleAgent.cpp; sourceTree = "<group>"; };
 		F3FB34D3C8B0041EA738900D /* Ellipsis.svg */ = {isa = PBXFileReference; lastKnownFileType = text; path = Ellipsis.svg; sourceTree = "<group>"; };
@@ -23476,6 +23471,7 @@
 		FB92DF4915FED08700994433 /* PathOperation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PathOperation.h; sourceTree = "<group>"; };
 		FB965B8117BBB5F900E835B9 /* CSSFilterImageValue.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CSSFilterImageValue.h; sourceTree = "<group>"; };
 		FB965B8217BBB62C00E835B9 /* CSSFilterImageValue.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = CSSFilterImageValue.cpp; sourceTree = "<group>"; };
+		FBCE61FFFCC0A29F0D842C51 /* UnifiedSource41-header-RenderStyleGetters.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = "UnifiedSource41-header-RenderStyleGetters.cpp"; sourceTree = "<group>"; };
 		FBD6AF8615EF21D4008B7110 /* CSSBasicShapeValue.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = CSSBasicShapeValue.cpp; sourceTree = "<group>"; };
 		FBD6AF8715EF21D4008B7110 /* CSSBasicShapeValue.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CSSBasicShapeValue.h; sourceTree = "<group>"; };
 		FBDB619A16D6032A00BB3394 /* ElementRuleCollector.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ElementRuleCollector.cpp; sourceTree = "<group>"; };
@@ -23483,6 +23479,12 @@
 		FBDB619E16D6036500BB3394 /* ElementRuleCollector.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ElementRuleCollector.h; sourceTree = "<group>"; };
 		FBDB61A016D6037E00BB3394 /* PageRuleCollector.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PageRuleCollector.h; sourceTree = "<group>"; };
 		FBF89044169E9F1F0052D86E /* CSSGroupingRule.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = CSSGroupingRule.cpp; sourceTree = "<group>"; };
+		FC2600000000000C00000001 /* OTPCredentialRequestOptions.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = OTPCredentialRequestOptions.h; sourceTree = "<group>"; };
+		FC2600000000000C00000002 /* OTPCredentialRequestOptions.idl */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = OTPCredentialRequestOptions.idl; sourceTree = "<group>"; };
+		FC260000000000DC00000001 /* IdentityCredentialRequestOptions.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = IdentityCredentialRequestOptions.h; sourceTree = "<group>"; };
+		FC260000000000DC00000002 /* IdentityCredentialRequestOptions.idl */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = IdentityCredentialRequestOptions.idl; sourceTree = "<group>"; };
+		FC260000000000FC00000001 /* FederatedCredentialRequestOptions.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = FederatedCredentialRequestOptions.h; sourceTree = "<group>"; };
+		FC260000000000FC00000002 /* FederatedCredentialRequestOptions.idl */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = FederatedCredentialRequestOptions.idl; sourceTree = "<group>"; };
 		FC63BDB1167AABAC00F9380F /* CSSSupportsRule.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CSSSupportsRule.h; sourceTree = "<group>"; };
 		FC63BDB2167AABAC00F9380F /* CSSSupportsRule.idl */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = CSSSupportsRule.idl; sourceTree = "<group>"; };
 		FC84802E167AB444008CD100 /* JSCSSSupportsRule.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = JSCSSSupportsRule.h; sourceTree = "<group>"; };
@@ -23764,6 +23766,7 @@
 		FE699870192087E7006936BD /* FloatingPointEnvironment.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FloatingPointEnvironment.h; sourceTree = "<group>"; };
 		FE80DA5F0E9C4703000D6F75 /* JSGeolocation.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = JSGeolocation.cpp; sourceTree = "<group>"; };
 		FE80DA600E9C4703000D6F75 /* JSGeolocation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = JSGeolocation.h; sourceTree = "<group>"; };
+		FE824821D37F631F1A942B28 /* UnifiedSource29-header-RenderStyleGetters.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = "UnifiedSource29-header-RenderStyleGetters.cpp"; sourceTree = "<group>"; };
 		FE8A674516CDD19E00930BF8 /* SQLStatement.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = SQLStatement.cpp; sourceTree = "<group>"; };
 		FE8A674616CDD19E00930BF8 /* SQLStatement.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SQLStatement.h; sourceTree = "<group>"; };
 		FE9E89F916E2DC0400A908F8 /* OriginLock.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = OriginLock.cpp; sourceTree = "<group>"; };
@@ -37809,6 +37812,8 @@
 				BC63ACE62F08340A007B62C4 /* StyleGridItemData.h */,
 				BC63ACE92F08340A007B62C4 /* StyleInheritedData.cpp */,
 				BC63ACE82F08340A007B62C4 /* StyleInheritedData.h */,
+				7A4D884E2FA28596002C8D1C /* StyleInheritedRareCSSData.cpp */,
+				7A4D884D2FA28596002C8D1C /* StyleInheritedRareCSSData.h */,
 				BC63AD502F085657007B62C4 /* StyleInheritedRareData.cpp */,
 				BC63AD4F2F085657007B62C4 /* StyleInheritedRareData.h */,
 				BC63ACFA2F083F79007B62C4 /* StyleMarqueeData.cpp */,
@@ -48556,6 +48561,7 @@
 				BC731E752E636D8700A6584F /* StyleImageOrNone.h in Headers */,
 				BC22AA9E2E36A2BD009AC0C3 /* StyleImageWrapper.h in Headers */,
 				BC63AD3E2F084C2F007B62C4 /* StyleInheritedData.h in Headers */,
+				7A4D884F2FA285B8002C8D1C /* StyleInheritedRareCSSData.h in Headers */,
 				BC63AD512F08565F007B62C4 /* StyleInheritedRareData.h in Headers */,
 				BC9ABA192DED227400F7E52D /* StyleInset.h in Headers */,
 				BCB272092CC1F1DB00265123 /* StyleInsetFunction.h in Headers */,

--- a/Source/WebCore/css/CSSProperties.json
+++ b/Source/WebCore/css/CSSProperties.json
@@ -245,7 +245,7 @@
             ],
             "codegen-properties": {
                 "settings-flag": "accentColorEnabled",
-                "computed-style-storage-path": ["m_inheritedRareData"],
+                "computed-style-storage-path": ["m_inheritedRareData", "cssData"],
                 "computed-style-storage-kind": "reference",
                 "computed-style-type": "Style::AccentColor",
                 "color-property": true,
@@ -374,10 +374,10 @@
                 "color-property-traits-color-custom": true,
                 "color-property-traits-visited-link-color-custom": true,
                 "style-extractor-custom": true,
-                "computed-style-storage-path": ["m_inheritedRareData"],
+                "computed-style-storage-path": ["m_inheritedRareData", "cssData"],
                 "computed-style-storage-kind": "reference",
                 "computed-style-type": "Style::CaretColor",
-                "computed-style-visited-link-storage-path": ["m_inheritedRareData"],
+                "computed-style-visited-link-storage-path": ["m_inheritedRareData", "cssData"],
                 "parser-grammar": "auto | <color>"
             },
             "specification": {
@@ -858,7 +858,7 @@
             ],
             "codegen-properties": {
                 "computed-style-initial-constexpr": true,
-                "computed-style-storage-path": ["m_inheritedRareData"],
+                "computed-style-storage-path": ["m_inheritedRareData", "cssData"],
                 "computed-style-storage-kind": "value",
                 "computed-style-type": "Style::TextBoxEdge",
                 "parser-function": "consumeTextBoxEdge",
@@ -1494,7 +1494,7 @@
                 "style-builder-custom": "Value",
                 "computed-style-name-for-methods": "TextSizeAdjust",
                 "computed-style-initial-constexpr": true,
-                "computed-style-storage-path": ["m_inheritedRareData"],
+                "computed-style-storage-path": ["m_inheritedRareData", "cssData"],
                 "computed-style-storage-kind": "value",
                 "computed-style-type": "Style::TextSizeAdjust",
                 "parser-grammar": "auto | none | <percentage [0,inf]>"
@@ -1655,7 +1655,7 @@
             "codegen-properties": {
                 "style-builder-custom": "Value",
                 "high-priority": true,
-                "computed-style-storage-path": ["m_inheritedRareData"],
+                "computed-style-storage-path": ["m_inheritedRareData", "cssData"],
                 "computed-style-storage-kind": "enum",
                 "computed-style-type": "TextZoom",
                 "parser-grammar": "<<values>>"
@@ -1709,7 +1709,7 @@
             "codegen-properties": {
                 "top-priority": true,
                 "top-priority-reason": "This is a top priority property to ensure that its value can be checked when determining a smart default font size', (<https://trac.webkit.org/browser/trunk/Source/WebCore/ChangeLog?rev=172861>).",
-                "computed-style-storage-path": ["m_inheritedRareData"],
+                "computed-style-storage-path": ["m_inheritedRareData", "cssData"],
                 "computed-style-storage-kind": "enum",
                 "computed-style-type": "RubyPosition",
                 "parser-grammar": "<<values>>",
@@ -2459,7 +2459,7 @@
             ],
             "codegen-properties": {
                 "settings-flag": "cssLineClampEnabled",
-                "computed-style-storage-path": ["m_inheritedRareData"],
+                "computed-style-storage-path": ["m_inheritedRareData", "cssData"],
                 "computed-style-storage-kind": "reference",
                 "computed-style-type": "Style::BlockEllipsis",
                 "parser-grammar": "none | auto | <string>",
@@ -4685,7 +4685,7 @@
             ],
             "codegen-properties": {
                 "settings-flag": "supportHDRDisplayEnabled",
-                "computed-style-storage-path": ["m_inheritedRareData"],
+                "computed-style-storage-path": ["m_inheritedRareData", "cssData"],
                 "computed-style-storage-kind": "reference",
                 "computed-style-type": "Style::DynamicRangeLimit",
                 "parser-function": "consumeDynamicRangeLimit",
@@ -4897,7 +4897,7 @@
                 "last"
             ],
             "codegen-properties": {
-                "computed-style-storage-path": ["m_inheritedRareData"],
+                "computed-style-storage-path": ["m_inheritedRareData", "cssData"],
                 "computed-style-storage-kind": "raw",
                 "computed-style-type": "Style::HangingPunctuation",
                 "parser-grammar": "none | [ first || [ force-end | allow-end ] || last ]@(preserve-order no-single-item-opt)"
@@ -4971,7 +4971,7 @@
                 "none"
             ],
             "codegen-properties": {
-                "computed-style-storage-path": ["m_inheritedRareData"],
+                "computed-style-storage-path": ["m_inheritedRareData", "cssData"],
                 "computed-style-storage-kind": "enum",
                 "computed-style-type": "Style::ImageOrientation",
                 "parser-grammar": "<<values>>",
@@ -5016,7 +5016,7 @@
                 }
             ],
             "codegen-properties": {
-                "computed-style-storage-path": ["m_inheritedRareData"],
+                "computed-style-storage-path": ["m_inheritedRareData", "cssData"],
                 "computed-style-storage-kind": "enum",
                 "computed-style-type": "ImageRendering",
                 "parser-grammar": "<<values>>"
@@ -5308,7 +5308,7 @@
             "codegen-properties": {
                 "settings-flag": "cssLineFitEdgeEnabled",
                 "computed-style-initial-constexpr": true,
-                "computed-style-storage-path": ["m_inheritedRareData"],
+                "computed-style-storage-path": ["m_inheritedRareData", "cssData"],
                 "computed-style-storage-kind": "value",
                 "computed-style-type": "Style::LineFitEdge",
                 "parser-function": "consumeLineFitEdge",
@@ -5381,7 +5381,7 @@
                 "none"
             ],
             "codegen-properties": {
-                "computed-style-storage-path": ["m_inheritedRareData"],
+                "computed-style-storage-path": ["m_inheritedRareData", "cssData"],
                 "computed-style-storage-kind": "reference",
                 "computed-style-type": "Style::ImageOrNone",
                 "parser-grammar": "<image> | none"
@@ -5513,7 +5513,7 @@
                 "none"
             ],
             "codegen-properties": {
-                "computed-style-storage-path": ["m_inheritedRareData"],
+                "computed-style-storage-path": ["m_inheritedRareData", "cssData"],
                 "computed-style-storage-kind": "reference",
                 "computed-style-type": "Style::ListStyleType",
                 "parser-grammar": "<counter-style> | <string> | none",
@@ -6310,7 +6310,7 @@
                 "top-priority": true,
                 "top-priority-reason": "This is top priority since it affects 'font-size', which is 'high-priority'",
                 "computed-style-initial-constexpr": true,
-                "computed-style-storage-path": ["m_inheritedRareData"],
+                "computed-style-storage-path": ["m_inheritedRareData", "cssData"],
                 "computed-style-storage-kind": "value",
                 "computed-style-type": "Style::MathDepth",
                 "parser-grammar": "auto-add | add(<integer>) | <integer>"
@@ -6329,7 +6329,7 @@
                 "compact"
             ],
             "codegen-properties": {
-                "computed-style-storage-path": ["m_inheritedRareData"],
+                "computed-style-storage-path": ["m_inheritedRareData", "cssData"],
                 "computed-style-storage-kind": "enum",
                 "computed-style-type": "MathShift",
                 "parser-grammar": "<<values>>"
@@ -6348,7 +6348,7 @@
                 "compact"
             ],
             "codegen-properties": {
-                "computed-style-storage-path": ["m_inheritedRareData"],
+                "computed-style-storage-path": ["m_inheritedRareData", "cssData"],
                 "computed-style-storage-kind": "enum",
                 "computed-style-type": "MathStyle",
                 "parser-grammar": "<<values>>"
@@ -6991,7 +6991,7 @@
             "codegen-properties": {
                 "style-extractor-custom": true,
                 "computed-style-initial-constexpr": true,
-                "computed-style-storage-path": ["m_inheritedRareData"],
+                "computed-style-storage-path": ["m_inheritedRareData", "cssData"],
                 "computed-style-storage-kind": "value",
                 "computed-style-type": "Style::Orphans",
                 "parser-grammar": "<integer [1,inf]>"
@@ -7163,7 +7163,7 @@
                 "aliases": [
                     "word-wrap"
                 ],
-                "computed-style-storage-path": ["m_inheritedRareData"],
+                "computed-style-storage-path": ["m_inheritedRareData", "cssData"],
                 "computed-style-storage-kind": "enum",
                 "computed-style-type": "OverflowWrap",
                 "parser-grammar": "<<values>>"
@@ -7712,7 +7712,7 @@
             ],
             "codegen-properties": {
                 "computed-style-initial-constexpr": true,
-                "computed-style-storage-path": ["m_inheritedRareData"],
+                "computed-style-storage-path": ["m_inheritedRareData", "cssData"],
                 "computed-style-storage-kind": "raw",
                 "computed-style-type": "Style::SVGPaintOrder",
                 "parser-function": "consumePaintOrder",
@@ -7790,7 +7790,7 @@
                 "none"
             ],
             "codegen-properties": {
-                "computed-style-storage-path": ["m_inheritedRareData"],
+                "computed-style-storage-path": ["m_inheritedRareData", "cssData"],
                 "computed-style-storage-kind": "reference",
                 "computed-style-type": "Style::Quotes",
                 "parser-function": "consumeQuotes",
@@ -7880,7 +7880,7 @@
                 "space-around"
             ],
             "codegen-properties": {
-                "computed-style-storage-path": ["m_inheritedRareData"],
+                "computed-style-storage-path": ["m_inheritedRareData", "cssData"],
                 "computed-style-storage-kind": "enum",
                 "computed-style-type": "RubyAlign",
                 "parser-grammar": "<<values>>"
@@ -7900,7 +7900,7 @@
                 "none"
             ],
             "codegen-properties": {
-                "computed-style-storage-path": ["m_inheritedRareData"],
+                "computed-style-storage-path": ["m_inheritedRareData", "cssData"],
                 "computed-style-storage-kind": "enum",
                 "computed-style-type": "RubyOverhang",
                 "parser-grammar": "<<values>>"
@@ -8080,7 +8080,7 @@
             ],
             "codegen-properties": {
                 "computed-style-name-for-methods": "CapStyle",
-                "computed-style-storage-path": ["m_inheritedRareData"],
+                "computed-style-storage-path": ["m_inheritedRareData", "cssData"],
                 "computed-style-storage-kind": "enum",
                 "computed-style-type": "LineCap",
                 "parser-grammar": "<<values>>"
@@ -8104,7 +8104,7 @@
             ],
             "codegen-properties": {
                 "computed-style-name-for-methods": "JoinStyle",
-                "computed-style-storage-path": ["m_inheritedRareData"],
+                "computed-style-storage-path": ["m_inheritedRareData", "cssData"],
                 "computed-style-storage-kind": "enum",
                 "computed-style-type": "LineJoin",
                 "parser-grammar": "<<values>>",
@@ -8125,7 +8125,7 @@
             "codegen-properties": {
                 "computed-style-initial-constexpr": true,
                 "computed-style-name-for-methods": "StrokeMiterLimit",
-                "computed-style-storage-path": ["m_inheritedRareData"],
+                "computed-style-storage-path": ["m_inheritedRareData", "cssData"],
                 "computed-style-storage-kind": "value",
                 "computed-style-type": "Style::StrokeMiterlimit",
                 "parser-grammar": "<number [0,inf]>",
@@ -8164,11 +8164,11 @@
                 "animation-wrapper-comment": "FIXME: Why doesn't this use VisitedAffectedStyleTypeWrapper?",
                 "animation-wrapper-requires-override-parameters": ["CSSPropertyID::CSSPropertyStrokeColor", "&ComputedStyle::strokeColor", "&ComputedStyle::setStrokeColor"],
                 "computed-style-has-explicitly-set-policy": "value-only",
-                "computed-style-has-explicitly-set-storage-path": ["m_inheritedRareData"],
-                "computed-style-storage-path": ["m_inheritedRareData"],
+                "computed-style-has-explicitly-set-storage-path": ["m_inheritedRareData", "cssData"],
+                "computed-style-storage-path": ["m_inheritedRareData", "cssData"],
                 "computed-style-storage-kind": "reference",
                 "computed-style-type": "Style::Color",
-                "computed-style-visited-link-storage-path": ["m_inheritedRareData"],
+                "computed-style-visited-link-storage-path": ["m_inheritedRareData", "cssData"],
                 "visited-link-color-support": true,
                 "color-property": true,
                 "parser-grammar": "<color>"
@@ -8185,8 +8185,8 @@
             "initial": "1px",
             "codegen-properties": {
                 "computed-style-has-explicitly-set-policy": "value-only",
-                "computed-style-has-explicitly-set-storage-path": ["m_inheritedRareData"],
-                "computed-style-storage-path": ["m_inheritedRareData"],
+                "computed-style-has-explicitly-set-storage-path": ["m_inheritedRareData", "cssData"],
+                "computed-style-storage-path": ["m_inheritedRareData", "cssData"],
                 "computed-style-storage-kind": "reference",
                 "computed-style-type": "Style::StrokeWidth",
                 "parser-grammar": "<length-percentage [0,inf]> | <number [0,inf]>"
@@ -8215,7 +8215,7 @@
                 }
             ],
             "codegen-properties": {
-                "computed-style-storage-path": ["m_inheritedRareData"],
+                "computed-style-storage-path": ["m_inheritedRareData", "cssData"],
                 "computed-style-storage-kind": "raw",
                 "computed-style-type": "Style::SpeakAs",
                 "parser-grammar": "none | [ [ normal | spell-out ] || digits || [ literal-punctuation | no-punctuation ] ]@(no-single-item-opt)",
@@ -8250,7 +8250,7 @@
             "initial": "8",
             "codegen-properties": {
                 "computed-style-initial-constexpr": true,
-                "computed-style-storage-path": ["m_inheritedRareData"],
+                "computed-style-storage-path": ["m_inheritedRareData", "cssData"],
                 "computed-style-storage-kind": "reference",
                 "computed-style-type": "Style::TabSize",
                 "parser-grammar": "<number [0,inf]> | <length [0,inf]>"
@@ -8328,7 +8328,7 @@
                 "match-parent"
             ],
             "codegen-properties": {
-                "computed-style-storage-path": ["m_inheritedRareData"],
+                "computed-style-storage-path": ["m_inheritedRareData", "cssData"],
                 "computed-style-storage-kind": "enum",
                 "computed-style-type": "Style::TextAlignLast",
                 "parser-grammar": "<<values>>"
@@ -8393,7 +8393,7 @@
             ],
             "codegen-properties": {
                 "accepts-quirky-length": true,
-                "computed-style-storage-path": ["m_inheritedRareData"],
+                "computed-style-storage-path": ["m_inheritedRareData", "cssData"],
                 "computed-style-storage-kind": "reference",
                 "computed-style-type": "Style::TextIndent",
                 "parser-grammar": "<length-percentage> && hanging? && each-line?"
@@ -8423,7 +8423,7 @@
             ],
             "codegen-properties": {
                 "settings-flag": "cssTextJustifyEnabled",
-                "computed-style-storage-path": ["m_inheritedRareData"],
+                "computed-style-storage-path": ["m_inheritedRareData", "cssData"],
                 "computed-style-storage-kind": "enum",
                 "computed-style-type": "TextJustify",
                 "parser-grammar": "<<values>>"
@@ -8459,7 +8459,7 @@
                 "none"
             ],
             "codegen-properties": {
-                "computed-style-storage-path": ["m_inheritedRareData"],
+                "computed-style-storage-path": ["m_inheritedRareData", "cssData"],
                 "computed-style-storage-kind": "reference",
                 "computed-style-type": "Style::TextShadows",
                 "parser-function": "consumeTextShadow",
@@ -8906,7 +8906,7 @@
             "codegen-properties": {
                 "style-extractor-custom": true,
                 "computed-style-initial-constexpr": true,
-                "computed-style-storage-path": ["m_inheritedRareData"],
+                "computed-style-storage-path": ["m_inheritedRareData", "cssData"],
                 "computed-style-storage-kind": "value",
                 "computed-style-type": "Style::Widows",
                 "parser-grammar": "<integer [1,inf]>"
@@ -9014,7 +9014,7 @@
                 "aliases": [
                     "-epub-word-break"
                 ],
-                "computed-style-storage-path": ["m_inheritedRareData"],
+                "computed-style-storage-path": ["m_inheritedRareData", "cssData"],
                 "computed-style-storage-kind": "enum",
                 "computed-style-type": "WordBreak",
                 "parser-grammar": "<<values>>"
@@ -10138,7 +10138,7 @@
             ],
             "codegen-properties": {
                 "settings-flag": "colorFilterEnabled",
-                "computed-style-storage-path": ["m_inheritedRareData", "appleColorFilter"],
+                "computed-style-storage-path": ["m_inheritedRareData", "cssData", "appleColorFilter"],
                 "computed-style-storage-kind": "reference",
                 "computed-style-type": "Style::AppleColorFilter",
                 "parser-function": "consumeAppleColorFilter",
@@ -10873,7 +10873,7 @@
                 "aliases": [
                     "-webkit-hyphenate-character"
                 ],
-                "computed-style-storage-path": ["m_inheritedRareData"],
+                "computed-style-storage-path": ["m_inheritedRareData", "cssData"],
                 "computed-style-storage-kind": "reference",
                 "computed-style-type": "Style::HyphenateCharacter",
                 "parser-grammar": "auto | <string>"
@@ -10892,7 +10892,7 @@
             ],
             "codegen-properties": {
                 "computed-style-initial-constexpr": true,
-                "computed-style-storage-path": ["m_inheritedRareData"],
+                "computed-style-storage-path": ["m_inheritedRareData", "cssData"],
                 "computed-style-storage-kind": "value",
                 "computed-style-type": "Style::HyphenateLimitEdge",
                 "parser-grammar": "auto | <number [0,inf]>"
@@ -10908,7 +10908,7 @@
             ],
             "codegen-properties": {
                 "computed-style-initial-constexpr": true,
-                "computed-style-storage-path": ["m_inheritedRareData"],
+                "computed-style-storage-path": ["m_inheritedRareData", "cssData"],
                 "computed-style-storage-kind": "value",
                 "computed-style-type": "Style::HyphenateLimitEdge",
                 "parser-grammar": "auto | <number [0,inf]>"
@@ -10924,7 +10924,7 @@
             ],
             "codegen-properties": {
                 "computed-style-initial-constexpr": true,
-                "computed-style-storage-path": ["m_inheritedRareData"],
+                "computed-style-storage-path": ["m_inheritedRareData", "cssData"],
                 "computed-style-storage-kind": "value",
                 "computed-style-type": "Style::HyphenateLimitLines",
                 "parser-grammar": "no-limit | <number [0,inf]>"
@@ -10951,7 +10951,7 @@
                     "-epub-hyphens",
                     "-webkit-hyphens"
                 ],
-                "computed-style-storage-path": ["m_inheritedRareData"],
+                "computed-style-storage-path": ["m_inheritedRareData", "cssData"],
                 "computed-style-storage-kind": "enum",
                 "computed-style-type": "Hyphens",
                 "parser-grammar": "<<values>>"
@@ -10999,7 +10999,7 @@
             ],
             "codegen-properties": {
                 "computed-style-initial-custom": true,
-                "computed-style-storage-path": ["m_inheritedRareData"],
+                "computed-style-storage-path": ["m_inheritedRareData", "cssData"],
                 "computed-style-storage-kind": "raw",
                 "computed-style-type": "Style::WebkitLineBoxContain",
                 "parser-grammar": "none | [ block || inline || font || glyphs || replaced || inline-box || initial-letter ]"
@@ -11018,7 +11018,7 @@
                 "edges"
             ],
             "codegen-properties": {
-                "computed-style-storage-path": ["m_inheritedRareData"],
+                "computed-style-storage-path": ["m_inheritedRareData", "cssData"],
                 "computed-style-storage-kind": "enum",
                 "computed-style-type": "LineAlign",
                 "parser-grammar": "<<values>>"
@@ -11052,7 +11052,7 @@
                 "aliases": [
                     "-webkit-line-break"
                 ],
-                "computed-style-storage-path": ["m_inheritedRareData"],
+                "computed-style-storage-path": ["m_inheritedRareData", "cssData"],
                 "computed-style-storage-kind": "enum",
                 "computed-style-type": "LineBreak",
                 "parser-grammar": "<<values>>"
@@ -11103,7 +11103,7 @@
                 "none"
             ],
             "codegen-properties": {
-                "computed-style-storage-path": ["m_inheritedRareData"],
+                "computed-style-storage-path": ["m_inheritedRareData", "cssData"],
                 "computed-style-storage-kind": "reference",
                 "computed-style-type": "Style::WebkitLineGrid",
                 "parser-grammar": "none | <custom-ident>"
@@ -11126,7 +11126,7 @@
                 "contain"
             ],
             "codegen-properties": {
-                "computed-style-storage-path": ["m_inheritedRareData"],
+                "computed-style-storage-path": ["m_inheritedRareData", "cssData"],
                 "computed-style-storage-kind": "enum",
                 "computed-style-type": "LineSnap",
                 "parser-grammar": "<<values>>"
@@ -11330,7 +11330,7 @@
             "codegen-properties": {
                 "computed-style-initial": "initialNBSPMode",
                 "computed-style-setter": "setNBSPMode",
-                "computed-style-storage-path": ["m_inheritedRareData"],
+                "computed-style-storage-path": ["m_inheritedRareData", "cssData"],
                 "computed-style-storage-kind": "enum",
                 "computed-style-type": "NBSPMode",
                 "parser-grammar": "<<values>>"
@@ -11354,7 +11354,7 @@
                 "enable-if": "ENABLE_DARK_MODE_CSS",
                 "computed-style-has-explicitly-set-policy": "value-only",
                 "computed-style-has-explicitly-set-storage-path": ["m_nonInheritedData", "miscData"],
-                "computed-style-storage-path": ["m_inheritedRareData"],
+                "computed-style-storage-path": ["m_inheritedRareData", "cssData"],
                 "computed-style-storage-kind": "value",
                 "computed-style-type": "Style::ColorScheme",
                 "top-priority": true,
@@ -11559,7 +11559,7 @@
             ],
             "codegen-properties": {
                 "computed-style-name-for-methods": "TextCombine",
-                "computed-style-storage-path": ["m_inheritedRareData"],
+                "computed-style-storage-path": ["m_inheritedRareData", "cssData"],
                 "computed-style-storage-kind": "enum",
                 "computed-style-type": "TextCombine",
                 "parser-grammar": "<<values>>"
@@ -11694,7 +11694,7 @@
                 "all"
             ],
             "codegen-properties": {
-                "computed-style-storage-path": ["m_inheritedRareData"],
+                "computed-style-storage-path": ["m_inheritedRareData", "cssData"],
                 "computed-style-storage-kind": "enum",
                 "computed-style-type": "TextDecorationSkipInk",
                 "parser-grammar": "<<values>>"
@@ -11719,7 +11719,7 @@
                 "aliases": [
                     "-webkit-text-underline-position"
                 ],
-                "computed-style-storage-path": ["m_inheritedRareData"],
+                "computed-style-storage-path": ["m_inheritedRareData", "cssData"],
                 "computed-style-storage-kind": "raw",
                 "computed-style-type": "Style::TextUnderlinePosition",
                 "parser-grammar": "auto | [ [ under | from-font ] || [ left | right ] ]@(no-single-item-opt)"
@@ -11734,7 +11734,7 @@
             "inherited": true,
             "initial": "auto",
             "codegen-properties": {
-                "computed-style-storage-path": ["m_inheritedRareData"],
+                "computed-style-storage-path": ["m_inheritedRareData", "cssData"],
                 "computed-style-storage-kind": "reference",
                 "computed-style-type": "Style::TextUnderlineOffset",
                 "parser-grammar": "auto | <length-percentage>"
@@ -11821,10 +11821,10 @@
                 ],
                 "visited-link-color-support": true,
                 "color-property": true,
-                "computed-style-storage-path": ["m_inheritedRareData"],
+                "computed-style-storage-path": ["m_inheritedRareData", "cssData"],
                 "computed-style-storage-kind": "reference",
                 "computed-style-type": "Style::Color",
-                "computed-style-visited-link-storage-path": ["m_inheritedRareData"],
+                "computed-style-visited-link-storage-path": ["m_inheritedRareData", "cssData"],
                 "parser-grammar": "<color>"
             },
             "specification": {
@@ -11841,7 +11841,7 @@
                     "-webkit-text-emphasis-position"
                 ],
                 "computed-style-initial-custom": true,
-                "computed-style-storage-path": ["m_inheritedRareData"],
+                "computed-style-storage-path": ["m_inheritedRareData", "cssData"],
                 "computed-style-storage-kind": "raw",
                 "computed-style-type": "Style::TextEmphasisPosition",
                 "parser-grammar": "[ [ over | under ] && [ right | left ]? ]@(no-single-item-opt)"
@@ -11860,7 +11860,7 @@
                     "-epub-text-emphasis-style",
                     "-webkit-text-emphasis-style"
                 ],
-                "computed-style-storage-path": ["m_inheritedRareData"],
+                "computed-style-storage-path": ["m_inheritedRareData", "cssData"],
                 "computed-style-storage-kind": "reference",
                 "computed-style-type": "Style::TextEmphasisStyle",
                 "parser-grammar": "none | [ [ filled | open ] || [ dot | circle | double-circle | triangle | sesame ] ] | <string>"
@@ -11877,10 +11877,10 @@
             "codegen-properties": {
                 "visited-link-color-support": true,
                 "color-property": true,
-                "computed-style-storage-path": ["m_inheritedRareData"],
+                "computed-style-storage-path": ["m_inheritedRareData", "cssData"],
                 "computed-style-storage-kind": "reference",
                 "computed-style-type": "Style::Color",
-                "computed-style-visited-link-storage-path": ["m_inheritedRareData"],
+                "computed-style-visited-link-storage-path": ["m_inheritedRareData", "cssData"],
                 "parser-grammar": "<color>"
             },
             "status": {
@@ -11899,7 +11899,7 @@
                 "none"
             ],
             "codegen-properties": {
-                "computed-style-storage-path": ["m_inheritedRareData"],
+                "computed-style-storage-path": ["m_inheritedRareData", "cssData"],
                 "computed-style-storage-kind": "enum",
                 "computed-style-type": "TextSecurity",
                 "parser-grammar": "<<values>>"
@@ -11926,10 +11926,10 @@
             "codegen-properties": {
                 "visited-link-color-support": true,
                 "color-property": true,
-                "computed-style-storage-path": ["m_inheritedRareData"],
+                "computed-style-storage-path": ["m_inheritedRareData", "cssData"],
                 "computed-style-storage-kind": "reference",
                 "computed-style-type": "Style::Color",
-                "computed-style-visited-link-storage-path": ["m_inheritedRareData"],
+                "computed-style-visited-link-storage-path": ["m_inheritedRareData", "cssData"],
                 "parser-grammar": "<color>"
             },
             "status": {
@@ -11948,7 +11948,7 @@
             ],
             "codegen-properties": {
                 "computed-style-initial-constexpr": true,
-                "computed-style-storage-path": ["m_inheritedRareData"],
+                "computed-style-storage-path": ["m_inheritedRareData", "cssData"],
                 "computed-style-storage-kind": "value",
                 "computed-style-type": "Style::WebkitTextStrokeWidth",
                 "parser-grammar": "<line-width>"
@@ -12199,7 +12199,7 @@
                 "read-write-plaintext-only"
             ],
             "codegen-properties": {
-                "computed-style-storage-path": ["m_inheritedRareData"],
+                "computed-style-storage-path": ["m_inheritedRareData", "cssData"],
                 "computed-style-storage-kind": "enum",
                 "computed-style-type": "UserModify",
                 "parser-grammar": "<<values>>"
@@ -12223,7 +12223,7 @@
                 "all"
             ],
             "codegen-properties": {
-                "computed-style-storage-path": ["m_inheritedRareData"],
+                "computed-style-storage-path": ["m_inheritedRareData", "cssData"],
                 "computed-style-storage-kind": "enum",
                 "computed-style-type": "UserSelect",
                 "parser-grammar": "<<values>>"
@@ -12818,7 +12818,7 @@
             ],
             "codegen-properties": {
                 "settings-flag": "cssScrollbarColorEnabled",
-                "computed-style-storage-path": ["m_inheritedRareData"],
+                "computed-style-storage-path": ["m_inheritedRareData", "cssData"],
                 "computed-style-storage-kind": "reference",
                 "computed-style-type": "Style::ScrollbarColor",
                 "parser-function": "consumeScrollbarColor",
@@ -13229,7 +13229,7 @@
                 "color-property": true,
                 "computed-style-initial-custom": true,
                 "computed-style-initial-inline": false,
-                "computed-style-storage-path": ["m_inheritedRareData"],
+                "computed-style-storage-path": ["m_inheritedRareData", "cssData"],
                 "computed-style-storage-kind": "reference",
                 "computed-style-type": "Style::Color",
                 "computed-style-resolving-current-color-exported": true,
@@ -13248,7 +13248,7 @@
             "codegen-properties": {
                 "enable-if": "ENABLE_WEBKIT_OVERFLOW_SCROLLING_CSS_PROPERTY",
                 "settings-flag": "legacyOverflowScrollingTouchEnabled",
-                "computed-style-storage-path": ["m_inheritedRareData"],
+                "computed-style-storage-path": ["m_inheritedRareData", "cssData"],
                 "computed-style-storage-kind": "enum",
                 "computed-style-type": "Style::WebkitOverflowScrolling",
                 "parser-grammar": "<<values>>"
@@ -13311,7 +13311,7 @@
             ],
             "codegen-properties": {
                 "enable-if": "ENABLE_WEBKIT_TOUCH_CALLOUT_CSS_PROPERTY",
-                "computed-style-storage-path": ["m_inheritedRareData"],
+                "computed-style-storage-path": ["m_inheritedRareData", "cssData"],
                 "computed-style-storage-kind": "enum",
                 "computed-style-type": "Style::WebkitTouchCallout",
                 "parser-grammar": "<<values>>"

--- a/Source/WebCore/rendering/style/RenderStyle.cpp
+++ b/Source/WebCore/rendering/style/RenderStyle.cpp
@@ -135,7 +135,10 @@ RenderStyle RenderStyle::replace(RenderStyle&& newStyle)
 
 void RenderStyle::copyPseudoElementsFrom(const RenderStyle& other)
 {
-    for (auto& [key, pseudoElementStyle] : other.m_computedStyle.cachedPseudoStyles()) {
+    auto* otherCache = other.m_computedStyle.cachedPseudoStyles();
+    if (!otherCache)
+        return;
+    for (auto& [key, pseudoElementStyle] : *otherCache) {
         if (!pseudoElementStyle) {
             ASSERT_NOT_REACHED();
             continue;

--- a/Source/WebCore/rendering/style/RenderStyle.h
+++ b/Source/WebCore/rendering/style/RenderStyle.h
@@ -213,7 +213,7 @@ public:
     RenderStyle* addCachedPseudoStyle(std::unique_ptr<RenderStyle>) LIFETIME_BOUND;
 
     bool hasCachedPseudoStyles() const { return m_computedStyle.hasCachedPseudoStyles(); }
-    const Style::PseudoStyleCache& cachedPseudoStyles() const LIFETIME_BOUND { return m_computedStyle.cachedPseudoStyles(); }
+    const Style::PseudoStyleCache* cachedPseudoStyles() const LIFETIME_BOUND { return m_computedStyle.cachedPseudoStyles(); }
 
     // MARK: - Custom properties
 

--- a/Source/WebCore/rendering/updating/RenderTreeUpdater.cpp
+++ b/Source/WebCore/rendering/updating/RenderTreeUpdater.cpp
@@ -392,7 +392,10 @@ void RenderTreeUpdater::updateAfterDescendants(Element& element, const Style::El
 static bool pseudoStyleCacheIsInvalid(RenderElement* renderer, RenderStyle* newStyle)
 {
     const auto& currentStyle = renderer->style();
-    for (auto& [key, value] : currentStyle.cachedPseudoStyles()) {
+    auto* cache = currentStyle.cachedPseudoStyles();
+    if (!cache)
+        return false;
+    for (auto& [key, value] : *cache) {
         auto newPseudoStyle = renderer->getUncachedPseudoStyle(*value->pseudoElementIdentifier(), newStyle, newStyle);
         if (!newPseudoStyle)
             return true;

--- a/Source/WebCore/style/StyleDifference.cpp
+++ b/Source/WebCore/style/StyleDifference.cpp
@@ -97,8 +97,8 @@ public:
             }
 
             if (&a.inheritedRareData() != &b.inheritedRareData()) {
-                if (a.inheritedRareData().textUnderlineOffset != b.inheritedRareData().textUnderlineOffset
-                    || a.inheritedRareData().textUnderlinePosition != b.inheritedRareData().textUnderlinePosition)
+                if (a.inheritedRareData().cssData->textUnderlineOffset != b.inheritedRareData().cssData->textUnderlineOffset
+                    || a.inheritedRareData().cssData->textUnderlinePosition != b.inheritedRareData().cssData->textUnderlinePosition)
                         return true;
             }
 
@@ -109,7 +109,7 @@ public:
             return true;
 
         if (&a.inheritedRareData() != &b.inheritedRareData()
-            && a.inheritedRareData().textShadow != b.inheritedRareData().textShadow)
+            && a.inheritedRareData().cssData->textShadow != b.inheritedRareData().cssData->textShadow)
             return true;
 
         if (textDecorationsDiffer()) {
@@ -329,58 +329,62 @@ public:
     {
         ASSERT(&a != &b);
 
-        if (a.textIndent != b.textIndent
-            || a.textAlignLast != b.textAlignLast
-            || a.textJustify != b.textJustify
-            || a.textBoxEdge != b.textBoxEdge
-            || a.lineFitEdge != b.lineFitEdge
-            || a.usedZoom != b.usedZoom
-            || a.textZoom != b.textZoom
+        if (a.usedZoom != b.usedZoom
+            || a.usedContentVisibility != b.usedContentVisibility)
+            return true;
+
+        if (a.cssData.ptr() == b.cssData.ptr())
+            return false;
+
+        if (a.cssData->textIndent != b.cssData->textIndent
+            || a.cssData->textAlignLast != b.cssData->textAlignLast
+            || a.cssData->textJustify != b.cssData->textJustify
+            || a.cssData->textBoxEdge != b.cssData->textBoxEdge
+            || a.cssData->lineFitEdge != b.cssData->lineFitEdge
+            || a.cssData->textZoom != b.cssData->textZoom
     #if ENABLE(TEXT_AUTOSIZING)
-            || a.textSizeAdjust != b.textSizeAdjust
+            || a.cssData->textSizeAdjust != b.cssData->textSizeAdjust
     #endif
-            || a.wordBreak != b.wordBreak
-            || a.overflowWrap != b.overflowWrap
-            || a.nbspMode != b.nbspMode
-            || a.lineBreak != b.lineBreak
-            || a.textSecurity != b.textSecurity
-            || a.hyphens != b.hyphens
-            || a.hyphenateLimitBefore != b.hyphenateLimitBefore
-            || a.hyphenateLimitAfter != b.hyphenateLimitAfter
-            || a.hyphenateCharacter != b.hyphenateCharacter
-            || a.rubyPosition != b.rubyPosition
-            || a.rubyAlign != b.rubyAlign
-            || a.rubyOverhang != b.rubyOverhang
-            || a.textCombine != b.textCombine
-            || a.textEmphasisStyle != b.textEmphasisStyle
-            || a.textEmphasisPosition != b.textEmphasisPosition
-            || a.tabSize != b.tabSize
-            || a.lineBoxContain != b.lineBoxContain
-            || a.lineGrid != b.lineGrid
-            || a.imageOrientation != b.imageOrientation
-            || a.lineSnap != b.lineSnap
-            || a.lineAlign != b.lineAlign
-            || a.hangingPunctuation != b.hangingPunctuation
-            || a.usedContentVisibility != b.usedContentVisibility
+            || a.cssData->wordBreak != b.cssData->wordBreak
+            || a.cssData->overflowWrap != b.cssData->overflowWrap
+            || a.cssData->nbspMode != b.cssData->nbspMode
+            || a.cssData->lineBreak != b.cssData->lineBreak
+            || a.cssData->textSecurity != b.cssData->textSecurity
+            || a.cssData->hyphens != b.cssData->hyphens
+            || a.cssData->hyphenateLimitBefore != b.cssData->hyphenateLimitBefore
+            || a.cssData->hyphenateLimitAfter != b.cssData->hyphenateLimitAfter
+            || a.cssData->hyphenateCharacter != b.cssData->hyphenateCharacter
+            || a.cssData->rubyPosition != b.cssData->rubyPosition
+            || a.cssData->rubyAlign != b.cssData->rubyAlign
+            || a.cssData->rubyOverhang != b.cssData->rubyOverhang
+            || a.cssData->textCombine != b.cssData->textCombine
+            || a.cssData->textEmphasisStyle != b.cssData->textEmphasisStyle
+            || a.cssData->textEmphasisPosition != b.cssData->textEmphasisPosition
+            || a.cssData->tabSize != b.cssData->tabSize
+            || a.cssData->lineBoxContain != b.cssData->lineBoxContain
+            || a.cssData->lineGrid != b.cssData->lineGrid
+            || a.cssData->imageOrientation != b.cssData->imageOrientation
+            || a.cssData->lineSnap != b.cssData->lineSnap
+            || a.cssData->lineAlign != b.cssData->lineAlign
+            || a.cssData->hangingPunctuation != b.cssData->hangingPunctuation
     #if ENABLE(WEBKIT_OVERFLOW_SCROLLING_CSS_PROPERTY)
-            || a.overflowScrolling != b.overflowScrolling
+            || a.cssData->overflowScrolling != b.cssData->overflowScrolling
     #endif
-            || a.listStyleType != b.listStyleType
-            || a.listStyleImage != b.listStyleImage
-            || a.blockEllipsis != b.blockEllipsis)
+            || a.cssData->listStyleType != b.cssData->listStyleType
+            || a.cssData->listStyleImage != b.cssData->listStyleImage
+            || a.cssData->blockEllipsis != b.cssData->blockEllipsis)
             return true;
 
-        if (a.textStrokeWidth != b.textStrokeWidth)
+        if (a.cssData->textStrokeWidth != b.cssData->textStrokeWidth)
             return true;
 
-        // These properties affect the cached stroke bounding box rects.
-        if (a.capStyle != b.capStyle
-            || a.joinStyle != b.joinStyle
-            || a.strokeWidth != b.strokeWidth
-            || a.strokeMiterLimit != b.strokeMiterLimit)
+        if (a.cssData->capStyle != b.cssData->capStyle
+            || a.cssData->joinStyle != b.cssData->joinStyle
+            || a.cssData->strokeWidth != b.cssData->strokeWidth
+            || a.cssData->strokeMiterLimit != b.cssData->strokeMiterLimit)
             return true;
 
-        if (a.quotes != b.quotes)
+        if (a.cssData->quotes != b.cssData->quotes)
             return true;
 
         return false;
@@ -501,7 +505,7 @@ public:
         }
 
         if (static_cast<DisplayType>(a.nonInheritedFlags().display) == DisplayType::BlockFlowListItem) {
-            if (a.inheritedFlags().listStylePosition != b.inheritedFlags().listStylePosition || a.inheritedRareData().listStyleType != b.inheritedRareData().listStyleType)
+            if (a.inheritedFlags().listStylePosition != b.inheritedFlags().listStylePosition || a.inheritedRareData().cssData->listStyleType != b.inheritedRareData().cssData->listStyleType)
                 return true;
         }
 
@@ -623,7 +627,7 @@ public:
         }
 
         if (&a.inheritedRareData() != &b.inheritedRareData()
-            && a.inheritedRareData().dynamicRangeLimit != b.inheritedRareData().dynamicRangeLimit) {
+            && a.inheritedRareData().cssData->dynamicRangeLimit != b.inheritedRareData().cssData->dynamicRangeLimit) {
             return true;
         }
 
@@ -781,16 +785,21 @@ public:
 
     static bool rareInheritedDataChangeRequiresRepaint(const InheritedRareData& a, const InheritedRareData& b)
     {
-        return a.effectiveInert != b.effectiveInert
-            || a.userModify != b.userModify
-            || a.userSelect != b.userSelect
-            || a.appleColorFilter != b.appleColorFilter
-            || a.imageRendering != b.imageRendering
-            || a.accentColor != b.accentColor
+        if (a.effectiveInert != b.effectiveInert
             || a.insideDefaultButton != b.insideDefaultButton
-            || a.insideSubmitButton != b.insideSubmitButton
+            || a.insideSubmitButton != b.insideSubmitButton)
+            return true;
+
+        if (a.cssData.ptr() == b.cssData.ptr())
+            return false;
+
+        return a.cssData->userModify != b.cssData->userModify
+            || a.cssData->userSelect != b.cssData->userSelect
+            || a.cssData->appleColorFilter != b.cssData->appleColorFilter
+            || a.cssData->imageRendering != b.cssData->imageRendering
+            || a.cssData->accentColor != b.cssData->accentColor
     #if ENABLE(DARK_MODE_CSS)
-            || a.colorScheme != b.colorScheme
+            || a.cssData->colorScheme != b.cssData->colorScheme
     #endif
         ;
     }
@@ -892,14 +901,14 @@ public:
             return true;
 
         if (&a.inheritedRareData() != &b.inheritedRareData()) {
-            if (a.inheritedRareData().textDecorationSkipInk != b.inheritedRareData().textDecorationSkipInk
-                || a.inheritedRareData().textFillColor != b.inheritedRareData().textFillColor
-                || a.inheritedRareData().textStrokeColor != b.inheritedRareData().textStrokeColor
-                || a.inheritedRareData().textEmphasisColor != b.inheritedRareData().textEmphasisColor
-                || a.inheritedRareData().textEmphasisStyle != b.inheritedRareData().textEmphasisStyle
-                || a.inheritedRareData().strokeColor != b.inheritedRareData().strokeColor
-                || a.inheritedRareData().caretColor != b.inheritedRareData().caretColor
-                || a.inheritedRareData().textUnderlineOffset != b.inheritedRareData().textUnderlineOffset)
+            if (a.inheritedRareData().cssData->textDecorationSkipInk != b.inheritedRareData().cssData->textDecorationSkipInk
+                || a.inheritedRareData().cssData->textFillColor != b.inheritedRareData().cssData->textFillColor
+                || a.inheritedRareData().cssData->textStrokeColor != b.inheritedRareData().cssData->textStrokeColor
+                || a.inheritedRareData().cssData->textEmphasisColor != b.inheritedRareData().cssData->textEmphasisColor
+                || a.inheritedRareData().cssData->textEmphasisStyle != b.inheritedRareData().cssData->textEmphasisStyle
+                || a.inheritedRareData().cssData->strokeColor != b.inheritedRareData().cssData->strokeColor
+                || a.inheritedRareData().cssData->caretColor != b.inheritedRareData().cssData->caretColor
+                || a.inheritedRareData().cssData->textUnderlineOffset != b.inheritedRareData().cssData->textUnderlineOffset)
                 return true;
         }
 

--- a/Source/WebCore/style/computed/StyleComputedStyle.cpp
+++ b/Source/WebCore/style/computed/StyleComputedStyle.cpp
@@ -55,7 +55,7 @@ struct SameSizeAsComputedStyle : CanMakeCheckedPtr<SameSizeAsComputedStyle> {
     } m_inheritedFlags;
     void* nonInheritedDataRefs[1];
     void* inheritedDataRefs[2];
-    HashMap<PseudoElementIdentifier, std::unique_ptr<RenderStyle>> pseudos;
+    void* pseudos;
     void* dataRefSvgStyle;
 
 #if ASSERT_ENABLED || ENABLE(SECURITY_ASSERTIONS)
@@ -77,10 +77,10 @@ void ComputedStyle::inheritFrom(const ComputedStyle& inheritParent)
 
 void ComputedStyle::inheritIgnoringCustomPropertiesFrom(const ComputedStyle& inheritParent)
 {
-    auto oldCustomProperties = m_inheritedRareData->customProperties;
+    auto oldCustomProperties = m_inheritedRareData->cssData->customProperties;
     inheritFrom(inheritParent);
-    if (oldCustomProperties != m_inheritedRareData->customProperties)
-        m_inheritedRareData.access().customProperties = oldCustomProperties;
+    if (oldCustomProperties != m_inheritedRareData->cssData->customProperties)
+        m_inheritedRareData.access().cssData.access().customProperties = oldCustomProperties;
 }
 
 void ComputedStyle::inheritUnicodeBidiFrom(const ComputedStyle& inheritParent)

--- a/Source/WebCore/style/computed/StyleComputedStyleBase+GettersInlines.h
+++ b/Source/WebCore/style/computed/StyleComputedStyleBase+GettersInlines.h
@@ -287,7 +287,7 @@ inline bool ComputedStyleBase::hasAnyPublicPseudoStyles() const
 
 inline const CustomPropertyData& ComputedStyleBase::inheritedCustomProperties() const
 {
-    return m_inheritedRareData->customProperties.get();
+    return m_inheritedRareData->cssData->customProperties.get();
 }
 
 inline const CustomPropertyData& ComputedStyleBase::nonInheritedCustomProperties() const

--- a/Source/WebCore/style/computed/StyleComputedStyleBase.cpp
+++ b/Source/WebCore/style/computed/StyleComputedStyleBase.cpp
@@ -99,7 +99,9 @@ std::optional<PseudoElementIdentifier> ComputedStyleBase::pseudoElementIdentifie
 
 RenderStyle* ComputedStyleBase::getCachedPseudoStyle(const PseudoElementIdentifier& pseudoElementIdentifier) const
 {
-    return m_cachedPseudoStyles.get(pseudoElementIdentifier);
+    if (!m_cachedPseudoStyles)
+        return nullptr;
+    return m_cachedPseudoStyles->get(pseudoElementIdentifier);
 }
 
 RenderStyle* ComputedStyleBase::addCachedPseudoStyle(std::unique_ptr<RenderStyle> pseudo)
@@ -110,7 +112,9 @@ RenderStyle* ComputedStyleBase::addCachedPseudoStyle(std::unique_ptr<RenderStyle
     ASSERT(pseudo->pseudoElementType());
 
     auto* result = pseudo.get();
-    m_cachedPseudoStyles.add(*result->pseudoElementIdentifier(), WTF::move(pseudo));
+    if (!m_cachedPseudoStyles)
+        m_cachedPseudoStyles = makeUnique<PseudoStyleCache>();
+    m_cachedPseudoStyles->add(*result->pseudoElementIdentifier(), WTF::move(pseudo));
     return result;
 }
 
@@ -129,8 +133,8 @@ void ComputedStyleBase::setCustomPropertyValue(Ref<const CustomProperty>&& value
 {
     auto& name = value->name();
     if (isInherited) {
-        if (RefPtr existingValue = m_inheritedRareData->customProperties->get(name); !existingValue || *existingValue != value.get())
-            m_inheritedRareData.access().customProperties.access().set(name, WTF::move(value));
+        if (RefPtr existingValue = m_inheritedRareData->cssData->customProperties->get(name); !existingValue || *existingValue != value.get())
+            m_inheritedRareData.access().cssData.access().customProperties.access().set(name, WTF::move(value));
     } else {
         if (RefPtr existingValue = m_nonInheritedData->rareData->customProperties->get(name); !existingValue || *existingValue != value.get())
             m_nonInheritedData.access().rareData.access().customProperties.access().set(name, WTF::move(value));
@@ -154,7 +158,7 @@ bool ComputedStyleBase::customPropertyValueEqual(const ComputedStyleBase& other,
 bool ComputedStyleBase::customPropertiesEqual(const ComputedStyleBase& other) const
 {
     return m_nonInheritedData->rareData->customProperties == other.m_nonInheritedData->rareData->customProperties
-        && m_inheritedRareData->customProperties == other.m_inheritedRareData->customProperties;
+        && m_inheritedRareData->cssData->customProperties == other.m_inheritedRareData->cssData->customProperties;
 }
 
 void ComputedStyleBase::deduplicateCustomProperties(const ComputedStyleBase& other)
@@ -167,7 +171,7 @@ void ComputedStyleBase::deduplicateCustomProperties(const ComputedStyleBase& oth
         properties = otherProperties;
     };
 
-    deduplicate(m_inheritedRareData, other.m_inheritedRareData);
+    deduplicate(m_inheritedRareData->cssData, other.m_inheritedRareData->cssData);
     deduplicate(m_nonInheritedData->rareData, other.m_nonInheritedData->rareData);
 }
 

--- a/Source/WebCore/style/computed/StyleComputedStyleBase.h
+++ b/Source/WebCore/style/computed/StyleComputedStyleBase.h
@@ -590,8 +590,8 @@ public:
     RenderStyle* NODELETE getCachedPseudoStyle(const PseudoElementIdentifier&) const;
     RenderStyle* addCachedPseudoStyle(std::unique_ptr<RenderStyle>);
 
-    bool hasCachedPseudoStyles() const { return !m_cachedPseudoStyles.isEmpty(); }
-    const PseudoStyleCache& cachedPseudoStyles() const LIFETIME_BOUND { return m_cachedPseudoStyles; }
+    bool hasCachedPseudoStyles() const { return m_cachedPseudoStyles && !m_cachedPseudoStyles->isEmpty(); }
+    const PseudoStyleCache* cachedPseudoStyles() const LIFETIME_BOUND { return m_cachedPseudoStyles.get(); }
 
     // MARK: - Custom properties
 
@@ -853,7 +853,7 @@ protected:
     DataRef<SVGData> m_svgData;
 
     // Associated pseudo styles
-    PseudoStyleCache m_cachedPseudoStyles;
+    std::unique_ptr<PseudoStyleCache> m_cachedPseudoStyles;
 
 #if ASSERT_ENABLED || ENABLE(SECURITY_ASSERTIONS)
     bool m_deletionHasBegun { false };

--- a/Source/WebCore/style/computed/StyleComputedStyleProperties+GettersCustomInlines.h
+++ b/Source/WebCore/style/computed/StyleComputedStyleProperties+GettersCustomInlines.h
@@ -104,7 +104,7 @@ namespace Style {
 
 inline Cursor ComputedStyleProperties::cursor() const
 {
-    return { m_inheritedRareData->cursorImages, static_cast<CursorType>(m_inheritedFlags.cursorType) };
+    return { m_inheritedRareData->cssData->cursorImages, static_cast<CursorType>(m_inheritedFlags.cursorType) };
 }
 
 inline ZIndex ComputedStyleProperties::specifiedZIndex() const

--- a/Source/WebCore/style/computed/StyleComputedStyleProperties+SettersCustomInlines.h
+++ b/Source/WebCore/style/computed/StyleComputedStyleProperties+SettersCustomInlines.h
@@ -110,7 +110,7 @@ inline void ComputedStyleProperties::setSpecifiedZIndex(ZIndex index)
 inline void ComputedStyleProperties::setCursor(Cursor cursor)
 {
     m_inheritedFlags.cursorType = static_cast<unsigned>(cursor.predefined);
-    SET(m_inheritedRareData, cursorImages, WTF::move(cursor.images));
+    SET_NESTED(m_inheritedRareData, cssData, cursorImages, WTF::move(cursor.images));
 }
 
 // MARK: Fonts

--- a/Source/WebCore/style/computed/data/StyleInheritedRareCSSData.cpp
+++ b/Source/WebCore/style/computed/data/StyleInheritedRareCSSData.cpp
@@ -1,0 +1,441 @@
+/*
+ * Copyright (C) 1999 Antti Koivisto (koivisto@kde.org)
+ * Copyright (C) 2004-2023 Apple Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Library General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Library General Public License for more details.
+ *
+ * You should have received a copy of the GNU Library General Public License
+ * along with this library; see the file COPYING.LIB.  If not, write to
+ * the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301, USA.
+ *
+ */
+
+#include "config.h"
+#include "StyleInheritedRareCSSData.h"
+
+#include "StyleComputedStyle+DifferenceLogging.h"
+#include "StyleComputedStyle+InitialInlines.h"
+#include "StyleKeyword+Logging.h"
+#include "StylePrimitiveNumericTypes+Logging.h"
+
+namespace WebCore {
+namespace Style {
+
+DEFINE_ALLOCATOR_WITH_HEAP_IDENTIFIER(InheritedRareCSSData);
+
+InheritedRareCSSData::InheritedRareCSSData()
+    : textStrokeWidth(ComputedStyle::initialTextStrokeWidth())
+    , textStrokeColor(ComputedStyle::initialTextStrokeColor())
+    , textFillColor(ComputedStyle::initialTextFillColor())
+    , textEmphasisColor(ComputedStyle::initialTextEmphasisColor())
+    , visitedLinkTextStrokeColor(ComputedStyle::initialTextStrokeColor())
+    , visitedLinkTextFillColor(ComputedStyle::initialTextFillColor())
+    , visitedLinkTextEmphasisColor(ComputedStyle::initialTextEmphasisColor())
+    , caretColor(ComputedStyle::initialCaretColor())
+    , visitedLinkCaretColor(ComputedStyle::initialCaretColor())
+    , accentColor(ComputedStyle::initialAccentColor())
+    , scrollbarColor(ComputedStyle::initialScrollbarColor())
+    , textEmphasisStyle(ComputedStyle::initialTextEmphasisStyle())
+    , quotes(ComputedStyle::initialQuotes())
+    , strokeColor(ComputedStyle::initialStrokeColor())
+    , visitedLinkStrokeColor(Color::currentColor())
+#if ENABLE(DARK_MODE_CSS)
+    , colorScheme(ComputedStyle::initialColorScheme())
+#endif
+    , cursorImages(ComputedStyle::initialCursor().images)
+#if ENABLE(CSS_TAP_HIGHLIGHT_COLOR)
+    , tapHighlightColor(ComputedStyle::initialTapHighlightColor())
+#endif
+    , listStyleType(ComputedStyle::initialListStyleType())
+    , blockEllipsis(ComputedStyle::initialBlockEllipsis())
+    , textIndent(ComputedStyle::initialTextIndent())
+    , listStyleImage(ComputedStyle::initialListStyleImage())
+    , dynamicRangeLimit(ComputedStyle::initialDynamicRangeLimit())
+    , textShadow(ComputedStyle::initialTextShadow())
+    , hyphenateCharacter(ComputedStyle::initialHyphenateCharacter())
+    , customProperties(CustomPropertyData::create())
+    , strokeWidth(ComputedStyle::initialStrokeWidth())
+    , textUnderlineOffset(ComputedStyle::initialTextUnderlineOffset())
+    , appleColorFilter(AppleColorFilterData::create())
+    , lineGrid(ComputedStyle::initialLineGrid())
+    , tabSize(ComputedStyle::initialTabSize())
+    , strokeMiterLimit(ComputedStyle::initialStrokeMiterLimit())
+#if ENABLE(TEXT_AUTOSIZING)
+    , textSizeAdjust(ComputedStyle::initialTextSizeAdjust())
+#endif
+    , mathDepth(ComputedStyle::initialMathDepth())
+    , textBoxEdge(ComputedStyle::initialTextBoxEdge())
+    , lineFitEdge(ComputedStyle::initialLineFitEdge())
+    , widows(ComputedStyle::initialWidows())
+    , orphans(ComputedStyle::initialOrphans())
+    , hyphenateLimitBefore(ComputedStyle::initialHyphenateLimitBefore())
+    , hyphenateLimitAfter(ComputedStyle::initialHyphenateLimitAfter())
+    , hyphenateLimitLines(ComputedStyle::initialHyphenateLimitLines())
+    , textSecurity(static_cast<unsigned>(ComputedStyle::initialTextSecurity()))
+    , userModify(static_cast<unsigned>(UserModify::ReadOnly))
+    , wordBreak(static_cast<unsigned>(ComputedStyle::initialWordBreak()))
+    , overflowWrap(static_cast<unsigned>(ComputedStyle::initialOverflowWrap()))
+    , nbspMode(static_cast<unsigned>(NBSPMode::Normal))
+    , lineBreak(static_cast<unsigned>(LineBreak::Auto))
+    , userSelect(static_cast<unsigned>(ComputedStyle::initialUserSelect()))
+    , speakAs(ComputedStyle::initialSpeakAs().toRaw())
+    , hyphens(static_cast<unsigned>(Hyphens::Manual))
+    , textCombine(static_cast<unsigned>(ComputedStyle::initialTextCombine()))
+    , textEmphasisPosition(static_cast<unsigned>(ComputedStyle::initialTextEmphasisPosition().toRaw()))
+    , textUnderlinePosition(static_cast<unsigned>(ComputedStyle::initialTextUnderlinePosition().toRaw()))
+    , lineBoxContain(static_cast<unsigned>(ComputedStyle::initialLineBoxContain().toRaw()))
+    , imageOrientation(static_cast<unsigned>(ComputedStyle::initialImageOrientation()))
+    , imageRendering(static_cast<unsigned>(ComputedStyle::initialImageRendering()))
+    , lineSnap(static_cast<unsigned>(ComputedStyle::initialLineSnap()))
+    , lineAlign(static_cast<unsigned>(ComputedStyle::initialLineAlign()))
+#if ENABLE(WEBKIT_OVERFLOW_SCROLLING_CSS_PROPERTY)
+    , overflowScrolling(static_cast<unsigned>(ComputedStyle::initialOverflowScrolling()))
+#endif
+    , textAlignLast(static_cast<unsigned>(ComputedStyle::initialTextAlignLast()))
+    , textJustify(static_cast<unsigned>(ComputedStyle::initialTextJustify()))
+    , textDecorationSkipInk(static_cast<unsigned>(ComputedStyle::initialTextDecorationSkipInk()))
+    , mathShift(static_cast<unsigned>(ComputedStyle::initialMathShift()))
+    , mathStyle(static_cast<unsigned>(ComputedStyle::initialMathStyle()))
+    , rubyPosition(static_cast<unsigned>(ComputedStyle::initialRubyPosition()))
+    , rubyAlign(static_cast<unsigned>(ComputedStyle::initialRubyAlign()))
+    , rubyOverhang(static_cast<unsigned>(ComputedStyle::initialRubyOverhang()))
+    , textZoom(static_cast<unsigned>(ComputedStyle::initialTextZoom()))
+#if ENABLE(WEBKIT_TOUCH_CALLOUT_CSS_PROPERTY)
+    , touchCallout(static_cast<unsigned>(ComputedStyle::initialTouchCallout()))
+#endif
+    , hangingPunctuation(ComputedStyle::initialHangingPunctuation().toRaw())
+    , paintOrder(static_cast<unsigned>(ComputedStyle::initialPaintOrder().type()))
+    , capStyle(static_cast<unsigned>(ComputedStyle::initialCapStyle()))
+    , joinStyle(static_cast<unsigned>(ComputedStyle::initialJoinStyle()))
+    , hasExplicitlySetStrokeWidth(false)
+    , hasExplicitlySetStrokeColor(false)
+{
+}
+
+inline InheritedRareCSSData::InheritedRareCSSData(const InheritedRareCSSData& o)
+    : RefCounted<InheritedRareCSSData>()
+    , textStrokeWidth(o.textStrokeWidth)
+    , textStrokeColor(o.textStrokeColor)
+    , textFillColor(o.textFillColor)
+    , textEmphasisColor(o.textEmphasisColor)
+    , visitedLinkTextStrokeColor(o.visitedLinkTextStrokeColor)
+    , visitedLinkTextFillColor(o.visitedLinkTextFillColor)
+    , visitedLinkTextEmphasisColor(o.visitedLinkTextEmphasisColor)
+    , caretColor(o.caretColor)
+    , visitedLinkCaretColor(o.visitedLinkCaretColor)
+    , accentColor(o.accentColor)
+    , scrollbarColor(o.scrollbarColor)
+    , textEmphasisStyle(o.textEmphasisStyle)
+    , quotes(o.quotes)
+    , strokeColor(o.strokeColor)
+    , visitedLinkStrokeColor(o.visitedLinkStrokeColor)
+#if ENABLE(DARK_MODE_CSS)
+    , colorScheme(o.colorScheme)
+#endif
+    , cursorImages(o.cursorImages)
+#if ENABLE(CSS_TAP_HIGHLIGHT_COLOR)
+    , tapHighlightColor(o.tapHighlightColor)
+#endif
+    , listStyleType(o.listStyleType)
+    , blockEllipsis(o.blockEllipsis)
+    , textIndent(o.textIndent)
+    , listStyleImage(o.listStyleImage)
+    , dynamicRangeLimit(o.dynamicRangeLimit)
+    , textShadow(o.textShadow)
+    , hyphenateCharacter(o.hyphenateCharacter)
+    , customProperties(o.customProperties)
+    , strokeWidth(o.strokeWidth)
+    , textUnderlineOffset(o.textUnderlineOffset)
+    , appleColorFilter(o.appleColorFilter)
+    , lineGrid(o.lineGrid)
+    , tabSize(o.tabSize)
+    , strokeMiterLimit(o.strokeMiterLimit)
+#if ENABLE(TEXT_AUTOSIZING)
+    , textSizeAdjust(o.textSizeAdjust)
+#endif
+    , mathDepth(o.mathDepth)
+    , textBoxEdge(o.textBoxEdge)
+    , lineFitEdge(o.lineFitEdge)
+    , widows(o.widows)
+    , orphans(o.orphans)
+    , hyphenateLimitBefore(o.hyphenateLimitBefore)
+    , hyphenateLimitAfter(o.hyphenateLimitAfter)
+    , hyphenateLimitLines(o.hyphenateLimitLines)
+    , textSecurity(o.textSecurity)
+    , userModify(o.userModify)
+    , wordBreak(o.wordBreak)
+    , overflowWrap(o.overflowWrap)
+    , nbspMode(o.nbspMode)
+    , lineBreak(o.lineBreak)
+    , userSelect(o.userSelect)
+    , speakAs(o.speakAs)
+    , hyphens(o.hyphens)
+    , textCombine(o.textCombine)
+    , textEmphasisPosition(o.textEmphasisPosition)
+    , textUnderlinePosition(o.textUnderlinePosition)
+    , lineBoxContain(o.lineBoxContain)
+    , imageOrientation(o.imageOrientation)
+    , imageRendering(o.imageRendering)
+    , lineSnap(o.lineSnap)
+    , lineAlign(o.lineAlign)
+#if ENABLE(WEBKIT_OVERFLOW_SCROLLING_CSS_PROPERTY)
+    , overflowScrolling(o.overflowScrolling)
+#endif
+    , textAlignLast(o.textAlignLast)
+    , textJustify(o.textJustify)
+    , textDecorationSkipInk(o.textDecorationSkipInk)
+    , mathShift(o.mathShift)
+    , mathStyle(o.mathStyle)
+    , rubyPosition(o.rubyPosition)
+    , rubyAlign(o.rubyAlign)
+    , rubyOverhang(o.rubyOverhang)
+    , textZoom(o.textZoom)
+#if ENABLE(WEBKIT_TOUCH_CALLOUT_CSS_PROPERTY)
+    , touchCallout(o.touchCallout)
+#endif
+    , hangingPunctuation(o.hangingPunctuation)
+    , paintOrder(o.paintOrder)
+    , capStyle(o.capStyle)
+    , joinStyle(o.joinStyle)
+    , hasExplicitlySetStrokeWidth(o.hasExplicitlySetStrokeWidth)
+    , hasExplicitlySetStrokeColor(o.hasExplicitlySetStrokeColor)
+{
+    ASSERT(o == *this, "InheritedRareCSSData should be properly copied.");
+}
+
+Ref<InheritedRareCSSData> InheritedRareCSSData::copy() const
+{
+    return adoptRef(*new InheritedRareCSSData(*this));
+}
+
+InheritedRareCSSData::~InheritedRareCSSData() = default;
+
+bool InheritedRareCSSData::operator==(const InheritedRareCSSData& o) const
+{
+    return textStrokeWidth == o.textStrokeWidth
+        && textStrokeColor == o.textStrokeColor
+        && textFillColor == o.textFillColor
+        && textEmphasisColor == o.textEmphasisColor
+        && visitedLinkTextStrokeColor == o.visitedLinkTextStrokeColor
+        && visitedLinkTextFillColor == o.visitedLinkTextFillColor
+        && visitedLinkTextEmphasisColor == o.visitedLinkTextEmphasisColor
+        && caretColor == o.caretColor
+        && visitedLinkCaretColor == o.visitedLinkCaretColor
+        && accentColor == o.accentColor
+        && scrollbarColor == o.scrollbarColor
+        && dynamicRangeLimit == o.dynamicRangeLimit
+#if ENABLE(CSS_TAP_HIGHLIGHT_COLOR)
+        && tapHighlightColor == o.tapHighlightColor
+#endif
+        && textShadow == o.textShadow
+        && cursorImages == o.cursorImages
+        && textEmphasisStyle == o.textEmphasisStyle
+        && textIndent == o.textIndent
+        && textUnderlineOffset == o.textUnderlineOffset
+        && textBoxEdge == o.textBoxEdge
+        && lineFitEdge == o.lineFitEdge
+        && strokeMiterLimit == o.strokeMiterLimit
+        && widows == o.widows
+        && orphans == o.orphans
+        && textSecurity == o.textSecurity
+        && userModify == o.userModify
+        && wordBreak == o.wordBreak
+        && overflowWrap == o.overflowWrap
+        && nbspMode == o.nbspMode
+        && lineBreak == o.lineBreak
+#if ENABLE(WEBKIT_OVERFLOW_SCROLLING_CSS_PROPERTY)
+        && overflowScrolling == o.overflowScrolling
+#endif
+#if ENABLE(TEXT_AUTOSIZING)
+        && textSizeAdjust == o.textSizeAdjust
+#endif
+        && userSelect == o.userSelect
+        && speakAs == o.speakAs
+        && hyphens == o.hyphens
+        && hyphenateLimitBefore == o.hyphenateLimitBefore
+        && hyphenateLimitAfter == o.hyphenateLimitAfter
+        && hyphenateLimitLines == o.hyphenateLimitLines
+#if ENABLE(DARK_MODE_CSS)
+        && colorScheme == o.colorScheme
+#endif
+        && textCombine == o.textCombine
+        && textEmphasisPosition == o.textEmphasisPosition
+        && lineBoxContain == o.lineBoxContain
+#if ENABLE(WEBKIT_TOUCH_CALLOUT_CSS_PROPERTY)
+        && touchCallout == o.touchCallout
+#endif
+        && hyphenateCharacter == o.hyphenateCharacter
+        && quotes == o.quotes
+        && appleColorFilter == o.appleColorFilter
+        && tabSize == o.tabSize
+        && lineGrid == o.lineGrid
+        && imageOrientation == o.imageOrientation
+        && imageRendering == o.imageRendering
+        && textAlignLast == o.textAlignLast
+        && textJustify == o.textJustify
+        && textDecorationSkipInk == o.textDecorationSkipInk
+        && textUnderlinePosition == o.textUnderlinePosition
+        && rubyPosition == o.rubyPosition
+        && rubyAlign == o.rubyAlign
+        && rubyOverhang == o.rubyOverhang
+        && textZoom == o.textZoom
+        && lineSnap == o.lineSnap
+        && lineAlign == o.lineAlign
+        && hangingPunctuation == o.hangingPunctuation
+        && paintOrder == o.paintOrder
+        && capStyle == o.capStyle
+        && joinStyle == o.joinStyle
+        && hasExplicitlySetStrokeWidth == o.hasExplicitlySetStrokeWidth
+        && hasExplicitlySetStrokeColor == o.hasExplicitlySetStrokeColor
+        && mathShift == o.mathShift
+        && mathStyle == o.mathStyle
+        && strokeWidth == o.strokeWidth
+        && strokeColor == o.strokeColor
+        && visitedLinkStrokeColor == o.visitedLinkStrokeColor
+        && customProperties == o.customProperties
+        && listStyleImage == o.listStyleImage
+        && listStyleType == o.listStyleType
+        && blockEllipsis == o.blockEllipsis
+        && mathDepth == o.mathDepth;
+}
+
+#if !LOG_DISABLED
+void InheritedRareCSSData::dumpDifferences(TextStream& ts, const InheritedRareCSSData& other) const
+{
+    customProperties->dumpDifferences(ts, other.customProperties);
+
+    LOG_IF_DIFFERENT(listStyleImage);
+
+    LOG_IF_DIFFERENT(textStrokeWidth);
+
+    LOG_IF_DIFFERENT(textStrokeColor);
+    LOG_IF_DIFFERENT(textFillColor);
+    LOG_IF_DIFFERENT(textEmphasisColor);
+
+    LOG_IF_DIFFERENT(visitedLinkTextStrokeColor);
+    LOG_IF_DIFFERENT(visitedLinkTextFillColor);
+    LOG_IF_DIFFERENT(visitedLinkTextEmphasisColor);
+
+    LOG_IF_DIFFERENT(caretColor);
+    LOG_IF_DIFFERENT(visitedLinkCaretColor);
+
+    LOG_IF_DIFFERENT(accentColor);
+
+    LOG_IF_DIFFERENT(scrollbarColor);
+
+    LOG_IF_DIFFERENT(dynamicRangeLimit);
+
+    LOG_IF_DIFFERENT(textShadow);
+
+    LOG_IF_DIFFERENT(cursorImages);
+
+    LOG_IF_DIFFERENT(textEmphasisStyle);
+    LOG_IF_DIFFERENT(textIndent);
+    LOG_IF_DIFFERENT(textUnderlineOffset);
+
+    LOG_IF_DIFFERENT(textBoxEdge);
+    LOG_IF_DIFFERENT(lineFitEdge);
+
+    LOG_IF_DIFFERENT(strokeMiterLimit);
+
+    LOG_IF_DIFFERENT(widows);
+    LOG_IF_DIFFERENT(orphans);
+
+    LOG_IF_DIFFERENT_WITH_CAST(TextSecurity, textSecurity);
+    LOG_IF_DIFFERENT_WITH_CAST(UserModify, userModify);
+
+    LOG_IF_DIFFERENT_WITH_CAST(WordBreak, wordBreak);
+    LOG_IF_DIFFERENT_WITH_CAST(OverflowWrap, overflowWrap);
+    LOG_IF_DIFFERENT_WITH_CAST(NBSPMode, nbspMode);
+    LOG_IF_DIFFERENT_WITH_CAST(LineBreak, lineBreak);
+    LOG_IF_DIFFERENT_WITH_CAST(UserSelect, userSelect);
+
+    LOG_IF_DIFFERENT_WITH_FROM_RAW(SpeakAs, speakAs);
+
+    LOG_IF_DIFFERENT_WITH_CAST(Hyphens, hyphens);
+    LOG_IF_DIFFERENT_WITH_CAST(TextCombine, textCombine);
+    LOG_IF_DIFFERENT_WITH_FROM_RAW(TextEmphasisPosition, textEmphasisPosition);
+    LOG_IF_DIFFERENT_WITH_FROM_RAW(TextUnderlinePosition, textUnderlinePosition);
+
+    LOG_IF_DIFFERENT_WITH_FROM_RAW(WebkitLineBoxContain, lineBoxContain);
+
+    LOG_IF_DIFFERENT_WITH_CAST(ImageOrientation, imageOrientation);
+    LOG_IF_DIFFERENT_WITH_CAST(ImageRendering, imageRendering);
+    LOG_IF_DIFFERENT_WITH_CAST(LineSnap, lineSnap);
+    LOG_IF_DIFFERENT_WITH_CAST(LineAlign, lineAlign);
+
+#if ENABLE(WEBKIT_OVERFLOW_SCROLLING_CSS_PROPERTY)
+    LOG_IF_DIFFERENT_WITH_CAST(WebkitOverflowScrolling, overflowScrolling);
+#endif
+
+    LOG_IF_DIFFERENT_WITH_CAST(TextAlignLast, textAlignLast);
+    LOG_IF_DIFFERENT_WITH_CAST(TextJustify, textJustify);
+    LOG_IF_DIFFERENT_WITH_CAST(TextDecorationSkipInk, textDecorationSkipInk);
+
+    LOG_IF_DIFFERENT_WITH_CAST(RubyPosition, rubyPosition);
+    LOG_IF_DIFFERENT_WITH_CAST(RubyAlign, rubyAlign);
+    LOG_IF_DIFFERENT_WITH_CAST(RubyOverhang, rubyOverhang);
+
+    LOG_IF_DIFFERENT_WITH_CAST(TextZoom, textZoom);
+
+#if ENABLE(WEBKIT_TOUCH_CALLOUT_CSS_PROPERTY)
+    LOG_IF_DIFFERENT_WITH_CAST(WebkitTouchCallout, touchCallout);
+#endif
+
+    LOG_IF_DIFFERENT_WITH_FROM_RAW(HangingPunctuation, hangingPunctuation);
+
+    LOG_IF_DIFFERENT_WITH_FROM_RAW(SVGPaintOrder, paintOrder);
+    LOG_IF_DIFFERENT_WITH_CAST(LineCap, capStyle);
+    LOG_IF_DIFFERENT_WITH_CAST(LineJoin, joinStyle);
+
+    LOG_IF_DIFFERENT_WITH_CAST(bool, hasExplicitlySetStrokeWidth);
+    LOG_IF_DIFFERENT_WITH_CAST(bool, hasExplicitlySetStrokeColor);
+
+    LOG_IF_DIFFERENT_WITH_CAST(MathShift, mathShift);
+    LOG_IF_DIFFERENT_WITH_CAST(MathStyle, mathStyle);
+
+    LOG_IF_DIFFERENT(strokeWidth);
+    LOG_IF_DIFFERENT(strokeColor);
+    LOG_IF_DIFFERENT(visitedLinkStrokeColor);
+
+    LOG_IF_DIFFERENT(hyphenateCharacter);
+    LOG_IF_DIFFERENT(hyphenateLimitBefore);
+    LOG_IF_DIFFERENT(hyphenateLimitAfter);
+    LOG_IF_DIFFERENT(hyphenateLimitLines);
+
+#if ENABLE(DARK_MODE_CSS)
+    LOG_IF_DIFFERENT(colorScheme);
+#endif
+
+    LOG_IF_DIFFERENT(quotes);
+
+    appleColorFilter->dumpDifferences(ts, other.appleColorFilter);
+
+    LOG_IF_DIFFERENT(lineGrid);
+    LOG_IF_DIFFERENT(tabSize);
+
+#if ENABLE(TEXT_AUTOSIZING)
+    LOG_IF_DIFFERENT(textSizeAdjust);
+#endif
+#if ENABLE(CSS_TAP_HIGHLIGHT_COLOR)
+    LOG_IF_DIFFERENT(tapHighlightColor);
+#endif
+
+    LOG_IF_DIFFERENT(listStyleType);
+    LOG_IF_DIFFERENT(blockEllipsis);
+
+    LOG_IF_DIFFERENT(mathDepth);
+}
+#endif
+
+} // namespace Style
+} // namespace WebCore

--- a/Source/WebCore/style/computed/data/StyleInheritedRareCSSData.h
+++ b/Source/WebCore/style/computed/data/StyleInheritedRareCSSData.h
@@ -1,0 +1,207 @@
+/*
+ * Copyright (C) 2000 Lars Knoll (knoll@kde.org)
+ *           (C) 2000 Antti Koivisto (koivisto@kde.org)
+ *           (C) 2000 Dirk Mueller (mueller@kde.org)
+ * Copyright (C) 2003-2023 Apple Inc. All rights reserved.
+ * Copyright (C) 2006 Graham Dennis (graham.dennis@gmail.com)
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Library General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Library General Public License for more details.
+ *
+ * You should have received a copy of the GNU Library General Public License
+ * along with this library; see the file COPYING.LIB.  If not, write to
+ * the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301, USA.
+ *
+ */
+
+#pragma once
+
+#include <WebCore/RenderStyleConstants.h>
+#include <WebCore/StyleAccentColor.h>
+#include <WebCore/StyleBlockEllipsis.h>
+#include <WebCore/StyleCaretColor.h>
+#include <WebCore/StyleColor.h>
+#include <WebCore/StyleCursor.h>
+#include <WebCore/StyleDynamicRangeLimit.h>
+#include <WebCore/StyleHangingPunctuation.h>
+#include <WebCore/StyleHyphenateCharacter.h>
+#include <WebCore/StyleHyphenateLimitEdge.h>
+#include <WebCore/StyleHyphenateLimitLines.h>
+#include <WebCore/StyleImageOrNone.h>
+#include <WebCore/StyleImageOrientation.h>
+#include <WebCore/StyleLineFitEdge.h>
+#include <WebCore/StyleListStyleType.h>
+#include <WebCore/StyleMathDepth.h>
+#include <WebCore/StyleOrphans.h>
+#include <WebCore/StyleQuotes.h>
+#include <WebCore/StyleSVGPaintOrder.h>
+#include <WebCore/StyleScrollbarColor.h>
+#include <WebCore/StyleSpeakAs.h>
+#include <WebCore/StyleStrokeMiterlimit.h>
+#include <WebCore/StyleStrokeWidth.h>
+#include <WebCore/StyleTabSize.h>
+#include <WebCore/StyleTextAlignLast.h>
+#include <WebCore/StyleTextBoxEdge.h>
+#include <WebCore/StyleTextEmphasisPosition.h>
+#include <WebCore/StyleTextEmphasisStyle.h>
+#include <WebCore/StyleTextIndent.h>
+#include <WebCore/StyleTextShadow.h>
+#include <WebCore/StyleTextUnderlineOffset.h>
+#include <WebCore/StyleTextUnderlinePosition.h>
+#include <WebCore/StyleWebKitLineBoxContain.h>
+#include <WebCore/StyleWebKitLineGrid.h>
+#include <WebCore/StyleWebKitOverflowScrolling.h>
+#include <WebCore/StyleWebKitTextStrokeWidth.h>
+#include <WebCore/StyleWebKitTouchCallout.h>
+#include <WebCore/StyleWidows.h>
+#include <wtf/DataRef.h>
+#include <wtf/Ref.h>
+#include <wtf/RefCounted.h>
+
+#if ENABLE(TEXT_AUTOSIZING)
+#include <WebCore/StyleTextSizeAdjust.h>
+#endif
+
+#if ENABLE(DARK_MODE_CSS)
+#include <WebCore/StyleColorScheme.h>
+#endif
+
+namespace WebCore {
+namespace Style {
+
+class AppleColorFilterData;
+class CustomPropertyData;
+
+DECLARE_ALLOCATOR_WITH_HEAP_IDENTIFIER(InheritedRareCSSData);
+class InheritedRareCSSData : public RefCounted<InheritedRareCSSData> {
+    WTF_DEPRECATED_MAKE_FAST_ALLOCATED_WITH_HEAP_IDENTIFIER(InheritedRareCSSData, InheritedRareCSSData);
+public:
+    static Ref<InheritedRareCSSData> create() { return adoptRef(*new InheritedRareCSSData); }
+    Ref<InheritedRareCSSData> copy() const;
+    ~InheritedRareCSSData();
+
+    bool operator==(const InheritedRareCSSData&) const;
+
+#if !LOG_DISABLED
+    void dumpDifferences(TextStream&, const InheritedRareCSSData&) const;
+#endif
+
+    WebkitTextStrokeWidth textStrokeWidth;
+
+    Color textStrokeColor;
+    Color textFillColor;
+    Color textEmphasisColor;
+    Color visitedLinkTextStrokeColor;
+    Color visitedLinkTextFillColor;
+    Color visitedLinkTextEmphasisColor;
+    CaretColor caretColor;
+    CaretColor visitedLinkCaretColor;
+
+    AccentColor accentColor;
+
+    ScrollbarColor scrollbarColor;
+
+    TextEmphasisStyle textEmphasisStyle;
+
+    Quotes quotes;
+
+    Color strokeColor;
+    Color visitedLinkStrokeColor;
+
+#if ENABLE(DARK_MODE_CSS)
+    ColorScheme colorScheme;
+#endif
+
+    Cursor::Images cursorImages;
+
+#if ENABLE(CSS_TAP_HIGHLIGHT_COLOR)
+    Color tapHighlightColor;
+#endif
+
+    ListStyleType listStyleType;
+    BlockEllipsis blockEllipsis;
+
+    TextIndent textIndent;
+
+    ImageOrNone listStyleImage;
+    DynamicRangeLimit dynamicRangeLimit;
+    TextShadows textShadow;
+    HyphenateCharacter hyphenateCharacter;
+    DataRef<CustomPropertyData> customProperties;
+    StrokeWidth strokeWidth;
+    TextUnderlineOffset textUnderlineOffset;
+    DataRef<AppleColorFilterData> appleColorFilter;
+    WebkitLineGrid lineGrid;
+    TabSize tabSize;
+
+    StrokeMiterlimit strokeMiterLimit;
+
+#if ENABLE(TEXT_AUTOSIZING)
+    TextSizeAdjust textSizeAdjust;
+#endif
+
+    MathDepth mathDepth;
+
+    TextBoxEdge textBoxEdge;
+    LineFitEdge lineFitEdge;
+
+    Widows widows;
+    Orphans orphans;
+    HyphenateLimitEdge hyphenateLimitBefore;
+    HyphenateLimitEdge hyphenateLimitAfter;
+    HyphenateLimitLines hyphenateLimitLines;
+
+    PREFERRED_TYPE(TextSecurity) unsigned textSecurity : 2;
+    PREFERRED_TYPE(UserModify) unsigned userModify : 2;
+    PREFERRED_TYPE(WordBreak) unsigned wordBreak : 3;
+    PREFERRED_TYPE(OverflowWrap) unsigned overflowWrap : 2;
+    PREFERRED_TYPE(NBSPMode) unsigned nbspMode : 1;
+    PREFERRED_TYPE(LineBreak) unsigned lineBreak : 3;
+    PREFERRED_TYPE(UserSelect) unsigned userSelect : 2;
+    PREFERRED_TYPE(SpeakAs) unsigned speakAs : 4;
+    PREFERRED_TYPE(Hyphens) unsigned hyphens : 2;
+    PREFERRED_TYPE(TextCombine) unsigned textCombine : 1;
+    PREFERRED_TYPE(TextEmphasisPosition) unsigned textEmphasisPosition : 4;
+    PREFERRED_TYPE(TextUnderlinePosition) unsigned textUnderlinePosition : 4;
+    PREFERRED_TYPE(WebkitLineBoxContain) unsigned lineBoxContain: 7;
+    PREFERRED_TYPE(ImageOrientation) unsigned imageOrientation : 1;
+    PREFERRED_TYPE(ImageRendering) unsigned imageRendering : 3;
+    PREFERRED_TYPE(LineSnap) unsigned lineSnap : 2;
+    PREFERRED_TYPE(LineAlign) unsigned lineAlign : 1;
+#if ENABLE(WEBKIT_OVERFLOW_SCROLLING_CSS_PROPERTY)
+    PREFERRED_TYPE(WebkitOverflowScrolling) unsigned overflowScrolling: 1;
+#endif
+    PREFERRED_TYPE(TextAlignLast) unsigned textAlignLast : 3;
+    PREFERRED_TYPE(TextJustify) unsigned textJustify : 2;
+    PREFERRED_TYPE(TextDecorationSkipInk) unsigned textDecorationSkipInk : 2;
+    PREFERRED_TYPE(MathShift) unsigned mathShift : 1;
+    PREFERRED_TYPE(MathStyle) unsigned mathStyle : 1;
+    PREFERRED_TYPE(RubyPosition) unsigned rubyPosition : 2;
+    PREFERRED_TYPE(RubyAlign) unsigned rubyAlign : 2;
+    PREFERRED_TYPE(RubyOverhang) unsigned rubyOverhang : 1;
+    PREFERRED_TYPE(TextZoom) unsigned textZoom: 1;
+#if ENABLE(WEBKIT_TOUCH_CALLOUT_CSS_PROPERTY)
+    PREFERRED_TYPE(WebkitTouchCallout) unsigned touchCallout : 1;
+#endif
+    PREFERRED_TYPE(HangingPunctuation) unsigned hangingPunctuation : 4;
+    PREFERRED_TYPE(SVGPaintOrder::Type) unsigned paintOrder : 3;
+    PREFERRED_TYPE(LineCap) unsigned capStyle : 2;
+    PREFERRED_TYPE(LineJoin) unsigned joinStyle : 2;
+    PREFERRED_TYPE(bool) unsigned hasExplicitlySetStrokeWidth : 1;
+    PREFERRED_TYPE(bool) unsigned hasExplicitlySetStrokeColor : 1;
+
+private:
+    InheritedRareCSSData();
+    InheritedRareCSSData(const InheritedRareCSSData&);
+};
+
+} // namespace Style
+} // namespace WebCore

--- a/Source/WebCore/style/computed/data/StyleInheritedRareData.cpp
+++ b/Source/WebCore/style/computed/data/StyleInheritedRareData.cpp
@@ -25,8 +25,6 @@
 
 #include "StyleComputedStyle+DifferenceLogging.h"
 #include "StyleComputedStyle+InitialInlines.h"
-#include "StyleKeyword+Logging.h"
-#include "StylePrimitiveNumericTypes+Logging.h"
 
 namespace WebCore {
 namespace Style {
@@ -35,93 +33,9 @@ DEFINE_ALLOCATOR_WITH_HEAP_IDENTIFIER(InheritedRareData);
 
 InheritedRareData::InheritedRareData()
     : usedZoom(1.0f)
-    , textStrokeWidth(ComputedStyle::initialTextStrokeWidth())
-    , textStrokeColor(ComputedStyle::initialTextStrokeColor())
-    , textFillColor(ComputedStyle::initialTextFillColor())
-    , textEmphasisColor(ComputedStyle::initialTextEmphasisColor())
-    , visitedLinkTextStrokeColor(ComputedStyle::initialTextStrokeColor())
-    , visitedLinkTextFillColor(ComputedStyle::initialTextFillColor())
-    , visitedLinkTextEmphasisColor(ComputedStyle::initialTextEmphasisColor())
-    , caretColor(ComputedStyle::initialCaretColor())
-    , visitedLinkCaretColor(ComputedStyle::initialCaretColor())
-    , accentColor(ComputedStyle::initialAccentColor())
-    , scrollbarColor(ComputedStyle::initialScrollbarColor())
-    , textEmphasisStyle(ComputedStyle::initialTextEmphasisStyle())
-    , quotes(ComputedStyle::initialQuotes())
-    , strokeColor(ComputedStyle::initialStrokeColor())
-    , visitedLinkStrokeColor(Color::currentColor())
-#if ENABLE(DARK_MODE_CSS)
-    , colorScheme(ComputedStyle::initialColorScheme())
-#endif
-    , cursorImages(ComputedStyle::initialCursor().images)
-#if ENABLE(CSS_TAP_HIGHLIGHT_COLOR)
-    , tapHighlightColor(ComputedStyle::initialTapHighlightColor())
-#endif
-    , listStyleType(ComputedStyle::initialListStyleType())
-    , blockEllipsis(ComputedStyle::initialBlockEllipsis())
-    , textIndent(ComputedStyle::initialTextIndent())
-    , listStyleImage(ComputedStyle::initialListStyleImage())
-    , dynamicRangeLimit(ComputedStyle::initialDynamicRangeLimit())
-    , textShadow(ComputedStyle::initialTextShadow())
-    , hyphenateCharacter(ComputedStyle::initialHyphenateCharacter())
-    , customProperties(CustomPropertyData::create())
-    , eventListenerRegionTypes { }
-    , strokeWidth(ComputedStyle::initialStrokeWidth())
-    , textUnderlineOffset(ComputedStyle::initialTextUnderlineOffset())
-    , appleColorFilter(AppleColorFilterData::create())
-    , lineGrid(ComputedStyle::initialLineGrid())
-    , tabSize(ComputedStyle::initialTabSize())
-    , strokeMiterLimit(ComputedStyle::initialStrokeMiterLimit())
-#if ENABLE(TEXT_AUTOSIZING)
-    , textSizeAdjust(ComputedStyle::initialTextSizeAdjust())
-#endif
-    , mathDepth(ComputedStyle::initialMathDepth())
-    , textBoxEdge(ComputedStyle::initialTextBoxEdge())
-    , lineFitEdge(ComputedStyle::initialLineFitEdge())
-    , widows(ComputedStyle::initialWidows())
-    , orphans(ComputedStyle::initialOrphans())
-    , hyphenateLimitBefore(ComputedStyle::initialHyphenateLimitBefore())
-    , hyphenateLimitAfter(ComputedStyle::initialHyphenateLimitAfter())
-    , hyphenateLimitLines(ComputedStyle::initialHyphenateLimitLines())
     , usedTouchAction(ComputedStyle::initialTouchAction())
-    , textSecurity(static_cast<unsigned>(ComputedStyle::initialTextSecurity()))
-    , userModify(static_cast<unsigned>(UserModify::ReadOnly))
-    , wordBreak(static_cast<unsigned>(ComputedStyle::initialWordBreak()))
-    , overflowWrap(static_cast<unsigned>(ComputedStyle::initialOverflowWrap()))
-    , nbspMode(static_cast<unsigned>(NBSPMode::Normal))
-    , lineBreak(static_cast<unsigned>(LineBreak::Auto))
-    , userSelect(static_cast<unsigned>(ComputedStyle::initialUserSelect()))
-    , speakAs(ComputedStyle::initialSpeakAs().toRaw())
-    , hyphens(static_cast<unsigned>(Hyphens::Manual))
-    , textCombine(static_cast<unsigned>(ComputedStyle::initialTextCombine()))
-    , textEmphasisPosition(static_cast<unsigned>(ComputedStyle::initialTextEmphasisPosition().toRaw()))
-    , textUnderlinePosition(static_cast<unsigned>(ComputedStyle::initialTextUnderlinePosition().toRaw()))
-    , lineBoxContain(static_cast<unsigned>(ComputedStyle::initialLineBoxContain().toRaw()))
-    , imageOrientation(static_cast<unsigned>(ComputedStyle::initialImageOrientation()))
-    , imageRendering(static_cast<unsigned>(ComputedStyle::initialImageRendering()))
-    , lineSnap(static_cast<unsigned>(ComputedStyle::initialLineSnap()))
-    , lineAlign(static_cast<unsigned>(ComputedStyle::initialLineAlign()))
-#if ENABLE(WEBKIT_OVERFLOW_SCROLLING_CSS_PROPERTY)
-    , overflowScrolling(static_cast<unsigned>(ComputedStyle::initialOverflowScrolling()))
-#endif
-    , textAlignLast(static_cast<unsigned>(ComputedStyle::initialTextAlignLast()))
-    , textJustify(static_cast<unsigned>(ComputedStyle::initialTextJustify()))
-    , textDecorationSkipInk(static_cast<unsigned>(ComputedStyle::initialTextDecorationSkipInk()))
-    , mathShift(static_cast<unsigned>(ComputedStyle::initialMathShift()))
-    , mathStyle(static_cast<unsigned>(ComputedStyle::initialMathStyle()))
-    , rubyPosition(static_cast<unsigned>(ComputedStyle::initialRubyPosition()))
-    , rubyAlign(static_cast<unsigned>(ComputedStyle::initialRubyAlign()))
-    , rubyOverhang(static_cast<unsigned>(ComputedStyle::initialRubyOverhang()))
-    , textZoom(static_cast<unsigned>(ComputedStyle::initialTextZoom()))
-#if ENABLE(WEBKIT_TOUCH_CALLOUT_CSS_PROPERTY)
-    , touchCallout(static_cast<unsigned>(ComputedStyle::initialTouchCallout()))
-#endif
-    , hangingPunctuation(ComputedStyle::initialHangingPunctuation().toRaw())
-    , paintOrder(static_cast<unsigned>(ComputedStyle::initialPaintOrder().type()))
-    , capStyle(static_cast<unsigned>(ComputedStyle::initialCapStyle()))
-    , joinStyle(static_cast<unsigned>(ComputedStyle::initialJoinStyle()))
-    , hasExplicitlySetStrokeWidth(false)
-    , hasExplicitlySetStrokeColor(false)
+    , eventListenerRegionTypes { }
+    , cssData(InheritedRareCSSData::create())
     , effectiveInert(false)
     , effectivelyTransparent(false)
     , isInSubtreeWithBlendMode(false)
@@ -140,93 +54,9 @@ InheritedRareData::InheritedRareData()
 inline InheritedRareData::InheritedRareData(const InheritedRareData& o)
     : RefCounted<InheritedRareData>()
     , usedZoom(o.usedZoom)
-    , textStrokeWidth(o.textStrokeWidth)
-    , textStrokeColor(o.textStrokeColor)
-    , textFillColor(o.textFillColor)
-    , textEmphasisColor(o.textEmphasisColor)
-    , visitedLinkTextStrokeColor(o.visitedLinkTextStrokeColor)
-    , visitedLinkTextFillColor(o.visitedLinkTextFillColor)
-    , visitedLinkTextEmphasisColor(o.visitedLinkTextEmphasisColor)
-    , caretColor(o.caretColor)
-    , visitedLinkCaretColor(o.visitedLinkCaretColor)
-    , accentColor(o.accentColor)
-    , scrollbarColor(o.scrollbarColor)
-    , textEmphasisStyle(o.textEmphasisStyle)
-    , quotes(o.quotes)
-    , strokeColor(o.strokeColor)
-    , visitedLinkStrokeColor(o.visitedLinkStrokeColor)
-#if ENABLE(DARK_MODE_CSS)
-    , colorScheme(o.colorScheme)
-#endif
-    , cursorImages(o.cursorImages)
-#if ENABLE(CSS_TAP_HIGHLIGHT_COLOR)
-    , tapHighlightColor(o.tapHighlightColor)
-#endif
-    , listStyleType(o.listStyleType)
-    , blockEllipsis(o.blockEllipsis)
-    , textIndent(o.textIndent)
-    , listStyleImage(o.listStyleImage)
-    , dynamicRangeLimit(o.dynamicRangeLimit)
-    , textShadow(o.textShadow)
-    , hyphenateCharacter(o.hyphenateCharacter)
-    , customProperties(o.customProperties)
-    , eventListenerRegionTypes(o.eventListenerRegionTypes)
-    , strokeWidth(o.strokeWidth)
-    , textUnderlineOffset(o.textUnderlineOffset)
-    , appleColorFilter(o.appleColorFilter)
-    , lineGrid(o.lineGrid)
-    , tabSize(o.tabSize)
-    , strokeMiterLimit(o.strokeMiterLimit)
-#if ENABLE(TEXT_AUTOSIZING)
-    , textSizeAdjust(o.textSizeAdjust)
-#endif
-    , mathDepth(o.mathDepth)
-    , textBoxEdge(o.textBoxEdge)
-    , lineFitEdge(o.lineFitEdge)
-    , widows(o.widows)
-    , orphans(o.orphans)
-    , hyphenateLimitBefore(o.hyphenateLimitBefore)
-    , hyphenateLimitAfter(o.hyphenateLimitAfter)
-    , hyphenateLimitLines(o.hyphenateLimitLines)
     , usedTouchAction(o.usedTouchAction)
-    , textSecurity(o.textSecurity)
-    , userModify(o.userModify)
-    , wordBreak(o.wordBreak)
-    , overflowWrap(o.overflowWrap)
-    , nbspMode(o.nbspMode)
-    , lineBreak(o.lineBreak)
-    , userSelect(o.userSelect)
-    , speakAs(o.speakAs)
-    , hyphens(o.hyphens)
-    , textCombine(o.textCombine)
-    , textEmphasisPosition(o.textEmphasisPosition)
-    , textUnderlinePosition(o.textUnderlinePosition)
-    , lineBoxContain(o.lineBoxContain)
-    , imageOrientation(o.imageOrientation)
-    , imageRendering(o.imageRendering)
-    , lineSnap(o.lineSnap)
-    , lineAlign(o.lineAlign)
-#if ENABLE(WEBKIT_OVERFLOW_SCROLLING_CSS_PROPERTY)
-    , overflowScrolling(o.overflowScrolling)
-#endif
-    , textAlignLast(o.textAlignLast)
-    , textJustify(o.textJustify)
-    , textDecorationSkipInk(o.textDecorationSkipInk)
-    , mathShift(o.mathShift)
-    , mathStyle(o.mathStyle)
-    , rubyPosition(o.rubyPosition)
-    , rubyAlign(o.rubyAlign)
-    , rubyOverhang(o.rubyOverhang)
-    , textZoom(o.textZoom)
-#if ENABLE(WEBKIT_TOUCH_CALLOUT_CSS_PROPERTY)
-    , touchCallout(o.touchCallout)
-#endif
-    , hangingPunctuation(o.hangingPunctuation)
-    , paintOrder(o.paintOrder)
-    , capStyle(o.capStyle)
-    , joinStyle(o.joinStyle)
-    , hasExplicitlySetStrokeWidth(o.hasExplicitlySetStrokeWidth)
-    , hasExplicitlySetStrokeColor(o.hasExplicitlySetStrokeColor)
+    , eventListenerRegionTypes(o.eventListenerRegionTypes)
+    , cssData(o.cssData)
     , effectiveInert(o.effectiveInert)
     , effectivelyTransparent(o.effectivelyTransparent)
     , isInSubtreeWithBlendMode(o.isInSubtreeWithBlendMode)
@@ -253,203 +83,34 @@ InheritedRareData::~InheritedRareData() = default;
 bool InheritedRareData::operator==(const InheritedRareData& o) const
 {
     return usedZoom == o.usedZoom
-        && textStrokeWidth == o.textStrokeWidth
-        && textStrokeColor == o.textStrokeColor
-        && textFillColor == o.textFillColor
-        && textEmphasisColor == o.textEmphasisColor
-        && visitedLinkTextStrokeColor == o.visitedLinkTextStrokeColor
-        && visitedLinkTextFillColor == o.visitedLinkTextFillColor
-        && visitedLinkTextEmphasisColor == o.visitedLinkTextEmphasisColor
-        && caretColor == o.caretColor
-        && visitedLinkCaretColor == o.visitedLinkCaretColor
-        && accentColor == o.accentColor
-        && scrollbarColor == o.scrollbarColor
-        && dynamicRangeLimit == o.dynamicRangeLimit
-#if ENABLE(CSS_TAP_HIGHLIGHT_COLOR)
-        && tapHighlightColor == o.tapHighlightColor
-#endif
-        && textShadow == o.textShadow
-        && cursorImages == o.cursorImages
-        && textEmphasisStyle == o.textEmphasisStyle
-        && textIndent == o.textIndent
-        && textUnderlineOffset == o.textUnderlineOffset
-        && textBoxEdge == o.textBoxEdge
-        && lineFitEdge == o.lineFitEdge
-        && strokeMiterLimit == o.strokeMiterLimit
-        && widows == o.widows
-        && orphans == o.orphans
-        && textSecurity == o.textSecurity
-        && userModify == o.userModify
-        && wordBreak == o.wordBreak
-        && overflowWrap == o.overflowWrap
-        && nbspMode == o.nbspMode
-        && lineBreak == o.lineBreak
-#if ENABLE(WEBKIT_OVERFLOW_SCROLLING_CSS_PROPERTY)
-        && overflowScrolling == o.overflowScrolling
-#endif
-#if ENABLE(TEXT_AUTOSIZING)
-        && textSizeAdjust == o.textSizeAdjust
-#endif
-        && userSelect == o.userSelect
-        && speakAs == o.speakAs
-        && hyphens == o.hyphens
-        && hyphenateLimitBefore == o.hyphenateLimitBefore
-        && hyphenateLimitAfter == o.hyphenateLimitAfter
-        && hyphenateLimitLines == o.hyphenateLimitLines
-#if ENABLE(DARK_MODE_CSS)
-        && colorScheme == o.colorScheme
-#endif
-        && textCombine == o.textCombine
-        && textEmphasisPosition == o.textEmphasisPosition
-        && lineBoxContain == o.lineBoxContain
-#if ENABLE(WEBKIT_TOUCH_CALLOUT_CSS_PROPERTY)
-        && touchCallout == o.touchCallout
-#endif
-        && hyphenateCharacter == o.hyphenateCharacter
-        && quotes == o.quotes
-        && appleColorFilter == o.appleColorFilter
-        && tabSize == o.tabSize
-        && lineGrid == o.lineGrid
-        && imageOrientation == o.imageOrientation
-        && imageRendering == o.imageRendering
-        && textAlignLast == o.textAlignLast
-        && textJustify == o.textJustify
-        && textDecorationSkipInk == o.textDecorationSkipInk
-        && textUnderlinePosition == o.textUnderlinePosition
-        && rubyPosition == o.rubyPosition
-        && rubyAlign == o.rubyAlign
-        && rubyOverhang == o.rubyOverhang
-        && textZoom == o.textZoom
-        && lineSnap == o.lineSnap
-        && lineAlign == o.lineAlign
-        && hangingPunctuation == o.hangingPunctuation
-        && paintOrder == o.paintOrder
-        && capStyle == o.capStyle
-        && joinStyle == o.joinStyle
-        && hasExplicitlySetStrokeWidth == o.hasExplicitlySetStrokeWidth
-        && hasExplicitlySetStrokeColor == o.hasExplicitlySetStrokeColor
-        && mathShift == o.mathShift
-        && mathStyle == o.mathStyle
-        && isInSubtreeWithBlendMode == o.isInSubtreeWithBlendMode
-        && isForceHidden == o.isForceHidden
-        && autoRevealsWhenFound == o.autoRevealsWhenFound
         && usedTouchAction == o.usedTouchAction
         && eventListenerRegionTypes == o.eventListenerRegionTypes
+        && cssData == o.cssData
         && effectiveInert == o.effectiveInert
         && effectivelyTransparent == o.effectivelyTransparent
+        && isInSubtreeWithBlendMode == o.isInSubtreeWithBlendMode
+        && isForceHidden == o.isForceHidden
         && usedContentVisibility == o.usedContentVisibility
+        && autoRevealsWhenFound == o.autoRevealsWhenFound
         && insideDefaultButton == o.insideDefaultButton
         && insideSubmitButton == o.insideSubmitButton
+        && evaluationTimeZoomEnabled == o.evaluationTimeZoomEnabled
 #if HAVE(CORE_MATERIAL)
         && usedAppleVisualEffectForSubtree == o.usedAppleVisualEffectForSubtree
 #endif
-        && strokeWidth == o.strokeWidth
-        && strokeColor == o.strokeColor
-        && visitedLinkStrokeColor == o.visitedLinkStrokeColor
-        && customProperties == o.customProperties
-        && listStyleImage == o.listStyleImage
-        && listStyleType == o.listStyleType
-        && blockEllipsis == o.blockEllipsis
-        && evaluationTimeZoomEnabled == o.evaluationTimeZoomEnabled
-        && mathDepth == o.mathDepth;
+        ;
 }
 
 #if !LOG_DISABLED
 void InheritedRareData::dumpDifferences(TextStream& ts, const InheritedRareData& other) const
 {
-    customProperties->dumpDifferences(ts, other.customProperties);
-
     LOG_IF_DIFFERENT(usedZoom);
 
-    LOG_IF_DIFFERENT(listStyleImage);
+    LOG_IF_DIFFERENT(usedTouchAction);
+    LOG_IF_DIFFERENT(eventListenerRegionTypes);
 
-    LOG_IF_DIFFERENT(textStrokeWidth);
-
-    LOG_IF_DIFFERENT(textStrokeColor);
-    LOG_IF_DIFFERENT(textFillColor);
-    LOG_IF_DIFFERENT(textEmphasisColor);
-
-    LOG_IF_DIFFERENT(visitedLinkTextStrokeColor);
-    LOG_IF_DIFFERENT(visitedLinkTextFillColor);
-    LOG_IF_DIFFERENT(visitedLinkTextEmphasisColor);
-
-    LOG_IF_DIFFERENT(caretColor);
-    LOG_IF_DIFFERENT(visitedLinkCaretColor);
-
-    LOG_IF_DIFFERENT(accentColor);
-
-    LOG_IF_DIFFERENT(scrollbarColor);
-
-    LOG_IF_DIFFERENT(dynamicRangeLimit);
-
-    LOG_IF_DIFFERENT(textShadow);
-
-    LOG_IF_DIFFERENT(cursorImages);
-
-    LOG_IF_DIFFERENT(textEmphasisStyle);
-    LOG_IF_DIFFERENT(textIndent);
-    LOG_IF_DIFFERENT(textUnderlineOffset);
-
-    LOG_IF_DIFFERENT(textBoxEdge);
-    LOG_IF_DIFFERENT(lineFitEdge);
-
-    LOG_IF_DIFFERENT(strokeMiterLimit);
-
-    LOG_IF_DIFFERENT(widows);
-    LOG_IF_DIFFERENT(orphans);
-
-    LOG_IF_DIFFERENT_WITH_CAST(TextSecurity, textSecurity);
-    LOG_IF_DIFFERENT_WITH_CAST(UserModify, userModify);
-
-    LOG_IF_DIFFERENT_WITH_CAST(WordBreak, wordBreak);
-    LOG_IF_DIFFERENT_WITH_CAST(OverflowWrap, overflowWrap);
-    LOG_IF_DIFFERENT_WITH_CAST(NBSPMode, nbspMode);
-    LOG_IF_DIFFERENT_WITH_CAST(LineBreak, lineBreak);
-    LOG_IF_DIFFERENT_WITH_CAST(UserSelect, userSelect);
-
-    LOG_IF_DIFFERENT_WITH_FROM_RAW(SpeakAs, speakAs);
-
-    LOG_IF_DIFFERENT_WITH_CAST(Hyphens, hyphens);
-    LOG_IF_DIFFERENT_WITH_CAST(TextCombine, textCombine);
-    LOG_IF_DIFFERENT_WITH_FROM_RAW(TextEmphasisPosition, textEmphasisPosition);
-    LOG_IF_DIFFERENT_WITH_FROM_RAW(TextUnderlinePosition, textUnderlinePosition);
-
-    LOG_IF_DIFFERENT_WITH_FROM_RAW(WebkitLineBoxContain, lineBoxContain);
-
-    LOG_IF_DIFFERENT_WITH_CAST(ImageOrientation, imageOrientation);
-    LOG_IF_DIFFERENT_WITH_CAST(ImageRendering, imageRendering);
-    LOG_IF_DIFFERENT_WITH_CAST(LineSnap, lineSnap);
-    LOG_IF_DIFFERENT_WITH_CAST(LineAlign, lineAlign);
-
-#if ENABLE(WEBKIT_OVERFLOW_SCROLLING_CSS_PROPERTY)
-    LOG_IF_DIFFERENT_WITH_CAST(WebkitOverflowScrolling, overflowScrolling);
-#endif
-
-    LOG_IF_DIFFERENT_WITH_CAST(TextAlignLast, textAlignLast);
-    LOG_IF_DIFFERENT_WITH_CAST(TextJustify, textJustify);
-    LOG_IF_DIFFERENT_WITH_CAST(TextDecorationSkipInk, textDecorationSkipInk);
-
-    LOG_IF_DIFFERENT_WITH_CAST(RubyPosition, rubyPosition);
-    LOG_IF_DIFFERENT_WITH_CAST(RubyAlign, rubyAlign);
-    LOG_IF_DIFFERENT_WITH_CAST(RubyOverhang, rubyOverhang);
-
-    LOG_IF_DIFFERENT_WITH_CAST(TextZoom, textZoom);
-
-#if ENABLE(WEBKIT_TOUCH_CALLOUT_CSS_PROPERTY)
-    LOG_IF_DIFFERENT_WITH_CAST(WebkitTouchCallout, touchCallout);
-#endif
-
-    LOG_IF_DIFFERENT_WITH_FROM_RAW(HangingPunctuation, hangingPunctuation);
-
-    LOG_IF_DIFFERENT_WITH_FROM_RAW(SVGPaintOrder, paintOrder);
-    LOG_IF_DIFFERENT_WITH_CAST(LineCap, capStyle);
-    LOG_IF_DIFFERENT_WITH_CAST(LineJoin, joinStyle);
-
-    LOG_IF_DIFFERENT_WITH_CAST(bool, hasExplicitlySetStrokeWidth);
-    LOG_IF_DIFFERENT_WITH_CAST(bool, hasExplicitlySetStrokeColor);
-
-    LOG_IF_DIFFERENT_WITH_CAST(MathShift, mathShift);
-    LOG_IF_DIFFERENT_WITH_CAST(MathStyle, mathStyle);
+    if (cssData.ptr() != other.cssData.ptr())
+        cssData->dumpDifferences(ts, other.cssData);
 
     LOG_IF_DIFFERENT_WITH_CAST(bool, effectiveInert);
     LOG_IF_DIFFERENT_WITH_CAST(bool, effectivelyTransparent);
@@ -463,46 +124,11 @@ void InheritedRareData::dumpDifferences(TextStream& ts, const InheritedRareData&
     LOG_IF_DIFFERENT_WITH_CAST(bool, insideDefaultButton);
     LOG_IF_DIFFERENT_WITH_CAST(bool, insideSubmitButton);
 
+    LOG_IF_DIFFERENT(evaluationTimeZoomEnabled);
+
 #if HAVE(CORE_MATERIAL)
     LOG_IF_DIFFERENT_WITH_CAST(AppleVisualEffect, usedAppleVisualEffectForSubtree);
 #endif
-
-    LOG_IF_DIFFERENT(usedTouchAction);
-    LOG_IF_DIFFERENT(eventListenerRegionTypes);
-
-    LOG_IF_DIFFERENT(strokeWidth);
-    LOG_IF_DIFFERENT(strokeColor);
-    LOG_IF_DIFFERENT(visitedLinkStrokeColor);
-
-    LOG_IF_DIFFERENT(hyphenateCharacter);
-    LOG_IF_DIFFERENT(hyphenateLimitBefore);
-    LOG_IF_DIFFERENT(hyphenateLimitAfter);
-    LOG_IF_DIFFERENT(hyphenateLimitLines);
-
-#if ENABLE(DARK_MODE_CSS)
-    LOG_IF_DIFFERENT(colorScheme);
-#endif
-
-    LOG_IF_DIFFERENT(quotes);
-
-    appleColorFilter->dumpDifferences(ts, other.appleColorFilter);
-
-    LOG_IF_DIFFERENT(lineGrid);
-    LOG_IF_DIFFERENT(tabSize);
-
-#if ENABLE(TEXT_AUTOSIZING)
-    LOG_IF_DIFFERENT(textSizeAdjust);
-#endif
-#if ENABLE(CSS_TAP_HIGHLIGHT_COLOR)
-    LOG_IF_DIFFERENT(tapHighlightColor);
-#endif
-
-    LOG_IF_DIFFERENT(listStyleType);
-    LOG_IF_DIFFERENT(blockEllipsis);
-
-    LOG_IF_DIFFERENT(evaluationTimeZoomEnabled);
-
-    LOG_IF_DIFFERENT(mathDepth);
 }
 #endif
 

--- a/Source/WebCore/style/computed/data/StyleInheritedRareData.h
+++ b/Source/WebCore/style/computed/data/StyleInheritedRareData.h
@@ -26,44 +26,8 @@
 #pragma once
 
 #include <WebCore/RenderStyleConstants.h>
-#include <WebCore/StyleAccentColor.h>
-#include <WebCore/StyleBlockEllipsis.h>
-#include <WebCore/StyleCaretColor.h>
-#include <WebCore/StyleColor.h>
-#include <WebCore/StyleCursor.h>
-#include <WebCore/StyleDynamicRangeLimit.h>
-#include <WebCore/StyleHangingPunctuation.h>
-#include <WebCore/StyleHyphenateCharacter.h>
-#include <WebCore/StyleHyphenateLimitEdge.h>
-#include <WebCore/StyleHyphenateLimitLines.h>
-#include <WebCore/StyleImageOrNone.h>
-#include <WebCore/StyleImageOrientation.h>
-#include <WebCore/StyleLineFitEdge.h>
-#include <WebCore/StyleListStyleType.h>
-#include <WebCore/StyleMathDepth.h>
-#include <WebCore/StyleOrphans.h>
-#include <WebCore/StyleQuotes.h>
-#include <WebCore/StyleSVGPaintOrder.h>
-#include <WebCore/StyleScrollbarColor.h>
-#include <WebCore/StyleSpeakAs.h>
-#include <WebCore/StyleStrokeMiterlimit.h>
-#include <WebCore/StyleStrokeWidth.h>
-#include <WebCore/StyleTabSize.h>
-#include <WebCore/StyleTextAlignLast.h>
-#include <WebCore/StyleTextBoxEdge.h>
-#include <WebCore/StyleTextEmphasisPosition.h>
-#include <WebCore/StyleTextEmphasisStyle.h>
-#include <WebCore/StyleTextIndent.h>
-#include <WebCore/StyleTextShadow.h>
-#include <WebCore/StyleTextUnderlineOffset.h>
-#include <WebCore/StyleTextUnderlinePosition.h>
+#include <WebCore/StyleInheritedRareCSSData.h>
 #include <WebCore/StyleTouchAction.h>
-#include <WebCore/StyleWebKitLineBoxContain.h>
-#include <WebCore/StyleWebKitLineGrid.h>
-#include <WebCore/StyleWebKitOverflowScrolling.h>
-#include <WebCore/StyleWebKitTextStrokeWidth.h>
-#include <WebCore/StyleWebKitTouchCallout.h>
-#include <WebCore/StyleWidows.h>
 #include <wtf/DataRef.h>
 #include <wtf/OptionSet.h>
 #include <wtf/Ref.h>
@@ -73,23 +37,9 @@
 #include <WebCore/AppleVisualEffect.h>
 #endif
 
-#if ENABLE(TEXT_AUTOSIZING)
-#include <WebCore/StyleTextSizeAdjust.h>
-#endif
-
-#if ENABLE(DARK_MODE_CSS)
-#include <WebCore/StyleColorScheme.h>
-#endif
-
 namespace WebCore {
 namespace Style {
 
-class AppleColorFilterData;
-class CustomPropertyData;
-
-// This class is for rarely used inherited property data. By grouping them
-// together, we save space, and only allocate this object when someone actually
-// uses one of these properties.
 DECLARE_ALLOCATOR_WITH_HEAP_IDENTIFIER(InheritedRareData);
 class InheritedRareData : public RefCounted<InheritedRareData> {
     WTF_DEPRECATED_MAKE_FAST_ALLOCATED_WITH_HEAP_IDENTIFIER(InheritedRareData, InheritedRareData);
@@ -105,112 +55,11 @@ public:
 #endif
 
     float usedZoom;
-    WebkitTextStrokeWidth textStrokeWidth;
-
-    Color textStrokeColor;
-    Color textFillColor;
-    Color textEmphasisColor;
-    Color visitedLinkTextStrokeColor;
-    Color visitedLinkTextFillColor;
-    Color visitedLinkTextEmphasisColor;
-    CaretColor caretColor;
-    CaretColor visitedLinkCaretColor;
-
-    AccentColor accentColor;
-
-    ScrollbarColor scrollbarColor;
-
-    TextEmphasisStyle textEmphasisStyle;
-
-    Quotes quotes;
-
-    Color strokeColor;
-    Color visitedLinkStrokeColor;
-
-#if ENABLE(DARK_MODE_CSS)
-    ColorScheme colorScheme;
-#endif
-
-    Cursor::Images cursorImages;
-
-#if ENABLE(CSS_TAP_HIGHLIGHT_COLOR)
-    Color tapHighlightColor;
-#endif
-
-    ListStyleType listStyleType;
-    BlockEllipsis blockEllipsis;
-
-    TextIndent textIndent;
-
-    ImageOrNone listStyleImage;
-    DynamicRangeLimit dynamicRangeLimit;
-    TextShadows textShadow;
-    HyphenateCharacter hyphenateCharacter;
-    DataRef<CustomPropertyData> customProperties;
-    OptionSet<EventListenerRegionType> eventListenerRegionTypes;
-    StrokeWidth strokeWidth;
-    TextUnderlineOffset textUnderlineOffset;
-    DataRef<AppleColorFilterData> appleColorFilter;
-    WebkitLineGrid lineGrid;
-    TabSize tabSize;
-
-    StrokeMiterlimit strokeMiterLimit;
-
-#if ENABLE(TEXT_AUTOSIZING)
-    TextSizeAdjust textSizeAdjust;
-#endif
-
-    MathDepth mathDepth;
-
-    TextBoxEdge textBoxEdge;
-    LineFitEdge lineFitEdge;
-
-    Widows widows;
-    Orphans orphans;
-    HyphenateLimitEdge hyphenateLimitBefore;
-    HyphenateLimitEdge hyphenateLimitAfter;
-    HyphenateLimitLines hyphenateLimitLines;
-
     TouchAction usedTouchAction;
+    OptionSet<EventListenerRegionType> eventListenerRegionTypes;
 
-    PREFERRED_TYPE(TextSecurity) unsigned textSecurity : 2;
-    PREFERRED_TYPE(UserModify) unsigned userModify : 2;
-    PREFERRED_TYPE(WordBreak) unsigned wordBreak : 3;
-    PREFERRED_TYPE(OverflowWrap) unsigned overflowWrap : 2;
-    PREFERRED_TYPE(NBSPMode) unsigned nbspMode : 1;
-    PREFERRED_TYPE(LineBreak) unsigned lineBreak : 3;
-    PREFERRED_TYPE(UserSelect) unsigned userSelect : 2;
-    PREFERRED_TYPE(SpeakAs) unsigned speakAs : 4;
-    PREFERRED_TYPE(Hyphens) unsigned hyphens : 2;
-    PREFERRED_TYPE(TextCombine) unsigned textCombine : 1;
-    PREFERRED_TYPE(TextEmphasisPosition) unsigned textEmphasisPosition : 4;
-    PREFERRED_TYPE(TextUnderlinePosition) unsigned textUnderlinePosition : 4;
-    PREFERRED_TYPE(WebkitLineBoxContain) unsigned lineBoxContain: 7;
-    PREFERRED_TYPE(ImageOrientation) unsigned imageOrientation : 1;
-    PREFERRED_TYPE(ImageRendering) unsigned imageRendering : 3;
-    PREFERRED_TYPE(LineSnap) unsigned lineSnap : 2;
-    PREFERRED_TYPE(LineAlign) unsigned lineAlign : 1;
-#if ENABLE(WEBKIT_OVERFLOW_SCROLLING_CSS_PROPERTY)
-    PREFERRED_TYPE(WebkitOverflowScrolling) unsigned overflowScrolling: 1;
-#endif
-    PREFERRED_TYPE(TextAlignLast) unsigned textAlignLast : 3;
-    PREFERRED_TYPE(TextJustify) unsigned textJustify : 2;
-    PREFERRED_TYPE(TextDecorationSkipInk) unsigned textDecorationSkipInk : 2;
-    PREFERRED_TYPE(MathShift) unsigned mathShift : 1;
-    PREFERRED_TYPE(MathStyle) unsigned mathStyle : 1;
-    PREFERRED_TYPE(RubyPosition) unsigned rubyPosition : 2;
-    PREFERRED_TYPE(RubyAlign) unsigned rubyAlign : 2;
-    PREFERRED_TYPE(RubyOverhang) unsigned rubyOverhang : 1;
-    PREFERRED_TYPE(TextZoom) unsigned textZoom: 1;
-#if ENABLE(WEBKIT_TOUCH_CALLOUT_CSS_PROPERTY)
-    PREFERRED_TYPE(WebkitTouchCallout) unsigned touchCallout : 1;
-#endif
-    PREFERRED_TYPE(HangingPunctuation) unsigned hangingPunctuation : 4;
-    PREFERRED_TYPE(SVGPaintOrder::Type) unsigned paintOrder : 3;
-    PREFERRED_TYPE(LineCap) unsigned capStyle : 2;
-    PREFERRED_TYPE(LineJoin) unsigned joinStyle : 2;
-    PREFERRED_TYPE(bool) unsigned hasExplicitlySetStrokeWidth : 1;
-    PREFERRED_TYPE(bool) unsigned hasExplicitlySetStrokeColor : 1;
+    DataRef<InheritedRareCSSData> cssData;
+
     PREFERRED_TYPE(bool) unsigned effectiveInert : 1;
     PREFERRED_TYPE(bool) unsigned effectivelyTransparent : 1;
     PREFERRED_TYPE(bool) unsigned isInSubtreeWithBlendMode : 1;


### PR DESCRIPTION
#### abddff5319d7bb86fc41448721c740fa73584a9a
<pre>
Partition InheritedRareData to reduce copy-on-write overhead from CSS zoom
<a href="https://bugs.webkit.org/show_bug.cgi?id=313588">https://bugs.webkit.org/show_bug.cgi?id=313588</a>
<a href="https://rdar.apple.com/175800158">rdar://175800158</a>

Reviewed by NOBODY (OOPS!).

When CSS zoom is applied to an element, every descendant that inherits usedZoom triggers
DataRef copy-on-write on InheritedRareData, copying all ~59 fields just to change one
float. This also breaks pointer sharing, so subsequent DataRef equality checks must do a
deep comparison instead of a pointer short-circuit.

This change partitions InheritedRareData into a small top-level struct containing the
frequently-mutated values (usedZoom, effectiveInert,  usedTouchAction, etc.) and a new
sub-DataRef containing the ~46 rarely-mutated CSS property fields. This follows the
existing NonInheritedData partitioning pattern.

When only usedZoom changes, the copy is now ~38 bytes (used values + one DataRef pointer)
instead of ~450 bytes. The CSS properties stay shared via the sub-DataRef. Style difference
checks also benefit from a pointer short-circuit on the cssData sub-DataRef.

For a 5,000 element document, this means that instead of using ~2.5 MB of additional
storage following a zoom operation, we only need ~190 KB.

Tests: perf/style-recalc-zoom.html

* LayoutTests/perf/style-recalc-zoom-expected.txt: Added.
* LayoutTests/perf/style-recalc-zoom.html: Added.
* Source/WebCore/Headers.cmake:
* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/css/CSSProperties.json:
* Source/WebCore/rendering/style/RenderStyle.cpp:
(WebCore::RenderStyle::copyPseudoElementsFrom):
* Source/WebCore/rendering/style/RenderStyle.h:
* Source/WebCore/rendering/updating/RenderTreeUpdater.cpp:
(WebCore::pseudoStyleCacheIsInvalid):
* Source/WebCore/style/StyleDifference.cpp:
* Source/WebCore/style/computed/StyleComputedStyle.cpp:
(WebCore::Style::ComputedStyle::inheritIgnoringCustomPropertiesFrom):
* Source/WebCore/style/computed/StyleComputedStyleBase+GettersInlines.h:
(WebCore::Style::ComputedStyleBase::inheritedCustomProperties const):
* Source/WebCore/style/computed/StyleComputedStyleBase.cpp:
(WebCore::Style::ComputedStyleBase::getCachedPseudoStyle const):
(WebCore::Style::ComputedStyleBase::addCachedPseudoStyle):
(WebCore::Style::ComputedStyleBase::setCustomPropertyValue):
(WebCore::Style::ComputedStyleBase::customPropertiesEqual const):
(WebCore::Style::ComputedStyleBase::deduplicateCustomProperties):
* Source/WebCore/style/computed/StyleComputedStyleBase.h:
(WebCore::Style::ComputedStyleBase::hasCachedPseudoStyles const):
* Source/WebCore/style/computed/StyleComputedStyleProperties+GettersCustomInlines.h:
(WebCore::Style::ComputedStyleProperties::cursor const):
* Source/WebCore/style/computed/StyleComputedStyleProperties+SettersCustomInlines.h:
(WebCore::Style::ComputedStyleProperties::setCursor):
* Source/WebCore/style/computed/data/StyleInheritedRareCSSData.cpp: Copied from Source/WebCore/style/computed/data/StyleInheritedRareData.cpp.
(WebCore::Style::InheritedRareCSSData::InheritedRareCSSData):
(WebCore::Style::InheritedRareCSSData::copy const):
(WebCore::Style::InheritedRareCSSData::operator== const):
(WebCore::Style::InheritedRareCSSData::dumpDifferences const):
* Source/WebCore/style/computed/data/StyleInheritedRareCSSData.h: Copied from Source/WebCore/style/computed/data/StyleInheritedRareData.h.
(WebCore::Style::InheritedRareCSSData::create):
* Source/WebCore/style/computed/data/StyleInheritedRareData.cpp:
(WebCore::Style::InheritedRareData::InheritedRareData):
(WebCore::Style::InheritedRareData::operator== const):
(WebCore::Style::InheritedRareData::dumpDifferences const): Ditto.
* Source/WebCore/style/computed/data/StyleInheritedRareData.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/abddff5319d7bb86fc41448721c740fa73584a9a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/160870 "7 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/34343 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/27444 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/169773 "Built successfully") | [❌ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/117023 "Failed to checkout and rebase branch from PR 63857") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/aab28e58-e746-4db2-80d5-7fb08c26f78e) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/162739 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/34444 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/34343 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/124777 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/59/builds/117023 "Failed to checkout and rebase branch from PR 63857") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/1969217f-f343-4133-9d2f-60e30910e746) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/163829 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/27033 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/144504 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/105374 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/59a54d5c-dd71-436a-98ed-1cb102893eb5) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/26085 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/24584 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/17493 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/135779 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/22267 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/172256 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/19277 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/23908 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/133050 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/34017 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/28677 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/133061 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/34001 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/144062 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/95840 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/27651 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/20877 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/33512 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/100937 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/33011 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/33255 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/33159 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->