### PR TITLE
[WebCore] Check for liveliness before dereferencing m_document WeakPtr in DocumentThreadableLoader

### DIFF
--- a/Source/WebCore/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations
@@ -266,7 +266,6 @@ layout/layouttree/FormattingContextBoxIterator.h
 layout/layouttree/LayoutContainingBlockChainIterator.h
 layout/layouttree/LayoutTreeBuilder.cpp
 loader/ApplicationManifestLoader.cpp
-loader/CrossOriginPreflightChecker.cpp
 loader/DocumentLoader.cpp
 loader/DocumentWriter.cpp
 loader/FrameLoadRequest.cpp

--- a/Source/WebCore/loader/CrossOriginPreflightChecker.cpp
+++ b/Source/WebCore/loader/CrossOriginPreflightChecker.cpp
@@ -70,13 +70,19 @@ CrossOriginPreflightChecker::~CrossOriginPreflightChecker()
 
 void CrossOriginPreflightChecker::validatePreflightResponse(DocumentThreadableLoader& loader, ResourceRequest&& request, std::optional<ResourceLoaderIdentifier> identifier, const ResourceResponse& response)
 {
-    RefPtr frame = loader.document().frame();
+    RefPtr loaderDocument = loader.document();
+    if (!loaderDocument) {
+        ASSERT_NOT_REACHED();
+        return;
+    }
+
+    RefPtr frame = loaderDocument->frame();
     if (!frame) {
         ASSERT_NOT_REACHED();
         return;
     }
 
-    RefPtr page = loader.document().page();
+    RefPtr page = loaderDocument->page();
     if (!page) {
         ASSERT_NOT_REACHED();
         return;
@@ -84,7 +90,7 @@ void CrossOriginPreflightChecker::validatePreflightResponse(DocumentThreadableLo
 
     auto result = WebCore::validatePreflightResponse(page->sessionID(), request, response, loader.options().storedCredentialsPolicy, loader.topOrigin(), loader.securityOrigin(), &CrossOriginAccessControlCheckDisabler::singleton());
     if (!result) {
-        loader.document().addConsoleMessage(MessageSource::Security, MessageLevel::Error, result.error());
+        loaderDocument->addConsoleMessage(MessageSource::Security, MessageLevel::Error, result.error());
         loader.preflightFailure(identifier, ResourceError(errorDomainWebKitInternal, 0, request.url(), result.error(), ResourceError::Type::AccessControl));
         return;
     }
@@ -114,8 +120,10 @@ void CrossOriginPreflightChecker::notifyFinished(CachedResource& resource, const
         if (preflightError.isNull() || preflightError.isCancellation() || preflightError.isGeneral())
             preflightError.setType(ResourceError::Type::AccessControl);
 
-        if (!preflightError.isTimeout())
-            loader->document().addConsoleMessage(MessageSource::Security, MessageLevel::Error, "CORS-preflight request was blocked"_s);
+        if (!preflightError.isTimeout()) {
+            if (RefPtr loaderDocument = loader->document())
+                loaderDocument->addConsoleMessage(MessageSource::Security, MessageLevel::Error, "CORS-preflight request was blocked"_s);
+        }
         loader->preflightFailure(m_resource->resourceLoaderIdentifier(), preflightError);
         return;
     }
@@ -133,18 +141,22 @@ void CrossOriginPreflightChecker::redirectReceived(CachedResource& resource, Res
 void CrossOriginPreflightChecker::startPreflight()
 {
     RefPtr loader = m_loader.get();
+    RefPtr loaderDocument = loader->document();
+    if (!loaderDocument)
+        return;
+
     ResourceLoaderOptions options;
     options.referrerPolicy = loader->options().referrerPolicy;
     options.contentSecurityPolicyImposition = ContentSecurityPolicyImposition::SkipPolicyCheck;
     options.serviceWorkersMode = ServiceWorkersMode::None;
     options.initiatorContext = loader->options().initiatorContext;
 
-    bool includeFetchMetadata = !loader->document().quirks().shouldDisableFetchMetadata();
+    bool includeFetchMetadata = !loaderDocument->quirks().shouldDisableFetchMetadata();
     CachedResourceRequest preflightRequest(createAccessControlPreflightRequest(m_request, loader->securityOrigin(), loader->referrer(), includeFetchMetadata), options);
     preflightRequest.setInitiatorType(AtomString { loader->options().initiatorType });
 
     ASSERT(!m_resource);
-    if (auto result = protect(loader->document().cachedResourceLoader())->requestRawResource(WTF::move(preflightRequest)))
+    if (auto result = protect(loaderDocument->cachedResourceLoader())->requestRawResource(WTF::move(preflightRequest)))
         m_resource = WTF::move(result.value());
     else
         m_resource = nullptr;
@@ -154,16 +166,20 @@ void CrossOriginPreflightChecker::startPreflight()
 
 void CrossOriginPreflightChecker::doPreflight(DocumentThreadableLoader& loader, ResourceRequest&& request)
 {
-    if (!loader.document().frame())
+    RefPtr loaderDocument = loader.document();
+    if (!loaderDocument)
         return;
 
-    bool includeFetchMetadata = !loader.document().quirks().shouldDisableFetchMetadata();
+    if (!loaderDocument->frame())
+        return;
+
+    bool includeFetchMetadata = !loaderDocument->quirks().shouldDisableFetchMetadata();
     ResourceRequest preflightRequest = createAccessControlPreflightRequest(request, loader.securityOrigin(), loader.referrer(), includeFetchMetadata);
     ResourceError error;
     ResourceResponse response;
     RefPtr<SharedBuffer> data;
 
-    auto identifier = loader.document().frame()->loader().loadResourceSynchronously(preflightRequest, ClientCredentialPolicy::CannotAskClientForCredentials, FetchOptions { }, { }, error, response, data);
+    auto identifier = loaderDocument->frame()->loader().loadResourceSynchronously(preflightRequest, ClientCredentialPolicy::CannotAskClientForCredentials, FetchOptions { }, { }, error, response, data);
 
     if (!error.isNull()) {
         // If the preflight was cancelled by underlying code, it probably means the request was blocked due to some access control policy.
@@ -172,7 +188,7 @@ void CrossOriginPreflightChecker::doPreflight(DocumentThreadableLoader& loader, 
             error.setType(ResourceError::Type::AccessControl);
 
         if (!error.isTimeout())
-            protect(loader.document())->addConsoleMessage(MessageSource::Security, MessageLevel::Error, "CORS-preflight request was blocked"_s);
+            loaderDocument->addConsoleMessage(MessageSource::Security, MessageLevel::Error, "CORS-preflight request was blocked"_s);
 
         loader.preflightFailure(identifier, error);
         return;
@@ -182,7 +198,7 @@ void CrossOriginPreflightChecker::doPreflight(DocumentThreadableLoader& loader, 
     bool isRedirect = preflightRequest.url().strippedForUseAsReferrer().string != response.url().strippedForUseAsReferrer().string;
     if (isRedirect || !response.isSuccessful()) {
         auto errorMessage = makeString("Preflight response is not successful. Status code: "_s, response.httpStatusCode());
-        protect(loader.document())->addConsoleMessage(MessageSource::Security, MessageLevel::Error, errorMessage);
+        loaderDocument->addConsoleMessage(MessageSource::Security, MessageLevel::Error, errorMessage);
 
         loader.preflightFailure(identifier, ResourceError { errorDomainWebKitInternal, 0, request.url(), errorMessage, ResourceError::Type::AccessControl });
         return;

--- a/Source/WebCore/loader/DocumentThreadableLoader.cpp
+++ b/Source/WebCore/loader/DocumentThreadableLoader.cpp
@@ -108,8 +108,11 @@ bool DocumentThreadableLoader::shouldSetHTTPHeadersToKeep() const
     if (m_options.mode == FetchOptions::Mode::Cors && shouldPerformSecurityChecks())
         return true;
 
-    if (m_options.serviceWorkersMode == ServiceWorkersMode::All && m_async)
-        return m_options.serviceWorkerRegistrationIdentifier || m_document->activeServiceWorker();
+    if (m_options.serviceWorkersMode == ServiceWorkersMode::All && m_async) {
+        RefPtr document = m_document;
+        return m_options.serviceWorkerRegistrationIdentifier || (document && document->activeServiceWorker());
+    }
+
 
     return false;
 }
@@ -206,7 +209,10 @@ void DocumentThreadableLoader::makeCrossOriginAccessRequest(ResourceRequest&& re
         if (checkURLSchemeAsCORSEnabled(request.url()))
             makeSimpleCrossOriginAccessRequest(WTF::move(request));
     } else {
-        Ref document = *m_document;
+        RefPtr document = m_document;
+        if (!document)
+            return;
+
         if (m_options.serviceWorkersMode == ServiceWorkersMode::All && m_async) {
             if (m_options.serviceWorkerRegistrationIdentifier || document->activeServiceWorker()) {
                 ASSERT(!m_bypassingPreflightForServiceWorkerRequest);
@@ -261,7 +267,8 @@ void DocumentThreadableLoader::cancel()
     if (RefPtr client = m_client.get(); client && m_resource) {
         // FIXME: This error is sent to the client in didFail(), so it should not be an internal one. Use LocalFrameLoaderClient::cancelledError() instead.
         ResourceError error(errorDomainWebKitInternal, 0, protect(m_resource)->url(), "Load cancelled"_s, ResourceError::Type::Cancellation);
-        client->didFail(m_document->identifier(), error); // May destroy the client.
+        if (RefPtr document = m_document)
+            client->didFail(document->identifier(), error); // May destroy the client.
     }
     clearResource();
     m_client = nullptr;
@@ -416,28 +423,32 @@ void DocumentThreadableLoader::didReceiveResponse(ResourceLoaderIdentifier ident
         }
     }
 
-    InspectorInstrumentation::didReceiveThreadableLoaderResponse(protect(*m_document), *this, identifier);
+    RefPtr document = m_document;
+    if (!document)
+        return;
+
+    InspectorInstrumentation::didReceiveThreadableLoaderResponse(*document, *this, identifier);
 
     if (m_delayCallbacksForIntegrityCheck)
         return;
 
     if (options().filteringPolicy == ResponseFilteringPolicy::Disable) {
-        client->didReceiveResponse(m_document->identifier(), identifier, WTF::move(response));
+        client->didReceiveResponse(document->identifier(), identifier, WTF::move(response));
         return;
     }
 
     if (response.type() == ResourceResponse::Type::Default) {
-        client->didReceiveResponse(m_document->identifier(), identifier, ResourceResponse::filter(response, m_options.credentials == FetchOptions::Credentials::Include ? ResourceResponse::PerformExposeAllHeadersCheck::No : ResourceResponse::PerformExposeAllHeadersCheck::Yes));
+        client->didReceiveResponse(document->identifier(), identifier, ResourceResponse::filter(response, m_options.credentials == FetchOptions::Credentials::Include ? ResourceResponse::PerformExposeAllHeadersCheck::No : ResourceResponse::PerformExposeAllHeadersCheck::Yes));
         client = nullptr; // Avoid calling didFinishLoading() if the call to didReceiveResponse() causes the client to go away.
         if (response.tainting() == ResourceResponse::Tainting::Opaque) {
             clearResource();
             if (RefPtr client = m_client.get())
-                client->didFinishLoading(m_document->identifier(), identifier, { });
+                client->didFinishLoading(document->identifier(), identifier, { });
         }
         return;
     }
     ASSERT(response.type() == ResourceResponse::Type::Opaqueredirect || response.source() == ResourceResponse::Source::ServiceWorker || response.source() == ResourceResponse::Source::MemoryCache);
-    client->didReceiveResponse(m_document->identifier(), identifier, WTF::move(response));
+    client->didReceiveResponse(document->identifier(), identifier, WTF::move(response));
 }
 
 void DocumentThreadableLoader::dataReceived(CachedResource& resource, const SharedBuffer& buffer)
@@ -532,12 +543,13 @@ void DocumentThreadableLoader::didFail(std::optional<ResourceLoaderIdentifier>, 
         return;
     }
 
-    if (m_shouldLogError == ShouldLogError::Yes)
-        logError(protect(*m_document), error, m_options.initiatorType);
-
     RefPtr document = m_document;
     if (!document)
         return;
+
+    if (m_shouldLogError == ShouldLogError::Yes)
+        logError(*document, error, m_options.initiatorType);
+
     if (RefPtr client = m_client.get())
         client->didFail(document->identifier(), error); // May cause the client to get destroyed.
 }
@@ -557,20 +569,28 @@ void DocumentThreadableLoader::preflightFailure(std::optional<ResourceLoaderIden
 {
     m_preflightChecker = nullptr;
 
-    RefPtr frame = m_document->frame();
+    RefPtr document = m_document;
+    if (!document)
+        return;
+
+    RefPtr frame = document->frame();
     if (identifier)
         InspectorInstrumentation::didFailLoading(frame.get(), protect(frame->loader().documentLoader()), *identifier, error);
 
     if (m_shouldLogError == ShouldLogError::Yes)
-        logError(protect(*m_document), error, m_options.initiatorType);
+        logError(*document, error, m_options.initiatorType);
 
     if (RefPtr client = m_client.get())
-        client->didFail(m_document->identifier(), error);
+        client->didFail(document->identifier(), error);
 }
 
 void DocumentThreadableLoader::loadRequest(ResourceRequest&& request, SecurityCheckPolicy securityCheck)
 {
     Ref<DocumentThreadableLoader> protectedThis(*this);
+
+    RefPtr document = m_document;
+    if (!document)
+        return;
 
     // Any credential should have been removed from the cross-site requests.
     m_responseURL = request.url();
@@ -601,7 +621,7 @@ void DocumentThreadableLoader::loadRequest(ResourceRequest&& request, SecurityCh
         if (RefPtr resource = std::exchange(m_resource, nullptr))
             resource->removeClient(*this);
 
-        auto cachedResource = protect(protect(*m_document)->cachedResourceLoader())->requestRawResource(WTF::move(newRequest));
+        auto cachedResource = protect(document->cachedResourceLoader())->requestRawResource(WTF::move(newRequest));
         if (cachedResource)
             m_resource = WTF::move(cachedResource.value());
         else
@@ -620,7 +640,7 @@ void DocumentThreadableLoader::loadRequest(ResourceRequest&& request, SecurityCh
     loadTiming.markStartTime();
 
     // FIXME: ThreadableLoaderOptions.sniffContent is not supported for synchronous requests.
-    RefPtr frame = m_document->frame();
+    RefPtr frame = document->frame();
     if (!frame)
         return;
 
@@ -694,7 +714,7 @@ void DocumentThreadableLoader::loadRequest(ResourceRequest&& request, SecurityCh
     if (options().initiatorContext == InitiatorContext::Worker)
         finishedTimingForWorkerLoad(resourceTiming);
     else {
-        if (RefPtr window = document().window())
+        if (RefPtr window = document->window())
             protect(window->performance())->addResourceTiming(WTF::move(resourceTiming));
     }
 
@@ -732,7 +752,7 @@ bool DocumentThreadableLoader::isAllowedRedirect(const URL& url)
 
 SecurityOrigin& DocumentThreadableLoader::securityOrigin() const
 {
-    return m_origin ? *m_origin : protect(m_document)->securityOrigin();
+    return m_origin ? *m_origin : protect(*m_document)->securityOrigin();
 }
 
 Ref<SecurityOrigin> DocumentThreadableLoader::topOrigin() const
@@ -744,14 +764,15 @@ const ContentSecurityPolicy& DocumentThreadableLoader::contentSecurityPolicy() c
 {
     if (m_contentSecurityPolicy)
         return *m_contentSecurityPolicy.get();
-    ASSERT(m_document->contentSecurityPolicy());
-    return *m_document->contentSecurityPolicy();
+
+    return *(protect(*m_document)->contentSecurityPolicy());
 }
 
 const CrossOriginEmbedderPolicy& DocumentThreadableLoader::crossOriginEmbedderPolicy() const
 {
     if (m_crossOriginEmbedderPolicy)
         return *m_crossOriginEmbedderPolicy;
+
     return m_document->crossOriginEmbedderPolicy();
 }
 
@@ -777,15 +798,17 @@ void DocumentThreadableLoader::reportIntegrityMetadataError(const CachedResource
 
 void DocumentThreadableLoader::logErrorAndFail(const ResourceError& error)
 {
+    RefPtr document = m_document;
+    if (!document)
+        return;
     if (m_shouldLogError == ShouldLogError::Yes) {
-        Ref document = *m_document;
         if (error.isAccessControl() && error.domain() != InspectorNetworkAgent::errorDomain() && !error.localizedDescription().isEmpty())
             document->addConsoleMessage(MessageSource::Security, MessageLevel::Error, error.localizedDescription());
-        logError(document, error, m_options.initiatorType);
+        logError(*document, error, m_options.initiatorType);
     }
     ASSERT(m_client);
     if (RefPtr client = m_client.get())
-        client->didFail(m_document->identifier(), error); // May cause the client to get destroyed.
+        client->didFail(document->identifier(), error); // May cause the client to get destroyed.
 }
 
 } // namespace WebCore

--- a/Source/WebCore/loader/DocumentThreadableLoader.h
+++ b/Source/WebCore/loader/DocumentThreadableLoader.h
@@ -112,7 +112,7 @@ class CachedRawResource;
         const ContentSecurityPolicy& contentSecurityPolicy() const;
         const CrossOriginEmbedderPolicy& NODELETE crossOriginEmbedderPolicy() const;
 
-        Document& document() { return *m_document; }
+        Document* document() { return m_document; }
 
         const ThreadableLoaderOptions& options() const LIFETIME_BOUND { return m_options; }
         const String& referrer() const LIFETIME_BOUND { return m_referrer; }


### PR DESCRIPTION
#### 83847541408d0aa216e3537317bef1bbcb9444bc
<pre>
[WebCore] Check for liveliness before dereferencing m_document WeakPtr in DocumentThreadableLoader
<a href="https://bugs.webkit.org/show_bug.cgi?id=301373">https://bugs.webkit.org/show_bug.cgi?id=301373</a>
<a href="https://rdar.apple.com/161561780">rdar://161561780</a>

Reviewed by Ryosuke Niwa.

This patch adds liveliness checks for dereferencing a WeakPtr
in WebCore::DocumentThreadableLoader.
Previously the `m_document` `WeakPtr` was dereferenced by calling
the `document()` or `protectedDocument()` member functions.

Since it&apos;s possible for the `WeakPtr` `m_document` to be null, we
should add checks before dereferencing it to avoid hitting
a RELEASE_ASSERT in `WeakPtr`&apos;s * operator. To ensure that
m_document is kept alive after performing the null check,
we convert it to a `RefPtr`.

* Source/WebCore/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations:
* Source/WebCore/loader/CrossOriginPreflightChecker.cpp:
(WebCore::CrossOriginPreflightChecker::validatePreflightResponse):
(WebCore::CrossOriginPreflightChecker::notifyFinished):
(WebCore::CrossOriginPreflightChecker::startPreflight):
(WebCore::CrossOriginPreflightChecker::doPreflight):
* Source/WebCore/loader/DocumentThreadableLoader.cpp:
(WebCore::DocumentThreadableLoader::shouldSetHTTPHeadersToKeep const):
(WebCore::DocumentThreadableLoader::makeCrossOriginAccessRequest):
(WebCore::DocumentThreadableLoader::cancel):
(WebCore::DocumentThreadableLoader::didReceiveResponse):
(WebCore::DocumentThreadableLoader::didFail):
(WebCore::DocumentThreadableLoader::preflightFailure):
(WebCore::DocumentThreadableLoader::loadRequest):
(WebCore::DocumentThreadableLoader::securityOrigin const):
(WebCore::DocumentThreadableLoader::contentSecurityPolicy const):
(WebCore::DocumentThreadableLoader::crossOriginEmbedderPolicy const):
(WebCore::DocumentThreadableLoader::logErrorAndFail):

Originally-landed-as: 301765.317@safari-7623-branch (f6b5d41d0e82). <a href="https://rdar.apple.com/168335001">rdar://168335001</a>
Canonical link: <a href="https://commits.webkit.org/312606@main">https://commits.webkit.org/312606@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/30aeec580c377449dd1ebc63912d1f091ccdbba6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/160465 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/33938 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/27039 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/169368 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/115531 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/1117d78b-e414-448f-b5e2-399dc38ac469) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/162334 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/34039 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/33938 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/124418 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/87879 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/7971bbb8-df3d-42ce-8510-9712f59c0b07) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/163423 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/26662 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/144140 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/105017 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/52e405f4-228f-411c-bd22-25e98fa6ce41) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/25714 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/24217 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/17087 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/135408 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/21903 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/171846 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/18265 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/23543 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/132678 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/33612 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/28311 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/132698 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35873 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/33596 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/143698 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/95378 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/27302 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/20512 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/33106 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/99928 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/32606 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/32850 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/32754 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->