### PR TITLE
[JSC] Make `GatherAvailableAncestors` O(N) instead of O(N^2)

### DIFF
--- a/JSTests/modules/async-gather-diamond.js
+++ b/JSTests/modules/async-gather-diamond.js
@@ -1,0 +1,24 @@
+// Diamond fan-in through GatherAvailableAncestors:
+//
+//   leaf (TLA)
+//   /        \
+//  A          B           (sync sibling re-exporters)
+//   \        /
+//    \      /
+//      C                  (sync, depends on both A and B)
+//
+// When leaf fulfills, GatherAvailableAncestors walks leaf's
+// AsyncParentModules ([A, B]). For each, it appends to execList and recurses
+// into its sync parents (only C). C is reachable via two paths (leaf -> A -> C
+// and leaf -> B -> C) within a single gather call, so C must be appended
+// exactly once. This exercises the membership-test path that the
+// "PendingAsyncDependencies != 0" optimization replaces; if the equivalence
+// were broken, C would either be appended twice (executing its body twice)
+// or be skipped entirely.
+
+import { shouldBe } from "./resources/assert.js";
+import { c } from "./async-gather-diamond/C.js";
+import { log } from "./async-gather-diamond/log.js";
+
+shouldBe(c, 2);
+shouldBe(log.join(","), "A,B,C");

--- a/JSTests/modules/async-gather-diamond/A.js
+++ b/JSTests/modules/async-gather-diamond/A.js
@@ -1,0 +1,4 @@
+import { leafValue } from "./leaf.js";
+import { log } from "./log.js";
+log.push("A");
+export const a = leafValue;

--- a/JSTests/modules/async-gather-diamond/B.js
+++ b/JSTests/modules/async-gather-diamond/B.js
@@ -1,0 +1,4 @@
+import { leafValue } from "./leaf.js";
+import { log } from "./log.js";
+log.push("B");
+export const b = leafValue;

--- a/JSTests/modules/async-gather-diamond/C.js
+++ b/JSTests/modules/async-gather-diamond/C.js
@@ -1,0 +1,5 @@
+import { a } from "./A.js";
+import { b } from "./B.js";
+import { log } from "./log.js";
+log.push("C");
+export const c = a + b;

--- a/JSTests/modules/async-gather-diamond/leaf.js
+++ b/JSTests/modules/async-gather-diamond/leaf.js
@@ -1,0 +1,5 @@
+// TLA leaf — both A and B (siblings in the diamond) await this module's
+// completion, so when leaf fulfills GatherAvailableAncestors visits A and B,
+// each of which has C as its single sync ancestor.
+await Promise.resolve();
+export const leafValue = 1;

--- a/JSTests/modules/async-gather-diamond/log.js
+++ b/JSTests/modules/async-gather-diamond/log.js
@@ -1,0 +1,4 @@
+// Append-only evaluation log shared by A, B, C.
+// If C is mistakenly appended twice to the gather execList, its body would
+// run twice and C would appear twice here.
+export const log = [];

