### PR TITLE
AX: Reduce AXIsolatedTree::applyPendingChanges lock contention and skip work when no changes are pending

### DIFF
--- a/LayoutTests/accessibility/mac/client/hierarchical-level.html
+++ b/LayoutTests/accessibility/mac/client/hierarchical-level.html
@@ -1,4 +1,4 @@
-<html>
+<html><!-- webkit-test-runner [ runSingly=true ] -->
 <head>
 <script src="../../../resources/accessibility-helper.js"></script>
 <script src="../../../resources/js-test.js"></script>

--- a/Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.cpp
+++ b/Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.cpp
@@ -97,6 +97,7 @@ void AXIsolatedTree::queueForDestruction()
 
     Locker locker { m_changeLogLock };
     m_queuedForDestruction = true;
+    m_hasPendingChanges.store(true);
     s_anyTreeNeedsTearDown.store(true, std::memory_order_relaxed);
 }
 
@@ -161,7 +162,7 @@ void AXIsolatedTree::createEmptyContent(AccessibilityObject& axRoot)
     {
         Locker locker { m_changeLogLock };
         setPendingRootNodeIDLocked(axRoot.objectID());
-        m_pendingFocusedNodeID = axWebArea->objectID();
+        mutablePendingChanges()->focusedNodeID = axWebArea->objectID();
     }
     Vector<NodeChange> appends;
     appends.reserveInitialCapacity(2);
@@ -230,32 +231,6 @@ RefPtr<AXIsolatedTree> AXIsolatedTree::create(AXObjectCache& axObjectCache)
     if (AXObjectCache::isAppleInternalInstall()) [[unlikely]]
         WTFEndSignpostAlways(tree.ptr(), InitialAccessibilityIsolatedTreeBuild);
     return tree;
-}
-
-void AXIsolatedTree::applyPendingRootNodeLocked()
-{
-    AX_ASSERT(!isMainThread());
-    AX_ASSERT(m_changeLogLock.isLocked());
-
-    if (m_pendingRootNodeID) {
-        if (RefPtr root = objectForID(m_pendingRootNodeID)) {
-            m_rootNode = WTF::move(root);
-            m_pendingRootNodeID = std::nullopt;
-
-#if ASSERT_ENABLED
-            auto markReachableNodes = [](AXCoreObject* object, HashSet<AXID>& reachableNodes, auto& self) -> void {
-                reachableNodes.add(object->objectID());
-                for (auto& child : object->children())
-                    self(&child.get(), reachableNodes, self);
-            };
-            HashSet<AXID> reachableNodes;
-            if (m_rootNode) {
-                markReachableNodes(m_rootNode.get(), reachableNodes, markReachableNodes);
-                ASSERT_WITH_MESSAGE(reachableNodes.size() == m_readerThreadNodeMap.size(), "AX: After applying pending root node, %u reachable nodes but %u are in the node map", reachableNodes.size(), m_readerThreadNodeMap.size());
-            }
-#endif
-        }
-    }
 }
 
 void AXIsolatedTree::storeTree(AXObjectCache& cache, const Ref<AXIsolatedTree>& tree)
@@ -369,17 +344,18 @@ void AXIsolatedTree::queueChange(NodeChange&& nodeChange)
 
     AXID objectID = nodeChange.data.axID;
     Markable parentID = nodeChange.data.parentID;
-    m_pendingAppends.append(WTF::move(nodeChange));
+    auto pending = mutablePendingChanges();
+    pending->appends.append(WTF::move(nodeChange));
 
     if (parentID) {
         auto siblingsIDs = m_nodeMap.get(*parentID).childrenIDs;
-        m_pendingChildrenUpdates.append({ *parentID, WTF::move(siblingsIDs) });
+        pending->childrenUpdates.append({ *parentID, WTF::move(siblingsIDs) });
     }
 
     ASSERT_WITH_MESSAGE(objectID != parentID, "object ID was the same as its parent ID (%s) when queueing a node change", objectID.loggingString().utf8().data());
     ASSERT_WITH_MESSAGE(m_nodeMap.contains(objectID), "node map should've contained objectID: %s", objectID.loggingString().utf8().data());
     auto childrenIDs = m_nodeMap.get(objectID).childrenIDs;
-    m_pendingChildrenUpdates.append({ objectID, WTF::move(childrenIDs) });
+    pending->childrenUpdates.append({ objectID, WTF::move(childrenIDs) });
 }
 
 void AXIsolatedTree::addUnconnectedNode(Ref<AccessibilityObject> axObject)
@@ -401,7 +377,7 @@ void AXIsolatedTree::addUnconnectedNode(Ref<AccessibilityObject> axObject)
     AXLOG(makeString("AXIsolatedTree::addUnconnectedNode creating isolated object from live object ID "_s, objectID.loggingString()));
 
     // Because we are queuing a change for an object not intended to be connected to the rest of the tree,
-    // we don't need to update m_nodeMap or m_pendingChildrenUpdates for this object or its parent as is
+    // we don't need to update m_nodeMap or m_pendingChanges.childrenUpdates for this object or its parent as is
     // done in AXIsolatedTree::nodeChangeForObject and AXIsolatedTree::queueChange.
     //
     // Instead, just directly create and queue the node change so m_readerThreadNodeMap can hold a reference
@@ -409,7 +385,7 @@ void AXIsolatedTree::addUnconnectedNode(Ref<AccessibilityObject> axObject)
     // other entity is removed from the page.
     NodeChange nodeChange { createIsolatedObjectData(axObject, *this), axObject->wrapper() };
     Locker locker { m_changeLogLock };
-    m_pendingAppends.append(WTF::move(nodeChange));
+    mutablePendingChanges()->appends.append(WTF::move(nodeChange));
     m_unconnectedNodes.add(objectID);
 }
 
