### PR TITLE
Unmuting doesn't persist across ad rollovers on cbssports.com

### DIFF
--- a/Source/WebCore/dom/Document.h
+++ b/Source/WebCore/dom/Document.h
@@ -1704,6 +1704,8 @@ public:
     void setActiveSpeechRecognition(SpeechRecognition*);
     MediaProducerMediaStateFlags mediaState() const { return m_mediaState; }
     void noteUserInteractionWithMediaElement();
+    bool hasUserInitiatedMediaUnmute() const { return m_hasUserInitiatedMediaUnmute; }
+    void setHasUserInitiatedMediaUnmute() { m_hasUserInitiatedMediaUnmute = true; }
     bool NODELETE isCapturing() const;
     WEBCORE_EXPORT void updateIsPlayingMedia();
 
@@ -2778,6 +2780,7 @@ private:
     bool m_mayHaveRenderedSVGRootElements { false };
 
     bool m_userHasInteractedWithMediaElement { false };
+    bool m_hasUserInitiatedMediaUnmute { false };
 
     bool m_hasEverHadSelectionInsideTextFormControl { false };
 

--- a/Source/WebCore/html/HTMLMediaElement.cpp
+++ b/Source/WebCore/html/HTMLMediaElement.cpp
@@ -4791,8 +4791,17 @@ ExceptionOr<void> HTMLMediaElement::setVolume(double volume)
     }
 
     if (!m_volumeLocked) {
-        if (volume && processingUserGestureForMedia())
+        if (volume && processingUserGestureForMedia()) {
             removeBehaviorRestrictionsAfterFirstUserGesture(MediaElementSession::AllRestrictions & ~MediaElementSession::RequireUserGestureToControlControlsManager);
+
+            if (!m_volume) {
+                if (RefPtr page = document().page())
+                    page->setLastUnmuteAuthorization(protect(document())->securityOrigin().data());
+            }
+        } else if (!volume && m_volume && processingUserGestureForMedia()) {
+            if (RefPtr page = document().page())
+                page->clearLastUnmuteAuthorization();
+        }
 
         m_volume = volume;
         m_volumeInitialized = true;
@@ -4856,6 +4865,14 @@ void HTMLMediaElement::setMutedInternal(bool muted, ForceMuteChange forceChange)
 
             if (hasAudio() && muted)
                 userDidInterfereWithAutoplay();
+
+            if (!muted && m_muted) {
+                if (RefPtr page = document().page())
+                    page->setLastUnmuteAuthorization(protect(document())->securityOrigin().data());
+            } else if (muted && !m_muted) {
+                if (RefPtr page = document().page())
+                    page->clearLastUnmuteAuthorization();
+            }
         }
         Style::PseudoClassChangeInvalidation styleInvalidation(*this, CSSSelector::PseudoClass::Muted, muted);
         m_muted = muted;

--- a/Source/WebCore/html/MediaElementSession.cpp
+++ b/Source/WebCore/html/MediaElementSession.cpp
@@ -483,6 +483,14 @@ Expected<void, MediaPlaybackDenialExplanation> MediaElementSession::playbackStat
         && mainFrameDocument->quirks().needsPerDocumentAutoplayBehavior())
         return { };
 
+    if (mainFrameDocument
+        && mainFrameDocument->quirks().shouldAllowUnmutedAutoplayAfterUserUnmute()) {
+        if (RefPtr page = document->page()) {
+            if (page->hasValidUnmuteAuthorizationForOrigin(document->securityOrigin().data()))
+                return { };
+        }
+    }
+
     if (m_restrictions & RequireUserGestureForVideoRateChange && element->isVideo() && !document->processingUserGestureForMedia())
         return makeUnexpectedDenial(MediaPlaybackDenialReason::UserGestureRequired, "User gesture required for video rate change"_s);
 

--- a/Source/WebCore/page/Page.cpp
+++ b/Source/WebCore/page/Page.cpp
@@ -5946,6 +5946,24 @@ bool Page::requiresUserGestureForVideoPlayback() const
     return m_settings->requiresUserGestureForVideoPlayback();
 }
 
