### PR TITLE
[WebXR Layers][OpenXR] WebKit crashes in immersiveweb's quad-ab-test.html

### DIFF
--- a/Source/WebCore/Modules/webxr/WebXRLayer.h
+++ b/Source/WebCore/Modules/webxr/WebXRLayer.h
@@ -49,6 +49,7 @@ public:
 
     virtual void startFrame(PlatformXR::FrameData&) = 0;
     virtual PlatformXR::DeviceLayer endFrame() = 0;
+    virtual PlatformXR::LayerHandle layerHandle() const = 0;
 
     virtual bool isWebXRWebGLLayer() const { return false; }
     virtual bool isXRCompositionLayer() const { return false; }

--- a/Source/WebCore/Modules/webxr/WebXRSession.cpp
+++ b/Source/WebCore/Modules/webxr/WebXRSession.cpp
@@ -585,9 +585,19 @@ void WebXRSession::applyPendingRenderState()
         m_activeRenderState->setOutputCanvas(nullptr);
     }
 
-    m_requestData = { {
+    m_requestData = {
         .isPassthroughFullyObscured = m_activeRenderState->passthroughFullyObscured().value_or(false),
-        .depthRange = PlatformXR::DepthRange { static_cast<float>(m_activeRenderState->depthNear()), static_cast<float>(m_activeRenderState->depthFar()) } }}; // NOLINT
+        .depthRange = PlatformXR::DepthRange { static_cast<float>(m_activeRenderState->depthNear()), static_cast<float>(m_activeRenderState->depthFar()) },
+        .activeLayerHandles = { }
+    };
+
+    if (RefPtr baseLayer = m_activeRenderState->baseLayer()) {
+        if (baseLayer->isCompositionEnabled())
+            m_requestData->activeLayerHandles.append(baseLayer->layerHandle());
+    } else {
+        for (Ref layer : m_activeRenderState->layers())
+            m_requestData->activeLayerHandles.append(layer->layerHandle());
+    }
 }
 
 void WebXRSession::minimalUpdateRendering()

--- a/Source/WebCore/Modules/webxr/WebXRWebGLLayer.cpp
+++ b/Source/WebCore/Modules/webxr/WebXRWebGLLayer.cpp
@@ -97,7 +97,7 @@ static ExceptionOr<std::unique_ptr<WebXROpaqueFramebuffer>> createOpaqueFramebuf
     auto framebuffer = WebXROpaqueFramebuffer::create(layerInfo->handle, context, WTF::move(attributes), size);
     if (!framebuffer)
         return Exception { ExceptionCode::OperationError, "Unable to create a framebuffer."_s };
-    
+
     return framebuffer;
 }
 
@@ -142,7 +142,7 @@ ExceptionOr<Ref<WebXRWebGLLayer>> WebXRWebGLLayer::create(WebXRSession& session,
             bool antialias = false;
             std::unique_ptr<WebXROpaqueFramebuffer> framebuffer;
 
-            // 9. If layer's composition enabled boolean is true: 
+            // 9. If layer's composition enabled boolean is true:
             if (isCompositionEnabled) {
                 auto createResult = createOpaqueFramebuffer(session, baseContext, init);
                 if (createResult.hasException())
@@ -317,6 +317,12 @@ void WebXRWebGLLayer::startFrame(PlatformXR::FrameData& data)
     }
 
     m_framebuffer->startFrame(it->value);
+}
+
+PlatformXR::LayerHandle WebXRWebGLLayer::layerHandle() const
+{
+    ASSERT(m_framebuffer);
+    return m_framebuffer->handle();
 }
 
 PlatformXR::DeviceLayer WebXRWebGLLayer::endFrame()

--- a/Source/WebCore/Modules/webxr/WebXRWebGLLayer.h
+++ b/Source/WebCore/Modules/webxr/WebXRWebGLLayer.h
@@ -91,6 +91,7 @@ public:
     // WebXRLayer
     void startFrame(PlatformXR::FrameData&) final;
     PlatformXR::DeviceLayer endFrame() final;
