### PR TITLE
Use protect() instead of Ref { } in editing code

### DIFF
--- a/Source/WebCore/editing/DictationCommand.cpp
+++ b/Source/WebCore/editing/DictationCommand.cpp
@@ -50,9 +50,9 @@ public:
     void operator()(size_t lineOffset, size_t lineLength, bool isLastLine) const
     {
         if (lineLength > 0)
-            Ref { m_dictationCommand.get() }->insertTextRunWithoutNewlines(lineOffset, lineLength);
+            protect(m_dictationCommand.get())->insertTextRunWithoutNewlines(lineOffset, lineLength);
         if (!isLastLine)
-            Ref { m_dictationCommand.get() }->insertParagraphSeparator();
+            protect(m_dictationCommand.get())->insertParagraphSeparator();
     }
 private:
     WeakRef<DictationCommand> m_dictationCommand;

--- a/Source/WebCore/editing/EditingStyle.cpp
+++ b/Source/WebCore/editing/EditingStyle.cpp
@@ -296,7 +296,7 @@ public:
         if (!m_keywordValue)
             return false;
         RefPtr valueList = dynamicDowncast<CSSValueList>(WTF::move(styleValue));
-        return valueList && valueList->hasValue(Ref { *m_keywordValue });
+        return valueList && valueList->hasValue(protect(*m_keywordValue));
     }
 
 private:
@@ -892,7 +892,7 @@ TriState EditingStyle::triStateOfStyle(EditingStyle* style) const
 {
     if (!style || !style->m_mutableStyle)
         return TriState::False;
-    return triStateOfStyle(Ref { *style->m_mutableStyle }.get(), ShouldIgnoreTextOnlyProperties::No);
+    return triStateOfStyle(protect(*style->m_mutableStyle).get(), ShouldIgnoreTextOnlyProperties::No);
 }
 
 template<typename T>
@@ -1160,7 +1160,7 @@ bool EditingStyle::styleIsPresentInComputedStyleOfNode(Node& node) const
             return false;
     }
 
-    return !m_mutableStyle || getPropertiesNotIn(Ref { *m_mutableStyle }, computedStyle)->isEmpty();
+    return !m_mutableStyle || getPropertiesNotIn(protect(*m_mutableStyle), computedStyle)->isEmpty();
 }
 
 bool EditingStyle::elementIsStyledSpanOrHTMLEquivalent(const HTMLElement& element)
