### PR TITLE
[GStreamer] Restore DMABuf caching code removed in 306270@main

### DIFF
--- a/Source/WebCore/platform/graphics/gstreamer/VideoFrameGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/VideoFrameGStreamer.cpp
@@ -797,6 +797,13 @@ RefPtr<DMABufBuffer> VideoFrameGStreamer::getDMABuf()
         return nullptr;
 
     auto buffer = gst_sample_get_buffer(m_sample.get());
+
+    static GQuark dmabufQuark = g_quark_from_static_string("wk-dmabuf-buffer");
+    auto memory = GST_MINI_OBJECT_CAST(gst_buffer_peek_memory(buffer, 0));
+    RefPtr cachedDmaBuf = static_cast<DMABufBuffer*>(gst_mini_object_get_qdata(memory, dmabufQuark));
+    if (cachedDmaBuf)
+        return cachedDmaBuf;
+
     const auto* videoMeta = gst_buffer_get_video_meta(buffer);
     if (!videoMeta) [[unlikely]] {
         GST_WARNING("Unable to retrieve DMABuf information due to missing video meta");
@@ -848,6 +855,11 @@ RefPtr<DMABufBuffer> VideoFrameGStreamer::getDMABuf()
         colorSpace = DMABufBuffer::ColorSpace::Smpte240M;
     dmabuf->setColorSpace(colorSpace);
     dmabuf->setTransferFunction(transferFunction);
+
+    dmabuf->ref();
+    gst_mini_object_set_qdata(memory, dmabufQuark, dmabuf.ptr(), [](gpointer data) {
+        static_cast<DMABufBuffer*>(data)->deref();
+    });
 
     return dmabuf;
 }


### PR DESCRIPTION
#### 58a716d2bd759014260fa508b4d2fa5674f8cc61
<pre>
[GStreamer] Restore DMABuf caching code removed in 306270@main
<a href="https://bugs.webkit.org/show_bug.cgi?id=313811">https://bugs.webkit.org/show_bug.cgi?id=313811</a>

Reviewed by Carlos Garcia Campos.

DMABufs are tied to the underlying GstMemory, so caching them allows us to prevent un-necessary FD
duplications.

* Source/WebCore/platform/graphics/gstreamer/VideoFrameGStreamer.cpp:
(WebCore::VideoFrameGStreamer::getDMABuf):

Canonical link: <a href="https://commits.webkit.org/312506@main">https://commits.webkit.org/312506@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ec15eb024102a3c5ff9ff9ed797300165b4b4fcd

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/159907 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/33375 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/26481 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/168777 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/114288 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/161776 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/33479 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/33379 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/123930 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/86921 "9 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/162865 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/26184 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/143627 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/104551 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/25236 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/23705 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/16528 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/134928 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/21397 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/171263 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/17275 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/23035 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/132197 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/33053 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/27788 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/132222 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35814 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/33038 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/143192 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/91162 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/26842 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/20005 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/32547 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/98944 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/32044 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/32291 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/32195 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->