### PR TITLE
Unify Builder Lists in Config

### DIFF
--- a/Tools/CISupport/ews-app/ews/common/buildbot.py
+++ b/Tools/CISupport/ews-app/ews/common/buildbot.py
@@ -39,6 +39,9 @@ class Buildbot():
     icons_for_queues_mapping = {}
     queue_name_by_shortname_mapping = {}
     builder_name_to_id_mapping = {}
+    all_queues = []
+    pr_column_by_shortname = {}
+    pr_comment_misc_handlers = []
 
     # FIXME: Auto-generate the queue's trigger relationship
     QUEUE_TRIGGERS = {
@@ -127,6 +130,15 @@ class Buildbot():
             shortname = builder.get('shortname')
             Buildbot.icons_for_queues_mapping[shortname] = builder.get('icon')
             Buildbot.queue_name_by_shortname_mapping[shortname] = builder.get('name')
+            pr_column = builder.get('pr_column')
+            if pr_column:
+                Buildbot.pr_column_by_shortname[shortname] = pr_column
+        bubble_order = config.get('status_bubble_order')
+        if bubble_order:
+            Buildbot.all_queues = list(bubble_order)
+        misc_handlers = config.get('pr_comment_misc_handlers')
+        if misc_handlers:
+            Buildbot.pr_comment_misc_handlers = list(misc_handlers)
 
     @classmethod
     def update_builder_name_to_id_mapping(cls):

--- a/Tools/CISupport/ews-app/ews/common/github.py
+++ b/Tools/CISupport/ews-app/ews/common/github.py
@@ -20,16 +20,19 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-import copy
 import json
 import logging
-import re
 import requests
+
+from django.utils import timezone
 
 from ews.common.buildbot import Buildbot
 from ews.models.patch import Change
-from ews.views.statusbubble import StatusBubble
-import ews.config as config
+from ews.views.bubble.compute import compute_bubble
+from ews.views.bubble.config import BUILDER_ICON, BubbleConfig
+from ews.views.bubble.fetcher import BubbleDataFetcher
+from ews.views.bubble.model import BubbleInputs
+from ews.views.bubble.render_markdown import GithubIcons, render_markdown_bubble
 import ews.common.util as util
 
 _log = logging.getLogger(__name__)
@@ -216,20 +219,23 @@ class GitHubEWS(GitHub):
     ICON_EMPTY_SPACE = u'\U00002003'
     STATUS_BUBBLE_START = u'<!--EWS-Status-Bubble-Start-->'
     STATUS_BUBBLE_END = u'<!--EWS-Status-Bubble-End-->'
-    STATUS_BUBBLE_ROWS = [['style', 'ios', 'mac', 'wpe', 'win'],  # FIXME: generate this list dynamically to have merge queue show up on top
-                          ['bindings', 'ios-sim', 'mac-AS-debug', 'wpe-wk2', 'win-tests'],
-                          ['webkitperl', 'ios-wk2', 'api-mac', 'api-wpe', ''],
-                          ['webkitpy', 'ios-wk2-wpt', 'api-mac-debug', 'gtk3-libwebrtc', ''],
-                          ['jsc-x86-64', 'api-ios', 'mac-wk1', 'gtk', ''],
-                          ['jsc-debug-arm64', 'ios-safer-cpp', 'mac-wk2', 'gtk-wk2', ''],
-                          ['services', 'vision', 'mac-AS-debug-wk2', 'api-gtk', ''],
-                          ['merge', 'vision-sim', 'mac-wk2-stress', 'playstation', ''],
-                          ['unsafe-merge', 'vision-wk2', 'mac-intel-wk2', 'jsc-armv7', ''],
-                          ['', 'tv', 'mac-safer-cpp', 'jsc-armv7-tests', ''],
-                          ['', 'tv-sim', '', '', ''],
-                          ['', 'watch', '', '', ''],
-                          ['', 'watch-sim', '', '', '']]
+    PR_COLUMN_DISPLAY_ORDER = ['misc', 'embedded', 'macos', 'linux', 'windows']
     approved_user_list_for_apple_internal_builds = []
+
+    @classmethod
+    def _compute_status_bubble_rows(cls):
+        columns = {key: [] for key in cls.PR_COLUMN_DISPLAY_ORDER}
+        columns['misc'].extend(Buildbot.pr_comment_misc_handlers)
+        for shortname in Buildbot.all_queues:
+            column = Buildbot.pr_column_by_shortname.get(shortname)
+            if column in columns:
+                columns[column].append(shortname)
+        ordered_columns = [columns[key] for key in cls.PR_COLUMN_DISPLAY_ORDER]
+        height = max((len(c) for c in ordered_columns), default=0)
+        rows = []
+        for i in range(height):
+            rows.append([col[i] if i < len(col) else '' for col in ordered_columns])
+        return rows
 
     @classmethod
     def update_approved_user_list_for_apple_internal_builds(cls):
@@ -267,7 +273,7 @@ class GitHubEWS(GitHub):
         comment = '\n\n| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |'
         comment += '\n| ----- | ---------------------- | ------- |  ----- |  --------- |'
 
-        status_bubble_rows = copy.deepcopy(self.STATUS_BUBBLE_ROWS)
+        status_bubble_rows = self._compute_status_bubble_rows()
         if include_apple_internal_builds:
             comment = comment.replace('Windows', f'Windows | {self.APPLE_INTERNAL_BUILDS_TITLE}')
             comment += ' ------ |'
@@ -310,7 +316,7 @@ class GitHubEWS(GitHub):
         return self.github_status_for_buildbot_queue(change, queue)
 
     def github_status_for_cibuild(self, change, queue):
-        name = f'{StatusBubble.BUILDER_ICON} {queue}'
+        name = f'{BUILDER_ICON} {queue}'
         builds = util.get_cibuilds_for_queue(change, queue)
         build = None
         if builds:
@@ -334,97 +340,51 @@ class GitHubEWS(GitHub):
         return f'| [{icon} {name}]({url}) '
 
     def github_status_for_buildbot_queue(self, change, queue):
-        name = queue
-        is_tester_queue = Buildbot.is_tester_queue(queue)
-        is_builder_queue = Buildbot.is_builder_queue(queue)
-        if is_tester_queue:
-            name = StatusBubble.TESTER_ICON + ' ' + name
-        if is_builder_queue:
-            name = StatusBubble.BUILDER_ICON + ' ' + name
+        cfg = BubbleConfig.from_buildbot_globals()
+        fetcher = BubbleDataFetcher(cfg)
+        parent_queue = cfg.get_parent_queue(queue)
+        builds, is_parent_build = fetcher.fetch_builds_for_queue(change, queue, parent_queue)
 
-        builds, is_parent_build = StatusBubble().get_all_builds_for_queue(change, queue, Buildbot.get_parent_queue(queue))
-        # FIXME: Handle parent build case
-        build = None
-        if builds:
-            build = builds[0]
-            builds = builds[:10]  # Limit number of builds to display in status-bubble hover over message
+        if not builds and queue in cfg.pr_comment_misc_handlers:
+            return u'| '
 
-        hover_over_text = ''
-        icon = GitHubEWS.ICON_BUILD_WAITING
-        if not build:
-            if queue in ['merge', 'unsafe-merge']:
-                return u'| '
-            if Buildbot.get_parent_queue(queue):
-                queue = Buildbot.get_parent_queue(queue)
-            queue_full_name = Buildbot.queue_name_by_shortname_mapping.get(queue)
-            url = None
-            if queue_full_name:
-                url = 'https://{}/#/builders/{}'.format(config.BUILDBOT_SERVER_HOST, queue_full_name)
-            hover_over_text = 'Waiting in queue, processing has not started yet'
-            return u'| [{icon} {name} ]({url} "{hover_over_text}") '.format(icon=icon, name=name, url=url, hover_over_text=hover_over_text)
+        # Force a "waiting" bubble for non-misc-handler queues with no build by
+        # supplying a placeholder queue position; the markdown renderer ignores
+        # the queue_position field.
+        queue_position = None if builds else cfg.unknown_queue_position
 
-        url = 'https://{}/#/builders/{}/builds/{}'.format(config.BUILDBOT_SERVER_HOST, build.builder_id, build.number)
+        inputs = BubbleInputs(
+            change=fetcher.fetch_change_snapshot(change),
+            queue=queue,
+            builds=builds,
+            is_parent_build=is_parent_build,
+            queue_position=queue_position,
+            hide_icons=False,
+            sent_to_buildbot=True,
+        )
+        data = compute_bubble(inputs, cfg, now=timezone.now())
+        if data is None:
+            return u'| '
 
-        if build.result is None:
-            if self._does_build_contains_any_failed_step(build):
-                icon = GitHubEWS.ICON_BUILD_ONGOING_WITH_FAILURES
-            else:
-                icon = GitHubEWS.ICON_BUILD_ONGOING
-            hover_over_text = 'Build is in progress. Recent messages:' + self._steps_messages(build)
-        elif build.result == Buildbot.SUCCESS:
-            if is_parent_build:
-                icon = GitHubEWS.ICON_BUILD_WAITING
-                hover_over_text = 'Waiting to run tests'
-                queue_full_name = Buildbot.queue_name_by_shortname_mapping.get(queue)
-                if queue_full_name:
-                    url = 'https://{}/#/builders/{}'.format(config.BUILDBOT_SERVER_HOST, queue_full_name)
-            else:
-                icon = GitHubEWS.ICON_BUILD_PASS
-                if is_builder_queue and is_tester_queue:
-                    hover_over_text = 'Built successfully and passed tests'
-                elif is_builder_queue:
-                    hover_over_text = 'Built successfully'
-                elif is_tester_queue:
-                    if queue == 'style':
-                        hover_over_text = 'Passed style check'
-                    else:
-                        hover_over_text = 'Passed tests'
-                else:
-                    hover_over_text = 'Pass'
-        elif build.result == Buildbot.WARNINGS:
-            icon = GitHubEWS.ICON_BUILD_PASS
-        elif build.result == Buildbot.FAILURE:
-            icon = GitHubEWS.ICON_BUILD_FAIL
-            hover_over_text = self._most_recent_failure_message(build)
-        elif build.result == Buildbot.CANCELLED:
-            icon = GitHubEWS.ICON_EMPTY_SPACE
-            name = u'~~{}~~'.format(name)
-            hover_over_text = 'Build was cancelled. Recent messages:' + self._steps_messages(build)
-        elif build.result == Buildbot.SKIPPED:
-            icon = GitHubEWS.ICON_EMPTY_SPACE
-            if re.search(r'Pull request .* doesn\'t have relevant changes', build.state_string):
-                return u'| '
-            name = u'~~{}~~'.format(name)
-            hover_over_text = 'The change is no longer eligible for processing.'
-            if re.search(r'Pull request .* is already closed', build.state_string):
-                hover_over_text += ' Pull Request was already closed when EWS attempted to process it.'
-            elif re.search(r'Hash .* on PR .* is outdated', build.state_string):
-                hover_over_text += ' Commit was outdated when EWS attempted to process it.'
-            elif re.search(r'Skipping as PR .* has skip-ews label', build.state_string):
-                hover_over_text = 'EWS skipped this build as PR had skip-ews label when EWS attempted to process it.'
-        elif build.result == Buildbot.RETRY:
-            hover_over_text = 'Build is being retried. Recent messages:' + self._steps_messages(build)
-            icon = GitHubEWS.ICON_BUILD_ONGOING
-        elif build.result == Buildbot.EXCEPTION:
-            hover_over_text = 'An unexpected error occured. Recent messages:' + self._steps_messages(build)
-            icon = GitHubEWS.ICON_BUILD_ERROR
-        else:
-            icon = GitHubEWS.ICON_BUILD_ERROR
-            hover_over_text = 'An unexpected error occured. Recent messages:' + self._steps_messages(build)
+        is_in_progress = bool(builds and builds[0].result is None)
+        return render_markdown_bubble(
+            data,
+            icons=self._github_icons(),
+            is_in_progress=is_in_progress,
+            escape=self.escape_github_markdown,
+        )
 
-        # Hover-over text comes from buildbot and can contain special characters (newlines, quotes, pipes) that break markdown, sanitize it
-        hover_over_text = self.escape_github_markdown(hover_over_text)
-        return u'| [{icon} {name}]({url} "{hover_over_text}") '.format(icon=icon, name=name, url=url, hover_over_text=hover_over_text)
+    @classmethod
+    def _github_icons(cls) -> GithubIcons:
+        return GithubIcons(
+            pass_=cls.ICON_BUILD_PASS,
+            fail=cls.ICON_BUILD_FAIL,
+            waiting=cls.ICON_BUILD_WAITING,
+            ongoing=cls.ICON_BUILD_ONGOING,
+            ongoing_with_failures=cls.ICON_BUILD_ONGOING_WITH_FAILURES,
+            error=cls.ICON_BUILD_ERROR,
+            empty=cls.ICON_EMPTY_SPACE,
+        )
 
     @classmethod
     def add_or_update_comment_for_change_id(self, sha, pr_number, pr_project=None, pr_author='', allow_new_comment=False):
@@ -466,21 +426,3 @@ class GitHubEWS(GitHub):
             new_comment_id = gh.update_or_leave_comment_on_pr(pr_number, folded_comment, repository_url=repository_url, comment_id=comment_id)
 
         return comment_id
-
-    def _steps_messages(self, build):
-        # FIXME: figure out if it is possible to have multi-line hover-over messages in GitHub UI.
-        return '; '.join([step.state_string for step in build.step_set.all().order_by('uid')])
-
-    def _does_build_contains_any_failed_step(self, build):
-        for step in build.step_set.all():
-            if step.result and step.result != Buildbot.SUCCESS and step.result != Buildbot.WARNINGS and step.result != Buildbot.SKIPPED:
-                return True
-        return False
-
-    def _most_recent_failure_message(self, build):
-        for step in build.step_set.all().order_by('-uid'):
-            if step.result == Buildbot.SUCCESS and 'retrying build' in step.state_string:
-                return step.state_string
-            if step.result == Buildbot.FAILURE:
-                return step.state_string
-        return ''

--- a/Tools/CISupport/ews-app/ews/tests.py
+++ b/Tools/CISupport/ews-app/ews/tests.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2018 Apple Inc. All rights reserved.
+# Copyright (C) 2018-2026 Apple Inc. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -22,6 +22,908 @@
 
 from __future__ import unicode_literals
 
-from django.test import TestCase
+import datetime
+import json
+import os
 
-# Create your tests here.
+from unittest.mock import patch
+
+from django.test import TestCase
+from django.utils import timezone as django_timezone
+
+from ews.common.buildbot import Buildbot
+from ews.common.github import GitHubEWS
+from ews.views.bubble.compute import compute_bubble
+from ews.views.bubble.config import BUILDER_ICON, TESTER_ICON, BubbleConfig
+from ews.views.bubble.model import (
+    BubbleData,
+    BubbleInputs,
+    BuildSnapshot,
+    ChangeSnapshot,
+    StepSnapshot,
+)
+from ews.views.bubble.render_html import render_html_bubble
+from ews.views.bubble.render_markdown import GithubIcons, render_markdown_bubble
+
+
+class BuildbotAllQueuesTest(TestCase):
+    def setUp(self):
+        self._prev_all_queues = Buildbot.all_queues
+        self._prev_icons = dict(Buildbot.icons_for_queues_mapping)
+        self._prev_names = dict(Buildbot.queue_name_by_shortname_mapping)
+        self._prev_pr_column = dict(Buildbot.pr_column_by_shortname)
+        self._prev_misc_handlers = list(Buildbot.pr_comment_misc_handlers)
+
+    def tearDown(self):
+        Buildbot.all_queues = self._prev_all_queues
+        Buildbot.icons_for_queues_mapping = self._prev_icons
+        Buildbot.queue_name_by_shortname_mapping = self._prev_names
+        Buildbot.pr_column_by_shortname = self._prev_pr_column
+        Buildbot.pr_comment_misc_handlers = self._prev_misc_handlers
+
+    def test_all_queues_populated_from_status_bubble_order(self):
+        canned = {
+            'builders': [
+                {'name': 'Style-EWS', 'shortname': 'style', 'icon': 'testOnly'},
+                {'name': 'iOS-Build-EWS', 'shortname': 'ios', 'icon': 'buildOnly'},
+                {'name': 'Merge-Queue', 'shortname': 'merge', 'icon': 'buildAndTest'},
+            ],
+            'status_bubble_order': ['style', 'ios'],
+        }
+        Buildbot.all_queues = []
+        with patch.object(Buildbot, 'fetch_config', classmethod(lambda cls: canned)):
+            Buildbot.update_icons_for_queues_mapping()
+        self.assertEqual(Buildbot.all_queues, ['style', 'ios'])
+
+    def test_all_queues_preserved_when_key_missing(self):
+        Buildbot.all_queues = ['style', 'ios']
+        canned = {'builders': []}
+        with patch.object(Buildbot, 'fetch_config', classmethod(lambda cls: canned)):
+            Buildbot.update_icons_for_queues_mapping()
+        self.assertEqual(Buildbot.all_queues, ['style', 'ios'])
+
+    def test_all_queues_preserved_when_fetch_fails(self):
+        Buildbot.all_queues = ['style', 'ios']
+        with patch.object(Buildbot, 'fetch_config', classmethod(lambda cls: {})):
+            Buildbot.update_icons_for_queues_mapping()
+        self.assertEqual(Buildbot.all_queues, ['style', 'ios'])
+
+    def test_pr_column_by_shortname_populated(self):
+        canned = {
+            'builders': [
+                {'name': 'Style-EWS', 'shortname': 'style', 'pr_column': 'misc'},
+                {'name': 'iOS-Build-EWS', 'shortname': 'ios', 'pr_column': 'embedded'},
+            ],
+        }
+        Buildbot.pr_column_by_shortname = {}
+        with patch.object(Buildbot, 'fetch_config', classmethod(lambda cls: canned)):
+            Buildbot.update_icons_for_queues_mapping()
+        self.assertEqual(Buildbot.pr_column_by_shortname, {'style': 'misc', 'ios': 'embedded'})
+
+    def test_pr_comment_misc_handlers_populated(self):
+        canned = {
+            'builders': [],
+            'pr_comment_misc_handlers': ['merge', 'unsafe-merge'],
+        }
+        Buildbot.pr_comment_misc_handlers = []
+        with patch.object(Buildbot, 'fetch_config', classmethod(lambda cls: canned)):
+            Buildbot.update_icons_for_queues_mapping()
+        self.assertEqual(Buildbot.pr_comment_misc_handlers, ['merge', 'unsafe-merge'])
+
+    def test_pr_comment_misc_handlers_preserved_when_key_missing(self):
+        Buildbot.pr_comment_misc_handlers = ['merge', 'unsafe-merge']
+        with patch.object(Buildbot, 'fetch_config', classmethod(lambda cls: {'builders': []})):
+            Buildbot.update_icons_for_queues_mapping()
+        self.assertEqual(Buildbot.pr_comment_misc_handlers, ['merge', 'unsafe-merge'])
+
+
+class GitHubEWSStatusBubbleRowsTest(TestCase):
+    def setUp(self):
+        self._prev_all_queues = Buildbot.all_queues
+        self._prev_pr_column = dict(Buildbot.pr_column_by_shortname)
+        self._prev_misc_handlers = list(Buildbot.pr_comment_misc_handlers)
+
+    def tearDown(self):
+        Buildbot.all_queues = self._prev_all_queues
+        Buildbot.pr_column_by_shortname = self._prev_pr_column
+        Buildbot.pr_comment_misc_handlers = self._prev_misc_handlers
+
+    def test_grid_layout_with_canned_data(self):
+        Buildbot.all_queues = ['style', 'ios', 'ios-sim', 'mac', 'wpe', 'win', 'win-tests']
+        Buildbot.pr_column_by_shortname = {
+            'style': 'misc', 'ios': 'embedded', 'ios-sim': 'embedded',
+            'mac': 'macos', 'wpe': 'linux', 'win': 'windows', 'win-tests': 'windows',
+        }
+        Buildbot.pr_comment_misc_handlers = ['merge', 'unsafe-merge']
+        rows = GitHubEWS._compute_status_bubble_rows()
+        # Each row has 5 columns; height = max column length = misc(3)
+        self.assertEqual(len(rows), 3)
+        for row in rows:
+            self.assertEqual(len(row), 5)
+        # Column display order is [misc, embedded, macos, linux, windows].
+        misc_col = [row[0] for row in rows]
+        self.assertEqual(misc_col, ['merge', 'unsafe-merge', 'style'])
+        embedded_col = [row[1] for row in rows]
+        self.assertEqual(embedded_col, ['ios', 'ios-sim', ''])
+        macos_col = [row[2] for row in rows]
+        self.assertEqual(macos_col, ['mac', '', ''])
+        linux_col = [row[3] for row in rows]
+        self.assertEqual(linux_col, ['wpe', '', ''])
+        windows_col = [row[4] for row in rows]
+        self.assertEqual(windows_col, ['win', 'win-tests', ''])
+
+    def test_grid_respects_status_bubble_order(self):
+        Buildbot.all_queues = ['ios-sim', 'ios']  # reversed ordering
+        Buildbot.pr_column_by_shortname = {'ios': 'embedded', 'ios-sim': 'embedded'}
+        Buildbot.pr_comment_misc_handlers = []
+        rows = GitHubEWS._compute_status_bubble_rows()
+        embedded_col = [row[1] for row in rows]
+        self.assertEqual(embedded_col, ['ios-sim', 'ios'])
+
+    def test_grid_skips_shortnames_without_pr_column(self):
+        Buildbot.all_queues = ['mac', 'orphan']
+        Buildbot.pr_column_by_shortname = {'mac': 'macos'}
+        Buildbot.pr_comment_misc_handlers = []
+        rows = GitHubEWS._compute_status_bubble_rows()
+        flat = [cell for row in rows for cell in row]
+        self.assertNotIn('orphan', flat)
+        self.assertIn('mac', flat)
+
+
+class GitHubEWSLegacyDriftGuardTest(TestCase):
+    # Drift guard: the computed grid should partition the real config.json into
+    # the same column membership as the pre-refactor STATUS_BUBBLE_ROWS hardcoded
+    # grid (with `merge` and `unsafe-merge` moved to the top of Misc). Remove
+    # once the derived values are trusted.
+    LEGACY_COLUMN_MEMBERSHIP = {
+        'misc':     {'merge', 'unsafe-merge', 'style', 'bindings', 'webkitperl', 'webkitpy', 'jsc-x86-64', 'jsc-debug-arm64', 'services'},
+        'embedded': {'ios', 'ios-sim', 'ios-wk2', 'ios-wk2-wpt', 'api-ios', 'ios-safer-cpp', 'vision', 'vision-sim', 'vision-wk2', 'tv', 'tv-sim', 'watch', 'watch-sim'},
+        'macos':    {'mac', 'mac-AS-debug', 'api-mac', 'api-mac-debug', 'mac-wk1', 'mac-wk2', 'mac-AS-debug-wk2', 'mac-wk2-stress', 'mac-intel-wk2', 'mac-safer-cpp'},
+        'linux':    {'wpe', 'wpe-wk2', 'api-wpe', 'gtk3-libwebrtc', 'gtk', 'gtk-wk2', 'api-gtk', 'playstation', 'jsc-armv7', 'jsc-armv7-tests'},
+        'windows':  {'win', 'win-tests'},
+    }
+
+    def setUp(self):
+        self._prev_all_queues = Buildbot.all_queues
+        self._prev_pr_column = dict(Buildbot.pr_column_by_shortname)
+        self._prev_misc_handlers = list(Buildbot.pr_comment_misc_handlers)
+        cwd = os.path.dirname(os.path.abspath(__file__))
+        config_path = os.path.join(cwd, '..', '..', 'ews-build', 'config.json')
+        with open(config_path) as f:
+            config = json.load(f)
+        Buildbot.all_queues = list(config.get('status_bubble_order', []))
+        Buildbot.pr_column_by_shortname = {
+            b['shortname']: b['pr_column']
+            for b in config.get('builders', [])
+            if b.get('pr_column')
+        }
+        Buildbot.pr_comment_misc_handlers = list(config.get('pr_comment_misc_handlers', []))
+
+    def tearDown(self):
+        Buildbot.all_queues = self._prev_all_queues
+        Buildbot.pr_column_by_shortname = self._prev_pr_column
+        Buildbot.pr_comment_misc_handlers = self._prev_misc_handlers
+
+    def test_column_membership_matches_legacy(self):
+        rows = GitHubEWS._compute_status_bubble_rows()
+        columns = {key: set() for key in GitHubEWS.PR_COLUMN_DISPLAY_ORDER}
+        for row in rows:
+            for i, key in enumerate(GitHubEWS.PR_COLUMN_DISPLAY_ORDER):
+                if row[i]:
+                    columns[key].add(row[i])
+        self.assertEqual(columns, self.LEGACY_COLUMN_MEMBERSHIP)
+
+    def test_misc_column_starts_with_merge_handlers(self):
+        rows = GitHubEWS._compute_status_bubble_rows()
+        misc_col = [row[0] for row in rows if row[0]]
+        self.assertEqual(misc_col[:2], ['merge', 'unsafe-merge'])
+
+
+# ---------------------------------------------------------------------------
+# Status bubble compute / render tests
+# ---------------------------------------------------------------------------
+
+NOW = datetime.datetime(2026, 5, 5, 12, 0, tzinfo=datetime.timezone.utc)
+
+
+class _Fixtures(object):
+    @staticmethod
+    def cfg(**overrides):
+        defaults = dict(
+            icons_for_queues={'ios-sim': 'buildAndTest', 'style': 'testOnly',
+                              'mac': 'buildOnly', 'misc-q': '', 'wpe': 'buildOnly'},
+            queue_name_by_shortname={'ios-sim': 'iOS-Simulator-EWS', 'mac': 'macOS-EWS',
+                                     'style': 'Style-EWS', 'wpe': 'WPE-EWS'},
+            all_queues=('style', 'ios-sim', 'mac', 'wpe'),
+            pr_column_by_shortname={},
+            pr_comment_misc_handlers=('merge', 'unsafe-merge'),
+            queue_triggers={'ios-wk2': 'ios-sim'},
+            buildbot_server_host='ews-build.test',
+        )
+        defaults.update(overrides)
+        return BubbleConfig(**defaults)
+
+    @staticmethod
+    def step(uid='1', state='Passed tests', result=Buildbot.SUCCESS, started_at=1700000000):
+        return StepSnapshot(uid=uid, state_string=state, result=result, started_at=started_at)
+
+    @staticmethod
+    def build(*, result=Buildbot.SUCCESS, steps=(), builder_display_name='ios-sim',
+              builder_name='iOS-Simulator-EWS', builder_id=42, number=7,
+              state_string='', started_at=1700000000, complete_at=1700000060):
+        asc = tuple(steps)
+        desc = tuple(reversed(asc))
+        return BuildSnapshot(
+            builder_id=builder_id,
+            builder_name=builder_name,
+            builder_display_name=builder_display_name,
+            number=number,
+            result=result,
+            state_string=state_string,
+            started_at=started_at,
+            complete_at=complete_at,
+            steps_by_uid_asc=asc,
+            steps_by_uid_desc=desc,
+            last_step=asc[-1] if asc else None,
+        )
+
+    @staticmethod
+    def change(*, created=None, sent_to_buildbot=True, sent_to_commit_queue=False, obsolete=False):
+        return ChangeSnapshot(
+            change_id='abc123',
+            created=created or (NOW - datetime.timedelta(hours=1)),
+            sent_to_buildbot=sent_to_buildbot,
+            sent_to_commit_queue=sent_to_commit_queue,
+            obsolete=obsolete,
+            pr_number=999,
+            pr_project='WebKit/WebKit',
+            comment_id=-1,
+        )
+
+    @staticmethod
+    def inputs(*, builds=(), is_parent_build=False, queue='ios-sim',
+               queue_position=None, hide_icons=False, sent_to_buildbot=True,
+               change=None):
+        return BubbleInputs(
+            change=change or _Fixtures.change(),
+            queue=queue,
+            builds=tuple(builds),
+            is_parent_build=is_parent_build,
+            queue_position=queue_position,
+            hide_icons=hide_icons,
+            sent_to_buildbot=sent_to_buildbot,
+        )
+
+
+class ComputeBubbleBuildOutcomesTest(TestCase):
+    def test_in_progress_no_failed_step_yields_started(self):
+        build = _Fixtures.build(result=None, steps=(_Fixtures.step(state='Compiling'),))
+        data = compute_bubble(_Fixtures.inputs(builds=[build]), _Fixtures.cfg(), now=NOW)
+        self.assertEqual(data.state, 'started')
+        self.assertIn('Build is in-progress', data.details_message)
+
+    def test_in_progress_with_failed_step_yields_provisional_fail(self):
+        steps = (_Fixtures.step(uid='1', state='ok', result=Buildbot.SUCCESS),
+                 _Fixtures.step(uid='2', state='boom', result=Buildbot.FAILURE))
+        build = _Fixtures.build(result=None, steps=steps)
+        data = compute_bubble(_Fixtures.inputs(builds=[build]), _Fixtures.cfg(), now=NOW)
+        self.assertEqual(data.state, 'provisional-fail')
+
+    def test_success_non_parent_builder_only_says_built_successfully(self):
+        cfg = _Fixtures.cfg(icons_for_queues={'mac': 'buildOnly'})
+        build = _Fixtures.build(result=Buildbot.SUCCESS, builder_display_name='mac')
+        data = compute_bubble(_Fixtures.inputs(builds=[build], queue='mac'), cfg, now=NOW)
+        self.assertEqual(data.state, 'pass')
+        self.assertEqual(data.details_message, 'Built successfully')
+
+    def test_success_non_parent_tester_only_says_passed_tests(self):
+        cfg = _Fixtures.cfg(icons_for_queues={'ios-wk2': 'testOnly'})
+        build = _Fixtures.build(result=Buildbot.SUCCESS, builder_display_name='ios-wk2')
+        data = compute_bubble(_Fixtures.inputs(builds=[build], queue='ios-wk2'), cfg, now=NOW)
+        self.assertEqual(data.details_message, 'Passed tests')
+
+    def test_success_non_parent_style_queue_says_passed_style_check(self):
+        cfg = _Fixtures.cfg(icons_for_queues={'style': 'testOnly'})
+        build = _Fixtures.build(result=Buildbot.SUCCESS, builder_display_name='style')
+        data = compute_bubble(_Fixtures.inputs(builds=[build], queue='style'), cfg, now=NOW)
+        self.assertEqual(data.details_message, 'Passed style check')
+
+    def test_success_non_parent_build_and_test_says_built_and_passed(self):
+        cfg = _Fixtures.cfg(icons_for_queues={'ios-sim': 'buildAndTest'})
+        build = _Fixtures.build(result=Buildbot.SUCCESS)
+        data = compute_bubble(_Fixtures.inputs(builds=[build], queue='ios-sim'), cfg, now=NOW)
+        self.assertEqual(data.details_message, 'Built successfully and passed tests')
+
+    def test_success_non_parent_with_no_icon_says_pass(self):
+        cfg = _Fixtures.cfg(icons_for_queues={})
+        build = _Fixtures.build(result=Buildbot.SUCCESS, builder_display_name='unknown')
+        data = compute_bubble(_Fixtures.inputs(builds=[build], queue='unknown'), cfg, now=NOW)
+        self.assertEqual(data.details_message, 'Pass')
+
+    def test_success_parent_build_within_window_yields_started_waiting(self):
+        cfg = _Fixtures.cfg()
+        change = _Fixtures.change(created=NOW - datetime.timedelta(days=1))
+        build = _Fixtures.build(result=Buildbot.SUCCESS)
+        data = compute_bubble(
+            _Fixtures.inputs(builds=[build], is_parent_build=True, change=change),
+            cfg, now=NOW,
+        )
+        self.assertEqual(data.state, 'started')
+        self.assertEqual(data.details_message, 'Waiting to run tests.')
+        self.assertIn('iOS-Simulator-EWS', data.url)
+
+    def test_success_parent_build_outside_hide_window_returns_none(self):
+        cfg = _Fixtures.cfg()
+        old = NOW - datetime.timedelta(days=cfg.days_to_hide_bubble + 1)
+        change = _Fixtures.change(created=old)
+        build = _Fixtures.build(result=Buildbot.SUCCESS)
+        data = compute_bubble(
+            _Fixtures.inputs(builds=[build], is_parent_build=True, change=change),
+            cfg, now=NOW,
+        )
+        self.assertIsNone(data)
+
+    def test_warnings_yields_pass_state_with_warning_message(self):
+        build = _Fixtures.build(result=Buildbot.WARNINGS,
+                                steps=(_Fixtures.step(state='warn step'),))
+        data = compute_bubble(_Fixtures.inputs(builds=[build]), _Fixtures.cfg(), now=NOW)
+        self.assertEqual(data.state, 'pass')
+        self.assertTrue(data.details_message.startswith('Warning'))
+
+    def test_failure_yields_fail_state_with_recent_failure_message(self):
+        steps = (_Fixtures.step(uid='1', state='compile failed', result=Buildbot.FAILURE),)
+        build = _Fixtures.build(result=Buildbot.FAILURE, steps=steps)
+        data = compute_bubble(_Fixtures.inputs(builds=[build]), _Fixtures.cfg(), now=NOW)
+        self.assertEqual(data.state, 'fail')
+        self.assertEqual(data.details_message, 'compile failed')
+
+    def test_failure_with_retry_message_yields_provisional_fail(self):
+        steps = (_Fixtures.step(uid='1', state='retrying build now',
+                                result=Buildbot.SUCCESS),)
+        build = _Fixtures.build(result=Buildbot.FAILURE, steps=steps)
+        data = compute_bubble(_Fixtures.inputs(builds=[build]), _Fixtures.cfg(), now=NOW)
+        self.assertEqual(data.state, 'provisional-fail')
+
+    def test_skipped_bug_already_closed_appends_message(self):
+        build = _Fixtures.build(result=Buildbot.SKIPPED,
+                                state_string='Bug 12345 is already closed')
+        data = compute_bubble(_Fixtures.inputs(builds=[build]), _Fixtures.cfg(), now=NOW)
+        self.assertEqual(data.state, 'skipped')
+        self.assertIn('Bug was already closed', data.details_message)
+
+    def test_skipped_patch_marked_r_minus_appends_message(self):
+        build = _Fixtures.build(result=Buildbot.SKIPPED,
+                                state_string='Patch 555 is marked r-')
+        data = compute_bubble(_Fixtures.inputs(builds=[build]), _Fixtures.cfg(), now=NOW)
+        self.assertIn('marked r-', data.details_message)
+
+    def test_skipped_patch_obsolete_appends_message(self):
+        build = _Fixtures.build(result=Buildbot.SKIPPED,
+                                state_string='Patch 555 is obsolete')
+        data = compute_bubble(_Fixtures.inputs(builds=[build]), _Fixtures.cfg(), now=NOW)
+        self.assertIn('Patch was obsolete', data.details_message)
+
+    def test_skipped_pull_request_already_closed_appends_message(self):
+        build = _Fixtures.build(result=Buildbot.SKIPPED,
+                                state_string='Pull request 99 is already closed')
+        data = compute_bubble(_Fixtures.inputs(builds=[build]), _Fixtures.cfg(), now=NOW)
+        self.assertIn('Pull Request was already closed', data.details_message)
+
+    def test_skipped_hash_outdated_appends_message(self):
+        build = _Fixtures.build(result=Buildbot.SKIPPED,
+                                state_string='Hash abc on PR 99 is outdated')
+        data = compute_bubble(_Fixtures.inputs(builds=[build]), _Fixtures.cfg(), now=NOW)
+        self.assertIn('Commit was outdated', data.details_message)
+
+    def test_skipped_skip_ews_label_overrides_message(self):
+        build = _Fixtures.build(result=Buildbot.SKIPPED,
+                                state_string='Skipping as PR 99 has skip-ews label')
+        data = compute_bubble(_Fixtures.inputs(builds=[build]), _Fixtures.cfg(), now=NOW)
+        self.assertEqual(
+            data.details_message,
+            'EWS skipped this build as PR had skip-ews label when EWS attempted to process it.',
+        )
+
+    def test_skipped_with_extra_eligible_builds_appends_step_log(self):
+        old_build = _Fixtures.build(result=Buildbot.FAILURE, number=6,
+                                    steps=(_Fixtures.step(state='earlier failure',
+                                                          result=Buildbot.FAILURE),))
+        skipped = _Fixtures.build(result=Buildbot.SKIPPED, number=7,
+                                  state_string='Bug 1 is already closed')
+        data = compute_bubble(_Fixtures.inputs(builds=[skipped, old_build]),
+                              _Fixtures.cfg(), now=NOW)
+        self.assertIn('Some messages were logged while the change was still eligible', data.details_message)
+        self.assertIn('earlier failure', data.details_message)
+
+    def test_exception_yields_error_state(self):
+        build = _Fixtures.build(result=Buildbot.EXCEPTION,
+                                steps=(_Fixtures.step(state='boom'),))
+        data = compute_bubble(_Fixtures.inputs(builds=[build]), _Fixtures.cfg(), now=NOW)
+        self.assertEqual(data.state, 'error')
+        self.assertIn('unexpected error', data.details_message)
+
+    def test_retry_yields_provisional_fail_state(self):
+        build = _Fixtures.build(result=Buildbot.RETRY,
+                                steps=(_Fixtures.step(state='retry step'),))
+        data = compute_bubble(_Fixtures.inputs(builds=[build]), _Fixtures.cfg(), now=NOW)
+        self.assertEqual(data.state, 'provisional-fail')
+        self.assertIn('being retried', data.details_message)
+
+    def test_cancelled_yields_cancelled_state(self):
+        build = _Fixtures.build(result=Buildbot.CANCELLED,
+                                steps=(_Fixtures.step(state='cancel step'),))
+        data = compute_bubble(_Fixtures.inputs(builds=[build]), _Fixtures.cfg(), now=NOW)
+        self.assertEqual(data.state, 'cancelled')
+        self.assertIn('cancelled', data.details_message)
+
+    def test_unknown_result_code_yields_error_state(self):
+        build = _Fixtures.build(result=99,
+                                steps=(_Fixtures.step(state='who knows'),))
+        data = compute_bubble(_Fixtures.inputs(builds=[build]), _Fixtures.cfg(), now=NOW)
+        self.assertEqual(data.state, 'error')
+
+    def test_builder_full_name_and_timestamp_present(self):
+        build = _Fixtures.build(result=Buildbot.SUCCESS, complete_at=1700000123)
+        data = compute_bubble(_Fixtures.inputs(builds=[build]), _Fixtures.cfg(), now=NOW)
+        self.assertEqual(data.builder_full_name, 'iOS Simulator EWS')
+        self.assertIsNotNone(data.build_timestamp_iso)
+        self.assertTrue(data.build_timestamp_iso.startswith('[['))
+
+    def test_os_details_present_when_step_starts_with_os_prefix(self):
+        steps = (_Fixtures.step(state='OS: macOS 14.0', result=Buildbot.SUCCESS),)
+        build = _Fixtures.build(result=Buildbot.SUCCESS, steps=steps)
+        data = compute_bubble(_Fixtures.inputs(builds=[build]), _Fixtures.cfg(), now=NOW)
+        self.assertEqual(data.os_details, 'OS: macOS 14.0')
+
+
+class ComputeBubbleQueuePositionTest(TestCase):
+    def test_no_build_with_integer_queue_position_yields_none_state_with_position(self):
+        data = compute_bubble(_Fixtures.inputs(queue_position=3),
+                              _Fixtures.cfg(), now=NOW)
+        self.assertEqual(data.state, 'none')
+        self.assertEqual(data.queue_position, 3)
+        self.assertIn('Position in queue: 3', data.details_message)
+
+    def test_no_build_with_unknown_queue_position_omits_position_field(self):
+        cfg = _Fixtures.cfg()
+        data = compute_bubble(_Fixtures.inputs(queue_position=cfg.unknown_queue_position),
+                              cfg, now=NOW)
+        self.assertEqual(data.state, 'none')
+        self.assertIsNone(data.queue_position)
+        self.assertIn('Position in queue: ?', data.details_message)
+
+    def test_no_build_with_none_queue_position_returns_none(self):
+        data = compute_bubble(_Fixtures.inputs(queue_position=None),
+                              _Fixtures.cfg(), now=NOW)
+        self.assertIsNone(data)
+
+    def test_no_build_falls_back_to_parent_queue_full_name_for_url(self):
+        cfg = _Fixtures.cfg(
+            queue_triggers={'ios-wk2': 'ios-sim'},
+            queue_name_by_shortname={'ios-sim': 'iOS-Simulator-EWS'},
+        )
+        data = compute_bubble(_Fixtures.inputs(queue='ios-wk2', queue_position=2),
+                              cfg, now=NOW)
+        self.assertIn('iOS-Simulator-EWS', data.url)
+
+    def test_no_build_unknown_queue_full_name_omits_url(self):
+        cfg = _Fixtures.cfg(queue_name_by_shortname={})
+        data = compute_bubble(_Fixtures.inputs(queue='nope', queue_position=1),
+                              cfg, now=NOW)
+        self.assertIsNone(data.url)
+
+
+class ComputeBubbleVisibilityTest(TestCase):
+    def test_no_build_and_not_sent_to_buildbot_hides_bubble(self):
+        data = compute_bubble(_Fixtures.inputs(sent_to_buildbot=False, queue_position=1),
+                              _Fixtures.cfg(), now=NOW)
+        self.assertIsNone(data)
+
+    def test_no_build_and_sent_to_buildbot_shows_bubble(self):
+        data = compute_bubble(_Fixtures.inputs(sent_to_buildbot=True, queue_position=1),
+                              _Fixtures.cfg(), now=NOW)
+        self.assertIsNotNone(data)
+
+    def test_skipped_irrelevant_changes_patch_phrasing_hides_bubble(self):
+        build = _Fixtures.build(result=Buildbot.SKIPPED,
+                                state_string="Patch 1 doesn't have relevant changes")
+        data = compute_bubble(_Fixtures.inputs(builds=[build]), _Fixtures.cfg(), now=NOW)
+        self.assertIsNone(data)
+
+    def test_skipped_irrelevant_changes_pr_phrasing_hides_bubble(self):
+        build = _Fixtures.build(result=Buildbot.SKIPPED,
+                                state_string="Pull request 1 doesn't have relevant changes")
+        data = compute_bubble(_Fixtures.inputs(builds=[build]), _Fixtures.cfg(), now=NOW)
+        self.assertIsNone(data)
+
+    def test_hide_icons_true_omits_builder_and_tester_icons(self):
+        build = _Fixtures.build(result=Buildbot.SUCCESS)
+        data = compute_bubble(
+            _Fixtures.inputs(builds=[build], hide_icons=True), _Fixtures.cfg(), now=NOW,
+        )
+        self.assertEqual(data.name, 'ios-sim')
+        self.assertNotIn(BUILDER_ICON, data.name)
+        self.assertNotIn(TESTER_ICON, data.name)
+
+    def test_hide_icons_false_prepends_tester_icon_for_tester_queue(self):
+        cfg = _Fixtures.cfg(icons_for_queues={'style': 'testOnly'})
+        build = _Fixtures.build(result=Buildbot.SUCCESS, builder_display_name='style')
+        data = compute_bubble(_Fixtures.inputs(builds=[build], queue='style'), cfg, now=NOW)
+        self.assertTrue(data.name.startswith(TESTER_ICON))
+
+    def test_hide_icons_false_prepends_builder_icon_for_builder_queue(self):
+        cfg = _Fixtures.cfg(icons_for_queues={'mac': 'buildOnly'})
+        build = _Fixtures.build(result=Buildbot.SUCCESS, builder_display_name='mac')
+        data = compute_bubble(_Fixtures.inputs(builds=[build], queue='mac'), cfg, now=NOW)
+        self.assertTrue(data.name.startswith(BUILDER_ICON))
+
+    def test_hide_icons_false_prepends_both_icons_for_build_and_test_queue(self):
+        cfg = _Fixtures.cfg(icons_for_queues={'ios-sim': 'buildAndTest'})
+        build = _Fixtures.build(result=Buildbot.SUCCESS)
+        data = compute_bubble(_Fixtures.inputs(builds=[build]), cfg, now=NOW)
+        self.assertIn(BUILDER_ICON, data.name)
+        self.assertIn(TESTER_ICON, data.name)
+
+
+class RenderHtmlBubbleTest(TestCase):
+    def test_render_html_bubble_returns_template_keys(self):
+        data = BubbleData(name='ios', state='pass', url='http://x',
+                          details_message='Built successfully',
+                          builder_full_name='iOS Simulator EWS',
+                          os_details='OS: macOS', build_timestamp_iso='[[t]]',
+                          queue_position=None)
+        out = render_html_bubble(data)
+        self.assertEqual(out['name'], 'ios')
+        self.assertEqual(out['state'], 'pass')
+        self.assertEqual(out['url'], 'http://x')
+        self.assertIn('iOS Simulator EWS', out['details_message'])
+        self.assertIn('Built successfully', out['details_message'])
+        self.assertIn('OS: macOS', out['details_message'])
+        self.assertIn('[[t]]', out['details_message'])
+
+    def test_render_html_bubble_omits_queue_position_when_none(self):
+        data = BubbleData(name='ios', state='pass', url=None,
+                          details_message='ok', builder_full_name=None,
+                          os_details=None, build_timestamp_iso=None,
+                          queue_position=None)
+        out = render_html_bubble(data)
+        self.assertNotIn('queue_position', out)
+
+    def test_render_html_bubble_includes_queue_position_when_set(self):
+        data = BubbleData(name='ios', state='none', url=None,
+                          details_message='waiting', builder_full_name=None,
+                          os_details=None, build_timestamp_iso=None,
+                          queue_position=4)
+        out = render_html_bubble(data)
+        self.assertEqual(out['queue_position'], 4)
+
+    def test_render_html_bubble_appends_os_and_timestamp_with_single_newline_between(self):
+        data = BubbleData(name='ios', state='pass', url=None,
+                          details_message='body', builder_full_name='Builder',
+                          os_details='OS: x', build_timestamp_iso='[[t]]',
+                          queue_position=None)
+        out = render_html_bubble(data)
+        self.assertEqual(out['details_message'], 'Builder\n\nbody\n\nOS: x\n[[t]]')
+
+    def test_render_html_bubble_omits_url_when_none(self):
+        data = BubbleData(name='ios', state='pass', url=None,
+                          details_message='ok', builder_full_name=None,
+                          os_details=None, build_timestamp_iso=None,
+                          queue_position=None)
+        out = render_html_bubble(data)
+        self.assertNotIn('url', out)
+
+
+_GH_ICONS = GithubIcons(
+    pass_='[PASS]', fail='[FAIL]', waiting='[WAIT]', ongoing='[ONGOING]',
+    ongoing_with_failures='[ONGOING-FAIL]', error='[ERROR]', empty='[EMPTY]',
+)
+
+
+class RenderMarkdownBubbleTest(TestCase):
+    def test_pass_state_emits_pass_icon_and_url(self):
+        data = BubbleData(name='ios', state='pass', url='http://x',
+                          details_message='ok', builder_full_name=None,
+                          os_details=None, build_timestamp_iso=None, queue_position=None)
+        out = render_markdown_bubble(data, icons=_GH_ICONS, is_in_progress=False,
+                                     escape=lambda s: s)
+        self.assertIn('[PASS]', out)
+        self.assertIn('http://x', out)
+
+    def test_fail_state_emits_fail_icon(self):
+        data = BubbleData(name='ios', state='fail', url='http://x',
+                          details_message='broken', builder_full_name=None,
+                          os_details=None, build_timestamp_iso=None, queue_position=None)
+        out = render_markdown_bubble(data, icons=_GH_ICONS, is_in_progress=False,
+                                     escape=lambda s: s)
+        self.assertIn('[FAIL]', out)
+
+    def test_provisional_fail_in_progress_uses_ongoing_with_failures_icon(self):
+        data = BubbleData(name='ios', state='provisional-fail', url='http://x',
+                          details_message='', builder_full_name=None,
+                          os_details=None, build_timestamp_iso=None, queue_position=None)
+        out = render_markdown_bubble(data, icons=_GH_ICONS, is_in_progress=True,
+                                     escape=lambda s: s)
+        self.assertIn('[ONGOING-FAIL]', out)
+
+    def test_provisional_fail_not_in_progress_uses_ongoing_icon(self):
+        data = BubbleData(name='ios', state='provisional-fail', url='http://x',
+                          details_message='', builder_full_name=None,
+                          os_details=None, build_timestamp_iso=None, queue_position=None)
+        out = render_markdown_bubble(data, icons=_GH_ICONS, is_in_progress=False,
+                                     escape=lambda s: s)
+        self.assertIn('[ONGOING]', out)
+
+    def test_cancelled_strikes_through_name(self):
+        data = BubbleData(name='ios', state='cancelled', url='http://x',
+                          details_message='', builder_full_name=None,
+                          os_details=None, build_timestamp_iso=None, queue_position=None)
+        out = render_markdown_bubble(data, icons=_GH_ICONS, is_in_progress=False,
+                                     escape=lambda s: s)
+        self.assertIn('~~ios~~', out)
+        self.assertIn('[EMPTY]', out)
+
+    def test_skipped_strikes_through_name(self):
+        data = BubbleData(name='ios', state='skipped', url='http://x',
+                          details_message='', builder_full_name=None,
+                          os_details=None, build_timestamp_iso=None, queue_position=None)
+        out = render_markdown_bubble(data, icons=_GH_ICONS, is_in_progress=False,
+                                     escape=lambda s: s)
+        self.assertIn('~~ios~~', out)
+
+    def test_hover_text_is_escaped(self):
+        data = BubbleData(name='ios', state='pass', url='http://x',
+                          details_message='one|two\nthree', builder_full_name=None,
+                          os_details=None, build_timestamp_iso=None, queue_position=None)
+        recorded = []
+        def spy(s):
+            recorded.append(s)
+            return s.replace('|', '\\|').replace('\n', ' ')
+        out = render_markdown_bubble(data, icons=_GH_ICONS, is_in_progress=False, escape=spy)
+        self.assertEqual(recorded, ['one|two\nthree'])
+        self.assertIn('one\\|two three', out)
+
+    def test_started_state_uses_ongoing_icon(self):
+        data = BubbleData(name='ios', state='started', url='http://x',
+                          details_message='', builder_full_name=None,
+                          os_details=None, build_timestamp_iso=None, queue_position=None)
+        out = render_markdown_bubble(data, icons=_GH_ICONS, is_in_progress=True,
+                                     escape=lambda s: s)
+        self.assertIn('[ONGOING]', out)
+
+    def test_error_state_uses_error_icon(self):
+        data = BubbleData(name='ios', state='error', url='http://x',
+                          details_message='', builder_full_name=None,
+                          os_details=None, build_timestamp_iso=None, queue_position=None)
+        out = render_markdown_bubble(data, icons=_GH_ICONS, is_in_progress=False,
+                                     escape=lambda s: s)
+        self.assertIn('[ERROR]', out)
+
+    def test_none_state_uses_waiting_icon(self):
+        data = BubbleData(name='ios', state='none', url='http://x',
+                          details_message='', builder_full_name=None,
+                          os_details=None, build_timestamp_iso=None, queue_position=None)
+        out = render_markdown_bubble(data, icons=_GH_ICONS, is_in_progress=False,
+                                     escape=lambda s: s)
+        self.assertIn('[WAIT]', out)
+
+    def test_unknown_state_falls_back_to_error_icon(self):
+        data = BubbleData(name='ios', state='totally-unknown', url='http://x',
+                          details_message='', builder_full_name=None,
+                          os_details=None, build_timestamp_iso=None, queue_position=None)
+        out = render_markdown_bubble(data, icons=_GH_ICONS, is_in_progress=False,
+                                     escape=lambda s: s)
+        self.assertIn('[ERROR]', out)
+
+
+# ---------------------------------------------------------------------------
+# Status bubble end-to-end and DB-backed tests
+# ---------------------------------------------------------------------------
+
+class StatusBubbleTemplateRenderTest(TestCase):
+    """Renders a real Change through StatusBubble.get() and asserts on HTML."""
+
+    def setUp(self):
+        from ews.models.patch import Change
+        from ews.models.build import Build
+        Build.objects.all().delete()
+        Change.objects.all().delete()
+        self.change = Change.objects.create(
+            change_id='abc123', bug_id=1,
+            sent_to_buildbot=True, sent_to_commit_queue=False, obsolete=False,
+        )
+        Build.objects.create(
+            change=self.change, uid='b1', builder_id=42, builder_name='iOS-Simulator-EWS',
+            builder_display_name='ios-sim', number=7,
+            result=Buildbot.SUCCESS, state_string='', started_at=1700000000,
+            complete_at=1700000060,
+        )
+        self._test_cfg = BubbleConfig(
+            icons_for_queues={'ios-sim': 'buildAndTest'},
+            queue_name_by_shortname={'ios-sim': 'iOS-Simulator-EWS'},
+            all_queues=('ios-sim',),
+            pr_column_by_shortname={},
+            pr_comment_misc_handlers=(),
+            queue_triggers={},
+            buildbot_server_host='ews-build.test',
+        )
+        self._cfg_patch = patch.object(
+            BubbleConfig, 'from_buildbot_globals',
+            classmethod(lambda cls: self._test_cfg),
+        )
+        self._cfg_patch.start()
+        self._now_patch = patch.object(
+            django_timezone, 'now',
+            lambda: NOW,
+        )
+        self._now_patch.start()
+
+    def tearDown(self):
+        self._cfg_patch.stop()
+        self._now_patch.stop()
+
+    def _get(self):
+        return self.client.get('/status-bubble/abc123/').content.decode('utf-8')
+
+    def test_get_returns_anchor_with_status_pass_class(self):
+        self.assertIn('class="status pass"', self._get())
+
+    def test_get_renders_href_to_buildbot_build_page(self):
+        self.assertIn('href="https://ews-build.test/#/builders/42/builds/7"', self._get())
+
+    def test_get_renders_title_attribute_with_details_message(self):
+        body = self._get()
+        self.assertIn('title="', body)
+        self.assertIn('Built successfully and passed tests', body)
+
+    def test_get_omits_submit_form_when_sent_to_buildbot(self):
+        self.assertNotIn('Submit for EWS analysis', self._get())
+
+    def test_get_renders_submit_form_when_not_sent_to_buildbot(self):
+        self.change.sent_to_buildbot = False
+        self.change.save()
+        self.assertIn('Submit for EWS analysis', self._get())
+
+    def test_get_renders_none_state_with_queue_position_when_no_build(self):
+        from ews.models.build import Build
+        Build.objects.all().delete()
+        body = self._get()
+        self.assertIn('class="status none"', body)
+        self.assertIn('<span class="queue_position">#1</span>', body)
+        self.assertIn('Position in queue: 1', body)
+        self.assertIn('href="https://ews-build.test/#/builders/iOS-Simulator-EWS"', body)
+
+
+class BubbleDataFetcherQueuePositionTest(TestCase):
+    """DB-backed tests for the queue-position SQL in fetch_queue_position."""
+
+    def setUp(self):
+        from ews.models.patch import Change
+        from ews.models.build import Build
+        Build.objects.all().delete()
+        Change.objects.all().delete()
+        self._cfg = BubbleConfig(
+            icons_for_queues={'ios-sim': 'buildAndTest'},
+            queue_name_by_shortname={'ios-sim': 'iOS-Simulator-EWS'},
+            all_queues=('ios-sim',),
+            pr_column_by_shortname={},
+            pr_comment_misc_handlers=(),
+            queue_triggers={'ios-wk2': 'ios-sim'},
+            buildbot_server_host='ews-build.test',
+        )
+
+    def _make_change(self, change_id, *, created, sent_to_buildbot=True, obsolete=False):
+        from ews.models.patch import Change
+        change = Change.objects.create(
+            change_id=change_id, bug_id=0,
+            sent_to_buildbot=sent_to_buildbot, sent_to_commit_queue=False,
+            obsolete=obsolete,
+        )
+        Change.objects.filter(pk=change.pk).update(created=created)
+        return Change.objects.get(pk=change.pk)
+
+    def _make_build(self, change, *, builder_display_name, created):
+        from ews.models.build import Build
+        build = Build.objects.create(
+            change=change, uid='u-{}-{}'.format(change.change_id, builder_display_name),
+            builder_id=1, builder_name='Bldr', builder_display_name=builder_display_name,
+            number=1, result=Buildbot.SUCCESS, state_string='', started_at=1, complete_at=2,
+        )
+        Build.objects.filter(pk=build.pk).update(created=created)
+        return Build.objects.get(pk=build.pk)
+
+    def test_position_one_when_no_prior_changes(self):
+        from ews.views.bubble.fetcher import BubbleDataFetcher
+        ch = self._make_change('c1', created=NOW - datetime.timedelta(hours=1))
+        fetcher = BubbleDataFetcher(self._cfg, now_provider=lambda: NOW)
+        self.assertEqual(fetcher.fetch_queue_position(ch, 'ios-sim', None), 1)
+
+    def test_position_counts_only_unprocessed_prior_changes(self):
+        from ews.views.bubble.fetcher import BubbleDataFetcher
+        prior_processed = self._make_change('c1', created=NOW - datetime.timedelta(hours=3))
+        self._make_build(prior_processed, builder_display_name='ios-sim',
+                         created=NOW - datetime.timedelta(hours=2))
+        self._make_change('c2', created=NOW - datetime.timedelta(hours=2))
+        target = self._make_change('c3', created=NOW - datetime.timedelta(hours=1))
+        fetcher = BubbleDataFetcher(self._cfg, now_provider=lambda: NOW)
+        # Two prior changes, one processed, so position = 2.
+        self.assertEqual(fetcher.fetch_queue_position(target, 'ios-sim', None), 2)
+
+    def test_outside_hide_window_returns_none(self):
+        from ews.views.bubble.fetcher import BubbleDataFetcher
+        ch = self._make_change('c1', created=NOW - datetime.timedelta(days=10))
+        fetcher = BubbleDataFetcher(self._cfg, now_provider=lambda: NOW)
+        self.assertIsNone(fetcher.fetch_queue_position(ch, 'ios-sim', None))
+
+    def test_between_check_and_hide_window_returns_unknown_position_marker(self):
+        from ews.views.bubble.fetcher import BubbleDataFetcher
+        ch = self._make_change('c1', created=NOW - datetime.timedelta(days=2))
+        fetcher = BubbleDataFetcher(self._cfg, now_provider=lambda: NOW)
+        self.assertEqual(
+            fetcher.fetch_queue_position(ch, 'ios-sim', None),
+            self._cfg.unknown_queue_position,
+        )
+
+    def test_parent_queue_fallback_subtracts_parent_built_changes(self):
+        from ews.views.bubble.fetcher import BubbleDataFetcher
+        prior = self._make_change('c1', created=NOW - datetime.timedelta(hours=3))
+        self._make_build(prior, builder_display_name='ios-sim',
+                         created=NOW - datetime.timedelta(hours=2))
+        target = self._make_change('c2', created=NOW - datetime.timedelta(hours=1))
+        fetcher = BubbleDataFetcher(self._cfg, now_provider=lambda: NOW)
+        # Target is on ios-wk2 whose parent is ios-sim. Prior built on ios-sim
+        # is subtracted, leaving 0 unprocessed -> position 1.
+        self.assertEqual(fetcher.fetch_queue_position(target, 'ios-wk2', 'ios-sim'), 1)
+
+
+class GitHubEWSMiscHandlerEmptyCellTest(TestCase):
+    """Covers the `| ` empty-cell branch in github_status_for_buildbot_queue:
+    when a queue listed in pr_comment_misc_handlers has no build for the change,
+    the markdown comment must render an empty table cell rather than a bubble."""
+
+    def setUp(self):
+        from ews.models.patch import Change
+        from ews.models.build import Build
+        Build.objects.all().delete()
+        Change.objects.all().delete()
+        self.change = Change.objects.create(
+            change_id='abc123', bug_id=1,
+            sent_to_buildbot=True, sent_to_commit_queue=False, obsolete=False,
+        )
+        self._test_cfg = BubbleConfig(
+            icons_for_queues={'merge': '', 'unsafe-merge': '', 'ios-sim': 'buildAndTest'},
+            queue_name_by_shortname={'ios-sim': 'iOS-Simulator-EWS'},
+            all_queues=('merge', 'unsafe-merge', 'ios-sim'),
+            pr_column_by_shortname={},
+            pr_comment_misc_handlers=('merge', 'unsafe-merge'),
+            queue_triggers={},
+            buildbot_server_host='ews-build.test',
+        )
+        self._cfg_patch = patch.object(
+            BubbleConfig, 'from_buildbot_globals',
+            classmethod(lambda cls: self._test_cfg),
+        )
+        self._cfg_patch.start()
+
+    def tearDown(self):
+        self._cfg_patch.stop()
+
+    def test_merge_queue_with_no_build_returns_empty_cell(self):
+        self.assertEqual(
+            GitHubEWS().github_status_for_buildbot_queue(self.change, 'merge'),
+            u'| ',
+        )
+
+    def test_unsafe_merge_queue_with_no_build_returns_empty_cell(self):
+        self.assertEqual(
+            GitHubEWS().github_status_for_buildbot_queue(self.change, 'unsafe-merge'),
+            u'| ',
+        )
+
+    def test_non_misc_handler_with_no_build_renders_waiting_bubble(self):
+        # Sanity: misc-handler short-circuit must not swallow regular queues.
+        # ios-sim has no build but isn't a misc handler, so we should get a
+        # rendered bubble cell (starts with `| [`), not the bare `| `.
+        result = GitHubEWS().github_status_for_buildbot_queue(self.change, 'ios-sim')
+        self.assertNotEqual(result, u'| ')
+        self.assertTrue(result.startswith('| ['), 'expected bubble cell, got: {!r}'.format(result))

--- a/Tools/CISupport/ews-app/ews/views/bubble/__init__.py
+++ b/Tools/CISupport/ews-app/ews/views/bubble/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2018 Apple Inc. All rights reserved.
+# Copyright (C) 2026 Apple Inc. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -19,25 +19,3 @@
 # CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
-from __future__ import unicode_literals
-
-import logging
-
-from django.apps import AppConfig
-
-_log = logging.getLogger(__name__)
-
-
-class EwsConfig(AppConfig):
-    name = 'ews'
-
-    def ready(self):
-        # FIXME: Ensure that this method is called only once.
-        from ews.common.buildbot import Buildbot
-        from ews.fetcher import FetchLoop
-        try:
-            Buildbot.update_icons_for_queues_mapping()
-        except Exception as e:
-            _log.error('Failed to bootstrap buildbot queue metadata: {}'.format(e))
-        FetchLoop()

--- a/Tools/CISupport/ews-app/ews/views/bubble/compute.py
+++ b/Tools/CISupport/ews-app/ews/views/bubble/compute.py
@@ -1,0 +1,258 @@
+# Copyright (C) 2026 Apple Inc. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1.  Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+# 2.  Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS'' AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR
+# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+from __future__ import unicode_literals
+
+import datetime
+import re
+from typing import Iterable, Optional
+
+from ews.common.buildbot import Buildbot
+from ews.views.bubble.config import BubbleConfig
+from ews.views.bubble.model import (
+    BubbleData,
+    BubbleInputs,
+    BuildSnapshot,
+)
+
+
+SKIPPED_IRRELEVANT_PATTERNS = (
+    re.compile(r"Patch .* doesn't have relevant changes"),
+    re.compile(r"Pull request .* doesn't have relevant changes"),
+)
+
+SKIPPED_REASON_MESSAGES = (
+    (re.compile(r'Bug .* is already closed'),
+     'Bug was already closed when EWS attempted to process it.'),
+    (re.compile(r'Patch .* is marked r-'),
+     'Patch was already marked r- when EWS attempted to process it.'),
+    (re.compile(r'Patch .* is obsolete'),
+     'Patch was obsolete when EWS attempted to process it.'),
+    (re.compile(r'Pull request .* is already closed'),
+     'Pull Request was already closed when EWS attempted to process it.'),
+    (re.compile(r'Hash .* on PR .* is outdated'),
+     'Commit was outdated when EWS attempted to process it.'),
+)
+
+SKIPPED_OVERRIDE_MESSAGES = (
+    (re.compile(r'Skipping as PR .* has skip-ews label'),
+     'EWS skipped this build as PR had skip-ews label when EWS attempted to process it.'),
+)
+
+
+def _decorated_queue_name(queue: str, hide_icons: bool, config: BubbleConfig) -> str:
+    name = queue
+    if hide_icons:
+        return name
+    if config.is_tester_queue(queue):
+        name = config.tester_icon + '  ' + name
+    if config.is_builder_queue(queue):
+        name = config.builder_icon + '  ' + name
+    return name
+
+
+def _should_show_bubble_for_build(build: Optional[BuildSnapshot], sent_to_buildbot: bool) -> bool:
+    if build is not None and build.result == Buildbot.SKIPPED:
+        for pattern in SKIPPED_IRRELEVANT_PATTERNS:
+            if pattern.search(build.state_string):
+                return False
+    if build is None and not sent_to_buildbot:
+        return False
+    return True
+
+
+def _does_build_contain_failed_step(build: BuildSnapshot) -> bool:
+    for step in build.steps_by_uid_asc:
+        if step.result and step.result not in (Buildbot.SUCCESS, Buildbot.WARNINGS, Buildbot.SKIPPED):
+            return True
+    return False
+
+
+def _most_recent_failure_message(build: BuildSnapshot, retry_msg: str) -> str:
+    for step in build.steps_by_uid_desc:
+        if step.result == Buildbot.SUCCESS and retry_msg in step.state_string:
+            return step.state_string
+        if step.result == Buildbot.FAILURE:
+            return step.state_string
+    return ''
+
+
+def _steps_messages(build: BuildSnapshot, *, sep: str = '\n') -> str:
+    return sep.join(step.state_string for step in build.steps_by_uid_asc)
+
+
+def _steps_messages_from_multiple_builds(builds: Iterable[BuildSnapshot], *, sep: str = '\n') -> str:
+    out = ''
+    for build in reversed(list(builds)):
+        out += '\n\n' + _steps_messages(build, sep=sep)
+    return out
+
+
+def _iso_time(unix_ts: int) -> str:
+    return '[[' + datetime.datetime.fromtimestamp(unix_ts).isoformat() + 'Z]]'
+
+
+def _get_os_details(build: BuildSnapshot) -> str:
+    for step in build.steps_by_uid_asc:
+        if step.state_string.startswith('OS:'):
+            return step.state_string
+    return ''
+
+
+def _get_build_timestamp_iso(build: BuildSnapshot) -> Optional[str]:
+    if build.complete_at:
+        return _iso_time(build.complete_at)
+    if build.last_step and build.last_step.started_at:
+        return _iso_time(build.last_step.started_at)
+    if build.started_at:
+        return _iso_time(build.started_at)
+    return None
+
+
+def _no_build_bubble(inputs: BubbleInputs, config: BubbleConfig, name: str) -> Optional[BubbleData]:
+    queue_position = inputs.queue_position
+    if not queue_position:
+        return None
+    display_position = queue_position if queue_position != config.unknown_queue_position else None
+
+    effective_queue = config.get_parent_queue(inputs.queue) or inputs.queue
+    queue_full_name = config.queue_full_name(effective_queue)
+    url = config.builder_url(queue_full_name) if queue_full_name else None
+    details = 'Waiting in queue, processing has not started yet.\n\nPosition in queue: {}'.format(queue_position)
+    return BubbleData(
+        name=name,
+        state='none',
+        url=url,
+        details_message=details,
+        builder_full_name=None,
+        os_details=None,
+        build_timestamp_iso=None,
+        queue_position=display_position,
+    )
+
+
+def _success_parent_build_message(inputs: BubbleInputs, config: BubbleConfig, name: str) -> Optional[BubbleData]:
+    queue_full_name = config.queue_full_name(inputs.queue)
+    url = config.builder_url(queue_full_name) if queue_full_name else config.build_url(
+        inputs.builds[0].builder_id, inputs.builds[0].number)
+    builder_full_name = (queue_full_name.replace('-', ' ')
+                         if queue_full_name else inputs.builds[0].builder_name.replace('-', ' '))
+    return BubbleData(
+        name=name,
+        state='started',
+        url=url,
+        details_message='Waiting to run tests.',
+        builder_full_name=builder_full_name,
+        os_details=_get_os_details(inputs.builds[0]) or None,
+        build_timestamp_iso=_get_build_timestamp_iso(inputs.builds[0]),
+        queue_position=None,
+    )
+
+
+def _success_message(queue: str, config: BubbleConfig) -> str:
+    is_builder = config.is_builder_queue(queue)
+    is_tester = config.is_tester_queue(queue)
+    if is_builder and is_tester:
+        return 'Built successfully and passed tests'
+    if is_builder:
+        return 'Built successfully'
+    if is_tester:
+        return 'Passed style check' if queue == 'style' else 'Passed tests'
+    return 'Pass'
+
+
+def _skipped_message(build: BuildSnapshot, builds_seen: int) -> str:
+    for pattern, override in SKIPPED_OVERRIDE_MESSAGES:
+        if pattern.search(build.state_string):
+            base = override
+            break
+    else:
+        base = 'The change is no longer eligible for processing.'
+        for pattern, suffix in SKIPPED_REASON_MESSAGES:
+            if pattern.search(build.state_string):
+                base += ' ' + suffix
+                break
+    if builds_seen > 1:
+        base += '\nSome messages were logged while the change was still eligible:'
+    return base
+
+
+def compute_bubble(inputs: BubbleInputs, config: BubbleConfig, *, now: datetime.datetime) -> Optional[BubbleData]:
+    name = _decorated_queue_name(inputs.queue, inputs.hide_icons, config)
+
+    builds = inputs.builds
+    build = builds[0] if builds else None
+
+    if not _should_show_bubble_for_build(build, inputs.sent_to_buildbot):
+        return None
+
+    if build is None:
+        return _no_build_bubble(inputs, config, name)
+
+    builder_full_name = build.builder_name.replace('-', ' ')
+    url = config.build_url(build.builder_id, build.number)
+
+    if build.result is None:
+        state = 'provisional-fail' if _does_build_contain_failed_step(build) else 'started'
+        details = 'Build is in-progress. Recent messages:' + _steps_messages_from_multiple_builds(builds)
+    elif build.result == Buildbot.SUCCESS:
+        if inputs.is_parent_build:
+            hide_threshold = now - datetime.timedelta(days=config.days_to_hide_bubble)
+            if inputs.change.created < hide_threshold:
+                return None
+            return _success_parent_build_message(inputs, config, name)
+        state = 'pass'
+        details = _success_message(inputs.queue, config)
+    elif build.result == Buildbot.WARNINGS:
+        state = 'pass'
+        details = 'Warning' + _steps_messages_from_multiple_builds(builds)
+    elif build.result == Buildbot.FAILURE:
+        details = _most_recent_failure_message(build, config.build_retry_msg)
+        state = 'provisional-fail' if config.build_retry_msg in details else 'fail'
+    elif build.result == Buildbot.SKIPPED:
+        state = 'skipped'
+        details = _skipped_message(build, len(builds))
+        if len(builds) > 1:
+            details += _steps_messages_from_multiple_builds(builds)
+    elif build.result == Buildbot.EXCEPTION:
+        state = 'error'
+        details = 'An unexpected error occured. Recent messages:' + _steps_messages_from_multiple_builds(builds)
+    elif build.result == Buildbot.RETRY:
+        state = 'provisional-fail'
+        details = 'Build is being retried. Recent messages:' + _steps_messages_from_multiple_builds(builds)
+    elif build.result == Buildbot.CANCELLED:
+        state = 'cancelled'
+        details = 'Build was cancelled. Recent messages:' + _steps_messages_from_multiple_builds(builds)
+    else:
+        state = 'error'
+        details = 'An unexpected error occured. Recent messages:' + _steps_messages_from_multiple_builds(builds)
+
+    return BubbleData(
+        name=name,
+        state=state,
+        url=url,
+        details_message=details,
+        builder_full_name=builder_full_name,
+        os_details=_get_os_details(build) or None,
+        build_timestamp_iso=_get_build_timestamp_iso(build),
+        queue_position=None,
+    )

--- a/Tools/CISupport/ews-app/ews/views/bubble/config.py
+++ b/Tools/CISupport/ews-app/ews/views/bubble/config.py
@@ -1,0 +1,80 @@
+# Copyright (C) 2026 Apple Inc. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1.  Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+# 2.  Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS'' AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR
+# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+from __future__ import unicode_literals
+
+from dataclasses import dataclass
+from typing import Mapping, Optional, Sequence
+
+
+BUILDER_ICON = u'\U0001f6e0'
+TESTER_ICON = u'\U0001f9ea'
+
+
+@dataclass(frozen=True)
+class BubbleConfig:
+    icons_for_queues: Mapping[str, str]
+    queue_name_by_shortname: Mapping[str, str]
+    all_queues: Sequence[str]
+    pr_column_by_shortname: Mapping[str, str]
+    pr_comment_misc_handlers: Sequence[str]
+    queue_triggers: Mapping[str, str]
+    buildbot_server_host: str
+    builder_icon: str = BUILDER_ICON
+    tester_icon: str = TESTER_ICON
+    days_to_check_queue_position: float = 0.5
+    days_to_hide_bubble: int = 7
+    build_retry_msg: str = 'retrying build'
+    unknown_queue_position: str = '?'
+
+    def is_tester_queue(self, queue: str) -> bool:
+        return self.icons_for_queues.get(queue) in ('testOnly', 'buildAndTest')
+
+    def is_builder_queue(self, queue: str) -> bool:
+        return self.icons_for_queues.get(queue) in ('buildOnly', 'buildAndTest')
+
+    def get_parent_queue(self, queue: str) -> Optional[str]:
+        return self.queue_triggers.get(queue)
+
+    def queue_full_name(self, queue: str) -> Optional[str]:
+        return self.queue_name_by_shortname.get(queue)
+
+    def builder_url(self, queue_full_name: str) -> str:
+        return 'https://{}/#/builders/{}'.format(self.buildbot_server_host, queue_full_name)
+
+    def build_url(self, builder_id: int, number: int) -> str:
+        return 'https://{}/#/builders/{}/builds/{}'.format(self.buildbot_server_host, builder_id, number)
+
+    @classmethod
+    def from_buildbot_globals(cls) -> 'BubbleConfig':
+        # Imported lazily so this module can be imported without Django settings loaded.
+        from ews.common.buildbot import Buildbot
+        import ews.config as ews_config
+        return cls(
+            icons_for_queues=dict(Buildbot.icons_for_queues_mapping),
+            queue_name_by_shortname=dict(Buildbot.queue_name_by_shortname_mapping),
+            all_queues=tuple(Buildbot.all_queues),
+            pr_column_by_shortname=dict(Buildbot.pr_column_by_shortname),
+            pr_comment_misc_handlers=tuple(Buildbot.pr_comment_misc_handlers),
+            queue_triggers=dict(Buildbot.QUEUE_TRIGGERS),
+            buildbot_server_host=ews_config.BUILDBOT_SERVER_HOST,
+        )

--- a/Tools/CISupport/ews-app/ews/views/bubble/fetcher.py
+++ b/Tools/CISupport/ews-app/ews/views/bubble/fetcher.py
@@ -1,0 +1,154 @@
+# Copyright (C) 2026 Apple Inc. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1.  Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+# 2.  Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS'' AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR
+# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+from __future__ import unicode_literals
+
+import datetime
+from typing import List, Optional, Tuple, Union
+
+from django.utils import timezone
+
+from ews.models.build import Build
+from ews.models.patch import Change
+from ews.views.bubble.config import BubbleConfig
+from ews.views.bubble.model import (
+    BubbleInputs,
+    BuildSnapshot,
+    ChangeSnapshot,
+    StepSnapshot,
+)
+
+
+MAX_BUILDS_DISPLAYED = 10
+
+
+def _step_snapshot(step) -> StepSnapshot:
+    return StepSnapshot(
+        uid=step.uid,
+        state_string=step.state_string,
+        result=step.result,
+        started_at=step.started_at,
+    )
+
+
+def _build_snapshot(build) -> BuildSnapshot:
+    asc = tuple(_step_snapshot(s) for s in build.step_set.all().order_by('uid'))
+    desc = tuple(reversed(asc))
+    last_step = asc[-1] if asc else None
+    return BuildSnapshot(
+        builder_id=build.builder_id,
+        builder_name=build.builder_name,
+        builder_display_name=build.builder_display_name,
+        number=build.number,
+        result=build.result,
+        state_string=build.state_string,
+        started_at=build.started_at,
+        complete_at=build.complete_at,
+        steps_by_uid_asc=asc,
+        steps_by_uid_desc=desc,
+        last_step=last_step,
+    )
+
+
+def _change_snapshot(change) -> ChangeSnapshot:
+    return ChangeSnapshot(
+        change_id=change.change_id,
+        created=change.created,
+        sent_to_buildbot=change.sent_to_buildbot,
+        sent_to_commit_queue=change.sent_to_commit_queue,
+        obsolete=change.obsolete,
+        pr_number=change.pr_number,
+        pr_project=change.pr_project,
+        comment_id=change.comment_id,
+    )
+
+
+class BubbleDataFetcher(object):
+    def __init__(self, config: BubbleConfig, *, now_provider=None):
+        self.config = config
+        self._now_provider = now_provider
+
+    def now(self) -> datetime.datetime:
+        if self._now_provider is not None:
+            return self._now_provider()
+        return timezone.now()
+
+    def fetch_change_snapshot(self, change) -> ChangeSnapshot:
+        return _change_snapshot(change)
+
+    def _fetch_raw_builds(self, change, queue: str, parent_queue: Optional[str]) -> Tuple[List, bool]:
+        builds = [b for b in change.build_set.all() if b.builder_display_name == queue]
+        is_parent_build = False
+        if not builds and parent_queue:
+            builds = [b for b in change.build_set.all() if b.builder_display_name == parent_queue]
+            is_parent_build = True
+        if not builds:
+            return ([], is_parent_build)
+        builds.sort(key=lambda b: b.number, reverse=True)
+        return (builds, is_parent_build)
+
+    def fetch_builds_for_queue(self, change, queue: str, parent_queue: Optional[str]) -> Tuple[Tuple[BuildSnapshot, ...], bool]:
+        raw_builds, is_parent_build = self._fetch_raw_builds(change, queue, parent_queue)
+        if not raw_builds:
+            return ((), is_parent_build)
+        capped = raw_builds[:MAX_BUILDS_DISPLAYED]
+        return (tuple(_build_snapshot(b) for b in capped), is_parent_build)
+
+    def fetch_queue_position(self, change, queue: str, parent_queue: Optional[str]) -> Union[int, str, None]:
+        now = self.now()
+        from_timestamp = now - datetime.timedelta(days=self.config.days_to_check_queue_position)
+        hide_from_timestamp = now - datetime.timedelta(days=self.config.days_to_hide_bubble)
+
+        if change.created < hide_from_timestamp:
+            return None
+
+        if change.created < from_timestamp:
+            return self.config.unknown_queue_position
+
+        sent_field = 'sent_to_commit_queue' if queue == 'commit' else 'sent_to_buildbot'
+        previously_sent_changes = set(Change.objects
+                                      .filter(created__gte=from_timestamp)
+                                      .filter(**{sent_field: True})
+                                      .filter(obsolete=False)
+                                      .filter(created__lt=change.created))
+        target_queue = parent_queue if parent_queue else queue
+        recent_builds = Build.objects \
+            .filter(created__gte=from_timestamp) \
+            .filter(builder_display_name=target_queue)
+        processed_changes = set(b.change for b in recent_builds)
+        return len(previously_sent_changes - processed_changes) + 1
+
+    def build_inputs(self, change, queue: str, *, hide_icons: bool, sent_to_buildbot: bool) -> BubbleInputs:
+        parent_queue = self.config.get_parent_queue(queue)
+        builds, is_parent_build = self.fetch_builds_for_queue(change, queue, parent_queue)
+        queue_position = None
+        if not builds:
+            queue_position = self.fetch_queue_position(change, queue, parent_queue)
+        return BubbleInputs(
+            change=self.fetch_change_snapshot(change),
+            queue=queue,
+            builds=builds,
+            is_parent_build=is_parent_build,
+            queue_position=queue_position,
+            hide_icons=hide_icons,
+            sent_to_buildbot=sent_to_buildbot,
+        )

--- a/Tools/CISupport/ews-app/ews/views/bubble/model.py
+++ b/Tools/CISupport/ews-app/ews/views/bubble/model.py
@@ -1,0 +1,85 @@
+# Copyright (C) 2026 Apple Inc. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1.  Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+# 2.  Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS'' AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR
+# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+from __future__ import unicode_literals
+
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Optional, Tuple, Union
+
+
+@dataclass(frozen=True)
+class StepSnapshot:
+    uid: str
+    state_string: str
+    result: Optional[int]
+    started_at: Optional[int]
+
+
+@dataclass(frozen=True)
+class BuildSnapshot:
+    builder_id: int
+    builder_name: str
+    builder_display_name: str
+    number: int
+    result: Optional[int]
+    state_string: str
+    started_at: Optional[int]
+    complete_at: Optional[int]
+    steps_by_uid_asc: Tuple[StepSnapshot, ...]
+    steps_by_uid_desc: Tuple[StepSnapshot, ...]
+    last_step: Optional[StepSnapshot]
+
+
+@dataclass(frozen=True)
+class ChangeSnapshot:
+    change_id: str
+    created: datetime
+    sent_to_buildbot: bool
+    sent_to_commit_queue: bool
+    obsolete: bool
+    pr_number: int
+    pr_project: str
+    comment_id: int
+
+
+@dataclass(frozen=True)
+class BubbleInputs:
+    change: ChangeSnapshot
+    queue: str
+    builds: Tuple[BuildSnapshot, ...]
+    is_parent_build: bool
+    queue_position: Union[int, str, None]
+    hide_icons: bool
+    sent_to_buildbot: bool
+
+
+@dataclass(frozen=True)
+class BubbleData:
+    name: str
+    state: str
+    url: Optional[str]
+    details_message: Optional[str]
+    builder_full_name: Optional[str]
+    os_details: Optional[str]
+    build_timestamp_iso: Optional[str]
+    queue_position: Union[int, str, None]

--- a/Tools/CISupport/ews-app/ews/views/bubble/render_html.py
+++ b/Tools/CISupport/ews-app/ews/views/bubble/render_html.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2018 Apple Inc. All rights reserved.
+# Copyright (C) 2026 Apple Inc. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -22,22 +22,37 @@
 
 from __future__ import unicode_literals
 
-import logging
+from typing import Any, Dict
 
-from django.apps import AppConfig
-
-_log = logging.getLogger(__name__)
+from ews.views.bubble.model import BubbleData
 
 
-class EwsConfig(AppConfig):
-    name = 'ews'
+def _assemble_html_details(data: BubbleData) -> str:
+    parts = []
+    if data.builder_full_name:
+        parts.append(data.builder_full_name)
+    if data.details_message:
+        parts.append(data.details_message)
+    suffix_lines = []
+    if data.os_details:
+        suffix_lines.append(data.os_details)
+    if data.build_timestamp_iso:
+        suffix_lines.append(data.build_timestamp_iso)
+    if suffix_lines:
+        parts.append('\n'.join(suffix_lines))
+    return '\n\n'.join(parts)
 
-    def ready(self):
-        # FIXME: Ensure that this method is called only once.
-        from ews.common.buildbot import Buildbot
-        from ews.fetcher import FetchLoop
-        try:
-            Buildbot.update_icons_for_queues_mapping()
-        except Exception as e:
-            _log.error('Failed to bootstrap buildbot queue metadata: {}'.format(e))
-        FetchLoop()
+
+def render_html_bubble(data: BubbleData) -> Dict[str, Any]:
+    out = {
+        'name': data.name,
+        'state': data.state,
+    }
+    if data.url:
+        out['url'] = data.url
+    details = _assemble_html_details(data)
+    if details:
+        out['details_message'] = details
+    if data.queue_position is not None:
+        out['queue_position'] = data.queue_position
+    return out

--- a/Tools/CISupport/ews-app/ews/views/bubble/render_markdown.py
+++ b/Tools/CISupport/ews-app/ews/views/bubble/render_markdown.py
@@ -1,0 +1,79 @@
+# Copyright (C) 2026 Apple Inc. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1.  Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+# 2.  Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS'' AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR
+# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+from __future__ import unicode_literals
+
+from dataclasses import dataclass
+from typing import Callable, Optional
+
+from ews.views.bubble.model import BubbleData
+
+
+@dataclass(frozen=True)
+class GithubIcons:
+    pass_: str
+    fail: str
+    waiting: str
+    ongoing: str
+    ongoing_with_failures: str
+    error: str
+    empty: str
+
+
+_STATE_TO_ICON_ATTR = {
+    'pass': 'pass_',
+    'fail': 'fail',
+    'started': 'ongoing',
+    'provisional-fail': 'ongoing_with_failures',
+    'error': 'error',
+    'cancelled': 'empty',
+    'skipped': 'empty',
+    'none': 'waiting',
+}
+
+
+def _icon_for_state(state: str, icons: GithubIcons, *, in_progress: bool) -> str:
+    if state == 'provisional-fail' and not in_progress:
+        return icons.ongoing
+    attr = _STATE_TO_ICON_ATTR.get(state, 'error')
+    return getattr(icons, attr)
+
+
+def render_markdown_bubble(
+    data: BubbleData,
+    *,
+    icons: GithubIcons,
+    is_in_progress: bool,
+    escape: Callable[[str], str],
+) -> str:
+    name = data.name
+    if data.state in ('cancelled', 'skipped'):
+        name = u'~~{}~~'.format(name)
+
+    icon = _icon_for_state(data.state, icons, in_progress=is_in_progress)
+    hover = escape(data.details_message or '')
+    url = data.url if data.url is not None else ''
+    return u'| [{icon} {name}]({url} "{hover}") '.format(icon=icon, name=name, url=url, hover=hover)
+
+
+def render_markdown_no_build_misc(name: Optional[str] = None) -> str:
+    return u'| '

--- a/Tools/CISupport/ews-app/ews/views/status.py
+++ b/Tools/CISupport/ews-app/ews/views/status.py
@@ -50,7 +50,7 @@ class Status(View):
             return {}
 
         statuses = {}
-        for queue in StatusBubble.ALL_QUEUES:
+        for queue in Buildbot.all_queues:
             status = self._build_status(change, queue)
             if status:
                 statuses[queue] = status

--- a/Tools/CISupport/ews-app/ews/views/statusbubble.py
+++ b/Tools/CISupport/ews-app/ews/views/statusbubble.py
@@ -22,195 +22,73 @@
 
 from __future__ import unicode_literals
 
-import datetime
 import logging
-import re
 
-from django.http import HttpResponse
 from django.shortcuts import render
 from django.utils import timezone
 from django.views import View
 from django.views.decorators.clickjacking import xframe_options_exempt
-from ews.common.buildbot import Buildbot
-from ews.models.build import Build
+
 from ews.models.patch import Change
-import ews.config as config
+from ews.views.bubble.compute import compute_bubble
+from ews.views.bubble.config import BUILDER_ICON, TESTER_ICON, BubbleConfig
+from ews.views.bubble.fetcher import BubbleDataFetcher
+from ews.views.bubble.render_html import render_html_bubble
 
 _log = logging.getLogger(__name__)
 
 
 class StatusBubble(View):
-    # These queue names are from shortname in https://github.com/webkit/webkit/blob/main/Tools/CISupport/ews-build/config.json
-    # FIXME: Auto-generate this list https://bugs.webkit.org/show_bug.cgi?id=195640
-    # Note: This list is sorted in the order of which bubbles appear in bugzilla.
-    ALL_QUEUES = ['style', 'ios', 'ios-sim', 'mac', 'mac-AS-debug', 'vision', 'vision-sim', 'tv', 'tv-sim', 'watch', 'watch-sim', 'gtk', 'wpe', 'gtk3-libwebrtc', 'playstation', 'win', 'win-tests',
-                  'ios-wk2', 'ios-wk2-wpt', 'mac-wk1', 'mac-wk2', 'mac-wk2-stress', 'mac-intel-wk2', 'mac-AS-debug-wk2', 'mac-safer-cpp', 'ios-safer-cpp', 'vision-wk2', 'gtk-wk2', 'wpe-wk2', 'api-ios', 'api-mac',
-                  'api-mac-debug', 'api-gtk', 'api-wpe', 'bindings', 'jsc-x86-64', 'jsc-debug-arm64', 'jsc-armv7', 'jsc-armv7-tests', 'webkitperl', 'webkitpy', 'services']
-
+    # Backward-compatibility constants. External callers (github.py, fetcher.py,
+    # views/status.py) read these — keep them in sync with BubbleConfig defaults.
     DAYS_TO_CHECK_QUEUE_POSITION = 0.5
     DAYS_TO_HIDE_BUBBLE = 7
-    BUILDER_ICON = u'\U0001f6e0'
-    TESTER_ICON = u'\U0001f9ea'
+    BUILDER_ICON = BUILDER_ICON
+    TESTER_ICON = TESTER_ICON
     BUILD_RETRY_MSG = 'retrying build'
     UNKNOWN_QUEUE_POSITION = '?'
 
-    def _build_bubble(self, change, queue, hide_icons=False, sent_to_buildbot=True):
-        bubble = {
-            'name': queue,
+    @xframe_options_exempt
+    def get(self, request, change_id):
+        hide_icons = bool(request.GET.get('hide_icons', False))
+        change = Change.get_change(change_id)
+        config = BubbleConfig.from_buildbot_globals()
+        fetcher = BubbleDataFetcher(config)
+        now = timezone.now()
+
+        bubbles = []
+        if change:
+            for queue in config.all_queues:
+                inputs = fetcher.build_inputs(
+                    change, queue,
+                    hide_icons=hide_icons,
+                    sent_to_buildbot=change.sent_to_buildbot,
+                )
+                data = compute_bubble(inputs, config, now=now)
+                if data:
+                    bubbles.append(render_html_bubble(data))
+
+            if change.sent_to_commit_queue:
+                cq_hide_icons = hide_icons or not change.sent_to_buildbot
+                inputs = fetcher.build_inputs(
+                    change, 'commit',
+                    hide_icons=cq_hide_icons,
+                    sent_to_buildbot=True,
+                )
+                data = compute_bubble(inputs, config, now=now)
+                if data:
+                    bubbles.insert(0, render_html_bubble(data))
+
+        show_submit_to_ews = not (change and change.sent_to_buildbot)
+        template_values = {
+            'bubbles': bubbles,
+            'change_id': change_id,
+            'show_submit_to_ews': show_submit_to_ews,
+            'show_failure_to_apply': False,
         }
-        is_tester_queue = Buildbot.is_tester_queue(queue)
-        is_builder_queue = Buildbot.is_builder_queue(queue)
-        if hide_icons == False:
-            if is_tester_queue:
-                bubble['name'] = StatusBubble.TESTER_ICON + '  ' + bubble['name']
-            if is_builder_queue:
-                bubble['name'] = StatusBubble.BUILDER_ICON + '  ' + bubble['name']
+        return render(request, 'statusbubble.html', template_values)
 
-        builds, is_parent_build = self.get_all_builds_for_queue(change, queue, Buildbot.get_parent_queue(queue))
-        build = None
-        if builds:
-            build = builds[0]
-            builds = builds[:10]  # Limit number of builds to display in status-bubble hover over message
-        if not self._should_show_bubble_for_build(build, sent_to_buildbot):
-            return None
-
-        if not build:
-            bubble['state'] = 'none'
-            queue_position = self._queue_position(change, queue, Buildbot.get_parent_queue(queue))
-            if not queue_position:
-                return None
-            if queue_position != StatusBubble.UNKNOWN_QUEUE_POSITION:
-                bubble['queue_position'] = queue_position
-            if Buildbot.get_parent_queue(queue):
-                queue = Buildbot.get_parent_queue(queue)
-            queue_full_name = Buildbot.queue_name_by_shortname_mapping.get(queue)
-            if queue_full_name:
-                bubble['url'] = 'https://{}/#/builders/{}'.format(config.BUILDBOT_SERVER_HOST, queue_full_name)
-            bubble['details_message'] = 'Waiting in queue, processing has not started yet.\n\nPosition in queue: {}'.format(queue_position)
-            return bubble
-
-        bubble['url'] = 'https://{}/#/builders/{}/builds/{}'.format(config.BUILDBOT_SERVER_HOST, build.builder_id, build.number)
-        builder_full_name = build.builder_name.replace('-', ' ')
-
-        if build.result is None:  # In-progress build
-            if self._does_build_contains_any_failed_step(build):
-                bubble['state'] = 'provisional-fail'
-            else:
-                bubble['state'] = 'started'
-            bubble['details_message'] = 'Build is in-progress. Recent messages:' + self._steps_messages_from_multiple_builds(builds)
-        elif build.result == Buildbot.SUCCESS:
-            if is_parent_build:
-                if change.created < (timezone.now() - datetime.timedelta(days=StatusBubble.DAYS_TO_HIDE_BUBBLE)):
-                    # Do not display bubble for old change for which no build has been reported on given queue.
-                    # Most likely the change would never be processed on this queue, since either the queue was
-                    # added after the change was submitted, or build request for that change was cancelled.
-                    return None
-                bubble['state'] = 'started'
-                bubble['details_message'] = 'Waiting to run tests.'
-                queue_full_name = Buildbot.queue_name_by_shortname_mapping.get(queue)
-                if queue_full_name:
-                    bubble['url'] = 'https://{}/#/builders/{}'.format(config.BUILDBOT_SERVER_HOST, queue_full_name)
-                    builder_full_name = queue_full_name.replace('-', ' ')
-            else:
-                bubble['state'] = 'pass'
-                if is_builder_queue and is_tester_queue:
-                    bubble['details_message'] = 'Built successfully and passed tests'
-                elif is_builder_queue:
-                    bubble['details_message'] = 'Built successfully'
-                elif is_tester_queue:
-                    if queue == 'style':
-                        bubble['details_message'] = 'Passed style check'
-                    else:
-                        bubble['details_message'] = 'Passed tests'
-                else:
-                    bubble['details_message'] = 'Pass'
-        elif build.result == Buildbot.WARNINGS:
-            bubble['state'] = 'pass'
-            bubble['details_message'] = 'Warning' + self._steps_messages_from_multiple_builds(builds)
-        elif build.result == Buildbot.FAILURE:
-            bubble['state'] = 'fail'
-            bubble['details_message'] = self._most_recent_failure_message(build)
-            if StatusBubble.BUILD_RETRY_MSG in bubble['details_message']:
-                bubble['state'] = 'provisional-fail'
-        elif build.result == Buildbot.SKIPPED:
-            bubble['state'] = 'skipped'
-            bubble['details_message'] = 'The change is no longer eligible for processing.'
-            if re.search(r'Bug .* is already closed', build.state_string):
-                bubble['details_message'] += ' Bug was already closed when EWS attempted to process it.'
-            elif re.search(r'Patch .* is marked r-', build.state_string):
-                bubble['details_message'] += ' Patch was already marked r- when EWS attempted to process it.'
-            elif re.search(r'Patch .* is obsolete', build.state_string):
-                bubble['details_message'] += ' Patch was obsolete when EWS attempted to process it.'
-
-            if len(builds) > 1:
-                bubble['details_message'] += '\nSome messages were logged while the change was still eligible:'
-                bubble['details_message'] += self._steps_messages_from_multiple_builds(builds)
-
-        elif build.result == Buildbot.EXCEPTION:
-            bubble['state'] = 'error'
-            bubble['details_message'] = 'An unexpected error occured. Recent messages:' + self._steps_messages_from_multiple_builds(builds)
-        elif build.result == Buildbot.RETRY:
-            bubble['state'] = 'provisional-fail'
-            bubble['details_message'] = 'Build is being retried. Recent messages:' + self._steps_messages_from_multiple_builds(builds)
-        elif build.result == Buildbot.CANCELLED:
-            bubble['state'] = 'cancelled'
-            bubble['details_message'] = 'Build was cancelled. Recent messages:' + self._steps_messages_from_multiple_builds(builds)
-        else:
-            bubble['state'] = 'error'
-            bubble['details_message'] = 'An unexpected error occured. Recent messages:' + self._steps_messages_from_multiple_builds(builds)
-
-        if 'details_message' in bubble:
-            bubble['details_message'] = builder_full_name + '\n\n' + bubble['details_message']
-            os_details = self.get_os_details(build)
-            timestamp = self.get_build_timestamp(build)
-            if os_details:
-                bubble['details_message'] += '\n\n' + os_details + '\n' + timestamp
-            else:
-                bubble['details_message'] += '\n\n' + timestamp
-
-        return bubble
-
-    def get_os_details(self, build):
-        for step in build.step_set.all():
-            if step.state_string.startswith('OS:'):
-                return step.state_string
-        return ''
-
-    def get_build_timestamp(self, build):
-        if build.complete_at:
-            return self._iso_time(build.complete_at)
-
-        recent_build_step = build.step_set.last()
-        if recent_build_step:
-            return self._iso_time(recent_build_step.started_at)
-
-        return self._iso_time(build.started_at)
-
-    def _iso_time(self, time):
-        return '[[' + datetime.datetime.fromtimestamp(time).isoformat() + 'Z]]'
-
-    def _steps_messages(self, build):
-        return '\n'.join([step.state_string for step in build.step_set.all().order_by('uid')])
-
-    def _steps_messages_from_multiple_builds(self, builds):
-        message = ''
-        for build in reversed(builds):
-            message += '\n\n' + self._steps_messages(build)
-        return message
-
-    def _does_build_contains_any_failed_step(self, build):
-        for step in build.step_set.all():
-            if step.result and step.result != Buildbot.SUCCESS and step.result != Buildbot.WARNINGS and step.result != Buildbot.SKIPPED:
-                return True
-        return False
-
-    def _most_recent_failure_message(self, build):
-        for step in build.step_set.all().order_by('-uid'):
-            if step.result == Buildbot.SUCCESS and StatusBubble.BUILD_RETRY_MSG in step.state_string:
-                return step.state_string
-            if step.result == Buildbot.FAILURE:
-                return step.state_string
-        return ''
+    # --- Backward-compatibility shims for callers outside the bubble package ---
 
     def get_latest_build_for_queue(self, change, queue, parent_queue=None):
         builds, is_parent_build = self.get_all_builds_for_queue(change, queue, parent_queue)
@@ -219,95 +97,9 @@ class StatusBubble(View):
         return (builds[0], is_parent_build)
 
     def get_all_builds_for_queue(self, change, queue, parent_queue=None):
-        builds = self.get_builds_for_queue(change, queue)
-        is_parent_build = False
-        if not builds and parent_queue:
-            builds = self.get_builds_for_queue(change, parent_queue)
-            is_parent_build = True
+        config = BubbleConfig.from_buildbot_globals()
+        fetcher = BubbleDataFetcher(config)
+        builds, is_parent_build = fetcher._fetch_raw_builds(change, queue, parent_queue)
         if not builds:
             return (None, None)
-        builds.sort(key=lambda build: build.number, reverse=True)
         return (builds, is_parent_build)
-
-    def get_builds_for_queue(self, change, queue):
-        return [build for build in change.build_set.all() if build.builder_display_name == queue]
-
-    def _should_show_bubble_for_build(self, build, sent_to_buildbot=True):
-        if build and build.result == Buildbot.SKIPPED and re.search(r'Patch .* doesn\'t have relevant changes', build.state_string):
-            return False
-        if (not build) and (not sent_to_buildbot):
-            return False
-        return True
-
-    def _queue_position(self, change, queue, parent_queue=None):
-        # FIXME: Handle retried builds and cancelled build-requests as well.
-        from_timestamp = timezone.now() - datetime.timedelta(days=StatusBubble.DAYS_TO_CHECK_QUEUE_POSITION)
-        hide_from_timestamp = timezone.now() - datetime.timedelta(days=StatusBubble.DAYS_TO_HIDE_BUBBLE)
-
-        if change.created < hide_from_timestamp:
-            # Do not display bubble for old change for which no build has been reported on given queue.
-            # Most likely the change would never be processed on this queue, since either the queue was
-            # added after the change was submitted, or build request for that change was cancelled.
-            return None
-
-        if change.created < from_timestamp:
-            # This means change has been waiting on given queue for long time, but not long enough to hide the status-bubble.
-            # Instead of calculating exact queue position (which might be slow), we display a fixed high queue position.
-            return StatusBubble.UNKNOWN_QUEUE_POSITION
-
-        sent = 'sent_to_commit_queue' if queue == 'commit' else 'sent_to_buildbot'
-        previously_sent_changes = set(Change.objects
-                                          .filter(created__gte=from_timestamp)
-                                          .filter(**{sent: True})
-                                          .filter(obsolete=False)
-                                          .filter(created__lt=change.created))
-        if parent_queue:
-            recent_builds_parent_queue = Build.objects \
-                                             .filter(created__gte=from_timestamp) \
-                                             .filter(builder_display_name=parent_queue)
-            processed_changes_parent_queue = set([build.change for build in recent_builds_parent_queue])
-            return len(previously_sent_changes - processed_changes_parent_queue) + 1
-
-        recent_builds = Build.objects \
-                            .filter(created__gte=from_timestamp) \
-                            .filter(builder_display_name=queue)
-        processed_changes = set([build.change for build in recent_builds])
-        _log.debug('Change: {}, queue: {}, previous changes: {}'.format(change.change_id, queue, previously_sent_changes - processed_changes))
-        return len(previously_sent_changes - processed_changes) + 1
-
-    def _build_bubbles_for_change(self, change, hide_icons=False):
-        show_submit_to_ews = True
-        failed_to_apply = False  # TODO: https://bugs.webkit.org/show_bug.cgi?id=194598
-        bubbles = []
-
-        if not change:
-            return (None, show_submit_to_ews, failed_to_apply)
-
-        for queue in StatusBubble.ALL_QUEUES:
-            bubble = self._build_bubble(change, queue, hide_icons, change.sent_to_buildbot)
-            if bubble:
-                bubbles.append(bubble)
-
-        if change.sent_to_commit_queue:
-            if not change.sent_to_buildbot:
-                hide_icons = True
-            cq_bubble = self._build_bubble(change, 'commit', hide_icons)
-            if cq_bubble:
-                bubbles.insert(0, cq_bubble)
-
-        show_submit_to_ews = not change.sent_to_buildbot
-        return (bubbles, show_submit_to_ews, failed_to_apply)
-
-    @xframe_options_exempt
-    def get(self, request, change_id):
-        hide_icons = request.GET.get('hide_icons', False)
-        change = Change.get_change(change_id)
-        bubbles, show_submit_to_ews, show_failure_to_apply = self._build_bubbles_for_change(change, hide_icons)
-
-        template_values = {
-            'bubbles': bubbles,
-            'change_id': change_id,
-            'show_submit_to_ews': show_submit_to_ews,
-            'show_failure_to_apply': show_failure_to_apply,
-        }
-        return render(request, 'statusbubble.html', template_values)

--- a/Tools/CISupport/ews-build/config.json
+++ b/Tools/CISupport/ews-build/config.json
@@ -236,39 +236,39 @@
   ],
   "builders": [
     {
-      "name": "Style-EWS", "shortname": "style", "icon": "testOnly",
+      "name": "Style-EWS", "shortname": "style", "icon": "testOnly", "pr_column": "misc",
       "factory": "StyleFactory", "platform": "*",
       "workernames": ["ews151", "ews253", "webkit-misc"]
     },
     {
-      "name": "GTK-Build-EWS", "shortname": "gtk", "icon": "buildOnly",
+      "name": "GTK-Build-EWS", "shortname": "gtk", "icon": "buildOnly", "safe_merge_queue": "linux", "pr_column": "linux",
       "factory": "GTKBuildFactory", "platform": "gtk",
       "configuration": "release", "architectures": ["x86_64"],
       "triggers": ["api-tests-gtk-ews", "gtk-wk2-tests-ews"],
       "workernames": ["aperez-gtk-ews", "csaavedra-gtk-ews", "igalia1-gtk-wk2-ews", "igalia2-gtk-wk2-ews", "igalia13-gtk-wk2-ews"]
     },
     {
-      "name": "GTK-WK2-Tests-EWS", "shortname": "gtk-wk2", "icon": "testOnly",
+      "name": "GTK-WK2-Tests-EWS", "shortname": "gtk-wk2", "icon": "testOnly", "safe_merge_queue": "linux", "pr_column": "linux",
       "factory": "GTKTestsFactory", "platform": "gtk",
       "configuration": "release",
       "triggered_by": ["gtk-build-ews"],
       "workernames": ["igalia5-gtk-wk2-ews", "igalia6-gtk-wk2-ews", "igalia7-gtk-wk2-ews", "igalia8-gtk-wk2-ews", "igalia9-gtk-wk2-ews", "igalia10-gtk-wk2-ews", "igalia11-gtk-wk2-ews", "igalia12-gtk-wk2-ews"]
     },
     {
-      "name": "iOS-26-Build-EWS", "shortname": "ios", "icon": "buildOnly",
+      "name": "iOS-26-Build-EWS", "shortname": "ios", "icon": "buildOnly", "safe_merge_queue": "embedded", "pr_column": "embedded",
       "factory": "iOSEmbeddedBuildFactory", "platform": "ios-26",
       "configuration": "release", "architectures": ["arm64"],
       "workernames": ["ews152", "ews154", "ews108", "ews109", "ews130", "ews131", "ews132", "ews133"]
     },
     {
-      "name": "iOS-26-Simulator-Build-EWS", "shortname": "ios-sim", "icon": "buildOnly",
+      "name": "iOS-26-Simulator-Build-EWS", "shortname": "ios-sim", "icon": "buildOnly", "safe_merge_queue": "embedded", "pr_column": "embedded",
       "factory": "iOSBuildFactory", "platform": "ios-simulator-26",
       "configuration": "release", "architectures": ["arm64"],
       "triggers": ["api-tests-ios-sim-ews", "ios-26-sim-wk2-tests-ews", "ios-26-sim-wpt-wk2-tests-ews"],
       "workernames": ["ews152", "ews154", "ews108", "ews130", "ews132", "ews133", "ews134", "ews135"]
     },
     {
-      "name": "iOS-26-Simulator-WK2-Tests-EWS", "shortname": "ios-wk2", "icon": "testOnly",
+      "name": "iOS-26-Simulator-WK2-Tests-EWS", "shortname": "ios-wk2", "icon": "testOnly", "safe_merge_queue": "embedded", "pr_column": "embedded",
       "factory": "iOSTestsFactory", "platform": "ios-simulator-26",
       "configuration": "release",
       "triggered_by": ["ios-26-sim-build-ews"],
@@ -276,7 +276,7 @@
       "workernames": ["ews121", "ews122", "ews123", "ews124", "ews125", "ews126", "ews184", "ews185"]
     },
     {
-      "name": "iOS-26-Simulator-WPT-WK2-Tests-EWS", "shortname": "ios-wk2-wpt", "icon": "testOnly",
+      "name": "iOS-26-Simulator-WPT-WK2-Tests-EWS", "shortname": "ios-wk2-wpt", "icon": "testOnly", "safe_merge_queue": "embedded", "pr_column": "embedded",
       "factory": "iOSTestsFactory", "platform": "ios-simulator-26",
       "configuration": "release",
       "triggered_by": ["ios-26-sim-build-ews"],
@@ -284,28 +284,28 @@
       "workernames": ["ews191", "ews192", "ews193", "ews194", "ews195", "ews196", "ews197", "ews198"]
     },
     {
-      "name": "macOS-Tahoe-Debug-Build-EWS", "shortname": "mac-AS-debug", "icon": "buildOnly",
+      "name": "macOS-Tahoe-Debug-Build-EWS", "shortname": "mac-AS-debug", "icon": "buildOnly", "safe_merge_queue": "macos", "pr_column": "macos",
       "factory": "macOSBuildOnlyFactory", "platform": "mac-tahoe",
       "configuration": "debug", "architectures": ["arm64"],
       "triggers": ["macos-tahoe-debug-api-tests-ews", "macos-tahoe-debug-wk2-tests-ews"],
       "workernames": ["ews171", "ews172", "ews173", "ews174"]
     },
     {
-      "name": "macOS-Tahoe-Debug-API-Tests-EWS", "shortname": "api-mac-debug", "icon": "testOnly",
+      "name": "macOS-Tahoe-Debug-API-Tests-EWS", "shortname": "api-mac-debug", "icon": "testOnly", "safe_merge_queue": "macos", "pr_column": "macos",
       "factory": "APITestsFactory", "platform": "mac-tahoe",
       "configuration": "debug",
       "triggered_by": ["macos-tahoe-debug-build-ews"],
       "workernames": ["ews207", "ews208", "ews209", "ews210", "ews211", "ews212", "ews213", "ews214"]
     },
     {
-      "name": "macOS-Tahoe-Debug-WK2-Tests-EWS", "shortname": "mac-AS-debug-wk2", "icon": "testOnly",
+      "name": "macOS-Tahoe-Debug-WK2-Tests-EWS", "shortname": "mac-AS-debug-wk2", "icon": "testOnly", "safe_merge_queue": "macos", "pr_column": "macos",
       "factory": "macOSWK2Factory", "platform": "mac-tahoe",
       "configuration": "debug",
       "triggered_by": ["macos-tahoe-debug-build-ews"],
       "workernames": ["ews110", "ews111", "ews114", "ews138", "ews139", "ews140", "ews175", "ews176", "ews177", "ews178", "ews179", "ews180"]
     },
     {
-      "name": "macOS-Sequoia-Release-Build-EWS", "shortname": "mac", "icon": "buildOnly",
+      "name": "macOS-Sequoia-Release-Build-EWS", "shortname": "mac", "icon": "buildOnly", "safe_merge_queue": "macos", "pr_column": "macos",
       "factory": "macOSBuildFactory", "platform": "mac-sequoia",
       "configuration": "release", "architectures": ["x86_64", "arm64"],
       "deployment_target": "15.4",
@@ -314,84 +314,84 @@
       "workernames": ["ews101", "ews102", "ews103", "ews105", "ews116", "ews117", "ews118", "ews119", "ews120", "ews141", "ews145", "ews147", "ews148", "ews161", "ews162"]
     },
     {
-      "name": "macOS-Sequoia-Release-WK1-Tests-EWS", "shortname": "mac-wk1", "icon": "testOnly",
+      "name": "macOS-Sequoia-Release-WK1-Tests-EWS", "shortname": "mac-wk1", "icon": "testOnly", "safe_merge_queue": "macos", "pr_column": "macos",
       "factory": "macOSWK1Factory", "platform": "mac-sequoia",
       "configuration": "release",
       "triggered_by": ["macos-sequoia-release-build-ews"],
       "workernames": ["ews112", "ews116"]
     },
     {
-      "name": "macOS-Sequoia-Release-WK2-Tests-EWS", "shortname": "mac-wk2", "icon": "testOnly",
+      "name": "macOS-Sequoia-Release-WK2-Tests-EWS", "shortname": "mac-wk2", "icon": "testOnly", "safe_merge_queue": "macos", "pr_column": "macos",
       "factory": "macOSWK2Factory", "platform": "mac-sequoia",
       "configuration": "release",
       "triggered_by": ["macos-sequoia-release-build-ews"],
       "workernames": ["ews104", "ews106", "ews107", "ews113", "ews115", "ews144", "ews146", "ews149", "ews169", "ews186", "ews187", "ews188", "ews189"]
     },
     {
-      "name": "macOS-Sequoia-Release-WK2-Intel-Tests-EWS", "shortname": "mac-intel-wk2", "icon": "testOnly",
+      "name": "macOS-Sequoia-Release-WK2-Intel-Tests-EWS", "shortname": "mac-intel-wk2", "icon": "testOnly", "pr_column": "macos",
       "factory": "macOSWK2Factory", "platform": "mac-sequoia",
       "configuration": "release",
       "triggered_by": ["macos-sequoia-release-build-ews"],
       "workernames": ["ews200", "ews201", "ews202", "ews203", "ews204"]
     },
     {
-      "name": "macOS-Release-WK2-Stress-Tests-EWS", "shortname": "mac-wk2-stress", "icon": "testOnly",
+      "name": "macOS-Release-WK2-Stress-Tests-EWS", "shortname": "mac-wk2-stress", "icon": "testOnly", "safe_merge_queue": "macos", "pr_column": "macos",
       "factory": "StressTestFactory", "platform": "mac-sequoia",
       "configuration": "release",
       "triggered_by": ["macos-sequoia-release-build-ews"],
       "workernames": ["ews181", "ews182"]
     },
     {
-      "name": "macOS-Safer-CPP-Checks-EWS", "shortname": "mac-safer-cpp", "icon": "buildOnly",
+      "name": "macOS-Safer-CPP-Checks-EWS", "shortname": "mac-safer-cpp", "icon": "buildOnly", "safe_merge_queue": "macos", "pr_column": "macos",
       "factory": "SaferCPPStaticAnalyzerFactory", "platform": "mac-tahoe",
       "configuration": "release", "architectures": ["arm64"],
       "workernames": ["ews237", "ews246", "ews247", "ews248", "ews249", "ews250", "ews260", "ews261", "ews262", "ews263", "ews264"]
     },
     {
-      "name": "Apple-iOS-26-Safer-CPP-Checks-EWS", "shortname": "ios-safer-cpp", "icon": "buildOnly",
+      "name": "Apple-iOS-26-Safer-CPP-Checks-EWS", "shortname": "ios-safer-cpp", "icon": "buildOnly", "safe_merge_queue": "embedded", "pr_column": "embedded",
       "factory": "SaferCPPStaticAnalyzerFactory", "platform": "ios-26",
       "configuration": "release", "architectures": ["arm64"],
       "workernames": ["ews2000", "ews2001", "ews2002", "ews2003", "ews2004", "ews2006", "ews2007", "ews2008", "ews2009", "ews2010"]
     },
     {
-      "name": "watchOS-26-Build-EWS", "shortname": "watch", "icon": "buildOnly",
+      "name": "watchOS-26-Build-EWS", "shortname": "watch", "icon": "buildOnly", "safe_merge_queue": "embedded", "pr_column": "embedded",
       "factory": "watchOSBuildFactory", "platform": "watchos-26",
       "configuration": "release", "architectures": ["arm64_32", "arm64"],
       "workernames": ["ews163", "ews164", "ews165", "ews238", "ews239"]
     },
     {
-      "name": "watchOS-26-Simulator-Build-EWS", "shortname": "watch-sim", "icon": "buildOnly",
+      "name": "watchOS-26-Simulator-Build-EWS", "shortname": "watch-sim", "icon": "buildOnly", "safe_merge_queue": "embedded", "pr_column": "embedded",
       "factory": "watchOSBuildFactory", "platform": "watchos-simulator-26",
       "configuration": "release", "architectures": ["arm64"],
       "workernames": ["ews164", "ews165", "ews166", "ews240"]
     },
     {
-      "name": "tvOS-26-Build-EWS", "shortname": "tv", "icon": "buildOnly",
+      "name": "tvOS-26-Build-EWS", "shortname": "tv", "icon": "buildOnly", "safe_merge_queue": "embedded", "pr_column": "embedded",
       "factory": "tvOSBuildFactory", "platform": "tvos-26",
       "configuration": "release", "architectures": ["arm64"],
       "workernames": ["ews167", "ews168", "ews243", "ews244"]
     },
     {
-      "name": "tvOS-26-Simulator-Build-EWS", "shortname": "tv-sim", "icon": "buildOnly",
+      "name": "tvOS-26-Simulator-Build-EWS", "shortname": "tv-sim", "icon": "buildOnly", "safe_merge_queue": "embedded", "pr_column": "embedded",
       "factory": "tvOSBuildFactory", "platform": "tvos-simulator-26",
       "configuration": "release", "architectures": ["arm64"],
       "workernames": ["ews168", "ews170", "ews245"]
     },
     {
-      "name": "visionOS-26-Build-EWS", "shortname": "vision", "icon": "buildOnly",
+      "name": "visionOS-26-Build-EWS", "shortname": "vision", "icon": "buildOnly", "safe_merge_queue": "embedded", "pr_column": "embedded",
       "factory": "visionOSEmbeddedBuildFactory", "platform": "visionos-26",
       "configuration": "release", "architectures": ["arm64"],
       "workernames": ["ews216", "ews217", "ews218", "ews219", "ews220", "ews221"]
     },
     {
-      "name": "visionOS-26-Simulator-Build-EWS", "shortname": "vision-sim", "icon": "buildOnly",
+      "name": "visionOS-26-Simulator-Build-EWS", "shortname": "vision-sim", "icon": "buildOnly", "safe_merge_queue": "embedded", "pr_column": "embedded",
       "factory": "visionOSBuildFactory", "platform": "visionos-simulator-26",
       "configuration": "release", "architectures": ["arm64"],
       "triggers": ["visionos-26-sim-wk2-tests-ews"],
       "workernames": ["ews220", "ews221", "ews222", "ews223", "ews224", "ews225"]
     },
     {
-      "name": "visionOS-26-Simulator-WK2-Tests-EWS", "shortname": "vision-wk2", "icon": "testOnly",
+      "name": "visionOS-26-Simulator-WK2-Tests-EWS", "shortname": "vision-wk2", "icon": "testOnly", "safe_merge_queue": "embedded", "pr_column": "embedded",
       "factory": "visionOSTestsFactory", "platform": "visionos-simulator-26",
       "configuration": "release",
       "triggered_by": ["visionos-26-sim-build-ews"],
@@ -399,114 +399,114 @@
       "workernames": ["ews226", "ews227", "ews228", "ews229", "ews230"]
     },
     {
-      "name": "PlayStation-Build-EWS", "shortname": "playstation", "icon": "buildOnly",
+      "name": "PlayStation-Build-EWS", "shortname": "playstation", "icon": "buildOnly", "pr_column": "linux",
       "factory": "PlayStationBuildFactory", "configuration": "release",
       "architectures": ["x86_64"], "platform": "playstation",
       "workernames": ["playstation-ews-001", "playstation-ews-002", "playstation-ews-003", "playstation-ews-004", "playstation-ews-005", "playstation-ews-006", "playstation-ews-007", "playstation-ews-008", "playstation-ews-009"]
     },
     {
-      "name": "Win-Build-EWS", "shortname": "win", "icon": "buildOnly",
+      "name": "Win-Build-EWS", "shortname": "win", "icon": "buildOnly", "safe_merge_queue": "windows", "pr_column": "windows",
       "factory": "WinBuildFactory", "configuration": "release",
       "architectures": ["x86_64"], "platform": "win",
       "triggers": ["win-tests-ews"],
       "workernames": ["wincairo-ews-001", "wincairo-ews-002", "wincairo-ews-003", "wincairo-ews-004", "win-bot-001", "win-bot-002"]
     },
     {
-      "name": "Win-Tests-EWS", "shortname": "win-tests", "icon": "testOnly",
+      "name": "Win-Tests-EWS", "shortname": "win-tests", "icon": "testOnly", "pr_column": "windows",
       "factory": "WinTestsFactory", "configuration": "release",
       "architectures": ["x86_64"], "platform": "win",
       "triggered_by": ["win-build-ews"],
       "workernames": ["win-bot-003", "win-bot-004", "win-bot-005", "win-bot-006"]
     },
     {
-      "name": "WPE-Build-EWS", "shortname": "wpe", "icon": "buildOnly",
+      "name": "WPE-Build-EWS", "shortname": "wpe", "icon": "buildOnly", "safe_merge_queue": "linux", "pr_column": "linux",
       "factory": "WPEBuildFactory", "platform": "wpe",
       "configuration": "release", "architectures": ["x86_64"],
       "triggers": ["wpe-wk2-tests-ews", "api-tests-wpe-ews"],
       "workernames": ["aperez-wpe-ews", "igalia-wpe-ews", "igalia2-wpe-ews", "igalia3-wpe-ews"]
     },
     {
-      "name": "WPE-WK2-Tests-EWS", "shortname": "wpe-wk2", "icon": "testOnly",
+      "name": "WPE-WK2-Tests-EWS", "shortname": "wpe-wk2", "icon": "testOnly", "safe_merge_queue": "linux", "pr_column": "linux",
       "factory": "WPETestsFactory", "platform": "wpe",
       "configuration": "release", "architectures": ["x86_64"],
       "triggered_by": ["wpe-build-ews"],
       "workernames": ["igalia4-wpe-ews", "igalia5-wpe-ews", "igalia6-wpe-ews", "igalia7-wpe-ews", "igalia8-wpe-ews", "igalia9-wpe-ews", "igalia10-wpe-ews", "igalia11-wpe-ews"]
     },
     {
-      "name": "GTK-GTK3-LibWebRTC-Build-EWS", "shortname": "gtk3-libwebrtc", "icon": "buildOnly",
+      "name": "GTK-GTK3-LibWebRTC-Build-EWS", "shortname": "gtk3-libwebrtc", "icon": "buildOnly", "safe_merge_queue": "linux", "pr_column": "linux",
       "factory": "GTK3LibWebRTCBuildFactory", "platform": "gtk",
       "configuration": "release", "architectures": ["x86_64"],
       "workernames": ["igalia16-wpe-ews", "igalia17-wpe-ews", "igalia18-wpe-ews", "igalia19-wpe-ews"]
     },
     {
-      "name": "JSC-Tests-EWS", "shortname": "jsc-x86-64", "icon": "buildAndTest",
+      "name": "JSC-Tests-EWS", "shortname": "jsc-x86-64", "icon": "buildAndTest", "safe_merge_queue": "macos", "pr_column": "misc",
       "factory": "JSCBuildAndTestsFactory", "platform": "mac-sequoia",
       "configuration": "release", "runTests": "true",
       "workernames": ["ews127", "ews128", "ews205", "ews206", "ews251", "ews252"]
     },
     {
-      "name": "JSC-Tests-O3-Debug-arm64-EWS", "shortname": "jsc-debug-arm64", "icon": "buildAndTest",
+      "name": "JSC-Tests-O3-Debug-arm64-EWS", "shortname": "jsc-debug-arm64", "icon": "buildAndTest", "safe_merge_queue": "macos", "pr_column": "misc",
       "factory": "JSCBuildO3AndTestsFactory", "platform": "mac-sequoia",
       "configuration": "debug", "runTests": "true",
       "workernames": ["ews136", "ews137", "ews265", "ews266"]
     },
     {
-      "name": "JSC-ARMv7-32bits-Build-EWS", "shortname": "jsc-armv7", "icon": "buildOnly",
+      "name": "JSC-ARMv7-32bits-Build-EWS", "shortname": "jsc-armv7", "icon": "buildOnly", "pr_column": "linux",
       "factory": "JSCBuildFactory", "platform": "jsc-only",
       "configuration": "release", "architectures": ["armv7"],
       "triggers": ["jsc-tests-armv7-tests-ews"],
       "workernames": ["igalia-jsc32-armv7-ews"]
     },
     {
-      "name": "JSC-ARMv7-32bits-Tests-EWS", "shortname": "jsc-armv7-tests", "icon": "testOnly",
+      "name": "JSC-ARMv7-32bits-Tests-EWS", "shortname": "jsc-armv7-tests", "icon": "testOnly", "pr_column": "linux",
       "factory": "JSCTestsFactory", "platform": "jsc-only",
       "configuration": "release", "architectures": ["armv7"],
       "workernames": ["igalia-jsc32-armv7-ews-02"]
     },
     {
-      "name": "Bindings-Tests-EWS", "shortname": "bindings", "icon": "testOnly",
+      "name": "Bindings-Tests-EWS", "shortname": "bindings", "icon": "testOnly", "pr_column": "misc",
       "factory": "BindingsFactory", "platform": "*",
       "workernames": ["ews151", "ews253", "webkit-misc"]
     },
     {
-      "name": "WebKitPy-Tests-EWS", "shortname": "webkitpy", "icon": "testOnly",
+      "name": "WebKitPy-Tests-EWS", "shortname": "webkitpy", "icon": "testOnly", "pr_column": "misc",
       "factory": "WebKitPyFactory", "platform": "*",
       "workernames": ["ews151", "ews253", "webkit-misc"]
     },
     {
-      "name": "WebKitPerl-Tests-EWS", "shortname": "webkitperl", "icon": "testOnly",
+      "name": "WebKitPerl-Tests-EWS", "shortname": "webkitperl", "icon": "testOnly", "pr_column": "misc",
       "factory": "WebKitPerlFactory", "platform": "*",
       "workernames": ["ews151", "ews253", "webkit-misc"]
     },
     {
-      "name": "API-Tests-iOS-Simulator-EWS", "shortname": "api-ios", "icon": "testOnly",
+      "name": "API-Tests-iOS-Simulator-EWS", "shortname": "api-ios", "icon": "testOnly", "safe_merge_queue": "embedded", "pr_column": "embedded",
       "factory": "APITestsFactory", "platform": "*",
       "triggered_by": ["ios-26-sim-build-ews"],
       "additionalArguments": ["--child-processes=3"],
       "workernames": ["ews156", "ews157", "ews158", "ews159", "ews160", "ews183", "ews254", "ews255", "ews256", "ews257", "ews258", "ews259"]
     },
     {
-      "name": "API-Tests-macOS-EWS", "shortname": "api-mac", "icon": "testOnly",
+      "name": "API-Tests-macOS-EWS", "shortname": "api-mac", "icon": "testOnly", "safe_merge_queue": "macos", "pr_column": "macos",
       "factory": "APITestsFactory", "platform": "mac-sequoia",
       "triggered_by": ["macos-sequoia-release-build-ews"],
       "workernames": ["ews100", "ews129", "ews142", "ews143", "ews150", "ews153", "ews155"]
     },
     {
-      "name": "API-Tests-GTK-EWS", "shortname": "api-gtk", "icon": "testOnly",
+      "name": "API-Tests-GTK-EWS", "shortname": "api-gtk", "icon": "testOnly", "safe_merge_queue": "linux", "pr_column": "linux",
       "factory": "APITestsFactory", "platform": "gtk",
       "configuration": "release",
       "triggered_by": ["gtk-build-ews"],
       "workernames": ["igalia3-gtk-wk2-ews", "igalia4-gtk-wk2-ews", "igalia14-gtk-wk2-ews", "igalia15-gtk-wk2-ews"]
     },
     {
-      "name": "API-Tests-WPE-EWS", "shortname": "api-wpe", "icon": "testOnly",
+      "name": "API-Tests-WPE-EWS", "shortname": "api-wpe", "icon": "testOnly", "safe_merge_queue": "linux", "pr_column": "linux",
       "factory": "APITestsFactory", "platform": "wpe",
       "configuration": "release", "architectures": ["x86_64"],
       "triggered_by": ["wpe-build-ews"],
       "workernames": ["igalia12-wpe-ews", "igalia13-wpe-ews", "igalia14-wpe-ews", "igalia15-wpe-ews"]
     },
     {
-      "name": "Services-EWS", "shortname": "services", "icon": "testOnly",
+      "name": "Services-EWS", "shortname": "services", "icon": "testOnly", "pr_column": "misc",
       "factory": "ServicesFactory", "platform": "*",
       "workernames": ["ews151", "ews253", "webkit-misc"]
     },
@@ -534,6 +534,15 @@
       "workernames": ["webkit-cq-01", "webkit-cq-02", "webkit-cq-03", "webkit-cq-04", "webkit-cq-05", "webkit-cq-06"]
     }
   ],
