### PR TITLE
citroen.fr: one section fails to display properly after scrolling

### DIFF
--- a/LayoutTests/media/video-source-mime-sniff-mp4-expected.txt
+++ b/LayoutTests/media/video-source-mime-sniff-mp4-expected.txt
@@ -1,0 +1,10 @@
+RUN(video = document.createElement("video"))
+RUN(source = document.createElement("source"))
+RUN(source.type = "video/webm")
+RUN(source.src = "content/test-25fps.mp4")
+RUN(video.appendChild(source))
+RUN(document.body.appendChild(video))
+loadeddata fired
+selected source: test-25fps.mp4
+END OF TEST
+

--- a/LayoutTests/media/video-source-mime-sniff-mp4.html
+++ b/LayoutTests/media/video-source-mime-sniff-mp4.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>video-source-mime-sniff-mp4</title>
+    <script src=video-test.js></script>
+    <script>
+        // The <source> declares video/webm, but the body is actually MP4. MediaPlayer should
+        // detect the engine-selection failure, sniff the actual Content-Type, re-run engine
+        // selection with video/mp4, and let the AVF engine play the file.
+        window.addEventListener('load', () => {
+            run('video = document.createElement("video")');
+            run('source = document.createElement("source")');
+            run('source.type = "video/webm"');
+            run('source.src = "content/test-25fps.mp4"');
+            run('video.appendChild(source)');
+            run('document.body.appendChild(video)');
+
+            video.muted = 1;
+
+            source.addEventListener('error', () => {
+                failTest('<source> error fired - sniff fallback did not recover from misdeclared type');
+            });
+
+            video.addEventListener('error', () => {
+                failTest('<video> error fired - sniff fallback failed to play the file');
+            });
+
+            video.addEventListener('loadeddata', () => {
+                consoleWrite(`loadeddata fired`);
+                consoleWrite(`selected source: ${video.currentSrc.split('/').pop()}`);
+                endTest();
+            });
+        });
+    </script>
+</head>
+<body>
+</body>
+</html>

--- a/LayoutTests/media/video-source-mime-sniff-webm-expected.txt
+++ b/LayoutTests/media/video-source-mime-sniff-webm-expected.txt
@@ -1,0 +1,10 @@
+RUN(video = document.createElement("video"))
+RUN(source = document.createElement("source"))
+RUN(source.type = "video/mp4")
+RUN(source.src = "content/test-vp8.webm")
+RUN(video.appendChild(source))
+RUN(document.body.appendChild(video))
+loadeddata fired
+selected source: test-vp8.webm
+END OF TEST
+

--- a/LayoutTests/media/video-source-mime-sniff-webm.html
+++ b/LayoutTests/media/video-source-mime-sniff-webm.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>video-source-mime-sniff-webm</title>
+    <script src=video-test.js></script>
+    <script>
+        window.addEventListener('load', () => {
+            // The <source> declares video/mp4, but the body is actually WebM.
+            // MediaPlayer should detect the engine-selection failure, sniff the
+            // actual Content-Type, re-run engine selection with video/webm, and
+            // let the WebM engine play the file.
+            run('video = document.createElement("video")');
+            run('source = document.createElement("source")');
+            run('source.type = "video/mp4"');
+            run('source.src = "content/test-vp8.webm"');
+            run('video.appendChild(source)');
+            run('document.body.appendChild(video)');
+
+            video.muted = 1;
+
+            source.addEventListener('error', () => {
+                failTest("<source> error fired - sniff fallback did not select the source");
+            });
+
+            video.addEventListener('error', () => {
+                failTest("<video> error fired - sniff fallback failed to play the file");
+            });
+
+            video.addEventListener('loadeddata', () => {
+                consoleWrite(`loadeddata fired`);
+                consoleWrite(`selected source: ${video.currentSrc.split('/').pop()}`);
+                endTest();
+            });
+        });
+    </script>
+</head>
+<body>
+</body>
+</html>

--- a/Source/WebCore/html/HTMLMediaElement.cpp
+++ b/Source/WebCore/html/HTMLMediaElement.cpp
@@ -102,7 +102,6 @@
 #include "MediaPlayer.h"
 #include "MediaQueryEvaluator.h"
 #include "MediaResourceLoader.h"
-#include "MediaResourceSniffer.h"
 #include "MediaSession.h"
 #include "MessageClientForTesting.h"
 #include "Navigator.h"
@@ -844,8 +843,6 @@ HTMLMediaElement::~HTMLMediaElement()
 #endif
 
     m_completelyLoaded = true;
