### PR TITLE
[JSC] Inline 16-bit string equality in DFG/FTL

### DIFF
--- a/JSTests/microbenchmarks/string-equality-256-16bit.js
+++ b/JSTests/microbenchmarks/string-equality-256-16bit.js
@@ -1,0 +1,26 @@
+function makeString(len, ch) {
+    let s = "";
+    for (let i = 0; i < len; ++i)
+        s += ch;
+    return s;
+}
+
+// Embedding a non-Latin1 character forces 16-bit storage.
+let a = makeString(255, "α") + "β";
+let b = makeString(255, "α") + "β";
+let c = makeString(255, "α") + "γ";
+
+function eq(x, y) {
+    return x === y;
+}
+noInline(eq);
+
+let n = 0;
+for (let i = 0; i < 1e6; ++i) {
+    if (eq(a, b))
+        n++;
+    if (eq(a, c))
+        n++;
+}
+if (n !== 1e6)
+    throw "Bad result: " + n;

--- a/JSTests/microbenchmarks/string-equality-long-16bit.js
+++ b/JSTests/microbenchmarks/string-equality-long-16bit.js
@@ -1,0 +1,26 @@
+function makeString(len, ch) {
+    let s = "";
+    for (let i = 0; i < len; ++i)
+        s += ch;
+    return s;
+}
+
+// Two distinct JSString cells with identical 16-bit content (avoid pointer-equal fast path).
+let a = makeString(64, "α") + "β";
+let b = makeString(64, "α") + "β";
+let c = makeString(64, "α") + "γ";
+
+function eq(x, y) {
+    return x === y;
+}
+noInline(eq);
+
+let n = 0;
+for (let i = 0; i < 1e6; ++i) {
+    if (eq(a, b))
+        n++;
+    if (eq(a, c))
+        n++;
+}
+if (n !== 1e6)
+    throw "Bad result: " + n;

--- a/JSTests/microbenchmarks/string-equality-short-16bit.js
+++ b/JSTests/microbenchmarks/string-equality-short-16bit.js
@@ -1,0 +1,26 @@
+function makeString(len, ch) {
+    let s = "";
+    for (let i = 0; i < len; ++i)
+        s += ch;
+    return s;
+}
+
+// Embedding a non-Latin1 character forces 16-bit storage.
+let a = makeString(2, "α") + "β";
+let b = makeString(2, "α") + "β";
+let c = makeString(2, "α") + "γ";
+
+function eq(x, y) {
+    return x === y;
+}
+noInline(eq);
+
+let n = 0;
+for (let i = 0; i < 1e6; ++i) {
+    if (eq(a, b))
+        n++;
+    if (eq(a, c))
+        n++;
+}
+if (n !== 1e6)
+    throw "Bad result: " + n;

--- a/JSTests/stress/string-equality-mixed-width-slow-path.js
+++ b/JSTests/stress/string-equality-mixed-width-slow-path.js
@@ -1,0 +1,15 @@
+function eq(a, b) { return a === b; }
+noInline(eq);
+
+let s16a = String.fromCharCode(0x3042, 0x3044, 0x3046);
+let s16b = String.fromCharCode(0x3042, 0x3044, 0x3046);
+let s8 = createNonRopeNonAtomString("abc");
+
+for (let i = 0; i < 1e5; ++i) {
+    if (eq(s16a, s8))
+        throw new Error("FAIL: 16bit !== 8bit at i=" + i);
+    if (eq(s8, s16a))
+        throw new Error("FAIL: 8bit !== 16bit at i=" + i);
+    if (!eq(s16a, s16b))
+        throw new Error("FAIL: 16bit === 16bit at i=" + i);
+}

