### PR TITLE
[libpas] Use static TLS destructor instead of FLS

### DIFF
--- a/Source/bmalloc/libpas/src/libpas/pas_fast_tls.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_fast_tls.h
@@ -33,7 +33,36 @@ PAS_BEGIN_EXTERN_C;
 struct pas_fast_tls;
 typedef struct pas_fast_tls pas_fast_tls;
 
-#if PAS_HAVE_PTHREAD_MACHDEP_H
+#if PAS_OS(WINDOWS)
+
+/* Windows uses __declspec(thread) for both GET and SET. Per-thread teardown is
+   registered once at link time via a static TLS callback in the .CRT$XLB
+   segment (see pas_thread_local_cache.c), so there is no runtime destructor
+   registration and no per-TLS state to track. */
+
+#define PAS_HAVE_THREAD_KEYWORD 1
+#define PAS_HAVE_PTHREAD_TLS 0
+
+struct pas_fast_tls {
+    char unused;
+};
+
+#define PAS_FAST_TLS_INITIALIZER { 0 }
+
+#define PAS_FAST_TLS_CONSTRUCT_IF_NECESSARY(static_key, passed_fast_tls, passed_destructor) do { \
+        PAS_UNUSED_PARAM(passed_fast_tls); \
+        PAS_UNUSED_PARAM(passed_destructor); \
+        pas_heap_lock_assert_held(); \
+    } while (false)
+
+#define PAS_FAST_TLS_GET(static_key, fast_tls) static_key
+
+#define PAS_FAST_TLS_SET(static_key, passed_fast_tls, passed_value) do { \
+        PAS_UNUSED_PARAM(passed_fast_tls); \
+        static_key = (passed_value); \
+    } while (false)
+
+#elif PAS_HAVE_PTHREAD_MACHDEP_H
 
 #define PAS_HAVE_THREAD_KEYWORD 0
 #define PAS_HAVE_PTHREAD_TLS 0

--- a/Source/bmalloc/libpas/src/libpas/pas_thread.c
+++ b/Source/bmalloc/libpas/src/libpas/pas_thread.c
@@ -125,38 +125,6 @@ int pthread_once(pthread_once_t* once_control, void (*init_routine)(void))
     return 0;
 }
 
-/* Thread Local Storage
-   The regular Windows Thread Local Storage APIs like TlsAlloc don't have a way an easy way
-   to register a per-thread destructor to be able to clean up the memory.
-   Blink gets around this with some crazy pragmas to manually insert a function to be called
-   on each thread's exit:
-   https://web.archive.org/web/20070921204540/https://www.codeproject.com/threads/tls.asp
-   https://source.chromium.org/chromium/chromium/src/+/main:base/threading/thread_local_storage_win.cc;l=38-48
-  
-   However the fiber-local storage APIs do let you register a per-thread destructor. Even
-   though we don't care about fibers, the API is strictly better and avoids the magic:
-   https://devblogs.microsoft.com/oldnewthing/20191011-00/?p=102989
-  
-   TODO: FlsGetValue is around 2x slower than TlsGetValue on single threaded access, so we should
-   switch to Thread Local Storage and deal with the extra complexity. */
-int pthread_key_create(pthread_key_t* key, void (*destructor)(void*))
-{
-    DWORD result = FlsAlloc(destructor);
-    PAS_ASSERT(result != FLS_OUT_OF_INDEXES);
-    *key = result;
-    return 0;
-}
-
-void *pthread_getspecific(pthread_key_t key)
-{
-    return FlsGetValue(key);
-}
-
-int pthread_setspecific(pthread_key_t key, void* value)
-{
-    return FlsSetValue(key, value);
-}
-
 /* Mutexes, conditions */
 
 int pthread_mutex_init(pthread_mutex_t* mutex, const void* unused_attr)

--- a/Source/bmalloc/libpas/src/libpas/pas_thread.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_thread.h
@@ -56,15 +56,6 @@ int sched_yield();
 #define PTHREAD_ONCE_INIT INIT_ONCE_STATIC_INIT
 int pthread_once(pthread_once_t *once_control, void (*init_routine)(void));
 
-/* Thread Local Storage */
-
-#define pthread_key_t uintptr_t
-
-int pthread_key_create(pthread_key_t *key, void (*destructor)(void*));
-
-void *pthread_getspecific(pthread_key_t key);
-int pthread_setspecific(pthread_key_t key, void *value);
-
 /* Mutexes, conditions */
 
 typedef SRWLOCK pthread_mutex_t;

