### PR TITLE
[JSC] Optimize Array.prototype.lastIndexOf

### DIFF
--- a/JSTests/microbenchmarks/array-prototype-lastIndexOf-contiguous-long.js
+++ b/JSTests/microbenchmarks/array-prototype-lastIndexOf-contiguous-long.js
@@ -1,0 +1,16 @@
+var array = new Array(4096);
+for (var i = 0; i < array.length; ++i)
+    array[i] = { value: i };
+var needle = array[1];
+var missing = { value: -1 };
+
+function test(array) {
+    var result = 0;
+    result += array.lastIndexOf(needle);
+    result += array.lastIndexOf(missing);
+    return result;
+}
+noInline(test);
+
+for (var i = 0; i < testLoopCount; ++i)
+    test(array);

--- a/JSTests/microbenchmarks/array-prototype-lastIndexOf-int32-long.js
+++ b/JSTests/microbenchmarks/array-prototype-lastIndexOf-int32-long.js
@@ -1,0 +1,14 @@
+var array = new Array(4096);
+for (var i = 0; i < array.length; ++i)
+    array[i] = i;
+
+function test(array) {
+    var result = 0;
+    result += array.lastIndexOf(1);
+    result += array.lastIndexOf(-1);
+    return result;
+}
+noInline(test);
+
+for (var i = 0; i < testLoopCount; ++i)
+    test(array);

--- a/Source/JavaScriptCore/runtime/ArrayPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/ArrayPrototype.cpp
@@ -1239,13 +1239,10 @@ ALWAYS_INLINE JSValue fastIndexOf(JSGlobalObject* globalObject, VM& vm, JSArray*
             if (result)
                 return jsNumber(result - data);
         } else {
-            do {
-                ASSERT(index < length);
-                // Array#lastIndexOf uses `===` semantics (not UncheckedKeyHashMap isEqual semantics).
-                // And the hole never matches against Int32 value.
-                if (searchInt32 == data[index].get())
-                    return jsNumber(index);
-            } while (index--);
+            EncodedJSValue encodedSearchElement = JSValue::encode(searchInt32);
+            auto* result = std::bit_cast<const WriteBarrier<Unknown>*>(WTF::reverseFind64(std::bit_cast<const uint64_t*>(data), encodedSearchElement, static_cast<uint64_t>(index) + 1));
+            if (result)
+                return jsNumber(result - data);
         }
         return jsNumber(-1);
     }
