### PR TITLE
Remove workaround for CookieObserver issue.

### DIFF
--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -2676,13 +2676,13 @@ EnhancedSecurityHeuristicsEnabled:
   humanReadableDescription: "Triggers EnhancedSecurity when insecure HTTP loads occur"
   defaultValue:
     WebKitLegacy:
-      "PLATFORM(COCOA)": true
+      "PLATFORM(COCOA) && HAVE(ENHANCED_SECURITY_HEURISTICS)": true
       default: false
     WebKit:
-      "PLATFORM(COCOA)": true
+      "PLATFORM(COCOA) && HAVE(ENHANCED_SECURITY_HEURISTICS)": true
       default: false
     WebCore:
-      "PLATFORM(COCOA)": true
+      "PLATFORM(COCOA) && HAVE(ENHANCED_SECURITY_HEURISTICS)": true
       default: false
 
 EnhancedSecurityLinksEnabled:

--- a/Source/WebCore/platform/network/cocoa/CookieStorageObserver.h
+++ b/Source/WebCore/platform/network/cocoa/CookieStorageObserver.h
@@ -55,8 +55,6 @@ public:
 
     void cookiesDidChange();
 
-    void registerInternalsForNotifications(bool isReregistering);
-
 private:
     RetainPtr<NSHTTPCookieStorage> m_cookieStorage;
     bool m_hasRegisteredInternalsForNotifications { false };

--- a/Source/WebCore/platform/network/cocoa/CookieStorageObserver.mm
+++ b/Source/WebCore/platform/network/cocoa/CookieStorageObserver.mm
@@ -110,26 +110,15 @@ void CookieStorageObserver::startObserving(WTF::Function<void()>&& callback)
     m_observerAdapter = adoptNS([[WebCookieObserverAdapter alloc] initWithObserver:*this]);
 
     if (!m_hasRegisteredInternalsForNotifications) {
-        registerInternalsForNotifications(false);
+        if (m_cookieStorage.get() != [NSHTTPCookieStorage sharedHTTPCookieStorage]) {
+            RetainPtr internalObject = (static_cast<WebNSHTTPCookieStorageDummyForInternalAccess *>(m_cookieStorage.get()))->_internal;
+            [internalObject registerForPostingNotificationsWithContext:m_cookieStorage.get()];
+        }
+
         m_hasRegisteredInternalsForNotifications = true;
     }
 
     [[NSNotificationCenter defaultCenter] addObserver:m_observerAdapter.get() selector:@selector(cookiesChangedNotificationHandler:) name:NSHTTPCookieManagerCookiesChangedNotification object:m_cookieStorage.get()];
-}
-
-void CookieStorageObserver::registerInternalsForNotifications(bool isReregistering)
-{
-    // FIXME: rdar://168454473 (Remove workaround in CookieStorageObserver once CFNetwork bug is resolved)
-    ASSERT(isMainThread());
-    ASSERT(hasProcessPrivilege(ProcessPrivilege::CanAccessRawCookies));
-
-    if (isReregistering && !m_hasRegisteredInternalsForNotifications)
-        return;
-
-    if (m_cookieStorage.get() != [NSHTTPCookieStorage sharedHTTPCookieStorage]) {
-        RetainPtr internalObject = (static_cast<WebNSHTTPCookieStorageDummyForInternalAccess *>(m_cookieStorage.get()))->_internal;
-        [internalObject registerForPostingNotificationsWithContext:m_cookieStorage.get()];
-    }
 }
 
 void CookieStorageObserver::stopObserving()

--- a/Source/WebCore/platform/network/cocoa/NetworkStorageSessionCocoa.mm
+++ b/Source/WebCore/platform/network/cocoa/NetworkStorageSessionCocoa.mm
@@ -139,14 +139,9 @@ void NetworkStorageSession::hasCookies(const RegistrableDomain& domain, Completi
     
     for (NSHTTPCookie *nsCookie in [nsCookieStorage() cookies]) {
         if (RegistrableDomain::uncheckedCreateFromHost(nsCookie.domain) == domain) {
-            hasCookieForDomain = true;
-            break;
+            return completionHandler(true);
         }
     }
-
-    // FIXME: rdar://168454473 (Remove workaround in CookieStorageObserver once CFNetwork bug is resolved)
-    if (m_cookieStorageObserver && cookieStorage().get())
-        protect(cookieStorageObserver())->registerInternalsForNotifications(true);
 
     completionHandler(hasCookieForDomain);
 }

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/EnhancedSecurityPolicies.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/EnhancedSecurityPolicies.mm
@@ -1345,6 +1345,8 @@ static void runHttpThenNavigateToHttpsSiteWithCookiesViaAPIAndSeenOutsideEnhance
 
 TEST_WITH_AND_WITHOUT_SITE_ISOLATION(HttpThenNavigateToHttpsSiteWithCookiesViaAPIAndSeenOutsideEnhancedSecurity)
 
