### PR TITLE
[Unified PDF] Add an internal setting to align the trailing page of a PDF in two-up display to the left edge

### DIFF
--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -8463,6 +8463,20 @@ TwoUpPDFDisplayModeSupportEnabled:
     WebCore:
       default: true
 
+TwoUpPDFTrailingPageLeftAlignmentEnabled:
+  type: bool
+  status: internal
+  humanReadableName: "Two-Up PDF Trailing Page Left Alignment"
+  humanReadableDescription: "In two-up PDF display mode, align the trailing odd page to the same column as the first page instead of centering it"
+  condition: ENABLE(UNIFIED_PDF)
+  defaultValue:
+    WebKitLegacy:
+      default: false
+    WebKit:
+      default: false
+    WebCore:
+      default: false
+
 # FIXME: Is this implemented for WebKitLegacy? If not, this should be excluded from WebKitLegacy entirely.
 UndoManagerAPIEnabled:
   type: bool

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFDocumentLayout.h
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFDocumentLayout.h
@@ -111,6 +111,9 @@ public:
     void setDisplayMode(PDFDisplayMode displayMode) { m_displayMode = displayMode; }
     PDFDisplayMode displayMode() const { return m_displayMode; }
 
+    void setShouldLeftAlignTrailingTwoUpPage(bool value) { m_shouldLeftAlignTrailingTwoUpPage = value; }
+    bool shouldLeftAlignTrailingTwoUpPage() const { return m_shouldLeftAlignTrailingTwoUpPage; }
+
     bool isSinglePageDisplayMode() const { return isSinglePagePDFDisplayMode(m_displayMode); }
     bool isTwoUpDisplayMode() const { return isTwoUpPDFDisplayMode(m_displayMode); }
 
@@ -146,6 +149,7 @@ private:
     WebCore::FloatRect m_documentBounds;
     float m_scale { 1 };
     PDFDisplayMode m_displayMode { PDFDisplayMode::SinglePageContinuous };
+    bool m_shouldLeftAlignTrailingTwoUpPage { false };
 };
 
 struct PDFLayoutRow {

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFDocumentLayout.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFDocumentLayout.mm
@@ -437,7 +437,14 @@ FloatRect PDFDocumentLayout::layoutRow(const PDFLayoutRow& row, FloatSize maxRow
     case 1: {
         auto pageIndex = row.pages[0];
         auto pageBounds = m_pageGeometry[pageIndex].layoutBounds;
-        auto pageLeft = documentMargin.width() + std::max<float>(std::floor((maxRowSize.width() - pageBounds.width()) / 2), 0);
+
+        float pageLeft;
+        if (m_shouldLeftAlignTrailingTwoUpPage && isTwoUpDisplayMode()) {
+            float horizontalSpace = maxRowSize.width() - pageBounds.width() - pageBounds.width() - pageMargin.width();
+            pageLeft = std::floor(documentMargin.width() + std::max<float>(horizontalSpace / 2, 0));
+        } else
+            pageLeft = documentMargin.width() + std::max<float>(std::floor((maxRowSize.width() - pageBounds.width()) / 2), 0);
+
         auto pageTop = rowTop;
 
         if (centerVertically == CenterRowVertically::Yes)

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm
@@ -1352,6 +1352,9 @@ void UnifiedPDFPlugin::updateLayout(AdjustScaleAfterLayout shouldAdjustScale, st
     auto layoutSize = availableContentsRect().size();
     auto autoSizeMode = shouldUpdateAutoSizeScaleOverride.value_or(m_didLayoutWithValidDocument ? m_shouldUpdateAutoSizeScale : ShouldUpdateAutoSizeScale::Yes);
 
+    if (RefPtr corePage = page())
+        m_documentLayout.setShouldLeftAlignTrailingTwoUpPage(corePage->settings().twoUpPDFTrailingPageLeftAlignmentEnabled());
+
     Ref presentationController = *m_presentationController;
     auto computeAnchoringInfo = [&] {
         return presentationController->pdfPositionForCurrentView(PDFPresentationController::AnchorPoint::TopLeft, shouldAdjustScale == AdjustScaleAfterLayout::Yes || autoSizeMode == ShouldUpdateAutoSizeScale::Yes);


### PR DESCRIPTION
#### 1397b00aa951d4921c301c775c39c59a0db3fc89
<pre>
[Unified PDF] Add an internal setting to align the trailing page of a PDF in two-up display to the left edge
<a href="https://bugs.webkit.org/show_bug.cgi?id=313761">https://bugs.webkit.org/show_bug.cgi?id=313761</a>
<a href="https://rdar.apple.com/175955315">rdar://175955315</a>

Reviewed by Abrar Rahman Protyasha.

Currently, when PDFs are displayed in two-up, and there are an odd number of
pages, the last page is centered.

This patch adds an internal setting to make the alignment of the last odd page
match the alignment of the first page.

* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml:
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFDocumentLayout.h:
(WebKit::PDFDocumentLayout::setShouldLeftAlignTrailingTwoUpPage):
(WebKit::PDFDocumentLayout::shouldLeftAlignTrailingTwoUpPage const):
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFDocumentLayout.mm:
(WebKit::PDFDocumentLayout::layoutRow):
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm:
(WebKit::UnifiedPDFPlugin::updateLayout):

Canonical link: <a href="https://commits.webkit.org/312457@main">https://commits.webkit.org/312457@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/58ac3b9593672b9d16a8383ed9f7bff74e621971

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/159761 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/33228 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/26335 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/168619 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/114142 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/f1e6edc4-4673-45af-ad63-dbcdaf7e72ef) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/33333 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/33232 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/123806 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/86856 "2 flakes 9 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/a293ad40-71f7-4411-b58f-ac2340b2e9e8) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/162719 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/26062 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/143492 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/104443 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/a98fb8e9-c553-4fcc-a103-cad686fb0cf5) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/25114 "Passed tests") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/23579 "Found 1 new API test failure: TestWebKitAPI.WKBackForwardList.BackForwardNavigationSkipsItemsWithoutUserGestureFragment (failure)") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/16382 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/151817 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/134805 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/21264 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/171111 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/20598 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/17129 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/22901 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/132057 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/32907 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/27658 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/132105 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/32892 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/143058 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/90990 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/24349 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/26728 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/19871 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/192045 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/32401 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/98797 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/49385 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/31898 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/32145 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/32049 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->