### PR TITLE
Align writingSuggestions IDL attribute with the HTML specification

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/html/dom/idlharness.https_include=HTML._-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/dom/idlharness.https_include=HTML._-expected.txt
@@ -139,7 +139,7 @@ PASS HTMLElement interface: attribute accessKey
 PASS HTMLElement interface: attribute accessKeyLabel
 PASS HTMLElement interface: attribute draggable
 PASS HTMLElement interface: attribute spellcheck
-FAIL HTMLElement interface: attribute writingSuggestions assert_true: The prototype object must have a property "writingSuggestions" expected true got false
+PASS HTMLElement interface: attribute writingSuggestions
 PASS HTMLElement interface: attribute autocapitalize
 PASS HTMLElement interface: attribute autocorrect
 PASS HTMLElement interface: attribute innerText
@@ -248,7 +248,7 @@ PASS HTMLElement interface: document.createElement("noscript") must inherit prop
 PASS HTMLElement interface: document.createElement("noscript") must inherit property "accessKeyLabel" with the proper type
 PASS HTMLElement interface: document.createElement("noscript") must inherit property "draggable" with the proper type
 PASS HTMLElement interface: document.createElement("noscript") must inherit property "spellcheck" with the proper type
-FAIL HTMLElement interface: document.createElement("noscript") must inherit property "writingSuggestions" with the proper type assert_inherits: property "writingSuggestions" not found in prototype chain
+PASS HTMLElement interface: document.createElement("noscript") must inherit property "writingSuggestions" with the proper type
 PASS HTMLElement interface: document.createElement("noscript") must inherit property "autocapitalize" with the proper type
 PASS HTMLElement interface: document.createElement("noscript") must inherit property "autocorrect" with the proper type
 PASS HTMLElement interface: document.createElement("noscript") must inherit property "innerText" with the proper type

--- a/LayoutTests/imported/w3c/web-platform-tests/html/editing/editing-0/writing-suggestions/WEB_FEATURES.yml
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/editing/editing-0/writing-suggestions/WEB_FEATURES.yml
@@ -1,0 +1,3 @@
+features:
+- name: writingsuggestions
+  files: "**"

--- a/LayoutTests/imported/w3c/web-platform-tests/html/editing/editing-0/writing-suggestions/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/editing/editing-0/writing-suggestions/w3c-import.log
@@ -1,0 +1,18 @@
+The tests in this directory were imported from the W3C repository.
+Do NOT modify these tests directly in WebKit.
+Instead, create a pull request on the WPT github:
+	https://github.com/web-platform-tests/wpt
+
+Then run the Tools/Scripts/import-w3c-tests in WebKit to reimport
+
+Do NOT modify or remove this file.
+
+------------------------------------------------------------------------
+Properties requiring vendor prefixes:
+None
+Property values requiring vendor prefixes:
+None
+------------------------------------------------------------------------
+List of files:
+/LayoutTests/imported/w3c/web-platform-tests/html/editing/editing-0/writing-suggestions/WEB_FEATURES.yml
+/LayoutTests/imported/w3c/web-platform-tests/html/editing/editing-0/writing-suggestions/writingsuggestions.html