+    PlatformXR::LayerHandle layerHandle() const final;
 
 private:
     WebXRWebGLLayer(WebXRSession&, WebXRRenderingContext&&, std::unique_ptr<WebXROpaqueFramebuffer>&&, bool antialias, bool ignoreDepthValues, bool isCompositionEnabled);

--- a/Source/WebCore/Modules/webxr/XRCompositionLayer.cpp
+++ b/Source/WebCore/Modules/webxr/XRCompositionLayer.cpp
@@ -58,6 +58,11 @@ XRLayerBacking& XRCompositionLayer::backing()
     return m_backing;
 }
 
+PlatformXR::LayerHandle XRCompositionLayer::layerHandle() const
+{
+    return m_backing->handle();
+}
+
 void XRCompositionLayer::setColorTextures(Vector<RefPtr<WebGLOpaqueTexture>>&& colorTextures)
 {
     m_colorTextures = WTF::move(colorTextures);

--- a/Source/WebCore/Modules/webxr/XRCompositionLayer.h
+++ b/Source/WebCore/Modules/webxr/XRCompositionLayer.h
@@ -77,6 +77,7 @@ public:
     void setIsStatic(bool isStatic) { m_isStatic = isStatic; }
 
     XRLayerBacking& backing();
+    PlatformXR::LayerHandle layerHandle() const final;
     WebXRSession* session() const;
 
     void destroy() { }

--- a/Source/WebCore/platform/xr/PlatformXR.h
+++ b/Source/WebCore/platform/xr/PlatformXR.h
@@ -287,6 +287,7 @@ struct DepthRange {
 struct RequestData {
     bool isPassthroughFullyObscured;
     DepthRange depthRange;
+    Vector<LayerHandle> activeLayerHandles;
 };
 
 struct RateMapDescription {

--- a/Source/WebKit/Shared/XR/PlatformXR.serialization.in
+++ b/Source/WebKit/Shared/XR/PlatformXR.serialization.in
@@ -90,6 +90,7 @@ header: <WebCore/PlatformXR.h>
 [CustomHeader] struct PlatformXR::RequestData {
     bool isPassthroughFullyObscured;
     PlatformXR::DepthRange depthRange;
+    Vector<PlatformXR::LayerHandle> activeLayerHandles;
 };
 
 [Nested] struct PlatformXR::FrameData::FloatQuaternion {

--- a/Source/WebKit/UIProcess/XR/openxr/OpenXRLayer.cpp
+++ b/Source/WebKit/UIProcess/XR/openxr/OpenXRLayer.cpp
@@ -397,6 +397,8 @@ std::optional<PlatformXR::FrameData::LayerData> OpenXRLayerProjection::startFram
 
 Vector<XrCompositionLayerBaseHeader*> OpenXRLayerProjection::endFrame(const PlatformXR::DeviceLayer& layer, XrSpace space, const Vector<XrView>& frameViews)
 {
+    ASSERT(m_swapchain->acquiredTexture());
+
 #if OS(ANDROID) || USE(GBM)
     if (needsBlitTexture()) {
         if (!m_fbosForBlitting[0])
@@ -499,10 +501,7 @@ std::optional<PlatformXR::FrameData::LayerData> OpenXRQuadLayer::startFrame()
 
 Vector<XrCompositionLayerBaseHeader*> OpenXRQuadLayer::endFrame(const PlatformXR::DeviceLayer& layer, XrSpace space, const Vector<XrView>& frameViews)
 {
-    if (!m_swapchain->acquiredTexture()) {
-        LOG_ERROR("OpenXRQuadLayer::endFrame called without a valid acquired texture");
-        return { };
-    }
+    ASSERT(m_swapchain->acquiredTexture());
 
 #if OS(ANDROID) || USE(GBM)
     if (needsBlitTexture()) {
@@ -633,10 +632,7 @@ std::optional<PlatformXR::FrameData::LayerData> OpenXREquirectLayer::startFrame(
 
 Vector<XrCompositionLayerBaseHeader*> OpenXREquirectLayer::endFrame(const PlatformXR::DeviceLayer& layer, XrSpace space, const Vector<XrView>& frameViews)
 {
-    if (!m_swapchain->acquiredTexture()) {
-        LOG_ERROR("OpenXREquirectLayer::endFrame called without a valid acquired texture");
-        return { };
-    }
+    ASSERT(m_swapchain->acquiredTexture());
 
 #if OS(ANDROID) || USE(GBM)
     if (needsBlitTexture()) {

--- a/Source/WebKit/UIProcess/XR/openxr/PlatformXROpenXR.cpp
+++ b/Source/WebKit/UIProcess/XR/openxr/PlatformXROpenXR.cpp
@@ -65,6 +65,8 @@ struct OpenXRCoordinator::RenderState {
     PlatformXR::Device::RequestFrameCallback onFrameUpdate;
     XrFrameState frameState;
     bool passthroughFullyObscured { false };
+    Vector<PlatformXR::LayerHandle> activeLayerHandles;
+    Vector<PlatformXR::LayerHandle> currentFrameLayerHandles;
 #if ENABLE(WEBXR_HIT_TEST)
     HashMap<PlatformXR::HitTestSource, UniqueRef<PlatformXR::HitTestOptions>> hitTestSources;
     HashMap<PlatformXR::TransientInputHitTestSource, UniqueRef<PlatformXR::TransientInputHitTestOptions>> transientInputHitTestSources;
@@ -429,7 +431,10 @@ void OpenXRCoordinator::scheduleAnimationFrame(WebPageProxy& page, std::optional
             }
 
             active.renderQueue->dispatch([this, renderState = active.renderState, requestData = WTF::move(requestData), onFrameUpdateCallback = WTF::move(onFrameUpdateCallback)]() mutable {
-                renderState->passthroughFullyObscured = requestData ? requestData->isPassthroughFullyObscured : false;
+                if (requestData) {
+                    renderState->passthroughFullyObscured = requestData->isPassthroughFullyObscured;
+                    renderState->activeLayerHandles = requestData->activeLayerHandles;
+                }
                 renderState->onFrameUpdate = WTF::move(onFrameUpdateCallback);
                 renderLoop(renderState);
             });
@@ -1104,6 +1109,8 @@ PlatformXR::FrameData OpenXRCoordinator::populateFrameData(Box<RenderState> rend
         frameData.floorTransform = XrIdentityPose();
 
     for (auto& layer : m_layers) {
+        if (!renderState->currentFrameLayerHandles.contains(layer.key))
+            continue;
         auto layerData = layer.value->startFrame();
         if (layerData) {
             auto layerDataRef = makeUniqueRef<PlatformXR::FrameData::LayerData>(WTF::move(*layerData));
@@ -1224,6 +1231,7 @@ void OpenXRCoordinator::beginFrame(Box<RenderState> renderState)
 
     // We should not directly use renderState->frameState in the xrWaitFrame() in order not to override the previous (ongoing) value.
     renderState->frameState = frameState;
+    renderState->currentFrameLayerHandles = renderState->activeLayerHandles;
 
     createReferenceSpacesIfNeeded(renderState);
     PlatformXR::FrameData frameData = populateFrameData(renderState);
@@ -1247,6 +1255,8 @@ void OpenXRCoordinator::endFrame(Box<RenderState> renderState, Vector<PlatformXR
 
     Vector<XrCompositionLayerBaseHeader*> frameEndLayers;
     for (auto& layer : layers) {
+        ASSERT(renderState->currentFrameLayerHandles.contains(layer.handle));
+
         auto it = m_layers.find(layer.handle);
         if (it == m_layers.end()) {
             LOG(XR, "Didn't find a OpenXRLayer with %d handle", layer.handle);


### PR DESCRIPTION
#### e5dac2f2642fedd5c1a289f5491875972e666ebd
<pre>
[WebXR Layers][OpenXR] WebKit crashes in immersiveweb&apos;s quad-ab-test.html
<a href="https://bugs.webkit.org/show_bug.cgi?id=313625">https://bugs.webkit.org/show_bug.cgi?id=313625</a>

Reviewed by Dan Glastonbury.

The immersiveweb&apos;s quad AB example is a test that demonstrates rendering
the same picture using a quad layer or embedded in the projection layer.
The UIProcess was crashing soon after starting the WebXR session (it
requires the not landed yet cylinder layer support from PR#63785).

The sequence was more or less the following:
1. Layer A is created, and updateRenderState() is
   called so the list of active layers becomes [ A ]
2. Another layer B is created, but updateRenderState is not called yet.
3. populateFrameData() called startFrame() over all *created* layers,
   i.e. [A, B]
4. submitFrame() was later called with only [ A ] as updateRenderState()
   was not called yet
5. On the render thread endFrame() processes layer A (calling
   releaseImage()). Layer B was never submitted, so B-&gt;endFrame() is
   never called.
6. In the next frame populateFrameData() was calling startFrame over [A,
   B] again, but since B&apos;s texture was not released, the call to
   acquireImage() failed.

As it can be seen the problem was that startFrame() was always called
over all created layers, but endFrame() was created only over the active
layers in WebXR. OpenXR should only operate on the layers selected by
WebXR.

We actually tried to solve this previously adding an acquiredTexture
check in endFrame() but that was wrong because it was indeed fixing the
crash (the sympthon) but not the proper flow of calls (ensuring that
startFrame/endFrame -acquireImage/releaseImage- happen always in pairs).
This patch replaced that with ASSERTs.

Now we keep a list of active textures on the PlatformXR side which is
updated everytime the user calls updateRenderState() in WebXR. Actually
we need to keep two lists in order to use the same list during the whole
lifetime of a frame while allowing the code to update that list for the
next one.

Last but not least, this allowed us to unveil a bug when setting
passthroughFullyObscured. We were resetting it to false if no
requestData was provided, That&apos;s wrong, requestData is only received
when the render state changes, so if it&apos;s null then it means that
nothing should change and that it should keep the previous value.

No new tests as this can only be reproduced with an actual OpenXR
runtime runing.

* Source/WebCore/Modules/webxr/WebXRLayer.h:
* Source/WebCore/Modules/webxr/WebXRSession.cpp:
(WebCore::WebXRSession::applyPendingRenderState):
* Source/WebCore/Modules/webxr/WebXRWebGLLayer.cpp:
(WebCore::createOpaqueFramebuffer):
(WebCore::WebXRWebGLLayer::create):
(WebCore::WebXRWebGLLayer::layerHandle const):
* Source/WebCore/Modules/webxr/WebXRWebGLLayer.h:
* Source/WebCore/Modules/webxr/XRCompositionLayer.cpp:
(WebCore::XRCompositionLayer::layerHandle const):
* Source/WebCore/Modules/webxr/XRCompositionLayer.h:
* Source/WebCore/platform/xr/PlatformXR.h:
* Source/WebKit/Shared/XR/PlatformXR.serialization.in:
* Source/WebKit/UIProcess/XR/openxr/OpenXRLayer.cpp:
* Source/WebKit/UIProcess/XR/openxr/PlatformXROpenXR.cpp:
(WebKit::OpenXRCoordinator::scheduleAnimationFrame):
(WebKit::OpenXRCoordinator::populateFrameData):
(WebKit::OpenXRCoordinator::beginFrame):
(WebKit::OpenXRCoordinator::endFrame):

Canonical link: <a href="https://commits.webkit.org/312422@main">https://commits.webkit.org/312422@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/72f97d19b53a8acdb36ca872ee3a0bab0bd1b67d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/159452 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/32881 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/25988 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/168284 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/113832 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/161321 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/32948 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/32869 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/123547 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/86721 "1 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/162409 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/25791 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/143223 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/104210 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/24851 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/23308 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/16055 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/134542 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/21003 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/170776 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/16810 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/22629 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/131753 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/32569 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/27375 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/131866 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35768 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/32513 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/142796 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/90650 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/26526 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/19605 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/32024 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/98476 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/31544 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/31817 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/31699 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->