### PR TITLE
NEW TEST(311561@main): [iOS Release] TestWebKitAPI.FullscreenVideoTextRecognition.NoOverlayInstalledAfterSeekAndExitingNativeVideoFullscreen is a flaky timeout

### DIFF
--- a/Tools/TestWebKitAPI/Resources/cocoa/element-fullscreen.html
+++ b/Tools/TestWebKitAPI/Resources/cocoa/element-fullscreen.html
@@ -33,8 +33,9 @@ var video = document.querySelector("video");
 
 async function loadSource(source)
 {
-    return new Promise(resolve => {
-        video.addEventListener("load", resolve, { once: true });
+    return new Promise((resolve, reject) => {
+        video.addEventListener("loadeddata", () => resolve(), { once: true });
+        video.addEventListener("error", () => reject(new Error("video error code=" + (video.error ? video.error.code : "null"))), { once: true });
         video.src = source;
     });
 }

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/FullscreenVideoTextRecognition.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/FullscreenVideoTextRecognition.mm
@@ -143,7 +143,7 @@ static void swizzledSetAnalysis(VKCImageAnalysisInteraction *, SEL, VKCImageAnal
 - (void)loadVideoSource:(NSString *)source
 {
     __block bool done = false;
-    [self callAsyncJavaScript:@"loadSource(source)" arguments:@{ @"source" : source } inFrame:nil inContentWorld:WKContentWorld.pageWorld completionHandler:^(id, NSError *error) {
+    [self callAsyncJavaScript:@"return loadSource(source)" arguments:@{ @"source" : source } inFrame:nil inContentWorld:WKContentWorld.pageWorld completionHandler:^(id, NSError *error) {
         EXPECT_NULL(error);
         done = true;
     }];
@@ -382,9 +382,8 @@ TEST(FullscreenVideoTextRecognition, NoOverlayInstalledAfterSeekAndExitingFullsc
     Util::run(&doneWaiting);
 }
 
-// FIXME when webkit.org/b/313031 is resolved
 #if PLATFORM(MAC)
-TEST(FullscreenVideoTextRecognition, DISABLED_NoOverlayInstalledAfterExitingVideoFullscreenViaEscape)
+TEST(FullscreenVideoTextRecognition, NoOverlayInstalledAfterExitingVideoFullscreenViaEscape)
 {
     auto webView = [FullscreenVideoTextRecognitionWebView createForVideoFullscreen];
     [webView loadVideoSource:@"test.mp4"];
@@ -407,8 +406,7 @@ TEST(FullscreenVideoTextRecognition, DISABLED_NoOverlayInstalledAfterExitingVide
     Util::run(&doneWaiting);
 }
 
-// FIXME when webkit.org/b/313031 is resolved
-TEST(FullscreenVideoTextRecognition, DISABLED_NoOverlayInstalledAfterSeekAndExitingVideoFullscreenViaEscape)
+TEST(FullscreenVideoTextRecognition, NoOverlayInstalledAfterSeekAndExitingVideoFullscreenViaEscape)
 {
     auto webView = [FullscreenVideoTextRecognitionWebView createForVideoFullscreen];
     [webView loadVideoSource:@"test.mp4"];
@@ -442,8 +440,7 @@ TEST(FullscreenVideoTextRecognition, DISABLED_NoOverlayInstalledAfterSeekAndExit
 
 #endif // PLATFORM(MAC)
 
-// FIXME when webkit.org/b/312934 is resolved for Release.
-#if PLATFORM(IOS_FAMILY) && !defined(NDEBUG)
+#if PLATFORM(IOS_FAMILY)
 TEST(FullscreenVideoTextRecognition, NoOverlayInstalledAfterExitingNativeVideoFullscreen)
 {
     auto configuration = [WKWebViewConfiguration _test_configurationWithTestPlugInClassName:@"WebProcessPlugInWithInternals" configureJSCForTesting:YES];
@@ -484,12 +481,7 @@ TEST(FullscreenVideoTextRecognition, NoOverlayInstalledAfterExitingNativeVideoFu
     Util::run(&doneWaiting);
 }
 
-// FIXME when webkit.org/b/312934 is resolved for Release.
-#if PLATFORM(IOS) && defined(NDEBUG)
-TEST(FullscreenVideoTextRecognition, DISABLED_NoOverlayInstalledAfterSeekAndExitingNativeVideoFullscreen)
-#else
 TEST(FullscreenVideoTextRecognition, NoOverlayInstalledAfterSeekAndExitingNativeVideoFullscreen)
-#endif
 {
     auto configuration = [WKWebViewConfiguration _test_configurationWithTestPlugInClassName:@"WebProcessPlugInWithInternals" configureJSCForTesting:YES];
     RetainPtr webView = adoptNS([[FullscreenVideoTextRecognitionWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 568) configuration:configuration]);


### PR DESCRIPTION
#### 2b6529663f248b24dfdc74c13e969a7062979cd0
<pre>
NEW TEST(311561@main): [iOS Release] TestWebKitAPI.FullscreenVideoTextRecognition.NoOverlayInstalledAfterSeekAndExitingNativeVideoFullscreen is a flaky timeout
<a href="https://bugs.webkit.org/show_bug.cgi?id=312934">https://bugs.webkit.org/show_bug.cgi?id=312934</a>
<a href="https://rdar.apple.com/175287130">rdar://175287130</a>

Reviewed by Jer Noble.

loadSource listened for load, an event &lt;video&gt; never fires, AND the calling JS body lacked return, so the harness&apos;s
async wrapper dropped the Promise. loadVideoSource never actually waited for the video to load.

On iOS, JavaScriptEvaluationResult was surfacing the result an NSError that looked exactly like a JS rejection.
We now listen to loadeddata event instead and add handling for error so we can be diagnosed potential issues.

We re-enable the disabled API tests.

* Tools/TestWebKitAPI/Resources/cocoa/element-fullscreen.html:
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/FullscreenVideoTextRecognition.mm:
(-[FullscreenVideoTextRecognitionWebView loadVideoSource:]):
(TestWebKitAPI::TEST(FullscreenVideoTextRecognition, NoOverlayInstalledAfterSeekAndExitingNativeVideoFullscreen)):

Canonical link: <a href="https://commits.webkit.org/312417@main">https://commits.webkit.org/312417@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/747c1d52d883559c881c68696717301dacf4b779

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/159632 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/33099 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/26206 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/168483 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/114013 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/161501 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/33204 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/33103 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/123678 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/86797 "1 flakes 8 failures") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/162589 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/25946 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/143382 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/104329 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/24997 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/23633 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/16246 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/134848 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/21154 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/170971 "Built successfully") | | 
| | | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/22788 "Found 1 new test failure: imported/w3c/web-platform-tests/css/selectors/invalidation/media-pseudo-classes-in-has.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/131918 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/32778 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/27533 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/131996 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35763 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/32763 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/142947 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/90845 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/26630 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/19761 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/32272 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/31769 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/32016 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/31920 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->