@@ -1413,7 +1413,7 @@ static Ref<MutableStyleProperties> styleFromMatchedRulesForElement(Element& elem
     if (!element.isConnected())
         return style;
 
-    for (auto& matchedRule : Ref { element.styleResolver() }->styleRulesForElement(&element, rulesToInclude))
+    for (auto& matchedRule : protect(element.styleResolver())->styleRulesForElement(&element, rulesToInclude))
         style->mergeAndOverrideOnConflict(protect(matchedRule->properties()));
     
     return style;
@@ -1490,7 +1490,7 @@ Ref<MutableStyleProperties> EditingStyle::removeInlineStyleRedundantDueToMatched
 {
     auto styleFromMatchedRules = styleFromMatchedRulesForElement(element, Style::Resolver::AllButEmptyCSSRules);
     if (!styleFromMatchedRules->isEmpty())
-        m_mutableStyle = getPropertiesNotIn(Ref { *m_mutableStyle }, styleFromMatchedRules.get());
+        m_mutableStyle = getPropertiesNotIn(protect(*m_mutableStyle), styleFromMatchedRules.get());
     return styleFromMatchedRules;
 }
 
@@ -1703,14 +1703,14 @@ bool EditingStyle::fontWeightIsBold()
     if (!m_mutableStyle)
         return false;
 
-    return WebCore::fontWeightIsBold(Ref { *m_mutableStyle }.get());
+    return WebCore::fontWeightIsBold(protect(*m_mutableStyle).get());
 }
 
 bool EditingStyle::fontStyleIsItalic()
 {
     if (!m_mutableStyle)
         return false;
-    RefPtr fontStyle = extractPropertyValue(Ref { *m_mutableStyle }, CSSPropertyFontStyle);
+    RefPtr fontStyle = extractPropertyValue(protect(*m_mutableStyle), CSSPropertyFontStyle);
     if (!fontStyle)
         return false;
 
@@ -1723,7 +1723,7 @@ bool EditingStyle::webkitTextDecorationsInEffectIsUnderline()
 {
     if (!m_mutableStyle)
         return false;
-    RefPtr textDecorations = dynamicDowncast<CSSValueList>(extractPropertyValue(Ref { *m_mutableStyle }, CSSPropertyWebkitTextDecorationsInEffect));
+    RefPtr textDecorations = dynamicDowncast<CSSValueList>(extractPropertyValue(protect(*m_mutableStyle), CSSPropertyWebkitTextDecorationsInEffect));
     if (!textDecorations)
         return false;
     return textDecorations->hasValue(CSSValueUnderline);
@@ -1865,7 +1865,7 @@ Ref<EditingStyle> EditingStyle::inverseTransformColorIfNeeded(Element& element)
 
     const auto& colorFilter = renderer->style().appleColorFilter();
     auto invertedColor = [&](CSSPropertyID propertyID) {
-        Color newColor = cssValueToColor(extractPropertyValue(Ref { *m_mutableStyle }, propertyID).get());
+        Color newColor = cssValueToColor(extractPropertyValue(protect(*m_mutableStyle), propertyID).get());
         colorFilter.inverseTransformColor(newColor);
         protect(styleWithInvertedColors->style())->setProperty(propertyID, serializationForCSS(newColor));
     };

--- a/Source/WebCore/editing/SplitElementCommand.cpp
+++ b/Source/WebCore/editing/SplitElementCommand.cpp
@@ -110,7 +110,7 @@ void SplitElementCommand::getNodesInCommand(NodeSet& nodes)
 {
     addNodeAndDescendants(protect(m_element1).get(), nodes);
     addNodeAndDescendants(m_element2.ptr(), nodes);
-    addNodeAndDescendants(Ref { m_atChild }.ptr(), nodes);
+    addNodeAndDescendants(protect(m_atChild).ptr(), nodes);
 }
 #endif
     

--- a/Source/WebCore/editing/markup.cpp
+++ b/Source/WebCore/editing/markup.cpp
@@ -1672,10 +1672,10 @@ ExceptionOr<void> replaceChildrenWithFragment(ContainerNode& container, Ref<Docu
     SUPPRESS_UNCOUNTED_LOCAL auto* containerChild = dynamicDowncast<Text>(containerNode->firstChild());
     if (containerChild && !containerChild->nextSibling()) {
         if (RefPtr fragmentChild = singleTextChild(fragment); fragmentChild && canUseSetDataOptimization(*containerChild, mutation)) {
-            Ref { *containerChild }->setData(fragmentChild->data());
+            protect(*containerChild)->setData(fragmentChild->data());
             return { };
         }
-        return containerNode->replaceChild(fragment, Ref { *containerChild });
+        return containerNode->replaceChild(fragment, protect(*containerChild));
     }
 
     containerNode->removeChildren();


### PR DESCRIPTION
#### 61f44b170faba15be20e708b8067e11b14e6d70a
<pre>
Use protect() instead of Ref { } in editing code
<a href="https://bugs.webkit.org/show_bug.cgi?id=313810">https://bugs.webkit.org/show_bug.cgi?id=313810</a>
<a href="https://rdar.apple.com/176005151">rdar://176005151</a>

Reviewed by Ryosuke Niwa.

Mechanical migration from Ref { expr } to protect(expr) in editing code,
aligning with the codebase-wide transition away from brace-initialized smart
pointer temporaries.

No new tests needed (no behavioral change, style-only refactor).

* Source/WebCore/editing/DictationCommand.cpp:
(WebCore::DictationCommandLineOperation::operator() const):
* Source/WebCore/editing/EditingStyle.cpp:
(WebCore::EditingStyleKeywordValue::matchesMutableStyleProperty const):
(WebCore::EditingStyle::triStateOfStyle const):
(WebCore::EditingStyle::conflictsWithImplicitStyleOfAttributes const):
(WebCore::EditingStyle::styleRulesForElement):
(WebCore::EditingStyle::removeStyleConflictingWithStyleOfElement):
(WebCore::EditingStyle::fontIsBold const):
(WebCore::EditingStyle::fontStyle const):
(WebCore::EditingStyle::textDecorationIsUnderlineOrLineThrough const):
(WebCore::EditingStyle::colorForProperty const):
* Source/WebCore/editing/SplitElementCommand.cpp:
(WebCore::SplitElementCommand::doUnapply):
* Source/WebCore/editing/markup.cpp:
(WebCore::parseHTMLFragmentWithNewParsingAPI):

Canonical link: <a href="https://commits.webkit.org/312452@main">https://commits.webkit.org/312452@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/de01a7b5d7de2d3935520bf3e841b86fa7306ee4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/159905 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/33373 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/26479 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/168774 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/114286 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/12074357-0678-4f16-a169-1452975cfeef) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/161774 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/33477 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/33377 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/123928 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/86920 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/305f97e7-39f8-4a51-a255-ec69fed02997) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/162863 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/26180 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/143625 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/104549 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/25232 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/23788 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/16526 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/134924 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/21395 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/171261 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/17273 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/23033 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/132193 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/33051 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/27787 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/132221 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35789 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/33036 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/143190 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/91155 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/26840 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/20003 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/32545 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/98942 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/32042 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/32289 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/32193 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->