@@ -1271,6 +1268,13 @@ ALWAYS_INLINE JSValue fastIndexOf(JSGlobalObject* globalObject, VM& vm, JSArray*
                     return jsNumber(index);
             }
         } else {
+            if (searchElement.isObject()) {
+                auto* result = std::bit_cast<const WriteBarrier<Unknown>*>(WTF::reverseFind64(std::bit_cast<const uint64_t*>(data), JSValue::encode(searchElement), static_cast<uint64_t>(index) + 1));
+                if (result)
+                    return jsNumber(result - data);
+                return jsNumber(-1);
+            }
+
             do {
                 ASSERT(index < length);
                 JSValue value = data[index].get();

--- a/Source/WTF/wtf/text/StringCommon.h
+++ b/Source/WTF/wtf/text/StringCommon.h
@@ -785,6 +785,63 @@ ALWAYS_INLINE const uint32_t* NODELETE reverseFind32(const uint32_t* pointer, ui
     return reverseFindImpl(pointer, character, length);
 }
 
+SUPPRESS_NODELETE ALWAYS_INLINE const uint64_t* NODELETE reverseFind64(const uint64_t* pointer, uint64_t character, size_t length)
+{
+    constexpr size_t scalarThreshold = 4;
+    size_t index = length;
+    size_t runway = length > scalarThreshold ? length - scalarThreshold : 0;
+    while (index > runway) {
+        --index;
+        if (pointer[index] == character)
+            return pointer + index;
+    }
+    if (!runway)
+        return nullptr;
+
+    constexpr size_t stride = SIMD::stride<uint64_t>;
+    constexpr size_t unrollFactor = 4;
+    constexpr size_t unrolledStride = stride * unrollFactor;
+
+    auto charactersVector = SIMD::splat<uint64_t>(character);
+    auto vectorMatch = [&](auto value) ALWAYS_INLINE_LAMBDA {
+        auto mask = SIMD::equal(value, charactersVector);
+        return SIMD::findLastNonZeroIndex(mask);
+    };
+
+    auto* begin = pointer;
+    auto* cursor = pointer + runway;
+
+    while (cursor >= begin + unrolledStride) {
+        cursor -= unrolledStride;
+        auto v0 = SIMD::load(cursor);
+        auto v1 = SIMD::load(cursor + stride);
+        auto v2 = SIMD::load(cursor + stride * 2);
+        auto v3 = SIMD::load(cursor + stride * 3);
+
+        if (auto idx = vectorMatch(v3))
+            return cursor + stride * 3 + idx.value();
+        if (auto idx = vectorMatch(v2))
+            return cursor + stride * 2 + idx.value();
+        if (auto idx = vectorMatch(v1))
+            return cursor + stride + idx.value();
+        if (auto idx = vectorMatch(v0))
+            return cursor + idx.value();
+    }
+
+    while (cursor >= begin + stride) {
+        cursor -= stride;
+        if (auto idx = vectorMatch(SIMD::load(cursor)))
+            return cursor + idx.value();
+    }
+
+    if (cursor > begin) {
+        if (auto idx = vectorMatch(SIMD::load(begin)))
+            return begin + idx.value();
+    }
+
+    return nullptr;
+}
+
 SUPPRESS_NODELETE ALWAYS_INLINE const double* NODELETE findNaN(const double* pointer, size_t length)
 {
     constexpr size_t scalarThreshold = 4;


### PR DESCRIPTION
#### 90c053c6e5131530d4fc78327183c30e1ddb4f3f
<pre>
[JSC] Optimize Array.prototype.lastIndexOf
<a href="https://bugs.webkit.org/show_bug.cgi?id=313672">https://bugs.webkit.org/show_bug.cgi?id=313672</a>
<a href="https://rdar.apple.com/175874889">rdar://175874889</a>

Reviewed by Yijia Huang.

Add reverseFind64 and use it in Array.prototype.lastIndexOf
implementation.

array-prototype-lastIndexOf-contiguous-long 102.3369+-0.1355     ^     96.2670+-3.3248        ^ definitely 1.0631x faster

Tests: JSTests/microbenchmarks/array-prototype-lastIndexOf-contiguous-long.js
       JSTests/microbenchmarks/array-prototype-lastIndexOf-int32-long.js

* JSTests/microbenchmarks/array-prototype-lastIndexOf-contiguous-long.js: Added.
(test):
* JSTests/microbenchmarks/array-prototype-lastIndexOf-int32-long.js: Added.
(test):
* Source/JavaScriptCore/runtime/ArrayPrototype.cpp:
(JSC::fastIndexOf):
* Source/WTF/wtf/text/StringCommon.h:
(WTF::reverseFind64):

Canonical link: <a href="https://commits.webkit.org/312322@main">https://commits.webkit.org/312322@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2af97db285511bb531f924aabd44571c91fd6bbf

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/159525 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/32992 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/26070 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/168367 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/113906 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/b063bcb4-417f-4249-be3e-dce43e04be63) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/33102 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/32949 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/123616 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/113906 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/c4c81c29-67d1-4d87-a6ac-9ea7b6d75b2d) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/162482 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/25871 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/143291 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/104267 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/09ab11b5-f111-407a-8333-e402b68c044d) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/24923 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/23368 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/16134 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/151581 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/134614 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/21063 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/170860 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/20362 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/16893 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/22696 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/131830 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/32677 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/27444 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/131923 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/32656 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/142856 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/90738 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/24288 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/26575 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/19670 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/191809 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/32165 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/98561 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/49282 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/31662 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/31908 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/31813 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->