+static constexpr Seconds unmuteAuthorizationTimeout = 30_min;
+
+void Page::setLastUnmuteAuthorization(const SecurityOriginData& origin)
+{
+    m_lastUnmuteAuthorization = UnmuteAuthorization { origin, MonotonicTime::now() };
+}
+
+bool Page::hasValidUnmuteAuthorizationForOrigin(const SecurityOriginData& origin) const
+{
+    if (!m_lastUnmuteAuthorization)
+        return false;
+
+    if (MonotonicTime::now() - m_lastUnmuteAuthorization->timestamp > unmuteAuthorizationTimeout)
+        return false;
+
+    return RegistrableDomain(m_lastUnmuteAuthorization->origin) == RegistrableDomain(origin);
+}
+
 static RefPtr<PlatformMediaSessionManager>& NODELETE mediaSessionManagerSingleton()
 {
     static NeverDestroyed<RefPtr<PlatformMediaSessionManager>> manager;

--- a/Source/WebCore/page/Page.h
+++ b/Source/WebCore/page/Page.h
@@ -1078,6 +1078,10 @@ public:
     bool allowsPlaybackControlsForAutoplayingAudio() const { return m_allowsPlaybackControlsForAutoplayingAudio; }
     void setAllowsPlaybackControlsForAutoplayingAudio(bool allowsPlaybackControlsForAutoplayingAudio) { m_allowsPlaybackControlsForAutoplayingAudio = allowsPlaybackControlsForAutoplayingAudio; }
 
+    void setLastUnmuteAuthorization(const SecurityOriginData&);
+    void clearLastUnmuteAuthorization() { m_lastUnmuteAuthorization = std::nullopt; }
+    bool hasValidUnmuteAuthorizationForOrigin(const SecurityOriginData&) const;
+
     IDBClient::IDBConnectionToServer& idbConnection();
     WEBCORE_EXPORT IDBClient::IDBConnectionToServer* NODELETE optionalIDBConnection();
     WEBCORE_EXPORT void clearIDBConnection();
@@ -1670,6 +1674,12 @@ private:
 
     bool m_allowsMediaDocumentInlinePlayback { false };
     bool m_allowsPlaybackControlsForAutoplayingAudio { false };
+
+    struct UnmuteAuthorization {
+        SecurityOriginData origin;
+        MonotonicTime timestamp;
+    };
+    std::optional<UnmuteAuthorization> m_lastUnmuteAuthorization;
     bool m_showAllPlugins { false };
     bool m_controlledByAutomation { false };
     bool m_resourceCachingDisabledByWebInspector { false };

--- a/Source/WebCore/page/Quirks.cpp
+++ b/Source/WebCore/page/Quirks.cpp
@@ -309,6 +309,14 @@ bool Quirks::shouldAutoplayWebAudioForArbitraryUserGesture() const
     return m_quirksData.quirkIsEnabled(QuirksData::SiteSpecificQuirk::ShouldAutoplayWebAudioForArbitraryUserGestureQuirk);
 }
 
