### PR TITLE
[Site Isolation] http/tests/misc/will-send-request-returns-null-on-redirect.html fails

### DIFF
--- a/LayoutTests/platform/ios-site-isolation/TestExpectations
+++ b/LayoutTests/platform/ios-site-isolation/TestExpectations
@@ -170,7 +170,6 @@ http/tests/misc/authentication-redirect-3/authentication-sent-to-redirect-same-o
 http/tests/misc/authentication-redirect-4/authentication-sent-to-redirect-same-origin-url.html [ Failure ]
 http/tests/misc/iframe-beforeunload-dialog-not-matching-ancestor-securityorigin.html [ Failure ]
 http/tests/misc/webtiming-ssl.py [ Failure ]
-http/tests/misc/will-send-request-returns-null-on-redirect.html [ Failure ]
 http/tests/navigation/cross-origin-navigation-fires-onload.html [ Failure ]
 http/tests/navigation/cross-site-iframe-nav-with-bfcache.html [ Failure ]
 http/tests/navigation/fetch-pagecache.html [ Failure ]

--- a/LayoutTests/platform/mac-site-isolation/TestExpectations
+++ b/LayoutTests/platform/mac-site-isolation/TestExpectations
@@ -182,7 +182,6 @@ http/tests/misc/authentication-redirect-3/authentication-sent-to-redirect-same-o
 http/tests/misc/authentication-redirect-4/authentication-sent-to-redirect-same-origin-url.html [ Failure ]
 http/tests/misc/iframe-beforeunload-dialog-not-matching-ancestor-securityorigin.html [ Failure ]
 http/tests/misc/webtiming-ssl.py [ Failure ]
-http/tests/misc/will-send-request-returns-null-on-redirect.html [ Failure ]
 http/tests/navigation/cross-origin-navigation-fires-onload.html [ Failure ]
 http/tests/navigation/cross-site-iframe-nav-with-bfcache.html [ Failure ]
 http/tests/navigation/fetch-pagecache.html [ Failure ]

