### PR TITLE
<model> should not autoplay to respect Low Motion AX settings

### DIFF
--- a/Source/WebCore/Modules/model-element/HTMLModelElement.cpp
+++ b/Source/WebCore/Modules/model-element/HTMLModelElement.cpp
@@ -83,6 +83,7 @@
 #include "ScreenProperties.h"
 #include "ScriptController.h"
 #include "Settings.h"
+#include "Theme.h"
 #include <JavaScriptCore/ConsoleTypes.h>
 #include <JavaScriptCore/HeapInlines.h>
 #include <WebCore/HTTPStatusCodes.h>
@@ -404,6 +405,18 @@ void HTMLModelElement::didFinishLoading(ModelPlayer& modelPlayer)
         renderer->updateFromElement();
     if (!m_readyPromise->isFulfilled())
         m_readyPromise->resolve(*this);
+
+#if ENABLE(MODEL_ELEMENT_ANIMATIONS_CONTROL)
+    // Suppress animation if the page has disabled animations (e.g. "Pause All Animations"
+    // accessibility action) or the user has enabled "Reduce Motion" in system preferences.
+    RefPtr page = document().page();
+    bool animationsSuppressed = (page && !page->imageAnimationEnabled())
+        || Theme::singleton().userPrefersReducedMotion();
+    if (animationsSuppressed) {
+        if (RefPtr player = m_modelPlayer)
+            player->setAnimationIsPlaying(false, [](bool) { });
+    }
+#endif
 }
 
 void HTMLModelElement::didFailLoading(ModelPlayer& modelPlayer, const ResourceError&)
@@ -589,7 +602,16 @@ void HTMLModelElement::createModelPlayer()
     }
 
 #if ENABLE(MODEL_ELEMENT_ANIMATIONS_CONTROL)
-    modelPlayer->setAutoplay(autoplay());
+    // Suppress autoplay if the page has disabled animations (e.g. "Pause All Animations"
+    // accessibility action or "Auto-play Animated Images" sub-setting) or if the user
+    // has enabled "Reduce Motion" in system preferences. Checking upfront — before load()
+    // — avoids a race where the GPU process starts animating before a pause message arrives.
+    bool animationsSuppressed = false;
+    if (RefPtr page = document().page())
+        animationsSuppressed = !page->imageAnimationEnabled();
+    if (!animationsSuppressed)
+        animationsSuppressed = Theme::singleton().userPrefersReducedMotion();
+    modelPlayer->setAutoplay(autoplay() && !animationsSuppressed);
     modelPlayer->setLoop(loop());
     modelPlayer->setPlaybackRate(m_playbackRate, [&](double) { });
 #endif
@@ -1376,6 +1398,16 @@ void HTMLModelElement::isPlayingAnimation(IsPlayingAnimationPromise&& promise)
             promise.resolve(*isPlaying);
     });
 }
+
+#if ENABLE(ACCESSIBILITY_ANIMATION_CONTROL) && ENABLE(MODEL_ELEMENT_ANIMATIONS_CONTROL)
+void HTMLModelElement::setAllowsAnimation(bool allowsAnimation)
+{
+    // Also suppress if Reduce Motion is enabled, regardless of the page-level flag.
+    bool shouldPlay = allowsAnimation && !Theme::singleton().userPrefersReducedMotion();
+    if (RefPtr modelPlayer = m_modelPlayer)
+        modelPlayer->setAnimationIsPlaying(shouldPlay, [](bool) { });
+}
+#endif
 
 void HTMLModelElement::setAnimationIsPlaying(bool isPlaying, DOMPromiseDeferred<void>&& promise)
 {

--- a/Source/WebCore/Modules/model-element/HTMLModelElement.h
+++ b/Source/WebCore/Modules/model-element/HTMLModelElement.h
@@ -169,6 +169,10 @@ public:
     void setCurrentTime(double);
 #endif
 
+#if ENABLE(ACCESSIBILITY_ANIMATION_CONTROL) && ENABLE(MODEL_ELEMENT_ANIMATIONS_CONTROL)
+    void setAllowsAnimation(bool);
+#endif
+
 #if ENABLE(MODEL_ELEMENT_STAGE_MODE)
     bool canSetEntityTransform() const;
 #endif

--- a/Source/WebCore/rendering/RenderView.cpp
+++ b/Source/WebCore/rendering/RenderView.cpp
@@ -35,6 +35,9 @@
 #include "HTMLHtmlElement.h"
 #include "HTMLIFrameElement.h"
 #include "HTMLImageElement.h"
+#if ENABLE(MODEL_ELEMENT)
+#include "HTMLModelElement.h"
+#endif
 #include "HitTestResult.h"
 #include "ImageQualityController.h"
 #include "LayoutBoxGeometry.h"
@@ -1086,6 +1089,11 @@ void RenderView::updatePlayStateForAllAnimations(const IntRect& visibleRect)
                 m_SVGSVGElementsWithPausedImageAnimation.add(*svgSvgElement);
             }
         }