+  "status_bubble_order": [
+    "style", "ios", "ios-sim", "mac", "mac-AS-debug", "vision", "vision-sim", "tv", "tv-sim",
+    "watch", "watch-sim", "gtk", "wpe", "gtk3-libwebrtc", "playstation", "win", "win-tests",
+    "ios-wk2", "ios-wk2-wpt", "mac-wk1", "mac-wk2", "mac-wk2-stress", "mac-intel-wk2",
+    "mac-AS-debug-wk2", "mac-safer-cpp", "ios-safer-cpp", "vision-wk2", "gtk-wk2", "wpe-wk2",
+    "api-ios", "api-mac", "api-mac-debug", "api-gtk", "api-wpe", "bindings", "jsc-x86-64",
+    "jsc-debug-arm64", "jsc-armv7", "jsc-armv7-tests", "webkitperl", "webkitpy", "services"
+  ],
+  "pr_comment_misc_handlers": ["merge", "unsafe-merge"],
   "schedulers": [
     {
       "type": "Try_Userpass", "name": "try", "port": 5555,

--- a/Tools/CISupport/ews-build/loadConfig.py
+++ b/Tools/CISupport/ews-build/loadConfig.py
@@ -34,6 +34,14 @@ from buildbot.changes.filter import ChangeFilter
 from datetime import datetime, timezone
 from twisted.internet import defer
 
+STATUS_BUBBLE_ORDER = []
+SAFE_MERGE_BUCKETS = {'embedded': [], 'macos': [], 'linux': [], 'windows': []}
+SAFE_MERGE_QUEUE_VALUES = frozenset(SAFE_MERGE_BUCKETS)
+NON_BUBBLE_SHORTNAMES = frozenset(['commit', 'merge', 'unsafe-merge', 'safe-merge'])
+PR_COLUMN_VALUES = frozenset(['misc', 'embedded', 'macos', 'linux', 'windows'])
+PR_COLUMN_BY_SHORTNAME = {}
+PR_COMMENT_MISC_HANDLERS = []
+
 from .factories import (APITestsFactory, BindingsFactory, BuildFactory, CommitQueueFactory, Factory, GTKBuildFactory,
                         GTKTestsFactory, JSCBuildFactory, JSCBuildAndTestsFactory, JSCBuildO3AndTestsFactory, JSCTestsFactory, MergeQueueFactory, SafeMergeQueueFactory, StressTestFactory,
                         StyleFactory, TestFactory, tvOSBuildFactory, WPEBuildFactory, GTK3LibWebRTCBuildFactory, WPETestsFactory, WebKitPerlFactory, WebKitPyFactory, PlayStationBuildFactory,
@@ -62,6 +70,9 @@ def loadBuilderConfig(c, is_test_mode_enabled=False, setup_main_schedulers=True,
 
     checkWorkersAndBuildersForConsistency(config, config['workers'], config['builders'])
     checkValidSchedulers(config, config['schedulers'])
+    checkValidStatusBubbleOrder(config)
+    checkValidPrCommentStructure(config)
+    _populateQueueMetadata(config)
 
     c['workers'] = [Worker(worker['name'], passwords.get(worker['name'], 'password'), max_builds=worker.get('max_builds', 1)) for worker in config['workers']]
     if is_test_mode_enabled:
@@ -74,6 +85,10 @@ def loadBuilderConfig(c, is_test_mode_enabled=False, setup_main_schedulers=True,
         builder['description'] = builder.pop('shortname')
         if 'icon' in builder:
             del builder['icon']
+        if 'safe_merge_queue' in builder:
+            del builder['safe_merge_queue']
+        if 'pr_column' in builder:
+            del builder['pr_column']
         factorykwargs = {}
         for key in ['platform', 'configuration', 'architectures', 'triggers', 'remotes', 'additionalArguments', 'runTests', 'triggered_by', 'rebuild_without_change_on_builder', 'deployment_target']:
             value = builder.pop(key, None)
@@ -199,6 +214,76 @@ def checkValidBuilder(config, builder):
 
     if builder.get('rebuild_without_change_on_builder') and not builder.get('triggers'):
         raise Exception(f'rebuild_without_change_on_builder can only be set on builders with triggers. Builder: {builder["name"]}')
+
+    safe_merge_queue = builder.get('safe_merge_queue')
+    if safe_merge_queue is not None and safe_merge_queue not in SAFE_MERGE_QUEUE_VALUES:
+        raise Exception('Builder {} has invalid safe_merge_queue value: {}. Expected one of {}.'.format(
+            builder['name'], safe_merge_queue, sorted(SAFE_MERGE_QUEUE_VALUES)))
+
+    pr_column = builder.get('pr_column')
+    if pr_column is not None and pr_column not in PR_COLUMN_VALUES:
+        raise Exception('Builder {} has invalid pr_column value: {}. Expected one of {}.'.format(
+            builder['name'], pr_column, sorted(PR_COLUMN_VALUES)))
+
+
+def checkValidStatusBubbleOrder(config):
+    bubble_order = config.get('status_bubble_order')
+    if bubble_order is None:
+        raise Exception('config.json is missing top-level "status_bubble_order" array.')
+
+    seen = set()
+    for shortname in bubble_order:
+        if shortname in seen:
+            raise Exception('Duplicate entry in status_bubble_order: {}'.format(shortname))
+        seen.add(shortname)
+
+    builder_shortnames = {b.get('shortname') for b in config.get('builders', []) if b.get('shortname')}
+    unknown = seen - builder_shortnames
+    if unknown:
+        raise Exception('status_bubble_order references unknown shortnames: {}'.format(sorted(unknown)))
+
+    missing = builder_shortnames - NON_BUBBLE_SHORTNAMES - seen
+    if missing:
+        raise Exception('status_bubble_order is missing builder shortnames: {}'.format(sorted(missing)))
+
+
+def _populateQueueMetadata(config):
+    STATUS_BUBBLE_ORDER[:] = list(config.get('status_bubble_order', []))
+    for bucket_list in SAFE_MERGE_BUCKETS.values():
+        bucket_list.clear()
+    PR_COLUMN_BY_SHORTNAME.clear()
+    for builder in config.get('builders', []):
+        bucket = builder.get('safe_merge_queue')
+        if bucket in SAFE_MERGE_BUCKETS:
+            SAFE_MERGE_BUCKETS[bucket].append(builder.get('shortname'))
+        pr_column = builder.get('pr_column')
+        if pr_column in PR_COLUMN_VALUES:
+            PR_COLUMN_BY_SHORTNAME[builder.get('shortname')] = pr_column
+    PR_COMMENT_MISC_HANDLERS[:] = list(config.get('pr_comment_misc_handlers', []))
+
+
+def checkValidPrCommentStructure(config):
+    builder_shortnames = {b.get('shortname') for b in config.get('builders', []) if b.get('shortname')}
+
+    missing = []
+    for builder in config.get('builders', []):
+        shortname = builder.get('shortname')
+        if shortname in NON_BUBBLE_SHORTNAMES:
+            continue
+        if not builder.get('pr_column'):
+            missing.append(shortname)
+    if missing:
+        raise Exception('Builders missing required pr_column: {}'.format(sorted(missing)))
+
+    handlers = config.get('pr_comment_misc_handlers', [])
+    if not isinstance(handlers, list):
+        raise Exception('pr_comment_misc_handlers must be a list, got: {}'.format(type(handlers).__name__))
+    for handler in handlers:
+        if handler not in NON_BUBBLE_SHORTNAMES:
+            raise Exception('pr_comment_misc_handlers entry {} is not a handler queue. Expected one of {}.'.format(
+                handler, sorted(NON_BUBBLE_SHORTNAMES)))
+        if handler not in builder_shortnames:
+            raise Exception('pr_comment_misc_handlers entry {} does not correspond to any builder.'.format(handler))
 
 
 def checkValidSchedulers(config, schedulers):

--- a/Tools/CISupport/ews-build/loadConfig_unittest.py
+++ b/Tools/CISupport/ews-build/loadConfig_unittest.py
@@ -59,8 +59,9 @@ class ConfigDotJSONTest(unittest.TestCase):
         config = self.get_config()
         valid_builder_keys = ['additionalArguments', 'architectures', 'builddir', 'configuration', 'description',
                               'defaultProperties', 'deployment_target', 'env', 'factory', 'icon', 'locks', 'name',
-                              'platform', 'properties', 'rebuild_without_change_on_builder', 'remotes', 'runTests',
-                              'shortname', 'tags', 'triggers', 'triggered_by', 'workernames', 'workerbuilddir']
+                              'platform', 'pr_column', 'properties', 'rebuild_without_change_on_builder', 'remotes', 'runTests',
+                              'safe_merge_queue', 'shortname', 'tags', 'triggers', 'triggered_by', 'workernames',
+                              'workerbuilddir']
         for builder in config.get('builders', []):
             for key in builder:
                 self.assertTrue(key in valid_builder_keys, 'Unexpected key "{}" for builder {}'.format(key, builder.get('name')))
@@ -244,6 +245,167 @@ class TestcheckValidBuilder(unittest.TestCase):
     def test_rebuild_without_change_on_builder_valid(self):
         config = {'schedulers': [{'name': 'some-trigger', 'type': 'Triggerable'}]}
         loadConfig.checkValidBuilder(config, {'name': 'macOS-Build-EWS', 'shortname': 'mac', 'configuration': 'release', 'factory': 'BuildFactory', 'platform': 'mac-sierra', 'rebuild_without_change_on_builder': True, 'triggers': ['some-trigger']})
+
+    def test_builder_with_invalid_safe_merge_queue(self):
+        with self.assertRaises(Exception) as context:
+            loadConfig.checkValidBuilder({}, {'name': 'mac-wk2', 'shortname': 'mac-wk2', 'configuration': 'release', 'factory': 'WK2Factory', 'platform': 'mac-sierra', 'safe_merge_queue': 'bogus'})
+        self.assertIn('has invalid safe_merge_queue value: bogus', context.exception.args[0])
+
+    def test_builder_with_valid_safe_merge_queue(self):
+        loadConfig.checkValidBuilder({}, {'name': 'macOS-WK2-EWS', 'shortname': 'mac-wk2', 'configuration': 'release', 'factory': 'WK2Factory', 'platform': 'mac-sierra', 'safe_merge_queue': 'macos'})
+
+    def test_builder_with_invalid_pr_column(self):
+        with self.assertRaises(Exception) as context:
+            loadConfig.checkValidBuilder({}, {'name': 'mac-wk2', 'shortname': 'mac-wk2', 'configuration': 'release', 'factory': 'WK2Factory', 'platform': 'mac-sierra', 'pr_column': 'bogus'})
+        self.assertIn('has invalid pr_column value: bogus', context.exception.args[0])
+
+    def test_builder_with_valid_pr_column(self):
+        loadConfig.checkValidBuilder({}, {'name': 'macOS-WK2-EWS', 'shortname': 'mac-wk2', 'configuration': 'release', 'factory': 'WK2Factory', 'platform': 'mac-sierra', 'pr_column': 'macos'})
+
+
+class TestcheckValidStatusBubbleOrder(unittest.TestCase):
+    def _builder(self, shortname):
+        return {'name': '{}-EWS'.format(shortname), 'shortname': shortname}
+
+    def test_missing_status_bubble_order(self):
+        config = {'builders': [self._builder('mac')]}
+        with self.assertRaises(Exception) as context:
+            loadConfig.checkValidStatusBubbleOrder(config)
+        self.assertIn('missing top-level "status_bubble_order"', context.exception.args[0])
+
+    def test_duplicate_entry(self):
+        config = {'builders': [self._builder('mac')], 'status_bubble_order': ['mac', 'mac']}
+        with self.assertRaises(Exception) as context:
+            loadConfig.checkValidStatusBubbleOrder(config)
+        self.assertIn('Duplicate entry in status_bubble_order: mac', context.exception.args[0])
+
+    def test_unknown_shortname(self):
+        config = {'builders': [self._builder('mac')], 'status_bubble_order': ['mac', 'ghost']}
+        with self.assertRaises(Exception) as context:
+            loadConfig.checkValidStatusBubbleOrder(config)
+        self.assertIn("unknown shortnames: ['ghost']", context.exception.args[0])
+
+    def test_missing_coverage(self):
+        config = {'builders': [self._builder('mac'), self._builder('ios')], 'status_bubble_order': ['mac']}
+        with self.assertRaises(Exception) as context:
+            loadConfig.checkValidStatusBubbleOrder(config)
+        self.assertIn("missing builder shortnames: ['ios']", context.exception.args[0])
+
+    def test_handler_queues_are_exempt_from_coverage(self):
+        config = {
+            'builders': [self._builder('mac'), self._builder('commit'), self._builder('merge'), self._builder('unsafe-merge'), self._builder('safe-merge')],
+            'status_bubble_order': ['mac'],
+        }
+        loadConfig.checkValidStatusBubbleOrder(config)
+
+    def test_success(self):
+        config = {'builders': [self._builder('mac'), self._builder('ios')], 'status_bubble_order': ['mac', 'ios']}
+        loadConfig.checkValidStatusBubbleOrder(config)
+
+
+class TestcheckValidPrCommentStructure(unittest.TestCase):
+    def _builder(self, shortname, pr_column='misc'):
+        b = {'name': '{}-EWS'.format(shortname), 'shortname': shortname}
+        if pr_column is not None:
+            b['pr_column'] = pr_column
+        return b
+
+    def test_missing_pr_column_on_non_handler(self):
+        config = {'builders': [self._builder('mac', pr_column=None)], 'pr_comment_misc_handlers': []}
+        with self.assertRaises(Exception) as context:
+            loadConfig.checkValidPrCommentStructure(config)
+        self.assertIn("missing required pr_column: ['mac']", context.exception.args[0])
+
+    def test_handler_queues_are_exempt(self):
+        config = {
+            'builders': [self._builder('mac'), self._builder('merge', pr_column=None), self._builder('unsafe-merge', pr_column=None)],
+            'pr_comment_misc_handlers': ['merge', 'unsafe-merge'],
+        }
+        loadConfig.checkValidPrCommentStructure(config)
+
+    def test_handler_in_list_must_be_known_handler(self):
+        config = {
+            'builders': [self._builder('mac'), self._builder('merge', pr_column=None)],
+            'pr_comment_misc_handlers': ['mac'],
+        }
+        with self.assertRaises(Exception) as context:
+            loadConfig.checkValidPrCommentStructure(config)
+        self.assertIn('pr_comment_misc_handlers entry mac is not a handler queue', context.exception.args[0])
+
+    def test_handler_must_exist_as_builder(self):
+        config = {
+            'builders': [self._builder('mac')],
+            'pr_comment_misc_handlers': ['merge'],
+        }
+        with self.assertRaises(Exception) as context:
+            loadConfig.checkValidPrCommentStructure(config)
+        self.assertIn('pr_comment_misc_handlers entry merge does not correspond to any builder', context.exception.args[0])
+
+    def test_handlers_must_be_a_list(self):
+        config = {'builders': [self._builder('mac')], 'pr_comment_misc_handlers': 'merge'}
+        with self.assertRaises(Exception) as context:
+            loadConfig.checkValidPrCommentStructure(config)
+        self.assertIn('pr_comment_misc_handlers must be a list', context.exception.args[0])
+
+    def test_success(self):
+        config = {
+            'builders': [self._builder('mac', 'macos'), self._builder('merge', pr_column=None), self._builder('unsafe-merge', pr_column=None)],
+            'pr_comment_misc_handlers': ['merge', 'unsafe-merge'],
+        }
+        loadConfig.checkValidPrCommentStructure(config)
+
+
+class TestQueueMetadata(unittest.TestCase):
+    # Legacy hardcoded lists, kept here as drift guards against accidental config.json edits.
+    # Remove once the derived values are trusted.
+    LEGACY_STATUS_BUBBLE_ORDER = [
+        'style', 'ios', 'ios-sim', 'mac', 'mac-AS-debug', 'vision', 'vision-sim', 'tv', 'tv-sim',
+        'watch', 'watch-sim', 'gtk', 'wpe', 'gtk3-libwebrtc', 'playstation', 'win', 'win-tests',
+        'ios-wk2', 'ios-wk2-wpt', 'mac-wk1', 'mac-wk2', 'mac-wk2-stress', 'mac-intel-wk2',
+        'mac-AS-debug-wk2', 'mac-safer-cpp', 'ios-safer-cpp', 'vision-wk2', 'gtk-wk2', 'wpe-wk2',
+        'api-ios', 'api-mac', 'api-mac-debug', 'api-gtk', 'api-wpe', 'bindings', 'jsc-x86-64',
+        'jsc-debug-arm64', 'jsc-armv7', 'jsc-armv7-tests', 'webkitperl', 'webkitpy', 'services',
+    ]
+    LEGACY_EMBEDDED = ['ios', 'ios-safer-cpp', 'ios-sim', 'ios-wk2', 'ios-wk2-wpt', 'api-ios', 'vision', 'vision-sim', 'vision-wk2', 'tv', 'tv-sim', 'watch', 'watch-sim']
+    LEGACY_MACOS = ['mac', 'mac-AS-debug', 'api-mac', 'api-mac-debug', 'mac-wk1', 'mac-wk2', 'mac-AS-debug-wk2', 'mac-wk2-stress', 'mac-safer-cpp', 'jsc-x86-64', 'jsc-debug-arm64']
+    LEGACY_LINUX = ['gtk', 'gtk-wk2', 'api-gtk', 'wpe', 'gtk3-libwebrtc', 'wpe-wk2', 'api-wpe']
+    LEGACY_WINDOWS = ['win']
+
+    LEGACY_PR_COLUMN = {
+        'style': 'misc', 'bindings': 'misc', 'webkitperl': 'misc', 'webkitpy': 'misc',
+        'jsc-x86-64': 'misc', 'jsc-debug-arm64': 'misc', 'services': 'misc',
+        'ios': 'embedded', 'ios-sim': 'embedded', 'ios-wk2': 'embedded', 'ios-wk2-wpt': 'embedded',
+        'api-ios': 'embedded', 'ios-safer-cpp': 'embedded', 'vision': 'embedded',
+        'vision-sim': 'embedded', 'vision-wk2': 'embedded', 'tv': 'embedded', 'tv-sim': 'embedded',
+        'watch': 'embedded', 'watch-sim': 'embedded',
+        'mac': 'macos', 'mac-AS-debug': 'macos', 'api-mac': 'macos', 'api-mac-debug': 'macos',
+        'mac-wk1': 'macos', 'mac-wk2': 'macos', 'mac-AS-debug-wk2': 'macos',
+        'mac-wk2-stress': 'macos', 'mac-intel-wk2': 'macos', 'mac-safer-cpp': 'macos',
+        'wpe': 'linux', 'wpe-wk2': 'linux', 'api-wpe': 'linux', 'gtk3-libwebrtc': 'linux',
+        'gtk': 'linux', 'gtk-wk2': 'linux', 'api-gtk': 'linux', 'playstation': 'linux',
+        'jsc-armv7': 'linux', 'jsc-armv7-tests': 'linux',
+        'win': 'windows', 'win-tests': 'windows',
+    }
+    LEGACY_MISC_HANDLERS = ['merge', 'unsafe-merge']
+
+    def setUp(self):
+        cwd = os.path.dirname(os.path.abspath(__file__))
+        loadConfig.loadBuilderConfig({}, is_test_mode_enabled=True, master_prefix_path=cwd)
+
+    def test_status_bubble_order_matches_legacy(self):
+        self.assertEqual(loadConfig.STATUS_BUBBLE_ORDER, self.LEGACY_STATUS_BUBBLE_ORDER)
+
+    def test_safe_merge_buckets_match_legacy(self):
+        self.assertEqual(set(loadConfig.SAFE_MERGE_BUCKETS['embedded']), set(self.LEGACY_EMBEDDED))
+        self.assertEqual(set(loadConfig.SAFE_MERGE_BUCKETS['macos']), set(self.LEGACY_MACOS))
+        self.assertEqual(set(loadConfig.SAFE_MERGE_BUCKETS['linux']), set(self.LEGACY_LINUX))
+        self.assertEqual(set(loadConfig.SAFE_MERGE_BUCKETS['windows']), set(self.LEGACY_WINDOWS))
+
+    def test_pr_column_by_shortname_matches_legacy(self):
+        self.assertEqual(loadConfig.PR_COLUMN_BY_SHORTNAME, self.LEGACY_PR_COLUMN)
+
+    def test_pr_comment_misc_handlers_matches_legacy(self):
+        self.assertEqual(loadConfig.PR_COMMENT_MISC_HANDLERS, self.LEGACY_MISC_HANDLERS)
 
 
 class TestcheckWorkersAndBuildersForConsistency(unittest.TestCase):

--- a/Tools/CISupport/ews-build/steps.py
+++ b/Tools/CISupport/ews-build/steps.py
@@ -2659,10 +2659,6 @@ class CheckStatusOfPR(buildstep.BuildStep, GitHubMixin, AddToLogMixin):
     name = 'check-status-of-pr'
     flunkOnFailure = False
     haltOnFailure = False
-    EMBEDDED_CHECKS = ['ios', 'ios-safer-cpp', 'ios-sim', 'ios-wk2', 'ios-wk2-wpt', 'api-ios', 'vision', 'vision-sim', 'vision-wk2', 'tv', 'tv-sim', 'watch', 'watch-sim']
-    MACOS_CHECKS = ['mac', 'mac-AS-debug', 'api-mac', 'api-mac-debug', 'mac-wk1', 'mac-wk2', 'mac-AS-debug-wk2', 'mac-wk2-stress', 'mac-safer-cpp', 'jsc-x86-64', 'jsc-debug-arm64']
-    LINUX_CHECKS = ['gtk', 'gtk-wk2', 'api-gtk', 'wpe', 'gtk3-libwebrtc', 'wpe-wk2', 'api-wpe']
-    WINDOWS_CHECKS = ['win']
     EWS_WEBKIT_FAILED = 0
     EWS_WEBKIT_PASSED = 1
     EWS_WEBKIT_PENDING = 2
@@ -2748,11 +2744,11 @@ class CheckStatusOfPR(buildstep.BuildStep, GitHubMixin, AddToLogMixin):
                 else:
                     break
 
-        # FIXME: safe-merge-queue should obtain skipped status from EWS instead of hardcoding
-        queues_for_safe_merge = self.EMBEDDED_CHECKS + self.MACOS_CHECKS
+        from .loadConfig import SAFE_MERGE_BUCKETS
+        queues_for_safe_merge = SAFE_MERGE_BUCKETS['embedded'] + SAFE_MERGE_BUCKETS['macos']
         if self.getProperty('project') == CANONICAL_GITHUB_PROJECT:
-            queues_for_safe_merge += self.LINUX_CHECKS
-            queues_for_safe_merge += self.WINDOWS_CHECKS
+            queues_for_safe_merge += SAFE_MERGE_BUCKETS['linux']
+            queues_for_safe_merge += SAFE_MERGE_BUCKETS['windows']
 
         for queue in queues_for_safe_merge:
             queue_data = response.json().get(queue, None)


### PR DESCRIPTION
#### cc23a3a28020fc0ba8b7501654f791a95a3e4d2f
<pre>
Unify Builder Lists in Config
<a href="https://rdar.apple.com/175866614">rdar://175866614</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=313663">https://bugs.webkit.org/show_bug.cgi?id=313663</a>

Reviewed by NOBODY (OOPS!).

Builder ordering, PR-comment columns, and merge-queue groupings were
previously hardcoded across statusbubble.py, github.py, and buildbot.py,
which meant every reordering or recategorization required edits in
multiple places and drifted out of sync over time.

Move this metadata into config.json as the single source of truth:

    * Each builder gains `pr_column` (misc/embedded/macos/linux/windows)
      and `safe_merge_queue` fields.
    * New top-level `status_bubble_order` defines bubble display order.
    * New `pr_comment_misc_handlers` distinguishes handler queues
      (merge, unsafe-merge) from regular builders.

loadConfig.py validates the new structure (every non-handler builder
appears exactly once in status_bubble_order and declares a pr_column)
and populates SAFE_MERGE_BUCKETS and PR_COLUMN_BY_SHORTNAME at load
time. Buildbot exposes these as `all_queues`, `pr_column_by_shortname`,
and `pr_comment_misc_handlers`.

GitHubEWS replaces the hardcoded STATUS_BUBBLE_ROWS grid with
_compute_status_bubble_rows(), deriving layout from config.

Extract status-bubble logic out of statusbubble.py (312 -&gt; 122 lines)
into a new views/bubble/ package split by responsibility: config,
model, compute (pure state logic), fetcher (DB access), and separate
render_html / render_markdown backends. This makes the bubble
pipeline testable in isolation and unblocks additional output
formats.

Tests cover config validation, metadata extraction, grid layout, and
include drift guards comparing derived values against the former
hardcoded lists.

* Tools/CISupport/ews-app/ews/apps.py:
(EwsConfig.ready):
* Tools/CISupport/ews-app/ews/common/buildbot.py:
(Buildbot):
(Buildbot.update_icons_for_queues_mapping):
* Tools/CISupport/ews-app/ews/common/github.py:
(GitHubEWS):
(GitHubEWS._compute_status_bubble_rows):
(GitHubEWS.generate_comment_text_for_change):
(GitHubEWS.github_status_for_cibuild):
(GitHubEWS.github_status_for_buildbot_queue):
(GitHubEWS._github_icons):
(GitHubEWS.add_or_update_comment_for_change_id):
(GitHubEWS._steps_messages): Deleted.
(GitHubEWS._does_build_contains_any_failed_step): Deleted.
(GitHubEWS._most_recent_failure_message): Deleted.
* Tools/CISupport/ews-app/ews/tests.py:
(BuildbotAllQueuesTest):
(BuildbotAllQueuesTest.setUp):
(BuildbotAllQueuesTest.tearDown):
(BuildbotAllQueuesTest.test_all_queues_populated_from_status_bubble_order):
(BuildbotAllQueuesTest.test_all_queues_preserved_when_key_missing):
(BuildbotAllQueuesTest.test_all_queues_preserved_when_fetch_fails):
(BuildbotAllQueuesTest.test_pr_column_by_shortname_populated):
(BuildbotAllQueuesTest.test_pr_comment_misc_handlers_populated):
(BuildbotAllQueuesTest.test_pr_comment_misc_handlers_preserved_when_key_missing):
(GitHubEWSStatusBubbleRowsTest):
(GitHubEWSStatusBubbleRowsTest.setUp):
(GitHubEWSStatusBubbleRowsTest.tearDown):
(GitHubEWSStatusBubbleRowsTest.test_grid_layout_with_canned_data):
(GitHubEWSStatusBubbleRowsTest.test_grid_respects_status_bubble_order):
(GitHubEWSStatusBubbleRowsTest.test_grid_skips_shortnames_without_pr_column):
(GitHubEWSLegacyDriftGuardTest):
(GitHubEWSLegacyDriftGuardTest.setUp):
(GitHubEWSLegacyDriftGuardTest.tearDown):
(GitHubEWSLegacyDriftGuardTest.test_column_membership_matches_legacy):
(GitHubEWSLegacyDriftGuardTest.test_misc_column_starts_with_merge_handlers):
(_Fixtures):
(_Fixtures.cfg):
(_Fixtures.step):
(_Fixtures.build):
(_Fixtures.change):
(_Fixtures.inputs):
(ComputeBubbleBuildOutcomesTest):
(ComputeBubbleBuildOutcomesTest.test_in_progress_no_failed_step_yields_started):
(ComputeBubbleBuildOutcomesTest.test_in_progress_with_failed_step_yields_provisional_fail):
(ComputeBubbleBuildOutcomesTest.test_success_non_parent_builder_only_says_built_successfully):
(ComputeBubbleBuildOutcomesTest.test_success_non_parent_tester_only_says_passed_tests):
(ComputeBubbleBuildOutcomesTest.test_success_non_parent_style_queue_says_passed_style_check):
(ComputeBubbleBuildOutcomesTest.test_success_non_parent_build_and_test_says_built_and_passed):
(ComputeBubbleBuildOutcomesTest.test_success_non_parent_with_no_icon_says_pass):
(ComputeBubbleBuildOutcomesTest.test_success_parent_build_within_window_yields_started_waiting):
(ComputeBubbleBuildOutcomesTest.test_success_parent_build_outside_hide_window_returns_none):
(ComputeBubbleBuildOutcomesTest.test_warnings_yields_pass_state_with_warning_message):
(ComputeBubbleBuildOutcomesTest.test_failure_yields_fail_state_with_recent_failure_message):
(ComputeBubbleBuildOutcomesTest.test_failure_with_retry_message_yields_provisional_fail):
(ComputeBubbleBuildOutcomesTest.test_skipped_bug_already_closed_appends_message):
(ComputeBubbleBuildOutcomesTest.test_skipped_patch_marked_r_minus_appends_message):
(ComputeBubbleBuildOutcomesTest.test_skipped_patch_obsolete_appends_message):
(ComputeBubbleBuildOutcomesTest.test_skipped_pull_request_already_closed_appends_message):
(ComputeBubbleBuildOutcomesTest.test_skipped_hash_outdated_appends_message):
(ComputeBubbleBuildOutcomesTest.test_skipped_skip_ews_label_overrides_message):
(ComputeBubbleBuildOutcomesTest.test_skipped_with_extra_eligible_builds_appends_step_log):
(ComputeBubbleBuildOutcomesTest.test_exception_yields_error_state):
(ComputeBubbleBuildOutcomesTest.test_retry_yields_provisional_fail_state):
(ComputeBubbleBuildOutcomesTest.test_cancelled_yields_cancelled_state):
(ComputeBubbleBuildOutcomesTest.test_unknown_result_code_yields_error_state):
(ComputeBubbleBuildOutcomesTest.test_builder_full_name_and_timestamp_present):
(ComputeBubbleBuildOutcomesTest.test_os_details_present_when_step_starts_with_os_prefix):
(ComputeBubbleQueuePositionTest):
(ComputeBubbleQueuePositionTest.test_no_build_with_integer_queue_position_yields_none_state_with_position):
(ComputeBubbleQueuePositionTest.test_no_build_with_unknown_queue_position_omits_position_field):
(ComputeBubbleQueuePositionTest.test_no_build_with_none_queue_position_returns_none):
(ComputeBubbleQueuePositionTest.test_no_build_falls_back_to_parent_queue_full_name_for_url):
(ComputeBubbleQueuePositionTest.test_no_build_unknown_queue_full_name_omits_url):
(ComputeBubbleVisibilityTest):
(ComputeBubbleVisibilityTest.test_no_build_and_not_sent_to_buildbot_hides_bubble):
(ComputeBubbleVisibilityTest.test_no_build_and_sent_to_buildbot_shows_bubble):
(ComputeBubbleVisibilityTest.test_skipped_irrelevant_changes_patch_phrasing_hides_bubble):
(ComputeBubbleVisibilityTest.test_skipped_irrelevant_changes_pr_phrasing_hides_bubble):
(ComputeBubbleVisibilityTest.test_hide_icons_true_omits_builder_and_tester_icons):
(ComputeBubbleVisibilityTest.test_hide_icons_false_prepends_tester_icon_for_tester_queue):
(ComputeBubbleVisibilityTest.test_hide_icons_false_prepends_builder_icon_for_builder_queue):
(ComputeBubbleVisibilityTest.test_hide_icons_false_prepends_both_icons_for_build_and_test_queue):
(RenderHtmlBubbleTest):
(RenderHtmlBubbleTest.test_render_html_bubble_returns_template_keys):
(RenderHtmlBubbleTest.test_render_html_bubble_omits_queue_position_when_none):
(RenderHtmlBubbleTest.test_render_html_bubble_includes_queue_position_when_set):
(RenderHtmlBubbleTest.test_render_html_bubble_appends_os_and_timestamp_with_single_newline_between):
(RenderHtmlBubbleTest.test_render_html_bubble_omits_url_when_none):
(RenderMarkdownBubbleTest):
(RenderMarkdownBubbleTest.test_pass_state_emits_pass_icon_and_url):
(RenderMarkdownBubbleTest.test_fail_state_emits_fail_icon):
(RenderMarkdownBubbleTest.test_provisional_fail_in_progress_uses_ongoing_with_failures_icon):
(RenderMarkdownBubbleTest.test_provisional_fail_not_in_progress_uses_ongoing_icon):
(RenderMarkdownBubbleTest.test_cancelled_strikes_through_name):
(RenderMarkdownBubbleTest.test_skipped_strikes_through_name):
(RenderMarkdownBubbleTest.test_hover_text_is_escaped):
(RenderMarkdownBubbleTest.test_hover_text_is_escaped.spy):
(RenderMarkdownBubbleTest.test_started_state_uses_ongoing_icon):
(RenderMarkdownBubbleTest.test_error_state_uses_error_icon):
(RenderMarkdownBubbleTest.test_none_state_uses_waiting_icon):
(RenderMarkdownBubbleTest.test_unknown_state_falls_back_to_error_icon):
(StatusBubbleTemplateRenderTest):
(StatusBubbleTemplateRenderTest.setUp):
(StatusBubbleTemplateRenderTest.tearDown):
(StatusBubbleTemplateRenderTest._get):
(StatusBubbleTemplateRenderTest.test_get_returns_anchor_with_status_pass_class):
(StatusBubbleTemplateRenderTest.test_get_renders_href_to_buildbot_build_page):
(StatusBubbleTemplateRenderTest.test_get_renders_title_attribute_with_details_message):
(StatusBubbleTemplateRenderTest.test_get_omits_submit_form_when_sent_to_buildbot):
(StatusBubbleTemplateRenderTest.test_get_renders_submit_form_when_not_sent_to_buildbot):
(StatusBubbleTemplateRenderTest.test_get_renders_none_state_with_queue_position_when_no_build):
(BubbleDataFetcherQueuePositionTest):
(BubbleDataFetcherQueuePositionTest.setUp):
(BubbleDataFetcherQueuePositionTest._make_change):
(BubbleDataFetcherQueuePositionTest._make_build):
(BubbleDataFetcherQueuePositionTest.test_position_one_when_no_prior_changes):
(BubbleDataFetcherQueuePositionTest.test_position_counts_only_unprocessed_prior_changes):
(BubbleDataFetcherQueuePositionTest.test_outside_hide_window_returns_none):
(BubbleDataFetcherQueuePositionTest.test_between_check_and_hide_window_returns_unknown_position_marker):
(BubbleDataFetcherQueuePositionTest.test_parent_queue_fallback_subtracts_parent_built_changes):
(GitHubEWSMiscHandlerEmptyCellTest):
(GitHubEWSMiscHandlerEmptyCellTest.setUp):
(GitHubEWSMiscHandlerEmptyCellTest.tearDown):
(GitHubEWSMiscHandlerEmptyCellTest.test_merge_queue_with_no_build_returns_empty_cell):
(GitHubEWSMiscHandlerEmptyCellTest.test_unsafe_merge_queue_with_no_build_returns_empty_cell):
(GitHubEWSMiscHandlerEmptyCellTest.test_non_misc_handler_with_no_build_renders_waiting_bubble):
* Tools/CISupport/ews-app/ews/views/bubble/__init__.py: Copied from Tools/CISupport/ews-app/ews/tests.py.
* Tools/CISupport/ews-app/ews/views/bubble/compute.py: Added.
(_decorated_queue_name):
(_should_show_bubble_for_build):
(_does_build_contain_failed_step):
(_most_recent_failure_message):
(_steps_messages):
(_steps_messages_from_multiple_builds):
(_iso_time):
(_get_os_details):
(_get_build_timestamp_iso):
(_no_build_bubble):
(_success_parent_build_message):
(_success_message):
(_skipped_message):
(compute_bubble):
* Tools/CISupport/ews-app/ews/views/bubble/config.py: Added.
(BubbleConfig):
(BubbleConfig.is_tester_queue):
(BubbleConfig.is_builder_queue):
(BubbleConfig.get_parent_queue):
(BubbleConfig.queue_full_name):
(BubbleConfig.builder_url):
(BubbleConfig.build_url):
(BubbleConfig.from_buildbot_globals):
* Tools/CISupport/ews-app/ews/views/bubble/fetcher.py: Added.
(_step_snapshot):
(_build_snapshot):
(_change_snapshot):
(BubbleDataFetcher):
(BubbleDataFetcher.__init__):
(BubbleDataFetcher.now):
(BubbleDataFetcher.fetch_change_snapshot):
(BubbleDataFetcher._fetch_raw_builds):
(BubbleDataFetcher.fetch_builds_for_queue):
(BubbleDataFetcher.fetch_queue_position):
(BubbleDataFetcher.build_inputs):
* Tools/CISupport/ews-app/ews/views/bubble/model.py: Added.
(StepSnapshot):
(BuildSnapshot):
(ChangeSnapshot):
(BubbleInputs):
(BubbleData):
* Tools/CISupport/ews-app/ews/views/bubble/render_html.py: Copied from Tools/CISupport/ews-app/ews/apps.py.
(_assemble_html_details):
(render_html_bubble):
* Tools/CISupport/ews-app/ews/views/bubble/render_markdown.py: Added.
(GithubIcons):
(_icon_for_state):
(render_markdown_bubble):
(render_markdown_no_build_misc):
* Tools/CISupport/ews-app/ews/views/status.py:
(Status._build_statuses_for_change):
* Tools/CISupport/ews-app/ews/views/statusbubble.py:
(StatusBubble):
(StatusBubble.get):
(StatusBubble.get_all_builds_for_queue):
(StatusBubble._build_bubble): Deleted.
(StatusBubble.get_os_details): Deleted.
(StatusBubble.get_build_timestamp): Deleted.
(StatusBubble._iso_time): Deleted.
(StatusBubble._steps_messages): Deleted.
(StatusBubble._steps_messages_from_multiple_builds): Deleted.
(StatusBubble._does_build_contains_any_failed_step): Deleted.
(StatusBubble._most_recent_failure_message): Deleted.
(StatusBubble.get_builds_for_queue): Deleted.
(StatusBubble._should_show_bubble_for_build): Deleted.
(StatusBubble._queue_position): Deleted.
(StatusBubble._build_bubbles_for_change): Deleted.
* Tools/CISupport/ews-build/config.json:
* Tools/CISupport/ews-build/loadConfig.py:
(loadBuilderConfig):
(checkValidBuilder):
(checkValidStatusBubbleOrder):
(_populateQueueMetadata):
(checkValidPrCommentStructure):
* Tools/CISupport/ews-build/loadConfig_unittest.py:
(ConfigDotJSONTest.test_builder_keys):
(TestcheckValidBuilder.test_builder_with_invalid_safe_merge_queue):
(TestcheckValidBuilder):
(TestcheckValidBuilder.test_builder_with_valid_safe_merge_queue):
(TestcheckValidBuilder.test_builder_with_invalid_pr_column):
(TestcheckValidBuilder.test_builder_with_valid_pr_column):
(TestcheckValidStatusBubbleOrder):
(TestcheckValidStatusBubbleOrder._builder):
(TestcheckValidStatusBubbleOrder.test_missing_status_bubble_order):
(TestcheckValidStatusBubbleOrder.test_duplicate_entry):
(TestcheckValidStatusBubbleOrder.test_unknown_shortname):
(TestcheckValidStatusBubbleOrder.test_missing_coverage):
(TestcheckValidStatusBubbleOrder.test_handler_queues_are_exempt_from_coverage):
(TestcheckValidStatusBubbleOrder.test_success):
(TestcheckValidPrCommentStructure):
(TestcheckValidPrCommentStructure._builder):
(TestcheckValidPrCommentStructure.test_missing_pr_column_on_non_handler):
(TestcheckValidPrCommentStructure.test_handler_queues_are_exempt):
(TestcheckValidPrCommentStructure.test_handler_in_list_must_be_known_handler):
(TestcheckValidPrCommentStructure.test_handler_must_exist_as_builder):
(TestcheckValidPrCommentStructure.test_handlers_must_be_a_list):
(TestcheckValidPrCommentStructure.test_success):
(TestQueueMetadata):
(TestQueueMetadata.setUp):
(TestQueueMetadata.test_status_bubble_order_matches_legacy):
(TestQueueMetadata.test_safe_merge_buckets_match_legacy):
(TestQueueMetadata.test_pr_column_by_shortname_matches_legacy):
(TestQueueMetadata.test_pr_comment_misc_handlers_matches_legacy):
* Tools/CISupport/ews-build/steps.py:
(CheckStatusOfPR):
(CheckStatusOfPR.getQueueStatusFromList):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cc23a3a28020fc0ba8b7501654f791a95a3e4d2f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/160910 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/34383 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/27484 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/169813 "Built successfully") | [❌ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/117170 "Failed to checkout and rebase branch from PR 63904") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/9bf82b35-8927-45c3-9de7-7a37f1feec2a) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/162779 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/34484 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/34383 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/124809 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/59/builds/117170 "Failed to checkout and rebase branch from PR 63904") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/c2c0c9e2-6f79-496f-95f3-a84e73ffc690) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/163869 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/27065 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/144545 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/105406 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/a636d4c1-86b0-40cb-b54f-1a403491c8be) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/26117 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/24627 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/17533 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/135811 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/22307 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/172296 "Built successfully") | | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/23948 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/133080 "Passed tests") | | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/160307 "Passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/34057 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/28719 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/133090 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/34041 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/144102 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/95880 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/27676 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/20918 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/33552 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/33051 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/33295 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/33200 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->