### PR TITLE
Cannot delete partitioned cookies with WKHTTPCookieStore::deleteCookie

### DIFF
--- a/Source/WTF/wtf/cocoa/RuntimeApplicationChecksCocoa.h
+++ b/Source/WTF/wtf/cocoa/RuntimeApplicationChecksCocoa.h
@@ -141,6 +141,7 @@ enum class SDKAlignedBehavior {
     ManagedRefreshControlAppearance,
     EnableUserScriptAndUserStyleInterning,
     AllBackForwardItemsWithoutUserGestureInvisibleToUI,
+    ExposePartitionFromWKHTTPCookieStoreAPI,
 
     NumberOfBehaviors
 };
@@ -224,6 +225,7 @@ WTF_EXPORT_PRIVATE bool isMobileStore();
 WTF_EXPORT_PRIVATE bool isUNIQLOApp();
 WTF_EXPORT_PRIVATE bool isDOFUSTouch();
 WTF_EXPORT_PRIVATE bool isMyRideK12();
+WTF_EXPORT_PRIVATE bool isTableau();
 
 } // IOSApplication
 

--- a/Source/WTF/wtf/cocoa/RuntimeApplicationChecksCocoa.mm
+++ b/Source/WTF/wtf/cocoa/RuntimeApplicationChecksCocoa.mm
@@ -646,6 +646,12 @@ bool IOSApplication::isHimalaya()
     return isHimalayaApp;
 }
 
+bool IOSApplication::isTableau()
+{
+    static bool isTableau = applicationBundleIdentifier().startsWith("com.tableausoftware"_s);
+    return isTableau;
+}
+
 #endif // PLATFORM(IOS_FAMILY)
 
 } // namespace WTF

--- a/Source/WebKit/UIProcess/API/Cocoa/WKHTTPCookieStore.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKHTTPCookieStore.mm
@@ -37,8 +37,10 @@
 #import <wtf/TZoneMallocInlines.h>
 #import <wtf/URL.h>
 #import <wtf/WeakObjCPtr.h>
+#import <wtf/cocoa/RuntimeApplicationChecksCocoa.h>
 #import <wtf/cocoa/VectorCocoa.h>
 
+#if PLATFORM(IOS_FAMILY)
 static NSHTTPCookie *clearCookiePartitionPropertyIfNeeded(NSHTTPCookie *cookie, bool isCookiePartitioningEnabled)
 {
 #if ENABLE(OPT_IN_PARTITIONED_COOKIES) && defined(CFN_COOKIE_ACCEPTS_POLICY_PARTITION) && CFN_COOKIE_ACCEPTS_POLICY_PARTITION
@@ -59,11 +61,19 @@ static NSHTTPCookie *clearCookiePartitionPropertyIfNeeded(NSHTTPCookie *cookie, 
     return cookie;
 #endif
 }
+#endif
 
 static NSArray<NSHTTPCookie *> *coreCookiesToNSCookies(const Vector<WebCore::Cookie>& coreCookies, bool isCookiePartitioningEnabled)
 {
     return createNSArray(coreCookies, [isCookiePartitioningEnabled] (auto& cookie) -> NSHTTPCookie * {
-        return clearCookiePartitionPropertyIfNeeded(cookie.createNSHTTPCookie().autorelease(), isCookiePartitioningEnabled);
+#if PLATFORM(IOS_FAMILY)
+        if (!linkedOnOrAfterSDKWithBehavior(SDKAlignedBehavior::ExposePartitionFromWKHTTPCookieStoreAPI) && WTF::IOSApplication::isTableau())
+            return clearCookiePartitionPropertyIfNeeded(cookie.createNSHTTPCookie().autorelease(), isCookiePartitioningEnabled);
+#else
+        UNUSED_PARAM(isCookiePartitioningEnabled);
+#endif
+
+        return cookie.createNSHTTPCookie().autorelease();
     }).autorelease();
 }
 

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKHTTPCookieStore.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKHTTPCookieStore.mm
@@ -1153,7 +1153,7 @@ TEST(WKHTTPCookieStore, SetCookies)
 }
 
 #if ENABLE(OPT_IN_PARTITIONED_COOKIES)
