### PR TITLE
[JSC] Inline small sorting in DFG / FTL

### DIFF
--- a/JSTests/stress/array-sort-inline-boolean-comparator.js
+++ b/JSTests/stress/array-sort-inline-boolean-comparator.js
@@ -1,0 +1,148 @@
+// The DFG ArraySortIntrinsic's inline insertion sort must interpret the comparator
+// result the same way runtime/StableSort.h's coerceComparatorResultToBoolean does:
+//
+//   - Int32: shift iff `< 0`.
+//   - Boolean: shift iff `!result` (true->no shift, false->shift) -- webkit.org/b/47825.
+//   - Other: shift iff `toNumber(result) < 0` (NaN coerces to 0 in V8 but in JSC's
+//     path `NaN < 0` is false, matching StableSort.h's `toNumber() < 0` for NaN).
+//
+// Before the fix the intrinsic did only `cmp < 0`, which gave false for boolean
+// `false` (since 0 < 0 is false), so a `() => false` comparator was a no-op and
+// the legacy `(a, b) => a > b` pattern never sorted. The fix routes `cmp === false`
+// through an extra branch that also goes to the shift target.
+
+function check(got, expected) {
+    if (got.length !== expected.length)
+        throw new Error("length mismatch: " + JSON.stringify(got) + " vs " + JSON.stringify(expected));
+    for (let i = 0; i < expected.length; ++i) {
+        if (!Object.is(got[i], expected[i]))
+            throw new Error("index " + i + " mismatch: " + JSON.stringify(got) + " vs " + JSON.stringify(expected));
+    }
+}
+
+function sortIt(a, c) { return a.sort(c); }
+
+// Warm up with a well-typed Int32 comparator so DFG inlines the intrinsic on the
+// hot doSort path.
+for (let i = 0; i < testLoopCount; ++i)
+    sortIt([5, 3, 1, 4, 2], (a, b) => a - b);
+
+// Expected results are computed via the generic baseline sort on a fresh array
+// (no DFG intrinsic cached state). Matches runtime/StableSort.h exactly.
+function expected(input, cmp) { return [...input].sort(cmp); }
+
+// --- Case A: Int32 comparator (primary fast path). ----------------------------
+for (let i = 0; i < testLoopCount; ++i) {
+    const input = [5, 3, 1, 4, 2];
+    check(sortIt(input.slice(), (a, b) => a - b), [1, 2, 3, 4, 5]);
+    check(sortIt(input.slice(), (a, b) => b - a), [5, 4, 3, 2, 1]);
+}
+
+// Int32 boundary: zero / MIN_VALUE / MAX_VALUE / negative / positive.
+for (let i = 0; i < testLoopCount; ++i) {
+    const input = [5, 3, 1, 4, 2];
+    const cmp = (a, b) => {
+        const d = a - b;
+        if (d === 0) return 0;
+        return d < 0 ? -2147483648 : 2147483647;  // extreme Int32s
+    };
+    check(sortIt(input.slice(), cmp), expected(input, cmp));
+}
+
+// --- Case B: Boolean comparator (legacy b/47825 path). -----------------------
+// Constant-false: every comparison is "shift", insertion sort pushes each pivot
+// to the front.
+for (let i = 0; i < testLoopCount; ++i) {
+    const input = [5, 3, 1, 4, 2];
+    check(sortIt(input.slice(), () => false), expected(input, () => false));
+}
+
+// Constant-true: every comparison is "no shift", array stays as-is.
+for (let i = 0; i < testLoopCount; ++i) {
+    const input = [5, 3, 1, 4, 2];
+    check(sortIt(input.slice(), () => true), expected(input, () => true));
+}
+
+// The real-world legacy pattern: comparator returns a boolean. Both these must
+// end up ascending / descending respectively, matching baseline.
+for (let i = 0; i < testLoopCount; ++i) {
+    const input = [5, 3, 1, 4, 2];
+    check(sortIt(input.slice(), (a, b) => a > b), [1, 2, 3, 4, 5]);
+    check(sortIt(input.slice(), (a, b) => a < b), [5, 4, 3, 2, 1]);
+}
+
+// Mixed boolean / int return in a single comparator -- exercises both the
+// CompareLess branch (shift when < 0) and the CompareStrictEq branch (shift when
+// boolean false) in the same sort.
+for (let i = 0; i < testLoopCount; ++i) {
+    const input = [7, 2, 5, 3, 8, 1, 6, 4, 0, 9];
+    const cmp = (a, b) => {
+        if ((a ^ b) & 1) return a > b;  // boolean
+        return a - b;                   // int32
+    };
+    check(sortIt(input.slice(), cmp), expected(input, cmp));
+}
+
+// --- Case C: Double comparator. --------------------------------------------
+for (let i = 0; i < testLoopCount; ++i) {
+    const input = [5, 3, 1, 4, 2];
+    const cmp = (a, b) => (a - b) + 0.5 - 0.5;  // Double result.
+    check(sortIt(input.slice(), cmp), expected(input, cmp));
+}
+
+// Double edge cases: -0, +0, NaN, Infinity.
+for (let i = 0; i < testLoopCount; ++i) {
+    const input = [5, 3, 1, 4, 2];
+    const table = new Map([
+        ['lt', -Infinity],
+        ['gt', Infinity],
+        ['eq', 0],
+        ['negZero', -0],  // -0 < 0 is false per IEEE 754
+        ['nan', NaN],     // NaN < 0 is false
+    ]);
+    for (const [, v] of table) {
+        const cmp = (a, b) => a === b ? 0 : (a < b ? v : -v);
+        check(sortIt(input.slice(), cmp), expected(input, cmp));
+    }
+}
+
+// --- Case D: String comparator. Falls back to toNumber() < 0 path. -----------
+for (let i = 0; i < testLoopCount; ++i) {
+    const input = [5, 3, 1, 4, 2];
+    const cmp = (a, b) => a === b ? "0" : (a < b ? "-1" : "1");
+    check(sortIt(input.slice(), cmp), expected(input, cmp));
+}
+
+// String coerces to NaN → NaN < 0 → false → no shift.
+for (let i = 0; i < testLoopCount; ++i) {
+    const input = [5, 3, 1, 4, 2];
+    check(sortIt(input.slice(), () => "abc"), expected(input, () => "abc"));
+}
+
+// --- Case E: null / undefined. ------------------------------------------------
+// toNumber(null) = 0 → 0 < 0 = false → no shift.
+for (let i = 0; i < testLoopCount; ++i) {
+    const input = [5, 3, 1, 4, 2];
+    check(sortIt(input.slice(), () => null), expected(input, () => null));
+    check(sortIt(input.slice(), () => undefined), expected(input, () => undefined));
+}
+
+// --- Case F: Object with valueOf. toPrimitive then toNumber. ------------------
+for (let i = 0; i < testLoopCount; ++i) {
+    const input = [5, 3, 1, 4, 2];
+    const neg = { valueOf() { return -1; } };
+    const pos = { valueOf() { return 1; } };
+    const zero = { valueOf() { return 0; } };
+    // Return objects -- each sort iteration triggers valueOf.
+    check(sortIt(input.slice(), (a, b) => a < b ? neg : a > b ? pos : zero), [1, 2, 3, 4, 5]);
+    check(sortIt(input.slice(), () => neg), expected(input, () => neg));
+}
+
+// --- Case G: BigInt comparator. toNumber throws TypeError. -------------------
+// Both baseline and intrinsic must throw.
+for (let i = 0; i < testLoopCount; ++i) {
+    let threw = false;
+    try { sortIt([5, 3, 1], () => -1n); }
+    catch (e) { threw = e instanceof TypeError; }
+    if (!threw) throw new Error("BigInt comparator must throw TypeError");
+}

--- a/JSTests/stress/array-sort-inline-closure-comparator.js
+++ b/JSTests/stress/array-sort-inline-closure-comparator.js
@@ -1,0 +1,38 @@
+// Verifies the DFG ArraySortIntrinsic's comparator body-inlining path for a
+// NewArrowFunction / NewFunction closure comparator allocated fresh on every
+// sort call. This is the `.sort((a,b) => a - b)` idiom that every real-world
+// sort caller uses; it's the path the parser-level inliner must detect via
+// Node::isFunctionAllocation().
+
+function test(arr) {
+    arr.sort((a, b) => a - b);
+}
+
+const original = [5, 3, 8, 1, 9, 4, 7, 2, 6, 0, 11, 14, 13, 10, 12, 15];
+const expected = original.slice().sort((a, b) => a - b);
+
+for (let i = 0; i < testLoopCount; i++) {
+    const copy = original.slice();
+    test(copy);
+    for (let j = 0; j < expected.length; j++) {
+        if (copy[j] !== expected[j])
+            throw new Error("iter " + i + " index " + j
+                + ": got " + copy[j] + " expected " + expected[j]);
+    }
+}
+
+// Descending comparator -- separate closure shape, also re-allocated per call.
+function descendingTest(arr) {
+    arr.sort((a, b) => b - a);
+}
+
+const expectedDesc = original.slice().sort((a, b) => b - a);
+for (let i = 0; i < testLoopCount; i++) {
+    const copy = original.slice();
+    descendingTest(copy);
+    for (let j = 0; j < expectedDesc.length; j++) {
+        if (copy[j] !== expectedDesc[j])
+            throw new Error("desc iter " + i + " index " + j
+                + ": got " + copy[j] + " expected " + expectedDesc[j]);
+    }
+}

--- a/JSTests/stress/array-sort-inline-comparator-speculation-exit.js
+++ b/JSTests/stress/array-sort-inline-comparator-speculation-exit.js
@@ -1,0 +1,89 @@
+// Verifies that a naturally-occurring OSR exit inside the DFG-inlined comparator
+// (via Int32 speculation failure on ValueSub) recovers correctly and the sort
+// call completes with the right result. The existing
+// array-sort-inline-osr-exit-in-comparator.js uses `$vm.OSRExit()` to force an
+// exit synthetically; this test exercises the same code path that a real-world
+// caller would hit: warm up with Int32 inputs so DFG speculates Int32, then
+// feed doubles and watch the speculation fail mid-sort.
+//
+// The exit lands inside the comparator's inlined body. Per
+// InlineCallFrame::Kind::ArraySortComparatorCall, the comparator's baseline
+// resumes, completes, and returns via arraySortComparatorReturnTrampoline --
+// which discards the return value and re-dispatches the caller's op_call.
+// Baseline then calls sort generically with the correctly-preserved arguments.
+// The observable result must still be a correctly sorted array.
+
+function cmp(a, b) { return a - b; }
+
+function sortIt(a, c) { return a.sort(c); }
+
+function assertSorted(a, reference, label) {
+    if (a.length !== reference.length)
+        throw new Error(label + ": length " + a.length + " vs " + reference.length);
+    for (let i = 0; i < reference.length; ++i) {
+        if (a[i] !== reference[i])
+            throw new Error(label + ": @" + i + " got " + a[i] + " want " + reference[i]);
+    }
+}
+
+// --- Phase 1: warm up with Int32 arrays so DFG inlines sort + inlines the
+// comparator. DFG/FTL will profile `cmp`'s ValueSub as Int32Use.
+const int32Seed = [5, 3, 1, 4, 2, 8, 7, 6, 0, 9, 11, 14, 13, 10, 12, 15];
+const int32Expected = int32Seed.slice().sort(cmp);
+for (let w = 0; w < testLoopCount; ++w)
+    assertSorted(sortIt(int32Seed.slice(), cmp), int32Expected, "warmup int32 " + w);
+
+// --- Phase 2: now feed doubles. The comparator's Int32-speculated ValueSub
+// sees double operands and OSR-exits inside the comparator body. Baseline
+// finishes the comparator and jumps through the trampoline back to op_call,
+// which re-runs sort generically. Each iteration must still produce a
+// correctly sorted array.
+const doubleSeed = [5.5, 3.25, 1.75, 4.5, 2.125, 8.8, 7.1, 6.6, 0.5, 9.9, 11.1, 14.4, 13.3, 10.0, 12.2, 15.5];
+const doubleExpected = doubleSeed.slice().sort(cmp);
+for (let w = 0; w < testLoopCount; ++w)
+    assertSorted(sortIt(doubleSeed.slice(), cmp), doubleExpected, "double " + w);
+
+// --- Phase 3: alternate back to Int32. The call site has tiered back up by
+// now; must still sort correctly.
+for (let w = 0; w < testLoopCount; ++w)
+    assertSorted(sortIt(int32Seed.slice(), cmp), int32Expected, "back-to-int " + w);
+
+// --- Phase 4: mix Int32 and Double in the same array. Each iteration may
+// exit mid-sort as the comparator hits a double.
+const mixedSeed = [5, 3.25, 1, 4.5, 2, 8, 7.1, 0, 6.6, 9];
+const mixedExpected = mixedSeed.slice().sort(cmp);
+for (let w = 0; w < testLoopCount; ++w)
+    assertSorted(sortIt(mixedSeed.slice(), cmp), mixedExpected, "mixed " + w);
+
+// --- Phase 5: arrays of varying size around the 16-element boundary, each
+// with doubles, so the exit fires on both the insertion-sort fast path and
+// (for len > 16) the generic slow path. The array length 1 case is boring
+// (no comparator call) so start at 2.
+for (let len = 2; len <= 20; ++len) {
+    const seed = [];
+    for (let i = 0; i < len; ++i) seed.push((len - i) + 0.5);
+    const expected = seed.slice().sort(cmp);
+    for (let w = 0; w < 100; ++w)
+        assertSorted(sortIt(seed.slice(), cmp), expected, "len " + len + " w " + w);
+}
+
+// --- Phase 6: comparator that throws inside the inlined body. If OSR exit
+// handling is wrong, the exception might propagate from the wrong frame or
+// the sort call may appear to return a value (and spread would then crash,
+// which is the WebGPU bug we started from). Here we just assert the thrown
+// error is observed intact at the caller.
+let shouldThrow = false;
+function throwingCmp(a, b) {
+    if (shouldThrow)
+        throw new Error("boom");
+    return a - b;
+}
+// Warm up so the comparator is inlined.
+for (let w = 0; w < testLoopCount; ++w) sortIt([3, 1, 2], throwingCmp);
+
+shouldThrow = true;
+let threw = false;
+try { sortIt([5, 3, 1, 4, 2], throwingCmp); }
+catch (e) { threw = e.message === "boom"; }
+if (!threw)
+    throw new Error("throwing comparator did not propagate through the sort");

--- a/JSTests/stress/array-sort-inline-constant-comparator.js
+++ b/JSTests/stress/array-sort-inline-constant-comparator.js
@@ -1,0 +1,26 @@
+// Verifies the DFG ArraySortIntrinsic's comparator body-inlining path when
+// the comparator is a constant JSFunction (named global / hoisted) rather
+// than a closure. The parser detects this via Node::hasConstant() +
+// dynamicCastConstant<JSFunction*>() and routes through handleCall with
+// CallLinkStatus(CallVariant(function)).
+
+function cmp(a, b) {
+    return a - b;
+}
+
+function test(arr) {
+    arr.sort(cmp);
+}
+
+const original = [5, 3, 8, 1, 9, 4, 7, 2, 6, 0, 11, 14, 13, 10, 12, 15];
+const expected = original.slice().sort(cmp);
+
+for (let i = 0; i < testLoopCount; i++) {
+    const copy = original.slice();
+    test(copy);
+    for (let j = 0; j < expected.length; j++) {
+        if (copy[j] !== expected[j])
+            throw new Error("iter " + i + " index " + j
+                + ": got " + copy[j] + " expected " + expected[j]);
+    }
+}

--- a/JSTests/stress/array-sort-inline-contiguous.js
+++ b/JSTests/stress/array-sort-inline-contiguous.js
@@ -1,0 +1,43 @@
+// Verifies the DFG ArraySortIntrinsic's fast path handles ArrayWithContiguous arrays -- arrays
+// whose elements include non-Int32 values (doubles, strings, objects).
+
+function sortIt(a, cmp) { return a.sort(cmp); }
+
+// Contiguous (mixed-type) arrays: objects.
+{
+    const input = [{v:5},{v:3},{v:1},{v:4},{v:2}];
+    const expected = [1,2,3,4,5];
+    for (let w = 0; w < testLoopCount; w++) {
+        const a = input.slice();
+        const r = sortIt(a, (x, y) => x.v - y.v);
+        for (let i = 0; i < 5; i++)
+            if (r[i].v !== expected[i])
+                throw new Error("iter " + w + " index " + i + ": got " + r[i].v + " expected " + expected[i]);
+    }
+}
+
+// Contiguous (strings).
+{
+    const input = ["dd", "bb", "aa", "cc"];
+    const expected = ["aa", "bb", "cc", "dd"];
+    for (let w = 0; w < testLoopCount; w++) {
+        const a = input.slice();
+        const r = sortIt(a, (x, y) => x < y ? -1 : x > y ? 1 : 0);
+        for (let i = 0; i < 4; i++)
+            if (r[i] !== expected[i])
+                throw new Error("iter " + w + " index " + i + ": got " + r[i] + " expected " + expected[i]);
+    }
+}
+
+// Contiguous (doubles stored via contiguous indexing since allocated from literal with ints then a double).
+{
+    const input = [3.5, 1.2, 2.8, 0.4];
+    const expected = [0.4, 1.2, 2.8, 3.5];
+    for (let w = 0; w < testLoopCount; w++) {
+        const a = input.slice();
+        const r = sortIt(a, (x, y) => x - y);
+        for (let i = 0; i < 4; i++)
+            if (r[i] !== expected[i])
+                throw new Error("iter " + w + " index " + i + ": got " + r[i] + " expected " + expected[i]);
+    }
+}

