### PR TITLE
ANGLE: Metal: BaseInstanceOverflowTest.BaseInstanceOverflow fails validation

### DIFF
--- a/Source/ThirdParty/ANGLE/src/libANGLE/Caps.h
+++ b/Source/ThirdParty/ANGLE/src/libANGLE/Caps.h
@@ -157,6 +157,10 @@ struct Limitations
     // D3D does not support compressed textures where the base mip level is not a multiple of 4
     bool compressedBaseMipLevelMultipleOfFour = false;
 
+    // True if the underlying API uses `base instance + instance` as its native
+    // instance id representation.
+    bool instanceIdMayOverflow = false;
+
     // An extra limit for WebGL texture size. Ignored if 0.
     GLint webGLTextureSizeLimit = 0;
 

--- a/Source/ThirdParty/ANGLE/src/libANGLE/ErrorStrings.h
+++ b/Source/ThirdParty/ANGLE/src/libANGLE/ErrorStrings.h
@@ -243,6 +243,7 @@ inline constexpr const char *kInsufficientBufferSize = "Insufficient buffer size
 inline constexpr const char *kInsufficientParamCount = "The paramCount is less than the number of returned values.";
 inline constexpr const char *kInsufficientVertexBufferSize = "Vertex buffer is not big enough for the draw call.";
 inline constexpr const char *kIntegerOverflow = "Integer overflow.";
+inline constexpr const char *kInstanceIdOverflow = "Implementation does not support baseinstance + primcount - 1 overflowing GLuint.";
 inline constexpr const char *kInternalError = "Internal error.";
 inline constexpr const char *kInternalErrorFormatNotFound = "Internal error: unknown internal format.";
 inline constexpr const char *kInternalFormatRequiresTexture2D = "internalformat is an ETC1 or PVRTC1 format.";

--- a/Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/DisplayMtl.mm
+++ b/Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/DisplayMtl.mm
@@ -919,6 +919,10 @@ void DisplayMtl::ensureCapsInitialized() const
     // Apple platforms require PVRTC1 textures to be squares.
     mNativeLimitations.squarePvrtc1 = true;
 
+    // MSL `uint32 instance_id = baseInstance + count`, so GLES baseinstance + primcount
+    // must not overflow GLuint.
+    mNativeLimitations.instanceIdMayOverflow = true;
+
     if (mFeatures.disableProgrammableBlending.enabled || !supportsAppleGPUFamily(1))
     {
         const MTLReadWriteTextureTier readWriteTextureTier = [mMetalDevice readWriteTextureSupport];

--- a/Source/ThirdParty/ANGLE/src/libANGLE/validationES.cpp
+++ b/Source/ThirdParty/ANGLE/src/libANGLE/validationES.cpp
@@ -1014,6 +1014,11 @@ bool ValidateDrawElementsInstancedBase(const Context *context,
         return true;
     }
 
+    if (!ValidateDrawInstancedCounts(context, entryPoint, primcount, baseinstance))
+    {
+        return false;
+    }
+
     return ValidateDrawInstancedAttribs(context, entryPoint, primcount, baseinstance);
 }
 
