### PR TITLE
[LBSE] Introduce DOM-order paint infrastructure for non-layered SVG children

### DIFF
--- a/Source/WebCore/rendering/RenderLayer.cpp
+++ b/Source/WebCore/rendering/RenderLayer.cpp
@@ -101,6 +101,7 @@
 #include "ReferencedSVGResources.h"
 #include "RenderAncestorIterator.h"
 #include "RenderBoxInlines.h"
+#include "RenderDescendantIterator.h"
 #include "RenderElementInlines.h"
 #include "RenderFlexibleBox.h"
 #include "RenderFragmentContainer.h"
@@ -3888,6 +3889,40 @@ void RenderLayer::paintLayerContents(GraphicsContext& context, const LayerPainti
                 clipRectOptions.add(ClipRectsOption::Temporary);
             collectFragments(layerFragments, localPaintingInfo.rootLayer, paintDirtyRect, ExcludeCompositedPaginatedLayers, PaintingClipRects, clipRectOptions, offsetFromRoot);
             updatePaintingInfoForFragments(layerFragments, localPaintingInfo, localPaintFlags, shouldPaintContent, offsetFromRoot);
+
+            // When non-layer SVG ancestors (e.g. a transformed <g> without its own layer) have
+            // applied transforms to the graphics context, our fragment clip rects — computed in
+            // rootLayer coordinate space — must be inverse-mapped through the accumulated
+            // nonLayerSVGTransform so they end up in our local post-transform space, where the
+            // context is now drawing.
+            //
+            // Skip inverse mapping when rootLayer == this: a prior paintLayerByApplyingTransform
+            // promoted us to be our own rootLayer, so our clip rects (at offsetFromRoot=0 relative
+            // to self) are already in this local space; inverse-mapping would shift them incorrectly.
+            if (localPaintingInfo.nonLayerSVGTransform && localPaintingInfo.rootLayer != this) {
+                if (auto inverse = localPaintingInfo.nonLayerSVGTransform->inverse()) {
+                    float deviceScaleFactor = renderer().document().deviceScaleFactor();
+                    for (auto& fragment : layerFragments) {
+                        if (!fragment.rects.m_foregroundRect.isInfinite()) {
+                            auto mappedForegroundRect = LayoutRect(encloseRectToDevicePixels(inverse->mapRect(FloatRect(fragment.rects.m_foregroundRect.rect())), deviceScaleFactor));
+                            fragment.rects.m_foregroundRect = ClipRect(mappedForegroundRect);
+                        }
+                        if (!fragment.rects.m_backgroundRect.isInfinite()) {
+                            auto mappedBackgroundRect = LayoutRect(encloseRectToDevicePixels(inverse->mapRect(FloatRect(fragment.rects.m_backgroundRect.rect())), deviceScaleFactor));
+                            fragment.rects.m_backgroundRect = ClipRect(mappedBackgroundRect);
+                        }
+                    }
+                }
+            } else if (localPaintingInfo.nonLayerSVGTransform) {
+                // rootLayer == this: our fragment clip rects are at offsetFromRoot=0, already in
+                // this layer's local post-transform space, so the inverse mapping above is
+                // correctly skipped. Descendants will likewise compute their clip rects relative
+                // to rootLayer (=this), in this same local space. The inherited nonLayerSVGTransform
+                // — accumulated from non-layer SVG ancestors above the previous rootLayer — no
+                // longer applies; clear it so descendants do not inverse-map their clip rects
+                // through a stale transform.
+                localPaintingInfo.nonLayerSVGTransform = std::nullopt;
+            }
         }
         
         if (isPaintingCompositedBackground) {
@@ -3898,10 +3933,15 @@ void RenderLayer::paintLayerContents(GraphicsContext& context, const LayerPainti
             }
         }
 
-        // Now walk the sorted list of children with negative z-indices.
-        if (shouldPaintNegativeZIndexChildren)
-            paintList(negativeZOrderLayers(), currentContext, paintingInfo, localPaintFlags);
-        
+        if (shouldPaintNegativeZIndexChildren) {
+            if (m_svgData)
+                paintNegativeZOrderChildrenForSVG(currentContext, paintingInfo, localPaintFlags);
+            else {
+                // Now walk the sorted list of children with negative z-indices.
+                paintList(negativeZOrderLayers(), currentContext, paintingInfo, localPaintFlags);
+            }
+        }
+
         if (isPaintingCompositedForeground && shouldPaintContent)
             paintForegroundForFragments(layerFragments, currentContext, context, paintingInfo.paintDirtyRect, haveTransparency, localPaintingInfo, paintBehavior, subtreePaintRootForRenderer);
 
