### PR TITLE
[Site Isolation] http/tests/storage/storage-map-leaking.html

### DIFF
--- a/LayoutTests/http/tests/storage/resources/storage-map-leaking-window.html
+++ b/LayoutTests/http/tests/storage/resources/storage-map-leaking-window.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html>
+<body>
+<iframe src="http://localhost:8080/storage/resources/storage-map-leaking-iframe.html"></iframe>
+<iframe src="https://localhost:8443/storage/resources/storage-map-leaking-iframe.html"></iframe>
+<iframe src="http://127.0.0.1:8000/storage/resources/storage-map-leaking-iframe.html"></iframe>
+<iframe src="https://127.0.0.1:8443/storage/resources/storage-map-leaking-iframe.html"></iframe>
+<script>
+window.onload = function() {
+    opener.postMessage("loaded", "*");
+};
+</script>
+</body>
+</html>

--- a/LayoutTests/http/tests/storage/storage-map-leaking.html
+++ b/LayoutTests/http/tests/storage/storage-map-leaking.html
@@ -8,30 +8,44 @@ jsTestIsAsync = true;
 localStorage.setItem("foo", "bar");
 
 onload = function() {
-    initialStorageAreaMapCount = internals.storageAreaMapCount;
+    let attemptsRemaining = 5;
 
-    // We use 4 frames, one per origin that we support in layout tests so that we get 4 StorageAreaMap objects
-    // and 4 Storage JS wrappers. Because our GC is conservative, we consider that this test is passing if
-    // any of the Storage JS wrappers gets collected and thus any of the underlying StorageAreaMap objects
-    // get destroyed.
-    document.getElementById("testFrame1").remove();
-    document.getElementById("testFrame2").remove();
-    document.getElementById("testFrame3").remove();
-    document.getElementById("testFrame4").remove();
+    function attempt() {
+        let countBeforeOpen = testRunner.storageAreaMapCount;
+        let newWindow = window.open("resources/storage-map-leaking-window.html");
+        window.addEventListener("message", function handler(event) {
+            if (event.data !== "loaded")
+                return;
+            window.removeEventListener("message", handler);
+            newWindow.close();
+            newWindow = null;
 
-    handle = setInterval(() => {
-        gc()
-        if (internals.storageAreaMapCount < initialStorageAreaMapCount) {
-            testPassed("StorageAreaMap objects are not leaking");
-            clearInterval(handle);
-            finishJSTest();
-        }
-    }, 10);
+            let checksRemaining = 50;
+            handle = setInterval(() => {
+                if (window.GCController)
+                    GCController.collect();
+                let currentCount = testRunner.storageAreaMapCount;
+                if (currentCount <= countBeforeOpen) {
+                    testPassed("StorageAreaMap objects are not leaking");
+                    clearInterval(handle);
+                    finishJSTest();
+                    return;
+                }
+                if (--checksRemaining <= 0) {
+                    clearInterval(handle);
+                    if (--attemptsRemaining > 0)
+                        attempt();
+                    else {
+                        testFailed("StorageAreaMap objects are leaking (count=" + currentCount + ")");
+                        finishJSTest();
+                    }
+                }
+            }, 10);
+        });
+    }
+
+    attempt();
 }
 </script>
-<iframe id="testFrame1" src="http://localhost:8000/storage/resources/storage-map-leaking-iframe.html"></iframe>
-<iframe id="testFrame2" src="https://localhost:8443/storage/resources/storage-map-leaking-iframe.html"></iframe>
-<iframe id="testFrame3" src="http://127.0.0.1:8443/storage/resources/storage-map-leaking-iframe.html"></iframe>
-<iframe id="testFrame4" src="https://127.0.0.1:8443/storage/resources/storage-map-leaking-iframe.html"></iframe>
 </body>
 </html>

--- a/Source/WebCore/storage/StorageNamespaceProvider.cpp
+++ b/Source/WebCore/storage/StorageNamespaceProvider.cpp
@@ -96,4 +96,9 @@ void StorageNamespaceProvider::setSessionIDForTesting(PAL::SessionID newSessionI
     }
 }
 