--- a/JSTests/stress/string-equality-word-compare-16bit.js
+++ b/JSTests/stress/string-equality-word-compare-16bit.js
@@ -1,0 +1,43 @@
+function eq(a, b) { return a === b; }
+noInline(eq);
+
+function make(s) {
+    // Force a fresh, resolved, non-atom JSString with its own StringImpl.
+    return (s + "α").slice(0, s.length);
+}
+
+// Build 16-bit strings (each character is non-Latin1 so storage is forced to 16-bit).
+// Use a small alphabet of distinct non-Latin1 code points.
+let alphabet = [];
+for (let i = 0; i < 26; ++i)
+    alphabet.push(String.fromCharCode(0x0391 + i)); // Greek capital letters
+
+let cases = [];
+for (let len = 0; len <= 40; ++len) {
+    let base = "";
+    for (let i = 0; i < len; ++i)
+        base += alphabet[i % alphabet.length];
+    cases.push([make(base), make(base), true]);
+    if (len > 0) {
+        for (let pos of [0, (len >> 1), len - 1]) {
+            let arr = base.split("");
+            arr[pos] = String.fromCharCode(arr[pos].charCodeAt(0) + 1);
+            cases.push([make(base), make(arr.join("")), false]);
+        }
+    }
+}
+
+// Mixed-width pairs: same content but one side is 8-bit, the other 16-bit.
+// These must compare unequal because we treat differing widths as a slow-path
+// bail (the runtime helper handles equality across widths correctly).
+let ascii = "abcdefghij";
+let widened = ascii + "α";
+let widenedTrimmed = widened.slice(0, ascii.length);
+cases.push([ascii, widenedTrimmed, true]);
+
+for (let i = 0; i < 1e4; ++i) {
+    for (let [a, b, expected] of cases) {
+        if (eq(a, b) !== expected)
+            throw new Error("FAIL len=" + a.length + " a=" + a + " b=" + b + " expected=" + expected);
+    }
+}

