### PR TITLE
[JSC] Add TypedArray#lastIndexOf optimization

### DIFF
--- a/JSTests/microbenchmarks/bigint64-array-last-index-of-large.js
+++ b/JSTests/microbenchmarks/bigint64-array-last-index-of-large.js
@@ -1,0 +1,15 @@
+//@ memoryHog!
+let size = 20 << 20;
+let array = new BigInt64Array(size);
+for (let i = 0; i < size; ++i)
+    array[i] = 1n;
+array[0] = 42n;
+
+function test(array) {
+    let result = 0;
+    for (let i = 0; i < 1e2; ++i)
+        result += array.lastIndexOf(42n);
+    return result;
+}
+noInline(test);
+test(array);

--- a/JSTests/microbenchmarks/bigint64-array-last-index-of-medium.js
+++ b/JSTests/microbenchmarks/bigint64-array-last-index-of-medium.js
@@ -1,0 +1,15 @@
+//@ memoryHog!
+let size = 4096;
+let array = new BigInt64Array(size);
+for (let i = 0; i < size; ++i)
+    array[i] = 1n;
+array[0] = 42n;
+
+function test(array) {
+    let result = 0;
+    for (let i = 0; i < 1e2; ++i)
+        result += array.lastIndexOf(42n);
+    return result;
+}
+noInline(test);
+test(array);

--- a/JSTests/microbenchmarks/bigint64-array-last-index-of-small.js
+++ b/JSTests/microbenchmarks/bigint64-array-last-index-of-small.js
@@ -1,0 +1,15 @@
+//@ memoryHog!
+let size = 16;
+let array = new BigInt64Array(size);
+for (let i = 0; i < size; ++i)
+    array[i] = 1n;
+array[0] = 42n;
+
+function test(array) {
+    let result = 0;
+    for (let i = 0; i < 1e2; ++i)
+        result += array.lastIndexOf(42n);
+    return result;
+}
+noInline(test);
+test(array);

--- a/JSTests/microbenchmarks/biguint64-array-last-index-of-large.js
+++ b/JSTests/microbenchmarks/biguint64-array-last-index-of-large.js
@@ -1,0 +1,15 @@
+//@ memoryHog!
+let size = 20 << 20;
+let array = new BigUint64Array(size);
+for (let i = 0; i < size; ++i)
+    array[i] = 1n;
+array[0] = 42n;
+
+function test(array) {
+    let result = 0;
+    for (let i = 0; i < 1e2; ++i)
+        result += array.lastIndexOf(42n);
+    return result;
+}
+noInline(test);
+test(array);

--- a/JSTests/microbenchmarks/biguint64-array-last-index-of-medium.js
+++ b/JSTests/microbenchmarks/biguint64-array-last-index-of-medium.js
@@ -1,0 +1,15 @@
+//@ memoryHog!
+let size = 4096;
+let array = new BigUint64Array(size);
+for (let i = 0; i < size; ++i)
+    array[i] = 1n;
+array[0] = 42n;
+
+function test(array) {
+    let result = 0;
+    for (let i = 0; i < 1e2; ++i)
+        result += array.lastIndexOf(42n);
+    return result;
+}
+noInline(test);
+test(array);

--- a/JSTests/microbenchmarks/biguint64-array-last-index-of-small.js
+++ b/JSTests/microbenchmarks/biguint64-array-last-index-of-small.js
@@ -1,0 +1,15 @@
+//@ memoryHog!
+let size = 16;
+let array = new BigUint64Array(size);
+for (let i = 0; i < size; ++i)
+    array[i] = 1n;
+array[0] = 42n;
+
+function test(array) {
+    let result = 0;
+    for (let i = 0; i < 1e2; ++i)
+        result += array.lastIndexOf(42n);
+    return result;
+}
+noInline(test);
+test(array);

--- a/JSTests/microbenchmarks/float32-array-last-index-of-large.js
+++ b/JSTests/microbenchmarks/float32-array-last-index-of-large.js
@@ -1,0 +1,15 @@
+//@ memoryHog!
+let size = 20 << 20;
+let array = new Float32Array(size);
+for (let i = 0; i < size; ++i)
+    array[i] = 1;
+array[0] = 42;
+
+function test(array) {
+    let result = 0;
+    for (let i = 0; i < 1e2; ++i)
+        result += array.lastIndexOf(42);
+    return result;
+}
+noInline(test);
+test(array);

--- a/JSTests/microbenchmarks/float32-array-last-index-of-medium.js
+++ b/JSTests/microbenchmarks/float32-array-last-index-of-medium.js
@@ -1,0 +1,15 @@
+//@ memoryHog!
+let size = 4096;
+let array = new Float32Array(size);
+for (let i = 0; i < size; ++i)
+    array[i] = 1;
+array[0] = 42;
+
+function test(array) {
+    let result = 0;
+    for (let i = 0; i < 1e2; ++i)
+        result += array.lastIndexOf(42);
+    return result;
+}
+noInline(test);
+test(array);

