### PR TITLE
[Wasm] Use a lazy restore frame when returning from tail calls

### DIFF
--- a/JSTests/wasm/stress/tail-call-cross-instance-gc.js
+++ b/JSTests/wasm/stress/tail-call-cross-instance-gc.js
@@ -1,0 +1,85 @@
+//@ requireOptions("--useWasmTailCalls=true", "--wasmInliningMaximumWasmCalleeSize=0")
+import { instantiate } from "../wabt-wrapper.js"
+import * as assert from "../assert.js"
+
+// Test that GC during a cross-instance tail call chain doesn't corrupt the
+// RestoreInstanceCallee thunk frame. The thunk's Callee slot holds the
+// RestoreInstanceCallee singleton and CodeBlock holds a wasmInstance pointer;
+// both must survive GC scanning.
+
+let watPing = `
+(module
+    (type $pp (func (param i32) (result i32)))
+    (import "t" "table" (table 2 funcref))
+    (memory (export "mem") 1)
+    (data (i32.const 0) "\\2a\\00\\00\\00")
+
+    (func (export "ping") (param i32) (result i32)
+        (if (result i32) (i32.le_s (local.get 0) (i32.const 0))
+            (then (i32.load (i32.const 0)))
+            (else
+                (i32.sub (local.get 0) (i32.const 1))
+                (i32.const 1)
+                (return_call_indirect (type $pp))
+            )
+        )
+    )
+
+    (func (export "start") (param i32) (result i32)
+        (call 0 (local.get 0))
+    )
+)
+`
+
+let watPong = `
+(module
+    (type $pp (func (param i32) (result i32)))
+    (import "t" "table" (table 2 funcref))
+    (import "t" "triggerGC" (func $triggerGC))
+    (memory (export "mem") 1)
+    (data (i32.const 0) "\\ff\\00\\00\\00")
+
+    (func (export "pong") (param i32) (result i32)
+        (if (result i32) (i32.le_s (local.get 0) (i32.const 0))
+            (then
+                ;; Force a full GC while the thunk frame is on the stack.
+                (call $triggerGC)
+                (i32.load (i32.const 0))
+            )
+            (else
+                (i32.sub (local.get 0) (i32.const 1))
+                (i32.const 0)
+                (return_call_indirect (type $pp))
+            )
+        )
+    )
+)
+`
+
+async function test() {
+    const table = new WebAssembly.Table({ initial: 2, element: "funcref" });
+    function triggerGC() {
+        // Force a full collection. The thunk frame's Callee (RestoreInstanceCallee)
+        // and CodeBlock (wasmInstance) must be scannable by the GC.
+        $vm.gc();
+    }
+
+    const instPing = await instantiate(watPing, { t: { table } }, { tail_call: true });
+    const instPong = await instantiate(watPong, { t: { table, triggerGC } }, { tail_call: true });
+    table.set(0, instPing.exports.ping);
+    table.set(1, instPong.exports.pong);
+
+    // Single cross-instance hop + GC at base case.
+    assert.eq(instPing.exports.start(1), 255);
+
+    // Deeper chain — GC happens after several cross-instance tail calls.
+    assert.eq(instPing.exports.start(11), 255);
+
+    // Multiple rounds to stress GC interaction.
+    for (let i = 0; i < wasmTestLoopCount; i++) {
+        assert.eq(instPing.exports.start(1), 255);
+        assert.eq(instPing.exports.start(11), 255);
+    }
+}
+
+await assert.asyncTest(test())

--- a/JSTests/wasm/stress/tail-call-cross-instance-memory-reload.js
+++ b/JSTests/wasm/stress/tail-call-cross-instance-memory-reload.js
@@ -1,0 +1,79 @@
+//@ requireOptions("--useWasmTailCalls=true", "--wasmInliningMaximumWasmCalleeSize=0")
+import { instantiate } from "../wabt-wrapper.js"
+import * as assert from "../assert.js"
+
+// Test that ipintReloadMemory in the restore thunk correctly reloads the
+// caller's memory base and bounds after a cross-instance tail call returns.
+// The callee instance grows its own memory; after return through the thunk,
+// the caller must still see its own (ungrown) memory correctly.
+
+// Module A: calls B via tail call, then reads its own memory after return.
+let watA = `
+(module
+    (import "b" "grow_and_return" (func $b_grow (param i32) (result i32)))
+    (memory (export "mem") 1)
+    (data (i32.const 0) "\\2a\\00\\00\\00")  ;; memory[0] = 42
+
+    ;; Tail-call into B which will grow B's memory, then return.
+    (func (export "tail_call_b") (param i32) (result i32)
+        local.get 0
+        return_call $b_grow
+    )
+
+    ;; Regular call wrapper: calls tail_call_b, then reads A's memory to
+    ;; verify it's still accessible with correct base/bounds.
+    (func (export "call_then_read") (param i32) (result i32)
+        (call 0 (local.get 0))
+        drop
+        ;; After return through the thunk, A's memory must be restored.
+        (i32.load (i32.const 0))
+    )
+)
+`
+
+// Module B: grows its own memory, then returns a value.
+let watB = `
+(module
+    (memory (export "mem") 1)
+    (data (i32.const 0) "\\ff\\00\\00\\00")  ;; memory[0] = 255
+
+    ;; Grow our memory by N pages, then return memory[0].
+    (func (export "grow_and_return") (param i32) (result i32)
+        ;; Grow B's memory
+        (memory.grow (local.get 0))
+        drop
+        ;; Return B's memory[0]
+        (i32.load (i32.const 0))
+    )
+)
+`
+
+async function test() {
+    const instanceA = await instantiate(watA, {
+        b: { grow_and_return: () => 0 }  // placeholder
+    }, { tail_call: true });
+
+    const instanceB = await instantiate(watB, {}, { tail_call: true });
+
+    // Re-instantiate A with B's real export.
+    const instA = await instantiate(watA, {
+        b: { grow_and_return: instanceB.exports.grow_and_return }
+    }, { tail_call: true });
+
+    // tail_call_b(5) → B grows by 5 pages, returns 255.
+    // After return through thunk, A's memory must be intact.
+    assert.eq(instA.exports.call_then_read(5), 42);
+
+    // Do it again — B's memory is now larger but A's should be unchanged.
+    assert.eq(instA.exports.call_then_read(5), 42);
+
+    // Grow by a large amount to really stress the memory base/bounds reload.
+    assert.eq(instA.exports.call_then_read(100), 42);
+
+    // Multiple rounds — pass 0 so memory.grow is a no-op; we're stressing tier-up
+    // of the tail-call + thunk path, not repeated allocation.
+    for (let i = 0; i < wasmTestLoopCount; i++)
+        assert.eq(instA.exports.call_then_read(0), 42);
+}
+
+await assert.asyncTest(test())

--- a/JSTests/wasm/stress/tail-call-cross-instance-no-thunk-accumulation.js
+++ b/JSTests/wasm/stress/tail-call-cross-instance-no-thunk-accumulation.js
@@ -1,0 +1,67 @@
+//@ requireOptions("--useWasmTailCalls=true", "--wasmInliningMaximumWasmCalleeSize=0", "--maxPerThreadStackUsage=296960")
+import { instantiate } from "../wabt-wrapper.js"
+import * as assert from "../assert.js"
+
+// Test that repeated cross-instance tail calls reuse the thunk frame rather
+// than accumulating new ones. With a 64KB stack limit, if thunks accumulated
+// (32 bytes per hop), 5000 hops would need 160KB and overflow. With thunk
+// reuse, only one thunk exists so the chain completes at any depth.
+
+let watPing = `
+(module
+    (type $pp (func (param i32) (result i32)))
+    (import "t" "table" (table 2 funcref))
+    (memory (export "mem") 1)
+    (data (i32.const 0) "\\2a\\00\\00\\00")
+
+    (func (export "ping") (param i32) (result i32)
+        (if (result i32) (i32.le_s (local.get 0) (i32.const 0))
+            (then (i32.load (i32.const 0)))
+            (else
+                (i32.sub (local.get 0) (i32.const 1))
+                (i32.const 1)
+                (return_call_indirect (type $pp))
+            )
+        )
+    )
+
+    (func (export "start") (param i32) (result i32)
+        (call 0 (local.get 0))
+    )
+)
+`
+
+let watPong = `
+(module
+    (type $pp (func (param i32) (result i32)))
+    (import "t" "table" (table 2 funcref))
+    (memory (export "mem") 1)
+    (data (i32.const 0) "\\ff\\00\\00\\00")
+
+    (func (export "pong") (param i32) (result i32)
+        (if (result i32) (i32.le_s (local.get 0) (i32.const 0))
+            (then (i32.load (i32.const 0)))
+            (else
+                (i32.sub (local.get 0) (i32.const 1))
+                (i32.const 0)
+                (return_call_indirect (type $pp))
+            )
+        )
+    )
+)
+`
+
+async function test() {
+    const table = new WebAssembly.Table({ initial: 2, element: "funcref" });
+    const instPing = await instantiate(watPing, { t: { table } }, { tail_call: true });
+    const instPong = await instantiate(watPong, { t: { table } }, { tail_call: true });
+    table.set(0, instPing.exports.ping);
+    table.set(1, instPong.exports.pong);
+
+    // 5000 cross-instance hops. Without thunk reuse this would accumulate
+    // 160KB of redirect frames, overflowing our 64KB stack.
+    assert.eq(instPing.exports.start(5000), 42);
+    assert.eq(instPing.exports.start(5001), 255);
+}
+
+await assert.asyncTest(test())

