### PR TITLE
[:has() perf] Optimize non-subject sibling invalidation

### DIFF
--- a/LayoutTests/fast/selectors/has-invalidation-traversal-size-expected.txt
+++ b/LayoutTests/fast/selectors/has-invalidation-traversal-size-expected.txt
@@ -9,7 +9,7 @@
 :has(+ .trigger) with compound peer .c5
   Traversal count: 1
 :has(:is(.trigger + .other)) with compound peer .c6
-  Traversal count: 14
+  Traversal count: 13
 :has(.trigger) non-subject with scope-bounded traversal .c7
   Traversal count: 7
 :not(:has(.trigger)) inside :not() with compound peer .c8
@@ -18,4 +18,20 @@
   Traversal count: 7
 :is(.other :has(.trigger)) inside :is() with complex selector and compound peer .c10
   Traversal count: 7
+(Parent, DirectSibling) .c11:has(+ .trigger11) > .target
+  Traversal count: 6
+(Parent, IndirectSibling) .c12:has(~ .trigger12) > .target
+  Traversal count: 6
+(Ancestor, DirectSibling) .c13:has(+ .trigger13) .target
+  Traversal count: 6
+(Ancestor, IndirectSibling) .c14:has(~ .trigger14) .target
+  Traversal count: 6
+(Parent, SiblingChild) .c15:has(~ .other15 > .trigger15) > .target
+  Traversal count: 17
+(Parent, SiblingDescendant) .c16:has(~ .other16 .trigger16) > .target
+  Traversal count: 17
+(Ancestor, SiblingChild) .c17:has(~ .other17 > .trigger17) .target
+  Traversal count: 17
+(Ancestor, SiblingDescendant) .c18:has(~ .other18 .trigger18) .target
+  Traversal count: 17
 

--- a/LayoutTests/fast/selectors/has-invalidation-traversal-size.html
+++ b/LayoutTests/fast/selectors/has-invalidation-traversal-size.html
@@ -22,6 +22,22 @@
 .c9:is(:has(.trigger)) .target { color: green; }
 /* :has() inside :is() with complex selector and compound peer */
 .c10:is(.other :has(.trigger)) .target { color: green; }
+/* Non-subject (Parent, DirectSibling): bearer has direct next sibling */
+.c11:has(+ .trigger11) > .target { color: green; }
+/* Non-subject (Parent, IndirectSibling): bearer has any later sibling */
+.c12:has(~ .trigger12) > .target { color: green; }
+/* Non-subject (Ancestor, DirectSibling): subject is descendant of bearer */
+.c13:has(+ .trigger13) .target { color: green; }
+/* Non-subject (Ancestor, IndirectSibling): subject is descendant of bearer */
+.c14:has(~ .trigger14) .target { color: green; }
+/* Non-subject (Parent, SiblingChild): bearer ~ .other > .trigger */
+.c15:has(~ .other15 > .trigger15) > .target { color: green; }
+/* Non-subject (Parent, SiblingDescendant): bearer ~ .other .trigger */
+.c16:has(~ .other16 .trigger16) > .target { color: green; }
+/* Non-subject (Ancestor, SiblingChild): subject is descendant of bearer */
+.c17:has(~ .other17 > .trigger17) .target { color: green; }
+/* Non-subject (Ancestor, SiblingDescendant): subject is descendant of bearer */
+.c18:has(~ .other18 .trigger18) .target { color: green; }
 </style>
 <script>
 if (window.testRunner)
@@ -60,16 +76,16 @@ function makeTree(containerClass, childCount, wrapperClass) {
     return container;
 }
 
