### PR TITLE
REGRESSION (Safari 26): Select picker incorrect position

### DIFF
--- a/LayoutTests/fast/css/css-anchor-position/anchor-positioned-select-picker-expected.txt
+++ b/LayoutTests/fast/css/css-anchor-position/anchor-positioned-select-picker-expected.txt
@@ -1,0 +1,11 @@
+Checks that an anchor-positioned select element will display its picker at the same location as the element
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS popupLocation.x is buttonClientRect.x
+PASS popupLocation.y is buttonClientRect.y
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/css/css-anchor-position/anchor-positioned-select-picker.html
+++ b/LayoutTests/fast/css/css-anchor-position/anchor-positioned-select-picker.html
@@ -1,0 +1,66 @@
+<!DOCTYPE html>
+
+<script src="../../../resources/js-test-pre.js"></script>
+
+<style>
+  #anchor {
+    anchor-name: --anchor;
+  }
+
+  #anchored {
+    position-anchor: --anchor;
+    margin: 0;
+    border: 0;
+    top: anchor(bottom);
+    left: anchor(left);
+    display: block !important;
+  }
+</style>
+
+<div id="anchor"></div>
+<div id="anchored" popover>
+  <template shadowrootmode="open">
+    <select id="select">
+      <option>Option</option>
+    </select>
+  </template>
+</div>
+
+<script>
+  description("Checks that an anchor-positioned select element will display its picker at the same location as the element");
+  window.jsTestIsAsync = true;
+
+  const select = anchored.shadowRoot.getElementById("select");
+
+  buttonClientRect = select.getBoundingClientRect();
+  const buttonCenterX = buttonClientRect.x + (buttonClientRect.width / 2);
+  const buttonCenterY = buttonClientRect.y + (buttonClientRect.height / 2);
+
+  // eventSender.moveMouseTo/mouseDown/mouseUp would hang WebContent/UI process
+  // while it waits for something, so use UI script here to simulate clicking on
+  // the <select>. HTMLSelectElement.showPicker doesn't reproduce the issue,
+  // hence the need to simulate actual mouse clicks to open the picker.
+  const uiScript = `
+    uiController.activateAtPoint(${buttonCenterX}, ${buttonCenterY}, () => {
+      uiController.uiScriptComplete();
+    });`
+
+  function check() {
+    popupLocation = internals.lastSelectPopupLocation(select);
+    if (!popupLocation) {
+      setTimeout(check, 10);
+      return;
+    }
+
+    shouldBe('popupLocation.x', 'buttonClientRect.x');
+    shouldBe('popupLocation.y', 'buttonClientRect.y');
+    finishJSTest();
+  }
+
+  // It's not guaranteed that the system picker would be displayed after the
+  // UI script completes, so we poll every 10ms whether the picker has been
+  // displayed or not.
+  testRunner.runUIScript(uiScript, check);
+</script>
+
+<script src="../../../resources/js-test-post.js"></script>

--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -8501,6 +8501,9 @@ webrtc/getUserMedia-webaudio-autoplay.html [ Pass Failure ]
 fast/forms/ios/scroll-to-reveal-focused-select.html [ Pass ]
 fast/events/ios/should-be-able-to-dismiss-form-accessory-after-tapping-outside-iframe-with-focused-field.html [ Pass ]
 
+# This tests the system picker triggered by HTMLSelectElement::showPopup(), which iOS doesn't use.
+fast/css/css-anchor-position/anchor-positioned-select-picker.html [ Skip ]
+
 # from fast/ tests that are flaky: adding timeout
 webkit.org/b/304027 fast/block/basic/001.html [ Pass Failure Timeout ]
 

--- a/Source/WebCore/html/HTMLSelectElement.cpp
+++ b/Source/WebCore/html/HTMLSelectElement.cpp
@@ -2147,11 +2147,17 @@ void HTMLSelectElement::showPopup()
         m_popup = document().page()->chrome().createPopupMenu(*this);
     setPopupIsVisible(true);
 
+    // Ensure layout is up-to-date before computing the element location.
+    protect(document())->updateLayout();
+
     // Compute the top left taking transforms into account, but use
     // the actual width of the element to size the popup.
     FloatPoint absTopLeft = renderer->localToAbsolute(FloatPoint(), MapCoordinatesMode::UseTransforms);
+    m_lastPopupLocationForTesting = absTopLeft;
+
     IntRect absBounds = renderer->absoluteBoundingBoxRectIgnoringTransforms();
     absBounds.setLocation(roundedIntPoint(absTopLeft));
+
     protect(m_popup)->show(absBounds, *frameView, optionToListIndex(selectedIndex())); // May run JS.
 }
 

--- a/Source/WebCore/html/HTMLSelectElement.h
+++ b/Source/WebCore/html/HTMLSelectElement.h
@@ -125,6 +125,7 @@ public:
 
     bool popupIsVisible() const { return m_popupIsVisible; }
     WEBCORE_EXPORT void setPopupIsVisible(bool);
+    std::optional<FloatPoint> lastPopupLocationForTesting() const { return m_lastPopupLocationForTesting; }
 
     bool NODELETE isOpen() const;
 
@@ -322,6 +323,7 @@ private:
 #if !PLATFORM(IOS_FAMILY)
     RefPtr<PopupMenu> m_popup;
 #endif
