### PR TITLE
Re-import moveBefore() tests

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/moveBefore/moveBefore-id-map-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/moveBefore/moveBefore-id-map-expected.txt
@@ -1,0 +1,3 @@
+
+FAIL moveBefore() correctly updates id map assert_equals: expected Element node <span id="target" data-span=""></span> but got Element node <div id="target" data-target=""></div>
+

--- a/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/moveBefore/moveBefore-id-map.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/moveBefore/moveBefore-id-map.html
@@ -1,0 +1,27 @@
+<!-- webkit-test-runner [ MoveBeforeEnabled=true ] -->
+<!DOCTYPE html>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<body>
+  <div id="container"></div>
+  <div id="target" data-target></div>
+  <span id="target" data-span></span>
+</body>
+
+<script>
+  test(() => {
+      let shadowRoot = container.attachShadow({mode: "open"});
+      let div = document.createElement("div");
+      shadowRoot.appendChild(div);
+      let target = document.querySelector('[data-target]');
+
+      assert_equals(document.getElementById("target"), target);
+      assert_equals(shadowRoot.getElementById("target"), null);
+
+      div.moveBefore(target, null);
+
+      assert_equals(document.getElementById("target"), document.querySelector('[data-span]'));
+      assert_equals(shadowRoot.getElementById("target"), target);
+  }, 'moveBefore() correctly updates id map');
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/moveBefore/moveBefore-name-map-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/moveBefore/moveBefore-name-map-expected.txt
@@ -1,0 +1,4 @@
+
+
+FAIL moveBefore() correctly updates name map assert_equals: expected (undefined) undefined but got (object) Element node <img name="target" data-target=""></img>
+

--- a/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/moveBefore/moveBefore-name-map.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/moveBefore/moveBefore-name-map.html
@@ -1,0 +1,30 @@
+<!-- webkit-test-runner [ MoveBeforeEnabled=true ] -->
+<!DOCTYPE html>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<body>
+  <div id="container"></div>
+  <img name="target" data-target>
+</body>
+
+<script>
+  test(() => {
+      let shadowRoot = container.attachShadow({mode: "open"});
+      let div = document.createElement("div");
+      shadowRoot.appendChild(div);
+
+      let target = document.querySelector('[data-target]');
+
+      assert_equals(window.target, target);
+      let nameMap = document.getElementsByName("target");
+      assert_equals(nameMap.length, 1);
+      assert_equals(nameMap[0], target);
+
+      div.moveBefore(target, null);
+
+      assert_equals(window.target, undefined);
+      nameMap = document.getElementsByName("target");
+      assert_equals(nameMap.length, 0);
+  }, 'moveBefore() correctly updates name map');
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/moveBefore/script-move-before-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/moveBefore/script-move-before-expected.txt
@@ -1,0 +1,5 @@
+ window.__ranHTMLInsideMoveBefore = true; window.__ranSVGInsideMoveBefore = true;
+
+PASS Synchronous script execution in HTMLScriptElement during moveBefore should be blocked
+PASS Synchronous script execution in SVGScriptElement during moveBefore should be blocked
+

--- a/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/moveBefore/script-move-before.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/moveBefore/script-move-before.html
@@ -1,0 +1,36 @@
+<!-- webkit-test-runner [ MoveBeforeEnabled=true ] -->
+<!DOCTYPE html>
+<title>ScriptElement moveBefore synchronous script execution</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<body>
+<script id="htmlScript"></script>
+<svg><script id="svgScript"></script></svg>
+<script>
+  test(() => {
+    const htmlScript = document.getElementById('htmlScript');
+    window.__ranHTMLInsideMoveBefore = false;
+    const textNode = document.createTextNode(`
+      window.__ranHTMLInsideMoveBefore = true;
+    `);
+    document.body.appendChild(textNode);
+
+    htmlScript.moveBefore(textNode, null);
+
+    assert_false(window.__ranHTMLInsideMoveBefore, "<html:script> does not define moving steps which allow script execution.");
+  }, "Synchronous script execution in HTMLScriptElement during moveBefore should be blocked");
+
+  test(() => {
+    const svgScript = document.getElementById('svgScript');
+    window.__ranSVGInsideMoveBefore = false;
+    const textNode = document.createTextNode(`
+      window.__ranSVGInsideMoveBefore = true;
+    `);
+    document.body.appendChild(textNode);
+
+    svgScript.moveBefore(textNode, null);
+
+    assert_false(window.__ranSVGInsideMoveBefore, "<svg:script> does not define moving steps which allow script execution.");
+  }, "Synchronous script execution in SVGScriptElement during moveBefore should be blocked");
+</script>
+</body>