+uint64_t StorageNamespaceProvider::localStorageAreaMapCountForTesting() const
+{
+    return m_localStorageNamespace ? m_localStorageNamespace->storageAreaMapCountForTesting() : 0;
+}
+
 }

--- a/Source/WebCore/storage/StorageNamespaceProvider.h
+++ b/Source/WebCore/storage/StorageNamespaceProvider.h
@@ -53,6 +53,7 @@ public:
     virtual RefPtr<StorageNamespace> sessionStorageNamespace(const SecurityOrigin&, Page&, ShouldCreateNamespace = ShouldCreateNamespace::Yes) = 0;
 
     WEBCORE_EXPORT void setSessionIDForTesting(PAL::SessionID);
+    WEBCORE_EXPORT uint64_t localStorageAreaMapCountForTesting() const;
 
     void setSessionStorageQuota(unsigned quota) { m_sessionStorageQuota = quota; }
     virtual void cloneSessionStorageNamespaceForPage(Page&, Page&) { RELEASE_ASSERT_NOT_REACHED(); }

--- a/Source/WebKit/UIProcess/API/C/WKPage.cpp
+++ b/Source/WebKit/UIProcess/API/C/WKPage.cpp
@@ -3461,6 +3461,17 @@ bool WKPageIsEditingCommandEnabledForTesting(WKPageRef pageRef, WKStringRef comm
     return pageForTesting->isEditingCommandEnabled(protect(toImpl(command))->string());
 }
 
