### PR TITLE
Web Inspector: Audits: Replace audit version input field autosize with CSS field-sizing

### DIFF
--- a/Source/WebInspectorUI/UserInterface/Base/Utilities.js
+++ b/Source/WebInspectorUI/UserInterface/Base/Utilities.js
@@ -482,29 +482,6 @@ Object.defineProperty(DocumentFragment.prototype, "createChild",
     value: Element.prototype.createChild
 });
 
-(function() {
-    const fontSymbol = Symbol("font");
-
-    Object.defineProperty(HTMLInputElement.prototype, "autosize",
-    {
-        value(extra = 0)
-        {
-            extra += 6; // UserAgent styles add 1px padding and 2px border.
-            if (this.type === "number")
-                extra += 13; // Number input inner spin button width.
-            extra += 2; // Add extra pixels for the cursor.
-
-            WI.ImageUtilities.scratchCanvasContext2D((context) => {
-                this[fontSymbol] ||= window.getComputedStyle(this).font;
-
-                context.font = this[fontSymbol];
-                let textMetrics = context.measureText(this.value || this.placeholder);
-                this.style.setProperty("width", (textMetrics.width + extra) + "px");
-            });
-        },
-    });
-})();
-
 Object.defineProperty(HTMLCollection.prototype, "indexOf",
 {
     value(element)

--- a/Source/WebInspectorUI/UserInterface/Views/AuditTestContentView.css
+++ b/Source/WebInspectorUI/UserInterface/Views/AuditTestContentView.css
@@ -131,6 +131,8 @@
 
 .content-view.audit-test > header table.controls > tr.supports input[type="number"] {
     text-align: end;
+    field-sizing: content;
+    font-variant-numeric: tabular-nums;
 }
 
 .content-view.audit-test > header table.controls > tr.supports .warning {

--- a/Source/WebInspectorUI/UserInterface/Views/AuditTestContentView.js
+++ b/Source/WebInspectorUI/UserInterface/Views/AuditTestContentView.js
@@ -518,8 +518,6 @@ WI.AuditTestContentView = class AuditTestContentView extends WI.ContentView
     {
         console.assert(WI.auditManager.editing);
 
-        this._supportsInputElement.autosize(4);
-
         this._supportsWarningElement.removeChildren();
         if (this.representedObject.supports > WI.AuditTestBase.Version)
             this._supportsWarningElement.textContent = WI.UIString("too new to run in this Web Inspector", "too new to run in this Web Inspector @ Audit Tab", "Warning text shown if the version number in the 'supports' input is too new.");


### PR DESCRIPTION
#### 983b3503bc11f374891e666b6198a242e073ff10
<pre>
Web Inspector: Audits: Replace audit version input field autosize with CSS field-sizing
<a href="https://bugs.webkit.org/show_bug.cgi?id=313679">https://bugs.webkit.org/show_bug.cgi?id=313679</a>
<a href="https://rdar.apple.com/175880363">rdar://175880363</a>

Reviewed by Devin Rousso.

The CSS property `field-sizing: content` was implemented to solve the issue of
sizing input fields based on their contents. This can replace the custom logic
in Utilities.js used to calculate and approximate the element&apos;s content.

Since there are no other callers of the custom `Element.prototype.autosize()`,
it can be removed.

* Source/WebInspectorUI/UserInterface/Base/Utilities.js:
(get return):
* Source/WebInspectorUI/UserInterface/Views/AuditTestContentView.css:
(.content-view.audit-test &gt; header table.controls &gt; tr.supports input[type=&quot;number&quot;]):
* Source/WebInspectorUI/UserInterface/Views/AuditTestContentView.js:
(WI.AuditTestContentView.prototype._updateSupportsInputState):

Canonical link: <a href="https://commits.webkit.org/312436@main">https://commits.webkit.org/312436@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3585dc126380bee53cc4cb897712589a964ddece

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/159546 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/33013 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/26095 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/168392 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/113927 "Built successfully") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/33117 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/33017 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/123625 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/86759 "8 failures") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/162503 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/25868 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/143295 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/104277 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/24920 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/23388 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/16156 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/134611 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/21067 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/170878 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/16914 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/22700 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/131842 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/32690 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/27462 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/131932 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35780 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/32677 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/142860 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/90759 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/26584 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/19674 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/32186 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/98582 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/31683 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/31930 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/31834 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->