### PR TITLE
[LBSE] Update geometry parsing expectations

### DIFF
--- a/LayoutTests/platform/mac-tahoe-wk2-lbse-text/imported/w3c/web-platform-tests/svg/geometry/parsing/height-computed-expected.txt
+++ b/LayoutTests/platform/mac-tahoe-wk2-lbse-text/imported/w3c/web-platform-tests/svg/geometry/parsing/height-computed-expected.txt
@@ -22,11 +22,11 @@ PASS SVG Geometry Properties: getComputedStyle().height, <foreignObject> inline 
 FAIL SVG Geometry Properties: getComputedStyle().height, <foreignObject> inline style (pixels) assert_equals: inline style (pixels) expected "75px" but got "0px"
 FAIL SVG Geometry Properties: getComputedStyle().height, <foreignObject> inline style (percentage) assert_equals: inline style (percentage) expected "50px" but got "0px"
 PASS SVG Geometry Properties: getComputedStyle().height, <foreignObject> inline style but "display: none"
-FAIL SVG Geometry Properties: getComputedStyle().height, <svg> initial assert_equals: initial expected "100px" but got "auto"
-PASS SVG Geometry Properties: getComputedStyle().height, <svg> presentation attribute
-FAIL SVG Geometry Properties: getComputedStyle().height, <svg> inline style (auto) assert_equals: inline style (auto) expected "100px" but got "auto"
+PASS SVG Geometry Properties: getComputedStyle().height, <svg> initial
+FAIL SVG Geometry Properties: getComputedStyle().height, <svg> presentation attribute assert_equals: presentation attribute expected "auto" but got "200px"
+PASS SVG Geometry Properties: getComputedStyle().height, <svg> inline style (auto)
 PASS SVG Geometry Properties: getComputedStyle().height, <svg> inline style (pixels)
-FAIL SVG Geometry Properties: getComputedStyle().height, <svg> inline style (percentage) assert_equals: inline style (percentage) expected "50px" but got "50%"
+PASS SVG Geometry Properties: getComputedStyle().height, <svg> inline style (percentage)
 PASS SVG Geometry Properties: getComputedStyle().height, <svg> inline style but "display: none"
 PASS SVG Geometry Properties: getComputedStyle().height, <g> initial
 FAIL SVG Geometry Properties: getComputedStyle().height, <g> initial (with dummy attribute) assert_equals: initial (with dummy attribute) expected "auto" but got "42px"

--- a/LayoutTests/platform/mac-tahoe-wk2-lbse-text/imported/w3c/web-platform-tests/svg/geometry/parsing/width-computed-expected.txt
+++ b/LayoutTests/platform/mac-tahoe-wk2-lbse-text/imported/w3c/web-platform-tests/svg/geometry/parsing/width-computed-expected.txt
@@ -22,11 +22,11 @@ FAIL SVG Geometry Properties: getComputedStyle().width, <foreignObject> inline s
 PASS SVG Geometry Properties: getComputedStyle().width, <foreignObject> inline style (auto)
 FAIL SVG Geometry Properties: getComputedStyle().width, <foreignObject> inline style (pixels) assert_equals: inline style (pixels) expected "75px" but got "0px"
 PASS SVG Geometry Properties: getComputedStyle().width, <foreignObject> inline style but "display: none"
-FAIL SVG Geometry Properties: getComputedStyle().width, <svg> initial assert_equals: initial expected "200px" but got "auto"
-PASS SVG Geometry Properties: getComputedStyle().width, <svg> presentation attribute
-FAIL SVG Geometry Properties: getComputedStyle().width, <svg> inline style (auto) assert_equals: inline style (auto) expected "200px" but got "auto"
+PASS SVG Geometry Properties: getComputedStyle().width, <svg> initial
+FAIL SVG Geometry Properties: getComputedStyle().width, <svg> presentation attribute assert_equals: presentation attribute expected "auto" but got "100px"
+PASS SVG Geometry Properties: getComputedStyle().width, <svg> inline style (auto)
 PASS SVG Geometry Properties: getComputedStyle().width, <svg> inline style (pixels)
-FAIL SVG Geometry Properties: getComputedStyle().width, <svg> inline style (percentage) assert_equals: inline style (percentage) expected "100px" but got "50%"
+PASS SVG Geometry Properties: getComputedStyle().width, <svg> inline style (percentage)
 PASS SVG Geometry Properties: getComputedStyle().width, <svg> inline style but "display: none"
 PASS SVG Geometry Properties: getComputedStyle().width, <g> initial
 FAIL SVG Geometry Properties: getComputedStyle().width, <g> initial (with dummy attribute) assert_equals: initial (with dummy attribute) expected "auto" but got "100px"


### PR DESCRIPTION
#### 23680ee1058b5e7d7c453d053ebf7a36575c7f09
<pre>
[LBSE] Update geometry parsing expectations
<a href="https://bugs.webkit.org/show_bug.cgi?id=313628">https://bugs.webkit.org/show_bug.cgi?id=313628</a>

Reviewed by Nikolas Zimmermann.

Update geometry parsing expectations after 312018@main.

* LayoutTests/platform/mac-tahoe-wk2-lbse-text/imported/w3c/web-platform-tests/svg/geometry/parsing/height-computed-expected.txt:
* LayoutTests/platform/mac-tahoe-wk2-lbse-text/imported/w3c/web-platform-tests/svg/geometry/parsing/width-computed-expected.txt:

Canonical link: <a href="https://commits.webkit.org/312273@main">https://commits.webkit.org/312273@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5e54153e3857dd95e9d5edde032759792ccdd42b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/159436 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/32864 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/25972 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/168268 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/113814 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/32932 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/32852 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/123533 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/113814 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/162393 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/25780 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/143208 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/104197 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/24840 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/23286 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/16039 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/134519 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/20988 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/170760 "Built successfully") | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/22614 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/131738 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/32553 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/27361 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/131851 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35654 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/32497 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/142781 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/90627 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/26508 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/19590 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/32008 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/31528 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/31801 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/31683 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->