### PR TITLE
[CMake] Generate WebKit_Internal modulemap from canonical source for Swift

### DIFF
--- a/Source/WebKit/PlatformMac.cmake
+++ b/Source/WebKit/PlatformMac.cmake
@@ -87,36 +87,50 @@ set(GPUProcess_SOURCES
 set(WebProcess_INCLUDE_DIRECTORIES ${CMAKE_BINARY_DIR})
 set(NetworkProcess_INCLUDE_DIRECTORIES ${CMAKE_BINARY_DIR})
 
-# Stripped-down module map for Swift — full map's C++ submodules fail in CMake's explicit module context.
+# Generate WebKit_Internal modulemap by rewriting the canonical source-tree
+# modulemap to absolute paths, filtered to submodules the Swift build exercises.
 set(WebKit_CMAKE_MODULEMAP_DIR "${CMAKE_BINARY_DIR}/WebKit/SwiftModules")
 file(MAKE_DIRECTORY "${WebKit_CMAKE_MODULEMAP_DIR}")
-file(WRITE "${WebKit_CMAKE_MODULEMAP_DIR}/module.modulemap"
-"module WebKit_Internal [system] {
-    module WKPDFHUDView {
-        requires objc
-        header \"${WEBKIT_DIR}/UIProcess/PDF/WKPDFHUDView.h\"
-        export *
-    }
 
+file(READ "${WEBKIT_DIR}/Modules/Internal/module.modulemap" _webkit_internal_modulemap)
+string(REPLACE "../../" "${WEBKIT_DIR}/" _webkit_internal_modulemap "${_webkit_internal_modulemap}")
+string(REPLACE "header \"WebKitInternalCxx.h\""
+               "header \"${WEBKIT_DIR}/Modules/Internal/WebKitInternalCxx.h\""
+               _webkit_internal_modulemap "${_webkit_internal_modulemap}")
+
+set(_webkit_internal_allowed_submodules
+    WKMaterialHostingSupport
+    WKPDFHUDView
+    _WKTextExtractionInternal
+)
+string(REGEX MATCHALL
+    "[ \t]+module [A-Za-z_][A-Za-z0-9_]*[ \t]*\\{[^}]*\\}"
+    _webkit_internal_blocks "${_webkit_internal_modulemap}")
+foreach (_block IN LISTS _webkit_internal_blocks)
+    if (_block MATCHES "module ([A-Za-z_][A-Za-z0-9_]*)[ \t]*\\{")
+        set(_module_name "${CMAKE_MATCH_1}")
+        list(FIND _webkit_internal_allowed_submodules "${_module_name}" _idx)
+        if (_idx EQUAL -1)
+            string(REPLACE "${_block}" "" _webkit_internal_modulemap "${_webkit_internal_modulemap}")
+        endif ()
+    endif ()
+endforeach ()
+
+# WKWebView is declared in the public OSX.modulemap; re-expose it here so Swift
+# files using `internal import WebKit_Internal` can see the type.
+string(REGEX REPLACE "\n}[ \t\r\n]*$" "" _webkit_internal_modulemap "${_webkit_internal_modulemap}")
+string(APPEND _webkit_internal_modulemap "
     module WKWebView {
         requires objc
         header \"${WebKit_FRAMEWORK_HEADERS_DIR}/WebKit/WKWebView.h\"
         export *
     }
-
-    module WKMaterialHostingSupport {
-        requires objc
-        header \"${WEBKIT_DIR}/Platform/cocoa/WKMaterialHostingSupport.h\"
-        export *
-    }
-
-    module _WKTextExtractionInternal {
-        requires objc
-        header \"${WEBKIT_DIR}/UIProcess/API/Cocoa/_WKTextExtractionInternal.h\"
-        export *
-    }
 }
 ")
+
+string(REGEX REPLACE "\n\n+" "\n\n" _webkit_internal_modulemap "${_webkit_internal_modulemap}")
+
+file(WRITE "${WebKit_CMAKE_MODULEMAP_DIR}/module.modulemap" "${_webkit_internal_modulemap}")
 set(WebKit_SWIFT_INTEROP_MODULE_PATH "${WebKit_CMAKE_MODULEMAP_DIR}")
 
 # Mirror flags to target_compile_options so native Swift compilation matches typecheck.


### PR DESCRIPTION
#### a155ef54780519d19f27a729821e0647f4d22b28
<pre>
[CMake] Generate WebKit_Internal modulemap from canonical source for Swift
<a href="https://bugs.webkit.org/show_bug.cgi?id=313646">https://bugs.webkit.org/show_bug.cgi?id=313646</a>
<a href="https://rdar.apple.com/175847804">rdar://175847804</a>

Reviewed by NOBODY (OOPS!).

Phase 0 of 312067. Replace the inline four-entry WebKit_Internal modulemap
in PlatformMac.cmake with a canonical-derived generation: read
Source/WebKit/Modules/Internal/module.modulemap, rewrite its relative and
colocated header paths to absolute, then filter to an allowlist of
submodules that build under the current Swift -Xcc -I set. Coverage
matches today (WKPDFHUDView, WKMaterialHostingSupport,
_WKTextExtractionInternal, plus a hand-injected WKWebView entry that
preserves internal-import visibility); later phases extend the allowlist
per Swift source added. WebKit_Private is deferred pending JSC/WebCore
framework modulemap staging.

* Source/WebKit/PlatformMac.cmake:
Derive WebKit_Internal modulemap from the canonical source tree instead
of duplicating it inline.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a155ef54780519d19f27a729821e0647f4d22b28

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/160697 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/34170 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/27271 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/169600 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/115763 "Built successfully") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/34271 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/34170 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/124624 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/87993 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/163656 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/26868 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/144336 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/105221 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/25920 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/24422 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/17320 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/135614 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/172080 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/19003 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/23739 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/132885 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/33844 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/28514 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/132898 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/33828 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/143894 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/95637 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/27497 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/20709 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/33339 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/100615 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/32838 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/33082 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/32986 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->