### PR TITLE
REGRESSION (312195@main): ServiceWorkerProcessSwapWithNoDelay and WindowClientNavigate API tests failing

### DIFF
--- a/Source/WebCore/workers/service/server/SWServer.cpp
+++ b/Source/WebCore/workers/service/server/SWServer.cpp
@@ -567,12 +567,14 @@ SWServer::SWServer(SWServerDelegate& delegate, UniqueRef<SWOriginStore>&& origin
             if (result && !protectedThis->m_originListImportComplete) {
                 for (auto& origin : result.value())
                     protectedThis->m_originStore->add(origin.topOrigin);
+                auto originCount = result->size();
                 protectedThis->m_originsYetToBeImported = WTF::move(*result);
 #if !RELEASE_LOG_DISABLED
                 auto elapsed = MonotonicTime::now() - startTime;
-                RELEASE_LOG(ServiceWorker, "SWServer: Imported origin list with %u top origins in %.0f ms", result->size(), elapsed.milliseconds());
+                RELEASE_LOG(ServiceWorker, "SWServer: Imported origin list with %u top origins in %.0f ms", originCount, elapsed.milliseconds());
 #else
                 UNUSED_PARAM(startTime);
+                UNUSED_PARAM(originCount);
 #endif
             }
             protectedThis->m_originListImportComplete = true;

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ServiceWorkerBasic.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ServiceWorkerBasic.mm
@@ -562,6 +562,9 @@ static void runBasicSWTest(ShouldRunServiceWorkersOnMainThread shouldRunServiceW
     TestWebKitAPI::Util::run(&done);
     done = false;
 
+    // Disable ITP so it doesn't inadvertently delete our service worker registrations.
+    [[configuration websiteDataStore] _setResourceLoadStatisticsEnabled:NO];
+
     RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
 
     [webView loadRequest:server.request()];
@@ -660,6 +663,9 @@ TEST(ServiceWorkers, UserAgentOverride)
     TestWebKitAPI::Util::run(&done);
     done = false;
 
+    // Disable ITP so it doesn't inadvertently delete our service worker registrations.
+    [[WKWebsiteDataStore defaultDataStore] _setResourceLoadStatisticsEnabled:NO];
+
     RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
 
     RetainPtr messageHandler = adoptNS([[SWUserAgentMessageHandler alloc] initWithExpectedMessage:@"Message from worker: Foo Custom UserAgent"]);
@@ -712,6 +718,9 @@ TEST(ServiceWorkers, RestoreFromDisk)
     }];
     TestWebKitAPI::Util::run(&done);
     done = false;
+
+    // Disable ITP so it doesn't inadvertently delete our service worker registrations.
+    [[WKWebsiteDataStore defaultDataStore] _setResourceLoadStatisticsEnabled:NO];
 
     RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
 
@@ -774,6 +783,9 @@ TEST(ServiceWorkers, UpdateCheckAfterRestoreFromDisk)
     TestWebKitAPI::Util::run(&done);
     done = false;
 
+    // Disable ITP so it doesn't inadvertently delete our service worker registrations.
+    [[WKWebsiteDataStore defaultDataStore] _setResourceLoadStatisticsEnabled:NO];
+
     RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
 
     RetainPtr<SWMessageHandlerForRestoreFromDiskTest> messageHandler = adoptNS([[SWMessageHandlerForRestoreFromDiskTest alloc] initWithExpectedMessage:@"PASS: Registration was successful and service worker was activated"]);
@@ -834,6 +846,9 @@ TEST(ServiceWorkers, CheckRegistrationWithoutMainScript)
     }];
     TestWebKitAPI::Util::run(&done);
     done = false;
+
+    // Disable ITP so it doesn't inadvertently delete our service worker registrations.
+    [[WKWebsiteDataStore defaultDataStore] _setResourceLoadStatisticsEnabled:NO];
 
     RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
 
@@ -914,6 +929,9 @@ TEST(ServiceWorkers, CheckRegistrationWithoutImportedScript)
     }];
     TestWebKitAPI::Util::run(&done);
     done = false;
+
+    // Disable ITP so it doesn't inadvertently delete our service worker registrations.
+    [[WKWebsiteDataStore defaultDataStore] _setResourceLoadStatisticsEnabled:NO];
 
     RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
 
