### PR TITLE
Uninitialized memory write in WebCore::ContentExtensions::SerializedNFA::serialize

### DIFF
--- a/Source/WebCore/contentextensions/ImmutableNFA.h
+++ b/Source/WebCore/contentextensions/ImmutableNFA.h
@@ -36,6 +36,8 @@ namespace ContentExtensions {
 
 template <typename CharacterType>
 struct ImmutableRange {
+    ImmutableRange() { zeroBytes(*this); }
+
     uint32_t targetStart;
     uint32_t targetEnd;
     CharacterType first;

--- a/Source/WebCore/contentextensions/ImmutableNFANodeBuilder.h
+++ b/Source/WebCore/contentextensions/ImmutableNFANodeBuilder.h
@@ -195,7 +195,12 @@ private:
                 m_immutableNFA->targets.append(target);
             unsigned targetsEnd = m_immutableNFA->targets.size();
 
-            m_immutableNFA->transitions.append(ImmutableRange<CharacterType> { targetsStart, targetsEnd, range.first, range.last });
+            ImmutableRange<CharacterType> transition;
+            transition.targetStart = targetsStart;
+            transition.targetEnd = targetsEnd;
+            transition.first = range.first;
+            transition.last = range.last;
+            m_immutableNFA->transitions.append(WTF::move(transition));
         }
         unsigned transitionsEnd = m_immutableNFA->transitions.size();
 


### PR DESCRIPTION
#### 07918cccab884c5682df3809c603f116cbba3763
<pre>
Uninitialized memory write in WebCore::ContentExtensions::SerializedNFA::serialize
<a href="https://bugs.webkit.org/show_bug.cgi?id=312298">https://bugs.webkit.org/show_bug.cgi?id=312298</a>
<a href="https://rdar.apple.com/175273937">rdar://175273937</a>

Reviewed by Michael Catanzaro.

ImmutableRange&lt;char&gt; has 2 bytes of struct padding after its char fields.
When SerializedNFA serializes the transitions vector as raw bytes, valgrind
flags those uninitialized padding bytes passed to the write() syscall.

Add a default constructor that calls zeroBytes() to ensure padding is
always zeroed.

* Source/WebCore/contentextensions/ImmutableNFA.h:
(WebCore::ContentExtensions::ImmutableRange::ImmutableRange):
* Source/WebCore/contentextensions/ImmutableNFANodeBuilder.h:
(WebCore::ContentExtensions::ImmutableNFANodeBuilder::sinkTransitions):

Canonical link: <a href="https://commits.webkit.org/312425@main">https://commits.webkit.org/312425@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3237b0aa7007be778091d2d2c5d38c9110e081ce

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/159903 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/33371 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/26477 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/168772 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/114284 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/161772 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/33475 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/33375 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/123927 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/86917 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/162861 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/26177 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/143618 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/104548 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/25229 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/23702 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/16524 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/134921 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/21388 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/171259 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/17271 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/23026 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/132191 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/33049 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/27785 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/132219 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35771 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/33034 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/143183 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/91159 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/26835 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/19996 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/32543 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/98940 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/32040 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/32287 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/32191 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->