### PR TITLE
Add GenericTimeMixin::approximate() template function.

### DIFF
--- a/Source/JavaScriptCore/runtime/WaiterListManager.cpp
+++ b/Source/JavaScriptCore/runtime/WaiterListManager.cpp
@@ -90,7 +90,7 @@ WaiterListManager::WaitSyncResult WaiterListManager::waitSyncImpl(VM& vm, ValueT
         dataLogLnIf(WaiterListsManagerInternal::verbose, "<WaiterListManager> <Thread:", Thread::currentSingleton(), "> added a new SyncWaiter=", syncWaiter.get(), " to a waiterList for ptr ", RawPointer(ptr));
 
         while (syncWaiter->isOnList() && time.now() < time && !vm.hasTerminationRequest())
-            syncWaiter->condition().waitUntil(list->lock, time.approximateWallTime());
+            syncWaiter->condition().waitUntil(list->lock, time.approximate<WallTime>());
 
         // At this point, syncWaiter should be either notified (dequeued) or timeout (not dequeued).
         bool didGetDequeued = !syncWaiter->isOnList();

--- a/Source/WTF/wtf/ApproximateTime.cpp
+++ b/Source/WTF/wtf/ApproximateTime.cpp
@@ -32,20 +32,6 @@
 
 namespace WTF {
 
-WallTime ApproximateTime::approximateWallTime() const
-{
-    if (isInfinity())
-        return WallTime::fromRawSeconds(m_value);
-    return *this - now() + WallTime::now();
-}
-
-MonotonicTime ApproximateTime::approximateMonotonicTime() const
-{
-    if (isInfinity())
-        return MonotonicTime::fromRawSeconds(m_value);
-    return *this - now() + MonotonicTime::now();
-}
-
 void ApproximateTime::dump(PrintStream& out) const
 {
     out.print("Approximate(", m_value, " sec)");

--- a/Source/WTF/wtf/ApproximateTime.h
+++ b/Source/WTF/wtf/ApproximateTime.h
@@ -49,10 +49,6 @@ public:
 
     WTF_EXPORT_PRIVATE static ApproximateTime now();
 
-    ApproximateTime approximateApproximateTime() const { return *this; }
-    WTF_EXPORT_PRIVATE WallTime approximateWallTime() const;
-    WTF_EXPORT_PRIVATE MonotonicTime approximateMonotonicTime() const;
-
     WTF_EXPORT_PRIVATE void dump(PrintStream&) const;
 
 private:

--- a/Source/WTF/wtf/ContinuousApproximateTime.cpp
+++ b/Source/WTF/wtf/ContinuousApproximateTime.cpp
@@ -37,20 +37,6 @@ ContinuousApproximateTime ContinuousApproximateTime::fromWallTime(WallTime wallT
     return now() + (wallTime - WallTime::now());
 }
 
-WallTime ContinuousApproximateTime::approximateWallTime() const
-{
-    if (isInfinity())
-        return WallTime::fromRawSeconds(m_value);
-    return *this - now() + WallTime::now();
-}
-
-MonotonicTime ContinuousApproximateTime::approximateMonotonicTime() const
-{
-    if (isInfinity())
-        return MonotonicTime::fromRawSeconds(m_value);
-    return *this - now() + MonotonicTime::now();
-}
-
 void ContinuousApproximateTime::dump(PrintStream& out) const
 {
     out.print("ContinuousApproximate(", m_value, " sec)");

--- a/Source/WTF/wtf/ContinuousApproximateTime.h
+++ b/Source/WTF/wtf/ContinuousApproximateTime.h
@@ -52,9 +52,6 @@ public:
 
     WTF_EXPORT_PRIVATE static ContinuousApproximateTime now();
 
-    WTF_EXPORT_PRIVATE WallTime approximateWallTime() const;
-    WTF_EXPORT_PRIVATE MonotonicTime approximateMonotonicTime() const;
-
     WTF_EXPORT_PRIVATE void dump(PrintStream&) const;
 
 private:

--- a/Source/WTF/wtf/ContinuousTime.cpp
+++ b/Source/WTF/wtf/ContinuousTime.cpp
@@ -32,20 +32,6 @@
 
 namespace WTF {
 
-WallTime ContinuousTime::approximateWallTime() const
-{
-    if (isInfinity())
-        return WallTime::fromRawSeconds(m_value);
-    return *this - now() + WallTime::now();
-}
-
-MonotonicTime ContinuousTime::approximateMonotonicTime() const
-{
-    if (isInfinity())
-        return MonotonicTime::fromRawSeconds(m_value);
-    return *this - now() + MonotonicTime::now();
-}
-
 void ContinuousTime::dump(PrintStream& out) const
 {
     out.print("Continuous(", m_value, " sec)");

--- a/Source/WTF/wtf/ContinuousTime.h
+++ b/Source/WTF/wtf/ContinuousTime.h
@@ -49,9 +49,6 @@ public:
 
     WTF_EXPORT_PRIVATE static ContinuousTime now();
 
-    WTF_EXPORT_PRIVATE WallTime approximateWallTime() const;
-    WTF_EXPORT_PRIVATE MonotonicTime approximateMonotonicTime() const;
-
     WTF_EXPORT_PRIVATE void dump(PrintStream&) const;
 
 private:

--- a/Source/WTF/wtf/GenericTimeMixin.h
+++ b/Source/WTF/wtf/GenericTimeMixin.h
@@ -102,6 +102,22 @@ public:
         return DerivedTime::now() + relativeTimeFromNow;
     }
 
+    template<typename TargetTime>
+        requires (std::is_same_v<TargetTime, DerivedTime>)
+    inline DerivedTime approximate() const
+    {
+        return *reinterpret_cast<const DerivedTime*>(this);
+    }
+
+    template<typename TargetTime>
+        requires (std::derived_from<TargetTime, GenericTimeMixin<TargetTime>> && !std::is_same_v<TargetTime, DerivedTime>)
+    TargetTime approximate() const
+    {
+        if (isInfinity())
+            return TargetTime::fromRawSeconds(m_value);
+        return *reinterpret_cast<const DerivedTime*>(this) - DerivedTime::now() + TargetTime::now();
+    }
+
 protected:
     // This is the epoch. So, x.secondsSinceEpoch() should be the same as x - DerivedTime().
     constexpr GenericTimeMixin() = default;

--- a/Source/WTF/wtf/MonotonicTime.cpp
+++ b/Source/WTF/wtf/MonotonicTime.cpp
@@ -32,20 +32,6 @@
 
 namespace WTF {
 
-WallTime MonotonicTime::approximateWallTime() const
-{
-    if (isInfinity())
-        return WallTime::fromRawSeconds(m_value);
-    return *this - now() + WallTime::now();
-}
-
-ContinuousTime MonotonicTime::approximateContinuousTime() const
-{
-    if (isInfinity())
-        return ContinuousTime::fromRawSeconds(m_value);
-    return *this - now() + ContinuousTime::now();
-}
-
 void MonotonicTime::dump(PrintStream& out) const
 {
     out.print("Monotonic(", m_value, " sec)");

--- a/Source/WTF/wtf/MonotonicTime.h
+++ b/Source/WTF/wtf/MonotonicTime.h
@@ -53,10 +53,6 @@ public:
 
     WTF_EXPORT_PRIVATE static MonotonicTime now();
     
-    MonotonicTime approximateMonotonicTime() const { return *this; }
-    WTF_EXPORT_PRIVATE WallTime approximateWallTime() const;
-    WTF_EXPORT_PRIVATE ContinuousTime approximateContinuousTime() const;
-
     WTF_EXPORT_PRIVATE void dump(PrintStream&) const;
 
     friend struct MarkableTraits<MonotonicTime>;

--- a/Source/WTF/wtf/TimeWithDynamicClockType.cpp
+++ b/Source/WTF/wtf/TimeWithDynamicClockType.cpp
@@ -99,15 +99,15 @@ WallTime TimeWithDynamicClockType::approximateWallTime() const
     case ClockType::Wall:
         return wallTime();
     case ClockType::Monotonic:
-        return monotonicTime().approximateWallTime();
+        return monotonicTime().approximate<WallTime>();
     case ClockType::Approximate:
-        return approximateTime().approximateWallTime();
+        return approximateTime().approximate<WallTime>();
     case ClockType::Continuous:
-        return continuousTime().approximateWallTime();
+        return continuousTime().approximate<WallTime>();
     case ClockType::ContinuousApproximate:
-        return ContinuousApproximateTime().approximateWallTime();
+        return ContinuousApproximateTime().approximate<WallTime>();
     case ClockType::UnbarrieredMonotonic:
-        return unbarrieredMonotonicTime().approximateWallTime();
+        return unbarrieredMonotonicTime().approximate<WallTime>();
     }
     RELEASE_ASSERT_NOT_REACHED();
     return WallTime();
@@ -117,17 +117,17 @@ MonotonicTime TimeWithDynamicClockType::approximateMonotonicTime() const
 {
     switch (m_type) {
     case ClockType::Wall:
-        return wallTime().approximateMonotonicTime();
+        return wallTime().approximate<MonotonicTime>();
     case ClockType::Monotonic:
         return monotonicTime();
     case ClockType::Approximate:
-        return approximateTime().approximateMonotonicTime();
+        return approximateTime().approximate<MonotonicTime>();
     case ClockType::Continuous:
-        return continuousTime().approximateMonotonicTime();
+        return continuousTime().approximate<MonotonicTime>();
     case ClockType::ContinuousApproximate:
-        return ContinuousApproximateTime().approximateMonotonicTime();
+        return ContinuousApproximateTime().approximate<MonotonicTime>();
     case ClockType::UnbarrieredMonotonic:
-        return unbarrieredMonotonicTime().approximateMonotonicTime();
+        return unbarrieredMonotonicTime().approximate<MonotonicTime>();
     }
     RELEASE_ASSERT_NOT_REACHED();
     return MonotonicTime();

--- a/Source/WTF/wtf/UnbarrieredMonotonicTime.cpp
+++ b/Source/WTF/wtf/UnbarrieredMonotonicTime.cpp
@@ -55,28 +55,6 @@ void UnbarrieredMonotonicTime::calibrate()
 }
 #endif
 
-WallTime UnbarrieredMonotonicTime::approximateWallTime() const
-{
-    if (isInfinity())
-        return WallTime::fromRawSeconds(m_value);
-    return *this - now() + WallTime::now();
-}
-
-MonotonicTime UnbarrieredMonotonicTime::approximateMonotonicTime() const
-{
-    if (isInfinity())
-        return MonotonicTime::fromRawSeconds(m_value);
-    return *this - now() + MonotonicTime::now();
-
-}
-
-ContinuousTime UnbarrieredMonotonicTime::approximateContinuousTime() const
-{
-    if (isInfinity())
-        return ContinuousTime::fromRawSeconds(m_value);
-    return *this - now() + ContinuousTime::now();
-}
-
 void UnbarrieredMonotonicTime::dump(PrintStream& out) const
 {
     out.print("UnbarrieredMonotonic(", m_value, " sec)");

--- a/Source/WTF/wtf/UnbarrieredMonotonicTime.h
+++ b/Source/WTF/wtf/UnbarrieredMonotonicTime.h
@@ -74,11 +74,6 @@ public:
     WTF_EXPORT_PRIVATE static UnbarrieredMonotonicTime now();
 #endif
 
-    UnbarrieredMonotonicTime approximateUnbarrieredMonotonicTime() const { return *this; }
-    WTF_EXPORT_PRIVATE WallTime approximateWallTime() const;
-    WTF_EXPORT_PRIVATE MonotonicTime approximateMonotonicTime() const;
-    WTF_EXPORT_PRIVATE ContinuousTime approximateContinuousTime() const;
-
     WTF_EXPORT_PRIVATE void dump(PrintStream&) const;
 
     friend struct MarkableTraits<UnbarrieredMonotonicTime>;

--- a/Source/WTF/wtf/WallTime.cpp
+++ b/Source/WTF/wtf/WallTime.cpp
@@ -31,13 +31,6 @@
 
 namespace WTF {
 
-MonotonicTime WallTime::approximateMonotonicTime() const
-{
-    if (isInfinity())
-        return MonotonicTime::fromRawSeconds(m_value);
-    return *this - now() + MonotonicTime::now();
-}
-
 void WallTime::dump(PrintStream& out) const
 {
     out.print("Wall(", m_value, " sec)");

--- a/Source/WTF/wtf/WallTime.h
+++ b/Source/WTF/wtf/WallTime.h
@@ -48,9 +48,6 @@ public:
 
     WTF_EXPORT_PRIVATE static WallTime now();
     
-    WallTime approximateWallTime() const { return *this; }
-    WTF_EXPORT_PRIVATE MonotonicTime approximateMonotonicTime() const;
-    
     WTF_EXPORT_PRIVATE void dump(PrintStream&) const;
 
 private:

--- a/Source/WebCore/dom/WindowEventLoop.cpp
+++ b/Source/WebCore/dom/WindowEventLoop.cpp
@@ -232,7 +232,7 @@ void WindowEventLoop::didReachTimeToRun()
     Ref protectedThis { *this }; // Executing tasks may remove the last reference to this WindowEventLoop.
     auto deadline = ApproximateTime::now() + ThreadTimers::maxDurationOfFiringTimers;
     run(commonVM(), deadline);
-    opportunisticallyRunIdleCallbacks(deadline.approximateMonotonicTime());
+    opportunisticallyRunIdleCallbacks(deadline.approximate<MonotonicTime>());
 }
 
 void WindowEventLoop::didFireIdleTimer()

--- a/Source/WebCore/loader/ResourceMonitorPersistence.cpp
+++ b/Source/WebCore/loader/ResourceMonitorPersistence.cpp
@@ -67,7 +67,7 @@ static constexpr auto insertRecordSQL = "INSERT INTO records (host, access) VALU
 
 static double continuousApproximateTimeToDouble(ContinuousApproximateTime time)
 {
-    return time.approximateWallTime().secondsSinceEpoch().value();
+    return time.approximate<WallTime>().secondsSinceEpoch().value();
 }
 
 static ContinuousApproximateTime doubleToContinuousApproximateTime(double timestamp)

--- a/Source/WebCore/page/Performance.cpp
+++ b/Source/WebCore/page/Performance.cpp
@@ -87,7 +87,7 @@ Performance::Performance(ScriptExecutionContext* context, MonotonicTime timeOrig
     : ContextDestructionObserver(context)
     , m_resourceTimingBufferFullTimer(*this, &Performance::resourceTimingBufferFullTimerFired) // FIXME: Migrate this to the event loop as well. https://bugs.webkit.org/show_bug.cgi?id=229044
     , m_timeOrigin(timeOrigin)
-    , m_continuousTimeOrigin(timeOrigin.approximateContinuousTime())
+    , m_continuousTimeOrigin(timeOrigin.approximate<ContinuousTime>())
 {
     ASSERT(m_timeOrigin);
 }
@@ -107,7 +107,7 @@ DOMHighResTimeStamp Performance::now() const
 
 DOMHighResTimeStamp Performance::timeOrigin() const
 {
-    return reduceTimeResolution(m_timeOrigin.approximateWallTime().secondsSinceEpoch()).milliseconds();
+    return reduceTimeResolution(m_timeOrigin.approximate<WallTime>().secondsSinceEpoch()).milliseconds();
 }
 
 ReducedResolutionSeconds Performance::nowInReducedResolutionSeconds() const
@@ -540,7 +540,7 @@ ExceptionOr<Ref<PerformanceMeasure>> Performance::measure(JSC::JSGlobalObject& g
         }
 #endif
         {
-            auto timeOrigin = m_continuousTimeOrigin.approximateMonotonicTime();
+            auto timeOrigin = m_continuousTimeOrigin.approximate<MonotonicTime>();
             auto startTime = timeOrigin + Seconds::fromMilliseconds(entry->startTime());
             auto endTime = timeOrigin + Seconds::fromMilliseconds(entry->startTime() + entry->duration());
             JSC::ProfilerSupport::markInterval(entry.ptr(), JSC::ProfilerSupport::Category::WebKitPerformanceSignpost, startTime, endTime, WTF::move(message));

--- a/Source/WebCore/page/PerformanceTiming.cpp
+++ b/Source/WebCore/page/PerformanceTiming.cpp
@@ -389,7 +389,7 @@ unsigned long long PerformanceTiming::monotonicTimeToIntegerMilliseconds(Monoton
     ASSERT(timeStamp.secondsSinceEpoch().seconds() >= 0);
     if (!timeStamp)
         return 0;
-    Seconds reduced = Performance::reduceTimeResolution(timeStamp.approximateWallTime().secondsSinceEpoch());
+    Seconds reduced = Performance::reduceTimeResolution(timeStamp.approximate<WallTime>().secondsSinceEpoch());
     return static_cast<unsigned long long>(reduced.milliseconds());
 }
 

--- a/Source/WebCore/platform/network/cocoa/NetworkLoadMetrics.mm
+++ b/Source/WebCore/platform/network/cocoa/NetworkLoadMetrics.mm
@@ -34,7 +34,7 @@ namespace WebCore {
 static MonotonicTime dateToMonotonicTime(NSDate *date)
 {
     if (auto interval = date.timeIntervalSince1970)
-        return WallTime::fromRawSeconds(interval).approximateMonotonicTime();
+        return WallTime::fromRawSeconds(interval).approximate<MonotonicTime>();
     return { };
 }
 

--- a/Source/WebCore/platform/network/cocoa/WebCoreNSURLSession.mm
+++ b/Source/WebCore/platform/network/cocoa/WebCoreNSURLSession.mm
@@ -53,7 +53,7 @@ static NSDate * __nullable networkLoadMetricsDate(MonotonicTime time)
 {
     if (!time)
         return nil;
-    NSTimeInterval value = time.approximateWallTime().secondsSinceEpoch().seconds();
+    NSTimeInterval value = time.approximate<WallTime>().secondsSinceEpoch().seconds();
     if (value <= 0)
         return nil;
     return [NSDate dateWithTimeIntervalSince1970:value];

--- a/Source/WebCore/platform/network/cocoa/WebCoreResourceHandleAsOperationQueueDelegate.mm
+++ b/Source/WebCore/platform/network/cocoa/WebCoreResourceHandleAsOperationQueueDelegate.mm
@@ -338,7 +338,7 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_END
 
         if (auto metrics = protectedSelf->m_handle->networkLoadMetrics()) {
             if (double responseEndTime = [[timingData objectForKey:@"_kCFNTimingDataResponseEnd"] doubleValue])
-                metrics->responseEnd = WallTime::fromRawSeconds(adoptNS([[NSDate alloc] initWithTimeIntervalSinceReferenceDate:responseEndTime]).get().timeIntervalSince1970).approximateMonotonicTime();
+                metrics->responseEnd = WallTime::fromRawSeconds(adoptNS([[NSDate alloc] initWithTimeIntervalSinceReferenceDate:responseEndTime]).get().timeIntervalSince1970).approximate<MonotonicTime>();
             else
                 metrics->responseEnd = metrics->responseStart;
             metrics->protocol = checked_objc_cast<NSString>([timingData objectForKey:@"_kCFNTimingDataNetworkProtocolName"]);

--- a/Source/WebKit/NetworkProcess/cocoa/NetworkSessionCocoa.mm
+++ b/Source/WebKit/NetworkProcess/cocoa/NetworkSessionCocoa.mm
@@ -754,7 +754,7 @@ static NSDictionary<NSString *, id> *extractResolutionReport(NSError *error)
 
         auto dateToMonotonicTime = [] (NSDate *date) {
             if (auto interval = date.timeIntervalSince1970)
-                return WallTime::fromRawSeconds(interval).approximateMonotonicTime();
+                return WallTime::fromRawSeconds(interval).approximate<MonotonicTime>();
             return MonotonicTime { };
         };
 

--- a/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIAlarmsCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIAlarmsCocoa.mm
@@ -59,7 +59,7 @@ static inline NSDictionary *toWebAPI(const WebExtensionAlarmParameters& alarm)
     NSMutableDictionary *result = [NSMutableDictionary dictionaryWithCapacity:3];
 
     result[nameKey] = alarm.name.createNSString().get();
-    result[scheduledTimeKey] = @(floor(alarm.nextScheduledTime.approximateWallTime().secondsSinceEpoch().milliseconds()));
+    result[scheduledTimeKey] = @(floor(alarm.nextScheduledTime.approximate<WallTime>().secondsSinceEpoch().milliseconds()));
 
     if (alarm.repeatInterval)
         result[periodInMinutesKey] = @(alarm.repeatInterval.minutes());

--- a/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIWebNavigationCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIWebNavigationCocoa.mm
@@ -203,7 +203,7 @@ void WebExtensionContextProxy::dispatchWebNavigationEvent(WebExtensionEventListe
         tabIdKey: @(toWebAPI(tabID)),
         frameIdKey: @(toWebAPI(frameID)),
         parentFrameIdKey: @(toWebAPI(parentFrameID)),
-        timeStampKey: @(floor(timestamp.approximateWallTime().secondsSinceEpoch().milliseconds()))
+        timeStampKey: @(floor(timestamp.approximate<WallTime>().secondsSinceEpoch().milliseconds()))
     } mutableCopy];
 
     if (frameParameters.documentIdentifier)

--- a/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIWebRequestCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIWebRequestCocoa.mm
@@ -264,7 +264,7 @@ static NSMutableDictionary *webRequestDetailsForResourceLoad(const ResourceLoadI
         @"frameId": resourceLoad.parentFrameID ? @(toWebAPI(toWebExtensionFrameIdentifier(resourceLoad.frameID))) : @(toWebAPI(WebExtensionFrameConstants::MainFrameIdentifier)),
         parentFrameIdKey: resourceLoad.parentFrameID ? @(toWebAPI(toWebExtensionFrameIdentifier(resourceLoad.parentFrameID))) : @(toWebAPI(WebExtensionFrameConstants::NoneIdentifier)),
         requestIdKey: adoptNS([[NSString alloc] initWithFormat:@"%llu", resourceLoad.resourceLoadID.toUInt64()]).get(),
-        timeStampKey: @(floor(resourceLoad.eventTimestamp.approximateWallTime().secondsSinceEpoch().milliseconds())),
+        timeStampKey: @(floor(resourceLoad.eventTimestamp.approximate<WallTime>().secondsSinceEpoch().milliseconds())),
         @"url": resourceLoad.originalURL.string().createNSString().get(),
         @"tabId": @(toWebAPI(tabIdentifier)),
         typeKey: toWebAPI(resourceLoad.type),

--- a/Source/WebKit/WebProcess/InjectedBundle/API/gtk/DOM/WebKitDOMEvent.cpp
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/gtk/DOM/WebKitDOMEvent.cpp
@@ -364,7 +364,7 @@ guint32 webkit_dom_event_get_time_stamp(WebKitDOMEvent* self)
     WebCore::JSMainThreadNullState state;
     g_return_val_if_fail(WEBKIT_DOM_IS_EVENT(self), 0);
     WebCore::Event* item = WebKit::core(self);
-    guint32 result = item->timeStamp().approximateWallTime().secondsSinceEpoch().milliseconds();
+    guint32 result = item->timeStamp().approximate<WallTime>().secondsSinceEpoch().milliseconds();
     return result;
 }
 

--- a/Source/WebKitLegacy/mac/DOM/DOMEvent.mm
+++ b/Source/WebKitLegacy/mac/DOM/DOMEvent.mm
@@ -97,7 +97,7 @@
 - (DOMTimeStamp)timeStamp
 {
     WebCore::JSMainThreadNullState state;
-    return IMPL->timeStamp().approximateWallTime().secondsSinceEpoch().milliseconds();
+    return IMPL->timeStamp().approximate<WallTime>().secondsSinceEpoch().milliseconds();
 }
 
 - (BOOL)defaultPrevented


### PR DESCRIPTION
#### 23248aa32f5917aab02f946b1c64fb5ac01c529a
<pre>
Add GenericTimeMixin::approximate() template function.
<a href="https://bugs.webkit.org/show_bug.cgi?id=313675">https://bugs.webkit.org/show_bug.cgi?id=313675</a>
<a href="https://rdar.apple.com/175876462">rdar://175876462</a>

Reviewed by Yusuke Suzuki.

This removes the need to manually add approximate conversion functions in each Time type
e.g. approximateMonotonicTime() and approximateWallTime().  Every single one of these
approximate conversion functions applies the exact same conversion algorithm.  We can
capture this in GenericTimeMixin::approximate(), and avoid all the duplication.

No new tests needed.  This is just a refactoring patch.

* Source/JavaScriptCore/runtime/WaiterListManager.cpp:
(JSC::WaiterListManager::waitSyncImpl):
* Source/WTF/wtf/ApproximateTime.cpp:
(WTF::ApproximateTime::approximateWallTime const): Deleted.
(WTF::ApproximateTime::approximateMonotonicTime const): Deleted.
* Source/WTF/wtf/ApproximateTime.h:
* Source/WTF/wtf/ContinuousApproximateTime.cpp:
(WTF::ContinuousApproximateTime::approximateWallTime const): Deleted.
(WTF::ContinuousApproximateTime::approximateMonotonicTime const): Deleted.
* Source/WTF/wtf/ContinuousApproximateTime.h:
* Source/WTF/wtf/ContinuousTime.cpp:
(WTF::ContinuousTime::approximateWallTime const): Deleted.
(WTF::ContinuousTime::approximateMonotonicTime const): Deleted.
* Source/WTF/wtf/ContinuousTime.h:
* Source/WTF/wtf/GenericTimeMixin.h:
(WTF::GenericTimeMixin::approximate const):
* Source/WTF/wtf/MonotonicTime.cpp:
(WTF::MonotonicTime::approximateWallTime const): Deleted.
(WTF::MonotonicTime::approximateContinuousTime const): Deleted.
* Source/WTF/wtf/MonotonicTime.h:
* Source/WTF/wtf/TimeWithDynamicClockType.cpp:
(WTF::TimeWithDynamicClockType::approximateWallTime const):
(WTF::TimeWithDynamicClockType::approximateMonotonicTime const):
* Source/WTF/wtf/UnbarrieredMonotonicTime.cpp:
(WTF::UnbarrieredMonotonicTime::approximateWallTime const): Deleted.
(WTF::UnbarrieredMonotonicTime::approximateMonotonicTime const): Deleted.
(WTF::UnbarrieredMonotonicTime::approximateContinuousTime const): Deleted.
* Source/WTF/wtf/UnbarrieredMonotonicTime.h:
* Source/WTF/wtf/WallTime.cpp:
(WTF::WallTime::approximateMonotonicTime const): Deleted.
* Source/WTF/wtf/WallTime.h:
* Source/WebCore/dom/WindowEventLoop.cpp:
(WebCore::WindowEventLoop::didReachTimeToRun):
* Source/WebCore/loader/ResourceMonitorPersistence.cpp:
(WebCore::continuousApproximateTimeToDouble):
* Source/WebCore/page/Performance.cpp:
(WebCore::Performance::Performance):
(WebCore::Performance::timeOrigin const):
(WebCore::Performance::measure):
* Source/WebCore/page/PerformanceTiming.cpp:
(WebCore::PerformanceTiming::monotonicTimeToIntegerMilliseconds const):
* Source/WebCore/platform/network/cocoa/NetworkLoadMetrics.mm:
(WebCore::dateToMonotonicTime):
* Source/WebCore/platform/network/cocoa/WebCoreNSURLSession.mm:
(networkLoadMetricsDate):
* Source/WebCore/platform/network/cocoa/WebCoreResourceHandleAsOperationQueueDelegate.mm:
(-[WebCoreResourceHandleAsOperationQueueDelegate connectionDidFinishLoading:]):
* Source/WebKit/NetworkProcess/cocoa/NetworkSessionCocoa.mm:
(-[WKNetworkSessionDelegate URLSession:task:didFinishCollectingMetrics:]):
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIAlarmsCocoa.mm:
(WebKit::toWebAPI):
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIWebNavigationCocoa.mm:
(WebKit::WebExtensionContextProxy::dispatchWebNavigationEvent):
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIWebRequestCocoa.mm:
(WebKit::webRequestDetailsForResourceLoad):
* Source/WebKit/WebProcess/InjectedBundle/API/gtk/DOM/WebKitDOMEvent.cpp:
(webkit_dom_event_get_time_stamp):
* Source/WebKitLegacy/mac/DOM/DOMEvent.mm:
(-[DOMEvent timeStamp]):

Canonical link: <a href="https://commits.webkit.org/312332@main">https://commits.webkit.org/312332@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/473662a0020549065be7386bca3da5fc89589029

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/159620 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/159/builds/33087 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/26194 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/168469 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/114001 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/59b68d2e-b9d4-436d-aabd-0cad0aae83bb) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/161489 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/33192 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/33091 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/168469 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/114001 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/162577 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/25935 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/143370 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/168469 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/24986 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/23449 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/16233 "Built successfully") | | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/20/builds/151676 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/134678 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/21142 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/170965 "Built successfully") | | 
| [  ~~🛠 🧪 jsc-debug-arm64~~](https://ews-build.webkit.org/#/builders/171/builds/20457 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/16988 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/22776 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/131921 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/32766 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/27522 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/131999 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/32751 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/142935 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/90833 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/24293 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/160/builds/32751 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/19749 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/191904 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/32260 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/98656 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/49304 "Passed tests") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/31757 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/32004 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/31908 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->