### PR TITLE
Add more logging in the decidePolicyForNavigationAction and SSO area

### DIFF
--- a/Source/WebKit/UIProcess/Cocoa/NavigationState.mm
+++ b/Source/WebKit/UIProcess/Cocoa/NavigationState.mm
@@ -511,6 +511,7 @@ static void tryInterceptNavigation(Ref<API::NavigationAction>&& navigationAction
 
         auto* localCompletionHandler = new WTF::Function<void (bool)>([navigationAction = WTF::move(navigationAction), weakPage = WeakPtr { page }, completionHandler = WTF::move(completionHandler)] (bool success) mutable {
             ASSERT(RunLoop::isMain());
+            RELEASE_LOG(Loading, "tryInterceptNavigation: LSAppLink openWithURL completed, success=%d", success);
             if (!success && weakPage) {
                 trySOAuthorization(WTF::move(navigationAction), *weakPage, WTF::move(completionHandler));
                 return;
@@ -525,6 +526,7 @@ static void tryInterceptNavigation(Ref<API::NavigationAction>&& navigationAction
         RetainPtr<_LSOpenConfiguration> configuration = adoptNS([[_LSOpenConfiguration alloc] init]);
         configuration.get().referrerURL = referrerURL.get();
 
+        RELEASE_LOG(Loading, "tryInterceptNavigation: Calling async LSAppLink openWithURL");
         [LSAppLink openWithURL:url.createNSURL().get() configuration:configuration.get() completionHandler:[localCompletionHandler](BOOL success, NSError *) {
             RunLoop::mainSingleton().dispatch([localCompletionHandler, success] {
                 (*localCompletionHandler)(success);
@@ -568,6 +570,7 @@ void NavigationState::NavigationClient::decidePolicyForNavigationAction(WebPageP
     if (!m_navigationState || (!m_navigationState->m_navigationDelegateMethods.webViewDecidePolicyForNavigationActionDecisionHandler
         && !m_navigationState->m_navigationDelegateMethods.webViewDecidePolicyForNavigationActionWithPreferencesUserInfoDecisionHandler
         && !m_navigationState->m_navigationDelegateMethods.webViewDecidePolicyForNavigationActionWithPreferencesDecisionHandler)) {
+        RELEASE_LOG(Loading, "NavigationState::decidePolicyForNavigationAction: Client does not implement decidePolicyForNavigationAction");
         auto completionHandler = [webPage = protect(webPageProxy), listener = WTF::move(listener), navigationAction, defaultWebsitePolicies] (bool interceptedNavigation) {
             if (interceptedNavigation) {
                 listener->ignore(WasNavigationIntercepted::Yes);
@@ -632,6 +635,7 @@ void NavigationState::NavigationClient::decidePolicyForNavigationAction(WebPageP
         if (checker->completionHandlerHasBeenCalled())
             return;
         checker->didCallCompletionHandler();
+        RELEASE_LOG(Loading, "NavigationState::decidePolicyForNavigationAction: Client responded with policy %d", static_cast<int>(actionPolicy));
 
         RefPtr<API::WebsitePolicies> apiWebsitePolicies = preferences ?  protect(preferences->_websitePolicies.get()) : defaultWebsitePolicies;
 
@@ -773,6 +777,7 @@ void NavigationState::NavigationClient::decidePolicyForNavigationResponse(WebPag
 {
     RefPtr navigationState = m_navigationState.get();
     if (!navigationState || !navigationState->m_navigationDelegateMethods.webViewDecidePolicyForNavigationResponseDecisionHandler) {
+        RELEASE_LOG(Loading, "NavigationState::decidePolicyForNavigationResponse: Client does not implement decidePolicyForNavigationResponse");
         RetainPtr<NSURL> url = protect(navigationResponse->response().nsURLResponse()).get().URL;
         if ([url isFileURL]) {
             BOOL isDirectory = NO;
@@ -801,6 +806,7 @@ void NavigationState::NavigationClient::decidePolicyForNavigationResponse(WebPag
         if (checker->completionHandlerHasBeenCalled())
             return;
         checker->didCallCompletionHandler();
+        RELEASE_LOG(Loading, "NavigationState::decidePolicyForNavigationResponse: Client responded with policy %d", static_cast<int>(responsePolicy));
         ensureOnMainRunLoop([responsePolicy, localListener = WTF::move(localListener)] {
             switch (responsePolicy) {
             case WKNavigationResponsePolicyAllow:

--- a/Source/WebKit/UIProcess/Cocoa/SOAuthorization/SOAuthorizationCoordinator.mm
+++ b/Source/WebKit/UIProcess/Cocoa/SOAuthorization/SOAuthorizationCoordinator.mm
@@ -71,12 +71,15 @@ SOAuthorizationCoordinator::SOAuthorizationCoordinator()
 void SOAuthorizationCoordinator::canAuthorize(const URL& url, CompletionHandler<void(bool)>&& completionHandler)
 {
     if (!m_hasAppSSO) {
+        AUTHORIZATIONCOORDINATOR_RELEASE_LOG("canAuthorize: No AppSSO framework");
         completionHandler(false);
         return;
     }
     if ([PAL::getSOAuthorizationClassSingleton() respondsToSelector:@selector(canPerformAuthorizationWithURL:responseCode:callerBundleIdentifier:useInternalExtensions:completion:)]) {
+        AUTHORIZATIONCOORDINATOR_RELEASE_LOG("canAuthorize: Calling async canPerformAuthorizationWithURL");
         [PAL::getSOAuthorizationClassSingleton() canPerformAuthorizationWithURL:url.createNSURL().get() responseCode:0 callerBundleIdentifier:nil useInternalExtensions:YES completion:makeBlockPtr([completionHandler = WTF::move(completionHandler)] (BOOL result) mutable {
             ensureOnMainRunLoop([completionHandler = WTF::move(completionHandler), result] () mutable {
+                AUTHORIZATIONCOORDINATOR_RELEASE_LOG_STATIC("canAuthorize: Async canPerformAuthorizationWithURL completed, result=%d", result);
                 completionHandler(result);
             });
         }).get()];


### PR DESCRIPTION
#### c5000db96ac45d4eaf3e86dfd156797219b1e531
<pre>
Add more logging in the decidePolicyForNavigationAction and SSO area
<a href="https://bugs.webkit.org/show_bug.cgi?id=313812">https://bugs.webkit.org/show_bug.cgi?id=313812</a>

Reviewed by Per Arne Vollan.

Add more logging in the decidePolicyForNavigationAction and SSO area as
it would have been helpful to debug <a href="https://rdar.apple.com/176009393">rdar://176009393</a> faster.

* Source/WebKit/UIProcess/Cocoa/NavigationState.mm:
(WebKit::tryInterceptNavigation):
(WebKit::NavigationState::NavigationClient::decidePolicyForNavigationAction):
(WebKit::NavigationState::NavigationClient::decidePolicyForNavigationResponse):
* Source/WebKit/UIProcess/Cocoa/SOAuthorization/SOAuthorizationCoordinator.mm:
(WebKit::SOAuthorizationCoordinator::canAuthorize):

Canonical link: <a href="https://commits.webkit.org/312427@main">https://commits.webkit.org/312427@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a46819be462263420d2260fba172199da612f6bf

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/159920 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/33388 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/26494 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/168791 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/114301 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/33492 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/33392 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/123940 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/114301 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/162878 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/26196 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/143636 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/104560 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/25248 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/23716 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/16541 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/134940 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/171277 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/17288 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/23044 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/132205 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/33066 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/27800 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/132232 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35773 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/33051 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/143201 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/91176 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/26851 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/20014 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/32560 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/98957 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/32057 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/32304 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/32208 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->