### PR TITLE
[JSC] Optimize bit-rotate idiom in B3

### DIFF
--- a/Source/JavaScriptCore/b3/B3OptimizeAssociativeExpressionTrees.cpp
+++ b/Source/JavaScriptCore/b3/B3OptimizeAssociativeExpressionTrees.cpp
@@ -177,6 +177,7 @@ bool OptimizeAssociativeExpressionTrees::optimizeRootedTree(Value* root, Inserti
             leaves.append(val);
         }
     }
+
     if (isAbsorbingElement(op, constant)) {
         Value* newRoot;
         if (root->type() == Int32)
@@ -186,7 +187,79 @@ bool OptimizeAssociativeExpressionTrees::optimizeRootedTree(Value* root, Inserti
         root->replaceWithIdentity(newRoot);
         return true;
     }
-    if (numVisited < 4) {
+
+    // Pair up rotate halves inside XOR / OR trees so the `(x >>> N) ^ (x << (W-N))`
+    // idiom (and its sigma/Sigma chained variants) lowers to a single RotR instead of a
+    // pair of shifts + XOR.
+    bool foldedRotate = false;
+    if ((op == BitXor || op == BitOr) && (root->type() == Int32 || root->type() == Int64) && leaves.size() >= 2) {
+        unsigned width = root->type() == Int32 ? 32 : 64;
+
+        // In the leaf elements of BitOr / BitXor tree, we collect Shl and ZShr.
+        UncheckedKeyHashMap<Value*, Vector<unsigned, 4>> shlIndicesByBase;
+        UncheckedKeyHashMap<Value*, Vector<unsigned, 4>> zshrIndicesByBase;
+        for (unsigned i = 0; i < leaves.size(); ++i) {
+            Value* leaf = leaves[i];
+            if (leaf->opcode() == Shl && leaf->child(1)->hasInt32())
+                shlIndicesByBase.add(leaf->child(0), Vector<unsigned, 4>()).iterator->value.append(i);
+            else if (leaf->opcode() == ZShr && leaf->child(1)->hasInt32())
+                zshrIndicesByBase.add(leaf->child(0), Vector<unsigned, 4>()).iterator->value.append(i);
+        }
+
+        // Then for each Shl, searching for ZShr where,
+        // 1. Both's left child is the same. Shl(value, N) and ZShr(value, M).
+        // 2. N + M = width (32 or 64, depending on type).
+        // Then,
+        //
+        //     Turn this: BitOr(Shl(value, N), ZShr(value, M))
+        //                BitXor(Shl(value, N), ZShr(value, M))
+        //     Into this: RotR(value, M)
+        //
+        // And replace leaf with RotR.
+        for (auto& shlEntry : shlIndicesByBase) {
+            auto zshrIter = zshrIndicesByBase.find(shlEntry.key);
+            if (zshrIter == zshrIndicesByBase.end())
+                continue;
+            Vector<unsigned, 4>& zshrIndices = zshrIter->value;
+
+            for (unsigned shlIdx : shlEntry.value) {
+                Value* shl = leaves[shlIdx];
+                // leaf becomes nullptr when it is already replaced.
+                if (!shl)
+                    continue;
+
+                unsigned n = static_cast<unsigned>(shl->child(1)->asInt32()) & (width - 1);
+                if (!n)
+                    continue;
+
+                for (unsigned k = 0; k < zshrIndices.size(); ++k) {
+                    Value* zshr = leaves[zshrIndices[k]];
+                    // leaf becomes nullptr when it is already replaced.
+                    if (!zshr)
+                        continue;
+
+                    unsigned m = static_cast<unsigned>(zshr->child(1)->asInt32()) & (width - 1);
+                    if (n + m != width)
+                        continue;
+
+                    Value* amount = insertionSet.insert<Const32Value>(indexInBlock, root->origin(), static_cast<int32_t>(m));
+                    Value* rotate = insertionSet.insert<Value>(indexInBlock, RotR, root->origin(), shlEntry.key, amount);
+
+                    leaves[shlIdx] = rotate;
+                    leaves[zshrIndices[k]] = nullptr;
+                    zshrIndices[k] = zshrIndices.last();
+                    zshrIndices.removeLast();
+                    foldedRotate = true;
+                    break;
+                }
+            }
+        }
+
+        if (foldedRotate)
+            leaves.removeAllMatching([](Value* v) { return !v; });
+    }
+
+    if (numVisited < 4 && !foldedRotate) {
         // This is a nearly-trivial expression of size 3. B3ReduceStrength is still able to deal with such expressions competently, and there is no possible win from balancing them.
         return false;
     }

--- a/Source/JavaScriptCore/b3/B3ReduceStrength.cpp
+++ b/Source/JavaScriptCore/b3/B3ReduceStrength.cpp
@@ -1718,6 +1718,9 @@ private:
             if (handleBitAndDistributivity())
                 break;
 
+            if (handleRotateFromShiftXorOr())
+                break;
+
             break;
 
         case BitXor:
@@ -1766,6 +1769,9 @@ private:
             }
                 
             if (handleBitAndDistributivity())
+                break;
+
+            if (handleRotateFromShiftXorOr())
                 break;
 
             break;
@@ -4331,6 +4337,42 @@ private:
             std::swap(m_value->child(0), m_value->child(1));
             m_changed = true;
         }
