### PR TITLE
[JSC][JSPI] Throw on stack overflow instead of crashing

### DIFF
--- a/Source/JavaScriptCore/llint/InPlaceInterpreter.asm
+++ b/Source/JavaScriptCore/llint/InPlaceInterpreter.asm
@@ -1712,14 +1712,31 @@ macro populateSentinelVMEntryRecord(context, vmTemp, temp)
     storep 0, VM::topCallFrame[vmTemp]
 end
 
-# Allocate space for the slices to implant and prepare the implant call args.
+# Copy into the VM the values saved in VM entry record and set stack overflow flag in the context.
+# a0 must point to PinballHandlerContext; cfr must point to the sentinel frame.
+macro restoreSentinelVMEntryRecordAndReturnWithStackOverflow()
+    vmEntryRecord(cfr, sp)
+    loadp VMEntryRecord::m_vm[sp], ws0
+    loadp VMEntryRecord::m_prevTopCallFrame[sp], ws1
+    storep ws1, VM::topCallFrame[ws0]
+    loadp VMEntryRecord::m_prevTopEntryFrame[sp], ws1
+    storep ws1, VM::topEntryFrame[ws0]
+    storep 1, PinballHandlerContext::stackOverflowDetected[a0]
+    move cfr, sp
+    functionEpilogue()
+    ret
+end
+
+# Allocate space for the slice to implant and prepare the implant call args.
 # a0 should point at the context and is preserved; temp is a scratch register.
+# On stack overflow jump to failLabel with sp same as before the call.
 #
-macro prepareImplantationCall(temp)
+macro prepareImplantationCall(temp, stackOverflowLabel)
     loadp PinballHandlerContext::sliceByteSize[a0], temp
     subp temp, sp # sliceByteSize is always stack-aligned by construction
     bpa sp, JSWebAssemblyInstance::m_stackMirror + StackManager::Mirror::m_softStackLimit[wasmInstance], .stackOK
-    break
+    addp temp, sp
+    jmp stackOverflowLabel
 .stackOK:
     move sp, a1 # a1 = implantation base
     move cfr, a2 # a2 = returnFP (the sentinel frame)
@@ -1802,7 +1819,7 @@ _enterWebAssemblySuspendingFunction:
     cCall3(_runWebAssemblySuspendingFunction)
     # A non-zero return value is the stack frame to teleport to, skipping the evacuated frames.
     # A zero return means we return normally, typically because an exception was thrown.
-    btiz r0, .normalReturn
+    btiz r0, .enterWebAssemblySuspendingFunction_normal_return
 
     # Teleport over the evacuated frames by returning from the frame in r0.
     # This is where we need the pushed pointer to the callee saves buffer in vm.topEntryFrame.
@@ -1819,7 +1836,7 @@ else
     ret
 end
 
-.normalReturn:
+.enterWebAssemblySuspendingFunction_normal_return:
     move cfr, sp
     functionEpilogue()
     ret
@@ -1847,20 +1864,32 @@ _pinballHandlerFulfillFunction:
     loadp PinballHandlerContext::evacuatedCalleeSaves[sp], ws0
     restoreCalleeSavesFromBuffer(ws0)
 
-.execute:
+.pinballHandlerFulfillFunction_execute:
     move sp, a0
-    call .execute_evacuated_slice #(context)
+    call .jspi_execute_evacuated_slice #(context)
     # Execution returns here from the sentinel frame after the slice has completed.
     # The sentinel has already spilled Wasm argument registers into the context.
+    loadp PinballHandlerContext::stackOverflowDetected[sp], ws0
+    btpnz ws0, .pinballHandlerFulfillFunction_stack_overflow
     # Finish this iteration and loop to the next slice or exit with the result.
     move sp, a0
     call _pinballHandlerFulfillFunctionContinue #(context) -> true if we should do another cycle
-    btinz r0, .execute
+    btinz r0, .pinballHandlerFulfillFunction_execute
 
     # Done. The first Wasm argument is the return value.
     leap PinballHandlerContext::handlerCalleeSaves[sp], ws0
     restoreCalleeSavesFromBuffer(ws0)
     loadp PinballHandlerContext::arguments[sp], r0
+    move cfr, sp
+    functionEpilogue()
+    ret
+
+.pinballHandlerFulfillFunction_stack_overflow:
+    move sp, a0
+    call _pinballHandlerRejectWithStackOverflow #(context)
+    leap PinballHandlerContext::handlerCalleeSaves[sp], ws0
+    restoreCalleeSavesFromBuffer(ws0)
+    move 0, r0
     move cfr, sp
     functionEpilogue()
     ret
@@ -1894,14 +1923,14 @@ _pinballHandlerFulfillFunction:
 # as a single slice, so Frame 0 is always a WasmToJS frame and Frame N is always a JSToWasmFrame.
 # This assumption for now simplifies exception handling.
 #
