### PR TITLE
LCP buffer size seems to be set to 1 instead of 150

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/largest-contentful-paint/lcp-buffer-size-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/largest-contentful-paint/lcp-buffer-size-expected.txt
@@ -1,0 +1,4 @@
+LCP candidate textLCP candidate textLCP candidate textLCP candidate textLCP candidate textLCP candidate textLCP candidate textLCP candidate textLCP candidate textLCP candidate textLCP candidate textLCP candidate textLCP candidate textLCP candidate textLCP candidate textLCP candidate textLCP candidate textLCP candidate textLCP candidate textLCP candidate text
+
+PASS LCP buffer size should be greater than one
+

--- a/LayoutTests/imported/w3c/web-platform-tests/largest-contentful-paint/lcp-buffer-size.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/largest-contentful-paint/lcp-buffer-size.html
@@ -1,0 +1,45 @@
+<!DOCTYPE HTML>
+<meta charset=utf-8>
+<title>LargestContentfulPaint: buffer size is 150.</title>
+<link rel="help" href="https://w3c.github.io/timing-entrytypes-registry/#registry">
+<body>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<section id="container"></section>
+<script>
+  // The timing entry types registry specifies a maxBufferSize of 150
+  // for largest-contentful-paint entries, but generating 150 entries makes the test too slow,
+  // so check for 20.
+  const maxBufferSize = 150;
+  const entriesToGenerate = 20;
+
+  promise_test(async (t) => {
+    assert_implements(window.LargestContentfulPaint, "LargestContentfulPaint is not implemented");
+
+    const container = document.getElementById('container');
+
+    // Generate progressively larger text elements to produce LCP candidates.
+    // Each must be larger than the previous to trigger a new LCP entry.
+    // Text elements are reliable LCP candidates (unlike plain background-color divs).
+    for (let i = 0; i < entriesToGenerate; ++i) {
+      const size = 10 + i;
+      const p = document.createElement('p');
+      p.style.cssText = `font-size: ${size}px; position: absolute; top: 0; left: 0;`;
+      p.textContent = 'LCP candidate text';
+      container.appendChild(p);
+
+      // Each element needs its own rendering opportunity to be a separate LCP candidate.
+      await new Promise(resolve => requestAnimationFrame(() => requestAnimationFrame(resolve)));
+    }
+
+    const entries = await new Promise(resolve => {
+      new PerformanceObserver((entryList, observer) => {
+        resolve(entryList.getEntries());
+        observer.disconnect();
+      }).observe({ type: 'largest-contentful-paint', buffered: true });
+    });
+
+    assert_equals(entries.length, entriesToGenerate, `LCP buffer size is at least ${entriesToGenerate}`);
+  }, `LCP buffer size should be greater than one`);
+</script>
+</body>

--- a/LayoutTests/imported/w3c/web-platform-tests/user-timing/measures-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/user-timing/measures-expected.txt
@@ -42,11 +42,11 @@ PASS Checking all doubly measured entries.Entry_list 0. Entry "" should be one t
 PASS Checking all doubly measured entries.Entry_list 0. entryType should be "measure".
 PASS Checking all doubly measured entries.Entry_list 0. startTime should be a number.
 PASS Checking all doubly measured entries.Entry_list 0. duration should be a number.
-PASS Checking all doubly measured entries.Entry_list 1. Entry "" should be one that we have set.
+PASS Checking all doubly measured entries.Entry_list 1. Entry "aaa" should be one that we have set.
 PASS Checking all doubly measured entries.Entry_list 1. entryType should be "measure".
 PASS Checking all doubly measured entries.Entry_list 1. startTime should be a number.
 PASS Checking all doubly measured entries.Entry_list 1. duration should be a number.
-PASS Checking all doubly measured entries.Entry_list 2. Entry "aaa" should be one that we have set.
+PASS Checking all doubly measured entries.Entry_list 2. Entry "" should be one that we have set.
 PASS Checking all doubly measured entries.Entry_list 2. entryType should be "measure".
 PASS Checking all doubly measured entries.Entry_list 2. startTime should be a number.
 PASS Checking all doubly measured entries.Entry_list 2. duration should be a number.
@@ -72,26 +72,26 @@ PASS Second loop step 0: checking entry of name "".Entry_list 1. Entry "" should
 PASS Second loop step 0: checking entry of name "".Entry_list 1. entryType should be "measure".
 PASS Second loop step 0: checking entry of name "".Entry_list 1. startTime should be a number.
 PASS Second loop step 0: checking entry of name "".Entry_list 1. duration should be a number.