--- a/JSTests/microbenchmarks/float32-array-last-index-of-small.js
+++ b/JSTests/microbenchmarks/float32-array-last-index-of-small.js
@@ -1,0 +1,15 @@
+//@ memoryHog!
+let size = 16;
+let array = new Float32Array(size);
+for (let i = 0; i < size; ++i)
+    array[i] = 1;
+array[0] = 42;
+
+function test(array) {
+    let result = 0;
+    for (let i = 0; i < 1e2; ++i)
+        result += array.lastIndexOf(42);
+    return result;
+}
+noInline(test);
+test(array);

--- a/JSTests/microbenchmarks/float64-array-last-index-of-large.js
+++ b/JSTests/microbenchmarks/float64-array-last-index-of-large.js
@@ -1,0 +1,15 @@
+//@ memoryHog!
+let size = 20 << 20;
+let array = new Float64Array(size);
+for (let i = 0; i < size; ++i)
+    array[i] = 1;
+array[0] = 42;
+
+function test(array) {
+    let result = 0;
+    for (let i = 0; i < 1e2; ++i)
+        result += array.lastIndexOf(42);
+    return result;
+}
+noInline(test);
+test(array);

--- a/JSTests/microbenchmarks/float64-array-last-index-of-medium.js
+++ b/JSTests/microbenchmarks/float64-array-last-index-of-medium.js
@@ -1,0 +1,15 @@
+//@ memoryHog!
+let size = 4096;
+let array = new Float64Array(size);
+for (let i = 0; i < size; ++i)
+    array[i] = 1;
+array[0] = 42;
+
+function test(array) {
+    let result = 0;
+    for (let i = 0; i < 1e2; ++i)
+        result += array.lastIndexOf(42);
+    return result;
+}
+noInline(test);
+test(array);

--- a/JSTests/microbenchmarks/float64-array-last-index-of-small.js
+++ b/JSTests/microbenchmarks/float64-array-last-index-of-small.js
@@ -1,0 +1,15 @@
+//@ memoryHog!
+let size = 16;
+let array = new Float64Array(size);
+for (let i = 0; i < size; ++i)
+    array[i] = 1;
+array[0] = 42;
+
+function test(array) {
+    let result = 0;
+    for (let i = 0; i < 1e2; ++i)
+        result += array.lastIndexOf(42);
+    return result;
+}
+noInline(test);
+test(array);

--- a/JSTests/microbenchmarks/int16-array-last-index-of-large.js
+++ b/JSTests/microbenchmarks/int16-array-last-index-of-large.js
@@ -1,0 +1,14 @@
+let size = 20 << 20;
+let array = new Int16Array(size);
+for (let i = 0; i < size; ++i)
+    array[i] = 1;
+array[0] = 42;
+
+function test(array) {
+    let result = 0;
+    for (let i = 0; i < 1e2; ++i)
+        result += array.lastIndexOf(42);
+    return result;
+}
+noInline(test);
+test(array);

--- a/JSTests/microbenchmarks/int16-array-last-index-of-medium.js
+++ b/JSTests/microbenchmarks/int16-array-last-index-of-medium.js
@@ -1,0 +1,14 @@
+let size = 4096;
+let array = new Int16Array(size);
+for (let i = 0; i < size; ++i)
+    array[i] = 1;
+array[0] = 42;
+
+function test(array) {
+    let result = 0;
+    for (let i = 0; i < 1e4; ++i)
+        result += array.lastIndexOf(42);
+    return result;
+}
+noInline(test);
+test(array);

--- a/JSTests/microbenchmarks/int16-array-last-index-of-small.js
+++ b/JSTests/microbenchmarks/int16-array-last-index-of-small.js
@@ -1,0 +1,14 @@
+let size = 16;
+let array = new Int16Array(size);
+for (let i = 0; i < size; ++i)
+    array[i] = 1;
+array[0] = 42;
+
+function test(array) {
+    let result = 0;
+    for (let i = 0; i < 1e4; ++i)
+        result += array.lastIndexOf(42);
+    return result;
+}
+noInline(test);
+test(array);

--- a/JSTests/microbenchmarks/int32-array-last-index-of-large.js
+++ b/JSTests/microbenchmarks/int32-array-last-index-of-large.js
@@ -1,0 +1,15 @@
+//@ memoryHog!
+let size = 20 << 20;
+let array = new Int32Array(size);
+for (let i = 0; i < size; ++i)
+    array[i] = 1;
+array[0] = 42;
+
+function test(array) {
+    let result = 0;
+    for (let i = 0; i < 1e2; ++i)
+        result += array.lastIndexOf(42);
+    return result;
+}
+noInline(test);
+test(array);

--- a/JSTests/microbenchmarks/int32-array-last-index-of-medium.js
+++ b/JSTests/microbenchmarks/int32-array-last-index-of-medium.js
@@ -1,0 +1,15 @@
+//@ memoryHog!
+let size = 4096;
+let array = new Int32Array(size);
+for (let i = 0; i < size; ++i)
+    array[i] = 1;
+array[0] = 42;
+
+function test(array) {
+    let result = 0;
+    for (let i = 0; i < 1e2; ++i)
+        result += array.lastIndexOf(42);
+    return result;
+}
+noInline(test);
+test(array);

--- a/JSTests/microbenchmarks/int32-array-last-index-of-small.js
+++ b/JSTests/microbenchmarks/int32-array-last-index-of-small.js
@@ -1,0 +1,15 @@
+//@ memoryHog!
+let size = 16;
+let array = new Int32Array(size);
+for (let i = 0; i < size; ++i)
+    array[i] = 1;
+array[0] = 42;
+
+function test(array) {
+    let result = 0;
+    for (let i = 0; i < 1e2; ++i)
+        result += array.lastIndexOf(42);
+    return result;
+}
+noInline(test);
+test(array);

