### PR TITLE
copyExternalImageToTexture Missing convertedSource Null Check

### DIFF
--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteAdapter.cpp
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteAdapter.cpp
@@ -40,6 +40,8 @@
 #include <WebCore/WebGPUDevice.h>
 #include <wtf/TZoneMallocInlines.h>
 
+#define MESSAGE_CHECK(assertion) MESSAGE_CHECK_BASE(assertion, m_streamConnection)
+
 namespace WebKit {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(RemoteAdapter);
@@ -70,7 +72,7 @@ void RemoteAdapter::stopListeningForIPC()
 void RemoteAdapter::requestDevice(const WebGPU::DeviceDescriptor& descriptor, WebGPUIdentifier identifier, WebGPUIdentifier queueIdentifier, CompletionHandler<void(WebGPU::SupportedFeatures&&, WebGPU::SupportedLimits&&)>&& callback)
 {
     auto convertedDescriptor = m_objectHeap->convertFromBacking(descriptor);
-    ASSERT(convertedDescriptor);
+    MESSAGE_CHECK(convertedDescriptor);
     if (!convertedDescriptor) {
         callback({ { } }, { });
         return;

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteCommandEncoder.cpp
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteCommandEncoder.cpp
@@ -107,11 +107,9 @@ void RemoteCommandEncoder::copyBufferToBuffer(
 {
     Ref objectHeap = m_objectHeap.get();
     auto convertedSource = objectHeap->convertBufferFromBacking(source);
-    ASSERT(convertedSource);
+    MESSAGE_CHECK(convertedSource);
     auto convertedDestination = objectHeap->convertBufferFromBacking(destination);
-    ASSERT(convertedDestination);
-    if (!convertedSource || !convertedDestination)
-        return;
+    MESSAGE_CHECK(convertedDestination);
 
     protect(m_backing)->copyBufferToBuffer(*convertedSource, sourceOffset, *convertedDestination, destinationOffset, size);
 }
@@ -122,13 +120,11 @@ void RemoteCommandEncoder::copyBufferToTexture(
     const WebGPU::Extent3D& copySize)
 {
     auto convertedSource = m_objectHeap->convertFromBacking(source);
-    ASSERT(convertedSource);
+    MESSAGE_CHECK(convertedSource);
     auto convertedDestination = m_objectHeap->convertFromBacking(destination);
-    ASSERT(convertedDestination);
+    MESSAGE_CHECK(convertedDestination);
     auto convertedCopySize = m_objectHeap->convertFromBacking(copySize);
-    ASSERT(convertedCopySize);
-    if (!convertedSource || !convertedDestination || !convertedCopySize)
-        return;
+    MESSAGE_CHECK(convertedCopySize);
 
     protect(m_backing)->copyBufferToTexture(*convertedSource, *convertedDestination, *convertedCopySize);
 }
@@ -139,13 +135,11 @@ void RemoteCommandEncoder::copyTextureToBuffer(
     const WebGPU::Extent3D& copySize)
 {
     auto convertedSource = m_objectHeap->convertFromBacking(source);
-    ASSERT(convertedSource);
+    MESSAGE_CHECK(convertedSource);
     auto convertedDestination = m_objectHeap->convertFromBacking(destination);
-    ASSERT(convertedDestination);
+    MESSAGE_CHECK(convertedDestination);
     auto convertedCopySize = m_objectHeap->convertFromBacking(copySize);
-    ASSERT(convertedCopySize);
-    if (!convertedSource || !convertedDestination || !convertedCopySize)
-        return;
+    MESSAGE_CHECK(convertedCopySize);
 
     protect(m_backing)->copyTextureToBuffer(*convertedSource, *convertedDestination, *convertedCopySize);
 }
@@ -156,13 +150,11 @@ void RemoteCommandEncoder::copyTextureToTexture(
     const WebGPU::Extent3D& copySize)
 {
     auto convertedSource = m_objectHeap->convertFromBacking(source);
-    ASSERT(convertedSource);
+    MESSAGE_CHECK(convertedSource);
     auto convertedDestination = m_objectHeap->convertFromBacking(destination);
-    ASSERT(convertedDestination);
+    MESSAGE_CHECK(convertedDestination);
     auto convertedCopySize = m_objectHeap->convertFromBacking(copySize);
-    ASSERT(convertedCopySize);
-    if (!convertedSource || !convertedDestination || !convertedCopySize)
-        return;
+    MESSAGE_CHECK(convertedCopySize);
 
     protect(m_backing)->copyTextureToTexture(*convertedSource, *convertedDestination, *convertedCopySize);
 }
@@ -173,9 +165,7 @@ void RemoteCommandEncoder::clearBuffer(
     std::optional<WebCore::WebGPU::Size64> size)
 {
     auto convertedBuffer = protect(m_objectHeap)->convertBufferFromBacking(buffer);
-    ASSERT(convertedBuffer);
-    if (!convertedBuffer)
-        return;
+    MESSAGE_CHECK(convertedBuffer);
 
     protect(m_backing)->clearBuffer(*convertedBuffer, offset, size);
 }
@@ -198,9 +188,7 @@ void RemoteCommandEncoder::insertDebugMarker(String&& markerLabel)
 void RemoteCommandEncoder::writeTimestamp(WebGPUIdentifier querySet, WebCore::WebGPU::Size32 queryIndex)
 {
     auto convertedQuerySet = protect(m_objectHeap)->convertQuerySetFromBacking(querySet);
-    ASSERT(convertedQuerySet);
-    if (!convertedQuerySet)
-        return;
+    MESSAGE_CHECK(convertedQuerySet);
 
     protect(m_backing)->writeTimestamp(*convertedQuerySet, queryIndex);
 }
@@ -214,11 +202,9 @@ void RemoteCommandEncoder::resolveQuerySet(
 {
     Ref objectHeap = m_objectHeap.get();
     auto convertedQuerySet = objectHeap->convertQuerySetFromBacking(querySet);
-    ASSERT(convertedQuerySet);
+    MESSAGE_CHECK(convertedQuerySet);
     auto convertedDestination = objectHeap->convertBufferFromBacking(destination);
-    ASSERT(convertedDestination);
-    if (!convertedQuerySet || !convertedDestination)
-        return;
+    MESSAGE_CHECK(convertedDestination);
 
     protect(m_backing)->resolveQuerySet(*convertedQuerySet, firstQuery, queryCount, *convertedDestination, destinationOffset);
 }

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteComputePassEncoder.cpp
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteComputePassEncoder.cpp
@@ -37,6 +37,8 @@
 #include <WebCore/WebGPUComputePipeline.h>
 #include <wtf/TZoneMallocInlines.h>
 
+#define MESSAGE_CHECK(assertion) MESSAGE_CHECK_BASE(assertion, m_streamConnection)
+
 namespace WebKit {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(RemoteComputePassEncoder);
@@ -66,7 +68,7 @@ void RemoteComputePassEncoder::stopListeningForIPC()
 void RemoteComputePassEncoder::setPipeline(WebGPUIdentifier computePipeline)
 {
     auto convertedComputePipeline = protect(m_objectHeap)->convertComputePipelineFromBacking(computePipeline);
-    ASSERT(convertedComputePipeline);
+    MESSAGE_CHECK(convertedComputePipeline);
     if (!convertedComputePipeline)
         return;
 
@@ -81,7 +83,7 @@ void RemoteComputePassEncoder::dispatch(WebCore::WebGPU::Size32 workgroupCountX,
 void RemoteComputePassEncoder::dispatchIndirect(WebGPUIdentifier indirectBuffer, WebCore::WebGPU::Size64 indirectOffset)
 {
     auto convertedIndirectBuffer = protect(m_objectHeap)->convertBufferFromBacking(indirectBuffer);
-    ASSERT(convertedIndirectBuffer);
+    MESSAGE_CHECK(convertedIndirectBuffer);
     if (!convertedIndirectBuffer)
         return;
 
@@ -102,7 +104,7 @@ void RemoteComputePassEncoder::setBindGroup(WebCore::WebGPU::Index32 index, std:
     }
 
     RefPtr convertedBindGroup = protect(m_objectHeap)->convertBindGroupFromBacking(*bindGroup).get();
-    ASSERT(convertedBindGroup);
+    MESSAGE_CHECK(convertedBindGroup);
     if (!convertedBindGroup)
         return;
 

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteDevice.cpp
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteDevice.cpp
@@ -314,7 +314,7 @@ void RemoteDevice::createComputePipelineAsync(const WebGPU::ComputePipelineDescr
 {
     Ref objectHeap = m_objectHeap.get();
     auto convertedDescriptor = objectHeap->convertFromBacking(descriptor);
-    ASSERT(convertedDescriptor);
+    MESSAGE_CHECK(convertedDescriptor);
     if (!convertedDescriptor) {
         callback(false, ""_s);
         return;
@@ -334,7 +334,7 @@ void RemoteDevice::createRenderPipelineAsync(const WebGPU::RenderPipelineDescrip
 {
     Ref objectHeap = m_objectHeap.get();
     auto convertedDescriptor = objectHeap->convertFromBacking(descriptor);
-    ASSERT(convertedDescriptor);
+    MESSAGE_CHECK(convertedDescriptor);
     if (!convertedDescriptor) {
         callback(false, ""_s);
         return;

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteGPU.cpp
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteGPU.cpp
@@ -157,7 +157,7 @@ void RemoteGPU::requestAdapter(const WebGPU::RequestAdapterOptions& options, Web
 
     Ref objectHeap = m_objectHeap;
     auto convertedOptions = objectHeap->convertFromBacking(options);
-    ASSERT(convertedOptions);
+    MESSAGE_CHECK(convertedOptions);
     if (!convertedOptions) {
         callback(std::nullopt);
         return;

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemotePresentationContext.cpp
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemotePresentationContext.cpp
@@ -38,6 +38,8 @@
 #include <WebCore/WebGPUTexture.h>
 #include <wtf/TZoneMallocInlines.h>
 
+#define MESSAGE_CHECK(assertion) MESSAGE_CHECK_BASE(assertion, m_streamConnection)
+
 namespace WebKit {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(RemotePresentationContext);
@@ -63,7 +65,7 @@ void RemotePresentationContext::stopListeningForIPC()
 void RemotePresentationContext::configure(const WebGPU::CanvasConfiguration& canvasConfiguration)
 {
     auto convertedConfiguration = m_objectHeap->convertFromBacking(canvasConfiguration);
-    ASSERT(convertedConfiguration);
+    MESSAGE_CHECK(convertedConfiguration);
     if (!convertedConfiguration)
         return;
 

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteQueue.cpp
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteQueue.cpp
@@ -37,6 +37,8 @@
 #include <WebCore/WebGPUQueue.h>
 #include <wtf/TZoneMallocInlines.h>
 
+#define MESSAGE_CHECK(assertion) MESSAGE_CHECK_BASE(assertion, m_streamConnection)
+
 namespace WebKit {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(RemoteQueue);
@@ -69,9 +71,7 @@ void RemoteQueue::submit(Vector<WebGPUIdentifier>&& commandBuffers)
     convertedCommandBuffers.reserveInitialCapacity(commandBuffers.size());
     for (WebGPUIdentifier identifier : commandBuffers) {
         auto convertedCommandBuffer = protect(m_objectHeap)->convertCommandBufferFromBacking(identifier);
-        ASSERT(convertedCommandBuffer);
-        if (!convertedCommandBuffer)
-            return;
+        MESSAGE_CHECK(convertedCommandBuffer);
         convertedCommandBuffers.append(*convertedCommandBuffer);
     }
     protect(m_backing)->submit(WTF::move(convertedCommandBuffers));
@@ -92,7 +92,7 @@ void RemoteQueue::writeBuffer(
 {
     auto data = dataHandle ? WebCore::SharedMemory::map(WTF::move(*dataHandle), WebCore::SharedMemory::Protection::ReadOnly) : nullptr;
     auto convertedBuffer = protect(m_objectHeap)->convertBufferFromBacking(buffer);
-    ASSERT(convertedBuffer);
+    MESSAGE_CHECK(convertedBuffer);
     if (!convertedBuffer || !data || data->size() <= WebGPU::maxCrossProcessResourceCopySize) {
         completionHandler(false);
         return;
@@ -109,9 +109,7 @@ void RemoteQueue::writeBufferWithCopy(
 {
     Ref objectHeap = m_objectHeap.get();
     auto convertedBuffer = objectHeap->convertBufferFromBacking(buffer);
-    ASSERT(convertedBuffer);
-    if (!convertedBuffer)
-        return;
+    MESSAGE_CHECK(convertedBuffer);
 
     protect(m_backing)->writeBufferNoCopy(*convertedBuffer, bufferOffset, data.mutableSpan(), 0, std::nullopt);
 }
@@ -126,12 +124,12 @@ void RemoteQueue::writeTexture(
     auto data = dataHandle ? WebCore::SharedMemory::map(WTF::move(*dataHandle), WebCore::SharedMemory::Protection::ReadOnly) : nullptr;
     Ref objectHeap = m_objectHeap.get();
     auto convertedDestination = objectHeap->convertFromBacking(destination);
-    ASSERT(convertedDestination);
+    MESSAGE_CHECK(convertedDestination);
     auto convertedDataLayout = objectHeap->convertFromBacking(dataLayout);
-    ASSERT(convertedDestination);
+    MESSAGE_CHECK(convertedDataLayout);
     auto convertedSize = objectHeap->convertFromBacking(size);
-    ASSERT(convertedSize);
-    if (!convertedDestination || !convertedDestination || !convertedSize || !data || data->size() <= WebGPU::maxCrossProcessResourceCopySize) {
+    MESSAGE_CHECK(convertedSize);
+    if (!convertedDestination || !convertedDataLayout || !convertedSize || !data || data->size() <= WebGPU::maxCrossProcessResourceCopySize) {
         completionHandler(false);
         return;
     }
@@ -148,13 +146,11 @@ void RemoteQueue::writeTextureWithCopy(
 {
     Ref objectHeap = m_objectHeap.get();
     auto convertedDestination = objectHeap->convertFromBacking(destination);
-    ASSERT(convertedDestination);
+    MESSAGE_CHECK(convertedDestination);
     auto convertedDataLayout = objectHeap->convertFromBacking(dataLayout);
-    ASSERT(convertedDestination);
+    MESSAGE_CHECK(convertedDataLayout);
     auto convertedSize = objectHeap->convertFromBacking(size);
-    ASSERT(convertedSize);
-    if (!convertedDestination || !convertedDestination || !convertedSize)
-        return;
+    MESSAGE_CHECK(convertedSize);
 
     protect(m_backing)->writeTexture(*convertedDestination, data.mutableSpan(), *convertedDataLayout, *convertedSize);
 }
@@ -166,13 +162,11 @@ void RemoteQueue::copyExternalImageToTexture(
 {
     Ref objectHeap = m_objectHeap.get();
     auto convertedSource = objectHeap->convertFromBacking(source);
-    ASSERT(convertedSource);
+    MESSAGE_CHECK(convertedSource);
     auto convertedDestination = objectHeap->convertFromBacking(destination);
-    ASSERT(convertedDestination);
+    MESSAGE_CHECK(convertedDestination);
     auto convertedCopySize = objectHeap->convertFromBacking(copySize);
-    ASSERT(convertedCopySize);
-    if (!convertedDestination || !convertedDestination || !convertedCopySize)
-        return;
+    MESSAGE_CHECK(convertedCopySize);
 
     protect(m_backing)->copyExternalImageToTexture(*convertedSource, *convertedDestination, *convertedCopySize);
 }

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteRenderBundleEncoder.cpp
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteRenderBundleEncoder.cpp
@@ -73,7 +73,7 @@ void RemoteRenderBundleEncoder::stopListeningForIPC()
 void RemoteRenderBundleEncoder::setPipeline(WebGPUIdentifier renderPipeline)
 {
     auto convertedRenderPipeline = protect(m_objectHeap)->convertRenderPipelineFromBacking(renderPipeline);
-    ASSERT(convertedRenderPipeline);
+    MESSAGE_CHECK(convertedRenderPipeline);
     if (!convertedRenderPipeline)
         return;
 
@@ -83,7 +83,7 @@ void RemoteRenderBundleEncoder::setPipeline(WebGPUIdentifier renderPipeline)
 void RemoteRenderBundleEncoder::setIndexBuffer(WebGPUIdentifier buffer, WebCore::WebGPU::IndexFormat indexFormat, WebCore::WebGPU::Size64 offset, std::optional<WebCore::WebGPU::Size64> size)
 {
     RefPtr convertedBuffer = protect(m_objectHeap)->convertBufferFromBacking(buffer).get();
-    ASSERT(convertedBuffer);
+    MESSAGE_CHECK(convertedBuffer);
     if (!convertedBuffer)
         return;
 
@@ -93,7 +93,7 @@ void RemoteRenderBundleEncoder::setIndexBuffer(WebGPUIdentifier buffer, WebCore:
 void RemoteRenderBundleEncoder::setVertexBuffer(WebCore::WebGPU::Index32 slot, WebGPUIdentifier buffer, WebCore::WebGPU::Size64 offset, std::optional<WebCore::WebGPU::Size64> size)
 {
     RefPtr convertedBuffer = protect(m_objectHeap)->convertBufferFromBacking(buffer).get();
-    ASSERT(convertedBuffer);
+    MESSAGE_CHECK(convertedBuffer);
     if (!convertedBuffer)
         return;
 
@@ -122,7 +122,7 @@ void RemoteRenderBundleEncoder::drawIndexed(WebCore::WebGPU::Size32 indexCount, 
 void RemoteRenderBundleEncoder::drawIndirect(WebGPUIdentifier indirectBuffer, WebCore::WebGPU::Size64 indirectOffset)
 {
     RefPtr convertedIndirectBuffer = protect(m_objectHeap)->convertBufferFromBacking(indirectBuffer).get();
-    ASSERT(convertedIndirectBuffer);
+    MESSAGE_CHECK(convertedIndirectBuffer);
     if (!convertedIndirectBuffer)
         return;
 
@@ -132,7 +132,7 @@ void RemoteRenderBundleEncoder::drawIndirect(WebGPUIdentifier indirectBuffer, We
 void RemoteRenderBundleEncoder::drawIndexedIndirect(WebGPUIdentifier indirectBuffer, WebCore::WebGPU::Size64 indirectOffset)
 {
     RefPtr convertedIndirectBuffer = protect(m_objectHeap)->convertBufferFromBacking(indirectBuffer).get();
-    ASSERT(convertedIndirectBuffer);
+    MESSAGE_CHECK(convertedIndirectBuffer);
     if (!convertedIndirectBuffer)
         return;
 
@@ -148,7 +148,7 @@ void RemoteRenderBundleEncoder::setBindGroup(WebCore::WebGPU::Index32 index, std
     }
 
     RefPtr convertedBindGroup = protect(m_objectHeap)->convertBindGroupFromBacking(*bindGroup).get();
-    ASSERT(convertedBindGroup);
+    MESSAGE_CHECK(convertedBindGroup);
     if (!convertedBindGroup)
         return;
 

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteRenderPassEncoder.cpp
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteRenderPassEncoder.cpp
@@ -38,6 +38,8 @@
 #include <WebCore/WebGPURenderPipeline.h>
 #include <wtf/TZoneMallocInlines.h>
 
+#define MESSAGE_CHECK(assertion) MESSAGE_CHECK_BASE(assertion, m_streamConnection)
+
 namespace WebKit {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(RemoteRenderPassEncoder);
@@ -67,7 +69,7 @@ void RemoteRenderPassEncoder::stopListeningForIPC()
 void RemoteRenderPassEncoder::setPipeline(WebGPUIdentifier renderPipeline)
 {
     auto convertedRenderPipeline = protect(m_objectHeap)->convertRenderPipelineFromBacking(renderPipeline);
-    ASSERT(convertedRenderPipeline);
+    MESSAGE_CHECK(convertedRenderPipeline);
     if (!convertedRenderPipeline)
         return;
 
@@ -77,7 +79,7 @@ void RemoteRenderPassEncoder::setPipeline(WebGPUIdentifier renderPipeline)
 void RemoteRenderPassEncoder::setIndexBuffer(WebGPUIdentifier buffer, WebCore::WebGPU::IndexFormat indexFormat, WebCore::WebGPU::Size64 offset, std::optional<WebCore::WebGPU::Size64> size)
 {
     auto convertedBuffer = protect(m_objectHeap)->convertBufferFromBacking(buffer);
-    ASSERT(convertedBuffer);
+    MESSAGE_CHECK(convertedBuffer);
     if (!convertedBuffer)
         return;
 
@@ -87,7 +89,7 @@ void RemoteRenderPassEncoder::setIndexBuffer(WebGPUIdentifier buffer, WebCore::W
 void RemoteRenderPassEncoder::setVertexBuffer(WebCore::WebGPU::Index32 slot, WebGPUIdentifier buffer, WebCore::WebGPU::Size64 offset, std::optional<WebCore::WebGPU::Size64> size)
 {
     RefPtr convertedBuffer = protect(m_objectHeap)->convertBufferFromBacking(buffer).get();
-    ASSERT(convertedBuffer);
+    MESSAGE_CHECK(convertedBuffer);
     if (!convertedBuffer)
         return;
 
@@ -117,7 +119,7 @@ void RemoteRenderPassEncoder::drawIndexed(WebCore::WebGPU::Size32 indexCount,
 void RemoteRenderPassEncoder::drawIndirect(WebGPUIdentifier indirectBuffer, WebCore::WebGPU::Size64 indirectOffset)
 {
     auto convertedIndirectBuffer = protect(m_objectHeap)->convertBufferFromBacking(indirectBuffer);
-    ASSERT(convertedIndirectBuffer);
+    MESSAGE_CHECK(convertedIndirectBuffer);
     if (!convertedIndirectBuffer)
         return;
 
@@ -127,7 +129,7 @@ void RemoteRenderPassEncoder::drawIndirect(WebGPUIdentifier indirectBuffer, WebC
 void RemoteRenderPassEncoder::drawIndexedIndirect(WebGPUIdentifier indirectBuffer, WebCore::WebGPU::Size64 indirectOffset)
 {
     auto convertedIndirectBuffer = protect(m_objectHeap)->convertBufferFromBacking(indirectBuffer);
-    ASSERT(convertedIndirectBuffer);
+    MESSAGE_CHECK(convertedIndirectBuffer);
     if (!convertedIndirectBuffer)
         return;
 
@@ -180,7 +182,7 @@ void RemoteRenderPassEncoder::setScissorRect(WebCore::WebGPU::IntegerCoordinate 
 void RemoteRenderPassEncoder::setBlendConstant(WebGPU::Color color)
 {
     auto convertedColor = protect(m_objectHeap)->convertFromBacking(color);
-    ASSERT(convertedColor);
+    MESSAGE_CHECK(convertedColor);
     if (!convertedColor)
         return;
 
@@ -208,7 +210,7 @@ void RemoteRenderPassEncoder::executeBundles(Vector<WebGPUIdentifier>&& renderBu
     convertedBundles.reserveInitialCapacity(renderBundles.size());
     for (WebGPUIdentifier identifier : renderBundles) {
         auto convertedBundle = protect(m_objectHeap)->convertRenderBundleFromBacking(identifier);
-        ASSERT(convertedBundle);
+        MESSAGE_CHECK(convertedBundle);
         if (!convertedBundle)
             return;
         convertedBundles.append(*convertedBundle);


### PR DESCRIPTION
#### c3b4c4c0dda4bc199bd30c199304261a8b48c11f
<pre>
copyExternalImageToTexture Missing convertedSource Null Check
<a href="https://bugs.webkit.org/show_bug.cgi?id=313773">https://bugs.webkit.org/show_bug.cgi?id=313773</a>
<a href="https://rdar.apple.com/172402186">rdar://172402186</a>

Reviewed by NOBODY (OOPS!).

Use MESSAGE_CHECK across WebGPU&apos;s IPC receivers instead of ASSERT +
early return and fix a few typos.

* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteAdapter.cpp:
(WebKit::RemoteAdapter::requestDevice):
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteCommandEncoder.cpp:
(WebKit::RemoteCommandEncoder::copyBufferToBuffer):
(WebKit::RemoteCommandEncoder::copyBufferToTexture):
(WebKit::RemoteCommandEncoder::copyTextureToBuffer):
(WebKit::RemoteCommandEncoder::copyTextureToTexture):
(WebKit::RemoteCommandEncoder::clearBuffer):
(WebKit::RemoteCommandEncoder::writeTimestamp):
(WebKit::RemoteCommandEncoder::resolveQuerySet):
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteComputePassEncoder.cpp:
(WebKit::RemoteComputePassEncoder::setPipeline):
(WebKit::RemoteComputePassEncoder::dispatchIndirect):
(WebKit::RemoteComputePassEncoder::setBindGroup):
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteDevice.cpp:
(WebKit::RemoteDevice::createComputePipelineAsync):
(WebKit::RemoteDevice::createRenderPipelineAsync):
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteGPU.cpp:
(WebKit::RemoteGPU::requestAdapter):
* Source/WebKit/GPUProcess/graphics/WebGPU/RemotePresentationContext.cpp:
(WebKit::RemotePresentationContext::configure):
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteQueue.cpp:
(WebKit::RemoteQueue::submit):
(WebKit::RemoteQueue::writeBuffer):
(WebKit::RemoteQueue::writeBufferWithCopy):
(WebKit::RemoteQueue::writeTexture):
(WebKit::RemoteQueue::writeTextureWithCopy):
(WebKit::RemoteQueue::copyExternalImageToTexture):
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteRenderBundleEncoder.cpp:
(WebKit::RemoteRenderBundleEncoder::setPipeline):
(WebKit::RemoteRenderBundleEncoder::setIndexBuffer):
(WebKit::RemoteRenderBundleEncoder::setVertexBuffer):
(WebKit::RemoteRenderBundleEncoder::drawIndirect):
(WebKit::RemoteRenderBundleEncoder::drawIndexedIndirect):
(WebKit::RemoteRenderBundleEncoder::setBindGroup):
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteRenderPassEncoder.cpp:
(WebKit::RemoteRenderPassEncoder::setPipeline):
(WebKit::RemoteRenderPassEncoder::setIndexBuffer):
(WebKit::RemoteRenderPassEncoder::setVertexBuffer):
(WebKit::RemoteRenderPassEncoder::drawIndirect):
(WebKit::RemoteRenderPassEncoder::drawIndexedIndirect):
(WebKit::RemoteRenderPassEncoder::setBlendConstant):
(WebKit::RemoteRenderPassEncoder::executeBundles):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c3b4c4c0dda4bc199bd30c199304261a8b48c11f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/159794 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/33262 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/26368 "Built successfully") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/168654 "Hash c3b4c4c0 for PR 63995 does not build (failure)") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/114175 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/3b7cd670-d86e-4768-b6a6-49cb306bd75d) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/33366 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/33265 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/5/builds/168654 "Hash c3b4c4c0 for PR 63995 does not build (failure)") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/86871 "9 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/76ee9e4d-00eb-4cd5-acd8-42494fc601fe) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/162752 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/26077 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/143527 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/5/builds/168654 "Hash c3b4c4c0 for PR 63995 does not build (failure)") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/b57432ed-2764-4e61-81c4-55f131d64291) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/25128 "Passed tests") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/23603 "Found 2 new API test failures: TestWebKitAPI.WebKit.InterruptionBetweenSameProcessPages, TestWebKitAPI.WKBackForwardList.BackForwardNavigationSkipsItemsWithoutUserGestureFragment (failure)") | [❌ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/16415 "Hash c3b4c4c0 for PR 63995 does not build (failure)") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/134820 "Passed tests") | | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/171145 "Hash c3b4c4c0 for PR 63995 does not build (failure)") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/17162 "Built successfully") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/22935 "Found 1 new test failure: imported/w3c/web-platform-tests/css/selectors/has-specificity.html (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/2/builds/171145 "Hash c3b4c4c0 for PR 63995 does not build (failure)") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/32940 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/27683 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/2/builds/171145 "Hash c3b4c4c0 for PR 63995 does not build (failure)") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/32925 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/143092 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/91023 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/26744 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/19906 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/32434 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/98831 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/31931 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/32178 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/32082 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->