-function runTest(description, containerClass, mutate, expectGreen, wrapperClass) {
-    var container = makeTree(containerClass, 5, wrapperClass);
-    // Force initial style.
+function runTest(description, containerClass, mutate, expectGreen, options) {
+    options = options || {};
+    var container = makeTree(containerClass, 5, options.wrapperClass);
+    var mutateTarget = options.setup ? options.setup(container) : container;
     document.body.offsetHeight;
 
     internals.resetStyleInvalidationTraversalCount();
 
-    mutate(container);
+    mutate(mutateTarget);
 
-    // Force style resolution.
     document.body.offsetHeight;
 
     var count = internals.styleInvalidationTraversalCount;
@@ -82,7 +98,9 @@ function runTest(description, containerClass, mutate, expectGreen, wrapperClass)
     if (!passed)
         log("  FAIL: unexpected color " + color);
 
-    (container.parentNode === document.getElementById("tests") ? container : container.parentNode).remove();
+    var tests = document.getElementById("tests");
+    while (tests.firstChild)
+        tests.firstChild.remove();
 }
 
 runTest(":has(> .trigger) with compound peer .c1", "c1", function(container) {
@@ -143,7 +161,65 @@ runTest(":is(.other :has(.trigger)) inside :is() with complex selector and compo
     var trigger = document.createElement("div");
     trigger.className = "trigger";
     container.appendChild(trigger);
-}, true, "other");
+}, true, { wrapperClass: "other" });
+
+runTest("(Parent, DirectSibling) .c11:has(+ .trigger11) > .target", "c11", function(container) {
+    var trigger = document.createElement("div");
+    trigger.className = "trigger11";
+    container.parentNode.insertBefore(trigger, container.nextSibling);
+}, true);
+
+runTest("(Parent, IndirectSibling) .c12:has(~ .trigger12) > .target", "c12", function(container) {
+    var trigger = document.createElement("div");
+    trigger.className = "trigger12";
+    container.parentNode.appendChild(trigger);
+}, true);
+
+runTest("(Ancestor, DirectSibling) .c13:has(+ .trigger13) .target", "c13", function(container) {
+    var trigger = document.createElement("div");
+    trigger.className = "trigger13";
+    container.parentNode.insertBefore(trigger, container.nextSibling);
+}, true);
+
+runTest("(Ancestor, IndirectSibling) .c14:has(~ .trigger14) .target", "c14", function(container) {
+    var trigger = document.createElement("div");
+    trigger.className = "trigger14";
+    container.parentNode.appendChild(trigger);
+}, true);
+
+function setupFollowingOther(otherClass) {
+    return function(container) {
+        var other = document.createElement("div");
+        other.className = otherClass;
+        other.appendChild(document.createElement("div"));
+        container.parentNode.insertBefore(other, container.nextSibling);
+        return other;
+    };
+}
+
+runTest("(Parent, SiblingChild) .c15:has(~ .other15 > .trigger15) > .target", "c15", function(other) {
+    var trigger = document.createElement("div");
+    trigger.className = "trigger15";
+    other.appendChild(trigger);
+}, true, { setup: setupFollowingOther("other15") });
+
+runTest("(Parent, SiblingDescendant) .c16:has(~ .other16 .trigger16) > .target", "c16", function(other) {
+    var trigger = document.createElement("div");
+    trigger.className = "trigger16";
+    other.firstElementChild.appendChild(trigger);
+}, true, { setup: setupFollowingOther("other16") });
+
+runTest("(Ancestor, SiblingChild) .c17:has(~ .other17 > .trigger17) .target", "c17", function(other) {
+    var trigger = document.createElement("div");
+    trigger.className = "trigger17";
+    other.appendChild(trigger);
+}, true, { setup: setupFollowingOther("other17") });
+
+runTest("(Ancestor, SiblingDescendant) .c18:has(~ .other18 .trigger18) .target", "c18", function(other) {
+    var trigger = document.createElement("div");
+    trigger.className = "trigger18";
+    other.firstElementChild.appendChild(trigger);
+}, true, { setup: setupFollowingOther("other18") });
 </script>
 </script>
 </body>

--- a/Source/WebCore/css/parser/CSSSelectorParser.cpp
+++ b/Source/WebCore/css/parser/CSSSelectorParser.cpp
@@ -1593,11 +1593,18 @@ static CSSSelectorList buildScopeSelector(const HasCompoundContext& context)
     return CSSSelectorList { WTF::move(result) };
 }
 
+// Returns a selector for the :has() scope element. Encodes three cases:
+//   - Specific selectors: strong scope (e.g. `.c1` for `.c1:has(> .trigger)`).
+//   - Universal `*`: weak scope. Bearer has no compound peer (e.g. `:has(+ .trigger)`).
+//   - Empty list: scope-breaking. A nested :is()/:not() combinator reaches outside the scope.
 CSSSelectorList CSSSelectorParser::makeHasScopeSelector(const CSSSelector& hasPseudoClass)
 {
     auto context = collectHasCompoundContext(hasPseudoClass);
-    if (!context)
-        return { };
+    if (!context) {
+        MutableCSSSelectorList result;
+        result.append(makeUnique<MutableCSSSelector>(anyQName()));
+        return CSSSelectorList { WTF::move(result) };
+    }
     return buildScopeSelector(*context);
 }
 

--- a/Source/WebCore/style/StyleInvalidator.cpp
+++ b/Source/WebCore/style/StyleInvalidator.cpp
@@ -426,6 +426,60 @@ void Invalidator::invalidateStyleWithMatchElement(Element& element, MatchElement
                 return;
             }
         }
