### PR TITLE
`git-webkit find` fails when run from outside the OpenSource checkout

### DIFF
--- a/.claude/plugins/git-webkit/skills/find/SKILL.md
+++ b/.claude/plugins/git-webkit/skills/find/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: find-webkit-commit
-description: Convert between commit hashes and WebKit identifiers using git-webkit. Use whenever a commit hash appears in a tool result that will be shared with the user in the WebKit repository.
+description: Auto-invoke (1) to convert git commit hashes to WebKit identifiers (NNNNNN@main) and (2) to convert identifiers to commit hashes using git-webkit. Use whenever a commit hash appears in a tool result that will be shared with the user in the WebKit repository.
 user-invocable: false
 allowed-tools: Bash(git-webkit find:*), Bash(git webkit find:*), Bash(Tools/Scripts/git-webkit find:*), Bash(git-webkit log:*), Bash(git webkit log:*), Bash(Tools/Scripts/git-webkit log:*), Bash(git-webkit blame:*), Bash(git webkit blame:*), Bash(Tools/Scripts/git-webkit blame:*), Bash(git-webkit show:*), Bash(git webkit show:*), Bash(Tools/Scripts/git-webkit show:*)
 ---
@@ -48,7 +48,7 @@ These commands accept the same arguments as their git counterparts but output id
 
 ## Locating git-webkit
 
-If `git-webkit` is not in PATH, use `Tools/Scripts/git-webkit` instead (relative to the repository root).
+If `git-webkit` is not in PATH, use `/path/to/OpenSource/Tools/Scripts/git-webkit` (only for `find` subcommand), or use `Tools/Scripts/git-webkit` from within the OpenSource checkout instead.
 
 ## Rules
 
@@ -58,3 +58,5 @@ If `git-webkit` is not in PATH, use `Tools/Scripts/git-webkit` instead (relative
 4. When the user provides an identifier, you can use it directly with `git-webkit find` to get the hash if needed for git operations.
 5. Always display identifiers in backticks (e.g., `285301@main`).
 6. Never prefix `git-webkit` or `Tools/Scripts/git-webkit` with `python3`. The script is directly executable.
+7. Always invoke as `git-webkit` (hyphen), never `git webkit` (space). The space form depends on git's subcommand resolution, which requires `git-webkit` to be in PATH.
+8. Never use `git log --grep` to resolve WebKit identifiers to hashes. Cherry-picks and backports reference identifiers in their messages, producing wrong matches.

--- a/Tools/Scripts/git-webkit
+++ b/Tools/Scripts/git-webkit
@@ -60,10 +60,13 @@ def classifier():
 
 
 if '__main__' == __name__:
+    _script_dir = os.path.dirname(os.path.abspath(__file__))
+    _root = os.path.dirname(os.path.dirname(_script_dir))
     sys.exit(program.main(
         identifier_template=is_webkit_filter('Canonical link: https://commits.webkit.org/{}'),
         subversion=is_webkit_filter('https://svn.webkit.org/repository/webkit'),
-        hooks=os.path.join(os.path.abspath(os.path.join(os.path.dirname(__file__))), 'hooks'),
+        hooks=os.path.join(_script_dir, 'hooks'),
         classifier=is_webkit_filter(classifier()),
+        fallback_path=_root,
     ))
 

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/__init__.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/__init__.py
@@ -66,7 +66,7 @@ from webkitscmpy import local, log, remote
 def main(
     args=None, path=None, loggers=None, contributors=None,
     identifier_template=None, subversion=None, additional_setup=None, hooks=None,
-    canonical_svn=None, programs=None, classifier=None, **kwargs
+    canonical_svn=None, programs=None, classifier=None, fallback_path=None, **kwargs
 ):
     logging.basicConfig(level=logging.WARNING)
 
@@ -192,4 +192,5 @@ def main(
             additional_setup=additional_setup,
             hooks=hooks,
             canonical_svn=canonical_svn,
+            fallback_path=fallback_path,
         )

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/find.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/find.py
@@ -21,6 +21,7 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 import json
+import os
 import sys
 
 from .command import Command
@@ -160,5 +161,21 @@ class Find(Command):
         )
 
     @classmethod
