### PR TITLE
Web Inspector: Record first input far too small within Graphics tab

### DIFF
--- a/Source/WebInspectorUI/Localizations/en.lproj/localizedStrings.js
+++ b/Source/WebInspectorUI/Localizations/en.lproj/localizedStrings.js
@@ -1374,8 +1374,6 @@ localizedStrings["Readonly"] = "Readonly";
 localizedStrings["Ready"] = "Ready";
 localizedStrings["Reasons for compositing"] = "Reasons for compositing";
 localizedStrings["Reasons for compositing:"] = "Reasons for compositing:";
-localizedStrings["Record first %s frame"] = "Record first %s frame";
-localizedStrings["Record first %s frames"] = "Record first %s frames";
 localizedStrings["Recording"] = "Recording";
 localizedStrings["Recording %d"] = "Recording %d";
 localizedStrings["Recording Error: %s"] = "Recording Error: %s";
@@ -1398,6 +1396,8 @@ localizedStrings["Recording Type Offscreen Canvas WebGL"] = "WebGL (Offscreen)";
 /* A type of canvas recording in the Graphics Tab. */
 localizedStrings["Recording Type Offscreen Canvas WebGL2"] = "WebGL2 (Offscreen)";
 localizedStrings["Recording Warning: %s"] = "Recording Warning: %s";
+/* Label for input for number of frames to record @ Canvas section of Graphics tab */
+localizedStrings["Recording frame count: %s"] = "Recording frame count: %s";
 localizedStrings["Recordings"] = "Recordings";
 /* Label for red color component of CSS color. */
 localizedStrings["Red @ Color Picker"] = "Red";

--- a/Source/WebInspectorUI/UserInterface/Views/CanvasOverviewContentView.css
+++ b/Source/WebInspectorUI/UserInterface/Views/CanvasOverviewContentView.css
@@ -203,10 +203,10 @@
 }
 
 .navigation-bar > .item.canvas-recording-auto-capture > label > input {
-    width: 1.5em;
-    min-width: 1.5em;
+    min-width: 30px;
     margin: 0 4px;
-    text-align: center;
+    field-sizing: content;
+    font-variant-numeric: tabular-nums;
 }
 
 @media (prefers-color-scheme: dark) {

--- a/Source/WebInspectorUI/UserInterface/Views/CanvasOverviewContentView.js
+++ b/Source/WebInspectorUI/UserInterface/Views/CanvasOverviewContentView.js
@@ -56,9 +56,14 @@ WI.CanvasOverviewContentView = class CanvasOverviewContentView extends WI.Collec
         this._recordingAutoCaptureNavigationItem.visibilityPriority = WI.NavigationItem.VisibilityPriority.Low;
         this._recordingAutoCaptureNavigationItem.addEventListener(WI.CheckboxNavigationItem.Event.CheckedDidChange, this._handleRecordingAutoCaptureCheckedDidChange, this);
 
-        let frameCount = this._updateRecordingAutoCaptureInputElementSize();
-        this._setRecordingAutoCaptureFrameCount(frameCount);
-        this._updateRecordingAutoCaptureCheckboxLabel(frameCount);
+        let fragment = document.createDocumentFragment();
+        String.format(WI.UIString("Recording frame count: %s", "Label for input for number of frames to record @ Canvas section of Graphics tab"), [this._recordingAutoCaptureFrameCountInputElement], String.standardFormatters, fragment, (a, b) => {
+            a.append(b);
+            return a;
+        });
+        this._recordingAutoCaptureNavigationItem.label = fragment;
+
+        this._setRecordingAutoCaptureFrameCount(this._recordingAutoCaptureFrameCountInputElementValue);
 
         importNavigationItem.addEventListener(WI.ButtonNavigationItem.Event.Clicked, this._handleImportButtonNavigationItemClicked, this);
 
@@ -176,28 +181,6 @@ WI.CanvasOverviewContentView = class CanvasOverviewContentView extends WI.Collec
         WI.canvasManager.setRecordingAutoCaptureFrameCount(enabled, frameCount);
     }
 
-    _updateRecordingAutoCaptureCheckboxLabel(frameCount)
-    {
-        let active = document.activeElement === this._recordingAutoCaptureFrameCountInputElement;
-        let selectionStart = this._recordingAutoCaptureFrameCountInputElement.selectionStart;
-        let selectionEnd = this._recordingAutoCaptureFrameCountInputElement.selectionEnd;
-        let direction = this._recordingAutoCaptureFrameCountInputElement.direction;
-
-        let label = frameCount === 1 ? WI.UIString("Record first %s frame") : WI.UIString("Record first %s frames");
-        let fragment = document.createDocumentFragment();
-        String.format(label, [this._recordingAutoCaptureFrameCountInputElement], String.standardFormatters, fragment, (a, b) => {
-            a.append(b);
-            return a;
-        });
-        this._recordingAutoCaptureNavigationItem.label = fragment;
-
-        if (active) {
-            this._recordingAutoCaptureFrameCountInputElement.selectionStart = selectionStart;
-            this._recordingAutoCaptureFrameCountInputElement.selectionEnd = selectionEnd;
-            this._recordingAutoCaptureFrameCountInputElement.direction = direction;
-        }
-    }
-
     get _recordingAutoCaptureFrameCountInputElementValue()
     {
         return parseInt(this._recordingAutoCaptureFrameCountInputElement.value);
@@ -209,19 +192,6 @@ WI.CanvasOverviewContentView = class CanvasOverviewContentView extends WI.Collec
             this._recordingAutoCaptureFrameCountInputElement.value = frameCount;
 
         this._recordingAutoCaptureFrameCountInputElement.placeholder = frameCount;
-    }
-
-    _updateRecordingAutoCaptureInputElementSize()
-    {
-        let frameCount = this._recordingAutoCaptureFrameCountInputElementValue;
-        if (isNaN(frameCount) || frameCount < 0) {
-            frameCount = 0;
-            this._recordingAutoCaptureFrameCountInputElementValue = frameCount;
-        }
-
-        this._recordingAutoCaptureFrameCountInputElement.autosize();
-
-        return frameCount;
     }
 
     _addSavedRecording(recording)
