### PR TITLE
[iOS] 2 tests in imported/w3c/web-platform-tests/css/css-images/image-orientation are failing with image diff

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-images/image-orientation/image-orientation-background-image.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-images/image-orientation/image-orientation-background-image.html
@@ -4,7 +4,7 @@
 <link rel="author" title="Cameron McCormack" href="mailto:cam@mcc.id.au">
 <link rel="help" href="https://drafts.csswg.org/css-images-3/#propdef-image-orientation">
 <link rel="match" href="reference/image-orientation-background-image-ref.html">
-<meta name=fuzzy content="0-3;0-50">
+<meta name=fuzzy content="0-3;0-60">
 <style>
 div { width: 100px; height: 50px; background-image: url(support/exif-orientation-2-ur.jpg); }
 .no-orient { image-orientation: none; }

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-images/image-orientation/image-orientation-list-style-image.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-images/image-orientation/image-orientation-list-style-image.html
@@ -4,7 +4,7 @@
 <link rel="author" title="Cameron McCormack" href="mailto:cam@mcc.id.au">
 <link rel="help" href="https://drafts.csswg.org/css-images-3/#propdef-image-orientation">
 <link rel="match" href="reference/image-orientation-list-style-image-ref.html">
-<meta name=fuzzy content="0-3;0-50">
+<meta name=fuzzy content="0-3;0-60">
 <style>
 ul { margin-left: 100px; list-style-image: url(support/exif-orientation-2-ur.jpg); }
 .no-orient { image-orientation: none; }

--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -8635,7 +8635,3 @@ imported/w3c/web-platform-tests/html/semantics/popovers/popover-shadowhost-focus
 
 # rdar://168334716 (MTLCompilerService crashes when Metal Shader Validation is enabled on iOS Simulator)
 webgl/webgl2-provoking-vertex-primitive-restart-uint16-nocrash.html [ Skip ]
-
-# webkit.org/b/313677 [iOS] 2 tests in imported/w3c/web-platform-tests/css/css-images/image-orientation are failing with image diff
-imported/w3c/web-platform-tests/css/css-images/image-orientation/image-orientation-background-image.html [ ImageOnlyFailure ]
-imported/w3c/web-platform-tests/css/css-images/image-orientation/image-orientation-list-style-image.html [ ImageOnlyFailure ]


### PR DESCRIPTION
#### 4c075bcc2672f84d2def9b2288ee1d1e5535b08c
<pre>
[iOS] 2 tests in imported/w3c/web-platform-tests/css/css-images/image-orientation are failing with image diff
<a href="https://bugs.webkit.org/show_bug.cgi?id=313677">https://bugs.webkit.org/show_bug.cgi?id=313677</a>
<a href="https://rdar.apple.com/175878256">rdar://175878256</a>

Unreviewed test fix (image comparision fuzz factor)

These small pixel differences are caused by JPEG encoding differences in the before/after
images. We need to increase the fuzz factor to support macOS and iOS with the same
reference content.

* LayoutTests/imported/w3c/web-platform-tests/css/css-images/image-orientation/image-orientation-background-image.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-images/image-orientation/image-orientation-list-style-image.html:
* LayoutTests/platform/ios/TestExpectations:

Canonical link: <a href="https://commits.webkit.org/312442@main">https://commits.webkit.org/312442@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/de4d1ca766716dd09c92f89e3e484c28cbb875d1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/159839 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/33307 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/26413 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/168700 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/114220 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/0e594fdf-e00e-4028-9426-84ff4d9999df) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/33411 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/33310 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/123861 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/86892 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/0f5c7885-ec2b-4984-98d2-4b090dc446c3) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/162797 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/26120 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/143571 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/104493 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/2da1fe9c-3b10-4d89-be1b-5d5f2e7f58c2) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/25172 "Passed tests") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/23646 "Found 1 new API test failure: TestWebKitAPI.WKWebExtension.LoadFromiOSAppExtensionBundle (failure)") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/16460 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/134864 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/21342 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/171192 "Built successfully") | | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/22980 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/132125 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/32985 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/27725 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/132166 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35784 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/32970 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/143136 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/91068 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/26779 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/19950 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/32479 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/31976 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/32223 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/32127 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->