### PR TITLE
[LBSE] Prepare RenderSVGResourceClipper.cpp for non-layered SVG elements

### DIFF
--- a/Source/WebCore/rendering/svg/RenderSVGResourceClipper.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGResourceClipper.cpp
@@ -95,7 +95,6 @@ void RenderSVGResourceClipper::applyPathClipping(GraphicsContext& context, const
 
     auto* clipRendererPtr = graphicsElement.renderer();
     ASSERT(clipRendererPtr);
-    ASSERT(clipRendererPtr->hasLayer());
     auto& clipRenderer = downcast<RenderSVGModelObject>(*clipRendererPtr);
 
     AffineTransform clipPathTransform;
@@ -206,9 +205,45 @@ bool RenderSVGResourceClipper::hitTestClipContent(const FloatRect& objectBoundin
         point = LayoutPoint(applyTransform.inverse().value_or(AffineTransform()).mapPoint(point));
     }
 
-    HitTestResult result(toLayoutPoint(point - flooredLayoutPoint(this->objectBoundingBox().minXMinYCorner())));
+    // Iterate children directly and call nodeAtPoint() on each, rather than using
+    // layer()->hitTest(). The layer hit test infrastructure does not work for children
+    // inside <clipPath> because they are inside a RenderSVGHiddenContainer, where
+    // fragment collection and ancestor offset computation produce incorrect results.
+    // For transformed children (with or without layers), inverse-map the point through
+    // the child's SVG transform before testing.
     constexpr OptionSet<HitTestRequest::Type> hitType { HitTestRequest::Type::SVGClipContent, HitTestRequest::Type::DisallowUserAgentShadowContent };
-    return layer()->hitTest(hitType, result);
+    for (CheckedPtr child = lastChild(); child; child = child->previousSibling()) {
+        auto* svgChild = dynamicDowncast<RenderSVGModelObject>(*child);
+        if (!svgChild)
+            continue;
+
+        auto testPoint = point;
+        if (svgChild->isTransformed()) {
+            // Compute the child's SVG transform and inverse-map the point.
+            // For non-layer children, localTransform() is already populated.
+            // For layer children, localTransform() is not maintained, so compute it.
+            AffineTransform childTransform;
+            if (svgChild->hasLayer()) {
+                TransformationMatrix tm;
+                auto referenceBoxRect = svgChild->transformReferenceBoxRect(svgChild->style());
+                svgChild->applyTransform(tm, svgChild->style(), referenceBoxRect, Style::TransformResolver::allTransformOperations);
+                childTransform = tm.toAffineTransform();
+            } else
+                childTransform = svgChild->localTransform();
+
+            auto inverseTransform = childTransform.inverse();
+            if (!inverseTransform)
+                continue;
+            testPoint = LayoutPoint(inverseTransform->mapPoint(FloatPoint(point)));
+        }
+
+        HitTestLocation testHitTestLocation(testPoint);
+        HitTestResult result(testPoint);
+        auto accumulatedOffset = toLayoutPoint(toLayoutSize(svgChild->nominalSVGLayoutLocation()) - toLayoutSize(svgChild->currentSVGLayoutLocation()));
+        if (child->nodeAtPoint(hitType, result, testHitTestLocation, accumulatedOffset, HitTestAction::Foreground))
+            return true;
+    }
+    return false;
 }
 
 FloatRect RenderSVGResourceClipper::resourceBoundingBox(const RenderObject& object, RepaintRectCalculation repaintRectCalculation)


### PR DESCRIPTION
#### 40eaca3e144ac510731a624515ebabab24ac57f7
<pre>
[LBSE] Prepare RenderSVGResourceClipper.cpp for non-layered SVG elements
<a href="https://bugs.webkit.org/show_bug.cgi?id=313733">https://bugs.webkit.org/show_bug.cgi?id=313733</a>

Reviewed by Nikolas Zimmermann.

Prepare RenderSVGResourceClipper.cpp for non-layered SVG elements by using
custom hit-testing code, since the layer hit test infrastructure does not work for children
inside &lt;clipPath&gt; because they are inside a (non-layered) RenderSVGHiddenContainer, where
fragment collection and ancestor offset computation produce incorrect results.

For transformed children (with or without layers), inverse-map the point through
the child&apos;s SVG transform before testing.

* Source/WebCore/rendering/svg/RenderSVGResourceClipper.cpp:
(WebCore::RenderSVGResourceClipper::applyPathClipping):
(WebCore::RenderSVGResourceClipper::hitTestClipContent):

Canonical link: <a href="https://commits.webkit.org/312366@main">https://commits.webkit.org/312366@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c6ddcf0d6fcf890dc008f6aaf4274b8d89387f32

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/159718 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/33185 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/26292 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/168574 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/114099 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/161587 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/33290 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/33189 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/123754 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/114099 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/162676 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/26016 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/143456 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/104398 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/25067 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/23537 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/16339 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/134759 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/21228 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/171067 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/17086 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/22864 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/132006 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/32864 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/27614 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/132068 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35737 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/32849 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/143022 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/90931 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/26688 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/19835 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/32358 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/98754 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/31855 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/32102 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/32006 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->