### PR TITLE
REGRESSION(306362@main): `preventDefault` for `pointerdown` on iOS does not stop `mousedown` from firing

### DIFF
--- a/Source/WebKit/UIProcess/ios/WKTouchEventsGestureRecognizer.mm
+++ b/Source/WebKit/UIProcess/ios/WKTouchEventsGestureRecognizer.mm
@@ -125,7 +125,10 @@ static unsigned incrementingTouchIdentifier = 1;
     _lastTouchesBeganTime = 0;
     _lastTouchesBeganLocation = std::nullopt;
 
-    [protect(_contentView) _touchEventsGestureRecognizerReset];
+    // If the last touch sequence ended abnormally, clear the pointer capture
+    // controller so that its active touch map doesn't retain extra touches.
+    if (_lastTouchEvent.type != WebKit::WKTouchEventType::End)
+        [protect(_contentView) _touchEventsGestureRecognizerReset];
 }
 
 - (void)cancel


### PR DESCRIPTION
#### f375994f3f8e0c5c9c7eaf2b12c9ade8ca50dde4
<pre>
REGRESSION(306362@main): `preventDefault` for `pointerdown` on iOS does not stop `mousedown` from firing
<a href="https://bugs.webkit.org/show_bug.cgi?id=313688">https://bugs.webkit.org/show_bug.cgi?id=313688</a>
<a href="https://rdar.apple.com/174864309">rdar://174864309</a>

Reviewed by Richard Robinson and Abrar Rahman Protyasha.

In 306362@main we began to clear the pointer capture controller when
`[WKTouchEventsGestureRecognizer reset]` was called so that the map of
active touches wouldn&apos;t get stuck when an external gesture recognizer
handled the touch in a specific manner.

However, when the screen is tapped, after `pointerdown` is dispatched,
`PointerCaptureController::preventsCompatibilityMouseEventsForIdentifier`
is called to see if we should also dispatch `mousedown`. Critically, this
is done by examining the map of active touches, which now gets cleared
before the check, thus preventing us from making thte correct determination.

Fix the issue by only clearing the map from
`[WKTouchEventsGestureRecognizer reset]` if the last touch&apos;s type isn&apos;t
`WKTouchEventType::End`, indicating that the touch sequence finished abnormally.

Tested by
`pointerevents/ios/pointer-events-no-mousedown-when-prevent-default-called-on-pointerdown.html`

* Source/WebKit/UIProcess/ios/WKTouchEventsGestureRecognizer.mm:
(-[WKTouchEventsGestureRecognizer reset]):

Canonical link: <a href="https://commits.webkit.org/312396@main">https://commits.webkit.org/312396@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/28c11517276cf1b2db42abc3b29859670026fab6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/159622 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/33089 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/26196 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/168477 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/114003 "Built successfully") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/33194 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/33093 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/123673 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/86795 "8 failures") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/162579 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/25936 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/143373 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/104324 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/24987 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/23450 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/16235 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/134679 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/170958 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/16990 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/22779 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/131926 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/32768 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/27523 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/131987 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35755 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/32753 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/142938 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/90835 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/26627 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/19752 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/32262 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/98658 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/31759 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/32006 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/31910 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->