@@ -426,8 +402,9 @@ void AXIsolatedTree::queueRemovalsLocked(Vector<NodeAndParentID>&& subtreeRemova
     AX_ASSERT(isMainThread());
     AX_ASSERT(m_changeLogLock.isLocked());
 
-    m_pendingSubtreeRemovals.appendVector(WTF::move(subtreeRemovals));
-    m_pendingProtectedFromDeletionIDs.addAll(std::exchange(m_protectedFromDeletionIDs, { }));
+    auto pending = mutablePendingChanges();
+    pending->subtreeRemovals.appendVector(WTF::move(subtreeRemovals));
+    pending->protectedFromDeletionIDs.addAll(std::exchange(m_protectedFromDeletionIDs, { }));
 }
 
 void AXIsolatedTree::queueRemovalsAndUnresolvedChanges()
@@ -487,7 +464,7 @@ void AXIsolatedTree::queueAppendsAndRemovals(Vector<NodeChange>&& appends, Vecto
 
     for (const auto& axID : parentUpdateIDs) {
         ASSERT_WITH_MESSAGE(m_nodeMap.contains(axID), "An object marked as needing a parent update should've had an entry in the node map by now. ID was %s", axID.loggingString().utf8().data());
-        m_pendingParentUpdates.set(axID, *m_nodeMap.get(axID).parentID);
+        mutablePendingChanges()->parentUpdates.set(axID, *m_nodeMap.get(axID).parentID);
     }
 
     queueRemovalsLocked(WTF::move(subtreeRemovals));
@@ -950,7 +927,7 @@ void AXIsolatedTree::updateNodeProperties(AccessibilityObject& axObject, const A
         return;
 
     Locker locker { m_changeLogLock };
-    m_pendingPropertyChanges.append({ axObject.objectID(), WTF::move(properties) });
+    mutablePendingChanges()->propertyChanges.append({ axObject.objectID(), WTF::move(properties) });
 }
 
 void AXIsolatedTree::overrideNodeProperties(AXID axID, AXPropertyVector&& properties)
@@ -961,7 +938,7 @@ void AXIsolatedTree::overrideNodeProperties(AXID axID, AXPropertyVector&& proper
         return;
 
     Locker locker { m_changeLogLock };
-    m_pendingPropertyChanges.append({ axID, WTF::move(properties) });
+    mutablePendingChanges()->propertyChanges.append({ axID, WTF::move(properties) });
 }
 
 void AXIsolatedTree::updateDependentProperties(AccessibilityObject& axObject)
@@ -1203,7 +1180,7 @@ bool AXIsolatedTree::unsafeHasObjectForID(AXID axID) const
 std::optional<AXID> AXIsolatedTree::pendingRootNodeID()
 {
     Locker locker { m_changeLogLock };
-    return m_pendingRootNodeID;
+    return m_pendingChanges.rootNodeID;
 }
 
 RefPtr<AXIsolatedObject> AXIsolatedTree::rootWebArea()
@@ -1229,7 +1206,7 @@ void AXIsolatedTree::setPendingRootNodeIDLocked(AXID axID)
     AX_ASSERT(isMainThread());
     AX_ASSERT(m_changeLogLock.isLocked());
 
-    m_pendingRootNodeID = axID;
+    mutablePendingChanges()->rootNodeID = axID;
 }
 
 void AXIsolatedTree::setFocusedNodeID(std::optional<AXID> axID)
@@ -1239,7 +1216,7 @@ void AXIsolatedTree::setFocusedNodeID(std::optional<AXID> axID)
     AX_ASSERT(isMainThread());
 
     Locker locker { m_changeLogLock };
-    m_pendingFocusedNodeID = axID;
+    mutablePendingChanges()->focusedNodeID = axID;
 }
 
 void AXIsolatedTree::updateRelations(HashMap<AXID, AXRelations>&& relations)
@@ -1249,7 +1226,7 @@ void AXIsolatedTree::updateRelations(HashMap<AXID, AXRelations>&& relations)
 
     m_relationsNeedUpdate = false;
     Locker locker { m_changeLogLock };
-    m_pendingRelations = WTF::move(relations);
+    mutablePendingChanges()->relations = WTF::move(relations);
 }
 
 void AXIsolatedTree::setSelectedTextMarkerRange(AXTextMarkerRange&& range)
@@ -1258,15 +1235,16 @@ void AXIsolatedTree::setSelectedTextMarkerRange(AXTextMarkerRange&& range)
     AX_ASSERT(isMainThread());
 
     Locker locker { m_changeLogLock };
-    m_pendingSelectedTextMarkerRange = WTF::move(range);
+    mutablePendingChanges()->selectedTextMarkerRange = WTF::move(range);
 }
 
 #if ENABLE(ACCESSIBILITY_LOCAL_FRAME)
 void AXIsolatedTree::setFrameGeometry(AXFrameGeometry&& geometry, IntPoint viewOriginScrollPosition)
 {
     Locker locker { m_changeLogLock };
-    m_pendingFrameGeometry = WTF::move(geometry);
-    m_pendingFrameViewOriginScrollPosition = viewOriginScrollPosition;
+    auto pending = mutablePendingChanges();
+    pending->frameGeometry = WTF::move(geometry);
+    pending->frameViewOriginScrollPosition = viewOriginScrollPosition;
 }
 
 void AXIsolatedTree::updateFrameGeometryAndScrollPositionIfNeeded(AXObjectCache& cache)
@@ -1302,7 +1280,7 @@ void AXIsolatedTree::updateFrame(AXID axID, IntRect&& newFrame)
     // We can clear the initially-cached rough frame, since the object's frame has been cached.
     properties.append({ AXProperty::InitialLocalRect, FloatRect() });
     Locker locker { m_changeLogLock };
