### PR TITLE
StabilityTracer: Crash in WorkerConsoleClient::messageWithTypeAndLevel

### DIFF
--- a/Source/WebCore/workers/WorkerConsoleClient.cpp
+++ b/Source/WebCore/workers/WorkerConsoleClient.cpp
@@ -80,12 +80,17 @@ void WorkerConsoleClient::messageWithTypeAndLevel(MessageType type, MessageLevel
     arguments->getFirstArgumentAsString(messageText);
 
     auto message = makeUnique<Inspector::ConsoleMessage>(MessageSource::ConsoleAPI, type, level, messageText, arguments.copyRef(), exec);
+
+    auto url = message->url();
+    auto line = message->line();
+    auto column = message->column();
+
     protect(m_globalScope.get())->addConsoleMessage(WTF::move(message));
 
     auto* domGlobalObject = dynamicDowncast<JSDOMGlobalObject>(exec);
     if (level == MessageLevel::Error && domGlobalObject && domGlobalObject->hasScriptErrorCallbacks()) {
         auto fullMessageText = makeStringByJoining(arguments->getArgumentsAsStrings(), " "_s);
-        domGlobalObject->invokeScriptErrorCallbacks(fullMessageText, message->url(), message->line(), message->column());
+        domGlobalObject->invokeScriptErrorCallbacks(fullMessageText, url, line, column);
     }
 }
 


### PR DESCRIPTION
#### 41dd2c52de8717c56f80190045c1e85c7f830eda
<pre>
StabilityTracer: Crash in WorkerConsoleClient::messageWithTypeAndLevel
<a href="https://bugs.webkit.org/show_bug.cgi?id=313754">https://bugs.webkit.org/show_bug.cgi?id=313754</a>
<a href="https://rdar.apple.com/175775709">rdar://175775709</a>

Reviewed by Youenn Fablet.

In WorkerConsoleClient::messageWithTypeAndLevel(), &quot;message&quot; is used after it
has been moved, leading to a crash. The use-after-move was added in
<a href="https://commits.webkit.org/311150@main.">https://commits.webkit.org/311150@main.</a>

We fix it by making sure it&apos;s not used after its been moved.

* Source/WebCore/workers/WorkerConsoleClient.cpp:
(WebCore::WorkerConsoleClient::messageWithTypeAndLevel):

Canonical link: <a href="https://commits.webkit.org/312413@main">https://commits.webkit.org/312413@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0f5c17eb2770930caf5e042572752a20d1f1503f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/159743 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/33210 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/26317 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/168600 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/114124 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/cc3c882a-55c1-43da-8be6-a14317d09ab8) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/161612 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/33315 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/33214 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/123777 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/86850 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/761d6a93-f59f-4c86-9973-44d65ebc8825) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/162701 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/26039 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/143480 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/104419 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/9e3f8b69-768c-4e55-9b07-c4c64e68b0ef) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/25091 "Passed tests") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/23562 "Found 1 new API test failure: TestWebKitAPI.UnifiedPDF.EmbeddedPDFScrollbarDoesNotAdaptToDarkMode (failure)") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/16364 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/134782 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/21252 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/171093 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/17111 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/22889 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/132035 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/32889 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/27640 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/132090 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/32874 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/143046 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/90964 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/24331 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/26712 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/19859 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/32383 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/98779 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/31880 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/32127 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/32031 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->