### PR TITLE
[JSC] Teach IntegerRangeOptimizations about a bit missing patterns

### DIFF
--- a/JSTests/stress/integer-range-optimization-arith-bit-and-or.js
+++ b/JSTests/stress/integer-range-optimization-arith-bit-and-or.js
@@ -1,0 +1,105 @@
+// Exercises the ArithBitAnd / ArithBitOr rules in DFGIntegerRangeOptimizationPhase.
+// Only constant operands are used to derive bounds, because constants never change
+// across the phase's fixpoint iterations. Using rangeFor() on non-constant operands
+// would let stale facts accumulate on the result node.
+
+function assert(actual, expected) {
+    if (actual !== expected)
+        throw new Error("Expected " + expected + " but got " + actual);
+}
+
+// ArithBitAnd with a non-negative constant: (x & 0xFF) is in [0, 255],
+// so the array index is always in bounds.
+function bitAndIndex(arr, x) {
+    return arr[x & 0xFF];
+}
+noInline(bitAndIndex);
+
+// ArithBitAnd with the constant on the left side.
+function bitAndIndexLeftConst(arr, x) {
+    return arr[0xFF & x];
+}
+noInline(bitAndIndexLeftConst);
+
+// ArithBitAnd composed: inner result is [0, 0x7F], outer result is bounded by 0x0F.
+function bitAndTwoMasks(x, y) {
+    var a = x & 0x7F;
+    var b = y & 0x0F;
+    return (a & b) + 1;
+}
+noInline(bitAndTwoMasks);
+
+// ArithBitAnd with a negative constant: rule must not claim any bounds.
+// (x & -1) == x for all x, including negative.
+function bitAndPreserveNegative(x) {
+    return x & -1;
+}
+noInline(bitAndPreserveNegative);
+
+// ArithBitOr with a negative constant: result is always negative.
+function bitOrWithNegative(x) {
+    return (x & 0xFF) | -1;
+}
+noInline(bitOrWithNegative);
+
+// ArithBitOr with a non-negative constant: rule derives nothing (since the
+// non-constant side could be negative). Correctness must still hold.
+function bitOrZero(arr, x) {
+    return arr[(x & 0xFF) | 0];
+}
+noInline(bitOrZero);
+
+// ArithBitOr with a non-negative constant on the left.
+function bitOrOneLeft(x) {
+    return 1 | (x & 0xFF);
+}
+noInline(bitOrOneLeft);
+
+// ArithBitOr with a negative constant establishes a lower bound: (x | C) >= C
+// for C < 0. Using the result of (y & 0xFF) | -16 as an index requires the
+// optimizer to reason about both sides of the range.
+function bitOrNegativeLowerBound(x) {
+    return (x & 0xFF) | -16;
+}
+noInline(bitOrNegativeLowerBound);
+
+// ArithBitOr with INT32_MIN: result has the sign bit set, so it is negative,
+// but the lower-bound rule must not underflow while computing C - 1.
+function bitOrIntMin(x) {
+    return (x & 0xFF) | (-2147483647 - 1);
+}
+noInline(bitOrIntMin);
+
+var buf = new Array(256);
+for (var i = 0; i < 256; ++i)
+    buf[i] = i;
+
+for (var i = 0; i < testLoopCount; ++i) {
+    assert(bitAndIndex(buf, i), i & 0xFF);
+    assert(bitAndIndex(buf, -i), (-i) & 0xFF);
+
+    assert(bitAndIndexLeftConst(buf, i), i & 0xFF);
+    assert(bitAndIndexLeftConst(buf, -i), (-i) & 0xFF);
+
+    assert(bitAndTwoMasks(i, i * 3), ((i & 0x7F) & ((i * 3) & 0x0F)) + 1);
+
+    assert(bitAndPreserveNegative(i), i);
+    assert(bitAndPreserveNegative(-i), -i);
+    assert(bitAndPreserveNegative(-1), -1);
+
+    assert(bitOrWithNegative(i), -1);
+    assert(bitOrWithNegative(-i), -1);
+
+    assert(bitOrZero(buf, i), i & 0xFF);
+    assert(bitOrZero(buf, -i), (-i) & 0xFF);
+
+    assert(bitOrOneLeft(i), 1 | (i & 0xFF));
+    assert(bitOrOneLeft(0), 1);
+
+    assert(bitOrNegativeLowerBound(i), (i & 0xFF) | -16);
+    assert(bitOrNegativeLowerBound(-i), ((-i) & 0xFF) | -16);
+
+    assert(bitOrIntMin(i), (i & 0xFF) | -2147483648);
+    assert(bitOrIntMin(-i), ((-i) & 0xFF) | -2147483648);
+}
+