--- a/JSTests/microbenchmarks/int8-array-last-index-of-large.js
+++ b/JSTests/microbenchmarks/int8-array-last-index-of-large.js
@@ -1,0 +1,14 @@
+let size = 20 << 20;
+let array = new Int8Array(size);
+for (let i = 0; i < size; ++i)
+    array[i] = 1;
+array[0] = 42;
+
+function test(array) {
+    let result = 0;
+    for (let i = 0; i < 1e2; ++i)
+        result += array.lastIndexOf(42);
+    return result;
+}
+noInline(test);
+test(array);

--- a/JSTests/microbenchmarks/int8-array-last-index-of-medium.js
+++ b/JSTests/microbenchmarks/int8-array-last-index-of-medium.js
@@ -1,0 +1,14 @@
+let size = 4096;
+let array = new Int8Array(size);
+for (let i = 0; i < size; ++i)
+    array[i] = 1;
+array[0] = 42;
+
+function test(array) {
+    let result = 0;
+    for (let i = 0; i < 1e4; ++i)
+        result += array.lastIndexOf(42);
+    return result;
+}
+noInline(test);
+test(array);

--- a/JSTests/microbenchmarks/int8-array-last-index-of-small.js
+++ b/JSTests/microbenchmarks/int8-array-last-index-of-small.js
@@ -1,0 +1,14 @@
+let size = 16;
+let array = new Int8Array(size);
+for (let i = 0; i < size; ++i)
+    array[i] = 1;
+array[0] = 42;
+
+function test(array) {
+    let result = 0;
+    for (let i = 0; i < 1e4; ++i)
+        result += array.lastIndexOf(42);
+    return result;
+}
+noInline(test);
+test(array);

--- a/JSTests/microbenchmarks/typed-array-lastIndexOf-empty.js
+++ b/JSTests/microbenchmarks/typed-array-lastIndexOf-empty.js
@@ -1,0 +1,5 @@
+var empty = new Int8Array();
+noInline(Int8Array.prototype.lastIndexOf);
+
+for (var i = 0; i < 1e7; ++i)
+    empty.lastIndexOf(1);

--- a/JSTests/microbenchmarks/uint16-array-last-index-of-large.js
+++ b/JSTests/microbenchmarks/uint16-array-last-index-of-large.js
@@ -1,0 +1,14 @@
+let size = 20 << 20;
+let array = new Uint16Array(size);
+for (let i = 0; i < size; ++i)
+    array[i] = 1;
+array[0] = 42;
+
+function test(array) {
+    let result = 0;
+    for (let i = 0; i < 1e2; ++i)
+        result += array.lastIndexOf(42);
+    return result;
+}
+noInline(test);
+test(array);

--- a/JSTests/microbenchmarks/uint16-array-last-index-of-medium.js
+++ b/JSTests/microbenchmarks/uint16-array-last-index-of-medium.js
@@ -1,0 +1,14 @@
+let size = 4096;
+let array = new Uint16Array(size);
+for (let i = 0; i < size; ++i)
+    array[i] = 1;
+array[0] = 42;
+
+function test(array) {
+    let result = 0;
+    for (let i = 0; i < 1e4; ++i)
+        result += array.lastIndexOf(42);
+    return result;
+}
+noInline(test);
+test(array);

--- a/JSTests/microbenchmarks/uint16-array-last-index-of-small.js
+++ b/JSTests/microbenchmarks/uint16-array-last-index-of-small.js
@@ -1,0 +1,14 @@
+let size = 16;
+let array = new Uint16Array(size);
+for (let i = 0; i < size; ++i)
+    array[i] = 1;
+array[0] = 42;
+
+function test(array) {
+    let result = 0;
+    for (let i = 0; i < 1e4; ++i)
+        result += array.lastIndexOf(42);
+    return result;
+}
+noInline(test);
+test(array);

--- a/JSTests/microbenchmarks/uint32-array-last-index-of-large.js
+++ b/JSTests/microbenchmarks/uint32-array-last-index-of-large.js
@@ -1,0 +1,14 @@
+let size = 20 << 20;
+let array = new Uint32Array(size);
+for (let i = 0; i < size; ++i)
+    array[i] = 1;
+array[0] = 42;
+
+function test(array) {
+    let result = 0;
+    for (let i = 0; i < 1e2; ++i)
+        result += array.lastIndexOf(42);
+    return result;
+}
+noInline(test);
+test(array);

--- a/JSTests/microbenchmarks/uint32-array-last-index-of-medium.js
+++ b/JSTests/microbenchmarks/uint32-array-last-index-of-medium.js
@@ -1,0 +1,14 @@
+let size = 4096;
+let array = new Uint32Array(size);
+for (let i = 0; i < size; ++i)
+    array[i] = 1;
+array[0] = 42;
+
+function test(array) {
+    let result = 0;
+    for (let i = 0; i < 1e2; ++i)
+        result += array.lastIndexOf(42);
+    return result;
+}
+noInline(test);
+test(array);