--- a/LayoutTests/imported/w3c/web-platform-tests/html/editing/editing-0/writing-suggestions/writingsuggestions-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/editing/editing-0/writing-suggestions/writingsuggestions-expected.txt
@@ -1,0 +1,82 @@
+
+PASS Test that the writingsuggestions attribute is available on HTMLInputElement.
+PASS Test that the writingsuggestions attribute is available on HTMLTextAreaElement.
+PASS Test that the writingsuggestions attribute is available on HTMLDivElement.
+PASS Test that the writingsuggestions attribute is available on HTMLSpanElement.
+PASS Test that the writingsuggestions attribute is available on custom elements.
+PASS Test that the writingsuggestions attribute is available on an input type which the attribute doesn't apply. The User Agent is responsible that writing suggestions are not applied to the element.
+PASS Test that the writingsuggestions attribute is available on a disabled element. The User Agent is responsible that writing suggestions are not applied to the element.
+PASS Test setting the `writingsuggestions` IDL attribute to `true` directly on the target element.
+PASS Test setting the `writingsuggestions` content attribute to `true` directly on the target element.
+PASS Test setting the `writingsuggestions` IDL attribute to boolean `true` directly on the target element.
+PASS Test setting the `writingsuggestions` content attribute to boolean `true` directly on the target element.
+PASS Test setting the `writingsuggestions` IDL attribute to `TrUe` directly on the target element.
+PASS Test setting the `writingsuggestions` content attribute to `TrUe` directly on the target element.
+PASS Test setting the `writingsuggestions` IDL attribute to `false` directly on the target element.
+PASS Test setting the `writingsuggestions` content attribute to `false` directly on the target element.
+PASS Test setting the `writingsuggestions` IDL attribute to boolean `false` directly on the target element.
+PASS Test setting the `writingsuggestions` content attribute to boolean `false` directly on the target element.
+PASS Test setting the `writingsuggestions` IDL attribute to `FaLsE` directly on the target element.
+PASS Test setting the `writingsuggestions` content attribute to `FaLsE` directly on the target element.
+PASS Test setting the `writingsuggestions` IDL attribute to the empty string directly on the target element.
+PASS Test setting the `writingsuggestions` content attribute to the empty string directly on the target element.
+PASS Test setting the `writingsuggestions` IDL attribute to an invalid value directly on the target element.
+PASS Test setting the `writingsuggestions` content attribute to an invalid value directly on the target element.
+PASS Test the writing suggestions state when the `writingsuggestions` attribute is missing.
+PASS Test setting the `writingsuggestions` content attribute to `false` after the IDL attribute was set to `true`.
+PASS Test setting the `writingsuggestions` content attribute to the empty string after the IDL attribute was set to `true`.
+PASS Test setting the `writingsuggestions` content attribute to an invalid value after the IDL attribute was set to `true`.
+PASS Test setting the `writingsuggestions` content attribute to `TrUe` after the IDL attribute was set to `true`.
+PASS Test setting the `writingsuggestions` content attribute to `FaLsE` after the IDL attribute was set to `true`.
+PASS Test setting the `writingsuggestions` content attribute to boolean `true` after the IDL attribute was set to `true`.
+PASS Test setting the `writingsuggestions` content attribute to boolean `false` after the IDL attribute was set to `true`.
+PASS Test setting the `writingsuggestions` content attribute to `true` after the IDL attribute was set to `false`.
+PASS Test setting the `writingsuggestions` content attribute to the empty string after the IDL attribute was set to `false`.
+PASS Test setting the `writingsuggestions` content attribute to an invalid value after the IDL attribute was set to `false`.
+PASS Test setting the `writingsuggestions` content attribute to `TrUe` after the IDL attribute was set to `false`.
+PASS Test setting the `writingsuggestions` content attribute to `FaLsE` after the IDL attribute was set to `false`.
+PASS Test setting the `writingsuggestions` content attribute to boolean `true` after the IDL attribute was set to `false`.
+PASS Test setting the `writingsuggestions` content attribute to boolean `false` after the IDL attribute was set to `false`.
+PASS Test setting the `writingsuggestions` attribute with a missing value directly on the target element.
+PASS Test setting the `writingsuggestions` attribute to "true" on a parent element.
+PASS Test setting the `writingsuggestions` attribute to an empty string on a parent element.
+PASS Test setting the `writingsuggestions` attribute to "false" on a parent element.
+PASS Test setting the `writingsuggestions` attribute to an invalid value on a parent element.
+PASS Test overriding the parent element's `writingsuggestions` attribute from "true" to "false".
+PASS Test overriding the parent element's `writingsuggestions` attribute from the empty string to "false".
+PASS Test overriding the parent element's `writingsuggestions` attribute from "false" to "true".
+PASS Test overriding the parent element's `writingsuggestions` attribute from "false" to an invalid value.
+PASS Test overriding the parent element's `writingsuggestions` attribute from "false" to the empty string.
+PASS Test turning off writing suggestions for an entire document.
+PASS Test overriding a non-parent ancestor element's `writingsuggestions` attribute on an input element from "false" to "true".
+PASS Test overriding a non-parent ancestor element's `writingsuggestions` attribute on a textarea element from "false" to "true".
+PASS Test overriding a non-parent ancestor element's `writingsuggestions` attribute on a div element from "false" to "true".
+PASS Test overriding a non-parent ancestor element's `writingsuggestions` attribute on a span element from "false" to "true".
+PASS Test overriding a non-parent ancestor element's `writingsuggestions` attribute on an input type which the attribute doesn't apply from "false" to "true". The User Agent is responsible that writing suggestions are not applied to the element
+PASS Test overriding a non-parent ancestor element's `writingsuggestions` attribute on a disabled textarea element from "false" to "true". The User Agent is responsible that writing suggestions are not applied to the element
+PASS Test overriding a non-parent ancestor element's `writingsuggestions` attribute on an input element from "false" to the empty string.
+PASS Test overriding a non-parent ancestor element's `writingsuggestions` attribute on a textarea element from "false" to the empty string.
+PASS Test overriding a non-parent ancestor element's `writingsuggestions` attribute on a div element from "false" to the empty string.
+PASS Test overriding a non-parent ancestor element's `writingsuggestions` attribute on a span element from "false" to the empty string.
+PASS Test overriding a non-parent ancestor element's `writingsuggestions` attribute on an input type which the attribute doesn't apply from "false" to the empty string. The User Agent is responsible that writing suggestions are not applied to the element.
+PASS Test overriding a non-parent ancestor element's `writingsuggestions` attribute on a disabled textarea element from "false" to the empty string. The User Agent is responsible that writing suggestions are not applied to the element.
+PASS Test overriding a non-parent ancestor element's `writingsuggestions` attribute on an input element from "false" to an invalid value.
+PASS Test overriding a non-parent ancestor element's `writingsuggestions` attribute on a textarea element from "false" to an invalid value.
+PASS Test overriding a non-parent ancestor element's `writingsuggestions` attribute on a div element from "false" to an invalid value.
+PASS Test overriding a non-parent ancestor element's `writingsuggestions` attribute on a span element from "false" to an invalid value.
+PASS Test overriding a non-parent ancestor element's `writingsuggestions` attribute on an input type which the attribute doesn't apply from "false" to an invalid value. The User Agent is responsible that writing suggestions are not applied to the element.
+PASS Test overriding a non-parent ancestor element's `writingsuggestions` attribute on a disabled textarea element from "false" to an invalid value. The User Agent is responsible that writing suggestions are not applied to the element.
+PASS Test overriding a non-parent ancestor element's `writingsuggestions` attribute on an input element from "true" to "false".
+PASS Test overriding a non-parent ancestor element's `writingsuggestions` attribute on a textarea element from "true" to "false".
+PASS Test overriding a non-parent ancestor element's `writingsuggestions` attribute on a div element from "true" to "false".
+PASS Test overriding a non-parent ancestor element's `writingsuggestions` attribute on a span element from "true" to "false".
+PASS Test overriding a non-parent ancestor element's `writingsuggestions` attribute on an input type which the attribute doesn't apply from "true" to "false". The User Agent is responsible that writing suggestions are not applied to the element.
+PASS Test overriding a non-parent ancestor element's `writingsuggestions` attribute on a disabled textarea element from "true" to "false". The User Agent is responsible that writing suggestions are not applied to the element.
+PASS Test overriding a non-parent ancestor element's `writingsuggestions` attribute on an input element from the empty string to "false".
+PASS Test overriding a non-parent ancestor element's `writingsuggestions` attribute on a textarea element from the empty string to "false".
+PASS Test overriding a non-parent ancestor element's `writingsuggestions` attribute on a div element from the empty string to "false".
+PASS Test overriding a non-parent ancestor element's `writingsuggestions` attribute on a span element from the empty string to "false".
+PASS Test overriding a non-parent ancestor element's `writingsuggestions` attribute on an input type which the attribute doesn't apply from the empty string to "false". The User Agent is responsible that writing suggestions are not applied to the element.
+PASS Test overriding a non-parent ancestor element's `writingsuggestions` attribute on a disabled textarea element from the empty string to "false". The User Agent is responsible that writing suggestions are not applied to the element.
+PASS Test that for continuous text on the screen, writing suggestions may be allowed in one part but not another.
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/editing/editing-0/writing-suggestions/writingsuggestions.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/editing/editing-0/writing-suggestions/writingsuggestions.html
@@ -1,0 +1,599 @@
+<!DOCTYPE html>
+<title>Tests for the writingsuggestions attribute</title>
+<link rel='author' title='Sanket Joshi' href='mailto:sajos@microsoft.com'>
+<link rel="help" href="https://html.spec.whatwg.org/multipage/interaction.html#writingsuggestions">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script>
+'use strict';
+
+customElements.define('test-custom-element', class extends HTMLElement {});
+
+test(function() {
+    assert_true('writingSuggestions' in document.createElement('input'));
+}, 'Test that the writingsuggestions attribute is available on HTMLInputElement.');
+
+test(function() {
+    assert_true('writingSuggestions' in document.createElement('textarea'));
+}, 'Test that the writingsuggestions attribute is available on HTMLTextAreaElement.');
+
+test(function() {
+    assert_true('writingSuggestions' in document.createElement('div'));
+}, 'Test that the writingsuggestions attribute is available on HTMLDivElement.');
+
+test(function() {
+    assert_true('writingSuggestions' in document.createElement('span'));
+}, 'Test that the writingsuggestions attribute is available on HTMLSpanElement.');
+
+test(function() {
+    assert_true('writingSuggestions' in document.createElement('test-custom-element'));
+}, 'Test that the writingsuggestions attribute is available on custom elements.');
+
+test(function() {
+    let input = document.createElement('input');
+    input.type = 'color';
+    assert_true('writingSuggestions' in input);
+}, 'Test that the writingsuggestions attribute is available on an input type which the attribute doesn\'t apply. The User Agent is responsible that writing suggestions are not applied to the element.');
+
+test(function() {
+    let textarea = document.createElement('textarea');
+    textarea.disabled = true;
+    assert_true('writingSuggestions' in textarea);
+}, 'Test that the writingsuggestions attribute is available on a disabled element. The User Agent is responsible that writing suggestions are not applied to the element.');
+
+function testSetAttributeDirectly(IDLValue, contentValue, expectedIDLValue, expectedContentValue, testDescription) {
+  test(function() {
+      let input_color = document.createElement('input');
+      input_color.type = 'color';
+
+      let disabled_textarea = document.createElement('textarea');
+      disabled_textarea.disabled = true;
+
+      const elements = [document.createElement('input'),
+                        document.createElement('textarea'),
+                        document.createElement('div'),
+                        document.createElement('span'),
+                        document.createElement('test-custom-element'),
+                        disabled_textarea,
+                        input_color ];
+
+      elements.forEach(function(element) {
+        if (IDLValue != undefined) {
+          element.writingSuggestions = IDLValue;
+        }
+        if (contentValue != undefined) {
+          element.setAttribute('writingsuggestions', contentValue);
+        }
+        assert_equals(element.writingSuggestions, expectedIDLValue);
+        assert_equals(element.getAttribute('writingsuggestions'), expectedContentValue);
+      });
+  }, testDescription);
+}
+
+// Test setting either the `writingsuggestions` IDL or content attribute to some variation of 'true' directly on the target element.
+testSetAttributeDirectly('true', undefined, 'true', 'true', 'Test setting the `writingsuggestions` IDL attribute to `true` directly on the target element.');
+testSetAttributeDirectly(undefined, 'true', 'true', 'true', 'Test setting the `writingsuggestions` content attribute to `true` directly on the target element.');
+testSetAttributeDirectly(true, undefined, 'true', 'true', 'Test setting the `writingsuggestions` IDL attribute to boolean `true` directly on the target element.');
+testSetAttributeDirectly(undefined, true, 'true', 'true', 'Test setting the `writingsuggestions` content attribute to boolean `true` directly on the target element.');
+testSetAttributeDirectly('TrUe', undefined, 'true', 'TrUe', 'Test setting the `writingsuggestions` IDL attribute to `TrUe` directly on the target element.');
+testSetAttributeDirectly(undefined, 'TrUe', 'true', 'TrUe', 'Test setting the `writingsuggestions` content attribute to `TrUe` directly on the target element.');
+
+// Test setting either the `writingsuggestions` IDL or content attribute to some variation of 'false' directly on the target element.
+testSetAttributeDirectly('false', undefined, 'false', 'false', 'Test setting the `writingsuggestions` IDL attribute to `false` directly on the target element.');
+testSetAttributeDirectly(undefined, 'false', 'false', 'false', 'Test setting the `writingsuggestions` content attribute to `false` directly on the target element.');
+testSetAttributeDirectly(false, undefined, 'false', 'false', 'Test setting the `writingsuggestions` IDL attribute to boolean `false` directly on the target element.');
+testSetAttributeDirectly(undefined, false, 'false', 'false', 'Test setting the `writingsuggestions` content attribute to boolean `false` directly on the target element.');
+testSetAttributeDirectly('FaLsE', undefined, 'false', 'FaLsE', 'Test setting the `writingsuggestions` IDL attribute to `FaLsE` directly on the target element.');
+testSetAttributeDirectly(undefined, 'FaLsE', 'false', 'FaLsE', 'Test setting the `writingsuggestions` content attribute to `FaLsE` directly on the target element.');
+
+// Test setting either the `writingsuggestions` IDL or content attribute to the empty string directly on the target element.
+testSetAttributeDirectly('', undefined, 'true', '', 'Test setting the `writingsuggestions` IDL attribute to the empty string directly on the target element.');
+testSetAttributeDirectly(undefined, '', 'true', '', 'Test setting the `writingsuggestions` content attribute to the empty string directly on the target element.');
+
+// Test setting either the `writingsuggestions` IDL or content attribute to an invalid value directly on the target element.
+testSetAttributeDirectly('foo', undefined, 'true', 'foo', 'Test setting the `writingsuggestions` IDL attribute to an invalid value directly on the target element.');
+testSetAttributeDirectly(undefined, 'foo', 'true', 'foo', 'Test setting the `writingsuggestions` content attribute to an invalid value directly on the target element.');
+
+// Test setting neither the `writingsuggestions` IDL nor content attribute directly on the target element.
+testSetAttributeDirectly(undefined, undefined, 'true', null, 'Test the writing suggestions state when the `writingsuggestions` attribute is missing.');
+
+// Test setting the content attribute after the IDL attribute and making sure the IDL and content attributes are properly reflected.
+testSetAttributeDirectly('true', 'false', 'false', 'false', 'Test setting the `writingsuggestions` content attribute to `false` after the IDL attribute was set to `true`.');
+testSetAttributeDirectly('true', '', 'true', '', 'Test setting the `writingsuggestions` content attribute to the empty string after the IDL attribute was set to `true`.');
+testSetAttributeDirectly('true', 'foo', 'true', 'foo', 'Test setting the `writingsuggestions` content attribute to an invalid value after the IDL attribute was set to `true`.');
+testSetAttributeDirectly('true', 'TrUe', 'true', 'TrUe', 'Test setting the `writingsuggestions` content attribute to `TrUe` after the IDL attribute was set to `true`.');
+testSetAttributeDirectly('true', 'FaLsE', 'false', 'FaLsE', 'Test setting the `writingsuggestions` content attribute to `FaLsE` after the IDL attribute was set to `true`.');
+testSetAttributeDirectly('true', true, 'true', 'true', 'Test setting the `writingsuggestions` content attribute to boolean `true` after the IDL attribute was set to `true`.');
+testSetAttributeDirectly('true', false, 'false', 'false', 'Test setting the `writingsuggestions` content attribute to boolean `false` after the IDL attribute was set to `true`.');
+
+testSetAttributeDirectly('false', 'true', 'true', 'true', 'Test setting the `writingsuggestions` content attribute to `true` after the IDL attribute was set to `false`.');
+testSetAttributeDirectly('false', '', 'true', '', 'Test setting the `writingsuggestions` content attribute to the empty string after the IDL attribute was set to `false`.');
+testSetAttributeDirectly('false', 'foo', 'true', 'foo', 'Test setting the `writingsuggestions` content attribute to an invalid value after the IDL attribute was set to `false`.');
+testSetAttributeDirectly('false', 'TrUe', 'true', 'TrUe', 'Test setting the `writingsuggestions` content attribute to `TrUe` after the IDL attribute was set to `false`.');
+testSetAttributeDirectly('false', 'FaLsE', 'false', 'FaLsE', 'Test setting the `writingsuggestions` content attribute to `FaLsE` after the IDL attribute was set to `false`.');
+testSetAttributeDirectly('false', true, 'true', 'true', 'Test setting the `writingsuggestions` content attribute to boolean `true` after the IDL attribute was set to `false`.');
+testSetAttributeDirectly('false', false, 'false', 'false', 'Test setting the `writingsuggestions` content attribute to boolean `false` after the IDL attribute was set to `false`.');
+
+test(function() {
+  const elements = [ new DOMParser().parseFromString('<input writingsuggestions />', 'text/html').body.firstElementChild,
+                     new DOMParser().parseFromString('<textarea writingsuggestions></textarea>', 'text/html').body.firstElementChild,
+                     new DOMParser().parseFromString('<div writingsuggestions></div>', 'text/html').body.firstElementChild,
+                     new DOMParser().parseFromString('<span writingsuggestions></span>', 'text/html').body.firstElementChild,
+                     new DOMParser().parseFromString('<input type="color" writingsuggestions />', 'text/html').body.firstElementChild,
+                     new DOMParser().parseFromString('<textarea disabled writingsuggestions></textarea>', 'text/html').body.firstElementChild ];
+
+  elements.forEach(function(element) {
+    assert_equals(element.writingSuggestions, 'true');
+    assert_equals(element.getAttribute('writingsuggestions'), '');
+  });
+}, 'Test setting the `writingsuggestions` attribute with a missing value directly on the target element.');
+
+test(function() {
+  const elements = [ new DOMParser().parseFromString('<html><body writingsuggestions="true"><input /></body></html>', 'text/html').body.firstElementChild,
+                     new DOMParser().parseFromString('<html><body writingsuggestions="true"><textarea></textarea></body></html>', 'text/html').body.firstElementChild,
+                     new DOMParser().parseFromString('<html><body writingsuggestions="true"><div></div></body></html>', 'text/html').body.firstElementChild,
+                     new DOMParser().parseFromString('<html><body writingsuggestions="true"><span></span></body></html>', 'text/html').body.firstElementChild,
+                     new DOMParser().parseFromString('<html><body writingsuggestions="true"><input type="color"/></body></html>', 'text/html').body.firstElementChild,
+                     new DOMParser().parseFromString('<html><body writingsuggestions="true"><textarea disabled></textarea></body></html>', 'text/html').body.firstElementChild ];
+
+  elements.forEach(function(element) {
+    assert_equals(element.parentElement.writingSuggestions, 'true');
+    assert_equals(element.parentElement.getAttribute('writingsuggestions'), 'true');
+    assert_equals(element.writingSuggestions, 'true');
+    assert_equals(element.getAttribute('writingsuggestions'), null);
+  });
+}, 'Test setting the `writingsuggestions` attribute to "true" on a parent element.');
+
+test(function() {
+  const elements = [ new DOMParser().parseFromString('<html><body writingsuggestions=""><input /></body></html>', 'text/html').body.firstElementChild,
+                     new DOMParser().parseFromString('<html><body writingsuggestions=""><textarea></textarea></body></html>', 'text/html').body.firstElementChild,
+                     new DOMParser().parseFromString('<html><body writingsuggestions=""><div></div></body></html>', 'text/html').body.firstElementChild,
+                     new DOMParser().parseFromString('<html><body writingsuggestions=""><span></span></body></html>', 'text/html').body.firstElementChild,
+                     new DOMParser().parseFromString('<html><body writingsuggestions=""><input type="color"/></body></html>', 'text/html').body.firstElementChild,
+                     new DOMParser().parseFromString('<html><body writingsuggestions=""><textarea disabled></textarea></body></html>', 'text/html').body.firstElementChild ];
+
+  elements.forEach(function(element) {
+    assert_equals(element.parentElement.writingSuggestions, 'true');
+    assert_equals(element.parentElement.getAttribute('writingsuggestions'), '');
+    assert_equals(element.writingSuggestions, 'true');
+    assert_equals(element.getAttribute('writingsuggestions'), null);
+  });
+}, 'Test setting the `writingsuggestions` attribute to an empty string on a parent element.');
+
+test(function() {
+  const elements = [ new DOMParser().parseFromString('<html><body writingsuggestions="false"><input /></body></html>', 'text/html').body.firstElementChild,
+                     new DOMParser().parseFromString('<html><body writingsuggestions="false"><textarea></textarea></body></html>', 'text/html').body.firstElementChild,
+                     new DOMParser().parseFromString('<html><body writingsuggestions="false"><div></div></body></html>', 'text/html').body.firstElementChild,
+                     new DOMParser().parseFromString('<html><body writingsuggestions="false"><span></span></body></html>', 'text/html').body.firstElementChild,
+                     new DOMParser().parseFromString('<html><body writingsuggestions="false"><input type="color"/></body></html>', 'text/html').body.firstElementChild,
+                     new DOMParser().parseFromString('<html><body writingsuggestions="false"><textarea disabled></textarea></body></html>', 'text/html').body.firstElementChild ];
+
+  elements.forEach(function(element) {
+    assert_equals(element.parentElement.writingSuggestions, 'false');
+    assert_equals(element.parentElement.getAttribute('writingsuggestions'), 'false');
+    assert_equals(element.writingSuggestions, 'false');
+    assert_equals(element.getAttribute('writingsuggestions'), null);
+  });
+}, 'Test setting the `writingsuggestions` attribute to "false" on a parent element.');
+
+test(function() {
+  const elements = [ new DOMParser().parseFromString('<html><body writingsuggestions="foo"><input /></body></html>', 'text/html').body.firstElementChild,
+                     new DOMParser().parseFromString('<html><body writingsuggestions="foo"><textarea></textarea></body></html>', 'text/html').body.firstElementChild,
+                     new DOMParser().parseFromString('<html><body writingsuggestions="foo"><div></div></body></html>', 'text/html').body.firstElementChild,
+                     new DOMParser().parseFromString('<html><body writingsuggestions="foo"><span></span></body></html>', 'text/html').body.firstElementChild,
+                     new DOMParser().parseFromString('<html><body writingsuggestions="foo"><input type="color"/></body></html>', 'text/html').body.firstElementChild,
+                     new DOMParser().parseFromString('<html><body writingsuggestions="foo"><textarea disabled></textarea></body></html>', 'text/html').body.firstElementChild ];
+
+  elements.forEach(function(element) {
+    assert_equals(element.parentElement.writingSuggestions, 'true');
+    assert_equals(element.parentElement.getAttribute('writingsuggestions'), 'foo');
+    assert_equals(element.writingSuggestions, 'true');
+    assert_equals(element.getAttribute('writingsuggestions'), null);
+  });
+}, 'Test setting the `writingsuggestions` attribute to an invalid value on a parent element.');
+
+test(function() {
+  const elements = [ new DOMParser().parseFromString('<html><body writingsuggestions="true"><input writingsuggestions="false"/></body></html>', 'text/html').body.firstElementChild,
+                     new DOMParser().parseFromString('<html><body writingsuggestions="true"><textarea writingsuggestions="false"></textarea></body></html>', 'text/html').body.firstElementChild,
+                     new DOMParser().parseFromString('<html><body writingsuggestions="true"><div writingsuggestions="false"></div></body></html>', 'text/html').body.firstElementChild,
+                     new DOMParser().parseFromString('<html><body writingsuggestions="true"><span writingsuggestions="false"></span></body></html>', 'text/html').body.firstElementChild,
+                     new DOMParser().parseFromString('<html><body writingsuggestions="true"><input type="color" writingsuggestions="false"/></body></html>', 'text/html').body.firstElementChild,
+                     new DOMParser().parseFromString('<html><body writingsuggestions="true"><textarea disabled writingsuggestions="false"></textarea></body></html>', 'text/html').body.firstElementChild ];
+
+  elements.forEach(function(element) {
+    assert_equals(element.parentElement.writingSuggestions, 'true');
+    assert_equals(element.parentElement.getAttribute('writingsuggestions'), 'true');
+    assert_equals(element.writingSuggestions, 'false');
+    assert_equals(element.getAttribute('writingsuggestions'), 'false');
+  });
+}, 'Test overriding the parent element\'s `writingsuggestions` attribute from "true" to "false".');
+
+test(function() {
+  const elements = [ new DOMParser().parseFromString('<html><body writingsuggestions=""><input writingsuggestions="false"/></body></html>', 'text/html').body.firstElementChild,
+                     new DOMParser().parseFromString('<html><body writingsuggestions=""><textarea writingsuggestions="false"></textarea></body></html>', 'text/html').body.firstElementChild,
+                     new DOMParser().parseFromString('<html><body writingsuggestions=""><div writingsuggestions="false"></div></body></html>', 'text/html').body.firstElementChild,
+                     new DOMParser().parseFromString('<html><body writingsuggestions=""><span writingsuggestions="false"></span></body></html>', 'text/html').body.firstElementChild,
+                     new DOMParser().parseFromString('<html><body writingsuggestions=""><input type="color" writingsuggestions="false"/></body></html>', 'text/html').body.firstElementChild,
+                     new DOMParser().parseFromString('<html><body writingsuggestions=""><textarea disabled writingsuggestions="false"></textarea></body></html>', 'text/html').body.firstElementChild ];
+
+  elements.forEach(function(element) {
+    assert_equals(element.parentElement.writingSuggestions, 'true');
+    assert_equals(element.parentElement.getAttribute('writingsuggestions'), '');
+    assert_equals(element.writingSuggestions, 'false');
+    assert_equals(element.getAttribute('writingsuggestions'), 'false');
+  });
+}, 'Test overriding the parent element\'s `writingsuggestions` attribute from the empty string to "false".');
+
+test(function() {
+  const elements = [ new DOMParser().parseFromString('<html><body writingsuggestions="false"><input writingsuggestions="true" /></body></html>', 'text/html').body.firstElementChild,
+                     new DOMParser().parseFromString('<html><body writingsuggestions="false"><textarea writingsuggestions="true"></textarea></body></html>', 'text/html').body.firstElementChild,
+                     new DOMParser().parseFromString('<html><body writingsuggestions="false"><div writingsuggestions="true"></div></body></html>', 'text/html').body.firstElementChild,
+                     new DOMParser().parseFromString('<html><body writingsuggestions="false"><span writingsuggestions="true"></span></body></html>', 'text/html').body.firstElementChild,
+                     new DOMParser().parseFromString('<html><body writingsuggestions="false"><input type="color" writingsuggestions="true"/></body></html>', 'text/html').body.firstElementChild,
+                     new DOMParser().parseFromString('<html><body writingsuggestions="false"><textarea disabled writingsuggestions="true"></textarea></body></html>', 'text/html').body.firstElementChild, ];
+
+  elements.forEach(function(element) {
+    assert_equals(element.parentElement.writingSuggestions, 'false');
+    assert_equals(element.parentElement.getAttribute('writingsuggestions'), 'false');
+    assert_equals(element.writingSuggestions, 'true');
+    assert_equals(element.getAttribute('writingsuggestions'), 'true');
+  });
+}, 'Test overriding the parent element\'s `writingsuggestions` attribute from "false" to "true".');
+
+test(function() {
+  const elements = [ new DOMParser().parseFromString('<html><body writingsuggestions="false"><input writingsuggestions="foo" /></body></html>', 'text/html').body.firstElementChild,
+                     new DOMParser().parseFromString('<html><body writingsuggestions="false"><textarea writingsuggestions="foo"></textarea></body></html>', 'text/html').body.firstElementChild,
+                     new DOMParser().parseFromString('<html><body writingsuggestions="false"><div writingsuggestions="foo"></div></body></html>', 'text/html').body.firstElementChild,
+                     new DOMParser().parseFromString('<html><body writingsuggestions="false"><span writingsuggestions="foo"></span></body></html>', 'text/html').body.firstElementChild,
+                     new DOMParser().parseFromString('<html><body writingsuggestions="false"><input type="color" writingsuggestions="foo"/></body></html>', 'text/html').body.firstElementChild,
+                     new DOMParser().parseFromString('<html><body writingsuggestions="false"><textarea disabled writingsuggestions="foo"></textarea></body></html>', 'text/html').body.firstElementChild ];
+
+  elements.forEach(function(element) {
+    assert_equals(element.parentElement.writingSuggestions, 'false');
+    assert_equals(element.parentElement.getAttribute('writingsuggestions'), 'false');
+    assert_equals(element.writingSuggestions, 'true');
+    assert_equals(element.getAttribute('writingsuggestions'), 'foo');
+  });
+}, 'Test overriding the parent element\'s `writingsuggestions` attribute from "false" to an invalid value.');
+
+test(function() {
+  const elements = [ new DOMParser().parseFromString('<html><body writingsuggestions="false"><input writingsuggestions="" /></body></html>', 'text/html').body.firstElementChild,
+                     new DOMParser().parseFromString('<html><body writingsuggestions="false"><textarea writingsuggestions=""></textarea></body></html>', 'text/html').body.firstElementChild,
+                     new DOMParser().parseFromString('<html><body writingsuggestions="false"><div writingsuggestions=""></div></body></html>', 'text/html').body.firstElementChild,
+                     new DOMParser().parseFromString('<html><body writingsuggestions="false"><span writingsuggestions=""></span></body></html>', 'text/html').body.firstElementChild,
+                     new DOMParser().parseFromString('<html><body writingsuggestions="false"><input type="color" writingsuggestions=""/></body></html>', 'text/html').body.firstElementChild,
+                     new DOMParser().parseFromString('<html><body writingsuggestions="false"><textarea disabled writingsuggestions=""></textarea></body></html>', 'text/html').body.firstElementChild ];
+
+  elements.forEach(function(element) {
+    assert_equals(element.parentElement.writingSuggestions, 'false');
+    assert_equals(element.parentElement.getAttribute('writingsuggestions'), 'false');
+    assert_equals(element.writingSuggestions, 'true');
+    assert_equals(element.getAttribute('writingsuggestions'), '');
+  });
+}, 'Test overriding the parent element\'s `writingsuggestions` attribute from "false" to the empty string.');
+
+test(function() {
+  const doc = new DOMParser().parseFromString('<html writingsuggestions="false"><body><input /><textarea></textarea><div></div><span></span><input type="color"/><textarea disabled></textarea></body></html>', 'text/html');
+  assert_equals(doc.documentElement.writingSuggestions, 'false');
+  assert_equals(doc.body.writingSuggestions, 'false');
+  assert_equals(doc.querySelectorAll('input')[0].writingSuggestions, 'false');
+  assert_equals(doc.querySelectorAll('textarea')[0].writingSuggestions, 'false');
+  assert_equals(doc.querySelector('div').writingSuggestions, 'false');
+  assert_equals(doc.querySelector('span').writingSuggestions, 'false');
+  assert_equals(doc.querySelectorAll('input')[1].writingSuggestions, 'false');
+  assert_equals(doc.querySelectorAll('textarea')[1].writingSuggestions, 'false');
+}, 'Test turning off writing suggestions for an entire document.');
+
+test(function() {
+  const doc = new DOMParser().parseFromString('<html writingsuggestions="false"><body><input writingsuggestions="true" /><textarea></textarea><div></div><span></span></body></html>', 'text/html');
+  assert_equals(doc.documentElement.writingSuggestions, 'false');
+  assert_equals(doc.body.writingSuggestions, 'false');
+  assert_equals(doc.querySelector('input').writingSuggestions, 'true');
+  assert_equals(doc.querySelector('textarea').writingSuggestions, 'false');
+  assert_equals(doc.querySelector('div').writingSuggestions, 'false');
+  assert_equals(doc.querySelector('span').writingSuggestions, 'false');
+}, 'Test overriding a non-parent ancestor element\'s `writingsuggestions` attribute on an input element from "false" to "true".');
+
+test(function() {
+  const doc = new DOMParser().parseFromString('<html writingsuggestions="false"><body><input /><textarea writingsuggestions="true"></textarea><div></div><span></span></body></html>', 'text/html');
+  assert_equals(doc.documentElement.writingSuggestions, 'false');
+  assert_equals(doc.body.writingSuggestions, 'false');
+  assert_equals(doc.querySelector('input').writingSuggestions, 'false');
+  assert_equals(doc.querySelector('textarea').writingSuggestions, 'true');
+  assert_equals(doc.querySelector('div').writingSuggestions, 'false');
+  assert_equals(doc.querySelector('span').writingSuggestions, 'false');
+}, 'Test overriding a non-parent ancestor element\'s `writingsuggestions` attribute on a textarea element from "false" to "true".');
+
+test(function() {
+  const doc = new DOMParser().parseFromString('<html writingsuggestions="false"><body><input /><textarea></textarea><div writingsuggestions="true"></div><span></span></body></html>', 'text/html');
+  assert_equals(doc.documentElement.writingSuggestions, 'false');
+  assert_equals(doc.body.writingSuggestions, 'false');
+  assert_equals(doc.querySelector('input').writingSuggestions, 'false');
+  assert_equals(doc.querySelector('textarea').writingSuggestions, 'false');
+  assert_equals(doc.querySelector('div').writingSuggestions, 'true');
+  assert_equals(doc.querySelector('span').writingSuggestions, 'false');
+}, 'Test overriding a non-parent ancestor element\'s `writingsuggestions` attribute on a div element from "false" to "true".');
+
+test(function() {
+  const doc = new DOMParser().parseFromString('<html writingsuggestions="false"><body><input /><textarea></textarea><div></div><span writingsuggestions="true"></span></body></html>', 'text/html');
+  assert_equals(doc.documentElement.writingSuggestions, 'false');
+  assert_equals(doc.body.writingSuggestions, 'false');
+  assert_equals(doc.querySelector('input').writingSuggestions, 'false');
+  assert_equals(doc.querySelector('textarea').writingSuggestions, 'false');
+  assert_equals(doc.querySelector('div').writingSuggestions, 'false');
+  assert_equals(doc.querySelector('span').writingSuggestions, 'true');
+}, 'Test overriding a non-parent ancestor element\'s `writingsuggestions` attribute on a span element from "false" to "true".');
+
+test(function() {
+  const doc = new DOMParser().parseFromString('<html writingsuggestions="false"><body><input type="color" writingsuggestions="true"><textarea></textarea><div></div><span></span></body></html>', 'text/html');
+  assert_equals(doc.documentElement.writingSuggestions, 'false');
+  assert_equals(doc.body.writingSuggestions, 'false');
+  assert_equals(doc.querySelector('input').writingSuggestions, 'true');
+  assert_equals(doc.querySelector('textarea').writingSuggestions, 'false');
+  assert_equals(doc.querySelector('div').writingSuggestions, 'false');
+  assert_equals(doc.querySelector('span').writingSuggestions, 'false');
+}, 'Test overriding a non-parent ancestor element\'s `writingsuggestions` attribute on an input type which the attribute doesn\'t apply from "false" to "true". The User Agent is responsible that writing suggestions are not applied to the element');
+
+test(function() {
+  const doc = new DOMParser().parseFromString('<html writingsuggestions="false"><body><input><textarea disabled writingsuggestions="true"></textarea><div></div><span></span></body></html>', 'text/html');
+  assert_equals(doc.documentElement.writingSuggestions, 'false');
+  assert_equals(doc.body.writingSuggestions, 'false');
+  assert_equals(doc.querySelector('input').writingSuggestions, 'false');
+  assert_equals(doc.querySelector('textarea').writingSuggestions, 'true');
+  assert_equals(doc.querySelector('div').writingSuggestions, 'false');
+  assert_equals(doc.querySelector('span').writingSuggestions, 'false');
+}, 'Test overriding a non-parent ancestor element\'s `writingsuggestions` attribute on a disabled textarea element from "false" to "true". The User Agent is responsible that writing suggestions are not applied to the element');
+
+test(function() {
+  const doc = new DOMParser().parseFromString('<html writingsuggestions="false"><body><input writingsuggestions=""><textarea></textarea><div></div><span></span></body></html>', 'text/html');
+  assert_equals(doc.documentElement.writingSuggestions, 'false');
+  assert_equals(doc.body.writingSuggestions, 'false');
+  assert_equals(doc.querySelector('input').writingSuggestions, 'true');
+  assert_equals(doc.querySelector('textarea').writingSuggestions, 'false');
+  assert_equals(doc.querySelector('div').writingSuggestions, 'false');
+  assert_equals(doc.querySelector('span').writingSuggestions, 'false');
+}, 'Test overriding a non-parent ancestor element\'s `writingsuggestions` attribute on an input element from "false" to the empty string.');
+
+test(function() {
+  const doc = new DOMParser().parseFromString('<html writingsuggestions="false"><body><input><textarea writingsuggestions=""></textarea><div></div><span></span></body></html>', 'text/html');
+  assert_equals(doc.documentElement.writingSuggestions, 'false');
+  assert_equals(doc.body.writingSuggestions, 'false');
+  assert_equals(doc.querySelector('input').writingSuggestions, 'false');
+  assert_equals(doc.querySelector('textarea').writingSuggestions, 'true');
+  assert_equals(doc.querySelector('div').writingSuggestions, 'false');
+  assert_equals(doc.querySelector('span').writingSuggestions, 'false');
+}, 'Test overriding a non-parent ancestor element\'s `writingsuggestions` attribute on a textarea element from "false" to the empty string.');
+
+test(function() {
+  const doc = new DOMParser().parseFromString('<html writingsuggestions="false"><body><input><textarea></textarea><div writingsuggestions=""></div><span></span></body></html>', 'text/html');
+  assert_equals(doc.documentElement.writingSuggestions, 'false');
+  assert_equals(doc.body.writingSuggestions, 'false');
+  assert_equals(doc.querySelector('input').writingSuggestions, 'false');
+  assert_equals(doc.querySelector('textarea').writingSuggestions, 'false');
+  assert_equals(doc.querySelector('div').writingSuggestions, 'true');
+  assert_equals(doc.querySelector('span').writingSuggestions, 'false');
+}, 'Test overriding a non-parent ancestor element\'s `writingsuggestions` attribute on a div element from "false" to the empty string.');
+
+test(function() {
+  const doc = new DOMParser().parseFromString('<html writingsuggestions="false"><body><input><textarea></textarea><div></div><span writingsuggestions=""></span></body></html>', 'text/html');
+  assert_equals(doc.documentElement.writingSuggestions, 'false');
+  assert_equals(doc.body.writingSuggestions, 'false');
+  assert_equals(doc.querySelector('input').writingSuggestions, 'false');
+  assert_equals(doc.querySelector('textarea').writingSuggestions, 'false');
+  assert_equals(doc.querySelector('div').writingSuggestions, 'false');
+  assert_equals(doc.querySelector('span').writingSuggestions, 'true');
+}, 'Test overriding a non-parent ancestor element\'s `writingsuggestions` attribute on a span element from "false" to the empty string.');
+
+test(function() {
+  const doc = new DOMParser().parseFromString('<html writingsuggestions="false"><body><input type="color" writingsuggestions=""><textarea></textarea><div></div><span></span></body></html>', 'text/html');
+  assert_equals(doc.documentElement.writingSuggestions, 'false');
+  assert_equals(doc.body.writingSuggestions, 'false');
+  assert_equals(doc.querySelector('input').writingSuggestions, 'true');
+  assert_equals(doc.querySelector('textarea').writingSuggestions, 'false');
+  assert_equals(doc.querySelector('div').writingSuggestions, 'false');
+  assert_equals(doc.querySelector('span').writingSuggestions, 'false');
+}, 'Test overriding a non-parent ancestor element\'s `writingsuggestions` attribute on an input type which the attribute doesn\'t apply from "false" to the empty string. The User Agent is responsible that writing suggestions are not applied to the element.');
+
+test(function() {
+  const doc = new DOMParser().parseFromString('<html writingsuggestions="false"><body><input><textarea disabled writingsuggestions=""></textarea><div></div><span></span></body></html>', 'text/html');
+  assert_equals(doc.documentElement.writingSuggestions, 'false');
+  assert_equals(doc.body.writingSuggestions, 'false');
+  assert_equals(doc.querySelector('input').writingSuggestions, 'false');
+  assert_equals(doc.querySelector('textarea').writingSuggestions, 'true');
+  assert_equals(doc.querySelector('div').writingSuggestions, 'false');
+  assert_equals(doc.querySelector('span').writingSuggestions, 'false');
+}, 'Test overriding a non-parent ancestor element\'s `writingsuggestions` attribute on a disabled textarea element from "false" to the empty string. The User Agent is responsible that writing suggestions are not applied to the element.');
+
+test(function() {
+  const doc = new DOMParser().parseFromString('<html writingsuggestions="false"><body><input writingsuggestions="foo"><textarea></textarea><div></div><span></span></body></html>', 'text/html');
+  assert_equals(doc.documentElement.writingSuggestions, 'false');
+  assert_equals(doc.body.writingSuggestions, 'false');
+  assert_equals(doc.querySelector('input').writingSuggestions, 'true');
+  assert_equals(doc.querySelector('textarea').writingSuggestions, 'false');
+  assert_equals(doc.querySelector('div').writingSuggestions, 'false');
+  assert_equals(doc.querySelector('span').writingSuggestions, 'false');
+}, 'Test overriding a non-parent ancestor element\'s `writingsuggestions` attribute on an input element from "false" to an invalid value.');
+
+test(function() {
+  const doc = new DOMParser().parseFromString('<html writingsuggestions="false"><body><input><textarea writingsuggestions="foo"></textarea><div></div><span></span></body></html>', 'text/html');
+  assert_equals(doc.documentElement.writingSuggestions, 'false');
+  assert_equals(doc.body.writingSuggestions, 'false');
+  assert_equals(doc.querySelector('input').writingSuggestions, 'false');
+  assert_equals(doc.querySelector('textarea').writingSuggestions, 'true');
+  assert_equals(doc.querySelector('div').writingSuggestions, 'false');
+  assert_equals(doc.querySelector('span').writingSuggestions, 'false');
+}, 'Test overriding a non-parent ancestor element\'s `writingsuggestions` attribute on a textarea element from "false" to an invalid value.');
+
+test(function() {
+  const doc = new DOMParser().parseFromString('<html writingsuggestions="false"><body><input><textarea></textarea><div writingsuggestions="foo"></div><span></span></body></html>', 'text/html');
+  assert_equals(doc.documentElement.writingSuggestions, 'false');
+  assert_equals(doc.body.writingSuggestions, 'false');
+  assert_equals(doc.querySelector('input').writingSuggestions, 'false');
+  assert_equals(doc.querySelector('textarea').writingSuggestions, 'false');
+  assert_equals(doc.querySelector('div').writingSuggestions, 'true');
+  assert_equals(doc.querySelector('span').writingSuggestions, 'false');
+}, 'Test overriding a non-parent ancestor element\'s `writingsuggestions` attribute on a div element from "false" to an invalid value.');
+
+test(function() {
+  const doc = new DOMParser().parseFromString('<html writingsuggestions="false"><body><input><textarea></textarea><div></div><span writingsuggestions="foo"></span></body></html>', 'text/html');
+  assert_equals(doc.documentElement.writingSuggestions, 'false');
+  assert_equals(doc.body.writingSuggestions, 'false');
+  assert_equals(doc.querySelector('input').writingSuggestions, 'false');
+  assert_equals(doc.querySelector('textarea').writingSuggestions, 'false');
+  assert_equals(doc.querySelector('div').writingSuggestions, 'false');
+  assert_equals(doc.querySelector('span').writingSuggestions, 'true');
+}, 'Test overriding a non-parent ancestor element\'s `writingsuggestions` attribute on a span element from "false" to an invalid value.');
+
+test(function() {
+  const doc = new DOMParser().parseFromString('<html writingsuggestions="false"><body><input type="color" writingsuggestions="foo"><textarea></textarea><div></div><span></span></body></html>', 'text/html');
+  assert_equals(doc.documentElement.writingSuggestions, 'false');
+  assert_equals(doc.body.writingSuggestions, 'false');
+  assert_equals(doc.querySelector('input').writingSuggestions, 'true');
+  assert_equals(doc.querySelector('textarea').writingSuggestions, 'false');
+  assert_equals(doc.querySelector('div').writingSuggestions, 'false');
+  assert_equals(doc.querySelector('span').writingSuggestions, 'false');
+}, 'Test overriding a non-parent ancestor element\'s `writingsuggestions` attribute on an input type which the attribute doesn\'t apply from "false" to an invalid value. The User Agent is responsible that writing suggestions are not applied to the element.');
+
+test(function() {
+  const doc = new DOMParser().parseFromString('<html writingsuggestions="false"><body><input><textarea disabled writingsuggestions="foo"></textarea><div></div><span></span></body></html>', 'text/html');
+  assert_equals(doc.documentElement.writingSuggestions, 'false');
+  assert_equals(doc.body.writingSuggestions, 'false');
+  assert_equals(doc.querySelector('input').writingSuggestions, 'false');
+  assert_equals(doc.querySelector('textarea').writingSuggestions, 'true');
+  assert_equals(doc.querySelector('div').writingSuggestions, 'false');
+  assert_equals(doc.querySelector('span').writingSuggestions, 'false');
+}, 'Test overriding a non-parent ancestor element\'s `writingsuggestions` attribute on a disabled textarea element from "false" to an invalid value. The User Agent is responsible that writing suggestions are not applied to the element.');
+
+test(function() {
+  const doc = new DOMParser().parseFromString('<html writingsuggestions="true"><body><input writingsuggestions="false"><textarea></textarea><div></div><span></span></body></html>', 'text/html');
+  assert_equals(doc.documentElement.writingSuggestions, 'true');
+  assert_equals(doc.body.writingSuggestions, 'true');
+  assert_equals(doc.querySelector('input').writingSuggestions, 'false');
+  assert_equals(doc.querySelector('textarea').writingSuggestions, 'true');
+  assert_equals(doc.querySelector('div').writingSuggestions, 'true');
+  assert_equals(doc.querySelector('span').writingSuggestions, 'true');
+}, 'Test overriding a non-parent ancestor element\'s `writingsuggestions` attribute on an input element from "true" to "false".');
+
+test(function() {
+  const doc = new DOMParser().parseFromString('<html writingsuggestions="true"><body><input><textarea writingsuggestions="false"></textarea><div></div><span></span></body></html>', 'text/html');
+  assert_equals(doc.documentElement.writingSuggestions, 'true');
+  assert_equals(doc.body.writingSuggestions, 'true');
+  assert_equals(doc.querySelector('input').writingSuggestions, 'true');
+  assert_equals(doc.querySelector('textarea').writingSuggestions, 'false');
+  assert_equals(doc.querySelector('div').writingSuggestions, 'true');
+  assert_equals(doc.querySelector('span').writingSuggestions, 'true');
+}, 'Test overriding a non-parent ancestor element\'s `writingsuggestions` attribute on a textarea element from "true" to "false".');
+
+test(function() {
+  const doc = new DOMParser().parseFromString('<html writingsuggestions="true"><body><input><textarea></textarea><div writingsuggestions="false"></div><span></span></body></html>', 'text/html');
+  assert_equals(doc.documentElement.writingSuggestions, 'true');
+  assert_equals(doc.body.writingSuggestions, 'true');
+  assert_equals(doc.querySelector('input').writingSuggestions, 'true');
+  assert_equals(doc.querySelector('textarea').writingSuggestions, 'true');
+  assert_equals(doc.querySelector('div').writingSuggestions, 'false');
+  assert_equals(doc.querySelector('span').writingSuggestions, 'true');
+}, 'Test overriding a non-parent ancestor element\'s `writingsuggestions` attribute on a div element from "true" to "false".');
+
+test(function() {
+  const doc = new DOMParser().parseFromString('<html writingsuggestions="true"><body><input><textarea></textarea><div></div><span writingsuggestions="false"></span></body></html>', 'text/html');
+  assert_equals(doc.documentElement.writingSuggestions, 'true');
+  assert_equals(doc.body.writingSuggestions, 'true');
+  assert_equals(doc.querySelector('input').writingSuggestions, 'true');
+  assert_equals(doc.querySelector('textarea').writingSuggestions, 'true');
+  assert_equals(doc.querySelector('div').writingSuggestions, 'true');
+  assert_equals(doc.querySelector('span').writingSuggestions, 'false');
+}, 'Test overriding a non-parent ancestor element\'s `writingsuggestions` attribute on a span element from "true" to "false".');
+
+test(function() {
+  const doc = new DOMParser().parseFromString('<html writingsuggestions="true"><body><input type="color" writingsuggestions="false"><textarea></textarea><div></div><span></span></body></html>', 'text/html');
+  assert_equals(doc.documentElement.writingSuggestions, 'true');
+  assert_equals(doc.body.writingSuggestions, 'true');
+  assert_equals(doc.querySelector('input').writingSuggestions, 'false');
+  assert_equals(doc.querySelector('textarea').writingSuggestions, 'true');
+  assert_equals(doc.querySelector('div').writingSuggestions, 'true');
+  assert_equals(doc.querySelector('span').writingSuggestions, 'true');
+}, 'Test overriding a non-parent ancestor element\'s `writingsuggestions` attribute on an input type which the attribute doesn\'t apply from "true" to "false". The User Agent is responsible that writing suggestions are not applied to the element.');
+
+test(function() {
+  const doc = new DOMParser().parseFromString('<html writingsuggestions="true"><body><input><textarea disabled writingsuggestions="false"></textarea><div></div><span></span></body></html>', 'text/html');
+  assert_equals(doc.documentElement.writingSuggestions, 'true');
+  assert_equals(doc.body.writingSuggestions, 'true');
+  assert_equals(doc.querySelector('input').writingSuggestions, 'true');
+  assert_equals(doc.querySelector('textarea').writingSuggestions, 'false');
+  assert_equals(doc.querySelector('div').writingSuggestions, 'true');
+  assert_equals(doc.querySelector('span').writingSuggestions, 'true');
+}, 'Test overriding a non-parent ancestor element\'s `writingsuggestions` attribute on a disabled textarea element from "true" to "false". The User Agent is responsible that writing suggestions are not applied to the element.');
+
+test(function() {
+  const doc = new DOMParser().parseFromString('<html writingsuggestions=""><body><input writingsuggestions="false"><textarea></textarea><div></div><span></span></body></html>', 'text/html');
+  assert_equals(doc.documentElement.writingSuggestions, 'true');
+  assert_equals(doc.body.writingSuggestions, 'true');
+  assert_equals(doc.querySelector('input').writingSuggestions, 'false');
+  assert_equals(doc.querySelector('textarea').writingSuggestions, 'true');
+  assert_equals(doc.querySelector('div').writingSuggestions, 'true');
+  assert_equals(doc.querySelector('span').writingSuggestions, 'true');
+}, 'Test overriding a non-parent ancestor element\'s `writingsuggestions` attribute on an input element from the empty string to "false".');
+
+test(function() {
+  const doc = new DOMParser().parseFromString('<html writingsuggestions=""><body><input><textarea writingsuggestions="false"></textarea><div></div><span></span></body></html>', 'text/html');
+  assert_equals(doc.documentElement.writingSuggestions, 'true');
+  assert_equals(doc.body.writingSuggestions, 'true');
+  assert_equals(doc.querySelector('input').writingSuggestions, 'true');
+  assert_equals(doc.querySelector('textarea').writingSuggestions, 'false');
+  assert_equals(doc.querySelector('div').writingSuggestions, 'true');
+  assert_equals(doc.querySelector('span').writingSuggestions, 'true');
+}, 'Test overriding a non-parent ancestor element\'s `writingsuggestions` attribute on a textarea element from the empty string to "false".');
+
+test(function() {
+  const doc = new DOMParser().parseFromString('<html writingsuggestions=""><body><input><textarea></textarea><div writingsuggestions="false"></div><span></span></body></html>', 'text/html');
+  assert_equals(doc.documentElement.writingSuggestions, 'true');
+  assert_equals(doc.body.writingSuggestions, 'true');
+  assert_equals(doc.querySelector('input').writingSuggestions, 'true');
+  assert_equals(doc.querySelector('textarea').writingSuggestions, 'true');
+  assert_equals(doc.querySelector('div').writingSuggestions, 'false');
+  assert_equals(doc.querySelector('span').writingSuggestions, 'true');
+}, 'Test overriding a non-parent ancestor element\'s `writingsuggestions` attribute on a div element from the empty string to "false".');
+
+test(function() {
+  const doc = new DOMParser().parseFromString('<html writingsuggestions=""><body><input><textarea></textarea><div></div><span writingsuggestions="false"></span></body></html>', 'text/html');
+  assert_equals(doc.documentElement.writingSuggestions, 'true');
+  assert_equals(doc.body.writingSuggestions, 'true');
+  assert_equals(doc.querySelector('input').writingSuggestions, 'true');
+  assert_equals(doc.querySelector('textarea').writingSuggestions, 'true');
+  assert_equals(doc.querySelector('div').writingSuggestions, 'true');
+  assert_equals(doc.querySelector('span').writingSuggestions, 'false');
+}, 'Test overriding a non-parent ancestor element\'s `writingsuggestions` attribute on a span element from the empty string to "false".');
+
+test(function() {
+  const doc = new DOMParser().parseFromString('<html writingsuggestions=""><body><input type="color" writingsuggestions="false"><textarea></textarea><div></div><span></span></body></html>', 'text/html');
+  assert_equals(doc.documentElement.writingSuggestions, 'true');
+  assert_equals(doc.body.writingSuggestions, 'true');
+  assert_equals(doc.querySelector('input').writingSuggestions, 'false');
+  assert_equals(doc.querySelector('textarea').writingSuggestions, 'true');
+  assert_equals(doc.querySelector('div').writingSuggestions, 'true');
+  assert_equals(doc.querySelector('span').writingSuggestions, 'true');
+}, 'Test overriding a non-parent ancestor element\'s `writingsuggestions` attribute on an input type which the attribute doesn\'t apply from the empty string to "false". The User Agent is responsible that writing suggestions are not applied to the element.');
+
+test(function() {
+  const doc = new DOMParser().parseFromString('<html writingsuggestions=""><body><input><textarea disabled writingsuggestions="false"></textarea><div></div><span></span></body></html>', 'text/html');
+  assert_equals(doc.documentElement.writingSuggestions, 'true');
+  assert_equals(doc.body.writingSuggestions, 'true');
+  assert_equals(doc.querySelector('input').writingSuggestions, 'true');
+  assert_equals(doc.querySelector('textarea').writingSuggestions, 'false');
+  assert_equals(doc.querySelector('div').writingSuggestions, 'true');
+  assert_equals(doc.querySelector('span').writingSuggestions, 'true');
+}, 'Test overriding a non-parent ancestor element\'s `writingsuggestions` attribute on a disabled textarea element from the empty string to "false". The User Agent is responsible that writing suggestions are not applied to the element.');
+
+test(function() {
+  const doc = new DOMParser().parseFromString('<html writingsuggestions="true"><body><div contenteditable="true"><span>Writing suggestions allowed.</span> <span writingsuggestions="false">Writing suggestions not allowed.</span></div></body></html>', 'text/html');
+  const div = doc.querySelector('div');
+  const span1 = doc.querySelector('span');
+  const span2 = doc.querySelector('span:last-child');
+  assert_equals(div.writingSuggestions, 'true');
+  assert_equals(span1.writingSuggestions, 'true');
+  assert_equals(span2.writingSuggestions, 'false');
+}, 'Test that for continuous text on the screen, writing suggestions may be allowed in one part but not another.');
+
+</script>
+</body>
+</html>

