### PR TITLE
[WPE][GTK] Add a user-agent quirk for disney+

### DIFF
--- a/Source/WebCore/platform/glib/UserAgentQuirks.cpp
+++ b/Source/WebCore/platform/glib/UserAgentQuirks.cpp
@@ -92,6 +92,9 @@ static bool urlRequiresFirefoxBrowser(const String& domain)
 #if ENABLE(THUNDER)
     if (domain == "www.netflix.com"_s)
         return true;
+
+    if (domain == "www.disneyplus.com"_s)
+        return true;
 #endif
 
     return false;

--- a/Tools/TestWebKitAPI/Tests/WebCore/UserAgentQuirks.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/UserAgentQuirks.cpp
@@ -103,6 +103,7 @@ TEST(UserAgentTest, Quirks)
 
 #if ENABLE(THUNDER)
     assertUserAgentForURLHasFirefoxBrowserQuirk("http://www.netflix.com/");
+    assertUserAgentForURLHasFirefoxBrowserQuirk("http://www.disneyplus.com/");
 #endif
 
     assertUserAgentForURLHasMacPlatformQuirk("http://www.yahoo.com/");


### PR DESCRIPTION
#### 80b3082d0146429b826c057e5aa13636ce99dab0
<pre>
[WPE][GTK] Add a user-agent quirk for disney+
<a href="https://bugs.webkit.org/show_bug.cgi?id=313813">https://bugs.webkit.org/show_bug.cgi?id=313813</a>

Reviewed by Carlos Garcia Campos.

Without this quirk only Fairplay DRM is attempted when trying to play DRM content, because we would
be detected as a Safari UA. By faking a Firefox UA the page might prompt for more DRM systems, such
as Widevine.

* Source/WebCore/platform/glib/UserAgentQuirks.cpp:
(WebCore::urlRequiresFirefoxBrowser):

Canonical link: <a href="https://commits.webkit.org/312508@main">https://commits.webkit.org/312508@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b96c3889d979661aed8a16dc8d209ec47eb644b3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/159926 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/33394 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/26500 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/168798 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/114307 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/161795 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/33498 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/33398 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/123946 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/86934 "9 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/162884 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/26200 "Found 1 new test failure: fast/scrolling/ios/iframe-scroll-into-view.html (failure)") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/143642 "Found 1 new API test failure: TestWebKitAPI.WKInspectorExtension.EvaluateScriptInExtensionTabCanReturnPromises (failure)") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/104566 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/25252 "Passed tests") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/23722 "Found 2 new API test failures: TestWebKitAPI.WKWebExtension.LoadFromMacAppExtensionBundle, TestWebKitAPI.WKBackForwardList.BackForwardNavigationSkipsItemsWithoutUserGestureFragment (failure)") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/16547 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/134944 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/21412 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/171284 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/17294 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/23050 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/132212 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/33072 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/27806 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/132239 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35815 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/33057 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/143207 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/91183 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/26856 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/20020 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/32566 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/98963 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/32063 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/32310 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/32214 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->