--- a/JSTests/stress/integer-range-optimization-string-char-code-at.js
+++ b/JSTests/stress/integer-range-optimization-string-char-code-at.js
@@ -1,0 +1,63 @@
+// Exercises the StringCharCodeAt / StringCodePointAt rules in
+// DFGIntegerRangeOptimizationPhase. The results are known to lie in
+// [0, 0xFFFF] and [0, 0x10FFFF] respectively, which lets the phase fold
+// subsequent CheckInBounds and narrow downstream ranges.
+
+function assert(actual, expected) {
+    if (actual !== expected)
+        throw new Error("Expected " + expected + " but got " + actual);
+}
+
+// charCodeAt result is in [0, 0xFFFF], so indexing an array sized to that
+// range is always in bounds.
+function charCodeIndex(str, i, table) {
+    return table[str.charCodeAt(i)];
+}
+noInline(charCodeIndex);
+
+// codePointAt result is in [0, 0x10FFFF]. Combining it with a mask keeps the
+// result within a 32-bit signed range without overflow.
+function codePointIndex(str, i, table) {
+    return table[str.codePointAt(i) & 0xFFFF];
+}
+noInline(codePointIndex);
+
+// charCodeAt result feeding a bitwise AND: the combined range is the
+// intersection of [0, 0xFFFF] and [0, 0xFF].
+function charCodeLowByte(str, i) {
+    return str.charCodeAt(i) & 0xFF;
+}
+noInline(charCodeLowByte);
+
+// codePointAt followed by a comparison that is always true given the bound.
+function codePointBelowMax(str, i) {
+    var c = str.codePointAt(i);
+    return c <= 0x10FFFF;
+}
+noInline(codePointBelowMax);
+
+var asciiTable = new Array(0x10000);
+for (var i = 0; i < 0x10000; ++i)
+    asciiTable[i] = i;
+
+var bmpTable = new Array(0x10000);
+for (var i = 0; i < 0x10000; ++i)
+    bmpTable[i] = i * 2;
+
+var str = "Hello, World!";
+var supplementary = "a😀b"; // contains U+1F600 (GRINNING FACE).
+
+for (var i = 0; i < testLoopCount; ++i) {
+    assert(charCodeIndex(str, 0, asciiTable), 72);
+    assert(charCodeIndex(str, 7, asciiTable), 87);
+    assert(charCodeIndex(supplementary, 1, asciiTable), 0xD83D);
+
+    assert(codePointIndex(supplementary, 1, bmpTable), (0x1F600 & 0xFFFF) * 2);
+    assert(codePointIndex(str, 0, bmpTable), 72 * 2);
+
+    assert(charCodeLowByte(str, 0), 72 & 0xFF);
+    assert(charCodeLowByte(supplementary, 1), 0xD83D & 0xFF);
+
+    assert(codePointBelowMax(supplementary, 1), true);
+    assert(codePointBelowMax(str, 0), true);
+}

--- a/Source/JavaScriptCore/dfg/DFGIntegerRangeOptimizationPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGIntegerRangeOptimizationPhase.cpp
@@ -1671,6 +1671,54 @@ private:
             break;
         }
 