@@ -1079,6 +1097,9 @@ TEST(ServiceWorkers, ThirdPartyRestoredFromDisk)
     TestWebKitAPI::Util::run(&done);
     done = false;
 
+    // Disable ITP so it doesn't inadvertently delete our service worker registrations.
+    [dataStore _setResourceLoadStatisticsEnabled:NO];
+
     RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     configuration.get().websiteDataStore = dataStore.get();
 
@@ -1164,6 +1185,9 @@ TEST(ServiceWorkers, CacheStorageRestoreFromDisk)
     TestWebKitAPI::Util::run(&done);
     done = false;
 
+    // Disable ITP so it doesn't inadvertently delete our service worker registrations.
+    [[WKWebsiteDataStore defaultDataStore] _setResourceLoadStatisticsEnabled:NO];
+
     TestWebKitAPI::HTTPServer server({
         { "/"_s, { mainCacheStorageBytes } }
     });
@@ -1207,6 +1231,9 @@ TEST(ServiceWorkers, FetchAfterRestoreFromDisk)
     }];
     TestWebKitAPI::Util::run(&done);
     done = false;
+
+    // Disable ITP so it doesn't inadvertently delete our service worker registrations.
+    [[WKWebsiteDataStore defaultDataStore] _setResourceLoadStatisticsEnabled:NO];
 
     RetainPtr<WKWebViewConfiguration> configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
 
@@ -1252,6 +1279,9 @@ TEST(ServiceWorkers, InterceptFirstLoadAfterRestoreFromDisk)
     }];
     TestWebKitAPI::Util::run(&done);
     done = false;
+
+    // Disable ITP so it doesn't inadvertently delete our service worker registrations.
+    [[WKWebsiteDataStore defaultDataStore] _setResourceLoadStatisticsEnabled:NO];
 
     RetainPtr<WKWebViewConfiguration> configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
 
@@ -1304,6 +1334,9 @@ TEST(ServiceWorkers, MainThreadSWInterceptsLoad)
     TestWebKitAPI::Util::run(&done);
     done = false;
 
+    // Disable ITP so it doesn't inadvertently delete our service worker registrations.
+    [dataStore _setResourceLoadStatisticsEnabled:NO];
+
     RetainPtr messageHandler = adoptNS([[SWMessageHandlerWithExpectedMessage alloc] init]);
     [[configuration userContentController] addScriptMessageHandler:messageHandler.get() name:@"sw"];
 
@@ -1349,6 +1382,9 @@ TEST(ServiceWorkers, WaitForPolicyDelegate)
     }];
     TestWebKitAPI::Util::run(&done);
     done = false;
+
+    // Disable ITP so it doesn't inadvertently delete our service worker registrations.
+    [[WKWebsiteDataStore defaultDataStore] _setResourceLoadStatisticsEnabled:NO];
 
     RetainPtr<WKWebViewConfiguration> configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
 
@@ -1457,6 +1493,9 @@ TEST(ServiceWorkers, SWProcessConnectionCreation)
     TestWebKitAPI::Util::run(&done);
     done = false;
 
+    // Disable ITP so it doesn't inadvertently delete our service worker registrations.
+    [[configuration websiteDataStore] _setResourceLoadStatisticsEnabled:NO];
+
     [[configuration websiteDataStore] fetchDataRecordsOfTypes:[NSSet setWithObject:WKWebsiteDataTypeServiceWorkerRegistrations] completionHandler:^(NSArray<WKWebsiteDataRecord *> *websiteDataRecords) {
         EXPECT_EQ(0u, [websiteDataRecords count]);
 
@@ -1562,6 +1601,9 @@ TEST(ServiceWorkers, ServiceWorkerProcessCreation)
     TestWebKitAPI::Util::run(&done);
     done = false;
 
+    // Disable ITP so it doesn't inadvertently delete our service worker registrations.
+    [[configuration websiteDataStore] _setResourceLoadStatisticsEnabled:NO];
+
     [[configuration websiteDataStore] fetchDataRecordsOfTypes:[NSSet setWithObject:WKWebsiteDataTypeServiceWorkerRegistrations] completionHandler:^(NSArray<WKWebsiteDataRecord *> *websiteDataRecords) {
 
         done = true;
@@ -1619,6 +1661,9 @@ TEST(ServiceWorkers, ServiceWorkerProcessCreation)
     }];
     TestWebKitAPI::Util::run(&done);
     done = false;
+
+    // Disable ITP so it doesn't inadvertently delete our service worker registrations.
+    [[configuration websiteDataStore] _setResourceLoadStatisticsEnabled:NO];
 }
 
 static constexpr auto readCacheBytes = R"SWRESOURCE(
@@ -1738,6 +1783,9 @@ TEST(ServiceWorkers, ServiceWorkerCacheAccessEphemeralSession)
     }];
     TestWebKitAPI::Util::run(&done);
     done = false;
