### PR TITLE
[Mac][CMake] Build WebInspectorUI.fw on macOS so inspector works in CMade MiniBrowser

### DIFF
--- a/Source/WebInspectorUI/PlatformMac.cmake
+++ b/Source/WebInspectorUI/PlatformMac.cmake
@@ -1,0 +1,55 @@
+# NSBundle expects .lproj directories directly under Resources, not nested in Localizations.
+set(WebInspectorUI_LOCALIZED_STRINGS_DIR "${WebInspectorUI_RESOURCES_DIR}/WebInspectorUI/en.lproj")
+
+set(WebInspectorUI_FRAMEWORK_DIR "${CMAKE_BINARY_DIR}/WebInspectorUI.framework")
+set(WebInspectorUI_FRAMEWORK_RESOURCES_DIR "${WebInspectorUI_FRAMEWORK_DIR}/Versions/A/Resources")
+
+set(EXECUTABLE_NAME "WebInspectorUI")
+set(PRODUCT_BUNDLE_IDENTIFIER "com.apple.WebInspectorUI")
+set(PRODUCT_NAME "WebInspectorUI")
+set(SHORT_VERSION_STRING "1.0")
+set(BUNDLE_VERSION "1")
+
+configure_file(
+    ${WEBINSPECTORUI_DIR}/Info.plist
+    ${CMAKE_CURRENT_BINARY_DIR}/Info.plist
+)
+
+add_library(WebInspectorUIFramework SHARED ${WEBINSPECTORUI_DIR}/WebInspectorUI.cpp)
+set_target_properties(WebInspectorUIFramework PROPERTIES
+    OUTPUT_NAME WebInspectorUI
+    PREFIX ""
+    SUFFIX ""
+    LIBRARY_OUTPUT_DIRECTORY "${WebInspectorUI_FRAMEWORK_DIR}/Versions/A"
+    INSTALL_NAME_DIR "/System/Library/PrivateFrameworks/WebInspectorUI.framework/Versions/A"
+    BUILD_WITH_INSTALL_RPATH ON
+    MACOSX_RPATH OFF
+)
+
+add_custom_command(TARGET WebInspectorUIFramework POST_BUILD
+    COMMENT "Assembling WebInspectorUI.framework"
+    COMMAND ${CMAKE_COMMAND} -E make_directory ${WebInspectorUI_FRAMEWORK_RESOURCES_DIR}
+    COMMAND ${CMAKE_COMMAND} -E copy
+        ${CMAKE_CURRENT_BINARY_DIR}/Info.plist
+        ${WebInspectorUI_FRAMEWORK_RESOURCES_DIR}/Info.plist
+    COMMAND ${CMAKE_COMMAND} -E create_symlink A ${WebInspectorUI_FRAMEWORK_DIR}/Versions/Current
+    COMMAND ${CMAKE_COMMAND} -E create_symlink Versions/Current/WebInspectorUI ${WebInspectorUI_FRAMEWORK_DIR}/WebInspectorUI
+    COMMAND ${CMAKE_COMMAND} -E create_symlink Versions/Current/Resources ${WebInspectorUI_FRAMEWORK_DIR}/Resources
+    VERBATIM
+)
+
+add_custom_command(
+    OUTPUT ${CMAKE_BINARY_DIR}/inspector-framework-resources.stamp
+    DEPENDS ${CMAKE_BINARY_DIR}/inspector-resources.stamp WebInspectorUIFramework
+    COMMENT "Copying inspector resources into WebInspectorUI.framework"
+    COMMAND ${CMAKE_COMMAND} -E copy_directory
+        ${WebInspectorUI_RESOURCES_DIR}/WebInspectorUI
+        ${WebInspectorUI_FRAMEWORK_RESOURCES_DIR}
+    COMMAND ${CMAKE_COMMAND} -E touch ${CMAKE_BINARY_DIR}/inspector-framework-resources.stamp
+    VERBATIM
+)
+
+add_custom_target(WebInspectorUIFrameworkResources ALL
+    DEPENDS ${CMAKE_BINARY_DIR}/inspector-framework-resources.stamp
+)
+add_dependencies(WebInspectorUIFrameworkResources WebInspectorUI)

