### PR TITLE
SVG inline style should accept unitless lengths for geometry properties

### DIFF
--- a/Source/WebCore/css/parser/CSSParser.cpp
+++ b/Source/WebCore/css/parser/CSSParser.cpp
@@ -188,7 +188,10 @@ static Ref<ImmutableStyleProperties> createStyleProperties(ParsedPropertyVector&
 Ref<ImmutableStyleProperties> CSSParser::parseInlineStyleDeclaration(const String& string, const Element& element)
 {
     CSSParserContext context(element.document());
-    context.mode = strictToCSSParserMode(element.isHTMLElement() && !element.document().inQuirksMode());
+    if (element.isSVGElement())
+        context.mode = SVGAttributeMode;
+    else
+        context.mode = strictToCSSParserMode(element.isHTMLElement() && !element.document().inQuirksMode());
 
     CSSParser parser(context, string);
     parser.consumeDeclarationList(parser.tokenizer()->tokenRange(), StyleRuleType::Style);

--- a/Source/WebCore/dom/StyledElement.cpp
+++ b/Source/WebCore/dom/StyledElement.cpp
@@ -89,7 +89,8 @@ Ref<MutableStyleProperties> StyledElement::ensureMutableInlineStyle()
 {
     RefPtr<StyleProperties>& inlineStyle = ensureUniqueElementData().m_inlineStyle;
     if (!inlineStyle) {
-        Ref mutableProperties = MutableStyleProperties::create(strictToCSSParserMode(isHTMLElement() && !document().inQuirksMode()));
+        auto parserMode = isSVGElement() ? SVGAttributeMode : strictToCSSParserMode(isHTMLElement() && !document().inQuirksMode());
+        Ref mutableProperties = MutableStyleProperties::create(parserMode);
         inlineStyle = mutableProperties.copyRef();
         return mutableProperties;
     }


### PR DESCRIPTION
#### 7a2ff83912f5
<pre>
SVG inline style should accept unitless lengths for geometry properties
<a href="https://bugs.webkit.org/show_bug.cgi?id=313771">https://bugs.webkit.org/show_bug.cgi?id=313771</a>
<a href="https://rdar.apple.com/118415392">rdar://118415392</a>

Reviewed by NOBODY (OOPS!).

SVG geometry properties (x, y, width, height, etc.) set via the
style attribute on SVG elements reject unitless values like
&quot;x:222&quot;, even though SVG allows unitless lengths.

This PR fixes both the initial parse path and the CSSOM mutation path
to use SVGAttributeMode for SVG elements,

* Source/WebCore/css/parser/CSSParser.cpp:
(WebCore::CSSParser::parseInlineStyleDeclaration):
* Source/WebCore/dom/StyledElement.cpp:
(WebCore::StyledElement::ensureMutableInlineStyle):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7a2ff83912f5b4843e84e0910bcc676b33beb142

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/159786 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/33254 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/26360 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/168646 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/114167 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/9040e789-c673-4e93-89a7-f86ff45e9291) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/161655 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/33358 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/33257 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/123813 "Found 11 new test failures: imported/w3c/web-platform-tests/svg/geometry/parsing/cx-invalid.svg imported/w3c/web-platform-tests/svg/geometry/parsing/cy-invalid.svg imported/w3c/web-platform-tests/svg/geometry/parsing/r-invalid.svg imported/w3c/web-platform-tests/svg/geometry/parsing/rx-invalid.svg imported/w3c/web-platform-tests/svg/geometry/parsing/ry-invalid.svg imported/w3c/web-platform-tests/svg/geometry/parsing/x-invalid.svg imported/w3c/web-platform-tests/svg/geometry/parsing/y-invalid.svg imported/w3c/web-platform-tests/svg/painting/parsing/stroke-dashoffset-valid.svg imported/w3c/web-platform-tests/svg/painting/parsing/stroke-width-valid.svg imported/w3c/web-platform-tests/svg/text/parsing/inline-size-invalid.svg ... (failure)") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/86867 "1 flakes 10 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/8b95a448-5f84-4f20-8ed4-bb7aac8931b5) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/162744 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/26078 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/143516 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/104450 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/98f2c850-7fbc-4c58-b07a-db55a72f0c4b) 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/25129 "Found 12 new test failures: imported/w3c/web-platform-tests/css/selectors/has-specificity.html imported/w3c/web-platform-tests/svg/geometry/parsing/cx-invalid.svg imported/w3c/web-platform-tests/svg/geometry/parsing/cy-invalid.svg imported/w3c/web-platform-tests/svg/geometry/parsing/r-invalid.svg imported/w3c/web-platform-tests/svg/geometry/parsing/rx-invalid.svg imported/w3c/web-platform-tests/svg/geometry/parsing/ry-invalid.svg imported/w3c/web-platform-tests/svg/geometry/parsing/x-invalid.svg imported/w3c/web-platform-tests/svg/geometry/parsing/y-invalid.svg imported/w3c/web-platform-tests/svg/painting/parsing/stroke-dashoffset-valid.svg imported/w3c/web-platform-tests/svg/painting/parsing/stroke-width-valid.svg ... (failure)") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/23597 "Found 1 new API test failure: TestWebKitAPI.WKBackForwardList.BackForwardNavigationSkipsItemsWithoutUserGestureFragment (failure)") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/16407 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/134821 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/21287 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/171137 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/17154 "Built successfully") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/22924 "Found 11 new test failures: imported/w3c/web-platform-tests/svg/geometry/parsing/cx-invalid.svg imported/w3c/web-platform-tests/svg/geometry/parsing/cy-invalid.svg imported/w3c/web-platform-tests/svg/geometry/parsing/r-invalid.svg imported/w3c/web-platform-tests/svg/geometry/parsing/rx-invalid.svg imported/w3c/web-platform-tests/svg/geometry/parsing/ry-invalid.svg imported/w3c/web-platform-tests/svg/geometry/parsing/x-invalid.svg imported/w3c/web-platform-tests/svg/geometry/parsing/y-invalid.svg imported/w3c/web-platform-tests/svg/painting/parsing/stroke-dashoffset-valid.svg imported/w3c/web-platform-tests/svg/painting/parsing/stroke-width-valid.svg imported/w3c/web-platform-tests/svg/text/parsing/inline-size-invalid.svg ... (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/132075 "Found 11 new test failures: imported/w3c/web-platform-tests/svg/geometry/parsing/cx-invalid.svg imported/w3c/web-platform-tests/svg/geometry/parsing/cy-invalid.svg imported/w3c/web-platform-tests/svg/geometry/parsing/r-invalid.svg imported/w3c/web-platform-tests/svg/geometry/parsing/rx-invalid.svg imported/w3c/web-platform-tests/svg/geometry/parsing/ry-invalid.svg imported/w3c/web-platform-tests/svg/geometry/parsing/x-invalid.svg imported/w3c/web-platform-tests/svg/geometry/parsing/y-invalid.svg imported/w3c/web-platform-tests/svg/painting/parsing/stroke-dashoffset-valid.svg imported/w3c/web-platform-tests/svg/painting/parsing/stroke-width-valid.svg imported/w3c/web-platform-tests/svg/text/parsing/inline-size-invalid.svg ... (failure)") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/32932 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/27676 "Found 11 new test failures: imported/w3c/web-platform-tests/svg/geometry/parsing/cx-invalid.svg imported/w3c/web-platform-tests/svg/geometry/parsing/cy-invalid.svg imported/w3c/web-platform-tests/svg/geometry/parsing/r-invalid.svg imported/w3c/web-platform-tests/svg/geometry/parsing/rx-invalid.svg imported/w3c/web-platform-tests/svg/geometry/parsing/ry-invalid.svg imported/w3c/web-platform-tests/svg/geometry/parsing/x-invalid.svg imported/w3c/web-platform-tests/svg/geometry/parsing/y-invalid.svg imported/w3c/web-platform-tests/svg/painting/parsing/stroke-dashoffset-valid.svg imported/w3c/web-platform-tests/svg/painting/parsing/stroke-width-valid.svg imported/w3c/web-platform-tests/svg/text/parsing/inline-size-invalid.svg ... (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/132123 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/32917 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/143081 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/91015 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/26741 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/19895 "Found 11 new test failures: imported/w3c/web-platform-tests/svg/geometry/parsing/cx-invalid.svg imported/w3c/web-platform-tests/svg/geometry/parsing/cy-invalid.svg imported/w3c/web-platform-tests/svg/geometry/parsing/r-invalid.svg imported/w3c/web-platform-tests/svg/geometry/parsing/rx-invalid.svg imported/w3c/web-platform-tests/svg/geometry/parsing/ry-invalid.svg imported/w3c/web-platform-tests/svg/geometry/parsing/x-invalid.svg imported/w3c/web-platform-tests/svg/geometry/parsing/y-invalid.svg imported/w3c/web-platform-tests/svg/painting/parsing/stroke-dashoffset-valid.svg imported/w3c/web-platform-tests/svg/painting/parsing/stroke-width-valid.svg imported/w3c/web-platform-tests/svg/text/parsing/inline-size-invalid.svg ... (failure)") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/32426 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/98823 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/31923 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/32170 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/32074 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->