### PR TITLE
[JSC] Extract fields of descriptor in Object.defineProperty in DFG / FTL

### DIFF
--- a/JSTests/microbenchmarks/define-property-accessor.js
+++ b/JSTests/microbenchmarks/define-property-accessor.js
@@ -1,0 +1,11 @@
+function test(base, get, set)
+{
+    Object.defineProperty(base, "hey", {
+        get,
+        set,
+    });
+}
+noInline(test);
+
+for (var i = 0; i < testLoopCount; ++i)
+    test({ }, function get() { return 42 }, function set() { });

--- a/JSTests/microbenchmarks/define-property-data.js
+++ b/JSTests/microbenchmarks/define-property-data.js
@@ -1,0 +1,11 @@
+function test(base, value)
+{
+    Object.defineProperty(base, "hey", {
+        value: value,
+        writable: true,
+    });
+}
+noInline(test);
+
+for (var i = 0; i < testLoopCount; ++i)
+    test({ }, "property");

--- a/JSTests/microbenchmarks/define-property-getter-only.js
+++ b/JSTests/microbenchmarks/define-property-getter-only.js
@@ -1,0 +1,10 @@
+function test(base, get)
+{
+    Object.defineProperty(base, "hey", {
+        get,
+    });
+}
+noInline(test);
+
+for (var i = 0; i < testLoopCount; ++i)
+    test({ }, function get() { return 42 });

--- a/JSTests/microbenchmarks/define-property-setter-only.js
+++ b/JSTests/microbenchmarks/define-property-setter-only.js
@@ -1,0 +1,10 @@
+function test(base, set)
+{
+    Object.defineProperty(base, "hey", {
+        set,
+    });
+}
+noInline(test);
+
+for (var i = 0; i < testLoopCount; ++i)
+    test({ }, function set(v) { });

--- a/JSTests/microbenchmarks/object-define-property-put-by-id-direct.js
+++ b/JSTests/microbenchmarks/object-define-property-put-by-id-direct.js
@@ -1,0 +1,20 @@
+// Exercises the Object.defineProperty(fresh, key, { value, writable:true,
+// enumerable:true, configurable:true }) pattern. With a fresh object and
+// all-default attributes, the DFG/FTL ConstantFolding lowers the
+// ObjectDefineProperty → ObjectDefinePropertyFromFields →
+// DefineDataProperty → PutByIdDirect chain, so this should run through
+// the PutById inline cache on hot paths.
+
+function bench() {
+    var sum = 0;
+    for (var i = 0; i < 1000000; i++) {
+        var obj = {};
+        Object.defineProperty(obj, "prop", { value: i, writable: true, enumerable: true, configurable: true });
+        sum += obj.prop;
+    }
+    return sum;
+}
+
+var result = bench();
+if (result !== 499999500000)
+    throw new Error("Bad result: " + result);