--- a/JSTests/stress/string-equality-word-compare-thorough.js
+++ b/JSTests/stress/string-equality-word-compare-thorough.js
@@ -1,0 +1,145 @@
+// Thorough stress test for the inlined === fast path on JSStrings.
+// Covers:
+//   - 8-bit and 16-bit storage, all lengths 0..72 (well past several word boundaries)
+//   - Mismatch at every byte position (head, middle, tail) for both widths
+//   - Boundary lengths around the word loop (wordSize=8 bytes => 8-bit:8 chars, 16-bit:4 chars)
+//   - Pointer-equal strings, atom-equal strings, and freshly-allocated equal-content strings
+//   - Mixed-width pairs (8-bit vs 16-bit with identical code points): equality must be honored
+//     by the runtime helper even when our inline fast path bails on width mismatch.
+//   - Strings produced via different construction paths (literal, concat, slice, fromCharCode,
+//     repeat, replace, JSON.parse) so the StringImpl flag layout varies.
+//   - Sufficient iterations to tier up DFG and FTL.
+
+function eq(a, b) { return a === b; }
+noInline(eq);
+
+// Force a fresh, resolved, non-atom JSString with its own StringImpl.
+function freshCopy(s) {
+    if (s.length === 0)
+        return ("x").slice(1, 1);
+    return (s + "!").slice(0, s.length);
+}
+
+// Like freshCopy but routed through a different builder, so the resulting
+// StringImpl has different metadata (e.g., not from a slice).
+function freshCopyConcat(s) {
+    let out = "";
+    for (let i = 0; i < s.length; ++i)
+        out += s[i];
+    return out;
+}
+
+const ASCII_ALPHABET = (() => {
+    let s = "";
+    for (let i = 0; i < 26; ++i)
+        s += String.fromCharCode(97 + i);
+    return s;
+})();
+
+const GREEK_ALPHABET = (() => {
+    let s = "";
+    for (let i = 0; i < 24; ++i)
+        s += String.fromCharCode(0x0391 + i); // forces 16-bit
+    return s;
+})();
+
+function makeFromAlphabet(alpha, len) {
+    let s = "";
+    for (let i = 0; i < len; ++i)
+        s += alpha[i % alpha.length];
+    return s;
+}
+
+function flip(s, pos) {
+    let arr = s.split("");
+    arr[pos] = String.fromCharCode(arr[pos].charCodeAt(0) + 1);
+    return arr.join("");
+}
+
+let cases = [];
+const MAX_LEN = 72;
+
+for (let len = 0; len <= MAX_LEN; ++len) {
+    for (let alpha of [ASCII_ALPHABET, GREEK_ALPHABET]) {
+        let base = makeFromAlphabet(alpha, len);
+
+        // Equal pairs from several construction paths.
+        cases.push([freshCopy(base), freshCopy(base), true]);
+        cases.push([freshCopy(base), freshCopyConcat(base), true]);
+
+        // Identity cases (same JSString cell).
+        cases.push([base, base, true]);
+
+        if (len > 0) {
+            // Mismatch at every position.
+            for (let pos = 0; pos < len; ++pos)
+                cases.push([freshCopy(base), freshCopy(flip(base, pos)), false]);
+
+            // Different lengths (slow path's own concern, but still must be respected).
+            cases.push([freshCopy(base), freshCopy(base + alpha[0]), false]);
+            cases.push([freshCopy(base + alpha[0]), freshCopy(base), false]);
+        }
+    }
+
+    // Mixed-width pair: same code points stored with different bit widths.
+    // The 8-bit copy is built from ASCII; the 16-bit copy embeds a non-Latin1
+    // throwaway character then trims it, forcing 16-bit storage of ASCII content.
+    let ascii = makeFromAlphabet(ASCII_ALPHABET, len);
+    let widened = (ascii + "α").slice(0, len);
+    cases.push([ascii, widened, true]);
+    cases.push([widened, ascii, true]);
+}
+
+// Atom + non-atom equal pair.
+{
+    let atom = "static-atom-string";
+    let nonAtom = freshCopy("static-atom-string");
+    cases.push([atom, nonAtom, true]);
+    cases.push([nonAtom, atom, true]);
+}
+
+// Strings whose first/last word boundary differs.
+for (let len of [7, 8, 9, 15, 16, 17, 23, 24, 25, 31, 32, 33]) {
+    let base = makeFromAlphabet(ASCII_ALPHABET, len);
+    cases.push([freshCopy(base), freshCopy(base), true]);
+    cases.push([freshCopy(base), freshCopy(flip(base, 0)), false]);
+    cases.push([freshCopy(base), freshCopy(flip(base, len - 1)), false]);
+    if (len >= 2)
+        cases.push([freshCopy(base), freshCopy(flip(base, len >> 1)), false]);
+
+    let base16 = makeFromAlphabet(GREEK_ALPHABET, len);
+    cases.push([freshCopy(base16), freshCopy(base16), true]);
+    cases.push([freshCopy(base16), freshCopy(flip(base16, 0)), false]);
+    cases.push([freshCopy(base16), freshCopy(flip(base16, len - 1)), false]);
+    if (len >= 2)
+        cases.push([freshCopy(base16), freshCopy(flip(base16, len >> 1)), false]);
+}
+
+// Tier up: run a quick warmup on a fixed pair so DFG/FTL kicks in.
+{
+    let a = freshCopy("warmup-string-warmup");
+    let b = freshCopy("warmup-string-warmup");
+    let c = freshCopy("warmup-string-warmuq");
+    for (let i = 0; i < 200000; ++i) {
+        if (!eq(a, b)) throw "warmup1";
+        if (eq(a, c)) throw "warmup2";
+    }
+}
+
+// Main verification.
+let total = 0;
+for (let i = 0; i < 50; ++i) {
+    for (let [a, b, expected] of cases) {
+        let r = eq(a, b);
+        if (r !== expected) {
+            throw new Error(
+                "FAIL: a.length=" + a.length + " b.length=" + b.length +
+                " expected=" + expected + " got=" + r +
+                " a=" + JSON.stringify(a) + " b=" + JSON.stringify(b));
+        }
+        total++;
+    }
+}
+
+if (total < 1000)
+    throw "too few comparisons: " + total;