@@ -1046,6 +1051,11 @@ bool ValidateDrawArraysInstancedBase(const Context *context,
     {
         // Early exit.
         return true;
+    }
+
+    if (!ValidateDrawInstancedCounts(context, entryPoint, primcount, baseinstance))
+    {
+        return false;
     }
 
     return ValidateDrawInstancedAttribs(context, entryPoint, primcount, baseinstance);

--- a/Source/ThirdParty/ANGLE/src/libANGLE/validationES.h
+++ b/Source/ThirdParty/ANGLE/src/libANGLE/validationES.h
@@ -922,6 +922,28 @@ ANGLE_INLINE bool ValidateDrawInstancedAttribs(const Context *context,
     return true;
 }
 
+ANGLE_INLINE bool ValidateDrawInstancedCounts(const Context *context,
+                                              angle::EntryPoint entryPoint,
+                                              GLsizei primcount,
+                                              GLuint baseinstance)
+{
+    if (ANGLE_UNLIKELY(!context->getLimitations().instanceIdMayOverflow))
+    {
+        return true;
+    }
+
+    angle::CheckedNumeric<GLuint> checkedSum = baseinstance;
+    checkedSum += primcount - 1;
+
+    if (ANGLE_UNLIKELY(!checkedSum.IsValid()))
+    {
+        ANGLE_VALIDATION_ERROR(GL_INVALID_OPERATION, err::kInstanceIdOverflow);
+        return false;
+    }
+
+    return true;
+}
+
 ANGLE_INLINE bool ValidateDrawArraysCommon(const Context *context,
                                            angle::EntryPoint entryPoint,
                                            PrimitiveMode mode,

--- a/Source/ThirdParty/ANGLE/src/tests/gl_tests/BaseInstanceOverflowTest.cpp
+++ b/Source/ThirdParty/ANGLE/src/tests/gl_tests/BaseInstanceOverflowTest.cpp
@@ -72,9 +72,132 @@ TEST_P(BaseInstanceOverflowTest, BaseInstanceOverflow)
     {
         EXPECT_GL_ERROR(GL_INVALID_OPERATION);
     }
+    else if (isMetalRenderer())
+    {
+        EXPECT_GL_ERROR(GL_INVALID_OPERATION);
+    }
     else
     {
         EXPECT_GL_NO_ERROR();
+    }
+}
+
+// Test that baseinstance + primcount overflow is properly validated for backends that cannot draw
+// large baseInstance + primcount.
+TEST_P(BaseInstanceOverflowTest, BaseInstanceOverflow2)
+{
+    ANGLE_SKIP_TEST_IF(!EnsureGLExtensionEnabled("GL_ANGLE_base_vertex_base_instance"));
+
+    constexpr char kVS[] = R"(
+        attribute vec4 a_position;
+        attribute float a_instanceData;
+        varying float v_data;
+        void main() {
+            gl_Position = a_position;
+            v_data = a_instanceData;
+        })";
+
+    constexpr char kFS[] = R"(
+        precision mediump float;
+        varying float v_data;
+        void main() {
+            gl_FragColor = vec4(0.0, v_data, 0.0, 1.0);
+        })";
+
+    GLProgram program;
+    program.makeRaster(kVS, kFS);
+    ASSERT_TRUE(program.valid());
+    glUseProgram(program);
+
+    GLint posLoc  = glGetAttribLocation(program, "a_position");
+    GLint dataLoc = glGetAttribLocation(program, "a_instanceData");
+    ASSERT_NE(posLoc, -1);
+    ASSERT_NE(dataLoc, -1);
+
+    // Non-instanced position buffer: full-screen triangle.
+    // clang-format off
+    const GLfloat kQuadVerts[] = {
+        -1.0f, -1.0f,
+         3.0f, -1.0f,
+        -1.0f,  3.0f,
+    };
+    // clang-format on
+    GLBuffer posBuffer;
+    glBindBuffer(GL_ARRAY_BUFFER, posBuffer);
+    glBufferData(GL_ARRAY_BUFFER, sizeof(kQuadVerts), kQuadVerts, GL_STATIC_DRAW);
+    glEnableVertexAttribArray(posLoc);
+    glVertexAttribPointer(posLoc, 2, GL_FLOAT, GL_FALSE, 0, nullptr);
+
+    // Instanced attribute setup.
+    // Use a large divisor so that all instances read the same element:
+    //   element index = baseInstance + floor(i / divisor)
+    // With divisor >= primcount, floor(i / divisor) == 0 for all i in [0, primcount-1].
+    // So only element at index baseInstance is accessed.
+    glEnableVertexAttribArray(dataLoc);
+
+    struct Subcase
+    {
+        GLsizei primcount;
+        GLuint baseInstance;
+    };
+
+    // Three subcases:
+    //   small:  5 + 100 = 105, well within GLuint range -> should pass
+    //   medium: 0x7FFFFFFF + 1000 = 0x800003E7, within GLuint range -> should pass
+    //   large:  0xFFFFFF00 + 300 = overflow past GLuint max -> should fail
+    Subcase subcases[] = {
+        {100, 5},
+        {1000, 0x7FFFFFFFu},
+        {300, 0xFFFFFF00u},
+    };
+
+    for (const auto &subcase : subcases)
+    {
+        SCOPED_TRACE(testing::Message() << "primcount: " << subcase.primcount
+                                        << " baseInstance:" << subcase.baseInstance);
+        // Use divisor = primcount so only one element (at baseInstance) is accessed.
+        const GLuint divisor = static_cast<GLuint>(subcase.primcount);
+        glVertexAttribDivisor(dataLoc, divisor);
+
+        // Allocate attribute buffer large enough for the one element at baseInstance.
+        // Size needed: (baseInstance + 1) * sizeof(GLfloat).
+        GLsizeiptr bufSize = (static_cast<GLsizeiptr>(subcase.baseInstance) + 1) * sizeof(GLfloat);
+
+        GLBuffer instBuffer;
+        glBindBuffer(GL_ARRAY_BUFFER, instBuffer);
+        glBufferData(GL_ARRAY_BUFFER, bufSize, nullptr, GL_DYNAMIC_DRAW);
+        ANGLE_SKIP_TEST_IF(glGetError() == GL_OUT_OF_MEMORY);
+
+        // Write 1.0f at element index baseInstance.
+        GLfloat one = 1.0f;
+        glBufferSubData(GL_ARRAY_BUFFER, subcase.baseInstance * sizeof(GLfloat), sizeof(GLfloat),
+                        &one);
+        ASSERT_GL_NO_ERROR();
+
+        glVertexAttribPointer(dataLoc, 1, GL_FLOAT, GL_FALSE, sizeof(GLfloat), nullptr);
+
+        glClearColor(0.0f, 0.0f, 0.0f, 1.0f);
+        glClear(GL_COLOR_BUFFER_BIT);
+        glDrawArraysInstancedBaseInstanceANGLE(GL_TRIANGLES, 0, 3, subcase.primcount,
+                                               subcase.baseInstance);
+
+        const bool expectOverflow =
+            static_cast<uint64_t>(subcase.primcount - 1) + subcase.baseInstance >
+            std::numeric_limits<GLuint>::max();
+        GLenum error = glGetError();
+        if (error == GL_INVALID_OPERATION)
+        {
+            EXPECT_TRUE(expectOverflow);
+        }
+        else
+        {
+            EXPECT_EQ(error, static_cast<GLenum>(GL_NO_ERROR));
+            EXPECT_TRUE(!(isMetalRenderer() && expectOverflow));
+
+            // No overflow; the draw should succeed and produce green.
+            ASSERT_GL_NO_ERROR();
+            EXPECT_PIXEL_COLOR_EQ(0, 0, GLColor::green);
+        }
     }
 }
 