+
+    // Disable ITP so it doesn't inadvertently delete our service worker registrations.
+    [[WKWebsiteDataStore defaultDataStore] _setResourceLoadStatisticsEnabled:NO];
     
     RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
 
@@ -1821,6 +1869,9 @@ TEST(ServiceWorkers, DifferentSessionsUseDifferentRegistrations)
     }];
     TestWebKitAPI::Util::run(&done);
     done = false;
+
+    // Disable ITP so it doesn't inadvertently delete our service worker registrations.
+    [[WKWebsiteDataStore defaultDataStore] _setResourceLoadStatisticsEnabled:NO];
     
     RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     setConfigurationInjectedBundlePath(configuration.get());
@@ -1916,6 +1967,9 @@ TEST(ServiceWorkers, ServiceWorkerAndCacheStorageDefaultDirectories)
     }];
     TestWebKitAPI::Util::run(&done);
     done = false;
+
+    // Disable ITP so it doesn't inadvertently delete our service worker registrations.
+    [[configuration websiteDataStore] _setResourceLoadStatisticsEnabled:NO];
 }
 
 TEST(ServiceWorkers, ServiceWorkerAndCacheStorageSpecificDirectories)
@@ -1965,6 +2019,9 @@ TEST(ServiceWorkers, ServiceWorkerAndCacheStorageSpecificDirectories)
     }];
     TestWebKitAPI::Util::run(&done);
     done = false;
+
+    // Disable ITP so it doesn't inadvertently delete our service worker registrations.
+    [[configuration websiteDataStore] _setResourceLoadStatisticsEnabled:NO];
 }
 
 #endif // WK_HAVE_C_SPI
@@ -2049,6 +2106,9 @@ TEST(ServiceWorkers, ProcessPerSite)
     TestWebKitAPI::Util::run(&done);
     done = false;
 
+    // Disable ITP so it doesn't inadvertently delete our service worker registrations.
+    [dataStore _setResourceLoadStatisticsEnabled:NO];
+
     RetainPtr<WKWebViewConfiguration> configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     configuration.get().websiteDataStore = dataStore.get();
 
@@ -2126,6 +2186,9 @@ TEST(ServiceWorkers, ParallelProcessLaunch)
     TestWebKitAPI::Util::run(&done);
     done = false;
 
+    // Disable ITP so it doesn't inadvertently delete our service worker registrations.
+    [[WKWebsiteDataStore defaultDataStore] _setResourceLoadStatisticsEnabled:NO];
+
     RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
 
     RetainPtr messageHandler = adoptNS([[SWMessageHandler alloc] init]);
@@ -2162,6 +2225,9 @@ static size_t launchServiceWorkerProcess(bool useSeparateServiceWorkerProcess, b
     }];
     TestWebKitAPI::Util::run(&done);
     done = false;
+
+    // Disable ITP so it doesn't inadvertently delete our service worker registrations.
+    [[WKWebsiteDataStore defaultDataStore] _setResourceLoadStatisticsEnabled:NO];
 
     RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
 
@@ -2279,6 +2345,9 @@ TEST(ServiceWorkers, LockdownModeInSharedWorkerProcess)
     }];
     TestWebKitAPI::Util::run(&done);
     done = false;
+
+    // Disable ITP so it doesn't inadvertently delete our service worker registrations.
+    [[WKWebsiteDataStore defaultDataStore] _setResourceLoadStatisticsEnabled:NO];
 
     RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
 
@@ -2557,6 +2626,9 @@ TEST(ServiceWorkers, ThrottleCrash)
     TestWebKitAPI::Util::run(&done);
     done = false;
 