-
-    cancelSniffer();
 
     if (RefPtr player = m_player) {
         player->invalidate();
@@ -2032,87 +2029,6 @@ void HTMLMediaElement::loadResource(const URL& initialURL, const ContentType& in
             contentType = ContentType { m_blob->type() };
     }
 
-    auto completionHandler = [url, player = m_player, logSiteIdentifier, weakThis = WeakPtr { *this }](SnifferPromise::Result&& result) {
-        RefPtr protectedThis = weakThis.get();
-        if (!protectedThis)
-            return;
-
-        if (!result) {
-            if (result.error() != PlatformMediaError::Cancelled)
-                protectedThis->mediaLoadingFailed(MediaPlayer::NetworkState::NetworkError);
-            return;
-        }
-
-        MediaPlayer::LoadOptions options = {
-            .contentType = *result,
-            .requiresRemotePlayback = !!protectedThis->m_remotePlaybackConfiguration,
-            .supportsLimitedMatroska = protectedThis->limitedMatroskaSupportEnabled(),
-        };
-
-#if ENABLE(MEDIA_SOURCE)
-#if USE(AVFOUNDATION)
-        if (protectedThis->document().settings().mediaSourcePrefersDecompressionSession())
-            options.videoRendererPreferences = videoRendererPreferences(protectedThis->document().settings(), protectedThis->m_forceStereoDecoding);
-#endif
-        if (!protectedThis->m_mediaSource && url.protocolIs(mediaSourceBlobProtocol) && !protectedThis->m_remotePlaybackConfiguration) {
-            if (RefPtr mediaSource = MediaSource::lookup(url.string()))
-                protectedThis->m_mediaSource = MediaSourceInterfaceMainThread::create(mediaSource.releaseNonNull());
-        }
-
-        if (RefPtr mediaSource = protectedThis->m_mediaSource) {
-            ALWAYS_LOG_WITH_THIS(protectedThis, logSiteIdentifier, "loading MSE blob");
-#if !RELEASE_LOG_DISABLED
-            mediaSource->setLogIdentifier(protectedThis->m_logIdentifier);
-#endif
-            if (url.protocolIs(mediaSourceBlobProtocol) && mediaSource->detachable()) {
-                protect(protectedThis->document())->addConsoleMessage(MessageSource::MediaSource, MessageLevel::Error, makeString("Unable to attach detachable MediaSource via blob URL, use srcObject attribute"_s));
-                return protectedThis->mediaLoadingFailed(MediaPlayer::NetworkState::FormatError);
-            }
-
-#if PLATFORM(IOS_FAMILY)
-            if (protectedThis->canShowWhileLocked())
-                options.videoRendererPreferences |= VideoRendererPreference::CanShowWhileLocked;
-#endif
-
-            if (!mediaSource->attachToElement(protectedThis.get())) {
-                // Forget our reference to the MediaSource, so we leave it alone
-                // while processing remainder of load failure.
-                protectedThis->m_mediaSource = nullptr;
-            } else  if (!mediaSource->client() || !player->load(url, options, *mediaSource->client())) {
-                // We have to detach the MediaSource before we forget the reference to it.
-                mediaSource->detachFromElement();
-                protectedThis->m_mediaSource = nullptr;
-            }
-            if (!protectedThis->m_mediaSource)
-                protectedThis->mediaLoadingFailed(MediaPlayer::NetworkState::FormatError);
-            else
-                protectedThis->mediaPlayerRenderingModeChanged();
-            return;
-        }
-#else
-        UNUSED_PARAM(logSiteIdentifier);
-#endif
-
-#if ENABLE(MEDIA_STREAM)
-        if (RefPtr mediaStreamSrcObject = protectedThis->m_mediaStreamSrcObject; mediaStreamSrcObject && !protectedThis->m_remotePlaybackConfiguration) {
-            ALWAYS_LOG_WITH_THIS(protectedThis, logSiteIdentifier, "loading media stream blob ", mediaStreamSrcObject->logIdentifier());
-            if (!player->load(protect(mediaStreamSrcObject->privateStream())))
-                protectedThis->mediaLoadingFailed(MediaPlayer::NetworkState::FormatError);
-            else
-                protectedThis->mediaPlayerRenderingModeChanged();
-            return;
-        }
-#endif
-#if PLATFORM(IOS_FAMILY)
-        if (protectedThis->canShowWhileLocked())
-            options.videoRendererPreferences |= VideoRendererPreference::CanShowWhileLocked;
-#endif
-        if (!player->load(url, options))
-            protectedThis->mediaLoadingFailed(MediaPlayer::NetworkState::FormatError);
-        else
-            protectedThis->mediaPlayerRenderingModeChanged();
-    };
-
     if (needsContentTypeToPlay() && !url.isEmpty()) {
         if (contentType.isEmpty() && url.protocolIsData())
             contentType = ContentType(mimeTypeFromDataURL(url.string()));
@@ -2122,10 +2038,74 @@ void HTMLMediaElement::loadResource(const URL& initialURL, const ContentType& in
             if (containerType.isEmpty() || containerType == applicationOctetStreamAtom() || containerType == textPlainContentTypeAtom())
                 contentType = ContentType::fromURL(url);
         }
-        m_lastContentTypeUsed = contentType;
     }
 
-    completionHandler(WTF::move(contentType));
+    MediaPlayer::LoadOptions options = {
+        .contentType = WTF::move(contentType),
+        .requiresRemotePlayback = !!m_remotePlaybackConfiguration,
+        .supportsLimitedMatroska = limitedMatroskaSupportEnabled(),
+    };
+
+#if ENABLE(MEDIA_SOURCE)
+#if USE(AVFOUNDATION)
+    if (document().settings().mediaSourcePrefersDecompressionSession())
+        options.videoRendererPreferences = videoRendererPreferences(document().settings(), m_forceStereoDecoding);
+#endif
+    if (!m_mediaSource && url.protocolIs(mediaSourceBlobProtocol) && !m_remotePlaybackConfiguration) {
+        if (RefPtr mediaSource = MediaSource::lookup(url.string()))
+            m_mediaSource = MediaSourceInterfaceMainThread::create(mediaSource.releaseNonNull());
+    }
+
+    if (RefPtr mediaSource = m_mediaSource) {
+        ALWAYS_LOG(logSiteIdentifier, "loading MSE blob");
+#if !RELEASE_LOG_DISABLED
+        mediaSource->setLogIdentifier(m_logIdentifier);
+#endif
+        if (url.protocolIs(mediaSourceBlobProtocol) && mediaSource->detachable()) {
+            protect(document())->addConsoleMessage(MessageSource::MediaSource, MessageLevel::Error, makeString("Unable to attach detachable MediaSource via blob URL, use srcObject attribute"_s));
+            return mediaLoadingFailed(MediaPlayer::NetworkState::FormatError);
+        }
+
+#if PLATFORM(IOS_FAMILY)
+        if (canShowWhileLocked())
+            options.videoRendererPreferences |= VideoRendererPreference::CanShowWhileLocked;
+#endif
+
+        if (!mediaSource->attachToElement(this)) {
+            // Forget our reference to the MediaSource, so we leave it alone
+            // while processing remainder of load failure.
+            m_mediaSource = nullptr;
+        } else  if (!mediaSource->client() || !player->load(url, options, *mediaSource->client())) {
+            // We have to detach the MediaSource before we forget the reference to it.
+            mediaSource->detachFromElement();
+            m_mediaSource = nullptr;
+        }
+        if (!m_mediaSource)
+            mediaLoadingFailed(MediaPlayer::NetworkState::FormatError);
+        else
+            mediaPlayerRenderingModeChanged();
+        return;
+    }
+#endif
+
+#if ENABLE(MEDIA_STREAM)
+    if (RefPtr mediaStreamSrcObject = m_mediaStreamSrcObject; mediaStreamSrcObject && !m_remotePlaybackConfiguration) {
+        ALWAYS_LOG(logSiteIdentifier, "loading media stream blob ", mediaStreamSrcObject->logIdentifier());
+        if (!player->load(protect(mediaStreamSrcObject->privateStream())))
+            mediaLoadingFailed(MediaPlayer::NetworkState::FormatError);
+        else
+            mediaPlayerRenderingModeChanged();
+        return;
+    }
+#endif
+#if PLATFORM(IOS_FAMILY)
+    if (canShowWhileLocked())
+        options.videoRendererPreferences |= VideoRendererPreference::CanShowWhileLocked;
+#endif
+    if (!player->load(url, options))
+        mediaLoadingFailed(MediaPlayer::NetworkState::FormatError);
+    else
+        mediaPlayerRenderingModeChanged();
 }
 
 bool HTMLMediaElement::needsContentTypeToPlay() const