+
+        // Null scopeSelector means scope-breaking: no scope element can be identified.
+        // Universal-selector (`*`) scope stays non-null and flows into the optimized paths.
+        auto someRuleSetIsScopeBreaking = [&] {
+            for (auto& ruleSet : m_ruleSets) {
+                if (!ruleSet.scopeSelector)
+                    return true;
+            }
+            return false;
+        }();
+        if (someRuleSetIsScopeBreaking) {
+            SelectorMatchingState selectorMatchingState;
+            invalidateStyleForDescendants(*element.document().documentElement(), &selectorMatchingState);
+            return;
+        }
+
+        auto invalidateScopeElementChildren = [&](Element& scopeElement) {
+            SelectorMatchingState selectorMatchingState;
+            selectorMatchingState.selectorFilter.pushParentInitializingIfNeeded(scopeElement);
+            for (Ref child : childrenOfType<Element>(scopeElement))
+                invalidateIfNeeded(child.get(), &selectorMatchingState);
+        };
+        auto invalidateScopeElementDescendants = [&](Element& scopeElement) {
+            SelectorMatchingState selectorMatchingState;
+            invalidateStyleForDescendants(scopeElement, &selectorMatchingState);
+        };
+
+        if (matchElement.relation == Relation::Parent && hasRelation == HasRelation::DirectSibling) {
+            // :has(+ .changed) > .subject — :has() scope element is element's previous sibling.
+            if (RefPtr scopeElement = element.previousElementSibling())
+                invalidateScopeElementChildren(*scopeElement);
+            return;
+        }
+        if (matchElement.relation == Relation::Ancestor && hasRelation == HasRelation::DirectSibling) {
+            // :has(+ .changed) .subject
+            if (RefPtr scopeElement = element.previousElementSibling())
+                invalidateScopeElementDescendants(*scopeElement);
+            return;
+        }
+        if (matchElement.relation == Relation::Parent && hasRelation == HasRelation::IndirectSibling) {
+            // :has(~ .changed) > .subject — any earlier sibling can be the :has() scope element.
+            for (RefPtr scopeElement = element.previousElementSibling(); scopeElement; scopeElement = scopeElement->previousElementSibling())
+                invalidateScopeElementChildren(*scopeElement);
+            return;
+        }
+        if (matchElement.relation == Relation::Ancestor && hasRelation == HasRelation::IndirectSibling) {
+            // :has(~ .changed) .subject
+            for (RefPtr scopeElement = element.previousElementSibling(); scopeElement; scopeElement = scopeElement->previousElementSibling())
+                invalidateScopeElementDescendants(*scopeElement);
+            return;
+        }
+        // FIXME: SiblingChild and SiblingDescendant cases (e.g. :has(~ .other > .changed)) need
+        // additional info beyond matchElement to identify the :has() scope element correctly when
+        // the entry is for a non-rightmost compound in the :has() argument chain.
         // Remaining non-subject :has() cases fall back to full document traversal.
 
         SelectorMatchingState selectorMatchingState;

--- a/Source/WebCore/style/StyleScopeRuleSets.h
+++ b/Source/WebCore/style/StyleScopeRuleSets.h
@@ -55,8 +55,11 @@ struct InvalidationRuleSet {
     CSSSelectorList invalidationSelectors;
     MatchElement matchElement;
     IsNegation isNegation;
-    // For non-subject :has(), a selector matching the :has() scope element.
-    // Used to bound the invalidation traversal to the scope element's subtree.
+    // Selector for the :has() scope element, used to bound invalidation traversal.
+    //   - Specific selectors: strong scope.
+    //   - Universal `*`: weak scope (bearer has no compound peer); scope element is still
+    //     DOM-identifiable relative to a changed element.
+    //   - Empty: scope-breaking (nested :is()/:not() reaches outside the scope).
     CSSSelectorList scopeSelector;
 };
 


### PR DESCRIPTION
#### 5b42d60b4ff3f9fc0d4676c72b4e418260e9952d
<pre>
[:has() perf] Optimize non-subject sibling invalidation
<a href="https://bugs.webkit.org/show_bug.cgi?id=313629">https://bugs.webkit.org/show_bug.cgi?id=313629</a>
<a href="https://rdar.apple.com/175835568">rdar://175835568</a>

Reviewed by Alan Baradlay.

Avoid full document invalidation traversal in cases like

.c:has(+ .trigger) &gt; .target
.c:has(~ .trigger) &gt; .target
.c:has(+ .trigger) .target
.c:has(~ .trigger) .target

* Source/WebCore/css/parser/CSSSelectorParser.cpp:
(WebCore::CSSSelectorParser::makeHasScopeSelector):

Also ensure we differentiate between scope breaking and weakly scoped cases.

* Source/WebCore/style/StyleInvalidator.cpp:
(WebCore::Style::Invalidator::invalidateStyleWithMatchElement):
* Source/WebCore/style/StyleScopeRuleSets.h:

Add additional traversal paths.

Canonical link: <a href="https://commits.webkit.org/312513@main">https://commits.webkit.org/312513@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2e0faaa941a4a8194128fec82a88d5dc15349244

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/159453 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/32882 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/25989 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/168285 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/113833 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/e625e4f1-e51b-4b1b-b91b-89c1d97c92c4) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/161322 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/32949 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/32870 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/123549 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/86722 "1 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/06a4f3fe-50dc-4e72-86bd-8ff971f073dc) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/162410 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/25795 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/143217 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/104212 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/3fa3617b-7057-4550-8e87-8e3baebdb24a) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/24855 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/23310 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/16056 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/134546 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/20997 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/170777 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/16811 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/22623 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/131755 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/32570 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/27377 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/131868 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35819 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/32514 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/142790 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/90652 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/26523 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/19599 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/32025 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/98477 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/31545 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/31818 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/31700 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->