+    // Disable ITP so it doesn't inadvertently delete our service worker registrations.
+    [[WKWebsiteDataStore defaultDataStore] _setResourceLoadStatisticsEnabled:NO];
+
     RetainPtr messageHandler = adoptNS([[SWMessageHandler alloc] init]);
 
     TestWebKitAPI::HTTPServer server({
@@ -2622,6 +2694,9 @@ TEST(ServiceWorkers, LoadData)
     }];
     TestWebKitAPI::Util::run(&done);
     done = false;
+
+    // Disable ITP so it doesn't inadvertently delete our service worker registrations.
+    [[WKWebsiteDataStore defaultDataStore] _setResourceLoadStatisticsEnabled:NO];
 
     RetainPtr<WKWebViewConfiguration> configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
 
@@ -2735,6 +2810,9 @@ TEST(ServiceWorkers, SuspendNetworkProcess)
     TestWebKitAPI::Util::run(&done);
     done = false;
 
+    // Disable ITP so it doesn't inadvertently delete our service worker registrations.
+    [websiteDataStore _setResourceLoadStatisticsEnabled:NO];
+
     RetainPtr<WKWebViewConfiguration> configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     [configuration setWebsiteDataStore:websiteDataStore.get()];
     RetainPtr<SWMessageHandler> messageHandler = adoptNS([[SWMessageHandler alloc] init]);
@@ -2821,6 +2899,9 @@ TEST(ServiceWorkers, V2DatabaseUpgrade)
     TestWebKitAPI::Util::run(&done);
     done = false;
 
+    // Disable ITP so it doesn't inadvertently delete our service worker registrations.
+    [[WKWebsiteDataStore defaultDataStore] _setResourceLoadStatisticsEnabled:NO];
+
     NSURL *swPath = [NSURL fileURLWithPath:[@"~/Library/Caches/com.apple.WebKit.TestWebKitAPI/WebKit/ServiceWorkers/" stringByExpandingTildeInPath]];
     [[NSFileManager defaultManager] removeItemAtURL:swPath error:nil];
     EXPECT_FALSE([[NSFileManager defaultManager] fileExistsAtPath:swPath.path]);
@@ -2866,6 +2947,9 @@ TEST(ServiceWorkers, ProcessPerSession)
     }];
     TestWebKitAPI::Util::run(&done);
     done = false;
+
+    // Disable ITP so it doesn't inadvertently delete our service worker registrations.
+    [[WKWebsiteDataStore defaultDataStore] _setResourceLoadStatisticsEnabled:NO];
 
     RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
 
@@ -2934,6 +3018,9 @@ TEST(ServiceWorkers, ContentRuleList)
     }];
     TestWebKitAPI::Util::run(&done);
     done = false;
+
+    // Disable ITP so it doesn't inadvertently delete our service worker registrations.
+    [[WKWebsiteDataStore defaultDataStore] _setResourceLoadStatisticsEnabled:NO];
 
     RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
 
@@ -3166,6 +3253,9 @@ TEST(ServiceWorkers, ClearDOMCacheAlsoIncludesServiceWorkerRegistrations)
     TestWebKitAPI::Util::run(&done);
     done = false;
 
+    // Disable ITP so it doesn't inadvertently delete our service worker registrations.
+    [[WKWebsiteDataStore defaultDataStore] _setResourceLoadStatisticsEnabled:NO];
+
     RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
 
     RetainPtr messageHandler = adoptNS([[SWMessageHandler alloc] init]);
@@ -3290,6 +3380,9 @@ TEST(ServiceWorkers, WebProcessCache)
     }];
     TestWebKitAPI::Util::run(&done);
     done = false;
+
+    // Disable ITP so it doesn't inadvertently delete our service worker registrations.
+    [[WKWebsiteDataStore defaultDataStore] _setResourceLoadStatisticsEnabled:NO];
 
     RetainPtr processPoolConfiguration = adoptNS([[_WKProcessPoolConfiguration alloc] init]);
     processPoolConfiguration.get().processSwapsOnNavigation = YES;
@@ -3447,6 +3540,9 @@ TEST(ServiceWorker, ExtensionServiceWorker)
     TestWebKitAPI::Util::run(&done);
     done = false;
 
