### PR TITLE
Preserve sticky user activation across same-origin navigations

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -845,8 +845,6 @@ imported/w3c/web-platform-tests/html/user-activation/activation-trigger-keyboard
 imported/w3c/web-platform-tests/html/user-activation/activation-trigger-keyboard-escape.html [ Skip ]
 imported/w3c/web-platform-tests/html/user-activation/activation-trigger-mouse-left.html [ Skip ]
 imported/w3c/web-platform-tests/html/user-activation/activation-trigger-mouse-right.html [ Skip ]
-webkit.org/b/313716 imported/w3c/web-platform-tests/html/user-activation/navigate-to-crossorigin-redirect.html [ Skip ]
-webkit.org/b/313716 imported/w3c/web-platform-tests/html/user-activation/navigate-to-sameorigin.html [ Skip ]
 imported/w3c/web-platform-tests/html/webappapis/scripting/processing-model-2/unhandled-promise-rejections/allow-crossorigin.html [ Skip ]
 imported/w3c/web-platform-tests/html/webappapis/scripting/processing-model-2/unhandled-promise-rejections/disallow-crossorigin.html [ Skip ]
 imported/w3c/web-platform-tests/html/webappapis/scripting/processing-model-2/unhandled-promise-rejections/promise-rejection-events.html [ Skip ]

--- a/LayoutTests/imported/w3c/web-platform-tests/html/user-activation/navigate-to-crossorigin-redirect-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/user-activation/navigate-to-crossorigin-redirect-expected.txt
@@ -1,0 +1,5 @@
+Non-zero-sized body to allow clicks.
+
+
+PASS User activation propagation across a same-origin navigation
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/user-activation/navigate-to-sameorigin-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/user-activation/navigate-to-sameorigin-expected.txt
@@ -1,0 +1,5 @@
+Non-zero-sized body to allow clicks.
+
+
+PASS User activation propagation across a same-origin navigation
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/user-activation/navigation-state-reset-sameorigin-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/user-activation/navigation-state-reset-sameorigin-expected.txt
@@ -5,5 +5,5 @@ Tests that navigating a same-origin child frame resets its activation states.
 Click inside the yellow area.
 
 
-FAIL Post-navigation state reset. assert_true: child-two sticky user activation state after loaded expected true got false
+PASS Post-navigation state reset.
 

--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -6899,6 +6899,8 @@ imported/w3c/web-platform-tests/html/user-activation/navigation-state-reset-cros
 imported/w3c/web-platform-tests/html/user-activation/navigation-state-reset-sameorigin.html [ Skip ]
 imported/w3c/web-platform-tests/html/user-activation/user-activation-interface.html [ Skip ]
 imported/w3c/web-platform-tests/html/user-activation/activation-same-and-cross-origin.sub.html [ Skip ]
+imported/w3c/web-platform-tests/html/user-activation/navigate-to-crossorigin-redirect.html [ Skip ]
+imported/w3c/web-platform-tests/html/user-activation/navigate-to-sameorigin.html [ Skip ]
 
 # WebGL in OffscreenCanvas requires the GPUP.
 imported/w3c/web-platform-tests/html/canvas/offscreen/manual/the-offscreen-canvas/offscreencanvas.getcontext.worker.html [ Skip ]

--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -8114,6 +8114,20 @@ StandardFontFamily:
     WebCore:
       default: '""_str'
 
+StickyUserActivationAcrossSameOriginNavigationsEnabled:
+  type: bool
+  status: testable
+  category: dom
+  humanReadableName: "Sticky user activation across same-origin navigations"
+  humanReadableDescription: "Preserve sticky user activation when navigating to a same-origin page (per whatwg/html#11454)"
+  defaultValue:
+    WebKitLegacy:
+      default: false
+    WebKit:
+      default: false
+    WebCore:
+      default: false
+
 StorageAPIEnabled:
   type: bool
   status: stable

