### PR TITLE
Add a release log listing settings which have non-default values

### DIFF
--- a/Source/WebKit/Shared/WebPreferencesStore.cpp
+++ b/Source/WebKit/Shared/WebPreferencesStore.cpp
@@ -26,8 +26,10 @@
 #include "config.h"
 #include "WebPreferencesStore.h"
 
+#include "Logging.h"
 #include "WebPreferencesKeys.h"
 #include <wtf/NeverDestroyed.h>
+#include <wtf/text/StringBuilder.h>
 
 namespace WebKit {
 
@@ -150,6 +152,51 @@ void WebPreferencesStore::deleteKey(const String& key)
 {
     m_values.remove(key);
     m_overriddenDefaults.remove(key);
+}
+
+#if !RELEASE_LOG_DISABLED
+static void appendValueToStringBuilder(StringBuilder& builder, const WebPreferencesStore::Value& value)
+{
+    WTF::switchOn(value,
+        [&](bool b) { builder.append(b ? "true"_s : "false"_s); },
+        [&](uint32_t u) { builder.append(u); },
+        [&](double d) { builder.append(d); },
+        [&](const String& s) { builder.append('"', s, '"'); }
+    );
+}
+#endif
+
+void WebPreferencesStore::logNonDefaultValues() const
+{
+#if !RELEASE_LOG_DISABLED
+    if (m_values.isEmpty() && m_overriddenDefaults.isEmpty())
+        return;
+
+    auto& defaultsMap = defaults();
+
+    StringBuilder nonDefaultPrefs;
+
+    auto checkEntry = [&](const String& key, const Value& value) {
+        auto it = defaultsMap.find(key);
+        if (it != defaultsMap.end() && it->value == value)
+            return;
+        if (!nonDefaultPrefs.isEmpty())
+            nonDefaultPrefs.append(", "_s);
+        nonDefaultPrefs.append(key, '=');
+        appendValueToStringBuilder(nonDefaultPrefs, value);
+    };
+
+    for (auto& [key, value] : m_overriddenDefaults) {
+        if (!m_values.contains(key))
+            checkEntry(key, value);
+    }
+
+    for (auto& [key, value] : m_values)
+        checkEntry(key, value);
+
+    if (!nonDefaultPrefs.isEmpty())
+        RELEASE_LOG(Loading, "WebPreferencesStore: non-default preferences: %" PUBLIC_LOG_STRING, nonDefaultPrefs.toString().utf8().data());
+#endif
 }
 
 } // namespace WebKit

--- a/Source/WebKit/Shared/WebPreferencesStore.h
+++ b/Source/WebKit/Shared/WebPreferencesStore.h
@@ -63,6 +63,8 @@ struct WebPreferencesStore {
 
     void deleteKey(const String& key);
 
+    void logNonDefaultValues() const;
+
     // For WebKitTestRunner usage.
     static void overrideBoolValueForKey(const String& key, bool value);
     static void removeTestRunnerOverrides();

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -5144,6 +5144,8 @@ void WebPage::updatePreferences(const WebPreferencesStore& store)
     WebProcess::singleton().updateSharedPreferencesForWebProcess(WebKit::sharedPreferencesForWebProcess(store, WebProcess::singleton().isLockdownModeEnabled()));
 
     protect(corePage())->settingsDidChange();
+
+    store.logNonDefaultValues();
 }
 
 #if ENABLE(DATA_DETECTION)


### PR DESCRIPTION
#### 251da2ff962e758ee6704f20c9ce850802c68dc9
<pre>
Add a release log listing settings which have non-default values
<a href="https://bugs.webkit.org/show_bug.cgi?id=313798">https://bugs.webkit.org/show_bug.cgi?id=313798</a>
<a href="https://rdar.apple.com/175994613">rdar://175994613</a>

Reviewed by Cameron McCormack and Brent Fulgham.

Add a RELEASE_LOG that dumps all the settings that have non-default values, and those values.

This is helpful for analyzing diagnostic reports.

* Source/WebKit/Shared/WebPreferencesStore.cpp:
(WebKit::appendValueToStringBuilder):
(WebKit::WebPreferencesStore::logNonDefaultValues const):
* Source/WebKit/Shared/WebPreferencesStore.h:
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::updatePreferences):

Canonical link: <a href="https://commits.webkit.org/312461@main">https://commits.webkit.org/312461@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f334a37ccb3b0b41ae4334b3578fd6e6322f88f1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/159942 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/33410 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/26516 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/168817 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/114323 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/4c678ee5-b079-43a8-8935-2fc89a2d6137) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/33514 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/33414 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/123962 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/86944 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/44320551-624b-4e41-8e95-6cf702c400d8) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/162900 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/26214 "Passed tests") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/143660 "Found 1 new API test failure: TestWebKitAPI.WKInspectorExtension.EvaluateScriptInExtensionTabCanReturnPromises (failure)") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/104580 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/5c880bc4-b8af-4f00-ad68-abc72543ae4b) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/25266 "Passed tests") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/23737 "Found 1 new API test failure: TestWebKitAPI.WKBackForwardList.BackForwardNavigationSkipsItemsWithoutUserGestureFragment (failure)") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/16563 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/134958 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/171302 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/17310 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/23068 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/132226 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/33088 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/27823 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/132253 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35792 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/33073 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/143225 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/91221 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/26875 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/20038 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/32582 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/98979 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/32079 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/32326 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/32230 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->