--- a/Source/WebInspectorUI/WebInspectorUI.cpp
+++ b/Source/WebInspectorUI/WebInspectorUI.cpp
@@ -1,0 +1,28 @@
+/*
+ * Copyright (C) 2013 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "WebInspectorUI.h" // NOLINT(build/include_order) -- no config.h in this framework.
+
+void WebInspectorUIFrameworkLoad(void) { }

--- a/Source/WebInspectorUI/WebInspectorUI.h
+++ b/Source/WebInspectorUI/WebInspectorUI.h
@@ -23,4 +23,7 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-// Intentionally empty. This file is needed to create a linkable framework binary.
+#pragma once
+
+// Prevents -dead_strip_dylibs from pruning the framework's load command.
+extern "C" __attribute__((visibility("default"))) void WebInspectorUIFrameworkLoad(void);

--- a/Source/WebInspectorUI/WebInspectorUI.xcodeproj/project.pbxproj
+++ b/Source/WebInspectorUI/WebInspectorUI.xcodeproj/project.pbxproj
@@ -8,7 +8,8 @@
 
 /* Begin PBXBuildFile section */
 		1C60FF1614E6E3F7006CD77D /* localizedStrings.js in Resources */ = {isa = PBXBuildFile; fileRef = 1C60FF1314E6E35D006CD77D /* localizedStrings.js */; };
-		1C78EE1717611340002F6AA5 /* WebInspectorUI.c in Sources */ = {isa = PBXBuildFile; fileRef = 1C78EE1617611340002F6AA5 /* WebInspectorUI.c */; };
+		1C78EE1717611340002F6AA5 /* WebInspectorUI.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 1C78EE1617611340002F6AA5 /* WebInspectorUI.cpp */; };
+		BF0A00032E18A0A10063278B /* WebInspectorUI.h in Headers */ = {isa = PBXBuildFile; fileRef = BF0A00042E18A0A10063278B /* WebInspectorUI.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		DDE9931A278D0D8000F60D26 /* libWebKitAdditions.a in Product Dependencies */ = {isa = PBXBuildFile; fileRef = DDE992FB278D078100F60D26 /* libWebKitAdditions.a */; };
 		DDE9931D278D0DA400F60D26 /* JavaScriptCore.framework in Product Dependencies */ = {isa = PBXBuildFile; fileRef = DDE9931C278D0D9900F60D26 /* JavaScriptCore.framework */; };
 /* End PBXBuildFile section */
@@ -38,7 +39,8 @@
 		1C60FF1A14E73DCA006CD77D /* remove-console-asserts.pl */ = {isa = PBXFileReference; lastKnownFileType = text.script.perl; path = "remove-console-asserts.pl"; sourceTree = "<group>"; };
 		1C60FFE114E79B0F006CD77D /* copy-user-interface-resources.pl */ = {isa = PBXFileReference; lastKnownFileType = text.script.perl; path = "copy-user-interface-resources.pl"; sourceTree = "<group>"; };
 		1C78EE131760E115002F6AA5 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-		1C78EE1617611340002F6AA5 /* WebInspectorUI.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = WebInspectorUI.c; sourceTree = "<group>"; };
+		1C78EE1617611340002F6AA5 /* WebInspectorUI.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = WebInspectorUI.cpp; sourceTree = "<group>"; };
+		BF0A00042E18A0A10063278B /* WebInspectorUI.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WebInspectorUI.h; sourceTree = "<group>"; };
 		A54C2257148B23DF00373FA3 /* WebInspectorUI.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = WebInspectorUI.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		DDE992FB278D078100F60D26 /* libWebKitAdditions.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; path = libWebKitAdditions.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		DDE9931C278D0D9900F60D26 /* JavaScriptCore.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = JavaScriptCore.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -84,7 +86,8 @@
 				1C60FF1514E6E39B006CD77D /* Resources */,
 				1C60FFE014E79B0F006CD77D /* Scripts */,
 				1C60FF1014E6D992006CD77D /* UserInterface */,
-				1C78EE1617611340002F6AA5 /* WebInspectorUI.c */,
+				1C78EE1617611340002F6AA5 /* WebInspectorUI.cpp */,
+				BF0A00042E18A0A10063278B /* WebInspectorUI.h */,
 			);
 			sourceTree = "<group>";
 		};
@@ -112,6 +115,7 @@
 			buildConfigurationList = A54C226C148B23DF00373FA3 /* Build configuration list for PBXNativeTarget "WebInspectorUI" */;
 			buildPhases = (
 				DDE992FA278D076300F60D26 /* Product Dependencies */,
+				BF0A00052E18A0A10063278C /* Headers */,
 				A54C2255148B23DF00373FA3 /* Resources */,
 				1C60FF1214E6D9AF006CD77D /* Copy User Interface Resources */,
 				1C78EE1417611302002F6AA5 /* Sources */,
@@ -153,6 +157,17 @@
 			);
 		};
 /* End PBXProject section */