--- a/JSTests/microbenchmarks/uint32-array-last-index-of-small.js
+++ b/JSTests/microbenchmarks/uint32-array-last-index-of-small.js
@@ -1,0 +1,14 @@
+let size = 16;
+let array = new Uint32Array(size);
+for (let i = 0; i < size; ++i)
+    array[i] = 1;
+array[0] = 42;
+
+function test(array) {
+    let result = 0;
+    for (let i = 0; i < 1e2; ++i)
+        result += array.lastIndexOf(42);
+    return result;
+}
+noInline(test);
+test(array);

--- a/JSTests/microbenchmarks/uint8-array-last-index-of-large.js
+++ b/JSTests/microbenchmarks/uint8-array-last-index-of-large.js
@@ -1,0 +1,14 @@
+let size = 20 << 20;
+let array = new Uint8Array(size);
+for (let i = 0; i < size; ++i)
+    array[i] = 1;
+array[0] = 42;
+
+function test(array) {
+    let result = 0;
+    for (let i = 0; i < 1e2; ++i)
+        result += array.lastIndexOf(42);
+    return result;
+}
+noInline(test);
+test(array);

--- a/JSTests/microbenchmarks/uint8-array-last-index-of-medium.js
+++ b/JSTests/microbenchmarks/uint8-array-last-index-of-medium.js
@@ -1,0 +1,14 @@
+let size = 4096;
+let array = new Uint8Array(size);
+for (let i = 0; i < size; ++i)
+    array[i] = 1;
+array[0] = 42;
+
+function test(array) {
+    let result = 0;
+    for (let i = 0; i < 1e4; ++i)
+        result += array.lastIndexOf(42);
+    return result;
+}
+noInline(test);
+test(array);

--- a/JSTests/microbenchmarks/uint8-array-last-index-of-small.js
+++ b/JSTests/microbenchmarks/uint8-array-last-index-of-small.js
@@ -1,0 +1,14 @@
+let size = 16;
+let array = new Uint8Array(size);
+for (let i = 0; i < size; ++i)
+    array[i] = 1;
+array[0] = 42;
+
+function test(array) {
+    let result = 0;
+    for (let i = 0; i < 1e4; ++i)
+        result += array.lastIndexOf(42);
+    return result;
+}
+noInline(test);
+test(array);

--- a/JSTests/microbenchmarks/uint8-clamped-array-last-index-of-large.js
+++ b/JSTests/microbenchmarks/uint8-clamped-array-last-index-of-large.js
@@ -1,0 +1,14 @@
+let size = 20 << 20;
+let array = new Uint8ClampedArray(size);
+for (let i = 0; i < size; ++i)
+    array[i] = 1;
+array[0] = 42;
+
+function test(array) {
+    let result = 0;
+    for (let i = 0; i < 1e2; ++i)
+        result += array.lastIndexOf(42);
+    return result;
+}
+noInline(test);
+test(array);

--- a/JSTests/microbenchmarks/uint8-clamped-array-last-index-of-medium.js
+++ b/JSTests/microbenchmarks/uint8-clamped-array-last-index-of-medium.js
@@ -1,0 +1,14 @@
+let size = 4096;
+let array = new Uint8ClampedArray(size);
+for (let i = 0; i < size; ++i)
+    array[i] = 1;
+array[0] = 42;
+
+function test(array) {
+    let result = 0;
+    for (let i = 0; i < 1e4; ++i)
+        result += array.lastIndexOf(42);
+    return result;
+}
+noInline(test);
+test(array);

--- a/JSTests/microbenchmarks/uint8-clamped-array-last-index-of-small.js
+++ b/JSTests/microbenchmarks/uint8-clamped-array-last-index-of-small.js
@@ -1,0 +1,14 @@
+let size = 16;
+let array = new Uint8ClampedArray(size);
+for (let i = 0; i < size; ++i)
+    array[i] = 1;
+array[0] = 42;
+
+function test(array) {
+    let result = 0;
+    for (let i = 0; i < 1e4; ++i)
+        result += array.lastIndexOf(42);
+    return result;
+}
+noInline(test);
+test(array);

--- a/Source/JavaScriptCore/runtime/JSGenericTypedArrayViewPrototypeFunctions.h
+++ b/Source/JavaScriptCore/runtime/JSGenericTypedArrayViewPrototypeFunctions.h
@@ -431,6 +431,69 @@ static ALWAYS_INLINE size_t typedArrayIndexOfImpl(typename ViewClass::ElementTyp
 }
 
 template<typename ViewClass>
