### PR TITLE
Use protect() instead of Ref { } in beacon and applepay code

### DIFF
--- a/Source/WebCore/Modules/applepay/ApplePayRequestBase.cpp
+++ b/Source/WebCore/Modules/applepay/ApplePayRequestBase.cpp
@@ -49,7 +49,7 @@ static bool NODELETE requiresSupportedNetworks(unsigned version, const ApplePayR
 
 static Vector<String> convertAndValidate(Document& document, unsigned version, const Vector<String>& supportedNetworks, const PaymentCoordinator& paymentCoordinator)
 {
-    return WTF::compactMap(supportedNetworks, [document = Ref { document }, paymentCoordinator = Ref { paymentCoordinator }, version](const auto& supportedNetwork) {
+    return WTF::compactMap(supportedNetworks, [document = protect(document), paymentCoordinator = protect(paymentCoordinator), version](const auto& supportedNetwork) {
         auto validatedNetwork = paymentCoordinator->validatedPaymentNetwork(document, version, supportedNetwork);
         if (!validatedNetwork)
             document->addConsoleMessage(MessageSource::PaymentRequest, MessageLevel::Warning, makeString("'"_s, supportedNetwork, "' is not a valid payment network."_s));

--- a/Source/WebCore/Modules/applepay/paymentrequest/ApplePayPaymentHandler.cpp
+++ b/Source/WebCore/Modules/applepay/paymentrequest/ApplePayPaymentHandler.cpp
@@ -97,7 +97,7 @@ static ExceptionOr<ApplePayRequest> convertAndValidateApplePayRequest(Document& 
         return Exception { ExceptionCode::ExistingExceptionError };
     auto applePayRequest = applePayRequestConversion.releaseReturnValue();
 
-    auto validatedRequest = convertAndValidate(document, applePayRequest.version, applePayRequest, Ref { paymentCoordinator(document) }.get());
+    auto validatedRequest = convertAndValidate(document, applePayRequest.version, applePayRequest, protect(paymentCoordinator(document)).get());
     if (validatedRequest.hasException())
         return validatedRequest.releaseException();
 

--- a/Source/WebCore/Modules/beacon/NavigatorBeacon.cpp
+++ b/Source/WebCore/Modules/beacon/NavigatorBeacon.cpp
@@ -50,7 +50,7 @@ NavigatorBeacon::NavigatorBeacon(Navigator& navigator)
 NavigatorBeacon::~NavigatorBeacon()
 {
     for (auto& beacon : m_inflightBeacons)
-        RefPtr { beacon }->removeClient(*this);
+        protect(beacon)->removeClient(*this);
 }
 
 void NavigatorBeacon::ref() const


### PR DESCRIPTION
#### 4b7f1c8a3116277a541c1bc6234088054a78a539
<pre>
Use protect() instead of Ref { } in beacon and applepay code
<a href="https://bugs.webkit.org/show_bug.cgi?id=313604">https://bugs.webkit.org/show_bug.cgi?id=313604</a>
<a href="https://rdar.apple.com/175806396">rdar://175806396</a>

Reviewed by Abrar Rahman Protyasha.

Mechanical migration from Ref { expr } / RefPtr { expr } to protect(expr)
in beacon and applepay code, aligning with the codebase-wide transition away
from brace-initialized smart pointer temporaries.

No new tests needed (no behavioral change, style-only refactor).

* Source/WebCore/Modules/applepay/ApplePayRequestBase.cpp:
(WebCore::convertAndValidate):
* Source/WebCore/Modules/applepay/paymentrequest/ApplePayPaymentHandler.cpp:
(WebCore::ApplePayPaymentHandler::show):
* Source/WebCore/Modules/beacon/NavigatorBeacon.cpp:
(WebCore::NavigatorBeacon::~NavigatorBeacon):

Canonical link: <a href="https://commits.webkit.org/312320@main">https://commits.webkit.org/312320@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b41a731705d770d7a3cf654850e24ee2782a8f56

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/159385 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/32813 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/25921 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/168217 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/113763 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/6585b0cb-f95e-4569-946a-33f1c222658c) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/161254 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/32881 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/32801 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/123488 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/86720 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/ad1bf051-3e0c-4e3b-be14-473b4568ee77) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/162342 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/25773 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/143159 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/104152 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/dc592b14-e2dd-4806-b165-261fce4abb7a) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/24790 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/23245 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/15988 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/134477 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/20939 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/170709 "Built successfully") | | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/20218 "Build is in progress. Recent messages:") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/16743 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/22565 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/131694 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/32502 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/27319 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/131807 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/32446 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/142732 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/90571 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/24286 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/26465 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/19541 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/31957 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/98409 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/31477 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/31750 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/31632 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->