+
+/* Begin PBXHeadersBuildPhase section */
+		BF0A00052E18A0A10063278C /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				BF0A00032E18A0A10063278B /* WebInspectorUI.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXHeadersBuildPhase section */
 
 /* Begin PBXResourcesBuildPhase section */
 		A54C2255148B23DF00373FA3 /* Resources */ = {
@@ -209,7 +224,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				1C78EE1717611340002F6AA5 /* WebInspectorUI.c in Sources */,
+				1C78EE1717611340002F6AA5 /* WebInspectorUI.cpp in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Source/WebKit/PlatformMac.cmake
+++ b/Source/WebKit/PlatformMac.cmake
@@ -621,7 +621,9 @@ set(ObjCForwardingHeaders
 )
 
 set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -compatibility_version 1 -current_version ${WEBKIT_MAC_VERSION}")
-target_link_options(WebKit PRIVATE -lsandbox -framework AuthKit)
+# -Wl,-u forces a symbol reference so -dead_strip_dylibs won't prune the weak framework.
+target_link_options(WebKit PRIVATE -lsandbox -framework AuthKit -F${CMAKE_BINARY_DIR} -weak_framework WebInspectorUI -Wl,-u,_WebInspectorUIFrameworkLoad)
+add_dependencies(WebKit WebInspectorUIFramework)
 
 # Match WebKit.xcconfig REEXPORTED_FRAMEWORK_NAMES / REEXPORTED_LIBRARY_NAMES so
 # the CMake-built framework exports the same ABI as the Xcode build. Without the


### PR DESCRIPTION
#### 62e2ae37bc7e35296509afb798d2878b19a2987a
<pre>
[Mac][CMake] Build WebInspectorUI.fw on macOS so inspector works in CMade MiniBrowser
<a href="https://bugs.webkit.org/show_bug.cgi?id=313833">https://bugs.webkit.org/show_bug.cgi?id=313833</a>

Reviewed by BJ Burg.

The CMake Mac build originally produced the inspector resource files but
never assembled them into a WebInspectorUI.framework bundle. At runtime,
WKInspectorResourceURLSchemeHandler looked up the bundle by identifier
(com.apple.WebInspectorUI), which only found bundles already loaded by
dyld. In the Xcode build, -weak_framework WebInspectorUI let dyld
load it, but in the CMake build, nothing did, so the lookup returned nil
and hit RELEASE_ASSERT. Opening Web Inspector in a CMake-built
MiniBrowser resulted in a crash.

With this change, a CMake-built MiniBrowser can open Web Inspector out
of the box. Example:
    cmake --preset mac-dev-release
    cmake --build --preset mac-dev-release
    DYLD_FRAMEWORK_PATH=WebKitBuild/cmake-mac/Release \
        WebKitBuild/cmake-mac/Release/MiniBrowser.app/Contents/MacOS/MiniBrowser

Layout tests also work with the CMake build via --root:
    run-webkit-tests --release --root WebKitBuild/cmake-mac/Release \
        inspector/console/console-message.html

No new tests; build system change only.

* Source/WebInspectorUI/PlatformMac.cmake:
Build a WebInspectorUI.framework with a stub dylib and the standard
Versions/A symlink structure, then copy inspector resources into it.

* Source/WebInspectorUI/WebInspectorUI.cpp: Copied from Source/WebInspectorUI/WebInspectorUI.c.
(WebInspectorUIFrameworkLoad):
* Source/WebInspectorUI/WebInspectorUI.h: Copied from Source/WebInspectorUI/WebInspectorUI.c.
* Source/WebInspectorUI/WebInspectorUI.xcodeproj/project.pbxproj:
* Source/WebKit/PlatformMac.cmake:
- Because the CMake build passes -dead_strip_dylibs globally
  (OptionsMac.cmake), the linker would prune the unused weak dependency.
  Export a dummy symbol to let WebKit reference it via -Wl,-u to keep
  the load command alive.
- Rename WebInspectorUI.c to .cpp so TAPI&apos;s C++ header scan and the
  source agree on symbol linkage.

Canonical link: <a href="https://commits.webkit.org/313182@main">https://commits.webkit.org/313182@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/443f1405cbfc232d62a8b65cf50366d5a84e19ee

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/162163 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/35639 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/28768 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/171071 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/118536 "Built successfully") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/35743 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/35640 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/125852 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/88713 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/165122 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/28186 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/145802 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/106430 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/27233 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/25743 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/18792 "Built successfully") | | 
| [⏳ 🛠 🧪 jsc ](https://ews-build.webkit.org/#/builders/JSC-Tests-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/136934 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/23420 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/173565 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/20918 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/25063 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/134150 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/35313 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/29831 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/134151 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/35296 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/145216 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/97499 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/24659 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/28683 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/22044 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/34806 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/102558 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/34307 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/34552 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/34455 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->