+    // Disable ITP so it doesn't inadvertently delete our service worker registrations.
+    [[WKWebsiteDataStore defaultDataStore] _setResourceLoadStatisticsEnabled:NO];
+
     RetainPtr schemeHandler = adoptNS([ServiceWorkerSchemeHandler new]);
     [schemeHandler addMappingFromURLString:@"sw-ext://ABC/other.html" toData:"foo"];
     [schemeHandler addMappingFromURLString:@"sw-ext://ABC/sw.js" toData:"importScripts('sw-ext://ABC/importedScript.js');"];
@@ -3528,6 +3624,9 @@ TEST(ServiceWorker, ExtensionServiceWorkerDisableCORS)
     Util::run(&done);
     done = false;
 
+    // Disable ITP so it doesn't inadvertently delete our service worker registrations.
+    [[WKWebsiteDataStore defaultDataStore] _setResourceLoadStatisticsEnabled:NO];
+
     bool madeHTTPGetRequest = false;
     bool madeHTTPOptionsRequest = false;
     String filenameRequestedOverHTTP;
@@ -3598,6 +3697,9 @@ TEST(ServiceWorker, ExtensionServiceWorkerWithModules)
     TestWebKitAPI::Util::run(&done);
     done = false;
 
+    // Disable ITP so it doesn't inadvertently delete our service worker registrations.
+    [[WKWebsiteDataStore defaultDataStore] _setResourceLoadStatisticsEnabled:NO];
+
     RetainPtr schemeHandler = adoptNS([ServiceWorkerSchemeHandler new]);
 
     [schemeHandler addMappingFromURLString:@"sw-ext://ABC/exports.js" toData:"const x = 805; export { x };"];
@@ -3634,6 +3736,9 @@ TEST(ServiceWorker, ExtensionServiceWorkerFailureBadScript)
     TestWebKitAPI::Util::run(&done);
     done = false;
 
+    // Disable ITP so it doesn't inadvertently delete our service worker registrations.
+    [[WKWebsiteDataStore defaultDataStore] _setResourceLoadStatisticsEnabled:NO];
+
     RetainPtr schemeHandler = adoptNS([ServiceWorkerSchemeHandler new]);
     [schemeHandler addMappingFromURLString:@"sw-ext://ABC/bad-sw.js" toData:"1 = 1;"];
 
@@ -3667,6 +3772,9 @@ TEST(ServiceWorker, ExtensionServiceWorkerFailureBadURL)
     TestWebKitAPI::Util::run(&done);
     done = false;
 
+    // Disable ITP so it doesn't inadvertently delete our service worker registrations.
+    [[WKWebsiteDataStore defaultDataStore] _setResourceLoadStatisticsEnabled:NO];
+
     WKWebViewConfiguration *webViewConfiguration = [WKWebViewConfiguration _test_configurationWithTestPlugInClassName:@"ServiceWorkerPagePlugIn"];
     RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration]);
 
@@ -3693,6 +3801,9 @@ TEST(ServiceWorker, ExtensionServiceWorkerFailureViewClosed)
     TestWebKitAPI::Util::run(&done);
     done = false;
 
+    // Disable ITP so it doesn't inadvertently delete our service worker registrations.
+    [[WKWebsiteDataStore defaultDataStore] _setResourceLoadStatisticsEnabled:NO];
+
     WKWebViewConfiguration *webViewConfiguration = [WKWebViewConfiguration _test_configurationWithTestPlugInClassName:@"ServiceWorkerPagePlugIn"];
     RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration]);
 
@@ -3718,6 +3829,9 @@ TEST(ServiceWorker, ExtensionServiceWorkerFailureViewDestroyed)
     }];
     TestWebKitAPI::Util::run(&done);
     done = false;
+
+    // Disable ITP so it doesn't inadvertently delete our service worker registrations.
+    [[WKWebsiteDataStore defaultDataStore] _setResourceLoadStatisticsEnabled:NO];
 
     @autoreleasepool {
         WKWebViewConfiguration *webViewConfiguration = [WKWebViewConfiguration _test_configurationWithTestPlugInClassName:@"ServiceWorkerPagePlugIn"];
@@ -3767,6 +3881,9 @@ TEST(ServiceWorker, RemovalOfSameRegistrableDomainButDifferentOrigin)
     }];
     TestWebKitAPI::Util::run(&done);
     done = false;