+static ALWAYS_INLINE size_t typedArrayLastIndexOfImpl(typename ViewClass::ElementType* array, size_t searchLength, typename ViewClass::ElementType target)
+{
+    if (!searchLength)
+        return WTF::notFound;
+
+    if constexpr (ViewClass::Adaptor::isInteger) {
+        if constexpr (ViewClass::elementSize == 1) {
+            auto* result = std::bit_cast<typename ViewClass::ElementType*>(WTF::reverseFind8(std::bit_cast<const uint8_t*>(array), target, searchLength));
+            if (result)
+                return result - array;
+            return WTF::notFound;
+        }
+
+        if constexpr (ViewClass::elementSize == 2) {
+            auto* result = std::bit_cast<typename ViewClass::ElementType*>(WTF::reverseFind16(std::bit_cast<const uint16_t*>(array), target, searchLength));
+            if (result)
+                return result - array;
+            return WTF::notFound;
+        }
+
+        if constexpr (ViewClass::elementSize == 4) {
+            auto* result = std::bit_cast<typename ViewClass::ElementType*>(WTF::reverseFind32(std::bit_cast<const uint32_t*>(array), target, searchLength));
+            if (result)
+                return result - array;
+            return WTF::notFound;
+        }
+
+        if constexpr (ViewClass::elementSize == 8) {
+            auto* result = std::bit_cast<typename ViewClass::ElementType*>(WTF::reverseFind64(std::bit_cast<const uint64_t*>(array), target, searchLength));
+            if (result)
+                return result - array;
+            return WTF::notFound;
+        }
+    }
+
+    if constexpr (ViewClass::Adaptor::isFloat) {
+        if constexpr (ViewClass::elementSize == 2) {
+            auto* result = std::bit_cast<typename ViewClass::ElementType*>(WTF::reverseFindFloat16(std::bit_cast<const Float16*>(array), target, searchLength));
+            if (result)
+                return result - array;
+            return WTF::notFound;
+        }
+
+        if constexpr (ViewClass::elementSize == 4) {
+            auto* result = std::bit_cast<typename ViewClass::ElementType*>(WTF::reverseFindFloat(std::bit_cast<const float*>(array), target, searchLength));
+            if (result)
+                return result - array;
+            return WTF::notFound;
+        }
+
+        if constexpr (ViewClass::elementSize == 8) {
+            auto* result = std::bit_cast<typename ViewClass::ElementType*>(WTF::reverseFindDouble(std::bit_cast<const double*>(array), target, searchLength));
+            if (result)
+                return result - array;
+            return WTF::notFound;
+        }
+    }
+
+    ASSERT_NOT_REACHED();
+    return WTF::notFound;
+}
+
+template<typename ViewClass>
 ALWAYS_INLINE EncodedJSValue genericTypedArrayViewProtoFuncIncludes(VM& vm, JSGlobalObject* globalObject, CallFrame* callFrame)
 {
     auto scope = DECLARE_THROW_SCOPE(vm);
@@ -712,16 +775,11 @@ ALWAYS_INLINE EncodedJSValue genericTypedArrayViewProtoFuncLastIndexOf(VM& vm, J
     scope.assertNoExceptionExceptTermination();
     RELEASE_ASSERT(!thisObject->isDetached());
 
-    // We always have at least one iteration, since we checked that length is different from 0 earlier.
-    do {
-        if (array[index] == targetOption.value())
-            return JSValue::encode(jsNumber(index));
-        if (!index)
-            break;
-        --index;
-    } while (true);
-
-    return JSValue::encode(jsNumber(-1));
+    size_t searchLength = index + 1;
+    size_t result = typedArrayLastIndexOfImpl<ViewClass>(array, searchLength, targetOption.value());
+    if (result == WTF::notFound)
+        return JSValue::encode(jsNumber(-1));
+    return JSValue::encode(jsNumber(result));
 }
 
 template<typename ViewClass>

--- a/Source/WTF/wtf/SIMDHelpers.h
+++ b/Source/WTF/wtf/SIMDHelpers.h
@@ -150,6 +150,11 @@ ALWAYS_INLINE simde_uint64x2_t load(const uint64_t* ptr)
     return simde_vld1q_u64(ptr);
 }
 
