### PR TITLE
amazon.design: bottom of navigation menu is clipped on devices with certain viewports

### DIFF
--- a/Source/WebCore/page/Quirks.cpp
+++ b/Source/WebCore/page/Quirks.cpp
@@ -2573,6 +2573,35 @@ bool Quirks::needsHideSelectionDuringOverflowScrollQuirk() const
     QUIRKS_EARLY_RETURN_IF_DISABLED_WITH_VALUE(false);
     return m_quirksData.quirkIsEnabled(QuirksData::SiteSpecificQuirk::NeedsHideSelectionDuringOverflowScrollQuirk);
 }
+
+// amazon.design rdar://175953409
+bool Quirks::needsAmazonDesignMenuViewportUnitQuirk(const Style::ComputedStyle& style, const Style::ComputedStyle& parentStyle) const
+{
+    QUIRKS_EARLY_RETURN_IF_DISABLED_WITH_VALUE(false);
+
+    if (!m_quirksData.quirkIsEnabled(QuirksData::SiteSpecificQuirk::NeedsAmazonDesignMenuViewportUnitQuirk))
+        return false;
+
+    if (style.display() != Style::DisplayType::BlockFlex)
+        return false;
+
+    if (!style.usesViewportUnits())
+        return false;
+
+    auto fixedPaddingTop = parentStyle.paddingTop().tryFixed();
+    if (!fixedPaddingTop)
+        return false;
+
+    auto fixedHeight = style.height().tryFixed();
+    if (!fixedHeight)
+        return false;
+
+    auto resolvedPaddingTop = fixedPaddingTop->resolveZoom(Style::ZoomFactor::none());
+    auto resolvedHeight = fixedHeight->resolveZoom(Style::ZoomFactor::none());
+    auto dynamicViewportHeight = m_document->renderView()->sizeForCSSDynamicViewportUnits().height();
+
+    return (resolvedPaddingTop + resolvedHeight) > dynamicViewportHeight;
+}
 #endif
 
 bool Quirks::needsLimitedMatroskaSupport() const