+
+    // Disable ITP so it doesn't inadvertently delete our service worker registrations.
+    [[WKWebsiteDataStore defaultDataStore] _setResourceLoadStatisticsEnabled:NO];
 
     [[WKWebsiteDataStore defaultDataStore] _terminateNetworkProcess];
 
@@ -3881,6 +3998,9 @@ TEST(ServiceWorkers, CacheStorageNetworkProcessCrash)
     TestWebKitAPI::Util::run(&done);
     done = false;
 
+    // Disable ITP so it doesn't inadvertently delete our service worker registrations.
+    [[WKWebsiteDataStore defaultDataStore] _setResourceLoadStatisticsEnabled:NO];
+
     RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     configuration.get().websiteDataStore = [WKWebsiteDataStore nonPersistentDataStore];
 
@@ -3976,6 +4096,9 @@ TEST(ServiceWorker, ServiceWorkerWindowClientFocus)
     TestWebKitAPI::Util::run(&done);
     done = false;
 
+    // Disable ITP so it doesn't inadvertently delete our service worker registrations.
+    [[WKWebsiteDataStore defaultDataStore] _setResourceLoadStatisticsEnabled:NO];
+
     RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     auto preferences = [configuration preferences];
 
@@ -4063,6 +4186,9 @@ TEST(ServiceWorker, ServiceWorkerWindowClientFocusRequiresUserGesture)
     TestWebKitAPI::Util::run(&done);
     done = false;
 
+    // Disable ITP so it doesn't inadvertently delete our service worker registrations.
+    [[WKWebsiteDataStore defaultDataStore] _setResourceLoadStatisticsEnabled:NO];
+
     RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     auto preferences = [configuration preferences];
 
@@ -4143,6 +4269,9 @@ TEST(ServiceWorker, openWindowWithoutDelegate)
     }];
     TestWebKitAPI::Util::run(&done);
     done = false;
+
+    // Disable ITP so it doesn't inadvertently delete our service worker registrations.
+    [[WKWebsiteDataStore defaultDataStore] _setResourceLoadStatisticsEnabled:NO];
 
     RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     auto preferences = [configuration preferences];
@@ -4292,6 +4421,9 @@ TEST(ServiceWorker, WindowClientNavigate)
     TestWebKitAPI::Util::run(&done);
     done = false;
 
+    // Disable ITP so it doesn't inadvertently delete our service worker registrations.
+    [[WKWebsiteDataStore defaultDataStore] _setResourceLoadStatisticsEnabled:NO];
+
     RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     for (_WKFeature *feature in [WKPreferences _features]) {
         if ([feature.key isEqualToString:@"CrossOriginOpenerPolicyEnabled"])
@@ -4362,6 +4494,9 @@ TEST(ServiceWorker, WindowClientNavigateCrossOrigin)
     TestWebKitAPI::Util::run(&done);
     done = false;
 
+    // Disable ITP so it doesn't inadvertently delete our service worker registrations.
+    [[WKWebsiteDataStore defaultDataStore] _setResourceLoadStatisticsEnabled:NO];
+
     RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
 
     RetainPtr webView1 = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 300, 300) configuration:configuration.get() addToWindow:YES]);
@@ -4426,6 +4561,9 @@ TEST(ServiceWorker, OpenWindowWebsiteDataStoreDelegate)
     TestWebKitAPI::Util::run(&done);
     done = false;
 
+    // Disable ITP so it doesn't inadvertently delete our service worker registrations.
+    [[WKWebsiteDataStore defaultDataStore] _setResourceLoadStatisticsEnabled:NO];
+
     RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
 
     auto preferences = [configuration preferences];
@@ -4476,6 +4614,9 @@ TEST(ServiceWorker, OpenWindowCOOP)
     }];
     TestWebKitAPI::Util::run(&done);
     done = false;
+
+    // Disable ITP so it doesn't inadvertently delete our service worker registrations.
+    [[WKWebsiteDataStore defaultDataStore] _setResourceLoadStatisticsEnabled:NO];
 
     RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
 
@@ -4598,6 +4739,9 @@ TEST(ServiceWorker, FocusNotYetLoadedClient)
     }];
     TestWebKitAPI::Util::run(&done);
     done = false;
+
+    // Disable ITP so it doesn't inadvertently delete our service worker registrations.
+    [[WKWebsiteDataStore defaultDataStore] _setResourceLoadStatisticsEnabled:NO];
 
     RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
 