--- a/JSTests/wasm/stress/tail-call-cross-instance-restore.js
+++ b/JSTests/wasm/stress/tail-call-cross-instance-restore.js
@@ -1,0 +1,341 @@
+//@ requireOptions("--useWasmTailCalls=true", "--wasmInliningMaximumWasmCalleeSize=0")
+import { instantiate } from "../wabt-wrapper.js"
+import * as assert from "../assert.js"
+
+// Test cross-instance tail calls with stack arguments/results, memory restoration,
+// and deep recursion (no stack overflow).
+
+// Module A: exports a callee that sums many parameters (some on stack) and reads its own memory.
+let watA = `
+(module
+    (memory (export "mem") 1)
+    (data (i32.const 0) "\\2a\\00\\00\\00")  ;; memory[0] = 42
+
+    ;; Callee with enough params to force stack usage (>6 GPR args on ARM64, >4 on x86).
+    ;; Returns sum of all params + memory[0].
+    (func (export "sum_with_memory")
+        (param i32 i32 i32 i32 i32 i32 i32 i32 i32 i32) (result i32)
+        local.get 0
+        local.get 1  i32.add
+        local.get 2  i32.add
+        local.get 3  i32.add
+        local.get 4  i32.add
+        local.get 5  i32.add
+        local.get 6  i32.add
+        local.get 7  i32.add
+        local.get 8  i32.add
+        local.get 9  i32.add
+        ;; Also load from our own memory to verify instance was restored correctly.
+        (i32.load (i32.const 0))
+        i32.add
+    )
+
+    ;; Multi-value callee: returns several values (some on stack).
+    (func (export "multi_return") (param i32) (result i32 i32 i32 i32 i32)
+        (i32.add (local.get 0) (i32.const 1))
+        (i32.add (local.get 0) (i32.const 2))
+        (i32.add (local.get 0) (i32.const 3))
+        (i32.add (local.get 0) (i32.const 4))
+        ;; Last result reads memory to verify correct instance.
+        (i32.load (i32.const 0))
+    )
+)
+`
+
+// Module B: has its own memory, imports A's functions, and tail-calls them.
+let watB = `
+(module
+    (import "a" "sum_with_memory" (func $imported_sum
+        (param i32 i32 i32 i32 i32 i32 i32 i32 i32 i32) (result i32)))
+    (import "a" "multi_return" (func $imported_multi (param i32) (result i32 i32 i32 i32 i32)))
+    (import "a" "countdown" (func $imported_countdown (param i32) (result i32)))
+
+    (memory (export "mem") 1)
+    (data (i32.const 0) "\\ff\\00\\00\\00")  ;; memory[0] = 255 (different from A's 42)
+
+    ;; call -> return_call import: caller calls us, we tail-call into A's function.
+    (func $do_tail_call_sum (export "tail_call_sum")
+        (param i32 i32 i32 i32 i32 i32 i32 i32 i32 i32) (result i32)
+        local.get 0  local.get 1  local.get 2  local.get 3  local.get 4
+        local.get 5  local.get 6  local.get 7  local.get 8  local.get 9
+        return_call $imported_sum
+    )
+
+    ;; Wrapper that calls the tail-calling function (tests call -> tail_call -> cross-instance).
+    (func (export "call_then_tail_call_sum")
+        (param i32 i32 i32 i32 i32 i32 i32 i32 i32 i32) (result i32)
+        local.get 0  local.get 1  local.get 2  local.get 3  local.get 4
+        local.get 5  local.get 6  local.get 7  local.get 8  local.get 9
+        call $do_tail_call_sum
+        ;; After the call returns, B's memory must be accessible again.
+        (i32.load (i32.const 0))
+        i32.add
+    )
+
+    ;; Tail-call the multi-return import.
+    (func $tail_call_multi_internal (export "tail_call_multi") (param i32) (result i32 i32 i32 i32 i32)
+        local.get 0
+        return_call $imported_multi
+    )
+
+    ;; Wrapper: call -> tail_call multi-value cross-instance.
+    (func (export "call_then_tail_call_multi") (param i32) (result i32 i32 i32 i32 i32)
+        local.get 0
+        call $tail_call_multi_internal
+    )
+
+    ;; Deep tail-call recursion: counts down via tail calls, alternating cross-instance.
+    (func (export "countdown") (param i32) (result i32)
+        (if (result i32) (i32.le_s (local.get 0) (i32.const 0))
+            (then
+                (i32.load (i32.const 0))
+            )
+            (else
+                (i32.sub (local.get 0) (i32.const 1))
+                return_call $imported_countdown
+            )
+        )
+    )
+)
+`
+
+// Module A also needs a countdown that tail-calls back to B.
+let watA_with_countdown = `
+(module
+    (import "b" "countdown" (func $b_countdown (param i32) (result i32)))
+
+    (memory (export "mem") 1)
+    (data (i32.const 0) "\\2a\\00\\00\\00")  ;; memory[0] = 42
+
+    (func (export "sum_with_memory")
+        (param i32 i32 i32 i32 i32 i32 i32 i32 i32 i32) (result i32)
+        local.get 0
+        local.get 1  i32.add
+        local.get 2  i32.add
+        local.get 3  i32.add
+        local.get 4  i32.add
+        local.get 5  i32.add
+        local.get 6  i32.add
+        local.get 7  i32.add
+        local.get 8  i32.add
+        local.get 9  i32.add
+        (i32.load (i32.const 0))
+        i32.add
+    )
+
+    (func (export "multi_return") (param i32) (result i32 i32 i32 i32 i32)
+        (i32.add (local.get 0) (i32.const 1))
+        (i32.add (local.get 0) (i32.const 2))
+        (i32.add (local.get 0) (i32.const 3))
+        (i32.add (local.get 0) (i32.const 4))
+        (i32.load (i32.const 0))
+    )
+
+    (func (export "countdown") (param i32) (result i32)
+        (if (result i32) (i32.le_s (local.get 0) (i32.const 0))
+            (then
+                (i32.load (i32.const 0))
+            )
+            (else
+                (i32.sub (local.get 0) (i32.const 1))
+                return_call $b_countdown
+            )
+        )
+    )
+)
+`
+
+async function test() {
+    // --- Set up mutually-recursive modules A and B ---
+    // A imports B's countdown, B imports A's functions.
+    // We use a two-phase approach: instantiate A with a JS trampoline for B's countdown,
+    // then instantiate B with A's exports, then patch A's import.
+
+    // Phase 1: Instantiate A with a placeholder for B's countdown.
+    let bCountdownRef = { fn: null };
+    const instanceA = await instantiate(watA_with_countdown, {
+        b: { countdown: (n) => bCountdownRef.fn(n) }
+    }, { tail_call: true });
+
+    // Phase 2: Instantiate B with A's exports.
+    const instanceB = await instantiate(watB, {
+        a: {
+            sum_with_memory: instanceA.exports.sum_with_memory,
+            multi_return: instanceA.exports.multi_return,
+            countdown: instanceA.exports.countdown,
+        }
+    }, { tail_call: true });
+
+    // Patch the trampoline.
+    bCountdownRef.fn = instanceB.exports.countdown;
+
+    const { call_then_tail_call_sum, tail_call_sum, tail_call_multi, call_then_tail_call_multi } = instanceB.exports;
+    const aCountdown = instanceA.exports.countdown;
+
+    // --- Test 1: Stack arguments through cross-instance tail call ---
+    // sum(0..9) = 45, plus A's memory[0] = 42 => 87.
+    for (let i = 0; i < wasmTestLoopCount; ++i) {
+        assert.eq(tail_call_sum(0, 1, 2, 3, 4, 5, 6, 7, 8, 9), 87);
+    }
+
+    // --- Test 2: call -> tail_call -> cross-instance, memory restored ---
+    // sum = 87 (from A), plus B's memory[0] = 255 (loaded after return) => 342.
+    for (let i = 0; i < wasmTestLoopCount; ++i) {
+        assert.eq(call_then_tail_call_sum(0, 1, 2, 3, 4, 5, 6, 7, 8, 9), 342);
+    }
+
+    // --- Test 3: Multi-value return through cross-instance tail call ---
+    for (let i = 0; i < wasmTestLoopCount; ++i) {
+        let results = tail_call_multi(10);
+        assert.eq(results[0], 11);
+        assert.eq(results[1], 12);
+        assert.eq(results[2], 13);
+        assert.eq(results[3], 14);
+        assert.eq(results[4], 42);  // A's memory[0]
+    }
+
+    // --- Test 4: call -> tail_call multi-value cross-instance ---
+    for (let i = 0; i < wasmTestLoopCount; ++i) {
+        let results = call_then_tail_call_multi(10);
+        assert.eq(results[0], 11);
+        assert.eq(results[1], 12);
+        assert.eq(results[2], 13);
+        assert.eq(results[3], 14);
+        assert.eq(results[4], 42);  // A's memory[0]
+    }
+
+    // --- Test 5: Deep mutual tail-call recursion (must not stack overflow) ---
+    // A.countdown(n) tail-calls B.countdown(n-1), which tail-calls A.countdown(n-2), etc.
+    // At n=0 the base case returns memory[0]. Even n stops in A (returns 42),
+    // odd n stops in B (returns 255).
+    // Note: A→B goes through a JS trampoline (import resolved at instantiation time).
+    assert.eq(aCountdown(0), 42);
+    assert.eq(aCountdown(1), 255);
+    assert.eq(aCountdown(100), 42);    // moderate depth, even => A's memory
+    assert.eq(aCountdown(101), 255);   // moderate depth, odd => B's memory
+
+}
+
+async function testPingPong() {
+    // Ping and Pong are in different instances and tail-call each other via a shared table.
+    // Both directions are wasm-to-wasm return_call_indirect. Deep recursion must not
+    // overflow — repeated cross-instance tail calls must reuse the thunk frame.
+    let watPing = `
+    (module
+        (type $pp (func (param i32) (result i32)))
+        (import "t" "table" (table 2 funcref))
+        (memory (export "mem") 1)
+        (data (i32.const 0) "\\2a\\00\\00\\00")  ;; memory[0] = 42
+
+        ;; ping: if n<=0 return memory[0], else return_call_indirect table[1](n-1) (= pong)
+        (func (export "ping") (param i32) (result i32)
+            (if (result i32) (i32.le_s (local.get 0) (i32.const 0))
+                (then (i32.load (i32.const 0)))
+                (else
+                    (i32.sub (local.get 0) (i32.const 1))
+                    (i32.const 1)
+                    (return_call_indirect (type $pp))
+                )
+            )
+        )
+
+        ;; start: regular call to ping so there's a non-tail caller on the stack
+        (func (export "start") (param i32) (result i32)
+            (call 0 (local.get 0))
+        )
+    )
+    `
+
+    let watPong = `
+    (module
+        (type $pp (func (param i32) (result i32)))
+        (import "t" "table" (table 2 funcref))
+        (import "t" "breaker" (func))
+        (memory (export "mem") 1)
+        (data (i32.const 0) "\\ff\\00\\00\\00")  ;; memory[0] = 255
+
+        ;; pong: if n<=0 return memory[0], else return_call_indirect table[0](n-1) (= ping)
+        (func (export "pong") (param i32) (result i32)
+            (if (result i32) (i32.le_s (local.get 0) (i32.const 0))
+                (then (call 0) (i32.load (i32.const 0)))
+                (else
+                    (i32.sub (local.get 0) (i32.const 1))
+                    (i32.const 0)
+                    (return_call_indirect (type $pp))
+                )
+            )
+        )
+    )
+    `
+
+    const table = new WebAssembly.Table({ initial: 2, element: "funcref" });
+    function breaker() {
+    }
+    const instPing = await instantiate(watPing, { t: { table } }, { tail_call: true });
+    const instPong = await instantiate(watPong, { t: { table, breaker } }, { tail_call: true });
+
+    // table[0] = ping, table[1] = pong
+    table.set(0, instPing.exports.ping);
+    table.set(1, instPong.exports.pong);
+
+    // start(n) -> ping(n) -> pong(n-1) -> ping(n-2) -> ... (all wasm tail calls)
+    assert.eq(instPing.exports.start(0), 42);    // stops in Ping
+    assert.eq(instPing.exports.start(1), 255);   // stops in Pong
+    assert.eq(instPing.exports.start(100), 42);  // moderate depth, even => Ping's memory
+    assert.eq(instPing.exports.start(101), 255); // moderate depth, odd => Pong's memory
+
+
+    // Run near the stack limit to ensure that cross-instance tail calls don't accumulate
+    // thunk frames. If each cross-instance hop created a new 32-byte thunk, even moderate
+    // recursion would overflow when we're already close to the limit.
+    function runNearStackLimit(f) {
+        function t() {
+            try { return t(); } catch (e) { return f(); }
+        }
+        return t();
+    }
+    runNearStackLimit(() => {
+        assert.eq(instPing.exports.start(1000), 42);
+    });
+
+}
+
+await assert.asyncTest(test())
+await assert.asyncTest(testPingPong())
+
+// --- Test: Verify instance (not just memory) is restored via globals ---
+async function testInstanceRestoredViaGlobals() {
+    let watCallee = `
+    (module
+        (func (export "identity") (param i32) (result i32)
+            local.get 0
+        )
+    )`
+
+    let watCaller = `
+    (module
+        (import "m" "identity" (func $identity (param i32) (result i32)))
+        (global $marker (mut i32) (i32.const 99))
+        (func $tail_identity (export "tail_identity") (param i32) (result i32)
+            local.get 0
+            return_call $identity
+        )
+        (func (export "call_then_check_global") (param i32) (result i32)
+            local.get 0
+            call $tail_identity
+            drop
+            global.get $marker
+        )
+    )`
+
+    const instCallee = await instantiate(watCallee, {}, { tail_call: true });
+    const instCaller = await instantiate(watCaller, {
+        m: { identity: instCallee.exports.identity }
+    }, { tail_call: true });
+
+    for (let i = 0; i < wasmTestLoopCount; ++i) {
+        assert.eq(instCaller.exports.call_then_check_global(42), 99);
+    }
+}
+
+await assert.asyncTest(testInstanceRestoredViaGlobals())

--- a/JSTests/wasm/stress/tail-call-cross-instance-sampling-profiler.js
+++ b/JSTests/wasm/stress/tail-call-cross-instance-sampling-profiler.js
@@ -1,0 +1,69 @@
+//@ skip if $architecture == "arm"
+//@ skip if $platform == "tvos" || $platform == "watchos"
+//@ requireOptions("--useWasmTailCalls=true", "--useSamplingProfiler=1", "--wasmInliningMaximumWasmCalleeSize=0")
+import { instantiate } from "../wabt-wrapper.js"
+import * as assert from "../assert.js"
+
+// Test that the sampling profiler does not crash when it encounters
+// RestoreInstanceCallee thunk frames from cross-instance tail calls.
+
+let watPing = `
+(module
+    (type $pp (func (param i32) (result i32)))
+    (import "t" "table" (table 2 funcref))
+    (memory (export "mem") 1)
+    (data (i32.const 0) "\\2a\\00\\00\\00")
+
+    (func (export "ping") (param i32) (result i32)
+        (if (result i32) (i32.le_s (local.get 0) (i32.const 0))
+            (then (i32.load (i32.const 0)))
+            (else
+                (i32.sub (local.get 0) (i32.const 1))
+                (i32.const 1)
+                (return_call_indirect (type $pp))
+            )
+        )
+    )
+
+    (func (export "start") (param i32) (result i32)
+        (call 0 (local.get 0))
+    )
+)
+`
+
+let watPong = `
+(module
+    (type $pp (func (param i32) (result i32)))
+    (import "t" "table" (table 2 funcref))
+    (memory (export "mem") 1)
+    (data (i32.const 0) "\\ff\\00\\00\\00")
+
+    (func (export "pong") (param i32) (result i32)
+        (if (result i32) (i32.le_s (local.get 0) (i32.const 0))
+            (then (i32.load (i32.const 0)))
+            (else
+                (i32.sub (local.get 0) (i32.const 1))
+                (i32.const 0)
+                (return_call_indirect (type $pp))
+            )
+        )
+    )
+)
+`
+
+async function test() {
+    const table = new WebAssembly.Table({ initial: 2, element: "funcref" });
+    const instPing = await instantiate(watPing, { t: { table } }, { tail_call: true });
+    const instPong = await instantiate(watPong, { t: { table } }, { tail_call: true });
+    table.set(0, instPing.exports.ping);
+    table.set(1, instPong.exports.pong);
+
+    // Run many iterations to give the profiler plenty of chances to sample
+    // while a RestoreInstanceCallee thunk frame is on the stack.
+    for (let i = 0; i < wasmTestLoopCount; i++) {
+        assert.eq(instPing.exports.start(100), 42);
+        assert.eq(instPing.exports.start(101), 255);
+    }
+}
+
+await assert.asyncTest(test())

