### PR TITLE
document.exitFullscreen() rejects with `Not in fullscreen` when a video is fullscreen

### DIFF
--- a/Source/WebCore/dom/DocumentFullscreen.cpp
+++ b/Source/WebCore/dom/DocumentFullscreen.cpp
@@ -481,6 +481,18 @@ static void clearFullscreenFlags(Element& element)
 void DocumentFullscreen::exitFullscreen(Document& document, Ref<DeferredPromise>&& promise)
 {
     if (!document.isFullyActive() || !protect(document.fullscreen())->fullscreenElement()) {
+#if ENABLE(VIDEO) && PLATFORM(IOS_FAMILY)
+        RefPtr<HTMLMediaElement> fullscreenVideo;
+        document.forEachMediaElement([&](HTMLMediaElement& element) {
+            if (!fullscreenVideo && element.isStandardFullscreen())
+                fullscreenVideo = &element;
+        });
+        if (fullscreenVideo) {
+            fullscreenVideo->exitFullscreen();
+            promise->resolve();
+            return;
+        }
+#endif
         promise->reject(Exception { ExceptionCode::TypeError, "Not in fullscreen"_s });
         return;
     }


### PR DESCRIPTION
#### 85a67b8080ab34afd628361bbfe8239a2a2454ab
<pre>
document.exitFullscreen() rejects with `Not in fullscreen` when a video is fullscreen
<a href="https://bugs.webkit.org/show_bug.cgi?id=313674">https://bugs.webkit.org/show_bug.cgi?id=313674</a>
<a href="https://rdar.apple.com/175680486">rdar://175680486</a>

Reviewed by NOBODY (OOPS!).

On iOS, HTMLVideoElement::requestFullscreen() enters fullscreen via presentation
mode without updating the Fullscreen API state (top layer, fullscreen flag). When
document.exitFullscreen() is called, it finds no fullscreenElement() and rejects.

Fix this by checking for a media element in presentation mode fullscreen before
rejecting, and routing the exit through HTMLMediaElement::exitFullscreen().

* Source/WebCore/dom/DocumentFullscreen.cpp:
(WebCore::DocumentFullscreen::exitFullscreen):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/85a67b8080ab34afd628361bbfe8239a2a2454ab

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/159529 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/32996 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/26074 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/168369 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/113910 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/161398 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/33067 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/32972 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/123613 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/86754 "8 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/162486 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/25861 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/143280 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/104266 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/24913 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/23371 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/16138 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/134604 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/21052 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/170861 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/16897 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/22685 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/131834 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/32663 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/27447 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/131922 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/32660 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/142845 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/90742 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/26573 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/19659 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/32169 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/98565 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/31666 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/31912 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/31817 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->