### PR TITLE
[TestWebKitAPI] Guard WebCore and WebKit includes per target in config.h Xcode path

### DIFF
--- a/Tools/TestWebKitAPI/config.h
+++ b/Tools/TestWebKitAPI/config.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2010-2024 Apple Inc. All rights reserved.
+ * Copyright (C) 2010-2026 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -67,9 +67,10 @@
 
 // XCode path
 #include <JavaScriptCore/JSExportMacros.h>
+#if !defined(BUILDING_TEST_WGSL) && !defined(BUILDING_TEST_WTF)
 #include <WebCore/PlatformExportMacros.h>
 #include <pal/ExportMacros.h>
-#if !PLATFORM(IOS_FAMILY)
+#if !PLATFORM(IOS_FAMILY) && !defined(BUILDING_TEST_IPC)
 #include <WebKit/WebKit2_C.h>
 #endif
 #if PLATFORM(COCOA) && defined(__OBJC__)
@@ -79,8 +80,9 @@
 // on macCatalyst, WebKit.h does not include WebKitLegacy.h, so we need
 // to do it explicitly here.
 #import <WebKit/WebKitLegacy.h>
-#endif
-#endif
+#endif // PLATFORM(MACCATALYST)
+#endif // PLATFORM(COCOA) && defined(__OBJC__)
+#endif // !defined(BUILDING_TEST_WGSL) && !defined(BUILDING_TEST_WTF)
 
 #endif
 


### PR DESCRIPTION
#### 882d478e53f184ca8e9461bf21dcc43e3396b0a3
<pre>
[TestWebKitAPI] Guard WebCore and WebKit includes per target in config.h Xcode path
&lt;<a href="https://bugs.webkit.org/show_bug.cgi?id=313638">https://bugs.webkit.org/show_bug.cgi?id=313638</a>&gt;
&lt;<a href="https://rdar.apple.com/175841808">rdar://175841808</a>&gt;

Reviewed by Jonathan Bedard.

Guard WebCore, PAL, and WebKit includes in the Xcode path of
config.h so targets that do not link those frameworks skip
headers they cannot find in Production builds.

`WebCore.framework` is not part of the macOS SDK -- it only
exists as a build product.  In Production builds, WebCore
headers are provided to dependent targets through the build
record system, but targets that do not link WebCore (TestWGSL,
TestWTF) cannot find `&lt;WebCore/PlatformExportMacros.h&gt;` and do
not need it.  Similarly, `&lt;WebKit/WebKit2_C.h&gt;` is not needed
by TestIPC, TestWGSL, or TestWTF; and `&lt;WebKit/WebKit.h&gt;` and
`&lt;WebKit/WebKitLegacy.h&gt;` are not needed by TestWGSL or
TestWTF.

* Tools/TestWebKitAPI/config.h:

Canonical link: <a href="https://commits.webkit.org/312294@main">https://commits.webkit.org/312294@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9b2b56176e03b5007300e6f280e41a1da4f3395b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/159447 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/32875 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/25983 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/168279 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/113825 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/161316 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/32943 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/32863 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/123542 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/113825 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/162404 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/25786 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/143213 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/104205 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/24846 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/23295 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/16050 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/134525 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/20993 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/170771 "Built successfully") | | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/22619 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/131748 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/32564 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/27370 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/131861 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/32508 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/142786 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/90644 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/24272 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/26519 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/19595 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/32019 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/31539 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/31812 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/31694 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->