### PR TITLE
Revert workaround for Swift pointee issue

### DIFF
--- a/Source/WebKit/Modules/Internal/module.modulemap
+++ b/Source/WebKit/Modules/Internal/module.modulemap
@@ -291,15 +291,8 @@ module WebKit_Internal [system] {
         export *
     }
 
-    module IPCTesterReceiver {
-        requires cplusplus20
-        header "../../Shared/IPCTesterReceiver.h"
-        export *
-    }
-
     module ModelTypes {
         header "../../GPUProcess/graphics/Model/ModelTypes.h"
-        export *
         requires objc
     }
 

--- a/Source/WebKit/Shared/IPCTesterReceiver.h
+++ b/Source/WebKit/Shared/IPCTesterReceiver.h
@@ -55,16 +55,3 @@ private:
 }
 
 #endif
-
-#if ENABLE(IPC_TESTING_API) && ENABLE(IPC_TESTING_SWIFT)
-
-#include "IPCTesterReceiverMessages.h"
-
-// Workaround for rdar://170233903
-// The Swift call can be replaced with fn.pointee(args) when this is fixed
-inline void callFunction(CompletionHandlers::IPCTesterReceiver::AsyncMessageCompletionHandler& fn, uint32_t value)
-{
-    (*fn)(value);
-}
-
-#endif

--- a/Source/WebKit/Shared/IPCTesterReceiver.swift
+++ b/Source/WebKit/Shared/IPCTesterReceiver.swift
@@ -43,7 +43,7 @@ final class IPCTesterReceiver {
     }
 
     func asyncMessage(data: UInt32, completionHandler: CompletionHandlers.IPCTesterReceiver.AsyncMessageCompletionHandler) {
-        callFunction(completionHandler, data + 2)
+        completionHandler.pointee(data + 2)
     }
 }
 

