### PR TITLE
Setting the entityTransform on <model> should override the auto fit behavior

### DIFF
--- a/Source/WebKit/WebProcess/GPU/graphics/Model/RemoteMeshProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/Model/RemoteMeshProxy.cpp
@@ -201,8 +201,10 @@ std::pair<simd_float4, simd_float4> RemoteMeshProxy::getCenterAndExtents() const
 void RemoteMeshProxy::setEntityTransform(const WebModel::Float4x4& transform)
 {
 #if ENABLE(GPU_PROCESS_MODEL)
+    m_entityTransformSetByScript = true;
     m_transform = transform;
-    setStageMode(m_stageMode);
+    m_computedTransform = transform;
+    setEntityTransformInternal(transform);
 #else
     UNUSED_PARAM(transform);
 #endif
@@ -344,6 +346,8 @@ void RemoteMeshProxy::setStageMode(WebCore::StageModeOperation stageMode)
 {
 #if ENABLE(GPU_PROCESS_MODEL)
     m_stageMode = stageMode;
+    if (m_stageMode == WebCore::StageModeOperation::Orbit)
+        m_entityTransformSetByScript = false;
     computeTransform();
 #else
     UNUSED_PARAM(stageMode);
@@ -368,6 +372,9 @@ void RemoteMeshProxy::processRemovals(Vector<WebModel::TypedResourceId>&& meshRe
 #if ENABLE(GPU_PROCESS_MODEL)
 void RemoteMeshProxy::computeTransform()
 {
+    if (m_entityTransformSetByScript)
+        return;
+
     static constexpr float kCSSPixelsPerMeter = 96 / 2.54 * 100;
     // Fixed camera distance matching the ModelRenderer
     static constexpr float kCameraDistance = 0.5;

--- a/Source/WebKit/WebProcess/GPU/graphics/Model/RemoteMeshProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/Model/RemoteMeshProxy.h
@@ -131,6 +131,7 @@ private:
     float m_viewportWidth { 0.f };
     float m_viewportHeight { 0.f };
     WebCore::StageModeOperation m_stageMode;
+    bool m_entityTransformSetByScript { false };
 #endif
 };
 


### PR DESCRIPTION
#### 84ee097bb243144d9b10814ee3dd3f9eaeff5992
<pre>
Setting the entityTransform on &lt;model&gt; should override the auto fit behavior
<a href="https://bugs.webkit.org/show_bug.cgi?id=313747">https://bugs.webkit.org/show_bug.cgi?id=313747</a>
&lt;<a href="https://rdar.apple.com/175774632">rdar://175774632</a>&gt;

Reviewed by Mike Wyrzykowski.

When stage mode is None, setting an `entityTransform` on a model should
override the computed auto fit transform.
But we should still attempt to auto fit on load and until the transform
is set by script.

* Source/WebKit/WebProcess/GPU/graphics/Model/RemoteMeshProxy.cpp:
(WebKit::RemoteMeshProxy::setEntityTransform):
Directly set the entityTransform without computing the auto fit
transform.
Also updated the m_computedTransform since this is what we report back
to script.
(WebKit::RemoteMeshProxy::setStageMode):
Reset the &quot;set by script&quot; flag when the stage mode is updated to orbit.
(WebKit::RemoteMeshProxy::computeTransform):
Skip computation when the entity transform has been set by script.
* Source/WebKit/WebProcess/GPU/graphics/Model/RemoteMeshProxy.h:
Add a flag to keep track of when the entityTransform is set by script.

Canonical link: <a href="https://commits.webkit.org/312520@main">https://commits.webkit.org/312520@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/956d17a387c233510694fd836b9ed128cde1abaf

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/160243 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/33713 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/26817 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/169145 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/114624 "Built successfully") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/33817 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/33715 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/124229 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/87147 "2 failures") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/163201 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/26477 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/143933 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/104828 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/25530 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/24022 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/16865 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/135222 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/171623 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/17611 "Built successfully") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/23336 "Found 1 new test failure: imported/w3c/web-platform-tests/css/selectors/invalidation/media-pseudo-classes-in-has.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/132481 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/33389 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/28117 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/132507 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35820 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/33374 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/143491 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/91657 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/27126 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/20305 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/32883 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/99280 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/32381 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/32627 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/32531 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->