--- a/Source/bmalloc/libpas/src/libpas/pas_thread_local_cache.c
+++ b/Source/bmalloc/libpas/src/libpas/pas_thread_local_cache.c
@@ -44,7 +44,9 @@
 #include "pas_thread_local_cache_node.h"
 #include "pas_thread_suspend_lock.h"
 #include "pas_zero_memory.h"
-#if !PAS_OS(WINDOWS)
+#if PAS_OS(WINDOWS)
+#include <windows.h>
+#else
 #include <unistd.h>
 #endif
 #if PAS_OS(DARWIN)
@@ -175,6 +177,51 @@ static void destructor(void* arg)
             pas_log("[%d] Repeated destructor call for TLS %p\n", getpid(), thread_local_cache);
     }
 }
+
+#if PAS_OS(WINDOWS)
+
+/* Windows teardown of the thread-local cache runs from a static TLS callback
+   registered in the .CRT$XLB segment. Unlike FLS destructors, this fires
+   deterministically during DLL_THREAD_DETACH on the exiting thread.
+   Force the linker to emit the PE TLS directory (via _tls_used) and retain our
+   callback pointer through /OPT:REF. The leading-underscore decoration differs
+   between x86 and x64. */
+
+#ifdef _WIN64
+#pragma comment(linker, "/INCLUDE:_tls_used")
+#pragma comment(linker, "/INCLUDE:pas_tls_callback_func")
+#else
+#pragma comment(linker, "/INCLUDE:__tls_used")
+#pragma comment(linker, "/INCLUDE:_pas_tls_callback_func")
+#endif
+
+static void NTAPI pas_tls_on_thread_exit(PVOID handle, DWORD reason, PVOID reserved)
+{
+    PAS_UNUSED_PARAM(handle);
+    PAS_UNUSED_PARAM(reserved);
+
+    if (reason != DLL_THREAD_DETACH && reason != DLL_PROCESS_DETACH)
+        return;
+
+    void* value = pas_thread_local_cache_pointer;
+    if (!value)
+        return;
+
+    destructor(value);
+}
+
+#ifdef _WIN64
+#pragma const_seg(push, ".CRT$XLB")
+extern const PIMAGE_TLS_CALLBACK pas_tls_callback_func;
+const PIMAGE_TLS_CALLBACK pas_tls_callback_func = pas_tls_on_thread_exit;
+#pragma const_seg(pop)
+#else
+#pragma data_seg(push, ".CRT$XLB")
+PIMAGE_TLS_CALLBACK pas_tls_callback_func = pas_tls_on_thread_exit;
+#pragma data_seg(pop)
+#endif
+
+#endif /* PAS_OS(WINDOWS) */
 
 static pas_thread_local_cache* allocate_cache(unsigned allocator_index_capacity)
 {


### PR DESCRIPTION
#### 5fa71ca77d1f1fc64bbae8abceee10d67f441b40
<pre>
[libpas] Use static TLS destructor instead of FLS
<a href="https://bugs.webkit.org/show_bug.cgi?id=313793">https://bugs.webkit.org/show_bug.cgi?id=313793</a>
<a href="https://rdar.apple.com/175988080">rdar://175988080</a>

Reviewed by Marcus Plutowski and Mark Lam.

Making libpas Windows TLS mechanism simpler by using static TLS destructor,
which is well-known old technique. We register a function via segment
annotation. This function will be called when thread dies. And we just
read TLS pointer, mark it as destroying, and destroying it when it is
not nullptr and it is not a marker. This removes stub of
pthread_key_create etc. completely. Also destructor will be called
automatically when libpas is loaded, while we do not need to register it
explicitly at runtime.

* Source/bmalloc/libpas/src/libpas/pas_fast_tls.h:
* Source/bmalloc/libpas/src/libpas/pas_thread.c:
(pthread_key_create): Deleted.
(pthread_getspecific): Deleted.
(pthread_setspecific): Deleted.
* Source/bmalloc/libpas/src/libpas/pas_thread.h:
* Source/bmalloc/libpas/src/libpas/pas_thread_local_cache.c:
(pas_tls_on_thread_exit):

Canonical link: <a href="https://commits.webkit.org/312466@main">https://commits.webkit.org/312466@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/da52902e0b2af6c8ba86b7da7ad41829c3133bd7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/159897 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/33365 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/26471 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/168765 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/114278 "Built successfully") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/33469 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/33369 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/123918 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/86915 "9 failures") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/162855 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/26179 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/143622 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/104541 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/25231 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/23700 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/16518 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/151953 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/134923 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/21392 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/171253 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/20734 "Built successfully and passed tests") | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/23030 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/132184 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/33043 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/27783 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/132214 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/33028 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/143187 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/91143 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/24355 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/26837 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/20000 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/192181 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/32537 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/49416 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/32034 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/32281 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/32185 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->