### PR TITLE
Use `NotAllowedError` for transient activation error during immersive request

### DIFF
--- a/LayoutTests/model-element/immersive/model-element-immersive-basic.html
+++ b/LayoutTests/model-element/immersive/model-element-immersive-basic.html
@@ -26,11 +26,11 @@ promise_test(async t => {
 promise_test(async t => {
     const [model, source] = createModelAndSource(t, "../resources/cube.usdz");
     
-    await promise_rejects_js(t, TypeError, 
+    await promise_rejects_dom(t, "NotAllowedError",
         model.requestImmersive(),
         'Should reject without user activation'
     );
-    
+
     assert_equals(document.immersiveElement, null, 'No immersive element without user gesture');
 }, 'Model immersive request fails without user activation');
 
@@ -151,14 +151,14 @@ promise_test(async t => {
     const errorHandler = () => { errorFired = true; };
     model.addEventListener('immersiveerror', errorHandler);
     
-    await promise_rejects_js(t, TypeError, 
+    await promise_rejects_dom(t, "NotAllowedError",
         model.requestImmersive(),
         'Should reject without user activation'
     );
-    
+
     await new Promise(resolve => setTimeout(resolve, 100));
     model.removeEventListener('immersiveerror', errorHandler);
-    
+
     assert_true(errorFired, 'immersiveerror event should fire on failed request');
 }, 'Immersiveerror event fires when request fails');
 
@@ -192,7 +192,7 @@ promise_test(async t => {
     
     await test_driver.bless("immersive");
     const promise1 = model1.requestImmersive();
-    const promise2 = promise_rejects_js(t, TypeError, 
+    const promise2 = promise_rejects_dom(t, "NotAllowedError",
         model2.requestImmersive(),
         'Should reject without user activation'
     );

--- a/Source/WebCore/dom/DocumentImmersive.cpp
+++ b/Source/WebCore/dom/DocumentImmersive.cpp
@@ -111,7 +111,7 @@ void DocumentImmersive::requestImmersive(HTMLModelElement* element, CompletionHa
         return handleImmersiveError(element, *errorMessage, document().isFullyActive() ? EmitErrorEvent::Yes : EmitErrorEvent::No, ExceptionCode::InvalidAccessError, WTF::move(completionHandler));
 
     if (RefPtr window = document().window(); !window || !window->consumeTransientActivation())
-        return handleImmersiveError(element, "Cannot request immersive without transient activation."_s, EmitErrorEvent::Yes, ExceptionCode::TypeError, WTF::move(completionHandler));
+        return handleImmersiveError(element, "Cannot request immersive without transient activation."_s, EmitErrorEvent::Yes, ExceptionCode::NotAllowedError, WTF::move(completionHandler));
 
     if (immersiveElement() == element && !m_pendingExitImmersive)
         return completionHandler({ });


### PR DESCRIPTION
#### 2163aef4894420c40b06a914a890d79026f85a58
<pre>
Use `NotAllowedError` for transient activation error during immersive request
<a href="https://bugs.webkit.org/show_bug.cgi?id=313676">https://bugs.webkit.org/show_bug.cgi?id=313676</a>
<a href="https://rdar.apple.com/175832849">rdar://175832849</a>

Reviewed by Etienne Segonzac.

TypeError is not the correct exception for a missing user gesture. Use
NotAllowedError, which is the standard exception type for operations
that require transient activation, consistent with the Fullscreen API.

* LayoutTests/model-element/immersive/model-element-immersive-basic.html:
* Source/WebCore/dom/DocumentImmersive.cpp:
(WebCore::DocumentImmersive::requestImmersive):

Canonical link: <a href="https://commits.webkit.org/312612@main">https://commits.webkit.org/312612@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9a7f395c8555e7079f2b171a1334fce21943ce8d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/159536 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/33003 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/26084 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/168377 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/113917 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/161405 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/33105 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/33006 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/123614 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/86758 "8 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/162493 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/25865 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/143287 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/104269 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/24917 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/23376 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/16145 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/134608 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/21059 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/170868 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/16904 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/22692 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/131832 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/32679 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/27451 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/131925 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35876 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/32667 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/142852 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/90749 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/26579 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/19666 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/32176 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/98572 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/31673 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/31920 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/31824 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->