### PR TITLE
Improve comments referencing the fetch spec

### DIFF
--- a/Source/WebCore/Modules/fetch/FetchRequest.cpp
+++ b/Source/WebCore/Modules/fetch/FetchRequest.cpp
@@ -75,9 +75,12 @@ static ExceptionOr<String> computeReferrer(ScriptExecutionContext& context, cons
 
 static std::optional<Exception> buildOptions(FetchOptions& options, ResourceRequest& request, String& referrer, RequestPriority& priority, ScriptExecutionContext& context, const FetchRequest::Init& init)
 {
+    // https://fetch.spec.whatwg.org/#dom-request
+    // 10. If init["window"] exists and is non-null, then throw a TypeError.
     if (!init.window.isUndefinedOrNull() && !init.window.isEmpty())
         return Exception { ExceptionCode::TypeError, "Window can only be null."_s };
 
+    // 13. If init is not empty, then:
     if (init.hasMembers()) {
         if (options.mode == FetchOptions::Mode::Navigate)
             options.mode = FetchOptions::Mode::SameOrigin;
@@ -85,6 +88,7 @@ static std::optional<Exception> buildOptions(FetchOptions& options, ResourceRequ
         options.referrerPolicy = { };
     }
 
+    // 14. If init["referrer"] exists, then:
     if (!init.referrer.isNull()) {
         auto result = computeReferrer(context, init.referrer);
         if (result.hasException())
@@ -92,39 +96,52 @@ static std::optional<Exception> buildOptions(FetchOptions& options, ResourceRequ
         referrer = result.releaseReturnValue();
     }
 
+    // 15. If init["referrerPolicy"] exists, then set request’s referrer policy to it.
     if (init.referrerPolicy)
         options.referrerPolicy = init.referrerPolicy.value();
 
-    if (init.priority)
-        priority = *init.priority;
-
+    // 16. Let mode be init["mode"] if it exists, and fallbackMode otherwise.
+    // 17. If mode is "navigate", then throw a TypeError.
+    // 18. If mode is non-null, set request’s mode to mode.
     if (init.mode) {
         options.mode = init.mode.value();
         if (options.mode == FetchOptions::Mode::Navigate)
             return Exception { ExceptionCode::TypeError, "Request constructor does not accept navigate fetch mode."_s };
     }
 
+    // 19. If init["credentials"] exists, then set request’s credentials mode to it.
     if (init.credentials)
         options.credentials = init.credentials.value();
 
+    // 20. If init["cache"] exists, then set request’s cache mode to it.
     if (init.cache)
         options.cache = init.cache.value();
+
+    // 21. If request’s cache mode is "only-if-cached" and request’s mode is not "same-origin", then throw a TypeError.
     if (options.cache == FetchOptions::Cache::OnlyIfCached && options.mode != FetchOptions::Mode::SameOrigin)
         return Exception { ExceptionCode::TypeError, "only-if-cached cache option requires fetch mode to be same-origin."_s  };
 
+    // 22. If init["redirect"] exists, then set request’s redirect mode to it.
     if (init.redirect)
         options.redirect = init.redirect.value();
 
+    // 23. If init["integrity"] exists, then set request’s integrity metadata to it.
     if (!init.integrity.isNull())
         options.integrity = init.integrity;
 
+    // 24. If init["keepalive"] exists, then set request’s keepalive to it.
     if (init.keepalive && init.keepalive.value())
         options.keepAlive = true;
 
+    // 25. If init["method"] exists, then:
     if (!init.method.isNull()) {
         if (auto exception = setMethod(request, init.method))
             return exception;
     }
+
+    // 27. If init["priority"] exists, then:
+    if (init.priority)
+        priority = *init.priority;
 
     return std::nullopt;
 }
@@ -168,6 +185,8 @@ ExceptionOr<void> FetchRequest::initializeOptions(const Init& init)
     if (exception)
         return WTF::move(exception.value());
 
+    // https://fetch.spec.whatwg.org/#dom-request
+    // 32. If this’s request’s mode is "no-cors", then:
     if (m_options.mode == FetchOptions::Mode::NoCors) {
         const String& method = m_request.httpMethod();
         if (method != "GET"_s && method != "POST"_s && method != "HEAD"_s)
@@ -320,14 +339,18 @@ ExceptionOr<void> FetchRequest::setBody(FetchRequest& request)
 
 ExceptionOr<Ref<FetchRequest>> FetchRequest::create(ScriptExecutionContext& context, Info&& input, Init&& init)
 {
+    // https://fetch.spec.whatwg.org/#dom-request
+
     auto request = adoptRef(*new FetchRequest(context, std::nullopt, FetchHeaders::create(FetchHeaders::Guard::Request), { }, { }, { }));
     request->suspendIfNeeded();
 
     if (std::holds_alternative<String>(input)) {
+        // 5. If input is a string, then:
         auto result = request->initializeWith(std::get<String>(input), WTF::move(init));
         if (result.hasException())
             return result.releaseException();
     } else {
+        // 6.Otherwise:
         auto result = request->initializeWith(std::get<Ref<FetchRequest>>(input).get(), WTF::move(init));
         if (result.hasException())
             return result.releaseException();

--- a/Source/WebCore/loader/CrossOriginAccessControl.cpp
+++ b/Source/WebCore/loader/CrossOriginAccessControl.cpp
@@ -269,15 +269,22 @@ bool CrossOriginAccessControlCheckDisabler::crossOriginAccessControlCheckEnabled
 
 Expected<void, String> passesAccessControlCheck(const ResourceResponse& response, StoredCredentialsPolicy storedCredentialsPolicy, const SecurityOrigin& securityOrigin, const CrossOriginAccessControlCheckDisabler* checkDisabler)
 {
+    // https://fetch.spec.whatwg.org/#cors-check
+
     // A wildcard Access-Control-Allow-Origin can not be used if credentials are to be sent,
     // even with Access-Control-Allow-Credentials set to true.
+
+    // 1. Let origin be the result of getting `Access-Control-Allow-Origin` from response’s header list.
     const String& accessControlOriginString = response.httpHeaderField(HTTPHeaderName::AccessControlAllowOrigin);
+
+    // 3. If request’s credentials mode is not "include" and origin is `*`, then return success.
     bool starAllowed = storedCredentialsPolicy == StoredCredentialsPolicy::DoNotUse;
     if (!starAllowed)
         starAllowed = checkDisabler && !checkDisabler->crossOriginAccessControlCheckEnabled();
     if (accessControlOriginString == "*"_s && starAllowed)
         return { };
 
+    // 4. If the result of byte-serializing a request origin with request is not origin, then return failure.
     String securityOriginString = securityOrigin.toString();
     if (accessControlOriginString != securityOriginString) {
         if (accessControlOriginString == "*"_s)
@@ -287,13 +294,19 @@ Expected<void, String> passesAccessControlCheck(const ResourceResponse& response
         return makeUnexpected(makeString("Origin "_s, securityOriginString, " is not allowed by Access-Control-Allow-Origin."_s, " Status code: "_s, response.httpStatusCode()));
     }
 
-    if (storedCredentialsPolicy == StoredCredentialsPolicy::Use) {
-        const String& accessControlCredentialsString = response.httpHeaderField(HTTPHeaderName::AccessControlAllowCredentials);
-        if (accessControlCredentialsString != "true"_s)
-            return makeUnexpected("Credentials flag is true, but Access-Control-Allow-Credentials is not \"true\"."_s);
-    }
+    // 5. If request’s credentials mode is not "include", then return success.
+    if (storedCredentialsPolicy != StoredCredentialsPolicy::Use)
+        return { };
 
-    return { };
+    // 6. Let credentials be the result of getting `Access-Control-Allow-Credentials` from response’s header list.
+    const String& accessControlCredentialsString = response.httpHeaderField(HTTPHeaderName::AccessControlAllowCredentials);
+
+    // 7. If credentials is `true`, then return success.
+    if (accessControlCredentialsString == "true"_s)
+        return { };
+
+    // 8. Return failure.
+    return makeUnexpected("Credentials flag is true, but Access-Control-Allow-Credentials is not \"true\"."_s);
 }
 
 Expected<void, String> validatePreflightResponse(PAL::SessionID sessionID, const ResourceRequest& request, const ResourceResponse& response, StoredCredentialsPolicy storedCredentialsPolicy, const SecurityOrigin& topOrigin, const SecurityOrigin& securityOrigin, const CrossOriginAccessControlCheckDisabler* checkDisabler)

--- a/Source/WebCore/loader/FrameLoader.cpp
+++ b/Source/WebCore/loader/FrameLoader.cpp
@@ -4343,6 +4343,8 @@ void FrameLoader::loadedResourceFromMemoryCache(CachedResource& resource, Resour
 
 void FrameLoader::applyUserAgentIfNeeded(ResourceRequest& request)
 {
+    // https://fetch.spec.whatwg.org/#http-network-or-cache-fetch
+    // 8.15. If httpRequest’s header list does not contain `User-Agent`, then user agents should:
     if (!request.hasHTTPHeaderField(HTTPHeaderName::UserAgent)) {
         String userAgent = this->userAgent(request.url());
         ASSERT(!userAgent.isNull());

--- a/Source/WebCore/loader/SubresourceLoader.cpp
+++ b/Source/WebCore/loader/SubresourceLoader.cpp
@@ -283,6 +283,8 @@ void SubresourceLoader::willSendRequestInternal(ResourceRequest&& newRequest, co
             return completionHandler(WTF::move(newRequest));
         }
 
+        // https://fetch.spec.whatwg.org/#http-redirect-fetch
+        // 7. If request’s redirect count is 20, then return a network error.
         if (m_redirectCount++ >= options().maxRedirectCount) {
             SUBRESOURCELOADER_RELEASE_LOG(SubResourceLoaderWillSendRequestInternalResourceLoadCancelledTooManyRedirects);
             cancel(ResourceError(String(), 0, request().url(), "Too many redirections"_s, ResourceError::Type::General));
@@ -724,7 +726,8 @@ Expected<void, String> SubresourceLoader::checkRedirectionCrossOriginAccessContr
 
     newRequest.redirectAsGETIfNeeded(previousRequest, redirectResponse);
 
-    // Implementing https://fetch.spec.whatwg.org/#concept-http-redirect-fetch step 14.
+    // https://fetch.spec.whatwg.org/#http-redirect-fetch
+    // 19. Invoke set request’s referrer policy on redirect on request and internalResponse.
     updateReferrerPolicy(redirectResponse.httpHeaderField(HTTPHeaderName::ReferrerPolicy));
 
     if (options().mode == FetchOptions::Mode::Cors && redirectingToNewOrigin) {
@@ -741,6 +744,7 @@ Expected<void, String> SubresourceLoader::checkRedirectionCrossOriginAccessContr
 
 void SubresourceLoader::updateReferrerPolicy(const String& referrerPolicyValue)
 {
+    // https://w3c.github.io/webappsec-referrer-policy/#set-requests-referrer-policy-on-redirect
     if (auto referrerPolicy = parseReferrerPolicy(referrerPolicyValue, ReferrerPolicySource::HTTPHeader)) {
         ASSERT(*referrerPolicy != ReferrerPolicy::EmptyString);
         setReferrerPolicy(*referrerPolicy);

--- a/Source/WebCore/loader/cache/CachedResource.cpp
+++ b/Source/WebCore/loader/cache/CachedResource.cpp
@@ -212,13 +212,18 @@ void CachedResource::load(CachedResourceLoader& cachedResourceLoader)
             ASSERT(cachedResourceLoader.cachePolicy(type(), url()) != CachePolicy::Reload);
             if (cachedResourceLoader.cachePolicy(type(), url()) == CachePolicy::Revalidate)
                 m_resourceRequest.setHTTPHeaderField(HTTPHeaderName::CacheControl, HTTPHeaderValues::maxAge0());
-            if (!lastModified.isEmpty())
-                m_resourceRequest.setHTTPHeaderField(HTTPHeaderName::IfModifiedSince, lastModified);
+            // https://fetch.spec.whatwg.org/#http-network-or-cache-fetch
+            // 8.26.2.2.1 If storedResponse’s header list contains `ETag`, then append (`If-None-Match`, `ETag`'s value) to httpRequest’s header list.
             if (!eTag.isEmpty())
                 m_resourceRequest.setHTTPHeaderField(HTTPHeaderName::IfNoneMatch, eTag);
+            // 8.26.2.2.2 If storedResponse’s header list contains `Last-Modified`, then append (`If-Modified-Since`, `Last-Modified`'s value) to httpRequest’s header list.
+            if (!lastModified.isEmpty())
+                m_resourceRequest.setHTTPHeaderField(HTTPHeaderName::IfModifiedSince, lastModified);
         }
     }
 
+    // https://fetch.spec.whatwg.org/#http-network-or-cache-fetch
+    // 8.14. If httpRequest’s initiator is "prefetch", then set a structured field value given (`Sec-Purpose`, the token prefetch) in httpRequest’s header list.
     if (type() == Type::LinkPrefetch)
         m_resourceRequest.setHTTPHeaderField(HTTPHeaderName::SecPurpose, "prefetch"_s);
     m_resourceRequest.setPriority(loadPriority());
@@ -240,6 +245,8 @@ void CachedResource::load(CachedResourceLoader& cachedResourceLoader)
         m_fragmentIdentifierForRequest = String();
     }
 
+    // https://fetch.spec.whatwg.org/#http-network-or-cache-fetch
+    // 8.10. If contentLength is non-null and httpRequest’s keepalive is true, then:
     if (m_options.keepAlive && type() != Type::Ping && !cachedResourceLoader.keepaliveRequestTracker().tryRegisterRequest(*this)) {
         setResourceError({ errorDomainWebKitInternal, 0, request.url(), "Reached maximum amount of queued data of 64Kb for keepalive requests"_s, ResourceError::Type::AccessControl });
         failBeforeStarting();

--- a/Source/WebCore/loader/cache/CachedResourceLoader.cpp
+++ b/Source/WebCore/loader/cache/CachedResourceLoader.cpp
@@ -697,7 +697,8 @@ const String& convertEnumerationToString(FetchMetadataSite enumerationValue)
 
 static void updateRequestFetchMetadataHeaders(ResourceRequest& request, const ResourceLoaderOptions& options, FetchMetadataSite site)
 {
-    // Implementing step 13 of https://fetch.spec.whatwg.org/#http-network-or-cache-fetch as of 22 Feb 2022
+    // https://fetch.spec.whatwg.org/#http-network-or-cache-fetch
+    // 8.13. Append the Fetch metadata headers for httpRequest.
     // https://w3c.github.io/webappsec-fetch-metadata/#fetch-integration
     Ref requestOrigin = SecurityOrigin::create(request.url());
     if (!requestOrigin->isPotentiallyTrustworthy())
@@ -1007,24 +1008,30 @@ static bool shouldUpdateFetchMetadata(const LocalFrame& frame, const ResourceReq
 
 void CachedResourceLoader::updateHTTPRequestHeaders(FrameLoader& frameLoader, CachedResource::Type type, CachedResourceRequest& request)
 {
-    // Implementing steps 11 to 19 of https://fetch.spec.whatwg.org/#http-network-or-cache-fetch as of 22 Feb 2022.
-
+    // Implementing steps 8.11 to 8.12 of https://fetch.spec.whatwg.org/#http-network-or-cache-fetch.
     // FIXME: We should reconcile handling of MainResource with other resources.
     if (type != CachedResource::Type::MainResource && request.options().cachingPolicy != CachingPolicy::AllowCachingMainResourcePrefetch)
         request.updateReferrerAndOriginHeaders(frameLoader);
+
     // FetchMetadata depends on PSL to determine same-site relationships and without this
     // ability it is best to not set any FetchMetadata headers as sites generally expect
     // all of them or none.
+    // Implementing step 8.13 of https://fetch.spec.whatwg.org/#http-network-or-cache-fetch.
     Ref frame = frameLoader.frame();
     if (shouldUpdateFetchMetadata(frame, request.resourceRequest(), type, request.options().mode)) {
         auto site = computeFetchMetadataSite(request.resourceRequest(), type, request.options().mode, frame, frame->isMainFrame() && m_documentLoader && m_documentLoader->isRequestFromClientOrUserInput(), m_documentLoader.get());
         updateRequestFetchMetadataHeaders(request.resourceRequest(), request.options(), site);
     }
+    // Implementing step 8.15 of https://fetch.spec.whatwg.org/#http-network-or-cache-fetch.
     request.updateUserAgentHeader(frameLoader);
 
     if (frame->loader().loadType() == FrameLoadType::ReloadFromOrigin)
         request.updateCacheModeIfNeeded(cachePolicy(type, request.resourceRequest().url()));
+
+    // Implementing steps 8.16 to 8.18 of https://fetch.spec.whatwg.org/#http-network-or-cache-fetch.
     request.updateAccordingCacheMode();
+
+    // Implementing step 8.19 of https://fetch.spec.whatwg.org/#http-network-or-cache-fetch.
     request.updateAcceptEncodingHeader();
 }
 

--- a/Source/WebCore/loader/cache/CachedResourceRequest.cpp
+++ b/Source/WebCore/loader/cache/CachedResourceRequest.cpp
@@ -222,6 +222,8 @@ void CachedResourceRequest::disableCachingIfNeeded()
 
 void CachedResourceRequest::updateAccordingCacheMode()
 {
+    // https://fetch.spec.whatwg.org/#http-network-or-cache-fetch
+    // 16. If httpRequest’s cache mode is "default" and httpRequest’s header list contains `If-Modified-Since`, `If-None-Match`, `If-Unmodified-Since`, `If-Match`, or `If-Range`, then set httpRequest’s cache mode to "no-store".
     if (m_options.cache == FetchOptions::Cache::Default
         && (m_resourceRequest.hasHTTPHeaderField(HTTPHeaderName::IfModifiedSince)
             || m_resourceRequest.hasHTTPHeaderField(HTTPHeaderName::IfNoneMatch)
@@ -233,16 +235,21 @@ void CachedResourceRequest::updateAccordingCacheMode()
     switch (m_options.cache) {
     case FetchOptions::Cache::NoCache:
         m_resourceRequest.setCachePolicy(ResourceRequestCachePolicy::RefreshAnyCacheData);
+        // 8.17. If httpRequest’s cache mode is "no-cache", httpRequest’s prevent no-cache cache-control header modification flag is unset, and httpRequest’s header list does not contain `Cache-Control`, then append (`Cache-Control`, `max-age=0`) to httpRequest’s header list.
         m_resourceRequest.addHTTPHeaderFieldIfNotPresent(HTTPHeaderName::CacheControl, HTTPHeaderValues::maxAge0());
         break;
     case FetchOptions::Cache::NoStore:
         m_resourceRequest.setCachePolicy(ResourceRequestCachePolicy::DoNotUseAnyCache);
+        // 8.18.1. If httpRequest’s header list does not contain `Pragma`, then append (`Pragma`, `no-cache`) to httpRequest’s header list.
         m_resourceRequest.addHTTPHeaderFieldIfNotPresent(HTTPHeaderName::Pragma, HTTPHeaderValues::noCache());
+        // 8.18.2. If httpRequest’s header list does not contain `Cache-Control`, then append (`Cache-Control`, `no-cache`) to httpRequest’s header list.
         m_resourceRequest.addHTTPHeaderFieldIfNotPresent(HTTPHeaderName::CacheControl, HTTPHeaderValues::noCache());
         break;
     case FetchOptions::Cache::Reload:
         m_resourceRequest.setCachePolicy(ResourceRequestCachePolicy::ReloadIgnoringCacheData);
+        // 8.18.1. If httpRequest’s header list does not contain `Pragma`, then append (`Pragma`, `no-cache`) to httpRequest’s header list.
         m_resourceRequest.addHTTPHeaderFieldIfNotPresent(HTTPHeaderName::Pragma, HTTPHeaderValues::noCache());
+        // 8.18.2. If httpRequest’s header list does not contain `Cache-Control`, then append (`Cache-Control`, `no-cache`) to httpRequest’s header list.
         m_resourceRequest.addHTTPHeaderFieldIfNotPresent(HTTPHeaderName::CacheControl, HTTPHeaderValues::noCache());
         break;
     case FetchOptions::Cache::Default:
@@ -264,6 +271,8 @@ void CachedResourceRequest::updateCacheModeIfNeeded(CachePolicy cachePolicy)
 
 void CachedResourceRequest::updateAcceptEncodingHeader()
 {
+    // https://fetch.spec.whatwg.org/#http-network-or-cache-fetch
+    // 8.19. If httpRequest’s header list contains `Range`, then append (`Accept-Encoding`, `identity`) to httpRequest’s header list.
     if (!m_resourceRequest.hasHTTPHeaderField(HTTPHeaderName::Range))
         return;
 
@@ -297,7 +306,8 @@ void CachedResourceRequest::updateReferrerPolicy(ReferrerPolicy defaultPolicy)
 
 void CachedResourceRequest::updateReferrerAndOriginHeaders(FrameLoader& frameLoader)
 {
-    // Implementing step 9 to 11 of https://fetch.spec.whatwg.org/#http-network-or-cache-fetch as of 16 March 2018
+    // https://fetch.spec.whatwg.org/#http-network-or-cache-fetch
+    // 8.11. If httpRequest’s referrer is a URL, then:
     URL outgoingReferrerURL;
     if (m_resourceRequest.hasHTTPReferrer())
         outgoingReferrerURL = URL { m_resourceRequest.httpReferrer() };
@@ -308,14 +318,23 @@ void CachedResourceRequest::updateReferrerAndOriginHeaders(FrameLoader& frameLoa
     if (!m_resourceRequest.httpOrigin().isEmpty())
         return;
 
+    // https://fetch.spec.whatwg.org/#http-network-or-cache-fetch
+    // 8.12. Append a request `Origin` header for httpRequest.
+
+    // https://fetch.spec.whatwg.org/#append-a-request-origin-header
+    // 2. Let serializedOrigin be the result of byte-serializing a request origin with request.
     RefPtr document = frameLoader.frame().document();
     auto actualOrigin = (document && m_options.destination == FetchOptionsDestination::EmptyString && m_initiatorType == cachedResourceRequestInitiatorTypes().fetch) ? Ref { document->securityOrigin() } : SecurityOrigin::create(outgoingReferrerURL);
     String outgoingOrigin;
-    if (m_options.mode == FetchOptions::Mode::Cors)
+    if (m_options.mode == FetchOptions::Mode::Cors) {
+        // 3. If request’s response tainting is "cors" or request’s mode is either "websocket" or "webtransport", then append (`Origin`, serializedOrigin) to request’s header list.
         outgoingOrigin = actualOrigin->toString();
-    else
+    } else {
+        // 4. Otherwise, if request’s method is neither `GET` nor `HEAD`, then:
         outgoingOrigin = SecurityPolicy::generateOriginHeader(m_options.referrerPolicy, m_resourceRequest.url(), actualOrigin, OriginAccessPatternsForWebProcess::singleton());
+    }
 
+    // 3. or 4.2. Append (`Origin`, serializedOrigin) to request’s header list.
     FrameLoader::addHTTPOriginIfNeeded(m_resourceRequest, outgoingOrigin);
 }
 

--- a/Source/WebCore/page/SecurityPolicy.cpp
+++ b/Source/WebCore/page/SecurityPolicy.cpp
@@ -138,6 +138,8 @@ String SecurityPolicy::generateReferrerHeader(ReferrerPolicy referrerPolicy, con
 
 String SecurityPolicy::generateOriginHeader(ReferrerPolicy referrerPolicy, const URL& url, const SecurityOrigin& securityOrigin, const OriginAccessPatterns& patterns)
 {
+    // https://fetch.spec.whatwg.org/#append-a-request-origin-header
+    // 4.1. If request’s mode is not "cors", then switch on request’s referrer policy:
     switch (referrerPolicy) {
     case ReferrerPolicy::NoReferrer:
         return "null"_s;

--- a/Source/WebKit/NetworkProcess/curl/NetworkDataTaskCurl.cpp
+++ b/Source/WebKit/NetworkProcess/curl/NetworkDataTaskCurl.cpp
@@ -335,6 +335,8 @@ void NetworkDataTaskCurl::willPerformHTTPRedirection()
 {
     static const int maxRedirects = 20;
 
+    // https://fetch.spec.whatwg.org/#http-redirect-fetch
+    // 7. If request’s redirect count is 20, then return a network error.
     if (m_redirectCount++ > maxRedirects) {
         m_client->didCompleteWithError(ResourceError(CURLE_TOO_MANY_REDIRECTS, m_response.url()));
         return;


### PR DESCRIPTION
#### 7cb5d45de21ccb118e3b2a19e13fa0434d29eec1
<pre>
Improve comments referencing the fetch spec
<a href="https://bugs.webkit.org/show_bug.cgi?id=313620">https://bugs.webkit.org/show_bug.cgi?id=313620</a>

Reviewed by NOBODY (OOPS!).

This patch updates and adds comments against the fetch spec, quoting
normative text to make it more robust against future spec updates.
It also has some minor code reorganization to make it easier to
compare against the spec, but no behavior changes.

* Source/WebCore/Modules/fetch/FetchRequest.cpp:
(WebCore::buildOptions):
(WebCore::FetchRequest::initializeOptions):
(WebCore::FetchRequest::create):
* Source/WebCore/loader/CrossOriginAccessControl.cpp:
(WebCore::passesAccessControlCheck):
* Source/WebCore/loader/FrameLoader.cpp:
(WebCore::FrameLoader::applyUserAgentIfNeeded):
* Source/WebCore/loader/SubresourceLoader.cpp:
(WebCore::SubresourceLoader::willSendRequestInternal):
(WebCore::SubresourceLoader::checkRedirectionCrossOriginAccessControl):
(WebCore::SubresourceLoader::updateReferrerPolicy):
* Source/WebCore/loader/cache/CachedResource.cpp:
(WebCore::CachedResource::load):
* Source/WebCore/loader/cache/CachedResourceLoader.cpp:
(WebCore::updateRequestFetchMetadataHeaders):
(WebCore::CachedResourceLoader::updateHTTPRequestHeaders):
* Source/WebCore/loader/cache/CachedResourceRequest.cpp:
(WebCore::CachedResourceRequest::updateAccordingCacheMode):
(WebCore::CachedResourceRequest::updateAcceptEncodingHeader):
(WebCore::CachedResourceRequest::updateReferrerAndOriginHeaders):
* Source/WebCore/page/SecurityPolicy.cpp:
(WebCore::SecurityPolicy::generateOriginHeader):
* Source/WebKit/NetworkProcess/curl/NetworkDataTaskCurl.cpp:
(WebKit::NetworkDataTaskCurl::willPerformHTTPRedirection):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7cb5d45de21ccb118e3b2a19e13fa0434d29eec1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/159426 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/32854 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/25962 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/168258 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/113804 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/161295 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/32922 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/32842 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/123523 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/86705 "1 flakes 1 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/162383 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/25767 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/143196 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/104187 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/24829 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/23278 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/16029 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/134507 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/20976 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/170750 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/16784 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/22602 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/131730 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/32543 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/27353 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/131843 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/32487 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/142769 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/90612 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/26498 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/19578 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/31998 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/98450 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/31518 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/31791 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/31673 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->