@@ -2139,15 +2119,6 @@ bool HTMLMediaElement::needsContentTypeToPlay() const
             return false;
 #endif
     return !m_remotePlaybackConfiguration;
-}
-
-Ref<HTMLMediaElement::SnifferPromise> HTMLMediaElement::sniffForContentType(const URL& url)
-{
-    ResourceRequest request(URL { url });
-    request.setAllowCookies(true);
-    // https://mimesniff.spec.whatwg.org/#reading-the-resource-header defines a maximum size of 1445 bytes fetch.
-    m_sniffer = MediaResourceSniffer::create(mediaPlayerCreateResourceLoader(), WTF::move(request), 1445);
-    return Ref { *m_sniffer }->promise();
 }
 
 void HTMLMediaElement::mediaSourceWasDetached()
@@ -3125,42 +3096,6 @@ void HTMLMediaElement::setNetworkState(MediaPlayer::NetworkState state)
         m_networkState = NETWORK_EMPTY;
         updateBufferingState();
         updateStalledState();
-        return;
-    }
-
-    if (state == MediaPlayer::NetworkState::FormatError && m_readyState < HAVE_METADATA && m_loadState == LoadingFromSrcAttr && needsContentTypeToPlay() && m_firstTimePlaying && !m_sniffer && !m_networkErrorOccured && m_lastContentTypeUsed) {
-        // We couldn't find a suitable MediaPlayer, this could be due to the content-type having been initially set incorrectly.
-        auto url = m_blob ? m_blobURLForReading.url() : currentSrc();
-        sniffForContentType(url)->whenSettled(RunLoop::mainSingleton(), [weakThis = WeakPtr { *this }, url, player = m_player, lastContentType = *m_lastContentTypeUsed](auto&& result) {
-            RefPtr protectedThis = weakThis.get();
-            if (!protectedThis)
-                return;
-            if (!result) {
-                if (result.error() != PlatformMediaError::Cancelled)
-                    protectedThis->mediaLoadingFailed(MediaPlayer::NetworkState::NetworkError);
-                return;
-            }
-            player->reset();
-
-            MediaPlayer::LoadOptions options = {
-                .contentType = *result,
-                .requiresRemotePlayback = !!protectedThis->m_remotePlaybackConfiguration,
-                .supportsLimitedMatroska = protectedThis->limitedMatroskaSupportEnabled(),
-            };
-#if ENABLE(MEDIA_SOURCE) && USE(AVFOUNDATION)
-            if (protectedThis->document().settings().mediaSourcePrefersDecompressionSession())
-                options.videoRendererPreferences = videoRendererPreferences(protectedThis->document().settings(), protectedThis->m_forceStereoDecoding);
-#endif
-#if PLATFORM(IOS_FAMILY)
-            if (protectedThis->canShowWhileLocked())
-                options.videoRendererPreferences |= VideoRendererPreference::CanShowWhileLocked;
-#endif
-
-            if (result->isEmpty() || lastContentType == *result || !player->load(url, options))
-                protectedThis->mediaLoadingFailed(MediaPlayer::NetworkState::FormatError);
-            else
-                protectedThis->mediaPlayerRenderingModeChanged();
-        });
         return;
     }
 