+ALWAYS_INLINE simde_float32x4_t load(const float* ptr)
+{
+    return simde_vld1q_f32(ptr);
+}
+
 ALWAYS_INLINE simde_float64x2_t load(const double* ptr)
 {
     return simde_vld1q_f64(ptr);

--- a/Source/WTF/wtf/text/StringCommon.h
+++ b/Source/WTF/wtf/text/StringCommon.h
@@ -842,6 +842,129 @@ SUPPRESS_NODELETE ALWAYS_INLINE const uint64_t* NODELETE reverseFind64(const uin
     return nullptr;
 }
 
+ALWAYS_INLINE const Float16* NODELETE reverseFindFloat16(const Float16* pointer, Float16 target, size_t length)
+{
+    for (size_t index = length; index--;) {
+        if (pointer[index] == target)
+            return pointer + index;
+    }
+    return nullptr;
+}
+
+SUPPRESS_NODELETE ALWAYS_INLINE const float* NODELETE reverseFindFloat(const float* pointer, float target, size_t length)
+{
+    constexpr size_t scalarThreshold = 8;
+    size_t index = length;
+    size_t runway = length > scalarThreshold ? length - scalarThreshold : 0;
+    while (index > runway) {
+        --index;
+        if (pointer[index] == target)
+            return pointer + index;
+    }
+    if (!runway)
+        return nullptr;
+
+    constexpr size_t stride = SIMD::stride<float>;
+    constexpr size_t unrollFactor = 4;
+    constexpr size_t unrolledStride = stride * unrollFactor;
+
+    simde_float32x4_t targetsVector = simde_vdupq_n_f32(target);
+    auto vectorMatch = [&](simde_float32x4_t value) ALWAYS_INLINE_LAMBDA {
+        simde_uint32x4_t mask = simde_vceqq_f32(value, targetsVector);
+        return SIMD::findLastNonZeroIndex(mask);
+    };
+
+    auto* begin = pointer;
+    auto* cursor = pointer + runway;
+
+    while (cursor >= begin + unrolledStride) {
+        cursor -= unrolledStride;
+        auto v0 = SIMD::load(cursor);
+        auto v1 = SIMD::load(cursor + stride);
+        auto v2 = SIMD::load(cursor + stride * 2);
+        auto v3 = SIMD::load(cursor + stride * 3);
+
+        if (auto idx = vectorMatch(v3))
+            return cursor + stride * 3 + idx.value();
+        if (auto idx = vectorMatch(v2))
+            return cursor + stride * 2 + idx.value();
+        if (auto idx = vectorMatch(v1))
+            return cursor + stride + idx.value();
+        if (auto idx = vectorMatch(v0))
+            return cursor + idx.value();
+    }
+
+    while (cursor >= begin + stride) {
+        cursor -= stride;
+        if (auto idx = vectorMatch(simde_vld1q_f32(cursor)))
+            return cursor + idx.value();
+    }
+
+    if (cursor > begin) {
+        if (auto idx = vectorMatch(simde_vld1q_f32(begin)))
+            return begin + idx.value();
+    }
+
+    return nullptr;
+}
+
+SUPPRESS_NODELETE ALWAYS_INLINE const double* NODELETE reverseFindDouble(const double* pointer, double target, size_t length)
+{
+    constexpr size_t scalarThreshold = 4;
+    size_t index = length;
+    size_t runway = length > scalarThreshold ? length - scalarThreshold : 0;
+    while (index > runway) {
+        --index;
+        if (pointer[index] == target)
+            return pointer + index;
+    }
+    if (!runway)
+        return nullptr;
+
+    constexpr size_t stride = SIMD::stride<double>;
+    constexpr size_t unrollFactor = 4;
+    constexpr size_t unrolledStride = stride * unrollFactor;
+
+    simde_float64x2_t targetsVector = simde_vdupq_n_f64(target);
+    auto vectorMatch = [&](simde_float64x2_t value) ALWAYS_INLINE_LAMBDA {
+        simde_uint64x2_t mask = simde_vceqq_f64(value, targetsVector);
+        return SIMD::findLastNonZeroIndex(mask);
+    };
+
+    auto* begin = pointer;
+    auto* cursor = pointer + runway;
+
+    while (cursor >= begin + unrolledStride) {
+        cursor -= unrolledStride;
+        auto v0 = SIMD::load(cursor);
+        auto v1 = SIMD::load(cursor + stride);
+        auto v2 = SIMD::load(cursor + stride * 2);
+        auto v3 = SIMD::load(cursor + stride * 3);
+
+        if (auto idx = vectorMatch(v3))
+            return cursor + stride * 3 + idx.value();
+        if (auto idx = vectorMatch(v2))
+            return cursor + stride * 2 + idx.value();
+        if (auto idx = vectorMatch(v1))
+            return cursor + stride + idx.value();
+        if (auto idx = vectorMatch(v0))
+            return cursor + idx.value();
+    }
+
+    while (cursor >= begin + stride) {
+        cursor -= stride;
+        if (auto idx = vectorMatch(SIMD::load(cursor)))
+            return cursor + idx.value();
+    }
+
+    if (cursor > begin) {
+        if (auto idx = vectorMatch(SIMD::load(begin)))
+            return begin + idx.value();
+    }
+
+    return nullptr;
+}
+
 SUPPRESS_NODELETE ALWAYS_INLINE const double* NODELETE findNaN(const double* pointer, size_t length)
 {
     constexpr size_t scalarThreshold = 4;


### PR DESCRIPTION
#### ecb783a152dc3747a2da39408d7d9a07a41a8815
<pre>
[JSC] Add TypedArray#lastIndexOf optimization
<a href="https://bugs.webkit.org/show_bug.cgi?id=313707">https://bugs.webkit.org/show_bug.cgi?id=313707</a>
<a href="https://rdar.apple.com/175904377">rdar://175904377</a>

Reviewed by Yijia Huang.

We added reverseFind families for fp numbers, and then use them in
TypedArray#lastIndexOf. This is well-aligned to TypedArray#indexOf optimization.

                                                         ToT                     Patched

    uint32-array-last-index-of-medium               0.3030+-0.0352            0.2276+-0.0522          might be 1.3315x faster
    int16-array-last-index-of-medium               11.2249+-0.3554     ^      2.0253+-0.0690        ^ definitely 5.5424x faster
    int32-array-last-index-of-large               567.2856+-0.6059     ^    165.9670+-4.8270        ^ definitely 3.4181x faster
    int16-array-last-index-of-large               566.6340+-1.3116     ^     85.4925+-1.0674        ^ definitely 6.6279x faster
    biguint64-array-last-index-of-large           746.6768+-1.1196     ^    420.6055+-4.1806        ^ definitely 1.7752x faster
    int32-array-last-index-of-medium                0.3292+-0.0401     ^      0.2260+-0.0451        ^ definitely 1.4567x faster
    int32-array-last-index-of-small                 0.1973+-0.0383            0.1863+-0.0417          might be 1.0590x faster
    biguint64-array-last-index-of-small             0.1907+-0.0457     ?      0.2070+-0.0160        ? might be 1.0854x slower
    float32-array-last-index-of-medium              0.3240+-0.0146     ^      0.2488+-0.0345        ^ definitely 1.3023x faster
    uint16-array-last-index-of-medium              11.1243+-0.5143     ^      1.9501+-0.0818        ^ definitely 5.7045x faster
    int16-array-last-index-of-small                 0.3291+-0.0211     ?      0.3650+-0.0216        ? might be 1.1091x slower
    uint8-array-last-index-of-medium               11.1230+-0.0383     ^      1.4262+-0.0577        ^ definitely 7.7990x faster
    float64-array-last-index-of-small               0.2112+-0.0060     ^      0.1971+-0.0043        ^ definitely 1.0718x faster
    float64-array-last-index-of-large             575.3604+-4.8133     ^    234.7345+-1.9510        ^ definitely 2.4511x faster
    float32-array-last-index-of-large             571.8342+-5.7791     ^    119.8253+-1.2086        ^ definitely 4.7722x faster
    uint16-array-last-index-of-large              569.0002+-7.9021     ^     85.2038+-0.6646        ^ definitely 6.6781x faster
    uint8-clamped-array-last-index-of-medium       11.2017+-0.2085     ^      1.4171+-0.0261        ^ definitely 7.9046x faster
    uint32-array-last-index-of-large              567.3750+-1.1759     ^    163.4587+-0.4689        ^ definitely 3.4711x faster
    biguint64-array-last-index-of-medium            0.3577+-0.0311     ^      0.2677+-0.0400        ^ definitely 1.3361x faster
    uint16-array-last-index-of-small                0.3617+-0.0602            0.3481+-0.0461          might be 1.0391x faster
    float32-array-last-index-of-small               0.1862+-0.0287     ?      0.2023+-0.0404        ? might be 1.0862x slower
    uint32-array-last-index-of-small                0.1996+-0.0387            0.1899+-0.0338          might be 1.0508x faster
    int8-array-last-index-of-small                  0.3448+-0.0281            0.3239+-0.0240          might be 1.0646x faster
    int8-array-last-index-of-medium                11.0264+-0.3901     ^      1.4152+-0.0692        ^ definitely 7.7913x faster
    int8-array-last-index-of-large                566.6000+-3.0132     ^     53.8640+-0.7808        ^ definitely 10.5191x faster
    uint8-array-last-index-of-small                 0.3303+-0.0488     ?      0.3346+-0.0158        ? might be 1.0129x slower
    bigint64-array-last-index-of-small              0.1859+-0.0314            0.1855+-0.0272
    bigint64-array-last-index-of-medium             0.3650+-0.0139     ^      0.2827+-0.0444        ^ definitely 1.2910x faster
    uint8-array-last-index-of-large               566.7697+-3.2210     ^     53.5338+-0.3509        ^ definitely 10.5871x faster
    bigint64-array-last-index-of-large            746.7503+-0.8889     ^    417.3829+-1.1634        ^ definitely 1.7891x faster
    uint8-clamped-array-last-index-of-small         0.3332+-0.0515     ?      0.3569+-0.0373        ? might be 1.0713x slower
    float64-array-last-index-of-medium              0.3312+-0.0255     ^      0.2532+-0.0395        ^ definitely 1.3080x faster
    uint8-clamped-array-last-index-of-large       565.7103+-0.6944     ^     55.5995+-2.3503        ^ definitely 10.1747x faster

Tests: JSTests/microbenchmarks/bigint64-array-last-index-of-large.js
       JSTests/microbenchmarks/bigint64-array-last-index-of-medium.js
       JSTests/microbenchmarks/bigint64-array-last-index-of-small.js
       JSTests/microbenchmarks/biguint64-array-last-index-of-large.js
       JSTests/microbenchmarks/biguint64-array-last-index-of-medium.js
       JSTests/microbenchmarks/biguint64-array-last-index-of-small.js
       JSTests/microbenchmarks/float32-array-last-index-of-large.js
       JSTests/microbenchmarks/float32-array-last-index-of-medium.js
       JSTests/microbenchmarks/float32-array-last-index-of-small.js
       JSTests/microbenchmarks/float64-array-last-index-of-large.js
       JSTests/microbenchmarks/float64-array-last-index-of-medium.js
       JSTests/microbenchmarks/float64-array-last-index-of-small.js
       JSTests/microbenchmarks/int16-array-last-index-of-large.js
       JSTests/microbenchmarks/int16-array-last-index-of-medium.js
       JSTests/microbenchmarks/int16-array-last-index-of-small.js
       JSTests/microbenchmarks/int32-array-last-index-of-large.js
       JSTests/microbenchmarks/int32-array-last-index-of-medium.js
       JSTests/microbenchmarks/int32-array-last-index-of-small.js
       JSTests/microbenchmarks/int8-array-last-index-of-large.js
       JSTests/microbenchmarks/int8-array-last-index-of-medium.js
       JSTests/microbenchmarks/int8-array-last-index-of-small.js
       JSTests/microbenchmarks/typed-array-lastIndexOf-empty.js
       JSTests/microbenchmarks/uint16-array-last-index-of-large.js
       JSTests/microbenchmarks/uint16-array-last-index-of-medium.js
       JSTests/microbenchmarks/uint16-array-last-index-of-small.js
       JSTests/microbenchmarks/uint32-array-last-index-of-large.js
       JSTests/microbenchmarks/uint32-array-last-index-of-medium.js
       JSTests/microbenchmarks/uint32-array-last-index-of-small.js
       JSTests/microbenchmarks/uint8-array-last-index-of-large.js
       JSTests/microbenchmarks/uint8-array-last-index-of-medium.js
       JSTests/microbenchmarks/uint8-array-last-index-of-small.js
       JSTests/microbenchmarks/uint8-clamped-array-last-index-of-large.js
       JSTests/microbenchmarks/uint8-clamped-array-last-index-of-medium.js
       JSTests/microbenchmarks/uint8-clamped-array-last-index-of-small.js

* JSTests/microbenchmarks/bigint64-array-last-index-of-large.js: Added.
(test):
* JSTests/microbenchmarks/bigint64-array-last-index-of-medium.js: Added.
(test):
* JSTests/microbenchmarks/bigint64-array-last-index-of-small.js: Added.
(test):
* JSTests/microbenchmarks/biguint64-array-last-index-of-large.js: Added.
(test):
* JSTests/microbenchmarks/biguint64-array-last-index-of-medium.js: Added.
(test):
* JSTests/microbenchmarks/biguint64-array-last-index-of-small.js: Added.
(test):
* JSTests/microbenchmarks/float32-array-last-index-of-large.js: Added.
(test):
* JSTests/microbenchmarks/float32-array-last-index-of-medium.js: Added.
(test):
* JSTests/microbenchmarks/float32-array-last-index-of-small.js: Added.
(test):
* JSTests/microbenchmarks/float64-array-last-index-of-large.js: Added.
(test):
* JSTests/microbenchmarks/float64-array-last-index-of-medium.js: Added.
(test):
* JSTests/microbenchmarks/float64-array-last-index-of-small.js: Added.
(test):
* JSTests/microbenchmarks/int16-array-last-index-of-large.js: Added.
(test):
* JSTests/microbenchmarks/int16-array-last-index-of-medium.js: Added.
(test):
* JSTests/microbenchmarks/int16-array-last-index-of-small.js: Added.
(test):
* JSTests/microbenchmarks/int32-array-last-index-of-large.js: Added.
(test):
* JSTests/microbenchmarks/int32-array-last-index-of-medium.js: Added.
(test):
* JSTests/microbenchmarks/int32-array-last-index-of-small.js: Added.
(test):
* JSTests/microbenchmarks/int8-array-last-index-of-large.js: Added.
(test):
* JSTests/microbenchmarks/int8-array-last-index-of-medium.js: Added.
(test):
* JSTests/microbenchmarks/int8-array-last-index-of-small.js: Added.
(test):
* JSTests/microbenchmarks/typed-array-lastIndexOf-empty.js: Added.
* JSTests/microbenchmarks/uint16-array-last-index-of-large.js: Added.
(test):
* JSTests/microbenchmarks/uint16-array-last-index-of-medium.js: Added.
(test):
* JSTests/microbenchmarks/uint16-array-last-index-of-small.js: Added.
(test):
* JSTests/microbenchmarks/uint32-array-last-index-of-large.js: Added.
(test):
* JSTests/microbenchmarks/uint32-array-last-index-of-medium.js: Added.
(test):
* JSTests/microbenchmarks/uint32-array-last-index-of-small.js: Added.
(test):
* JSTests/microbenchmarks/uint8-array-last-index-of-large.js: Added.
(test):
* JSTests/microbenchmarks/uint8-array-last-index-of-medium.js: Added.
(test):
* JSTests/microbenchmarks/uint8-array-last-index-of-small.js: Added.
(test):
* JSTests/microbenchmarks/uint8-clamped-array-last-index-of-large.js: Added.
(test):
* JSTests/microbenchmarks/uint8-clamped-array-last-index-of-medium.js: Added.
(test):
* JSTests/microbenchmarks/uint8-clamped-array-last-index-of-small.js: Added.
(test):
* Source/JavaScriptCore/runtime/JSGenericTypedArrayViewPrototypeFunctions.h:
(JSC::typedArrayLastIndexOfImpl):
(JSC::genericTypedArrayViewProtoFuncLastIndexOf):
* Source/WTF/wtf/SIMDHelpers.h:
(WTF::SIMD::load):
* Source/WTF/wtf/text/StringCommon.h:
(WTF::reverseFind64):
(WTF::reverseFindFloat16):
(WTF::reverseFindFloat):
(WTF::reverseFindDouble):

Canonical link: <a href="https://commits.webkit.org/312383@main">https://commits.webkit.org/312383@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/df4640e06b8c8c2811fcd9273cd8b8886bdeb06d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/159627 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/33094 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/26201 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/168478 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/114008 "Built successfully") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/33199 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/33098 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/123695 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/86799 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/162584 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/25940 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/143376 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/104345 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/24991 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/23455 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/16258 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/151683 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/134683 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/21148 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/170966 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/20464 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/16995 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/22782 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/131923 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/32773 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/27530 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/132001 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/32758 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/142941 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/90840 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/24312 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/26632 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/19755 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/191911 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/32267 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/98663 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/49307 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/31764 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/32011 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/31915 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->