+// cbssports.com rdar://171214502
+bool Quirks::shouldAllowUnmutedAutoplayAfterUserUnmute() const
+{
+    QUIRKS_EARLY_RETURN_IF_DISABLED_WITH_VALUE(false);
+
+    return m_quirksData.quirkIsEnabled(QuirksData::SiteSpecificQuirk::ShouldAllowUnmutedAutoplayAfterUserUnmuteQuirk);
+}
+
 // youtube.com https://bugs.webkit.org/show_bug.cgi?id=195598
 bool Quirks::hasBrokenEncryptedMediaAPISupportQuirk() const
 {
@@ -2670,14 +2678,21 @@ static void handleATTQuirks(QuirksData& quirksData, const URL& /* quirksURL */, 
     quirksData.enableQuirk(QuirksData::SiteSpecificQuirk::ShouldUseLegacySelectPopoverDismissalBehaviorInDataActivationQuirk);
 }
 
+#endif // PLATFORM(IOS_FAMILY)
+
 static void handleCBSSportsQuirks(QuirksData& quirksData, const URL& /* quirksURL */, const String& quirksDomainString, const URL& /* documentURL */)
 {
     QUIRKS_EARLY_RETURN_IF_NOT_DOMAIN("cbssports.com"_s);
 
     quirksData.isCBSSports = true;
+#if PLATFORM(IOS_FAMILY)
     // Remove this once rdar://139478801 is resolved.
     quirksData.enableQuirk(QuirksData::SiteSpecificQuirk::ShouldSynthesizeTouchEventsAfterNonSyntheticClickQuirk);
+#endif
+    quirksData.enableQuirk(QuirksData::SiteSpecificQuirk::ShouldAllowUnmutedAutoplayAfterUserUnmuteQuirk);
 }
+
+#if PLATFORM(IOS_FAMILY)
 
 static void handleCNNQuirks(QuirksData& quirksData, const URL& /* quirksURL */, const String& quirksDomainString, const URL&  /* documentURL */)
 {
@@ -3760,8 +3775,8 @@ void Quirks::determineRelevantQuirks()
         { "bing"_s, &handleBingQuirks },
         { "bungalow"_s, &handleBungalowQuirks },
         { "capitalgroup"_s, &handleCapitalGroupQuirks },
-#if PLATFORM(IOS_FAMILY)
         { "cbssports"_s, &handleCBSSportsQuirks },
+#if PLATFORM(IOS_FAMILY)
         { "cnn"_s, &handleCNNQuirks },
         { "digitaltrends"_s, &handleDigitalTrendsQuirks },
         { "discord"_s, &handleDiscordQuirks },

--- a/Source/WebCore/page/Quirks.h
+++ b/Source/WebCore/page/Quirks.h
@@ -77,6 +77,7 @@ public:
     bool needsPerDocumentAutoplayBehavior() const;
     bool needsExpediaGroupAnimationQuirk(Element&) const;
     bool shouldAutoplayWebAudioForArbitraryUserGesture() const;
+    bool shouldAllowUnmutedAutoplayAfterUserUnmute() const;
     bool hasBrokenEncryptedMediaAPISupportQuirk() const;
 #if ENABLE(TOUCH_EVENTS)
     bool shouldDispatchSimulatedMouseEvents(const EventTarget*) const;

--- a/Source/WebCore/page/QuirksData.h
+++ b/Source/WebCore/page/QuirksData.h
@@ -253,6 +253,7 @@ struct QuirksData {
 #if PLATFORM(IOS_FAMILY)
         NeedsChromeOSNavigatorUserAgentQuirk,
 #endif
+        ShouldAllowUnmutedAutoplayAfterUserUnmuteQuirk,
         ShouldLimitHLSPlaybackRate,
         ShouldDeferIntersectionObserversDuringResize,
 


### PR DESCRIPTION
#### 660af603b964331cfd6c1049d5590f878c8fedc6
<pre>
Unmuting doesn&apos;t persist across ad rollovers on cbssports.com
<a href="https://bugs.webkit.org/show_bug.cgi?id=313790">https://bugs.webkit.org/show_bug.cgi?id=313790</a>
<a href="https://rdar.apple.com/171214502">rdar://171214502</a>

Reviewed by NOBODY (OOPS!).

cbssports.com&apos;s video player caches an autoplay capability probe at page init. When the user
unmutes mid-playback it works, but on ad rollover a newly created &lt;video&gt; element&apos;s unmuted play()
is rejected by WebKit&apos;s autoplay policy, causing the player to fall back to muted.

Add a Page-scoped unmute authorization that records when a user unmutes a media element via
gesture. On cbssports.com, subsequent unmuted play() calls from the same registrable domain are
permitted to bypass the autoplay gate, surviving across navigations within the same tab. The
authorization is cleared when the user explicitly mutes and expires after 30 minutes.

* Source/WebCore/dom/Document.h:
(WebCore::Document::hasUserInitiatedMediaUnmute const):
(WebCore::Document::setHasUserInitiatedMediaUnmute):
* Source/WebCore/html/HTMLMediaElement.cpp:
(WebCore::HTMLMediaElement::setVolume):
(WebCore::HTMLMediaElement::setMutedInternal):
* Source/WebCore/html/MediaElementSession.cpp:
(WebCore::MediaElementSession::playbackStateChangePermitted const):
* Source/WebCore/page/Page.cpp:
(WebCore::Page::setLastUnmuteAuthorization):
(WebCore::Page::hasValidUnmuteAuthorizationForOrigin const):
* Source/WebCore/page/Page.h:
(WebCore::Page::clearLastUnmuteAuthorization):
* Source/WebCore/page/Quirks.cpp:
* Source/WebCore/page/Quirks.h:
* Source/WebCore/page/QuirksData.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/660af603b964331cfd6c1049d5590f878c8fedc6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/159869 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/33337 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/26443 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/168734 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/114250 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/f2cf9b62-41c3-4e54-b30f-cbb6c99ee663) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/161738 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/33441 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/33341 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/123896 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/86903 "9 failures") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/162827 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/26149 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/143595 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/104522 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/9a5daa92-b236-4722-bdf0-8bad041807b1) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/25201 "Passed tests") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/23675 "Found 1 new API test failure: TestWebKitAPI.WKBackForwardList.BackForwardNavigationSkipsItemsWithoutUserGestureFragment (failure)") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/16490 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/134893 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/21366 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/171223 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/17237 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/23004 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/132157 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/33015 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/27755 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/132192 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/33000 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/143160 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/91101 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/26809 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/19974 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/32509 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/98906 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/32006 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/32253 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/32157 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->