@@ -3915,11 +3955,15 @@ void RenderLayer::paintLayerContents(GraphicsContext& context, const LayerPainti
             paintOutlineForFragments(layerFragments, currentContext, localPaintingInfo, paintBehavior, subtreePaintRootForRenderer);
 
         if (isPaintingCompositedForeground) {
-            // Paint any child layers that have overflow.
-            paintList(normalFlowLayers(), currentContext, paintingInfo, localPaintFlags);
+            if (m_svgData)
+                paintForegroundChildrenForSVG(currentContext, paintingInfo, localPaintingInfo, localPaintFlags, layerFragments, paintBehavior, subtreePaintRootForRenderer);
+            else {
+                // Paint any child layers that have overflow.
+                paintList(normalFlowLayers(), currentContext, paintingInfo, localPaintFlags);
 
-            // Now walk the sorted list of children with positive z-indices.
-            paintList(positiveZOrderLayers(), currentContext, localPaintingInfo, localPaintFlags);
+                // Now walk the sorted list of children with positive z-indices.
+                paintList(positiveZOrderLayers(), currentContext, localPaintingInfo, localPaintFlags);
+            }
         }
 
         if (m_scrollableArea) {

--- a/Source/WebCore/rendering/RenderLayer.h
+++ b/Source/WebCore/rendering/RenderLayer.h
@@ -44,6 +44,7 @@
 
 #pragma once
 
+#include <WebCore/AffineTransform.h>
 #include <WebCore/ClipRect.h>
 #include <WebCore/GraphicsLayerEnums.h>
 #include <WebCore/LayerFragment.h>
@@ -1016,6 +1017,7 @@ public:
         OptionSet<PaintBehavior> paintBehavior;
         bool requireSecurityOriginAccessForWidgets { false };
         CheckedPtr<RegionContext> regionContext;
+        std::optional<AffineTransform> nonLayerSVGTransform;
     };
 
 private:
@@ -1030,6 +1032,8 @@ private:
     // SVG-specific methods -- defined in RenderLayerSVGAdditions.cpp.
     bool setupClipPathIfNeededForSVG(OptionSet<PaintLayerFlag>&);
     bool paintForegroundForFragmentsForSVG(const LayerFragments&, GraphicsContext&, const LayerPaintingInfo&, OptionSet<PaintBehavior>, RenderObject*);
+    void paintNegativeZOrderChildrenForSVG(GraphicsContext&, const LayerPaintingInfo&, OptionSet<PaintLayerFlag>);
+    void paintForegroundChildrenForSVG(GraphicsContext&, const LayerPaintingInfo&, const LayerPaintingInfo& localPaintingInfo, OptionSet<PaintLayerFlag>, const LayerFragments&, OptionSet<PaintBehavior>, RenderObject* subtreePaintRoot);
 
     void collectChildrenInDOMOrderForSVG();
     // Returns true if this subtree contains any child that must be painted as
@@ -1037,7 +1041,16 @@ private:
     // children), signaling that the parent needs a "split" entry.
     bool appendChildrenInDOMOrderForSVG(RenderElement& parent, LayoutSize ancestorOffset, bool& anyNonZeroZIndex);
     const Vector<SVGPaintOrderLayerItem>& childrenInDOMOrderForSVG();
+    void paintChildrenInDOMOrderForSVG(GraphicsContext&, const LayerPaintingInfo&, OptionSet<PaintLayerFlag>, const LayerFragments&, OptionSet<PaintBehavior>, RenderObject*);
+    void paintNonLayerChildForFragmentsForSVG(RenderElement&, const LayoutSize& accumulatedAncestorOffset, PaintPhase, const LayerFragments&, GraphicsContext&, const LayerPaintingInfo&, OptionSet<PaintBehavior>, RenderObject*, const LayoutPoint& containerBaseOffset, bool isSVGRoot);
+    void paintRendererByApplyingTransformForSVG(GraphicsContext&, CheckedRef<RenderElement>, const LayoutSize& positionOffset, const LayerPaintingInfo&, OptionSet<PaintLayerFlag>, const LayerFragments&, OptionSet<PaintBehavior>, RenderObject*, const LayerPaintingInfo& outerPaintingInfo, const AffineTransform& accumulatedTransform);
+    void paintSubtreeWithinTransformScopeForSVG(GraphicsContext&, RenderElement& container, const LayoutPoint& paintOffset, const LayerPaintingInfo&, OptionSet<PaintLayerFlag>, OptionSet<PaintBehavior>, RenderObject*, const LayerPaintingInfo& outerPaintingInfo, const AffineTransform& accumulatedTransform);
 
+    struct SVGRendererTransform {
+        TransformationMatrix transform;
+        LayoutSize containerOffset;
+    };
+    std::optional<SVGRendererTransform> computeRendererTransformForSVG(CheckedRef<RenderElement>, const LayoutSize& positionOffset) const;
     void dirtyPaintOrderListsOnChildChange(RenderLayer&);
 
     bool shouldBeNormalFlowOnly() const;

--- a/Source/WebCore/rendering/RenderLayerSVGAdditions.cpp
+++ b/Source/WebCore/rendering/RenderLayerSVGAdditions.cpp
@@ -20,24 +20,35 @@
 #include "RenderLayer.h"
 
 #include "CSSFilterRenderer.h"
+#include "HitTestRequest.h"
+#include "HitTestResult.h"
 #include "ReferencedSVGResources.h"
 #include "RenderAncestorIterator.h"
 #include "RenderDescendantIterator.h"
 #include "RenderElementInlines.h"
+#include "RenderLayerBacking.h"
 #include "RenderLayerFilters.h"
 #include "RenderLayerInlines.h"
 #include "RenderLayerModelObject.h"
 #include "RenderLayerSVGAdditionsInlines.h"
 #include "RenderObjectInlines.h"
 #include "RenderSVGContainer.h"
+#include "RenderSVGForeignObject.h"
 #include "RenderSVGHiddenContainer.h"
+#include "RenderSVGInline.h"
 #include "RenderSVGModelObject.h"
 #include "RenderSVGModelObjectInlines.h"
 #include "RenderSVGResourceClipper.h"
 #include "RenderSVGResourceContainer.h"
 #include "RenderSVGRoot.h"
+#include "RenderSVGText.h"
 #include "RenderSVGViewportContainer.h"
 #include "SVGFilterElement.h"
+#include "SVGRenderSupport.h"
+#include "Settings.h"
+#include "StyleTransformResolver.h"
+#include "TransformPaintScope.h"
+#include "TransformationMatrix.h"
 #include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
@@ -48,18 +59,23 @@ bool RenderLayer::hasVisibleContentForPaintingForSVG() const
 {
     ASSERT(m_svgData);
     ASSERT(renderer().document().settings().layerBasedSVGEngineEnabled());
-    if (!m_svgData->enclosingHiddenOrResourceContainer)
-        return true;
+
+    // Layers belonging to a resource container (mask, clipPath, marker, pattern) — either as
+    // the container itself or a descendant — are only visible when actively painting via
+    // paintResourceLayerForSVG(). The flag lives on the resource container's own layer.
+    CheckedPtr resourceContainer = dynamicDowncast<RenderSVGResourceContainer>(renderer());
+    if (!resourceContainer)
+        resourceContainer = dynamicDowncast<RenderSVGResourceContainer>(m_svgData->enclosingHiddenOrResourceContainer.get());
+    if (resourceContainer) {
+        ASSERT(resourceContainer->hasLayer());
+        return resourceContainer->layer()->isPaintingResourceLayerForSVG();
+    }
 
     // Hidden SVG containers (<defs> / <symbol> ...) and their children are never painted directly.
-    CheckedPtr container = m_svgData->enclosingHiddenOrResourceContainer.get();
-    if (!is<RenderSVGResourceContainer>(container.get()))
+    if (m_svgData->enclosingHiddenOrResourceContainer)
         return false;
 
-    // SVG resource layers and their children are only painted indirectly, via paintResourceLayerForSVG().
-    ASSERT(container->hasLayer());
-    CheckedPtr containerLayer = container->layer();
-    return containerLayer->isPaintingResourceLayerForSVG();
+    return hasVisibleContent();
 }
 
 void RenderLayer::paintResourceLayerForSVG(GraphicsContext& context, const AffineTransform& layerContentTransform)
@@ -73,15 +89,7 @@ void RenderLayer::paintResourceLayerForSVG(GraphicsContext& context, const Affin
 
     auto localPaintDirtyRect = LayoutRect::infiniteRect();
 
-    CheckedPtr rootPaintingLayer = [&] () -> RenderLayer* {
-        auto* curr = parent();
-        while (curr && !(curr->renderer().isAnonymous() && is<RenderSVGViewportContainer>(curr->renderer())))
-            curr = curr->parent();
-        return curr;
-    }();
-    ASSERT(rootPaintingLayer);
-
-    LayerPaintingInfo paintingInfo(rootPaintingLayer, localPaintDirtyRect, PaintBehavior::Normal, LayoutSize());
+    LayerPaintingInfo paintingInfo(this, localPaintDirtyRect, PaintBehavior::Normal, LayoutSize());
 
     OptionSet<PaintLayerFlag> flags { PaintLayerFlag::TemporaryClipRects };
     if (!renderer().hasNonVisibleOverflow())
@@ -125,15 +133,41 @@ bool RenderLayer::paintForegroundForFragmentsForSVG(const LayerFragments& layerF
     return true;
 }
 
+void RenderLayer::paintNegativeZOrderChildrenForSVG(GraphicsContext& context, const LayerPaintingInfo& paintingInfo, OptionSet<PaintLayerFlag> paintFlags)
+{
+    ASSERT(m_svgData);
+
+    // foreignObject uses HTML-style z-order painting.
+    if (renderer().isRenderSVGForeignObject()) {
+        paintList(negativeZOrderLayers(), context, paintingInfo, paintFlags);
+        return;
+    }
+
+    // SVG: no-op. Negative z-order children are handled in DOM-order painting
+    // (paintChildrenInDOMOrderForSVG handles all children including negative z-index).
+}
+
+void RenderLayer::paintForegroundChildrenForSVG(GraphicsContext& context, const LayerPaintingInfo& paintingInfo, const LayerPaintingInfo& localPaintingInfo, OptionSet<PaintLayerFlag> paintFlags, const LayerFragments& layerFragments, OptionSet<PaintBehavior> paintBehavior, RenderObject* subtreePaintRoot)
+{
+    ASSERT(m_svgData);
+
+    // foreignObject uses HTML-style z-order painting.
+    if (renderer().isRenderSVGForeignObject()) {
+        // HTML layers and foreignObject use normal z-order list painting.
+        paintList(normalFlowLayers(), context, paintingInfo, paintFlags);
+        paintList(positiveZOrderLayers(), context, localPaintingInfo, paintFlags);
+        return;
+    }
+
+    paintChildrenInDOMOrderForSVG(context, localPaintingInfo, paintFlags, layerFragments, paintBehavior, subtreePaintRoot);
+}
+
 bool RenderLayer::shouldSkipRepaintAfterLayoutForSVG() const
 {
     ASSERT(m_svgData);
     ASSERT(renderer().document().settings().layerBasedSVGEngineEnabled());
 
     // The SVG containers themselves never trigger repaints, only their contents are allowed to.
-    // SVG container sizes/positions are only ever determined by their children, so they will
-    // change as a reaction on a re-position/re-sizing of the children - which already properly
-    // trigger repaints.
     return is<RenderSVGContainer>(renderer()) && !shouldPaintWithFilters();
 }
 
@@ -304,6 +338,307 @@ const Vector<SVGPaintOrderLayerItem>& RenderLayer::childrenInDOMOrderForSVG()
     if (m_svgData->childrenInDOMOrderDirty)
         collectChildrenInDOMOrderForSVG();
     return m_svgData->childrenInDOMOrder;
+}
+
+void RenderLayer::paintNonLayerChildForFragmentsForSVG(RenderElement& childRenderer, const LayoutSize& accumulatedAncestorOffset,
+    PaintPhase phase, const LayerFragments& layerFragments, GraphicsContext& context, const LayerPaintingInfo& paintingInfo,
+    OptionSet<PaintBehavior> paintBehavior, RenderObject* subtreePaintRootForRenderer, const LayoutPoint& containerBaseOffset, bool isSVGRoot)
+{
+    LayoutPoint svgRootScrollAdjustment;
+    if (isSVGRoot)
+        svgRootScrollAdjustment = LayoutPoint(-downcast<RenderSVGRoot>(renderer()).scrollPosition());
+
+    for (const auto& fragment : layerFragments) {
+        if (!fragment.shouldPaintContent || fragment.dirtyForegroundRect().isEmpty())
+            continue;
+
+        GraphicsContextStateSaver stateSaver(context, false);
+        RegionContextStateSaver regionContextStateSaver(paintingInfo.regionContext);
+        clipToRect(context, stateSaver, regionContextStateSaver, paintingInfo, paintBehavior, fragment.dirtyForegroundRect());
+
+        PaintInfo paintInfo(context, fragment.dirtyForegroundRect().rect(),
+            phase, paintBehavior, subtreePaintRootForRenderer,
+            nullptr, nullptr, &paintingInfo.rootLayer->renderer(), this,
+            paintingInfo.requireSecurityOriginAccessForWidgets);
+        if (phase == PaintPhase::Foreground)
+            paintInfo.overlapTestRequests = paintingInfo.overlapTestRequests;
+        paintInfo.updateSubtreePaintRootForChildren(&renderer());
+
+        auto containerPaintOffset = paintOffsetForRenderer(fragment, paintingInfo);
+        auto childPaintOffset = containerBaseOffset.isZero() ? containerPaintOffset : containerPaintOffset + containerBaseOffset;
+        if (isSVGRoot)
+            childPaintOffset.moveBy(svgRootScrollAdjustment);
+
+        auto finalOffset = childPaintOffset + accumulatedAncestorOffset;
+        childRenderer.paint(paintInfo, finalOffset);
+    }
+}
+
+void RenderLayer::paintChildrenInDOMOrderForSVG(GraphicsContext& context, const LayerPaintingInfo& paintingInfo, OptionSet<PaintLayerFlag> paintFlags,
+    const LayerFragments& layerFragments, OptionSet<PaintBehavior> paintBehavior, RenderObject* subtreePaintRootForRenderer)
+{
+    ASSERT(m_svgData);
+    auto& allChildren = childrenInDOMOrderForSVG();
+    if (allChildren.isEmpty())
+        return;
+
+    bool isSVGRoot = is<RenderSVGRoot>(renderer());
+    LayoutPoint containerBaseOffset;
+    LayoutPoint layerResourceOffset;
+
+    if (auto* svgModelObject = dynamicDowncast<RenderSVGModelObject>(renderer())) {
+        containerBaseOffset = svgModelObject->currentSVGLayoutLocation();
+        if (isPaintingResourceLayerForSVG()) {
+            layerResourceOffset = svgModelObject->nominalSVGLayoutLocation();
+            containerBaseOffset.moveBy(layerResourceOffset);
+        }
+    } else if (auto* svgRoot = dynamicDowncast<RenderSVGRoot>(renderer()))
+        containerBaseOffset = svgRoot->location();
+
+    for (auto& childToPaint : allChildren) {
+        if (CheckedPtr childLayer = childToPaint.layer.get()) {
+            // Composited children paint themselves via the compositor.
+            if (childLayer->isComposited())
+                continue;
+
+            if (isPaintingResourceLayerForSVG() && !layerResourceOffset.isZero()) {
+                GraphicsContextStateSaver stateSaver(context);
+                context.translate(layerResourceOffset.x(), layerResourceOffset.y());
+                childLayer->paintLayer(context, paintingInfo, paintFlags);
+            } else
+                childLayer->paintLayer(context, paintingInfo, paintFlags);
+            continue;
+        }
+
+        CheckedPtr childRendererPtr = childToPaint.renderer.get();
+        if (!childRendererPtr)
+            continue;
+        CheckedRef childRenderer = *childRendererPtr;
+
+        // Transformed non-layer children: apply the transform and recursively paint the subtree.
+        if (childRenderer->isTransformed()) {
+            for (const auto& fragment : layerFragments) {
+                if (!fragment.shouldPaintContent || fragment.dirtyForegroundRect().isEmpty())
+                    continue;
+
+                GraphicsContextStateSaver stateSaver(context, false);
+                RegionContextStateSaver regionContextStateSaver(paintingInfo.regionContext);
+                clipToRect(context, stateSaver, regionContextStateSaver, paintingInfo, paintBehavior, fragment.dirtyForegroundRect());
+
+                paintRendererByApplyingTransformForSVG(context, childRenderer,
+                    childToPaint.accumulatedAncestorOffset, paintingInfo, paintFlags,
+                    layerFragments, paintBehavior, subtreePaintRootForRenderer,
+                    paintingInfo, AffineTransform());
+            }
+            continue;
+        }
+
+        for (auto phase : childToPaint.phasesToPaint) {
+            paintNonLayerChildForFragmentsForSVG(childRenderer.get(), childToPaint.accumulatedAncestorOffset,
+                phase, layerFragments, context, paintingInfo, paintBehavior, subtreePaintRootForRenderer, containerBaseOffset, isSVGRoot);
+        }
+    }
+}
+
+std::optional<RenderLayer::SVGRendererTransform> RenderLayer::computeRendererTransformForSVG(
+    CheckedRef<RenderElement> rendererRef, const LayoutSize& positionOffset) const
+{
+    CheckedRef layerModelObject = downcast<RenderLayerModelObject>(rendererRef.get());
+    TransformationMatrix transform;
+    CheckedRef style = layerModelObject->style();
+    auto referenceBoxRect = layerModelObject->transformReferenceBoxRect(style);
+
+    // For non-layer renderers, undo the alignReferenceBox shift applied in transformReferenceBoxRect().
+    if (!rendererRef->hasSelfPaintingLayer()) {
+        if (CheckedPtr svgModel = dynamicDowncast<RenderSVGModelObject>(rendererRef.get()))
+            referenceBoxRect.moveBy(svgModel->nominalSVGLayoutLocation());
+    }
+
+    layerModelObject->applyTransform(transform, style, referenceBoxRect, Style::TransformResolver::allTransformOperations);
+
+    // For the outermost viewport container (anonymous child of RenderSVGRoot), apply the
+    // content-box origin offset (border+padding).
+    if (auto* viewportContainer = dynamicDowncast<RenderSVGViewportContainer>(rendererRef.get()); viewportContainer && viewportContainer->isAnonymous()) {
+        if (CheckedPtr svgRoot = dynamicDowncast<RenderSVGRoot>(viewportContainer->parent())) {
+            auto contentBoxLocation = svgRoot->contentBoxLocation();
+            if (!contentBoxLocation.isZero())
+                transform.translateRight(contentBoxLocation.x(), contentBoxLocation.y());
+        }
+    }
+
+    if (!transform.isInvertible())
+        return std::nullopt;
+
+    bool isOutermostViewportContainer = is<RenderSVGViewportContainer>(rendererRef.get()) && rendererRef->isAnonymous();
+    LayoutSize containerOffset;
+    if (rendererRef->hasSelfPaintingLayer() && !isOutermostViewportContainer) {
+        containerOffset = positionOffset;
+        if (auto* box = dynamicDowncast<RenderBox>(rendererRef.get()))
+            containerOffset += toLayoutSize(box->location());
+        else if (auto* svgModel = dynamicDowncast<RenderSVGModelObject>(rendererRef.get()))
+            containerOffset += toLayoutSize(svgModel->currentSVGLayoutLocation());
+    }
+
+    transform.translateRight(containerOffset.width().toFloat(), containerOffset.height().toFloat());
+    return SVGRendererTransform { transform, containerOffset };
+}
+
+void RenderLayer::paintRendererByApplyingTransformForSVG(GraphicsContext& context, CheckedRef<RenderElement> rendererToPaint,
+    const LayoutSize& positionOffset, const LayerPaintingInfo& paintingInfo, OptionSet<PaintLayerFlag> paintFlags,
+    const LayerFragments&, OptionSet<PaintBehavior> paintBehavior, RenderObject* subtreePaintRoot,
+    const LayerPaintingInfo& outerPaintingInfo, const AffineTransform& accumulatedTransform)
+{
+    ASSERT(rendererToPaint->isTransformed());
+    auto rendererTransform = computeRendererTransformForSVG(rendererToPaint, positionOffset);
+    if (!rendererTransform)
+        return;
+
+    Ref document = rendererToPaint->document();
+    float deviceScaleFactor = document->deviceScaleFactor();
+
+    ASSERT(paintingInfo.subpixelOffset.isZero());
+    LayoutSize adjustedSubpixelOffset;
+
+    TransformPaintScope scope(context, paintingInfo, rendererTransform->transform, deviceScaleFactor, adjustedSubpixelOffset);
+
+    auto adjustedPaintFlags = paintFlags;
+    adjustedPaintFlags.remove(PaintLayerFlag::PaintingOverflowContents);
+
+    AffineTransform newAccumulatedTransform = accumulatedTransform;
+    newAccumulatedTransform *= scope.appliedTransform();
+
+    if (rendererToPaint->hasSelfPaintingLayer()) {
+        CheckedRef layerModelObject = downcast<RenderLayerModelObject>(rendererToPaint.get());
+        CheckedPtr childLayer = layerModelObject->layer();
+
+        LayerPaintingInfo childPaintingInfo(childLayer.get(), scope.transformedPaintingInfo().paintDirtyRect, paintBehavior, LayoutSize());
+
+        if (!accumulatedTransform.isIdentity())
+            childPaintingInfo.nonLayerSVGTransform = accumulatedTransform;
+
+        childLayer->paintLayer(context, childPaintingInfo,
+            adjustedPaintFlags | PaintLayerFlag::AppliedTransform);
+    } else if (rendererToPaint->isRenderSVGContainer()) {
+        LayoutPoint containerPaintOffset;
+        if (auto* viewportContainer = dynamicDowncast<RenderSVGViewportContainer>(rendererToPaint.get()); viewportContainer && viewportContainer->isAnonymous()) {
+            // Outermost viewport container: coordinate system starts at (0, 0).
+        } else if (auto* svgModel = dynamicDowncast<RenderSVGModelObject>(rendererToPaint.get()))
+            containerPaintOffset = svgModel->nominalSVGLayoutLocation();
+        paintSubtreeWithinTransformScopeForSVG(context, rendererToPaint.get(), containerPaintOffset, scope.transformedPaintingInfo(), adjustedPaintFlags, paintBehavior, subtreePaintRoot, outerPaintingInfo, newAccumulatedTransform);
+
+        auto& transformedPaintingInfo = scope.transformedPaintingInfo();
+        PaintInfo outlinePaintInfo(context, transformedPaintingInfo.paintDirtyRect, PaintPhase::SelfOutline, paintBehavior, subtreePaintRoot,
+            nullptr, nullptr, &transformedPaintingInfo.rootLayer->renderer(), this,
+            transformedPaintingInfo.requireSecurityOriginAccessForWidgets);
+        rendererToPaint->paint(outlinePaintInfo, containerPaintOffset);
+    } else {
+        LayoutPoint leafPaintOffset;
+        if (auto* svgModel = dynamicDowncast<RenderSVGModelObject>(rendererToPaint.get())) {
+            leafPaintOffset = svgModel->nominalSVGLayoutLocation();
+            leafPaintOffset.moveBy(-svgModel->currentSVGLayoutLocation());
+        }
+        auto& transformedPaintingInfo = scope.transformedPaintingInfo();
+        LayoutRect dirtyRect = transformedPaintingInfo.paintDirtyRect;
+        PaintInfo paintInfo(context, dirtyRect, PaintPhase::Foreground, paintBehavior, subtreePaintRoot,
+            nullptr, nullptr, &transformedPaintingInfo.rootLayer->renderer(), this,
+            transformedPaintingInfo.requireSecurityOriginAccessForWidgets);
+        rendererToPaint->paint(paintInfo, leafPaintOffset);
+        PaintInfo outlinePaintInfo(paintInfo);
+        outlinePaintInfo.phase = PaintPhase::Outline;
+        rendererToPaint->paint(outlinePaintInfo, leafPaintOffset);
+    }
+}
+
+void RenderLayer::paintSubtreeWithinTransformScopeForSVG(GraphicsContext& context, RenderElement& container,
+    const LayoutPoint& paintOffset, const LayerPaintingInfo& paintingInfo, OptionSet<PaintLayerFlag> paintFlags,
+    OptionSet<PaintBehavior> paintBehavior, RenderObject* subtreePaintRoot,
+    const LayerPaintingInfo& outerPaintingInfo, const AffineTransform& accumulatedTransform)
+{
+    // Apply viewport clipping for nested <svg> elements without layers.
+    GraphicsContextStateSaver clipSaver(context, false);
+    if (CheckedPtr viewportContainer = dynamicDowncast<RenderSVGViewportContainer>(container)) {
+        if (!viewportContainer->hasSelfPaintingLayer() && SVGRenderSupport::isOverflowHidden(*viewportContainer)) {
+            clipSaver.save();
+            auto clipOffset = viewportContainer->isTransformed() ? LayoutPoint() : paintOffset;
+            context.clip(FloatRect(static_cast<const RenderSVGModelObject&>(*viewportContainer).overflowClipRect(clipOffset)));
+        }
+    }
+
+    Vector<SVGPaintOrderLayerItem> sortedChildren;
+    for (CheckedRef child : childrenOfType<RenderElement>(container)) {
+        if (child->isRenderSVGHiddenContainer())
+            continue;
+        if (child->style().display() == Style::DisplayType::None)
+            continue;
+
+        if (child->hasSelfPaintingLayer()) {
+            CheckedRef layerModelObject = downcast<RenderLayerModelObject>(child.get());
+            if (CheckedPtr childLayer = layerModelObject->layer()) {
+                sortedChildren.append(SVGPaintOrderLayerItem::makeLayered(child.get(), *childLayer, childLayer->zIndex()));
+                continue;
+            }
+        }
+        sortedChildren.append(SVGPaintOrderLayerItem::makeAtomic(child.get(), { }));
+    }
+
+    std::stable_sort(sortedChildren.begin(), sortedChildren.end(),
+        [](const SVGPaintOrderLayerItem& a, const SVGPaintOrderLayerItem& b) {
+            return a.zIndex < b.zIndex;
+        });
+
+    for (auto& entry : sortedChildren) {
+        CheckedRef child = *entry.renderer;
+
+        if (child->isTransformed()) {
+            paintRendererByApplyingTransformForSVG(context, child, toLayoutSize(paintOffset), paintingInfo, paintFlags,
+                { }, paintBehavior, subtreePaintRoot, outerPaintingInfo, accumulatedTransform);
+            continue;
+        }
+
+        if (child->hasSelfPaintingLayer()) {
+            CheckedRef layerModelObject = downcast<RenderLayerModelObject>(child.get());
+            CheckedPtr childLayer = layerModelObject->layer();
+
+            auto adjustedFlags = paintFlags;
+            adjustedFlags.remove(PaintLayerFlag::PaintingOverflowContents);
+
+            RenderLayer::LayerPaintingInfo childPaintingInfo(paintingInfo);
+            if (!accumulatedTransform.isIdentity())
+                childPaintingInfo.nonLayerSVGTransform = accumulatedTransform;
+
+            if (isPaintingResourceLayerForSVG() && !paintOffset.isZero()) {
+                GraphicsContextStateSaver stateSaver(context);
+                context.translate(paintOffset.x(), paintOffset.y());
+                childLayer->paintLayer(context, childPaintingInfo, adjustedFlags);
+            } else
+                childLayer->paintLayer(context, childPaintingInfo, adjustedFlags);
+            continue;
+        }
+
+        // Non-layer, non-transformed child.
+        auto adjustedPaintOffset = paintOffset;
+        if (CheckedPtr childSvgModel = dynamicDowncast<RenderSVGModelObject>(child.get()))
+            adjustedPaintOffset.moveBy(childSvgModel->currentSVGLayoutLocation());
+
+        if (child->isRenderSVGContainer()) {
+            paintSubtreeWithinTransformScopeForSVG(context, child.get(), adjustedPaintOffset, paintingInfo, paintFlags, paintBehavior, subtreePaintRoot, outerPaintingInfo, accumulatedTransform);
+
+            PaintInfo outlinePaintInfo(context, paintingInfo.paintDirtyRect, PaintPhase::SelfOutline, paintBehavior, subtreePaintRoot,
+                nullptr, nullptr, &paintingInfo.rootLayer->renderer(), this,
+                paintingInfo.requireSecurityOriginAccessForWidgets);
+            child->paint(outlinePaintInfo, paintOffset);
+        } else {
+            LayoutRect dirtyRect = paintingInfo.paintDirtyRect;
+            PaintInfo paintInfo(context, dirtyRect, PaintPhase::Foreground, paintBehavior, subtreePaintRoot,
+                nullptr, nullptr, &paintingInfo.rootLayer->renderer(), this,
+                paintingInfo.requireSecurityOriginAccessForWidgets);
+            child->paint(paintInfo, paintOffset);
+
+            PaintInfo outlinePaintInfo(paintInfo);
+            outlinePaintInfo.phase = PaintPhase::Outline;
+            child->paint(outlinePaintInfo, paintOffset);
+        }
+    }
 }
 
 } // namespace WebCore

