### PR TITLE
Move hasURLsRequiringEnhancedSecurityCheck to the UI process

### DIFF
--- a/Source/WebKit/Shared/Cocoa/EnhancedSecurityLinkUtilities.h
+++ b/Source/WebKit/Shared/Cocoa/EnhancedSecurityLinkUtilities.h
@@ -35,6 +35,7 @@ class URL;
 
 namespace WebKit {
 
+bool hasURLsRequiringEnhancedSecurityCheck();
 void isEnhancedSecurityEnabledForURL(const WTF::URL&, CompletionHandler<void(bool)>&&);
 
 } // namespace WebKit

--- a/Source/WebKit/Shared/Cocoa/EnhancedSecurityLinkUtilities.mm
+++ b/Source/WebKit/Shared/Cocoa/EnhancedSecurityLinkUtilities.mm
@@ -33,6 +33,11 @@
 #else
 namespace WebKit {
 
+bool hasURLsRequiringEnhancedSecurityCheck()
+{
+    return false;
+}
+
 void isEnhancedSecurityEnabledForURL(const WTF::URL& url, CompletionHandler<void(bool)>&& completionHandler)
 {
     completionHandler(false);

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -476,6 +476,10 @@
 #include "RemoteMediaSessionManagerProxy.h"
 #endif
 
+#if HAVE(ENHANCED_SECURITY_LINKS)
+#include "EnhancedSecurityLinkUtilities.h"
+#endif
+
 #define MESSAGE_CHECK(process, assertion) MESSAGE_CHECK_BASE(assertion, process->connection())
 #define MESSAGE_CHECK_URL(process, url) MESSAGE_CHECK_BASE(checkURLReceivedFromCurrentOrPreviousWebProcess(process, url), process->connection())
 #define MESSAGE_CHECK_URL_COROUTINE(process, url) MESSAGE_CHECK_BASE_COROUTINE(checkURLReceivedFromCurrentOrPreviousWebProcess(process, url), process->connection())
@@ -17440,6 +17444,9 @@ void WebPageProxy::beginEnhancedSecurityLinkCheck(const URL& url, API::Navigatio
             listener->didReceiveEnhancedSecurityLinkResults();
         }
     };
+
+    if (!hasURLsRequiringEnhancedSecurityCheck())
+        return completionHandler(false);
 
     if (RefPtr networkProcess = websiteDataStore().networkProcessIfExists())
         networkProcess->sendWithAsyncReply(Messages::NetworkProcess::IsEnhancedSecurityLink(url), WTF::move(completionHandler));

--- a/Tools/MiniBrowser/MiniBrowser.entitlements
+++ b/Tools/MiniBrowser/MiniBrowser.entitlements
@@ -35,6 +35,7 @@
 	<key>com.apple.security.temporary-exception.shared-preference.read-only</key>
 	<array>
 		<string>com.apple.Safari.SandboxBroker</string>
+		<string>com.apple.messages.EnhancedLinkSecurity</string>
 	</array>
 </dict>
 </plist>

--- a/Tools/MobileMiniBrowser/MobileMiniBrowser/MobileMiniBrowser.entitlements
+++ b/Tools/MobileMiniBrowser/MobileMiniBrowser/MobileMiniBrowser.entitlements
@@ -16,5 +16,9 @@
 	<array>
 		<string>EnableQuickLookSandboxResources</string>
 	</array>
+	<key>com.apple.security.exception.shared-preference.read-only</key>
+	<array>
+		<string>com.apple.messages.EnhancedLinkSecurity</string>
+	</array>
 </dict>
 </plist>


### PR DESCRIPTION
#### 956abb5b3f2a0b9f080cd35804bdebced73e3cbc
<pre>
Move hasURLsRequiringEnhancedSecurityCheck to the UI process
<a href="https://bugs.webkit.org/show_bug.cgi?id=313448">https://bugs.webkit.org/show_bug.cgi?id=313448</a>
<a href="https://rdar.apple.com/175684546">rdar://175684546</a>

Reviewed by NOBODY (OOPS!).

We can move the hasURLsRequiringEnhancedSecurityCheck to the UI process, rather than
in the Network process. This allows avoiding the UI -&gt; Network IPC roundtrip when the
check returns false which should be the majority of cases.

Tests to follow.

* Source/WebKit/Shared/Cocoa/EnhancedSecurityLinkUtilities.h:
* Source/WebKit/Shared/Cocoa/EnhancedSecurityLinkUtilities.mm:
(WebKit::hasURLsRequiringEnhancedSecurityCheck):
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::beginEnhancedSecurityLinkCheck):
* Tools/MiniBrowser/MiniBrowser.entitlements:
* Tools/MobileMiniBrowser/MobileMiniBrowser/MobileMiniBrowser.entitlements:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/956abb5b3f2a0b9f080cd35804bdebced73e3cbc

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/159719 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/33186 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/26293 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/168575 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/114100 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/0bcea639-53c0-4e74-a53e-5def33149a49) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/161588 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/33291 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/33190 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/123755 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/114100 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/eca98c70-5e4b-4066-b878-c767d7cae6b6) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/162677 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/26017 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/143457 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/104399 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/2bc9bd5d-5a1c-4f87-9edc-b41066048393) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/25068 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/23539 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/16340 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/134760 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/167/builds/21229 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/171068 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/17087 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/22865 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/132007 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/32865 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/27616 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/132069 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/32850 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/143023 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/90932 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/26689 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/19836 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/32359 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/98755 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/31856 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/32103 "Built successfully") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/32007 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->