### PR TITLE
[GTK] Test 'anchor-ping-and-follow-redirect-when-sending-ping.html' is a flaky failure

### DIFF
--- a/LayoutTests/http/tests/navigation/ping-attribute/anchor-ping-and-follow-redirect-when-sending-ping.html
+++ b/LayoutTests/http/tests/navigation/ping-attribute/anchor-ping-and-follow-redirect-when-sending-ping.html
@@ -19,9 +19,9 @@ function checkPing()
     {
         window.location = "../resources/check-ping.py";
     }
-    // We assume that if redirects were followed when saving a ping that they will complete within one second.
+    // We assume that if redirects were followed when saving a ping that they will complete within two seconds.
     // FIXME: Is there are better way to test that a redirect occurred?
-    window.setTimeout(actualCheckPing, 1000);
+    window.setTimeout(actualCheckPing, 2000);
 }
 
 window.onload = function ()

--- a/LayoutTests/platform/gtk/TestExpectations
+++ b/LayoutTests/platform/gtk/TestExpectations
@@ -593,8 +593,6 @@ webkit.org/b/211836 imported/w3c/web-platform-tests/fetch/api/abort/general.any.
 
 webkit.org/b/214801 fast/forms/datalist/datalist-show-hide.html [ Failure Pass ]
 
-webkit.org/b/214802 http/tests/navigation/ping-attribute/anchor-ping-and-follow-redirect-when-sending-ping.html [ Failure Pass ]
-
 webkit.org/b/262852 fast/forms/datalist/datalist-show-picker.html [ Failure ]
 
 webkit.org/b/230017 http/wpt/cross-origin-opener-policy/non-secure-to-secure-context-navigation.https.html [ Failure Pass ]


### PR DESCRIPTION
#### 68f2a0d2a5f6fc91cbfb573ccf94fceaaa2f162c
<pre>
[GTK] Test &apos;anchor-ping-and-follow-redirect-when-sending-ping.html&apos; is a flaky failure
<a href="https://bugs.webkit.org/show_bug.cgi?id=214802">https://bugs.webkit.org/show_bug.cgi?id=214802</a>

Reviewed by Fujii Hironori.

Increase time elapse before checking ping was successful.

The test is also flaky in other platforms, for instance Mac Debug.

* LayoutTests/http/tests/navigation/ping-attribute/anchor-ping-and-follow-redirect-when-sending-ping.html:
* LayoutTests/platform/gtk/TestExpectations:

Canonical link: <a href="https://commits.webkit.org/312504@main">https://commits.webkit.org/312504@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d425cd842180e31f646bebef68290e989b5b7eb8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/159879 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/33347 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/26453 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/168746 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/114260 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/33451 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/33351 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/123903 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/86909 "1 flakes 9 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/162837 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/26157 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/143602 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/104527 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/25209 "Passed tests") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/23682 "Found 2 new API test failures: TestWebKitAPI.WKInspectorExtension.EvaluateScriptInExtensionTabCanReturnPromises, TestWebKitAPI.WKWebExtension.LoadFromZipArchiveWithParentDirectory (failure)") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/16500 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/134901 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/21373 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/171234 "Built successfully") | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/23011 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/132168 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/33025 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/27763 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/132199 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/33010 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/143167 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/91119 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/24374 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/26818 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/19981 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/32519 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/32016 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/32263 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/32167 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->