--- a/JSTests/stress/array-sort-inline-full.js
+++ b/JSTests/stress/array-sort-inline-full.js
@@ -1,0 +1,62 @@
+// Full insertion sort inlining: lengths 0..16, fresh closure comparator.
+
+function sortAsc(a, cmp) { return a.sort(cmp); }
+
+// Exercise lengths 0..16 with a fresh arrow comparator on each call.
+function runSize(n) {
+    let a = [];
+    for (let i = n - 1; i >= 0; i--) a.push(i);
+    let r = sortAsc(a, (x, y) => x - y);
+    if (r.length !== n) throw new Error("len " + n + " wrong length");
+    for (let i = 0; i < n; i++) {
+        if (r[i] !== i)
+            throw new Error("len " + n + " wrong at " + i + ": " + r[i]);
+    }
+}
+
+// Warm up the DFG compile of sortAsc with a mix of sizes, then exercise the
+// compiled path for a while.
+for (let w = 0; w < testLoopCount; w++)
+    for (let n = 0; n <= 16; n++)
+        runSize(n);
+
+// length > 16 must fall back to the generic sort via the slow-path call.
+function bigTest() {
+    let a = [];
+    for (let i = 49; i >= 0; i--) a.push(i);
+    let r = sortAsc(a, (x, y) => x - y);
+    for (let i = 0; i < 50; i++)
+        if (r[i] !== i) throw new Error("big wrong at " + i);
+}
+for (let i = 0; i < testLoopCount; i++) bigTest();
+
+// Stability check via a pair-of-keys sort.
+function stableTest() {
+    let items = [];
+    for (let i = 0; i < 12; i++)
+        items.push({ k: i % 3, seq: i });
+    let r = sortAsc(items, (x, y) => x.k - y.k);
+    // Within each key group, seq must be preserved in original order.
+    for (let i = 1; i < r.length; i++) {
+        if (r[i].k < r[i - 1].k)
+            throw new Error("unstable: out of key order at " + i);
+        if (r[i].k === r[i - 1].k && r[i].seq < r[i - 1].seq)
+            throw new Error("unstable: seq reversed at " + i);
+    }
+}
+for (let i = 0; i < testLoopCount; i++) stableTest();
+
+// Undefined comparator should still behave correctly. This falls out of the fast path
+// because we speculate CellUse on the comparator.
+let r0 = [3, 1, 2].sort();
+if (r0[0] !== 1 || r0[1] !== 2 || r0[2] !== 3)
+    throw new Error("default sort wrong: " + r0);
+
+// Non-callable comparator must throw TypeError -- matches spec.
+let threw = false;
+try {
+    sortAsc([1, 2, 3], {});
+} catch (e) {
+    threw = e instanceof TypeError;
+}
+if (!threw) throw new Error("non-callable comparator did not throw TypeError");

--- a/JSTests/stress/array-sort-inline-holey.js
+++ b/JSTests/stress/array-sort-inline-holey.js
@@ -1,0 +1,45 @@
+// Verifies the DFG ArraySortIntrinsic's hole handling: a holey Int32 array must sort correctly.
+// ArraySortCompact returns vm.m_sortScratchSentinel on a hole; the parser's pointer-compare
+// against the sentinel routes hits to the slow path's DirectCall to arrayProtoFuncSort (which
+// handles holes per spec).
+
+function cmp(a, b) { return a - b; }
+function sortIt(a) { return a.sort(cmp); }
+
+// Warm up the DFG/FTL compile of sortIt with dense Int32 arrays.
+for (let w = 0; w < testLoopCount; w++) {
+    const a = [5, 3, 1, 4, 2];
+    const r = sortIt(a);
+    if (r[0] !== 1 || r[4] !== 5)
+        throw new Error("dense warm-up wrong: " + JSON.stringify(r));
+}
+
+// Now feed in a holey Int32 array. Fast path pointer-compares the sentinel and dispatches to
+// the slow-path DirectCall, which sorts correctly.
+function runHoley(iter) {
+    const a = [5, , 3, , 1, , 4, , 2];
+    const r = sortIt(a);
+    // After sort with default comparator, non-hole elements are moved to the front (ascending),
+    // and holes are pushed to the end. Test's custom cmp treats undefined -> NaN -> stable at end.
+    // For our (a,b)=>a-b comparator, NaN comparisons return NaN so sort preserves some order.
+    // Assert the non-hole multiset is preserved: {1,2,3,4,5} plus 4 holes.
+    let nonHoleCount = 0;
+    let multiset = new Map();
+    for (let i = 0; i < r.length; i++) {
+        const v = r[i];
+        if (i in r) {
+            nonHoleCount++;
+            multiset.set(v, (multiset.get(v) || 0) + 1);
+        }
+    }
+    if (r.length !== 9)
+        throw new Error("iter " + iter + " wrong length " + r.length);
+    // Expected: 5 non-hole values (1..5) + 4 holes.
+    for (let v = 1; v <= 5; v++) {
+        if (multiset.get(v) !== 1)
+            throw new Error("iter " + iter + " missing " + v + " (multiset = " + JSON.stringify([...multiset]) + ")");
+    }
+}
+
+for (let i = 0; i < testLoopCount; i++)
+    runHoley(i);

--- a/JSTests/stress/array-sort-inline-large.js
+++ b/JSTests/stress/array-sort-inline-large.js
@@ -1,0 +1,104 @@
+// The DFG ArraySortIntrinsic dispatcher uses `sortScratchSlotCount + 1` (17) as
+// the boundary between the inline insertion-sort fast path and the DirectCall
+// slow path. Arrays strictly greater than 16 must be routed to the slow path
+// (arrayProtoFuncSort) via the dispatcher's `isSmall` branch.
+//
+// If the fast path accidentally accepted length > 16, the 16-slot scratch
+// would overflow silently (ArraySortCompact would only copy 16 of N elements).
+// If the slow path were mis-wired the DirectCall would sort with the wrong
+// `this` or `argv` and either throw or produce a wrong result.
+//
+// This test covers sizes right at the boundary (17) and well above (64, 128).
+
+function cmp(a, b) { return a - b; }
+function cmpDesc(a, b) { return b - a; }
+
+function doSort(a, c) { return a.sort(c); }
+
+function makeReversed(n) {
+    const a = new Array(n);
+    for (let i = 0; i < n; ++i) a[i] = n - 1 - i;
+    return a;
+}
+
+function makeRandomish(n) {
+    const a = new Array(n);
+    for (let i = 0; i < n; ++i) a[i] = ((i * 31 + 7) % n) - (n >> 1);
+    return a;
+}
+
+function assertSorted(a, cmp) {
+    for (let i = 0; i + 1 < a.length; ++i) {
+        if (cmp(a[i], a[i + 1]) > 0)
+            throw new Error("not sorted at index " + i + ": " + a[i] + " vs " + a[i + 1]);
+    }
+}
+
+// Just above the 16 boundary: exercises the `isSmall` dispatcher's
+// not-taken edge to slowBlock.
+for (let w = 0; w < testLoopCount; ++w) {
+    const arr = makeReversed(17);
+    doSort(arr, cmp);
+    assertSorted(arr, cmp);
+    if (arr.length !== 17 || arr[0] !== 0 || arr[16] !== 16)
+        throw new Error("len 17 wrong: " + JSON.stringify(arr));
+}
+
+// Larger sizes -- well above the boundary.
+for (const size of [32, 64, 128, 256]) {
+    for (let w = 0; w < testLoopCount; ++w) {
+        const arr = makeReversed(size);
+        doSort(arr, cmp);
+        assertSorted(arr, cmp);
+        if (arr[0] !== 0 || arr[size - 1] !== size - 1)
+            throw new Error("len " + size + " wrong ends: " + arr[0] + ".." + arr[size - 1]);
+    }
+}
+
+// Mix sort directions to ensure the slow path calls the user comparator each
+// invocation (not a cached default-compare).
+for (let w = 0; w < testLoopCount; ++w) {
+    const arr = makeRandomish(32);
+    const a1 = arr.slice();
+    const a2 = arr.slice();
+    doSort(a1, cmp);
+    doSort(a2, cmpDesc);
+    assertSorted(a1, cmp);
+    assertSorted(a2, cmpDesc);
+    if (a1[0] !== a2[a2.length - 1] || a1[a1.length - 1] !== a2[0])
+        throw new Error("asc/desc mismatch @w=" + w);
+}
+
+// Alternating small/large at the same call site must not cause tier-down.
+// mixed-sizes.js already guards this, but re-covering here with a dedicated
+// large-side test catches any regression specific to the size > 16 path.
+function alternating(N) {
+    const small = [3, 1, 4, 1, 5, 9, 2, 6, 5, 3];
+    const large = makeReversed(64);
+    for (let i = 0; i < N; ++i) {
+        const arr = (i & 1) ? small.slice() : large.slice();
+        doSort(arr, cmp);
+        assertSorted(arr, cmp);
+    }
+}
+alternating(testLoopCount);
+
+// Sizes that are exactly on the boundary edge: 16 (fast path) and 17 (slow path)
+// interleaved. Ensures the dispatcher correctly routes both.
+const atEdge = 16;
+const overEdge = 17;
+for (let w = 0; w < testLoopCount; ++w) {
+    const at = makeReversed(atEdge);
+    const over = makeReversed(overEdge);
+    doSort(at, cmp);
+    doSort(over, cmp);
+    assertSorted(at, cmp);
+    assertSorted(over, cmp);
+}
+
+// Comparator that throws on a large-array sort must propagate the exception
+// from the slow-path DirectCall cleanly.
+let threw = false;
+try { doSort(makeReversed(32), (a, b) => { throw new Error("late"); }); }
+catch (e) { threw = e.message === "late"; }
+if (!threw) throw new Error("large sort lost thrown comparator error");

--- a/JSTests/stress/array-sort-inline-len2.js
+++ b/JSTests/stress/array-sort-inline-len2.js
@@ -1,0 +1,41 @@
+// Exercises the DFG ArraySortIntrinsic inline insertion sort fast path
+// (length <= 2) with an inlined comparator Call, and its fallback path.
+
+function cmpAsc(a, b) { return a - b; }
+
+function sortWith(a) { return a.sort(cmpAsc); }
+
+// Warm up with length-1 and length-2 Int32 arrays to profile Int32 indexing.
+for (let i = 0; i < testLoopCount; i++) {
+    let r1 = sortWith([42]);
+    if (r1.length !== 1 || r1[0] !== 42) throw new Error("len1 wrong");
+    let r2a = sortWith([1, 2]);
+    if (r2a[0] !== 1 || r2a[1] !== 2) throw new Error("len2 sorted wrong");
+    let r2b = sortWith([2, 1]);
+    if (r2b[0] !== 1 || r2b[1] !== 2) throw new Error("len2 unsorted wrong: " + r2b);
+}
+
+// Empty array: should take the fast path too.
+let r0 = sortWith([]);
+if (r0.length !== 0) throw new Error("len0 wrong");
+
+// Length > 2: must fall back to the generic C++ sort via the slow-path DirectCall.
+let rBig = sortWith([5, 3, 1, 4, 2]);
+for (let i = 0; i < 5; i++) if (rBig[i] !== i + 1) throw new Error("len5 wrong at " + i);
+
+// Larger reverse-sorted.
+let rev = [];
+for (let i = 99; i >= 0; i--) rev.push(i);
+let sorted = sortWith(rev);
+for (let i = 0; i < 100; i++) if (sorted[i] !== i) throw new Error("len100 wrong at " + i);
+
+// Comparator with side effects on a global: we still run the comparator the right number of
+// times. For length 2 with elements already in order, comparator runs once and returns <= 0.
+let count = 0;
+function countingCmp(a, b) { count++; return a - b; }
+[1, 2].sort(countingCmp);
+if (count !== 1) throw new Error("expected 1 comparator call for len 2, got " + count);
+
+count = 0;
+[2, 1].sort(countingCmp);
+if (count !== 1) throw new Error("expected 1 comparator call for len 2, got " + count);

--- a/JSTests/stress/array-sort-inline-mixed-sizes.js
+++ b/JSTests/stress/array-sort-inline-mixed-sizes.js
@@ -1,0 +1,107 @@
+// A single sort call site that alternates between small (length <= 16,
+// inlined insertion sort) and large (length > 16, inlined slow-path
+// DirectCall to arrayProtoFuncSort) arrays must compile once and stay
+// compiled. The dispatcher inside the intrinsic branches on runtime length
+// so neither size should trigger an OSR exit at the dispatcher.
+//
+// If the dispatcher were broken (e.g. the slow path triggered BadIndexingType
+// / BadType / OutOfBounds when seeing an unexpected size), this loop would
+// repeatedly tier-down to baseline and recompile. We assert via $vm.ftlTrue()
+// that the call site stays in FTL once it gets there.
+//
+// Hot loop runs inside `harness` rather than at <global> scope so:
+//   (a) ftlTrue() reflects harness's tier directly, and
+//   (b) heavyweight error-path code (correctness check) is moved out of the
+//       inner loop, where it would otherwise pollute the tier with its own
+//       OSR exits.
+// Arrays are constructed via `new Array(N)` + indexed assignment so every
+// iteration's argument has identical structure (no `.slice()` profiling
+// noise that could trigger a CheckStructure churn at the intrinsic's entry).
+
+function cmp(a, b) { return a - b; }
+noInline(cmp);
+
+const SMALL_LEN = 16;
+const LARGE_LEN = 32;
+
+const SMALL_SEED = [5, 3, 8, 1, 7, 2, 4, 6, 0, 9, 12, 14, 11, 13, 10, 15];
+
+function makeSmall() {
+    const a = new Array(SMALL_LEN);
+    for (let i = 0; i < SMALL_LEN; i++) a[i] = SMALL_SEED[i];
+    return a;
+}
+
+function makeLarge() {
+    const a = new Array(LARGE_LEN);
+    for (let i = 0; i < LARGE_LEN; i++) a[i] = LARGE_LEN - 1 - i;
+    return a;
+}
+
+// Returns [inFTLCount, accumulator]. The accumulator sums each sorted array's
+// first element. For both sizes that's 0, so the final accumulator must be
+// exactly 0 (a cheap correctness sanity check that doesn't perturb the tier).
+function harness(N) {
+    let inFTL = 0;
+    let acc = 0;
+    for (let i = 0; i < N; i++) {
+        let a;
+        if (i & 1) {
+            a = new Array(SMALL_LEN);
+            for (let j = 0; j < SMALL_LEN; j++) a[j] = SMALL_SEED[j];
+        } else {
+            a = new Array(LARGE_LEN);
+            for (let j = 0; j < LARGE_LEN; j++) a[j] = LARGE_LEN - 1 - j;
+        }
+        a.sort(cmp);
+        if ($vm.ftlTrue()) inFTL++;
+        acc += a[0];
+    }
+    return [inFTL, acc];
+}
+
+// Warm up: alternate sizes from the start so the DFG/FTL profile sees both
+// shapes during compilation. A broken dispatcher would already have
+// re-OSR'd into baseline several times by the end of warm-up.
+harness(testLoopCount * 10);
+
+// Steady state: by now harness is FTL-compiled (sort intrinsic + dispatcher
+// fully inlined). Run a long stretch of mixed sizes and assert ftlTrue() is
+// observed for every iteration, i.e. we are not bouncing between baseline
+// and FTL.
+const [inFTLCount, acc] = harness(testLoopCount);
+
+if (acc !== 0)
+    throw new Error("sort produced wrong leading element across iterations: acc=" + acc);
+
+// In the steady state the harness must spend essentially all its time in
+// FTL. Anything below 95% indicates repeated tier-down, the bug we are
+// guarding against. Skip when FTL is not enabled: `ftlTrue()` is always false
+// under --useFTLJIT=false / no-ftl / dfg-eager / mini-mode / lockdown etc.
+if ($vm.useFTLJIT() && inFTLCount * 100 < testLoopCount * 95) {
+    throw new Error("ArraySortIntrinsic appears to be tiering down repeatedly: "
+        + "in FTL only " + inFTLCount + " / " + testLoopCount
+        + " steady-state calls (expected >=95%)");
+}
+
+// Also do a one-shot full correctness check, independent of the hot loop,
+// to make sure both small and large really do sort correctly.
+function check(actual, expected) {
+    if (actual.length !== expected.length)
+        throw new Error("length mismatch " + actual.length + " vs " + expected.length);
+    for (let i = 0; i < expected.length; i++)
+        if (actual[i] !== expected[i])
+            throw new Error("at " + i + " got " + actual[i] + " expected " + expected[i]);
+}
+
+const small = makeSmall();
+small.sort(cmp);
+check(small, [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]);
+
+const large = makeLarge();
+large.sort(cmp);
+{
+    const expected = new Array(LARGE_LEN);
+    for (let i = 0; i < LARGE_LEN; i++) expected[i] = i;
+    check(large, expected);
+}