--- a/JSTests/wasm/stress/tail-call-cross-instance-stack-args.js
+++ b/JSTests/wasm/stress/tail-call-cross-instance-stack-args.js
@@ -1,0 +1,328 @@
+//@ requireOptions("--useWasmTailCalls=true", "--wasmInliningMaximumWasmCalleeSize=0")
+import { instantiate } from "../wabt-wrapper.js"
+import * as assert from "../assert.js"
+
+// Test cross-instance tail calls specifically exercising stack arguments (10+ params),
+// indirect calls (call_ref via table), chained A→B→C, and deep recursion for tier-up.
+
+// --- Test 1: Direct import with stack args ---
+async function testDirectImportStackArgs() {
+    let watCallee = `
+    (module
+        (memory (export "mem") 1)
+        (data (i32.const 0) "\\2a\\00\\00\\00")  ;; memory[0] = 42
+
+        (func (export "big_sum")
+            (param i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32) (result i32)
+            local.get 0  local.get 1  i32.add
+            local.get 2  i32.add  local.get 3  i32.add
+            local.get 4  i32.add  local.get 5  i32.add
+            local.get 6  i32.add  local.get 7  i32.add
+            local.get 8  i32.add  local.get 9  i32.add
+            local.get 10 i32.add  local.get 11 i32.add
+            (i32.load (i32.const 0))
+            i32.add
+        )
+    )
+    `
+
+    let watCaller = `
+    (module
+        (import "m" "big_sum" (func $big_sum
+            (param i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32) (result i32)))
+
+        (memory (export "mem") 1)
+        (data (i32.const 0) "\\ff\\00\\00\\00")  ;; memory[0] = 255
+
+        (func $tail_call_big_sum (export "tail_call_big_sum")
+            (param i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32) (result i32)
+            local.get 0  local.get 1  local.get 2  local.get 3
+            local.get 4  local.get 5  local.get 6  local.get 7
+            local.get 8  local.get 9  local.get 10 local.get 11
+            return_call $big_sum
+        )
+
+        ;; Wrapper: call -> tail_call, then check our memory is restored.
+        (func (export "call_then_tail")
+            (param i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32) (result i32)
+            local.get 0  local.get 1  local.get 2  local.get 3
+            local.get 4  local.get 5  local.get 6  local.get 7
+            local.get 8  local.get 9  local.get 10 local.get 11
+            call $tail_call_big_sum
+            ;; After return, our instance (caller) must be restored.
+            (i32.load (i32.const 0))
+            i32.add
+        )
+    )
+    `
+
+    const instCallee = await instantiate(watCallee, {}, { tail_call: true });
+    const instCaller = await instantiate(watCaller, {
+        m: { big_sum: instCallee.exports.big_sum }
+    }, { tail_call: true });
+
+    // sum(0..11) = 66, + callee memory[0]=42 => 108
+    for (let i = 0; i < wasmTestLoopCount; ++i) {
+        assert.eq(instCaller.exports.tail_call_big_sum(0,1,2,3,4,5,6,7,8,9,10,11), 108);
+    }
+
+    // call_then_tail: 108 + caller memory[0]=255 => 363
+    for (let i = 0; i < wasmTestLoopCount; ++i) {
+        assert.eq(instCaller.exports.call_then_tail(0,1,2,3,4,5,6,7,8,9,10,11), 363);
+    }
+}
+
+// --- Test 2: Indirect (call_ref via table) with stack args ---
+async function testIndirectStackArgs() {
+    let watCallee = `
+    (module
+        (type $big (func (param i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32) (result i32)))
+        (memory (export "mem") 1)
+        (data (i32.const 0) "\\2a\\00\\00\\00")  ;; memory[0] = 42
+
+        (func (export "big_sum") (type $big)
+            local.get 0  local.get 1  i32.add
+            local.get 2  i32.add  local.get 3  i32.add
+            local.get 4  i32.add  local.get 5  i32.add
+            local.get 6  i32.add  local.get 7  i32.add
+            local.get 8  i32.add  local.get 9  i32.add
+            local.get 10 i32.add  local.get 11 i32.add
+            (i32.load (i32.const 0))
+            i32.add
+        )
+    )
+    `
+
+    let watCaller = `
+    (module
+        (type $big (func (param i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32) (result i32)))
+        (import "t" "table" (table 1 funcref))
+
+        (memory (export "mem") 1)
+        (data (i32.const 0) "\\ff\\00\\00\\00")  ;; memory[0] = 255
+
+        ;; Indirect tail call via table[0].
+        (func $indirect_tail (export "indirect_tail")
+            (param i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32) (result i32)
+            local.get 0  local.get 1  local.get 2  local.get 3
+            local.get 4  local.get 5  local.get 6  local.get 7
+            local.get 8  local.get 9  local.get 10 local.get 11
+            (i32.const 0)
+            (return_call_indirect (type $big))
+        )
+
+        ;; Wrapper: call -> indirect tail call, then verify memory restored.
+        (func (export "call_then_indirect_tail")
+            (param i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32) (result i32)
+            local.get 0  local.get 1  local.get 2  local.get 3
+            local.get 4  local.get 5  local.get 6  local.get 7
+            local.get 8  local.get 9  local.get 10 local.get 11
+            call $indirect_tail
+            (i32.load (i32.const 0))
+            i32.add
+        )
+    )
+    `
+
+    const table = new WebAssembly.Table({ initial: 1, element: "funcref" });
+    const instCallee = await instantiate(watCallee, {}, { tail_call: true });
+    const instCaller = await instantiate(watCaller, { t: { table } }, { tail_call: true });
+    table.set(0, instCallee.exports.big_sum);
+
+    // sum(0..11) = 66, + callee memory[0]=42 => 108
+    for (let i = 0; i < wasmTestLoopCount; ++i) {
+        assert.eq(instCaller.exports.indirect_tail(0,1,2,3,4,5,6,7,8,9,10,11), 108);
+    }
+
+    // call_then_indirect_tail: 108 + caller memory[0]=255 => 363
+    for (let i = 0; i < wasmTestLoopCount; ++i) {
+        assert.eq(instCaller.exports.call_then_indirect_tail(0,1,2,3,4,5,6,7,8,9,10,11), 363);
+    }
+}
+
+// --- Test 3: Chain A→B→C with stack args (tests hasExistingThunk path) ---
+async function testChainABC() {
+    let watC = `
+    (module
+        (memory (export "mem") 1)
+        (data (i32.const 0) "\\63\\00\\00\\00")  ;; memory[0] = 99
+
+        (func (export "final_sum")
+            (param i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32) (result i32)
+            local.get 0  local.get 1  i32.add
+            local.get 2  i32.add  local.get 3  i32.add
+            local.get 4  i32.add  local.get 5  i32.add
+            local.get 6  i32.add  local.get 7  i32.add
+            local.get 8  i32.add  local.get 9  i32.add
+            local.get 10 i32.add  local.get 11 i32.add
+            (i32.load (i32.const 0))
+            i32.add
+        )
+    )
+    `
+
+    let watB = `
+    (module
+        (import "c" "final_sum" (func $c_sum
+            (param i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32) (result i32)))
+
+        (memory (export "mem") 1)
+        (data (i32.const 0) "\\bb\\00\\00\\00")  ;; memory[0] = 187
+
+        ;; B tail-calls C — second cross-instance hop, hasExistingThunk path.
+        (func (export "relay")
+            (param i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32) (result i32)
+            local.get 0  local.get 1  local.get 2  local.get 3
+            local.get 4  local.get 5  local.get 6  local.get 7
+            local.get 8  local.get 9  local.get 10 local.get 11
+            return_call $c_sum
+        )
+    )
+    `
+
+    let watA = `
+    (module
+        (import "b" "relay" (func $b_relay
+            (param i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32) (result i32)))
+
+        (memory (export "mem") 1)
+        (data (i32.const 0) "\\aa\\00\\00\\00")  ;; memory[0] = 170
+
+        ;; A tail-calls B — first cross-instance hop.
+        (func $start_chain (export "start_chain")
+            (param i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32) (result i32)
+            local.get 0  local.get 1  local.get 2  local.get 3
+            local.get 4  local.get 5  local.get 6  local.get 7
+            local.get 8  local.get 9  local.get 10 local.get 11
+            return_call $b_relay
+        )
+
+        ;; Wrapper with regular call so memory restoration is tested.
+        (func (export "call_start_chain")
+            (param i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32) (result i32)
+            local.get 0  local.get 1  local.get 2  local.get 3
+            local.get 4  local.get 5  local.get 6  local.get 7
+            local.get 8  local.get 9  local.get 10 local.get 11
+            call $start_chain
+            ;; After return, A's instance must be restored.
+            (i32.load (i32.const 0))
+            i32.add
+        )
+    )
+    `
+
+    const instC = await instantiate(watC, {}, { tail_call: true });
+    const instB = await instantiate(watB, { c: { final_sum: instC.exports.final_sum } }, { tail_call: true });
+    const instA = await instantiate(watA, { b: { relay: instB.exports.relay } }, { tail_call: true });
+
+    // A -> B -> C: sum(0..11)=66 + C's memory[0]=99 => 165
+    for (let i = 0; i < wasmTestLoopCount; ++i) {
+        assert.eq(instA.exports.start_chain(0,1,2,3,4,5,6,7,8,9,10,11), 165);
+    }
+
+    // call_start_chain: 165 + A's memory[0]=170 => 335
+    for (let i = 0; i < wasmTestLoopCount; ++i) {
+        assert.eq(instA.exports.call_start_chain(0,1,2,3,4,5,6,7,8,9,10,11), 335);
+    }
+}
+
+// --- Test 4: Deep recursion with stack args (tier-up test) ---
+async function testDeepRecursionStackArgs() {
+    let watPing = `
+    (module
+        (type $rec (func (param i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32) (result i32)))
+        (import "t" "table" (table 2 funcref))
+        (memory (export "mem") 1)
+        (data (i32.const 0) "\\2a\\00\\00\\00")  ;; memory[0] = 42
+
+        (func $ping (export "ping") (type $rec)
+            (param i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32) (result i32)
+            (if (result i32) (i32.le_s (local.get 0) (i32.const 0))
+                (then
+                    ;; Base case: return sum of params 1..11 + memory[0]
+                    local.get 1  local.get 2  i32.add
+                    local.get 3  i32.add  local.get 4  i32.add
+                    local.get 5  i32.add  local.get 6  i32.add
+                    local.get 7  i32.add  local.get 8  i32.add
+                    local.get 9  i32.add  local.get 10 i32.add
+                    local.get 11 i32.add
+                    (i32.load (i32.const 0))
+                    i32.add
+                )
+                (else
+                    ;; Tail call pong (table[1]) with n-1
+                    (i32.sub (local.get 0) (i32.const 1))
+                    local.get 1  local.get 2  local.get 3
+                    local.get 4  local.get 5  local.get 6
+                    local.get 7  local.get 8  local.get 9
+                    local.get 10 local.get 11
+                    (i32.const 1)
+                    (return_call_indirect (type $rec))
+                )
+            )
+        )
+
+        (func (export "start") (param i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32) (result i32)
+            local.get 0  local.get 1  local.get 2  local.get 3
+            local.get 4  local.get 5  local.get 6  local.get 7
+            local.get 8  local.get 9  local.get 10 local.get 11
+            call $ping
+        )
+    )
+    `
+
+    let watPong = `
+    (module
+        (type $rec (func (param i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32) (result i32)))
+        (import "t" "table" (table 2 funcref))
+        (memory (export "mem") 1)
+        (data (i32.const 0) "\\ff\\00\\00\\00")  ;; memory[0] = 255
+
+        (func (export "pong") (type $rec)
+            (param i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32) (result i32)
+            (if (result i32) (i32.le_s (local.get 0) (i32.const 0))
+                (then
+                    local.get 1  local.get 2  i32.add
+                    local.get 3  i32.add  local.get 4  i32.add
+                    local.get 5  i32.add  local.get 6  i32.add
+                    local.get 7  i32.add  local.get 8  i32.add
+                    local.get 9  i32.add  local.get 10 i32.add
+                    local.get 11 i32.add
+                    (i32.load (i32.const 0))
+                    i32.add
+                )
+                (else
+                    (i32.sub (local.get 0) (i32.const 1))
+                    local.get 1  local.get 2  local.get 3
+                    local.get 4  local.get 5  local.get 6
+                    local.get 7  local.get 8  local.get 9
+                    local.get 10 local.get 11
+                    (i32.const 0)
+                    (return_call_indirect (type $rec))
+                )
+            )
+        )
+    )
+    `
+
+    const table = new WebAssembly.Table({ initial: 2, element: "funcref" });
+    const instPing = await instantiate(watPing, { t: { table } }, { tail_call: true });
+    const instPong = await instantiate(watPong, { t: { table } }, { tail_call: true });
+    table.set(0, instPing.exports.ping);
+    table.set(1, instPong.exports.pong);
+
+    // sum(1..11) = 66, + memory[0]:
+    // Even n stops in ping (memory=42), odd n stops in pong (memory=255).
+    // sum(1..11) = 1+2+3+4+5+6+7+8+9+10+11 = 66
+    assert.eq(instPing.exports.start(0,1,2,3,4,5,6,7,8,9,10,11), 66 + 42);  // n=0 base in ping
+    assert.eq(instPing.exports.start(1,1,2,3,4,5,6,7,8,9,10,11), 66 + 255); // n=1 base in pong
+
+    // Deep recursion (10000 iterations) — must not stack overflow.
+    assert.eq(instPing.exports.start(10000,1,2,3,4,5,6,7,8,9,10,11), 66 + 42);   // even => ping
+    assert.eq(instPing.exports.start(10001,1,2,3,4,5,6,7,8,9,10,11), 66 + 255);  // odd => pong
+}
+
+await assert.asyncTest(testDirectImportStackArgs());
+await assert.asyncTest(testIndirectStackArgs());
+await assert.asyncTest(testChainABC());
+await assert.asyncTest(testDeepRecursionStackArgs());

--- a/JSTests/wasm/stress/tail-call-cross-instance-stacktrace.js
+++ b/JSTests/wasm/stress/tail-call-cross-instance-stacktrace.js
@@ -1,0 +1,99 @@
+//@ requireOptions("--useWasmTailCalls=true", "--wasmInliningMaximumWasmCalleeSize=0")
+import { instantiate } from "../wabt-wrapper.js"
+import * as assert from "../assert.js"
+
+// Test that Error().stack captured during a cross-instance tail call chain
+// does not include the RestoreInstanceCallee thunk frame.
+
+let watPing = `
+(module
+    (type $pp (func (param i32) (result i32)))
+    (import "t" "table" (table 2 funcref))
+    (memory (export "mem") 1)
+    (data (i32.const 0) "\\2a\\00\\00\\00")
+
+    (func (export "ping") (param i32) (result i32)
+        (if (result i32) (i32.le_s (local.get 0) (i32.const 0))
+            (then (i32.load (i32.const 0)))
+            (else
+                (i32.sub (local.get 0) (i32.const 1))
+                (i32.const 1)
+                (return_call_indirect (type $pp))
+            )
+        )
+    )
+
+    (func (export "start") (param i32) (result i32)
+        (call 0 (local.get 0))
+    )
+)
+`
+
+let watPong = `
+(module
+    (type $pp (func (param i32) (result i32)))
+    (import "t" "table" (table 2 funcref))
+    (import "t" "captureStack" (func $captureStack))
+    (memory (export "mem") 1)
+    (data (i32.const 0) "\\ff\\00\\00\\00")
+
+    (func (export "pong") (param i32) (result i32)
+        (if (result i32) (i32.le_s (local.get 0) (i32.const 0))
+            (then (call $captureStack) (i32.load (i32.const 0)))
+            (else
+                (i32.sub (local.get 0) (i32.const 1))
+                (i32.const 0)
+                (return_call_indirect (type $pp))
+            )
+        )
+    )
+)
+`
+
+async function test() {
+    const table = new WebAssembly.Table({ initial: 2, element: "funcref" });
+    let capturedStack = null;
+    function captureStack() {
+        capturedStack = new Error().stack;
+    }
+
+    const instPing = await instantiate(watPing, { t: { table } }, { tail_call: true });
+    const instPong = await instantiate(watPong, { t: { table, captureStack } }, { tail_call: true });
+    table.set(0, instPing.exports.ping);
+    table.set(1, instPong.exports.pong);
+
+    // Single cross-instance hop: start -> ping(1) -> pong(0) -> captureStack
+    instPing.exports.start(1);
+    assert.truthy(capturedStack !== null, "Stack should have been captured");
+
+    // The stack should contain wasm-function frames but NOT any restore/thunk artifacts.
+    // RestoreInstanceCallee has index 0xBADBADBA = 3131961274.
+    let lines = capturedStack.split("\n");
+    for (let line of lines) {
+        assert.falsy(line.includes("3131961274"), "Stack should not contain RestoreInstanceCallee index: " + line);
+        assert.falsy(line.includes("restoreInstance"), "Stack should not contain restoreInstance: " + line);
+        assert.falsy(line.includes("restore_instance"), "Stack should not contain restore_instance: " + line);
+    }
+
+    // Should see wasm-function entries in the trace.
+    let hasWasmFrame = lines.some(l => l.includes("wasm-function"));
+    assert.truthy(hasWasmFrame, "Stack should contain wasm-function frames");
+
+    // Deep chain: start -> ping(11) -> pong(10) -> ... -> pong(0) -> captureStack
+    capturedStack = null;
+    instPing.exports.start(11);
+    assert.truthy(capturedStack !== null, "Stack should have been captured (deep)");
+
+    lines = capturedStack.split("\n");
+    for (let line of lines) {
+        assert.falsy(line.includes("3131961274"), "Deep stack should not contain RestoreInstanceCallee index: " + line);
+        assert.falsy(line.includes("restoreInstance"), "Deep stack should not contain restoreInstance: " + line);
+    }
+
+    // Because of tail calls, the stack should NOT grow with depth — we should see
+    // roughly the same number of wasm frames regardless of depth.
+    let wasmFrameCount = lines.filter(l => l.includes("wasm-function")).length;
+    assert.truthy(wasmFrameCount <= 4, "Tail calls should collapse frames, got " + wasmFrameCount);
+}
+
+await assert.asyncTest(test())

--- a/JSTests/wasm/stress/tail-call-cross-instance-throw.js
+++ b/JSTests/wasm/stress/tail-call-cross-instance-throw.js
@@ -1,0 +1,122 @@
+//@ requireOptions("--useWasmTailCalls=true", "--wasmInliningMaximumWasmCalleeSize=0")
+import { instantiate } from "../wabt-wrapper.js"
+import * as assert from "../assert.js"
+
+// Test that exceptions thrown by a tail callee in a different instance
+// correctly unwind through the RestoreInstance thunk frame.
+
+// Module A: tail-calls into B's thrower function.
+let watA = `
+(module
+    (import "b" "thrower" (func $thrower (param i32) (result i32)))
+    (memory (export "mem") 1)
+    (data (i32.const 0) "\\2a\\00\\00\\00")  ;; memory[0] = 42
+
+    ;; Tail-calls into B, which will throw.
+    (func (export "do_tail_call") (param i32) (result i32)
+        local.get 0
+        return_call $thrower
+    )
+
+    ;; Regular call wrapper so there's a non-tail frame on the stack.
+    (func (export "call_then_tail_call") (param i32) (result i32)
+        local.get 0
+        call 0
+    )
+
+    ;; Reads our own memory after the callee returns (should never execute if callee throws).
+    (func (export "call_with_memory_after") (param i32) (result i32)
+        local.get 0
+        call 0
+        ;; If we get here, the callee didn't throw. Read our memory to verify restore.
+        (i32.load (i32.const 0))
+        i32.add
+    )
+)
+`
+
+// Module B: throws when n <= 0, otherwise tail-calls back to A.
+let watB = `
+(module
+    (import "a" "do_tail_call" (func $a_do_tail_call (param i32) (result i32)))
+    (import "js" "doThrow" (func $doThrow))
+    (memory (export "mem") 1)
+    (data (i32.const 0) "\\ff\\00\\00\\00")  ;; memory[0] = 255
+
+    ;; If n <= 0, throw via JS import. Otherwise tail-call back to A with n-1.
+    (func (export "thrower") (param i32) (result i32)
+        (if (i32.le_s (local.get 0) (i32.const 0))
+            (then
+                call $doThrow
+                unreachable
+            )
+        )
+        (i32.sub (local.get 0) (i32.const 1))
+        return_call $a_do_tail_call
+    )
+)
+`
+
+async function test() {
+    const sentinel = new Error("cross-instance-throw-test");
+
+    const instanceA = await instantiate(watA, {
+        b: { thrower: () => { throw sentinel; } }  // placeholder, replaced below
+    }, { tail_call: true });
+
+    const instanceB = await instantiate(watB, {
+        a: { do_tail_call: instanceA.exports.do_tail_call },
+        js: { doThrow: () => { throw sentinel; } },
+    }, { tail_call: true });
+
+    // Re-instantiate A with B's real thrower.
+    const instA = await instantiate(watA, {
+        b: { thrower: instanceB.exports.thrower },
+    }, { tail_call: true });
+
+    // --- Test 1: Direct throw (n=0), single cross-instance hop ---
+    let caught = false;
+    try {
+        instA.exports.call_then_tail_call(0);
+    } catch (e) {
+        caught = true;
+        assert.eq(e, sentinel);
+    }
+    assert.eq(caught, true, "Exception should propagate through thunk");
+
+    // --- Test 2: Throw after several cross-instance hops (n=10) ---
+    caught = false;
+    try {
+        instA.exports.call_then_tail_call(10);
+    } catch (e) {
+        caught = true;
+        assert.eq(e, sentinel);
+    }
+    assert.eq(caught, true, "Exception should propagate through deep cross-instance chain");
+
+    // --- Test 3: After a successful cross-instance tail call, a throwing one should not
+    //     corrupt the caller's state. Do a non-throwing call first, then a throwing one. ---
+    // First, verify non-throwing path works (thrower with n > 0 tail-calls back to A
+    // which tail-calls back, etc. We need a non-throwing variant).
+    // Instead, just verify that after catching the throw, we can still call successfully.
+    caught = false;
+    try {
+        instA.exports.call_then_tail_call(0);
+    } catch (e) {
+        caught = true;
+    }
+    assert.eq(caught, true);
+
+    // After the throw, calling again should still work (no corrupted state).
+    caught = false;
+    try {
+        instA.exports.call_then_tail_call(0);
+    } catch (e) {
+        caught = true;
+        assert.eq(e, sentinel);
+    }
+    assert.eq(caught, true, "Repeated throws should work");
+
+}
+
+await assert.asyncTest(test())

