### PR TITLE
[iOS] Improve scroll position preservation on rotation in RTL pages

### DIFF
--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h
@@ -235,7 +235,7 @@ using TextValidationMapValue = Variant<String, SimilarToOriginalTextTag>;
 #if PLATFORM(IOS_FAMILY)
 struct LiveResizeParameters {
     CGFloat viewWidth;
-    CGPoint initialScrollPosition;
+    CGPoint initialScrollOffset;
 };
 
 struct OverriddenLayoutParameters {

--- a/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm
+++ b/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm
@@ -764,6 +764,17 @@ static WebCore::Color scrollViewBackgroundColor(WKWebView *webView, AllowPageBac
     return result;
 }
 
+- (CGPoint)_scrollOffsetAdjustedForObscuredInset:(CGPoint)contentOffset
+{
+    CGPoint result = contentOffset;
+    UIEdgeInsets contentInset = [self _computedObscuredInset];
+
+    result.x += contentInset.left;
+    result.y += contentInset.top;
+
+    return result;
+}
+
 - (UIRectEdge)_effectiveObscuredInsetEdgesAffectedBySafeArea
 {
     if (![self usesStandardContentView])
@@ -983,14 +994,14 @@ static void changeContentOffsetBoundedInValidRange(UIScrollView *scrollView, Web
         return;
 
     double pageScale = mainFrameData.pageScaleFactor;
-    WebCore::IntPoint scrollPosition = layerTreeTransaction.scrollPosition();
+    auto scrollOffset = WebCore::ScrollableArea::scrollOffsetFromPosition(layerTreeTransaction.scrollPosition(), layerTreeTransaction.scrollOrigin());
 
     CGFloat animatingScaleTarget = [[_resizeAnimationView layer] transform].m11;
     double currentTargetScale = animatingScaleTarget * [[_contentView layer] transform].m11;
     double scale = pageScale / currentTargetScale;
     _resizeAnimationTransformAdjustments = CATransform3DMakeScale(scale, scale, 1);
 
-    CGPoint newContentOffset = [self _contentOffsetAdjustedForObscuredInset:CGPointMake(scrollPosition.x() * pageScale, scrollPosition.y() * pageScale)];
+    CGPoint newContentOffset = [self _contentOffsetAdjustedForObscuredInset:CGPointMake(scrollOffset.x() * pageScale, scrollOffset.y() * pageScale)];
     CGPoint currentContentOffset = [_scrollView contentOffset];
 
     _resizeAnimationTransformAdjustments.m41 = (currentContentOffset.x - newContentOffset.x) / animatingScaleTarget;
@@ -2535,7 +2546,7 @@ static WebCore::FloatPoint constrainContentOffset(WebCore::FloatPoint contentOff
     CGFloat scale = self.bounds.size.width / _perProcessState.liveResizeParameters->viewWidth;
     CGAffineTransform transform = CGAffineTransformMakeScale(scale, scale);
 
-    CGPoint newContentOffset = [self _contentOffsetAdjustedForObscuredInset:CGPointMake(_perProcessState.liveResizeParameters->initialScrollPosition.x * scale, _perProcessState.liveResizeParameters->initialScrollPosition.y * scale)];
+    CGPoint newContentOffset = [self _contentOffsetAdjustedForObscuredInset:CGPointMake(_perProcessState.liveResizeParameters->initialScrollOffset.x * scale, _perProcessState.liveResizeParameters->initialScrollOffset.y * scale)];
     CGPoint currentContentOffset = [_scrollView contentOffset];
 
     transform.tx = currentContentOffset.x - newContentOffset.x;
@@ -3557,12 +3568,10 @@ static WebCore::UserInterfaceLayoutDirection toUserInterfaceLayoutDirection(UISe
 
     WKWEBVIEW_RELEASE_LOG("%p (pageProxyID=%llu) -[WKWebView _beginLiveResize]", self, _page->identifier().toUInt64());
 
-    CGPoint contentOffsetWithoutObscuredInset = self.scrollView.contentOffset;
-    UIEdgeInsets contentInset = [self _computedObscuredInset];
-    contentOffsetWithoutObscuredInset.x += contentInset.left;
-    contentOffsetWithoutObscuredInset.y += contentInset.top;
-
-    _perProcessState.liveResizeParameters = { { self.bounds.size.width, contentOffsetWithoutObscuredInset } };
+    _perProcessState.liveResizeParameters = { {
+        .viewWidth = self.bounds.size.width,
+        .initialScrollOffset = [self _scrollOffsetAdjustedForObscuredInset:self.scrollView.contentOffset]
+    } };
 
     [self _ensureResizeAnimationView];
 }


### PR DESCRIPTION
#### 23e019f46ecb45cfb2262881ec29172be7d861cf
<pre>
[iOS] Improve scroll position preservation on rotation in RTL pages
<a href="https://bugs.webkit.org/show_bug.cgi?id=313714">https://bugs.webkit.org/show_bug.cgi?id=313714</a>
<a href="https://rdar.apple.com/175910769">rdar://175910769</a>

Reviewed by Mike Wyrzykowski.

Add `_scrollOffsetAdjustedForObscuredInset:`, which is the inverse of
`_contentOffsetAdjustedForObscuredInset:`, and use it in `_beginLiveResize`.

`_didCommitLayerTreeDuringAnimatedResize:` had the classic scroll position/
scroll offset confusion, which breaks side-scrolling RTL pages with non-zero
scrollOrigin. Fix by converting the scrollPosition to a scroll offset before
computing contentOffsets.

No test, because rotation is not reliably testable. Manual testing shows
that this improves the behavior.

* Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h:
* Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm:
(-[WKWebView _scrollOffsetAdjustedForObscuredInset:]):
(-[WKWebView _didCommitLayerTreeDuringAnimatedResize:mainFrameData:]):
(-[WKWebView _updateLiveResizeTransform]):
(-[WKWebView _beginLiveResize]):

Canonical link: <a href="https://commits.webkit.org/312391@main">https://commits.webkit.org/312391@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9ed214d1efac9b388907f60369b0d2fbbb681bd8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/159641 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/33108 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/26215 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/168492 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/114022 "Built successfully") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/33213 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/33112 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/123683 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/86801 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/162598 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/25956 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/143390 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/104334 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/25007 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/23470 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/16255 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/134699 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/170982 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/17009 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/22796 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/131942 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/32787 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/27545 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/132003 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35751 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/32772 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/142956 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/90854 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/26635 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/19769 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/32281 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/98677 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/31778 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/32025 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/31929 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->