### PR TITLE
[JSC] Delay PC advancement until after operationCallMayThrow in IPInt

### DIFF
--- a/JSTests/wasm/stress/call-indirect-exceptions.js
+++ b/JSTests/wasm/stress/call-indirect-exceptions.js
@@ -1,0 +1,47 @@
+import * as assert from "../assert.js";
+
+/*
+    (module
+        (type (func (result i32)))
+        (type (func))
+
+        (tag (type 1))
+
+        (table 1 funcref)
+        (elem (table 0) (i32.const 0) funcref (ref.func 1))
+
+        (func (export "test") (result i32)
+            try
+                i32.const 0
+                ;; Should throw and jump to the outer catch block (with `i32.const 10`)
+                call_indirect 0 (type 0)
+                try
+                    i32.const 30
+                    return
+                catch 0
+                    ;; Should never be executed, as the contents of the inner try block cannot throw.
+                    i32.const 40
+                    return
+                end
+                drop
+            catch 0
+                i32.const 10
+                return
+            end
+            i32.const 20
+        )
+        (func (result i32)
+            throw 0
+        )
+    )
+*/
+let wasm = Uint8Array.fromBase64("AGFzbQEAAAABCAJgAAF/YAAAAwMCAAAEBAFwAAENAwEAAQcIAQR0ZXN0AAAJCwEGAEEAC3AB0gELCiQCHQAGQEEAEQAABkBBHg8HAEEoDwsaBwBBCg8LQRQLBAAIAAs=");
+
+async function test() {
+    const { instance } = await WebAssembly.instantiate(wasm);
+    const { test } = instance.exports;
+    for (let i = 0; i < wasmTestLoopCount; i++)
+        assert.eq(test(), 10);
+}
+
+await assert.asyncTest(test());

--- a/Source/JavaScriptCore/llint/InPlaceInterpreter64.asm
+++ b/Source/JavaScriptCore/llint/InPlaceInterpreter64.asm
@@ -538,18 +538,20 @@ ipintOp(_call_indirect, macro()
     // The operationCall below already calls validateOpcodeConfig().
     saveCallSiteIndex()
 
-    loadb IPInt::CallIndirectMetadata::length[MC], t2
-    advancePCByReg(t2)
-
     # Get function index by pointer, use it as a return for callee
     move sp, a2
 
     # Get callIndirectMetadata
     move cfr, a1
     move MC, a3
-    advanceMC(IPInt::CallIndirectMetadata::signature)
 
     operationCallMayThrow(macro() cCall4(_ipint_extern_prepare_call_indirect) end)
+
+    # operationCallMayThrow saves the call site index, so we have to advance the PC after.
+    # Otherwise, the wrong call site index will be saved.
+    loadb IPInt::CallIndirectMetadata::length[MC], t3
+    advancePCByReg(t3)
+    advanceMC(IPInt::CallIndirectMetadata::signature)
 
     loadq [sp], IPIntCallCallee
     loadq 8[sp], IPIntCallFunctionSlot
@@ -587,9 +589,6 @@ ipintOp(_return_call_indirect, macro()
     // The operationCallMayThrow below already calls validateOpcodeConfig().
     saveCallSiteIndex()
 
-    loadb IPInt::TailCallIndirectMetadata::length[MC], t2
-    advancePCByReg(t2)
-
     # Get function index by pointer, use it as a return for callee
     move sp, a2
 
@@ -597,6 +596,11 @@ ipintOp(_return_call_indirect, macro()
     move cfr, a1
     move MC, a3
     operationCallMayThrow(macro() cCall4(_ipint_extern_prepare_call_indirect) end)
+
+    # operationCallMayThrow saves the call site index, so we have to advance the PC after.
+    # Otherwise, the wrong call site index will be saved.
+    loadb IPInt::TailCallIndirectMetadata::length[MC], t3
+    advancePCByReg(t3)
 
     loadq [sp], IPIntCallCallee
     loadq 8[sp], IPIntCallFunctionSlot
@@ -631,13 +635,16 @@ ipintOp(_return_call_ref, macro()
     // The operationCallMayThrow below already calls validateOpcodeConfig().
     saveCallSiteIndex()
 
-    loadb IPInt::TailCallRefMetadata::length[MC], t2
-    advancePCByReg(t2)
-
     move cfr, a1
     move MC, a2
     move sp, a3
     operationCallMayThrow(macro() cCall4(_ipint_extern_prepare_call_ref) end)
+
+    # operationCallMayThrow saves the call site index, so we have to advance the PC after.
+    # Otherwise, the wrong call site index will be saved.
+    loadb IPInt::TailCallRefMetadata::length[MC], t3
+    advancePCByReg(t3)
+
     loadq [sp], IPIntCallCallee
     loadq 8[sp], IPIntCallFunctionSlot
     addq 16, sp


### PR DESCRIPTION
#### 714bf5b1e05ac3494a1384f93a83246abe857518
<pre>
[JSC] Delay PC advancement until after operationCallMayThrow in IPInt
<a href="https://bugs.webkit.org/show_bug.cgi?id=305148">https://bugs.webkit.org/show_bug.cgi?id=305148</a>
<a href="https://rdar.apple.com/166602356">rdar://166602356</a>

Reviewed by Yusuke Suzuki.

Currently, some IPInt instructions will advance the PC before invoking
operationCallMayThrow. Because that invocation will save the call site index,
this means that the call site index of the next instruction will be saved
instead of the call site index of the instruction currently being executed.
If the call does throw, it will then choose a handler based on the index of
the next instruction. Therefore, it&apos;s necessary to move the PC advancement
instructions past the invocation of operationCallMayThrow.

Test: JSTests/wasm/stress/call-indirect-exceptions.js

* JSTests/wasm/stress/call-indirect-exceptions.js: Added.
(async test): Tests that exceptions are properly handled.
* Source/JavaScriptCore/llint/InPlaceInterpreter64.asm: Delay PC advancement

Originally-landed-as: 305413.149@safari-7624-branch (63358b77f417). <a href="https://rdar.apple.com/174957939">rdar://174957939</a>
Canonical link: <a href="https://commits.webkit.org/312338@main">https://commits.webkit.org/312338@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2413895672206e6bd923f3c9856dd8e5751a92a3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/159515 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/32982 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/26060 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/168353 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/113896 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/8176c830-56c7-4b73-b774-4a8e4e6d4b37) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/33016 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/32935 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/123598 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/86748 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/6bcd10b5-eb4d-4d9e-a99d-e4f186005c9d) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/162472 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/25855 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/143278 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/104256 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/760630e9-1e74-453f-9a2d-b0f0e30cc1f8) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/24908 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/23375 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/16133 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/151571 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/134599 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/21050 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/170846 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/20352 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/16883 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/22683 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/131818 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/32639 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/27436 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/131912 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35716 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/32646 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/142843 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/90728 "The change is no longer eligible for processing.") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/26565 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/19657 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/191799 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/32155 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/98551 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/49280 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/31652 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/31889 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/31803 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->