### PR TITLE
Refine UnbarrieredMonotonicTime's calibration to minimize displacement from MonotonicTime.

### DIFF
--- a/Source/WTF/wtf/UnbarrieredMonotonicTime.cpp
+++ b/Source/WTF/wtf/UnbarrieredMonotonicTime.cpp
@@ -27,9 +27,14 @@
 #include <wtf/UnbarrieredMonotonicTime.h>
 
 #include <wtf/ContinuousTime.h>
+#include <wtf/Lock.h>
 #include <wtf/MonotonicTime.h>
 #include <wtf/PrintStream.h>
 #include <wtf/WallTime.h>
+
+#if OS(DARWIN)
+#include <mach/mach_time.h>
+#endif
 
 namespace WTF {
 
@@ -39,19 +44,54 @@ UnbarrieredMonotonicTime::Calibration UnbarrieredMonotonicTime::s_calibration;
 void UnbarrieredMonotonicTime::calibrate()
 {
     constexpr double nanosecondsPerSecond = 1000'000'000;
-    if (!s_calibration.nanosecondsPerTick) [[unlikely]] {
-        auto readCounterFrequency = [] -> uint64_t {
-            uint64_t val;
-            __asm__ volatile("mrs %0, CNTFRQ_EL0" : "=r"(val) : : "memory");
-            return val;
-        };
+    static Lock lock;
 
-        auto currentTime = MonotonicTime::now();
-        s_calibration.startCntpct = readCounter();
-        s_calibration.startNanoseconds = currentTime.secondsSinceEpoch().nanoseconds();
-        uint64_t ticksPerSecond = readCounterFrequency();
-        s_calibration.nanosecondsPerTick = nanosecondsPerSecond / ticksPerSecond;
+    Locker locker { lock };
+    if (s_calibration.nanosecondsPerTick)
+        return; // Already calibrated.
+
+    auto readCounterFrequency = [] -> uint64_t {
+        uint64_t val;
+        __asm__ volatile("mrs %0, CNTFRQ_EL0" : "=r"(val) : : "memory");
+        return val;
+    };
+
+    // We're going straight to mach_absolute_time() instead of MonotonicTime::now()
+    // because we want to miminize the time difference between sampling it and sampling
+    // CNTVCT_EL0. MonotonicTime::now() can be deterministically computed from the
+    // value of mach_absolute_time().
+    //
+    // Note that the value of mach_absolute_time() relies on when the kernel samples
+    // CNTVCT_EL0 and update it. Effectively, mach_absolute_time may be of a lower
+    // resolution than CNTVCT_EL0 depending on when the kernel updates it. So, for our
+    // calibration, to minimize the difference between the 2 values, we'll sample
+    // them until we see mach_absolute_time()'s value change 2 times. This allows
+    // us to catch the CNTVCT_EL0 value right as mach_absolute_time() changes.
+    //
+    // We look for 2 transitions of mach_absolute_time() because the first transition
+    // may race against us and occur just as we enter the sampling loop. Waiting for
+    // the 2nd transition reduces the impact of such a race.
+
+    uint64_t counter = readCounter();
+    uint64_t startAbsTime = mach_absolute_time();
+    uint64_t absTime = startAbsTime;
+    for (int i = 0; i < 2; ++i) {
+        do {
+            counter = readCounter();
+            absTime = mach_absolute_time();
+        } while (absTime == startAbsTime);
     }
+
+    // Now that we have the closely paired samples of mach_absolute_time() and CNTVCT_EL0,
+    // determinstically compute the calibration values.
+    mach_timebase_info_data_t info;
+    kern_return_t kr = mach_timebase_info(&info);
+    ASSERT_UNUSED(kr, kr == KERN_SUCCESS);
+    s_calibration.startCounter = counter;
+    s_calibration.startNanoseconds = absTime * info.numer / (double)info.denom;
+
+    uint64_t ticksPerSecond = readCounterFrequency();
+    s_calibration.nanosecondsPerTick = nanosecondsPerSecond / ticksPerSecond;
 }
 #endif
 

--- a/Source/WTF/wtf/UnbarrieredMonotonicTime.h
+++ b/Source/WTF/wtf/UnbarrieredMonotonicTime.h
@@ -87,7 +87,7 @@ private:
 
 #if USE(HARDWARE_UNBARRIERED_MONOTONIC_TIME)
     struct Calibration {
-        uint64_t startCntpct;
+        uint64_t startCounter;
         double startNanoseconds;
         double nanosecondsPerTick;
     };
@@ -114,7 +114,7 @@ inline UnbarrieredMonotonicTime UnbarrieredMonotonicTime::now()
         calibrate();
 
     constexpr double nanosecondsPerSecond = 1000'000'000;
-    double nanoseconds = (readCounter() - s_calibration.startCntpct) * s_calibration.nanosecondsPerTick + s_calibration.startNanoseconds;
+    double nanoseconds = (readCounter() - s_calibration.startCounter) * s_calibration.nanosecondsPerTick + s_calibration.startNanoseconds;
     return UnbarrieredMonotonicTime::fromRawSeconds(nanoseconds / nanosecondsPerSecond);
 }
 #endif // USE(HARDWARE_UNBARRIERED_MONOTONIC_TIME)


### PR DESCRIPTION
#### 75aab8192b94f6746dcc426c84864e40ec76ae96
<pre>
Refine UnbarrieredMonotonicTime&apos;s calibration to minimize displacement from MonotonicTime.
<a href="https://bugs.webkit.org/show_bug.cgi?id=313704">https://bugs.webkit.org/show_bug.cgi?id=313704</a>
<a href="https://rdar.apple.com/175902778">rdar://175902778</a>

Reviewed by Yusuke Suzuki.

This is to enable cheap conversion between UnbarrieredMonotonicTime and MonotonicTime
values for some use cases.  For starters, we&apos;ll only be using this in some local perf
experiments for now.

Tested locally and manually.  Also covered by uses of ApproximateTime (which forwards
to UnbarrieredMonotonicTime on the OS(DARWIN) + ARM64 port) via existing tests.

* Source/WTF/wtf/UnbarrieredMonotonicTime.cpp:
(WTF::UnbarrieredMonotonicTime::calibrate):
* Source/WTF/wtf/UnbarrieredMonotonicTime.h:
(WTF::UnbarrieredMonotonicTime::now):

Canonical link: <a href="https://commits.webkit.org/312339@main">https://commits.webkit.org/312339@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0ac4083864892f2d911dc0aa2ddacc624e8ad03e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/159625 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/33092 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/26199 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/168474 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/114006 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/33197 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/33096 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/123671 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/114006 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/162582 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/25943 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/143374 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/104322 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/24994 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/23453 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/16239 "Built successfully") | | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/20/builds/151681 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/134686 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/21146 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/170961 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/20462 "Built successfully and passed tests") | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/16993 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/22780 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/131910 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/32771 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/27526 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/131990 "Passed tests") | | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/32756 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/142939 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/90838 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/24296 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/160/builds/32756 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/19753 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/191909 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/32265 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/98661 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/49305 "Passed tests") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/31762 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/32009 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/31913 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->