--- a/JSTests/stress/object-define-property-fields-refinement.js
+++ b/JSTests/stress/object-define-property-fields-refinement.js
@@ -1,0 +1,511 @@
+// Exercise the DFG/FTL constant-folding rule that tries to refine
+// ObjectDefinePropertyFromFields into DefineDataProperty /
+// DefineAccessorProperty. The rule fires when:
+//   - data path: get/set slots are both absent AND enumerable/
+//     configurable/writable are each either absent or a known
+//     bool constant.
+//   - accessor path: value/writable both absent AND get/set are
+//     present with AbstractValue proven to be SpecFunction.
+// Tests below cover both converted and non-converted shapes; if any
+// observable behavior is wrong the tests throw.
+
+function shouldBe(actual, expected, msg) {
+    if (actual !== expected)
+        throw new Error((msg || "") + " expected " + expected + " got " + actual);
+}
+
+function shouldThrow(fn, ctor, msg) {
+    let threw = false;
+    try { fn(); } catch (e) {
+        threw = true;
+        if (!(e instanceof ctor))
+            throw new Error((msg || "") + " wrong error type: " + e);
+    }
+    if (!threw)
+        throw new Error((msg || "") + " expected throw");
+}
+
+function readDesc(o, k) {
+    return Object.getOwnPropertyDescriptor(o, k);
+}
+
+// ----- data: all attrs are constant true (refinable) -----
+function testAllTrueData(v) {
+    const o = {};
+    Object.defineProperty(o, "p", { value: v, writable: true, enumerable: true, configurable: true });
+    return o;
+}
+noInline(testAllTrueData);
+for (let i = 0; i < testLoopCount; ++i) {
+    const o = testAllTrueData(i);
+    shouldBe(o.p, i, "allTrue value");
+    const d = readDesc(o, "p");
+    shouldBe(d.writable, true, "allTrue writable");
+    shouldBe(d.enumerable, true, "allTrue enumerable");
+    shouldBe(d.configurable, true, "allTrue configurable");
+}
+
+// ----- data: only value present (refinable, partial attrs) -----
+function testValueOnly(v) {
+    const o = {};
+    Object.defineProperty(o, "p", { value: v });
+    return o;
+}
+noInline(testValueOnly);
+for (let i = 0; i < testLoopCount; ++i) {
+    const o = testValueOnly(i);
+    shouldBe(o.p, i, "valueOnly value");
+    const d = readDesc(o, "p");
+    shouldBe(d.writable, false, "valueOnly writable default");
+    shouldBe(d.enumerable, false, "valueOnly enumerable default");
+    shouldBe(d.configurable, false, "valueOnly configurable default");
+}
+
+// ----- data: writable:false baked in -----
+function testWritableFalse(v) {
+    const o = {};
+    Object.defineProperty(o, "p", { value: v, writable: false, configurable: true });
+    return o;
+}
+noInline(testWritableFalse);
+for (let i = 0; i < testLoopCount; ++i) {
+    const o = testWritableFalse(i);
+    shouldBe(o.p, i, "wFalse value");
+    o.p = i + 1; // sloppy: silent no-op
+    shouldBe(o.p, i, "wFalse not writable");
+    shouldBe(readDesc(o, "p").writable, false, "wFalse writable");
+    shouldBe(readDesc(o, "p").configurable, true, "wFalse configurable");
+}
+
+// ----- data: generic (no fields) -----
+function testGeneric() {
+    const o = {};
+    Object.defineProperty(o, "p", {});
+    return o;
+}
+noInline(testGeneric);
+for (let i = 0; i < testLoopCount; ++i) {
+    const o = testGeneric();
+    const d = readDesc(o, "p");
+    shouldBe(d.value, undefined, "generic value");
+    shouldBe(d.writable, false, "generic writable");
+    shouldBe(d.enumerable, false, "generic enumerable");
+    shouldBe(d.configurable, false, "generic configurable");
+}
+
+// ----- NOT refinable: opaque (non-constant) configurable -----
+// The slot is present but its value isn't a compile-time bool.
+// The rule must bail and keep ObjectDefinePropertyFromFields; behavior
+// must still match the spec (ToBoolean on the runtime value).
+function testOpaqueConfigurable(v, c) {
+    const o = {};
+    Object.defineProperty(o, "p", { value: v, configurable: c });
+    return o;
+}
+noInline(testOpaqueConfigurable);
+for (let i = 0; i < testLoopCount; ++i) {
+    // Alternate truthy/falsy non-bool values so the slot is variable
+    // and no constant can be baked in.
+    const c = (i & 1) ? "nonempty" : "";
+    const o = testOpaqueConfigurable(i, c);
+    shouldBe(o.p, i, "opaque value");
+    shouldBe(readDesc(o, "p").configurable, !!c, "opaque configurable");
+}
+
+// ----- NOT refinable: opaque enumerable -----
+function testOpaqueEnumerable(v, e) {
+    const o = {};
+    Object.defineProperty(o, "p", { value: v, enumerable: e, writable: true, configurable: true });
+    return o;
+}
+noInline(testOpaqueEnumerable);
+for (let i = 0; i < testLoopCount; ++i) {
+    const e = (i & 1) ? {} : 0;
+    const o = testOpaqueEnumerable(i, e);
+    shouldBe(readDesc(o, "p").enumerable, !!e, "opaque enumerable");
+}
+
+// ----- NOT refinable: opaque writable -----
+function testOpaqueWritable(v, w) {
+    const o = {};
+    Object.defineProperty(o, "p", { value: v, writable: w });
+    return o;
+}
+noInline(testOpaqueWritable);
+for (let i = 0; i < testLoopCount; ++i) {
+    const w = (i & 1) ? 1 : null;
+    const o = testOpaqueWritable(i, w);
+    shouldBe(readDesc(o, "p").writable, !!w, "opaque writable");
+}
+
+// ----- accessor: get+set present with literal functions -----
+function testAccessorLiterals() {
+    let box = 0;
+    const o = {};
+    Object.defineProperty(o, "p", {
+        get: function () { return box; },
+        set: function (v) { box = v; },
+        configurable: true,
+    });
+    o.p = 42;
+    return o.p;
+}
+noInline(testAccessorLiterals);
+for (let i = 0; i < testLoopCount; ++i)
+    shouldBe(testAccessorLiterals(), 42, "accessor literal");
+
+// ----- accessor: get+set from arguments (may or may not refine) -----
+function testAccessorArgs(o, g, s) {
+    Object.defineProperty(o, "p", { get: g, set: s, configurable: true });
+}
+noInline(testAccessorArgs);
+for (let i = 0; i < testLoopCount; ++i) {
+    let box = 0;
+    const o = {};
+    testAccessorArgs(o, function () { return box; }, function (v) { box = v; });
+    o.p = i;
+    shouldBe(o.p, i, "accessor args");
+}
+
+// ----- accessor: only get present (one-sided fold to DefineAccessorProperty) -----
+// The fold reuses the getter cell as a dummy for the absent setter slot;
+// the runtime's toPropertyDescriptor skips the setter when hasSet is unset,
+// so the dummy is never observed. Reading returns the getter's value, and
+// writing is a silent no-op in sloppy mode / TypeError in strict mode.
+function testGetOnly(o, g) {
+    Object.defineProperty(o, "p", { get: g, configurable: true });
+}
+noInline(testGetOnly);
+for (let i = 0; i < testLoopCount; ++i) {
+    const o = {};
+    testGetOnly(o, function () { return 7; });
+    shouldBe(o.p, 7, "getOnly");
+    shouldBe(readDesc(o, "p").set, undefined, "getOnly no set");
+    shouldBe(typeof readDesc(o, "p").get, "function", "getOnly get is function");
+    o.p = 99; // sloppy: silent no-op
+    shouldBe(o.p, 7, "getOnly sloppy write is no-op");
+}
+
+// Strict-mode write on a getter-only accessor must throw TypeError.
+function testGetOnlyStrictWrite(o) {
+    "use strict";
+    o.p = 0;
+}
+noInline(testGetOnlyStrictWrite);
+for (let i = 0; i < testLoopCount; ++i) {
+    const o = {};
+    testGetOnly(o, function () { return 7; });
+    shouldThrow(() => testGetOnlyStrictWrite(o), TypeError, "getOnly strict write");
+}
+
+// ----- accessor: only set present (one-sided fold) -----
+// Mirrors testGetOnly on the setter side. Reading the property returns
+// undefined (no getter installed). Absent getter slot is filled with the
+// setter cell as a dummy; toPropertyDescriptor skips it.
+function testSetOnly(o, s) {
+    Object.defineProperty(o, "p", { set: s, configurable: true });
+}
+noInline(testSetOnly);
+for (let i = 0; i < testLoopCount; ++i) {
+    let box = 0;
+    const o = {};
+    testSetOnly(o, function (v) { box = v; });
+    o.p = i;
+    shouldBe(box, i, "setOnly setter invoked");
+    shouldBe(o.p, undefined, "setOnly read returns undefined");
+    shouldBe(readDesc(o, "p").get, undefined, "setOnly no get");
+    shouldBe(typeof readDesc(o, "p").set, "function", "setOnly set is function");
+}
+
+// ----- accessor: one-sided get that isn't callable (must NOT fold) -----
+// `isProvenCallable` on the present side must hold. `get: 42` is a
+// descriptor error at runtime (TypeError), and the fold must not convert
+// into DefineAccessorProperty (which would silently install a non-callable
+// getter). The fallback ObjectDefinePropertyFromFields path throws.
+function testBadGetOnly() {
+    const o = {};
+    Object.defineProperty(o, "p", { get: 42, configurable: true });
+}
+for (let i = 0; i < testLoopCount; ++i)
+    shouldThrow(testBadGetOnly, TypeError, "badGetOnly");
+
+function testBadSetOnly() {
+    const o = {};
+    Object.defineProperty(o, "p", { set: "nope", configurable: true });
+}
+for (let i = 0; i < testLoopCount; ++i)
+    shouldThrow(testBadSetOnly, TypeError, "badSetOnly");
+
+// ----- accessor: non-callable getter must throw TypeError -----
+// Covers the case where the fold would be unsafe: a descriptor with
+// `get:` present but not a function. The rule must not convert into
+// DefineAccessorProperty (which wouldn't throw), so a TypeError must
+// still be observed.
+function testBadGetter() {
+    const o = {};
+    Object.defineProperty(o, "p", { get: 42 });
+}
+for (let i = 0; i < testLoopCount; ++i)
+    shouldThrow(testBadGetter, TypeError, "badGetter");
+
+// ----- mixed data+accessor must still throw TypeError -----
+function testMixed() {
+    const o = {};
+    Object.defineProperty(o, "p", { value: 1, get: function () {} });
+}
+for (let i = 0; i < testLoopCount; ++i)
+    shouldThrow(testMixed, TypeError, "mixed");
+
+// ----- null-prototype descriptor: refinable (no proto to watch) -----
+// `Object.create(null)` descriptors have no prototype chain so the fold
+// can run without arming propertyDescriptorFastPathWatchpointSet or
+// objectPrototypeChainIsSaneWatchpointSet. The extracted
+// GetByOffsets still produce correct values, and any descriptor-name
+// additions on Object.prototype do not affect the result.
+function testNullProtoData(v) {
+    const d = Object.create(null);
+    d.value = v;
+    d.writable = true;
+    d.enumerable = true;
+    d.configurable = true;
+    const o = {};
+    Object.defineProperty(o, "p", d);
+    return o;
+}
+noInline(testNullProtoData);
+for (let i = 0; i < testLoopCount; ++i) {
+    const o = testNullProtoData(i);
+    shouldBe(o.p, i, "nullProto value");
+    const rd = readDesc(o, "p");
+    shouldBe(rd.writable, true, "nullProto writable");
+    shouldBe(rd.enumerable, true, "nullProto enumerable");
+    shouldBe(rd.configurable, true, "nullProto configurable");
+}
+
+// ----- DefineDataProperty -> PutByIdDirect lowering -----
+// When the descriptor is {value, writable:true, enumerable:true,
+// configurable:true} and we know the base has a structure that
+// doesn't already define this property, defineProperty is semantically
+// equivalent to a direct data-property put (attrs=0 aka all-default).
+// The lowering targets this exact shape; other shapes must keep the
+// DefineDataProperty (or ObjectDefinePropertyFromFields) semantics.
+function testDefineAllTruePutsDirect(v) {
+    const o = {};
+    Object.defineProperty(o, "p", { value: v, writable: true, enumerable: true, configurable: true });
+    return o;
+}
+noInline(testDefineAllTruePutsDirect);
+for (let i = 0; i < testLoopCount; ++i) {
+    const o = testDefineAllTruePutsDirect(i);
+    shouldBe(o.p, i, "putDirect value");
+    const d = readDesc(o, "p");
+    shouldBe(d.writable, true, "putDirect writable");
+    shouldBe(d.enumerable, true, "putDirect enumerable");
+    shouldBe(d.configurable, true, "putDirect configurable");
+    // Reassignment must still work (the created property is writable).
+    o.p = i + 1;
+    shouldBe(o.p, i + 1, "putDirect reassign");
+    // Deletion must still work (configurable).
+    delete o.p;
+    shouldBe("p" in o, false, "putDirect deletable");
+}
+
+// Defaulted descriptor (only value present) must NOT lower to
+// PutByIdDirect: defineProperty with a bare {value} creates a non-
+// writable, non-enumerable, non-configurable property, whereas
+// PutByIdDirect would create an all-default (writable+enumerable+
+// configurable) property. The two are observably different.
+function testBareValueDoesNotLower(v) {
+    const o = {};
+    Object.defineProperty(o, "p", { value: v });
+    return o;
+}
+noInline(testBareValueDoesNotLower);
+for (let i = 0; i < testLoopCount; ++i) {
+    const o = testBareValueDoesNotLower(i);
+    shouldBe(o.p, i, "bareValue value");
+    const d = readDesc(o, "p");
+    shouldBe(d.writable, false, "bareValue non-writable");
+    shouldBe(d.enumerable, false, "bareValue non-enumerable");
+    shouldBe(d.configurable, false, "bareValue non-configurable");
+}
+
+// When the base already has the property, the lowering must bail:
+// PutByIdDirect on a non-writable existing property would fail with
+// ReadonlyPropertyChangeError, while defineProperty with the same
+// attrs would either succeed or throw the spec-defined TypeError.
+// Here the existing property is non-writable+configurable, and
+// defineProperty must succeed (attrs change + value change allowed
+// because configurable is true).
+function testExistingPropertyDoesNotLower() {
+    const o = {};
+    Object.defineProperty(o, "p", { value: 1, writable: false, configurable: true });
+    Object.defineProperty(o, "p", { value: 2, writable: true, enumerable: true, configurable: true });
+    return o;
+}
+noInline(testExistingPropertyDoesNotLower);
+for (let i = 0; i < testLoopCount; ++i) {
+    const o = testExistingPropertyDoesNotLower();
+    shouldBe(o.p, 2, "existing value updated");
+    shouldBe(readDesc(o, "p").writable, true, "existing writable updated");
+}
+
+// Dynamic property name: not a compile-time identifier, can't lower.
+function testDynamicPropertyDoesNotLower(v, name) {
+    const o = {};
+    Object.defineProperty(o, name, { value: v, writable: true, enumerable: true, configurable: true });
+    return o;
+}
+noInline(testDynamicPropertyDoesNotLower);
+for (let i = 0; i < testLoopCount; ++i) {
+    const name = (i & 1) ? "a" : "b";
+    const o = testDynamicPropertyDoesNotLower(i, name);
+    shouldBe(o[name], i, "dynamic name value");
+    shouldBe(readDesc(o, name).writable, true, "dynamic name writable");
+}
+
+// Indexed property: must not go through PutByIdDirect (would need
+// PutByVal semantics). The runtime still handles it correctly.
+function testIndexedPropertyDoesNotLower(v) {
+    const o = {};
+    Object.defineProperty(o, "0", { value: v, writable: true, enumerable: true, configurable: true });
+    return o;
+}
+noInline(testIndexedPropertyDoesNotLower);
+for (let i = 0; i < testLoopCount; ++i) {
+    const o = testIndexedPropertyDoesNotLower(i);
+    shouldBe(o[0], i, "indexed value");
+    shouldBe(readDesc(o, "0").writable, true, "indexed writable");
+}
+
+// ----- descriptor with accessor on a descriptor-field name -----
+// Each of these descriptors stores an accessor at one of the names the
+// fold otherwise extracts via GetByOffset ("value", "writable", "get").
+// If the fold ran, the extracted edge would be the GetterSetter cell
+// itself instead of the getter's return value — that would be wrong.
+// The existing structure guard (canPerformFastPropertyEnumerationCommon
+// rejects accessors) must prevent the fold here, and semantics must
+// still go through [[Get]].
+function testAccessorOnValue() {
+    let reads = 0;
+    const d = {};
+    Object.defineProperty(d, "value", {
+        get: function () { ++reads; return 99; },
+    });
+    d.writable = true;
+    const o = {};
+    Object.defineProperty(o, "p", d);
+    shouldBe(o.p, 99, "accessorOnValue read via getter");
+    shouldBe(reads, 1, "accessorOnValue getter invoked once");
+}
+noInline(testAccessorOnValue);
+for (let i = 0; i < testLoopCount; ++i)
+    testAccessorOnValue();
+
+function testAccessorOnWritable() {
+    let reads = 0;
+    const d = { value: 7 };
+    Object.defineProperty(d, "writable", {
+        get: function () { ++reads; return false; }, // ToBoolean: false
+    });
+    const o = {};
+    Object.defineProperty(o, "p", d);
+    shouldBe(o.p, 7, "accessorOnWritable value");
+    shouldBe(reads, 1, "accessorOnWritable getter invoked once");
+    o.p = 99; // sloppy: silent no-op
+    shouldBe(o.p, 7, "accessorOnWritable observed as non-writable");
+}
+noInline(testAccessorOnWritable);
+for (let i = 0; i < testLoopCount; ++i)
+    testAccessorOnWritable();
+
+function testAccessorOnGet() {
+    let reads = 0;
+    const fn = function () { return 123; };
+    const d = {};
+    Object.defineProperty(d, "get", {
+        get: function () { ++reads; return fn; },
+    });
+    const o = {};
+    Object.defineProperty(o, "p", d);
+    shouldBe(o.p, 123, "accessorOnGet getter installed");
+    shouldBe(reads, 1, "accessorOnGet meta-getter invoked once");
+}
+noInline(testAccessorOnGet);
+for (let i = 0; i < testLoopCount; ++i)
+    testAccessorOnGet();
+
+// ----- dictionary descriptor must not use the structure snapshot -----
+// Dictionaries (cacheable or uncacheable) allow property addition in
+// place, without a structure transition. A compiled code path that
+// extracts fields via offsets pinned to the structure would miss
+// properties added after compilation. The fold must bail on any
+// dictionary structure.
+function testDictionaryMutation(o, d) {
+    Object.defineProperty(o, "p", d);
+}
+noInline(testDictionaryMutation);
+{
+    const d = { value: 1, writable: true };
+    $vm.toCacheableDictionary(d);
+    // Warm up with only value + writable present.
+    for (let i = 0; i < testLoopCount; ++i) {
+        const o = {};
+        testDictionaryMutation(o, d);
+        shouldBe(o.p, 1, "dict phase1 value");
+        shouldBe(readDesc(o, "p").writable, true, "dict phase1 writable");
+        shouldBe(readDesc(o, "p").enumerable, false, "dict phase1 enumerable default");
+        shouldBe(readDesc(o, "p").configurable, false, "dict phase1 configurable default");
+    }
+    // Add a new field in place — dictionary structure is mutated,
+    // no transition. A stale-snapshot fold would still treat enumerable
+    // as absent here.
+    d.enumerable = true;
+    d.configurable = true;
+    for (let i = 0; i < testLoopCount; ++i) {
+        const o = {};
+        testDictionaryMutation(o, d);
+        shouldBe(readDesc(o, "p").enumerable, true, "dict phase2 enumerable");
+        shouldBe(readDesc(o, "p").configurable, true, "dict phase2 configurable");
+    }
+}
+
+// ----- symbol key (covers non-string property path) -----
+const SYM = Symbol("p");
+function testSymbolKey(v) {
+    const o = {};
+    Object.defineProperty(o, SYM, { value: v, writable: true, enumerable: true, configurable: true });
+    return o[SYM];
+}
+noInline(testSymbolKey);
+for (let i = 0; i < testLoopCount; ++i)
+    shouldBe(testSymbolKey(i), i, "symbol key");
+
+// ----- cross-realm descriptor must not fold -----
+// The fold compares descriptorStructure->storedPrototype() against the
+// compile-time globalObject->objectPrototype(). A descriptor created in
+// another realm inherits from that realm's Object.prototype, so the
+// identity check fails and the fold bails to the generic runtime path.
+// Semantics must still be correct.
+if (typeof createGlobalObject === "function") {
+    const other = createGlobalObject();
+    function testCrossRealm(v) {
+        const d = new other.Object();
+        d.value = v;
+        d.writable = true;
+        d.enumerable = true;
+        d.configurable = true;
+        const o = {};
+        Object.defineProperty(o, "p", d);
+        return o;
+    }
+    noInline(testCrossRealm);
+    for (let i = 0; i < testLoopCount; ++i) {
+        const o = testCrossRealm(i);
+        shouldBe(o.p, i, "crossRealm value");
+        const descOut = readDesc(o, "p");
+        shouldBe(descOut.writable, true, "crossRealm writable");
+        shouldBe(descOut.enumerable, true, "crossRealm enumerable");
+        shouldBe(descOut.configurable, true, "crossRealm configurable");
+    }
+}