--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/html/editing/editing-0/writing-suggestions/writingsuggestions-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/html/editing/editing-0/writing-suggestions/writingsuggestions-expected.txt
@@ -1,0 +1,82 @@
+
+FAIL Test that the writingsuggestions attribute is available on HTMLInputElement. assert_true: expected true got false
+FAIL Test that the writingsuggestions attribute is available on HTMLTextAreaElement. assert_true: expected true got false
+FAIL Test that the writingsuggestions attribute is available on HTMLDivElement. assert_true: expected true got false
+FAIL Test that the writingsuggestions attribute is available on HTMLSpanElement. assert_true: expected true got false
+FAIL Test that the writingsuggestions attribute is available on custom elements. assert_true: expected true got false
+FAIL Test that the writingsuggestions attribute is available on an input type which the attribute doesn't apply. The User Agent is responsible that writing suggestions are not applied to the element. assert_true: expected true got false
+FAIL Test that the writingsuggestions attribute is available on a disabled element. The User Agent is responsible that writing suggestions are not applied to the element. assert_true: expected true got false
+FAIL Test setting the `writingsuggestions` IDL attribute to `true` directly on the target element. assert_equals: expected (string) "true" but got (object) null
+FAIL Test setting the `writingsuggestions` content attribute to `true` directly on the target element. assert_equals: expected (string) "true" but got (undefined) undefined
+FAIL Test setting the `writingsuggestions` IDL attribute to boolean `true` directly on the target element. assert_equals: expected (string) "true" but got (boolean) true
+FAIL Test setting the `writingsuggestions` content attribute to boolean `true` directly on the target element. assert_equals: expected (string) "true" but got (undefined) undefined
+FAIL Test setting the `writingsuggestions` IDL attribute to `TrUe` directly on the target element. assert_equals: expected "true" but got "TrUe"
+FAIL Test setting the `writingsuggestions` content attribute to `TrUe` directly on the target element. assert_equals: expected (string) "true" but got (undefined) undefined
+FAIL Test setting the `writingsuggestions` IDL attribute to `false` directly on the target element. assert_equals: expected (string) "false" but got (object) null
+FAIL Test setting the `writingsuggestions` content attribute to `false` directly on the target element. assert_equals: expected (string) "false" but got (undefined) undefined
+FAIL Test setting the `writingsuggestions` IDL attribute to boolean `false` directly on the target element. assert_equals: expected (string) "false" but got (boolean) false
+FAIL Test setting the `writingsuggestions` content attribute to boolean `false` directly on the target element. assert_equals: expected (string) "false" but got (undefined) undefined
+FAIL Test setting the `writingsuggestions` IDL attribute to `FaLsE` directly on the target element. assert_equals: expected "false" but got "FaLsE"
+FAIL Test setting the `writingsuggestions` content attribute to `FaLsE` directly on the target element. assert_equals: expected (string) "false" but got (undefined) undefined
+FAIL Test setting the `writingsuggestions` IDL attribute to the empty string directly on the target element. assert_equals: expected "true" but got ""
+FAIL Test setting the `writingsuggestions` content attribute to the empty string directly on the target element. assert_equals: expected (string) "true" but got (undefined) undefined
+FAIL Test setting the `writingsuggestions` IDL attribute to an invalid value directly on the target element. assert_equals: expected "true" but got "foo"
+FAIL Test setting the `writingsuggestions` content attribute to an invalid value directly on the target element. assert_equals: expected (string) "true" but got (undefined) undefined
+FAIL Test the writing suggestions state when the `writingsuggestions` attribute is missing. assert_equals: expected (string) "true" but got (undefined) undefined
+FAIL Test setting the `writingsuggestions` content attribute to `false` after the IDL attribute was set to `true`. assert_equals: expected "false" but got "true"
+PASS Test setting the `writingsuggestions` content attribute to the empty string after the IDL attribute was set to `true`.
+PASS Test setting the `writingsuggestions` content attribute to an invalid value after the IDL attribute was set to `true`.
+PASS Test setting the `writingsuggestions` content attribute to `TrUe` after the IDL attribute was set to `true`.
+FAIL Test setting the `writingsuggestions` content attribute to `FaLsE` after the IDL attribute was set to `true`. assert_equals: expected "false" but got "true"
+PASS Test setting the `writingsuggestions` content attribute to boolean `true` after the IDL attribute was set to `true`.
+FAIL Test setting the `writingsuggestions` content attribute to boolean `false` after the IDL attribute was set to `true`. assert_equals: expected "false" but got "true"
+FAIL Test setting the `writingsuggestions` content attribute to `true` after the IDL attribute was set to `false`. assert_equals: expected "true" but got "false"
+FAIL Test setting the `writingsuggestions` content attribute to the empty string after the IDL attribute was set to `false`. assert_equals: expected "true" but got "false"
+FAIL Test setting the `writingsuggestions` content attribute to an invalid value after the IDL attribute was set to `false`. assert_equals: expected "true" but got "false"
+FAIL Test setting the `writingsuggestions` content attribute to `TrUe` after the IDL attribute was set to `false`. assert_equals: expected "true" but got "false"
+PASS Test setting the `writingsuggestions` content attribute to `FaLsE` after the IDL attribute was set to `false`.
+FAIL Test setting the `writingsuggestions` content attribute to boolean `true` after the IDL attribute was set to `false`. assert_equals: expected "true" but got "false"
+PASS Test setting the `writingsuggestions` content attribute to boolean `false` after the IDL attribute was set to `false`.
+FAIL Test setting the `writingsuggestions` attribute with a missing value directly on the target element. assert_equals: expected (string) "true" but got (undefined) undefined
+FAIL Test setting the `writingsuggestions` attribute to "true" on a parent element. assert_equals: expected (string) "true" but got (undefined) undefined
+FAIL Test setting the `writingsuggestions` attribute to an empty string on a parent element. assert_equals: expected (string) "true" but got (undefined) undefined
+FAIL Test setting the `writingsuggestions` attribute to "false" on a parent element. assert_equals: expected (string) "false" but got (undefined) undefined
+FAIL Test setting the `writingsuggestions` attribute to an invalid value on a parent element. assert_equals: expected (string) "true" but got (undefined) undefined
+FAIL Test overriding the parent element's `writingsuggestions` attribute from "true" to "false". assert_equals: expected (string) "true" but got (undefined) undefined
+FAIL Test overriding the parent element's `writingsuggestions` attribute from the empty string to "false". assert_equals: expected (string) "true" but got (undefined) undefined
+FAIL Test overriding the parent element's `writingsuggestions` attribute from "false" to "true". assert_equals: expected (string) "false" but got (undefined) undefined
+FAIL Test overriding the parent element's `writingsuggestions` attribute from "false" to an invalid value. assert_equals: expected (string) "false" but got (undefined) undefined
+FAIL Test overriding the parent element's `writingsuggestions` attribute from "false" to the empty string. assert_equals: expected (string) "false" but got (undefined) undefined
+FAIL Test turning off writing suggestions for an entire document. assert_equals: expected (string) "false" but got (undefined) undefined
+FAIL Test overriding a non-parent ancestor element's `writingsuggestions` attribute on an input element from "false" to "true". assert_equals: expected (string) "false" but got (undefined) undefined
+FAIL Test overriding a non-parent ancestor element's `writingsuggestions` attribute on a textarea element from "false" to "true". assert_equals: expected (string) "false" but got (undefined) undefined
+FAIL Test overriding a non-parent ancestor element's `writingsuggestions` attribute on a div element from "false" to "true". assert_equals: expected (string) "false" but got (undefined) undefined
+FAIL Test overriding a non-parent ancestor element's `writingsuggestions` attribute on a span element from "false" to "true". assert_equals: expected (string) "false" but got (undefined) undefined
+FAIL Test overriding a non-parent ancestor element's `writingsuggestions` attribute on an input type which the attribute doesn't apply from "false" to "true". The User Agent is responsible that writing suggestions are not applied to the element assert_equals: expected (string) "false" but got (undefined) undefined
+FAIL Test overriding a non-parent ancestor element's `writingsuggestions` attribute on a disabled textarea element from "false" to "true". The User Agent is responsible that writing suggestions are not applied to the element assert_equals: expected (string) "false" but got (undefined) undefined
+FAIL Test overriding a non-parent ancestor element's `writingsuggestions` attribute on an input element from "false" to the empty string. assert_equals: expected (string) "false" but got (undefined) undefined
+FAIL Test overriding a non-parent ancestor element's `writingsuggestions` attribute on a textarea element from "false" to the empty string. assert_equals: expected (string) "false" but got (undefined) undefined
+FAIL Test overriding a non-parent ancestor element's `writingsuggestions` attribute on a div element from "false" to the empty string. assert_equals: expected (string) "false" but got (undefined) undefined
+FAIL Test overriding a non-parent ancestor element's `writingsuggestions` attribute on a span element from "false" to the empty string. assert_equals: expected (string) "false" but got (undefined) undefined
+FAIL Test overriding a non-parent ancestor element's `writingsuggestions` attribute on an input type which the attribute doesn't apply from "false" to the empty string. The User Agent is responsible that writing suggestions are not applied to the element. assert_equals: expected (string) "false" but got (undefined) undefined
+FAIL Test overriding a non-parent ancestor element's `writingsuggestions` attribute on a disabled textarea element from "false" to the empty string. The User Agent is responsible that writing suggestions are not applied to the element. assert_equals: expected (string) "false" but got (undefined) undefined
+FAIL Test overriding a non-parent ancestor element's `writingsuggestions` attribute on an input element from "false" to an invalid value. assert_equals: expected (string) "false" but got (undefined) undefined
+FAIL Test overriding a non-parent ancestor element's `writingsuggestions` attribute on a textarea element from "false" to an invalid value. assert_equals: expected (string) "false" but got (undefined) undefined
+FAIL Test overriding a non-parent ancestor element's `writingsuggestions` attribute on a div element from "false" to an invalid value. assert_equals: expected (string) "false" but got (undefined) undefined
+FAIL Test overriding a non-parent ancestor element's `writingsuggestions` attribute on a span element from "false" to an invalid value. assert_equals: expected (string) "false" but got (undefined) undefined
+FAIL Test overriding a non-parent ancestor element's `writingsuggestions` attribute on an input type which the attribute doesn't apply from "false" to an invalid value. The User Agent is responsible that writing suggestions are not applied to the element. assert_equals: expected (string) "false" but got (undefined) undefined
+FAIL Test overriding a non-parent ancestor element's `writingsuggestions` attribute on a disabled textarea element from "false" to an invalid value. The User Agent is responsible that writing suggestions are not applied to the element. assert_equals: expected (string) "false" but got (undefined) undefined
+FAIL Test overriding a non-parent ancestor element's `writingsuggestions` attribute on an input element from "true" to "false". assert_equals: expected (string) "true" but got (undefined) undefined
+FAIL Test overriding a non-parent ancestor element's `writingsuggestions` attribute on a textarea element from "true" to "false". assert_equals: expected (string) "true" but got (undefined) undefined
+FAIL Test overriding a non-parent ancestor element's `writingsuggestions` attribute on a div element from "true" to "false". assert_equals: expected (string) "true" but got (undefined) undefined
+FAIL Test overriding a non-parent ancestor element's `writingsuggestions` attribute on a span element from "true" to "false". assert_equals: expected (string) "true" but got (undefined) undefined
+FAIL Test overriding a non-parent ancestor element's `writingsuggestions` attribute on an input type which the attribute doesn't apply from "true" to "false". The User Agent is responsible that writing suggestions are not applied to the element. assert_equals: expected (string) "true" but got (undefined) undefined
+FAIL Test overriding a non-parent ancestor element's `writingsuggestions` attribute on a disabled textarea element from "true" to "false". The User Agent is responsible that writing suggestions are not applied to the element. assert_equals: expected (string) "true" but got (undefined) undefined
+FAIL Test overriding a non-parent ancestor element's `writingsuggestions` attribute on an input element from the empty string to "false". assert_equals: expected (string) "true" but got (undefined) undefined
+FAIL Test overriding a non-parent ancestor element's `writingsuggestions` attribute on a textarea element from the empty string to "false". assert_equals: expected (string) "true" but got (undefined) undefined
+FAIL Test overriding a non-parent ancestor element's `writingsuggestions` attribute on a div element from the empty string to "false". assert_equals: expected (string) "true" but got (undefined) undefined
+FAIL Test overriding a non-parent ancestor element's `writingsuggestions` attribute on a span element from the empty string to "false". assert_equals: expected (string) "true" but got (undefined) undefined
+FAIL Test overriding a non-parent ancestor element's `writingsuggestions` attribute on an input type which the attribute doesn't apply from the empty string to "false". The User Agent is responsible that writing suggestions are not applied to the element. assert_equals: expected (string) "true" but got (undefined) undefined
+FAIL Test overriding a non-parent ancestor element's `writingsuggestions` attribute on a disabled textarea element from the empty string to "false". The User Agent is responsible that writing suggestions are not applied to the element. assert_equals: expected (string) "true" but got (undefined) undefined
+FAIL Test that for continuous text on the screen, writing suggestions may be allowed in one part but not another. assert_equals: expected (string) "true" but got (undefined) undefined
+

