### PR TITLE
Navigating with the Layers inspector tab open breaks the visualization

### DIFF
--- a/Source/WebCore/inspector/agents/InspectorLayerTreeAgent.cpp
+++ b/Source/WebCore/inspector/agents/InspectorLayerTreeAgent.cpp
@@ -360,7 +360,7 @@ Inspector::CommandResult<String> InspectorLayerTreeAgent::requestContent(const I
 
     FloatSize layerSize = graphicsLayer->size();
     if (layerSize.isEmpty())
-        return makeUnexpected("Layer has zero size"_s);
+        return emptyString();
 
     // Limit scale factor for large layers to prevent excessive memory usage.
     constexpr float maxScaleFactor = 2;

--- a/Source/WebInspectorUI/UserInterface/Controllers/LayerTreeManager.js
+++ b/Source/WebInspectorUI/UserInterface/Controllers/LayerTreeManager.js
@@ -216,7 +216,7 @@ WI.LayerTreeManager = class LayerTreeManager extends WI.Object
                 callback(null);
                 return;
             }
-            callback(content);
+            callback(content || null);
         });
     }
 


### PR DESCRIPTION
#### 95810670932e82e28b1967418c8558a4fcfc7146
<pre>
Navigating with the Layers inspector tab open breaks the visualization
<a href="https://bugs.webkit.org/show_bug.cgi?id=307431">https://bugs.webkit.org/show_bug.cgi?id=307431</a>
<a href="https://rdar.apple.com/170836910">rdar://170836910</a>

Reviewed by Devin Rousso and Qianlang Chen.

There&apos;s a race condition that occurs between backend and frontend during page reload/navigation
while the Layers tab is open resulting in requesting layer snapshots for layers that have been
resized to zero during the transition.

Page navigation triggers a `WI.LayerTreeManager.Event.LayerTreeDidChange` event which
`WI.Layers3DContentView.prototype._layerTreeDidChange` handles by causing layout of the Layers tab.

Layout fetches layers via `WI.Layers3DContentView.prototype.layersForNode()`. At this point,
layers exist and have valid sizes. Then for each layer, the frontend calls:
`_populateLayerGroup()` → `_loadLayerTexture()` → `snapshotForLayer()`.

The request for snapshot sends `LayerTreeAgent.requestContent` to the backend. But, during the
navigation, the render tree has changed: layers may have been destroyed, lost their compositing backing,
lost their graphics layer, or resized to zero during the transition.
All states throw errors in `InspectorLayerTreeAgent::requestContent`.

The zero-size case is common because, during navigation, the new page&apos;s render tree initially creates
layers with zero dimensions before layout runs.

The error returned by the backend is handled by calling the callback to `snapshotForLayer()` with `null`
which is a case handled further down the call chain in `WI.Layers3DContentView.prototype._loadLayerTexture()`.

This is only an issue in Engineering / Debug builds of Web Inspector where
`WI.reportInternalError(error)` surfaces the exception. In release builds, the `null` case is silently handled.
This patch changes the backend to return an empty string instead of throwing an error for zero-size layers
given how common the case is during page navigation and that zero-sized layers aren&apos;t really an error state.

The issue itself is transient because during reload/navigation, more layer tree change events are dispatched.

The compositing update that resized layers to zero isn&apos;t the last one. When the new page finishes loading and layout,
`RenderLayerCompositor::updateCompositingLayers` runs again, firing another event.

The failed snapshot from the transitional state just results in `callback(null)` in
`WI.Layers3DContentView.prototype._loadLayerTexture`, which means no texture is applied to that layer group.
Then, the next successful cycle replaces it with the correct textured mesh.

The zero-size layer error only hits during the intermediate state. The final stable state always produces a clean pass.

* Source/WebCore/inspector/agents/InspectorLayerTreeAgent.cpp:
(WebCore::InspectorLayerTreeAgent::requestContent):
* Source/WebInspectorUI/UserInterface/Controllers/LayerTreeManager.js:
(WI.LayerTreeManager.prototype.snapshotForLayer):

Canonical link: <a href="https://commits.webkit.org/312435@main">https://commits.webkit.org/312435@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e3d33caa6572834a8e556c18601811a1754c974a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/159939 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/33407 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/26513 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/168814 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/114320 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/88cc725d-80fb-4471-86ad-0f8f7f272432) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/161808 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/33511 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/33411 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/123959 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/114320 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/15a041ff-e4ad-4703-8d74-7c3b1630666b) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/162897 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/26212 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/143657 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/104577 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/0df76c6c-83b8-4f53-aa18-cf07a3ca1900) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/25264 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/23735 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/16560 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/134956 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/21427 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/171298 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/17307 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/23065 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/132224 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/33085 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/27820 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/132251 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35778 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/33070 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/143222 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/91213 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/26870 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/20035 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/32579 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/98976 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/32076 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/32323 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/32227 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->