### PR TITLE
Cherry-pick 312266@main (07ed81f30130). https://bugs.webkit.org/show_bug.cgi?id=313560

### DIFF
--- a/Source/cmake/WebKitCompilerFlags.cmake
+++ b/Source/cmake/WebKitCompilerFlags.cmake
@@ -486,6 +486,10 @@ int main() {
         set(CMAKE_REQUIRED_LIBRARIES atomic)
         check_cxx_source_compiles("${ATOMIC_TEST_SOURCE}" ATOMICS_REQUIRE_LIBATOMIC)
         unset(CMAKE_REQUIRED_LIBRARIES)
+        # If we failed to build the test source with libatomic then something is wrong
+        if (NOT ATOMICS_REQUIRE_LIBATOMIC)
+            message(FATAL_ERROR "Failed to detect support for atomic variables")
+        endif ()
     endif ()
 
     # <filesystem> vs <experimental/filesystem>

--- a/Source/cmake/WebKitCompilerFlags.cmake
+++ b/Source/cmake/WebKitCompilerFlags.cmake
@@ -481,24 +481,25 @@ int main() {
     return static_cast<int>(result + d.load().value());
 }
     ]=])
+    cmake_push_check_state(RESET)
     set(CMAKE_REQUIRED_FLAGS "--std=c++17")
     check_cxx_source_compiles("${ATOMIC_TEST_SOURCE}" ATOMICS_ARE_BUILTIN)
     if (NOT ATOMICS_ARE_BUILTIN)
         set(CMAKE_REQUIRED_LIBRARIES atomic)
         check_cxx_source_compiles("${ATOMIC_TEST_SOURCE}" ATOMICS_REQUIRE_LIBATOMIC)
-        unset(CMAKE_REQUIRED_LIBRARIES)
         # If we failed to build the test source with libatomic then something is wrong
         if (NOT ATOMICS_REQUIRE_LIBATOMIC)
             message(FATAL_ERROR "Failed to detect support for atomic variables")
         endif ()
     endif ()