--- a/Source/JavaScriptCore/runtime/CyclicModuleRecord.cpp
+++ b/Source/JavaScriptCore/runtime/CyclicModuleRecord.cpp
@@ -502,6 +502,11 @@ static void gatherAvailableAncestors(CyclicModuleRecord* module, Vector<CyclicMo
 {
     // GatherAvailableAncestors(module, execList)
     // https://tc39.es/ecma262/#sec-gather-available-ancestors
+    //
+    // We replace the spec's "execList does not contain m" membership test with
+    // "m.[[PendingAsyncDependencies]] != 0" so the loop is O(N) instead of O(N^2).
+    // Within a single gather call, the two are equivalent under the spec's invariants;
+    // see commit message for the proof. The ASSERT below verifies this at runtime.
 
     // 1. For each Cyclic Module Record m of module.[[AsyncParentModules]], do
     for (const WriteBarrier<AbstractModuleRecord>& barrier : module->asyncParentModules()) {
@@ -509,26 +514,32 @@ static void gatherAvailableAncestors(CyclicModuleRecord* module, Vector<CyclicMo
         // 1.a. If execList does not contain m and m.[[CycleRoot]].[[EvaluationError]] is empty, then
         // (Probable spec bug (https://github.com/tc39/ecma262/issues/3766). We need an additional check here that m.[[CycleRoot]] isn't empty.)
         ASSERT_IMPLIES(!m->cycleRoot(), m->evaluationError());
-        if (CyclicModuleRecord* root = m->cycleRoot(); root && root->evaluationError() == nullptr && !execList.contains(m)) {
-            // 1.a.i. Assert: m.[[Status]] is EVALUATING-ASYNC.
-            ASSERT(m->status() == CyclicModuleRecord::Status::EvaluatingAsync);
-            // 1.a.ii. Assert: m.[[EvaluationError]] is EMPTY.
-            ASSERT(m->evaluationError() == nullptr);
-            // 1.a.iii. Assert: m.[[AsyncEvaluationOrder]] is an integer.
-            ASSERT(m->asyncEvaluationOrder().hasOrder());
-            // 1.a.iv. Assert: m.[[PendingAsyncDependencies]] > 0.
-            ASSERT(m->pendingAsyncDependencies() > 0);
-            // 1.a.v. Set m.[[PendingAsyncDependencies]] to m.[[PendingAsyncDependencies]] - 1.
-            int newDependencies = m->pendingAsyncDependencies().value() - 1;
-            m->setPendingAsyncDependencies(newDependencies);
-            // 1.a.vi. If m.[[PendingAsyncDependencies]] = 0, then
-            if (!newDependencies) {
-                // 1.a.vi.1. Append m to execList.
-                execList.append(m);
-                // 1.a.vi.2. If m.[[HasTLA]] is false, perform GatherAvailableAncestors(m, execList).
-                if (!m->hasTLA())
-                    gatherAvailableAncestors(m, execList);
-            }
+        CyclicModuleRecord* root = m->cycleRoot();
+        if (!root || root->evaluationError() != nullptr)
+            continue;
+        auto pending = m->pendingAsyncDependencies();
+        // Verify the invariant in debug: execList ∋ m  iff  pending == 0 (under cycleRoot OK).
+        ASSERT(pending);
+        ASSERT(execList.contains(m) == !*pending);
+        if (!*pending)
+            continue;
+        // 1.a.i. Assert: m.[[Status]] is EVALUATING-ASYNC.
+        ASSERT(m->status() == CyclicModuleRecord::Status::EvaluatingAsync);
+        // 1.a.ii. Assert: m.[[EvaluationError]] is EMPTY.
+        ASSERT(m->evaluationError() == nullptr);
+        // 1.a.iii. Assert: m.[[AsyncEvaluationOrder]] is an integer.
+        ASSERT(m->asyncEvaluationOrder().hasOrder());
+        // 1.a.iv. Assert: m.[[PendingAsyncDependencies]] > 0. (Implied by *pending != 0 above.)
+        // 1.a.v. Set m.[[PendingAsyncDependencies]] to m.[[PendingAsyncDependencies]] - 1.
+        int newDependencies = *pending - 1;
+        m->setPendingAsyncDependencies(newDependencies);
+        // 1.a.vi. If m.[[PendingAsyncDependencies]] = 0, then
+        if (!newDependencies) {
+            // 1.a.vi.1. Append m to execList.
+            execList.append(m);
+            // 1.a.vi.2. If m.[[HasTLA]] is false, perform GatherAvailableAncestors(m, execList).
+            if (!m->hasTLA())
+                gatherAvailableAncestors(m, execList);
         }
     }
     // 2. Return UNUSED.


### PR DESCRIPTION
#### 8f7132dd0edc7900ce7a7d3c9614cb30229bb72d
<pre>
[JSC] Make `GatherAvailableAncestors` O(N) instead of O(N^2)
<a href="https://bugs.webkit.org/show_bug.cgi?id=313753">https://bugs.webkit.org/show_bug.cgi?id=313753</a>

Reviewed by Yusuke Suzuki.

The spec&apos;s &quot;execList does not contain m&quot; check [1] was implemented with
Vector::contains, making each gather call O(N^2) over a sync-parent
cascade. Replace it with &quot;m.[[PendingAsyncDependencies]] != 0&quot;, which
is equivalent within a single gather call (spec step 1.a.iv guarantees
one direction; the other follows from pending only being driven to 0
inside step 1.a.v + 1.a.vi.1, with no concurrent mutation). V8 DCHECKs
the same invariant [2].

Both directions are verified by ASSERT.

[1]: <a href="https://tc39.es/ecma262/#sec-gather-available-ancestors">https://tc39.es/ecma262/#sec-gather-available-ancestors</a>
[2]: <a href="https://github.com/v8/v8/blob/82ed9d774565c1c6192d0e83e2ee9ad1360670c6/src/objects/source-text-module.cc#L814-L820">https://github.com/v8/v8/blob/82ed9d774565c1c6192d0e83e2ee9ad1360670c6/src/objects/source-text-module.cc#L814-L820</a>

* JSTests/modules/async-gather-diamond.js: Added.
* JSTests/modules/async-gather-diamond/A.js: Added.
* JSTests/modules/async-gather-diamond/B.js: Added.
* JSTests/modules/async-gather-diamond/C.js: Added.
* JSTests/modules/async-gather-diamond/leaf.js: Added.
* JSTests/modules/async-gather-diamond/log.js: Added.
* Source/JavaScriptCore/runtime/CyclicModuleRecord.cpp:
(JSC::gatherAvailableAncestors):

Canonical link: <a href="https://commits.webkit.org/312498@main">https://commits.webkit.org/312498@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c8ba2f55e94249bc5d2fa881dbae5fd926a77a4a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/159741 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/33208 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/26315 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/168598 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/114122 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/33313 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/33212 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/123776 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/86847 "3 flakes 10 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/162699 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/26040 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/143477 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/104418 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/25092 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/23560 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/16362 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/151797 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/134783 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/21249 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/171091 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/20578 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/17109 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/22886 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/132033 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/32887 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/27638 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/132088 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35807 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/32872 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/143043 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/90961 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/26711 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/19856 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/192025 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/32381 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/98777 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/49376 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/31878 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/32125 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/32029 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->