### PR TITLE
Unreviewed, reverting 312334@main (43f24006d708)

### DIFF
--- a/Source/WebKit/GPUProcess/graphics/Model/ModelRenderer.swift
+++ b/Source/WebKit/GPUProcess/graphics/Model/ModelRenderer.swift
@@ -29,6 +29,12 @@ import USDKit
 @_spi(RealityCoreRendererAPI) @_spi(Private) import RealityKit
 import simd
 
+internal struct CameraTransform {
+    var rotation: simd_quatf
+    var translation: simd_float3
+    var scale: simd_float3
+}
+
 class Renderer {
     let device: any MTLDevice
     let commandQueue: any MTLCommandQueue
@@ -121,29 +127,19 @@ class Renderer {
         commandBuffer.commit()
     }
 
-    func setFOV(_ fovYRadians: Float) {
+    internal func setFOV(_ fovYRadians: Float) {
         fovY = fovYRadians
     }
 
-    func setBackgroundColor(_ color: simd_float3) {
+    internal func setBackgroundColor(_ color: simd_float3) {
         clearColor = MTLClearColor(red: 0.0, green: 0.0, blue: 0.0, alpha: 0.0)
     }
 
-    func setCameraTransformForModelTransform(_ modelTransform: simd_float4x4) {
-        // To keep the model stationary while achieving the same visual result as applying
-        // modelTransform to the model, derive the equivalent camera pose by composing the
-        // inverse model transform with the default camera matrix.
-        var defaultCameraMatrix = matrix_identity_float4x4
-        defaultCameraMatrix.columns.3 = [0, 0, Self.cameraDistance, 1]
-        let cameraMatrix = simd_inverse(modelTransform) * defaultCameraMatrix
-
-        let col0 = simd_float3(cameraMatrix.columns.0.x, cameraMatrix.columns.0.y, cameraMatrix.columns.0.z)
-        let col1 = simd_float3(cameraMatrix.columns.1.x, cameraMatrix.columns.1.y, cameraMatrix.columns.1.z)
-        let col2 = simd_float3(cameraMatrix.columns.2.x, cameraMatrix.columns.2.y, cameraMatrix.columns.2.z)
-        let scale = simd_float3(simd_length(col0), simd_length(col1), simd_length(col2))
-        let rotation = simd_quatf(simd_float3x3(col0 / scale.x, col1 / scale.y, col2 / scale.z))
-        let translation = simd_float3(cameraMatrix.columns.3.x, cameraMatrix.columns.3.y, cameraMatrix.columns.3.z)
-        pose = .init(translation: translation, rotation: rotation)
+    internal func setCameraTransform(_ transform: CameraTransform) {
+        pose = .init(
+            translation: transform.translation,
+            rotation: transform.rotation,
+        )
     }
 }
 

--- a/Source/WebKit/GPUProcess/graphics/Model/USDModel.swift
+++ b/Source/WebKit/GPUProcess/graphics/Model/USDModel.swift
@@ -444,6 +444,8 @@ extension WKBridgeReceiver {
     @nonobjc
     fileprivate var meshToMeshInstances: [WKBridgeTypedResourceId: [_Proto_LowLevelMeshInstance_v1]] = [:]
     @nonobjc
+    fileprivate var meshTransforms: [WKBridgeTypedResourceId: [simd_float4x4]] = [:]
+    @nonobjc
     fileprivate var rotationAngle: Float = 0
 
     @nonobjc
@@ -465,6 +467,9 @@ extension WKBridgeReceiver {
     fileprivate var textureHashesAndResources: [WKBridgeTypedResourceId: (String, _Proto_LowLevelTextureResource_v1)] = [:]
 
     @nonobjc
+    fileprivate var modelTransform: simd_float4x4
+
+    @nonobjc
     fileprivate var dontCaptureAgain: Bool = false
 
     @nonobjc
@@ -479,23 +484,11 @@ extension WKBridgeReceiver {
         enum UpdateType {
             // First time mesh update, should add mesh instances to the scene
             case newMesh
-            // Transform update on existing mesh, should only update the transform on relevant mesh instances
-            case transformUpdate([simd_float4x4])
         }
 
         let identifier: WKBridgeTypedResourceId
         let type: UpdateType
         var updatedInstances: [_Proto_LowLevelMeshInstance_v1]
-
-        init(identifier: WKBridgeTypedResourceId, type: UpdateType, updatedInstances: [_Proto_LowLevelMeshInstance_v1]) {
-            self.identifier = identifier
-            self.type = type
-            self.updatedInstances = updatedInstances
-
-            if case .transformUpdate(let newTransforms) = type {
-                assert(newTransforms.count == updatedInstances.count)
-            }
-        }
     }
 
     init(
@@ -510,6 +503,7 @@ extension WKBridgeReceiver {
         self.textureProcessingContext = _Proto_LowLevelTextureProcessingContext_v1(device: configuration.device)
         self.commandQueue = configuration.commandQueue
         self.deformationSystem = try _Proto_LowLevelDeformationSystem_v1.make(configuration.device, configuration.commandQueue).get()
+        modelTransform = matrix_identity_float4x4
         let meshInstances = try configuration.renderContext.makeMeshInstanceArray(renderTargets: [configuration.renderTarget], count: 16)
         self.meshInstancePool = MeshInstancePool(renderContext: configuration.renderContext, meshInstances: meshInstances)
         let lightingFunction = configuration.renderContext.makePhysicallyBasedLightingFunction()
@@ -567,6 +561,19 @@ extension WKBridgeReceiver {
 
     @objc(renderWithTexture:commandBuffer:)
     func render(with texture: any MTLTexture, commandBuffer: any MTLCommandBuffer) {
+        for (identifier, meshes) in meshToMeshInstances {
+            let originalTransforms = meshTransforms[identifier]
+            // FIXME: https://bugs.webkit.org/show_bug.cgi?id=305857
+            // swift-format-ignore: NeverForceUnwrap
+
+            for (index, meshInstance) in meshes.enumerated() {
+                // FIXME: https://bugs.webkit.org/show_bug.cgi?id=305857
+                // swift-format-ignore: NeverForceUnwrap
+                let computedTransform = modelTransform * originalTransforms![index]
+                meshInstance.setTransform(.single(computedTransform))
+            }
+        }
+
         // animate
         if !meshResourceToDeformationContext.isEmpty {
             let commandBuffer = self.commandQueue.makeCommandBuffer()!
@@ -783,6 +790,7 @@ extension WKBridgeReceiver {
                 if meshData.instanceTransformsCount > 0 {
                     if meshToMeshInstances[identifier] == nil {
                         meshToMeshInstances[identifier] = []
+                        meshTransforms[identifier] = []
 
                         var deferredMeshUpdate = DeferredMeshUpdate(identifier: identifier, type: .newMesh, updatedInstances: [])
 
@@ -831,6 +839,9 @@ extension WKBridgeReceiver {
                                 // FIXME: https://bugs.webkit.org/show_bug.cgi?id=305857
                                 // swift-format-ignore: NeverForceUnwrap
                                 meshToMeshInstances[identifier]!.append(meshInstance)
+                                // FIXME: https://bugs.webkit.org/show_bug.cgi?id=305857
+                                // swift-format-ignore: NeverForceUnwrap
+                                meshTransforms[identifier]!.append(instanceTransform)
                                 deferredMeshUpdate.updatedInstances.append(meshInstance)
                             }
                         }
@@ -840,26 +851,14 @@ extension WKBridgeReceiver {
                         // Update transforms otherwise
                         // FIXME: https://bugs.webkit.org/show_bug.cgi?id=305857
                         // swift-format-ignore: NeverForceUnwrap
-                        var newTransforms: [simd_float4x4] = []
-                        var updatedInstances: [_Proto_LowLevelMeshInstance_v1] = []
-
                         let partCount = meshToMeshInstances[identifier]!.count / meshData.instanceTransforms.count
                         for (instanceIndex, instanceTransform) in meshData.instanceTransforms.enumerated() {
                             for partIndex in 0..<partCount {
                                 // FIXME: https://bugs.webkit.org/show_bug.cgi?id=305857
                                 // swift-format-ignore: NeverForceUnwrap
-                                let meshInstance = meshToMeshInstances[identifier]![instanceIndex * meshData.parts.count + partIndex]
-                                updatedInstances.append(meshInstance)
-                                newTransforms.append(instanceTransform)
+                                meshTransforms[identifier]![instanceIndex * partCount + partIndex] = instanceTransform
                             }
                         }
-
-                        let deferredMeshUpdate = DeferredMeshUpdate(
-                            identifier: identifier,
-                            type: .transformUpdate(newTransforms),
-                            updatedInstances: updatedInstances
-                        )
-                        deferredMeshUpdates.append(deferredMeshUpdate)
                     }
                 }
 
@@ -875,10 +874,6 @@ extension WKBridgeReceiver {
                     for newMeshInstance in deferredUpdate.updatedInstances {
                         try meshInstancePool.add(newMeshInstance)
                     }
-                case .transformUpdate(let newTransforms):
-                    for (instanceIndex, meshInstance) in deferredUpdate.updatedInstances.enumerated() {
-                        meshInstance.setTransform(.single(newTransforms[instanceIndex]))
-                    }
                 }
             }
         } catch {
@@ -888,7 +883,7 @@ extension WKBridgeReceiver {
 
     @objc(setTransform:)
     func setTransform(_ transform: simd_float4x4) {
-        appRenderer.setCameraTransformForModelTransform(transform)
+        modelTransform = transform
     }
 
     func setFOV(_ fovY: Float) {


### PR DESCRIPTION
#### f071d53b17c7f891918cc4a628a85ce00cde3dd6
<pre>
Unreviewed, reverting 312334@main (43f24006d708)
<a href="https://bugs.webkit.org/show_bug.cgi?id=313776">https://bugs.webkit.org/show_bug.cgi?id=313776</a>
<a href="https://rdar.apple.com/175367866">rdar://175367866</a>

312334@main breaks viewing some 3d models

Reverted change:

    Transform camera instead of model
    <a href="https://bugs.webkit.org/show_bug.cgi?id=313026">https://bugs.webkit.org/show_bug.cgi?id=313026</a>
    <a href="https://rdar.apple.com/175367866">rdar://175367866</a>
    312334@main (43f24006d708)

Canonical link: <a href="https://commits.webkit.org/312392@main">https://commits.webkit.org/312392@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bdd775c96c6bab4d404e76abd7734fd1c72a1a12

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/159806 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/159/builds/33274 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/26380 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/168666 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/114187 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/33378 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/33277 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/168666 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/114187 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/162764 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/33378 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/143530 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/168666 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/33378 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/23612 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk3-libwebrtc~~](https://ews-build.webkit.org/#/builders/173/builds/16427 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/33378 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/171158 "Failed to checkout and rebase branch from PR 63997") | | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/17174 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/22938 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/2/builds/171158 "Failed to checkout and rebase branch from PR 63997") | | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/32952 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/27692 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/2/builds/171158 "Failed to checkout and rebase branch from PR 63997") | | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/32937 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/143095 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/91035 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/24319 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/160/builds/32937 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/19909 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/32446 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/98843 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/31943 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/32190 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/32094 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->