+    }
+
+    // Turn this: BitOr(Shl(value, N), ZShr(value, M))
+    //            BitXor(Shl(value, N), ZShr(value, M))
+    // Into this: RotR(value, M)
+    // where N, M are constants in (0, width) and N + M == width (32 or 64).
+    // We emit RotR rather than RotL because ARM64 has no rotate-left directly.
+    bool handleRotateFromShiftXorOr()
+    {
+        ASSERT(m_value->opcode() == BitOr || m_value->opcode() == BitXor);
+        unsigned width = m_value->type() == Int32 ? 32 : m_value->type() == Int64 ? 64 : 0;
+        if (!width)
+            return false;
+
+        auto tryMatch = [&](Value* shl, Value* shr) -> bool {
+            if (shl->opcode() != Shl || shr->opcode() != ZShr)
+                return false;
+            if (shl->child(0) != shr->child(0))
+                return false;
+            if (!shl->child(1)->hasInt32() || !shr->child(1)->hasInt32())
+                return false;
+            unsigned n = static_cast<unsigned>(shl->child(1)->asInt32()) & (width - 1);
+            unsigned m = static_cast<unsigned>(shr->child(1)->asInt32()) & (width - 1);
+            if (!n || n + m != width)
+                return false;
+
+            Value* amount = m_insertionSet.insert<Const32Value>(m_index, m_value->origin(), static_cast<int32_t>(m));
+            replaceWithNew<Value>(RotR, m_value->origin(), shl->child(0), amount);
+            return true;
+        };
+
+        if (tryMatch(m_value->child(0), m_value->child(1)))
+            return true;
+        if (tryMatch(m_value->child(1), m_value->child(0)))
+            return true;
+        return false;
     }
 
     // For Op==Add or Sub, turn any of these:

--- a/Source/JavaScriptCore/b3/testb3.h
+++ b/Source/JavaScriptCore/b3/testb3.h
@@ -1568,4 +1568,12 @@ void testVectorSwizzleComposition();
 void testVectorSwizzleUnaryComposition();
 void testVectorSwizzleCompositionMultiUse();
 
+void testRotRFromShiftXorChainSHA256Sigma1_32(int32_t);
+void testRotRFromShiftXorChainSHA512Sigma1_64(int64_t);
+void testRotRFromShiftXorChainSHA256sigma0_32(int32_t);
+void testRotRFromShiftOrChainSHA256Sigma1_32(int32_t);
+void testRotRFromShiftXorChainSharedShiftOperand(int32_t);
+void testShiftOrDifferentBasesNoRotate(int32_t, int32_t, int32_t);
+void testShiftOrMismatchedAmountsNoRotate(int32_t);
+
 #endif // ENABLE(B3_JIT)