-.execute_evacuated_slice:
+.jspi_execute_evacuated_slice:
     # Construct the sentinel and make it a VM entry frame.
     # The sentinel must be right below the PinballHandlerContext allocated by the caller.
     functionPrologue()
     vmEntryRecord(cfr, sp)
     populateSentinelVMEntryRecord(a0, ws0, ws1)
 
-    prepareImplantationCall(ws0) # moves sp further down to allocate space for implanted frames, loads a1-a2
+    prepareImplantationCall(ws0, .jspi_execute_evacuated_slice_stack_overflow) # moves sp further down to allocate space for implanted frames, loads a1-a2
     # IMPORTANT: Preserve a0-a2 from here on until the _pinballHandlerImplantSlice call!
     checkStackPointerAlignment(ws0, 0xbad0fff1)
     # Preserve on the stack the arguments buffer ptr. Two copies to keep stack aligned
@@ -1932,6 +1961,9 @@ if ARM64E
 else
     ret
 end
+
+.jspi_execute_evacuated_slice_stack_overflow:
+    restoreSentinelVMEntryRecordAndReturnWithStackOverflow()
 
 
 # Returning into a sentinel frame executes this code
@@ -1976,9 +2008,11 @@ _pinballHandlerRejectFunction:
     restoreCalleeSavesFromBuffer(ws0)
 
     move sp, a0
-    call .unwind_current_slice
+    call .jspi_unwind_current_slice
     # Execution returns here from the sentinel frame if the exception was caught in Wasm.
     # Wasm argument registers were already spilled into the context by the sentinel.
+    loadp PinballHandlerContext::stackOverflowDetected[sp], ws0
+    btpnz ws0, .pinballHandlerRejectFunction_stack_overflow
     move sp, a0
     call _pinballHandlerFinishReject #(context)
 
@@ -1989,8 +2023,18 @@ _pinballHandlerRejectFunction:
     functionEpilogue()
     ret
 
+.pinballHandlerRejectFunction_stack_overflow:
+    move sp, a0
+    call _pinballHandlerRejectWithStackOverflow #(context)
+    leap PinballHandlerContext::handlerCalleeSaves[sp], ws1
+    restoreCalleeSavesFromBuffer(ws1)
+    move 0, r0
+    move cfr, sp
+    functionEpilogue()
+    ret
 
-# This is almost the same as .execute_evacuated_slice in how the stack is shaped
+
+# This is almost the same as .jspi_execute_evacuated_slice in how the stack is shaped
 # by the time we get to the end of this function. The differences are:
 #
 # - What used to be a return frame is shaped as a pretend throwing frame,
@@ -2000,12 +2044,12 @@ _pinballHandlerRejectFunction:
 #   into the VM and jump to the unwind logic. All together this works as if
 #   the exception was thrown from somewhere in our pretend throwing frame.
 #
-.unwind_current_slice:
+.jspi_unwind_current_slice:
     functionPrologue()
     vmEntryRecord(cfr, sp)
     populateSentinelVMEntryRecord(a0, ws0, ws1)
 
-    prepareImplantationCall(ws0) # moves sp further down to allocate space for implanted frames, loads a1-a2
+    prepareImplantationCall(ws0, .jspi_unwind_current_slice_stack_overflow) # moves sp further down to allocate space for implanted frames, loads a1-a2
     checkStackPointerAlignment(ws0, 0xbad0fff3)
 
     # Set up a pretend throwing frame with a zombie callee and a null codeblock.
@@ -2029,6 +2073,9 @@ _pinballHandlerRejectFunction:
     storep t2, VM::m_exception[t1]
 
     jmp _wasm_unwind_from_slow_path_trampoline
+
+.jspi_unwind_current_slice_stack_overflow:
+    restoreSentinelVMEntryRecordAndReturnWithStackOverflow()
 
 
 #################################

--- a/Source/JavaScriptCore/runtime/PinballCompletion.cpp
+++ b/Source/JavaScriptCore/runtime/PinballCompletion.cpp
@@ -31,6 +31,7 @@
 #include "ConservativeRoots.h"
 #include "EvacuatedStack.h"
 #include "Exception.h"
+#include "ExceptionHelpers.h"
 #include "JSCellInlines.h"
 #include "JSPIContextInlines.h"
 #include "JSPromise.h"
