### PR TITLE
[WebDriver][BiDi] Fix object serialization in script.evaluate to use [key, value] pairs

### DIFF
--- a/Source/WebKit/WebProcess/Automation/WebAutomationSessionProxy.js
+++ b/Source/WebKit/WebProcess/Automation/WebAutomationSessionProxy.js
@@ -409,14 +409,13 @@ let AutomationSessionProxy = class AutomationSessionProxy
                     }
                     return { type: "array", value: serializedArray };
                 } else {
-                    // Deterministic key ordering for plain objects.
-                    let serializedObject = {};
+                    let serializedPairs = [];
                     let keys = Object.keys(value).sort();
                     for (let i = 0; i < keys.length; ++i) {
                         let key = keys[i];
-                        serializedObject[key] = this.serializeBidiRemoteValue(value[key], maxObjectDepth, depth + 1, visitedObjects);
+                        serializedPairs.push([key, this.serializeBidiRemoteValue(value[key], maxObjectDepth, depth + 1, visitedObjects)]);
                     }
-                    return { type: "object", value: serializedObject };
+                    return { type: "object", value: serializedPairs };
                 }
             } finally {
                 visitedObjects.delete(value);


### PR DESCRIPTION
#### 76cc2f00ff29837163d5642d3b6ce428f32bae97
<pre>
[WebDriver][BiDi] Fix object serialization in script.evaluate to use [key, value] pairs
<a href="https://bugs.webkit.org/show_bug.cgi?id=313656">https://bugs.webkit.org/show_bug.cgi?id=313656</a>
<a href="https://rdar.apple.com/175855693">rdar://175855693</a>

Reviewed by NOBODY (OOPS!).

serializeBidiRemoteValue was serializing plain JS objects as a dictionary
({ key: RemoteValue }), but the BiDi spec defines ObjectRemoteValue.value
as a MappingRemoteValue [1], which is an array of [key, RemoteValue] pairs
not a dictionary. The C++ deserialization in BidiScriptAgent already expected
this format

[1] <a href="https://w3c.github.io/webdriver-bidi/#cddl-type-scriptmappingremotevalue">https://w3c.github.io/webdriver-bidi/#cddl-type-scriptmappingremotevalue</a>

* Source/WebKit/WebProcess/Automation/WebAutomationSessionProxy.js:
(let.AutomationSessionProxy):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/76cc2f00ff29837163d5642d3b6ce428f32bae97

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/159481 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/32910 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/26017 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/168313 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/113861 "Built successfully") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/32977 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/32898 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/123574 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/88768 "1 failures") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/162438 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/25826 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/143249 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/104232 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/24878 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/23334 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/16085 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/134569 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/170805 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/16850 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/22680 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/131781 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/32604 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/27410 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/131888 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/32542 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/142815 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/90696 "Built successfully") | | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/26549 "Build is in progress. Recent messages:OS: Tahoe (26.2), Xcode: 26.2; Skipping applying patch since patch_id isn't provided; Checked out pull request") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/19629 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/32053 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/98517 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/31573 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/31853 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/31728 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->