-PASS Second loop step 1: checking entry of name "".There should be 2 entries.
-PASS Second loop step 1: checking entry of name "".Entries in entrylist should be in order.
-PASS Second loop step 1: checking entry of name "".Entry_list 0. Entry "" should be one that we have set.
-PASS Second loop step 1: checking entry of name "".Entry_list 0. entryType should be "measure".
-PASS Second loop step 1: checking entry of name "".Entry_list 0. startTime should be a number.
-PASS Second loop step 1: checking entry of name "".Entry_list 0. duration should be a number.
-PASS Second loop step 1: checking entry of name "".Entry_list 1. Entry "" should be one that we have set.
-PASS Second loop step 1: checking entry of name "".Entry_list 1. entryType should be "measure".
-PASS Second loop step 1: checking entry of name "".Entry_list 1. startTime should be a number.
-PASS Second loop step 1: checking entry of name "".Entry_list 1. duration should be a number.
-PASS Second loop step 2: checking entry of name "aaa".There should be 2 entries.
-PASS Second loop step 2: checking entry of name "aaa".Entries in entrylist should be in order.
-PASS Second loop step 2: checking entry of name "aaa".Entry_list 0. Entry "aaa" should be one that we have set.
-PASS Second loop step 2: checking entry of name "aaa".Entry_list 0. entryType should be "measure".
-PASS Second loop step 2: checking entry of name "aaa".Entry_list 0. startTime should be a number.
-PASS Second loop step 2: checking entry of name "aaa".Entry_list 0. duration should be a number.
-PASS Second loop step 2: checking entry of name "aaa".Entry_list 1. Entry "aaa" should be one that we have set.
-PASS Second loop step 2: checking entry of name "aaa".Entry_list 1. entryType should be "measure".
-PASS Second loop step 2: checking entry of name "aaa".Entry_list 1. startTime should be a number.
-PASS Second loop step 2: checking entry of name "aaa".Entry_list 1. duration should be a number.
+PASS Second loop step 1: checking entry of name "aaa".There should be 2 entries.
+PASS Second loop step 1: checking entry of name "aaa".Entries in entrylist should be in order.
+PASS Second loop step 1: checking entry of name "aaa".Entry_list 0. Entry "aaa" should be one that we have set.
+PASS Second loop step 1: checking entry of name "aaa".Entry_list 0. entryType should be "measure".
+PASS Second loop step 1: checking entry of name "aaa".Entry_list 0. startTime should be a number.
+PASS Second loop step 1: checking entry of name "aaa".Entry_list 0. duration should be a number.
+PASS Second loop step 1: checking entry of name "aaa".Entry_list 1. Entry "aaa" should be one that we have set.
+PASS Second loop step 1: checking entry of name "aaa".Entry_list 1. entryType should be "measure".
+PASS Second loop step 1: checking entry of name "aaa".Entry_list 1. startTime should be a number.
+PASS Second loop step 1: checking entry of name "aaa".Entry_list 1. duration should be a number.
+PASS Second loop step 2: checking entry of name "".There should be 2 entries.
+PASS Second loop step 2: checking entry of name "".Entries in entrylist should be in order.
+PASS Second loop step 2: checking entry of name "".Entry_list 0. Entry "" should be one that we have set.
+PASS Second loop step 2: checking entry of name "".Entry_list 0. entryType should be "measure".
+PASS Second loop step 2: checking entry of name "".Entry_list 0. startTime should be a number.
+PASS Second loop step 2: checking entry of name "".Entry_list 0. duration should be a number.
+PASS Second loop step 2: checking entry of name "".Entry_list 1. Entry "" should be one that we have set.
+PASS Second loop step 2: checking entry of name "".Entry_list 1. entryType should be "measure".
+PASS Second loop step 2: checking entry of name "".Entry_list 1. startTime should be a number.
+PASS Second loop step 2: checking entry of name "".Entry_list 1. duration should be a number.
 PASS Second loop step 3: checking entry of name "aaa".There should be 2 entries.
 PASS Second loop step 3: checking entry of name "aaa".Entries in entrylist should be in order.
 PASS Second loop step 3: checking entry of name "aaa".Entry_list 0. Entry "aaa" should be one that we have set.