--- a/Source/WebKit/UIProcess/WebBackForwardList.swift
+++ b/Source/WebKit/UIProcess/WebBackForwardList.swift
@@ -622,7 +622,7 @@ final class WebBackForwardList {
         }
 
         for (i, entry) in entries.enumerated() {
-            if filterSpecified(filter) && !callFilter(filter, entry) {
+            if filter.pointee.__convertToBool() && !filter.pointee(entry) {
                 if let stateCurrentIndex = Optional(fromCxx: backForwardListState.currentIndex) {
                     if i <= stateCurrentIndex && stateCurrentIndex != 0 {
                         setOptionalUInt32Value(&backForwardListState.currentIndex, stateCurrentIndex - 1)
@@ -666,7 +666,7 @@ final class WebBackForwardList {
     }
 
     func setItemsAsRestoredFromSessionIf(functor: WebBackForwardListItemFilter) {
-        for entry in entries where callFilter(functor, entry) {
+        for entry in entries where functor.pointee(entry) {
             entry.setWasRestoredFromSession()
         }
     }
@@ -1052,7 +1052,7 @@ final class WebBackForwardList {
         // value. Since the load is really going on in a new provisional process, we want to ignore such requests from the committed process.
         // Any real new load in the committed process would have cleared m_provisionalPage.
         if let webPageProxy = page.get(), webPageProxy.hasProvisionalPage() {
-            callCompletionHandler(completionHandler, consuming: counts())
+            completionHandler.pointee(consuming: counts())
             return
         }
 
@@ -1063,7 +1063,7 @@ final class WebBackForwardList {
         itemID: WebCore.BackForwardItemIdentifier,
         completionHandler: CompletionHandlers.WebBackForwardList.BackForwardListContainsItemCompletionHandler
     ) {
-        callCompletionHandler(completionHandler, itemForID(identifier: itemID) != nil)
+        completionHandler.pointee(itemForID(identifier: itemID) != nil)
     }
 
     func backForwardGoToItemShared(
@@ -1073,7 +1073,7 @@ final class WebBackForwardList {
         if let webPageProxy = page.get() {
             if messageCheckCompletion(
                 process: WebKit.RefWebProcessProxy(webPageProxy.legacyMainFrameProcess()),
-                completionHandler: { callCompletionHandler(completionHandler, consuming: counts()) },
+                completionHandler: { completionHandler.pointee(consuming: counts()) },
                 !WebKit.isInspectorPage(webPageProxy)
             ) {
                 return
@@ -1084,7 +1084,7 @@ final class WebBackForwardList {
             goToItem(item: item)
         }
 
-        callCompletionHandler(completionHandler, consuming: counts())
+        completionHandler.pointee(consuming: counts())
     }
 
     func backForwardAllItems(
@@ -1097,7 +1097,7 @@ final class WebBackForwardList {
                 frameStates.append(frameItem.copyFrameStateWithChildren().ptr())
             }
         }
-        callCompletionHandler(completionHandler, consuming: WebKit.VectorRefFrameState(array: frameStates))
+        completionHandler.pointee(consuming: WebKit.VectorRefFrameState(array: frameStates))
     }
 
     func backForwardItemAtIndexForWebContent(
@@ -1108,18 +1108,18 @@ final class WebBackForwardList {
         // FIXME: This should verify that the web process requesting the item hosts the specified frame.
         let delta = Int(delta)
         guard let item = itemAtDeltaFromCurrentIndex(delta: delta, allowSkipping: false) else {
-            callCompletionHandler(completionHandler, consuming: WebKit.RefPtrFrameState())
+            completionHandler.pointee(consuming: WebKit.RefPtrFrameState())
             return
         }
         guard let frameItem = item.mainFrameItem().childItemForFrameID(frameID) else {
-            callCompletionHandler(completionHandler, consuming: WebKit.RefPtrFrameState(item.copyMainFrameStateWithChildren().ptr()))
+            completionHandler.pointee(consuming: WebKit.RefPtrFrameState(item.copyMainFrameStateWithChildren().ptr()))
             return
         }
-        callCompletionHandler(completionHandler, consuming: WebKit.RefPtrFrameState(frameItem.copyFrameStateWithChildren().ptr()))
+        completionHandler.pointee(consuming: WebKit.RefPtrFrameState(frameItem.copyFrameStateWithChildren().ptr()))
     }
 
     func backForwardListCounts(completionHandler: CompletionHandlers.WebBackForwardList.BackForwardListCountsCompletionHandler) {
-        callCompletionHandler(completionHandler, consuming: counts())
+        completionHandler.pointee(consuming: counts())
     }
 }
 

--- a/Source/WebKit/UIProcess/WebBackForwardListSwiftUtilities.h
+++ b/Source/WebKit/UIProcess/WebBackForwardListSwiftUtilities.h
@@ -26,7 +26,6 @@
 #pragma once
 
 #include "Logging.h"
-#include "SessionState.h"
 #include "WebBackForwardListFrameItem.h"
 #include "WebBackForwardListItem.h"
 #include "WebBackForwardListMessages.h"
@@ -67,33 +66,6 @@ inline void setOptionalUInt32Value(std::optional<uint32_t>& optional, uint32_t v
 }
 
 using WebBackForwardListItemFilter = WTF::RefCountable<WTF::Function<bool (WebKit::WebBackForwardListItem&)>>;
-
-// Workaround for rdar://170233903
-// In each case the Swift call can be replaced with fn.pointee(args) when this is fixed
-inline bool callFilter(WebBackForwardListItemFilter& fn, WebKit::WebBackForwardListItem& item)
-{
-    return (*fn)(item);
-}
-inline void callCompletionHandler(CompletionHandlers::WebBackForwardList::BackForwardGoToItemCompletionHandler& fn, WebKit::WebBackForwardListCounts&& counts)
-{
-    (*fn)(WTF::move(counts));
-}
-inline void callCompletionHandler(CompletionHandlers::WebBackForwardList::BackForwardListContainsItemCompletionHandler& fn, bool found)
-{
-    (*fn)(found);
-}
-inline void callCompletionHandler(CompletionHandlers::WebBackForwardList::BackForwardAllItemsCompletionHandler& fn, WebKit::VectorRefFrameState&& items)
-{
-    (*fn)(WTF::move(items));
-}
-inline void callCompletionHandler(CompletionHandlers::WebBackForwardList::BackForwardItemAtIndexForWebContentCompletionHandler& fn, WebKit::RefPtrFrameState&& state)
-{
-    (*fn)(WTF::move(state));
-}
-inline bool filterSpecified(WebBackForwardListItemFilter& fn)
-{
-    return bool(*fn);
-}
 
 // Workaround for rdar://168057355
 inline WebKit::FrameState* getFrameState(WebKit::WebBackForwardListFrameItem& item)


### PR DESCRIPTION
#### 8573d9185f1b0093da7f0c4d1569ad3969276c03
<pre>
Revert workaround for Swift pointee issue
<a href="https://bugs.webkit.org/show_bug.cgi?id=313724">https://bugs.webkit.org/show_bug.cgi?id=313724</a>
<a href="https://rdar.apple.com/175925699">rdar://175925699</a>

Reviewed by Richard Robinson.

This reverts a workaround which was added for a temporary Swift compiler bug.

Canonical link: <a href="https://commits.webkit.org/312901@main">https://commits.webkit.org/312901@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a46ee2a3a830965d157ad37af878640eb82b05c7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/159689 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/33156 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/26263 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/168542 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/114070 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/1505112e-c635-4e54-8dd6-64e82a6affcc) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/33261 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/33160 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/123728 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/86825 "1 flakes 9 failures") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/162647 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/25991 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/143423 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/104374 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/25042 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/23510 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/16309 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/134734 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/171035 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/17057 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/22829 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/131973 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/32835 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/27586 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/132044 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36066 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/32820 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/142989 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/90902 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/26664 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/19802 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/32329 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/98725 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/31826 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/32073 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/31977 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->