### PR TITLE
Optionally Restrict Queues to Specific Base Branches

### DIFF
--- a/Tools/CISupport/ews-build/loadConfig.py
+++ b/Tools/CISupport/ews-build/loadConfig.py
@@ -74,6 +74,9 @@ def loadBuilderConfig(c, is_test_mode_enabled=False, setup_main_schedulers=True,
         builder['description'] = builder.pop('shortname')
         if 'icon' in builder:
             del builder['icon']
+        allowed_base_branches = builder.pop('allowed_base_branches', None)
+        if allowed_base_branches is not None:
+            builder.setdefault('properties', {})['allowed_base_branches'] = allowed_base_branches
         factorykwargs = {}
         for key in ['platform', 'configuration', 'architectures', 'triggers', 'remotes', 'additionalArguments', 'runTests', 'triggered_by', 'rebuild_without_change_on_builder', 'deployment_target']:
             value = builder.pop(key, None)
@@ -199,6 +202,14 @@ def checkValidBuilder(config, builder):
 
     if builder.get('rebuild_without_change_on_builder') and not builder.get('triggers'):
         raise Exception(f'rebuild_without_change_on_builder can only be set on builders with triggers. Builder: {builder["name"]}')
+
+    if 'allowed_base_branches' in builder:
+        allowed_base_branches = builder['allowed_base_branches']
+        if not isinstance(allowed_base_branches, list) or not allowed_base_branches:
+            raise Exception(f'allowed_base_branches must be a non-empty list of glob strings. Builder: {builder["name"]}')
+        for pattern in allowed_base_branches:
+            if not isinstance(pattern, str) or not pattern:
+                raise Exception(f'allowed_base_branches must contain non-empty glob strings. Builder: {builder["name"]}')
 
 
 def checkValidSchedulers(config, schedulers):

--- a/Tools/CISupport/ews-build/loadConfig_unittest.py
+++ b/Tools/CISupport/ews-build/loadConfig_unittest.py
@@ -57,7 +57,7 @@ class ConfigDotJSONTest(unittest.TestCase):
 
     def test_builder_keys(self):
         config = self.get_config()
-        valid_builder_keys = ['additionalArguments', 'architectures', 'builddir', 'configuration', 'description',
+        valid_builder_keys = ['additionalArguments', 'allowed_base_branches', 'architectures', 'builddir', 'configuration', 'description',
                               'defaultProperties', 'deployment_target', 'env', 'factory', 'icon', 'locks', 'name',
                               'platform', 'properties', 'rebuild_without_change_on_builder', 'remotes', 'runTests',
                               'shortname', 'tags', 'triggers', 'triggered_by', 'workernames', 'workerbuilddir']
@@ -244,6 +244,32 @@ class TestcheckValidBuilder(unittest.TestCase):
     def test_rebuild_without_change_on_builder_valid(self):
         config = {'schedulers': [{'name': 'some-trigger', 'type': 'Triggerable'}]}
         loadConfig.checkValidBuilder(config, {'name': 'macOS-Build-EWS', 'shortname': 'mac', 'configuration': 'release', 'factory': 'BuildFactory', 'platform': 'mac-sierra', 'rebuild_without_change_on_builder': True, 'triggers': ['some-trigger']})
+
+    def test_allowed_base_branches_absent(self):
+        loadConfig.checkValidBuilder({}, {'name': 'macOS-Build-EWS', 'shortname': 'mac', 'configuration': 'release', 'factory': 'BuildFactory', 'platform': 'mac-sierra'})
+
+    def test_allowed_base_branches_valid(self):
+        loadConfig.checkValidBuilder({}, {'name': 'macOS-Build-EWS', 'shortname': 'mac', 'configuration': 'release', 'factory': 'BuildFactory', 'platform': 'mac-sierra', 'allowed_base_branches': ['main', 'safari-*-branch']})
+
+    def test_allowed_base_branches_not_a_list(self):
+        with self.assertRaises(Exception) as context:
+            loadConfig.checkValidBuilder({}, {'name': 'macOS-Build-EWS', 'shortname': 'mac', 'configuration': 'release', 'factory': 'BuildFactory', 'platform': 'mac-sierra', 'allowed_base_branches': 'main'})
+        self.assertEqual(context.exception.args, ('allowed_base_branches must be a non-empty list of glob strings. Builder: macOS-Build-EWS',))
+
+    def test_allowed_base_branches_empty_list(self):
+        with self.assertRaises(Exception) as context:
+            loadConfig.checkValidBuilder({}, {'name': 'macOS-Build-EWS', 'shortname': 'mac', 'configuration': 'release', 'factory': 'BuildFactory', 'platform': 'mac-sierra', 'allowed_base_branches': []})
+        self.assertEqual(context.exception.args, ('allowed_base_branches must be a non-empty list of glob strings. Builder: macOS-Build-EWS',))
+
+    def test_allowed_base_branches_empty_entry(self):
+        with self.assertRaises(Exception) as context:
+            loadConfig.checkValidBuilder({}, {'name': 'macOS-Build-EWS', 'shortname': 'mac', 'configuration': 'release', 'factory': 'BuildFactory', 'platform': 'mac-sierra', 'allowed_base_branches': ['main', '']})
+        self.assertEqual(context.exception.args, ('allowed_base_branches must contain non-empty glob strings. Builder: macOS-Build-EWS',))
+
+    def test_allowed_base_branches_non_string_entry(self):
+        with self.assertRaises(Exception) as context:
+            loadConfig.checkValidBuilder({}, {'name': 'macOS-Build-EWS', 'shortname': 'mac', 'configuration': 'release', 'factory': 'BuildFactory', 'platform': 'mac-sierra', 'allowed_base_branches': ['main', 123]})
+        self.assertEqual(context.exception.args, ('allowed_base_branches must contain non-empty glob strings. Builder: macOS-Build-EWS',))
 
 
 class TestcheckWorkersAndBuildersForConsistency(unittest.TestCase):

--- a/Tools/CISupport/ews-build/steps.py
+++ b/Tools/CISupport/ews-build/steps.py
@@ -38,6 +38,7 @@ from .results_db import ResultsDatabase
 from .twisted_additions import TwistedAdditions
 from .utils import load_password, get_custom_suffix
 
+import fnmatch
 import json
 import os
 import re
@@ -1890,8 +1891,13 @@ class ValidateChange(buildstep.BuildStep, BugzillaMixin, GitHubMixin):
         patch_id = self.getProperty('patch_id', '')
         pr_number = self.getProperty('github.number', self.getProperty('pr_number', ''))
         branch = self.getProperty('github.base.ref', DEFAULT_BRANCH)
+        allowed_base_branches = self.getProperty('allowed_base_branches', None)
 
-        if not any(candidate.match(branch) for candidate in self.branches):
+        if allowed_base_branches is not None:
+            if not any(fnmatch.fnmatchcase(branch, pattern) for pattern in allowed_base_branches):
+                rc = yield self.skip_build(f"Base branch '{branch}' is not allowed for this builder")
+                return defer.returnValue(rc)
+        elif not any(candidate.match(branch) for candidate in self.branches):
             rc = yield self.skip_build(f"Changes to '{branch}' are not tested")
             return defer.returnValue(rc)
 

--- a/Tools/CISupport/ews-build/steps_unittest.py
+++ b/Tools/CISupport/ews-build/steps_unittest.py
@@ -6801,6 +6801,61 @@ class TestValidateChange(BuildStepMixinAdditions, unittest.TestCase):
         self.expect_property('fast_commit_queue', None, 'fast_commit_queue is unexpectedly set')
         return rc
 
+    def test_allowed_base_branches_exact_match(self):
+        self.setup_step(ValidateChange(verifyBugClosed=False))
+        ValidateChange.get_pr_json = lambda x, pull_request, repository_url=None, retry=None: self.get_pr(pr_number=pull_request)
+        self.setProperty('github.number', '1234')
+        self.setProperty('repository', 'https://github.com/WebKit/WebKit')
+        self.setProperty('github.head.sha', '7496f8ecc4cc8011f19c8cc1bc7b18fe4a88ad5c')
+        self.setProperty('github.base.ref', 'main')
+        self.setProperty('allowed_base_branches', ['main'])
+        self.expect_outcome(result=SUCCESS, state_string='Validated change')
+        return self.run_step()
+
+    def test_allowed_base_branches_no_match(self):
+        self.setup_step(ValidateChange(verifyBugClosed=False))
+        ValidateChange.get_pr_json = lambda x, pull_request, repository_url=None, retry=None: self.get_pr(pr_number=pull_request)
+        self.setProperty('github.number', '1234')
+        self.setProperty('repository', 'https://github.com/WebKit/WebKit')
+        self.setProperty('github.head.sha', '7496f8ecc4cc8011f19c8cc1bc7b18fe4a88ad5c')
+        self.setProperty('github.base.ref', 'safari-7620-branch')
+        self.setProperty('allowed_base_branches', ['main'])
+        self.expect_outcome(result=FAILURE, state_string="Base branch 'safari-7620-branch' is not allowed for this builder")
+        return self.run_step()
+
+    def test_allowed_base_branches_glob_match(self):
+        self.setup_step(ValidateChange(verifyBugClosed=False))
+        ValidateChange.get_pr_json = lambda x, pull_request, repository_url=None, retry=None: self.get_pr(pr_number=pull_request)
+        self.setProperty('github.number', '1234')
+        self.setProperty('repository', 'https://github.com/WebKit/WebKit')
+        self.setProperty('github.head.sha', '7496f8ecc4cc8011f19c8cc1bc7b18fe4a88ad5c')
+        self.setProperty('github.base.ref', 'safari-7620-branch')
+        self.setProperty('allowed_base_branches', ['safari-*-branch'])
+        self.expect_outcome(result=SUCCESS, state_string='Validated change')
+        return self.run_step()
+
+    def test_allowed_base_branches_multi_pattern_no_match(self):
+        self.setup_step(ValidateChange(verifyBugClosed=False))
+        ValidateChange.get_pr_json = lambda x, pull_request, repository_url=None, retry=None: self.get_pr(pr_number=pull_request)
+        self.setProperty('github.number', '1234')
+        self.setProperty('repository', 'https://github.com/WebKit/WebKit')
+        self.setProperty('github.head.sha', '7496f8ecc4cc8011f19c8cc1bc7b18fe4a88ad5c')
+        self.setProperty('github.base.ref', 'webkitgtk-2.44')
+        self.setProperty('allowed_base_branches', ['main', 'safari-*-branch'])
+        self.expect_outcome(result=FAILURE, state_string="Base branch 'webkitgtk-2.44' is not allowed for this builder")
+        return self.run_step()
+
+    def test_allowed_base_branches_overrides_factory_branches(self):
+        self.setup_step(ValidateChange(verifyBugClosed=False, branches=[r'main']))
+        ValidateChange.get_pr_json = lambda x, pull_request, repository_url=None, retry=None: self.get_pr(pr_number=pull_request)
+        self.setProperty('github.number', '1234')
+        self.setProperty('repository', 'https://github.com/WebKit/WebKit')
+        self.setProperty('github.head.sha', '7496f8ecc4cc8011f19c8cc1bc7b18fe4a88ad5c')
+        self.setProperty('github.base.ref', 'safari-7620-branch')
+        self.setProperty('allowed_base_branches', ['safari-*-branch'])
+        self.expect_outcome(result=SUCCESS, state_string='Validated change')
+        return self.run_step()
+
 
 class TestRetrievePRDataFromLabel(BuildStepMixinAdditions, unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
#### 55a8ace221b74f54f299e637a3fa5dac74e1acd4
<pre>
Optionally Restrict Queues to Specific Base Branches
<a href="https://bugs.webkit.org/show_bug.cgi?id=313756">https://bugs.webkit.org/show_bug.cgi?id=313756</a>
<a href="https://rdar.apple.com/175951675">rdar://175951675</a>

Reviewed by NOBODY (OOPS!).

Optionally allow restricting queues to be run only on specific base branches.

For example
```
 {
    &quot;name&quot;: &quot;Build-EWS&quot;, &quot;shortname&quot;: &quot;build&quot;, &quot;icon&quot;: &quot;buildOnly&quot;,
    &quot;factory&quot;: &quot;BuildFactory&quot;, &quot;platform&quot;: &quot;*&quot;,
    &quot;allowed_base_branches&quot;: [&quot;main&quot;, &quot;webkit-*&quot;],
    ...
  }
```

Would restrict Build-EWS to only run on PRs whos base branch matches &quot;main&quot; or &quot;webkit-*&quot;.

* Tools/CISupport/ews-build/loadConfig.py:
(loadBuilderConfig):
(checkValidBuilder):
* Tools/CISupport/ews-build/loadConfig_unittest.py:
(ConfigDotJSONTest.test_builder_keys):
(TestcheckValidBuilder.test_allowed_base_branches_absent):
(TestcheckValidBuilder):
(TestcheckValidBuilder.test_allowed_base_branches_valid):
(TestcheckValidBuilder.test_allowed_base_branches_not_a_list):
(TestcheckValidBuilder.test_allowed_base_branches_empty_list):
(TestcheckValidBuilder.test_allowed_base_branches_empty_entry):
(TestcheckValidBuilder.test_allowed_base_branches_non_string_entry):
* Tools/CISupport/ews-build/steps.py:
(ValidateChange.run):
* Tools/CISupport/ews-build/steps_unittest.py:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/55a8ace221b74f54f299e637a3fa5dac74e1acd4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/159745 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/33212 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/26319 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/168603 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/114126 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/662c9173-17a4-4fdc-9a1d-c9d6a6a4b7ad) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/161614 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/33317 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/33216 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/123779 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/86851 "9 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/edddb7f3-eb57-44a2-b0dd-21062d44f06c) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/162703 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/26042 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/143481 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/104421 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/2f4cf593-3ae0-4d17-ba23-b4c446fb4424) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/25094 "Passed tests") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/23563 "Found 1 new API test failure: TestWebKitAPI.WKBackForwardList.BackForwardNavigationSkipsItemsWithoutUserGestureFragment (failure)") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/16366 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/134815 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/21253 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/171095 "Built successfully") | | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/22890 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/132054 "Passed tests") | | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/159204 "Passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/32891 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/27641 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/132091 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/32876 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/143047 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/90969 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/26713 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/19860 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/32385 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/31882 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/32129 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/32033 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->