@@ -6727,13 +6662,6 @@ void HTMLMediaElement::cancelPendingTasks()
     m_updateShouldAutoplayTaskCancellationGroup.cancel();
     if (m_volumeLocked)
         m_volumeRevertTaskCancellationGroup.cancel();
-    cancelSniffer();
-}
-
-void HTMLMediaElement::cancelSniffer()
-{
-    if (auto sniffer = std::exchange(m_sniffer, { }))
-        sniffer->cancel();
 }
 
 void HTMLMediaElement::userCancelledLoad()
@@ -8242,13 +8170,8 @@ void HTMLMediaElement::createMediaPlayer() WTF_IGNORES_THREAD_SAFETY_ANALYSIS
         setIsPlayingToWirelessTarget(false);
 #endif
 
-    m_networkErrorOccured = false;
-    m_lastContentTypeUsed.reset();
-    if (RefPtr player = std::exchange(m_player, { })) {
-        // The sniffer completionHandler would have taken a reference to the old MediaPlayer.
-        cancelSniffer();
+    if (RefPtr player = std::exchange(m_player, { }))
         player->invalidate();
-    }
 
     m_player = MediaPlayer::create(*this);
     RefPtr player = m_player;
@@ -8762,9 +8685,6 @@ void HTMLMediaElement::mediaPlayerEngineFailedToLoad()
     RefPtr player = m_player;
     if (!player)
         return;
-
-    if (player->networkState() == MediaPlayer::NetworkState::NetworkError)
-        m_networkErrorOccured = true;
 
     if (RefPtr page = document().page())
         protect(page->diagnosticLoggingClient())->logDiagnosticMessageWithValue(DiagnosticLoggingKeys::engineFailedToLoadKey(), player->engineDescription(), player->platformErrorCode(), 4, ShouldSample::No);

--- a/Source/WebCore/html/HTMLMediaElement.h
+++ b/Source/WebCore/html/HTMLMediaElement.h
@@ -42,7 +42,6 @@
 #include <WebCore/MediaElementSession.h>
 #include <WebCore/MediaPlayer.h>
 #include <WebCore/MediaProducer.h>
