### PR TITLE
WebRTCVideoDecoderVTB::flush can be called with a null internal decoder

### DIFF
--- a/LayoutTests/http/wpt/webcodecs/flush-after-failing-decoder-expected.txt
+++ b/LayoutTests/http/wpt/webcodecs/flush-after-failing-decoder-expected.txt
@@ -1,0 +1,3 @@
+
+PASS Flush decoder that tried decoding bad data
+

--- a/LayoutTests/http/wpt/webcodecs/flush-after-failing-decoder.html
+++ b/LayoutTests/http/wpt/webcodecs/flush-after-failing-decoder.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html>
+<header>
+<script src='/resources/testharness.js'></script>
+<script src='/resources/testharnessreport.js'></script>
+</header>
+<body>
+<script>
+promise_test(async t => {
+    const decoder = new VideoDecoder({
+        output: frame => { },
+        error: e => { }
+    });
+
+    decoder.configure({
+        codec: 'vp09.00.10.08',
+        codedWidth: 16,
+        codedHeight: 16,
+    });
+
+    decoder.decode(new EncodedVideoChunk({
+        timestamp: 0,
+        type: "key",
+        data: new ArrayBuffer(1024)
+    }));
+    await decoder.flush().then(() => { }, () => { });
+}, "Flush decoder that tried decoding bad data");
+</script>
+</body>
+</html>

--- a/Source/WebCore/platform/video-codecs/cocoa/WebRTCVideoDecoderVTB.mm
+++ b/Source/WebCore/platform/video-codecs/cocoa/WebRTCVideoDecoderVTB.mm
@@ -156,7 +156,8 @@ void WebRTCVideoDecoderVTB::setVideoFormat(RetainPtr<CMVideoFormatDescriptionRef
 
 void WebRTCVideoDecoderVTB::flush()
 {
-    protect(m_decoder)->flush();
+    if (RefPtr decoder = m_decoder)
+        decoder->flush();
     if (RefPtr queue = m_queue)
         queue->flush(m_callback.get());
 }


### PR DESCRIPTION
#### 5040f2d4b615dd1ed497f4d97a9827df960f08c8
<pre>
WebRTCVideoDecoderVTB::flush can be called with a null internal decoder
<a href="https://rdar.apple.com/175795592">rdar://175795592</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=313622">https://bugs.webkit.org/show_bug.cgi?id=313622</a>

Reviewed by Eric Carlson.

We need to check for m_decoder to be nullptr since flush can be called without having created a valid m_decoder.

Test: http/wpt/webcodecs/flush-after-failing-decoder.html
* LayoutTests/http/wpt/webcodecs/flush-after-failing-decoder-expected.txt: Added.
* LayoutTests/http/wpt/webcodecs/flush-after-failing-decoder.html: Added.
* Source/WebCore/platform/video-codecs/cocoa/WebRTCVideoDecoderVTB.mm:
(WebCore::WebRTCVideoDecoderVTB::flush):

Canonical link: <a href="https://commits.webkit.org/312296@main">https://commits.webkit.org/312296@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7cff0d0a907d97ad61439cc10202de0c9dc98aec

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/159433 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/32877 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/25969 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/168265 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/113811 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/9360590b-6f2a-4c3d-877e-798a24058dc6) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/161302 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/32929 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/32865 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/123532 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/86707 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/162390 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/25774 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/143200 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/104196 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/24834 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/23306 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/16036 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/134513 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/20980 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/170757 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/16791 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/22606 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/131735 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/32550 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/27372 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/131848 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35669 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/32494 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/142773 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/90621 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/26505 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/19582 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/32005 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/98457 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/31525 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/31798 "Built successfully") | | | | 
| | [❌ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/31680 "Hash 7cff0d0a for PR 63873 does not build (failure)") | | | | 
<!--EWS-Status-Bubble-End-->