@@ -4734,6 +4878,9 @@ TEST(ServiceWorkers, ServiceWorkerStorageTiming)
     TestWebKitAPI::Util::run(&done);
     done = false;
 
+    // Disable ITP so it doesn't inadvertently delete our service worker registrations.
+    [[WKWebsiteDataStore defaultDataStore] _setResourceLoadStatisticsEnabled:NO];
+
     RetainPtr messageHandler = adoptNS([[SWMessageHandlerWithExpectedMessage alloc] init]);
 
     TestWebKitAPI::HTTPServer server({
@@ -4831,9 +4978,14 @@ TEST(ServiceWorker, ServiceWorkerProcessSwapWithNoDelay)
     TestWebKitAPI::Util::run(&done);
     done = false;
 
+    // Disable ITP so it doesn't inadvertently delete our service worker registrations.
+    [[WKWebsiteDataStore defaultDataStore] _setResourceLoadStatisticsEnabled:NO];
+
     RetainPtr dataStoreConfiguration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] init]);
     [dataStoreConfiguration setServiceWorkerProcessTerminationDelayEnabled:NO];
     RetainPtr dataStore = adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:dataStoreConfiguration.get()]);
+    // Disable ITP so it doesn't inadvertently delete our service worker registrations.
+    [dataStore _setResourceLoadStatisticsEnabled:NO];
 
     RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     setConfigurationInjectedBundlePath(configuration.get());
@@ -4965,6 +5117,9 @@ TEST(ServiceWorkers, ServiceWorkerCacheReference)
     }];
     TestWebKitAPI::Util::run(&done);
     done = false;
+
+    // Disable ITP so it doesn't inadvertently delete our service worker registrations.
+    [[WKWebsiteDataStore defaultDataStore] _setResourceLoadStatisticsEnabled:NO];
 
     RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
 
@@ -5108,6 +5263,9 @@ TEST(ServiceWorker, ServiceWorkerIdleOnMemoryPressure)
     TestWebKitAPI::Util::run(&done);
     done = false;
 
+    // Disable ITP so it doesn't inadvertently delete our service worker registrations.
+    [[WKWebsiteDataStore defaultDataStore] _setResourceLoadStatisticsEnabled:NO];
+
     RetainPtr dataStoreConfiguration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] init]);
     [dataStoreConfiguration setServiceWorkerProcessTerminationDelayEnabled:NO];
     RetainPtr dataStore = adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:dataStoreConfiguration.get()]);
@@ -5247,6 +5405,9 @@ TEST(ServiceWorker, ServiceWorkerReadableStreamDownloadCancel)
     }];
     TestWebKitAPI::Util::run(&done);
     done = false;
+
+    // Disable ITP so it doesn't inadvertently delete our service worker registrations.
+    [[WKWebsiteDataStore defaultDataStore] _setResourceLoadStatisticsEnabled:NO];
 
     RetainPtr dataStoreConfiguration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] init]);
     [dataStoreConfiguration setServiceWorkerProcessTerminationDelayEnabled:NO];


### PR DESCRIPTION
#### b95b9b255ec4b8494fe03dde36118e18f2be1d71
<pre>
REGRESSION (312195@main): ServiceWorkerProcessSwapWithNoDelay and WindowClientNavigate API tests failing
<a href="https://bugs.webkit.org/show_bug.cgi?id=313642">https://bugs.webkit.org/show_bug.cgi?id=313642</a>

Reviewed by Youenn Fablet.

After 312195@main made service worker registration imports lazy, the origin list
became available much faster than before. This changed timing so that ITP&apos;s
ResourceLoadStatisticsStore::removeDataRecords() could discover and clear
service worker registrations before the tests&apos; navigations completed.

Fix by disabling ITP in both tests, matching the pattern already used by
other service worker tests in this file.

Apply this to other tests in this file as well since this is likely causing
flakiness for them too.

Also fix a logging bug introduced in 312195@main where RELEASE_LOG read
result-&gt;size() after the HashSet had been moved from, always printing 0.

Test: Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ServiceWorkerBasic.mm