--- a/Source/JavaScriptCore/b3/testb3_1.cpp
+++ b/Source/JavaScriptCore/b3/testb3_1.cpp
@@ -107,13 +107,298 @@ void testRotLWithImmShift(T valueInt, int32_t shift)
     Procedure proc;
     BasicBlock* root = proc.addBlock();
     auto arguments = cCallArgumentValues<T>(proc, root);
-    
+
     Value* value = arguments[0];
     Value* ammount = root->appendIntConstant(proc, Origin(), Int32, shift);
     root->appendNewControlValue(proc, Return, Origin(),
         root->appendNew<Value>(proc, RotL, Origin(), value, ammount));
-    
+
     CHECK_EQ(compileAndRun<T>(proc, valueInt, shift), rotateLeft(valueInt, shift));
+}
+
+// Tests for scalar rotate-from-shift-xor-or synthesis added in
+// B3ReduceStrength::handleRotateFromShiftXorOr (direct-sibling match) and
+// B3OptimizeAssociativeExpressionTrees::optimizeRootedTree (chained XOR/OR).
+// The value computed is invariant under the fold, so these tests cover both
+// the folded and unfolded paths by construction.
+template<typename T>
+void testRotRFromShiftOr(T valueInt, int32_t shift)
+{
+    constexpr uint32_t width = sizeof(T) * 8;
+    uint32_t normalizedShift = static_cast<uint32_t>(shift) % width;
+    if (normalizedShift == 0)
+        return;
+
+    Procedure proc;
+    BasicBlock* root = proc.addBlock();
+    auto arguments = cCallArgumentValues<T>(proc, root);
+
+    Value* value = arguments[0];
+    Value* shlAmount = root->appendIntConstant(proc, Origin(), Int32, width - normalizedShift);
+    Value* zshrAmount = root->appendIntConstant(proc, Origin(), Int32, normalizedShift);
+    Value* shl = root->appendNew<Value>(proc, Shl, Origin(), value, shlAmount);
+    Value* zshr = root->appendNew<Value>(proc, ZShr, Origin(), value, zshrAmount);
+    root->appendNewControlValue(proc, Return, Origin(),
+        root->appendNew<Value>(proc, BitOr, Origin(), shl, zshr));
+
+    CHECK_EQ(compileAndRun<T>(proc, valueInt), rotateRight(valueInt, static_cast<int32_t>(normalizedShift)));
+}
+
+template<typename T>
+void testRotRFromShiftXor(T valueInt, int32_t shift)
+{
+    constexpr uint32_t width = sizeof(T) * 8;
+    uint32_t normalizedShift = static_cast<uint32_t>(shift) % width;
+    if (normalizedShift == 0)
+        return;
+
+    Procedure proc;
+    BasicBlock* root = proc.addBlock();
+    auto arguments = cCallArgumentValues<T>(proc, root);
+
+    Value* value = arguments[0];
+    Value* shlAmount = root->appendIntConstant(proc, Origin(), Int32, width - normalizedShift);
+    Value* zshrAmount = root->appendIntConstant(proc, Origin(), Int32, normalizedShift);
+    Value* shl = root->appendNew<Value>(proc, Shl, Origin(), value, shlAmount);
+    Value* zshr = root->appendNew<Value>(proc, ZShr, Origin(), value, zshrAmount);
+    root->appendNewControlValue(proc, Return, Origin(),
+        root->appendNew<Value>(proc, BitXor, Origin(), shl, zshr));
+
+    CHECK_EQ(compileAndRun<T>(proc, valueInt), rotateRight(valueInt, static_cast<int32_t>(normalizedShift)));
+}
+
+// Reversed operand order: ZShr first, Shl second. The fold must handle both orderings.
+template<typename T>
+void testRotRFromShiftXorReversed(T valueInt, int32_t shift)
+{
+    constexpr uint32_t width = sizeof(T) * 8;
+    uint32_t normalizedShift = static_cast<uint32_t>(shift) % width;
+    if (normalizedShift == 0)
+        return;
+
+    Procedure proc;
+    BasicBlock* root = proc.addBlock();
+    auto arguments = cCallArgumentValues<T>(proc, root);
+
+    Value* value = arguments[0];
+    Value* shlAmount = root->appendIntConstant(proc, Origin(), Int32, width - normalizedShift);
+    Value* zshrAmount = root->appendIntConstant(proc, Origin(), Int32, normalizedShift);
+    Value* zshr = root->appendNew<Value>(proc, ZShr, Origin(), value, zshrAmount);
+    Value* shl = root->appendNew<Value>(proc, Shl, Origin(), value, shlAmount);
+    root->appendNewControlValue(proc, Return, Origin(),
+        root->appendNew<Value>(proc, BitXor, Origin(), zshr, shl));
+
+    CHECK_EQ(compileAndRun<T>(proc, valueInt), rotateRight(valueInt, static_cast<int32_t>(normalizedShift)));
+}
+
+// SHA-256 Sigma1 pattern for 32-bit inputs:
+//   (x >>> 6) ^ (x >>> 11) ^ (x >>> 25) ^ (x << 26) ^ (x << 21) ^ (x << 7)
+// Pairs: (>>>6, <<26), (>>>11, <<21), (>>>25, <<7). Each pair is a rotate-right.
+// Exercises the multi-leaf path in OptimizeAssociativeExpressionTrees::optimizeRootedTree.
+void testRotRFromShiftXorChainSHA256Sigma1_32(int32_t valueInt)
+{
+    Procedure proc;
+    BasicBlock* root = proc.addBlock();
+    auto arguments = cCallArgumentValues<int32_t>(proc, root);
+
+    Value* x = arguments[0];
+    auto buildShift = [&](B3::Opcode op, int32_t amt) -> Value* {
+        Value* amount = root->appendIntConstant(proc, Origin(), Int32, amt);
+        return root->appendNew<Value>(proc, op, Origin(), x, amount);
+    };
+    Value* zshr6 = buildShift(ZShr, 6);
+    Value* zshr11 = buildShift(ZShr, 11);
+    Value* zshr25 = buildShift(ZShr, 25);
+    Value* shl26 = buildShift(Shl, 26);
+    Value* shl21 = buildShift(Shl, 21);
+    Value* shl7 = buildShift(Shl, 7);
+    Value* xor0 = root->appendNew<Value>(proc, BitXor, Origin(), zshr6, zshr11);
+    Value* xor1 = root->appendNew<Value>(proc, BitXor, Origin(), xor0, zshr25);
+    Value* xor2 = root->appendNew<Value>(proc, BitXor, Origin(), xor1, shl26);
+    Value* xor3 = root->appendNew<Value>(proc, BitXor, Origin(), xor2, shl21);
+    Value* xor4 = root->appendNew<Value>(proc, BitXor, Origin(), xor3, shl7);
+    root->appendNewControlValue(proc, Return, Origin(), xor4);
+
+    int32_t expected = rotateRight(valueInt, 6) ^ rotateRight(valueInt, 11) ^ rotateRight(valueInt, 25);
+    CHECK_EQ(compileAndRun<int32_t>(proc, valueInt), expected);
+}
+
+// Analogous pattern at 64 bits: (x >>> 14) ^ (x >>> 18) ^ (x >>> 41) ^ (x << 50) ^ (x << 46) ^ (x << 23)
+// Pairs: (>>>14, <<50), (>>>18, <<46), (>>>41, <<23). Each pair is a 64-bit rotate-right.
+void testRotRFromShiftXorChainSHA512Sigma1_64(int64_t valueInt)
+{
+    Procedure proc;
+    BasicBlock* root = proc.addBlock();
+    auto arguments = cCallArgumentValues<int64_t>(proc, root);
+
+    Value* x = arguments[0];
+    auto buildShift = [&](B3::Opcode op, int32_t amt) -> Value* {
+        Value* amount = root->appendIntConstant(proc, Origin(), Int32, amt);
+        return root->appendNew<Value>(proc, op, Origin(), x, amount);
+    };
+    Value* zshr14 = buildShift(ZShr, 14);
+    Value* zshr18 = buildShift(ZShr, 18);
+    Value* zshr41 = buildShift(ZShr, 41);
+    Value* shl50 = buildShift(Shl, 50);
+    Value* shl46 = buildShift(Shl, 46);
+    Value* shl23 = buildShift(Shl, 23);
+    Value* xor0 = root->appendNew<Value>(proc, BitXor, Origin(), zshr14, zshr18);
+    Value* xor1 = root->appendNew<Value>(proc, BitXor, Origin(), xor0, zshr41);
+    Value* xor2 = root->appendNew<Value>(proc, BitXor, Origin(), xor1, shl50);
+    Value* xor3 = root->appendNew<Value>(proc, BitXor, Origin(), xor2, shl46);
+    Value* xor4 = root->appendNew<Value>(proc, BitXor, Origin(), xor3, shl23);
+    root->appendNewControlValue(proc, Return, Origin(), xor4);
+
+    int64_t expected = rotateRight(valueInt, 14) ^ rotateRight(valueInt, 18) ^ rotateRight(valueInt, 41);
+    CHECK_EQ(compileAndRun<int64_t>(proc, valueInt), expected);
+}
+
+// SHA-256 lowercase sigma0 pattern: (x >>> 7) ^ (x >>> 18) ^ (x >>> 3) ^ (x << 25) ^ (x << 14)
+// Pairs: (>>>7, <<25), (>>>18, <<14). The lone (>>>3) stays as a raw shift.
+// Verifies that the fold only consumes matching halves and leaves unrelated shifts alone.
+void testRotRFromShiftXorChainSHA256sigma0_32(int32_t valueInt)
+{
+    Procedure proc;
+    BasicBlock* root = proc.addBlock();
+    auto arguments = cCallArgumentValues<int32_t>(proc, root);
+
+    Value* x = arguments[0];
+    auto buildShift = [&](B3::Opcode op, int32_t amt) -> Value* {
+        Value* amount = root->appendIntConstant(proc, Origin(), Int32, amt);
+        return root->appendNew<Value>(proc, op, Origin(), x, amount);
+    };
+    Value* zshr7 = buildShift(ZShr, 7);
+    Value* zshr18 = buildShift(ZShr, 18);
+    Value* zshr3 = buildShift(ZShr, 3);
+    Value* shl25 = buildShift(Shl, 25);
+    Value* shl14 = buildShift(Shl, 14);
+    Value* xor0 = root->appendNew<Value>(proc, BitXor, Origin(), zshr7, zshr18);
+    Value* xor1 = root->appendNew<Value>(proc, BitXor, Origin(), xor0, zshr3);
+    Value* xor2 = root->appendNew<Value>(proc, BitXor, Origin(), xor1, shl25);
+    Value* xor3 = root->appendNew<Value>(proc, BitXor, Origin(), xor2, shl14);
+    root->appendNewControlValue(proc, Return, Origin(), xor3);
+
+    int32_t expected = rotateRight(valueInt, 7) ^ rotateRight(valueInt, 18) ^ (static_cast<uint32_t>(valueInt) >> 3);
+    CHECK_EQ(compileAndRun<int32_t>(proc, valueInt), expected);
+}
+
+// BitOr analogue of the SHA-256 Sigma1 pattern for Int32:
+//   (x >>> 6) | (x >>> 11) | (x >>> 25) | (x << 26) | (x << 21) | (x << 7)
+// Each rotate pair has non-overlapping bits, so OR is equivalent to XOR here.
+// Exercises the BitOr path of the multi-leaf handling in
+// OptimizeAssociativeExpressionTrees::optimizeRootedTree.
+void testRotRFromShiftOrChainSHA256Sigma1_32(int32_t valueInt)
+{
+    Procedure proc;
+    BasicBlock* root = proc.addBlock();
+    auto arguments = cCallArgumentValues<int32_t>(proc, root);
+
+    Value* x = arguments[0];
+    auto buildShift = [&](B3::Opcode op, int32_t amt) -> Value* {
+        Value* amount = root->appendIntConstant(proc, Origin(), Int32, amt);
+        return root->appendNew<Value>(proc, op, Origin(), x, amount);
+    };
+    Value* zshr6 = buildShift(ZShr, 6);
+    Value* zshr11 = buildShift(ZShr, 11);
+    Value* zshr25 = buildShift(ZShr, 25);
+    Value* shl26 = buildShift(Shl, 26);
+    Value* shl21 = buildShift(Shl, 21);
+    Value* shl7 = buildShift(Shl, 7);
+    Value* or0 = root->appendNew<Value>(proc, BitOr, Origin(), zshr6, zshr11);
+    Value* or1 = root->appendNew<Value>(proc, BitOr, Origin(), or0, zshr25);
+    Value* or2 = root->appendNew<Value>(proc, BitOr, Origin(), or1, shl26);
+    Value* or3 = root->appendNew<Value>(proc, BitOr, Origin(), or2, shl21);
+    Value* or4 = root->appendNew<Value>(proc, BitOr, Origin(), or3, shl7);
+    root->appendNewControlValue(proc, Return, Origin(), or4);
+
+    int32_t expected = rotateRight(valueInt, 6) | rotateRight(valueInt, 11) | rotateRight(valueInt, 25);
+    CHECK_EQ(compileAndRun<int32_t>(proc, valueInt), expected);
+}
+
+// Use-count safety: when a shift Value inside the XOR/OR tree is ALSO used by an
+// external consumer, the fold must not mutate that shift. It can only replace
+// the pointer inside its local leaf vector. Here Shl(x, 26) is used both inside
+// the SHA-256 Sigma1 chain and as an operand of the outer Add, so its useCount
+// is >= 2 and the original Shl must survive.
+void testRotRFromShiftXorChainSharedShiftOperand(int32_t valueInt)
+{
+    Procedure proc;
+    BasicBlock* root = proc.addBlock();
+    auto arguments = cCallArgumentValues<int32_t>(proc, root);
+
+    Value* x = arguments[0];
+    auto buildShift = [&](B3::Opcode op, int32_t amt) -> Value* {
+        Value* amount = root->appendIntConstant(proc, Origin(), Int32, amt);
+        return root->appendNew<Value>(proc, op, Origin(), x, amount);
+    };
+    Value* zshr6 = buildShift(ZShr, 6);
+    Value* zshr11 = buildShift(ZShr, 11);
+    Value* zshr25 = buildShift(ZShr, 25);
+    Value* shl26 = buildShift(Shl, 26);
+    Value* shl21 = buildShift(Shl, 21);
+    Value* shl7 = buildShift(Shl, 7);
+    Value* xor0 = root->appendNew<Value>(proc, BitXor, Origin(), zshr6, zshr11);
+    Value* xor1 = root->appendNew<Value>(proc, BitXor, Origin(), xor0, zshr25);
+    Value* xor2 = root->appendNew<Value>(proc, BitXor, Origin(), xor1, shl26);
+    Value* xor3 = root->appendNew<Value>(proc, BitXor, Origin(), xor2, shl21);
+    Value* xor4 = root->appendNew<Value>(proc, BitXor, Origin(), xor3, shl7);
+    // shl26 is used twice: once inside the XOR chain, once as an Add operand.
+    root->appendNewControlValue(proc, Return, Origin(),
+        root->appendNew<Value>(proc, Add, Origin(), xor4, shl26));
+
+    int32_t sigma1 = rotateRight(valueInt, 6) ^ rotateRight(valueInt, 11) ^ rotateRight(valueInt, 25);
+    int32_t expected = static_cast<int32_t>(sigma1 + (static_cast<uint32_t>(valueInt) << 26));
+    CHECK_EQ(compileAndRun<int32_t>(proc, valueInt), expected);
+}
+
+// Negative test: two shifts on DIFFERENT base values must NOT be folded into a rotate.
+// This exists to guard against accidental matches when the fold is extended; the
+// computed value depends on the distinction between x and y.
+void testShiftOrDifferentBasesNoRotate(int32_t xValue, int32_t yValue, int32_t shift)
+{
+    constexpr uint32_t width = 32;
+    uint32_t normalizedShift = static_cast<uint32_t>(shift) % width;
+    if (normalizedShift == 0)
+        return;
+
+    Procedure proc;
+    BasicBlock* root = proc.addBlock();
+    auto arguments = cCallArgumentValues<int32_t, int32_t>(proc, root);
+
+    Value* x = arguments[0];
+    Value* y = arguments[1];
+    Value* shlAmount = root->appendIntConstant(proc, Origin(), Int32, width - normalizedShift);
+    Value* zshrAmount = root->appendIntConstant(proc, Origin(), Int32, normalizedShift);
+    Value* shl = root->appendNew<Value>(proc, Shl, Origin(), x, shlAmount);
+    Value* zshr = root->appendNew<Value>(proc, ZShr, Origin(), y, zshrAmount);
+    root->appendNewControlValue(proc, Return, Origin(),
+        root->appendNew<Value>(proc, BitOr, Origin(), shl, zshr));
+
+    int32_t expected = static_cast<int32_t>(
+        (static_cast<uint32_t>(xValue) << (width - normalizedShift))
+        | (static_cast<uint32_t>(yValue) >> normalizedShift));
+    CHECK_EQ(compileAndRun<int32_t>(proc, xValue, yValue), expected);
+}
+
+// Shifts whose amounts do not sum to the type width must NOT be folded into a rotate.
+void testShiftOrMismatchedAmountsNoRotate(int32_t valueInt)
+{
+    Procedure proc;
+    BasicBlock* root = proc.addBlock();
+    auto arguments = cCallArgumentValues<int32_t>(proc, root);
+
+    Value* value = arguments[0];
+    // N + M = 5 + 10 = 15, not 32 - so this is NOT a rotate.
+    Value* shlAmount = root->appendIntConstant(proc, Origin(), Int32, 5);
+    Value* zshrAmount = root->appendIntConstant(proc, Origin(), Int32, 10);
+    Value* shl = root->appendNew<Value>(proc, Shl, Origin(), value, shlAmount);
+    Value* zshr = root->appendNew<Value>(proc, ZShr, Origin(), value, zshrAmount);
+    root->appendNewControlValue(proc, Return, Origin(),
+        root->appendNew<Value>(proc, BitOr, Origin(), shl, zshr));
+
+    int32_t expected = static_cast<int32_t>(
+        (static_cast<uint32_t>(valueInt) << 5) | (static_cast<uint32_t>(valueInt) >> 10));
+    CHECK_EQ(compileAndRun<int32_t>(proc, valueInt), expected);
 }
 
 template<typename T>