--- a/Source/WebCore/loader/DocumentWriter.cpp
+++ b/Source/WebCore/loader/DocumentWriter.cpp
@@ -47,6 +47,7 @@
 #include "LocalFrameView.h"
 #include "MIMETypeRegistry.h"
 #include "Navigation.h"
+#include "NetworkLoadMetrics.h"
 #include "Page.h"
 #include "PluginDocument.h"
 #include "RawDataDocumentParser.h"
@@ -207,6 +208,21 @@ bool DocumentWriter::begin(const URL& urlReference, bool dispatch, Document* own
 
     frameLoader->setOutgoingReferrer(url);
     frame->setDocument(document.copyRef());
+
+    // whatwg/html#11454: carry sticky activation over same-origin navigations,
+    // except when the redirect chain crossed origins (A -> B -> A).
+    if (previousWindow && existingDocument) {
+        bool hadCrossOriginRedirect = false;
+        if (RefPtr documentLoader = frameLoader->documentLoader()) {
+            if (auto* metrics = documentLoader->response().deprecatedNetworkLoadMetricsOrNull())
+                hadCrossOriginRedirect = metrics->hasCrossOriginRedirect;
+        }
+        if (RefPtr newWindow = document->window()) {
+            Ref previousOrigin = existingDocument->securityOrigin();
+            Ref targetOrigin = SecurityOrigin::create(url);
+            newWindow->carryOverStickyActivationFromPreviousWindow(*previousWindow, previousOrigin, targetOrigin, hadCrossOriginRedirect);
+        }
+    }
 
     if (m_decoder)
         document->setDecoder(m_decoder.copyRef());

--- a/Source/WebCore/loader/FrameLoader.cpp
+++ b/Source/WebCore/loader/FrameLoader.cpp
@@ -2824,6 +2824,13 @@ void FrameLoader::open(CachedFrameBase& cachedFrame)
     Ref document = *cachedFrame.document();
     ASSERT(document->window());
 
+    // Snapshot the previous page before clear() detaches it; used for
+    // sticky-activation carry-over below.
+    RefPtr previousWindow = m_frame->window();
+    RefPtr<SecurityOrigin> previousOrigin;
+    if (RefPtr previousDocument = m_frame->document())
+        previousOrigin = &previousDocument->securityOrigin();
+
     clear(document.ptr(), true, true, cachedFrame.isMainFrame());
 
     document->attachToCachedFrame(cachedFrame);
@@ -2860,6 +2867,16 @@ void FrameLoader::open(CachedFrameBase& cachedFrame)
     frame->setDocument(document.copyRef());
 
     protect(document->window())->resumeFromBackForwardCache();
+
+    // whatwg/html#11454 bfcache reactivation: carry sticky activation from a
+    // same-origin previous page onto the cached window. No network load, so
+    // the redirect-chain suppressor does not apply.
+    if (previousWindow && previousOrigin && previousWindow.get() != document->window()) {
+        if (RefPtr cachedWindow = document->window()) {
+            Ref targetOrigin = document->securityOrigin();
+            cachedWindow->carryOverStickyActivationFromPreviousWindow(*previousWindow, *previousOrigin, targetOrigin, /* hadCrossOriginRedirect */ false);
+        }
+    }
 
     updateFirstPartyForCookies();
 

--- a/Source/WebCore/page/LocalDOMWindow.cpp
+++ b/Source/WebCore/page/LocalDOMWindow.cpp
@@ -1605,6 +1605,20 @@ void LocalDOMWindow::consumeLastActivationIfNecessary()
         m_lastActivationTimestamp = -MonotonicTime::infinity();
 }
 
