### PR TITLE
[CMake] Compile WKScrollGeometryAdapter and Foundation+Extras Swift sources

### DIFF
--- a/Source/WebKit/PlatformMac.cmake
+++ b/Source/WebKit/PlatformMac.cmake
@@ -39,6 +39,9 @@ list(APPEND WebKit_PRIVATE_LIBRARIES "-weak_framework PowerLog")
 list(APPEND WebKit_SOURCES
     NetworkProcess/mac/NetworkConnectionToWebProcessMac.mm
 
+    ${WEBKIT_DIR}/UIProcess/Cocoa/Foundation+Extras.swift
+    ${WEBKIT_DIR}/UIProcess/Cocoa/WKScrollGeometryAdapter.swift
+
     UIProcess/PDF/WKPDFHUDView.mm
     ${WEBKIT_DIR}/UIProcess/PDF/WKPDFHUDView.swift
     ${WEBKIT_DIR}/Platform/cocoa/WKMaterialHostingSupport.swift
@@ -101,6 +104,7 @@ string(REPLACE "header \"WebKitInternalCxx.h\""
 set(_webkit_internal_allowed_submodules
     WKMaterialHostingSupport
     WKPDFHUDView
+    WKScrollGeometry
     _WKTextExtractionInternal
 )
 string(REGEX MATCHALL
@@ -138,6 +142,7 @@ set(WebKit_SWIFT_INTEROP_MODULE_PATH "${WebKit_CMAKE_MODULEMAP_DIR}")
 # Must go in WebKit_COMPILE_OPTIONS (applied after -warnings-as-errors in _WEBKIT_TARGET_SETUP).
 list(APPEND WebKit_COMPILE_OPTIONS "$<$<COMPILE_LANGUAGE:Swift>:-no-warnings-as-errors>")
 target_compile_options(WebKit PRIVATE
+    "$<$<COMPILE_LANGUAGE:Swift>:-DENABLE_SWIFTUI>"
     "$<$<COMPILE_LANGUAGE:Swift>:-DHAVE_MATERIAL_HOSTING>"
     "$<$<COMPILE_LANGUAGE:Swift>:-I${WEBKIT_DIR}/Platform/spi/Cocoa>"
     "$<$<COMPILE_LANGUAGE:Swift>:-I${WEBKIT_DIR}/Platform/spi/Cocoa/Modules>"
@@ -150,6 +155,7 @@ target_compile_options(WebKit PRIVATE
 )
 
 set(WebKit_SWIFT_EXTRA_OPTIONS
+    -DENABLE_SWIFTUI
     -DHAVE_MATERIAL_HOSTING
     -Xcc -I${WebKit_FRAMEWORK_HEADERS_DIR}
     -Xcc -I${WTF_FRAMEWORK_HEADERS_DIR}

--- a/Source/WebKit/PlatformMac.cmake
+++ b/Source/WebKit/PlatformMac.cmake
@@ -87,36 +87,50 @@ set(GPUProcess_SOURCES
 set(WebProcess_INCLUDE_DIRECTORIES ${CMAKE_BINARY_DIR})
 set(NetworkProcess_INCLUDE_DIRECTORIES ${CMAKE_BINARY_DIR})
 
-# Stripped-down module map for Swift — full map's C++ submodules fail in CMake's explicit module context.
+# Generate WebKit_Internal modulemap by rewriting the canonical source-tree
+# modulemap to absolute paths, filtered to submodules the Swift build exercises.
 set(WebKit_CMAKE_MODULEMAP_DIR "${CMAKE_BINARY_DIR}/WebKit/SwiftModules")
 file(MAKE_DIRECTORY "${WebKit_CMAKE_MODULEMAP_DIR}")
-file(WRITE "${WebKit_CMAKE_MODULEMAP_DIR}/module.modulemap"
-"module WebKit_Internal [system] {
-    module WKPDFHUDView {
-        requires objc
-        header \"${WEBKIT_DIR}/UIProcess/PDF/WKPDFHUDView.h\"
-        export *
-    }
 
+file(READ "${WEBKIT_DIR}/Modules/Internal/module.modulemap" _webkit_internal_modulemap)
+string(REPLACE "../../" "${WEBKIT_DIR}/" _webkit_internal_modulemap "${_webkit_internal_modulemap}")
+string(REPLACE "header \"WebKitInternalCxx.h\""
+               "header \"${WEBKIT_DIR}/Modules/Internal/WebKitInternalCxx.h\""
+               _webkit_internal_modulemap "${_webkit_internal_modulemap}")
+
+set(_webkit_internal_allowed_submodules
+    WKMaterialHostingSupport
+    WKPDFHUDView
+    _WKTextExtractionInternal
+)
+string(REGEX MATCHALL
+    "[ \t]+module [A-Za-z_][A-Za-z0-9_]*[ \t]*\\{[^}]*\\}"
+    _webkit_internal_blocks "${_webkit_internal_modulemap}")
+foreach (_block IN LISTS _webkit_internal_blocks)
+    if (_block MATCHES "module ([A-Za-z_][A-Za-z0-9_]*)[ \t]*\\{")
+        set(_module_name "${CMAKE_MATCH_1}")
+        list(FIND _webkit_internal_allowed_submodules "${_module_name}" _idx)
+        if (_idx EQUAL -1)
+            string(REPLACE "${_block}" "" _webkit_internal_modulemap "${_webkit_internal_modulemap}")
+        endif ()
+    endif ()
+endforeach ()
+
+# WKWebView is declared in the public OSX.modulemap; re-expose it here so Swift
+# files using `internal import WebKit_Internal` can see the type.
+string(REGEX REPLACE "\n}[ \t\r\n]*$" "" _webkit_internal_modulemap "${_webkit_internal_modulemap}")
+string(APPEND _webkit_internal_modulemap "
     module WKWebView {
         requires objc
         header \"${WebKit_FRAMEWORK_HEADERS_DIR}/WebKit/WKWebView.h\"
         export *
     }
-
-    module WKMaterialHostingSupport {
-        requires objc
-        header \"${WEBKIT_DIR}/Platform/cocoa/WKMaterialHostingSupport.h\"
-        export *
-    }
-
-    module _WKTextExtractionInternal {
-        requires objc
-        header \"${WEBKIT_DIR}/UIProcess/API/Cocoa/_WKTextExtractionInternal.h\"
-        export *
-    }
 }
 ")
+
+string(REGEX REPLACE "\n\n+" "\n\n" _webkit_internal_modulemap "${_webkit_internal_modulemap}")
+
+file(WRITE "${WebKit_CMAKE_MODULEMAP_DIR}/module.modulemap" "${_webkit_internal_modulemap}")
 set(WebKit_SWIFT_INTEROP_MODULE_PATH "${WebKit_CMAKE_MODULEMAP_DIR}")
 
 # Mirror flags to target_compile_options so native Swift compilation matches typecheck.


### PR DESCRIPTION
#### ce4030bfa0d88dfa753d516c0ee56d36e68a44d5
<pre>
[CMake] Compile WKScrollGeometryAdapter and Foundation+Extras Swift sources
&lt;<a href="https://bugs.webkit.org/show_bug.cgi?id=313650">https://bugs.webkit.org/show_bug.cgi?id=313650</a>&gt;
&lt;<a href="https://rdar.apple.com/problem/175850345">rdar://problem/175850345</a>&gt;

Reviewed by NOBODY (OOPS!).

Phase 1 of 312067. Add Foundation+Extras.swift (Foundation-only) and
WKScrollGeometryAdapter.swift (needs WKScrollGeometry from
WebKit_Internal, header is clean). Extend the allowlist accordingly
and pass -DENABLE_SWIFTUI to swiftc so the file&apos;s top-level gate
opens on Mac.

* Source/WebKit/PlatformMac.cmake:
Add the two Swift sources, allowlist WKScrollGeometry, pass -DENABLE_SWIFTUI to Swift.
</pre>
----------------------------------------------------------------------
#### 8e84ff64531ff52255bfaa4f49a487e99f9df4ac
<pre>
[CMake] Generate WebKit_Internal modulemap from canonical source for Swift
<a href="https://bugs.webkit.org/show_bug.cgi?id=313646">https://bugs.webkit.org/show_bug.cgi?id=313646</a>
<a href="https://rdar.apple.com/175847804">rdar://175847804</a>

Reviewed by NOBODY (OOPS!).

Phase 0 of 312067. Replace the inline four-entry WebKit_Internal modulemap
in PlatformMac.cmake with a canonical-derived generation: read
Source/WebKit/Modules/Internal/module.modulemap, rewrite its relative and
colocated header paths to absolute, then filter to an allowlist of
submodules that build under the current Swift -Xcc -I set. Coverage
matches today (WKPDFHUDView, WKMaterialHostingSupport,
_WKTextExtractionInternal, plus a hand-injected WKWebView entry that
preserves internal-import visibility); later phases extend the allowlist
per Swift source added. WebKit_Private is deferred pending JSC/WebCore
framework modulemap staging.

* Source/WebKit/PlatformMac.cmake:
Derive WebKit_Internal modulemap from the canonical source tree instead
of duplicating it inline.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ce4030bfa0d88dfa753d516c0ee56d36e68a44d5

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/160688 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/34161 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/27262 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/169591 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/115754 "Built successfully") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/34262 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/34161 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/124613 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/87986 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/163647 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/26859 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/144331 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/105210 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/25911 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/24413 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/17311 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/135605 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/172071 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/18982 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/23734 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/132879 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/33835 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/28505 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/132892 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/33819 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/143889 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/95628 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/27487 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/20704 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/33330 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/100596 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/32829 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/33073 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/32977 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->