### PR TITLE
Use StaticStringImpl for CSS property names and value keywords to avoid heap allocations

### DIFF
--- a/Source/WTF/wtf/text/StringImpl.h
+++ b/Source/WTF/wtf/text/StringImpl.h
@@ -412,6 +412,7 @@ public:
         template<unsigned characterCount> explicit constexpr StaticStringImpl(const char16_t (&characters)[characterCount], StringKind = StringNormal);
         operator StringImpl&();
         operator const StringImpl&() const;
+        ASCIILiteral literal() const { return ASCIILiteral::fromLiteralUnsafe(m_data8Char); }
     };
 
     WTF_EXPORT_PRIVATE static StaticStringImpl s_emptyAtomString;

--- a/Source/WebCore/css/scripts/process-css-properties.py
+++ b/Source/WebCore/css/scripts/process-css-properties.py
@@ -3512,11 +3512,12 @@ class GenerateCSSPropertyNames:
         to.write("};")
         to.newline()
 
-        all_property_name_strings = quote_iterable((f"{property.name}" for property in self.properties_and_descriptors.all_unique), suffix="_s,")
-        to.write(f"constexpr ASCIILiteral propertyNameStrings[numCSSProperties] = {{")
+        property_count = len(self.properties_and_descriptors.all_unique)
+        to.write(f"static constexpr std::array<StringImpl::StaticStringImpl, {property_count}> propertyNameData = {{{{")
         with to.indent():
-            to.write_lines(all_property_name_strings)
-        to.write("};")
+            for property in self.properties_and_descriptors.all_unique:
+                to.write(f'StringImpl::StaticStringImpl("{property.name}", StringImpl::StringAtom),')
+        to.write("}};")
         to.newline()
 
         to.write("%}")
@@ -3583,7 +3584,7 @@ class GenerateCSSPropertyNames:
                 unsigned index = id - firstCSSProperty;
                 if (index >= numCSSProperties)
                     return { };
-                return propertyNameStrings[index];
+                return propertyNameData[index].literal();
             }
 
             const AtomString& nameString(CSSPropertyID id)
@@ -3597,7 +3598,7 @@ class GenerateCSSPropertyNames:
                 static NeverDestroyed<std::array<AtomString, numCSSProperties>> atomStrings;
                 auto& string = atomStrings.get()[index];
                 if (string.isNull())
-                    string = propertyNameStrings[index];
+                    string = propertyNameData[index];
                 return string;
             }
 

--- a/Source/WebCore/css/scripts/process-css-values.py
+++ b/Source/WebCore/css/scripts/process-css-values.py
@@ -164,9 +164,11 @@ class GenerationContext:
             #include "config.h"
             #include "CSSValueKeywords.h"
 
+            #include <array>
             #include <wtf/ASCIICType.h>
             #include <wtf/NeverDestroyed.h>
             #include <wtf/text/AtomString.h>
+            #include <wtf/text/StringImpl.h>
             #include <string.h>
 
             WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
@@ -210,22 +212,23 @@ class GenerationContext:
         to.write("%%\n")
 
     def _generate_name_string_tables(self, *, to):
-        to.write(f"constexpr ASCIILiteral valueList[] = {{\n")
-        to.write(f"    \"\"_s,\n")
+        value_count = len(self.values) + 2
+        to.write(f"static constexpr std::array<StringImpl::StaticStringImpl, {value_count}> valueData = {{{{\n")
+        to.write(f"    StringImpl::StaticStringImpl(\"\", StringImpl::StringAtom),\n")
 
         for value in self.values:
-            to.write(f"    \"{value.name}\"_s,\n")
+            to.write(f"    StringImpl::StaticStringImpl(\"{value.name}\", StringImpl::StringAtom),\n")
 
-        to.write(f"    ASCIILiteral()\n")
-        to.write(f"}};\n")
-        to.write(f"constexpr ASCIILiteral valueListForSerialization[] = {{\n")
-        to.write(f"    \"\"_s,\n")
+        to.write(f"    StringImpl::StaticStringImpl(\"\", StringImpl::StringAtom)\n")
+        to.write(f"}}}};\n")
+        to.write(f"static constexpr std::array<StringImpl::StaticStringImpl, {value_count}> valueDataForSerialization = {{{{\n")
+        to.write(f"    StringImpl::StaticStringImpl(\"\", StringImpl::StringAtom),\n")
 
         for value in self.values:
-            to.write(f"    \"{value.name_lowercase}\"_s,\n")
+            to.write(f"    StringImpl::StaticStringImpl(\"{value.name_lowercase}\", StringImpl::StringAtom),\n")
 
-        to.write(f"    ASCIILiteral()\n")
-        to.write(f"}};\n")
+        to.write(f"    StringImpl::StaticStringImpl(\"\", StringImpl::StringAtom)\n")
+        to.write(f"}}}};\n")
 
     def _generate_lookup_functions(self, *, to):
         to.write(textwrap.dedent("""
@@ -239,7 +242,7 @@ class GenerationContext:
             {
                 if (static_cast<uint16_t>(id) >= numCSSValueKeywords)
                     return { };
-                return valueList[id];
+                return valueData[id].literal();
             }
 
             // When serializing a CSS keyword, it should be converted to ASCII lowercase.
@@ -248,7 +251,7 @@ class GenerationContext:
             {
                 if (static_cast<uint16_t>(id) >= numCSSValueKeywords)
                     return { };
-                return valueListForSerialization[id];
+                return valueDataForSerialization[id].literal();
             }
 
             const AtomString& nameString(CSSValueID id)
@@ -259,7 +262,7 @@ class GenerationContext:
                 static NeverDestroyed<std::array<AtomString, numCSSValueKeywords>> strings;
                 auto& string = strings.get()[id];
                 if (string.isNull())
-                    string = valueList[id];
+                    string = valueData[id];
                 return string;
             }
 
@@ -273,7 +276,7 @@ class GenerationContext:
                 static NeverDestroyed<std::array<AtomString, numCSSValueKeywords>> strings;
                 auto& string = strings.get()[id];
                 if (string.isNull())
-                    string = valueListForSerialization[id];
+                    string = valueDataForSerialization[id];
                 return string;
             }
 


### PR DESCRIPTION
#### f6d1f488ddcb07a5f54796920b5a5c4358fef24c
<pre>
Use StaticStringImpl for CSS property names and value keywords to avoid heap allocations
<a href="https://bugs.webkit.org/show_bug.cgi?id=313722">https://bugs.webkit.org/show_bug.cgi?id=313722</a>

Reviewed by Sam Weinig.

Similarly to what was done for EventNames in 312329@main, use
static constexpr StaticStringImpl with the StringAtom flag for CSS property
names (~589 strings) and CSS value keywords (~2 x 1301 strings). When nameString()
constructs an AtomString from a StaticStringImpl with StringAtom, the isAtom()
fast path returns the static pointer directly, avoiding heap allocation and
runtime hash computation.

Also added a literal() getter on StaticStringImpl to cleanly convert back to
ASCIILiteral, used by nameLiteral() functions.

* Source/WTF/wtf/text/StringImpl.h:
(WTF::StringImpl::StaticStringImpl::literal const):
* Source/WebCore/css/scripts/process-css-properties.py:
(GenerateCSSPropertyNames._generate_css_property_names_gperf_prelude):
(GenerateCSSPropertyNames):
* Source/WebCore/css/scripts/process-css-values.py:
(GenerationContext._generate_css_value_keywords_gperf_heading):
(GenerationContext):

Canonical link: <a href="https://commits.webkit.org/312580@main">https://commits.webkit.org/312580@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8148412234c2af6801f2da88d43416ea2d138493

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/159934 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/33402 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/26508 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/168807 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/114315 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/3a34a8cf-02c5-405e-bbef-1c562bed6100) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/161803 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/33506 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/33406 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/123953 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/86940 "1 flakes 9 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/250aad0b-5699-4bf0-bded-7d943efdb5cd) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/162892 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/26208 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/143653 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/104572 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/202a97ac-0951-4bd1-a4fd-7358780d57eb) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/25260 "Passed tests") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/23842 "Found 1 new API test failure: TestWebKitAPI.WKBackForwardList.BackForwardNavigationSkipsItemsWithoutUserGestureFragment (failure)") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/16555 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/151990 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/134952 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/21423 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/171293 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/20771 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/17302 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/23061 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/132219 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/33080 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/27816 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/132246 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35850 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/33065 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/143218 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/91203 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/26865 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/20031 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/192218 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/32574 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/98971 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/49429 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/32071 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/32318 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/32222 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->