### PR TITLE
[AutoFill Debugging] Omit origin for same-origin iframes and shorten cross-origin iframe origins in debug text

### DIFF
--- a/LayoutTests/http/tests/text-extraction/debug-text-extraction-subframes-expected.txt
+++ b/LayoutTests/http/tests/text-extraction/debug-text-extraction-subframes-expected.txt
@@ -2,19 +2,19 @@ root
 	label='Main content'
 		'Before subframes'
 		role=document
-			iframe title='Same origin iframe' origin=http://127.0.0.1:8000
+			iframe title='Same origin iframe'
 				label=Heading 'Hello world'
 				form autocomplete=on
 					label='Sign in with email'
 						input placeholder='Enter your email'
 						link url=javascript: 'Forgot your email?'
 					input placeholder='Enter your password' secure
-				iframe origin=http://127.0.0.1:8000
+				iframe
 					contentEditable role=textbox focused
 						label=Heading 'Nested subframe'
 				link url=www.apple.com 'Link in subframe'
 				image label='Square icon' src=square20.jpg
 		role=document
-			iframe title='Cross origin iframe' origin=http://localhost:8000
+			iframe title='Cross origin iframe' origin=localhost:8000
 		button label=Submit 'After subframes'
 		link url=webkit.org 'Link in mainframe'

--- a/Source/WebCore/page/text-extraction/TextExtraction.cpp
+++ b/Source/WebCore/page/text-extraction/TextExtraction.cpp
@@ -211,6 +211,36 @@ static String NODELETE stringOnlyIfHumanReadable(const String& string)
     return { };
 }
 