@@ -760,6 +1045,20 @@ void run(const TestConfig* config)
     RUN_BINARY(testRotRWithImmShift, int64Operands(), int32Operands());
     RUN_BINARY(testRotLWithImmShift, int32Operands(), int32Operands());
     RUN_BINARY(testRotLWithImmShift, int64Operands(), int32Operands());
+
+    RUN_BINARY(testRotRFromShiftOr<int32_t>, int32Operands(), int32Operands());
+    RUN_BINARY(testRotRFromShiftOr<int64_t>, int64Operands(), int32Operands());
+    RUN_BINARY(testRotRFromShiftXor<int32_t>, int32Operands(), int32Operands());
+    RUN_BINARY(testRotRFromShiftXor<int64_t>, int64Operands(), int32Operands());
+    RUN_BINARY(testRotRFromShiftXorReversed<int32_t>, int32Operands(), int32Operands());
+    RUN_BINARY(testRotRFromShiftXorReversed<int64_t>, int64Operands(), int32Operands());
+    RUN_UNARY(testRotRFromShiftXorChainSHA256Sigma1_32, int32Operands());
+    RUN_UNARY(testRotRFromShiftXorChainSHA512Sigma1_64, int64Operands());
+    RUN_UNARY(testRotRFromShiftXorChainSHA256sigma0_32, int32Operands());
+    RUN_UNARY(testRotRFromShiftOrChainSHA256Sigma1_32, int32Operands());
+    RUN_UNARY(testRotRFromShiftXorChainSharedShiftOperand, int32Operands());
+    RUN_TERNARY(testShiftOrDifferentBasesNoRotate, int32Operands(), int32Operands(), int32Operands());
+    RUN_UNARY(testShiftOrMismatchedAmountsNoRotate, int32Operands());
 
     RUN(testComputeDivisionMagic<int32_t>(2, -2147483647, 0));
     RUN(testTrivialInfiniteLoop());