--- a/JSTests/stress/array-sort-inline-noncallable-typeerror.js
+++ b/JSTests/stress/array-sort-inline-noncallable-typeerror.js
@@ -1,0 +1,61 @@
+// Per ECMAScript, Array.prototype.sort(comparator) must throw TypeError when the
+// comparator is not undefined and not callable, even when the array is empty or
+// length 1 so the comparator is never actually invoked. Before the fix, the DFG
+// ArraySortIntrinsic speculated CellUse on the comparator and then, for an empty
+// array, returned the receiver without a callability check. For length 1, the
+// insertion sort header branched to Commit without a comparator call either.
+
+function expectThrow(body, iter) {
+    try { body(); }
+    catch (e) {
+        if (!(e instanceof TypeError))
+            throw new Error("iter " + iter + ": expected TypeError, got " + e);
+        return;
+    }
+    throw new Error("iter " + iter + ": expected TypeError, got nothing");
+}
+
+// Use a factory to get a non-COW empty / single-element array -- DFG's intrinsic
+// skips COW arrays, which is why [] directly doesn't reproduce the bug.
+function makeEmpty() { const a = [1]; a.pop(); return a; }
+function makeSingle() { return [42]; }
+
+function sortIt(a, c) { return a.sort(c); }
+
+// Warm up with valid callable + empty so DFG inlines the intrinsic on ArrayWithInt32.
+for (let i = 0; i < testLoopCount; ++i)
+    sortIt(makeEmpty(), (a, b) => a - b);
+
+// Non-callable cell on empty array -- used to silently succeed, must throw now.
+for (let i = 0; i < testLoopCount; ++i)
+    expectThrow(() => sortIt(makeEmpty(), {}), i);
+
+// Length-1 array falls into the intrinsic's fast path but never calls the
+// comparator from the insertion loop.
+for (let i = 0; i < testLoopCount; ++i)
+    expectThrow(() => sortIt(makeSingle(), {}), i);
+
+// Symbols and other non-cell non-undefined values must also throw. These fall
+// out of CellUse via OSR exit and the baseline handles them; re-asserting here
+// catches any regression that would promote the intrinsic to accept them.
+for (let i = 0; i < testLoopCount; ++i)
+    expectThrow(() => sortIt(makeSingle(), Symbol.iterator), i);
+for (let i = 0; i < testLoopCount; ++i)
+    expectThrow(() => sortIt(makeEmpty(), null), i);
+for (let i = 0; i < testLoopCount; ++i)
+    expectThrow(() => sortIt(makeEmpty(), 42), i);
+
+// Callable non-JSFunction cells (bound functions, native functions) remain valid
+// and must not throw.
+const bound = ((a, b) => a - b).bind(null);
+for (let i = 0; i < testLoopCount; ++i) {
+    if (sortIt([3, 1, 2], bound)[0] !== 1)
+        throw new Error("iter " + i + ": bound comparator produced wrong order");
+}
+
+// undefined comparator uses the default compare and must not throw.
+for (let i = 0; i < testLoopCount; ++i) {
+    const r = sortIt([3, 1, 2], undefined);
+    if (r[0] !== 1 || r[2] !== 3)
+        throw new Error("iter " + i + ": undefined comparator wrong order: " + r);
+}

--- a/JSTests/stress/array-sort-inline-osr-exit-in-comparator-with-spread.js
+++ b/JSTests/stress/array-sort-inline-osr-exit-in-comparator-with-spread.js
@@ -1,0 +1,34 @@
+// Regression test: OSR exit inside a DFG-inlined Array.prototype.sort comparator
+// must not clobber op_call's dst with the comparator's return value. Before the
+// fix, exiting inside `(a, b) => a - b` and resuming in the comparator's baseline
+// would make its return value flow into op_call's dst and advance past op_call,
+// so `[...arr.sort(cmp)]` ended up spreading a number instead of the sorted array.
+
+function cmp(a, b) { return a - b; }
+
+function sortAndSpread(arr) {
+    return [...arr.sort(cmp)];
+}
+
+function check(got, expected) {
+    if (got.length !== expected.length)
+        throw new Error("length mismatch: " + got.length + " vs " + expected.length);
+    for (let i = 0; i < expected.length; ++i) {
+        if (got[i] !== expected[i])
+            throw new Error("element " + i + " mismatch: " + got[i] + " vs " + expected[i]);
+    }
+}
+
+// Warm up with Int32 arrays so DFG inlines sort + comparator with Int32 speculation.
+for (let w = 0; w < testLoopCount; ++w)
+    check(sortAndSpread([5, 3, 1, 4, 2]), [1, 2, 3, 4, 5]);
+
+// Feed doubles so the Int32-speculated subtract in the comparator OSR-exits.
+for (let i = 0; i < testLoopCount; ++i)
+    check(sortAndSpread([5.5, 3.25, 1.75, 4.5, 2.125]), [1.75, 2.125, 3.25, 4.5, 5.5]);
+
+for (let i = 0; i < testLoopCount; ++i)
+    check(sortAndSpread([5, 3.25, 1, 4.5, 2]), [1, 2, 3.25, 4.5, 5]);
+
+for (let i = 0; i < testLoopCount; ++i)
+    check(sortAndSpread([9.9, -1.5, 3.5, 7.0, 0.5, 4.4, 8.2]), [-1.5, 0.5, 3.5, 4.4, 7.0, 8.2, 9.9]);

--- a/JSTests/stress/array-sort-inline-osr-exit-in-comparator.js
+++ b/JSTests/stress/array-sort-inline-osr-exit-in-comparator.js
@@ -1,0 +1,71 @@
+// Verifies that triggering OSR exit inside the comparator (mid-sort, after the
+// DFG ArraySortIntrinsic's inlined body has started rearranging the receiver)
+// still produces a correctly sorted array with the original multiset intact.
+//
+// The in-place insertion sort in the DFG intrinsic mutates the receiver. When
+// OSR exit fires from inside the comparator, baseline re-runs `op_call`,
+// which calls the generic C++ sort on the partially-sorted receiver. Because
+// sort is idempotent on any intermediate state (and takes a snapshot of the
+// element contents), the receiver must end up both:
+//   (1) correctly sorted according to the comparator's ordering, and
+//   (2) with its original multiset preserved: no duplicates, no missing,
+//       no corrupted values.
+
+let exitCount = 0;
+let callCount = 0;
+
+function inlinedComparator(a, b) {
+    callCount++;
+    if ($vm.ftlTrue()) {
+        exitCount++;
+        OSRExit();
+    }
+    return a - b;
+}
+
+function test(arr) {
+    arr.sort(inlinedComparator);
+}
+
+const original = [5, 3, 8, 1, 9, 4, 7, 2, 6, 0, 11, 14, 13, 10, 12, 15];
+const expectedSorted = original.slice().sort((a, b) => a - b);
+
+function multiset(a) {
+    const counts = new Map();
+    for (const v of a)
+        counts.set(v, (counts.get(v) || 0) + 1);
+    return counts;
+}
+
+function sameMultiset(a, b) {
+    const ma = multiset(a);
+    const mb = multiset(b);
+    if (ma.size !== mb.size) return false;
+    for (const [k, v] of ma)
+        if (mb.get(k) !== v) return false;
+    return true;
+}
+
+// Warm up so DFG and then FTL compile `test`; once FTL is hot, every sort
+// call will trigger at least one OSRExit() inside the comparator.
+for (let i = 0; i < testLoopCount; i++) {
+    const copy = original.slice();
+    test(copy);
+
+    // Final state must have the original multiset of elements.
+    if (!sameMultiset(copy, original))
+        throw new Error("iter " + i + ": receiver's multiset changed:\n"
+            + "  original=" + JSON.stringify(original) + "\n"
+            + "  result  =" + JSON.stringify(copy));
+
+    // Final state must be sorted.
+    for (let j = 0; j < expectedSorted.length; j++) {
+        if (copy[j] !== expectedSorted[j])
+            throw new Error("iter " + i + " index " + j
+                + ": got " + copy[j] + " expected " + expectedSorted[j]
+                + " (exitCount=" + exitCount + ")");
+    }
+}
+
+if (exitCount === 0 && $vm.useFTLJIT())
+    throw new Error("expected at least one OSR exit during the run");

--- a/JSTests/stress/array-sort-inline-polymorphic-comparator.js
+++ b/JSTests/stress/array-sort-inline-polymorphic-comparator.js
@@ -1,0 +1,68 @@
+// The DFG ArraySortIntrinsic's comparator shape detection (tryInlineComparator)
+// checks for a JSFunction constant or a same-graph NewFunction allocation. A
+// sort call site that sees multiple distinct comparator functions fails both
+// checks and falls through to a plain Call node at the comparator call site.
+//
+// This test rotates several comparator functions at a single sort call site:
+//   * The DFG cannot statically resolve the comparator -> uses the plain-Call
+//     path (addCallWithoutSettingResult) instead of handleCall inlining.
+//   * The IsCallable runtime guard must fire correctly whether or not the
+//     comparator is the same as the most recent one.
+//   * Sort results must remain correct across all comparator shapes.
+
+function cmpAsc(a, b) { return a - b; }
+function cmpDesc(a, b) { return b - a; }
+function cmpMod3Asc(a, b) { return (a % 3) - (b % 3); }
+function cmpByAbs(a, b) { return Math.abs(a) - Math.abs(b); }
+
+const comparators = [cmpAsc, cmpDesc, cmpMod3Asc, cmpByAbs];
+
+function doSort(a, c) { return a.sort(c); }
+
+function expectedFor(input, cmp) { return [...input].sort(cmp); }
+
+// Warm up with a rotating comparator so the call site is polymorphic from the
+// start -- DFG/FTL never see a single callee at this site.
+const seed = [5, -3, 1, -4, 2, 8, -7, 0, 6, -1];
+for (let w = 0; w < testLoopCount; ++w) {
+    const cmp = comparators[w % comparators.length];
+    const got = doSort(seed.slice(), cmp);
+    const want = expectedFor(seed, cmp);
+    if (got.length !== want.length)
+        throw new Error("warmup " + w + ": length mismatch");
+    for (let i = 0; i < want.length; ++i) {
+        if (got[i] !== want[i])
+            throw new Error("warmup " + w + " cmp=" + cmp.name
+                + " index " + i + ": got " + got[i] + " want " + want[i]);
+    }
+}
+
+// Non-callable comparators must still throw TypeError from this polymorphic
+// call site (IsCallable guard must not be skipped for non-provably-callable
+// comparators).
+for (let w = 0; w < 100; ++w) {
+    let threw = false;
+    try { doSort(seed.slice(), {}); } catch (e) { threw = e instanceof TypeError; }
+    if (!threw) throw new Error("polymorphic site: {} must throw TypeError");
+}
+
+// A comparator that throws from the body must propagate correctly even when
+// the call site is polymorphic (plain-Call path, no inlining).
+function cmpThrow(a, b) { throw new Error("boom"); }
+let threw = false;
+try { doSort([3, 1], cmpThrow); }
+catch (e) { threw = e.message === "boom"; }
+if (!threw) throw new Error("polymorphic site: throwing comparator lost the exception");
+
+// Large array + polymorphic comparator (slow-path dispatcher + plain Call).
+const bigSeed = [];
+for (let i = 0; i < 32; ++i) bigSeed.push(((i * 17) % 32) - 16);
+for (let w = 0; w < testLoopCount; ++w) {
+    const cmp = comparators[w % comparators.length];
+    const got = doSort(bigSeed.slice(), cmp);
+    const want = expectedFor(bigSeed, cmp);
+    for (let i = 0; i < want.length; ++i) {
+        if (got[i] !== want[i])
+            throw new Error("large poly w=" + w + " cmp=" + cmp.name + " @" + i);
+    }
+}

--- a/JSTests/stress/array-sort-inline-small.js
+++ b/JSTests/stress/array-sort-inline-small.js
@@ -1,0 +1,38 @@
+// Exercises the DFG ArraySortIntrinsic inline fast path for empty
+// (Undecided-indexing) arrays and verifies non-empty arrays still sort
+// correctly via OSR exit to the generic C++ sort.
+
+function cmp(a, b) { return a - b; }
+
+function callSort(a) { return a.sort(cmp); }
+noInline(cmp);
+
+// Warm up with empty arrays so DFG picks the Undecided-array fast path.
+for (let i = 0; i < testLoopCount; i++) {
+    let r = callSort([]);
+    if (r.length !== 0) throw new Error("empty sort length != 0");
+}
+
+// A non-empty Int32 array: OSR exits from the inline fast path to baseline,
+// which runs the generic C++ sort. Must produce the correct sorted output.
+let r2 = callSort([2, 1]);
+if (r2.length !== 2 || r2[0] !== 1 || r2[1] !== 2)
+    throw new Error("length-2 fallback sort produced wrong order: " + r2);
+
+// A 16-element reversed array: fallback must still sort correctly.
+let big = [];
+for (let i = 15; i >= 0; i--) big.push(i);
+let rBig = callSort(big);
+for (let i = 0; i < 16; i++) {
+    if (rBig[i] !== i)
+        throw new Error("length-16 fallback sort wrong at " + i + ": " + rBig[i]);
+}
+
+// Random-ish 100-element array for good measure.
+let rand = [];
+for (let i = 0; i < 100; i++) rand.push((i * 37 + 11) % 100);
+let randSorted = rand.slice().sort(cmp);
+for (let i = 0; i < 99; i++) {
+    if (randSorted[i] > randSorted[i + 1])
+        throw new Error("length-100 fallback sort not ordered at " + i);
+}

--- a/JSTests/stress/array-sort-inline-stack-trace.js
+++ b/JSTests/stress/array-sort-inline-stack-trace.js
@@ -1,0 +1,41 @@
+// Verifies that when a comparator inlined by the DFG ArraySortIntrinsic throws
+// after the function has been JIT-compiled, the error stack contains frames for
+// `test`, `sort`, and `inlined`.
+//
+// This exercises frame reconstruction on exception: even though the DFG inlined
+// sort's body and the comparator call, the stack unwinder must still report a
+// `sort` frame (the generic host function) between `inlined` and `test`.
+
+let counter = 0;
+const throwAt = testLoopCount;
+
+function inlined(a, b) {
+    counter++;
+    if (counter >= throwAt)
+        throw new Error("thrown from inlined");
+    return a - b;
+}
+
+function test() {
+    let a = [3, 1, 2, 5, 4];
+    a.sort(inlined);
+}
+
+let caught = null;
+try {
+    while (true)
+        test();
+} catch (e) {
+    caught = e;
+}
+
+if (!caught)
+    throw new Error("no exception was caught");
+
+const stack = caught.stack;
+
+const expected = ["test", "sort", "inlined"];
+for (const name of expected) {
+    if (!stack.includes(name))
+        throw new Error("error.stack is missing '" + name + "' frame:\n" + stack);
+}

--- a/Source/JavaScriptCore/bytecode/BytecodeList.rb
+++ b/Source/JavaScriptCore/bytecode/BytecodeList.rb
@@ -1427,6 +1427,7 @@ op :llint_polymorphic_closure_call_trampoline
 op :checkpoint_osr_exit_from_inlined_call_trampoline
 op :checkpoint_osr_exit_trampoline
 op :normal_osr_exit_trampoline
+op :array_sort_comparator_return_trampoline
 op :fuzzer_return_early_from_loop_hint
 op :loop_osr_entry_gate
 op :llint_get_host_call_return_value

--- a/Source/JavaScriptCore/bytecode/InlineCallFrame.cpp
+++ b/Source/JavaScriptCore/bytecode/InlineCallFrame.cpp
@@ -133,6 +133,9 @@ void printInternal(PrintStream& out, JSC::InlineCallFrame::Kind kind)
     case JSC::InlineCallFrame::BoundFunctionTailCall:
         out.print("BoundFunctionTailCall");
         return;
+    case JSC::InlineCallFrame::ArraySortComparatorCall:
+        out.print("ArraySortComparatorCall");
+        return;
     }
     RELEASE_ASSERT_NOT_REACHED();
 }

