### PR TITLE
[CMake] Align Release / RelWithDebInfo optimization-level and debug-info to Xcode

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -100,7 +100,25 @@
             "name": "mac-release",
             "displayName": "macOS Release",
             "inherits": ["mac", "release"],
-            "binaryDir": "WebKitBuild/cmake-mac/Release"
+            "binaryDir": "WebKitBuild/cmake-mac/Release",
+            "cacheVariables": {
+                "CMAKE_C_FLAGS_RELEASE": {
+                    "type": "STRING",
+                    "value": "-O3 -DNDEBUG -g"
+                },
+                "CMAKE_CXX_FLAGS_RELEASE": {
+                    "type": "STRING",
+                    "value": "-O3 -DNDEBUG -g"
+                },
+                "CMAKE_OBJC_FLAGS_RELEASE": {
+                    "type": "STRING",
+                    "value": "-O3 -DNDEBUG -g"
+                },
+                "CMAKE_OBJCXX_FLAGS_RELEASE": {
+                    "type": "STRING",
+                    "value": "-O3 -DNDEBUG -g"
+                }
+            }
         },
         {
             "name": "mac-debug",
@@ -131,6 +149,14 @@
                 "CMAKE_CXX_FLAGS_DEBUG": {
                     "type": "STRING",
                     "value": "-g -O3"
+                },
+                "CMAKE_OBJC_FLAGS_DEBUG": {
+                    "type": "STRING",
+                    "value": "-g -O3"
+                },
+                "CMAKE_OBJCXX_FLAGS_DEBUG": {
+                    "type": "STRING",
+                    "value": "-g -O3"
                 }
             }
         },
@@ -143,6 +169,22 @@
                 "CMAKE_BUILD_TYPE": {
                     "type": "STRING",
                     "value": "RelWithDebInfo"
+                },
+                "CMAKE_C_FLAGS_RELWITHDEBINFO": {
+                    "type": "STRING",
+                    "value": "-O3 -g -DNDEBUG"
+                },
+                "CMAKE_CXX_FLAGS_RELWITHDEBINFO": {
+                    "type": "STRING",
+                    "value": "-O3 -g -DNDEBUG"
+                },
+                "CMAKE_OBJC_FLAGS_RELWITHDEBINFO": {
+                    "type": "STRING",
+                    "value": "-O3 -g -DNDEBUG"
+                },
+                "CMAKE_OBJCXX_FLAGS_RELWITHDEBINFO": {
+                    "type": "STRING",
+                    "value": "-O3 -g -DNDEBUG"
                 }
             }
         },


### PR DESCRIPTION
#### 15962ef4b57b04723511e04e7fea7bcc2deab83f
<pre>
[CMake] Align Release / RelWithDebInfo optimization-level and debug-info to Xcode
<a href="https://bugs.webkit.org/show_bug.cgi?id=313788">https://bugs.webkit.org/show_bug.cgi?id=313788</a>
<a href="https://rdar.apple.com/175982252">rdar://175982252</a>

Reviewed by Pascoe.

Aligning build configuration to Xcode.

1. Xcode Release WebKit build is always having `-g`. Align CMake to this.
2. RelWithDebInfo is using O2 while Release is using O3. Aligning it to O3.

* CMakePresets.json:

Canonical link: <a href="https://commits.webkit.org/312402@main">https://commits.webkit.org/312402@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3a0108a9ea9636f8678d4c7e65ceb5323af293d9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/159847 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/33315 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/26421 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/168709 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/114228 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/33419 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/33318 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/123867 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/114228 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/162805 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/26126 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/143570 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/104498 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/5a81c3ea-7bd8-4ab5-9dd8-02caf13b3dee) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/25178 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/23651 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/16468 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/134870 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/171200 "Built successfully") | | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/22979 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/132131 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/32993 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/27730 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/132171 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/32978 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/143135 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/91076 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/24325 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/164/builds/26785 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/19949 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/32487 "Built successfully") | | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/31984 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/32231 "Built successfully") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/32135 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->