### PR TITLE
[Windows] Fix linux container sdk cross build

### DIFF
--- a/Tools/Scripts/build-webkit
+++ b/Tools/Scripts/build-webkit
@@ -209,10 +209,25 @@ if ((isAppleWebKit() || isPlayStation()) && !-d "WebKitLibraries") {
 
 if (isWinCrossCompileFromLinux()) {
     $ENV{"VCPKG_ROOT"} = winCrossCompileVcpkgRoot();
-    # Prevent pkg-config from finding host system packages during cross-compilation.
+    # Prevent pkg-config from finding host system packages during cross-compilation,
+    # but still allow finding vcpkg.
     # The triplet sets VCPKG_ENV_PASSTHROUGH_UNTRACKED to forward this to port builds.
     $ENV{"PKG_CONFIG_LIBDIR"} = "";
     $ENV{"PKG_CONFIG_PATH"} = "";
+    my $vcpkgPkgConfig = File::Spec->catdir(productDir(), "vcpkg_installed", "x64-windows-webkit", "lib", "pkgconfig");
+    $ENV{"PKG_CONFIG_LIBDIR"} = $vcpkgPkgConfig;
+    $ENV{"PKG_CONFIG_PATH"} = "";
+    # The WebKit container sdk sets these, causing interference.
+    delete $ENV{"C_INCLUDE_PATH"};
+    delete $ENV{"CPLUS_INCLUDE_PATH"};
+    delete $ENV{"CPATH"};
+    delete $ENV{"LIBRARY_PATH"};
+    delete $ENV{"LD_LIBRARY_PATH"};
+    delete $ENV{"LDFLAGS"};
+    delete $ENV{"CFLAGS"};
+    delete $ENV{"CXXFLAGS"};
+    delete $ENV{"CPPFLAGS"};
+    delete $ENV{"CMAKE_PREFIX_PATH"};
     # Add WebKitLibraries/windows/bin to PATH for dummy pwsh (satisfies vcpkg's PowerShell check)
     my $winBinDir = File::Spec->catdir(sourceDir(), "WebKitLibraries", "windows", "bin");
     $ENV{"PATH"} = "$winBinDir:$ENV{PATH}";


### PR DESCRIPTION
#### dc625f6e97de3a3721b48e8336ca3c4329544ac4
<pre>
[Windows] Fix linux container sdk cross build
<a href="https://bugs.webkit.org/show_bug.cgi?id=313770">https://bugs.webkit.org/show_bug.cgi?id=313770</a>

Reviewed by Yusuke Suzuki.

Canonical link: <a href="https://commits.webkit.org/312634@main">https://commits.webkit.org/312634@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6455c1ae7d3f0f8a464bf99074d259f64cdd55d8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/159781 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/33249 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/26355 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/168640 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/114162 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/161650 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/33353 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/33252 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/123808 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/86863 "2 flakes 9 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/162739 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/26069 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/143514 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/104445 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/25121 "Passed tests") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/23594 "Found 1 new API test failure: TestWebKitAPI.WKBackForwardList.BackForwardNavigationSkipsItemsWithoutUserGestureFragment (failure)") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/16402 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/151837 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/134812 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/21285 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/171132 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/20618 "Built successfully and passed tests") | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/22922 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/132068 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/32927 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/27673 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/132118 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35892 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/32912 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/143079 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/91010 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/26731 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/19893 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/192065 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/32421 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/49390 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/31918 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/32165 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/32069 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->