--- a/LayoutTests/platform/ios/imported/w3c/web-platform-tests/html/dom/idlharness.https_include=HTML._-expected.txt
+++ b/LayoutTests/platform/ios/imported/w3c/web-platform-tests/html/dom/idlharness.https_include=HTML._-expected.txt
@@ -139,7 +139,7 @@ PASS HTMLElement interface: attribute accessKey
 PASS HTMLElement interface: attribute accessKeyLabel
 PASS HTMLElement interface: attribute draggable
 PASS HTMLElement interface: attribute spellcheck
-FAIL HTMLElement interface: attribute writingSuggestions assert_true: The prototype object must have a property "writingSuggestions" expected true got false
+PASS HTMLElement interface: attribute writingSuggestions
 PASS HTMLElement interface: attribute autocapitalize
 PASS HTMLElement interface: attribute autocorrect
 PASS HTMLElement interface: attribute innerText
@@ -248,7 +248,7 @@ PASS HTMLElement interface: document.createElement("noscript") must inherit prop
 PASS HTMLElement interface: document.createElement("noscript") must inherit property "accessKeyLabel" with the proper type
 PASS HTMLElement interface: document.createElement("noscript") must inherit property "draggable" with the proper type
 PASS HTMLElement interface: document.createElement("noscript") must inherit property "spellcheck" with the proper type