-TEST(WKHTTPCookieStore, PartitionedCookieShouldNotHavePartitionProperty)
+TEST(WKHTTPCookieStore, PartitionedCookieShouldHavePartitionProperty)
 {
     using namespace TestWebKitAPI;
 
@@ -1163,8 +1163,10 @@ TEST(WKHTTPCookieStore, PartitionedCookieShouldNotHavePartitionProperty)
 
     RetainPtr storeConfiguration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] initNonPersistentConfiguration]);
     [storeConfiguration setHTTPSProxy:[NSURL URLWithString:[NSString stringWithFormat:@"https://127.0.0.1:%d/", server.port()]]];
+    RetainPtr dataStore = adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:storeConfiguration.get()]);
+    [dataStore _setResourceLoadStatisticsEnabled:YES];
     RetainPtr viewConfiguration = adoptNS([WKWebViewConfiguration new]);
-    [viewConfiguration setWebsiteDataStore:adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:storeConfiguration.get()]).get()];
+    [viewConfiguration setWebsiteDataStore:dataStore.get()];
 
     RetainPtr delegate = adoptNS([TestNavigationDelegate new]);
     [delegate allowAnyTLSCertificate];
@@ -1182,9 +1184,46 @@ TEST(WKHTTPCookieStore, PartitionedCookieShouldNotHavePartitionProperty)
         EXPECT_WK_STREQ(cookies[0].value, @"value");
         EXPECT_WK_STREQ(cookies[0].properties[NSHTTPCookieName], @"test");
         EXPECT_WK_STREQ(cookies[0].properties[NSHTTPCookieValue], @"value");
-        EXPECT_NULL(cookies[0].properties[@"StoragePartition"]);
+        EXPECT_WK_STREQ(cookies[0].properties[@"StoragePartition"], @"https://example.com");
         gotCookieCallback = true;
     }];
     Util::run(&gotCookieCallback);
 }
-#endif
+
+TEST(WKHTTPCookieStore, DeletePartitionedCookie)
+{
+    using namespace TestWebKitAPI;
+
+    TestWebKitAPI::HTTPServer server({
+        { "/"_s, { { { "Content-Type"_s, "text/html"_s }, { "Set-Cookie"_s, "test=value;Secure;SameSite=None;Partitioned"_s } }, ""_s } }
+    }, TestWebKitAPI::HTTPServer::Protocol::HttpsProxy);
+
+    RetainPtr storeConfiguration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] initNonPersistentConfiguration]);
+    [storeConfiguration setHTTPSProxy:[NSURL URLWithString:[NSString stringWithFormat:@"https://127.0.0.1:%d/", server.port()]]];
+    RetainPtr dataStore = adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:storeConfiguration.get()]);
+    [dataStore _setResourceLoadStatisticsEnabled:YES];
+    RetainPtr viewConfiguration = adoptNS([WKWebViewConfiguration new]);
+    [viewConfiguration setWebsiteDataStore:dataStore.get()];
+
+    RetainPtr delegate = adoptNS([TestNavigationDelegate new]);
+    [delegate allowAnyTLSCertificate];
+
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:CGRectZero configuration:viewConfiguration.get()]);
+    [webView setNavigationDelegate:delegate.get()];
+
+    [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://example.com/"]]];
+    [delegate waitForDidFinishNavigation];
+
+    __block bool done { false };
+    [viewConfiguration.get().websiteDataStore.httpCookieStore getAllCookies:^(NSArray<NSHTTPCookie *> *cookies) {
+        EXPECT_EQ(cookies.count, 1u);
+        [viewConfiguration.get().websiteDataStore.httpCookieStore deleteCookie:cookies[0] completionHandler:^{
+            [viewConfiguration.get().websiteDataStore.httpCookieStore getAllCookies:^(NSArray<NSHTTPCookie *> *cookies) {
+                EXPECT_EQ(cookies.count, 0u);
+                done = true;
+            }];
+        }];
+    }];
+    Util::run(&done);
+}
+#endif // ENABLE(OPT_IN_PARTITIONED_COOKIES)