--- a/Source/JavaScriptCore/dfg/DFGAbstractInterpreterInlines.h
+++ b/Source/JavaScriptCore/dfg/DFGAbstractInterpreterInlines.h
@@ -5378,9 +5378,10 @@ bool AbstractInterpreter<AbstractStateType>::executeEffects(unsigned clobberLimi
     case DefineDataProperty:
     case DefineAccessorProperty:
     case ObjectDefineProperty:
+    case ObjectDefinePropertyFromFields:
         clobberWorld();
         break;
-        
+
     case InById:
     case InByIdMegamorphic: {
         // FIXME: We can determine when the property definitely exists based on abstract

--- a/Source/JavaScriptCore/dfg/DFGClobberize.h
+++ b/Source/JavaScriptCore/dfg/DFGClobberize.h
@@ -788,6 +788,7 @@ void clobberize(Graph& graph, Node* node, const ReadFunctor& read, const WriteFu
     case DefineDataProperty:
     case DefineAccessorProperty:
     case ObjectDefineProperty:
+    case ObjectDefinePropertyFromFields:
     case DeleteById:
     case DeleteByVal:
     case ArrayPush:

--- a/Source/JavaScriptCore/dfg/DFGConstantFoldingPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGConstantFoldingPhase.cpp
@@ -36,6 +36,7 @@
 #include "DFGInPlaceAbstractState.h"
 #include "DFGInsertionSet.h"
 #include "DFGPhase.h"
+#include "DefinePropertyAttributes.h"
 #include "GetByStatus.h"
 #include "JSCInlines.h"
 #include "JSCJSValueBigInt.h"
@@ -1251,6 +1252,282 @@ private:
                 break;
             }
 
+            case ObjectDefineProperty: {
+                JSGlobalObject* globalObject = m_graph.globalObjectFor(node->origin.semantic);
+                VM& vm = m_graph.m_vm;
+
+                AbstractValue& descriptor = m_state.forNode(node->child3());
+                RegisteredStructure registered = descriptor.m_structure.onlyStructure();
+                if (!registered)
+                    break;
+
+                Structure* descriptorStructure = registered.get();
+                if (descriptorStructure->typeInfo().type() != FinalObjectType)
+                    break;
+                // Common (not Enumeration) is enough: we only read six named offsets below and never
+                // iterate indexed storage, so indexed properties on the descriptor cannot affect the fold.
+                if (!descriptorStructure->canPerformFastPropertyEnumerationCommon())
+                    break;
+                // CacheableDictionary (and UncacheableDictionary) is not usable here as it can add more properties without transition.
+                // This means we may start seeing new descriptor related properties while compiler believes we will not have them.
+                if (descriptorStructure->isDictionary())
+                    break;
+                if (descriptorStructure->hasNonReifiedStaticProperties())
+                    break;
+                if (descriptorStructure->hasPolyProto())
+                    break;
+
+                JSValue descriptorPrototype = descriptorStructure->storedPrototype();
+                bool hasNullPrototype = descriptorPrototype.isNull();
+                bool hasObjectPrototype = descriptorPrototype == globalObject->objectPrototype();
+                if (!hasNullPrototype && !hasObjectPrototype)
+                    break;
+
+                std::array<UniquedStringImpl*, Node::numberOfDescriptorSlots> descriptorKeyImpls = {
+                    vm.propertyNames->enumerable.impl(),
+                    vm.propertyNames->configurable.impl(),
+                    vm.propertyNames->value.impl(),
+                    vm.propertyNames->writable.impl(),
+                    vm.propertyNames->get.impl(),
+                    vm.propertyNames->set.impl(),
+                };
+
+                std::array<PropertyOffset, Node::numberOfDescriptorSlots> offsets;
+                offsets.fill(invalidOffset);
+
+                bool ok = true;
+                descriptorStructure->forEachPropertyConcurrently([&](const PropertyTableEntry& entry) -> bool {
+                    UniquedStringImpl* impl = entry.key();
+                    for (unsigned i = 0; i < Node::numberOfDescriptorSlots; ++i) {
+                        if (impl == descriptorKeyImpls[i]) {
+                            offsets[i] = entry.offset();
+                            return true;
+                        }
+                    }
+                    ok = false;
+                    return false;
+                });
+                if (!ok)
+                    break;
+
+                // If [[Prototype]] is null, we do not need to watch these watchpoints.
+                if (hasObjectPrototype) {
+                    if (globalObject->propertyDescriptorFastPathWatchpointSet().state() != IsWatched)
+                        break;
+                    if (!globalObject->objectPrototypeChainIsSaneWatchpointSet().isStillValid())
+                        break;
+
+                    m_graph.watchpoints().addLazily(globalObject->propertyDescriptorFastPathWatchpointSet());
+                    m_graph.watchpoints().addLazily(globalObject->objectPrototypeChainIsSaneWatchpointSet());
+                }
+
+                m_interpreter.execute(indexInBlock);
+                alreadyHandled = true;
+                if (!m_state.isValid())
+                    break;
+
+                NodeOrigin origin = node->origin;
+                Edge targetEdge = node->child1();
+                Edge keyEdge = node->child2();
+                Edge descriptorEdge = node->child3();
+
+                std::array<Edge, Node::numberOfDescriptorSlots> slotEdges;
+                Node* butterfly = nullptr;
+                Node* emptyConstant = nullptr;
+                for (unsigned i = 0; i < Node::numberOfDescriptorSlots; ++i) {
+                    if (offsets[i] != invalidOffset) {
+                        unsigned identifierNumber = m_graph.identifiers().ensure(descriptorKeyImpls[i]);
+                        Edge storageEdge;
+                        if (isInlineOffset(offsets[i]))
+                            storageEdge = Edge(descriptorEdge.node(), KnownStorageUse);
+                        else {
+                            if (!butterfly)
+                                butterfly = m_insertionSet.insertNode(indexInBlock, SpecNone, GetButterfly, origin, Edge(descriptorEdge.node(), KnownCellUse));
+                            storageEdge = Edge(butterfly, KnownStorageUse);
+                        }
+                        StorageAccessData& data = *m_graph.m_storageAccessData.add();
+                        data.offset = offsets[i];
+                        data.identifierNumber = identifierNumber;
+                        Node* getByOffset = m_insertionSet.insertNode(indexInBlock, SpecBytecodeTop, GetByOffset, origin, OpInfo(&data), storageEdge, Edge(descriptorEdge.node(), KnownCellUse));
+                        slotEdges[i] = Edge(getByOffset, UntypedUse);
+                    } else {
+                        if (!emptyConstant)
+                            emptyConstant = m_insertionSet.insertConstant(indexInBlock, origin, JSValue());
+                        slotEdges[i] = Edge(emptyConstant, UntypedUse);
+                    }
+                }
+
+                node->convertToObjectDefinePropertyFromFields(
+                    m_graph,
+                    Edge(targetEdge.node(), ObjectUse),
+                    Edge(keyEdge.node(), UntypedUse),
+                    slotEdges[Node::EnumerableSlot],
+                    slotEdges[Node::ConfigurableSlot],
+                    slotEdges[Node::ValueSlot],
+                    slotEdges[Node::WritableSlot],
+                    slotEdges[Node::GetSlot],
+                    slotEdges[Node::SetSlot]);
+
+                changed = true;
+                break;
+            }
+
+            case ObjectDefinePropertyFromFields: {
+                ASSERT(node->numChildren() == 8);
+
+                auto slotEdge = [&](unsigned i) -> Edge {
+                    return m_graph.varArgChild(node, 2 + i);
+                };
+
+                auto isAbsent = [&](Edge edge) -> bool {
+                    auto* n = edge.node();
+                    return n->isConstant() && !n->constant()->value();
+                };
+
+                auto asBoolAttribute = [&](Edge edge) -> std::optional<bool> {
+                    JSValue v = m_state.forNode(edge).m_value;
+                    if (!v)
+                        return std::nullopt;
+                    switch (v.pureToBoolean()) {
+                    case TriState::True:
+                        return true;
+                    case TriState::False:
+                        return false;
+                    case TriState::Indeterminate:
+                        return std::nullopt;
+                    }
+                    return std::nullopt;
+                };
+
+                auto isProvenCallable = [&](Edge edge) -> bool {
+                    auto& value = m_state.forNode(edge);
+                    return value.m_type != SpecNone && value.isType(SpecFunction);
+                };
+
+                bool getAbsent = isAbsent(slotEdge(Node::GetSlot));
+                bool setAbsent = isAbsent(slotEdge(Node::SetSlot));
+                bool valueAbsent = isAbsent(slotEdge(Node::ValueSlot));
+                bool writableAbsent = isAbsent(slotEdge(Node::WritableSlot));
+                bool enumerableAbsent = isAbsent(slotEdge(Node::EnumerableSlot));
+                bool configurableAbsent = isAbsent(slotEdge(Node::ConfigurableSlot));
+
+                auto tryBuildBaseAttributes = [&]() -> std::optional<DefinePropertyAttributes> {
+                    DefinePropertyAttributes attrs;
+                    if (!enumerableAbsent) {
+                        auto b = asBoolAttribute(slotEdge(Node::EnumerableSlot));
+                        if (!b)
+                            return std::nullopt;
+                        attrs.setEnumerable(*b);
+                    }
+                    if (!configurableAbsent) {
+                        auto b = asBoolAttribute(slotEdge(Node::ConfigurableSlot));
+                        if (!b)
+                            return std::nullopt;
+                        attrs.setConfigurable(*b);
+                    }
+                    return attrs;
+                };
+
+                NodeOrigin origin = node->origin;
+                Edge targetEdge = m_graph.varArgChild(node, 0);
+                Edge keyEdge = m_graph.varArgChild(node, 1);
+
+                if (getAbsent && setAbsent) {
+                    // DefineDataProperty (covers generic descriptors too). The follow-up
+                    // DefineDataProperty → PutByIdDirect lowering runs on the next iteration via
+                    // the DefineDataProperty case, so we don't chain it here.
+                    auto attrsOpt = tryBuildBaseAttributes();
+                    if (!attrsOpt)
+                        break;
+
+                    DefinePropertyAttributes attrs = *attrsOpt;
+                    if (!writableAbsent) {
+                        auto b = asBoolAttribute(slotEdge(Node::WritableSlot));
+                        if (!b)
+                            break;
+                        attrs.setWritable(*b);
+                    }
+
+                    // Execute the original ObjectDefinePropertyFromFields (clobbers world) on the
+                    // unmodified node so the state we propagate matches what the converted
+                    // DefineDataProperty's clobber would produce; then set alreadyHandled so the
+                    // main loop doesn't re-execute.
+                    m_interpreter.execute(indexInBlock);
+                    alreadyHandled = true;
+
+                    Node* valueNode;
+                    if (valueAbsent)
+                        valueNode = m_insertionSet.insertConstant(indexInBlock, origin, jsUndefined());
+                    else {
+                        attrs.setValue();
+                        valueNode = slotEdge(Node::ValueSlot).node();
+                    }
+
+                    Node* attrsNode = m_insertionSet.insertConstant(indexInBlock, origin, jsNumber(static_cast<int32_t>(attrs.rawRepresentation())));
+
+                    node->convertToDefineDataProperty(
+                        m_graph,
+                        Edge(targetEdge.node(), ObjectUse),
+                        Edge(keyEdge.node(), UntypedUse),
+                        Edge(valueNode, UntypedUse),
+                        Edge(attrsNode, Int32Use));
+
+                    changed = true;
+                    break;
+                }
+
+                if (valueAbsent && writableAbsent && (!getAbsent || !setAbsent)) {
+                    // DefineAccessorProperty. Each present side must be provably callable (DefineAccessorProperty
+                    // speculates CellUse and the runtime dereferences it when hasGet/hasSet is set). For the
+                    // absent side we reuse the present side's cell as a dummy — toPropertyDescriptor skips it
+                    // when the corresponding hasGet/hasSet bit is unset, so the value is never observed.
+                    if (!getAbsent && !isProvenCallable(slotEdge(Node::GetSlot)))
+                        break;
+                    if (!setAbsent && !isProvenCallable(slotEdge(Node::SetSlot)))
+                        break;
+
+                    auto attrsOpt = tryBuildBaseAttributes();
+                    if (!attrsOpt)
+                        break;
+
+                    DefinePropertyAttributes attrs = *attrsOpt;
+                    if (!getAbsent)
+                        attrs.setGet();
+                    if (!setAbsent)
+                        attrs.setSet();
+
+                    // See the DefineDataProperty branch above for the execute/alreadyHandled rationale.
+                    m_interpreter.execute(indexInBlock);
+                    alreadyHandled = true;
+
+                    Node* getterNode = getAbsent ? slotEdge(Node::SetSlot).node() : slotEdge(Node::GetSlot).node();
+                    Node* setterNode = setAbsent ? slotEdge(Node::GetSlot).node() : slotEdge(Node::SetSlot).node();
+
+                    Node* attrsNode = m_insertionSet.insertConstant(indexInBlock, origin, jsNumber(static_cast<int32_t>(attrs.rawRepresentation())));
+
+                    node->convertToDefineAccessorProperty(
+                        m_graph,
+                        Edge(targetEdge.node(), ObjectUse),
+                        Edge(keyEdge.node(), UntypedUse),
+                        Edge(getterNode, CellUse),
+                        Edge(setterNode, CellUse),
+                        Edge(attrsNode, Int32Use));
+
+                    changed = true;
+                    break;
+                }
+
+                break;
+            }
+
+            case DefineDataProperty: {
+                if (tryFoldDefineDataPropertyToPutByIdDirect(node, indexInBlock)) {
+                    alreadyHandled = true;
+                    changed = true;
+                }
+                break;
+            }
+
             case Check: {
                 alreadyHandled = true;
                 m_interpreter.execute(indexInBlock);
@@ -2133,7 +2410,96 @@ private:
             indexInBlock, SpecNone, CheckStructure, origin,
             OpInfo(m_graph.addStructureSet(structure)), Edge(weakConstant, CellUse));
     }
-    
+
+    bool tryFoldDefineDataPropertyToPutByIdDirect(Node* node, unsigned indexInBlock)
+    {
+        ASSERT(node->op() == DefineDataProperty);
+
+        Edge baseEdge = m_graph.varArgChild(node, 0);
+        Edge propertyEdge = m_graph.varArgChild(node, 1);
+        Edge valueEdge = m_graph.varArgChild(node, 2);
+        Edge attrsEdge = m_graph.varArgChild(node, 3);
+
+        if (!attrsEdge.node()->isInt32Constant())
+            return false;
+
+        DefinePropertyAttributes attrs(static_cast<unsigned>(attrsEdge.node()->asInt32()));
+        if (!attrs.hasValue())
+            return false;
+        if (attrs.hasGet() || attrs.hasSet())
+            return false;
+        if (attrs.writable() != std::optional<bool>(true))
+            return false;
+        if (attrs.enumerable() != std::optional<bool>(true))
+            return false;
+        if (attrs.configurable() != std::optional<bool>(true))
+            return false;
+
+        Node* propNode = propertyEdge.node();
+        if (!propNode->isConstant())
+            return false;
+
+        JSValue propValue = propNode->constant()->value();
+        if (!propValue || !propValue.isCell())
+            return false;
+
+        JSCell* propCell = propValue.asCell();
+        if (!CacheableIdentifier::isCacheableIdentifierCell(propCell))
+            return false;
+
+        CacheableIdentifier cacheableIdentifier = CacheableIdentifier::createFromCell(propCell);
+        SUPPRESS_UNCOUNTED_LOCAL UniquedStringImpl* uid = cacheableIdentifier.uid();
+        if (parseIndex(uid))
+            return false;
+
+        AbstractValue& baseValue = m_state.forNode(baseEdge);
+        if (!baseValue.m_structure.isFinite() || !baseValue.m_structure.size())
+            return false;
+
+        bool ok = true;
+        SUPPRESS_UNCOUNTED_LAMBDA_CAPTURE baseValue.m_structure.forEach([&, uid](RegisteredStructure registered) {
+            Structure* structure = registered.get();
+            if (structure->typeInfo().type() != FinalObjectType) {
+                ok = false;
+                return;
+            }
+            if (structure->isDictionary()) {
+                ok = false;
+                return;
+            }
+            if (!structure->isStructureExtensible()) {
+                ok = false;
+                return;
+            }
+            if (structure->typeInfo().overridesPut()) {
+                ok = false;
+                return;
+            }
+            if (structure->getConcurrently(uid) != invalidOffset) {
+                ok = false;
+                return;
+            }
+        });
+        if (!ok)
+            return false;
+
+        // Execute the original DefineDataProperty (clobbers world) before we mutate the node,
+        // so the abstract state we propagate matches post-fold semantics — PutByIdDirect also
+        // clobbers world. The caller sets alreadyHandled to suppress the default execute.
+        m_interpreter.execute(indexInBlock);
+
+        NodeOrigin origin = node->origin;
+        m_insertionSet.insertNode(indexInBlock, SpecNone, Check, origin, Edge(baseEdge.node(), baseEdge.useKind()));
+        m_insertionSet.insertNode(indexInBlock, SpecNone, Check, origin, Edge(propertyEdge.node(), propertyEdge.useKind()));
+        m_insertionSet.insertNode(indexInBlock, SpecNone, Check, origin, Edge(attrsEdge.node(), attrsEdge.useKind()));
+
+        m_graph.freezeStrong(propCell);
+        m_graph.identifiers().ensure(const_cast<UniquedStringImpl*>(uid));
+
+        node->convertToPutByIdDirect(m_graph, Edge(baseEdge.node(), CellUse), Edge(valueEdge.node()), cacheableIdentifier, ECMAMode::strict());
+        return true;
+    }
+
     void fixUpsilons(BasicBlock* block)
     {
         for (unsigned nodeIndex = block->size(); nodeIndex--;) {

--- a/Source/JavaScriptCore/dfg/DFGDoesGC.cpp
+++ b/Source/JavaScriptCore/dfg/DFGDoesGC.cpp
@@ -310,6 +310,7 @@ bool doesGC(Graph& graph, Node* node)
     case DefineDataProperty:
     case DefineAccessorProperty:
     case ObjectDefineProperty:
+    case ObjectDefinePropertyFromFields:
     case DeleteById:
     case DeleteByVal:
     case DirectCall:

--- a/Source/JavaScriptCore/dfg/DFGFixupPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGFixupPhase.cpp
@@ -2806,6 +2806,7 @@ private:
         case RegExpExecNonGlobalOrSticky:
         case RegExpMatchFastGlobal:
         case GetUndetachedTypeArrayLength:
+        case ObjectDefinePropertyFromFields:
             // These are just nodes that we don't currently expect to see during fixup.
             // If we ever wanted to insert them prior to fixup, then we just have to create
             // fixup rules for them.
@@ -3236,7 +3237,7 @@ private:
         }
 
         case DefineDataProperty: {
-            fixEdge<CellUse>(m_graph.varArgChild(node, 0));
+            fixEdge<ObjectUse>(m_graph.varArgChild(node, 0));
             Edge& propertyEdge = m_graph.varArgChild(node, 1);
             if (propertyEdge->shouldSpeculateSymbol())
                 fixEdge<SymbolUse>(propertyEdge);
@@ -3305,7 +3306,7 @@ private:
         }
 
         case DefineAccessorProperty: {
-            fixEdge<CellUse>(m_graph.varArgChild(node, 0));
+            fixEdge<ObjectUse>(m_graph.varArgChild(node, 0));
             Edge& propertyEdge = m_graph.varArgChild(node, 1);
             if (propertyEdge->shouldSpeculateSymbol())
                 fixEdge<SymbolUse>(propertyEdge);

--- a/Source/JavaScriptCore/dfg/DFGNode.cpp
+++ b/Source/JavaScriptCore/dfg/DFGNode.cpp
@@ -367,6 +367,65 @@ void Node::convertToRegExpMatchFastGlobalWithoutChecks(FrozenValue* regExp)
     m_opInfo = regExp;
 }
 
+void Node::convertToDefineDataProperty(Graph& graph, Edge base, Edge property, Edge value, Edge attributes)
+{
+    ASSERT(op() == ObjectDefinePropertyFromFields);
+    setOpAndDefaultFlags(DefineDataProperty);
+
+    unsigned firstChild = graph.m_varArgChildren.size();
+    graph.m_varArgChildren.append(base);
+    graph.m_varArgChildren.append(property);
+    graph.m_varArgChildren.append(value);
+    graph.m_varArgChildren.append(attributes);
+    children = AdjacencyList(AdjacencyList::Variable, firstChild, 4);
+}
+
+void Node::convertToDefineAccessorProperty(Graph& graph, Edge base, Edge property, Edge getter, Edge setter, Edge attributes)
+{
+    ASSERT(op() == ObjectDefinePropertyFromFields);
+    setOpAndDefaultFlags(DefineAccessorProperty);
+
+    unsigned firstChild = graph.m_varArgChildren.size();
+    graph.m_varArgChildren.append(base);
+    graph.m_varArgChildren.append(property);
+    graph.m_varArgChildren.append(getter);
+    graph.m_varArgChildren.append(setter);
+    graph.m_varArgChildren.append(attributes);
+    children = AdjacencyList(AdjacencyList::Variable, firstChild, 5);
+}
+
+void Node::convertToObjectDefinePropertyFromFields(Graph& graph, Edge target, Edge key, Edge enumerable, Edge configurable, Edge value, Edge writable, Edge getter, Edge setter)
+{
+    ASSERT(op() == ObjectDefineProperty);
+    setOpAndDefaultFlags(ObjectDefinePropertyFromFields);
+
+    unsigned firstChild = graph.m_varArgChildren.size();
+    graph.m_varArgChildren.append(target);
+    graph.m_varArgChildren.append(key);
+    graph.m_varArgChildren.append(enumerable);
+    graph.m_varArgChildren.append(configurable);
+    graph.m_varArgChildren.append(value);
+    graph.m_varArgChildren.append(writable);
+    graph.m_varArgChildren.append(getter);
+    graph.m_varArgChildren.append(setter);
+    children = AdjacencyList(AdjacencyList::Variable, firstChild, 8);
+}
+
+void Node::convertToPutByIdDirect(Graph& graph, Edge base, Edge value, CacheableIdentifier identifier, ECMAMode ecmaMode)
+{
+    ASSERT(op() == DefineDataProperty);
+    for (unsigned i = 0; i < numChildren(); ++i)
+        graph.varArgChild(this, i) = Edge();
+
+    children.reset();
+    clearFlags(NodeHasVarArgs);
+    setOpAndDefaultFlags(PutByIdDirect);
+    child1() = base;
+    child2() = value;
+    m_opInfo = identifier;
+    m_opInfo2 = ecmaMode.value();
+}
+
 void Node::convertToRegExpTestInline(FrozenValue* globalObject, FrozenValue* regExp)
 {
     ASSERT(op() == RegExpTest);

--- a/Source/JavaScriptCore/dfg/DFGNode.h
+++ b/Source/JavaScriptCore/dfg/DFGNode.h
@@ -929,6 +929,20 @@ public:
     void NODELETE convertToRegExpMatchFastGlobalWithoutChecks(FrozenValue* regExp);
     void NODELETE convertToRegExpTestInline(FrozenValue* globalObject, FrozenValue* regExp);
 
+    enum DescriptorSlot : unsigned {
+        EnumerableSlot = 0,
+        ConfigurableSlot,
+        ValueSlot,
+        WritableSlot,
+        GetSlot,
+        SetSlot,
+    };
+    static constexpr unsigned numberOfDescriptorSlots = 6;
+    void convertToDefineDataProperty(Graph&, Edge base, Edge property, Edge value, Edge attributes);
+    void convertToDefineAccessorProperty(Graph&, Edge base, Edge property, Edge getter, Edge setter, Edge attributes);
+    void convertToObjectDefinePropertyFromFields(Graph&, Edge target, Edge key, Edge enumerable, Edge configurable, Edge value, Edge writable, Edge getter, Edge setter);
+    void convertToPutByIdDirect(Graph&, Edge base, Edge value, CacheableIdentifier, ECMAMode);
+
     void convertToSetRegExpObjectLastIndex()
     {
         setOp(SetRegExpObjectLastIndex);

--- a/Source/JavaScriptCore/dfg/DFGNodeType.h
+++ b/Source/JavaScriptCore/dfg/DFGNodeType.h
@@ -250,6 +250,7 @@ namespace JSC { namespace DFG {
     macro(DefineDataProperty, NodeMustGenerate | NodeHasVarArgs) \
     macro(DefineAccessorProperty, NodeMustGenerate | NodeHasVarArgs) \
     macro(ObjectDefineProperty, NodeMustGenerate) \
+    macro(ObjectDefinePropertyFromFields, NodeMustGenerate | NodeHasVarArgs) \
     macro(DeleteById, NodeResultBoolean | NodeMustGenerate) \
     macro(DeleteByVal, NodeResultBoolean | NodeMustGenerate) \
     macro(CheckStructure, NodeMustGenerate) \

--- a/Source/JavaScriptCore/dfg/DFGOperations.cpp
+++ b/Source/JavaScriptCore/dfg/DFGOperations.cpp
@@ -2178,6 +2178,65 @@ JSC_DEFINE_JIT_OPERATION(operationObjectDefineProperty, void, (JSGlobalObject* g
     OPERATION_RETURN(scope);
 }
 
+JSC_DEFINE_JIT_OPERATION(operationObjectDefinePropertyFromFields, void, (JSGlobalObject* globalObject, JSObject* target, EncodedJSValue encodedKey, EncodedJSValue encodedEnumerable, EncodedJSValue encodedConfigurable, EncodedJSValue encodedValue, EncodedJSValue encodedWritable, EncodedJSValue encodedGetter, EncodedJSValue encodedSetter))
+{
+    VM& vm = globalObject->vm();
+    CallFrame* callFrame = DECLARE_CALL_FRAME(vm);
+    JITOperationPrologueCallFrameTracer tracer(vm, callFrame);
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
+    auto propertyName = JSValue::decode(encodedKey).toPropertyKey(globalObject);
+    OPERATION_RETURN_IF_EXCEPTION(scope);
+
+    JSValue enumerable = JSValue::decode(encodedEnumerable);
+    JSValue configurable = JSValue::decode(encodedConfigurable);
+    JSValue value = JSValue::decode(encodedValue);
+    JSValue writable = JSValue::decode(encodedWritable);
+    JSValue getter = JSValue::decode(encodedGetter);
+    JSValue setter = JSValue::decode(encodedSetter);
+
+    PropertyDescriptor desc;
+    if (enumerable)
+        desc.setEnumerable(enumerable.toBoolean(globalObject));
+    if (configurable)
+        desc.setConfigurable(configurable.toBoolean(globalObject));
+    if (value)
+        desc.setValue(value);
+    if (writable)
+        desc.setWritable(writable.toBoolean(globalObject));
+    if (getter) {
+        if (!getter.isUndefined() && !getter.isCallable()) [[unlikely]] {
+            throwTypeError(globalObject, scope, "Getter must be a function."_s);
+            OPERATION_RETURN(scope);
+        }
+        desc.setGetter(getter);
+    }
+    if (setter) {
+        if (!setter.isUndefined() && !setter.isCallable()) [[unlikely]] {
+            throwTypeError(globalObject, scope, "Setter must be a function."_s);
+            OPERATION_RETURN(scope);
+        }
+        desc.setSetter(setter);
+    }
+
+    if (desc.isAccessorDescriptor()) {
+        if (desc.value()) [[unlikely]] {
+            throwTypeError(globalObject, scope, "Invalid property.  'value' present on property with getter or setter."_s);
+            OPERATION_RETURN(scope);
+        }
+        if (desc.writablePresent()) [[unlikely]] {
+            throwTypeError(globalObject, scope, "Invalid property.  'writable' present on property with getter or setter."_s);
+            OPERATION_RETURN(scope);
+        }
+    }
+
+    ASSERT((desc.attributes() & PropertyAttribute::Accessor) || (!desc.isAccessorDescriptor()));
+
+    scope.release();
+    target->methodTable()->defineOwnProperty(target, globalObject, propertyName, desc, true);
+    OPERATION_RETURN(scope);
+}
+
 ALWAYS_INLINE static void defineDataProperty(JSGlobalObject* globalObject, JSObject* base, PropertyName propertyName, JSValue value, int32_t attributes)
 {
     PropertyDescriptor descriptor = toPropertyDescriptor(value, jsUndefined(), jsUndefined(), DefinePropertyAttributes(attributes));

--- a/Source/JavaScriptCore/dfg/DFGOperations.h
+++ b/Source/JavaScriptCore/dfg/DFGOperations.h
@@ -204,6 +204,7 @@ JSC_DECLARE_JIT_OPERATION(operationPutByIdWithThisStrict, void, (JSGlobalObject*
 JSC_DECLARE_JIT_OPERATION(operationPutByValWithThis, void, (JSGlobalObject*, EncodedJSValue, EncodedJSValue, EncodedJSValue, EncodedJSValue));
 JSC_DECLARE_JIT_OPERATION(operationPutByValWithThisStrict, void, (JSGlobalObject*, EncodedJSValue, EncodedJSValue, EncodedJSValue, EncodedJSValue));
 JSC_DECLARE_JIT_OPERATION(operationObjectDefineProperty, void, (JSGlobalObject*, JSObject*, EncodedJSValue, JSObject*));
+JSC_DECLARE_JIT_OPERATION(operationObjectDefinePropertyFromFields, void, (JSGlobalObject*, JSObject*, EncodedJSValue, EncodedJSValue, EncodedJSValue, EncodedJSValue, EncodedJSValue, EncodedJSValue, EncodedJSValue));
 JSC_DECLARE_JIT_OPERATION(operationDefineDataProperty, void, (JSGlobalObject*, JSObject*, EncodedJSValue, EncodedJSValue, int32_t));
 JSC_DECLARE_JIT_OPERATION(operationDefineDataPropertyString, void, (JSGlobalObject*, JSObject*, JSString*, EncodedJSValue, int32_t));
 JSC_DECLARE_JIT_OPERATION(operationDefineDataPropertyStringIdent, void, (JSGlobalObject*, JSObject*, UniquedStringImpl*, EncodedJSValue, int32_t));

--- a/Source/JavaScriptCore/dfg/DFGPredictionPropagationPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGPredictionPropagationPhase.cpp
@@ -1748,6 +1748,7 @@ private:
         case DefineDataProperty:
         case DefineAccessorProperty:
         case ObjectDefineProperty:
+        case ObjectDefinePropertyFromFields:
         case CallCustomAccessorSetter:
         case DFG::Jump:
         case Branch:

--- a/Source/JavaScriptCore/dfg/DFGSafeToExecute.h
+++ b/Source/JavaScriptCore/dfg/DFGSafeToExecute.h
@@ -627,6 +627,7 @@ bool safeToExecute(AbstractStateType& state, Graph& graph, Node* node, bool igno
     case DefineDataProperty:
     case DefineAccessorProperty:
     case ObjectDefineProperty:
+    case ObjectDefinePropertyFromFields:
     case Arrayify:
     case ArrayifyToStructure:
     case PutClosureVar:

--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp
@@ -14298,13 +14298,14 @@ void SpeculativeJIT::compileDefineDataProperty(Node* node)
     static_assert(GPRInfo::numberOfRegisters >= 6, "We are assuming we have enough registers to make this call without incrementally setting up the arguments.");
 #endif
 
-    SpeculateCellOperand base(this, m_graph.varArgChild(node, 0));
-    GPRReg baseGPR = base.gpr();
+    Edge& baseEdge = m_graph.varArgChild(node, 0);
 
+    SpeculateCellOperand base(this, baseEdge);
     JSValueOperand value(this, m_graph.varArgChild(node, 2));
-    JSValueRegs valueRegs = value.jsValueRegs();
-
     SpeculateInt32Operand attributes(this, m_graph.varArgChild(node, 3));
+
+    GPRReg baseGPR = base.gpr();
+    JSValueRegs valueRegs = value.jsValueRegs();
     GPRReg attributesGPR = attributes.gpr();
 
     Edge& propertyEdge = m_graph.varArgChild(node, 1);
@@ -14312,6 +14313,8 @@ void SpeculativeJIT::compileDefineDataProperty(Node* node)
     case StringUse: {
         SpeculateCellOperand property(this, propertyEdge);
         GPRReg propertyGPR = property.gpr();
+
+        speculateObject(baseEdge, baseGPR);
         speculateString(propertyEdge, propertyGPR);
 
         useChildren(node);
@@ -14327,6 +14330,7 @@ void SpeculativeJIT::compileDefineDataProperty(Node* node)
         GPRReg propertyGPR = property.gpr();
         GPRReg identGPR = ident.gpr();
 
+        speculateObject(baseEdge, baseGPR);
         speculateString(propertyEdge, propertyGPR);
         speculateStringIdentAndLoadStorage(propertyEdge, propertyGPR, identGPR);
 
@@ -14339,6 +14343,8 @@ void SpeculativeJIT::compileDefineDataProperty(Node* node)
     case SymbolUse: {
         SpeculateCellOperand property(this, propertyEdge);
         GPRReg propertyGPR = property.gpr();
+
+        speculateObject(baseEdge, baseGPR);
         speculateSymbol(propertyEdge, propertyGPR);
 
         useChildren(node);
@@ -14350,6 +14356,8 @@ void SpeculativeJIT::compileDefineDataProperty(Node* node)
     case UntypedUse: {
         JSValueOperand property(this, propertyEdge);
         JSValueRegs propertyRegs = property.jsValueRegs();
+
+        speculateObject(baseEdge, baseGPR);
 
         useChildren(node);
 
@@ -14372,16 +14380,16 @@ void SpeculativeJIT::compileDefineAccessorProperty(Node* node)
     static_assert(GPRInfo::numberOfRegisters >= 6, "We are assuming we have enough registers to make this call without incrementally setting up the arguments.");
 #endif
 
-    SpeculateCellOperand base(this, m_graph.varArgChild(node, 0));
-    GPRReg baseGPR = base.gpr();
+    Edge& baseEdge = m_graph.varArgChild(node, 0);
 
+    SpeculateCellOperand base(this, baseEdge);
     SpeculateCellOperand getter(this, m_graph.varArgChild(node, 2));
-    GPRReg getterGPR = getter.gpr();
-
     SpeculateCellOperand setter(this, m_graph.varArgChild(node, 3));
-    GPRReg setterGPR = setter.gpr();
-
     SpeculateInt32Operand attributes(this, m_graph.varArgChild(node, 4));
+
+    GPRReg baseGPR = base.gpr();
+    GPRReg getterGPR = getter.gpr();
+    GPRReg setterGPR = setter.gpr();
     GPRReg attributesGPR = attributes.gpr();
 
     Edge& propertyEdge = m_graph.varArgChild(node, 1);
@@ -14389,6 +14397,8 @@ void SpeculativeJIT::compileDefineAccessorProperty(Node* node)
     case StringUse: {
         SpeculateCellOperand property(this, propertyEdge);
         GPRReg propertyGPR = property.gpr();
+
+        speculateObject(baseEdge, baseGPR);
         speculateString(propertyEdge, propertyGPR);
 
         useChildren(node);
@@ -14404,6 +14414,7 @@ void SpeculativeJIT::compileDefineAccessorProperty(Node* node)
         GPRReg propertyGPR = property.gpr();
         GPRReg identGPR = ident.gpr();
 
+        speculateObject(baseEdge, baseGPR);
         speculateString(propertyEdge, propertyGPR);
         speculateStringIdentAndLoadStorage(propertyEdge, propertyGPR, identGPR);
 
@@ -14416,6 +14427,8 @@ void SpeculativeJIT::compileDefineAccessorProperty(Node* node)
     case SymbolUse: {
         SpeculateCellOperand property(this, propertyEdge);
         GPRReg propertyGPR = property.gpr();
+
+        speculateObject(baseEdge, baseGPR);
         speculateSymbol(propertyEdge, propertyGPR);
 
         useChildren(node);
@@ -14427,6 +14440,8 @@ void SpeculativeJIT::compileDefineAccessorProperty(Node* node)
     case UntypedUse: {
         JSValueOperand property(this, propertyEdge);
         JSValueRegs propertyRegs = property.jsValueRegs();
+
+        speculateObject(baseEdge, baseGPR);
 
         useChildren(node);
 
@@ -14456,6 +14471,45 @@ void SpeculativeJIT::compileObjectDefineProperty(Node* node)
 
     flushRegisters();
     callOperation(operationObjectDefineProperty, LinkableConstant::globalObject(*this, node), targetGPR, keyRegs, descriptorGPR);
+    noResult(node);
+}
+
+void SpeculativeJIT::compileObjectDefinePropertyFromFields(Node* node)
+{
+    ASSERT(node->op() == ObjectDefinePropertyFromFields);
+    ASSERT(m_graph.varArgNumChildren(node) == 8);
+
+    // Children layout:
+    //   [0] target (ObjectUse)
+    //   [1] key (UntypedUse)
+    //   [2] enumerable  (UntypedUse or JSConstant(empty) if absent)
+    //   [3] configurable
+    //   [4] value
+    //   [5] writable
+    //   [6] get
+    //   [7] set
+    SpeculateCellOperand target(this, m_graph.varArgChild(node, 0));
+    JSValueOperand key(this, m_graph.varArgChild(node, 1));
+    JSValueOperand enumerable(this, m_graph.varArgChild(node, 2));
+    JSValueOperand configurable(this, m_graph.varArgChild(node, 3));
+    JSValueOperand value(this, m_graph.varArgChild(node, 4));
+    JSValueOperand writable(this, m_graph.varArgChild(node, 5));
+    JSValueOperand getter(this, m_graph.varArgChild(node, 6));
+    JSValueOperand setter(this, m_graph.varArgChild(node, 7));
+
+    GPRReg targetGPR = target.gpr();
+    JSValueRegs keyRegs = key.jsValueRegs();
+    JSValueRegs enumerableRegs = enumerable.jsValueRegs();
+    JSValueRegs configurableRegs = configurable.jsValueRegs();
+    JSValueRegs valueRegs = value.jsValueRegs();
+    JSValueRegs writableRegs = writable.jsValueRegs();
+    JSValueRegs getterRegs = getter.jsValueRegs();
+    JSValueRegs setterRegs = setter.jsValueRegs();
+
+    speculateObject(m_graph.varArgChild(node, 0), targetGPR);
+
+    flushRegisters();
+    callOperation(operationObjectDefinePropertyFromFields, LinkableConstant::globalObject(*this, node), targetGPR, keyRegs, enumerableRegs, configurableRegs, valueRegs, writableRegs, getterRegs, setterRegs);
     noResult(node);
 }
 

--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.h
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.h
@@ -1731,6 +1731,7 @@ public:
     void compileDefineDataProperty(Node*);
     void compileDefineAccessorProperty(Node*);
     void compileObjectDefineProperty(Node*);
+    void compileObjectDefinePropertyFromFields(Node*);
     void compileStringSlice(Node*);
     void compileStringSubstring(Node*);
     void compileToUpperCase(Node*);

--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT32_64.cpp
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT32_64.cpp
@@ -3681,6 +3681,11 @@ void SpeculativeJIT::compile(Node* node)
         break;
     }
 
+    case ObjectDefinePropertyFromFields: {
+        compileObjectDefinePropertyFromFields(node);
+        break;
+    }
+
     case DefineAccessorProperty: {
         compileDefineAccessorProperty(node);
         break;

--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT64.cpp
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT64.cpp
@@ -5104,6 +5104,11 @@ void SpeculativeJIT::compile(Node* node)
         break;
     }
 
+    case ObjectDefinePropertyFromFields: {
+        compileObjectDefinePropertyFromFields(node);
+        break;
+    }
+
     case DefineAccessorProperty: {
         compileDefineAccessorProperty(node);
         break;

--- a/Source/JavaScriptCore/ftl/FTLCapabilities.cpp
+++ b/Source/JavaScriptCore/ftl/FTLCapabilities.cpp
@@ -431,6 +431,7 @@ inline CapabilityLevel canCompile(Node* node)
     case DefineDataProperty:
     case DefineAccessorProperty:
     case ObjectDefineProperty:
+    case ObjectDefinePropertyFromFields:
     case StringValueOf:
     case StringSlice:
     case StringSubstring:

--- a/Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp
+++ b/Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp
@@ -1172,6 +1172,9 @@ private:
         case ObjectDefineProperty:
             compileObjectDefineProperty();
             break;
+        case ObjectDefinePropertyFromFields:
+            compileObjectDefinePropertyFromFields();
+            break;
         case DefineAccessorProperty:
             compileDefineAccessorProperty();
             break;
@@ -5502,7 +5505,7 @@ private:
     void compileDefineDataProperty()
     {
         JSGlobalObject* globalObject = m_graph.globalObjectFor(m_origin.semantic);
-        LValue base = lowCell(m_graph.varArgChild(m_node, 0));
+        LValue base = lowObject(m_graph.varArgChild(m_node, 0));
         LValue value  = lowJSValue(m_graph.varArgChild(m_node, 2));
         LValue attributes = lowInt32(m_graph.varArgChild(m_node, 3));
         Edge& propertyEdge = m_graph.varArgChild(m_node, 1);
@@ -5541,10 +5544,26 @@ private:
         vmCall(Void, operationObjectDefineProperty, weakPointer(globalObject), target, key, descriptor);
     }
 
+    void compileObjectDefinePropertyFromFields()
+    {
+        JSGlobalObject* globalObject = m_graph.globalObjectFor(m_origin.semantic);
+        ASSERT(m_node->op() == ObjectDefinePropertyFromFields);
+        ASSERT(m_graph.varArgNumChildren(m_node) == 8);
+        LValue target = lowObject(m_graph.varArgChild(m_node, 0));
+        LValue key = lowJSValue(m_graph.varArgChild(m_node, 1));
+        LValue enumerable = lowJSValue(m_graph.varArgChild(m_node, 2));
+        LValue configurable = lowJSValue(m_graph.varArgChild(m_node, 3));
+        LValue value = lowJSValue(m_graph.varArgChild(m_node, 4));
+        LValue writable = lowJSValue(m_graph.varArgChild(m_node, 5));
+        LValue getter = lowJSValue(m_graph.varArgChild(m_node, 6));
+        LValue setter = lowJSValue(m_graph.varArgChild(m_node, 7));
+        vmCall(Void, operationObjectDefinePropertyFromFields, weakPointer(globalObject), target, key, enumerable, configurable, value, writable, getter, setter);
+    }
+
     void compileDefineAccessorProperty()
     {
         JSGlobalObject* globalObject = m_graph.globalObjectFor(m_origin.semantic);
-        LValue base = lowCell(m_graph.varArgChild(m_node, 0));
+        LValue base = lowObject(m_graph.varArgChild(m_node, 0));
         LValue getter = lowCell(m_graph.varArgChild(m_node, 2));
         LValue setter = lowCell(m_graph.varArgChild(m_node, 3));
         LValue attributes = lowInt32(m_graph.varArgChild(m_node, 4));


### PR DESCRIPTION
#### 93e29091710ce0fa437e19fa63f345d5d706fa74
<pre>
[JSC] Extract fields of descriptor in Object.defineProperty in DFG / FTL
<a href="https://bugs.webkit.org/show_bug.cgi?id=313636">https://bugs.webkit.org/show_bug.cgi?id=313636</a>
<a href="https://rdar.apple.com/175837797">rdar://175837797</a>

Reviewed by Yijia Huang.

Given that we have

1. sane chain watchpoint
2. descriptor field watchpoint on Object.prototype
3. typically object literal / constant descriptor is used

AbstractInterpreter / ConstantFolding can detect finite structure. And we can extract
fields via GetByOffset insertion. This means that we can convert

    ObjectDefineProperty(Object, Key, Descriptor)

to

    enumerable = GetByOffset(Descriptor, enumerable-offset) OR empty
    configurable = GetByOffset(Descriptor, configurable-offset) OR empty
    value = GetByOffset(Descriptor, value-offset) OR empty
    writable = GetByOffset(Descriptor, writable-offset) OR empty
    get = GetByOffset(Descriptor, get-offset) OR empty
    set = GetByOffset(Descriptor, set-offset) OR empty
    ObjectDefinePropertyFromFields(Object, Key, enumerable, configurable, value, writable, get, set)

This is good since,

1. We can remove object property access in C++
2. We can teach DFG / FTL about descriptor access. FTL can potentially
   do object-allocation-sinking and remove object literal for this
   descriptor completely!

Also, we convert DefineDataProperty to PutByIdDirect when its attributes
are enumerable: true / configurable: true, writable: true, and base
object does not have a property for this id.

                                                        ToT                     Patched

    object-define-property-value-only             23.8154+-0.3948     ^     17.6551+-0.6358        ^ definitely 1.3489x faster
    define-property-accessor                       0.6917+-0.1979            0.5889+-0.1481          might be 1.1746x faster
    redefine-property-accessor-dictionary          2.6613+-0.0682            2.4801+-0.1592          might be 1.0731x faster
    redefine-property-previous-attributes         23.5308+-0.2114     ^     18.6530+-0.1750        ^ definitely 1.2615x faster
    redefine-property-data-dictionary              2.1729+-0.0655     ^      1.9438+-0.0311        ^ definitely 1.1178x faster
    define-property-simple                         0.9628+-0.0761            0.8713+-0.0361          might be 1.1050x faster
    object-define-property-put-by-id-direct       30.7412+-0.4415     ^      2.5854+-0.3793        ^ definitely 11.8905x faster
    redefine-property-data                         1.9969+-0.1488     ^      1.6229+-0.0350        ^ definitely 1.2305x faster
    redefine-property-accessor                     2.2817+-0.1191     ^      1.9361+-0.0258        ^ definitely 1.1785x faster
    define-property-data                           0.4759+-0.0098     ?      0.5339+-0.1655        ? might be 1.1219x slower

* JSTests/microbenchmarks/define-property-accessor.js: Added.
(set get Object):
(test):
(set get noInline):
* JSTests/microbenchmarks/define-property-data.js: Added.
(test):
* JSTests/microbenchmarks/define-property-getter-only.js: Added.
(get Object):
(test):
(get noInline):
* JSTests/microbenchmarks/define-property-setter-only.js: Added.
(set Object):
(test):
(set noInline):
* JSTests/microbenchmarks/object-define-property-put-by-id-direct.js: Added.
(bench):
* JSTests/stress/object-define-property-fields-refinement.js: Added.
(shouldBe):
(shouldThrow):
(readDesc):
(testAllTrueData):
(testValueOnly):
(testWritableFalse):
(testGeneric):
(testOpaqueConfigurable):
(testOpaqueEnumerable):
(i.const.e):
(testOpaqueWritable):
(testAccessorLiterals.):
(testAccessorArgs):
(set get noInline):
(testGetOnly):
(get noInline):
(testGetOnlyStrictWrite):
(testAccessorLiterals.set get o):
(testAccessorLiterals):
(set noInline):
(testBadGetOnly):
(testBadSetOnly):
(testBadGetter):
(testMixed.):
(testMixed):
(testNullProtoData):
(get for):
(testDefineAllTruePutsDirect):
(testBareValueDoesNotLower):
(set for):
(testExistingPropertyDoesNotLower):
(testDynamicPropertyDoesNotLower):
(testIndexedPropertyDoesNotLower):
(testAccessorOnValue.):
(testAccessorOnValue.get d):
(testAccessorOnValue):
(testAccessorOnWritable.):
(testAccessorOnWritable.get const):
(testAccessorOnWritable):
(testAccessorOnGet.const.fn):
(testAccessorOnGet.):
(testAccessorOnGet.get const):
(testAccessorOnGet):
(testDictionaryMutation):
(noInline):
(testSymbolKey):
(typeof.createGlobalObject.string_appeared_here.testCrossRealm):
* Source/JavaScriptCore/dfg/DFGAbstractInterpreterInlines.h:
(JSC::DFG::AbstractInterpreter&lt;AbstractStateType&gt;::executeEffects):
* Source/JavaScriptCore/dfg/DFGClobberize.h:
(JSC::DFG::clobberize):
* Source/JavaScriptCore/dfg/DFGConstantFoldingPhase.cpp:
(JSC::DFG::ConstantFoldingPhase::foldConstants):
(JSC::DFG::ConstantFoldingPhase::tryFoldDefineDataPropertyToPutByIdDirect):
* Source/JavaScriptCore/dfg/DFGDoesGC.cpp:
(JSC::DFG::doesGC):
* Source/JavaScriptCore/dfg/DFGFixupPhase.cpp:
(JSC::DFG::FixupPhase::fixupNode):
* Source/JavaScriptCore/dfg/DFGNode.cpp:
(JSC::DFG::Node::convertToDefineDataProperty):
(JSC::DFG::Node::convertToDefineAccessorProperty):
(JSC::DFG::Node::convertToObjectDefinePropertyFromFields):
(JSC::DFG::Node::convertToPutByIdDirect):
* Source/JavaScriptCore/dfg/DFGNode.h:
* Source/JavaScriptCore/dfg/DFGNodeType.h:
* Source/JavaScriptCore/dfg/DFGOperations.cpp:
(JSC::DFG::JSC_DEFINE_JIT_OPERATION):
* Source/JavaScriptCore/dfg/DFGOperations.h:
* Source/JavaScriptCore/dfg/DFGPredictionPropagationPhase.cpp:
* Source/JavaScriptCore/dfg/DFGSafeToExecute.h:
(JSC::DFG::safeToExecute):
* Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp:
* Source/JavaScriptCore/dfg/DFGSpeculativeJIT.h:
* Source/JavaScriptCore/dfg/DFGSpeculativeJIT32_64.cpp:
(JSC::DFG::SpeculativeJIT::compile):
* Source/JavaScriptCore/dfg/DFGSpeculativeJIT64.cpp:
(JSC::DFG::SpeculativeJIT::compile):
* Source/JavaScriptCore/ftl/FTLCapabilities.cpp:
(JSC::FTL::canCompile):
* Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp:
(JSC::FTL::DFG::LowerDFGToB3::compileNode):
(JSC::FTL::DFG::LowerDFGToB3::compileDefineDataProperty):
(JSC::FTL::DFG::LowerDFGToB3::compileObjectDefinePropertyFromFields):
(JSC::FTL::DFG::LowerDFGToB3::compileDefineAccessorProperty):

Canonical link: <a href="https://commits.webkit.org/313124@main">https://commits.webkit.org/313124@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/51713e39355258f73fe4ac6a8f5e7024496d7993

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/162165 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/35641 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/28755 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/171073 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/118538 "Built successfully") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/35745 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/35642 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/125854 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/88717 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/165124 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/28180 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/145673 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/106432 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/27227 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/25745 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/18794 "Built successfully") | | 
| [⏳ 🛠 🧪 jsc ](https://ews-build.webkit.org/#/builders/JSC-Tests-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/136928 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/23412 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/173567 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/23004 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/20920 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/25055 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/134152 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/35315 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/29833 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/134153 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/35298 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/145208 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/97501 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/24632 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/28684 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/22036 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/194565 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/34808 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/102560 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/50159 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/34309 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/34554 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/34457 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->