+static String shortenedURLString(const URL& url)
+{
+    auto shortenedURL = StringEntropyHelpers::removeHighEntropyComponents(url);
+    if (shortenedURL.protocolIsFile()) {
+        String lastComponent;
+        String secondToLastComponent;
+        for (auto component : shortenedURL.path().split('/')) {
+            std::swap(secondToLastComponent, lastComponent);
+            lastComponent = component.toString();
+        }
+
+        if (!secondToLastComponent.isEmpty())
+            shortenedURL.setPath(makeString(WTF::move(secondToLastComponent), '/', WTF::move(lastComponent)));
+
+        return shortenedURL.path().toString();
+    }
+
+    auto shortenedString = shortenedURL.string();
+    if (!shortenedURL.protocolIsInHTTPFamily())
+        return shortenedString;
+
+    if (auto endOfProtocol = shortenedString.find("://"_s); endOfProtocol != notFound)
+        shortenedString = shortenedString.substring(endOfProtocol + 3);
+
+    if (shortenedString.endsWith('/'))
+        shortenedString = shortenedString.left(shortenedString.length() - 1);
+
+    return shortenedString;
+}
+
 static void addBoxShadowIfNeeded(Node& node, const String& colorAsString)
 {
     Ref document = node.document();
@@ -552,34 +582,7 @@ static inline Variant<SkipExtraction, ItemData, URL, Editable> extractItemData(N
                 if (context.mergeParagraphs)
                     return { WTF::move(url) };
 
-                auto shortenedURLString = [&] {
-                    auto shortenedURL = StringEntropyHelpers::removeHighEntropyComponents(url);
-                    if (shortenedURL.protocolIsFile()) {
-                        String lastComponent;
-                        String secondToLastComponent;
-                        for (auto component : shortenedURL.path().split('/')) {
-                            std::swap(secondToLastComponent, lastComponent);
-                            lastComponent = component.toString();
-                        }
-
-                        if (!secondToLastComponent.isEmpty())
-                            shortenedURL.setPath(makeString(WTF::move(secondToLastComponent), '/', WTF::move(lastComponent)));
-
-                        return shortenedURL.path().toString();
-                    }
-
-                    auto shortenedString = shortenedURL.string();
-                    if (!shortenedURL.protocolIsInHTTPFamily())
-                        return shortenedString;
-
-                    if (auto endOfProtocol = shortenedString.find("://"_s); endOfProtocol != notFound)
-                        shortenedString = shortenedString.substring(endOfProtocol + 3);
-
-                    if (shortenedString.endsWith('/'))
-                        shortenedString = shortenedString.left(shortenedString.length() - 1);
-
-                    return shortenedString;
-                }();
+                auto shortenedString = shortenedURLString(url);
 
                 String target;
                 if (RefPtr anchor = dynamicDowncast<HTMLAnchorElement>(*element))
@@ -588,7 +591,7 @@ static inline Variant<SkipExtraction, ItemData, URL, Editable> extractItemData(N
                 return { LinkItemData {
                     WTF::move(target),
                     WTF::move(url),
-                    WTF::move(shortenedURLString)
+                    WTF::move(shortenedString)
                 } };
             }
         }
@@ -630,8 +633,15 @@ static inline Variant<SkipExtraction, ItemData, URL, Editable> extractItemData(N
     if (RefPtr iframe = dynamicDowncast<HTMLIFrameElement>(element)) {
         if (RefPtr contentFrame = iframe->contentFrame()) {
             if (RefPtr frameOrigin = contentFrame->frameDocumentSecurityOrigin()) {
+                bool isSameOriginAsParent = frameOrigin->isSameOriginAs(protect(element->document())->securityOrigin());
+                auto originString = frameOrigin->toString();
+                String shortenedOrigin;
+                if (!isSameOriginAsParent && !originString.isEmpty())
+                    shortenedOrigin = shortenedURLString(URL { originString });
                 return { IFrameData {
-                    .origin = frameOrigin->toString(),
+                    .origin = WTF::move(originString),
+                    .shortenedOrigin = WTF::move(shortenedOrigin),
+                    .isSameOriginAsParent = isSameOriginAsParent,
                     .identifier = contentFrame->frameID(),
                 } };
             }

--- a/Source/WebCore/page/text-extraction/TextExtractionTypes.h
+++ b/Source/WebCore/page/text-extraction/TextExtractionTypes.h
@@ -146,6 +146,8 @@ struct LinkItemData {
 
 struct IFrameData {
     String origin;
+    String shortenedOrigin;
+    bool isSameOriginAsParent { false };
     FrameIdentifier identifier;
 };
 

--- a/Source/WebKit/Shared/TextExtractionToStringConversion.cpp
+++ b/Source/WebKit/Shared/TextExtractionToStringConversion.cpp
@@ -1126,8 +1126,10 @@ static void populateJSONForItem(JSON::Object& jsonObject, const TextExtraction::
                 jsonObject.setString("target"_s, linkData.target);
         },
         [&](const TextExtraction::IFrameData& iframeData) {
-            if (!iframeData.origin.isEmpty())
-                jsonObject.setString("origin"_s, iframeData.origin);
+            if (iframeData.isSameOriginAsParent)
+                return;
+            if (!iframeData.shortenedOrigin.isEmpty())
+                jsonObject.setString("origin"_s, iframeData.shortenedOrigin);
         },
         [](auto) { }
     );
@@ -1544,11 +1546,12 @@ static void addPartsForItem(const TextExtraction::Item& item, std::optional<Node
             aggregator.addResult(line, WTF::move(parts));
         },
         [&](const TextExtraction::IFrameData& iframeData) {
+            bool shouldEmitOrigin = !iframeData.isSameOriginAsParent && !iframeData.shortenedOrigin.isEmpty();
             if (aggregator.useHTMLOutput()) {
                 auto attributes = partsForItem(item, aggregator, includeRectForParentItem);
 
-                if (!iframeData.origin.isEmpty())
-                    attributes.append(makeString("src='"_s, iframeData.origin, '\''));
+                if (shouldEmitOrigin)
+                    attributes.append(makeString("src='"_s, iframeData.shortenedOrigin, '\''));
 
                 if (attributes.isEmpty())
                     parts.append(makeString('<', item.nodeName.convertToASCIILowercase(), '>'));
@@ -1558,8 +1561,8 @@ static void addPartsForItem(const TextExtraction::Item& item, std::optional<Node
                 parts.append("iframe"_s);
                 parts.appendVector(partsForItem(item, aggregator, includeRectForParentItem));
 
-                if (!iframeData.origin.isEmpty())
-                    parts.append(makeString("origin="_s, quoteValue(iframeData.origin, streamlined)));
+                if (shouldEmitOrigin)
+                    parts.append(makeString("origin="_s, quoteValue(iframeData.shortenedOrigin, streamlined)));
             }
 
             aggregator.addResult(line, WTF::move(parts));

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -6832,6 +6832,8 @@ header: <WebCore/TextExtractionTypes.h>
 header: <WebCore/TextExtractionTypes.h>
 [CustomHeader] struct WebCore::TextExtraction::IFrameData {
     String origin;
+    String shortenedOrigin;
+    bool isSameOriginAsParent;
     WebCore::FrameIdentifier identifier;
 };
 

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/TextExtractionTests.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/TextExtractionTests.mm
@@ -986,6 +986,39 @@ TEST(TextExtractionTests, SubframeInteractions)
     EXPECT_EQ(numberOfMatches(debugTextAfterClicks.get(), @"Click count: 1"), 2u);
 }
 
+TEST(TextExtractionTests, SubframeOriginInDebugText)
+{
+    HTTPServer server { {
+        { "/subframe-cross.html"_s, { subFrameMarkup("Cross"_s) } },
+        { "/subframe-same.html"_s, { subFrameMarkup("Same"_s) } },
+    }, HTTPServer::Protocol::Http };
+
+    server.addResponse("/"_s, { mainFrameMarkup(server.port()) });
+
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 400, 400) configuration:^{
+        RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+        [[configuration preferences] _setTextExtractionEnabled:YES];
+        return configuration.autorelease();
+    }()]);
+    [webView synchronouslyLoadRequest:server.request()];
+
+    Util::waitForConditionWithLogging([webView] {
+        return [[webView objectByEvaluatingJavaScript:@"subframeLoadedCount"] intValue] == 2;
+    }, 2, @"Expected subframes to finish loading.");
+
+    RetainPtr debugText = [webView synchronouslyGetDebugText:^{
+        RetainPtr configuration = adoptNS([_WKTextExtractionConfiguration new]);
+        [configuration setIncludeRects:NO];
+        [configuration setIncludeURLs:YES];
+        return configuration.autorelease();
+    }()];
+
+    auto crossOriginExpected = makeString("origin=localhost:"_s, server.port());
+    EXPECT_TRUE([debugText containsString:crossOriginExpected.createNSString()]);
+    EXPECT_FALSE([debugText containsString:@"origin=http://localhost"]);
+    EXPECT_FALSE([debugText containsString:@"origin=127.0.0.1"]);
+}
+
 TEST(TextExtractionTests, InjectedBundle)
 {
     WKWebViewConfiguration *configuration = [WKWebViewConfiguration _test_configurationWithTestPlugInClassName:@"JSHandlePlugIn"];


### PR DESCRIPTION
#### dd66a76087bf040eddc29668efff80bd3fe885b8
<pre>
[AutoFill Debugging] Omit origin for same-origin iframes and shorten cross-origin iframe origins in debug text
<a href="https://bugs.webkit.org/show_bug.cgi?id=313705">https://bugs.webkit.org/show_bug.cgi?id=313705</a>
<a href="https://rdar.apple.com/175902701">rdar://175902701</a>

Reviewed by Abrar Rahman Protyasha.

Follow-up to 305471@main. To further reduce noise in the debug text output of text extraction, omit
the iframe origin entirely when the iframe is same-origin with its embedding document, and apply the
same URL-shortening heuristic used for links and image sources when emitting cross-origin iframe
origins (i.e. drop the scheme prefix and trailing slash).

For example, given a top-level document at `<a href="https://webkit.org/`">https://webkit.org/`</a> with same-origin iframe
`<a href="https://webkit.org/foo.html`">https://webkit.org/foo.html`</a> and cross-origin iframe `<a href="https://example.com/`">https://example.com/`</a>, the debug text
previously emitted:

  iframe [...] origin=&apos;<a href="https://webkit.org/&apos">https://webkit.org/&apos</a>;
  iframe [...] origin=&apos;<a href="https://example.com/&apos">https://example.com/&apos</a>;

…and now emits:

  iframe [...]
  iframe [...] origin=&apos;example.com&apos;

Test: TextExtractionTests.SubframeOriginInDebugText

Test: Tools/TestWebKitAPI/Tests/WebKit/WKWebView/TextExtractionTests.mm
* LayoutTests/http/tests/text-extraction/debug-text-extraction-subframes-expected.txt:
* Source/WebCore/page/text-extraction/TextExtraction.cpp:
(WebCore::TextExtraction::shortenedURLString):

Factor the URL-shortening heuristic previously inlined inside the link extraction
code path into a file-scope helper, so it can also be reused when computing the
shortened origin for iframes.

(WebCore::TextExtraction::extractItemData):

Compute `isSameOriginAsParent` by comparing the iframe&apos;s content origin against the
embedding document&apos;s security origin, and populate the shortened origin using the
helper above when the iframe is cross-origin.

* Source/WebCore/page/text-extraction/TextExtractionTypes.h:

Add `shortenedOrigin` and `isSameOriginAsParent` to `IFrameData`, mirroring how
`LinkItemData` carries both `completedURL` and `shortenedURLString`.

* Source/WebKit/Shared/TextExtractionToStringConversion.cpp:
(WebKit::populateJSONForItem):
(WebKit::addPartsForItem):

Skip emitting the `origin` / `src` attribute entirely for same-origin iframes, and
emit the pre-shortened origin for cross-origin iframes across all three output
formats (JSON, plain text, and HTML).

* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:

Plumb the new fields through IPC.

* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/TextExtractionTests.mm:
(TestWebKitAPI::TEST(TextExtractionTests, SubframeOriginInDebugText)):

Add a test to exercise this change.

Canonical link: <a href="https://commits.webkit.org/312377@main">https://commits.webkit.org/312377@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/322e931c87e30bf766c57b0fb5233c9ec74ae4b2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/159728 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/33195 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/26302 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/168584 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/114109 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/161597 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/33300 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/33199 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/123763 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/114109 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/162686 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/26026 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/143466 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/104406 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/25077 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/23548 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/16349 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/134769 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/21238 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/171077 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/17096 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/22875 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/132020 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/32874 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/27625 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/132077 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35744 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/32859 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/143032 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/90942 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/26698 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/19845 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/32368 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/98764 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/31865 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/32112 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/32016 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->