+void LocalDOMWindow::carryOverStickyActivationFromPreviousWindow(const LocalDOMWindow& previousWindow, const SecurityOrigin& previousOrigin, const SecurityOrigin& targetOrigin, bool hadCrossOriginRedirect)
+{
+    RefPtr frame = this->frame();
+    if (!frame || !frame->settings().stickyUserActivationAcrossSameOriginNavigationsEnabled())
+        return;
+    if (hadCrossOriginRedirect)
+        return;
+    if (!previousWindow.hasStickyActivation())
+        return;
+    if (!previousOrigin.isSameOriginAs(targetOrigin))
+        return;
+    m_hasStickyActivation = true;
+}
+
 // https://html.spec.whatwg.org/multipage/interaction.html#consume-history-action-user-activation
 bool LocalDOMWindow::consumeHistoryActionUserActivation()
 {

--- a/Source/WebCore/page/LocalDOMWindow.h
+++ b/Source/WebCore/page/LocalDOMWindow.h
@@ -55,6 +55,7 @@ template <typename, ShouldStrongDestructorGrabLock> class Strong;
 namespace WebCore {
 
 class CloseWatcherManager;
+class SecurityOrigin;
 class SecurityOriginData;
 struct ScrollToOptions;
 struct UserGestureTokenData;
@@ -152,6 +153,11 @@ public:
     void notifyActivated(MonotonicTime);
     WEBCORE_EXPORT bool hasTransientActivation() const;
     bool hasStickyActivation() const;
+
+    // whatwg/html#11454: same-origin navigation preserves sticky activation;
+    // suppressed if the redirect chain crossed origins. |previousOrigin| is
+    // passed in because the previous document may already be detached.
+    void carryOverStickyActivationFromPreviousWindow(const LocalDOMWindow& previousWindow, const SecurityOrigin& previousOrigin, const SecurityOrigin& targetOrigin, bool hadCrossOriginRedirect);
     WEBCORE_EXPORT bool consumeTransientActivation();
     WEBCORE_EXPORT bool NODELETE hasHistoryActionActivation() const;
     WEBCORE_EXPORT bool NODELETE consumeHistoryActionUserActivation();


### PR DESCRIPTION
#### db9860c223cb0105828527821ac1e317f41cf924
<pre>
Preserve sticky user activation across same-origin navigations
<a href="https://bugs.webkit.org/show_bug.cgi?id=313716">https://bugs.webkit.org/show_bug.cgi?id=313716</a>

Reviewed by NOBODY (OOPS!).

Implement sticky user activation carry-over per whatwg/html#11454,
centralized in LocalDOMWindow::carryOverStickyActivationFromPreviousWindow
and applied at two entry points:

* DocumentWriter::begin: carry sticky activation onto a same-origin
  destination, suppressed when the redirect chain crossed origins
  (guards A -&gt; B -&gt; A confused-deputy patterns).
* FrameLoader::open(CachedFrameBase&amp;): apply the same rule on bfcache
  reactivation; no network load, so the redirect suppressor is N/A.

Migrate sticky and history-action activation from timestamp-derived
flags to explicit booleans on LocalDOMWindow, per the spec&apos;s updated
data model. m_lastActivationTimestamp continues to drive transient
activation only. notifyActivated, its propagation, consume-history-
action, and WebPage::updateUserActivationTimestamps update the
booleans alongside the timestamp.

Gated behind StickyUserActivationAcrossSameOriginNavigationsEnabled
(testable, off by default, auto-enabled in WebKitTestRunner). The
data-model migration is observationally equivalent and not gated.

navigation-state-reset-sameorigin.html now contains FAIL because
sticky activation is preserved across same-origin subframe navigations
per the spec change; revert the expected.txt once the WPT is imported.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5db185b96acf5e208750c492d6691a921bb99fb8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/173458 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/47390 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/41317 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/183031 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/131326 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/175323 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/48683 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/47072 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/134874 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/95222 "4 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/176416 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/38302 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/155802 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/115350 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/36943 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/35296 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/31516 "Built successfully") | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/4313 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/147367 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/35296 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/185456 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/34720 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/38327 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/39497 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/143741 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/47058 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/155358 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/143607 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/47737 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/31912 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/112849 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/38545 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/119629 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/210491 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/46243 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/10251 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/54911 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/45645 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/45876 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/45702 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->