@@ -253,7 +223,12 @@ WI.CanvasOverviewContentView = class CanvasOverviewContentView extends WI.Collec
 
     _handleRecordingAutoCaptureInput(event)
     {
-        let frameCount = this._updateRecordingAutoCaptureInputElementSize();
+        let frameCount = this._recordingAutoCaptureFrameCountInputElementValue;
+        if (isNaN(frameCount) || frameCount < 0) {
+            frameCount = 0;
+            this._recordingAutoCaptureFrameCountInputElementValue = frameCount;
+        }
+
         this._recordingAutoCaptureNavigationItem.checked = !!frameCount;
 
         this._setRecordingAutoCaptureFrameCount(frameCount);
@@ -271,11 +246,8 @@ WI.CanvasOverviewContentView = class CanvasOverviewContentView extends WI.Collec
 
     _handleCanvasRecordingAutoCaptureFrameCountChanged(event)
     {
-        // Only update the value if it is different to prevent mangling the selection.
         if (this._recordingAutoCaptureFrameCountInputElementValue !== WI.settings.canvasRecordingAutoCaptureFrameCount.value)
             this._recordingAutoCaptureFrameCountInputElementValue = WI.settings.canvasRecordingAutoCaptureFrameCount.value;
-
-        this._updateRecordingAutoCaptureCheckboxLabel(WI.settings.canvasRecordingAutoCaptureFrameCount.value);
     }
 
     _handleImportButtonNavigationItemClicked(event)


### PR DESCRIPTION
#### b5ebc12da8948321a58cf8aef37923e61692c072
<pre>
Web Inspector: Record first input far too small within Graphics tab
<a href="https://bugs.webkit.org/show_bug.cgi?id=297082">https://bugs.webkit.org/show_bug.cgi?id=297082</a>
<a href="https://rdar.apple.com/157787230">rdar://157787230</a>

Reviewed by Qianlang Chen.

The custom autosizing of the input field based on its content is replaced
with the standard CSS `field-sizing: content` property.

Also, increase the `min-width` to account for the number input increment/decrement
buttons in contemporary macOS. This is only applicable when the placeholder is set.
When a value is set, the `field-sizing: content` appropriately sizes the element.

The UX of the number input field was also broken making it impossible to type more
than one character at a time because on every keypress the DOM structure for the label,
which included the input field itself, would get rebuilt to represent the plural form
for the number of frames in the label text. This caused input focus to be lost on every keypress.

Previously, this was worked around using programmatic selection. That does not work anymore after
<a href="https://commits.webkit.org/247274@main">https://commits.webkit.org/247274@main</a> which made WebKit spec compliant and removed
support for `selectionStart` / `selectionEnd` from number input fields.

This patch changes the string used for the label so that it is no longer necessary
to account for pluralization and no need to update the DOM structure at runtime.

* Source/WebInspectorUI/Localizations/en.lproj/localizedStrings.js:
* Source/WebInspectorUI/UserInterface/Views/CanvasOverviewContentView.css:
(.navigation-bar &gt; .item.canvas-recording-auto-capture &gt; label &gt; input):
* Source/WebInspectorUI/UserInterface/Views/CanvasOverviewContentView.js:
(WI.CanvasOverviewContentView):
(WI.CanvasOverviewContentView.prototype._handleRecordingAutoCaptureInput):
(WI.CanvasOverviewContentView.prototype._handleCanvasRecordingAutoCaptureFrameCountChanged):
(WI.CanvasOverviewContentView.prototype._updateRecordingAutoCaptureCheckboxLabel): Deleted.
(WI.CanvasOverviewContentView.prototype._updateRecordingAutoCaptureInputElementSize): Deleted.

Canonical link: <a href="https://commits.webkit.org/312433@main">https://commits.webkit.org/312433@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/98493e67062147b74a650e55a7dbd516936f3b20

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/159726 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/33193 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/26300 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/168582 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/114107 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/c7ba4b44-6372-432b-86ca-132a45d4290a) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/33298 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/33197 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/123761 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/86840 "9 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/cdcbc992-5ab4-4d22-b7b8-aa61134f7abe) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/162684 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/26024 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/143462 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/104404 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/01f3c8fc-d8d9-4654-a75d-237b0d496045) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/25075 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/23546 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/16347 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/134767 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/21234 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/171075 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/17094 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/22870 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/132015 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/32872 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/27623 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/132074 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35779 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/32857 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/143028 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/90940 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/26696 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/19841 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/32366 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/98762 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/31863 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/32110 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/32014 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->