--- a/Source/WebKit/UIProcess/API/C/WKNavigationActionRef.cpp
+++ b/Source/WebKit/UIProcess/API/C/WKNavigationActionRef.cpp
@@ -65,3 +65,21 @@ WK_EXPORT bool WKNavigationActionHasUnconsumedUserGesture(WKNavigationActionRef 
 {
     return WebKit::toImpl(action)->isProcessingUnconsumedUserGesture();
 }
+
+bool WKNavigationActionIsRedirect(WKNavigationActionRef action)
+{
+    return WebKit::toImpl(action)->isRedirect();
+}
+
+WKURLRef WKNavigationActionCopyRedirectResponseURL(WKNavigationActionRef action)
+{
+    auto& response = WebKit::toImpl(action)->data().redirectResponse;
+    if (response.isNull())
+        return nullptr;
+    return WebKit::toCopiedURLAPI(response.url());
+}
+
+int WKNavigationActionGetRedirectResponseStatusCode(WKNavigationActionRef action)
+{
+    return WebKit::toImpl(action)->data().redirectResponse.httpStatusCode();
+}

--- a/Source/WebKit/UIProcess/API/C/WKNavigationActionRef.h
+++ b/Source/WebKit/UIProcess/API/C/WKNavigationActionRef.h
@@ -41,6 +41,9 @@ WK_EXPORT bool WKNavigationActionGetShouldOpenExternalSchemes(WKNavigationAction
 WK_EXPORT WKFrameInfoRef WKNavigationActionCopyTargetFrameInfo(WKNavigationActionRef action);
 WK_EXPORT WKFrameNavigationType WKNavigationActionGetNavigationType(WKNavigationActionRef action);
 WK_EXPORT bool WKNavigationActionHasUnconsumedUserGesture(WKNavigationActionRef action);
+WK_EXPORT bool WKNavigationActionIsRedirect(WKNavigationActionRef action);
+WK_EXPORT WKURLRef WKNavigationActionCopyRedirectResponseURL(WKNavigationActionRef action);
+WK_EXPORT int WKNavigationActionGetRedirectResponseStatusCode(WKNavigationActionRef action);
 
 #ifdef __cplusplus
 }

--- a/Tools/WebKitTestRunner/InjectedBundle/InjectedBundle.cpp
+++ b/Tools/WebKitTestRunner/InjectedBundle/InjectedBundle.cpp
@@ -377,6 +377,11 @@ void InjectedBundle::beginTesting(WKDictionaryRef settings, BegingTestingMode te
     if (m_timeout > 0_s)
         m_testRunner->setCustomTimeout(m_timeout);
 
+    if (booleanValue(settings, "WillSendRequestReturnsNullOnRedirect"))
+        m_testRunner->setWillSendRequestReturnsNullOnRedirect(true);
+    if (booleanValue(settings, "DumpResourceLoadCallbacks"))
+        m_testRunner->dumpResourceLoadCallbacks();
+
     if (testingMode != BegingTestingMode::New)
         return;
 

--- a/Tools/WebKitTestRunner/InjectedBundle/InjectedBundlePage.cpp
+++ b/Tools/WebKitTestRunner/InjectedBundle/InjectedBundlePage.cpp
@@ -907,13 +907,13 @@ WKURLRequestRef InjectedBundlePage::willSendRequestForFrame(WKBundlePageRef page
             mainFrameIsExternal = isMainFrameURLExternal(mainFrameURL.get());
         }
         if (!mainFrameIsExternal && !isAllowedHost(host.get())) {
+            auto blockedURL = sanitizeExternalURL(urlString.get());
             JSGlobalContextRef jsContext = WKBundleFrameGetJavaScriptContext(frame);
             if (!jsContext) {
-                WKRetain(request);
-                return request;
+                injectedBundle.outputText(makeString("CONSOLE MESSAGE: Blocked access to external URL "_s, blockedURL, '\n'));
+                return nullptr;
             }
 
-            auto blockedURL = sanitizeExternalURL(urlString.get());
             auto script = makeString("console.log('Blocked access to external URL "_s, blockedURL, "');"_s);
             auto scriptRef = adopt(JSStringCreateWithUTF8CString(script.utf8().data()));
             JSEvaluateScript(jsContext, scriptRef.get(), 0, 0, 0, 0);
@@ -997,6 +997,9 @@ void InjectedBundlePage::didFailLoadForResource(WKBundlePageRef, WKBundleFrameRe
         return;
 
     if (!testRunner->shouldDumpResourceLoadCallbacks())
+        return;
+
+    if (testRunner->willSendRequestReturnsNullOnRedirect() && WKErrorGetErrorCode(error) == kWKErrorCodeFrameLoadInterruptedByPolicyChange)
         return;
 
     StringBuilder stringBuilder;

--- a/Tools/WebKitTestRunner/InjectedBundle/TestRunner.cpp
+++ b/Tools/WebKitTestRunner/InjectedBundle/TestRunner.cpp
@@ -922,6 +922,18 @@ void TestRunner::dumpPolicyDelegateCallbacks()
     postMessage("DumpPolicyDelegateCallbacks");
 }
 
+void TestRunner::setWillSendRequestReturnsNullOnRedirect(bool f)
+{
+    m_willSendRequestReturnsNullOnRedirect = f;
+    postMessage("SetWillSendRequestReturnsNullOnRedirect", f);
+}
+
+void TestRunner::dumpResourceLoadCallbacks()
+{
+    m_dumpResourceLoadCallbacks = true;
+    postMessage("SetDumpResourceLoadCallbacks");
+}
+
 bool TestRunner::isStatisticsPrevalentResource(JSStringRef hostName)
 {
     return postSynchronousPageMessageReturningBoolean("IsStatisticsPrevalentResource", hostName);

--- a/Tools/WebKitTestRunner/InjectedBundle/TestRunner.h
+++ b/Tools/WebKitTestRunner/InjectedBundle/TestRunner.h
@@ -138,7 +138,7 @@ public:
     void dumpTitleChanges() { m_dumpTitleChanges = true; }
     void dumpFrameLoadCallbacks() { setShouldDumpFrameLoadCallbacks(true); }
     void dumpProgressFinishedCallback() { setShouldDumpProgressFinishedCallback(true); }
-    void dumpResourceLoadCallbacks() { m_dumpResourceLoadCallbacks = true; }
+    void dumpResourceLoadCallbacks();
     void dumpResourceResponseMIMETypes() { m_dumpResourceResponseMIMETypes = true; }
     void dumpWillCacheResponse() { m_dumpWillCacheResponse = true; }
     void dumpApplicationCacheDelegateCallbacks() { m_dumpApplicationCacheDelegateCallbacks = true; }
@@ -259,7 +259,7 @@ public:
     bool willSendRequestReturnsNull() const { return m_willSendRequestReturnsNull; }
     void setWillSendRequestReturnsNull(bool f) { m_willSendRequestReturnsNull = f; }
     bool willSendRequestReturnsNullOnRedirect() const { return m_willSendRequestReturnsNullOnRedirect; }
-    void setWillSendRequestReturnsNullOnRedirect(bool f) { m_willSendRequestReturnsNullOnRedirect = f; }
+    void setWillSendRequestReturnsNullOnRedirect(bool);
     void setWillSendRequestAddsHTTPBody(JSStringRef body) { m_willSendRequestHTTPBody = toWTFString(body); }
     String willSendRequestHTTPBody() const { return m_willSendRequestHTTPBody; }
 

--- a/Tools/WebKitTestRunner/TestController.cpp
+++ b/Tools/WebKitTestRunner/TestController.cpp
@@ -1624,6 +1624,8 @@ bool TestController::resetStateToConsistentValues(const TestOptions& options, Re
     m_downloadIndex = 0;
     m_shouldDownloadContentDispositionAttachments = true;
     m_dumpPolicyDelegateCallbacks = false;
+    m_willSendRequestReturnsNullOnRedirect = false;
+    m_dumpResourceLoadCallbacks = false;
     m_dumpFullScreenCallbacks = false;
     m_waitBeforeFinishingFullscreenExit = false;
     m_scrollDuringEnterFullscreen = false;
@@ -4260,6 +4262,37 @@ void TestController::decidePolicyForNavigationAction(WKPageRef page, WKNavigatio
 
     auto request = adoptWK(WKNavigationActionCopyRequest(navigationAction));
     auto targetFrame = adoptWK(WKNavigationActionCopyTargetFrameInfo(navigationAction));
+
+    // Under site isolation, a cross-site redirect in a subframe triggers a process swap before the
+    // injected bundle's willSendRequestForFrame can handle it. When willSendRequestReturnsNullOnRedirect
+    // is set, emulate the injected bundle's output (willSendRequest + "Returning null for this redirect"
+    // + didFailLoadingWithError) and block the navigation to produce identical output as without site isolation.
+    if (targetFrame && !WKFrameInfoGetIsMainFrame(targetFrame.get()) && m_willSendRequestReturnsNullOnRedirect && protectedCurrentInvocation()->options().siteIsolationEnabled() && WKNavigationActionIsRedirect(navigationAction)) {
+        if (auto url = adoptWK(WKURLRequestCopyURL(request.get()))) {
+            auto host = adoptWK(WKURLCopyHostName(url.get()));
+            auto scheme = adoptWK(WKURLCopyScheme(url.get()));
+            if (isExternalURLBlockable(host.get(), scheme.get()) && !m_allowedHosts.count(toSTD(host))) {
+                auto redirectResponseURL = adoptWK(WKNavigationActionCopyRedirectResponseURL(navigationAction));
+                auto redirectResponseStatusCode = WKNavigationActionGetRedirectResponseStatusCode(navigationAction);
+                auto redirectResponseURLString = redirectResponseURL ? toWTFString(adoptWK(WKURLCopyString(redirectResponseURL.get()))) : "(null)"_s;
+
+                StringBuilder output;
+                if (m_dumpResourceLoadCallbacks) {
+                    output.append(redirectResponseURLString, " - willSendRequest "_s, string(request.get(), page),
+                        " redirectResponse <NSURLResponse "_s, redirectResponseURLString,
+                        ", http status code "_s, redirectResponseStatusCode, ">\n"_s);
+                }
+                output.append("Returning null for this redirect\n"_s);
+                if (m_dumpResourceLoadCallbacks) {
+                    output.append(redirectResponseURLString,
+                        " - didFailLoadingWithError: <NSError domain NSURLErrorDomain, code -999>\n"_s);
+                }
+                protectedCurrentInvocation()->outputText(output.toString());
+                WKFramePolicyListenerIgnore(listener);
+                return;
+            }
+        }
+    }
 
     // Block access to external URLs in subframe navigations when site isolation is enabled.
     // With site isolation, the injected bundle's willSendRequestForFrame callback cannot emit

--- a/Tools/WebKitTestRunner/TestController.h
+++ b/Tools/WebKitTestRunner/TestController.h
@@ -201,6 +201,10 @@ public:
     void setPluginSupportedMode(const String&);
 
     void dumpPolicyDelegateCallbacks() { m_dumpPolicyDelegateCallbacks = true; }
+    void setWillSendRequestReturnsNullOnRedirect(bool f) { m_willSendRequestReturnsNullOnRedirect = f; }
+    bool willSendRequestReturnsNullOnRedirect() const { return m_willSendRequestReturnsNullOnRedirect; }
+    void setDumpResourceLoadCallbacks(bool f) { m_dumpResourceLoadCallbacks = f; }
+    bool shouldDumpResourceLoadCallbacks() const { return m_dumpResourceLoadCallbacks; }
     void dumpFullScreenCallbacks() { m_dumpFullScreenCallbacks = true; }
     void waitBeforeFinishingFullscreenExit() { m_waitBeforeFinishingFullscreenExit = true; }
     void scrollDuringEnterFullscreen() { m_scrollDuringEnterFullscreen = true; }
@@ -884,6 +888,8 @@ private:
     size_t m_downloadIndex { 0 };
     bool m_shouldDownloadContentDispositionAttachments { true };
     bool m_dumpPolicyDelegateCallbacks { false };
+    bool m_willSendRequestReturnsNullOnRedirect { false };
+    bool m_dumpResourceLoadCallbacks { false };
     bool m_dumpFullScreenCallbacks { false };
     bool m_waitBeforeFinishingFullscreenExit { false };
     bool m_scrollDuringEnterFullscreen { false };

--- a/Tools/WebKitTestRunner/TestInvocation.cpp
+++ b/Tools/WebKitTestRunner/TestInvocation.cpp
@@ -143,6 +143,8 @@ WKRetainPtr<WKMutableDictionaryRef> TestInvocation::createTestSettingsDictionary
     for (auto& host : TestController::singleton().allowedHosts())
         WKArrayAppendItem(allowedHostsValue.get(), toWK(host.c_str()).get());
     setValue(beginTestMessageBody, "AllowedHosts", allowedHostsValue);
+    setValue(beginTestMessageBody, "WillSendRequestReturnsNullOnRedirect", TestController::singleton().willSendRequestReturnsNullOnRedirect());
+    setValue(beginTestMessageBody, "DumpResourceLoadCallbacks", TestController::singleton().shouldDumpResourceLoadCallbacks());
 #if ENABLE(VIDEO)
     setValue(beginTestMessageBody, "CaptionDisplayMode", options().captionDisplayMode().c_str());
 #endif
@@ -538,6 +540,16 @@ void TestInvocation::didReceiveMessageFromInjectedBundle(WKStringRef messageName
 
     if (WKStringIsEqualToUTF8CString(messageName, "DumpPolicyDelegateCallbacks")) {
         TestController::singleton().dumpPolicyDelegateCallbacks();
+        return;
+    }
+
+    if (WKStringIsEqualToUTF8CString(messageName, "SetWillSendRequestReturnsNullOnRedirect")) {
+        TestController::singleton().setWillSendRequestReturnsNullOnRedirect(booleanValue(messageBody));
+        return;
+    }
+
+    if (WKStringIsEqualToUTF8CString(messageName, "SetDumpResourceLoadCallbacks")) {
+        TestController::singleton().setDumpResourceLoadCallbacks(true);
         return;
     }
 


### PR DESCRIPTION
#### c201cdc89dc102fcbd7295f6faf67d5c2e699b9e
<pre>
[Site Isolation] http/tests/misc/will-send-request-returns-null-on-redirect.html fails
<a href="https://bugs.webkit.org/show_bug.cgi?id=313630">https://bugs.webkit.org/show_bug.cgi?id=313630</a>

Reviewed by NOBODY (OOPS!).

Under site isolation, when a subframe navigates to a URL that returns a cross-site 302 redirect
(e.g., 127.0.0.1 to <a href="http://www.example.com)">http://www.example.com)</a>, WebKit triggers a process swap at the UI process level
before the web process&apos;s willSendRequestForFrame callback fires. This means the InjectedBundle
never sees the redirect — it can&apos;t return null to cancel the load or produce the expected resource
load callback output. Instead the original process gets a &quot;frame load interrupted&quot; error (code 102),
and the new process starts a fresh navigation (not a redirect) to the external URL. This caused the
differences in the test output.

This PR implements a few fixes.

  1. Flag propagation: When test JS calls testRunner.setWillSendRequestReturnsNullOnRedirect(true)
     or testRunner.dumpResourceLoadCallbacks(), the InjectedBundle posts messages to TestController
     so the UI process knows about these flags. TestController includes them in the settings sent
     to new processes during site-isolation process swaps, and resets them between tests.

  2. Redirect emulation in TestController: Added three C APIs (WKNavigationActionIsRedirect,
     WKNavigationActionCopyRedirectResponseURL, WKNavigationActionGetRedirectResponseStatusCode) to
     expose redirect information from the navigation action. In decidePolicyForNavigationAction,
     when willSendRequestReturnsNullOnRedirect is set and the navigation is a cross-site redirect
     in a subframe, TestController emulates the InjectedBundle&apos;s output - the willSendRequest line
     with redirect response details, &quot;Returning null for this redirect&quot;, and
     didFailLoadingWithError with NSURLErrorDomain -999 - then blocks the navigation. This produces
     output identical to the non-site-isolation path.

  3. Error suppression in old process: The original process still receives a didFailLoadForResource
     with error code 102 (frame load interrupted by policy change) when the redirect is blocked.
     This is suppressed when willSendRequestReturnsNullOnRedirect is set, since TestController
     already emitted the correct error line.

  4. jsContext null fix: When WKBundleFrameGetJavaScriptContext returns null for provisional frames
     in new processes, the external URL blocking code now uses outputText and returns nullptr
     instead of silently allowing the request through.

Test: http/tests/misc/will-send-request-returns-null-on-redirect.html

* LayoutTests/platform/ios-site-isolation/TestExpectations:
* LayoutTests/platform/mac-site-isolation/TestExpectations:
* Source/WebKit/UIProcess/API/C/WKNavigationActionRef.cpp:
(WKNavigationActionIsRedirect):
(WKNavigationActionCopyRedirectResponseURL):
(WKNavigationActionGetRedirectResponseStatusCode):
* Source/WebKit/UIProcess/API/C/WKNavigationActionRef.h:
* Tools/WebKitTestRunner/InjectedBundle/InjectedBundle.cpp:
(WTR::InjectedBundle::beginTesting):
* Tools/WebKitTestRunner/InjectedBundle/InjectedBundlePage.cpp:
(WTR::InjectedBundlePage::willSendRequestForFrame):
(WTR::InjectedBundlePage::didFailLoadForResource):
* Tools/WebKitTestRunner/InjectedBundle/TestRunner.cpp:
(WTR::TestRunner::setWillSendRequestReturnsNullOnRedirect):
(WTR::TestRunner::dumpResourceLoadCallbacks):
* Tools/WebKitTestRunner/InjectedBundle/TestRunner.h:
(WTR::TestRunner::dumpResourceLoadCallbacks): Deleted.
(WTR::TestRunner::setWillSendRequestReturnsNullOnRedirect): Deleted.
* Tools/WebKitTestRunner/TestController.cpp:
(WTR::TestController::resetStateToConsistentValues):
* Tools/WebKitTestRunner/TestController.h:
(WTR::TestController::setWillSendRequestReturnsNullOnRedirect):
(WTR::TestController::willSendRequestReturnsNullOnRedirect const):
(WTR::TestController::setDumpResourceLoadCallbacks):
(WTR::TestController::shouldDumpResourceLoadCallbacks const):
* Tools/WebKitTestRunner/TestInvocation.cpp:
(WTR::TestInvocation::createTestSettingsDictionary):
(WTR::TestInvocation::didReceiveMessageFromInjectedBundle):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c201cdc89dc102fcbd7295f6faf67d5c2e699b9e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/159440 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/32868 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/25976 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/168272 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/113818 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/161309 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/32936 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/32856 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/123536 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/86712 "1 flakes 1 failures") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/162397 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/25779 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/143204 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/104200 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/24839 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/23289 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/16043 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/134535 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/20984 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/170764 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/16798 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/22610 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/131742 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/32557 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/27364 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/131854 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/32501 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/142777 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/90635 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/26516 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/19586 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/32012 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/98464 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/31532 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/31805 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/31687 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->