--- a/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/moveBefore/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/moveBefore/w3c-import.log
@@ -48,6 +48,8 @@ List of files:
 /LayoutTests/imported/w3c/web-platform-tests/dom/nodes/moveBefore/moveBefore-as-flex-item-expected.html
 /LayoutTests/imported/w3c/web-platform-tests/dom/nodes/moveBefore/moveBefore-as-flex-item.html
 /LayoutTests/imported/w3c/web-platform-tests/dom/nodes/moveBefore/moveBefore-from-light-to-shadow.html
+/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/moveBefore/moveBefore-id-map.html
+/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/moveBefore/moveBefore-name-map.html
 /LayoutTests/imported/w3c/web-platform-tests/dom/nodes/moveBefore/moveBefore-option-recalc-style.html
 /LayoutTests/imported/w3c/web-platform-tests/dom/nodes/moveBefore/moveBefore-selector-matching.html
 /LayoutTests/imported/w3c/web-platform-tests/dom/nodes/moveBefore/moveBefore-shadow-inside.html
@@ -62,6 +64,7 @@ List of files:
 /LayoutTests/imported/w3c/web-platform-tests/dom/nodes/moveBefore/preserve-render-blocking-script.html
 /LayoutTests/imported/w3c/web-platform-tests/dom/nodes/moveBefore/preserve-render-blocking-style.html
 /LayoutTests/imported/w3c/web-platform-tests/dom/nodes/moveBefore/relevant-mutations.html
+/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/moveBefore/script-move-before.html
 /LayoutTests/imported/w3c/web-platform-tests/dom/nodes/moveBefore/select-option-optgroup.html
 /LayoutTests/imported/w3c/web-platform-tests/dom/nodes/moveBefore/selection-preserve.html
 /LayoutTests/imported/w3c/web-platform-tests/dom/nodes/moveBefore/slotchange-events.html


### PR DESCRIPTION
#### 33021ff8c806b588521b62ff79451d28a90d8dea
<pre>
Re-import moveBefore() tests
<a href="https://bugs.webkit.org/show_bug.cgi?id=313719">https://bugs.webkit.org/show_bug.cgi?id=313719</a>

Reviewed by Tim Nguyen.

Upstream commit: <a href="https://github.com/web-platform-tests/wpt/commit/4fea6ec04258c15019596ae9038dcce189adf70d">https://github.com/web-platform-tests/wpt/commit/4fea6ec04258c15019596ae9038dcce189adf70d</a>

* LayoutTests/imported/w3c/web-platform-tests/dom/nodes/moveBefore/moveBefore-id-map-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/dom/nodes/moveBefore/moveBefore-id-map.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/dom/nodes/moveBefore/moveBefore-name-map-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/dom/nodes/moveBefore/moveBefore-name-map.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/dom/nodes/moveBefore/script-move-before-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/dom/nodes/moveBefore/script-move-before.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/dom/nodes/moveBefore/w3c-import.log:

Canonical link: <a href="https://commits.webkit.org/312369@main">https://commits.webkit.org/312369@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1bc841a3ab5b494acbb9b96ea9f91d32775a0e8a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/159699 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/33166 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/26273 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/168553 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/114080 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/33271 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/33170 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/123742 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/114080 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/162657 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/26002 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/143441 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/104386 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/25053 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/23521 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/16320 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/134745 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/21213 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/171046 "Built successfully") | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/22848 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/131986 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/32845 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/27598 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/132054 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35739 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/32830 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/143007 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/90912 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/26673 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/19820 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/32339 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/31836 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/32083 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/31987 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->