### PR TITLE
IPInt multimemory bounds check underflows if memory size is 0

### DIFF
--- a/JSTests/wasm/stress/ipint-multimem-zero-page-oob.js
+++ b/JSTests/wasm/stress/ipint-multimem-zero-page-oob.js
@@ -1,0 +1,38 @@
+//@ requireOptions("--useWasmMultiMemory=1")
+
+import * as assert from "../assert.js";
+import { instantiate } from "../wabt-wrapper.js";
+
+// Test that loads and stores to a 0-page non-zero memory correctly trap OOB.
+
+let wat = `
+(module
+  (import "js" "mem0" (memory 1))
+  (import "js" "mem1" (memory 0 1))
+
+  (func (export "i32_load") (param i32) (result i32) (local.get 0) (i32.load 1))
+  (func (export "i64_load") (param i32) (result i64) (local.get 0) (i64.load 1))
+  (func (export "i32_load8u") (param i32) (result i32) (local.get 0) (i32.load8_u 1))
+  (func (export "i32_store") (param i32) (local.get 0) (i32.const 0) (i32.store 1))
+  (func (export "i64_store") (param i32) (local.get 0) (i64.const 0) (i64.store 1))
+  (func (export "i32_store8") (param i32) (local.get 0) (i32.const 0) (i32.store8 1))
+)
+`
+
+async function test() {
+    const mem0 = new WebAssembly.Memory({ initial: 1 });
+    const mem1 = new WebAssembly.Memory({ initial: 0, maximum: 1 });
+
+    const instance = await instantiate(wat, { js: { mem0, mem1 } }, { multi_memory: true });
+
+    const ops = ["i32_load", "i64_load", "i32_load8u", "i32_store", "i64_store", "i32_store8"];
+    const addrs = [0, 1, 100, 65535];
+
+    for (const op of ops) {
+        for (const addr of addrs) {
+            assert.throws(() => instance.exports[op](addr), WebAssembly.RuntimeError, "Out of bounds memory access");
+        }
+    }
+}
+
+await assert.asyncTest(test());

--- a/Source/JavaScriptCore/llint/InPlaceInterpreter64.asm
+++ b/Source/JavaScriptCore/llint/InPlaceInterpreter64.asm
@@ -959,9 +959,8 @@ macro loadStoreMakePointerSlow(cursor, wasmAddrReg, size, scratch, scratch2, dec
 .memoryIsNotZero:
     mulp constexpr (sizeof(JSWebAssemblyInstance::WasmMemoryBaseAndSize)), scratch
     # FIXME: it's probably worth trying to use a loadpair here, but that requires a separate x86 codepath
-    loadp (constexpr (JSWebAssemblyInstance::offsetOfCachedMemoryBaseSizePair(0) + sizeof(void*))) [wasmInstance, scratch], scratch2 # bounds checking size
-    subp size - 1, scratch2 # wasmAddrReg + (size-1) >= scratch2 is equivalent to wasmAddrReg >= scratch2 - (size-1)
-    bpaeq wasmAddrReg, scratch2, _ipint_throw_OutOfBoundsMemoryAccess
+    loadp (constexpr (JSWebAssemblyInstance::offsetOfCachedMemoryBaseSizePair(0) + sizeof(void*))) [wasmInstance, scratch], decodeScratch1 # bounds checking size
+    bpaeq scratch2, decodeScratch1, _ipint_throw_OutOfBoundsMemoryAccess # scratch2 contains wasm address + size - 1
     loadp (constexpr (JSWebAssemblyInstance::offsetOfCachedMemoryBaseSizePair(0))) [wasmInstance, scratch], scratch2 # memory base
     addp scratch2, wasmAddrReg
 .done:


### PR DESCRIPTION
#### c90b978eee248e990a39ad9f2b0d954ac51fc47c
<pre>
IPInt multimemory bounds check underflows if memory size is 0
<a href="https://bugs.webkit.org/show_bug.cgi?id=313789">https://bugs.webkit.org/show_bug.cgi?id=313789</a>
<a href="https://rdar.apple.com/175861149">rdar://175861149</a>

Reviewed by Yusuke Suzuki.

When accessing a memory with a nonzero index that has a size of 0 bytes,
the bounds check computes (memory size - (access size - 1)), which
underflows. This patch rewrites it without the subtraction to avoid the
underflow.

Test: JSTests/wasm/stress/ipint-multimem-zero-page-oob.js

* JSTests/wasm/stress/ipint-multimem-zero-page-oob.js: Added.
(let.wat.module.import.string_appeared_here.string_appeared_here.memory.1.import.string_appeared_here.string_appeared_here.memory.0.1.func.export.string_appeared_here.param.i32.result.i32.local.0.i32.load.1.func.export.string_appeared_here.param.i32.result.i64.local.0.i64.load.1.func.export.string_appeared_here.param.i32.result.i32.local.0.i32.load8_u.1.func.export.string_appeared_here.param.i32.local.0.i32.const.0.i32.store.1.func.export.string_appeared_here.param.i32.local.0.i64.const.0.i64.store.1.func.export.string_appeared_here.param.i32.local.0.i32.const.0.i32.store8.1.async test):
* Source/JavaScriptCore/llint/InPlaceInterpreter64.asm:

Canonical link: <a href="https://commits.webkit.org/312439@main">https://commits.webkit.org/312439@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/571ea90d9b18a2569a33ff0fb3e47cc6ffae9f1d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/159843 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/33311 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/26417 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/168705 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/114224 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/0fb95dfe-a253-40c3-a973-139b3be1a3ca) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/33415 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/33314 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/123866 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/86893 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/69edda4b-0225-4ef7-9f3f-b51e91e3cc6e) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/162801 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/26125 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/143568 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/104497 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/25177 "Passed tests") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/23650 "Found 2 new API test failures: TestWebKitAPI.WKWebExtension.LoadFromZipArchiveWithoutParentDirectory, TestWebKitAPI.WKBackForwardList.BackForwardNavigationSkipsItemsWithoutUserGestureFragment (failure)") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/16464 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/151899 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/134869 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/21339 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/171196 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/20680 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/17211 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/22977 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/132163 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/32989 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/27729 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/132170 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35785 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/32974 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/143133 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/91072 "The change is no longer eligible for processing.") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/26782 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/19947 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/192127 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/32483 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/98880 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/49406 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/31980 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/32227 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/32131 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->