### PR TITLE
[Smart Lists] Preserve styling of the initial dashes used to create the list

### DIFF
--- a/Source/WebCore/editing/TextListParser.cpp
+++ b/Source/WebCore/editing/TextListParser.cpp
@@ -98,11 +98,21 @@ std::optional<TextList> tryConsumeUnorderedDiscTextList(StringParsingBuffer<Char
 template<typename Character>
 std::optional<TextList> tryConsumeUnorderedDashTextList(StringParsingBuffer<Character>& input)
 {
-    static constexpr std::array marker { WTF::Unicode::enDash, WTF::Unicode::noBreakSpace, WTF::Unicode::noBreakSpace };
+    auto isDashCharacter = [](auto c) {
+        return c == WTF::Unicode::hyphenMinus
+            || c == WTF::Unicode::hyphen
+            || c == WTF::Unicode::emDash
+            || c == WTF::Unicode::enDash;
+    };
 
-    if (WTF::skipExactly(input, WTF::Unicode::hyphenMinus)) {
-        if (input.atEnd())
+    if (!input.atEnd() && isDashCharacter(*input)) {
+        auto dashCharacter = *input;
+        ++input;
+
+        if (input.atEnd()) {
+            std::array marker { static_cast<char16_t>(dashCharacter), WTF::Unicode::noBreakSpace, WTF::Unicode::noBreakSpace };
             return { { Style::ListStyleType { Style::String { WTF::String { std::span { marker } } } }, 0, false } };
+        }
 
         skipToEnd(input);
     }

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/SmartLists.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/SmartLists.mm
@@ -242,10 +242,9 @@ TEST(SmartLists, InsertingSpaceAndTextAfterBulletPointGeneratesListWithText)
     runTest(inputWithBullet.get(), expectedHTML.createNSString().get(), @"//body/ul/li[2]/text()", @"World".length);
 }
 
-TEST(SmartLists, InsertingSpaceAndTextAfterHyphenGeneratesDashedList)
+TEST(SmartLists, InsertingSpaceAfterHyphenMinusGeneratesDashedListWithHyphenMinusMarker)
 {
-    auto marker = WTF::makeString(WTF::Unicode::enDash, WTF::Unicode::noBreakSpace, WTF::Unicode::noBreakSpace);
-
+    auto marker = WTF::makeString(WTF::Unicode::hyphenMinus, WTF::Unicode::noBreakSpace, WTF::Unicode::noBreakSpace);
     static constexpr auto expectedHTMLTemplate = R"""(
     <body contenteditable="">
         <ul style="list-style-type: '<MARKER>';">
@@ -256,8 +255,63 @@ TEST(SmartLists, InsertingSpaceAndTextAfterHyphenGeneratesDashedList)
     )"""_s;
 
     RetainPtr expectedHTML = WTF::makeStringByReplacingAll(expectedHTMLTemplate, "<MARKER>"_s, marker).createNSString();
+    RetainPtr input = makeString(WTF::Unicode::hyphenMinus, " Hello\n"_s, WTF::Unicode::hyphenMinus, " World"_s).createNSString();
 
-    runTest(@"- Hello\n- World", expectedHTML.get(), @"//body/ul/li[2]/text()", @"World".length);
+    runTest(input.get(), expectedHTML.get(), @"//body/ul/li[2]/text()", @"World".length);
+}
+
+TEST(SmartLists, InsertingSpaceAfterUnicodeHyphenGeneratesDashedListWithHyphenMarker)
+{
+    auto marker = WTF::makeString(WTF::Unicode::hyphen, WTF::Unicode::noBreakSpace, WTF::Unicode::noBreakSpace);
+    static constexpr auto expectedHTMLTemplate = R"""(
+    <body contenteditable="">
+        <ul style="list-style-type: '<MARKER>';">
+            <li>Hello</li>
+            <li>World</li>
+        </ul>
+    </body>
+    )"""_s;
+
+    RetainPtr expectedHTML = WTF::makeStringByReplacingAll(expectedHTMLTemplate, "<MARKER>"_s, marker).createNSString();
+    RetainPtr input = makeString(WTF::Unicode::hyphen, " Hello\n"_s, WTF::Unicode::hyphen, " World"_s).createNSString();
+
+    runTest(input.get(), expectedHTML.get(), @"//body/ul/li[2]/text()", @"World".length);
+}
+
+TEST(SmartLists, InsertingSpaceAfterUnicodeEnDashGeneratesDashedListWithEnDashMarker)
+{
+    auto marker = WTF::makeString(WTF::Unicode::enDash, WTF::Unicode::noBreakSpace, WTF::Unicode::noBreakSpace);
+    static constexpr auto expectedHTMLTemplate = R"""(
+    <body contenteditable="">
+        <ul style="list-style-type: '<MARKER>';">
+            <li>Hello</li>
+            <li>World</li>
+        </ul>
+    </body>
+    )"""_s;
+
+    RetainPtr expectedHTML = WTF::makeStringByReplacingAll(expectedHTMLTemplate, "<MARKER>"_s, marker).createNSString();
+    RetainPtr input = makeString(WTF::Unicode::enDash, " Hello\n"_s, WTF::Unicode::enDash, " World"_s).createNSString();
+
+    runTest(input.get(), expectedHTML.get(), @"//body/ul/li[2]/text()", @"World".length);
+}
+
+TEST(SmartLists, InsertingSpaceAfterEmDashGeneratesDashedListWithEmDashMarker)
+{
+    auto marker = WTF::makeString(WTF::Unicode::emDash, WTF::Unicode::noBreakSpace, WTF::Unicode::noBreakSpace);
+    static constexpr auto expectedHTMLTemplate = R"""(
+    <body contenteditable="">
+        <ul style="list-style-type: '<MARKER>';">
+            <li>Hello</li>
+            <li>World</li>
+        </ul>
+    </body>
+    )"""_s;
+
+    RetainPtr expectedHTML = WTF::makeStringByReplacingAll(expectedHTMLTemplate, "<MARKER>"_s, marker).createNSString();
+    RetainPtr input = makeString(WTF::Unicode::emDash, " Hello\n"_s, WTF::Unicode::emDash, " World"_s).createNSString();
+
+    runTest(input.get(), expectedHTML.get(), @"//body/ul/li[2]/text()", @"World".length);
 }
 
 TEST(SmartLists, InsertingSpaceAfterBulletPointGeneratesEmptyList)
@@ -360,7 +414,7 @@ TEST(SmartLists, InsertingSpaceAfterLargeNumberDoesNotGenerateOrderedList)
 
 TEST(SmartLists, InsertingDifferentListStylesDoesNotMergeLists)
 {
-    auto dashMarker = WTF::makeString(WTF::Unicode::enDash, WTF::Unicode::noBreakSpace, WTF::Unicode::noBreakSpace);
+    auto dashMarker = WTF::makeString(WTF::Unicode::hyphenMinus, WTF::Unicode::noBreakSpace, WTF::Unicode::noBreakSpace);
 
     static constexpr auto expectedHTMLTemplate = R"""(
     <body contenteditable="">


### PR DESCRIPTION
#### 1f3404a0e9fa9f4e00501f3c2db7aba5edfb0a99
<pre>
[Smart Lists] Preserve styling of the initial dashes used to create the list
<a href="https://bugs.webkit.org/show_bug.cgi?id=313666">https://bugs.webkit.org/show_bug.cgi?id=313666</a>
<a href="https://rdar.apple.com/175057775">rdar://175057775</a>

Reviewed by Megan Gardner and Ryosuke Niwa.

Smart list dashed lists should include support for hyphens, en dashes, and em dashes.
Implement this along with preserving their style for smart lists. Include API
tests for creating lists of all supported dash styles.

Additionally, remove InsertingSpaceAndTextAfterHyphenGeneratesDashedList due to
the logic being included in the new tests, causing it to be redundant. Alter
InsertingDifferentListStylesDoesNotMergeLists to expect hyphens instead of en dashes
since the expectation is not for all dashed lists to be of en dashed type anymore.

* Source/WebCore/editing/TextListParser.cpp:
(WebCore::tryConsumeUnorderedDashTextList):
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/SmartLists.mm:
(InsertingSpaceAfterHyphenMinusGeneratesDashedListWithHyphenMinusMarker)):
((SmartLists, InsertingSpaceAfterUnicodeHyphenGeneratesDashedListWithHyphenMarker)):
((SmartLists, InsertingSpaceAfterUnicodeEnDashGeneratesDashedListWithEnDashMarker)):
((SmartLists, InsertingSpaceAfterEmDashGeneratesDashedListWithEmDashMarker)):
((SmartLists, InsertingDifferentListStylesDoesNotMergeLists)):
(InsertingSpaceAndTextAfterHyphenGeneratesDashedList)): Deleted.

Canonical link: <a href="https://commits.webkit.org/312368@main">https://commits.webkit.org/312368@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/417a50111d9ffef910150d27c38db669a1afba69

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/159599 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/33066 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/26173 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/168446 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/113980 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/9b5d1a07-1444-4d85-9f3e-f3e2e33501e1) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/161468 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/33171 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/33070 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/123654 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/86783 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/162556 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/25912 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/143339 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/104306 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/11f9a77e-1f2e-4855-9e90-d2da7468a61b) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/24963 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/23426 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/16212 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/134655 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/21111 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/170935 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/16967 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/22745 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/131887 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/32745 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/27499 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/131972 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/32730 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/142904 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/90812 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/24304 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/26614 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/19718 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/32239 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/98635 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/31736 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/31983 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/31887 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->