--- a/Source/JavaScriptCore/assembler/MacroAssembler.h
+++ b/Source/JavaScriptCore/assembler/MacroAssembler.h
@@ -2482,6 +2482,7 @@ public:
         MacroAssemblerBase::mul32(imm, src, dest);
     }
 
+    // Returned branch should be taken on ASSERT pass.
     void jitAssert(const WTF::ScopedLambda<Jump(void)>&);
 
     // This function emits code to preserve the CPUState (e.g. registers),

--- a/Source/JavaScriptCore/assembler/MacroAssemblerARM64E.h
+++ b/Source/JavaScriptCore/assembler/MacroAssemblerARM64E.h
@@ -78,7 +78,7 @@ public:
             m_assembler.pacibsp();
             return;
         }
-        RELEASE_ASSERT(Options::allowNonSPTagging());
+        RELEASE_ASSERT(Options::allowNonSPTagging() || (target == ARM64Registers::lr && tag == ARM64Registers::fp));
         m_assembler.pacib(target, tag);
     }
 

--- a/Source/JavaScriptCore/llint/InPlaceInterpreter.asm
+++ b/Source/JavaScriptCore/llint/InPlaceInterpreter.asm
@@ -426,7 +426,7 @@ end
 # ---------------------------------------
 
 # Memory
-macro ipintReloadMemory()
+macro ipintReloadMemory(scratch)
     if ARM64 or ARM64E
         loadpairq constexpr (JSWebAssemblyInstance::offsetOfCachedMemoryBaseSizePair(0))[wasmInstance], memoryBase, boundsCheckingSize
     elsif X86_64
@@ -434,7 +434,7 @@ macro ipintReloadMemory()
         loadp constexpr (JSWebAssemblyInstance::offsetOfCachedMemoryBaseSizePair(0) + 8)[wasmInstance], boundsCheckingSize
     end
     if not ARMv7
-        cagedPrimitiveMayBeNull(memoryBase, t2)
+        cagedPrimitiveMayBeNull(memoryBase, scratch)
     end
 end
 
@@ -533,7 +533,7 @@ if WEBASSEMBLY_BBQJIT
     preserveWasmArgumentRegisters()
 
 if not ARMv7
-    ipintReloadMemory()
+    ipintReloadMemory(t2)
     push memoryBase, boundsCheckingSize
 end
 
@@ -1379,7 +1379,7 @@ end
     loadp Wasm::IPIntCallee::m_metadata + VectorBufferOffset[ws0], MC
 
     # Load memory
-    ipintReloadMemory()
+    ipintReloadMemory(t2)
 
     nextIPIntInstruction()
 
@@ -1450,7 +1450,7 @@ if WEBASSEMBLY and (ARM64 or ARM64E or X86_64)
     move sp, a2
     operationCall(macro() cCall3(_ipint_extern_retrieve_and_clear_exception) end)
 
-    ipintReloadMemory()
+    ipintReloadMemory(t2)
     advanceMC(4)
     nextIPIntInstruction()
 else
@@ -1466,7 +1466,7 @@ if WEBASSEMBLY and (ARM64 or ARM64E or X86_64)
     move 0, a2
     operationCall(macro() cCall3(_ipint_extern_retrieve_and_clear_exception) end)
 
-    ipintReloadMemory()
+    ipintReloadMemory(t2)
     advanceMC(4)
     nextIPIntInstruction()
 else
@@ -1484,7 +1484,7 @@ if WEBASSEMBLY and (ARM64 or ARM64E or X86_64 or ARMv7)
     move sp, a2
     operationCall(macro() cCall3(_ipint_extern_retrieve_and_clear_exception) end)
 
-    ipintReloadMemory()
+    ipintReloadMemory(t2)
     advanceMC(4)
     jmp _ipint_block
 else
@@ -1502,7 +1502,7 @@ if WEBASSEMBLY and (ARM64 or ARM64E or X86_64 or ARMv7)
     move sp, a2
     operationCall(macro() cCall3(_ipint_extern_retrieve_clear_and_push_exception_and_arguments) end)
 
-    ipintReloadMemory()
+    ipintReloadMemory(t2)
     advanceMC(4)
     jmp _ipint_block
 else
@@ -1520,7 +1520,7 @@ if WEBASSEMBLY and (ARM64 or ARM64E or X86_64 or ARMv7)
     move 0, a2
     operationCall(macro() cCall3(_ipint_extern_retrieve_and_clear_exception) end)
 
-    ipintReloadMemory()
+    ipintReloadMemory(t2)
     advanceMC(4)
     jmp _ipint_block
 else
@@ -1538,7 +1538,7 @@ if WEBASSEMBLY and (ARM64 or ARM64E or X86_64 or ARMv7)
     move sp, a2
     operationCall(macro() cCall3(_ipint_extern_retrieve_clear_and_push_exception) end)
 
-    ipintReloadMemory()
+    ipintReloadMemory(t2)
     advanceMC(4)
     jmp _ipint_block
 else

--- a/Source/JavaScriptCore/llint/InPlaceInterpreter64.asm
+++ b/Source/JavaScriptCore/llint/InPlaceInterpreter64.asm
@@ -1271,7 +1271,7 @@ ipintOp(_memory_grow, macro()
     advanceMC(constexpr (sizeof(IPInt::MemoryGrowMetadata)))
     operationCall(macro() cCall3(_ipint_extern_memory_grow) end)
     pushInt32(r0)
-    ipintReloadMemory()
+    ipintReloadMemory(t2)
     advancePC(2)
     nextIPIntInstruction()
 end)
@@ -11876,6 +11876,94 @@ end
     jmp .ipint_mint_arg_dispatch
 
 .ipint_tail_call_common:
+    # Check if we need to insert a restore frame for cross-instance tail calls.
+    # Registers on entry:
+    #   r0 = entrypoint, r1 = targetInstance, wasmInstance = current instance,
+    #   t3 = callerStackArgSize, IPIntCallCallee = callee, IPIntCallFunctionSlot = func info
+    # Scratch: t4, t5. Do not clobber anything else.
+    # On x86_64 r1==t2 (both rdx) and on ARM64 r1==t1, so neither t2 nor t1
+    # may be used freely. The ARM64 copy loop uses t2 for pair loads; that is
+    # safe because r1==t1 there (t2 is a distinct register).
+    bpeq r1, wasmInstance, .ipint_tail_call_no_restore_frame
+
+    loadp ReturnPC[cfr], t4
+    removeCodePtrTag t4
+if ARM64E
+    leap _g_config, t5
+    loadp JSCConfigGateMapOffset + (constexpr Gate::wasmRestoreFrame) * PtrSize[t5], t5
+    removeCodePtrTag t5
+else
+    pcrtoaddr _wasm_restore_frame_return, t5
+end
+    bpeq t4, t5, .ipint_tail_call_no_restore_frame
+
+    const RestoreFrameSize = constexpr Wasm::RestoreFrameCallee::restoreFrameSizeInBytes
+
+    # Step 1: Write the restore frame at cfr + 16 + t3.
+    # cfr hasn't shifted yet, so this is cfr_old + (FirstArgumentOffset - RestoreFrameSize) + t3.
+    leap (FirstArgumentOffset - RestoreFrameSize)[cfr, t3], t4   # t4 = restore_cfr
+
+    loadp [cfr], t5
+    storep t5, [t4]                         # originalCallerFrame
+if ARM64E
+    loadp ReturnPC[cfr], lr
+    addp CallerFrameAndPCSize, cfr, t5
+    untagReturnAddress t5
+    addp CallerFrameAndPCSize, t4, t5
+    tagReturnAddress t5
+    storep lr, ReturnPC[t4]                 # originalReturnPC (resigned for restore_cfr)
+else
+    loadp ReturnPC[cfr], t5
+    storep t5, ReturnPC[t4]                 # originalReturnPC
+end
+    storep wasmInstance, CodeBlock[t4]       # saved instance
+    leap _g_restoreFrameCalleeBoxed, t5
+    loadp [t5], t5
+    storep t5, Callee[t4]                   # RestoreFrameCallee
+
+    # Step 2: Copy [sp, cfr) down by RestoreFrameSize bytes.
+    move sp, t4
+
+    # Move sp down now so don't write below it in the copy loop.
+    subp RestoreFrameSize, sp
+
+.ipint_restore_frame_copy_loop:
+    bpaeq t4, cfr, .ipint_restore_frame_copy_loop_done
+if ARM64 or ARM64E
+    # t2 is safe here because r1==t1 on ARM64 (t2 is x2, a distinct register).
+    loadpairq [t4], t2, t5
+    storepairq t2, t5, -RestoreFrameSize[t4]
+elsif X86_64
+    loadp [t4], t5
+    storep t5, -RestoreFrameSize[t4]
+    loadp 8[t4], t5
+    storep t5, (8 - RestoreFrameSize)[t4]
+end
+    addp 16, t4
+    jmp .ipint_restore_frame_copy_loop
+
+.ipint_restore_frame_copy_loop_done:
+
+    # Step 3: Shift cfr down by 32, sp was handled before the copy loop.
+    subp RestoreFrameSize, cfr
+
+    # Step 4: Write redirect at cfr_new.
+    # restore_cfr = cfr_new + FirstArgumentOffset + t3
+    leap FirstArgumentOffset[cfr, t3], t4   # t4 = restore_cfr
+    storep t4, [cfr]                        # CallerFrame = restore_cfr
+
+if ARM64E
+    leap _g_config, t4
+    loadp JSCConfigGateMapOffset + (constexpr Gate::wasmRestoreFrame) * PtrSize[t4], t4
+    removeCodePtrTag t4
+    addp CallerFrameAndPCSize, cfr, t5
+    tagCodePtr t4, t5
+else
+    pcrtoaddr _wasm_restore_frame_return, t4
+end
+    storep t4, ReturnPC[cfr]                # ReturnPC = wasmRestoreFrame gate
+
+.ipint_tail_call_no_restore_frame:
     # Free up r0 to be used as argument register
 
     #  <caller frame>
@@ -12179,9 +12267,7 @@ mintAlign(_call)
     storep sc1, ThisArgumentOffset[cfr]
 
     # Set up memory
-    push t2, t3
-    ipintReloadMemory()
-    pop t3, t2
+    ipintReloadMemory(ws1)
 
     # Make the call
 if ARM64E
@@ -12380,7 +12466,7 @@ end
     storep ws0, UnboxedWasmCalleeStackSlot[cfr]
 
     # Restore memory
-    ipintReloadMemory()
+    ipintReloadMemory(t2)
     nextIPIntInstruction()
 
 .ipint_perform_tail_call:
@@ -12490,9 +12576,7 @@ end
     move targetInstance, wasmInstance
 
     # set up memory
-    push t2, t3
-    ipintReloadMemory()
-    pop t3, t2
+    ipintReloadMemory(ws1)
 
     addp CallerFrameAndPCSize, sp
 
@@ -12791,4 +12875,28 @@ if ARM64E
     _wasmTailCallTrampoline:
         untagReturnAddress ws2
         jmp ws0, WasmEntryPtrTag
+end
+
+# Restore frame return stub: only used when JIT cage is disabled.
+# When JIT cage is enabled, the wasmRestoreFrame gate thunk handles this.
+# At entry: return values in wa/wfa registers and at sp (don't change these)
+global _wasm_restore_frame_return
+_wasm_restore_frame_return:
+    loadp CodeBlock[cfr], wasmInstance
+    ipintReloadMemory(ws0)
+
+if ARM64E
+    loadp ReturnPC[cfr], lr
+    addp CallerFrameAndPCSize, cfr, ws0
+    untagReturnAddress ws0
+    loadp [cfr], cfr
+    tagReturnAddress sp
+    ret
+elsif ARM64
+    loadpairq [cfr], cfr, lr
+    ret
+elsif X86_64
+    loadp ReturnPC[cfr], ws1
+    loadp [cfr], cfr
+    jmp ws1
 end

--- a/Source/JavaScriptCore/llint/LLIntData.cpp
+++ b/Source/JavaScriptCore/llint/LLIntData.cpp
@@ -80,6 +80,7 @@ extern "C" void relocate_jit_return_pc_trampoline(void);
 extern "C" void exit_implanted_slice(void);
 extern "C" void get_sentinel_frame_return_pc_return_location(void);
 extern "C" void get_sentinel_frame_return_pc_trampoline(void);
+extern "C" void wasm_restore_frame_return(void);
 JSC_ANNOTATE_JIT_OPERATION_RETURN(relocate_jit_return_pc_return_location);
 JSC_ANNOTATE_JIT_OPERATION_RETURN(exit_implanted_slice);
 JSC_ANNOTATE_JIT_OPERATION_RETURN(get_sentinel_frame_return_pc_return_location);
@@ -402,6 +403,16 @@ void initialize()
         else
             codeRef.construct(MacroAssemblerCodeRef<NativeToJITGatePtrTag>::createSelfManagedCodeRef(CodePtr<NativeToJITGatePtrTag>::fromTaggedPtr(retagCodePtr<void*, CFunctionPtrTag, NativeToJITGatePtrTag>(&get_sentinel_frame_return_pc_trampoline))));
         g_jscConfig.llint.gateMap[static_cast<unsigned>(Gate::getSentinelFrameReturnPCGate)] = codeRef.get().code().taggedPtr();
+    }
+    {
+        static LazyNeverDestroyed<MacroAssemblerCodeRef<NativeToJITGatePtrTag>> codeRef;
+#if ENABLE(JIT_CAGE)
+        if (Options::useJITCage())
+            codeRef.construct(wasmRestoreFrameGateThunk());
+        else
+#endif
+            codeRef.construct(MacroAssemblerCodeRef<NativeToJITGatePtrTag>::createSelfManagedCodeRef(CodePtr<NativeToJITGatePtrTag>::fromTaggedPtr(retagCodePtr<void*, CFunctionPtrTag, NativeToJITGatePtrTag>(&wasm_restore_frame_return))));
+        g_jscConfig.llint.gateMap[static_cast<unsigned>(Gate::wasmRestoreFrame)] = codeRef.get().code().taggedPtr();
     }
 #endif
 

--- a/Source/JavaScriptCore/llint/LLIntThunks.cpp
+++ b/Source/JavaScriptCore/llint/LLIntThunks.cpp
@@ -31,6 +31,7 @@
 #include "JSCConfig.h"
 #include "JSCJSValueInlines.h"
 #include "JSInterfaceJIT.h"
+#include "JSWebAssemblyInstance.h"
 #include "LLIntCLoop.h"
 #include "LLIntData.h"
 #include "LinkBuffer.h"
@@ -701,6 +702,43 @@ MacroAssemblerCodeRef<NativeToJITGatePtrTag> untagGateThunk(void* pointer)
 #endif // CPU(ARM64E)
 
 #if ENABLE(JIT_CAGE)