--- a/Source/ThirdParty/ANGLE/src/tests/test_utils/ANGLETest.h
+++ b/Source/ThirdParty/ANGLE/src/tests/test_utils/ANGLETest.h
@@ -592,6 +592,11 @@ class ANGLETestBase : public ::testing::Test
                mCurrentParams->isSwiftshader();
     }
 
+    bool isMetalRenderer() const
+    {
+        return mCurrentParams->getRenderer() == EGL_PLATFORM_ANGLE_TYPE_METAL_ANGLE;
+    }
+
     bool isDriverSystemEgl() const
     {
         return mCurrentParams->driver == angle::GLESDriverType::SystemEGL;


### PR DESCRIPTION
#### d4aae9fc6b343d0c4c66fd30544d288067d250e0
<pre>
ANGLE: Metal: BaseInstanceOverflowTest.BaseInstanceOverflow fails validation
<a href="https://bugs.webkit.org/show_bug.cgi?id=313730">https://bugs.webkit.org/show_bug.cgi?id=313730</a>
<a href="https://rdar.apple.com/175929622">rdar://175929622</a>

Reviewed by Dan Glastonbury.

Metal backend uses the instanced draw commands of Metal directly, passing
baseInstance and count without any emulation.
The language semantics differ:
MSL:  uint instance_id = baseInstance + instance
GLSL: GLuint gl_Instance = instance

Fix the BaseInstanceOverflowTest.BaseInstanceOverflow to not fail
by adding a backend-specific limitation to disallowing such big
baseInstanstance + primcount calls.

* Source/ThirdParty/ANGLE/src/libANGLE/Caps.h:
* Source/ThirdParty/ANGLE/src/libANGLE/ErrorStrings.h:
* Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/DisplayMtl.mm:
(rx::DisplayMtl::ensureCapsInitialized const):
* Source/ThirdParty/ANGLE/src/libANGLE/validationES.cpp:
(gl::ValidateDrawElementsInstancedBase):
(gl::ValidateDrawArraysInstancedBase):
* Source/ThirdParty/ANGLE/src/libANGLE/validationES.h:
(gl::ValidateDrawInstancedCounts):
* Source/ThirdParty/ANGLE/src/tests/gl_tests/BaseInstanceOverflowTest.cpp:
(TEST_P):
* Source/ThirdParty/ANGLE/src/tests/test_utils/ANGLETest.h:
(ANGLETestBase::isMetalRenderer const):

Canonical link: <a href="https://commits.webkit.org/312507@main">https://commits.webkit.org/312507@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4eff73a0509273a4b243bd3f72d28d50f72f90b1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/159706 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/33173 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/26280 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/168560 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/114087 "Built successfully") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/33278 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/33177 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/123746 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/86833 "9 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/566131d3-b153-441e-b24e-c75acf97a772) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/162664 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/26009 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/143449 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/104390 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/25060 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/23528 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/16327 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/134752 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/21221 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/171054 "Built successfully") | | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/22857 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/131995 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/32852 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/27605 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/132060 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35816 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/32837 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/143015 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/90919 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/26681 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/19828 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/32346 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/31843 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/32090 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/31994 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->