@@ -3293,7 +3322,7 @@ static void handleRedditQuirks(QuirksData& quirksData, const URL& /* quirksURL *
 }
 #endif
 
-static void handleAmazonQuirks(QuirksData& quirksData, const URL& /* quirksURL */, const String& /* quirksDomainString */, const URL&  /* documentURL */)
+static void handleAmazonQuirks(QuirksData& quirksData, const URL& /* quirksURL */, const String& quirksDomainString, const URL&  /* documentURL */)
 {
     // Note: There is a userAgent override for rdar://117771731, see needsCustomUserAgentOverride()
     quirksData.isAmazon = true;
@@ -3306,6 +3335,13 @@ static void handleAmazonQuirks(QuirksData& quirksData, const URL& /* quirksURL *
         QuirksData::SiteSpecificQuirk::NeedsPrimeVideoUserSelectNoneQuirk,
 #endif
     });
+
+#if PLATFORM(IOS_FAMILY)
+    if (quirksDomainString == "amazon.design"_s)
+        quirksData.enableQuirk(QuirksData::SiteSpecificQuirk::NeedsAmazonDesignMenuViewportUnitQuirk);
+#else
+    UNUSED_PARAM(quirksDomainString);
+#endif
 }
 
 static void handleBBCQuirks(QuirksData& quirksData, const URL& /* quirksURL */, const String& quirksDomainString, const URL&  /* documentURL */)

--- a/Source/WebCore/page/Quirks.h
+++ b/Source/WebCore/page/Quirks.h
@@ -299,6 +299,7 @@ public:
     WEBCORE_EXPORT bool needsPointerTouchCompatibility(const Element&) const;
     WEBCORE_EXPORT bool shouldHideSoftTopScrollEdgeEffectDuringFocus(const Element&) const;
 
+    bool needsAmazonDesignMenuViewportUnitQuirk(const Style::ComputedStyle&, const Style::ComputedStyle& parentStyle) const;
     bool needsClaudeSidebarViewportUnitQuirk(Element&, const Style::ComputedStyle&) const;
     WEBCORE_EXPORT bool needsHideSelectionDuringOverflowScrollQuirk() const;
     bool needsChromeOSNavigatorUserAgentQuirk(const Document&) const;

--- a/Source/WebCore/page/QuirksData.h
+++ b/Source/WebCore/page/QuirksData.h
@@ -85,6 +85,7 @@ struct QuirksData {
         NeedsChromeMediaControlsPseudoElementQuirk,
         NeedsLogoutCookieCleanupQuirk,
 #if PLATFORM(IOS_FAMILY)
+        NeedsAmazonDesignMenuViewportUnitQuirk,
         NeedsClaudeSidebarViewportUnitQuirk,
         NeedsHideSelectionDuringOverflowScrollQuirk,
 #endif

--- a/Source/WebCore/style/StyleAdjuster.cpp
+++ b/Source/WebCore/style/StyleAdjuster.cpp
@@ -1114,6 +1114,15 @@ void Adjuster::adjustForSiteSpecificQuirks(Style::ComputedStyle& style) const
 #if PLATFORM(IOS_FAMILY)
     if (documentQuirks.needsClaudeSidebarViewportUnitQuirk(*m_element, style))
         style.setHeight(PreferredSize::Fixed { m_document->renderView()->sizeForCSSDynamicViewportUnits().height() });
+
+    if (documentQuirks.needsAmazonDesignMenuViewportUnitQuirk(style, m_parentStyle)) {
+        if (auto fixedHeight = style.height().tryFixed()) {
+            auto resolvedHeight = fixedHeight->resolveZoom(ZoomFactor::none());
+            auto defaultViewportHeight = m_document->renderView()->sizeForCSSDefaultViewportUnits().height();
+            auto dynamicViewportHeight = m_document->renderView()->sizeForCSSDynamicViewportUnits().height();
+            style.setHeight(PreferredSize::Fixed { resolvedHeight - (defaultViewportHeight - dynamicViewportHeight) });
+        }
+    }
 #endif
 
 #if PLATFORM(MAC)


### PR DESCRIPTION
#### 23df7d03b8f7f9bbff942638be9b54f2631266fb
<pre>
amazon.design: bottom of navigation menu is clipped on devices with certain viewports
<a href="https://bugs.webkit.org/show_bug.cgi?id=306649">https://bugs.webkit.org/show_bug.cgi?id=306649</a>
<a href="https://rdar.apple.com/169307770">rdar://169307770</a>

Reviewed by Brent Fulgham.

On certain types of iOS devices, particularly Pro Max phones,
the bottom portion of the navigation menu gets obscured by Safari&apos;s navigation
toolbar. The page&apos;s navigation bar content is a flex item with margin-top:
auto inside a flexbox that has a height based off 100vh. It seems likes
there are some offests that are subtracted from the 100vh in an attempt
to make sure the content is placed correctly since the auto top margin
pushes the content to the bottom.

However, it does not seem like this is enough since on the aforementioned
devices the bottom of the &quot;Amazon Log In,&quot; text ends up getting hidden by
Safari&apos;s toolbar. The reason is does not seem to reproduce on Pro devices
is because those devices have a narrower viewport and second line is
created after the log in text. This line is created because there is a
SVG that appears after the text that does not fit on the line. That
pushes the &quot;Amazon Log In,&quot; text a bit up and what ends up happening is
the SVG ends up getting clicked. In fact, if you set the viewport
dimensions to the same dimensions as a Pro device on other browsers you
end up getting the same layout. However, it does not become visible
until you hover over the text so for the purposes of this targeted fix
it is probably ok.

To fix this we can apply a quirk that forces the flexbox that contains
the navigation bar content to use 100dvh, which takes into
convisderation the space taken up by Safari&apos;s navigation bar, instead of
100vh.

Canonical link: <a href="https://commits.webkit.org/315134@main">https://commits.webkit.org/315134@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ba89444f3e1999f90c6abeabb7e6c6e8b6767edc

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/168130 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/41628 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/35225 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/177458 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/125831 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/e9ff5587-1888-4b59-bd29-6aaf7e7018ca) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/169996 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/42062 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/41642 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/130826 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/91955 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/21a84251-8cfa-4928-9a06-4f6ea6b73f1c) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/171089 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/33298 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/151095 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/111338 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/bbdec9ad-d388-4f66-b19a-5f40c382cde8) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/32284 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/30986 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/26154 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/142269 "Passed tests") | [⏳ 🧪 mac-wk1 ](https://ews-build.webkit.org/#/builders/macOS-Sequoia-Release-WK1-Tests-EWS "Waiting in queue, processing has not started yet") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/180058 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/32781 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/30502 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/139259 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/41699 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/35145 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/139128 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37476 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/42387 "Built successfully") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/105744 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/34414 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/27461 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/40891 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/114147 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/40288 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/5557 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/40539 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/40433 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->