--- a/Source/WebCore/rendering/svg/RenderSVGContainer.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGContainer.cpp
@@ -36,6 +36,7 @@
 #include "RenderView.h"
 #include "SVGContainerLayout.h"
 #include "SVGLayerTransformUpdater.h"
+#include "SVGRenderSupport.h"
 #include "SVGVisitedRendererTracking.h"
 #include <wtf/SetForScope.h>
 #include <wtf/StackStats.h>
@@ -118,8 +119,21 @@ FloatRect RenderSVGContainer::strokeBoundingBox() const
 
 void RenderSVGContainer::paint(PaintInfo& paintInfo, const LayoutPoint& paintOffset)
 {
-    OptionSet<PaintPhase> relevantPaintPhases { PaintPhase::Foreground, PaintPhase::ClippingMask, PaintPhase::Mask, PaintPhase::Outline, PaintPhase::SelfOutline };
-    if (!shouldPaintSVGRenderer(paintInfo, relevantPaintPhases))
+    if (paintInfo.phase != PaintPhase::EventRegion && paintInfo.context().paintingDisabled())
+        return;
+
+    static constexpr OptionSet<PaintPhase> relevantPaintPhases { PaintPhase::Foreground, PaintPhase::ClippingMask, PaintPhase::Mask, PaintPhase::Outline, PaintPhase::SelfOutline, PaintPhase::EventRegion };
+    if (!relevantPaintPhases.contains(paintInfo.phase))
+        return;
+
+    if (!paintInfo.shouldPaintWithinRoot(*this))
+        return;
+
+    if (style().display() == Style::DisplayType::None)
+        return;
+
+    // Children can override with "visibility: visible", per SVG spec.
+    if (paintInfo.phase != PaintPhase::Foreground && style().usedVisibility() == Visibility::Hidden)
         return;
 
     if (paintInfo.phase == PaintPhase::ClippingMask) {
@@ -139,11 +153,39 @@ void RenderSVGContainer::paint(PaintInfo& paintInfo, const LayoutPoint& paintOff
         return;
 
     if (paintInfo.phase == PaintPhase::Outline || paintInfo.phase == PaintPhase::SelfOutline) {
+        // Children's outlines are painted per-child during the Foreground phase, so later
+        // DOM siblings paint on top of earlier siblings' outlines.
         paintSVGOutline(paintInfo, adjustedPaintOffset);
         return;
     }
 
-    ASSERT(paintInfo.phase == PaintPhase::Foreground);
+    ASSERT(paintInfo.phase == PaintPhase::Foreground || paintInfo.phase == PaintPhase::EventRegion);
+
+    // With a self-painting layer, children are painted by paintChildrenInDOMOrderForSVG().
+    if (hasSelfPaintingLayer())
+        return;
+
+    PaintInfo childPaintInfo(paintInfo);
+    GraphicsContextStateSaver stateSaver(childPaintInfo.context());
+
+    // For layer-backed containers, clipping is handled by RenderLayer::calculateClipRects().
+    if (isRenderSVGViewportContainer() && SVGRenderSupport::isOverflowHidden(*this))
+        childPaintInfo.context().clip(FloatRect(overflowClipRect(adjustedPaintOffset)));
+
+    childPaintInfo.updateSubtreePaintRootForChildren(this);
+    for (CheckedRef child : childrenOfType<RenderElement>(*this)) {
+        if (child->hasSelfPaintingLayer())
+            continue;
+
+        child->paint(childPaintInfo, adjustedPaintOffset);
+
+        if (paintInfo.phase == PaintPhase::Foreground) {
+            // Paint each child's outline immediately so later DOM siblings paint on top of it.
+            PaintInfo outlinePaintInfo(childPaintInfo);
+            outlinePaintInfo.phase = PaintPhase::Outline;
+            child->paint(outlinePaintInfo, adjustedPaintOffset);
+        }
+    }
 }
 
 bool RenderSVGContainer::nodeAtPoint(const HitTestRequest& request, HitTestResult& result, const HitTestLocation& locationInContainer, const LayoutPoint& accumulatedOffset, HitTestAction hitTestAction)

--- a/Source/WebCore/rendering/svg/RenderSVGRoot.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGRoot.cpp
@@ -371,6 +371,12 @@ void RenderSVGRoot::paintContents(PaintInfo& paintInfo, const LayoutPoint& paint
     else if (paintInfo.phase == PaintPhase::ChildBlockBackgrounds)
         paintInfoForChild.phase = PaintPhase::ChildBlockBackground;
 
+    // When the SVG root has a self-painting layer, children are painted by
+    // paintChildrenInDOMOrderForSVG() to ensure correct DOM-order interleaving
+    // of layer and non-layer children.
+    if (hasSelfPaintingLayer())
+        return;
+
     paintInfoForChild.updateSubtreePaintRootForChildren(this);
     for (auto& child : childrenOfType<RenderElement>(*this)) {
         if (!child.hasSelfPaintingLayer())


### PR DESCRIPTION
#### 657503c4ea11293a4cbc0d928e75ddbea887fbf6
<pre>
[LBSE] Introduce DOM-order paint infrastructure for non-layered SVG children
<a href="https://bugs.webkit.org/show_bug.cgi?id=313780">https://bugs.webkit.org/show_bug.cgi?id=313780</a>

Reviewed by Rob Buis.

Preparatory refactor for making RenderLayer creation conditional on LBSE
SVG renderers (bug 308565). Today every SVG renderer unconditionally owns a
layer, so painting can rely on walking z-order layer lists. Once layer
creation becomes conditional, SVG content will contain a mix of layered and
non-layered renderers that must paint in strict DOM document order,
interleaving both kinds.

This patch introduces the painting half of that infrastructure ahead of the
requiresLayer() change so it can be reviewed and landed independently. The
new code paths are gated by !hasSelfPaintingLayer() (in
RenderSVGContainer::paint and RenderSVGRoot::paintContents) and by m_svgData
(in RenderLayer::paintLayerContents). With every SVG renderer still owning a
layer the non-layered branches never fire, so output is equivalent to the
existing z-order list iteration. The follow-up bug 308565 patch flips
requiresLayer() and lights up the new paths. The hit-test counterpart lands
in a separate patch.

* Source/WebCore/rendering/RenderLayer.cpp:
(WebCore::RenderLayer::paintLayerContents):
* Source/WebCore/rendering/RenderLayer.h:
* Source/WebCore/rendering/RenderLayerSVGAdditions.cpp:
(WebCore::RenderLayer::hasVisibleContentForPaintingForSVG const):
(WebCore::RenderLayer::paintResourceLayerForSVG):
(WebCore::RenderLayer::paintNegativeZOrderChildrenForSVG):
(WebCore::RenderLayer::paintForegroundChildrenForSVG):
(WebCore::RenderLayer::shouldSkipRepaintAfterLayoutForSVG const):
(WebCore::RenderLayer::paintNonLayerChildForFragmentsForSVG):
(WebCore::RenderLayer::paintChildrenInDOMOrderForSVG):
(WebCore::RenderLayer::computeRendererTransformForSVG const):
(WebCore::RenderLayer::paintRendererByApplyingTransformForSVG):
(WebCore::RenderLayer::paintSubtreeWithinTransformScopeForSVG):
* Source/WebCore/rendering/svg/RenderSVGContainer.cpp:
(WebCore::RenderSVGContainer::paint):
* Source/WebCore/rendering/svg/RenderSVGRoot.cpp:
(WebCore::RenderSVGRoot::paintContents):

Canonical link: <a href="https://commits.webkit.org/312729@main">https://commits.webkit.org/312729@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c7c1f6a79e62ddbff48b306c3fd88952a8b896ca

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/160899 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/159/builds/34372 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/27473 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/169802 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/117159 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/162768 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/34473 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/34372 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/124800 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/117159 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/163858 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/27064 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/144534 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/105397 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/26116 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/24613 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/17522 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/135810 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/167/builds/22296 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/172285 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/19306 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/23937 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/133074 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/34046 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/28705 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/133084 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35936 "Built successfully and passed tests") | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/34030 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/144091 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/95869 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/160/builds/34030 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/20907 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/33541 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/100966 "Built successfully") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/33040 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/33284 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/33189 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->