--- a/Source/JavaScriptCore/bytecode/InlineCallFrame.h
+++ b/Source/JavaScriptCore/bytecode/InlineCallFrame.h
@@ -53,7 +53,7 @@ struct InlineCallFrame {
         CallVarargs,
         ConstructVarargs,
         TailCallVarargs,
-        
+
         // For these, the stackOffset incorporates the argument count plus the true return PC
         // slot.
         GetterCall,
@@ -63,6 +63,7 @@ struct InlineCallFrame {
         ProxyObjectInCall,
         BoundFunctionCall,
         BoundFunctionTailCall,
+        ArraySortComparatorCall,
     };
     static constexpr unsigned bitWidthOfKind = 4;
 
@@ -77,6 +78,7 @@ struct InlineCallFrame {
         case ProxyObjectStoreCall:
         case ProxyObjectInCall:
         case BoundFunctionCall:
+        case ArraySortComparatorCall:
             return CallMode::Regular;
         case TailCall:
         case TailCallVarargs:
@@ -129,6 +131,7 @@ struct InlineCallFrame {
         case ProxyObjectInCall:
         case BoundFunctionCall:
         case BoundFunctionTailCall:
+        case ArraySortComparatorCall:
             return CodeSpecializationKind::CodeForCall;
         case Construct:
         case ConstructVarargs:

--- a/Source/JavaScriptCore/dfg/DFGAbstractInterpreterInlines.h
+++ b/Source/JavaScriptCore/dfg/DFGAbstractInterpreterInlines.h
@@ -3839,6 +3839,27 @@ bool AbstractInterpreter<AbstractStateType>::executeEffects(unsigned clobberLimi
         clearForNode(node);
         break;
 
+    case GetCellButterflySlot:
+        switch (node->arrayMode().type()) {
+        case Array::Int32:
+            setNonCellTypeForNode(node, SpecInt32Only);
+            break;
+        default:
+            makeBytecodeTopForNode(node);
+            break;
+        }
+        break;
+
+    case PutCellButterflySlot:
+        break;
+
+    case ArraySortCompact:
+        setTypeForNode(node, SpecObjectOther);
+        break;
+
+    case ArraySortCommit:
+        break;
+
     case MaterializeNewArrayWithButterfly: {
 #if ASSERT_ENABLED
         SpeculatedType validTypes = [&]() {

--- a/Source/JavaScriptCore/dfg/DFGByteCodeParser.cpp
+++ b/Source/JavaScriptCore/dfg/DFGByteCodeParser.cpp
@@ -52,6 +52,7 @@
 #include "DFGGraph.h"
 #include "DFGGraphSafepoint.h"
 #include "DFGLiveCatchVariablePreservationPhase.h"
+#include "DFGOperations.h"
 #include "DOMJITGetterSetter.h"
 #include "DeleteByStatus.h"
 #include "FunctionCodeBlock.h"
@@ -219,6 +220,8 @@ private:
     // Handle intrinsic functions. Return true if it succeeded, false if we need to plant a call.
     template<typename ChecksFunctor>
     CallOptimizationResult handleIntrinsicCall(Node* callee, Operand result, CallVariant, Intrinsic, int registerOffset, int argumentCountIncludingThis, BytecodeIndex osrExitIndex, NodeType callOp, InlineCallFrame::Kind, CodeSpecializationKind, SpeculatedType prediction, const ChecksFunctor& insertChecks);
+    template<typename ChecksFunctor, typename SetResultFunctor>
+    CallOptimizationResult handleArraySort(Node* callee, Operand result, CallVariant, int registerOffset, int argumentCountIncludingThis, BytecodeIndex osrExitIndex, SpeculatedType prediction, const ChecksFunctor& insertChecks, const SetResultFunctor&);
     template<typename ChecksFunctor>
     bool handleDOMJITCall(Node* callee, Operand result, const DOMJIT::Signature*, int registerOffset, int argumentCountIncludingThis, SpeculatedType prediction, const ChecksFunctor& insertChecks);
     template<typename ChecksFunctor>
@@ -340,6 +343,12 @@ private:
         m_exitOK = true;
         processSetLocalQueue();
         return m_currentIndex;
+    }
+
+    void emitExitOK()
+    {
+        m_exitOK = true;
+        addToGraph(ExitOK);
     }
 
     VariableAccessData* newVariableAccessData(Operand operand)
@@ -2014,12 +2023,12 @@ ByteCodeParser::CallOptimizationResult ByteCodeParser::handleCallVariant(Node* c
     VERBOSE_LOG("    Considering callee ", callee, "\n");
 
     bool didInsertChecks = false;
-    bool didBoundFunctionInlining = false;
-    auto insertChecksWithAccounting = [&] (bool boundFunctionInlining = false) {
+    bool didDoInliningInsideIntrinsic = false;
+    auto insertChecksWithAccounting = [&](bool willDoInliningInsideIntrinsic = false) {
         if (needsToCheckCallee)
             emitFunctionChecks(callee, callTargetNode, thisArgument);
         didInsertChecks = true;
-        didBoundFunctionInlining = boundFunctionInlining;
+        didDoInliningInsideIntrinsic = willDoInliningInsideIntrinsic;
     };
 
     if (kind == InlineCallFrame::TailCall && ByteCodeParser::handleRecursiveTailCall(callTargetNode, callee, registerOffset, argumentCountIncludingThis, insertChecksWithAccounting)) {
@@ -2035,9 +2044,8 @@ ByteCodeParser::CallOptimizationResult ByteCodeParser::handleCallVariant(Node* c
 
     auto endSpecialCase = [&] () {
         RELEASE_ASSERT(didInsertChecks);
-        // Bound function's slots of them are not important. They are dead at OSR exit.
-        // As the same way to the arguments for normal calls, we do not do special things.
-        if (!didBoundFunctionInlining) {
+        // When we did inlining inside intrinsic, we need to manually keep necessary things alive.
+        if (!didDoInliningInsideIntrinsic) {
             addToGraph(Phantom, callTargetNode);
             emitArgumentPhantoms(registerOffset, argumentCountIncludingThis);
         }
@@ -2941,7 +2949,10 @@ auto ByteCodeParser::handleIntrinsicCall(Node* callee, Operand resultOperand, Ca
             return CallOptimizationResult::DidNothing;
 
         }
-            
+
+        case ArraySortIntrinsic:
+            return handleArraySort(callee, resultOperand, variant, registerOffset, argumentCountIncludingThis, osrExitIndex, prediction, insertChecks, setResult);
+
         case ArrayPopIntrinsic: {
             ArrayMode arrayMode = getArrayMode(Array::Write);
             if (!arrayMode.isJSArray())
@@ -11589,6 +11600,494 @@ void ByteCodeParser::handleIteratorNext(const JSInstruction* currentInstruction,
     m_currentIndex = startIndex;
     m_currentBlock = continuation;
     clearCaches();
+}
+
+template<typename ChecksFunctor, typename SetResultFunctor>
+auto ByteCodeParser::handleArraySort(Node* callee, Operand resultOperand, CallVariant variant, int registerOffset, int argumentCountIncludingThis, BytecodeIndex osrExitIndex, SpeculatedType prediction, const ChecksFunctor& insertChecks, const SetResultFunctor& setResult) -> CallOptimizationResult
+{
+    // Inline Array.prototype.sort(comparator) when:
+    //   - receiver is an original-structure JSArray with Undecided / Int32 / Contiguous indexing, and
+    //   - comparator is callable (CellUse speculation; non-callable cells throw TypeError from the Call just like the spec requires).
+    //
+    // Strategy:
+    //   * ArrayWithUndecided -> length is 0, return the receiver.
+    //   * Int32 / Contiguous -> dispatch on runtime length:
+    //       length > 16  -> fallback DirectCall to arrayProtoFuncSort. Avoids re-deopt loops
+    //         or hot sort sites with large arrays.
+    //       length <= 16 -> three-phase pipeline over a 16-slot JSCellButterfly scratch:
+    //         1. ArraySortCompact(array, length) -- acquires VM-cached scratch
+    //            JSCellButterfly and copies array content into that. On a hole it returns
+    //            vm.m_sortScratchSentinel. When we hit a sentinel, we go to the normal
+    //            slow path.
+    //         2. Inlined insertion sort over the scratch via GetCellButterflySlot /
+    //            PutCellButterflySlot, calling the comparator for each pair. Because we perform
+    //            onto the scratch, original array is not touched, making entire sort restartable.
+    //         3. ArraySortCommit(array, scratch, length) -- verifies the receiver's length
+    //            hasn't been changed during sorting, copies back to array, clears the scratch,
+    //            and stores it into the VM cache for the next sort. ArraySortCommit is the point
+    //            of committing the actual result to the input array.
+
+    UNUSED_PARAM(resultOperand);
+
+    if (!is64Bit())
+        return CallOptimizationResult::DidNothing;
+
+    if (argumentCountIncludingThis < 2)
+        return CallOptimizationResult::DidNothing;
+
+    if (m_inlineStackTop->m_exitProfile.hasExitSite(m_currentIndex, BadIndexingType)
+        || m_inlineStackTop->m_exitProfile.hasExitSite(m_currentIndex, BadConstantCache)
+        || m_inlineStackTop->m_exitProfile.hasExitSite(m_currentIndex, BadCache)
+        || m_inlineStackTop->m_exitProfile.hasExitSite(m_currentIndex, BadType)
+        || m_inlineStackTop->m_exitProfile.hasExitSite(m_currentIndex, OutOfBounds))
+        return CallOptimizationResult::DidNothing;
+
+    ArrayMode arrayMode = getArrayMode(Array::Read);
+    if (!arrayMode.isJSArray())
+        return CallOptimizationResult::DidNothing;
+    if (!arrayMode.isJSArrayWithOriginalStructure())
+        return CallOptimizationResult::DidNothing;
+    if (arrayMode.doesConversion())
+        return CallOptimizationResult::DidNothing;
+
+    IndexingType indexingType;
+    switch (arrayMode.type()) {
+    case Array::Undecided:
+        indexingType = ArrayWithUndecided;
+        break;
+    case Array::Int32:
+        indexingType = ArrayWithInt32;
+        break;
+    case Array::Contiguous:
+        indexingType = ArrayWithContiguous;
+        break;
+    default:
+        return CallOptimizationResult::DidNothing;
+    }
+
+    Node* comparatorNode = get(virtualRegisterForArgumentIncludingThis(1, registerOffset));
+
+    // Detect the comparator's static shape so we can route its Call through handleCall with
+    // a synthesized CallLinkStatus -- this lets the parser's inliner body-inline the
+    // comparator. Two shapes we recognize:
+    //   - JSFunction constant (named/hoisted function) -> CallVariant(function).
+    //   - NewFunction / NewArrowFunction allocation in the same graph -> CallVariant(executable).
+    // Neither -> fall back to a plain Call at the comparator call site.
+    //
+    // This is workaround since we do not have enough feedback about comparator here due to
+    // lack of CallLinkInfo inside native Array#sort function. However in practice, it is almost
+    // always a function literal or constant.
+    JSFunction* comparatorFunction = nullptr;
+    FunctionExecutable* comparatorExecutable = nullptr;
+    if (!m_graph.m_plan.isUnlinked()) {
+        if (comparatorNode->hasConstant())
+            comparatorFunction = comparatorNode->dynamicCastConstant<JSFunction*>();
+        else if (comparatorNode->isFunctionAllocation())
+            comparatorExecutable = comparatorNode->castOperand<FunctionExecutable*>();
+    }
+    bool tryInlineComparator = comparatorFunction || comparatorExecutable;
+
+    JSGlobalObject* globalObject = m_graph.globalObjectFor(currentNodeOrigin().semantic);
+    if (globalObject->arraySpeciesWatchpointSet().state() != IsWatched
+        || !globalObject->havingABadTimeWatchpointSet().isStillValid()
+        || globalObject->arrayPrototypeChainIsSaneWatchpointSet().state() != IsWatched)
+        return CallOptimizationResult::DidNothing;
+
+    m_graph.watchpoints().addLazily(globalObject->arraySpeciesWatchpointSet());
+    m_graph.watchpoints().addLazily(globalObject->havingABadTimeWatchpointSet());
+    m_graph.watchpoints().addLazily(globalObject->arrayPrototypeChainIsSaneWatchpointSet());
+
+    if (indexingType == ArrayWithUndecided) {
+        insertChecks();
+        Node* array = get(virtualRegisterForArgumentIncludingThis(0, registerOffset));
+        addToGraph(CheckStructure, OpInfo(m_graph.addStructureSet(globalObject->originalArrayStructureForIndexingType(indexingType))), array);
+        addToGraph(Check, Edge(comparatorNode, FunctionUse));
+        setResult(array);
+        return CallOptimizationResult::Inlined;
+    }
+
+    insertChecks(/* willDoInliningInsideIntrinsic */ true);
+    Node* array = get(virtualRegisterForArgumentIncludingThis(0, registerOffset));
+    addToGraph(CheckStructure, OpInfo(m_graph.addStructureSet(globalObject->originalArrayStructureForIndexingType(indexingType))), array);
+    addToGraph(Check, Edge(comparatorNode, FunctionUse));
+
+    // --- Runtime length dispatch -------------------------------------------------
+    // We deliberately do NOT emit GetArrayLength in the entry block -- instead each
+    // successor block re-emits it. This keeps FixupPhase's Int32 speculation Checks
+    // local to the block where the GetArrayLength lives, avoiding a CPS validation
+    // failure from cross-block ordering of the inserted Check vs. its producer.
+
+    // Allocate fresh tmps for cross-block flow. `tmpLength` caches the array length once
+    // (fetched just before entering the outer loop) so the sort loop doesn't re-fetch
+    // butterfly+length every iteration, and so Commit can check length stability against
+    // the original pre-sort length.
+    //
+    // tmpBase is *relative* to the current inline frame: set()/get() remap through
+    // tmpOffset, while ensureTmps() is keyed off the absolute m_numTmps. We place our tmps
+    // at `current_frame_numTmps + maxNumCheckpointTmps` in relative coordinates so they
+    // sit above any inlined comparator's checkpoint tmps (whose inline-call-frame claims
+    // the slot range [tmpOffset + caller_numTmps, tmpOffset + caller_numTmps + callee_numTmps),
+    // where callee_numTmps <= maxNumCheckpointTmps). Then we ensureTmps() to the absolute
+    // upper bound so the parser's bounds check (operand.value() >= m_numTmps) accepts the
+    // remapped indices.
+    unsigned tmpBase = m_inlineStackTop->m_codeBlock->numTmps() + maxNumCheckpointTmps;
+    unsigned currentTmpOffset = m_inlineStackTop->m_inlineCallFrame ? m_inlineStackTop->m_inlineCallFrame->tmpOffset : 0;
+    ensureTmps(currentTmpOffset + tmpBase + 9);
+    Operand tmpI = Operand::tmp(tmpBase + 0);
+    Operand tmpJ = Operand::tmp(tmpBase + 1);
+    Operand tmpPivot = Operand::tmp(tmpBase + 2);
+    Operand tmpArray = Operand::tmp(tmpBase + 3);
+    Operand tmpCallee = Operand::tmp(tmpBase + 4);
+    Operand tmpComparator = Operand::tmp(tmpBase + 5);
+    Operand tmpCmpResult = Operand::tmp(tmpBase + 6);
+    Operand tmpScratch = Operand::tmp(tmpBase + 7);
+    Operand tmpLength = Operand::tmp(tmpBase + 8);
+
+    // Stash cross-block values into tmps before the Branch so successor blocks see
+    // them via phi merges. Explicitly flush each tmp after the set: Flush changes
+    // variablesAtTail from SetLocal to Flush, which prevents getLocalOrTmp's
+    // same-block short-circuit from returning the raw producer node. Without this,
+    // CPS rethreading / block merging produces cross-block edges that violate the
+    // CPS validator's invariant (Check nodes end up scheduled before their producers).
+    set(tmpArray, array, ImmediateNakedSet);
+    flush(tmpArray);
+    set(tmpCallee, callee, ImmediateNakedSet);
+    flush(tmpCallee);
+    set(tmpComparator, comparatorNode, ImmediateNakedSet);
+    flush(tmpComparator);
+    emitExitOK();
+
+    BasicBlock* dispatcherBlock = allocateUntargetableBlock();
+    BasicBlock* fastBlock = allocateUntargetableBlock();
+    BasicBlock* slowBlock = allocateUntargetableBlock();
+    BasicBlock* continuation = allocateUntargetableBlock();
+
+    // Close the entry block with a Jump to the dispatcher. Putting the length
+    // compare in its own block avoids entangling the entry block's value-flow with
+    // FixupPhase's Check insertion for the Int32Use edge on length.
+    addToGraph(Jump, OpInfo(dispatcherBlock));
+    flushForTerminal();
+
+    {
+        m_currentBlock = dispatcherBlock;
+        clearCaches();
+        emitExitOK();
+        keepUsesOfCurrentInstructionAlive(m_currentInstruction, m_currentIndex.checkpoint());
+
+        Node* capPlusOne = jsConstant(jsNumber(sortScratchSlotCount + 1));
+        // Re-emit GetArrayLength locally in this block.
+        Node* dispatcherButterfly = addToGraph(GetButterfly, get(tmpArray));
+        Node* dispatcherLength = addToGraph(GetArrayLength, OpInfo(arrayMode.asWord()), Edge(get(tmpArray)), Edge(dispatcherButterfly, KnownStorageUse));
+        emitExitOK();
+        Node* isSmall = addToGraph(CompareBelow, Edge(dispatcherLength, Int32Use), Edge(capPlusOne, Int32Use));
+
+        {
+            BranchData* branchData = m_graph.m_branchData.add();
+            branchData->taken = BranchTarget(fastBlock);
+            branchData->notTaken = BranchTarget(slowBlock);
+            addToGraph(Branch, OpInfo(branchData), isSmall);
+            flushForTerminal();
+        }
+    }
+
+    // --- Slow path: fallback DirectCall to the generic sort ---------------------
+    {
+        m_currentBlock = slowBlock;
+        clearCaches();
+        emitExitOK();
+        keepUsesOfCurrentInstructionAlive(m_currentInstruction, m_currentIndex.checkpoint());
+
+        auto* sortExecutable = variant.executable();
+        Node* slowResult = addCallWithoutSettingResult(Call, OpInfo(), get(tmpCallee), argumentCountIncludingThis, registerOffset, OpInfo(prediction));
+        if (sortExecutable)
+            slowResult->convertToDirectCall(m_graph.freeze(sortExecutable));
+        emitExitOK();
+        addToGraph(Jump, OpInfo(continuation));
+    }
+
+    // --- Fast path: copy array into a 16-slot scratch via an atomic inline-JIT Compact,
+    // insertion-sort the scratch, then Commit the result back via another atomic
+    // inline-JIT copy. Compact and Commit do their loops inline in machine code with no
+    // InvalidationPoints and no per-element speculation -- so no mid-copy OSR exit can
+    // leave the receiver partially mutated.
+    //
+    // `length` is fetched ONCE (before the outer loop) and stashed in tmpLength. The
+    // outer loop reads it each iteration without re-walking the butterfly, and Commit
+    // checks it against the current butterfly length to detect comparator-induced
+    // mutation (OSR exit on mismatch via BadIndexingType).
+    //
+    // The blocks emitted below encode this C-equivalent program. Each labeled comment
+    // identifies the block where the following statement is emitted, and the branches
+    // match the actual BranchData wired up below.
+    //
+    //   int length = array.length;                                // fastBlock (GetArrayLength)
+    //   JSValue* scratch = ArraySortCompact(array, length);       // fastBlock
+    //   if (scratch == vm.m_sortScratchSentinel) goto slowBlock;  // fastBlock -> slowBlock / sortSetup
+    //   int i = 1;                                                // sortSetup
+    //   for (;;) {                                                // outerHeader:
+    //       if (i >= length) goto commit;                         //   CompareGreaterEq -> commitBlock / outerBody
+    //       JSValue pivot = scratch[i];                           // outerBody
+    //       int j = i - 1;                                        // outerBody
+    //       for (;;) {                                            // innerHeader:
+    //           if (j < 0) goto placePivot;                       //   CompareLess(j, 0) -> innerExit / innerCmpBlock
+    //           JSValue current = scratch[j];                     // innerCmpBlock
+    //           JSValue cmp = comparator(pivot, current);         //   inlined or Call
+    //           if (!(cmp < 0)) goto placePivot;                  //   CompareLess(cmp, 0) -> innerShift / innerExit
+    //           scratch[j + 1] = current;                         // innerShift
+    //           j = j - 1;                                        // innerShift
+    //           continue;                                         //   Jump -> innerHeader
+    //       }
+    //   placePivot:
+    //       scratch[j + 1] = pivot;                               // innerExit
+    //       i = i + 1;                                            // innerExit
+    //       continue;                                             //   Jump -> outerHeader
+    //   }
+    // commit:
+    //   ArraySortCommit(array, scratch, length);                  // commitBlock; OSR-exits
+    //                                                             //   if array.length != length
+    //   return array;                                             // commitBlock -> continuation
+    //
+
+    BasicBlock* sortSetup = allocateUntargetableBlock();
+    BasicBlock* outerHeader = allocateUntargetableBlock();
+    BasicBlock* outerBody = allocateUntargetableBlock();
+    BasicBlock* innerHeader = allocateUntargetableBlock();
+    BasicBlock* innerCmpBlock = allocateUntargetableBlock();
+    BasicBlock* innerShift = allocateUntargetableBlock();
+    BasicBlock* innerExit = allocateUntargetableBlock();
+    BasicBlock* commitBlock = allocateUntargetableBlock();
+
+    {
+        m_currentBlock = fastBlock;
+        clearCaches();
+        emitExitOK();
+        keepUsesOfCurrentInstructionAlive(m_currentInstruction, m_currentIndex.checkpoint());
+
+        Node* array = get(tmpArray);
+        Node* bfly = addToGraph(GetButterfly, array);
+        Node* lengthCompact = addToGraph(GetArrayLength, OpInfo(arrayMode.asWord()), Edge(array), Edge(bfly, KnownStorageUse));
+        emitExitOK();
+        Node* scratch = addToGraph(ArraySortCompact, OpInfo(arrayMode.asWord()), array, lengthCompact);
+        emitExitOK();
+        set(tmpScratch, scratch, ImmediateNakedSet);
+        flush(tmpScratch);
+        set(tmpLength, lengthCompact, ImmediateNakedSet);
+        flush(tmpLength);
+        emitExitOK();
+        // ArraySortCommit generates sentinel when we should go to the slow path (e.g. finding holes).
+        FrozenValue* sentinel = m_graph.freezeStrong(m_graph.m_vm.m_sortScratchSentinel.get());
+        Node* isHole = addToGraph(CompareEqPtr, OpInfo(sentinel), get(tmpScratch));
+        emitExitOK();
+        BranchData* branchData = m_graph.m_branchData.add();
+        branchData->taken = BranchTarget(slowBlock);
+        branchData->notTaken = BranchTarget(sortSetup);
+        addToGraph(Branch, OpInfo(branchData), isHole);
+        flushForTerminal();
+    }
+
+    {
+        m_currentBlock = sortSetup;
+        clearCaches();
+        emitExitOK();
+        keepUsesOfCurrentInstructionAlive(m_currentInstruction, m_currentIndex.checkpoint());
+        set(tmpI, jsConstant(jsNumber(1)), ImmediateNakedSet);
+        emitExitOK();
+        addToGraph(Jump, OpInfo(outerHeader));
+    }
+
+    {
+        m_currentBlock = outerHeader;
+        clearCaches();
+        emitExitOK();
+        keepUsesOfCurrentInstructionAlive(m_currentInstruction, m_currentIndex.checkpoint());
+        Node* i = get(tmpI);
+        Node* lengthL = get(tmpLength);
+        Node* atEnd = addToGraph(CompareGreaterEq, Edge(i, Int32Use), Edge(lengthL, Int32Use));
+        BranchData* branchData = m_graph.m_branchData.add();
+        branchData->taken = BranchTarget(commitBlock);
+        branchData->notTaken = BranchTarget(outerBody);
+        addToGraph(Branch, OpInfo(branchData), atEnd);
+        flushForTerminal();
+    }
+
+    {
+        m_currentBlock = outerBody;
+        clearCaches();
+        emitExitOK();
+        keepUsesOfCurrentInstructionAlive(m_currentInstruction, m_currentIndex.checkpoint());
+        Node* i = get(tmpI);
+        Node* pivot = addToGraph(GetCellButterflySlot, OpInfo(arrayMode.asWord()), get(tmpScratch), i);
+        emitExitOK();
+        set(tmpPivot, pivot, ImmediateNakedSet);
+        emitExitOK();
+        Node* jInit = addToGraph(ArithSub, OpInfo(Arith::Unchecked), OpInfo(SpecInt32Only), Edge(i, Int32Use), Edge(jsConstant(jsNumber(1)), Int32Use));
+        set(tmpJ, jInit, ImmediateNakedSet);
+        addToGraph(Jump, OpInfo(innerHeader));
+    }
+
+    {
+        m_currentBlock = innerHeader;
+        clearCaches();
+        emitExitOK();
+        keepUsesOfCurrentInstructionAlive(m_currentInstruction, m_currentIndex.checkpoint());
+        Node* j = get(tmpJ);
+        Node* jNegative = addToGraph(CompareLess, Edge(j, Int32Use), Edge(jsConstant(jsNumber(0)), Int32Use));
+        BranchData* branchData = m_graph.m_branchData.add();
+        branchData->taken = BranchTarget(innerExit);
+        branchData->notTaken = BranchTarget(innerCmpBlock);
+        addToGraph(Branch, OpInfo(branchData), jNegative);
+        flushForTerminal();
+    }
+
+    {
+        m_currentBlock = innerCmpBlock;
+        clearCaches();
+        emitExitOK();
+        keepUsesOfCurrentInstructionAlive(m_currentInstruction, m_currentIndex.checkpoint());
+        Node* j = get(tmpJ);
+        Node* pivot = get(tmpPivot);
+        Node* current = addToGraph(GetCellButterflySlot, OpInfo(arrayMode.asWord()), get(tmpScratch), j);
+        emitExitOK();
+
+        // Set up a fresh comparator call frame adjacent to the caller's locals.
+        constexpr int comparatorArgcIncludingThis = 3;
+        unsigned numberOfParameters = comparatorArgcIncludingThis;
+        numberOfParameters++; // True return PC.
+
+        int newRegisterOffset = virtualRegisterForLocal(m_inlineStackTop->m_profiledBlock->numCalleeLocals() - 1).offset();
+        newRegisterOffset -= numberOfParameters;
+        newRegisterOffset -= CallFrame::headerSizeInRegisters;
+        newRegisterOffset = -WTF::roundUpToMultipleOf(stackAlignmentRegisters(), -newRegisterOffset);
+
+        ensureLocals(m_inlineStackTop->remapOperand(VirtualRegister(newRegisterOffset)).toLocal());
+        unsigned parameterSlots = Graph::parameterSlotsForArgCount(comparatorArgcIncludingThis);
+        if (parameterSlots > m_parameterSlots)
+            m_parameterSlots = parameterSlots;
+
+        set(virtualRegisterForArgumentIncludingThis(0, newRegisterOffset), jsConstant(jsUndefined()), ImmediateNakedSet);
+        set(virtualRegisterForArgumentIncludingThis(1, newRegisterOffset), pivot, ImmediateNakedSet);
+        set(virtualRegisterForArgumentIncludingThis(2, newRegisterOffset), current, ImmediateNakedSet);
+        emitExitOK();
+
+        Node* cmpResult = nullptr;
+        if (tryInlineComparator) {
+            auto callLinkStatus = comparatorFunction ? CallLinkStatus(CallVariant(comparatorFunction)) : CallLinkStatus(CallVariant(comparatorExecutable));
+            auto* callTargetNode = comparatorFunction ? jsConstant(comparatorFunction) : get(tmpComparator);
+            handleCall(tmpCmpResult, Call, InlineCallFrame::ArraySortComparatorCall, osrExitIndex, callTargetNode, comparatorArgcIncludingThis, newRegisterOffset, callLinkStatus, SpecBytecodeTop, nullptr);
+            processSetLocalQueue();
+            emitExitOK();
+            cmpResult = get(tmpCmpResult);
+        } else {
+            cmpResult = addCallWithoutSettingResult(Call, OpInfo(), get(tmpComparator), comparatorArgcIncludingThis, newRegisterOffset, OpInfo(SpecBytecodeTop));
+            emitExitOK();
+            set(tmpCmpResult, cmpResult, ImmediateNakedSet);
+        }
+        flush(tmpCmpResult);
+        emitExitOK();
+
+        // Match StableSort.h's coerceComparatorResultToBoolean: shift when `cmp < 0`
+        // (numeric path) OR when `cmp === false` (legacy boolean special-case,
+        // webkit.org/b/47825). CompareLess(cmp, 0) alone misses the boolean-false case
+        // because `false` coerces to 0 (not `< 0`), so a second branch on
+        // CompareStrictEq(cmp, false) recovers that case.
+        Node* cmpIsNeg = addToGraph(CompareLess, Edge(cmpResult), Edge(jsConstant(jsNumber(0))));
+        BasicBlock* checkFalseBlock = allocateUntargetableBlock();
+        {
+            BranchData* branchData = m_graph.m_branchData.add();
+            branchData->taken = BranchTarget(innerShift);
+            branchData->notTaken = BranchTarget(checkFalseBlock);
+            addToGraph(Branch, OpInfo(branchData), cmpIsNeg);
+            flushForTerminal();
+        }
+
+        m_currentBlock = checkFalseBlock;
+        clearCaches();
+        emitExitOK();
+        keepUsesOfCurrentInstructionAlive(m_currentInstruction, m_currentIndex.checkpoint());
+        Node* cmpIsFalse = addToGraph(CompareStrictEq, Edge(get(tmpCmpResult)), Edge(jsConstant(jsBoolean(false))));
+        BranchData* branchData = m_graph.m_branchData.add();
+        branchData->taken = BranchTarget(innerShift);
+        branchData->notTaken = BranchTarget(innerExit);
+        addToGraph(Branch, OpInfo(branchData), cmpIsFalse);
+        flushForTerminal();
+    }
+
+    {
+        m_currentBlock = innerShift;
+        clearCaches();
+        emitExitOK();
+        keepUsesOfCurrentInstructionAlive(m_currentInstruction, m_currentIndex.checkpoint());
+        Node* j = get(tmpJ);
+        Node* current = addToGraph(GetCellButterflySlot, OpInfo(arrayMode.asWord()), get(tmpScratch), j);
+        emitExitOK();
+        Node* jPlusOne = addToGraph(ArithAdd, OpInfo(Arith::Unchecked), OpInfo(SpecInt32Only), Edge(j, Int32Use), Edge(jsConstant(jsNumber(1)), Int32Use));
+        addToGraph(PutCellButterflySlot, get(tmpScratch), jPlusOne, current);
+        emitExitOK();
+        Node* jMinusOne = addToGraph(ArithAdd, OpInfo(Arith::Unchecked), OpInfo(SpecInt32Only), Edge(j, Int32Use), Edge(jsConstant(jsNumber(-1)), Int32Use));
+        set(tmpJ, jMinusOne, ImmediateNakedSet);
+        addToGraph(Jump, OpInfo(innerHeader));
+    }
+
+    {
+        m_currentBlock = innerExit;
+        clearCaches();
+        emitExitOK();
+        keepUsesOfCurrentInstructionAlive(m_currentInstruction, m_currentIndex.checkpoint());
+        Node* j = get(tmpJ);
+        Node* insertionPoint = addToGraph(ArithAdd, OpInfo(Arith::Unchecked), OpInfo(SpecInt32Only), Edge(j, Int32Use), Edge(jsConstant(jsNumber(1)), Int32Use));
+        Node* pivot = get(tmpPivot);
+        addToGraph(PutCellButterflySlot, get(tmpScratch), insertionPoint, pivot);
+        emitExitOK();
+        Node* i = get(tmpI);
+        Node* nextI = addToGraph(ArithAdd, OpInfo(Arith::Unchecked), OpInfo(SpecInt32Only), Edge(i, Int32Use), Edge(jsConstant(jsNumber(1)), Int32Use));
+        set(tmpI, nextI, ImmediateNakedSet);
+        addToGraph(Jump, OpInfo(outerHeader));
+    }
+
+    // Commit: verify length stability (current butterfly length == the stashed pre-sort
+    // length, via the Commit node's BadIndexingType speculation), write scratch[0..length)
+    // back into array's butterfly, clear the scratch, and return it to the VM cache -- all
+    // inside a single inline-JIT node so no OSR exit can split the write.
+    {
+        m_currentBlock = commitBlock;
+        clearCaches();
+        emitExitOK();
+        keepUsesOfCurrentInstructionAlive(m_currentInstruction, m_currentIndex.checkpoint());
+        Node* array = get(tmpArray);
+        Node* lengthCommit = get(tmpLength);
+        addToGraph(CheckStructure, OpInfo(m_graph.addStructureSet(globalObject->originalArrayStructureForIndexingType(indexingType))), array);
+        emitExitOK();
+        addToGraph(ArraySortCommit, OpInfo(arrayMode.asWord()), array, get(tmpScratch), lengthCommit);
+        // After Commit clobbers exit state, emit an ExitOK before the Jump so later
+        // phases may place Exits-kind nodes between the clobberer and the block
+        // boundary. The continuation block feeds tmpArray into setResult, so there's
+        // no need for a separate set(resultOperand, ...) here.
+        emitExitOK();
+        addToGraph(Jump, OpInfo(continuation));
+    }
+
+    // --- Continuation -----------------------------------------------------------
+    {
+        m_currentBlock = continuation;
+        clearCaches();
+        emitExitOK();
+        keepUsesOfCurrentInstructionAlive(m_currentInstruction, m_currentIndex.checkpoint());
+
+        // Mirror endSpecialCase's emitArgumentPhantoms here so OSR exits inside our
+        // emitted blocks keep the op_call operand slots (callee, this, cmp) materializable.
+        // We use get() which is cross-block safe -- it emits GetLocal so the Phantom
+        // edge stays intra-continuation-block. We skip Phantom(callTargetNode) because
+        // that helper takes a raw Node* (from the caller's block) which would be a
+        // cross-block edge under our split control flow; the callee-slot Phantom below
+        // covers the equivalent liveness via the caller's stack position.
+        for (int i = 0; i < argumentCountIncludingThis; ++i)
+            addToGraph(Phantom, get(virtualRegisterForArgumentIncludingThis(i, registerOffset)));
+
+        // Array.prototype.sort returns its `this`. Both paths (slow DirectCall and
+        // commit) produce the same logical value, which is tmpArray.
+        setResult(get(tmpArray));
+    }
+    return CallOptimizationResult::Inlined;
 }
 
 void ByteCodeParser::pruneUnreachableNodes()

--- a/Source/JavaScriptCore/dfg/DFGClobberize.h
+++ b/Source/JavaScriptCore/dfg/DFGClobberize.h
@@ -184,6 +184,9 @@ void clobberize(Graph& graph, Node* node, const ReadFunctor& read, const WriteFu
         case AtomicsSub:
         case AtomicsXor:
         case NewArrayWithSpecies:
+        case ArraySortCompact:
+        case ArraySortCommit:
+        case GetCellButterflySlot:
             return clobberTop();
         default:
             DFG_CRASH(graph, node, "Unhandled ArrayMode opcode.");
@@ -1958,6 +1961,57 @@ void clobberize(Graph& graph, Node* node, const ReadFunctor& read, const WriteFu
         read(HeapObjectCount);
         write(HeapObjectCount);
         // FIXME: In this phase we say the Array is where the length of the array is def'd but this differs from ObjectAllocationSinking.
+        return;
+    }
+
+    case GetCellButterflySlot:
+        read(IndexedContiguousProperties);
+        return;
+
+    case PutCellButterflySlot:
+        write(IndexedContiguousProperties);
+        return;
+
+    case ArraySortCompact: {
+        AbstractHeap sourceHeap;
+        switch (node->arrayMode().type()) {
+        case Array::Int32:
+            sourceHeap = IndexedInt32Properties;
+            break;
+        case Array::Contiguous:
+            sourceHeap = IndexedContiguousProperties;
+            break;
+        default:
+            DFG_CRASH(graph, node, "Bad array mode for ArraySortCompact");
+            return;
+        }
+        read(JSObject_butterfly);
+        read(Butterfly_publicLength);
+        read(sourceHeap);
+        read(HeapObjectCount);
+        write(HeapObjectCount);
+        write(IndexedContiguousProperties);
+        return;
+    }
+
+    case ArraySortCommit: {
+        AbstractHeap targetHeap;
+        switch (node->arrayMode().type()) {
+        case Array::Int32:
+            targetHeap = IndexedInt32Properties;
+            break;
+        case Array::Contiguous:
+            targetHeap = IndexedContiguousProperties;
+            break;
+        default:
+            DFG_CRASH(graph, node, "Bad array mode for ArraySortCommit");
+            return;
+        }
+        read(JSObject_butterfly);
+        read(Butterfly_publicLength);
+        read(IndexedContiguousProperties);
+        write(IndexedContiguousProperties);
+        write(targetHeap);
         return;
     }
 

--- a/Source/JavaScriptCore/dfg/DFGDoesGC.cpp
+++ b/Source/JavaScriptCore/dfg/DFGDoesGC.cpp
@@ -179,6 +179,9 @@ bool doesGC(Graph& graph, Node* node)
     case FencedStoreBarrier:
     case InvalidationPoint:
     case NotifyWrite:
+    case GetCellButterflySlot:
+    case PutCellButterflySlot:
+    case ArraySortCommit:
     case AssertInBounds:
     case CheckInBounds:
     case CheckInBoundsInt52:
@@ -415,6 +418,7 @@ bool doesGC(Graph& graph, Node* node)
     case NewInternalFieldObject:
     case Spread:
     case NewButterflyWithSize:
+    case ArraySortCompact:
     case NewArrayWithSize:
     case NewArrayWithButterfly:
     case NewArrayWithSpecies:

--- a/Source/JavaScriptCore/dfg/DFGFixupPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGFixupPhase.cpp
@@ -2619,6 +2619,31 @@ private:
             node->remove(m_graph);
             break;
 
+        case GetCellButterflySlot: {
+            fixEdge<KnownCellUse>(node->child1());
+            fixEdge<Int32Use>(node->child2());
+            break;
+        }
+
+        case PutCellButterflySlot: {
+            fixEdge<KnownCellUse>(node->child1());
+            fixEdge<Int32Use>(node->child2());
+            break;
+        }
+
+        case ArraySortCompact: {
+            fixEdge<KnownCellUse>(node->child1());
+            fixEdge<KnownInt32Use>(node->child2());
+            break;
+        }
+
+        case ArraySortCommit: {
+            fixEdge<KnownCellUse>(node->child1());
+            fixEdge<KnownCellUse>(node->child2());
+            fixEdge<KnownInt32Use>(node->child3());
+            break;
+        }
+
         case FiatInt52: {
             RELEASE_ASSERT(enableInt52());
             node->convertToIdentity();

--- a/Source/JavaScriptCore/dfg/DFGMayExit.cpp
+++ b/Source/JavaScriptCore/dfg/DFGMayExit.cpp
@@ -207,6 +207,8 @@ ExitMode mayExitImpl(Graph& graph, Node* node, StateType& state)
     case NewArray:
     case NewArrayWithButterfly:
     case NewButterflyWithSize:
+    case GetCellButterflySlot:
+    case PutCellButterflySlot:
     case ToNumber:
     case ToNumeric:
     case ToObject:

--- a/Source/JavaScriptCore/dfg/DFGNode.h
+++ b/Source/JavaScriptCore/dfg/DFGNode.h
@@ -2688,6 +2688,9 @@ public:
         case AtomicsSub:
         case AtomicsXor:
         case NewArrayWithSpecies:
+        case ArraySortCompact:
+        case ArraySortCommit:
+        case GetCellButterflySlot:
             return true;
         default:
             return false;

--- a/Source/JavaScriptCore/dfg/DFGNodeType.h
+++ b/Source/JavaScriptCore/dfg/DFGNodeType.h
@@ -422,6 +422,10 @@ namespace JSC { namespace DFG {
     macro(NewArrayBuffer, NodeResultJS) \
     macro(NewArrayWithButterfly, NodeResultJS) \
     macro(NewButterflyWithSize, NodeResultStorage) \
+    macro(GetCellButterflySlot, NodeResultJS | NodeMustGenerate) \
+    macro(PutCellButterflySlot, NodeMustGenerate) \
+    macro(ArraySortCompact, NodeResultJS | NodeMustGenerate) \
+    macro(ArraySortCommit, NodeMustGenerate) \
     macro(NewInternalFieldObject, NodeResultJS) \
     macro(NewTypedArray, NodeResultJS | NodeMustGenerate) \
     macro(NewTypedArrayBuffer, NodeResultJS | NodeMustGenerate) \

--- a/Source/JavaScriptCore/dfg/DFGOSRExitCompilerCommon.cpp
+++ b/Source/JavaScriptCore/dfg/DFGOSRExitCompilerCommon.cpp
@@ -152,6 +152,13 @@ static CodePtr<JSEntryPtrTag> callerReturnPC(CodeBlock* baselineCodeBlockForCall
     if (callBytecodeIndex.checkpoint())
         return LLInt::checkpointOSRExitFromInlinedCallTrampolineThunk().code();
 
+    // Array.prototype.sort's comparator is inlined by the DFG ArraySortIntrinsic.
+    // Same stack layout as Call, but on OSR exit inside the comparator its return
+    // PC is arraySortComparatorReturnTrampoline, which discards the return value
+    // and re-dispatches the caller's op_call instead of advancing past it.
+    if (trueCallerCallKind == InlineCallFrame::ArraySortComparatorCall)
+        return LLInt::arraySortComparatorReturnTrampolineThunk().code();
+
     CodePtr<JSEntryPtrTag> jumpTarget;
 
     const auto& callInstruction = *baselineCodeBlockForCaller->instructions().at(callBytecodeIndex).ptr();

--- a/Source/JavaScriptCore/dfg/DFGOperations.cpp
+++ b/Source/JavaScriptCore/dfg/DFGOperations.cpp
@@ -2309,8 +2309,18 @@ JSC_DEFINE_JIT_OPERATION(operationNewEmptyArray, char*, (VM* vmPointer, Structur
     CallFrame* callFrame = DECLARE_CALL_FRAME(vm);
     JITOperationPrologueCallFrameTracer tracer(vm, callFrame);
     auto scope = DECLARE_THROW_SCOPE(vm);
-    
+
     OPERATION_RETURN(scope, std::bit_cast<char*>(JSArray::create(vm, arrayStructure)));
+}
+
+JSC_DEFINE_JIT_OPERATION(operationAcquireSortScratch, JSCell*, (VM* vmPointer))
+{
+    VM& vm = *vmPointer;
+    CallFrame* callFrame = DECLARE_CALL_FRAME(vm);
+    JITOperationPrologueCallFrameTracer tracer(vm, callFrame);
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
+    OPERATION_RETURN(scope, static_cast<JSCell*>(JSCellButterfly::create(vm, CopyOnWriteArrayWithContiguous, sortScratchSlotCount)));
 }
 
 JSC_DEFINE_JIT_OPERATION(operationNewArrayWithSize, char*, (JSGlobalObject* globalObject, Structure* arrayStructure, int32_t size, Butterfly* butterfly))

--- a/Source/JavaScriptCore/dfg/DFGOperations.h
+++ b/Source/JavaScriptCore/dfg/DFGOperations.h
@@ -143,6 +143,9 @@ JSC_DECLARE_JIT_OPERATION(operationNewRegExpUntyped, JSObject*, (JSGlobalObject*
 JSC_DECLARE_JIT_OPERATION(operationNewRegExpString, JSObject*, (JSGlobalObject*, Structure*, JSString*, JSString*));
 JSC_DECLARE_JIT_OPERATION(operationNewArray, char*, (JSGlobalObject*, Structure*, void*, size_t));
 JSC_DECLARE_JIT_OPERATION(operationNewEmptyArray, char*, (VM*, Structure*));
+
+static constexpr unsigned sortScratchSlotCount = 16;
+JSC_DECLARE_JIT_OPERATION(operationAcquireSortScratch, JSCell*, (VM*));
 JSC_DECLARE_JIT_OPERATION(operationNewArrayWithSize, char*, (JSGlobalObject*, Structure*, int32_t, Butterfly*));
 JSC_DECLARE_JIT_OPERATION(operationNewArrayWithSizeAndHint, char*, (JSGlobalObject*, Structure*, int32_t, int32_t, Butterfly*));
 JSC_DECLARE_JIT_OPERATION(operationNewInt8ArrayWithSize, char*, (JSGlobalObject*, Structure*, intptr_t, char*));

--- a/Source/JavaScriptCore/dfg/DFGPredictionPropagationPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGPredictionPropagationPhase.cpp
@@ -1335,6 +1335,28 @@ private:
             break;
         }
 
+        case GetCellButterflySlot: {
+            switch (m_currentNode->arrayMode().type()) {
+            case Array::Int32:
+                setPrediction(SpecInt32Only);
+                break;
+            default:
+                setPrediction(SpecBytecodeTop);
+                break;
+            }
+            break;
+        }
+
+        case PutCellButterflySlot:
+        case ArraySortCommit: {
+            break;
+        }
+
+        case ArraySortCompact: {
+            setPrediction(SpecObjectOther);
+            break;
+        }
+
         case GetGlobalThis:
             setPrediction(SpecGlobalProxy);
             break;

--- a/Source/JavaScriptCore/dfg/DFGSafeToExecute.h
+++ b/Source/JavaScriptCore/dfg/DFGSafeToExecute.h
@@ -663,6 +663,10 @@ bool safeToExecute(AbstractStateType& state, Graph& graph, Node* node, bool igno
     case NewArrayWithSize:
     case NewArrayWithButterfly:
     case NewButterflyWithSize:
+    case GetCellButterflySlot:
+    case PutCellButterflySlot:
+    case ArraySortCompact:
+    case ArraySortCommit:
     case NewArrayWithSpecies:
     case NewArrayWithSizeAndStructure:
     case NewArrayBuffer:

--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp
@@ -15384,6 +15384,109 @@ void SpeculativeJIT::compileNewButterflyWithSize(Node* node)
     storageResult(storageGPR, node);
 }
 
+void SpeculativeJIT::compileGetCellButterflySlot(Node* node)
+{
+    SpeculateCellOperand scratch(this, node->child1());
+    SpeculateInt32Operand index(this, node->child2());
+    GPRTemporary result(this);
+
+    GPRReg scratchGPR = scratch.gpr();
+    GPRReg indexGPR = index.gpr();
+    GPRReg resultGPR = result.gpr();
+
+    load64(BaseIndex(scratchGPR, indexGPR, TimesEight, JSCellButterfly::offsetOfData()), resultGPR);
+    jsValueResult(resultGPR, node);
+}
+
+void SpeculativeJIT::compilePutCellButterflySlot(Node* node)
+{
+    SpeculateCellOperand scratch(this, node->child1());
+    SpeculateInt32Operand index(this, node->child2());
+    JSValueOperand value(this, node->child3());
+
+    GPRReg scratchGPR = scratch.gpr();
+    GPRReg indexGPR = index.gpr();
+    JSValueRegs valueRegs = value.jsValueRegs();
+
+    store64(valueRegs.gpr(), BaseIndex(scratchGPR, indexGPR, TimesEight, JSCellButterfly::offsetOfData()));
+    noResult(node);
+}
+
+void SpeculativeJIT::compileArraySortCompact(Node* node)
+{
+    SpeculateCellOperand array(this, node->child1());
+    SpeculateInt32Operand length(this, node->child2());
+
+    GPRReg arrayGPR = array.gpr();
+    GPRReg lengthGPR = length.gpr();
+
+    GPRTemporary scratch(this);
+    GPRTemporary counter(this);
+    GPRTemporary value(this);
+    GPRTemporary butterfly(this);
+
+    GPRReg scratchGPR = scratch.gpr();
+    GPRReg counterGPR = counter.gpr();
+    GPRReg valueGPR = value.gpr();
+    GPRReg butterflyGPR = butterfly.gpr();
+
+    loadPtr(&vm().m_cachedSortScratch, scratchGPR);
+    move(TrustedImmPtr(nullptr), butterflyGPR);
+    storePtr(butterflyGPR, &vm().m_cachedSortScratch);
+
+    JumpList slowCases;
+    slowCases.append(branchTestPtr(Zero, scratchGPR));
+    addSlowPathGenerator(slowPathCall(slowCases, this, operationAcquireSortScratch, scratchGPR, TrustedImmPtr(&vm())));
+
+    loadPtr(Address(arrayGPR, JSObject::butterflyOffset()), butterflyGPR);
+
+    move(lengthGPR, counterGPR);
+    auto loop = label();
+    auto done = branchSub32(Signed, counterGPR, TrustedImm32(1), counterGPR);
+    load64(BaseIndex(butterflyGPR, counterGPR, TimesEight, 0), valueGPR);
+    Jump hole = branchTest64(Zero, valueGPR);
+    store64(valueGPR, BaseIndex(scratchGPR, counterGPR, TimesEight, JSCellButterfly::offsetOfData()));
+    jump().linkTo(loop, this);
+
+    hole.link(this);
+    move(TrustedImmPtr(std::bit_cast<void*>(vm().m_sortScratchSentinel.get())), scratchGPR);
+
+    done.link(this);
+    cellResult(scratchGPR, node);
+}
+
+void SpeculativeJIT::compileArraySortCommit(Node* node)
+{
+    SpeculateCellOperand array(this, node->child1());
+    SpeculateCellOperand storage(this, node->child2());
+    SpeculateInt32Operand length(this, node->child3());
+
+    GPRReg arrayGPR = array.gpr();
+    GPRReg storageGPR = storage.gpr();
+    GPRReg lengthGPR = length.gpr();
+
+    GPRTemporary counter(this);
+    GPRTemporary butterfly(this);
+
+    GPRReg counterGPR = counter.gpr();
+    GPRReg butterflyGPR = butterfly.gpr();
+
+    // If array.length gets modified during sorting, let's reject commit and do OSR exit.
+    loadPtr(Address(arrayGPR, JSObject::butterflyOffset()), butterflyGPR);
+    speculationCheck(BadIndexingType, JSValueRegs(), node, branch32(NotEqual, Address(butterflyGPR, Butterfly::offsetOfPublicLength()), lengthGPR));
+
+    move(lengthGPR, counterGPR);
+    auto loop = label();
+    auto done = branchSub32(Signed, counterGPR, TrustedImm32(1), counterGPR);
+    transfer64(BaseIndex(storageGPR, counterGPR, TimesEight, JSCellButterfly::offsetOfData()), BaseIndex(butterflyGPR, counterGPR, TimesEight, 0));
+    jump().linkTo(loop, this);
+
+    done.link(this);
+    emitFillStorageWithJSEmpty(storageGPR, JSCellButterfly::offsetOfData(), sortScratchSlotCount, counterGPR);
+    storePtr(storageGPR, &vm().m_cachedSortScratch);
+    noResult(node);
+}
+
 void SpeculativeJIT::compileNewArrayWithButterfly(Node* node)
 {
     ASSERT(m_graph.isWatchingHavingABadTimeWatchpoint(node));

--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.h
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.h
@@ -1763,6 +1763,10 @@ public:
     void compileStrCat(Node*);
     void compileNewArrayBuffer(Node*);
     void compileNewButterflyWithSize(Node*);
+    void compileGetCellButterflySlot(Node*);
+    void compilePutCellButterflySlot(Node*);
+    void compileArraySortCompact(Node*);
+    void compileArraySortCommit(Node*);
     void compileNewArrayWithSize(Node*);
     void compileNewArrayWithButterfly(Node*);
     void compileNewArrayWithSpecies(Node*);

--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT32_64.cpp
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT32_64.cpp
@@ -3227,6 +3227,13 @@ void SpeculativeJIT::compile(Node* node)
         break;
     }
 
+    case GetCellButterflySlot:
+    case PutCellButterflySlot:
+    case ArraySortCompact:
+    case ArraySortCommit:
+        RELEASE_ASSERT_NOT_REACHED();
+        break;
+
     case NewArrayWithButterfly: {
         compileNewArrayWithButterfly(node);
         break;

--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT64.cpp
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT64.cpp
@@ -4586,6 +4586,26 @@ void SpeculativeJIT::compile(Node* node)
         break;
     }
 
+    case GetCellButterflySlot: {
+        compileGetCellButterflySlot(node);
+        break;
+    }
+
+    case PutCellButterflySlot: {
+        compilePutCellButterflySlot(node);
+        break;
+    }
+
+    case ArraySortCompact: {
+        compileArraySortCompact(node);
+        break;
+    }
+
+    case ArraySortCommit: {
+        compileArraySortCommit(node);
+        break;
+    }
+
     case NewArrayWithButterfly: {
         compileNewArrayWithButterfly(node);
         break;

--- a/Source/JavaScriptCore/dfg/DFGStoreBarrierInsertionPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGStoreBarrierInsertionPhase.cpp
@@ -289,7 +289,14 @@ private:
                 }
                 break;
             }
-                
+            case ArraySortCommit: {
+                considerBarrier(m_node->child1());
+                break;
+            }
+            case ArraySortCompact: {
+                considerBarrier(Edge(m_node, KnownCellUse));
+                break;
+            }
             case PutPrivateName: {
                 if (!m_graph.m_slowPutByVal.contains(m_node) && (m_node->child1().useKind() == CellUse || m_node->child1().useKind() == KnownCellUse))
                     // FIXME: there are some cases where we can avoid a store barrier by considering the value https://bugs.webkit.org/show_bug.cgi?id=230377
@@ -339,6 +346,11 @@ private:
             case SetRegExpObjectLastIndex:
             case PutInternalField: {
                 considerBarrier(m_node->child1(), m_node->child2());
+                break;
+            }
+
+            case PutCellButterflySlot: {
+                considerBarrier(m_node->child1(), m_node->child3());
                 break;
             }
 

--- a/Source/JavaScriptCore/ftl/FTLCapabilities.cpp
+++ b/Source/JavaScriptCore/ftl/FTLCapabilities.cpp
@@ -255,6 +255,10 @@ inline CapabilityLevel canCompile(Node* node)
     case NewArrayWithSize:
     case NewArrayWithButterfly:
     case NewButterflyWithSize:
+    case GetCellButterflySlot:
+    case PutCellButterflySlot:
+    case ArraySortCompact:
+    case ArraySortCommit:
     case NewArrayWithSpecies:
     case NewArrayWithSizeAndStructure:
     case TryGetById:

--- a/Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp
+++ b/Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp
@@ -1284,6 +1284,18 @@ private:
         case NewButterflyWithSize:
             compileNewButterflyWithSize();
             break;
+        case GetCellButterflySlot:
+            compileGetCellButterflySlot();
+            break;
+        case PutCellButterflySlot:
+            compilePutCellButterflySlot();
+            break;
+        case ArraySortCompact:
+            compileArraySortCompact();
+            break;
+        case ArraySortCommit:
+            compileArraySortCommit();
+            break;
         case NewArrayWithSpecies:
             compileNewArrayWithSpecies();
             break;
@@ -10497,6 +10509,105 @@ IGNORE_CLANG_WARNINGS_END
 
         setStorage(butterfly);
         // No mutator fence is needed. Butterflies are only scanned when the GC discovers them in an object not on the stack.
+    }
+
+    void compileGetCellButterflySlot()
+    {
+        LValue scratch = lowCell(m_node->child1());
+        LValue index = lowInt32(m_node->child2());
+        setJSValue(m_out.load64(m_out.baseIndex(m_heaps.indexedContiguousProperties, scratch, m_out.zeroExt(index, pointerType()), JSValue(), JSCellButterfly::offsetOfData())));
+    }
+
+    void compilePutCellButterflySlot()
+    {
+        LValue scratch = lowCell(m_node->child1());
+        LValue index = lowInt32(m_node->child2());
+        LValue value = lowJSValue(m_node->child3());
+        m_out.store64(value, m_out.baseIndex(m_heaps.indexedContiguousProperties, scratch, m_out.zeroExt(index, pointerType()), JSValue(), JSCellButterfly::offsetOfData()));
+    }
+
+    void compileArraySortCompact()
+    {
+        LValue array = lowCell(m_node->child1());
+        LValue length = m_out.zeroExt(lowInt32(m_node->child2()), pointerType());
+
+        IndexedAbstractHeap& sourceHeap = m_node->arrayMode().type() == Array::Int32 ? m_heaps.indexedInt32Properties : m_heaps.indexedContiguousProperties;
+
+        LBasicBlock slowCase = m_out.newBlock();
+        LBasicBlock acquired = m_out.newBlock();
+        LBasicBlock loopHeader = m_out.newBlock();
+        LBasicBlock loopBody = m_out.newBlock();
+        LBasicBlock storeSlot = m_out.newBlock();
+        LBasicBlock continuation = m_out.newBlock();
+
+        LValue cached = m_out.loadPtr(m_out.absolute(&vm().m_cachedSortScratch));
+        m_out.storePtr(m_out.intPtrZero, m_out.absolute(&vm().m_cachedSortScratch));
+        ValueFromBlock fastResult = m_out.anchor(cached);
+        m_out.branch(m_out.isNull(cached), rarely(slowCase), usually(acquired));
+
+        LBasicBlock lastNext = m_out.appendTo(slowCase, acquired);
+        ValueFromBlock slowResult = m_out.anchor(vmCall(pointerType(), operationAcquireSortScratch, m_vmValue));
+        m_out.jump(acquired);
+
+        m_out.appendTo(acquired, loopHeader);
+        LValue scratch = m_out.phi(pointerType(), fastResult, slowResult);
+        LValue butterfly = m_out.loadPtr(array, m_heaps.JSObject_butterfly);
+        ValueFromBlock startIndex = m_out.anchor(m_out.intPtrZero);
+        m_out.jump(loopHeader);
+
+        m_out.appendTo(loopHeader, loopBody);
+        LValue index = m_out.phi(pointerType(), startIndex);
+        ValueFromBlock successResult = m_out.anchor(scratch);
+        m_out.branch(m_out.aboveOrEqual(index, length), unsure(continuation), unsure(loopBody));
+
+        m_out.appendTo(loopBody, storeSlot);
+        LValue value = m_out.load64(m_out.baseIndex(sourceHeap, butterfly, index));
+        ValueFromBlock holeResult = m_out.anchor(m_out.constIntPtr(std::bit_cast<void*>(vm().m_sortScratchSentinel.get())));
+        m_out.branch(m_out.isZero64(value), rarely(continuation), usually(storeSlot));
+
+        m_out.appendTo(storeSlot, continuation);
+        m_out.store64(value, m_out.baseIndex(m_heaps.indexedContiguousProperties, scratch, index, JSValue(), JSCellButterfly::offsetOfData()));
+        LValue nextIndex = m_out.add(index, m_out.intPtrOne);
+        m_out.addIncomingToPhi(index, m_out.anchor(nextIndex));
+        m_out.jump(loopHeader);
+
+        m_out.appendTo(continuation, lastNext);
+        setJSValue(m_out.phi(pointerType(), successResult, holeResult));
+    }
+
+    void compileArraySortCommit()
+    {
+        LValue array = lowCell(m_node->child1());
+        LValue scratch = lowCell(m_node->child2());
+        LValue length = m_out.zeroExt(lowInt32(m_node->child3()), pointerType());
+
+        IndexedAbstractHeap& targetHeap = m_node->arrayMode().type() == Array::Int32 ? m_heaps.indexedInt32Properties : m_heaps.indexedContiguousProperties;
+
+        LBasicBlock commitHeader = m_out.newBlock();
+        LBasicBlock commitBody = m_out.newBlock();
+        LBasicBlock continuation = m_out.newBlock();
+
+        LValue butterfly = m_out.loadPtr(array, m_heaps.JSObject_butterfly);
+        LValue currentLength = m_out.zeroExt(m_out.load32NonNegative(butterfly, m_heaps.Butterfly_publicLength), pointerType());
+        speculate(BadIndexingType, noValue(), nullptr, m_out.notEqual(currentLength, length));
+
+        ValueFromBlock startCommit = m_out.anchor(m_out.intPtrZero);
+        m_out.jump(commitHeader);
+
+        LBasicBlock lastNext = m_out.appendTo(commitHeader, commitBody);
+        LValue index = m_out.phi(pointerType(), startCommit);
+        m_out.branch(m_out.aboveOrEqual(index, length), unsure(continuation), unsure(commitBody));
+
+        m_out.appendTo(commitBody, continuation);
+        LValue value = m_out.load64(m_out.baseIndex(m_heaps.indexedContiguousProperties, scratch, index, JSValue(), JSCellButterfly::offsetOfData()));
+        m_out.store64(value, m_out.baseIndex(targetHeap, butterfly, index));
+        LValue nextIndex = m_out.add(index, m_out.intPtrOne);
+        m_out.addIncomingToPhi(index, m_out.anchor(nextIndex));
+        m_out.jump(commitHeader);
+
+        m_out.appendTo(continuation, lastNext);
+        splatWords(m_out.add(scratch, m_out.constIntPtr(JSCellButterfly::offsetOfData())), m_out.int32Zero, m_out.constInt32(sortScratchSlotCount), m_out.int64Zero, m_heaps.indexedContiguousProperties.atAnyIndex());
+        m_out.storePtr(scratch, m_out.absolute(&vm().m_cachedSortScratch));
     }
 
     void compileNewArrayWithButterfly()

--- a/Source/JavaScriptCore/llint/LLIntSlowPaths.cpp
+++ b/Source/JavaScriptCore/llint/LLIntSlowPaths.cpp
@@ -2676,6 +2676,28 @@ static inline UGPRPair dispatchToNextInstructionDuringExit(ThrowScope& scope, Co
     RELEASE_ASSERT_NOT_REACHED();
 }
 
+static inline UGPRPair dispatchToCurrentInstructionDuringExit(ThrowScope& scope, CodeBlock* codeBlock, JSInstructionStream::Ref pc)
+{
+    if (scope.exception())
+        return encodeResult(returnToThrow(scope.vm()), nullptr);
+
+    if (Options::forceOSRExitToLLInt() || codeBlock->jitType() == JITType::InterpreterThunk) {
+        const JSInstruction* currentPC = pc.ptr();
+#if ENABLE(JIT)
+        return encodeResult(currentPC, LLInt::normalOSRExitTrampolineThunk().code().taggedPtr());
+#else
+        return encodeResult(currentPC, LLInt::getCodeRef<JSEntryPtrTag>(normal_osr_exit_trampoline).code().taggedPtr());
+#endif
+    }
+
+#if ENABLE(JIT)
+    ASSERT(codeBlock->jitType() == JITType::BaselineJIT);
+    auto currentBytecode = codeBlock->jitCodeMap().find(pc.index());
+    return encodeResult(std::bit_cast<void*>(static_cast<uintptr_t>(1)), currentBytecode.taggedPtr());
+#endif
+    RELEASE_ASSERT_NOT_REACHED();
+}
+
 extern "C" UGPRPair SYSV_ABI llint_slow_path_checkpoint_osr_exit_from_inlined_call(CallFrame* callFrame, EncodedJSValue result)
 {
     // Since all our calling checkpoints do right now is move result into our dest we can just do that here and return.
@@ -2804,6 +2826,36 @@ extern "C" UGPRPair SYSV_ABI llint_slow_path_checkpoint_osr_exit(CallFrame* call
     }
 
     return dispatchToNextInstructionDuringExit(throwScope, codeBlock, pc);
+}
+
+extern "C" UGPRPair SYSV_ABI llint_slow_path_array_sort_comparator_return(CallFrame* callFrame, EncodedJSValue /* comparator return -- discarded */)
+{
+    // Called when the DFG ArraySortIntrinsic inlined the comparator and an OSR exit
+    // inside the comparator body routed through this trampoline. For example:
+    //
+    //     function test() {
+    //         array.sort(function userDefinedComparator(a, b) { ... });
+    //     }
+    //
+    //  If we inline both and userDefinedComparator OSR-exits, the stack is:
+    //
+    //      [ test frame                  ]
+    //      [ returnAddress => this fn    ]
+    //      [ userDefinedComparator frame ]
+    //
+    //  After the comparator's baseline finishes we land here. We re-execute
+    //  op_call (sort) instead of advancing past it. This is safe because
+    //  ArraySortCommit (the only node that mutates the array) is downstream of
+    //  the comparator in the DFG graph and has not yet run, and the spec allows
+    //  Array.prototype.sort to invoke the comparator any number of times.
+    LLINT_BEGIN_NO_SET_PC();
+    UNUSED_PARAM(globalObject);
+
+    // reifyInlinedCallFrames stored CallSiteIndex(op_call_bc) in argumentCountIncludingThis's tag.
+    BytecodeIndex bytecodeIndex = callFrame->bytecodeIndex();
+    auto pc = codeBlock->instructions().at(bytecodeIndex);
+    ASSERT_UNUSED(pc, pc->opcodeID() == op_call);
+    return dispatchToCurrentInstructionDuringExit(throwScope, codeBlock, pc);
 }
 
 extern "C" UGPRPair SYSV_ABI llint_throw_stack_overflow_error(VM* vm, ProtoCallFrame* protoFrame)

--- a/Source/JavaScriptCore/llint/LLIntSlowPaths.h
+++ b/Source/JavaScriptCore/llint/LLIntSlowPaths.h
@@ -162,6 +162,7 @@ extern "C" UGPRPair SYSV_ABI llint_check_stack_and_vm_traps(CallFrame*, const JS
 extern "C" UGPRPair SYSV_ABI llint_throw_stack_overflow_error(VM*, ProtoCallFrame*) REFERENCED_FROM_ASM WTF_INTERNAL;
 extern "C" UGPRPair SYSV_ABI llint_slow_path_checkpoint_osr_exit(CallFrame*, EncodedJSValue unused) REFERENCED_FROM_ASM WTF_INTERNAL;
 extern "C" UGPRPair SYSV_ABI llint_slow_path_checkpoint_osr_exit_from_inlined_call(CallFrame*, EncodedJSValue callResult) REFERENCED_FROM_ASM WTF_INTERNAL;
+extern "C" UGPRPair SYSV_ABI llint_slow_path_array_sort_comparator_return(CallFrame*, EncodedJSValue callResult) REFERENCED_FROM_ASM WTF_INTERNAL;
 #if ENABLE(C_LOOP)
 extern "C" UGPRPair SYSV_ABI llint_stack_check_at_vm_entry(VM*, Register*) REFERENCED_FROM_ASM WTF_INTERNAL;
 #endif

--- a/Source/JavaScriptCore/llint/LLIntThunks.cpp
+++ b/Source/JavaScriptCore/llint/LLIntThunks.cpp
@@ -787,6 +787,16 @@ MacroAssemblerCodeRef<JSEntryPtrTag> checkpointOSRExitFromInlinedCallTrampolineT
     return codeRef;
 }
 
+MacroAssemblerCodeRef<JSEntryPtrTag> arraySortComparatorReturnTrampolineThunk()
+{
+    static LazyNeverDestroyed<MacroAssemblerCodeRef<JSEntryPtrTag>> codeRef;
+    static std::once_flag onceKey;
+    std::call_once(onceKey, [&] {
+        codeRef.construct(generateThunkWithJumpToLLIntReturnPoint<JSEntryPtrTag>(array_sort_comparator_return_trampoline, "array_sort_comparator_return_trampoline thunk"));
+    });
+    return codeRef;
+}
+
 MacroAssemblerCodeRef<JSEntryPtrTag> returnLocationThunk(OpcodeID opcodeID, OpcodeSize size)
 {
 #define LLINT_RETURN_LOCATION(name) \

--- a/Source/JavaScriptCore/llint/LLIntThunks.h
+++ b/Source/JavaScriptCore/llint/LLIntThunks.h
@@ -121,6 +121,7 @@ MacroAssemblerCodeRef<JSEntryPtrTag> normalOSRExitTrampolineThunk();
 #if ENABLE(DFG_JIT)
 MacroAssemblerCodeRef<JSEntryPtrTag> checkpointOSRExitTrampolineThunk();
 MacroAssemblerCodeRef<JSEntryPtrTag> checkpointOSRExitFromInlinedCallTrampolineThunk();
+MacroAssemblerCodeRef<JSEntryPtrTag> arraySortComparatorReturnTrampolineThunk();
 MacroAssemblerCodeRef<JSEntryPtrTag> returnLocationThunk(OpcodeID, OpcodeSize);
 #endif
 

--- a/Source/JavaScriptCore/llint/LowLevelInterpreter.asm
+++ b/Source/JavaScriptCore/llint/LowLevelInterpreter.asm
@@ -3085,6 +3085,32 @@ op(normal_osr_exit_trampoline, macro ()
     dispatch(0)
 end)
 
+op(array_sort_comparator_return_trampoline, macro ()
+    if (JSVALUE64 and not C_LOOP) or ARMv7
+        restoreStackPointerAfterCall()
+
+        if ARMv7
+            move cfr, a0
+            cCall4(_llint_slow_path_array_sort_comparator_return)
+        else
+            move cfr, a0
+            cCall2(_llint_slow_path_array_sort_comparator_return)
+        end
+
+        setupReturnToBaselineAfterCheckpointExitIfNeeded()
+        restoreStateAfterCCall()
+        branchIfException(_llint_throw_from_slow_path_trampoline)
+        if ARM64E
+            move r1, a0
+            leap _g_config, a2
+            jmp JSCConfigGateMapOffset + (constexpr Gate::loopOSREntry) * PtrSize[a2], NativeToJITGatePtrTag # JSEntryPtrTag
+        else
+            jmp r1, JSEntryPtrTag
+        end
+    else
+        notSupported()
+    end
+end)
 
 # Lastly, make sure that we can link even though we don't support all opcodes.
 # These opcodes should never arise when using LLInt or either JIT. We assert

--- a/Source/JavaScriptCore/runtime/ArrayPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/ArrayPrototype.cpp
@@ -112,7 +112,7 @@ void ArrayPrototype::finishCreation(VM& vm, JSGlobalObject* globalObject)
     JSC_NATIVE_FUNCTION_WITHOUT_TRANSITION(vm.propertyNames->builtinNames().shiftPublicName(), arrayProtoFuncShift, static_cast<unsigned>(PropertyAttribute::DontEnum), 0, ImplementationVisibility::Public);
     JSC_NATIVE_FUNCTION_WITHOUT_TRANSITION(vm.propertyNames->builtinNames().shiftPrivateName(), arrayProtoFuncShift, PropertyAttribute::DontEnum | PropertyAttribute::DontDelete | PropertyAttribute::ReadOnly, 0, ImplementationVisibility::Public);
     JSC_NATIVE_INTRINSIC_FUNCTION_WITHOUT_TRANSITION(vm.propertyNames->slice, arrayProtoFuncSlice, static_cast<unsigned>(PropertyAttribute::DontEnum), 2, ImplementationVisibility::Public, ArraySliceIntrinsic);
-    JSC_NATIVE_FUNCTION_WITHOUT_TRANSITION(vm.propertyNames->sort, arrayProtoFuncSort, static_cast<unsigned>(PropertyAttribute::DontEnum), 1, ImplementationVisibility::Public);
+    JSC_NATIVE_INTRINSIC_FUNCTION_WITHOUT_TRANSITION(vm.propertyNames->sort, arrayProtoFuncSort, static_cast<unsigned>(PropertyAttribute::DontEnum), 1, ImplementationVisibility::Public, ArraySortIntrinsic);
     JSC_NATIVE_INTRINSIC_FUNCTION_WITHOUT_TRANSITION("splice"_s, arrayProtoFuncSplice, static_cast<unsigned>(PropertyAttribute::DontEnum), 2, ImplementationVisibility::Public, ArraySpliceIntrinsic);
     JSC_NATIVE_FUNCTION_WITHOUT_TRANSITION("unshift"_s, arrayProtoFuncUnShift, static_cast<unsigned>(PropertyAttribute::DontEnum), 1, ImplementationVisibility::Public);
     JSC_BUILTIN_FUNCTION_WITHOUT_TRANSITION(vm.propertyNames->builtinNames().everyPublicName(), arrayPrototypeEveryCodeGenerator, static_cast<unsigned>(PropertyAttribute::DontEnum));

--- a/Source/JavaScriptCore/runtime/Intrinsic.h
+++ b/Source/JavaScriptCore/runtime/Intrinsic.h
@@ -59,6 +59,7 @@ namespace JSC {
     macro(ArraySpliceIntrinsic) \
     macro(ArrayIncludesIntrinsic) \
     macro(ArrayIndexOfIntrinsic) \
+    macro(ArraySortIntrinsic) \
     macro(ArrayValuesIntrinsic) \
     macro(ArrayKeysIntrinsic) \
     macro(ArrayEntriesIntrinsic) \

--- a/Source/JavaScriptCore/runtime/VM.cpp
+++ b/Source/JavaScriptCore/runtime/VM.cpp
@@ -379,6 +379,7 @@ WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
     bigIntStructure.setWithoutWriteBarrier(JSBigInt::createStructure(*this, nullptr, jsNull()));
     m_orderedHashTableDeletedValue.setWithoutWriteBarrier(OrderedHashMap::createDeletedValue(*this));
     m_orderedHashTableSentinel.setWithoutWriteBarrier(OrderedHashMap::createSentinel(*this));
+    m_sortScratchSentinel.setWithoutWriteBarrier(JSCellButterfly::create(*this, CopyOnWriteArrayWithContiguous, 0));
 
     // Eagerly initialize constant cells since the concurrent compiler can access them.
     if (Options::useJIT()) {
@@ -1885,6 +1886,8 @@ void VM::visitAggregateImpl(Visitor& visitor)
     visitor.append(m_emptyPropertyNameEnumerator);
     visitor.append(m_orderedHashTableDeletedValue);
     visitor.append(m_orderedHashTableSentinel);
+    visitor.append(m_cachedSortScratch);
+    visitor.append(m_sortScratchSentinel);
     visitor.append(m_fastCanConstructBoundExecutable);
     visitor.append(m_slowCanConstructBoundExecutable);
     visitor.append(lastCachedString);

--- a/Source/JavaScriptCore/runtime/VM.h
+++ b/Source/JavaScriptCore/runtime/VM.h
@@ -580,6 +580,9 @@ public:
     WriteBarrier<JSCell> m_orderedHashTableDeletedValue;
     WriteBarrier<JSCell> m_orderedHashTableSentinel;
 
+    WriteBarrier<JSCell> m_cachedSortScratch;
+    WriteBarrier<JSCell> m_sortScratchSentinel;
+
     WriteBarrier<NativeExecutable> m_fastCanConstructBoundExecutable;
     WriteBarrier<NativeExecutable> m_slowCanConstructBoundExecutable;
 


### PR DESCRIPTION
#### cab7a45a413cbe0861fc34eb675a4d9cf22ea199
<pre>
[JSC] Inline small sorting in DFG / FTL
<a href="https://bugs.webkit.org/show_bug.cgi?id=313668">https://bugs.webkit.org/show_bug.cgi?id=313668</a>
<a href="https://rdar.apple.com/175871778">rdar://175871778</a>

Reviewed by Yijia Huang.

This patch enables fully-inlining Array.prototype.sort function in DFG /
FTL graph, including inlining a comparator call.

1. We fully inline Contiguous / Int32 / Undecided array sorting up to 16
   elements. Right now, we do not support Double array.
2. The form is

    scratch = ArraySortCompact(array)
    ... sorting scratch ...
    ArraySortCommit(scratch, array)

   And we do sorting inline against scratch. ArraySortCompact filters
   hole array case etc., and they are going to the slow path call (which
   just uses normal sort). ArraySortCommit will apply sorted result back
   to array.
3. The most notable interesting part is OSR exit handling. In
   Array.prototype.sort, all OSR exit will be handled as &quot;retry entire
   sorting again&quot;. This is fine because the spec does not define
   anything about how the comparator is called. This characteristics is
   leveraged in V8 too.
4. When comparator is inlined and OSR exit happens, then comparator must
   continue running its code. But after returning from the comparator,
   we are returning to array_sort_comparator_return_trampoline. Then it
   adjust the next PC and restart `op_call` of Array.prototype.sort again.

Tests: JSTests/stress/array-sort-inline-closure-comparator.js
       JSTests/stress/array-sort-inline-constant-comparator.js
       JSTests/stress/array-sort-inline-contiguous.js
       JSTests/stress/array-sort-inline-full.js
       JSTests/stress/array-sort-inline-holey.js
       JSTests/stress/array-sort-inline-len2.js
       JSTests/stress/array-sort-inline-osr-exit-in-comparator.js
       JSTests/stress/array-sort-inline-small.js
       JSTests/stress/array-sort-inline-stack-trace.js

* JSTests/stress/array-sort-inline-boolean-comparator.js: Added.
(check):
(sortIt):
(expected):
(i.const.cmp):
(i.const.neg.valueOf):
(i.const.pos.valueOf):
(i.const.zero.valueOf):
(i.catch):
* JSTests/stress/array-sort-inline-closure-comparator.js: Added.
(test):
(descendingTest):
* JSTests/stress/array-sort-inline-comparator-speculation-exit.js: Added.
(cmp):
(sortIt):
(assertSorted):
(throwingCmp):
(catch):
* JSTests/stress/array-sort-inline-constant-comparator.js: Added.
(cmp):
(test):
* JSTests/stress/array-sort-inline-contiguous.js: Added.
(sortIt):
(return.a.sort):
(throw.new.Error):
* JSTests/stress/array-sort-inline-full.js: Added.
(sortAsc):
(runSize):
(bigTest):
(stableTest):
(catch):
* JSTests/stress/array-sort-inline-holey.js: Added.
(cmp):
(sortIt):
(runHoley):
* JSTests/stress/array-sort-inline-large.js: Added.
(cmp):
(cmpDesc):
(doSort):
(makeReversed):
(makeRandomish):
(assertSorted):
(alternating):
(catch):
* JSTests/stress/array-sort-inline-len2.js: Added.
(cmpAsc):
(sortWith):
(countingCmp):
* JSTests/stress/array-sort-inline-mixed-sizes.js: Added.
(cmp):
(makeSmall):
(makeLarge):
(harness):
(vm.useFTLJIT):
(check):
(large.sort):
* JSTests/stress/array-sort-inline-noncallable-typeerror.js: Added.
(expectThrow):
(makeEmpty):
(makeSingle):
(sortIt):
(i.expectThrow.sortIt.makeEmpty):
(i.expectThrow.sortIt.makeSingle):
* JSTests/stress/array-sort-inline-osr-exit-in-comparator-with-spread.js: Added.
(cmp):
(sortAndSpread):
(check):
* JSTests/stress/array-sort-inline-osr-exit-in-comparator.js: Added.
(inlinedComparator):
(test):
(multiset):
(sameMultiset):
* JSTests/stress/array-sort-inline-polymorphic-comparator.js: Added.
(cmpAsc):
(cmpDesc):
(cmpMod3Asc):
(cmpByAbs):
(doSort):
(expectedFor):
(w.try.doSort.seed.slice):
(w.catch):
(cmpThrow):
(catch):
* JSTests/stress/array-sort-inline-small.js: Added.
(cmp):
(callSort):
* JSTests/stress/array-sort-inline-stack-trace.js: Added.
(inlined):
(test):
(catch):
* Source/JavaScriptCore/bytecode/BytecodeList.rb:
* Source/JavaScriptCore/bytecode/InlineCallFrame.cpp:
(WTF::printInternal):
* Source/JavaScriptCore/bytecode/InlineCallFrame.h:
(JSC::InlineCallFrame::callModeFor):
(JSC::InlineCallFrame::specializationKindFor):
* Source/JavaScriptCore/dfg/DFGAbstractInterpreterInlines.h:
(JSC::DFG::AbstractInterpreter&lt;AbstractStateType&gt;::executeEffects):
* Source/JavaScriptCore/dfg/DFGByteCodeParser.cpp:
(JSC::DFG::ByteCodeParser::emitExitOK):
(JSC::DFG::ByteCodeParser::handleCallVariant):
(JSC::DFG::ByteCodeParser::handleIntrinsicCall):
(JSC::DFG::ByteCodeParser::handleArraySort):
* Source/JavaScriptCore/dfg/DFGClobberize.h:
(JSC::DFG::clobberize):
* Source/JavaScriptCore/dfg/DFGDoesGC.cpp:
(JSC::DFG::doesGC):
* Source/JavaScriptCore/dfg/DFGFixupPhase.cpp:
(JSC::DFG::FixupPhase::fixupNode):
* Source/JavaScriptCore/dfg/DFGMayExit.cpp:
* Source/JavaScriptCore/dfg/DFGNode.h:
(JSC::DFG::Node::hasArrayMode):
* Source/JavaScriptCore/dfg/DFGNodeType.h:
* Source/JavaScriptCore/dfg/DFGOSRExitCompilerCommon.cpp:
(JSC::DFG::callerReturnPC):
* Source/JavaScriptCore/dfg/DFGOperations.cpp:
(JSC::DFG::JSC_DEFINE_JIT_OPERATION):
* Source/JavaScriptCore/dfg/DFGOperations.h:
* Source/JavaScriptCore/dfg/DFGPredictionPropagationPhase.cpp:
* Source/JavaScriptCore/dfg/DFGSafeToExecute.h:
(JSC::DFG::safeToExecute):
* Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp:
* Source/JavaScriptCore/dfg/DFGSpeculativeJIT.h:
* Source/JavaScriptCore/dfg/DFGSpeculativeJIT32_64.cpp:
(JSC::DFG::SpeculativeJIT::compile):
* Source/JavaScriptCore/dfg/DFGSpeculativeJIT64.cpp:
(JSC::DFG::SpeculativeJIT::compile):
* Source/JavaScriptCore/dfg/DFGStoreBarrierInsertionPhase.cpp:
* Source/JavaScriptCore/ftl/FTLCapabilities.cpp:
(JSC::FTL::canCompile):
* Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp:
(JSC::FTL::DFG::LowerDFGToB3::compileNode):
(JSC::FTL::DFG::LowerDFGToB3::compileGetCellButterflySlot):
(JSC::FTL::DFG::LowerDFGToB3::compilePutCellButterflySlot):
(JSC::FTL::DFG::LowerDFGToB3::compileArraySortCompact):
(JSC::FTL::DFG::LowerDFGToB3::compileArraySortCommit):
* Source/JavaScriptCore/llint/LLIntSlowPaths.cpp:
(JSC::LLInt::dispatchToCurrentInstructionDuringExit):
(JSC::LLInt::llint_slow_path_array_sort_comparator_return):
* Source/JavaScriptCore/llint/LLIntSlowPaths.h:
* Source/JavaScriptCore/llint/LLIntThunks.cpp:
(JSC::LLInt::arraySortComparatorReturnTrampolineThunk):
* Source/JavaScriptCore/llint/LLIntThunks.h:
* Source/JavaScriptCore/llint/LowLevelInterpreter.asm:
* Source/JavaScriptCore/runtime/ArrayPrototype.cpp:
(JSC::ArrayPrototype::finishCreation):
* Source/JavaScriptCore/runtime/Intrinsic.h:
* Source/JavaScriptCore/runtime/VM.cpp:
(JSC::VM::VM):
(JSC::VM::visitAggregateImpl):
* Source/JavaScriptCore/runtime/VM.h:

Canonical link: <a href="https://commits.webkit.org/312983@main">https://commits.webkit.org/312983@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/871bb824f19abffef93ac8193bd7a94184a21f13

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/161514 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/34988 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/28091 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/170417 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/117885 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/de4f717d-9ab2-4a4d-afdd-3e072e5d2679) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/35089 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/34989 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/125313 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/88254 "1 flakes 3 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/de1bbe87-1e29-4040-96ae-110a37e7461f) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/164473 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/27602 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/145091 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/105909 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/ce5d5169-efeb-4519-b998-4d631e7644fb) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/26651 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/25166 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/18138 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/153571 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/136345 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/22848 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/172904 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/22352 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/19946 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/24489 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/133601 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/34662 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/29262 "Found 8 new test failures: http/tests/site-isolation/inspector/console/message-from-iframe.html http/tests/site-isolation/inspector/console/message-from-worker.html http/tests/site-isolation/inspector/dom/getDocument-frame-target.html http/tests/site-isolation/inspector/page/override-user-agent-cross-origin-iframe.html http/tests/site-isolation/inspector/target/target-cross-origin-page-navigation.html http/tests/site-isolation/inspector/target/target.html http/tests/site-isolation/inspector/unit-tests/target-manager.html http/tests/site-isolation/inspector/worker/worker-in-cross-origin-iframe.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/133608 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/34646 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/144643 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/96551 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/24559 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/28132 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/21462 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/193913 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/34156 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/101601 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/49963 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/33656 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/33899 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/33805 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->