### PR TITLE
[visionOS] interaction-region/paused-video-regions.html is a constant text failure.

### DIFF
--- a/LayoutTests/platform/visionos/TestExpectations
+++ b/LayoutTests/platform/visionos/TestExpectations
@@ -186,8 +186,6 @@ overlay-region/full-page-scrolling.html [ Failure ]
 overlay-region/overlay-element.html [ Failure ]
 overlay-region/sticky.html [ Failure ]
 
-webkit.org/b/313782 interaction-region/paused-video-regions.html [ Failure ]
-
 ### END OF Triaged failures
 ###################################################################################################
 

--- a/LayoutTests/platform/visionos/interaction-region/paused-video-regions-expected.txt
+++ b/LayoutTests/platform/visionos/interaction-region/paused-video-regions-expected.txt
@@ -24,15 +24,15 @@
                 (rect (0,0) width=352 height=288)
               (touch event listener region: asynchronousDispatchRegion:
                 (rect (0,0) width=352 height=288)
-eventSpecificSynchronousDispatchRegions: eventName: pointerout eventRect:
-                (rect (0,0) width=352 height=288)
-eventSpecificSynchronousDispatchRegions: eventName: pointerleave eventRect:
+eventSpecificSynchronousDispatchRegions: eventName: pointerup eventRect:
                 (rect (0,0) width=352 height=288)
 eventSpecificSynchronousDispatchRegions: eventName: pointermove eventRect:
                 (rect (0,0) width=352 height=288)
-eventSpecificSynchronousDispatchRegions: eventName: pointerup eventRect:
+eventSpecificSynchronousDispatchRegions: eventName: pointerout eventRect:
                 (rect (0,0) width=352 height=288)
 eventSpecificSynchronousDispatchRegions: eventName: pointerdown eventRect:
+                (rect (0,0) width=352 height=288)
+eventSpecificSynchronousDispatchRegions: eventName: pointerleave eventRect:
                 (rect (0,0) width=352 height=288)
 
               )
@@ -52,11 +52,7 @@ eventSpecificSynchronousDispatchRegions: eventName: pointerdown eventRect:
                         (rect (8,0) width=35 height=8)
                         (rect (0,8) width=51 height=35)
                         (rect (8,43) width=35 height=8)
-eventSpecificSynchronousDispatchRegions: eventName: pointerout eventRect:
-                        (rect (8,0) width=35 height=8)
-                        (rect (0,8) width=51 height=35)
-                        (rect (8,43) width=35 height=8)
-eventSpecificSynchronousDispatchRegions: eventName: pointerleave eventRect:
+eventSpecificSynchronousDispatchRegions: eventName: pointerup eventRect:
                         (rect (8,0) width=35 height=8)
                         (rect (0,8) width=51 height=35)
                         (rect (8,43) width=35 height=8)
@@ -64,11 +60,15 @@ eventSpecificSynchronousDispatchRegions: eventName: pointermove eventRect:
                         (rect (8,0) width=35 height=8)
                         (rect (0,8) width=51 height=35)
                         (rect (8,43) width=35 height=8)
-eventSpecificSynchronousDispatchRegions: eventName: pointerup eventRect:
+eventSpecificSynchronousDispatchRegions: eventName: pointerout eventRect:
                         (rect (8,0) width=35 height=8)
                         (rect (0,8) width=51 height=35)
                         (rect (8,43) width=35 height=8)
 eventSpecificSynchronousDispatchRegions: eventName: pointerdown eventRect:
+                        (rect (8,0) width=35 height=8)
+                        (rect (0,8) width=51 height=35)
+                        (rect (8,43) width=35 height=8)
+eventSpecificSynchronousDispatchRegions: eventName: pointerleave eventRect:
                         (rect (8,0) width=35 height=8)
                         (rect (0,8) width=51 height=35)
                         (rect (8,43) width=35 height=8)
@@ -103,4 +103,3 @@ eventSpecificSynchronousDispatchRegions: eventName: pointerdown eventRect:
   )
 )
 EVENT(canplaythrough)
-


### PR DESCRIPTION
#### aa90fd6ede557ed76ea6ff896e1809c132067fa6
<pre>
[visionOS] interaction-region/paused-video-regions.html is a constant text failure.
<a href="https://bugs.webkit.org/show_bug.cgi?id=313782">https://bugs.webkit.org/show_bug.cgi?id=313782</a>
<a href="https://rdar.apple.com/175977737">rdar://175977737</a>

Unreviewed rebaseline to account for <a href="https://commits.webkit.org/312143@main">312143@main</a>.

* LayoutTests/platform/visionos/TestExpectations:
* LayoutTests/platform/visionos/interaction-region/paused-video-regions-expected.txt:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/aa90fd6ede557ed76ea6ff896e1809c132067fa6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/161232 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/34705 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/27806 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/170135 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/117603 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/34806 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/34706 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/125065 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/88156 "1 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/164191 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/27348 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/144831 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/105662 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/26396 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/24902 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/17855 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/136090 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/22591 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/172618 "Built successfully") | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/24232 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/133342 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/34379 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/28995 "Found 1 new test failure: imported/w3c/web-platform-tests/fullscreen/model/move-to-fullscreen-iframe.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/133351 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/34364 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/144386 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/96229 "Built successfully") | 
| | [❌ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/27900 "Exiting early after 10 failures. 10 tests run. 1 failures") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/21204 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/33874 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/33373 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/33617 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/33522 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->