+#if HAVE(ENHANCED_SECURITY_HEURISTICS)
+
 TEST(EnhancedSecurityPolicies, NonPersistentDataStoreCookieNotification)
 {
     HTTPServer plaintextServer({
@@ -1365,6 +1367,8 @@ TEST(EnhancedSecurityPolicies, NonPersistentDataStoreCookieNotification)
 
     EXPECT_EQ(observerCallbacks, 1u);
 }
+
+#endif // HAVE(ENHANCED_SECURITY_HEURISTICS)
 
 TEST(EnhancedSecurityPolicies, HistoryEventsUseCorrectOriginalRequest)
 {


### PR DESCRIPTION
#### 9e40cde169e536d489114265ee991a338d32b6dc
<pre>
Remove workaround for CookieObserver issue.
<a href="https://bugs.webkit.org/show_bug.cgi?id=313640">https://bugs.webkit.org/show_bug.cgi?id=313640</a>
<a href="https://rdar.apple.com/168454473">rdar://168454473</a>

Reviewed by NOBODY (OOPS!).

With the CFNetwork fix now resolved, we can remove the workaround. Doing so
does however require gating the Enhanced Security Heuristics feature to ensure
this issue doesn&apos;t surface on older builds, so we add this here.

Existing test applies, but should only run where the heuristics are default
enabled.

Test: Tools/TestWebKitAPI/Tests/WebKit/WKWebView/EnhancedSecurityPolicies.mm

* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml:
* Source/WebCore/platform/network/cocoa/CookieStorageObserver.h:
* Source/WebCore/platform/network/cocoa/CookieStorageObserver.mm:
(WebCore::CookieStorageObserver::startObserving):
(WebCore::CookieStorageObserver::registerInternalsForNotifications): Deleted.
* Source/WebCore/platform/network/cocoa/NetworkStorageSessionCocoa.mm:
(WebCore::NetworkStorageSession::hasCookies const):
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/EnhancedSecurityPolicies.mm:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9e40cde169e536d489114265ee991a338d32b6dc

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/159449 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/32878 "Built successfully") | [❌ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/25985 "Hash 9e40cde1 for PR 63884 does not build (failure)") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/168281 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/113830 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/5aaa9ea6-e407-46bb-8ffd-4f2e3b88303b) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/161318 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/32945 "Built successfully") | [❌ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/32866 "Hash 9e40cde1 for PR 63884 does not build (failure)") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/123544 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/86719 "layout-tests (failure) (timed out)") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/f190dd12-a0f1-4a88-a344-b8106404e7e4) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/162406 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/25788 "Passed tests") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/168/builds/25985 "Hash 9e40cde1 for PR 63884 does not build (failure)") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/104207 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/afbb0152-aaf9-4bb9-afdb-382a236f845e) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/24848 "Passed tests") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/156/builds/32866 "Hash 9e40cde1 for PR 63884 does not build (failure)") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/16052 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/151499 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/134540 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/168/builds/25985 "Hash 9e40cde1 for PR 63884 does not build (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/170773 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/20282 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/16807 "Built successfully") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/168/builds/25985 "Hash 9e40cde1 for PR 63884 does not build (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/131750 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/32566 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/156/builds/32866 "Hash 9e40cde1 for PR 63884 does not build (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/131863 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/32510 "Built successfully") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/168/builds/25985 "Hash 9e40cde1 for PR 63884 does not build (failure)") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/90646 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/26521 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/168/builds/25985 "Hash 9e40cde1 for PR 63884 does not build (failure)") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/191732 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/32021 "Built successfully") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/98473 "Failed to build and analyze WebKit") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/49267 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/31541 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/31814 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/31696 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->