-#include <WebCore/MediaResourceSniffer.h>
 #include <WebCore/MediaUniqueIdentifier.h>
 #include <WebCore/MessageTargetForTesting.h>
 #include <WebCore/PlatformDynamicRangeLimit.h>
@@ -1142,9 +1141,6 @@ private:
     void checkForAudioAndVideo();
 
     bool needsContentTypeToPlay() const;
-    using SnifferPromise = MediaResourceSniffer::Promise;
-    Ref<SnifferPromise> sniffForContentType(const URL&);
-    void cancelSniffer();
 
     void playPlayer();
     void pausePlayer();
@@ -1481,9 +1477,6 @@ private:
     bool m_changingSynthesisState { false };
 
     FloatSize m_videoLayerSize { };
-    RefPtr<MediaResourceSniffer> m_sniffer;
-    bool m_networkErrorOccured { false };
-    std::optional<ContentType> m_lastContentTypeUsed;
 
 #if HAVE(SPATIAL_TRACKING_LABEL)
     using DefaultSpatialTrackingLabelChangedObserver = WTF::Observer<void(String&&)>;

--- a/Source/WebCore/html/HTMLVideoElement.cpp
+++ b/Source/WebCore/html/HTMLVideoElement.cpp
@@ -59,6 +59,7 @@
 #include "Settings.h"
 #include "ShareableBitmap.h"
 #include "VideoFrameMetadata.h"
+#include <wtf/NativePromise.h>
 #include <wtf/TZoneMallocInlines.h>
 #include <wtf/text/TextStream.h>
 

--- a/Source/WebCore/platform/graphics/MediaPlayer.cpp
+++ b/Source/WebCore/platform/graphics/MediaPlayer.cpp
@@ -40,6 +40,7 @@
 #include "Logging.h"
 #include "MIMETypeRegistry.h"
 #include "MediaPlayerPrivate.h"
+#include "MediaResourceSniffer.h"
 #include "MediaStrategy.h"
 #include "MessageClientForTesting.h"
 #include "OriginAccessPatterns.h"
@@ -50,6 +51,7 @@
 #include "PlatformTextTrack.h"
 #include "PlatformTimeRanges.h"
 #include "ResourceError.h"
+#include "ResourceRequest.h"
 #include "SecurityOrigin.h"
 #include "ShareableBitmap.h"
 #include "VideoFrame.h"
@@ -542,6 +544,8 @@ bool MediaPlayer::load(const URL& url, const LoadOptions& options)
     // Protect against MediaPlayer being destroyed during a MediaPlayerClient callback.
     Ref<MediaPlayer> protectedThis(*this);
 
+    cancelSniffer();
+    m_sniffAttempted = false;
     m_url = url;
     m_loadOptions = options;
 