### PR DESCRIPTION
#### 334233564d5f16fee1f4de3a35b5e358552138fb
<pre>
[JSC] Optimize bit-rotate idiom in B3
<a href="https://bugs.webkit.org/show_bug.cgi?id=313718">https://bugs.webkit.org/show_bug.cgi?id=313718</a>
<a href="https://rdar.apple.com/175920259">rdar://175920259</a>

Reviewed by Yijia Huang and Keith Miller.

JavaScript does not have bit-rotate operation. If you would like to do
bit-rotate, then you need to write either,

    (z &lt;&lt; (32 - N)) | (z &gt;&gt;&gt; N)
    (z &lt;&lt; (32 - N)) ^ (z &gt;&gt;&gt; N)

While the above is performing multiple arithmetic operations, the intent
is &quot;rotate-to-right N&quot;. This patch detects it in B3 and optimize it in
two places.

1. B3ReduceStrength simply detects the leaf pattern of the above and
   transform it to rotate-to-right.
2. More complicated case is tree of them. For example,
   (z &lt;&lt; (32 - N)) ^ (z &gt;&gt;&gt; M) ^ (z &lt;&lt; (32 - M)) ^ (z &gt;&gt;&gt; N) ...
   Optimizing it in B3 reduce strength needs to traverse children in
   upward and it makes reduce-strength loop much more costly. Thus we
   do this in the appropriate phase: B3OptimizeAssociativeExpressionTrees.
   B3OptimizeAssociativeExpressionTrees detects the tree of associative
   expression (BitXor, BitOr, Add etc.) and attempt to optimize them by
   combining constants. When we construct a tree for BitOr / BitXor, we
   check leaves and attempt to fold a pattern

        (z &lt;&lt; (32 - N)) | (z &gt;&gt;&gt; N)
        (z &lt;&lt; (32 - N)) ^ (z &gt;&gt;&gt; N)

   and replace leaf with rotate-to-right when we detect this.