-    m_pendingPropertyChanges.append({ axID, WTF::move(properties) });
+    mutablePendingChanges()->propertyChanges.append({ axID, WTF::move(properties) });
 }
 
 void AXIsolatedTree::updateRootScreenRelativePosition()
@@ -1387,33 +1365,58 @@ std::optional<ListHashSet<AXID>> AXIsolatedTree::relatedObjectIDsFor(const AXIso
 
 void AXIsolatedTree::applyPendingChanges()
 {
-    Locker locker { m_changeLogLock };
-    applyPendingChangesLocked();
+    AX_ASSERT(!isMainThread());
+
+    if (!hasPendingChanges())
+        return;
+
+    PendingChanges snapshot;
+    {
+        Locker locker { m_changeLogLock };
+        // Release the lock before applying changes in the snapshot,
+        // since doing so can take time, and we don't want to block
+        // the main-thread unnecessarily.
+        snapshot = takePendingChangesLocked();
+    }
+    applyPendingChangesFromSnapshot(WTF::move(snapshot));
 }
 
 void AXIsolatedTree::applyPendingChangesUnlessQueuedForDestruction()
 {
     AX_ASSERT(!isMainThread());
 
-    Locker locker { m_changeLogLock };
-
-    if (m_queuedForDestruction) [[unlikely]]
+    if (!hasPendingChanges())
         return;
-    applyPendingChangesLocked();
+
+    PendingChanges snapshot;
+    {
+        Locker locker { m_changeLogLock };
+        if (m_queuedForDestruction) [[unlikely]]
+            return;
+        snapshot = takePendingChangesLocked();
+    }
+    applyPendingChangesFromSnapshot(WTF::move(snapshot));
 }
 
 DidTearDown AXIsolatedTree::applyPendingChangesOrTearDown()
 {
     AX_ASSERT(!isMainThread());
 
-    Locker locker { m_changeLogLock };
+    if (!hasPendingChanges())
+        return DidTearDown::No;
 
-    if (m_queuedForDestruction) [[unlikely]] {
-        clearTreeContentsLocked();
-        return DidTearDown::Yes;
+    PendingChanges snapshot;
+    {
+        Locker locker { m_changeLogLock };
+
+        if (m_queuedForDestruction) [[unlikely]] {
+            clearTreeContentsLocked();
+            return DidTearDown::Yes;
+        }
+
+        snapshot = takePendingChangesLocked();
     }
-
-    applyPendingChangesLocked();
+    applyPendingChangesFromSnapshot(WTF::move(snapshot));
     return DidTearDown::No;
 }
 
@@ -1430,7 +1433,7 @@ void AXIsolatedTree::clearTreeContentsLocked()
     // that holds an AXIsolatedObject so the ref-cycle is broken and this tree can be destroyed.
     m_readerThreadNodeMap.clear();
     m_rootNode = nullptr;
-    m_pendingAppends.clear();
+    m_pendingChanges.appends.clear();
     // We don't need to bother clearing out any other non-cycle-causing member variables as they
     // will be cleaned up automatically when the tree is destroyed.
 }
@@ -1438,7 +1441,7 @@ void AXIsolatedTree::clearTreeContentsLocked()
 // When a node is queued for both subtree removal and appending in the same
 // batch (e.g. when an in-process FrameHost is replaced with an out-of-process
 // one during site isolation), the old subtree snapshot and the new one can
-// both end up in m_pendingAppends. The removal root may not yet be in the
+// both end up in m_pendingChanges.appends. The removal root may not yet be in the
 // node map, so deleteSubtree won't encounter it.
 //
 // For each unique appended ID, this function walks up its parent chain to
@@ -1448,7 +1451,7 @@ void AXIsolatedTree::clearTreeContentsLocked()
 //
 // Nodes that were removed from one parent but appended under a different
 // parent are reparenting operations and should be kept.
-void AXIsolatedTree::removeStaleAppends(const Vector<NodeAndParentID>& removals)
+void AXIsolatedTree::removeStaleAppends(const Vector<NodeAndParentID>& removals, Vector<NodeChange>& pendingAppends)
 {
     // Build a map from removed AXID to the parent it was removed from, for
     // O(1) lookups during the ancestor walk.
@@ -1459,7 +1462,7 @@ void AXIsolatedTree::removeStaleAppends(const Vector<NodeAndParentID>& removals)
     // Build a map from appended AXID to its final parentID (last entry wins,
     // since later appends override earlier ones in the append loop).
     HashMap<AXID, Markable<AXID>> appendedParentIDs;
-    for (const auto& item : m_pendingAppends)
+    for (const auto& item : pendingAppends)
         appendedParentIDs.set(item.data.axID, item.data.parentID);
 
     // For each unique appended ID, walk up the parent chain to determine
@@ -1526,88 +1529,84 @@ void AXIsolatedTree::removeStaleAppends(const Vector<NodeAndParentID>& removals)
     }
 
     if (!idsToRemove.isEmpty()) {
-        m_pendingAppends.removeAllMatching([&](const NodeChange& change) {
+        pendingAppends.removeAllMatching([&](const NodeChange& change) {
             return idsToRemove.contains(change.data.axID);
         });
     }
 }
 
-void AXIsolatedTree::applyPendingChangesLocked()
+void AXIsolatedTree::deleteSubtree(Ref<AXCoreObject>&& coreObjectToDelete, const HashSet<AXID>& protectedFromDeletionIDs)
+{
+    auto& objectToDelete = downcast<AXIsolatedObject>(coreObjectToDelete.get());
+    while (objectToDelete.m_children.size()) {
+        Ref child = objectToDelete.m_children.takeLast();
+        if (!protectedFromDeletionIDs.contains(child->objectID()))
+            deleteSubtree(WTF::move(child), protectedFromDeletionIDs);
+    }
+
+    // There's no need to call the more comprehensive AXCoreObject::detach here since
+    // we're deleting the entire subtree of this object and thus don't need to `detachRemoteParts`.
+    objectToDelete.detachWrapper(AccessibilityDetachmentType::ElementDestroyed);
+
+    AXID deleteAXID = objectToDelete.objectID();
+    m_readerThreadNodeMap.remove(deleteAXID);
+
+    for (const AXID& childID : objectToDelete.m_unresolvedChildrenIDs) {
+        // Ideally, assuming m_children has been initialized, there would be no unresolved children IDs.
+        // But sometimes when initializing m_children, AXIsolatedTree::objectForID fails for an unknown
+        // reason, and thus we are left with an entry in m_unresolvedChildrenIDs. See the ASSERT in
+        // AXIsolatedObject::children. In case any of our unresolved IDs got populated with an object
+        // later somehow, try to clean them up.
+        if (!protectedFromDeletionIDs.contains(childID)) {
+            if (RefPtr child = m_readerThreadNodeMap.take(childID))
+                deleteSubtree(child.releaseNonNull(), protectedFromDeletionIDs);
+        }
+    }
+}
+
+AXIsolatedTree::PendingChanges AXIsolatedTree::takePendingChangesLocked()
+{
+    AX_ASSERT(m_changeLogLock.isLocked());
+
+    auto snapshot = std::exchange(m_pendingChanges, { });
+    // focusedNodeID represents persistent state (not a queue), so preserve it
+    // across snapshots. Otherwise it gets reset to empty and incorrectly clears
+    // the focused node on the next apply cycle.
+    m_pendingChanges.focusedNodeID = snapshot.focusedNodeID;
+    m_hasPendingChanges.store(false);
+    return snapshot;
+}
+
+void AXIsolatedTree::applyPendingChangesFromSnapshot(PendingChanges&& snapshot)
 {
     AXTRACE("AXIsolatedTree::applyPendingChanges"_s);
     AX_ASSERT(!isMainThread());
-    AX_ASSERT(m_changeLogLock.isLocked());
 
     if (AXObjectCache::isAppleInternalInstall()) [[unlikely]]
         WTFBeginSignpostAlways(this, AccessibilityIsolatedTreeApplyPendingChanges, "tree ID: %" PRIVATE_LOG_STRING "", treeID().loggingString().utf8().data());
 
-    if (m_queuedForDestruction) [[unlikely]] {
-        clearTreeContentsLocked();
-
-        AX_ASSERT(AXTreeStore::contains(treeID()));
-        AXTreeStore::remove(treeID());
-
-        if (AXObjectCache::isAppleInternalInstall()) [[unlikely]]
-            WTFEndSignpostAlways(this, AccessibilityIsolatedTreeApplyPendingChanges, "tree ID: %" PRIVATE_LOG_STRING "", treeID().loggingString().utf8().data());
-        return;
-    }
-
-    if (m_pendingFocusedNodeID != m_focusedNodeID) {
-        AXLOG(makeString("focusedNodeID "_s, m_focusedNodeID ? m_focusedNodeID->loggingString() : ""_str, " pendingFocusedNodeID "_s, m_pendingFocusedNodeID ? m_pendingFocusedNodeID->loggingString() : ""_str));
-        m_focusedNodeID = m_pendingFocusedNodeID;
+    if (snapshot.focusedNodeID != m_focusedNodeID) {
+        AXLOG(makeString("focusedNodeID "_s, m_focusedNodeID ? m_focusedNodeID->loggingString() : ""_str, " pendingFocusedNodeID "_s, snapshot.focusedNodeID ? snapshot.focusedNodeID->loggingString() : ""_str));
+        m_focusedNodeID = snapshot.focusedNodeID;
     }
 
     // Snapshot the IDs pending subtree removal before processing, so we can
-    // use them to filter stale nodes from m_pendingAppends afterwards. This is
+    // use them to filter stale nodes from snapshot.appends afterwards. This is
     // necessary because a pending removal root may not yet be in the node map
     // (e.g. when an in-process FrameHost is replaced with an out-of-process
     // one during site isolation), so deleteSubtree won't encounter it.
-    auto removedIDs = std::exchange(m_pendingSubtreeRemovals, { });
-
-    // WTF_IGNORES_THREAD_SAFETY_ANALYSIS because we _do_ hold the m_changeLogLock, but the thread-safety
-    // analysis throws a false-positive compile error when we access m_pendingProtectedFromDeletionIDs in
-    // this lambda.
-    std::function<void(Ref<AXCoreObject>&&)> deleteSubtree = [this, protectedThis = Ref { *this }, &deleteSubtree] (Ref<AXCoreObject>&& coreObjectToDelete) WTF_IGNORES_THREAD_SAFETY_ANALYSIS {
-        auto& objectToDelete = downcast<AXIsolatedObject>(coreObjectToDelete.get());
-        while (objectToDelete.m_children.size()) {
-            Ref child = objectToDelete.m_children.takeLast();
-            if (!m_pendingProtectedFromDeletionIDs.contains(child->objectID()))
-                deleteSubtree(WTF::move(child));
-        }
-
-        // There's no need to call the more comprehensive AXCoreObject::detach here since
-        // we're deleting the entire subtree of this object and thus don't need to `detachRemoteParts`.
-        objectToDelete.detachWrapper(AccessibilityDetachmentType::ElementDestroyed);
-
-        AXID deleteAXID = objectToDelete.objectID();
-        m_readerThreadNodeMap.remove(deleteAXID);
-
-        for (const AXID& childID : objectToDelete.m_unresolvedChildrenIDs) {
-            // Ideally, assuming m_children has been initialized, there would be no unresolved children IDs.
-            // But sometimes when initializing m_children, AXIsolatedTree::objectForID fails for an unknown
-            // reason, and thus we are left with an entry in m_unresolvedChildrenIDs. See the ASSERT in
-            // AXIsolatedObject::children. In case any of our unresolved IDs got populated with an object
-            // later somehow, try to clean them up.
-            if (!m_pendingProtectedFromDeletionIDs.contains(childID)) {
-                if (RefPtr child = m_readerThreadNodeMap.take(childID))
-                    deleteSubtree(child.releaseNonNull());
-            }
-        }
-    };
-
-    for (const auto& removal : removedIDs) {
-        if (m_pendingProtectedFromDeletionIDs.contains(removal.nodeID))
+    for (const auto& removal : snapshot.subtreeRemovals) {
+        if (snapshot.protectedFromDeletionIDs.contains(removal.nodeID))
             continue;
 
         if (RefPtr object = m_readerThreadNodeMap.take(removal.nodeID))
-            deleteSubtree(object.releaseNonNull());
+            deleteSubtree(object.releaseNonNull(), snapshot.protectedFromDeletionIDs);
     }
-    m_pendingProtectedFromDeletionIDs.clear();
 
-    if (!removedIDs.isEmpty())
-        removeStaleAppends(removedIDs);
+    if (!snapshot.subtreeRemovals.isEmpty())
+        removeStaleAppends(snapshot.subtreeRemovals, snapshot.appends);
 
-    for (auto& item : m_pendingAppends) {
+    for (auto& item : snapshot.appends) {
         auto axID = item.data.axID;
         AXLOG(makeString("appending axID "_s, axID.loggingString()));
 
@@ -1632,60 +1631,73 @@ void AXIsolatedTree::applyPendingChangesLocked()
         // Can hit this on many tests with ITM + ENABLE_ACCESSIBILITY_LOCAL_FRAME (e.g. accessibility/deleting-iframe-destroys-axcache.html).
         AX_BROKEN_ASSERT(object->wrapper());
         // The reference count of the just added IsolatedObject must be 2
-        // because it is referenced by m_readerThreadNodeMap and m_pendingAppends.
-        // When m_pendingAppends is cleared, the object will be held only by m_readerThreadNodeMap. The exception is the root node whose reference count is 3.
+        // because it is referenced by m_readerThreadNodeMap and the snapshot's appends.
+        // When the snapshot is destroyed, the object will be held only by m_readerThreadNodeMap. The exception is the root node whose reference count is 3.
     }
-    m_pendingAppends.clear();
 
-    for (const auto& parentUpdate : m_pendingParentUpdates) {
+    for (const auto& parentUpdate : snapshot.parentUpdates) {
         if (auto* object = objectForID(parentUpdate.key))
             object->setParent(parentUpdate.value);
     }
-    m_pendingParentUpdates.clear();
 
-    for (auto& update : m_pendingChildrenUpdates) {
+    for (auto& update : snapshot.childrenUpdates) {
         AXLOG(makeString("updating children for axID "_s, update.first.loggingString()));
         if (RefPtr object = objectForID(update.first))
             object->setChildrenIDs(WTF::move(update.second));
     }
-    m_pendingChildrenUpdates.clear();
 
-    for (auto& change : m_pendingPropertyChanges) {
+    for (auto& change : snapshot.propertyChanges) {
         if (RefPtr object = objectForID(change.axID)) {
             for (auto& property : change.properties)
                 object->setProperty(property.first, WTF::move(property.second));
             object->shrinkPropertiesAfterUpdates();
         }
     }
-    m_pendingPropertyChanges.clear();
 
-    if (m_pendingSortedLiveRegionIDs)
-        m_sortedLiveRegionIDs = std::exchange(m_pendingSortedLiveRegionIDs, std::nullopt).value();
+    if (snapshot.sortedLiveRegionIDs)
+        m_sortedLiveRegionIDs = WTF::move(*snapshot.sortedLiveRegionIDs);
 
-    if (m_pendingSortedNonRootWebAreaIDs)
-        m_sortedNonRootWebAreaIDs = std::exchange(m_pendingSortedNonRootWebAreaIDs, std::nullopt).value();
+    if (snapshot.sortedNonRootWebAreaIDs)
+        m_sortedNonRootWebAreaIDs = WTF::move(*snapshot.sortedNonRootWebAreaIDs);
 
-    if (m_pendingMostRecentlyPaintedText)
-        m_mostRecentlyPaintedText = std::exchange(m_pendingMostRecentlyPaintedText, std::nullopt).value();
+    if (snapshot.mostRecentlyPaintedText)
+        m_mostRecentlyPaintedText = WTF::move(*snapshot.mostRecentlyPaintedText);
 
-    if (m_pendingRelations)
-        m_relations = std::exchange(m_pendingRelations, std::nullopt).value();
+    if (snapshot.relations)
+        m_relations = WTF::move(*snapshot.relations);
 
-    if (m_pendingSelectedTextMarkerRange)
-        m_selectedTextMarkerRange = std::exchange(m_pendingSelectedTextMarkerRange, std::nullopt).value();
+    if (snapshot.selectedTextMarkerRange)
+        m_selectedTextMarkerRange = WTF::move(*snapshot.selectedTextMarkerRange);
 
 #if ENABLE(ACCESSIBILITY_LOCAL_FRAME)
-    if (m_pendingFrameGeometry) {
-        m_frameGeometry = std::exchange(m_pendingFrameGeometry, std::nullopt).value();
+    if (snapshot.frameGeometry) {
+        m_frameGeometry = WTF::move(*snapshot.frameGeometry);
         m_hasReceivedFrameGeometry = true;
     }
-    if (m_pendingFrameViewOriginScrollPosition)
-        m_frameViewOriginScrollPosition = std::exchange(m_pendingFrameViewOriginScrollPosition, std::nullopt).value();
+    if (snapshot.frameViewOriginScrollPosition)
+        m_frameViewOriginScrollPosition = *snapshot.frameViewOriginScrollPosition;
 #endif
 
     // Do this at the end because it requires looking up the root node by ID, so doing it at the end
     // ensures all additions to m_readerThreadNodeMap have been made by now.
-    applyPendingRootNodeLocked();
+    if (snapshot.rootNodeID) {
+        if (RefPtr root = objectForID(snapshot.rootNodeID)) {
+            m_rootNode = WTF::move(root);
+
+#if ASSERT_ENABLED
+            auto markReachableNodes = [](AXCoreObject* object, HashSet<AXID>& reachableNodes, auto& self) -> void {
+                reachableNodes.add(object->objectID());
+                for (auto& child : object->children())
+                    self(&child.get(), reachableNodes, self);
+            };
+            HashSet<AXID> reachableNodes;
+            if (m_rootNode) {
+                markReachableNodes(m_rootNode.get(), reachableNodes, markReachableNodes);
+                ASSERT_WITH_MESSAGE(reachableNodes.size() == m_readerThreadNodeMap.size(), "AX: After applying pending root node, %u reachable nodes but %u are in the node map", reachableNodes.size(), m_readerThreadNodeMap.size());
+            }
+#endif
+        }
+    }
 
     if (AXObjectCache::isAppleInternalInstall()) [[unlikely]]
         WTFEndSignpostAlways(this, AccessibilityIsolatedTreeApplyPendingChanges, "tree ID: %" PRIVATE_LOG_STRING "", treeID().loggingString().utf8().data());
@@ -1696,7 +1708,7 @@ void AXIsolatedTree::sortedLiveRegionsDidChange(Vector<AXID> liveRegionIDs)
     AX_ASSERT(isMainThread());
 
     Locker locker { m_changeLogLock };
-    m_pendingSortedLiveRegionIDs = WTF::move(liveRegionIDs);
+    mutablePendingChanges()->sortedLiveRegionIDs = WTF::move(liveRegionIDs);
 }
 
 void AXIsolatedTree::sortedNonRootWebAreasDidChange(Vector<AXID> webAreaIDs)
@@ -1704,10 +1716,10 @@ void AXIsolatedTree::sortedNonRootWebAreasDidChange(Vector<AXID> webAreaIDs)
     AX_ASSERT(isMainThread());
 
     Locker locker { m_changeLogLock };
-    // FIXME: m_pendingSortedLiveRegionIDs and m_pendingSortedNonRootWebAreaIDs should be synced in AXIsolatedTree::processQueuedNodeUpdates(),
+    // FIXME: m_pendingChanges.sortedLiveRegionIDs and m_pendingChanges.sortedNonRootWebAreaIDs should be synced in AXIsolatedTree::processQueuedNodeUpdates(),
     // not ad-hoc whenever the main-thread changes them. Otherwise we could sync IDs to the accessibility thread that don't have isolated objects
     // until the next actual tree-update cycle.
-    m_pendingSortedNonRootWebAreaIDs = WTF::move(webAreaIDs);
+    mutablePendingChanges()->sortedNonRootWebAreaIDs = WTF::move(webAreaIDs);
 }
 
 AXTreePtr findAXTree(Function<bool(AXTreePtr)>&& match)
@@ -1856,7 +1868,7 @@ void AXIsolatedTree::processQueuedNodeUpdates()
         // and only perform a move or copy while in the critical section to avoid a deadlock.
         auto mostRecentlyPaintedText = cache ? cache->mostRecentlyPaintedText() : HashMap<AXID, LineRange> { };
         Locker lock { m_changeLogLock };
-        m_pendingMostRecentlyPaintedText = WTF::move(mostRecentlyPaintedText);
+        mutablePendingChanges()->mostRecentlyPaintedText = WTF::move(mostRecentlyPaintedText);
     }
 
     queueRemovalsAndUnresolvedChanges();

--- a/Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.h
+++ b/Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.h
@@ -515,7 +515,6 @@ public:
     void setPendingRootNodeID(AXID);
     void NODELETE setPendingRootNodeIDLocked(AXID) WTF_REQUIRES_LOCK(m_changeLogLock);
     void setFocusedNodeID(std::optional<AXID>);
-    void applyPendingRootNodeLocked() WTF_REQUIRES_LOCK(m_changeLogLock);
 
     // Relationships between objects.
     std::optional<ListHashSet<AXID>> relatedObjectIDsFor(const AXIsolatedObject&, AXRelation);
@@ -579,9 +578,9 @@ private:
     // because it could be being used by the secondary thread to service an AX request.
     void queueForDestruction();
 
-    void applyPendingChangesLocked() WTF_REQUIRES_LOCK(m_changeLogLock);
-    void removeStaleAppends(const Vector<NodeAndParentID>&) WTF_REQUIRES_LOCK(m_changeLogLock);
+    void deleteSubtree(Ref<AXCoreObject>&&, const HashSet<AXID>& protectedFromDeletionIDs);
     void clearTreeContentsLocked() WTF_REQUIRES_LOCK(m_changeLogLock);
+    bool hasPendingChanges() const { return m_hasPendingChanges.load(); }
 
     static std::atomic<bool> s_anyTreeNeedsTearDown;
 
@@ -607,6 +606,63 @@ private:
         NodeChange(const NodeChange&) = delete;
         NodeChange(NodeChange&&) = default;
     };
+
+    struct PendingChanges {
+        Markable<AXID> focusedNodeID;
+        Markable<AXID> rootNodeID;
+        Vector<NodeChange> appends;
+        Vector<AXPropertyChange> propertyChanges;
+        Vector<NodeAndParentID> subtreeRemovals;
+        Vector<std::pair<AXID, Vector<AXID>>> childrenUpdates;
+        HashSet<AXID> protectedFromDeletionIDs;
+        HashMap<AXID, AXID> parentUpdates;
+        std::optional<Vector<AXID>> sortedLiveRegionIDs;
+        std::optional<Vector<AXID>> sortedNonRootWebAreaIDs;
+        std::optional<HashMap<AXID, LineRange>> mostRecentlyPaintedText;
+        std::optional<HashMap<AXID, AXRelations>> relations;
+        std::optional<AXTextMarkerRange> selectedTextMarkerRange;
+#if ENABLE(ACCESSIBILITY_LOCAL_FRAME)
+        std::optional<AXFrameGeometry> frameGeometry;
+        std::optional<IntPoint> frameViewOriginScrollPosition;
+#endif
+    };
+
+    class PendingChangesAccessor {
+        WTF_MAKE_NONCOPYABLE(PendingChangesAccessor);
+    public:
+        PendingChangesAccessor(PendingChanges& data, std::atomic<bool>& flagToSetOnCompletion)
+            : m_data(data), m_flagToSetOnCompletion(flagToSetOnCompletion) { }
+        ~PendingChangesAccessor()
+        {
+            // Don't create a PendingChangesAccessor without using it — the destructor
+            // unconditionally sets m_hasPendingChanges, so unused accessors cause
+            // false-positive dirty flags.
+            AX_ASSERT(m_wasAccessed);
+            m_flagToSetOnCompletion.store(true);
+        }
+        PendingChanges* operator->()
+        {
+#if ASSERT_ENABLED
+            m_wasAccessed = true;
+#endif
+            return &m_data;
+        }
+    private:
+        PendingChanges& m_data;
+        std::atomic<bool>& m_flagToSetOnCompletion;
+#if ASSERT_ENABLED
+        bool m_wasAccessed { false };
+#endif
+    };
+
+    PendingChangesAccessor mutablePendingChanges() WTF_REQUIRES_LOCK(m_changeLogLock)
+    {
+        return { m_pendingChanges, m_hasPendingChanges };
+    }
+
+    PendingChanges takePendingChangesLocked() WTF_REQUIRES_LOCK(m_changeLogLock);
+    void applyPendingChangesFromSnapshot(PendingChanges&&);
+    void removeStaleAppends(const Vector<NodeAndParentID>&, Vector<NodeChange>&);
 
     void updateChildren(AccessibilityObject&, ResolveNodeChanges = ResolveNodeChanges::Yes);
     void updateNode(AccessibilityObject&);
@@ -668,32 +724,17 @@ private:
     RefPtr<AXIsolatedObject> m_rootNode;
 
     // Written to by main thread under lock, accessed and applied by AX thread.
-    Markable<AXID> m_pendingRootNodeID WTF_GUARDED_BY_LOCK(m_changeLogLock);
-    Vector<NodeChange> m_pendingAppends WTF_GUARDED_BY_LOCK(m_changeLogLock); // Nodes to be added to the tree and platform-wrapped.
-    Vector<AXPropertyChange> m_pendingPropertyChanges WTF_GUARDED_BY_LOCK(m_changeLogLock);
-    Vector<NodeAndParentID> m_pendingSubtreeRemovals WTF_GUARDED_BY_LOCK(m_changeLogLock); // Nodes whose subtrees are to be removed from the tree, paired with the parent they were removed from.
-    Vector<std::pair<AXID, Vector<AXID>>> m_pendingChildrenUpdates WTF_GUARDED_BY_LOCK(m_changeLogLock);
-    HashSet<AXID> m_pendingProtectedFromDeletionIDs WTF_GUARDED_BY_LOCK(m_changeLogLock);
-    HashMap<AXID, AXID> m_pendingParentUpdates WTF_GUARDED_BY_LOCK(m_changeLogLock);
-    Markable<AXID> m_pendingFocusedNodeID WTF_GUARDED_BY_LOCK(m_changeLogLock);
-    std::optional<Vector<AXID>> m_pendingSortedLiveRegionIDs WTF_GUARDED_BY_LOCK(m_changeLogLock);
+    PendingChanges m_pendingChanges WTF_GUARDED_BY_LOCK(m_changeLogLock);
 
     // These three are placed here to fit in padding that would otherwise be between m_pendingSortedLiveRegionIDs and m_pendingSortedNonRootWebAreaIDs.
     OptionSet<ActivityState> m_pageActivityState;
     bool m_isEmptyContentTree { false };
     bool m_queuedForDestruction WTF_GUARDED_BY_LOCK(m_changeLogLock) { false };
 
-    std::optional<Vector<AXID>> m_pendingSortedNonRootWebAreaIDs WTF_GUARDED_BY_LOCK(m_changeLogLock);
-    std::optional<HashMap<AXID, LineRange>> m_pendingMostRecentlyPaintedText WTF_GUARDED_BY_LOCK(m_changeLogLock);
-    std::optional<HashMap<AXID, AXRelations>> m_pendingRelations WTF_GUARDED_BY_LOCK(m_changeLogLock);
-    std::optional<AXTextMarkerRange> m_pendingSelectedTextMarkerRange WTF_GUARDED_BY_LOCK(m_changeLogLock);
-#if ENABLE(ACCESSIBILITY_LOCAL_FRAME)
-    std::optional<AXFrameGeometry> m_pendingFrameGeometry WTF_GUARDED_BY_LOCK(m_changeLogLock);
-    std::optional<IntPoint> m_pendingFrameViewOriginScrollPosition WTF_GUARDED_BY_LOCK(m_changeLogLock);
-#endif
     Markable<AXID> m_focusedNodeID;
     std::atomic<double> m_loadingProgress { 0 };
     std::atomic<double> m_processingProgress { 1 };
+    std::atomic<bool> m_hasPendingChanges { false };
 
     // Only accessed on the accessibility thread.
     Vector<AXID> m_sortedLiveRegionIDs;


### PR DESCRIPTION
#### 680e227dc899bb9e77fccdaa294eb7bb506d07de
<pre>
AX: Reduce AXIsolatedTree::applyPendingChanges lock contention and skip work when no changes are pending
<a href="https://bugs.webkit.org/show_bug.cgi?id=313751">https://bugs.webkit.org/show_bug.cgi?id=313751</a>
<a href="https://rdar.apple.com/175648233">rdar://175648233</a>

Reviewed by Dominic Mazzoni.

applyPendingChanges() can be called extremely frequently, at least once per request, and potentially a lot
more via crossFrameChildObject(), which ensures the local frame accessibility tree is up-to-date. Based
on logging I added, ~98% of the time there are no pending changes to be applied, yet we do a bunch of
work anyways — set up signposts, checks tons of data structures, allocate a std::function of decent size.

Additionally, when there are changes to apply, it can take a decent amount of time to do so (as high as 22ms
from my measurement). We hold the m_changeLogLock this whole time, which caused frequent main-thread stalls
waiting for the lock (~300ms total over the course of 120 seconds of VO-Right on a fairly static webpage -- dynamic
webpages could be even worse).

This commit implements three optimizations:

  1. Add std::atomic&lt;bool&gt; m_hasPendingChanges flag checked before acquiring the lock,
     allowing the common no-op case to return without any locking. Uses relaxed memory
     ordering since the lock provides the real synchronization, the flag is just a hint.

  2. Snapshot-and-release: move all pending data into a local PendingChangesSnapshot under
     the lock, release the lock, then process the snapshot. This reduces main-thread lock
     contention from the full processing duration to ~15 pointer swaps.

  3. Convert the recursive deleteSubtree from a std::function lambda (which heap-allocated
     captures including Ref&lt;AXIsolatedTree&gt;) into a private member function, eliminating
     per-call allocation and refcount overhead.

Using TimingScope, I measured a before and after from ~120 seconds of VO-Right on a fairly static webpage:

BEFORE: applyPendingChanges(): 999660 calls, mean duration: 0.006174ms, total duration: 6172.396803ms, max duration 22.998125ms
AFTER: applyPendingChanges(): 999660 calls, mean duration: 0.000313ms, total duration: 312.858223ms, max duration 13.276667ms

And the main-thread went from frequent 5-20ms stalls waiting for the lock to significantly less frequent stalls that
wait 1ms at most.

* Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.cpp:
(WebCore::AXIsolatedTree::queueForDestruction):
(WebCore::AXIsolatedTree::createEmptyContent):
(WebCore::AXIsolatedTree::queueChange):
(WebCore::AXIsolatedTree::addUnconnectedNode):
(WebCore::AXIsolatedTree::queueRemovals):
(WebCore::AXIsolatedTree::queueRemovalsLocked):
(WebCore::AXIsolatedTree::updateNodeProperties):
(WebCore::AXIsolatedTree::overrideNodeProperties):
(WebCore::AXIsolatedTree::setPendingRootNodeIDLocked):
(WebCore::AXIsolatedTree::setFocusedNodeID):
(WebCore::AXIsolatedTree::updateRelations):
(WebCore::AXIsolatedTree::setSelectedTextMarkerRange):
(WebCore::AXIsolatedTree::setFrameGeometry):
(WebCore::AXIsolatedTree::updateFrame):
(WebCore::AXIsolatedTree::applyPendingChanges):
(WebCore::AXIsolatedTree::applyPendingChangesUnlessQueuedForDestruction):
(WebCore::AXIsolatedTree::applyPendingChangesOrTearDown):
(WebCore::AXIsolatedTree::removeStaleAppends):
(WebCore::AXIsolatedTree::deleteSubtree):
(WebCore::AXIsolatedTree::takePendingChangesLocked):
(WebCore::AXIsolatedTree::applyPendingChangesFromSnapshot):
(WebCore::AXIsolatedTree::sortedLiveRegionsDidChange):
(WebCore::AXIsolatedTree::sortedNonRootWebAreasDidChange):
(WebCore::AXIsolatedTree::processQueuedNodeUpdates):
(WebCore::AXIsolatedTree::applyPendingRootNodeLocked): Deleted.
(WebCore::AXIsolatedTree::applyPendingChangesLocked): Deleted.
* Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.h:
(WebCore::AXIsolatedTree::setHasPendingChanges):
(WebCore::AXIsolatedTree::hasPendingChanges const):

Canonical link: <a href="https://commits.webkit.org/312765@main">https://commits.webkit.org/312765@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/30fda3f555d33330168c277a2d6242e42dc48562

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/160858 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/34331 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/27432 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/169761 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/116380 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/a02102e1-0b7f-4147-a237-752a4e3ec866) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/162727 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/34432 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/34331 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/124765 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/116380 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/92f66d62-15fd-45e1-834c-f329c657c6a6) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/163817 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/27022 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/144495 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/105362 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/04c0e9bf-d3dc-42f3-8dfc-5b24a54ce72b) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/26074 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/24574 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/17481 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/135768 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/22258 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/172244 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/19265 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/23899 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/133039 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/34005 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/28667 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/133050 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35964 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/33989 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/144053 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/95828 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/27642 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/20868 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/33500 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/100925 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/32999 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/33243 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/33147 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->