@@ -147,6 +148,7 @@ extern "C" void SYSV_ABI pinballHandlerInitContextForReject(JSGlobalObject*, Cal
 extern "C" void SYSV_ABI pinballHandlerImplantSlice(PinballHandlerContext*, Register*, CallFrame*, CallerFrameAndPC*);
 extern "C" UCPURegister SYSV_ABI pinballHandlerFulfillFunctionContinue(PinballHandlerContext*);
 extern "C" void SYSV_ABI pinballHandlerFinishReject(PinballHandlerContext*);
+extern "C" void SYSV_ABI pinballHandlerRejectWithStackOverflow(PinballHandlerContext*);
 
 void pinballHandlerInitContextForFulfill(JSGlobalObject* globalObject, CallFrame* callFrame, PinballHandlerContext* context)
 {
@@ -258,6 +260,21 @@ void pinballHandlerFinishReject(PinballHandlerContext* context)
     }
 
     context->arguments[0] = JSValue::encode(jsNull());
+    context->~PinballHandlerContext();
+}
+
+void pinballHandlerRejectWithStackOverflow(PinballHandlerContext* context)
+{
+    ASSERT(context->magic == PinballHandlerContext::expectedMagic);
+
+    VM& vm = *context->vm;
+    JSPIContext& jspiContext = context->jspiContext;
+    PinballCompletion* pinball = context->pinball;
+    JSPromise* resultPromise = pinball->resultPromise();
+
+    resultPromise->reject(vm, context->globalObject, createStackOverflowError(context->globalObject));
+
+    jspiContext.deactivate(vm);
     context->~PinballHandlerContext();
 }
 

--- a/Source/JavaScriptCore/runtime/PinballHandlerContext.h
+++ b/Source/JavaScriptCore/runtime/PinballHandlerContext.h
@@ -71,6 +71,8 @@ public:
     // The following fields are only used for handling rejections.
     JSCallee* zombieFrameCallee;
     Exception* exception;
+    // Set to non-zero by assembly when stack overflow is detected during slice implantation.
+    size_t stackOverflowDetected { 0 };
 };
 
 } // namespace JSC


### PR DESCRIPTION
#### 84c4c7bf347e4984a6ab69abf2a384dbc6d25267
<pre>
[JSC][JSPI] Throw on stack overflow instead of crashing
<a href="https://bugs.webkit.org/show_bug.cgi?id=307563">https://bugs.webkit.org/show_bug.cgi?id=307563</a>
<a href="https://rdar.apple.com/170647866">rdar://170647866</a>

Reviewed by Yusuke Suzuki.

If the fulfillment or the rejection handler of a suspending promise tries to implant
an evacuated stack slice, and the slice is larger than the available room on the stack,
the existing implementation crashes.

Currently such a crash is impossible in practice because the main event loop and
microtasks use the same stack, and a microtask starts with a nearly empty stack. If a
stack slice previously was able to fit the main event loop stack, it should be able to fit
a microtask stack now. But it&apos;s still better to handle this gracefully, in case something
changes in the future.

This patch adds logic to throw a stack overflow error instead of crashing.

Key changes:

- The code that allocates stack space for the slice about to be implanted checks for stack
overflow as before, but if an overflow is detected, instead of crashing it sets a flag in
the current PinballHandlerContext to indicate that a stack overflow was detected and then
returns to the caller.

- Promise resolution handlers check that flag after trying to execute or unwind the
evacuated slice. If the flag is set, they call to C++ code to throw the stack overflow
error.

- Renamed top-level local labels in .asm code to avoid potential future name conflicts.

Testing:

- Regression-tested by existing tests.

- The actual stack overflow-throwing logic can&apos;t directly be tested by a stress test. As
explained above, we can&apos;t in plain .js code create a situation in which a suspended stack
fits the stack before evacuation, but is too large to fit the stack later in the microtask
which implants it. I tested the throwing logic manually by instrumenting the handler code
to move SP way down before trying to implant the slice, and verifying that the stack
overflow error is thrown as expected.

* Source/JavaScriptCore/llint/InPlaceInterpreter.asm:
* Source/JavaScriptCore/runtime/PinballCompletion.cpp:
(JSC::pinballHandlerRejectWithStackOverflow):
* Source/JavaScriptCore/runtime/PinballHandlerContext.h:

Canonical link: <a href="https://commits.webkit.org/312623@main">https://commits.webkit.org/312623@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/82c0e66b38b8a53bd42ec947a8599235b0e86421

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/159952 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/33420 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/26526 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/168827 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/114333 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/7cc07db2-6523-4eff-bba7-7c9c600b1fb0) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/33524 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/33424 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/123970 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/86951 "2 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/b01995c7-cb95-4b6e-ab68-51546892bb51) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/162910 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/26224 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/143666 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/104587 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/aa9e5bfc-62e8-4906-99fb-8a07eae2cc49) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/25276 "Passed tests") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/23746 "Found 2 new API test failures: TestWebKitAPI.TextManipulation.CompleteTextManipulationForTitleElement, TestWebKitAPI.WKBackForwardList.BackForwardNavigationSkipsItemsWithoutUserGestureFragment (failure)") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/16573 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/152008 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/134968 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/21436 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/171312 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/20789 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/17320 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/23074 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/132232 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/33098 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/27831 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/132259 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35884 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/33083 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/143231 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/91233 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/26880 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/20044 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/192236 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/32592 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/98989 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/49440 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/32089 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/32336 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/32240 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->