+        case ArithBitAnd: {
+            if (!node->isBinaryInt32UseKind())
+                break;
+
+            // Only infer from constant operands. A constant never changes across fixpoint
+            // iterations, so the derived relationship on @node stays valid; using rangeFor()
+            // on a non-constant operand would let stale facts accumulate on @node if that
+            // operand's relationships get invalidated later.
+            auto apply = [&](int32_t constant) {
+                if (constant < 0)
+                    return;
+                // (a & C) with C >= 0 has sign bit 0 and cannot exceed C.
+                setRelationship(Relationship(node, m_zero, Relationship::GreaterThan, -1));
+                if (constant < std::numeric_limits<int32_t>::max())
+                    setRelationship(Relationship(node, m_zero, Relationship::LessThan, constant + 1));
+            };
+
+            if (node->child1()->isInt32Constant())
+                apply(node->child1()->asInt32());
+            if (node->child2()->isInt32Constant())
+                apply(node->child2()->asInt32());
+            break;
+        }
+
+        case ArithBitOr: {
+            if (!node->isBinaryInt32UseKind())
+                break;
+
+            // Same reasoning as ArithBitAnd: only rely on constant operands so derived
+            // relationships cannot go stale across fixpoint iterations.
+            auto apply = [&](int32_t constant) {
+                if (constant >= 0)
+                    return;
+                // (a | C) with C < 0 has sign bit 1, so the result is negative.
+                setRelationship(Relationship(node, m_zero, Relationship::LessThan, 0));
+                // OR on a negative number can only flip zero bits to one, which in
+                // two's complement does not decrease the value, so (a | C) >= C.
+                if (constant > std::numeric_limits<int32_t>::min())
+                    setRelationship(Relationship(node, m_zero, Relationship::GreaterThan, constant - 1));
+            };
+
+            if (node->child1()->isInt32Constant())
+                apply(node->child1()->asInt32());
+            if (node->child2()->isInt32Constant())
+                apply(node->child2()->asInt32());
+            break;
+        }
+
         case GetArrayLength: {
             setRelationship(Relationship(node, m_zero, Relationship::GreaterThan, -1));
             switch (node->arrayMode().type()) {
@@ -1702,6 +1750,18 @@ private:
         case GetVectorLength: {
             setRelationship(Relationship(node, m_zero, Relationship::GreaterThan, -1));
             setRelationship(Relationship(node, m_zero, Relationship::LessThan, (MAX_STORAGE_VECTOR_LENGTH + 1)));
+            break;
+        }
+
+        case StringCharCodeAt: {
+            setRelationship(Relationship(node, m_zero, Relationship::GreaterThan, -1));
+            setRelationship(Relationship(node, m_zero, Relationship::LessThan, (static_cast<int32_t>(std::numeric_limits<char16_t>::max()) + 1)));
+            break;
+        }
+
+        case StringCodePointAt: {
+            setRelationship(Relationship(node, m_zero, Relationship::GreaterThan, -1));
+            setRelationship(Relationship(node, m_zero, Relationship::LessThan, (static_cast<int32_t>(0x10FFFF) + 1)));
             break;
         }
 


### PR DESCRIPTION
#### b4cca180f4d045284f6a3d79b0a2177664e2dd0e
<pre>
[JSC] Teach IntegerRangeOptimizations about a bit missing patterns
<a href="https://bugs.webkit.org/show_bug.cgi?id=313685">https://bugs.webkit.org/show_bug.cgi?id=313685</a>
<a href="https://rdar.apple.com/175885792">rdar://175885792</a>

Reviewed by Yijia Huang.

This patch teaches IntegerRangeOptimizations with following 4 patterns.

1. StringCharCodeAt

When it is used, it is guaranteed to reutnr Int32 result (if it is
out-of-range NaN, then OSR exit happens). Thus we can say that result
range is [0, 0xffff].

2. StringCodePointAt

It is the same to (1), but it handles all Unicode code point range,
thus, the range is [0, 0x10ffff].

3. ArithBitAnd

When it is specialized with Int32Use, very likely one side is constant,
and we can narrow the range of output. Narrowing the output via one
side&apos;s constant.

4. ArithBitOr

Similar to (3), we can also do some narrowing here based on one side&apos;s constant.

Test: JSTests/stress/integer-range-optimization-arith-bit-and-or.js

* JSTests/stress/integer-range-optimization-arith-bit-and-or.js: Added.
(assert):
(bitAndIndex):
(bitAndIndexLeftConst):
(bitAndTwoMasks):
(bitAndPreserveNegative):
(bitOrWithNegative):
(bitOrZero):
(bitOrOneLeft):
(bitOrNegativeLowerBound):
(bitOrIntMin):
* JSTests/stress/integer-range-optimization-string-char-code-at.js: Added.
(assert):
(charCodeIndex):
(codePointIndex):
(charCodeLowByte):
(codePointBelowMax):
* Source/JavaScriptCore/dfg/DFGIntegerRangeOptimizationPhase.cpp:

Canonical link: <a href="https://commits.webkit.org/312345@main">https://commits.webkit.org/312345@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a0e54beaa88bd3921dcc5cc262bb02521b4b5d1c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/159648 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/33115 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/26222 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/168499 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/114029 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/33220 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/33119 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/123694 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/114029 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/162605 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/25955 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/143397 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/104337 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/25006 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/23471 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/16263 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/151704 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/134698 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/21169 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/170990 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/20485 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/17016 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/22803 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/131931 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/32794 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/27546 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/132008 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/32779 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/142963 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/90861 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/24298 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/26641 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/19776 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/191932 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/32288 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/98684 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/49310 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/31785 "Built successfully") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/32032 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/31936 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->