### PR TITLE
Use protect() instead of Ref { } in applepay-ams-ui, mediacapabilities, and url-pattern code

### DIFF
--- a/Source/WebCore/Modules/applepay-ams-ui/ApplePayAMSUIPaymentHandler.cpp
+++ b/Source/WebCore/Modules/applepay-ams-ui/ApplePayAMSUIPaymentHandler.cpp
@@ -142,7 +142,7 @@ ExceptionOr<void> ApplePayAMSUIPaymentHandler::show(Document&)
 
 void ApplePayAMSUIPaymentHandler::hide()
 {
-    Ref { page() }->abortApplePayAMSUISession(*this);
+    protect(page())->abortApplePayAMSUISession(*this);
 }
 
 void ApplePayAMSUIPaymentHandler::canMakePayment(Document& document, Function<void(bool)>&& completionHandler)
@@ -171,7 +171,7 @@ ExceptionOr<void> ApplePayAMSUIPaymentHandler::complete(Document&, std::optional
 
 ExceptionOr<void> ApplePayAMSUIPaymentHandler::retry(PaymentValidationErrors&&)
 {
-    return show(Ref { document() }.get());
+    return show(protect(document()).get());
 }
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/mediacapabilities/MediaCapabilities.cpp
+++ b/Source/WebCore/Modules/mediacapabilities/MediaCapabilities.cpp
@@ -247,7 +247,7 @@ void MediaCapabilities::decodingInfo(ScriptExecutionContext& context, MediaDecod
     // 5. In parallel, run the create a MediaCapabilitiesInfo algorithm with configuration and resolve p with its result.
     // 6. Return p.
 
-    PlatformMediaEngineConfigurationFactory::DecodingConfigurationCallback callback = [promise = WTF::move(promise), context = Ref { context }](PlatformMediaCapabilitiesDecodingInfo&& info) mutable {
+    PlatformMediaEngineConfigurationFactory::DecodingConfigurationCallback callback = [promise = WTF::move(promise), context = protect(context)](PlatformMediaCapabilitiesDecodingInfo&& info) mutable {
         context->eventLoop().queueTask(TaskSource::MediaElement, [promise = WTF::move(promise), info = WTF::move(info)] mutable {
             promise->resolve<IDLDictionary<MediaCapabilitiesDecodingInfo>>(fromPlatform(WTF::move(info)));
         });
@@ -304,7 +304,7 @@ void MediaCapabilities::encodingInfo(ScriptExecutionContext& context, MediaEncod
     // 5. In parallel, run the create a MediaCapabilitiesInfo algorithm with configuration and resolve p with its result.
     // 6. Return p.
 
-    PlatformMediaEngineConfigurationFactory::EncodingConfigurationCallback callback = [promise = WTF::move(promise), context = Ref { context }](PlatformMediaCapabilitiesEncodingInfo&& info) mutable {
+    PlatformMediaEngineConfigurationFactory::EncodingConfigurationCallback callback = [promise = WTF::move(promise), context = protect(context)](PlatformMediaCapabilitiesEncodingInfo&& info) mutable {
         context->eventLoop().queueTask(TaskSource::MediaElement, [promise = WTF::move(promise), info = WTF::move(info)] () mutable {
             promise->resolve<IDLDictionary<MediaCapabilitiesEncodingInfo>>(fromPlatform(WTF::move(info)));
         });

--- a/Source/WebCore/Modules/url-pattern/URLPatternComponent.cpp
+++ b/Source/WebCore/Modules/url-pattern/URLPatternComponent.cpp
@@ -91,7 +91,7 @@ bool URLPatternComponent::matchSpecialSchemeProtocol(ScriptExecutionContext& con
         return false;
     auto protocolRegex = JSC::RegExpObject::create(vm, contextObject->regExpStructure(), m_regularExpression.get(), true);
 
-    auto isSchemeMatch = std::ranges::find_if(specialSchemeList, [context = Ref { context }, &vm, &protocolRegex](const String& scheme) {
+    auto isSchemeMatch = std::ranges::find_if(specialSchemeList, [context = protect(context), &vm, &protocolRegex](const String& scheme) {
         auto maybeMatch = protocolRegex->exec(context->globalObject(), JSC::jsString(vm, scheme));
         return !maybeMatch.isNull();
     });


### PR DESCRIPTION
#### 7de78360edc295f3a2bd0b11c063e029ec27422f
<pre>
Use protect() instead of Ref { } in applepay-ams-ui, mediacapabilities, and url-pattern code
<a href="https://bugs.webkit.org/show_bug.cgi?id=313624">https://bugs.webkit.org/show_bug.cgi?id=313624</a>
<a href="https://rdar.apple.com/175831255">rdar://175831255</a>

Reviewed by Abrar Rahman Protyasha.

Mechanical migration from Ref { expr } to protect(expr) in applepay-ams-ui,
mediacapabilities, and url-pattern code, aligning with the codebase-wide
transition away from brace-initialized smart pointer temporaries.

No new tests needed (no behavioral change, style-only refactor).

* Source/WebCore/Modules/applepay-ams-ui/ApplePayAMSUIPaymentHandler.cpp:
(WebCore::ApplePayAMSUIPaymentHandler::hide):
(WebCore::ApplePayAMSUIPaymentHandler::retry):
* Source/WebCore/Modules/mediacapabilities/MediaCapabilities.cpp:
(WebCore::MediaCapabilities::decodingInfo):
(WebCore::MediaCapabilities::encodingInfo):
* Source/WebCore/Modules/url-pattern/URLPatternComponent.cpp:
(WebCore::URLPatternComponent::patternMatchesSpecialScheme const):

Canonical link: <a href="https://commits.webkit.org/312321@main">https://commits.webkit.org/312321@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8c58b2039f3019d578be814acb7b4a73872c6568

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/159434 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/32862 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/25970 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/168266 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/113812 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/161303 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/32930 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/32850 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/123531 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/86708 "1 failures") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/162391 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/25776 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/143201 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/104195 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/24836 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/23285 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/16037 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/134533 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/20981 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/170758 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/16792 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/22607 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/131736 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/32703 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/27360 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/131849 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/32495 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/142774 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/90622 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/24287 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/26506 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/19583 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/32006 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/98458 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/31526 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/31799 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/31681 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->