### PR TITLE
[IPInt] Plan should have a RefPtr to the callees

### DIFF
--- a/Source/JavaScriptCore/wasm/WasmCalleeGroup.cpp
+++ b/Source/JavaScriptCore/wasm/WasmCalleeGroup.cpp
@@ -69,7 +69,7 @@ CalleeGroup::CalleeGroup(VM& vm, MemoryMode mode, ModuleInformation& moduleInfor
     , m_callers(m_calleeCount)
 {
     RefPtr<CalleeGroup> protectedThis = this;
-    m_plan = adoptRef(*new IPIntPlan(vm, moduleInformation, m_ipintCallees->span().data(), createSharedTask<Plan::CallbackType>([this, protectedThis = WTF::move(protectedThis)] (Plan&) {
+    m_plan = adoptRef(*new IPIntPlan(vm, moduleInformation, m_ipintCallees.copyRef(), createSharedTask<Plan::CallbackType>([this, protectedThis = WTF::move(protectedThis)] (Plan&) {
         Locker locker { m_lock };
         if (m_plan->failed()) {
             m_errorMessage = m_plan->errorMessage();

--- a/Source/JavaScriptCore/wasm/WasmIPIntPlan.cpp
+++ b/Source/JavaScriptCore/wasm/WasmIPIntPlan.cpp
@@ -55,11 +55,11 @@ IPIntPlan::IPIntPlan(VM& vm, Vector<uint8_t>&& source, CompilerMode compilerMode
         prepare();
 }
 
-IPIntPlan::IPIntPlan(VM& vm, Ref<ModuleInformation> info, const Ref<IPIntCallee>* callees, CompletionTask&& task)
+IPIntPlan::IPIntPlan(VM& vm, Ref<ModuleInformation> info, Ref<IPIntCallees> callees, CompletionTask&& task)
     : Base(vm, WTF::move(info), CompilerMode::FullCompile, WTF::move(task))
-    , m_callees(callees)
+    , m_ipintCallees(WTF::move(callees))
+    , m_calleesAlreadyRegistered(true)
 {
-    ASSERT(m_callees || !m_moduleInformation->functions.size());
     m_areWasmToJSStubsCompiled = true;
     prepare();
     m_currentIndex = m_moduleInformation->functions.size();
@@ -83,11 +83,8 @@ bool IPIntPlan::prepareImpl()
         return false;
     m_entrypoints.resize(functions.size());
 
-    if (!m_callees) {
-        if (!tryReserveCapacity(m_calleesVector, functions.size(), " WebAssembly functions"_s))
-            return false;
-        m_calleesVector.resize(functions.size());
-    }
+    if (!m_ipintCallees)
+        m_ipintCallees = IPIntCallees::create(functions.size());
     return true;
 }
 
@@ -128,7 +125,7 @@ void IPIntPlan::compileFunction(FunctionCodeIndex functionIndex)
     m_wasmInternalFunctions[functionIndex] = WTF::move(*parseAndCompileResult);
 
     IPIntCallee* ipintCallee = nullptr;
-    if (!m_callees) {
+    {
         auto callee = IPIntCallee::create(*m_wasmInternalFunctions[functionIndex], functionIndexSpace, m_moduleInformation->nameSection->get(functionIndexSpace));
         ASSERT(!callee->entrypoint());
         bool usesSIMD = m_moduleInformation->usesSIMD(functionIndex);
@@ -152,9 +149,8 @@ void IPIntPlan::compileFunction(FunctionCodeIndex functionIndex)
 
         callee->setEntrypointWithoutRegistration(entrypoint);
         ipintCallee = callee.ptr();
-        m_calleesVector[functionIndex] = WTF::move(callee);
-    } else
-        ipintCallee = m_callees[functionIndex].ptr();
+        m_ipintCallees->at(functionIndex) = WTF::move(callee);
+    }
 
     // If the function is exported via module, then we ensure JSToWasm entrypoint.
     if (m_compilerMode != CompilerMode::Validation) {
@@ -183,9 +179,8 @@ void IPIntPlan::didCompleteCompilation()
     generateStubsIfNecessary();
 
     unsigned functionCount = m_wasmInternalFunctions.size();
-    if (!m_callees && functionCount) {
-        m_callees = m_calleesVector.span().data();
-        NativeCalleeRegistry::singleton().registerCallees(m_calleesVector);
+    if (!m_calleesAlreadyRegistered && functionCount) {
+        NativeCalleeRegistry::singleton().registerCallees(*m_ipintCallees);
         if (!m_moduleInformation->clobberingTailCalls().isEmpty())
             computeTransitiveTailCalls();
     }
@@ -197,14 +192,14 @@ void IPIntPlan::didCompleteCompilation()
         if (!m_entrypoints[functionIndex]) {
             const FunctionSpaceIndex functionIndexSpace = FunctionSpaceIndex(functionIndex + m_moduleInformation->importFunctionCount());
             if (m_exportedFunctionIndices.contains(functionIndex) || m_moduleInformation->hasReferencedFunction(functionIndexSpace)) {
-                if (!ensureEntrypoint(m_callees[functionIndex].get(), FunctionCodeIndex(functionIndex))) {
+                if (!ensureEntrypoint(m_ipintCallees->at(functionIndex).get(), FunctionCodeIndex(functionIndex))) {
                     Base::fail(makeString("JIT is disabled, but the entrypoint for "_s, functionIndex, " requires JIT"_s));
                     return;
                 }
             }
         }
         if (auto& callee = m_entrypoints[functionIndex]) {
-            callee->setWasmCallee(CalleeBits::encodeNativeCallee(&m_callees[functionIndex].get()));
+            callee->setWasmCallee(CalleeBits::encodeNativeCallee(&m_ipintCallees->at(functionIndex).get()));
             m_jsToWasmCallees.add(functionIndex, callee);
         }
     }
@@ -217,7 +212,7 @@ void IPIntPlan::didCompleteCompilation()
                 // https://bugs.webkit.org/show_bug.cgi?id=166462
                 executableAddress = m_wasmToWasmExitStubs.at(call.functionIndexSpace).code();
             } else
-                executableAddress = m_callees[call.functionIndexSpace - m_moduleInformation->importFunctionCount()]->entrypoint();
+                executableAddress = m_ipintCallees->at(call.functionIndexSpace - m_moduleInformation->importFunctionCount())->entrypoint();
             MacroAssembler::repatchNearCall(call.callLocation, CodeLocationLabel<WasmEntryPtrTag>(executableAddress));
         }
     }

--- a/Source/JavaScriptCore/wasm/WasmIPIntPlan.h
+++ b/Source/JavaScriptCore/wasm/WasmIPIntPlan.h
@@ -47,13 +47,13 @@ class IPIntPlan final : public EntryPlan {
 
 public:
     JS_EXPORT_PRIVATE IPIntPlan(VM&, Vector<uint8_t>&&, CompilerMode, CompletionTask&&);
-    IPIntPlan(VM&, Ref<ModuleInformation>, const Ref<IPIntCallee>*, CompletionTask&&);
+    IPIntPlan(VM&, Ref<ModuleInformation>, Ref<IPIntCallees>, CompletionTask&&);
     IPIntPlan(VM&, Ref<ModuleInformation>, CompilerMode, CompletionTask&&); // For StreamingCompiler.
 
-    Vector<Ref<IPIntCallee>>&& takeCallees()
+    Ref<IPIntCallees> takeCallees()
     {
         RELEASE_ASSERT(!failed() && !hasWork());
-        return WTF::move(m_calleesVector);
+        return m_ipintCallees.releaseNonNull();
     }
 
     JSToWasmCalleeMap&& takeJSToWasmCallees()
@@ -89,8 +89,8 @@ private:
     bool ensureEntrypoint(IPIntCallee&, FunctionCodeIndex functionIndex);
 
     Vector<std::unique_ptr<FunctionIPIntMetadataGenerator>> m_wasmInternalFunctions;
-    const Ref<IPIntCallee>* m_callees { nullptr };
-    Vector<Ref<IPIntCallee>> m_calleesVector;
+    RefPtr<IPIntCallees> m_ipintCallees;
+    bool m_calleesAlreadyRegistered { false };
     Vector<RefPtr<JSToWasmCallee>> m_entrypoints;
     JSToWasmCalleeMap m_jsToWasmCallees;
     TailCallGraph m_tailCallGraph;

--- a/Source/JavaScriptCore/wasm/WasmModule.cpp
+++ b/Source/JavaScriptCore/wasm/WasmModule.cpp
@@ -42,7 +42,7 @@ namespace JSC { namespace Wasm {
 
 Module::Module(IPIntPlan& plan)
     : m_moduleInformation(plan.takeModuleInformation())
-    , m_ipintCallees(IPIntCallees::createFromVector(plan.takeCallees()))
+    , m_ipintCallees(plan.takeCallees())
     , m_wasmToJSExitStubs(plan.takeWasmToJSExitStubs())
 {
 #if ENABLE(WEBASSEMBLY_DEBUGGER)


### PR DESCRIPTION
#### 066fbb7ab98878ae994074eb8e64fe5e70ca431d
<pre>
[IPInt] Plan should have a RefPtr to the callees
<a href="https://bugs.webkit.org/show_bug.cgi?id=313774">https://bugs.webkit.org/show_bug.cgi?id=313774</a>
<a href="https://rdar.apple.com/175967204">rdar://175967204</a>

Reviewed by Yusuke Suzuki.

Right now it&apos;s a raw pointer to the data. This is both hard to reason
about and not SaferCPP friendly. Let&apos;s just take a ref to the callee
list. This also makes adopting a lazy parse less weird.

No new tests, no behavior change. Covered by existing tests.

Canonical link: <a href="https://commits.webkit.org/312426@main">https://commits.webkit.org/312426@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/982cb44da64efb49bd78224bd4eba8d2537b534c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/159792 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/33260 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/26366 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/168652 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/114173 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/885aa777-12da-4ddb-bab9-5d89be175910) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/33364 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/33263 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/123817 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/86870 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/d27fe897-ee4c-4778-b6f4-db1fd3ad671b) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/162750 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/26075 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/143522 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/104453 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/a685f93d-1ce6-47c6-ad07-e31360912c2d) 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/25126 "Found 1 new test failure: imported/w3c/web-platform-tests/navigation-api/navigate-event/signal-abort-window-stop.html (failure)") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/23601 "Found 1 new API test failure: TestWebKitAPI.WKWebExtension.LoadFromZipArchiveWithParentDirectory (failure)") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/16413 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/151848 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/134818 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/21293 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/171143 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/20629 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/17160 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/22930 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/132082 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/32938 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/27681 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/132127 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/32923 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/143087 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/91021 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/24336 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/26748 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/19901 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/192076 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/32432 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/98829 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/49394 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/31929 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/32176 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/32080 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->