### PR TITLE
Add test for entering value not in datalist - fixed in 311319@main.

### DIFF
--- a/LayoutTests/fast/forms/datalist/datalist-textinput-type-custom-value-expected.txt
+++ b/LayoutTests/fast/forms/datalist/datalist-textinput-type-custom-value-expected.txt
@@ -1,0 +1,16 @@
+
+This test verifies that typing into an input with a list attribute allows freely entering text that does not match any datalist option. The type-select filter on the context menu should not consume keystrokes.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS input.value became 'M'
+PASS input.value became 'Ma'
+PASS input.value became 'Man'
+PASS input.value became 'Mang'
+PASS input.value became 'Mango'
+PASS input.value is "Mango"
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/forms/datalist/datalist-textinput-type-custom-value.html
+++ b/LayoutTests/fast/forms/datalist/datalist-textinput-type-custom-value.html
@@ -1,0 +1,64 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ useFlexibleViewport=true ] -->
+<html>
+<head>
+<meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no">
+<script src="../../../resources/ui-helper.js"></script>
+<script src="../../../resources/js-test.js"></script>
+<style>
+input {
+    width: 300px;
+    height: 50px;
+}
+</style>
+</head>
+<body>
+
+<input id="input" list="fruits" type="text" autocapitalize="none"/>
+<datalist id="fruits">
+<option value="Apple">
+<option value="Kiwi">
+<option value="Melon">
+<option value="Orange">
+<option value="Pear">
+<option value="Strawberry">
+</datalist>
+<div id="console"></div>
+
+<script>
+jsTestIsAsync = true;
+
+if (window.testRunner)
+    testRunner.dumpAsText();
+
+description("This test verifies that typing into an input with a list attribute allows freely entering text that does not match any datalist option. The type-select filter on the context menu should not consume keystrokes.");
+
+(async () => {
+    if (!window.testRunner)
+        return;
+
+    await UIHelper.setHardwareKeyboardAttached(true);
+    await UIHelper.activateElement(input);
+
+    await UIHelper.typeCharacter("M");
+    await new Promise(resolve => shouldBecomeEqual("input.value", "'M'", resolve));
+
+    await UIHelper.typeCharacter("a");
+    await new Promise(resolve => shouldBecomeEqual("input.value", "'Ma'", resolve));
+
+    await UIHelper.typeCharacter("n");
+    await new Promise(resolve => shouldBecomeEqual("input.value", "'Man'", resolve));
+
+    await UIHelper.typeCharacter("g");
+    await new Promise(resolve => shouldBecomeEqual("input.value", "'Mang'", resolve));
+
+    await UIHelper.typeCharacter("o");
+    await new Promise(resolve => shouldBecomeEqual("input.value", "'Mango'", resolve));
+
+    shouldBeEqualToString("input.value", "Mango");
+
+    finishJSTest();
+})();
+
+</script>
+</body>
+</html>

--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -3184,6 +3184,7 @@ fast/block/basic/quirk-mode-percent-height.html [ Failure ]
 # Datalist
 webkit.org/b/186714 fast/forms/datalist/datalist-textinput-keydown.html [ Skip ]
 webkit.org/b/190613 fast/forms/datalist/update-range-with-datalist.html [ Skip ]
+webkit.org/b/312010 fast/forms/datalist/datalist-textinput-type-custom-value.html [ Skip ]
 
 # Audio session does not have a "none" category on iOS [ Skip ]
 webkit.org/b/188285 platform/mac/media/audio-session-category-video-paused.html [ Skip ]


### PR DESCRIPTION
#### 97a4b0d72f6a6bc3095316c7ac87bdb37e48459e
<pre>
Add test for entering value not in datalist - fixed in 311319@main.
<a href="https://bugs.webkit.org/show_bug.cgi?id=313686">https://bugs.webkit.org/show_bug.cgi?id=313686</a>
<a href="https://rdar.apple.com/175886408">rdar://175886408</a>

Reviewed by Aditya Keerthi.

Skip tests in open source until the bots have the UIKit fix that was
required for this to work.

* LayoutTests/fast/forms/datalist/datalist-textinput-type-custom-value-expected.txt: Added.
* LayoutTests/fast/forms/datalist/datalist-textinput-type-custom-value.html: Added.
* LayoutTests/platform/ios/TestExpectations:

Canonical link: <a href="https://commits.webkit.org/312668@main">https://commits.webkit.org/312668@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/11fc641dc69a3ca490c0871e6f1873a64eb17d20

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/160642 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/34115 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/27216 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/169545 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/115708 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/eba462ab-6920-4c27-bdd8-35d14ef4dec2) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/34216 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/34115 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/124577 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/87967 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/6139619d-5a18-4cd3-b732-f92240eeb969) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/163601 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/26822 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/144288 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/105177 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/213a5fa9-d55a-4d1d-b45e-d84660fa41d3) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/25874 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/24382 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/17265 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/135568 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/22051 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/172024 "Built successfully") | | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/23691 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/132843 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/33789 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/28474 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/132858 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35904 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/33773 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/143846 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/95582 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/27454 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/20661 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/33284 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/32783 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/33027 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/32931 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->