@@ -561,6 +565,8 @@ bool MediaPlayer::load(const URL& url, const LoadOptions& options, MediaSourcePr
 {
     ASSERT(!m_reloadTimer.isActive());
 
+    cancelSniffer();
+    m_sniffAttempted = false;
     m_mediaSource = mediaSource;
     m_url = url;
     m_loadOptions = options;
@@ -578,6 +584,8 @@ bool MediaPlayer::load(MediaStreamPrivate& mediaStream)
 {
     ASSERT(!m_reloadTimer.isActive());
 
+    cancelSniffer();
+    m_sniffAttempted = false;
     m_mediaStream = mediaStream;
     m_loadOptions = { };
     loadWithNextMediaEngine(nullptr);
@@ -1439,6 +1447,73 @@ void MediaPlayer::reloadTimerFired()
     loadWithNextMediaEngine(CheckedPtr { m_currentMediaEngine });
 }
 
+void MediaPlayer::cancelSniffer()
+{
+    if (RefPtr sniffer = std::exchange(m_sniffer, { }))
+        sniffer->cancel();
+}
+
+bool MediaPlayer::attemptSniffAndReload()
+{
+    if (m_sniffAttempted || m_sniffer)
+        return false;
+    if (m_url.isEmpty() || m_activeEngineIdentifier)
+        return false;
+    // Only makes sense for plain URL-backed loads. MSE and MediaStream bind to an in-memory
+    // object rather than a fetchable body, and remote playback does its own engine selection.
+#if ENABLE(MEDIA_SOURCE)
+    if (m_mediaSource.get())
+        return false;
+#endif
+#if ENABLE(MEDIA_STREAM)
+    if (m_mediaStream)
+        return false;
+#endif
+    if (m_loadOptions.requiresRemotePlayback)
+        return false;
+
+    m_sniffAttempted = true;
+
+    ResourceRequest request(URL { m_url });
+    request.setAllowCookies(true);
+    // https://mimesniff.spec.whatwg.org/#reading-the-resource-header defines a maximum size of 1445 bytes fetch.
+    m_sniffer = MediaResourceSniffer::create(protect(client())->mediaPlayerCreateResourceLoader(), WTF::move(request), 1445);
+    Ref sniffer = *m_sniffer;
+    sniffer->promise()->whenSettled(RunLoop::mainSingleton(), [weakThis = ThreadSafeWeakPtr { *this }, originalType = m_loadOptions.contentType](auto&& result) mutable {
+        RefPtr protectedThis = weakThis.get();
+        if (!protectedThis)
+            return;
+        protectedThis->m_sniffer = nullptr;
+
+        auto reportOriginalFailure = [&protectedThis] {
+            Ref client = protectedThis->client();
+            client->mediaPlayerNetworkStateChanged();
+        };
+
+        if (!result) {
+            // Sniffer failed (cancelled or network error). We can't do better than the original
+            // engine failure; propagate it up to the client.
+            reportOriginalFailure();
+            return;
+        }
+        auto& sniffed = *result;
+        if (sniffed.isEmpty() || sniffed == originalType) {
+            // No new information; nothing to retry.
+            reportOriginalFailure();
+            return;
+        }
+
+        // Reset engine state so a fresh selection runs with the sniffed type. Do not clear
+        // m_sniffAttempted — this is a one-shot so we don't loop on a persistent FormatError.
+        protectedThis->m_loadOptions.contentType = sniffed;
+        protectedThis->m_attemptedEngines.clear();
+        protectedThis->m_currentMediaEngine = nullptr;
+        protectedThis->m_private = nullptr;
+        protectedThis->loadWithNextMediaEngine(nullptr);
+    });
+    return true;
+}
+
 template<typename T>
 static void addToHash(HashSet<T>& toHash, HashSet<T>&& fromHash)
 {
@@ -1493,8 +1568,12 @@ void MediaPlayer::networkStateChanged()
         m_lastErrorMessage = playerPrivate->errorMessage();
     Ref client = this->client();
     // If more than one media engine is installed and this one failed before finding metadata,
-    // let the next engine try.
-    if (playerPrivate->networkState() >= MediaPlayer::NetworkState::FormatError && playerPrivate->readyState() < MediaPlayer::ReadyState::HaveMetadata) {
+    // let the next engine try. Trigger this engine-fallback only for FormatError or DecodeError
+    // (the engine inspected the body and couldn't decode/parse it); NetworkError means the loader
+    // itself failed and retrying against another engine would just hit the same loader failure
+    // against the same URL, wasting a request.
+    auto networkState = playerPrivate->networkState();
+    if ((networkState == MediaPlayer::NetworkState::FormatError || networkState == MediaPlayer::NetworkState::DecodeError) && playerPrivate->readyState() < MediaPlayer::ReadyState::HaveMetadata) {
         client->mediaPlayerEngineFailedToLoad();
         CheckedPtr currentMediaEngine = m_currentMediaEngine.get();
         if (!m_activeEngineIdentifier
@@ -1503,6 +1582,11 @@ void MediaPlayer::networkStateChanged()
             m_reloadTimer.startOneShot(0_s);
             return;
         }
+        // No further engine matches the declared content type. The body may have been mis-declared
+        // (e.g. server returns video/webm but the page's <source type> said video/mp4); fetch a
+        // short prefix and, if the sniffed type differs, re-run engine selection with it.
+        if (attemptSniffAndReload())
+            return;
     }
     client->mediaPlayerNetworkStateChanged();
 }
@@ -1725,6 +1809,8 @@ void MediaPlayer::resetMediaEngines()
 
 void MediaPlayer::reset()
 {
+    cancelSniffer();
+    m_sniffAttempted = false;
     m_attemptedEngines.clear();
 }
 

--- a/Source/WebCore/platform/graphics/MediaPlayer.h
+++ b/Source/WebCore/platform/graphics/MediaPlayer.h
@@ -99,6 +99,7 @@ class MediaSourcePrivateClient;
 class MediaStreamPrivate;
 class NativeImage;
 class PlatformMediaResourceLoader;
+class MediaResourceSniffer;
 class PlatformTimeRanges;
 class SecurityOriginData;
 class ShareableBitmap;
@@ -835,6 +836,14 @@ private:
     CheckedPtr<const MediaPlayerFactory> nextMediaEngine(const MediaPlayerFactory*);
     void reloadTimerFired();
 
+    // When the engine fallback chain is exhausted on FormatError/DecodeError and we haven't yet
+    // sniffed the body, fetch a short prefix of the resource, determine the actual Content-Type
+    // from magic bytes, and — if it differs from what we originally tried — re-run engine
+    // selection with the sniffed type. Returns true if a sniff was started (in which case the
+    // caller should defer reporting the failure up to the client until the sniff settles).
+    bool attemptSniffAndReload();
+    void cancelSniffer();
+
 #if ENABLE(WIRELESS_PLAYBACK_TARGET)
     MediaPlaybackTargetType playbackTargetType() const;
 #endif
@@ -864,6 +873,8 @@ private:
     PitchCorrectionAlgorithm m_pitchCorrectionAlgorithm { PitchCorrectionAlgorithm::BestAllAround };
     ViewportVisibility m_viewportVisibility { ViewportVisibility::NotVisible };
     RefPtr<PlatformMediaResourceLoader> m_mediaResourceLoader;
+    RefPtr<MediaResourceSniffer> m_sniffer;
+    bool m_sniffAttempted { false };
 
 #if ENABLE(MEDIA_SOURCE)
     ThreadSafeWeakPtr<MediaSourcePrivateClient> m_mediaSource;


### PR DESCRIPTION
#### 013da9aa8cc1a0e26f5f34408efa118956499193
<pre>
citroen.fr: one section fails to display properly after scrolling
<a href="https://bugs.webkit.org/show_bug.cgi?id=313652">https://bugs.webkit.org/show_bug.cgi?id=313652</a>
<a href="https://rdar.apple.com/166181001">rdar://166181001</a>

Reviewed by Eric Carlson

When a &lt;video&gt; used child &lt;source&gt; elements and the page-declared `type`
attribute disagreed with what the server actually returned (e.g. an Adobe
Scene7-served URL declared as video/mp4 whose response body was video/webm),
the page never played. WebKit&apos;s resource selection algorithm fed the page-
declared type into MediaPlayer engine selection: AVFoundation accepted the
candidate based on type=video/mp4 and rejected the body during decode.
MediaPlayer&apos;s engine fallback chain then tried MediaPlayerPrivateWebM, but
WebM aborted early in doPreload() because the contentType it was handed was
still video/mp4 — it never inspected the body. Every alternative engine
rejected the source for the same reason, the source-element resource
selection algorithm gave up, and an error was fired on &lt;source&gt;.

The src-attribute path (LoadingFromSrcAttr) already had a content-sniffer
fallback for this case implemented inside HTMLMediaElement::setNetworkState,
but the source-element path (LoadingFromSourceElement) did not. Rather than
duplicate the fallback logic in HTMLMediaElement for each load-state, the
sniff-and-reload is moved down into MediaPlayer, where it applies uniformly
to any load that reaches the engine layer:

- After an engine reports FormatError or DecodeError before reaching
    HaveMetadata, MediaPlayer first runs its existing engine-fallback chain
    (nextBestMediaEngine / nextMediaEngine) so a correctly-declared type
    still gets its other installed engines a chance.
- When the fallback chain is exhausted and we haven&apos;t sniffed yet,
    MediaPlayer starts a MediaResourceSniffer against m_url, fetches the
    first 1445 bytes, and uses the magic bytes to determine the actual
    container type. If the sniffed type differs from the originally-loaded
    m_loadOptions.contentType, MediaPlayer clears its attempted-engine set,
    updates m_loadOptions.contentType to the sniffed value, and re-runs
    engine selection with loadWithNextMediaEngine(nullptr). The correct
    engine is picked based on what the body actually is.
- If the sniffer returns the same type, an empty result, or a non-cancelled
    error, the original engine failure is propagated to the client
    unchanged. NetworkError never triggers the sniff — the loader has
    already failed and retrying through the same loader would just waste a
    request (and break content-blocker tests that count blocked loads).

Because the sniff lives at the engine layer, it is symmetric: a
&lt;source type=video/mp4&gt; pointing at a WebM body reloads into WebM, and a
&lt;source type=video/webm&gt; pointing at an MP4 body reloads into AVFoundation.
The HTMLMediaElement source-selection algorithm, selectNextSourceChild&apos;s
strict supportsType filter, and the per-&lt;source&gt; error-event timing are
unchanged — no spec deviation, no delay for the common &quot;first source has
an unsupported declared type&quot; fallback case, and `canPlayType` continues
to return &quot;&quot; for unknown types.

The HTMLMediaElement-side SrcAttr sniff fallback (sniffForContentType,
cancelSniffer, m_sniffer, m_networkErrorOccured, m_lastContentTypeUsed,
SnifferPromise) is removed; MediaPlayer handles the same case
transparently to the client.

* LayoutTests/media/video-source-mime-sniff-webm.html: Added.
* LayoutTests/media/video-source-mime-sniff-webm-expected.txt: Added.
End-to-end test: a &lt;source&gt; declares video/mp4 but points at a real WebM
file; asserts loadeddata fires (proving MediaPlayer&apos;s sniff reloaded into
the WebM engine).

* LayoutTests/media/video-source-mime-sniff-mp4.html: Added.
* LayoutTests/media/video-source-mime-sniff-mp4-expected.txt: Added.
Symmetric end-to-end test: a &lt;source&gt; declares video/webm but points at a
real MP4 file; asserts loadeddata fires (proving MediaPlayer&apos;s sniff
reloaded into the AVFoundation engine).

* Source/WebCore/platform/graphics/MediaPlayer.h:
Forward-declare MediaResourceSniffer, add m_sniffer and m_sniffAttempted
members, declare the private attemptSniffAndReload and cancelSniffer
helpers.

* Source/WebCore/platform/graphics/MediaPlayer.cpp:
(WebCore::MediaPlayer::load):
(WebCore::MediaPlayer::load with MediaSourcePrivateClient):
(WebCore::MediaPlayer::load with MediaStreamPrivate):
Cancel any in-flight sniffer and reset m_sniffAttempted on a fresh load.
(WebCore::MediaPlayer::networkStateChanged): Narrow the engine-fallback
trigger from `&gt;= FormatError` to `FormatError || DecodeError` so
NetworkError no longer probes additional engines (sniffer included).
When the fallback chain is exhausted, call attemptSniffAndReload() and
defer reporting the failure to the client if a sniff was started.
(WebCore::MediaPlayer::cancelSniffer): New. Cancels an in-flight sniffer.
(WebCore::MediaPlayer::attemptSniffAndReload): New. Single-shot sniff
against m_url; on a distinct sniffed type, clears m_attemptedEngines,
updates m_loadOptions.contentType, and re-runs engine selection via
loadWithNextMediaEngine(nullptr). On same-type/empty/error, propagates
the original engine failure via mediaPlayerNetworkStateChanged.
(WebCore::MediaPlayer::reset): Cancel any in-flight sniffer and reset
m_sniffAttempted alongside m_attemptedEngines.

* Source/WebCore/html/HTMLMediaElement.h:
* Source/WebCore/html/HTMLMediaElement.cpp:
Remove the HTMLMediaElement-side sniff fallback; MediaPlayer owns it now.
(WebCore::HTMLMediaElement::setNetworkState): Remove the SrcAttr-only
sniff-and-retry block; the engine-level sniff handles both src-attr and
source-element paths.
(WebCore::HTMLMediaElement::loadResource): Inline the completion-handler
lambda into the function body. It was invoked exactly once, synchronously,
at the end of the function, and its captures (url, player, logSiteIdentifier,
this) duplicated locals that were already in scope — it was purely a
lexical group with no async dispatch. Dropping the wrapper also removes a
dead UNUSED_PARAM(logSiteIdentifier) guard that only existed to silence
the unused-capture warning when ENABLE(MEDIA_SOURCE) was off. Also drops
the m_lastContentTypeUsed bookkeeping that belonged to the removed sniff
fallback.
(WebCore::HTMLMediaElement::createMediaPlayer): Drop the
m_networkErrorOccured / m_lastContentTypeUsed / cancelSniffer resets —
the flags, the helper, and the sniffer are all gone.

* Source/WebCore/html/HTMLVideoElement.cpp:
Add `#include &lt;wtf/NativePromise.h&gt;`. HTMLVideoElement::bitmapImageForCurrentTime
calls BitmapImagePromise::createAndReject(), which instantiates
NativePromise&lt;Ref&lt;ShareableBitmap&gt;, void&gt;. MediaPlayer.h only declares the
alias and does not include &lt;wtf/NativePromise.h&gt;; on Cocoa/GTK the template
definition reached this translation unit through a transitive include, but
on PlayStation that chain did not resolve and the build failed with
&quot;implicit instantiation of undefined template&quot;. Including the header
directly at the point of use makes the build independent of which other
headers happen to pull it in.

Canonical link: <a href="https://commits.webkit.org/312399@main">https://commits.webkit.org/312399@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5b5fb0478717ae1babf3316436fb126070881b84

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/159686 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/33153 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/26260 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/168539 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/114067 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/161555 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/33258 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/33157 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/123730 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/86826 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/162644 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/25990 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/143424 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/104375 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/25041 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/23508 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/16306 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/134733 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/21196 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/171031 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/17054 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/22830 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/131974 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/32832 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/27584 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/132043 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35756 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/32817 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/142990 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/90899 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/26670 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/19803 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/32326 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/98722 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/31823 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/32070 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/31974 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->