-FAIL HTMLElement interface: document.createElement("noscript") must inherit property "writingSuggestions" with the proper type assert_inherits: property "writingSuggestions" not found in prototype chain
+PASS HTMLElement interface: document.createElement("noscript") must inherit property "writingSuggestions" with the proper type
 PASS HTMLElement interface: document.createElement("noscript") must inherit property "autocapitalize" with the proper type
 PASS HTMLElement interface: document.createElement("noscript") must inherit property "autocorrect" with the proper type
 PASS HTMLElement interface: document.createElement("noscript") must inherit property "innerText" with the proper type

--- a/Source/WebCore/dom/Element.cpp
+++ b/Source/WebCore/dom/Element.cpp
@@ -5523,6 +5523,19 @@ bool Element::isSpellCheckingEnabled() const
     return true;
 }
 
+bool Element::computedWritingSuggestionsValue() const
+{
+    for (Ref ancestor : composedTreeLineage(*this)) {
+        auto& value = ancestor->attributeWithoutSynchronization(HTMLNames::writingsuggestionsAttr);
+        if (value.isNull())
+            continue;
+        if (equalLettersIgnoringASCIICase(value, "false"_s))
+            return false;
+        return true;
+    }
+    return true;
+}
+
 bool Element::isWritingSuggestionsEnabled() const
 {
     // If none of the following conditions are true, then return `false`.
@@ -5555,16 +5568,8 @@ bool Element::isWritingSuggestionsEnabled() const
     // not in the `default` state and the nearest such ancestor's `writingsuggestions` content attribute
     // is in the `false` state, then return `false`.
 
-    for (Ref ancestor : composedTreeLineage(*this)) {
-        auto& value = ancestor->attributeWithoutSynchronization(HTMLNames::writingsuggestionsAttr);
-
-        if (value.isNull())
-            continue;
-        if (value.isEmpty() || equalLettersIgnoringASCIICase(value, "true"_s))
-            return true;
-        if (equalLettersIgnoringASCIICase(value, "false"_s))
-            return false;
-    }
+    if (!computedWritingSuggestionsValue())
+        return false;
 
     // This is not yet part of the spec, but it improves web-compatibility; if autocomplete
     // is intentionally off, the site author probably wants writingsuggestions off too.

--- a/Source/WebCore/dom/Element.h
+++ b/Source/WebCore/dom/Element.h
@@ -758,6 +758,7 @@ public:
     bool isInVisibilityAdjustmentSubtree() const;
 
     bool isSpellCheckingEnabled() const;
+    bool computedWritingSuggestionsValue() const;
     WEBCORE_EXPORT bool isWritingSuggestionsEnabled() const;
 
     inline bool hasID() const;

--- a/Source/WebCore/html/HTMLElement.cpp
+++ b/Source/WebCore/html/HTMLElement.cpp
@@ -1,7 +1,7 @@
 /*
  * Copyright (C) 1999 Lars Knoll (knoll@kde.org)
  *           (C) 1999 Antti Koivisto (koivisto@kde.org)
- * Copyright (C) 2004-2025 Apple Inc. All rights reserved.
+ * Copyright (C) 2004-2026 Apple Inc. All rights reserved.
  * Copyright (C) 2021-2024 Google Inc. All rights reserved.
  * Copyright (C) 2009 Torch Mobile Inc. All rights reserved. (http://www.torchmobile.com/)
  * Copyright (C) 2011 Motorola Mobility. All rights reserved.
@@ -670,14 +670,9 @@ void HTMLElement::setSpellcheck(bool enable)
     setAttributeWithoutSynchronization(spellcheckAttr, enable ? trueAtom() : falseAtom());
 }
 
-bool HTMLElement::writingsuggestions() const
+const AtomString& HTMLElement::writingSuggestions() const
 {
-    return isWritingSuggestionsEnabled();
-}
-
-void HTMLElement::setWritingsuggestions(bool enable)
-{
-    setAttributeWithoutSynchronization(writingsuggestionsAttr, enable ? trueAtom() : falseAtom());
+    return computedWritingSuggestionsValue() ? trueAtom() : falseAtom();
 }
 
 void HTMLElement::effectiveSpellcheckAttributeChanged(bool newValue)

--- a/Source/WebCore/html/HTMLElement.h
+++ b/Source/WebCore/html/HTMLElement.h
@@ -1,7 +1,7 @@
 /*
  * Copyright (C) 1999 Lars Knoll (knoll@kde.org)
  *           (C) 1999 Antti Koivisto (koivisto@kde.org)
- * Copyright (C) 2004-2018 Apple Inc. All rights reserved.
+ * Copyright (C) 2004-2026 Apple Inc. All rights reserved.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Library General Public
@@ -77,8 +77,7 @@ public:
     WEBCORE_EXPORT bool spellcheck() const;
     WEBCORE_EXPORT void setSpellcheck(bool);
 
-    WEBCORE_EXPORT bool writingsuggestions() const;
-    WEBCORE_EXPORT void setWritingsuggestions(bool);
+    WEBCORE_EXPORT const AtomString& writingSuggestions() const;
 
     WEBCORE_EXPORT bool translate() const;
     WEBCORE_EXPORT void setTranslate(bool);

--- a/Source/WebCore/html/HTMLElement.h
+++ b/Source/WebCore/html/HTMLElement.h
@@ -1,7 +1,7 @@
 /*
  * Copyright (C) 1999 Lars Knoll (knoll@kde.org)
  *           (C) 1999 Antti Koivisto (koivisto@kde.org)
- * Copyright (C) 2004-2018 Apple Inc. All rights reserved.
+ * Copyright (C) 2004-2026 Apple Inc. All rights reserved.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Library General Public
@@ -78,8 +78,7 @@ public:
     WEBCORE_EXPORT bool spellcheck() const;
     WEBCORE_EXPORT void setSpellcheck(bool);
 
-    WEBCORE_EXPORT bool writingsuggestions() const;
-    WEBCORE_EXPORT void setWritingsuggestions(bool);
+    WEBCORE_EXPORT const AtomString& writingSuggestions() const;
 
     WEBCORE_EXPORT bool translate() const;
     WEBCORE_EXPORT void setTranslate(bool);

--- a/Source/WebCore/html/HTMLElement.idl
+++ b/Source/WebCore/html/HTMLElement.idl
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2006, 2007, 2009 Apple Inc. All rights reserved.
+ * Copyright (C) 2006-2026 Apple Inc. All rights reserved.
  * Copyright (C) 2006 Samuel Weinig <sam.weinig@gmail.com>
  *
  * This library is free software; you can redistribute it and/or
@@ -68,7 +68,7 @@
     // Non-standard: We are the only browser to support this now that Blink dropped it (http://crbug.com/688943).
     [CEReactions=Needed, Reflect] attribute DOMString webkitdropzone;
 
-    [Conditional=WRITING_SUGGESTIONS, CEReactions=Needed] attribute boolean writingsuggestions;
+    [Conditional=WRITING_SUGGESTIONS, CEReactions=Needed, ReflectSetter] attribute [AtomString] DOMString writingSuggestions;
 };
 
 // https://html.spec.whatwg.org/multipage/dom.html#showpopoveroptions


### PR DESCRIPTION
#### 5edc9a7e9d4ce75ea7950a8efc9d71e3482dbbf2
<pre>
Align writingSuggestions IDL attribute with the HTML specification
<a href="https://bugs.webkit.org/show_bug.cgi?id=313805">https://bugs.webkit.org/show_bug.cgi?id=313805</a>
<a href="https://rdar.apple.com/problem/176000886">rdar://problem/176000886</a>

Reviewed by Aditya Keerthi.

The writingSuggestions IDL attribute was exposed as &quot;writingsuggestions&quot;
(all lowercase, boolean) instead of &quot;writingSuggestions&quot; (camelCase,
DOMString) as defined by the specification [1].

The getter was also returning the result of isWritingSuggestionsEnabled(),
which implements the &quot;should offer suggestions&quot; algorithm — checking
element eligibility, mutability, and user preferences. Per the spec [2],
the getter should instead return the &quot;computed writing suggestions
value&quot;, which is purely based on content attribute state inheritance:

&quot;If element&apos;s writingsuggestions content attribute is in the False
 state, return &quot;false&quot;. If element&apos;s writingsuggestions content
 attribute is in the Default state, element has a parent element,
 and the computed writing suggestions value of element&apos;s parent
 element is &quot;false&quot;, then return &quot;false&quot;. Return &quot;true&quot;.&quot;

The spec [2] further clarifies: &quot;The writingSuggestions IDL attribute is
not affected by user preferences that override the writingsuggestions
content attribute, and therefore might not reflect the actual writing
suggestions state.&quot;

This ancestor traversal logic is extracted into
Element::computedWritingSuggestionsValue(), which is shared with
Element::isWritingSuggestionsEnabled() to avoid duplication.

The setter uses [ReflectSetter] in the IDL to directly set the content
attribute string value via codegen.

isWritingSuggestionsEnabled() remains unchanged and continues to be
used internally for deciding when to actually offer writing suggestions.

[1] <a href="https://html.spec.whatwg.org/multipage/dom.html#htmlelement">https://html.spec.whatwg.org/multipage/dom.html#htmlelement</a>
[2] <a href="https://html.spec.whatwg.org/multipage/interaction.html#writing-suggestions">https://html.spec.whatwg.org/multipage/interaction.html#writing-suggestions</a>

* Source/WebCore/dom/Element.cpp:
(WebCore::Element::computedWritingSuggestionsValue const): Helper function
(WebCore::Element::isWritingSuggestionsEnabled const):
* Source/WebCore/dom/Element.h:
* Source/WebCore/html/HTMLElement.cpp:
(WebCore::HTMLElement::writingSuggestions const):
(WebCore::HTMLElement::writingsuggestions const): Deleted.
(WebCore::HTMLElement::setWritingsuggestions): Deleted.
* Source/WebCore/html/HTMLElement.h:
* Source/WebCore/html/HTMLElement.idl:

&gt; Progressions:
* LayoutTests/platform/ios/imported/w3c/web-platform-tests/html/dom/idlharness.https_include=HTML._-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/dom/idlharness.https_include=HTML._-expected.txt:

&gt; WPT Sync (as of Upstream commit: <a href="https://github.com/web-platform-tests/wpt/commit/719d6108183fbad81611492080c9cf86b1a50a54)">https://github.com/web-platform-tests/wpt/commit/719d6108183fbad81611492080c9cf86b1a50a54)</a>:
* LayoutTests/imported/w3c/web-platform-tests/html/editing/editing-0/writing-suggestions/WEB_FEATURES.yml: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/editing/editing-0/writing-suggestions/w3c-import.log: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/editing/editing-0/writing-suggestions/writingsuggestions-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/editing/editing-0/writing-suggestions/writingsuggestions.html: Added.

&gt; Platform Specific Expectation:
* LayoutTests/platform/glib/imported/w3c/web-platform-tests/html/editing/editing-0/writing-suggestions/writingsuggestions-expected.txt: Added.

Canonical link: <a href="https://commits.webkit.org/312923@main">https://commits.webkit.org/312923@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1368c8f55b62dc0a5a28e8e8527cfc66e70feb56

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/160121 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/33591 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/26695 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/169013 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/114502 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/161990 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/33694 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/33593 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/124116 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/87050 "1 flakes 2 failures") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/163079 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/26366 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/143823 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/104725 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/25419 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/23909 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/16742 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/135111 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/21586 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/171491 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/17489 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/23226 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/132375 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/33267 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/27995 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/132401 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36088 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/33252 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/143381 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/91458 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/27016 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/20195 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/32761 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/99158 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/32259 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/32505 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/32409 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->