-    unset(CMAKE_REQUIRED_FLAGS)
+    cmake_pop_check_state()
 
     # <filesystem> vs <experimental/filesystem>
     set(FILESYSTEM_TEST_SOURCE "
         #include <filesystem>
         int main() { std::filesystem::path p1(\"\"); std::filesystem::status(p1); }
     ")
+    cmake_push_check_state(RESET)
     set(CMAKE_REQUIRED_FLAGS "--std=c++2b")
     check_cxx_source_compiles("${FILESYSTEM_TEST_SOURCE}" STD_FILESYSTEM_IS_AVAILABLE)
     if (NOT STD_FILESYSTEM_IS_AVAILABLE)
@@ -511,9 +512,8 @@ int main() {
         ")
         set(CMAKE_REQUIRED_LIBRARIES stdc++fs)
         check_cxx_source_compiles("${EXPERIMENTAL_FILESYSTEM_TEST_SOURCE}" STD_EXPERIMENTAL_FILESYSTEM_IS_AVAILABLE)
-        unset(CMAKE_REQUIRED_LIBRARIES)
     endif ()
-    unset(CMAKE_REQUIRED_FLAGS)
+    cmake_pop_check_state()
 endif ()
 
 if (NOT WTF_PLATFORM_COCOA)
@@ -542,9 +542,10 @@ if (WTF_CPU_ARM)
         set(CLANG_EXTRA_ARM_ARGS " -mthumb")
     endif ()
 
+    cmake_push_check_state(RESET)
     set(CMAKE_REQUIRED_FLAGS "${CLANG_EXTRA_ARM_ARGS}")
     CHECK_CXX_SOURCE_COMPILES("${ARM_THUMB2_TEST_SOURCE}" ARM_THUMB2_DETECTED)
-    unset(CMAKE_REQUIRED_FLAGS)
+    cmake_pop_check_state()
 
     if (ARM_THUMB2_DETECTED AND NOT (${CMAKE_SYSTEM_NAME} STREQUAL "Darwin"))
         string(APPEND CMAKE_C_FLAGS " ${CLANG_EXTRA_ARM_ARGS}")

--- a/Source/cmake/WebKitCompilerFlags.cmake
+++ b/Source/cmake/WebKitCompilerFlags.cmake
@@ -481,6 +481,7 @@ int main() {
     return static_cast<int>(result + d.load().value());
 }
     ]=])
+    set(CMAKE_REQUIRED_FLAGS "--std=c++17")
     check_cxx_source_compiles("${ATOMIC_TEST_SOURCE}" ATOMICS_ARE_BUILTIN)
     if (NOT ATOMICS_ARE_BUILTIN)
         set(CMAKE_REQUIRED_LIBRARIES atomic)
@@ -491,6 +492,7 @@ int main() {
             message(FATAL_ERROR "Failed to detect support for atomic variables")
         endif ()
     endif ()
+    unset(CMAKE_REQUIRED_FLAGS)
 
     # <filesystem> vs <experimental/filesystem>
     set(FILESYSTEM_TEST_SOURCE "


### PR DESCRIPTION
#### b7eabfc1efa45b94eeddc2de7c022cdfefee24cd
<pre>
Cherry-pick 312266@main (07ed81f30130). <a href="https://bugs.webkit.org/show_bug.cgi?id=313560">https://bugs.webkit.org/show_bug.cgi?id=313560</a>

    [CMake] Use cmake_{push,pop}_check_state() in WebKitCompilerFlags.cmake
    <a href="https://bugs.webkit.org/show_bug.cgi?id=313560">https://bugs.webkit.org/show_bug.cgi?id=313560</a>

    Reviewed by Yusuke Suzuki.

    This is a follow-up to 312222@main with a small cleanup.

    * Source/cmake/WebKitCompilerFlags.cmake: Use cmake_push_check_state()
      and cmake_pop_check_state() consistently to ensure that variables
      are restored to their original values after modifying them for tests.

    Canonical link: <a href="https://commits.webkit.org/312266@main">https://commits.webkit.org/312266@main</a>

Canonical link: <a href="https://commits.webkit.org/305877.462@webkitglib/2.52">https://commits.webkit.org/305877.462@webkitglib/2.52</a>
</pre>
----------------------------------------------------------------------
#### 07814fb34a55f2f76f4fe0a172d28ed5807c8862
<pre>
Cherry-pick 312222@main (cfb69a99823a). <a href="https://bugs.webkit.org/show_bug.cgi?id=313560">https://bugs.webkit.org/show_bug.cgi?id=313560</a>

    [CMake] Set --std=c++17 for the libatomic probe
    <a href="https://bugs.webkit.org/show_bug.cgi?id=313560">https://bugs.webkit.org/show_bug.cgi?id=313560</a>
    <a href="https://rdar.apple.com/175777090">rdar://175777090</a>

    Reviewed by Michael Catanzaro.

    The atomic source test uses std::atomic&lt;std::optional&lt;double&gt;&gt;, which
    requires C++17. check_cxx_source_compiles inherits the compiler&apos;s
    default C++ standard, and on compilers that default to C++14 or
    earlier the probe fails with &quot;no member named &apos;optional&apos; in namespace
    &apos;std&apos;&quot;. Pre-312202@main this was silent and the build proceeded
    (builtins suffice on arm64 without libatomic). 312202@main promoted
    the failure to FATAL_ERROR, which broke the CMake build on those
    compilers.

    Set CMAKE_REQUIRED_FLAGS to --std=c++17 (the actual minimum the test
    imposes) around the probe; unset() restores the previous state.

    * Source/cmake/WebKitCompilerFlags.cmake:
    Wrap the ATOMIC_TEST_SOURCE checks with set/unset of
    CMAKE_REQUIRED_FLAGS &quot;--std=c++17&quot;.

    Canonical link: <a href="https://commits.webkit.org/312222@main">https://commits.webkit.org/312222@main</a>

Canonical link: <a href="https://commits.webkit.org/305877.461@webkitglib/2.52">https://commits.webkit.org/305877.461@webkitglib/2.52</a>
</pre>
----------------------------------------------------------------------
#### 51fd5236ab3f6fafe9c2cffbf518bbb8207d1374
<pre>
Cherry-pick 312202@main (36c3761def82). <a href="https://bugs.webkit.org/show_bug.cgi?id=313534">https://bugs.webkit.org/show_bug.cgi?id=313534</a>

    Improve libatomic test in WebKitCompilerFlags.cmake
    <a href="https://bugs.webkit.org/show_bug.cgi?id=313534">https://bugs.webkit.org/show_bug.cgi?id=313534</a>

    Reviewed by Adrian Perez de Castro and Michael Catanzaro.

    Fail immediately if the atomic source test cannot be built, even when
    using libatomic.

    * Source/cmake/WebKitCompilerFlags.cmake:

    Canonical link: <a href="https://commits.webkit.org/312202@main">https://commits.webkit.org/312202@main</a>

Canonical link: <a href="https://commits.webkit.org/305877.460@webkitglib/2.52">https://commits.webkit.org/305877.460@webkitglib/2.52</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fd41c5d7ecda714c543a305971f08b473509c52c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/159431 "Passed style check") | [❌ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/32859 "Unable to build WebKit without PR, please check manually (failure)") | [❌ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/25967 "Unable to build WebKit without PR, please check manually (failure)") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/168263 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/113809 "The change is no longer eligible for processing.") 
| | [❌ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/32927 "Unable to build WebKit without PR, please check manually (failure)") | [❌ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/32847 "Unable to build WebKit without PR, please check manually (failure)") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/123527 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/113809 "The change is no longer eligible for processing.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/162388 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/155/builds/32927 "Unable to build WebKit without PR, please check manually (failure)") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/168/builds/25967 "Unable to build WebKit without PR, please check manually (failure)") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/104191 "Passed tests") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/155/builds/32927 "Unable to build WebKit without PR, please check manually (failure)") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/156/builds/32847 "Unable to build WebKit without PR, please check manually (failure)") | [❌ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/16034 "Unable to build WebKit without PR, please check manually (failure)") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/20/builds/151481 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/155/builds/32927 "Unable to build WebKit without PR, please check manually (failure)") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/168/builds/25967 "Unable to build WebKit without PR, please check manually (failure)") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/170755 "Unable to build WebKit without PR, please check manually (failure)") | 
| [  ~~🛠 🧪 jsc-debug-arm64~~](https://ews-build.webkit.org/#/builders/171/builds/20264 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/168/builds/25967 "Unable to build WebKit without PR, please check manually (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/2/builds/170755 "Unable to build WebKit without PR, please check manually (failure)") | 
| | [❌ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/32548 "Unable to build WebKit without PR, please check manually (failure)") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/156/builds/32847 "Unable to build WebKit without PR, please check manually (failure)") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/2/builds/170755 "Unable to build WebKit without PR, please check manually (failure)") | 
| | [❌ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/32492 "Unable to build WebKit without PR, please check manually (failure)") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/168/builds/25967 "Unable to build WebKit without PR, please check manually (failure)") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/90618 "The change is no longer eligible for processing.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/24263 "Built successfully and passed tests") | [❌ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/160/builds/32492 "Unable to build WebKit without PR, please check manually (failure)") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/168/builds/25967 "Unable to build WebKit without PR, please check manually (failure)") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/191714 "Built successfully") | 
| | [❌ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/32003 "Unable to build WebKit without PR, please check manually (failure)") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/49264 "Passed tests") | 
| | [❌ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/31523 "Unable to build WebKit without PR, please check manually (failure)") | | | 
| | [❌ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/31796 "Unable to build WebKit without PR, please check manually (failure)") | | | 
| | [❌ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/31678 "Unable to build WebKit without PR, please check manually (failure)") | | | 
<!--EWS-Status-Bubble-End-->