+
+#if ENABLE(MODEL_ELEMENT) && ENABLE(MODEL_ELEMENT_ANIMATIONS_CONTROL)
+        if (auto* modelElement = dynamicDowncast<HTMLModelElement>(renderElement.element()))
+            modelElement->setAllowsAnimation(shouldAnimate);
+#endif
     }
 }
 #endif // ENABLE(ACCESSIBILITY_ANIMATION_CONTROL)

--- a/Source/WebKit/Shared/Cocoa/AccessibilityPreferences.mm
+++ b/Source/WebKit/Shared/Cocoa/AccessibilityPreferences.mm
@@ -93,6 +93,12 @@ bool imageAnimationEnabled()
         return WebKit::initialImageAnimationEnabled;
     if (auto* functionPointer = _AXSReduceMotionAutoplayAnimatedImagesEnabledPtr())
         return functionPointer();
+#if HAVE(PER_APP_ACCESSIBILITY_PREFERENCES)
+    // Fall back to the general Reduce Motion flag: if it is on, treat animated content
+    // as disabled to match iOS behavior.
+    RetainPtr appId = applicationBundleIdentifier().createCFString();
+    return !_AXSReduceMotionEnabledApp(appId.get());
+#endif
 #endif
     return true;
 }


### PR DESCRIPTION
#### 29997a348771ccb238b17280a52a9234efe1e797
<pre>
&lt;model&gt; should not autoplay to respect Low Motion AX settings
<a href="https://bugs.webkit.org/show_bug.cgi?id=313616">https://bugs.webkit.org/show_bug.cgi?id=313616</a>
<a href="https://rdar.apple.com/175351454">rdar://175351454</a>

Reviewed by NOBODY (OOPS!).

Respect reduce motion / limit animations to avoid auto-playing
animations.

* Source/WebCore/Modules/model-element/HTMLModelElement.cpp:
(WebCore::HTMLModelElement::didFinishLoading):
(WebCore::HTMLModelElement::createModelPlayer):
(WebCore::HTMLModelElement::setAllowsAnimation):
* Source/WebCore/Modules/model-element/HTMLModelElement.h:
* Source/WebCore/rendering/RenderView.cpp:
(WebCore::RenderView::updatePlayStateForAllAnimations):
* Source/WebKit/Shared/Cocoa/AccessibilityPreferences.mm:
(AXPreferenceHelpers::imageAnimationEnabled):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/29997a348771ccb238b17280a52a9234efe1e797

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/159493 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/32962 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/26038 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/168337 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/113873 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/00892b2c-7671-4e41-93ce-9d3fd546da52) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/161362 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/32994 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/32913 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/123589 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/86737 "1 flakes 8 failures") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/a7645569-7369-4b47-9592-bcac788f7c16) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/162450 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/25837 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/143261 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/104247 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/427d34e0-c699-465c-a76a-8326540965df) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/24890 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/23346 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/16101 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/134581 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/21034 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/170822 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/16861 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/22665 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/131791 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/32615 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/27422 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/131899 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/32559 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/142827 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/90706 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/26556 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/19641 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/32135 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/98528 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/31587 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/31863 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/31781 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->