### PR TITLE
Add tests for animation cancel events on element removal

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-transitions/transition-cancel-elapsed-time-on-removal-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-transitions/transition-cancel-elapsed-time-on-removal-expected.txt
@@ -1,0 +1,3 @@
+
+PASS transitioncancel elapsedTime is non-zero when element is removed mid-transition
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-transitions/transition-cancel-elapsed-time-on-removal.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-transitions/transition-cancel-elapsed-time-on-removal.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="help" href="https://drafts.csswg.org/css-transitions/#event-transitionevent">
+<style>
+.target {
+    transition: margin-left 10s linear;
+    margin-left: 0px;
+}
+</style>
+</head>
+<body>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="./support/helper.js"></script>
+<script>
+
+promise_test(async t => {
+    const div = document.createElement('div');
+    div.classList.add('target');
+    document.body.appendChild(div);
+
+    getComputedStyle(div).marginLeft;
+    div.style.marginLeft = '100px';
+
+    const animation = div.getAnimations()[0];
+    await animation.ready;
+
+    // Two rAFs are needed. animation.ready can resolve in the same frame as the first rAF,
+    // so the timeline hasn't advanced yet and elapsedTime would be 0.
+    await waitForAnimationFrames(2);
+
+    const cancelEvent = new Promise(resolve => {
+        div.addEventListener('transitioncancel', resolve, { once: true });
+    });
+
+    div.remove();
+
+    // Force a rendering frame so the pending animation event queue is processed.
+    await new Promise(resolve => requestAnimationFrame(resolve));
+
+    const event = await cancelEvent;
+    assert_greater_than(event.elapsedTime, 0,
+        'elapsedTime should be non-zero when removed mid-transition');
+}, 'transitioncancel elapsedTime is non-zero when element is removed mid-transition');
+
+</script>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/web-animations/interfaces/Animation/cancel-event-on-element-removal-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/web-animations/interfaces/Animation/cancel-event-on-element-removal-expected.txt
@@ -1,0 +1,3 @@
+
+PASS Animation.cancel event fires when element is removed
+

--- a/LayoutTests/imported/w3c/web-platform-tests/web-animations/interfaces/Animation/cancel-event-on-element-removal.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/web-animations/interfaces/Animation/cancel-event-on-element-removal.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<meta charset=utf-8>
+<title>Cancel events on element removal</title>
+<link rel="help" href="https://drafts.csswg.org/web-animations/#canceling-an-animation-section">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<style>
+@keyframes anim { to { opacity: 0; } }
+</style>
+<body>
+<div id="log"></div>
+<script>
+'use strict';
+
+promise_test(async t => {
+    const div = document.createElement('div');
+    div.style.animation = 'anim 10s';
+    document.body.appendChild(div);
+
+    const animation = div.getAnimations()[0];
+    await animation.ready;
+
+    const cancelFired = new Promise(resolve => {
+        animation.addEventListener('cancel', resolve);
+    });
+
+    div.remove();
+
+    const result = await Promise.race([
+        cancelFired.then(() => 'fired'),
+        new Promise(resolve => step_timeout(() => resolve('timeout'), 100))
+    ]);
+
+    assert_equals(result, 'fired',
+        'Web Animations API cancel event should fire on element removal');
+}, 'Animation.cancel event fires when element is removed');
+
+</script>
+</body>


### PR DESCRIPTION
#### 3bde74e861e777a7cb3de1184a446a91cb63dab6
<pre>
Add tests for animation cancel events on element removal
<a href="https://rdar.apple.com/175873288">rdar://175873288</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=313681">https://bugs.webkit.org/show_bug.cgi?id=313681</a>

Reviewed by Antoine Quint.

Add test coverage for cancel events fired when an element with running
animations is removed from the DOM.

One WPT test added verifies that the Web Animations API cancel event
(AnimationPlaybackEvent) fires on the Animation object when its target
element is removed. This test defends against changes that skip the
playState() != Idle block in WebAnimation::cancel, which would
silently drop the event.

The second WPT test added verifies that transitioncancel&apos;s elapsedTime is
non-zero when an element is removed mid-transition. This defends
against changes that compute the cancellation time after the
animation has been made idle, which would report elapsedTime as 0
instead of the actual elapsed time.

No existing tests covered either of these behaviors.

* LayoutTests/imported/w3c/web-platform-tests/css/css-transitions/transition-cancel-elapsed-time-on-removal-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-transitions/transition-cancel-elapsed-time-on-removal.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/web-animations/interfaces/Animation/cancel-event-on-element-removal-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/web-animations/interfaces/Animation/cancel-event-on-element-removal.html: Added.

Canonical link: <a href="https://commits.webkit.org/312836@main">https://commits.webkit.org/312836@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/88665a6c7281201a267c84e17c7282ade10bd955

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/161240 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/34713 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/27814 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/170143 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/117611 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/34814 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/34714 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/125070 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/117611 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/164199 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/27358 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/144835 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/105667 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/26406 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/24905 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk3-libwebrtc~~](https://ews-build.webkit.org/#/builders/173/builds/17863 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/136100 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/167/builds/22595 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/172626 "Built successfully") | | 
| | | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/24236 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/133347 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/34387 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/28998 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/133356 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36011 "Built successfully and passed tests") | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/34372 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/144390 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/96237 "Built successfully") | | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/160/builds/34372 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/21208 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/33882 "Built successfully") | | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/33381 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/33625 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/33530 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->