### PR TITLE
Crash when animating transform-related properties from none to none

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-animations/crashtests/transform-properties-from-none-to-none-crash.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-animations/crashtests/transform-properties-from-none-to-none-crash.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+
+<html class="test-wait">
+
+<title>Crash when animating transform-related properties from none to none</title>
+<link rel="author" title="Kiet Ho" href="mailto:kiet.ho@apple.com">
+
+<style>
+  @keyframes anim {
+    from {
+      rotate: none;
+      scale: none;
+      translate: none;
+    }
+
+    to {
+      rotate: none;
+      scale: none;
+      translate: none;
+    }
+  }
+
+  #element {
+    animation: 1s anim running;
+  }
+</style>
+
+<div id="element"></div>
+
+<script>
+  // Let the animation play out for at least one frame.
+  requestAnimationFrame(() => {
+    requestAnimationFrame(() => {
+      document.documentElement.classList.remove("test-wait");
+    });
+  });
+</script>
+
+</html>

--- a/Source/WebCore/platform/animation/AcceleratedEffect.cpp
+++ b/Source/WebCore/platform/animation/AcceleratedEffect.cpp
@@ -339,19 +339,17 @@ AcceleratedEffect::AcceleratedEffect(const AcceleratedEffect& source, OptionSet<
 
 static RefPtr<TransformOperation> blend(const RefPtr<TransformOperation>& base, const RefPtr<TransformOperation>& from, const RefPtr<TransformOperation>& to, const BlendingContext& blendingContext, NOESCAPE const Function<Ref<TransformOperation>(const TransformOperation&)>& identity)
 {
-    if (to) {
-        // Explicit "from" and "to" values.
-        if (from)
-            return to->blend(from.get(), blendingContext);
-        // Implicit "from" value.
-        return to->blend(base.get(), blendingContext);
+    // Explicit |to|, from value is either |from| if not null, or |base|.
+    if (to)
+        return to->blend(from ? from : base, blendingContext);
+
+    // Explicit |from|, to value is either |base| if not null, or the identity value.
+    if (from) {
+        Ref toValue = base ? Ref { *base } : identity(*from);
+        return toValue->blend(from.get(), blendingContext);
     }
 
-    // Implicit "to" value.
-    ASSERT(from);
-    if (base)
-        return base->blend(from.get(), blendingContext);
-    return identity(*from)->blend(from.get(), blendingContext);
+    return base;
 }
 
 static void blend(AcceleratedEffectProperty property, AcceleratedEffectValues& output, const AcceleratedEffectValues& from, const AcceleratedEffectValues& to, BlendingContext& blendingContext)


### PR DESCRIPTION
#### 13bc2b4c5daf7bf4612ca3aa6e04b4ae2f8ac0d9
<pre>
Crash when animating transform-related properties from none to none
<a href="https://rdar.apple.com/175501798">rdar://175501798</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=313595">https://bugs.webkit.org/show_bug.cgi?id=313595</a>

Reviewed by Simon Fraser.

Animating transform-related properties (translate, rotate, scale) from none
to none would crash in WebCore::blend (in AcceleratedEffect.cpp) because
the from and to value is null. Account for this case by returning base
when from/to is null. Also simplify the logic a bit.

Test: imported/w3c/web-platform-tests/css/css-animations/crashtests/transform-properties-from-none-to-none-crash.html

* LayoutTests/imported/w3c/web-platform-tests/css/css-animations/crashtests/transform-properties-from-none-to-none-crash.html: Added.
* Source/WebCore/platform/animation/AcceleratedEffect.cpp:
(WebCore::blend):

Canonical link: <a href="https://commits.webkit.org/312394@main">https://commits.webkit.org/312394@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c613eb30b2de7da1d1bce7db74b66d38ccafd2e1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/159547 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/33014 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/26111 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/168388 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/113928 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/41cce291-028f-4a13-9a09-3beb1f6f3d2b) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/161416 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/33118 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/33018 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/123623 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/86761 "8 failures") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/d17168a3-7491-40b4-af39-2bfe8aca8179) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/162504 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/25870 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/143304 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/104275 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/49fef0cd-3a08-4d04-9c92-24df03c7f724) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/24922 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/23384 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/16157 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/134613 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/21076 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/170879 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/16915 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/22709 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/131844 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/32691 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/27459 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/131934 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35753 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/32678 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/142869 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/90760 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/26586 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/19683 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/32187 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/98583 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/31684 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/31931 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/31835 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->