--- a/Source/WebCore/page/Performance.cpp
+++ b/Source/WebCore/page/Performance.cpp
@@ -90,6 +90,7 @@ Performance::Performance(ScriptExecutionContext* context, MonotonicTime timeOrig
     , m_continuousTimeOrigin(timeOrigin.approximate<ContinuousTime>())
 {
     ASSERT(m_timeOrigin);
+    initializeEntryBufferMap();
 }
 
 Performance::~Performance() = default;
@@ -98,6 +99,60 @@ void Performance::contextDestroyed()
 {
     m_resourceTimingBufferFullTimer.stop();
     ContextDestructionObserver::contextDestroyed();
+}
+
+// https://w3c.github.io/performance-timeline/#performance-entry-buffer-map
+Performance::PerformanceEntryBuffer& Performance::entryBufferTuple(PerformanceEntry::Type type)
+{
+    return m_entryBufferMap[entryTypeIndex(type)];
+}
+
+const Performance::PerformanceEntryBuffer& Performance::entryBufferTuple(PerformanceEntry::Type type) const
+{
+    return m_entryBufferMap[entryTypeIndex(type)];
+}
+
+// https://w3c.github.io/timing-entrytypes-registry/#registry
+static constexpr unsigned maxResourceTimingBufferSize = 250;
+static constexpr unsigned maxPaintTimingBufferSize = 2;
+static constexpr unsigned maxFirstInputBufferSize = 1;
+static constexpr unsigned maxEventTimingBufferSize = 150;
+static constexpr unsigned maxLargestContentfulPaintBufferSize = 150;
+
+void Performance::initializeEntryBufferMap()
+{
+    // Default tuple has empty buffer, unlimited maxBufferSize, availableFromTimeline=true, droppedEntriesCount=0.
+    entryBufferTuple(PerformanceEntry::Type::Resource).maxBufferSize = maxResourceTimingBufferSize;
+    entryBufferTuple(PerformanceEntry::Type::Paint).maxBufferSize = maxPaintTimingBufferSize;
+    entryBufferTuple(PerformanceEntry::Type::FirstInput).maxBufferSize = maxFirstInputBufferSize;
+
+    auto& eventTuple = entryBufferTuple(PerformanceEntry::Type::Event);
+    eventTuple.maxBufferSize = maxEventTimingBufferSize;
+    eventTuple.availableFromTimeline = false;
+
+    auto& lcpTuple = entryBufferTuple(PerformanceEntry::Type::LargestContentfulPaint);
+    lcpTuple.maxBufferSize = maxLargestContentfulPaintBufferSize;
+    lcpTuple.availableFromTimeline = false;
+}
+
+bool Performance::addToEntryBuffer(PerformanceEntry& entry)
+{
+    auto& tuple = entryBufferTuple(entry.performanceEntryType());
+    if (tuple.buffer.size() >= tuple.maxBufferSize) {
+        tuple.droppedEntriesCount++;
+        return false;
+    }
+    tuple.buffer.append(entry);
+    return true;
+}
+
+void Performance::clearEntryBuffer(PerformanceEntry::Type type, const String& name)
+{
+    auto& buffer = entryBufferTuple(type).buffer;
+    if (name.isNull())
+        buffer.clear();
+    else
+        buffer.removeAllMatching([&](auto& entry) { return entry->name() == name; });
 }
 
 DOMHighResTimeStamp Performance::now() const
@@ -194,122 +249,78 @@ PerformanceTiming& Performance::timing()
 
 Vector<Ref<PerformanceEntry>> Performance::getEntries() const
 {
+    // https://w3c.github.io/performance-timeline/#dfn-filter-buffer-map-by-name-and-type
     Vector<Ref<PerformanceEntry>> entries;
-
-    if (m_navigationTiming)
-        entries.append(*m_navigationTiming);
-
-    entries.appendVector(m_resourceTimingBuffer);
-
-    if (m_userTiming) {
-        entries.appendVector(m_userTiming->getMarks());
-        entries.appendVector(m_userTiming->getMeasures());
+    for (auto& tuple : m_entryBufferMap) {
+        if (!tuple.availableFromTimeline)
+            continue;
+        entries.appendVector(tuple.buffer);
     }
-
-    if (m_firstContentfulPaint)
-        entries.append(*m_firstContentfulPaint);
-
-    // getEntries should not include largest-contentful-paint.
-
-    if (m_firstInput)
-        entries.append(*m_firstInput);
-
-    std::ranges::sort(entries, PerformanceEntry::startTimeCompareLessThan);
+    std::ranges::stable_sort(entries, PerformanceEntry::startTimeCompareLessThan);
     return entries;
 }
 
 Vector<Ref<PerformanceEntry>> Performance::getEntriesByType(const String& entryType) const
 {
+    // https://w3c.github.io/performance-timeline/#dfn-filter-buffer-map-by-name-and-type
+    auto type = PerformanceEntry::parseEntryTypeString(entryType);
+    if (!type)
+        return { };
+
+    auto& tuple = entryBufferTuple(*type);
+    if (!tuple.availableFromTimeline)
+        return { };
+
     Vector<Ref<PerformanceEntry>> entries;
-
-    if (m_navigationTiming && entryType == "navigation"_s)
-        entries.append(*m_navigationTiming);
-    
-    if (entryType == "resource"_s)
-        entries.appendVector(m_resourceTimingBuffer);
-
-    if (m_firstContentfulPaint && entryType == "paint"_s)
-        entries.append(*m_firstContentfulPaint);
-
-    // getEntriesByType should not include largest-contentful-paint.
-
-    if (m_userTiming) {
-        if (entryType == "mark"_s)
-            entries.appendVector(m_userTiming->getMarks());
-        else if (entryType == "measure"_s)
-            entries.appendVector(m_userTiming->getMeasures());
-    }
-
-    if (entryType == "first-input"_s && m_firstInput)
-        entries.append(*m_firstInput);
-
-    std::ranges::sort(entries, PerformanceEntry::startTimeCompareLessThan);
+    entries.appendVector(tuple.buffer);
+    std::ranges::stable_sort(entries, PerformanceEntry::startTimeCompareLessThan);
     return entries;
 }
 
 Vector<Ref<PerformanceEntry>> Performance::getEntriesByName(const String& name, const String& entryType) const
 {
+    // https://w3c.github.io/performance-timeline/#dfn-filter-buffer-map-by-name-and-type
     Vector<Ref<PerformanceEntry>> entries;
 
-    if (m_navigationTiming && (entryType.isNull() || entryType == "navigation"_s) && name == m_navigationTiming->name())
-        entries.append(*m_navigationTiming);
-
-    if (entryType.isNull() || entryType == "resource"_s) {
-        for (auto& resource : m_resourceTimingBuffer) {
-            if (resource->name() == name)
-                entries.append(resource);
+    auto filterAndAppend = [&](const PerformanceEntryBuffer& tuple) {
+        if (!tuple.availableFromTimeline)
+            return;
+        for (auto& entry : tuple.buffer) {
+            if (entry->name() == name)
+                entries.append(entry);
         }
+    };
+
+    if (!entryType.isNull()) {
+        auto type = PerformanceEntry::parseEntryTypeString(entryType);
+        if (!type)
+            return entries;
+        filterAndAppend(entryBufferTuple(*type));
+    } else {
+        for (auto& tuple : m_entryBufferMap)
+            filterAndAppend(tuple);
     }
 
-    if (m_firstContentfulPaint && (entryType.isNull() || entryType == "paint"_s) && name == "first-contentful-paint"_s)
-        entries.append(*m_firstContentfulPaint);
-
-    // getEntriesByName should not include largest-contentful-paint.
-
-    if (m_userTiming) {
-        if (entryType.isNull() || entryType == "mark"_s)
-            entries.appendVector(m_userTiming->getMarks(name));
-        if (entryType.isNull() || entryType == "measure"_s)
-            entries.appendVector(m_userTiming->getMeasures(name));
-    }
-
-    if (entryType.isNull() || entryType == "first-input"_s) {
-        if (m_firstInput && name == m_firstInput->name())
-            entries.append(*m_firstInput);
-    }
-
-    std::ranges::sort(entries, PerformanceEntry::startTimeCompareLessThan);
+    std::ranges::stable_sort(entries, PerformanceEntry::startTimeCompareLessThan);
     return entries;
 }
 
 void Performance::appendBufferedEntriesByType(const String& entryType, Vector<Ref<PerformanceEntry>>& entries, PerformanceObserver& observer) const
 {
-    if (m_navigationTiming && entryType == "navigation"_s && !observer.hasNavigationTiming()) {
-        entries.append(*m_navigationTiming);
+    // https://w3c.github.io/performance-timeline/#observe-method (step 8c)
+    // No availableFromTimeline check — buffered observers see all entry types.
+    auto type = PerformanceEntry::parseEntryTypeString(entryType);
+    if (!type)
+        return;
+
+    if (*type == PerformanceEntry::Type::Navigation && observer.hasNavigationTiming())
+        return;
+
+    auto& tuple = entryBufferTuple(*type);
+    entries.appendVector(tuple.buffer);
+
+    if (*type == PerformanceEntry::Type::Navigation && !tuple.buffer.isEmpty())
         observer.addedNavigationTiming();
-    }
-
-    if (entryType == "resource"_s)
-        entries.appendVector(m_resourceTimingBuffer);
-
-    if (entryType == "paint"_s && m_firstContentfulPaint)
-        entries.append(*m_firstContentfulPaint);
-
-    if (entryType == "largest-contentful-paint"_s && m_largestContentfulPaint)
-        entries.append(*m_largestContentfulPaint);
-
-    if (entryType == "event"_s)
-        entries.appendVector(m_eventTimingBuffer);
-
-    if (entryType == "first-input"_s && m_firstInput)
-        entries.append(*m_firstInput);
-
-    if (m_userTiming) {
-        if (entryType.isNull() || entryType == "mark"_s)
-            entries.appendVector(m_userTiming->getMarks());
-        if (entryType.isNull() || entryType == "measure"_s)
-            entries.appendVector(m_userTiming->getMeasures());
-    }
 }
 
 void Performance::countEvent(EventType type)
@@ -335,6 +346,7 @@ void Performance::processEventEntry(const PerformanceEventTimingCandidate& candi
     // spec discussion at https://github.com/w3c/event-timing/issues/159 :
     if (!m_firstInput && !candidate.interactionID.isUnassigned()) {
         m_firstInput = PerformanceEventTiming::create(candidate, true);
+        addToEntryBuffer(*m_firstInput);
         queueEntry(*m_firstInput);
         if (RefPtr document = dynamicDowncast<Document>(*scriptExecutionContext())) {
             if (auto* window = document->window())
@@ -352,21 +364,21 @@ void Performance::processEventEntry(const PerformanceEventTimingCandidate& candi
         return;
 
     auto entry = PerformanceEventTiming::create(candidate);
-    if (m_eventTimingBuffer.size() < m_eventTimingBufferSize && candidate.duration > defaultDurationCutoffBeforeRounding)
-        m_eventTimingBuffer.append(entry);
+    if (candidate.duration > defaultDurationCutoffBeforeRounding)
+        addToEntryBuffer(entry);
 
     queueEntry(entry);
 }
 
 void Performance::clearResourceTimings()
 {
-    m_resourceTimingBuffer.clear();
+    entryBufferTuple(PerformanceEntry::Type::Resource).buffer.clear();
     m_resourceTimingBufferFullFlag = false;
 }
 
 void Performance::setResourceTimingBufferSize(unsigned size)
 {
-    m_resourceTimingBufferSize = size;
+    entryBufferTuple(PerformanceEntry::Type::Resource).maxBufferSize = size;
     m_resourceTimingBufferFullFlag = false;
 }
 
@@ -375,9 +387,9 @@ void Performance::reportFirstContentfulPaint(DOMHighResTimeStamp timestamp)
     if (RefPtr context = scriptExecutionContext())
         InspectorInstrumentation::didEnqueueFirstContentfulPaint(*context);
 
-    ASSERT(!m_firstContentfulPaint);
-    m_firstContentfulPaint = PerformancePaintTiming::createFirstContentfulPaint(timestamp);
-    queueEntry(*m_firstContentfulPaint);
+    auto entry = PerformancePaintTiming::createFirstContentfulPaint(timestamp);
+    addToEntryBuffer(entry);
+    queueEntry(entry);
 }
 
 void Performance::enqueueLargestContentfulPaint(Ref<LargestContentfulPaint>&& paintEntry)
@@ -385,13 +397,14 @@ void Performance::enqueueLargestContentfulPaint(Ref<LargestContentfulPaint>&& pa
     if (RefPtr context = scriptExecutionContext())
         InspectorInstrumentation::didEnqueueLargestContentfulPaint(*context, paintEntry.get());
 
-    m_largestContentfulPaint = RefPtr { WTF::move(paintEntry) };
-    queueEntry(*m_largestContentfulPaint);
+    addToEntryBuffer(paintEntry);
+    queueEntry(paintEntry);
 }
 
 void Performance::addNavigationTiming(DocumentLoader& documentLoader, Document& document, CachedResource& resource, const DocumentLoadTiming& timing, const NetworkLoadMetrics& metrics)
 {
     m_navigationTiming = PerformanceNavigationTiming::create(m_timeOrigin, resource, timing, metrics, document.eventTiming(), document.securityOrigin(), documentLoader.triggeringAction().type());
+    addToEntryBuffer(*m_navigationTiming);
 }
 
 void Performance::documentLoadFinished(const NetworkLoadMetrics& metrics)
@@ -438,17 +451,20 @@ void Performance::addResourceTiming(ResourceTiming&& resourceTiming)
     }
 
     queueEntry(entry.get());
-    m_resourceTimingBuffer.append(WTF::move(entry));
+    entryBufferTuple(PerformanceEntry::Type::Resource).buffer.append(WTF::move(entry));
 }
 
 bool Performance::isResourceTimingBufferFull() const
 {
-    return m_resourceTimingBuffer.size() >= m_resourceTimingBufferSize;
+    auto& tuple = entryBufferTuple(PerformanceEntry::Type::Resource);
+    return tuple.buffer.size() >= tuple.maxBufferSize;
 }
 
 void Performance::resourceTimingBufferFullTimerFired()
 {
     ASSERT(scriptExecutionContext());
+
+    auto& resourceBuffer = entryBufferTuple(PerformanceEntry::Type::Resource).buffer;
 
     while (!m_backupResourceTimingBuffer.isEmpty()) {
         auto beforeCount = m_backupResourceTimingBuffer.size();
@@ -475,7 +491,7 @@ void Performance::resourceTimingBufferFullTimerFired()
 
         for (auto& entry : backupBuffer) {
             if (!isResourceTimingBufferFull()) {
-                m_resourceTimingBuffer.append(entry.copyRef());
+                resourceBuffer.append(entry.copyRef());
                 queueEntry(entry);
             } else
                 m_backupResourceTimingBuffer.append(entry.copyRef());
@@ -500,6 +516,7 @@ ExceptionOr<Ref<PerformanceMark>> Performance::mark(JSC::JSGlobalObject& globalO
     if (mark.hasException())
         return mark.releaseException();
 
+    addToEntryBuffer(mark.returnValue().get());
     queueEntry(mark.returnValue().get());
     return mark.releaseReturnValue();
 }
@@ -509,6 +526,7 @@ void Performance::clearMarks(const String& markName)
     if (!m_userTiming)
         m_userTiming = makeUnique<PerformanceUserTiming>(*this);
     m_userTiming->clearMarks(markName);
+    clearEntryBuffer(PerformanceEntry::Type::Mark, markName);
 }
 
 ExceptionOr<Ref<PerformanceMeasure>> Performance::measure(JSC::JSGlobalObject& globalObject, const String& measureName, StartOrMeasureOptions&& startOrMeasureOptions, const String& endMark)
@@ -547,6 +565,7 @@ ExceptionOr<Ref<PerformanceMeasure>> Performance::measure(JSC::JSGlobalObject& g
         }
     }
 
+    addToEntryBuffer(measure.returnValue().get());
     queueEntry(measure.returnValue().get());
     return measure.releaseReturnValue();
 }
@@ -556,6 +575,7 @@ void Performance::clearMeasures(const String& measureName)
     if (!m_userTiming)
         m_userTiming = makeUnique<PerformanceUserTiming>(*this);
     m_userTiming->clearMeasures(measureName);
+    clearEntryBuffer(PerformanceEntry::Type::Measure, measureName);
 }
 
 void Performance::removeAllObservers()

--- a/Source/WebCore/page/Performance.h
+++ b/Source/WebCore/page/Performance.h
@@ -36,9 +36,12 @@
 #include "DOMHighResTimeStamp.h"
 #include "EventTarget.h"
 #include "EventTargetInterfaces.h"
+#include "PerformanceEntry.h"
 #include "ReducedResolutionSeconds.h"
 #include "ScriptExecutionContext.h"
 #include "Timer.h"
+#include <array>
+#include <limits>
 #include <memory>
 #include <wtf/ContinuousTime.h>
 #include <wtf/ListHashSet.h>
@@ -58,13 +61,11 @@ class EventCounts;
 class LargestContentfulPaint;
 class NetworkLoadMetrics;
 class PerformanceUserTiming;
-class PerformanceEntry;
 class PerformanceMark;
 class PerformanceMeasure;
 class PerformanceNavigation;
 class PerformanceNavigationTiming;
 class PerformanceObserver;
-class PerformancePaintTiming;
 class PerformanceTiming;
 class ResourceResponse;
 class ResourceTiming;
@@ -155,22 +156,30 @@ private:
 
     void queueEntry(PerformanceEntry&);
 
+    // https://w3c.github.io/performance-timeline/#performance-entry-buffer-map
+    struct PerformanceEntryBuffer {
+        Vector<Ref<PerformanceEntry>> buffer;
+        unsigned maxBufferSize { std::numeric_limits<unsigned>::max() };
+        unsigned droppedEntriesCount { 0 };
+        bool availableFromTimeline { true };
+    };
+
+    static unsigned entryTypeIndex(PerformanceEntry::Type type) { return static_cast<unsigned>(type); }
+    PerformanceEntryBuffer& entryBufferTuple(PerformanceEntry::Type);
+    const PerformanceEntryBuffer& entryBufferTuple(PerformanceEntry::Type) const;
+
+    void initializeEntryBufferMap();
+    bool addToEntryBuffer(PerformanceEntry&);
+    void clearEntryBuffer(PerformanceEntry::Type, const String& name = { });
+
     const std::unique_ptr<EventCounts> m_eventCounts;
     mutable RefPtr<PerformanceNavigation> m_navigation;
     mutable RefPtr<PerformanceTiming> m_timing;
-
-    // https://w3c.github.io/resource-timing/#sec-extensions-performance-interface recommends initial buffer size of 250.
-    Vector<Ref<PerformanceEntry>> m_resourceTimingBuffer;
 
     Timer m_resourceTimingBufferFullTimer;
     Vector<Ref<PerformanceEntry>> m_backupResourceTimingBuffer;
 
     RefPtr<PerformanceEntry> m_firstInput;
-    Vector<Ref<PerformanceEntry>> m_eventTimingBuffer;
-
-    // Sizes recommended by https://w3c.github.io/timing-entrytypes-registry/#registry:
-    unsigned m_eventTimingBufferSize { 150 };
-    unsigned m_resourceTimingBufferSize { 250 };
 
     // https://w3c.github.io/resource-timing/#dfn-resource-timing-buffer-full-flag
     bool m_resourceTimingBufferFullFlag { false };
@@ -181,10 +190,9 @@ private:
     ContinuousTime m_continuousTimeOrigin;
 
     RefPtr<PerformanceNavigationTiming> m_navigationTiming;
-    RefPtr<PerformancePaintTiming> m_firstContentfulPaint;
-    RefPtr<PerformanceEntry> m_largestContentfulPaint;
     std::unique_ptr<PerformanceUserTiming> m_userTiming;
 
+    std::array<PerformanceEntryBuffer, PerformanceEntry::performanceEntryTypeCount> m_entryBufferMap;
     ListHashSet<Ref<PerformanceObserver>> m_observers;
 };
 

--- a/Source/WebCore/page/PerformanceEntry.h
+++ b/Source/WebCore/page/PerformanceEntry.h
@@ -47,15 +47,17 @@ public:
     virtual double duration() const { return m_duration; }
 
     enum class Type : uint8_t {
-        Navigation              = 1 << 0,
-        Mark                    = 1 << 1,
-        Measure                 = 1 << 2,
-        Resource                = 1 << 3,
-        Paint                   = 1 << 4,
-        Event                   = 1 << 5,
-        FirstInput              = 1 << 6,
-        LargestContentfulPaint  = 1 << 7,
+        Navigation,
+        Mark,
+        Measure,
+        Resource,
+        Paint,
+        Event,
+        FirstInput,
+        LargestContentfulPaint,
     };
+
+    static constexpr unsigned performanceEntryTypeCount = 8;
 
     virtual Type performanceEntryType() const = 0;
     virtual ASCIILiteral entryType() const = 0;

--- a/Source/WebCore/page/PerformanceObserver.cpp
+++ b/Source/WebCore/page/PerformanceObserver.cpp
@@ -62,7 +62,7 @@ ExceptionOr<void> PerformanceObserver::observe(Init&& init)
         return Exception { ExceptionCode::TypeError };
 
     bool isBuffered = false;
-    OptionSet<PerformanceEntry::Type> filter;
+    EnumSet<PerformanceEntry::Type> filter;
     if (init.entryTypes) {
         if (!init.type.isNull())
             return Exception { ExceptionCode::TypeError, "either entryTypes or type must be provided"_s };

--- a/Source/WebCore/page/PerformanceObserver.h
+++ b/Source/WebCore/page/PerformanceObserver.h
@@ -62,7 +62,7 @@ public:
     void disconnect();
     Vector<Ref<PerformanceEntry>> takeRecords();
 
-    OptionSet<PerformanceEntry::Type> typeFilter() const { return m_typeFilter; }
+    EnumSet<PerformanceEntry::Type> typeFilter() const { return m_typeFilter; }
 
     bool hasNavigationTiming() const { return m_hasNavigationTiming; }
     void addedNavigationTiming() { m_hasNavigationTiming = true; }
@@ -80,7 +80,7 @@ private:
     RefPtr<Performance> m_performance;
     Vector<Ref<PerformanceEntry>> m_entriesToDeliver;
     const Ref<PerformanceObserverCallback> m_callback;
-    OptionSet<PerformanceEntry::Type> m_typeFilter;
+    EnumSet<PerformanceEntry::Type> m_typeFilter;
     Seconds m_durationThreshold;
     bool m_registered { false };
     bool m_isTypeObserver { false };


### PR DESCRIPTION
#### 86af7895045818824f56bd8ac1c08ea52428669d
<pre>
LCP buffer size seems to be set to 1 instead of 150
<a href="https://bugs.webkit.org/show_bug.cgi?id=305256">https://bugs.webkit.org/show_bug.cgi?id=305256</a>
<a href="https://rdar.apple.com/168015751">rdar://168015751</a>

Reviewed by Ryosuke Niwa.

The `Performance` object stored only one LCP entry, instead of the buffer of 150 entries
as specified by [1].

Fix by implementing the `performance entry buffer map` per spec [2], allowing us to
specify the max buffer size on a per-entryType basis. This replaces the ad-hoc
buffers, and brings the code closer to spec terminology.

Change PerformanceEntry::Type to be a normal enum; we can use EnumSet where
necessary, and now just trivially cast the values to get indexes into the std::array.

[1] <a href="https://w3c.github.io/timing-entrytypes-registry/#registry">https://w3c.github.io/timing-entrytypes-registry/#registry</a>
[2] <a href="https://w3c.github.io/performance-timeline/#performance-entry-buffer-map">https://w3c.github.io/performance-timeline/#performance-entry-buffer-map</a>

Test: imported/w3c/web-platform-tests/largest-contentful-paint/lcp-buffer-size.html

* LayoutTests/imported/w3c/web-platform-tests/largest-contentful-paint/lcp-buffer-size-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/largest-contentful-paint/lcp-buffer-size.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/user-timing/measures-expected.txt:
* Source/WebCore/page/Performance.cpp:
(WebCore::Performance::Performance):
(WebCore::Performance::entryBufferTuple):
(WebCore::Performance::entryBufferTuple const):
(WebCore::Performance::initializeEntryBufferMap):
(WebCore::Performance::addToEntryBuffer):
(WebCore::Performance::clearEntryBuffer):
(WebCore::Performance::getEntries const):
(WebCore::Performance::getEntriesByType const):
(WebCore::Performance::getEntriesByName const):
(WebCore::Performance::appendBufferedEntriesByType const):
(WebCore::Performance::processEventEntry):
(WebCore::Performance::clearResourceTimings):
(WebCore::Performance::setResourceTimingBufferSize):
(WebCore::Performance::reportFirstContentfulPaint):
(WebCore::Performance::enqueueLargestContentfulPaint):
(WebCore::Performance::addNavigationTiming):
(WebCore::Performance::addResourceTiming):
(WebCore::Performance::isResourceTimingBufferFull const):
(WebCore::Performance::resourceTimingBufferFullTimerFired):
(WebCore::Performance::mark):
(WebCore::Performance::clearMarks):
(WebCore::Performance::measure):
(WebCore::Performance::clearMeasures):
* Source/WebCore/page/Performance.h:
* Source/WebCore/page/PerformanceEntry.h:
* Source/WebCore/page/PerformanceObserver.cpp:
(WebCore::PerformanceObserver::observe):
* Source/WebCore/page/PerformanceObserver.h:
(WebCore::PerformanceObserver::typeFilter const):

Canonical link: <a href="https://commits.webkit.org/312393@main">https://commits.webkit.org/312393@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fd4d40edff0ce47ddd568a47662849ce88970abf

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/159803 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/33271 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/26377 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/168663 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/114184 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/161672 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/33375 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/33274 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/123826 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/114184 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/162761 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/26084 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/143525 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/104462 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/25135 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/23609 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/16424 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/134827 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/21296 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/171155 "Built successfully") | | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/17171 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/22933 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/132090 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/32949 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/27689 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/132135 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35752 "Built successfully and passed tests") | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/32934 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/143090 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/91032 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/160/builds/32934 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/19904 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/32443 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/98840 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/31940 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/32187 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/32091 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->