+#if ENABLE(WEBASSEMBLY)
+MacroAssemblerCodeRef<NativeToJITGatePtrTag> wasmRestoreFrameGateThunk()
+{
+    static LazyNeverDestroyed<MacroAssemblerCodeRef<NativeToJITGatePtrTag>> codeRef;
+    static std::once_flag onceKey;
+    std::call_once(onceKey, [&] {
+        CCallHelpers jit;
+
+        JIT_COMMENT(jit, "wasmRestoreFrame gate: restore instance and memory");
+        jit.loadPtr(CCallHelpers::Address(GPRInfo::callFrameRegister, CallFrameSlot::codeBlock * sizeof(Register)), GPRInfo::wasmContextInstancePointer);
+        jit.loadPairPtr(GPRInfo::wasmContextInstancePointer, CCallHelpers::TrustedImm32(JSWebAssemblyInstance::offsetOfCachedMemoryBaseSizePair(0)), GPRInfo::wasmBaseMemoryPointer, GPRInfo::wasmBoundsCheckingSizeRegister);
+        jit.cageConditionally(Gigacage::Primitive, GPRInfo::wasmBaseMemoryPointer, GPRInfo::wasmBoundsCheckingSizeRegister, Wasm::wasmCallingConvention().prologueScratchGPRs[0]);
+
+        JIT_COMMENT(jit, "wasmRestoreFrame gate: untag return PC, load caller frame, retag, return");
+#if CPU(ARM64E)
+        jit.loadPtr(CCallHelpers::Address(GPRInfo::callFrameRegister, CallFrame::returnPCOffset()), ARM64Registers::lr);
+        jit.addPtr(CCallHelpers::TrustedImm32(sizeof(CallerFrameAndPC)), GPRInfo::callFrameRegister, jit.scratchRegister());
+        jit.untagPtr(jit.scratchRegister(), ARM64Registers::lr);
+        jit.validateUntaggedPtr(ARM64Registers::lr, jit.scratchRegister());
+        jit.loadPtr(CCallHelpers::Address(GPRInfo::callFrameRegister), GPRInfo::callFrameRegister);
+        jit.tagPtr(MacroAssembler::stackPointerRegister, ARM64Registers::lr);
+        jit.ret();
+#elif CPU(ARM64)
+        jit.loadPairPtr(GPRInfo::callFrameRegister, GPRInfo::callFrameRegister, ARM64Registers::lr);
+        jit.ret();
+#elif CPU(X86_64)
+        jit.loadPtr(CCallHelpers::Address(GPRInfo::callFrameRegister, CallFrame::returnPCOffset()), GPRInfo::nonPreservedNonArgumentGPR0);
+        jit.loadPtr(CCallHelpers::Address(GPRInfo::callFrameRegister), GPRInfo::callFrameRegister);
+        jit.farJump(GPRInfo::nonPreservedNonArgumentGPR0, NoPtrTag);
+#endif
+
+        LinkBuffer patchBuffer(jit, GLOBAL_THUNK_ID, LinkBuffer::Profile::LLIntThunk);
+        codeRef.construct(FINALIZE_CODE(patchBuffer, NativeToJITGatePtrTag, "wasmRestoreFrame"_s, "wasmRestoreFrame thunk"));
+    });
+    return codeRef;
+}
+#endif // ENABLE(WEBASSEMBLY)
 
 MacroAssemblerCodeRef<NativeToJITGatePtrTag> jitCagePtrThunk()
 {

--- a/Source/JavaScriptCore/llint/LLIntThunks.h
+++ b/Source/JavaScriptCore/llint/LLIntThunks.h
@@ -137,6 +137,9 @@ MacroAssemblerCodeRef<NativeToJITGatePtrTag> relocateJITReturnPCThunk(void*);
 MacroAssemblerCodeRef<NativeToJITGatePtrTag> exitImplantedSliceGateThunk(void*);
 MacroAssemblerCodeRef<NativeToJITGatePtrTag> getSentinelFrameReturnPCGateThunk(void*);
 #endif
+#if ENABLE(JIT_CAGE)
+MacroAssemblerCodeRef<NativeToJITGatePtrTag> wasmRestoreFrameGateThunk();
+#endif // ENABLE(JIT_CAGE)
 #endif // ENABLE(WEBASSEMBLY)
 
 } } // namespace JSC::LLInt