### PR DESCRIPTION
#### 29ed7a84dc8525afe42f8a94ebde345c565d067e
<pre>
Cannot delete partitioned cookies with WKHTTPCookieStore::deleteCookie
<a href="https://bugs.webkit.org/show_bug.cgi?id=313708">https://bugs.webkit.org/show_bug.cgi?id=313708</a>
<a href="https://rdar.apple.com/174557252">rdar://174557252</a>

Reviewed by Matthew Finkel and Chris Dumez.

The test app in the radar loads a URL into a webview, uses
WKHTTPCookieStore::getAllCookies to retrieve the cookie that was set, and
then uses WKHTTPCookieStore::deleteCookie to delete the retrieved cookie.
This deletion fails.

This cookie is set via the Set-Cookie HTTP header (so it is set directly via
CFNetwork and not through a WebKit code path). It is a partitioned cookie.

When WKHTTPCookieStore::getAllCookies returns the cookies, it strips the
partition attribute by calling clearCookiePartitionPropertyIfNeeded(). Then,
when WKHTTPCookieStore::deleteCookie is called, CFNetwork finds that the stored
cookie doesn&apos;t match the passed in the cookie because the stored cookie has a
partition attribute. Since the two cookies don&apos;t match, CFNetwork does not delete
the stored one.

The behavior of stripping the partition attribute when returning the cookie
was added in <a href="https://commits.webkit.org/300838@main.">https://commits.webkit.org/300838@main.</a> Before that patch, the
partition attribute was exposed. We found that this broke the Tableau app that
was retrieving these cookies from a webview, storing them, and then later using
them in an fetch requests via URLSession outside of this webview. These cookies
were being ignored (rightfully) by the networking layer since they had a
partitioned attribute that didn&apos;t line up with the requests. Since this was
a regression caused by adding support for partitioned cookies, that patch fixed
this by not exposing the partition attribute via the WKHTTPCookieStore API.

Unfortunately, it is the reason why deleting partitioned cookies fails today.

To fix this, we amend the API to once again expose the partition attribute.
To prevent this from breaking the Tableau app as it once did, we won&apos;t expose
the attribute for it until it links against future SDKs. In the future, it must
filter out these partitioned cookies should it wish to use them outside the
webview from which it got them.

This is covered by a new test:
Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKHTTPCookieStore.mm

We also modify the existing test: PartitionedCookieShouldHavePartitionProperty.
It was passing faultily since partitioned cookies aren&apos;t used unless ITP is on
(See WebsiteDataStore::propagateSettingUpdates()). So we turn it on.

* Source/WTF/wtf/cocoa/RuntimeApplicationChecksCocoa.h:
* Source/WTF/wtf/cocoa/RuntimeApplicationChecksCocoa.mm:
(WTF::IOSApplication::isTableau):
* Source/WebKit/UIProcess/API/Cocoa/WKHTTPCookieStore.mm:
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKHTTPCookieStore.mm:
(TEST(WKHTTPCookieStore, PartitionedCookieShouldHavePartitionProperty)):
(TEST(WKHTTPCookieStore, DeletePartitionedCookie)):
(TEST(WKHTTPCookieStore, PartitionedCookieShouldNotHavePartitionProperty)): Deleted.

Canonical link: <a href="https://commits.webkit.org/312478@main">https://commits.webkit.org/312478@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cbae41e0a3749109de52f30d8a4ac94a05b8d65f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/159997 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/33467 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/26571 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/168875 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/114378 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/decf6a13-460b-4d1f-b5bb-b49fee6c5ea0) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/161866 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/33570 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/33469 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/124002 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/86976 "1 flakes 2 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/11fcb2a4-b862-47e0-8bf6-6fc0250fe9af) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/162955 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/26255 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/143703 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/104618 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/fa8ce56b-2198-4c8a-a20e-010f96b47c17) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/25308 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/23795 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/16618 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/152053 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/134999 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/21472 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/171357 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/20834 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/17365 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/23110 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/132267 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/33143 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/27877 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/132293 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/33128 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/143267 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/91278 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/24359 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/26912 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/20080 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/192281 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/32637 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/99034 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/49462 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/32135 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/32381 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/32285 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->