### PR TITLE
[WPE][GTK] Instantiate Vulkan device for the current display

### DIFF
--- a/Source/WebCore/platform/graphics/vulkan/VulkanTypes.cpp
+++ b/Source/WebCore/platform/graphics/vulkan/VulkanTypes.cpp
@@ -90,6 +90,80 @@ void PhysicalDevice::fillProperties(PhysicalDeviceProperties& properties) const
     vkGetPhysicalDeviceProperties2(m_inner, properties.ptr());
 }
 
+Vector<QueueFamilyProperties> PhysicalDevice::queueFamilies() const
+{
+    uint32_t queueFamilyCount;
+    vkGetPhysicalDeviceQueueFamilyProperties(m_inner, &queueFamilyCount, nullptr);
+
+    Vector<QueueFamilyProperties> queueFamilies(queueFamilyCount);
+    static_assert(sizeof(QueueFamilyProperties) == sizeof(VkQueueFamilyProperties));
+    auto queueFamiliesSpan = spanReinterpretCast<VkQueueFamilyProperties>(queueFamilies.mutableSpan());
+    ASSERT(queueFamiliesSpan.size() == queueFamilyCount);
+    vkGetPhysicalDeviceQueueFamilyProperties(m_inner, &queueFamilyCount, queueFamiliesSpan.data());
+
+    return queueFamilies;
+}
+
+DeviceQueueCreateInfo::DeviceQueueCreateInfo(uint32_t familyIndex, std::span<const float> queuePriorities)
+{
+    m_inner.queueFamilyIndex = familyIndex;
+    m_inner.queueCount = queuePriorities.size();
+    m_inner.pQueuePriorities = queuePriorities.data();
+}
+
+DeviceCreateInfo::DeviceCreateInfo(const DeviceQueueCreateInfo& queueCreateInfo, std::span<const char* const> enabledExtensions)
+{
+    m_inner.queueCreateInfoCount = 1;
+    m_inner.pQueueCreateInfos = queueCreateInfo.ptr();
+
+    m_inner.enabledExtensionCount = enabledExtensions.size();
+    m_inner.ppEnabledExtensionNames = enabledExtensions.data();
+}
+
+Device::Device(VkDevice inner)
+    : Base(WTF::move(inner))
+{
+    volkLoadDeviceTable(&m_table, m_inner);
+}
+
+Device::~Device()
+{
+    if (m_inner) {
+        ASSERT(m_table.vkDestroyDevice);
+        m_table.vkDestroyDevice(m_inner, nullptr);
+    }
+}
+
+Result<Device> Device::create(PhysicalDevice& deviceInfo, const DeviceCreateInfo& creationInfo)
+{
+    VkDevice device;
+    if (auto result = vkCreateDevice(*deviceInfo.ptr(), creationInfo.ptr(), nullptr, &device); result != VK_SUCCESS)
+        return makeUnexpected(result);
+
+    return Device(device);
+}
+
+Device Device::s_sharedDevice { StaticAllocation };
+
+void Device::setSharedDevice(Device&& device)
+{
+    if (s_sharedDevice.m_inner)
+        RELEASE_ASSERT_NOT_REACHED_WITH_MESSAGE("Attempted to reset already initialized Vulkan shared device");
+    s_sharedDevice = WTF::move(device);
+}
+
+Device* Device::sharedDeviceIfExists()
+{
+    return s_sharedDevice.m_inner ? &s_sharedDevice : nullptr;
+}
+
+Device& Device::sharedDevice()
+{
+    if (!s_sharedDevice.m_inner) [[unlikely]]
+        RELEASE_ASSERT_NOT_REACHED_WITH_MESSAGE("Attempted to use Vulkan shared device before its initialization");
+    return s_sharedDevice;
+}
+
 const Vector<VkLayerProperties>& Instance::availableLayers()
 {
     static const auto layerProperties = ([]() -> Vector<VkLayerProperties> {

--- a/Source/WebCore/platform/graphics/vulkan/VulkanTypes.h
+++ b/Source/WebCore/platform/graphics/vulkan/VulkanTypes.h
@@ -26,6 +26,11 @@
 #pragma once
 
 #if USE(VULKAN)
+// The Volk header can leave device functions undefined to prevent accidental
+// usage. Instead, use the per-device functions table to avoid the dispatch
+// overhead (up to 7%), see https://github.com/zeux/volk#optimizing-device-calls
+#define VOLK_NO_DEVICE_PROTOTYPES
+
 #include <expected>
 #include <volk.h>
 #include <wtf/Noncopyable.h>
@@ -141,6 +146,15 @@ struct InstanceCreateInfo : Structure<VkInstanceCreateInfo, VK_STRUCTURE_TYPE_IN
     InstanceCreateInfo(const ApplicationInfo& applicationInfo LIFETIME_BOUND, std::span<const char* const> enabledLayers LIFETIME_BOUND = { }, std::span<const char* const> enabledExtensions LIFETIME_BOUND = { });
 };
 
+struct QueueFamilyProperties : BaseStruct<VkQueueFamilyProperties> {
+    const VkQueueFamilyProperties* LIFETIME_BOUND operator->() const { return &m_inner; }
+    VkQueueFamilyProperties* LIFETIME_BOUND operator->() { return &m_inner; }
+};
+
+struct DeviceQueueCreateInfo : Structure<VkDeviceQueueCreateInfo, VK_STRUCTURE_TYPE_DEVICE_QUEUE_CREATE_INFO> {
+    DeviceQueueCreateInfo(uint32_t familyIndex, std::span<const float> queuePriorities);
+};
+
 struct PhysicalDeviceProperties : Structure<VkPhysicalDeviceProperties2, VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PROPERTIES_2> {
     const VkPhysicalDeviceProperties* LIFETIME_BOUND operator->() const { return &m_inner.properties; }
     VkPhysicalDeviceProperties* LIFETIME_BOUND operator->() { return &m_inner.properties; }
@@ -156,6 +170,7 @@ struct PhysicalDeviceIDProperties : Structure<VkPhysicalDeviceIDProperties, VK_S
 
 struct PhysicalDevice : BaseStruct<VkPhysicalDevice> {
     void fillProperties(PhysicalDeviceProperties&) const;
+    Vector<QueueFamilyProperties> queueFamilies() const;
 
     PhysicalDevice() = default;
 
@@ -165,6 +180,47 @@ struct PhysicalDevice : BaseStruct<VkPhysicalDevice> {
         : BaseStruct(const_cast<VkPhysicalDevice>(other.m_inner))
     {
     }
+};
+
+struct DeviceCreateInfo : Structure<VkDeviceCreateInfo, VK_STRUCTURE_TYPE_DEVICE_CREATE_INFO> {
+    DeviceCreateInfo(const DeviceQueueCreateInfo&, std::span<const char* const> enabledExtensions = { });
+};
+
+struct Device : BaseStruct<VkDevice> {
+    [[nodiscard]] static Result<Device> create(PhysicalDevice&, const DeviceCreateInfo&);
+    ~Device();
+
+    Device(Device&& other)
+    {
+        *this = WTF::move(other);
+    }
+
+    Device& operator=(Device&& other)
+    {
+        if (this != &other) {
+            std::swap(m_inner, other.m_inner);
+            std::swap(m_table, other.m_table);
+        }
+        return *this;
+    }
+
+    static void setSharedDevice(Device&&);
+    [[nodiscard]] static Device* sharedDeviceIfExists();
+    [[nodiscard]] static Device& sharedDevice();
+
+private:
+    Device(VkDevice);
+
+    // Needed to avoid calling volkLoadDeviceTable() on a null pointer.
+    enum StaticAllocationTag { StaticAllocation };
+    Device(StaticAllocationTag)
+        : Base(nullptr)
+    {
+    }
+
+    VolkDeviceTable m_table;
+
+    static Device s_sharedDevice;
 };
 
 struct Instance : BaseStruct<VkInstance> {

--- a/Source/WebCore/platform/graphics/vulkan/VulkanUtilities.cpp
+++ b/Source/WebCore/platform/graphics/vulkan/VulkanUtilities.cpp
@@ -249,17 +249,42 @@ void initializeIfNeeded()
     }
 #endif // VK_EXT_debug_utils
 
-    auto device = instance->deviceForDisplay(PlatformDisplay::sharedDisplay());
-    if (!device) {
-        RELEASE_LOG_ERROR(Vulkan, "Cannot find device for EGL display: %s (%d)", Vulkan::resultString(device), device.error());
+    auto deviceInfo = instance->deviceForDisplay(PlatformDisplay::sharedDisplay());
+    if (!deviceInfo) {
+        RELEASE_LOG_ERROR(Vulkan, "Cannot find device for EGL display: %s (%d)", Vulkan::resultString(deviceInfo), deviceInfo.error());
         return;
     }
 
     PhysicalDeviceProperties properties;
-    device->fillProperties(properties);
+    deviceInfo->fillProperties(properties);
     RELEASE_LOG(Vulkan, "Found device for EGL display: %s", properties->deviceName);
 
+    const auto queueFamilies = deviceInfo->queueFamilies();
+    auto queueIndex = queueFamilies.findIf([](const auto& queueProperties) {
+        return queueProperties->queueFlags & VK_QUEUE_GRAPHICS_BIT;
+    });
+    if (queueIndex == notFound) {
+        RELEASE_LOG_ERROR(Vulkan, "Cannot find graphics queue family");
+        return;
+    }
+
+    RELEASE_ASSERT(queueIndex <= std::numeric_limits<uint32_t>::max());
+    static constexpr float queuePriorities[] = { 0.0f };
+    DeviceQueueCreateInfo queueCreateInfo { static_cast<uint32_t>(queueIndex), std::span(queuePriorities) };
+
+    Vector<const char*, 2> deviceExtensions = {
+        VK_KHR_EXTERNAL_MEMORY_FD_EXTENSION_NAME,
+    };
+    auto device = Device::create(*deviceInfo, { queueCreateInfo, deviceExtensions.span() });
+    if (!device) {
+        RELEASE_LOG_ERROR(Vulkan, "Cannot instantiate device: %s (%d)", Vulkan::resultString(device), device.error());
+        return;
+    }
+
+    RELEASE_LOG(Vulkan, "Instantiated device %p", *device->ptr());
+
     Instance::setSharedInstance(WTF::move(*instance));
+    Device::setSharedDevice(WTF::move(*device));
 }
 
 } // namespace Vulkan


### PR DESCRIPTION
#### 12910db6408bf2aaa3d81309016ad6aed1d5374b
<pre>
[WPE][GTK] Instantiate Vulkan device for the current display
<a href="https://bugs.webkit.org/show_bug.cgi?id=313633">https://bugs.webkit.org/show_bug.cgi?id=313633</a>

Reviewed by Nikolas Zimmermann.

Define the Vulkan types needed to create a device and add the needed
bits to instantiate the chosen one.

* Source/WebCore/platform/graphics/vulkan/VulkanTypes.cpp:
(WebCore::Vulkan::PhysicalDevice::queueFamilies const):
(WebCore::Vulkan::DeviceQueueCreateInfo::DeviceQueueCreateInfo):
(WebCore::Vulkan::DeviceCreateInfo::DeviceCreateInfo):
(WebCore::Vulkan::Device::Device):
(WebCore::Vulkan::Device::~Device):
(WebCore::Vulkan::Device::create):
(WebCore::Vulkan::Device::setSharedDevice):
(WebCore::Vulkan::Device::sharedDeviceIfExists):
(WebCore::Vulkan::Device::sharedDevice):
* Source/WebCore/platform/graphics/vulkan/VulkanTypes.h:
(WebCore::Vulkan::QueueFamilyProperties::operator-&gt; const):
(WebCore::Vulkan::QueueFamilyProperties::operator-&gt;):
(WebCore::Vulkan::DeviceCreateInfo::DeviceCreateInfo):
(WebCore::Vulkan::Device::Device):
(WebCore::Vulkan::Device::operator=):
* Source/WebCore/platform/graphics/vulkan/VulkanUtilities.cpp:
(WebCore::Vulkan::initializeIfNeeded):

Canonical link: <a href="https://commits.webkit.org/312675@main">https://commits.webkit.org/312675@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/78b39f88fd55e9b1a6f11348d5583722ba3b47ec

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/160801 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/34274 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/27375 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/169704 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/115867 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/162670 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/34375 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/34274 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/169704 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/115867 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/163760 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/26971 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/144442 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/169704 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/26023 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/24522 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk3-libwebrtc~~](https://ews-build.webkit.org/#/builders/173/builds/17424 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/135717 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/167/builds/22205 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/172186 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/19208 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/23846 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/172186 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/33948 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/28614 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/172186 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/33932 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/144000 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/95749 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/24453 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/164/builds/27589 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/20815 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/33443 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/100868 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/32942 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/33186 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/33090 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->