-    def main(cls, args, repository, **kwargs):
+    def _needs_fallback(cls, repository):
+        if not repository:
+            return True
+        if not isinstance(repository, local.Scm):
+            return False
+        root = getattr(repository, 'root_path', None)
+        if root and not os.path.isfile(os.path.join(root, 'Tools', 'Scripts', 'git-webkit')):
+            return True
+        return False
+
+    @classmethod
+    def main(cls, args, repository, fallback_path=None, **kwargs):
+        if fallback_path and cls._needs_fallback(repository):
+            try:
+                repository = local.Scm.from_path(path=fallback_path)
+            except OSError:
+                pass
         return Info.main(args, repository=repository, reference=args.argument[0], **kwargs)

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/find_unittest.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/find_unittest.py
@@ -408,6 +408,43 @@ Identifier: 3@trunk
         self.assertEqual(captured.stdout.getvalue(), '')
         self.assertEqual(captured.stderr.getvalue(), "Can only use the '--scope' argument on a native Git repository\n")
 
+    def test_fallback_path_no_repo(self):
+        with OutputCapture() as captured, mocks.local.Git(self.path), mocks.local.Svn(), MockTime:
+            self.assertEqual(0, program.main(
+                args=('find', '3@main', '-q'),
+                path='/nonexistent',
+                fallback_path=self.path,
+            ))
+        self.assertEqual(
+            captured.stdout.getvalue(),
+            '3@main | 1abe25b443e9 | 4th commit\n',
+        )
+
+    def test_fallback_path_not_used_for_webkit_repo(self):
+        marker = os.path.join(self.path, 'Tools', 'Scripts')
+        os.makedirs(marker, exist_ok=True)
+        with open(os.path.join(marker, 'git-webkit'), 'w'):
+            pass
+        with OutputCapture() as captured, mocks.local.Git(self.path), mocks.local.Svn(), MockTime:
+            self.assertEqual(0, program.main(
+                args=('find', '3@main', '-q'),
+                path=self.path,
+                fallback_path='/other/repo',
+            ))
+        self.assertEqual(
+            captured.stdout.getvalue(),
+            '3@main | 1abe25b443e9 | 4th commit\n',
+        )
+
+    def test_fallback_path_ignored_for_info(self):
+        with OutputCapture() as captured, mocks.local.Git(self.path), mocks.local.Svn(), MockTime:
+            self.assertEqual(1, program.main(
+                args=('info', '-q'),
+                path='/nonexistent',
+                fallback_path=self.path,
+            ))
+        self.assertEqual(captured.stderr.getvalue(), 'No repository provided\n')
+
 
 class TestInfo(testing.TestCase):
     path = '/mock/repository'


### PR DESCRIPTION
#### d8199ef1f0196a36086e0ce808dd6a73dc4782ab
<pre>
`git-webkit find` fails when run from outside the OpenSource checkout
&lt;<a href="https://bugs.webkit.org/show_bug.cgi?id=313682">https://bugs.webkit.org/show_bug.cgi?id=313682</a>&gt;
&lt;<a href="https://rdar.apple.com/175882224">rdar://175882224</a>&gt;

Reviewed by Jonathan Bedard.

Teach `git-webkit find` to auto-detect the OpenSource checkout from the
script&apos;s own location when CWD is not in an OpenSource repo.  Without
this, running `git-webkit find` from a parent directory resolves against
the wrong repository and fails with &quot;Identifier N cannot be found on the
specified branch&quot;.  The presence of `Tools/Scripts/git-webkit` at the
repo root distinguishes an OpenSource checkout from an unrelated repo.

Also expand the skill description to make the skill more discoverable
when Claude searches for hash-to-identifier or identifier-to-hash
conversion tools.

Tests: Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/find_unittest.py

* .claude/plugins/git-webkit/skills/find/SKILL.md:
* Tools/Scripts/git-webkit:
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/__init__.py:
(main):
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/find.py:
(Find._needs_fallback): Add.
(Find.main):
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/find_unittest.py:
(TestFind.test_fallback_path_no_repo): Add.
(TestFind.test_fallback_path_not_used_for_webkit_repo): Add.
(TestFind.test_fallback_path_ignored_for_info): Add.

Canonical link: <a href="https://commits.webkit.org/312314@main">https://commits.webkit.org/312314@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b45ced52200c40a6e36d309ce4304224483202b4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/159552 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/159/builds/33019 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/26106 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/168397 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/113933 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/161421 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/33124 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/156/builds/33023 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/168397 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/113933 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/162509 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/33124 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/143303 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/168397 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | ⏳ 🛠 vision-apple 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/158872 "Passed tests") | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/33124 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/156/builds/33023 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk3-libwebrtc~~](https://ews-build.webkit.org/#/builders/173/builds/16162 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/33124 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/21075 "Passed tests") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/170884 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/22708 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/170884 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [❌ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/158948 "Failed buildbot checkconfig") | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/32696 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/156/builds/33023 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/170884 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/32683 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/142868 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/90765 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/24282 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/160/builds/32683 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/19682 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/32192 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/31689 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/31936 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/31840 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->