+    std::optional<FloatPoint> m_lastPopupLocationForTesting;
     bool m_popupIsVisible { false };
     bool m_wasBaseAppearance { false };
 };

--- a/Source/WebCore/testing/Internals.cpp
+++ b/Source/WebCore/testing/Internals.cpp
@@ -4975,6 +4975,20 @@ bool Internals::isSelectPopupVisible(HTMLSelectElement& element)
 #endif
 }
 
+RefPtr<DOMPointReadOnly> Internals::lastSelectPopupLocation(const HTMLSelectElement& element)
+{
+#if !PLATFORM(IOS_FAMILY)
+    auto location = element.lastPopupLocationForTesting();
+    if (!location)
+        return nullptr;
+
+    return DOMPointReadOnly::create(location->x(), location->y(), 0, 0);
+#else
+    UNUSED_PARAM(element);
+    return nullptr;
+#endif
+}
+
 ExceptionOr<String> Internals::captionsStyleSheetOverride()
 {
     Document* document = contextDocument();

--- a/Source/WebCore/testing/Internals.h
+++ b/Source/WebCore/testing/Internals.h
@@ -878,6 +878,7 @@ public:
     ExceptionOr<void> setIsPlayingToBluetoothOverride(std::optional<bool>);
 
     bool isSelectPopupVisible(HTMLSelectElement&);
+    RefPtr<DOMPointReadOnly> lastSelectPopupLocation(const HTMLSelectElement&);
 
     ExceptionOr<String> captionsStyleSheetOverride();
     ExceptionOr<void> setCaptionsStyleSheetOverride(const String&);

--- a/Source/WebCore/testing/Internals.idl
+++ b/Source/WebCore/testing/Internals.idl
@@ -1072,6 +1072,7 @@ enum ContentsFormat {
     [Conditional=VIDEO] MediaControlsHost? controlsHostForMediaElement(HTMLMediaElement element);
 
     boolean isSelectPopupVisible(HTMLSelectElement element);
+    DOMPointReadOnly? lastSelectPopupLocation(HTMLSelectElement element);
 
     DOMRect selectionBounds();
     StaticRange? selectedRange();


### PR DESCRIPTION
#### 7d2bb1ed4f24c36532f26b0cfec4d071faf98036
<pre>
REGRESSION (Safari 26): Select picker incorrect position
<a href="https://rdar.apple.com/175454476">rdar://175454476</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=313135">https://bugs.webkit.org/show_bug.cgi?id=313135</a>

Reviewed by Antti Koivisto.

HTMLSelectElement::showPopup() shows the system picker at the same position as
the &lt;select&gt; renderer, computed by localToAbsolute(). It&apos;s possible for the
layout info used by localToAbsolute() to be &quot;stale&quot;, leading to incorrect
computed position. One case is when &lt;select&gt; is anchor positioned.

Before showPopup() gets called, it&apos;s possible that document-&gt;resolveStyle() gets
called, either by something else, or by HTMLSelectElement::showPicker() calling
document-&gt;updateStyleIfNeeded() before showPickerInternal() -&gt; showPopup().

When the document uses anchor positioning, resolving its style involves multiple
rounds of style resolution and layout. At least two rounds are required: the first
round discovers and positions anchors, so the second round can position
anchor-positioned elements according to the positioned anchor. In some cases,
more rounds are required. The main points are (1) only the style/layout information
of the last round are valid and (2) all layout except the last one is synchronous,
the last layout is asynchronous using the layout timer.

It&apos;s possible for showPopup() to be called before the layout timer expires and
updates the layout for the final time. This leads to localToAbsolute using
stale layout info, which leads to the computed position being incorrect.

Fix this by forcing layout before computing the position of the &lt;select&gt; element.
The actual fix is one line, the rest is exposing the computed &lt;select&gt; element
position for testing purposes.

Test: fast/css/css-anchor-position/anchor-positioned-select-picker.html

* LayoutTests/fast/css/css-anchor-position/anchor-positioned-select-picker-expected.txt: Added.
* LayoutTests/fast/css/css-anchor-position/anchor-positioned-select-picker.html: Added.
* LayoutTests/platform/ios/TestExpectations:
* Source/WebCore/html/HTMLSelectElement.cpp:
(WebCore::HTMLSelectElement::menuListDefaultEventHandler):
* Source/WebCore/html/HTMLSelectElement.h:
* Source/WebCore/testing/Internals.cpp:
(WebCore::Internals::lastSelectPopupLocation):
* Source/WebCore/testing/Internals.h:
* Source/WebCore/testing/Internals.idl:

Canonical link: <a href="https://commits.webkit.org/312811@main">https://commits.webkit.org/312811@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/db4fa188689321952f31caf65821a99a1ca4bcef

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/160944 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/34417 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/27518 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/169847 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/117204 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/e24757e7-c8cc-4429-af57-901c352688dd) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/162813 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/34518 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/34417 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/124841 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/117204 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/85e870c8-9eed-4c15-919a-ad0890168762) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/163903 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/27103 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/144580 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/105438 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/e1f0de6e-023e-4904-8b8f-cd4f182c2d6c) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/26155 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/24656 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/17567 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/135849 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/22342 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/172330 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/19351 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/23983 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/133115 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/34091 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/28749 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/133125 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35998 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/34075 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/144137 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/95914 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/27697 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/20954 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/33586 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/101011 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/33085 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/33329 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/33234 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->