--- a/Source/JavaScriptCore/runtime/Gate.h
+++ b/Source/JavaScriptCore/runtime/Gate.h
@@ -69,6 +69,7 @@ namespace JSC {
     v(relocateJITReturnPC, NoPtrTag) \
     v(exitImplantedSliceGate, NoPtrTag) \
     v(getSentinelFrameReturnPCGate, NoPtrTag) \
+    v(wasmRestoreFrame, NoPtrTag) \
 
 #define JSC_WASM_GATE_OPCODES(v) \
     v(wasm_ipint_call, WasmEntryPtrTag) \

--- a/Source/JavaScriptCore/runtime/SamplingProfiler.cpp
+++ b/Source/JavaScriptCore/runtime/SamplingProfiler.cpp
@@ -1065,6 +1065,7 @@ static String tierName(SamplingProfiler::StackFrame& frame)
             case Wasm::CompilationMode::JSToWasmICMode:
             case Wasm::CompilationMode::WasmToJSMode:
             case Wasm::CompilationMode::WasmBuiltinMode:
+            case Wasm::CompilationMode::RestoreFrameMode:
                 // Just say "Wasm" for now.
                 break;
             case Wasm::CompilationMode::BBQMode:

--- a/Source/JavaScriptCore/wasm/WasmBBQJIT.cpp
+++ b/Source/JavaScriptCore/wasm/WasmBBQJIT.cpp
@@ -4406,6 +4406,8 @@ void BBQJIT::returnValuesFromCall(Vector<Value, N>& results, const RTT& function
 
 void BBQJIT::emitTailCall(FunctionSpaceIndex functionIndexSpace, const RTT& signature, ArgumentList& arguments)
 {
+    bool isImport = m_info.isImportedFunctionFromFunctionIndexSpace(functionIndexSpace);
+
     const auto& callingConvention = wasmCallingConvention();
     CallInformation callInfo = callingConvention.callInformationFor(signature, CallRole::Callee);
     Checked<int32_t> calleeStackSize = WTF::roundUpToMultipleOf(stackAlignmentBytes(), callInfo.headerAndArgumentStackSizeInBytes);
@@ -4434,6 +4436,25 @@ void BBQJIT::emitTailCall(FunctionSpaceIndex functionIndexSpace, const RTT& sign
     ScratchScope<1, 0> scratches(*this, WTF::move(preserved));
     GPRReg callerFramePointer = scratches.gpr(0);
     scratches.unbindPreserved();
+
+    if (isImport) {
+        int32_t topSource = -static_cast<int32_t>(m_frameSize);
+        for (unsigned i = 0; i < arguments.size(); i++) {
+            if (!arguments[i].value().isConst()) {
+                Location loc = locationOf(arguments[i]);
+                if (loc.isStack())
+                    topSource = std::max(topSource, loc.asStackOffset() + static_cast<int32_t>(sizeof(Register)));
+            }
+        }
+        Checked<int32_t> topSourceOffsetFromFP = static_cast<int32_t>(roundUpToMultipleOf<stackAlignmentBytes()>(topSource));
+
+        // We know we're going to do a cross instance call here since it's not semantically possible to import a function into the same instance.
+        auto targetInstOffset = JSWebAssemblyInstance::offsetOfTargetInstance(m_module.moduleInformation(), functionIndexSpace);
+        m_jit.loadPtr(Address(GPRInfo::wasmContextInstancePointer, targetInstOffset), wasmScratchGPR);
+
+        // We can trash wasmBaseMemoryPointer and wasmBoundsCheckingSizeRegister since we won't use them during argument setup and we'll restore them for our callee anyway.
+        emitRestoreInstanceFrameIfNeeded(m_jit, GPRInfo::wasmContextInstancePointer, callerStackSize, m_frameSize, topSourceOffsetFromFP, wasmScratchGPR, wasmBaseMemoryPointer);
+    }
 
 #if CPU(X86_64)
     m_jit.loadPtr(Address(MacroAssembler::framePointerRegister), callerFramePointer);
@@ -4492,7 +4513,7 @@ void BBQJIT::emitTailCall(FunctionSpaceIndex functionIndexSpace, const RTT& sign
 
     // Nothing should refer to FP after this point.
 
-    if (m_info.isImportedFunctionFromFunctionIndexSpace(functionIndexSpace)) {
+    if (isImport) {
         static_assert(sizeof(WasmOrJSImportableFunctionCallLinkInfo) * maxImports < std::numeric_limits<int32_t>::max());
         RELEASE_ASSERT(JSWebAssemblyInstance::offsetOfImportFunctionStub(m_module.moduleInformation(), functionIndexSpace) < std::numeric_limits<int32_t>::max());
         m_jit.farJump(Address(GPRInfo::wasmContextInstancePointer, JSWebAssemblyInstance::offsetOfImportFunctionStub(m_module.moduleInformation(), functionIndexSpace)), WasmEntryPtrTag);
@@ -4566,7 +4587,7 @@ void BBQJIT::emitTailCall(FunctionSpaceIndex functionIndexSpace, const RTT& sign
     // Our callee could have tail called someone else and changed SP so we need to restore it.
     m_jit.subPtr(GPRInfo::callFrameRegister, TrustedImm32(m_frameSize), MacroAssembler::stackPointerRegister);
 
-    if (m_info.callCanClobberInstance(functionIndexSpace) || m_info.isImportedFunctionFromFunctionIndexSpace(functionIndexSpace))
+    if (m_info.isImportedFunctionFromFunctionIndexSpace(functionIndexSpace))
         restoreWebAssemblyGlobalStateAfterWasmCall();
 
     LOG_INSTRUCTION("Call", functionIndexSpace, arguments, "=> ", results);
@@ -4656,18 +4677,6 @@ void BBQJIT::emitIndirectTailCall(const char* opcode, const Value& callee, GPRRe
     ASSERT(!RegisterSet::argumentGPRs().contains(importableFunction, IgnoreVectors));
     ASSERT(!RegisterSet::argumentGPRs().contains(wasmScratchGPR, IgnoreVectors));
 
-    m_jit.loadPtr(CCallHelpers::Address(importableFunction, WasmToWasmImportableFunction::offsetOfBoxedCallee()), wasmScratchGPR);
-    m_jit.storeWasmCalleeToCalleeCallFrame(wasmScratchGPR);
-
-    // Do a context switch if needed.
-    m_jit.loadPtr(CCallHelpers::Address(importableFunction, WasmToWasmImportableFunction::offsetOfTargetInstance()), wasmScratchGPR);
-    Jump isSameInstanceBefore = m_jit.branchPtr(RelationalCondition::Equal, wasmScratchGPR, GPRInfo::wasmContextInstancePointer);
-    m_jit.move(wasmScratchGPR, GPRInfo::wasmContextInstancePointer);
-#if USE(JSVALUE64)
-    loadWebAssemblyGlobalState(wasmBaseMemoryPointer, wasmBoundsCheckingSizeRegister);
-#endif
-    isSameInstanceBefore.link(&m_jit);
-
     const auto& callingConvention = wasmCallingConvention();
     CallInformation callInfo = callingConvention.callInformationFor(signature, CallRole::Callee);
     Checked<int32_t> calleeStackSize = WTF::roundUpToMultipleOf(stackAlignmentBytes(), callInfo.headerAndArgumentStackSizeInBytes);
@@ -4683,6 +4692,32 @@ void BBQJIT::emitIndirectTailCall(const char* opcode, const Value& callee, GPRRe
     ASSERT(callInfo.results.size() == wasmCallerInfo.results.size());
     ASSERT(arguments.size() == callInfo.params.size());
 
+    emitRestoreCalleeSaves();
+
+    {
+        int32_t topSource = -static_cast<int32_t>(m_frameSize);
+        for (unsigned i = 0; i < arguments.size(); i++) {
+            if (!arguments[i].value().isConst()) {
+                Location loc = locationOf(arguments[i]);
+                if (loc.isStack())
+                    topSource = std::max(topSource, loc.asStackOffset() + static_cast<int32_t>(sizeof(Register)));
+            }
+        }
+        Checked<int32_t> topSourceOffsetFromFP = static_cast<int32_t>(roundUpToMultipleOf<stackAlignmentBytes()>(topSource));
+
+        m_jit.loadPtr(CCallHelpers::Address(importableFunction, WasmToWasmImportableFunction::offsetOfTargetInstance()), wasmScratchGPR);
+        Jump isSameInstance = m_jit.branchPtr(RelationalCondition::Equal, wasmScratchGPR, GPRInfo::wasmContextInstancePointer);
+        emitRestoreInstanceFrameIfNeeded(m_jit, GPRInfo::wasmContextInstancePointer, callerStackSize, m_frameSize, topSourceOffsetFromFP, wasmScratchGPR, wasmBaseMemoryPointer);
+        m_jit.loadPtr(CCallHelpers::Address(importableFunction, WasmToWasmImportableFunction::offsetOfTargetInstance()), GPRInfo::wasmContextInstancePointer);
+#if USE(JSVALUE64)
+        loadWebAssemblyGlobalState(wasmBaseMemoryPointer, wasmBoundsCheckingSizeRegister);
+#endif
+        isSameInstance.link(m_jit);
+    }
+
+    m_jit.loadPtr(CCallHelpers::Address(importableFunction, WasmToWasmImportableFunction::offsetOfBoxedCallee()), wasmScratchGPR);
+    m_jit.storeWasmCalleeToCalleeCallFrame(wasmScratchGPR);
+
     Vector<Value, 8> resolvedArguments;
     const unsigned calleeArgument = 1;
     resolvedArguments.reserveInitialCapacity(arguments.size() + calleeArgument + isX86() * 2);
@@ -4694,8 +4729,6 @@ void BBQJIT::emitIndirectTailCall(const char* opcode, const Value& callee, GPRRe
     resolvedArguments.append(Value::pinned(TypeKind::I64, Location::fromStackArgument(CCallHelpers::addressOfCalleeCalleeFromCallerPerspective(0).offset)));
     parameterLocations.append(Location::fromStack(tailCallStackOffsetFromFP + Checked<int>(CallFrameSlot::callee * sizeof(Register))));
 
-    // Save the old Frame Pointer for later and make sure the return address gets saved to its canonical location.
-    emitRestoreCalleeSaves();
 #if CPU(X86_64)
     // There are no remaining non-argument non-preserved gprs left on X86_64 so we have to shuffle FP to a temp slot.
     resolvedArguments.append(Value::pinned(pointerType(), Location::fromStack(0)));

--- a/Source/JavaScriptCore/wasm/WasmCallee.cpp
+++ b/Source/JavaScriptCore/wasm/WasmCallee.cpp
@@ -28,6 +28,7 @@
 
 #if ENABLE(WEBASSEMBLY)
 
+#include "CalleeBits.h"
 #include "InPlaceInterpreter.h"
 #include "JSCJSValueInlines.h"
 #include "JSToWasm.h"
@@ -56,6 +57,7 @@ WTF_MAKE_COMPACT_TZONE_ALLOCATED_IMPL(Callee);
 WTF_MAKE_COMPACT_TZONE_ALLOCATED_IMPL(JITCallee);
 WTF_MAKE_COMPACT_TZONE_ALLOCATED_IMPL(JSToWasmCallee);
 WTF_MAKE_COMPACT_TZONE_ALLOCATED_IMPL(WasmToJSCallee);
+WTF_MAKE_COMPACT_TZONE_ALLOCATED_IMPL(RestoreFrameCallee);
 WTF_MAKE_COMPACT_TZONE_ALLOCATED_IMPL(IPIntCallee);
 WTF_MAKE_COMPACT_TZONE_ALLOCATED_IMPL(WasmBuiltinCallee);
 
@@ -141,6 +143,9 @@ inline void Callee::runWithDowncast(const Func& func)
         break;
     case CompilationMode::WasmBuiltinMode:
         func(uncheckedDowncast<WasmBuiltinCallee>(this));
+        break;
+    case CompilationMode::RestoreFrameMode:
+        func(uncheckedDowncast<RestoreFrameCallee>(this));
         break;
     }
 }
@@ -266,6 +271,25 @@ WasmToJSCallee& WasmToJSCallee::singleton()
     static std::once_flag onceKey;
     std::call_once(onceKey, [&]() {
         callee.construct(adoptRef(*new WasmToJSCallee));
+    });
+    return callee.get().get();
+}
+
+EncodedJSValue g_restoreFrameCalleeBoxed { };
+
+RestoreFrameCallee::RestoreFrameCallee()
+    : Callee(Wasm::CompilationMode::RestoreFrameMode)
+{
+    NativeCalleeRegistry::singleton().registerCallee(this);
+}
+
+RestoreFrameCallee& RestoreFrameCallee::singleton()
+{
+    static LazyNeverDestroyed<Ref<RestoreFrameCallee>> callee;
+    static std::once_flag onceKey;
+    std::call_once(onceKey, [&]() {
+        callee.construct(adoptRef(*new RestoreFrameCallee));
+        g_restoreFrameCalleeBoxed = CalleeBits::encodeNativeCallee(&callee.get().get());
     });
     return callee.get().get();
 }

--- a/Source/JavaScriptCore/wasm/WasmCallee.h
+++ b/Source/JavaScriptCore/wasm/WasmCallee.h
@@ -29,6 +29,7 @@
 
 #if ENABLE(WEBASSEMBLY)
 
+#include <JavaScriptCore/CallFrame.h>
 #include <JavaScriptCore/JITCompilation.h>
 #include <JavaScriptCore/NativeCallee.h>
 #include <JavaScriptCore/PCToCodeOriginMap.h>
@@ -211,6 +212,26 @@ private:
     CodePtr<WasmEntryPtrTag> entrypointImpl() const { return { }; }
     const RegisterAtOffsetList* calleeSaveRegistersImpl() { return nullptr; }
 };
+
+class RestoreFrameCallee final : public Callee {
+    WTF_MAKE_COMPACT_TZONE_ALLOCATED(RestoreFrameCallee);
+public:
+    friend class Callee;
+    friend class JSC::LLIntOffsetsExtractor;
+
+    static constexpr size_t restoreFrameSizeInBytes = (static_cast<size_t>(CallFrameSlot::callee) + 1) * sizeof(Register);
+
+    static RestoreFrameCallee& singleton();
+
+private:
+    RestoreFrameCallee();
+    std::tuple<void*, void*> rangeImpl() const { return { nullptr, nullptr }; }
+    CodePtr<WasmEntryPtrTag> entrypointImpl() const { return { }; }
+    const RegisterAtOffsetList* calleeSaveRegistersImpl() { return nullptr; }
+};
+
+extern "C" EncodedJSValue g_restoreFrameCalleeBoxed;
+extern "C" void wasm_restore_frame_return();
 
 #if ENABLE(JIT)
 
@@ -619,6 +640,13 @@ SPECIALIZE_TYPE_TRAITS_BEGIN(JSC::Wasm::WasmBuiltinCallee)
     static bool isType(const JSC::Wasm::Callee& callee)
     {
         return callee.compilationMode() == JSC::Wasm::CompilationMode::WasmBuiltinMode;
+    }
+SPECIALIZE_TYPE_TRAITS_END()
+
+SPECIALIZE_TYPE_TRAITS_BEGIN(JSC::Wasm::RestoreFrameCallee)
+    static bool isType(const JSC::Wasm::Callee& callee)
+    {
+        return callee.compilationMode() == JSC::Wasm::CompilationMode::RestoreFrameMode;
     }
 SPECIALIZE_TYPE_TRAITS_END()
 

--- a/Source/JavaScriptCore/wasm/WasmCalleeGroup.cpp
+++ b/Source/JavaScriptCore/wasm/WasmCalleeGroup.cpp
@@ -492,6 +492,7 @@ TriState CalleeGroup::calleeIsReferenced(const AbstractLocker& locker, Wasm::Cal
     case CompilationMode::JSToWasmICMode:
     case CompilationMode::WasmToJSMode:
     case CompilationMode::WasmBuiltinMode:
+    case CompilationMode::RestoreFrameMode:
         return TriState::True;
     default:
         RELEASE_ASSERT_NOT_REACHED();

--- a/Source/JavaScriptCore/wasm/WasmCompilationMode.h
+++ b/Source/JavaScriptCore/wasm/WasmCompilationMode.h
@@ -39,7 +39,8 @@ enum class CompilationMode : uint8_t {
     JSToWasmMode,
     JSToWasmICMode,
     WasmToJSMode,
-    WasmBuiltinMode
+    WasmBuiltinMode,
+    RestoreFrameMode
 };
 
 constexpr inline bool isAnyInterpreter(CompilationMode compilationMode)
@@ -54,6 +55,7 @@ constexpr inline bool isAnyInterpreter(CompilationMode compilationMode)
     case CompilationMode::JSToWasmICMode:
     case CompilationMode::WasmToJSMode:
     case CompilationMode::WasmBuiltinMode:
+    case CompilationMode::RestoreFrameMode:
         return false;
     }
     RELEASE_ASSERT_NOT_REACHED_UNDER_CONSTEXPR_CONTEXT();
@@ -71,6 +73,7 @@ constexpr inline bool isAnyBBQ(CompilationMode compilationMode)
     case CompilationMode::JSToWasmICMode:
     case CompilationMode::WasmToJSMode:
     case CompilationMode::WasmBuiltinMode:
+    case CompilationMode::RestoreFrameMode:
         return false;
     }
     RELEASE_ASSERT_NOT_REACHED_UNDER_CONSTEXPR_CONTEXT();
@@ -88,6 +91,7 @@ constexpr inline bool isAnyOMG(CompilationMode compilationMode)
     case CompilationMode::JSToWasmICMode:
     case CompilationMode::WasmToJSMode:
     case CompilationMode::WasmBuiltinMode:
+    case CompilationMode::RestoreFrameMode:
         return false;
     }
     RELEASE_ASSERT_NOT_REACHED_UNDER_CONSTEXPR_CONTEXT();
@@ -105,6 +109,7 @@ constexpr inline bool isAnyWasmToJS(CompilationMode compilationMode)
     case CompilationMode::JSToWasmMode:
     case CompilationMode::JSToWasmICMode:
     case CompilationMode::WasmBuiltinMode:
+    case CompilationMode::RestoreFrameMode:
         return false;
     }
     RELEASE_ASSERT_NOT_REACHED_UNDER_CONSTEXPR_CONTEXT();

--- a/Source/JavaScriptCore/wasm/WasmFunctionIPIntMetadataGenerator.cpp
+++ b/Source/JavaScriptCore/wasm/WasmFunctionIPIntMetadataGenerator.cpp
@@ -27,7 +27,6 @@
 #include "config.h"
 #include "WasmFunctionIPIntMetadataGenerator.h"
 
-#include <numeric>
 #include <wtf/TZoneMallocInlines.h>
 
 #if ENABLE(WEBASSEMBLY)
@@ -39,14 +38,6 @@ namespace JSC {
 namespace Wasm {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(FunctionIPIntMetadataGenerator);
-
-void FunctionIPIntMetadataGenerator::setTailCall(uint32_t functionIndex, bool isImportedFunctionFromFunctionIndexSpace)
-{
-    m_hasTailCallSuccessors = true;
-    m_tailCallSuccessors.set(functionIndex);
-    if (isImportedFunctionFromFunctionIndexSpace)
-        setTailCallClobbersInstance();
-}
 
 void FunctionIPIntMetadataGenerator::addLength(size_t length)
 {

--- a/Source/JavaScriptCore/wasm/WasmFunctionIPIntMetadataGenerator.h
+++ b/Source/JavaScriptCore/wasm/WasmFunctionIPIntMetadataGenerator.h
@@ -41,8 +41,6 @@ WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 #include <JavaScriptCore/WasmHandlerInfo.h>
 #include <JavaScriptCore/WasmIPIntGenerator.h>
 #include <JavaScriptCore/WasmIPIntTierUpCounter.h>
-#include <JavaScriptCore/WasmOps.h>
-#include <wtf/BitVector.h>
 #include <wtf/HashMap.h>
 #include <wtf/TZoneMalloc.h>
 #include <wtf/Vector.h>
@@ -81,11 +79,6 @@ public:
     }
 
     FunctionCodeIndex functionIndex() const { return m_functionIndex; }
-    bool hasTailCallSuccessors() const { return m_hasTailCallSuccessors; }
-    const BitVector& tailCallSuccessors() const LIFETIME_BOUND { return m_tailCallSuccessors; }
-    bool tailCallClobbersInstance() const { return m_tailCallClobbersInstance ; }
-    void setTailCall(uint32_t, bool);
-    void setTailCallClobbersInstance() { m_tailCallClobbersInstance = true; }
 
     const uint8_t* getBytecode() const LIFETIME_BOUND { return m_bytecode.data(); }
     const uint8_t* getMetadata() const LIFETIME_BOUND { return m_metadata.span().data(); }
@@ -129,9 +122,6 @@ private:
     void addReturnData(const RTT&, const CallInformation&);
 
     FunctionCodeIndex m_functionIndex;
-    bool m_hasTailCallSuccessors { false };
-    bool m_tailCallClobbersInstance { false };
-    BitVector m_tailCallSuccessors;
 
     std::span<const uint8_t> m_bytecode;
     MetadataBuffer m_metadata { };

--- a/Source/JavaScriptCore/wasm/WasmIPIntGenerator.cpp
+++ b/Source/JavaScriptCore/wasm/WasmIPIntGenerator.cpp
@@ -3044,8 +3044,6 @@ void IPIntGenerator::addTailCallCommonData(const RTT&, const CallInformation& ca
         // put arguments into registers / sp (reutilize mINT)
         // jump to entrypoint
         changeStackSize(-signature.argumentCount());
-        m_metadata->setTailCall(index, m_info.isImportedFunctionFromFunctionIndexSpace(index));
-
         Checked<uint32_t> tailCallFrameSize = WTF::roundUpToMultipleOf<stackAlignmentBytes()>(callConvention.headerAndArgumentStackSizeInBytes + sizeof(CallerFrameAndPC));
         m_metadata->m_maxCalleeStackSize = std::max(static_cast<unsigned>(tailCallFrameSize), m_metadata->m_maxCalleeStackSize);
 
@@ -3090,7 +3088,6 @@ void IPIntGenerator::addTailCallCommonData(const RTT&, const CallInformation& ca
     if (callType == CallType::TailCall) {
         const unsigned callIndex = 1;
         changeStackSize(-signature.argumentCount() - callIndex);
-        m_metadata->setTailCallClobbersInstance();
 
         Checked<uint32_t> tailCallFrameSize = WTF::roundUpToMultipleOf<stackAlignmentBytes()>(callConvention.headerAndArgumentStackSizeInBytes + sizeof(CallerFrameAndPC));
         m_metadata->m_maxCalleeStackSize = std::max(static_cast<unsigned>(tailCallFrameSize), m_metadata->m_maxCalleeStackSize);
@@ -3144,7 +3141,6 @@ void IPIntGenerator::addTailCallCommonData(const RTT&, const CallInformation& ca
     if (callType == CallType::TailCall) {
         const unsigned callIndex = 1;
         changeStackSize(-signature.argumentCount() - callIndex);
-        m_metadata->setTailCallClobbersInstance();
 
         Checked<uint32_t> tailCallFrameSize = WTF::roundUpToMultipleOf<stackAlignmentBytes()>(callConvention.headerAndArgumentStackSizeInBytes + sizeof(CallerFrameAndPC));
         m_metadata->m_maxCalleeStackSize = std::max(static_cast<unsigned>(tailCallFrameSize), m_metadata->m_maxCalleeStackSize);

--- a/Source/JavaScriptCore/wasm/WasmIPIntPlan.cpp
+++ b/Source/JavaScriptCore/wasm/WasmIPIntPlan.cpp
@@ -41,7 +41,6 @@
 #include "WasmFunctionIPIntMetadataGenerator.h"
 #include "WasmIPIntGenerator.h"
 #include "WasmTypeDefinitionInlines.h"
-#include <wtf/GraphNodeWorklist.h>
 #include <wtf/text/MakeString.h>
 
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
@@ -111,17 +110,6 @@ void IPIntPlan::compileFunction(FunctionCodeIndex functionIndex)
         return;
     }
 
-    if (Options::useWasmTailCalls()) {
-        if (parseAndCompileResult->get()->hasTailCallSuccessors()) {
-            Locker locker { m_lock };
-            for (auto successor : parseAndCompileResult->get()->tailCallSuccessors())
-                addTailCallEdge(m_moduleInformation->importFunctionCount() + parseAndCompileResult->get()->functionIndex(), successor);
-        }
-
-        if (parseAndCompileResult->get()->tailCallClobbersInstance())
-            m_moduleInformation->addClobberingTailCall(m_moduleInformation->toSpaceIndex(parseAndCompileResult->get()->functionIndex()));
-    }
-
     m_wasmInternalFunctions[functionIndex] = WTF::move(*parseAndCompileResult);
 
     IPIntCallee* ipintCallee = nullptr;
@@ -181,8 +169,8 @@ void IPIntPlan::didCompleteCompilation()
     unsigned functionCount = m_wasmInternalFunctions.size();
     if (!m_calleesAlreadyRegistered && functionCount) {
         NativeCalleeRegistry::singleton().registerCallees(*m_ipintCallees);
-        if (!m_moduleInformation->clobberingTailCalls().isEmpty())
-            computeTransitiveTailCalls();
+        if (Options::useWasmTailCalls())
+            RestoreFrameCallee::singleton();
     }
 
     if (m_compilerMode == CompilerMode::Validation)
@@ -254,36 +242,6 @@ bool IPIntPlan::didReceiveFunctionData(FunctionCodeIndex, const FunctionData&)
 {
     // Validation is done inline by the parser
     return true;
-}
-
-void IPIntPlan::addTailCallEdge(uint32_t callerIndex, uint32_t calleeIndex)
-{
-    auto it = m_tailCallGraph.find(calleeIndex);
-    if (it == m_tailCallGraph.end())
-        it = m_tailCallGraph.add(calleeIndex, TailCallGraph::MappedType()).iterator;
-    it->value.add(callerIndex);
-}
-
-void IPIntPlan::computeTransitiveTailCalls() const
-{
-    // FIXME: Use FunctionCodeIndex -> FunctionSpaceIndex by adding the right HashTraits.
-    GraphNodeWorklist<uint32_t, UncheckedKeyHashSet<uint32_t, IntHash<uint32_t>, WTF::UnsignedWithZeroKeyHashTraits<uint32_t>>> worklist;
-
-    for (auto clobberingTailCall : m_moduleInformation->clobberingTailCalls())
-        worklist.push(clobberingTailCall);
-
-    while (worklist.notEmpty()) {
-        auto node = worklist.pop();
-        auto it = m_tailCallGraph.find(node);
-        if (it == m_tailCallGraph.end())
-            continue;
-        for (const auto &successor : it->value) {
-            if (worklist.saw(successor))
-                continue;
-            m_moduleInformation->addClobberingTailCall(FunctionSpaceIndex(successor));
-            worklist.push(successor);
-        }
-    }
 }
 
 } } // namespace JSC::Wasm

--- a/Source/JavaScriptCore/wasm/WasmIPIntPlan.h
+++ b/Source/JavaScriptCore/wasm/WasmIPIntPlan.h
@@ -39,8 +39,6 @@ class IPIntCallee;
 
 using JSToWasmCalleeMap = UncheckedKeyHashMap<uint32_t, RefPtr<JSToWasmCallee>, DefaultHash<uint32_t>, WTF::UnsignedWithZeroKeyHashTraits<uint32_t>>;
 
-using TailCallGraph = UncheckedKeyHashMap<uint32_t, UncheckedKeyHashSet<uint32_t, IntHash<uint32_t>, WTF::UnsignedWithZeroKeyHashTraits<uint32_t>>, IntHash<uint32_t>, WTF::UnsignedWithZeroKeyHashTraits<uint32_t>>;
-
 
 class IPIntPlan final : public EntryPlan {
     using Base = EntryPlan;
@@ -83,9 +81,6 @@ private:
     bool prepareImpl() final;
     void didCompleteCompilation() WTF_REQUIRES_LOCK(m_lock) final;
 
-    void addTailCallEdge(uint32_t, uint32_t) WTF_REQUIRES_LOCK(m_lock);
-    void computeTransitiveTailCalls() const;
-
     bool ensureEntrypoint(IPIntCallee&, FunctionCodeIndex functionIndex);
 
     Vector<std::unique_ptr<FunctionIPIntMetadataGenerator>> m_wasmInternalFunctions;
@@ -93,7 +88,6 @@ private:
     bool m_calleesAlreadyRegistered { false };
     Vector<RefPtr<JSToWasmCallee>> m_entrypoints;
     JSToWasmCalleeMap m_jsToWasmCallees;
-    TailCallGraph m_tailCallGraph;
 };
 
 } } // namespace JSC::Wasm

--- a/Source/JavaScriptCore/wasm/WasmIPIntSlowPaths.cpp
+++ b/Source/JavaScriptCore/wasm/WasmIPIntSlowPaths.cpp
@@ -1205,6 +1205,7 @@ WASM_IPINT_EXTERN_CPP_DECL(prepare_call_ref, CallFrame* callFrame, CallRefMetada
     WASM_CALL_RETURN(calleeInstance, callTarget);
 }
 
+
 WASM_IPINT_EXTERN_CPP_DECL(set_global_ref, uint32_t globalIndex, JSValue value)
 {
     instance->setGlobal(globalIndex, value);

--- a/Source/JavaScriptCore/wasm/WasmIRGeneratorHelpers.h
+++ b/Source/JavaScriptCore/wasm/WasmIRGeneratorHelpers.h
@@ -31,10 +31,12 @@
 #include "B3StackmapGenerationParams.h"
 #include "B3StackmapValue.h"
 #include "CCallHelpers.h"
+#include "JSCConfig.h"
 #include "JSWebAssemblyException.h"
 #include "JSWebAssemblyInstance.h"
 #include "LinkBuffer.h"
 #include "ProbeContext.h"
+#include "WasmCallee.h"
 #include "WasmCompilationContext.h"
 #include "WasmOperations.h"
 
@@ -221,6 +223,117 @@ static inline void prepareForTailCall(CCallHelpers& jit, const B3::StackmapGener
 }
 
 #endif // ENABLE(WEBASSEMBLY_OMGJIT)
+
+// Emits a RestoreInstanceCallee frame to restore our instance when returning from a
+// cross instance tail call chain. This is done lazily for performance of intra-module
+// tail call chains.
+// Note: since we know we're making a cross instance call it's likely valid to use
+// GPRInfo::wasmBaseMemoryPointer and GPRInfo::wasmBoundsCheckingSizeRegister as
+// two of the scratches. They'll be filled later anyway.
+//
+// FIXME: In OMG and BBQ, emit restore frame creation on an out-of-line slow path
+// so the common case (same instance || restore frame exists) doesn't have to jump over
+// this code.
+inline void emitRestoreInstanceFrameIfNeeded(CCallHelpers& jit, GPRReg currentInstanceReg, Checked<int32_t> callerStackSize, Checked<int32_t> frameSize, Checked<int32_t> topSourceOffsetFromFP, GPRReg scratch1, GPRReg scratch2)
+{
+#if CPU(ARM64E)
+    auto* restoreFrameReturnAddress = untagCodePtr<NativeToJITGatePtrTag>(g_jscConfig.llint.gateMap[static_cast<unsigned>(Gate::wasmRestoreFrame)]);
+#else
+    auto* restoreFrameReturnAddress = untagCodePtr<CFunctionPtrTag>(wasm_restore_frame_return);
+#endif
+    ASSERT(restoreFrameReturnAddress);
+    ASSERT(noOverlap(currentInstanceReg, scratch1, scratch2));
+    ASSERT(topSourceOffsetFromFP <= callerStackSize);
+    ASSERT(isMultipleOf(stackAlignmentBytes(), topSourceOffsetFromFP));
+    static constexpr unsigned restoreFrameSize = RestoreFrameCallee::restoreFrameSizeInBytes;
+    Checked<int32_t> restoreFrameBase = callerStackSize - Checked<int32_t>(restoreFrameSize);
+    bool needsCopy = topSourceOffsetFromFP != -frameSize;
+
+    JIT_COMMENT(jit, "Check for existing restore frame");
+    jit.loadPtr(CCallHelpers::Address(MacroAssembler::framePointerRegister, CallFrame::returnPCOffset()), scratch1);
+#if CPU(ARM64E)
+    jit.removePtrTag(scratch1);
+#endif
+    auto hasExistingThunk = jit.branchPtr(CCallHelpers::Equal, scratch1,
+        CCallHelpers::TrustedImmPtr(restoreFrameReturnAddress));
+
+    JIT_COMMENT(jit, "Restore frame body for callerStackSize: ", callerStackSize, " frameSize: ", frameSize, " topSourceOffsetFromFP: ", topSourceOffsetFromFP, " restoreFrameBase: ", restoreFrameBase);
+    // Lower sp so we don't write below it if we take the loop.
+    jit.subPtr(CCallHelpers::TrustedImm32(restoreFrameSize), MacroAssembler::stackPointerRegister);
+
+    if (needsCopy) {
+        // Copy [sp, cfr + topSourceOffsetFromFP) down by restoreFrameSize bytes.
+        // The range above cfr is the caller's argument area. OMG may reference
+        // these slots via positive-FP-offset ValueReps, so they must shift too.
+        jit.move(MacroAssembler::stackPointerRegister, scratch1);
+
+        jit.jitAssert(scopedLambda<MacroAssembler::Jump()>([&] {
+            jit.addPtr(CCallHelpers::TrustedImm32(topSourceOffsetFromFP), GPRInfo::callFrameRegister, scratch2);
+            return jit.branchPtr(CCallHelpers::AboveOrEqual, scratch2, MacroAssembler::stackPointerRegister);
+        }));
+
+        JIT_COMMENT(jit, "Copy loop start");
+        auto loop = jit.label();
+        {
+            auto scratch3 = jit.scratchRegister();
+            DisallowMacroScratchRegisterUsage disallowScratch(jit);
+            jit.loadPair64(scratch1, scratch2, scratch3);
+            // FIXME: This could be a PostIndexAddress.
+            jit.storePair64(scratch2, scratch3, CCallHelpers::Address(scratch1, -restoreFrameSize));
+        }
+        jit.addPtr(CCallHelpers::TrustedImm32(16), scratch1);
+        // FIXME: It'd be nice to use the address scratch on ARM64 to hold the end point.
+        jit.addPtr(CCallHelpers::TrustedImm32(topSourceOffsetFromFP), GPRInfo::callFrameRegister, scratch2);
+        jit.branchPtr(CCallHelpers::Below, scratch1, scratch2).linkTo(loop, &jit);
+    }
+
+    CCallHelpers::Address callerFrameAndPCAddress(GPRInfo::callFrameRegister, topSourceOffsetFromFP > 0 ? -static_cast<int32_t>(restoreFrameSize) : 0);
+
+    JIT_COMMENT(jit, "Creating the restore frame");
+#if CPU(ARM64E)
+    jit.loadPairPtr(callerFrameAndPCAddress, scratch1, ARM64Registers::lr);
+    jit.addPtr(CCallHelpers::TrustedImm32(sizeof(CallerFrameAndPC)), MacroAssembler::framePointerRegister, scratch2);
+    jit.untagPtr(scratch2, ARM64Registers::lr);
+    jit.validateUntaggedPtr(ARM64Registers::lr, scratch2);
+    if (Options::allowNonSPTagging()) {
+        jit.addPtr(CCallHelpers::TrustedImm32(restoreFrameBase + static_cast<int32_t>(sizeof(CallerFrameAndPC))), MacroAssembler::framePointerRegister, scratch2);
+        jit.tagPtr(scratch2, ARM64Registers::lr);
+    } else {
+        jit.addPtr(CCallHelpers::TrustedImm32(restoreFrameBase + static_cast<int32_t>(sizeof(CallerFrameAndPC))), MacroAssembler::framePointerRegister, MacroAssembler::stackPointerRegister);
+        jit.tagPtr(MacroAssembler::stackPointerRegister, ARM64Registers::lr);
+
+        // SP was already moved down by restoreFrameSize above repeat that logic.
+        // FIXME: We could probably elide the original SP shift above when isARM64E() && !Options::allowNonSPTagging().
+        jit.subPtr(MacroAssembler::framePointerRegister, CCallHelpers::TrustedImm32(frameSize + restoreFrameSize), MacroAssembler::stackPointerRegister);
+    }
+    jit.storePairPtr(scratch1, ARM64Registers::lr, CCallHelpers::Address(MacroAssembler::framePointerRegister, restoreFrameBase));
+#else
+    jit.loadPairPtr(callerFrameAndPCAddress, scratch1, scratch2);
+    jit.storePairPtr(scratch1, scratch2, CCallHelpers::Address(MacroAssembler::framePointerRegister, restoreFrameBase));
+#endif
+    // Store current instance and callee to the frame.
+    jit.move(CCallHelpers::TrustedImm64(g_restoreFrameCalleeBoxed), scratch1);
+    jit.storePairPtr(currentInstanceReg, scratch1, CCallHelpers::Address(MacroAssembler::framePointerRegister, restoreFrameBase + static_cast<int32_t>(CallFrameSlot::codeBlock) * static_cast<int32_t>(sizeof(Register))));
+
+    // Account for the lowering of callFrameRegister we're going to do below.
+    jit.addPtr(CCallHelpers::TrustedImm32(restoreFrameBase), GPRInfo::callFrameRegister, scratch1);
+
+    JIT_COMMENT(jit, "Update CallerFrameAndPC to return to the restore frame");
+#if CPU(ARM64E)
+    // Move to where callFrameRegister will be when actually untagging.
+    jit.subPtr(CCallHelpers::TrustedImm32(restoreFrameSize - sizeof(CallerFrameAndPC)), GPRInfo::callFrameRegister);
+    jit.move(CCallHelpers::TrustedImmPtr(restoreFrameReturnAddress), ARM64Registers::lr);
+    jit.tagPtr(GPRInfo::callFrameRegister, ARM64Registers::lr);
+    jit.storePair64(scratch1, ARM64Registers::lr, CCallHelpers::PreIndexAddress(GPRInfo::callFrameRegister, -static_cast<ptrdiff_t>(sizeof(CallerFrameAndPC))));
+#else
+    jit.move(CCallHelpers::TrustedImmPtr(restoreFrameReturnAddress), scratch2);
+    jit.subPtr(CCallHelpers::TrustedImm32(restoreFrameSize), GPRInfo::callFrameRegister);
+    jit.storePairPtr(scratch1, scratch2, GPRInfo::callFrameRegister);
+#endif
+
+    hasExistingThunk.link(jit);
+}
+
 } } // namespace JSC::Wasm
 
 #endif // ENABLE(WEBASSEMBLY_OMGJIT) || ENABLE(WEBASSEMBLY_BBQJIT)

--- a/Source/JavaScriptCore/wasm/WasmInliningDecision.cpp
+++ b/Source/JavaScriptCore/wasm/WasmInliningDecision.cpp
@@ -69,10 +69,6 @@ bool InliningDecision::canInline(InliningNode* target, size_t initialWasmSize, s
     if (wasmSize > Options::wasmInliningMaximumWasmCalleeSize())
         return false;
 
-    // FIXME: There's no fundamental reason we can't inline these including imports.
-    if (m_module.moduleInformation().callCanClobberInstance(target->callee().index()))
-        return false;
-
     // For tiny functions, let's be a bit more generous.
     if (wasmSize < Options::wasmInliningTinyFunctionThreshold()) {
         if (inlinedWasmSize > 100)

--- a/Source/JavaScriptCore/wasm/WasmModuleInformation.h
+++ b/Source/JavaScriptCore/wasm/WasmModuleInformation.h
@@ -123,7 +123,6 @@ struct ModuleInformation final : public ThreadSafeRefCounted<ModuleInformation> 
     {
         size_t totalNumberOfFunctions = functionIndexSpaceSize();
         m_referencedFunctions = FixedBitVector(totalNumberOfFunctions);
-        m_clobberingTailCalls = FixedBitVector(totalNumberOfFunctions);
     }
 
     const FixedBitVector& referencedFunctions() const LIFETIME_BOUND { return m_referencedFunctions; }
@@ -188,11 +187,6 @@ struct ModuleInformation final : public ThreadSafeRefCounted<ModuleInformation> 
             : it->value.getBranchHint(branchOffset);
     }
 
-    // FIXME: This should probably be FunctionCodeIndex as calling an import always clobbers the instance.
-    const FixedBitVector& clobberingTailCalls() const LIFETIME_BOUND { return m_clobberingTailCalls; }
-    bool callCanClobberInstance(FunctionSpaceIndex functionIndexSpace) const { return m_clobberingTailCalls.test(functionIndexSpace); }
-    void addClobberingTailCall(FunctionSpaceIndex functionIndexSpace) { m_clobberingTailCalls.concurrentTestAndSet(functionIndexSpace); }
-
     void setTotalFunctionSize(size_t totalFunctionSize)
     {
         m_totalFunctionSize = totalFunctionSize;
@@ -240,7 +234,6 @@ struct ModuleInformation final : public ThreadSafeRefCounted<ModuleInformation> 
     BitVector m_declaredFunctions;
     BitVector m_declaredExceptions;
     mutable FixedBitVector m_referencedFunctions;
-    mutable FixedBitVector m_clobberingTailCalls;
     size_t m_totalFunctionSize { 0 };
     uint32_t m_numSmallFunctions { 0 };
 

--- a/Source/JavaScriptCore/wasm/WasmOMGIRGenerator.cpp
+++ b/Source/JavaScriptCore/wasm/WasmOMGIRGenerator.cpp
@@ -1951,6 +1951,61 @@ auto OMGIRGenerator::emitIndirectCall(Value* calleeInstance, Value* calleeCode, 
     if (callType == CallType::TailCall)
         m_makesTailCalls = true;
 
+    const auto& callingConvention = wasmCallingConvention();
+    CallInformation wasmCalleeInfo = callingConvention.callInformationFor(signature, CallRole::Caller);
+    CallInformation wasmCalleeInfoAsCallee = callingConvention.callInformationFor(signature, CallRole::Callee);
+    Checked<int32_t> calleeStackSize = WTF::roundUpToMultipleOf<stackAlignmentBytes()>(wasmCalleeInfo.headerAndArgumentStackSizeInBytes);
+    if (isTailCallRootCaller)
+        calleeStackSize = WTF::roundUpToMultipleOf<stackAlignmentBytes()>(wasmCalleeInfo.headerAndArgumentStackSizeInBytes * 2 + sizeof(Register));
+
+    m_proc.requestCallArgAreaSizeInBytes(calleeStackSize);
+
+    // Tail call patchpoint is emitted before the B3-level context switch so
+    // wasmContextInstancePointer still holds the caller's instance.
+    if (isTailCallRootCaller) {
+        const TypeSignatureIndex callerTypeSignatureIndex = m_info.internalFunctionTypeSignatureIndices[m_functionIndex];
+        const RTT& callerType = m_info.rtt(callerTypeSignatureIndex);
+        CallInformation wasmCallerInfoAsCallee = callingConvention.callInformationFor(callerType, CallRole::Callee);
+
+        auto [patchpoint, _, prepareForCall] = createTailCallPatchpoint(m_currentBlock, signature, wasmCallerInfoAsCallee, wasmCalleeInfoAsCallee, args, boxedCalleeCallee);
+        unsigned patchArgsIndex = patchpoint->reps().size();
+        patchpoint->append(calleeCode, ValueRep(GPRInfo::nonPreservedNonArgumentGPR0));
+        patchpoint->append(calleeInstance, ValueRep::SomeRegister);
+        // emitRestoreInstanceFrameIfNeeded needs two scratches. wasmBaseMemoryPointer is
+        // always pinned so B3 won't allocate it. wasmBoundsCheckingSizeRegister
+        // is only pinned in BoundsChecking mode, so in Signaling mode we need B3 to give us a
+        // scratch that avoids the inputs.
+        if (m_mode == MemoryMode::Signaling)
+            patchpoint->numGPScratchRegisters = 1;
+        patchArgsIndex += m_proc.resultCount(patchpoint->type());
+        Checked<int32_t> callerStackSize = WTF::roundUpToMultipleOf<stackAlignmentBytes()>(wasmCallerInfoAsCallee.headerAndArgumentStackSizeInBytes);
+        patchpoint->setGenerator([prepareForCall = prepareForCall, patchArgsIndex, callerStackSize = static_cast<int32_t>(callerStackSize), mode = m_mode](CCallHelpers& jit, const B3::StackmapGenerationParams& params) {
+            GPRReg calleeInstanceGPR = params[patchArgsIndex + 1].gpr();
+            GPRReg scratch2 = mode == MemoryMode::Signaling ? params.gpScratch(0) : GPRInfo::wasmBoundsCheckingSizeRegister;
+            auto sameInstance = jit.branchPtr(CCallHelpers::Equal, calleeInstanceGPR, GPRInfo::wasmContextInstancePointer);
+            {
+                AllowMacroScratchRegisterUsage allowScratch(jit);
+                int32_t topSource = -static_cast<int32_t>(params.code().frameSize());
+                for (unsigned i = 0; i < params.size(); ++i) {
+                    if (params[i].isStack())
+                        topSource = std::max(topSource, params[i].offsetFromFP() + static_cast<int32_t>(sizeof(Register)));
+                }
+                for (const auto& entry : params.code().calleeSaveRegisterAtOffsetList())
+                    topSource = std::max<int32_t>(topSource, entry.offset() + entry.byteSize());
+                Checked<int32_t> topSourceOffsetFromFP = static_cast<int32_t>(roundUpToMultipleOf<stackAlignmentBytes()>(topSource));
+                emitRestoreInstanceFrameIfNeeded(jit, GPRInfo::wasmContextInstancePointer, callerStackSize, params.code().frameSize(), topSourceOffsetFromFP, GPRInfo::wasmBaseMemoryPointer, scratch2);
+                jit.move(calleeInstanceGPR, GPRInfo::wasmContextInstancePointer);
+                jit.loadPairPtr(GPRInfo::wasmContextInstancePointer, CCallHelpers::TrustedImm32(JSWebAssemblyInstance::offsetOfCachedMemoryBaseSizePair(0)), GPRInfo::wasmBaseMemoryPointer, GPRInfo::wasmBoundsCheckingSizeRegister);
+                jit.cageConditionally(Gigacage::Primitive, GPRInfo::wasmBaseMemoryPointer, GPRInfo::wasmBoundsCheckingSizeRegister, calleeInstanceGPR);
+            }
+            sameInstance.link(&jit);
+            prepareForCall->run(jit, params);
+            AllowMacroScratchRegisterUsage allowScratch(jit);
+            jit.farJump(params[patchArgsIndex].gpr(), WasmEntryPtrTag);
+        });
+        return { };
+    }
+
     // Do a context switch if needed.
     {
         BasicBlock* continuation = m_proc.addBlock();
@@ -1986,32 +2041,6 @@ auto OMGIRGenerator::emitIndirectCall(Value* calleeInstance, Value* calleeCode, 
         doContextSwitch->appendNewControlValue(m_proc, Jump, origin(), continuation);
 
         m_currentBlock = continuation;
-    }
-
-    const auto& callingConvention = wasmCallingConvention();
-    CallInformation wasmCalleeInfo = callingConvention.callInformationFor(signature, CallRole::Caller);
-    CallInformation wasmCalleeInfoAsCallee = callingConvention.callInformationFor(signature, CallRole::Callee);
-    Checked<int32_t> calleeStackSize = WTF::roundUpToMultipleOf<stackAlignmentBytes()>(wasmCalleeInfo.headerAndArgumentStackSizeInBytes);
-    if (isTailCallRootCaller)
-        calleeStackSize = WTF::roundUpToMultipleOf<stackAlignmentBytes()>(wasmCalleeInfo.headerAndArgumentStackSizeInBytes * 2 + sizeof(Register));
-
-    m_proc.requestCallArgAreaSizeInBytes(calleeStackSize);
-
-    if (isTailCallRootCaller) {
-        const TypeSignatureIndex callerTypeSignatureIndex = m_info.internalFunctionTypeSignatureIndices[m_functionIndex];
-        const RTT& callerType = m_info.rtt(callerTypeSignatureIndex);
-        CallInformation wasmCallerInfoAsCallee = callingConvention.callInformationFor(callerType, CallRole::Callee);
-
-        auto [patchpoint, _, prepareForCall] = createTailCallPatchpoint(m_currentBlock, signature, wasmCallerInfoAsCallee, wasmCalleeInfoAsCallee, args, boxedCalleeCallee);
-        unsigned patchArgsIndex = patchpoint->reps().size();
-        patchpoint->append(calleeCode, ValueRep(GPRInfo::nonPreservedNonArgumentGPR0));
-        patchArgsIndex += m_proc.resultCount(patchpoint->type());
-        patchpoint->setGenerator([prepareForCall = prepareForCall, patchArgsIndex](CCallHelpers& jit, const B3::StackmapGenerationParams& params) {
-            prepareForCall->run(jit, params);
-            AllowMacroScratchRegisterUsage allowScratch(jit);
-            jit.farJump(params[patchArgsIndex].gpr(), WasmEntryPtrTag);
-        });
-        return { };
     }
 
     auto [patchpoint, handle, prepareForCall] = createCallPatchpoint(m_currentBlock, signature, wasmCalleeInfo, args);
@@ -5363,7 +5392,7 @@ static inline void prepareForTailCallImpl(unsigned functionIndex, CCallHelpers& 
     auto tmp = jit.scratchRegister();
 
 #if ASSERT_ENABLED
-    for (unsigned i = 0; i < params.size(); ++i) {
+    for (unsigned i = firstPatchArg; i < lastPatchArg; ++i) {
         auto arg = params[i];
         ASSERT_IMPLIES(arg.isGPR(), arg.gpr() != tmp);
     }
@@ -5839,6 +5868,7 @@ static inline void prepareForTailCallImpl(unsigned functionIndex, CCallHelpers& 
 
 #if ASSERT_ENABLED
         // Everything in the old stack might be overwritten anyway. Clobber for easier debugging.
+        JIT_COMMENT(jit, "Clobbering the old frame");
         jit.move(MacroAssembler::TrustedImm32(0xBFFF), tmp);
         constexpr int stackSlotsToClobber = 50;
         constexpr int stackBytesToClobber = stackSlotsToClobber * registerSize();
@@ -6090,9 +6120,28 @@ auto OMGIRGenerator::emitDirectCall(unsigned callProfileIndex, FunctionSpaceInde
             // We pessimistically assume we could be calling to something that is bounds checking.
             // FIXME: We shouldn't have to do this: https://bugs.webkit.org/show_bug.cgi?id=172181
             patchpoint->clobberLate(RegisterSet::wasmPinnedRegisters());
+            // emitRestoreInstanceFrameIfNeeded needs two scratches. wasmBaseMemoryPointer is
+            // always pinned so B3 won't allocate it. wasmBoundsCheckingSizeRegister
+            // is only pinned in BoundsChecking mode, so in Signaling mode we need B3 to give us a
+            // scratch that avoids the inputs.
+            if (isTailCallRootCaller && m_mode == MemoryMode::Signaling)
+                patchpoint->numGPScratchRegisters = 1;
             patchArgsIndex += m_proc.resultCount(patchpoint->type());
-            patchpoint->setGenerator([this, patchArgsIndex, handle, isTailCallRootCaller, tailCallStackOffsetFromFP, prepareForCall, signature = Ref<const RTT>(signature), wasmCalleeInfo](CCallHelpers& jit, const B3::StackmapGenerationParams& params) {
+            patchpoint->setGenerator([this, patchArgsIndex, handle, isTailCallRootCaller, tailCallStackOffsetFromFP, prepareForCall, signature = Ref<const RTT>(signature), wasmCalleeInfo, callerStackSize = static_cast<int32_t>(WTF::roundUpToMultipleOf<stackAlignmentBytes()>(wasmCallerInfoAsCallee.headerAndArgumentStackSizeInBytes)), mode = m_mode](CCallHelpers& jit, const B3::StackmapGenerationParams& params) {
                 AllowMacroScratchRegisterUsage allowScratch(jit);
+                if (isTailCallRootCaller) {
+                    int32_t topSource = -static_cast<int32_t>(params.code().frameSize());
+                    for (unsigned i = 0; i < params.size(); ++i) {
+                        if (params[i].isStack())
+                            topSource = std::max(topSource, params[i].offsetFromFP() + static_cast<int32_t>(sizeof(Register)));
+                    }
+                    for (const auto& entry : params.code().calleeSaveRegisterAtOffsetList())
+                        topSource = std::max<int32_t>(topSource, entry.offset() + entry.byteSize());
+                    Checked<int32_t> topSourceOffsetFromFP = static_cast<int32_t>(roundUpToMultipleOf<stackAlignmentBytes()>(topSource));
+                    GPRReg scratch2 = mode == MemoryMode::Signaling ? params.gpScratch(0) : GPRInfo::wasmBoundsCheckingSizeRegister;
+                    emitRestoreInstanceFrameIfNeeded(jit, GPRInfo::wasmContextInstancePointer, callerStackSize, params.code().frameSize(), topSourceOffsetFromFP, GPRInfo::wasmBaseMemoryPointer, scratch2);
+                    // Import stub sets up the pinned registers for us so we don't have to do anything here.
+                }
                 if (prepareForCall)
                     prepareForCall->run(jit, params);
                 ASSERT(!isTailCallRootCaller || !handle);
@@ -6191,11 +6240,6 @@ auto OMGIRGenerator::emitDirectCall(unsigned callProfileIndex, FunctionSpaceInde
         patchpoint->clobberLate(RegisterSet { GPRInfo::wasmBoundsCheckingSizeRegister });
 
     fillCallResults(patchpoint, signature, results);
-
-    if (m_info.callCanClobberInstance(functionIndexSpace)) {
-        patchpoint->clobberLate(RegisterSet::wasmPinnedRegisters());
-        restoreWebAssemblyGlobalState(m_info.memories, instanceValue(), m_currentBlock);
-    }
 
     return { };
 }


### PR DESCRIPTION
#### 5223ee5c243553bf6c99efd1b4fd1d06480f8d8a
<pre>
[Wasm] Use a lazy restore frame when returning from tail calls
<a href="https://bugs.webkit.org/show_bug.cgi?id=313732">https://bugs.webkit.org/show_bug.cgi?id=313732</a>
<a href="https://rdar.apple.com/175935387">rdar://175935387</a>

Reviewed by Yusuke Suzuki.

When a WebAssembly tail call crosses instance boundaries, the non-tail
caller&apos;s instance must be restored when the tail call chain eventually
returns. Previously this was handled by a compile-time transitive
analysis that marked functions whose callees could clobber the instance,
and callers of those functions would eagerly restore pinned registers
after every call. This was conservative and prevented inlining of those
functions.

This patch replaces that scheme with &quot;restore frames&quot;, a small frame
inserted lazily at runtime on the first cross-instance tail call.
A restore frame captures the caller&apos;s instance and original return
address. A return thunk (_wasm_restore_frame_return) restores the
instance and memory registers before returning to the original caller.

The restore frame is 32 bytes (4 slots) and is placed just above
the caller&apos;s argument area. The entire frame below it (including
callee-saves) is shifted down by 32 bytes to make room. The restore
frame contains the original CallerFrameAndPC, as well as a copy of the
original instance and RestoreFrameCallee.

When the tail callee eventually returns, it returns through the
redirect at new cfr, which lands in _wasm_restore_frame_return.
The thunk loads the saved instance from the restore frame, reloads
the memory base/bounds registers, then returns to the original caller.

The existing-frame check (comparing ReturnPC against the thunk address)
ensures that repeated cross-instance tail calls reuse the same restore
frame rather than accumulating new ones. This is expected as otherwise
restore frames could grow unboundedly when repeatedly making
cross-instance tail calls, violating the spec.

emitRestoreInstanceFrameIfNeeded is the shared helper used by BBQ and
OMG to create restore frames. It takes a frameSize parameter to skip
the copy loop entirely when no stack-located sources exist, and uses a
do-while loop when copying is needed. On ARM64E, the original return
PC is resigned from the caller&apos;s frame context to the restore frame
context, with proper handling for !Options::allowNonSPTagging().

For JIT cage support, a wasmRestoreFrame gate thunk is registered so
that JIT-compiled code and IPInt use a consistent address for the
restore thunk. The gate thunk reproduces _wasm_restore_frame_return&apos;s
logic in JIT code, allowing it to untag JIT-key-signed return PCs.

This patch also removes the compile-time transitive tail call
clobbering analysis (ModuleInformation::m_clobberingTailCalls,
computeTransitiveTailCalls, callCanClobberInstance) and the inlining
restriction for functions that could transitively clobber the instance,
since restore frames handle this at runtime.

Tests: JSTests/wasm/stress/tail-call-cross-instance-gc.js
       JSTests/wasm/stress/tail-call-cross-instance-memory-reload.js
       JSTests/wasm/stress/tail-call-cross-instance-no-thunk-accumulation.js
       JSTests/wasm/stress/tail-call-cross-instance-restore.js
       JSTests/wasm/stress/tail-call-cross-instance-sampling-profiler.js
       JSTests/wasm/stress/tail-call-cross-instance-stack-args.js
       JSTests/wasm/stress/tail-call-cross-instance-stacktrace.js
       JSTests/wasm/stress/tail-call-cross-instance-throw.js

Canonical link: <a href="https://commits.webkit.org/312795@main">https://commits.webkit.org/312795@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e53cdaf65abddc90a03f1ac2474f0d9a904f9e4f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/161146 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/34619 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/27720 "Build is in progress. Recent messages:OS: Sequoia (15.7.3), Xcode: 26.2; Running apply-patch; Checked out pull request; Compiled WebKit (warnings)") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/170049 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/117491 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/2f9f5ccb-b9a3-4434-b4e0-d9346d009c4b) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/34720 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/34620 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/124999 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/117491 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/5bc96d06-2bc4-49da-840d-9ef20230898d) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/164105 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/27274 "Build is in progress. Recent messages:") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/144749 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/105596 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/738222a8-6181-4342-bd36-76827321adb2) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/26322 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/24826 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/17769 "Build is in progress. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit") | | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/20/builds/153202 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/136016 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/168/builds/27720 "Build is in progress. Recent messages:OS: Sequoia (15.7.3), Xcode: 26.2; Running apply-patch; Checked out pull request; Compiled WebKit (warnings)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/172532 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/21984 "Built successfully and passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/19553 "Build is in progress. Recent messages:OS: Tahoe (26.2), Xcode: 26.2; Checked out pull request; Found 33158 issues") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/168/builds/27720 "Build is in progress. Recent messages:OS: Sequoia (15.7.3), Xcode: 26.2; Running apply-patch; Checked out pull request; Compiled WebKit (warnings)") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/133276 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/34293 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/28919 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/133286 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/34277 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/168/builds/27720 "Build is in progress. Recent messages:OS: Sequoia (15.7.3), Xcode: 26.2; Running apply-patch; Checked out pull request; Compiled WebKit (warnings)") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/96124 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/24498 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/164/builds/27834 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/21123 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/193545 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/33788 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/101213 "Built successfully") | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/49863 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/33287 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/33531 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/33436 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->