* Source/WebCore/workers/service/server/SWServer.cpp:
(WebCore::SWServer::SWServer):
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ServiceWorkerBasic.mm:
((ServiceWorkers, UserAgentOverride)):
((ServiceWorkers, RestoreFromDisk)):
((ServiceWorkers, UpdateCheckAfterRestoreFromDisk)):
((ServiceWorkers, CheckRegistrationWithoutMainScript)):
((ServiceWorkers, CheckRegistrationWithoutImportedScript)):
((ServiceWorkers, ThirdPartyRestoredFromDisk)):
((ServiceWorkers, CacheStorageRestoreFromDisk)):
((ServiceWorkers, FetchAfterRestoreFromDisk)):
((ServiceWorkers, InterceptFirstLoadAfterRestoreFromDisk)):
((ServiceWorkers, MainThreadSWInterceptsLoad)):
((ServiceWorkers, WaitForPolicyDelegate)):
((ServiceWorkers, SWProcessConnectionCreation)):
((ServiceWorkers, ServiceWorkerProcessCreation)):
((ServiceWorkers, ServiceWorkerCacheAccessEphemeralSession)):
((ServiceWorkers, DifferentSessionsUseDifferentRegistrations)):
((ServiceWorkers, ServiceWorkerAndCacheStorageDefaultDirectories)):
((ServiceWorkers, ServiceWorkerAndCacheStorageSpecificDirectories)):
((ServiceWorkers, ProcessPerSite)):
((ServiceWorkers, ParallelProcessLaunch)):
((ServiceWorkers, LockdownModeInSharedWorkerProcess)):
((ServiceWorkers, ThrottleCrash)):
((ServiceWorkers, LoadData)):
((ServiceWorkers, SuspendNetworkProcess)):
((ServiceWorkers, V2DatabaseUpgrade)):
((ServiceWorkers, ProcessPerSession)):
((ServiceWorkers, ContentRuleList)):
((ServiceWorkers, ClearDOMCacheAlsoIncludesServiceWorkerRegistrations)):
((ServiceWorkers, WebProcessCache)):
((ServiceWorker, ExtensionServiceWorker)):
((ServiceWorker, ExtensionServiceWorkerDisableCORS)):
((ServiceWorker, ExtensionServiceWorkerWithModules)):
((ServiceWorker, ExtensionServiceWorkerFailureBadScript)):
((ServiceWorker, ExtensionServiceWorkerFailureBadURL)):
((ServiceWorker, ExtensionServiceWorkerFailureViewClosed)):
((ServiceWorker, ExtensionServiceWorkerFailureViewDestroyed)):
((ServiceWorker, RemovalOfSameRegistrableDomainButDifferentOrigin)):
((ServiceWorkers, CacheStorageNetworkProcessCrash)):
((ServiceWorker, ServiceWorkerWindowClientFocus)):
((ServiceWorker, ServiceWorkerWindowClientFocusRequiresUserGesture)):
((ServiceWorker, openWindowWithoutDelegate)):
((ServiceWorker, WindowClientNavigate)):
((ServiceWorker, WindowClientNavigateCrossOrigin)):
((ServiceWorker, OpenWindowWebsiteDataStoreDelegate)):
((ServiceWorker, OpenWindowCOOP)):
((ServiceWorker, FocusNotYetLoadedClient)):
((ServiceWorkers, ServiceWorkerStorageTiming)):
((ServiceWorker, ServiceWorkerProcessSwapWithNoDelay)):
((ServiceWorkers, ServiceWorkerCacheReference)):
((ServiceWorker, ServiceWorkerIdleOnMemoryPressure)):
((ServiceWorker, ServiceWorkerReadableStreamDownloadCancel)):

Canonical link: <a href="https://commits.webkit.org/312279@main">https://commits.webkit.org/312279@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b765860b719a7314f2d2e6fde3c876ca52e1821e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/159461 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/32890 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/25997 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/168293 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/113841 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/afc035ea-7864-44db-b8a5-111f6919c8dc) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/161330 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/32957 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/32878 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/123555 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/113841 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/76aa9ffa-5077-4039-85d6-9adf001f20c3) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/162418 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/25801 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/143225 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/104218 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/f130aa2c-7318-4feb-ab99-800b38e55585) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/24861 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/23317 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/16064 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/134552 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/21005 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/170785 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/16819 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/22631 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/131760 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/32578 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/27384 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/131873 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35655 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/32522 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/142798 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/90661 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/26530 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/19607 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/32033 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/98485 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/31553 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/31826 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/31708 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->