### PR TITLE
[LBSE] Use weak references in SVGPaintOrderLayerItem to avoid keep-alive of dead renderers

### DIFF
--- a/Source/WebCore/rendering/RenderLayerSVGAdditions.h
+++ b/Source/WebCore/rendering/RenderLayerSVGAdditions.h
@@ -20,8 +20,9 @@
 
 #include <WebCore/LayoutRect.h>
 #include <WebCore/PaintPhase.h>
-#include <wtf/CheckedPtr.h>
+#include <wtf/InlineWeakPtr.h>
 #include <wtf/OptionSet.h>
+#include <wtf/WeakPtr.h>
 
 namespace WebCore {
 
@@ -45,8 +46,8 @@ public:
         return SVGPaintOrderLayerItem { &renderer, nullptr, 0, { PaintPhase::SelfOutline }, ancestorOffset };
     }
 
-    CheckedPtr<RenderElement> renderer;
-    CheckedPtr<RenderLayer> layer; // null for non-layer children
+    SingleThreadWeakPtr<RenderElement> renderer;
+    InlineWeakPtr<RenderLayer> layer; // null for non-layer children
     int zIndex { 0 };
     OptionSet<PaintPhase> phasesToPaint; // Empty for layered children; drives the non-layer paint loop.
     LayoutSize accumulatedAncestorOffset; // Precomputed offset from non-layered ancestors between child and layer's renderer.


### PR DESCRIPTION
#### 32cddbf2e03b66d3eea85af9afb9b9327f1184ab
<pre>
[LBSE] Use weak references in SVGPaintOrderLayerItem to avoid keep-alive of dead renderers
<a href="https://bugs.webkit.org/show_bug.cgi?id=313784">https://bugs.webkit.org/show_bug.cgi?id=313784</a>

Reviewed by Rob Buis.

SVGPaintOrderLayerItem caches direct or descendant RenderElement / RenderLayer
pointers as part of RenderLayer::m_svgData-&gt;childrenInDOMOrder. The previous
CheckedPtr&lt;RenderElement&gt; / CheckedPtr&lt;RenderLayer&gt; fields had keep-alive
semantics for both targets. The cache unintentionally extended renderer/layer
lifetime - avoid that.

Switch the fields to SingleThreadWeakPtr&lt;RenderElement&gt; / InlineWeakPtr&lt;RenderLayer&gt;.

* Source/WebCore/rendering/RenderLayerSVGAdditions.h:

Canonical link: <a href="https://commits.webkit.org/312420@main">https://commits.webkit.org/312420@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ec794a3d741d8d72e2ef12ad289351e11d11010b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/159831 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/33299 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/26405 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/168692 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/114212 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/161700 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/33403 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/33302 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/123853 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/86887 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/162789 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/26113 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/143562 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/104486 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/25165 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/23639 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/16452 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/134857 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/21333 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/171184 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/17199 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/22971 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/132117 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/32977 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/27718 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/132159 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35766 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/32962 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/143127 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/91060 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/26783 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/19941 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/32471 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/98868 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/31968 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/32215 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/32119 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->