+void WKPageGetStorageAreaMapCountForTesting(WKPageRef pageRef, void* context, WKPageGetStorageAreaMapCountForTestingFunction callback)
+{
+    RefPtr pageForTesting = toImpl(pageRef)->pageForTesting();
+    if (!pageForTesting)
+        return callback(0, context);
+
+    pageForTesting->storageAreaMapCount([context, callback](uint64_t count) {
+        callback(count, context);
+    });
+}
+
 void WKPageSetPermissionLevelForTesting(WKPageRef pageRef, WKStringRef origin, bool allowed)
 {
     if (RefPtr pageForTesting = toImpl(pageRef)->pageForTesting())

--- a/Source/WebKit/UIProcess/API/C/WKPagePrivate.h
+++ b/Source/WebKit/UIProcess/API/C/WKPagePrivate.h
@@ -220,6 +220,8 @@ WK_EXPORT void WKPagePermissionChanged(WKStringRef permissionName, WKStringRef o
 
 WK_EXPORT void WKPageExecuteCommandForTesting(WKPageRef pageRef, WKStringRef command, WKStringRef value);
 WK_EXPORT bool WKPageIsEditingCommandEnabledForTesting(WKPageRef page, WKStringRef command);
+typedef void (*WKPageGetStorageAreaMapCountForTestingFunction)(uint64_t count, void* functionContext);
+WK_EXPORT void WKPageGetStorageAreaMapCountForTesting(WKPageRef page, void* context, WKPageGetStorageAreaMapCountForTestingFunction callback);
 WK_EXPORT void WKPageSetPermissionLevelForTesting(WKPageRef page, WKStringRef origin, bool allowed);
 WK_EXPORT void WKPageResetStateBetweenTests(WKPageRef pageRef);
 

--- a/Source/WebKit/UIProcess/WebPageProxyTesting.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxyTesting.cpp
@@ -28,13 +28,13 @@
 
 #include "Connection.h"
 #include "MessageSenderInlines.h"
-#include "NetworkProcessMessages.h"
-#include "NetworkProcessProxy.h"
 #include "WebBackForwardList.h"
 #include "WebFrameProxy.h"
 #include "WebPageMessages.h"
 #include "WebPageProxy.h"
 #include "WebPageTestingMessages.h"
+#include "WebProcessMessages.h"
+#include "WebProcessPool.h"
 #include "WebProcessProxy.h"
 #include <WebCore/IntPoint.h>
 #include <wtf/CallbackAggregator.h>
@@ -256,6 +256,26 @@ void WebPageProxyTesting::displayAndTrackRepaints(CompletionHandler<void()>&& co
     protect(page())->forEachWebContentProcess([&](auto& webProcess, auto pageID) {
         webProcess.sendWithAsyncReply(Messages::WebPageTesting::DisplayAndTrackRepaints(), [callbackAggregator] { }, pageID);
     });
+}
+
+void WebPageProxyTesting::storageAreaMapCount(CompletionHandler<void(uint64_t)>&& completionHandler)
+{
+    Ref processPool = page().legacyMainFrameProcess().processPool();
+
+    struct TotalCount : RefCounted<TotalCount> {
+        uint64_t value { 0 };
+    };
+    Ref totalCount = adoptRef(*new TotalCount);
+    Ref callbackAggregator = CallbackAggregator::create([totalCount, completionHandler = WTF::move(completionHandler)]() mutable {
+        completionHandler(totalCount->value);
+    });
+    for (auto& process : processPool->processes()) {
+        if (!process->pageCount())
+            continue;
+        process->sendWithAsyncReply(Messages::WebProcess::GetStorageAreaMapCountForTesting(), [totalCount, callbackAggregator](uint64_t count) {
+            totalCount->value += count;
+        });
+    }
 }
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/WebPageProxyTesting.h
+++ b/Source/WebKit/UIProcess/WebPageProxyTesting.h
@@ -85,6 +85,8 @@ public:
     void setTracksRepaints(bool, CompletionHandler<void()>&&);
     void displayAndTrackRepaints(CompletionHandler<void()>&&);
 
+    void storageAreaMapCount(CompletionHandler<void(uint64_t)>&&);
+
 private:
     explicit WebPageProxyTesting(WebPageProxy&);
 

--- a/Source/WebKit/WebProcess/WebProcess.cpp
+++ b/Source/WebKit/WebProcess/WebProcess.cpp
@@ -90,6 +90,7 @@
 #include "WebSharedWorkerContextManagerConnection.h"
 #include "WebSharedWorkerContextManagerConnectionMessages.h"
 #include "WebSharedWorkerProvider.h"
+#include "WebStorageNamespaceProvider.h"
 #include "WebTransportSession.h"
 #include "WebUserContentController.h"
 #include "WebsiteData.h"
@@ -145,6 +146,7 @@
 #include <WebCore/Settings.h>
 #include <WebCore/SharedWorkerContextManager.h>
 #include <WebCore/SharedWorkerThreadProxy.h>
+#include <WebCore/StorageNamespaceProvider.h>
 #include <WebCore/UserGestureIndicator.h>
 #include <WebCore/WebKitJSHandle.h>
 #include <WebCore/WorkerGlobalScope.h>
@@ -1227,6 +1229,12 @@ void WebProcess::isEnhancedSecurityEnabled(CompletionHandler<void(bool)>&& compl
 void WebProcess::garbageCollectJavaScriptObjects()
 {
     GarbageCollectionController::singleton().garbageCollectNow();
+}
+
+void WebProcess::getStorageAreaMapCountForTesting(CompletionHandler<void(uint64_t)>&& completionHandler)
+{
+    GarbageCollectionController::singleton().garbageCollectNow();
+    completionHandler(WebStorageNamespaceProvider::getOrCreate()->localStorageAreaMapCountForTesting());
 }
 
 void WebProcess::backgroundResponsivenessPing()

--- a/Source/WebKit/WebProcess/WebProcess.h
+++ b/Source/WebKit/WebProcess/WebProcess.h
@@ -628,6 +628,7 @@ private:
     void stopMemorySampler();
     
     void garbageCollectJavaScriptObjects();
+    void getStorageAreaMapCountForTesting(CompletionHandler<void(uint64_t)>&&);
     void setJavaScriptGarbageCollectorTimerEnabled(bool flag);
 
     void backgroundResponsivenessPing();

--- a/Source/WebKit/WebProcess/WebProcess.messages.in
+++ b/Source/WebKit/WebProcess/WebProcess.messages.in
@@ -82,6 +82,7 @@ messages -> WebProcess : AuxiliaryProcess WantsAsyncDispatchMessage {
     BindAccessibilityFrameWithData(WebCore::FrameIdentifier frameID, std::span<const uint8_t> data);
 
     GarbageCollectJavaScriptObjects()
+    GetStorageAreaMapCountForTesting() -> (uint64_t storageAreaMapCount)
     SetJavaScriptGarbageCollectorTimerEnabled(bool enable)
 
     SetInjectedBundleParameter(String parameter, std::span<const uint8_t> value);

--- a/Tools/WebKitTestRunner/InjectedBundle/Bindings/TestRunner.idl
+++ b/Tools/WebKitTestRunner/InjectedBundle/Bindings/TestRunner.idl
@@ -131,6 +131,7 @@ interface TestRunner {
     undefined setDatabaseQuota(unsigned long long quota);
     DOMString pathToLocalResource(DOMString url);
     undefined syncLocalStorage();
+    readonly attribute unsigned long storageAreaMapCount;
 
     attribute double databaseDefaultQuota;
     attribute double databaseMaxQuota;

--- a/Tools/WebKitTestRunner/InjectedBundle/TestRunner.cpp
+++ b/Tools/WebKitTestRunner/InjectedBundle/TestRunner.cpp
@@ -345,6 +345,11 @@ void TestRunner::syncLocalStorage()
     postSynchronousMessage("SyncLocalStorage", true);
 }
 
+unsigned TestRunner::storageAreaMapCount()
+{
+    return postSynchronousPageMessageReturningUInt64("GetStorageAreaMapCount", WKRetainPtr<WKTypeRef> { });
+}
+
 bool TestRunner::isCommandEnabled(JSStringRef name)
 {
     return postSynchronousPageMessageReturningBoolean("IsCommandEnabled", toWK(name));

--- a/Tools/WebKitTestRunner/InjectedBundle/TestRunner.h
+++ b/Tools/WebKitTestRunner/InjectedBundle/TestRunner.h
@@ -196,6 +196,7 @@ public:
     void setDatabaseQuota(uint64_t);
     JSRetainPtr<JSStringRef> pathToLocalResource(JSStringRef);
     void syncLocalStorage();
+    unsigned storageAreaMapCount();
 
     void clearStorage();
 

--- a/Tools/WebKitTestRunner/TestController.cpp
+++ b/Tools/WebKitTestRunner/TestController.cpp
@@ -3496,6 +3496,17 @@ void TestController::didReceiveSynchronousMessageFromInjectedBundle(WKStringRef 
     }
 #endif
 
+    if (WKStringIsEqualToUTF8CString(messageName, "GetStorageAreaMapCount")) {
+        CompletionHandler<void(WKTypeRef)> replyHandler = [listener = retainWK(listener)](WKTypeRef reply) {
+            WKMessageListenerSendReply(listener.get(), reply);
+        };
+        WKPageGetStorageAreaMapCountForTesting(TestController::singleton().mainWebView()->page(), replyHandler.leak(), [](uint64_t count, void* context) {
+            auto replyHandler = WTF::adopt(static_cast<CompletionHandler<void(WKTypeRef)>::Impl*>(context));
+            replyHandler(adoptWK(WKUInt64Create(count)).get());
+        });
+        return;
+    }
+
     completionHandler(protectedCurrentInvocation()->didReceiveSynchronousMessageFromInjectedBundle(messageName, messageBody).get());
 }
 


### PR DESCRIPTION
#### cf1df9607a4917b6a6e98c3adefe076eb4e0f774
<pre>
[Site Isolation] http/tests/storage/storage-map-leaking.html
<a href="https://bugs.webkit.org/show_bug.cgi?id=313794">https://bugs.webkit.org/show_bug.cgi?id=313794</a>

Reviewed by Sihui Liu.

Under site isolation, cross-origin iframes run in separate web processes. The existing test
used internals.storageAreaMapCount, which only counted StorageAreaMap objects in the current
process. When the opened window&apos;s cross-origin iframes each got their own process, the main
test process couldn&apos;t see their StorageAreaMaps, so it couldn&apos;t detect whether they leaked.

This PR replaces internals.storageAreaMapCount with testRunner.storageAreaMapCount that
sends GetStorageAreaMapCountForTesting IPC to every web process, collects each process&apos;s
local StorageAreaMap count via StorageNamespaceProvider::localStorageAreaMapCountForTesting(),
and aggregates the results using a CallbackAggregator in the UI process. This gives the test
a global count across all web processes, making it work correctly under site isolation.

We can&apos;t get this information from the network process because StorageAreaMap is a proxy
object in web-process-side and lives in StorageNamespaceImpl::m_storageAreaMaps within each
web process. The network process has StorageArea objects (the server side), but those don&apos;t
correspond 1:1 with StorageAreaMap instances and don&apos;t reflect the leak we&apos;re testing for.
A StorageAreaMap leak means the web process is holding onto a proxy it should have released
- that&apos;s only observable from the web process itself.

In addition, this PR fixes a bug in the test that some of its iframes was pointing to
<a href="http://127.0.0.1">http://127.0.0.1</a>:8443, but port 8443 is HTTPS-only in the test server, so that iframe never
loaded and window.onload never fired, causing the test to time out.

Test: http/tests/storage/storage-map-leaking.html

* LayoutTests/http/tests/storage/resources/storage-map-leaking-window.html: Added.
* LayoutTests/http/tests/storage/storage-map-leaking.html:
* Source/WebCore/storage/StorageNamespaceProvider.cpp:
(WebCore::StorageNamespaceProvider::localStorageAreaMapCountForTesting const):
* Source/WebCore/storage/StorageNamespaceProvider.h:
* Source/WebKit/UIProcess/API/C/WKPage.cpp:
(WKPageGetStorageAreaMapCountForTesting):
* Source/WebKit/UIProcess/API/C/WKPagePrivate.h:
* Source/WebKit/UIProcess/WebPageProxyTesting.cpp:
(WebKit::WebPageProxyTesting::storageAreaMapCount):
* Source/WebKit/UIProcess/WebPageProxyTesting.h:
* Source/WebKit/WebProcess/WebProcess.cpp:
(WebKit::WebProcess::getStorageAreaMapCountForTesting):
* Source/WebKit/WebProcess/WebProcess.h:
* Source/WebKit/WebProcess/WebProcess.messages.in:
* Tools/WebKitTestRunner/InjectedBundle/Bindings/TestRunner.idl:
* Tools/WebKitTestRunner/InjectedBundle/TestRunner.cpp:
(WTR::TestRunner::storageAreaMapCount):
* Tools/WebKitTestRunner/InjectedBundle/TestRunner.h:
* Tools/WebKitTestRunner/TestController.cpp:

Canonical link: <a href="https://commits.webkit.org/312472@main">https://commits.webkit.org/312472@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5d4d3db80ee663335052c8f9d3404b3e216d4334

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/160038 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/33508 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/26612 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/168918 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/114419 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/daf1020b-c61e-4b12-ada2-19fa635b4f81) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/161907 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/33611 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/33510 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/124040 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/86995 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/eb4d5ebe-093a-429d-a408-b866b0a2422d) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/162996 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/26291 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/143741 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/104654 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/594e7bdc-4c63-40b6-b386-090c1cbbfb7b) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/25344 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/23829 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/16659 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/135035 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/21509 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/171399 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/17406 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/23147 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/132305 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/33184 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/27912 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/132331 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/33169 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/143304 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/91319 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/24358 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/26948 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/20117 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/32678 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/99075 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/32176 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/32422 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/32326 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->