### PR TITLE
[libpas] Clean up Windows shutdown handling

### DIFF
--- a/Source/WTF/wtf/Threading.cpp
+++ b/Source/WTF/wtf/Threading.cpp
@@ -27,6 +27,7 @@
 #include <wtf/Threading.h>
 
 #include <bmalloc/BPlatform.h>
+#include <bmalloc/pas_process.h>
 #include <cstring>
 #include <wtf/DateMath.h>
 #include <wtf/FastMalloc.h>
@@ -291,25 +292,14 @@ Ref<Thread> Thread::create(ASCIILiteral name, Function<void()>&& entryPoint, Thr
     return thread;
 }
 
-static bool NODELETE shouldRemoveThreadFromThreadGroup()
-{
-#if OS(WINDOWS)
-    // On Windows the thread specific destructor is also called when the
-    // main thread is exiting. This may lead to the main thread waiting
-    // forever for the thread group lock when exiting, if the sampling
-    // profiler thread was terminated by the system while holding the
-    // thread group lock.
-    if (WTF::isMainThread())
-        return false;
-#endif
-    return true;
-}
-
 void Thread::didExit()
 {
+    if (pas_process_is_shutting_down())
+        return;
+
     allThreads().remove(*this);
 
-    if (shouldRemoveThreadFromThreadGroup()) {
+    {
         {
             Vector<Ref<ThreadGroup>> threadGroups;
             {

--- a/Source/bmalloc/CMakeLists.txt
+++ b/Source/bmalloc/CMakeLists.txt
@@ -158,6 +158,7 @@ set(bmalloc_C_SOURCES
     libpas/src/libpas/pas_physical_memory_transaction.c
     libpas/src/libpas/pas_primitive_heap_ref.c
     libpas/src/libpas/pas_probabilistic_guard_malloc_allocator.c
+    libpas/src/libpas/pas_process.c
     libpas/src/libpas/pas_ptr_worklist.c
     libpas/src/libpas/pas_race_test_hooks.c
     libpas/src/libpas/pas_random.c
@@ -470,6 +471,7 @@ set(bmalloc_PUBLIC_HEADERS
     libpas/src/libpas/pas_platform.h
     libpas/src/libpas/pas_primitive_heap_ref.h
     libpas/src/libpas/pas_probabilistic_guard_malloc_allocator.h
+    libpas/src/libpas/pas_process.h
     libpas/src/libpas/pas_ptr_hash_map.h
     libpas/src/libpas/pas_ptr_hash_set.h
     libpas/src/libpas/pas_ptr_min_heap.h

--- a/Source/bmalloc/bmalloc.xcodeproj/project.pbxproj
+++ b/Source/bmalloc/bmalloc.xcodeproj/project.pbxproj
@@ -379,6 +379,7 @@
 		DD4BED5129CBA49700398E35 /* pas_simple_free_heap_declarations.def in Headers */ = {isa = PBXBuildFile; fileRef = 0FC40A462451498700876DA0 /* pas_simple_free_heap_declarations.def */; settings = {ATTRIBUTES = (Private, ); }; };
 		DD4BED5229CBA49700398E35 /* pas_compact_bitfit_directory_ptr.h in Headers */ = {isa = PBXBuildFile; fileRef = 0F5FE7D425B6210C001859FC /* pas_compact_bitfit_directory_ptr.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		DD4BED5329CBA49700398E35 /* pas_probabilistic_guard_malloc_allocator.c in Sources */ = {isa = PBXBuildFile; fileRef = 2CE2AE572769928300D02BBC /* pas_probabilistic_guard_malloc_allocator.c */; };
+		AF7B6AD7B2954EA99121E719 /* pas_process.c in Sources */ = {isa = PBXBuildFile; fileRef = 2843EB80047B4B46A4A00AE8 /* pas_process.c */; };
 		DD4BED5429CBA49700398E35 /* pas_compact_bootstrap_free_heap.h in Headers */ = {isa = PBXBuildFile; fileRef = 0FC409832451495F00876DA0 /* pas_compact_bootstrap_free_heap.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		DD4BED5529CBA49700398E35 /* minalign32_heap.c in Sources */ = {isa = PBXBuildFile; fileRef = 0F18F83D25C3467700721C2A /* minalign32_heap.c */; };
 		DD4BED5729CBA49700398E35 /* pas_enumerate_initially_unaccounted_pages.h in Headers */ = {isa = PBXBuildFile; fileRef = 0F87FFD425AF897C000E1ABF /* pas_enumerate_initially_unaccounted_pages.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -432,6 +433,7 @@
 		DD4BED8929CBA49700398E35 /* pas_bootstrap_free_heap.c in Sources */ = {isa = PBXBuildFile; fileRef = 0FC409BB2451496300876DA0 /* pas_bootstrap_free_heap.c */; };
 		DD4BED8A29CBA49700398E35 /* pas_ensure_heap_forced_into_reserved_memory.h in Headers */ = {isa = PBXBuildFile; fileRef = 0FC409942451496100876DA0 /* pas_ensure_heap_forced_into_reserved_memory.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		DD4BED8B29CBA49700398E35 /* pas_probabilistic_guard_malloc_allocator.h in Headers */ = {isa = PBXBuildFile; fileRef = 2CE2AE582769928300D02BBC /* pas_probabilistic_guard_malloc_allocator.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		3C8B4B436E304BE39DAB4864 /* pas_process.h in Headers */ = {isa = PBXBuildFile; fileRef = F31DBD0796DD4C2D906A6636 /* pas_process.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		DD4BED8C29CBA49700398E35 /* pas_reallocate_heap_teleport_rule.h in Headers */ = {isa = PBXBuildFile; fileRef = 0FC40A862451498C00876DA0 /* pas_reallocate_heap_teleport_rule.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		DD4BED8E29CBA49700398E35 /* pas_bitfit_page.h in Headers */ = {isa = PBXBuildFile; fileRef = 0F87FFC525AF897B000E1ABF /* pas_bitfit_page.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		DD4BED8F29CBA49700398E35 /* pas_simple_large_free_heap.h in Headers */ = {isa = PBXBuildFile; fileRef = 0FC40A9B2451498D00876DA0 /* pas_simple_large_free_heap.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -1179,6 +1181,8 @@
 		2CE2AE512769928200D02BBC /* pas_compact_tagged_void_ptr.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = pas_compact_tagged_void_ptr.h; path = libpas/src/libpas/pas_compact_tagged_void_ptr.h; sourceTree = "<group>"; };
 		2CE2AE572769928300D02BBC /* pas_probabilistic_guard_malloc_allocator.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = pas_probabilistic_guard_malloc_allocator.c; path = libpas/src/libpas/pas_probabilistic_guard_malloc_allocator.c; sourceTree = "<group>"; };
 		2CE2AE582769928300D02BBC /* pas_probabilistic_guard_malloc_allocator.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = pas_probabilistic_guard_malloc_allocator.h; path = libpas/src/libpas/pas_probabilistic_guard_malloc_allocator.h; sourceTree = "<group>"; };
+		2843EB80047B4B46A4A00AE8 /* pas_process.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = pas_process.c; path = libpas/src/libpas/pas_process.c; sourceTree = "<group>"; };
+		F31DBD0796DD4C2D906A6636 /* pas_process.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = pas_process.h; path = libpas/src/libpas/pas_process.h; sourceTree = "<group>"; };
 		3016D8E82B97BF77009A3809 /* pas_allocation_mode.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = pas_allocation_mode.h; path = libpas/src/libpas/pas_allocation_mode.h; sourceTree = "<group>"; };
 		3044790A2B992F4A00043E8E /* CompactAllocationMode.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = CompactAllocationMode.h; path = bmalloc/CompactAllocationMode.h; sourceTree = "<group>"; };
 		304B03502B19014B0063B1B5 /* libWebKitAdditions.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; path = libWebKitAdditions.a; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -1659,6 +1663,8 @@
 				0FC40AF82451499400876DA0 /* pas_primitive_heap_ref.h */,
 				2CE2AE572769928300D02BBC /* pas_probabilistic_guard_malloc_allocator.c */,
 				2CE2AE582769928300D02BBC /* pas_probabilistic_guard_malloc_allocator.h */,
+				2843EB80047B4B46A4A00AE8 /* pas_process.c */,
+				F31DBD0796DD4C2D906A6636 /* pas_process.h */,
 				314164E72D38449E006B8C0D /* pas_promote_intrinsic_heap.h */,
 				0F87004625AF8A18000E1ABF /* pas_ptr_hash_map.h */,
 				0FC40AC32451499000876DA0 /* pas_ptr_hash_set.h */,
@@ -2215,6 +2221,7 @@
 				DD4BEC6029CBA49700398E35 /* pas_platform.h in Headers */,
 				DD4BED1029CBA49700398E35 /* pas_primitive_heap_ref.h in Headers */,
 				DD4BED8B29CBA49700398E35 /* pas_probabilistic_guard_malloc_allocator.h in Headers */,
+				3C8B4B436E304BE39DAB4864 /* pas_process.h in Headers */,
 				314164E82D38449E006B8C0D /* pas_promote_intrinsic_heap.h in Headers */,
 				DD4BED6229CBA49700398E35 /* pas_ptr_hash_map.h in Headers */,
 				DD4BEDBB29CBA49700398E35 /* pas_ptr_hash_set.h in Headers */,
@@ -2587,6 +2594,7 @@
 				DD4BECD529CBA49700398E35 /* pas_physical_memory_transaction.c in Sources */,
 				DD4BED7729CBA49700398E35 /* pas_primitive_heap_ref.c in Sources */,
 				DD4BED5329CBA49700398E35 /* pas_probabilistic_guard_malloc_allocator.c in Sources */,
+				AF7B6AD7B2954EA99121E719 /* pas_process.c in Sources */,
 				DD4BED1A29CBA49700398E35 /* pas_ptr_worklist.c in Sources */,
 				DD4BECB329CBA49700398E35 /* pas_race_test_hooks.c in Sources */,
 				DD4BEC6129CBA49700398E35 /* pas_random.c in Sources */,

--- a/Source/bmalloc/libpas/libpas.xcodeproj/project.pbxproj
+++ b/Source/bmalloc/libpas/libpas.xcodeproj/project.pbxproj
@@ -545,6 +545,8 @@
 		0FFFD515256B0FBD001EB94C /* pas_deallocation_mode.h in Headers */ = {isa = PBXBuildFile; fileRef = 0FFFD514256B0FBC001EB94C /* pas_deallocation_mode.h */; };
 		2B2A58992742D803005EE07C /* pas_probabilistic_guard_malloc_allocator.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B2A58972742D802005EE07C /* pas_probabilistic_guard_malloc_allocator.h */; };
 		2B2A589A2742D803005EE07C /* pas_probabilistic_guard_malloc_allocator.c in Sources */ = {isa = PBXBuildFile; fileRef = 2B2A58982742D802005EE07C /* pas_probabilistic_guard_malloc_allocator.c */; };
+		0EAB3692DA184399AE69D6F8 /* pas_process.h in Headers */ = {isa = PBXBuildFile; fileRef = A6CCD9F0B3724EA198AAE8D3 /* pas_process.h */; };
+		565C4CAE4B9B462FBCDA92C1 /* pas_process.c in Sources */ = {isa = PBXBuildFile; fileRef = 53C8C4F225EB4310B2063E8F /* pas_process.c */; };
 		2B2A589C2742D815005EE07C /* PGMTests.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B2A589B2742D815005EE07C /* PGMTests.cpp */; };
 		2B2E2FD12949A41100F85C38 /* pas_malloc_stack_logging.c in Sources */ = {isa = PBXBuildFile; fileRef = 2B2E2FCF2949A41100F85C38 /* pas_malloc_stack_logging.c */; };
 		2B2E2FD22949A41100F85C38 /* pas_malloc_stack_logging.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B2E2FD02949A41100F85C38 /* pas_malloc_stack_logging.h */; };
@@ -1260,6 +1262,8 @@
 		0FFFD514256B0FBC001EB94C /* pas_deallocation_mode.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = pas_deallocation_mode.h; sourceTree = "<group>"; };
 		2B2A58972742D802005EE07C /* pas_probabilistic_guard_malloc_allocator.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = pas_probabilistic_guard_malloc_allocator.h; sourceTree = "<group>"; };
 		2B2A58982742D802005EE07C /* pas_probabilistic_guard_malloc_allocator.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = pas_probabilistic_guard_malloc_allocator.c; sourceTree = "<group>"; };
+		A6CCD9F0B3724EA198AAE8D3 /* pas_process.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = pas_process.h; sourceTree = "<group>"; };
+		53C8C4F225EB4310B2063E8F /* pas_process.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = pas_process.c; sourceTree = "<group>"; };
 		2B2A589B2742D815005EE07C /* PGMTests.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = PGMTests.cpp; sourceTree = "<group>"; };
 		2B2E2FCF2949A41100F85C38 /* pas_malloc_stack_logging.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = pas_malloc_stack_logging.c; sourceTree = "<group>"; };
 		2B2E2FD02949A41100F85C38 /* pas_malloc_stack_logging.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = pas_malloc_stack_logging.h; sourceTree = "<group>"; };
@@ -1836,6 +1840,8 @@
 				0FDEA577228E23440085E340 /* pas_primitive_heap_ref.h */,
 				2B2A58982742D802005EE07C /* pas_probabilistic_guard_malloc_allocator.c */,
 				2B2A58972742D802005EE07C /* pas_probabilistic_guard_malloc_allocator.h */,
+				53C8C4F225EB4310B2063E8F /* pas_process.c */,
+				A6CCD9F0B3724EA198AAE8D3 /* pas_process.h */,
 				0F9A1CAD2559961300C8D11B /* pas_promote_intrinsic_heap.h */,
 				0F4F615A259BF6EC008B4A82 /* pas_ptr_hash_map.h */,
 				0F4F6146259BB109008B4A82 /* pas_ptr_hash_set.h */,
@@ -2329,6 +2335,7 @@
 				0F78088722FA2E4900F37451 /* pas_physical_memory_transaction.h in Headers */,
 				0FE7EE2922960142004F4166 /* pas_primitive_heap_ref.h in Headers */,
 				2B2A58992742D803005EE07C /* pas_probabilistic_guard_malloc_allocator.h in Headers */,
+				0EAB3692DA184399AE69D6F8 /* pas_process.h in Headers */,
 				0F9A1CF92559961700C8D11B /* pas_promote_intrinsic_heap.h in Headers */,
 				0F4F615B259BF6EC008B4A82 /* pas_ptr_hash_map.h in Headers */,
 				0F4F6147259BB109008B4A82 /* pas_ptr_hash_set.h in Headers */,
@@ -2835,6 +2842,7 @@
 				0FF248F922FC9EDB0077202E /* pas_physical_memory_transaction.c in Sources */,
 				0FE7EDCC22960142004F4166 /* pas_primitive_heap_ref.c in Sources */,
 				2B2A589A2742D803005EE07C /* pas_probabilistic_guard_malloc_allocator.c in Sources */,
+				565C4CAE4B9B462FBCDA92C1 /* pas_process.c in Sources */,
 				0F4F6151259BC333008B4A82 /* pas_ptr_worklist.c in Sources */,
 				0F5E483823D6960F0046DA5C /* pas_race_test_hooks.c in Sources */,
 				0FD48B3023A9ABB30026C46D /* pas_random.c in Sources */,

--- a/Source/bmalloc/libpas/src/libpas/pas_process.c
+++ b/Source/bmalloc/libpas/src/libpas/pas_process.c
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "pas_process.h"
+
+#if PAS_OS(WINDOWS)
+
+#include <windows.h>
+
+typedef BOOLEAN (WINAPI *pas_rtl_dll_shutdown_in_progress_t)(void);
+
+bool pas_process_is_shutting_down(void)
+{
+    static pas_rtl_dll_shutdown_in_progress_t resolved = NULL;
+    static bool did_resolve = false;
+
+    if (!did_resolve) {
+        HMODULE ntdll = GetModuleHandleW(L"ntdll.dll");
+        if (ntdll) {
+            resolved = (pas_rtl_dll_shutdown_in_progress_t)GetProcAddress(
+                ntdll, "RtlDllShutdownInProgress");
+        }
+        did_resolve = true;
+    }
+
+    if (!resolved)
+        return false;
+    return resolved() ? true : false;
+}
+
+#else /* !PAS_OS(WINDOWS) */
+
+bool pas_process_is_shutting_down(void)
+{
+    return false;
+}
+
+#endif /* PAS_OS(WINDOWS) */

--- a/Source/bmalloc/libpas/src/libpas/pas_process.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_process.h
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef PAS_PROCESS_H
+#define PAS_PROCESS_H
+
+#include "pas_utils.h"
+
+PAS_BEGIN_EXTERN_C;
+
+/* Returns true when the current process is in the middle of shutting down.
+   This API is meaningful only on Windows, otherwise always returning false. */
+PAS_API bool pas_process_is_shutting_down(void);
+
+PAS_END_EXTERN_C;
+
+#endif /* PAS_PROCESS_H */

--- a/Source/bmalloc/libpas/src/libpas/pas_thread_local_cache.c
+++ b/Source/bmalloc/libpas/src/libpas/pas_thread_local_cache.c
@@ -35,6 +35,7 @@
 #include "pas_heap_lock.h"
 #include "pas_large_utility_free_heap.h"
 #include "pas_log.h"
+#include "pas_process.h"
 #include "pas_scavenger.h"
 #include "pas_segregated_deallocation_mode.h"
 #include "pas_segregated_page_inlines.h"
@@ -149,6 +150,13 @@ static void destructor(void* arg)
 
     if (verbose)
         pas_log("[%d] Destructor call for TLS %p\n", getpid(), thread_local_cache);
+
+    /* On Windows, ExitProcess asynchronously terminates other threads, which may still hold
+       a lock. However the caller thread of ExitProcess does normal TLS destruction, which may cause
+       a dead-lock when we need to take a lock which is held by other threads which gets forcefully terminated.
+       When we know this is in the middle of shutting down the process, ignore TLS destruction. */
+    if (pas_process_is_shutting_down())
+        return;
 
 #if !PAS_OS(DARWIN)
     /* If pthread_self_is_exiting_np does not exist, we set PAS_THREAD_LOCAL_CACHE_DESTROYED in the TLS so that


### PR DESCRIPTION
#### e9072ad4757f0b943b98e35ee6fac78935e62d0b
<pre>
[libpas] Clean up Windows shutdown handling
<a href="https://bugs.webkit.org/show_bug.cgi?id=313684">https://bugs.webkit.org/show_bug.cgi?id=313684</a>
<a href="https://rdar.apple.com/175884563">rdar://175884563</a>

Reviewed by Keith Miller.

Windows has a bit wierd behavior compared to the other platforms. When
the thread starting the process finishes (Windows does not have *main
thread*, but this is kind-of equivalent thing to the other platforms&apos;
main thread), typically ExitProcess is called. But the behavior of
ExitProcess is awkward: it terminates the other threads, but it attempts
to clean up the current calling thread in an usual manner. This means
that calling thread does TLS cleanup while the other threads are
terminated abruptly. As a result, it is possible that the other threads
die while they are holding a lock. If normal TLS cleanup takes a lock,
there is a chance that this lock gets never released.

This patch adds pas_process_is_shutting_down function, which returns
true when the process is in the middle of &quot;shutting down&quot; state. Other
than Windows, it always returns false. But on Windows, it can return
true. Then we use this flag to decide whether we should do TLS cleanup.

* Source/WTF/wtf/Threading.cpp:
(WTF::Thread::didExit):
(WTF::shouldRemoveThreadFromThreadGroup): Deleted.
* Source/bmalloc/CMakeLists.txt:
* Source/bmalloc/bmalloc.xcodeproj/project.pbxproj:
* Source/bmalloc/libpas/libpas.xcodeproj/project.pbxproj:
* Source/bmalloc/libpas/src/libpas/pas_process.c: Added.
(pas_process_is_shutting_down):
* Source/bmalloc/libpas/src/libpas/pas_process.h: Added.
* Source/bmalloc/libpas/src/libpas/pas_thread_local_cache.c:
(destructor):

Canonical link: <a href="https://commits.webkit.org/312389@main">https://commits.webkit.org/312389@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/97b258eccf29cebb9b017e7a85c998d31c2d4891

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/159567 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/33034 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/26139 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/168414 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/113948 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/77452faa-875c-479d-a5ed-cb43589d5213) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/33139 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/33038 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/123635 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/86769 "8 failures") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/162524 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/25887 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/143317 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/104287 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/7a74495d-b712-4ada-8d6e-bd42eb7ca617) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/24938 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/23405 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/16177 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/151623 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/134630 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/21089 "Build is in progress. Recent messages:OS: Sequoia (15.7.3), Xcode: 26.2; Skipping applying patch since patch_id isn't provided; Checked out pull request; Skipped layout-tests; Passed layout tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/170901 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/20404 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/16935 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/22722 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/131861 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/32713 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/27478 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/131950 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/32698 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/142882 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/90780 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/24318 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/26593 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/19696 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/191851 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/32207 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/98603 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/49291 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/31704 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/31951 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/31855 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->