--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp
@@ -7726,15 +7726,16 @@ void SpeculativeJIT::compileStringEquality(
     
     trueCase.append(branchTest32(Zero, lengthGPR));
     
-    slowCase.append(branchTest32(
-        Zero,
-        Address(leftTempGPR, StringImpl::flagsOffset()),
-        TrustedImm32(StringImpl::flagIs8Bit())));
-    slowCase.append(branchTest32(
-        Zero,
-        Address(rightTempGPR, StringImpl::flagsOffset()),
-        TrustedImm32(StringImpl::flagIs8Bit())));
-    
+    // leftTemp2GPR/rightTemp2GPR may alias leftGPR/rightGPR (Reuse), so we must not clobber
+    // them before the last slowCase branch is emitted.
+    Jump leftIs8Bit = branchTest32(NonZero, Address(leftTempGPR, StringImpl::flagsOffset()), TrustedImm32(StringImpl::flagIs8Bit()));
+    slowCase.append(branchTest32(NonZero, Address(rightTempGPR, StringImpl::flagsOffset()), TrustedImm32(StringImpl::flagIs8Bit())));
+    lshift32(TrustedImm32(1), lengthGPR);
+    Jump widthDone = jump();
+    leftIs8Bit.link(this);
+    slowCase.append(branchTest32(Zero, Address(rightTempGPR, StringImpl::flagsOffset()), TrustedImm32(StringImpl::flagIs8Bit())));
+    widthDone.link(this);
+
     loadPtr(Address(leftTempGPR, StringImpl::dataOffset()), leftTempGPR);
     loadPtr(Address(rightTempGPR, StringImpl::dataOffset()), rightTempGPR);
 

--- a/Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp
+++ b/Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp
@@ -21139,8 +21139,9 @@ IGNORE_CLANG_WARNINGS_END
         LBasicBlock notEmptyCase = m_out.newBlock();
         LBasicBlock leftReadyCase = m_out.newBlock();
         LBasicBlock rightReadyCase = m_out.newBlock();
-        LBasicBlock left8BitCase = m_out.newBlock();
-        LBasicBlock right8BitCase = m_out.newBlock();
+        LBasicBlock widthMatchedCase = m_out.newBlock();
+        LBasicBlock is16BitCase = m_out.newBlock();
+        LBasicBlock byteLengthReady = m_out.newBlock();
         LBasicBlock byteLoop = m_out.newBlock();
         LBasicBlock bytesEqual = m_out.newBlock();
         LBasicBlock wordLoopPreheader = m_out.newBlock();
@@ -21169,30 +21170,37 @@ IGNORE_CLANG_WARNINGS_END
         m_out.appendTo(notTriviallyUnequalCase, notEmptyCase);
         m_out.branch(m_out.isZero32(length), unsure(trueCase), unsure(notEmptyCase));
 
-        m_out.appendTo(notEmptyCase, left8BitCase);
-        m_out.branch(
-            m_out.testIsZero32(
-                m_out.load32(left, m_heaps.StringImpl_hashAndFlags),
-                m_out.constInt32(StringImpl::flagIs8Bit())),
-            unsure(slowCase), unsure(left8BitCase));
+        // Mixed-width pairs bail to the slow path; the runtime helper handles cross-width equality.
+        m_out.appendTo(notEmptyCase, widthMatchedCase);
+        LValue leftIs8Bit = m_out.bitAnd(
+            m_out.load32(left, m_heaps.StringImpl_hashAndFlags),
+            m_out.constInt32(StringImpl::flagIs8Bit()));
+        LValue rightIs8Bit = m_out.bitAnd(
+            m_out.load32(right, m_heaps.StringImpl_hashAndFlags),
+            m_out.constInt32(StringImpl::flagIs8Bit()));
+        m_out.branch(m_out.notEqual(leftIs8Bit, rightIs8Bit), rarely(slowCase), usually(widthMatchedCase));
 
-        m_out.appendTo(left8BitCase, right8BitCase);
-        m_out.branch(
-            m_out.testIsZero32(
-                m_out.load32(right, m_heaps.StringImpl_hashAndFlags),
-                m_out.constInt32(StringImpl::flagIs8Bit())),
-            unsure(slowCase), unsure(right8BitCase));
+        // 8-bit is the common case: fall through with byteLength == length. 16-bit converts char-count
+        // to byte-count via length << 1 so the byte-addressed loops below work unchanged.
+        m_out.appendTo(widthMatchedCase, is16BitCase);
+        ValueFromBlock byteLengthIf8Bit = m_out.anchor(length);
+        m_out.branch(m_out.isZero32(leftIs8Bit), rarely(is16BitCase), usually(byteLengthReady));
 
-        m_out.appendTo(right8BitCase, byteLoop);
+        m_out.appendTo(is16BitCase, byteLengthReady);
+        ValueFromBlock byteLengthIf16Bit = m_out.anchor(m_out.shl(length, m_out.int32One));
+        m_out.jump(byteLengthReady);
+
+        m_out.appendTo(byteLengthReady, byteLoop);
+        LValue byteLength = m_out.phi(Int32, byteLengthIf8Bit, byteLengthIf16Bit);
 
         LValue leftData = m_out.loadPtr(left, m_heaps.StringImpl_data);
         LValue rightData = m_out.loadPtr(right, m_heaps.StringImpl_data);
 
         constexpr unsigned wordSize = 8;
-        ValueFromBlock byteIndexAtStart = m_out.anchor(length);
+        ValueFromBlock byteIndexAtStart = m_out.anchor(byteLength);
         // Lay out the byte loop as the fall-through so that short strings only pay for a
         // not-taken branch; long strings easily amortize the taken-branch cost over the word loop.
-        m_out.branch(m_out.below(length, m_out.constInt32(wordSize)), usually(byteLoop), rarely(wordLoopPreheader));
+        m_out.branch(m_out.below(byteLength, m_out.constInt32(wordSize)), usually(byteLoop), rarely(wordLoopPreheader));
 
         // length in [1, wordSize): byte-at-a-time loop.
         m_out.appendTo(byteLoop, bytesEqual);
@@ -21208,9 +21216,9 @@ IGNORE_CLANG_WARNINGS_END
         m_out.addIncomingToPhi(byteIndexAtLoopTop, m_out.anchor(byteIndexInLoop));
         m_out.branch(m_out.notZero32(byteIndexInLoop), unsure(byteLoop), unsure(trueCase));
 
-        // length >= wordSize: compare a word at a time, walking backwards.
+        // byteLength >= wordSize: compare a word at a time, walking backwards.
         m_out.appendTo(wordLoopPreheader, wordLoop);
-        ValueFromBlock wordIndexAtStart = m_out.anchor(length);
+        ValueFromBlock wordIndexAtStart = m_out.anchor(byteLength);
         m_out.jump(wordLoop);
 
         m_out.appendTo(wordLoop, wordsEqual);
@@ -21225,7 +21233,7 @@ IGNORE_CLANG_WARNINGS_END
         m_out.addIncomingToPhi(wordIndexAtLoopTop, m_out.anchor(wordIndexInLoop));
         m_out.branch(m_out.aboveOrEqual(wordIndexInLoop, m_out.constInt32(wordSize)), unsure(wordLoop), unsure(wordTail));
 
-        // 0 <= wordIndexInLoop < wordSize bytes remain at the head. Since the original length was
+        // 0 <= wordIndexInLoop < wordSize bytes remain at the head. Since the byteLength was
         // >= wordSize, a single overlapping word load at offset 0 safely covers the remainder.
         m_out.appendTo(wordTail, wordTailCompare);
         m_out.branch(m_out.isZero32(wordIndexInLoop), unsure(trueCase), unsure(wordTailCompare));


### PR DESCRIPTION
#### be65d1a759a82e9edd0bcb80ee1637859a0eec3c
<pre>
[JSC] Inline 16-bit string equality in DFG/FTL
<a href="https://bugs.webkit.org/show_bug.cgi?id=313769">https://bugs.webkit.org/show_bug.cgi?id=313769</a>

Reviewed by Yusuke Suzuki.

312326@main inlined an 8-bit string equality fast path that compares a
pointer-sized word at a time with an overlapping head load. 16-bit
strings still bailed to operationCompareStringEq, which goes through
WTF::equal and the SIMD memcmp path but eats the C call overhead.

Reuse the existing byte-addressed word/byte loop for 16-bit strings by
converting the character count into a byte count (length &lt;&lt; 1) when both
StringImpls are 16-bit. Mixed-width pairs still bail to the runtime
helper, since the helper handles cross-width equality correctly.

The 8-bit fast path is also tightened: the two flag-bit tests are
collapsed into a single load + xor + masked test on the diff, so the
hot path costs one fewer load and one fewer mask. The FTL byte-length
phi is rarely-hinted so the 8-bit path falls through without an extra
mov on the short-string side.

                                  baseline                  patched

  string-equality-short-16bit  11.0109+-0.2215     ^      7.1928+-0.4227    ^ definitely 1.5308x faster
  string-equality-long-16bit   15.2884+-0.2858     ^     10.3145+-0.3964    ^ definitely 1.4822x faster
  string-equality-256-16bit    27.6626+-0.1356     ^     22.4260+-0.2634    ^ definitely 1.2335x faster

string-equality-short-8bit, string-equality-long-8bit, string-equality-256-8bit: unchanged from 312326@main.

Tests: JSTests/microbenchmarks/string-equality-256-16bit.js
       JSTests/microbenchmarks/string-equality-long-16bit.js
       JSTests/microbenchmarks/string-equality-short-16bit.js
       JSTests/stress/string-equality-word-compare-16bit.js
       JSTests/stress/string-equality-word-compare-thorough.js

* JSTests/microbenchmarks/string-equality-256-16bit.js: Added.
(makeString):
(eq):
* JSTests/microbenchmarks/string-equality-long-16bit.js: Added.
(makeString):
(eq):
* JSTests/microbenchmarks/string-equality-short-16bit.js: Added.
(makeString):
(eq):
* JSTests/stress/string-equality-mixed-width-slow-path.js: Added.
(eq):
* JSTests/stress/string-equality-word-compare-16bit.js: Added.
(eq):
(make):
* JSTests/stress/string-equality-word-compare-thorough.js: Added.
(eq):
(freshCopy):
(freshCopyConcat):
(const.ASCII_ALPHABET):
(const.GREEK_ALPHABET):
(makeFromAlphabet):
(flip):
(cases.push):
(freshCopy.flip):
* Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp:
* Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp:
(JSC::FTL::DFG::LowerDFGToB3::compileCompareStrictEq):

Canonical link: <a href="https://commits.webkit.org/312931@main">https://commits.webkit.org/312931@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6a8f541cdc5ae2f222e350f471e43a28a220d179

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/160381 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/33854 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/26955 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/169284 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/115447 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/33955 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/33854 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/124349 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/87846 "2 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/163339 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/26593 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/144054 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/104948 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/25645 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/24147 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/17003 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/152437 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/135338 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/21817 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/171761 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/21218 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/18119 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/23457 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/132605 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/33527 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/28241 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/132626 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36098 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/33512 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/143612 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/95294 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/27235 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/20426 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/192780 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/33021 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/99782 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/49636 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/32522 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/32766 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/32670 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->