Test: Source/JavaScriptCore/b3/testb3_1.cpp

* Source/JavaScriptCore/b3/B3OptimizeAssociativeExpressionTrees.cpp:
(JSC::B3::OptimizeAssociativeExpressionTrees::optimizeRootedTree):
* Source/JavaScriptCore/b3/B3ReduceStrength.cpp:
* Source/JavaScriptCore/b3/testb3.h:
* Source/JavaScriptCore/b3/testb3_1.cpp:
(testRotLWithImmShift):
(testRotRFromShiftOr):
(testRotRFromShiftXor):
(testRotRFromShiftXorReversed):
(testRotRFromShiftXorChainSHA256Sigma1_32):
(testRotRFromShiftXorChainSHA512Sigma1_64):
(testRotRFromShiftXorChainSHA256sigma0_32):
(testRotRFromShiftOrChainSHA256Sigma1_32):
(testRotRFromShiftXorChainSharedShiftOperand):
(testShiftOrDifferentBasesNoRotate):
(testShiftOrMismatchedAmountsNoRotate):
(run):

Canonical link: <a href="https://commits.webkit.org/312388@main">https://commits.webkit.org/312388@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/81528091e54d445a32ca3181788d841bc4c83410

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/159676 "13 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/33143 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/26250 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/168528 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/114057 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/1398447a-640c-430e-a033-f228700ef34f) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/33248 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/33147 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/123717 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/86821 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/162634 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/25978 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/143418 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/104364 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/7ed3f703-4d4c-48d8-8f41-cf63bd758f3e) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/25029 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/23496 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/16295 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/151732 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/134721 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/21190 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/171019 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/20513 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/17044 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/22824 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/131959 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/32822 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/27573 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/132033 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/32807 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/142984 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/90889 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/24317 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/26656 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/19797 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/191960 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/32316 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/98712 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/49365 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/31813 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/32060 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/31964 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->