### PR TITLE
[GStreamer][MSE] Tear down the pipeline upon EOS notification and re-create it when the MediaSource un-marks its EOS flag

### DIFF
--- a/LayoutTests/media/media-source/media-source-real-play-after-eos-expected.txt
+++ b/LayoutTests/media/media-source/media-source-real-play-after-eos-expected.txt
@@ -1,0 +1,16 @@
+
+EVENT(sourceopen)
+EVENT(updateend)
+EVENT(updateend)
+RUN(source.endOfStream())
+EXPECTED (source.readyState == 'ended') OK
+EVENT(seeked)
+EVENT(ended)
+EVENT(updateend)
+RUN(source.endOfStream())
+EXPECTED (source.readyState == 'ended') OK
+EXPECTED (source.duration == '8') OK
+EVENT(seeked)
+EVENT(ended)
+END OF TEST
+

--- a/LayoutTests/media/media-source/media-source-real-play-after-eos.html
+++ b/LayoutTests/media/media-source/media-source-real-play-after-eos.html
@@ -1,0 +1,92 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <title>media-source-real-play-after-eos (inspired from media-source-real-seek-and-play)</title>
+        <script src="mp4-generator.js"></script>
+        <script src="../video-test.js"></script>
+        <script>
+         // Tests sequential append of contiguous segments with real MP4 data.
+
+         // Verifies that playback of a second segment works after playback of the first segment
+         // ended with an EOS event at the platform level.
+
+         var source;
+         var videoSourceBuffer;
+
+         async function runTest() {
+             findMediaElement();
+
+             if (!MediaSource.isTypeSupported(MP4.VIDEO_TYPE)) {
+                 failTest(`${MP4.VIDEO_TYPE} is not supported`);
+                 return;
+             }
+
+             source = new MediaSource();
+             video.src = URL.createObjectURL(source);
+             await waitFor(source, 'sourceopen');
+
+             videoSourceBuffer = source.addSourceBuffer(MP4.VIDEO_TYPE);
+
+             var videoInitData = MP4.initSegment({
+                 timescale: 1000,
+                 tracks: [{ id: 1, type: 'video', timescale: 1000 }]
+             });
+
+             // First segment: 4 seconds
+             var videoSegment1 = MP4.mediaSegment({
+                 sequenceNumber: 1,
+                 tracks: [{ id: 1, type: 'video', baseDecodeTime: 0, samples: [
+                     { duration: 1000, compositionTimeOffset: 0, isSync: true },
+                     { duration: 1000, compositionTimeOffset: 0, isSync: false },
+                     { duration: 1000, compositionTimeOffset: 0, isSync: false },
+                     { duration: 1000, compositionTimeOffset: 0, isSync: false },
+                 ]}]
+             });
+
+             // Second segment: 4 more seconds (contiguous)
+             var videoSegment2 = MP4.mediaSegment({
+                 sequenceNumber: 2,
+                 tracks: [{ id: 1, type: 'video', baseDecodeTime: 4000, samples: [
+                     { duration: 1000, compositionTimeOffset: 0, isSync: true },
+                     { duration: 1000, compositionTimeOffset: 0, isSync: false },
+                     { duration: 1000, compositionTimeOffset: 0, isSync: false },
+                     { duration: 1000, compositionTimeOffset: 0, isSync: false },
+                 ]}]
+             });
+
+             videoSourceBuffer.appendBuffer(videoInitData);
+             await waitFor(videoSourceBuffer, 'updateend');
+
+             videoSourceBuffer.appendBuffer(videoSegment1);
+             await waitFor(videoSourceBuffer, 'updateend');
+
+             run('source.endOfStream()');
+             testExpected('source.readyState', 'ended');
+
+             // Play the first segment until EOS.
+             video.play();
+             video.currentTime = 3.5;
+             await waitFor(video, 'seeked');
+             await waitFor(video, 'ended');
+
+             videoSourceBuffer.appendBuffer(videoSegment2);
+             await waitFor(videoSourceBuffer, 'updateend');
+
+             run('source.endOfStream()');
+             testExpected('source.readyState', 'ended');
+             testExpectedEqualWithTolerance('source.duration', 8, 0.01);
+
+             // Play the second segment, the seek towards its end should work as well.
+             video.play();
+             video.currentTime = 7.5;
+             await waitFor(video, 'seeked');
+             await waitFor(video, 'ended');
+
+             endTest();
+         }
+        </script>
+    </head>
+    <body onload="runTest()">
+        <video></video>
+    </body>
+</html>

--- a/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp
@@ -226,14 +226,9 @@ void MediaPlayerPrivateGStreamer::tearDown(bool clearMediaPlayer)
 
     m_sinkTaskQueue.startAborting();
 
-    for (auto& track : m_audioTracks.values())
-        track->disconnect();
-
-    for (auto& track : m_textTracks.values())
-        track->disconnect();
-
-    for (auto& track : m_videoTracks.values())
-        track->disconnect();
+    m_audioTracks.clear();
+    m_videoTracks.clear();
+    m_textTracks.clear();
 
     if (m_fillTimer.isActive())
         m_fillTimer.stop();
@@ -270,6 +265,8 @@ void MediaPlayerPrivateGStreamer::tearDown(bool clearMediaPlayer)
     if (m_pipeline) {
         unregisterPipeline(m_pipeline);
         gst_element_set_state(m_pipeline.get(), GST_STATE_NULL);
+
+        m_source = nullptr;
 
         auto bus = adoptGRef(gst_pipeline_get_bus(GST_PIPELINE(m_pipeline.get())));
         gst_bus_disable_sync_message_emission(bus.get());
@@ -386,13 +383,27 @@ void MediaPlayerPrivateGStreamer::load(const String& urlString)
         m_isDelayingLoad = true;
     }
 
-    // Reset network and ready states. Those will be set properly once
-    // the pipeline pre-rolled.
-    m_networkState = m_isDelayingLoad ? MediaPlayer::NetworkState::Idle : MediaPlayer::NetworkState::Loading;
-    player->networkStateChanged();
-    m_readyState = MediaPlayer::ReadyState::HaveNothing;
-    player->readyStateChanged();
+    // Reset network and ready states. Those will be set properly once the pipeline pre-rolled.
+    // Those states are managed directly by the MSE player sub-class.
+    if (!isMediaSource()) {
+        m_networkState = m_isDelayingLoad ? MediaPlayer::NetworkState::Idle : MediaPlayer::NetworkState::Loading;
+        player->networkStateChanged();
+        m_readyState = MediaPlayer::ReadyState::HaveNothing;
+        player->readyStateChanged();
+    }
+
     m_areVolumeAndMuteInitialized = false;
+    m_isEndReached = false;
+    m_isCachedPositionValid = false;
+    m_cachedDuration = MediaTime::invalidTime();
+    m_isSeeking = false;
+    m_isSeekPending = false;
+    m_seekTarget = { };
+
+#if ENABLE(ENCRYPTED_MEDIA)
+    if (m_cdmContext)
+        gst_element_set_context(GST_ELEMENT(m_pipeline.get()), m_cdmContext.get());
+#endif
 
     if (!m_isDelayingLoad)
         commitLoad();
@@ -1521,7 +1532,8 @@ void MediaPlayerPrivateGStreamer::loadStateChanged()
 
 void MediaPlayerPrivateGStreamer::timeChanged(const MediaTime& seekedTime)
 {
-    updateStates();
+    if (!isMediaSource())
+        updateStates();
     GST_DEBUG_OBJECT(pipeline(), "Emitting timeChanged notification (seekCompleted:%d)", seekedTime.isValid());
     if (RefPtr player = m_player.get()) {
         if (seekedTime.isValid())
@@ -1940,13 +1952,6 @@ bool MediaPlayerPrivateGStreamer::handleNeedContextMessage(GstMessage* message)
     return false;
 }
 
-void MediaPlayerPrivateGStreamer::handleSyncErrorMessage(GstMessage*)
-{
-    GST_DEBUG_OBJECT(pipeline(), "Accounting queued sync error");
-    // This attribute is decremented later from handleMessage() in the main thread.
-    m_queuedSyncErrors.exchangeAdd(1);
-}
-
 // Returns the size of the video.
 FloatSize MediaPlayerPrivateGStreamer::naturalSize() const
 {
@@ -2121,68 +2126,54 @@ void MediaPlayerPrivateGStreamer::handleMessage(GstMessage* message)
 
     GST_LOG_OBJECT(pipeline(), "Message %s received from element %s", GST_MESSAGE_TYPE_NAME(message), GST_MESSAGE_SRC_NAME(message));
     switch (GST_MESSAGE_TYPE(message)) {
-    case GST_MESSAGE_ERROR:
-        {
-            auto onScopeExit = makeScopeExit([this] {
-                GST_DEBUG_OBJECT(pipeline(), "Decreasing m_queuedSyncErrors");
-                m_queuedSyncErrors.exchangeSub(1);
-            });
+    case GST_MESSAGE_ERROR: {
+        gst_message_parse_error(message, &err.outPtr(), nullptr);
 
-            gst_message_parse_error(message, &err.outPtr(), nullptr);
-
-            if (m_shouldResetPipeline || m_didErrorOccur || m_ignoreErrors) {
-                GST_WARNING_OBJECT(pipeline(), "Ignoring error: %s (url=%s) (code=%d)", err->message, m_url.string().utf8().data(), err->code);
-                // Deferred reset of m_ignoreErrors because there were queued sync errors not yet processed and
-                // we're processing the last one now.
-                if (m_ignoreErrors && m_queuedSyncErrors.loadFullyFenced() == 1) {
-                    m_ignoreErrors = false;
-                    GST_DEBUG_OBJECT(pipeline(), "Last queued error processed while on ignoring state. Not ignoring errors anymore.");
-                }
-                break;
-            }
-
-            GST_ERROR_OBJECT(pipeline(), "%s (url=%s) (code=%d)", err->message, m_url.string().utf8().data(), err->code);
-
-            m_errorMessage = String(byteCast<char8_t>(unsafeSpan(err->message)));
-#if ENABLE(MEDIA_TELEMETRY)
-            MediaTelemetryReport::singleton().reportPlaybackState(MediaTelemetryReport::AVPipelineState::PlaybackError,
-                m_errorMessage);
-#endif
-
-            error = MediaPlayer::NetworkState::Empty;
-            if (g_error_matches(err.get(), GST_STREAM_ERROR, GST_STREAM_ERROR_CODEC_NOT_FOUND)
-                || g_error_matches(err.get(), GST_STREAM_ERROR, GST_STREAM_ERROR_DECRYPT)
-                || g_error_matches(err.get(), GST_STREAM_ERROR, GST_STREAM_ERROR_DECRYPT_NOKEY)
-                || g_error_matches(err.get(), GST_STREAM_ERROR, GST_STREAM_ERROR_WRONG_TYPE)
-                || g_error_matches(err.get(), GST_STREAM_ERROR, GST_STREAM_ERROR_FAILED)
-                || g_error_matches(err.get(), GST_CORE_ERROR, GST_CORE_ERROR_MISSING_PLUGIN)
-                || g_error_matches(err.get(), GST_CORE_ERROR, GST_CORE_ERROR_PAD)
-                || g_error_matches(err.get(), GST_RESOURCE_ERROR, GST_RESOURCE_ERROR_NOT_FOUND))
-                error = MediaPlayer::NetworkState::FormatError;
-            else if (g_error_matches(err.get(), GST_STREAM_ERROR, GST_STREAM_ERROR_TYPE_NOT_FOUND)) {
-                GST_ERROR_OBJECT(pipeline(), "Decode error, let the Media element emit a stalled event.");
-                m_loadingStalled = true;
-                error = MediaPlayer::NetworkState::DecodeError;
-                attemptNextLocation = true;
-            } else if (err->domain == GST_STREAM_ERROR
-                || g_error_matches(err.get(), GST_STREAM_ERROR, GST_STREAM_ERROR_DECODE)) {
-                error = MediaPlayer::NetworkState::DecodeError;
-                attemptNextLocation = true;
-            } else if (err->domain == GST_RESOURCE_ERROR)
-                error = MediaPlayer::NetworkState::NetworkError;
-
-            if (attemptNextLocation)
-                issueError = !loadNextLocation();
-            if (issueError) {
-                m_didErrorOccur = true;
-                if (m_networkState != error) {
-                    m_networkState = error;
-                    if (player)
-                        player->networkStateChanged();
-                }
-            }
+        if (m_shouldResetPipeline || m_didErrorOccur) {
+            GST_WARNING_OBJECT(pipeline(), "Ignoring error: %s (url=%s) (code=%d)", err->message, m_url.string().utf8().data(), err->code);
             break;
         }
+
+        GST_ERROR_OBJECT(pipeline(), "%s (url=%s) (code=%d)", err->message, m_url.string().utf8().data(), err->code);
+
+        m_errorMessage = String(byteCast<char8_t>(unsafeSpan(err->message)));
+#if ENABLE(MEDIA_TELEMETRY)
+        MediaTelemetryReport::singleton().reportPlaybackState(MediaTelemetryReport::AVPipelineState::PlaybackError, m_errorMessage);
+#endif
+
+        error = MediaPlayer::NetworkState::Empty;
+        if (g_error_matches(err.get(), GST_STREAM_ERROR, GST_STREAM_ERROR_CODEC_NOT_FOUND)
+            || g_error_matches(err.get(), GST_STREAM_ERROR, GST_STREAM_ERROR_DECRYPT)
+            || g_error_matches(err.get(), GST_STREAM_ERROR, GST_STREAM_ERROR_DECRYPT_NOKEY)
+            || g_error_matches(err.get(), GST_STREAM_ERROR, GST_STREAM_ERROR_WRONG_TYPE)
+            || g_error_matches(err.get(), GST_STREAM_ERROR, GST_STREAM_ERROR_FAILED)
+            || g_error_matches(err.get(), GST_CORE_ERROR, GST_CORE_ERROR_MISSING_PLUGIN)
+            || g_error_matches(err.get(), GST_CORE_ERROR, GST_CORE_ERROR_PAD)
+            || g_error_matches(err.get(), GST_RESOURCE_ERROR, GST_RESOURCE_ERROR_NOT_FOUND))
+            error = MediaPlayer::NetworkState::FormatError;
+        else if (g_error_matches(err.get(), GST_STREAM_ERROR, GST_STREAM_ERROR_TYPE_NOT_FOUND)) {
+            GST_ERROR_OBJECT(pipeline(), "Decode error, let the Media element emit a stalled event.");
+            m_loadingStalled = true;
+            error = MediaPlayer::NetworkState::DecodeError;
+            attemptNextLocation = true;
+        } else if (err->domain == GST_STREAM_ERROR || g_error_matches(err.get(), GST_STREAM_ERROR, GST_STREAM_ERROR_DECODE)) {
+            error = MediaPlayer::NetworkState::DecodeError;
+            attemptNextLocation = true;
+        } else if (err->domain == GST_RESOURCE_ERROR)
+            error = MediaPlayer::NetworkState::NetworkError;
+
+        if (attemptNextLocation)
+            issueError = !loadNextLocation();
+        if (issueError) {
+            m_didErrorOccur = true;
+            if (m_networkState != error) {
+                m_networkState = error;
+                if (player)
+                    player->networkStateChanged();
+            }
+        }
+        break;
+    }
     case GST_MESSAGE_WARNING:
         gst_message_parse_warning(message, &err.outPtr(), nullptr);
         GST_WARNING_OBJECT(pipeline(), "%s (url=%s) (code=%d)", err->message, m_url.string().utf8().data(), err->code);
@@ -3556,10 +3547,6 @@ void MediaPlayerPrivateGStreamer::createGSTPlayBin(const URL& url)
         player->handleStreamCollectionMessage(message);
     }), this);
 
-    g_signal_connect_swapped(bus.get(), "sync-message::error", G_CALLBACK(+[](MediaPlayerPrivateGStreamer* player, GstMessage* message) {
-        player->handleSyncErrorMessage(message);
-    }), this);
-
     g_object_set(m_pipeline.get(), "mute", static_cast<gboolean>(player->muted()), nullptr);
 
     // From GStreamer 1.22.0, uridecodebin3 is created in playbin3's _init(), so "element-setup" isn't called with it.
@@ -4576,10 +4563,12 @@ void MediaPlayerPrivateGStreamer::cdmInstanceAttached(CDMInstance& instance)
     RELEASE_ASSERT(m_cdmInstance);
     m_cdmInstance->setPlayer(m_player.get());
 
-    GRefPtr<GstContext> context = adoptGRef(gst_context_new("drm-cdm-proxy", FALSE));
-    GstStructure* contextStructure = gst_context_writable_structure(context.get());
-    gst_structure_set(contextStructure, "cdm-proxy", G_TYPE_POINTER, m_cdmInstance->proxy().get(), nullptr);
-    gst_element_set_context(GST_ELEMENT(m_pipeline.get()), context.get());
+    if (!m_cdmContext) {
+        m_cdmContext = adoptGRef(gst_context_new("drm-cdm-proxy", TRUE));
+        GstStructure* contextStructure = gst_context_writable_structure(m_cdmContext.get());
+        gst_structure_set(contextStructure, "cdm-proxy", G_TYPE_POINTER, m_cdmInstance->proxy().get(), nullptr);
+    }
+    gst_element_set_context(GST_ELEMENT(m_pipeline.get()), m_cdmContext.get());
 
     GST_DEBUG_OBJECT(m_pipeline.get(), "CDM proxy instance %p dispatched as context", m_cdmInstance->proxy().get());
 
@@ -4600,8 +4589,9 @@ void MediaPlayerPrivateGStreamer::cdmInstanceDetached(CDMInstance& instance)
     ASSERT(m_cdmInstance == &instance);
     GST_DEBUG_OBJECT(m_pipeline.get(), "detaching CDM instance %p, setting empty context", m_cdmInstance.get());
     m_cdmInstance = nullptr;
-    GRefPtr<GstContext> context = adoptGRef(gst_context_new("drm-cdm-proxy", FALSE));
-    gst_element_set_context(GST_ELEMENT(m_pipeline.get()), context.get());
+    m_cdmContext = nullptr;
+    auto emptyContext = adoptGRef(gst_context_new("drm-cdm-proxy", TRUE));
+    gst_element_set_context(GST_ELEMENT(m_pipeline.get()), emptyContext.get());
 }
 
 void MediaPlayerPrivateGStreamer::attemptToDecryptWithInstance([[maybe_unused]] CDMInstance& instance)

--- a/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.h
+++ b/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.h
@@ -220,7 +220,6 @@ public:
     bool handleNeedContextMessage(GstMessage*);
 
     void handleStreamCollectionMessage(GstMessage*);
-    void handleSyncErrorMessage(GstMessage*);
     void handleMessage(GstMessage*);
 
     void triggerRepaint(GRefPtr<GstSample>&&);
@@ -361,8 +360,10 @@ protected:
     bool isPipelineWaitingPreroll(GstState current, GstState pending, GstStateChangeReturn) const;
     bool isPipelineWaitingPreroll() const;
 
-    void didEnd();
+    virtual void didEnd();
+    void tearDown(bool clearMediaPlayer);
 
+    URL m_url;
     Ref<MainThreadNotifier<MainThreadNotification>> m_notifier;
     ThreadSafeWeakPtr<MediaPlayer> m_player;
     String m_referrer;
@@ -445,8 +446,6 @@ protected:
 #endif
 
     std::optional<GstVideoDecoderPlatform> m_videoDecoderPlatform;
-    bool m_ignoreErrors { false };
-    Atomic<unsigned> m_queuedSyncErrors { 0 };
 
     TrackIDHashMap<Ref<AudioTrackPrivateGStreamer>> m_audioTracks;
     TrackIDHashMap<Ref<VideoTrackPrivateGStreamer>> m_videoTracks;
@@ -494,7 +493,6 @@ private:
         Function<void()> m_task = Function<void()>();
     };
 
-    void tearDown(bool clearMediaPlayer);
     bool isPlayerShuttingDown() const { return m_isPlayerShuttingDown.load(); }
     MediaTime maxTimeLoaded() const;
     bool setVideoSourceOrientation(ImageOrientation);
@@ -571,6 +569,8 @@ private:
     void initializationDataEncountered(InitData&&);
     InitData parseInitDataFromProtectionMessage(GstMessage*);
     bool waitForCDMAttachment();
+
+    GRefPtr<GstContext> m_cdmContext;
 #endif
 
 #if ENABLE(MEDIA_TELEMETRY)
@@ -612,7 +612,6 @@ private:
 
     bool m_hasWebKitWebSrcSentEOS { false };
     mutable unsigned long long m_totalBytes { 0 };
-    URL m_url;
     bool m_shouldPreservePitch { false };
     bool m_isLegacyPlaybin;
 #if ENABLE(MEDIA_STREAM)

--- a/Source/WebCore/platform/graphics/gstreamer/TrackPrivateBaseGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/TrackPrivateBaseGStreamer.cpp
@@ -156,6 +156,11 @@ TrackPrivateBaseGStreamer::TrackPrivateBaseGStreamer(ThreadSafeWeakPtr<MediaPlay
     m_data->installUpdateConfigurationHandlers();
 }
 
+TrackPrivateBaseGStreamer::~TrackPrivateBaseGStreamer()
+{
+    disconnect();
+}
+
 void TrackPrivateBaseGStreamer::setPad(GRefPtr<GstPad>&& pad)
 {
     m_data->setPad(WTF::move(pad));

--- a/Source/WebCore/platform/graphics/gstreamer/TrackPrivateBaseGStreamer.h
+++ b/Source/WebCore/platform/graphics/gstreamer/TrackPrivateBaseGStreamer.h
@@ -153,6 +153,7 @@ private:
     TrackPrivateBaseGStreamer(ThreadSafeWeakPtr<MediaPlayerPrivateGStreamer>&&, GStreamerTrackType, TrackPrivateBase*, unsigned index, GRefPtr<GstPad>&&, bool shouldHandleStreamStartEvent);
     TrackPrivateBaseGStreamer(ThreadSafeWeakPtr<MediaPlayerPrivateGStreamer>&&, GStreamerTrackType, TrackPrivateBase*, unsigned index, GRefPtr<GstPad>&&, TrackID);
     TrackPrivateBaseGStreamer(ThreadSafeWeakPtr<MediaPlayerPrivateGStreamer>&&, GStreamerTrackType, TrackPrivateBase*, unsigned index, GstStream*);
+    ~TrackPrivateBaseGStreamer();
 
     const Ref<TrackDataHolder> m_data;
 };

--- a/Source/WebCore/platform/graphics/gstreamer/mse/MediaPlayerPrivateGStreamerMSE.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/mse/MediaPlayerPrivateGStreamerMSE.cpp
@@ -126,8 +126,8 @@ void MediaPlayerPrivateGStreamerMSE::load(const String&)
 
 void MediaPlayerPrivateGStreamerMSE::load(const URL& url, const LoadOptions&, MediaSourcePrivateClient& mediaSource)
 {
-    auto mseBlobURI = makeString("mediasource"_s, url.string().isEmpty() ? "blob://"_s : url.string());
-    GST_DEBUG("Loading %s", mseBlobURI.ascii().data());
+    auto urlString = makeString("mediasource"_s, url.string().isEmpty() ? "blob://"_s : url.string());
+    GST_DEBUG("Loading %s", urlString.ascii().data());
     if (RefPtr mediaSourcePrivate = downcast<MediaSourcePrivateGStreamer>(mediaSource.mediaSourcePrivate())) {
         mediaSourcePrivate->setPlayer(this);
         m_mediaSourcePrivate = WTF::move(mediaSourcePrivate);
@@ -135,12 +135,14 @@ void MediaPlayerPrivateGStreamerMSE::load(const URL& url, const LoadOptions&, Me
     } else
         m_mediaSourcePrivate = MediaSourcePrivateGStreamer::open(mediaSource, *this);
 
-    MediaPlayerPrivateGStreamer::load(mseBlobURI);
+    MediaPlayerPrivateGStreamer::load(urlString);
 }
 
 void MediaPlayerPrivateGStreamerMSE::play()
 {
-    GST_DEBUG_OBJECT(pipeline(), "Play requested");
+    GST_INFO_OBJECT(pipeline(), "Play requested");
+    if (!pipeline())
+        rebuildPipeline();
     m_isPaused = false;
     if (!m_playbackRate && m_playbackRatePausedState == PlaybackRatePausedState::ManuallyPaused)
         m_playbackRatePausedState = PlaybackRatePausedState::RatePaused;
@@ -149,7 +151,7 @@ void MediaPlayerPrivateGStreamerMSE::play()
 
 void MediaPlayerPrivateGStreamerMSE::pause()
 {
-    GST_DEBUG_OBJECT(pipeline(), "Pause requested");
+    GST_INFO_OBJECT(pipeline(), "Pause requested");
     if (m_playbackRatePausedState == PlaybackRatePausedState::ManuallyPaused) {
         GST_DEBUG_OBJECT(pipeline(), "Player is paused already.");
         return;
@@ -234,8 +236,9 @@ MediaTime MediaPlayerPrivateGStreamerMSE::duration() const
 void MediaPlayerPrivateGStreamerMSE::seekToTarget(const SeekTarget& target)
 {
     if (!m_pipeline)
-        return;
-    GST_DEBUG_OBJECT(pipeline(), "Requested seek to %s", target.time.toString().utf8().data());
+        rebuildPipeline();
+
+    GST_INFO_OBJECT(pipeline(), "Requested seek to %s", target.time.toString().utf8().data());
     doSeek(target, m_playbackRate);
 }
 
@@ -243,7 +246,7 @@ bool MediaPlayerPrivateGStreamerMSE::doSeek(const SeekTarget& target, float rate
 {
     UNUSED_PARAM(isAsync);
     RefPtr player = m_player.get();
-    if (!player)
+    if (!player || !m_source)
         return false;
 
     // This method should only be called outside of MediaPlayerPrivateGStreamerMSE by MediaPlayerPrivateGStreamer::setRate().
@@ -275,6 +278,7 @@ bool MediaPlayerPrivateGStreamerMSE::doSeek(const SeekTarget& target, float rate
 
     // Important: In order to ensure correct propagation whether pre-roll has happened or not, we send the seek directly
     // to the source element, rather than letting playbin do the routing.
+    RELEASE_ASSERT(m_source);
     {
         // Take the STATE_LOCK of the __pipeline__.
         //
@@ -423,9 +427,9 @@ void MediaPlayerPrivateGStreamerMSE::didPreroll()
     // c) At the end of a flush (forced quality change). These should not produce either of these outcomes.
     // We identify (a) and (b) by setting m_isWaitingForPreroll = true at the initialization of the player and
     // at the beginning of a seek.
-    GST_DEBUG("Pipeline prerolled. currentMediaTime = %s", currentTime().toString().utf8().data());
+    GST_DEBUG_OBJECT(pipeline(), "Pipeline prerolled. currentMediaTime = %s", currentTime().toString().utf8().data());
     if (!m_isWaitingForPreroll) {
-        GST_DEBUG("Preroll was consequence of a flush, nothing to do at this level.");
+        GST_DEBUG_OBJECT(pipeline(), "Preroll was consequence of a flush, nothing to do at this level.");
         return;
     }
     m_isWaitingForPreroll = false;
@@ -444,6 +448,12 @@ void MediaPlayerPrivateGStreamerMSE::didPreroll()
     }
 
     propagateReadyStateToPlayer();
+}
+
+void MediaPlayerPrivateGStreamerMSE::didEnd()
+{
+    MediaPlayerPrivateGStreamer::didEnd();
+    tearDown(false);
 }
 
 const PlatformTimeRanges& MediaPlayerPrivateGStreamerMSE::buffered() const
@@ -480,7 +490,7 @@ void MediaPlayerPrivateGStreamerMSE::updateStates()
     bool shouldUpdatePlaybackState = false;
     bool shouldBePlaying = (!m_isPaused && !isPausedByViewport() && readyState() >= MediaPlayer::ReadyState::HaveFutureData && m_playbackRatePausedState != PlaybackRatePausedState::RatePaused)
         || m_playbackRatePausedState == PlaybackRatePausedState::ShouldMoveToPlaying;
-    GST_DEBUG_OBJECT(pipeline(), "shouldBePlaying = %s, m_isPipelinePlaying = %s, is seeking %s", boolForPrinting(shouldBePlaying),
+    GST_DEBUG_OBJECT(pipeline(), "shouldBePlaying = %s, m_isPipelinePlaying = %s, is waiting preroll = %s", boolForPrinting(shouldBePlaying),
         boolForPrinting(m_isPipelinePlaying), boolForPrinting(isWaitingPreroll));
     if (!isWaitingPreroll && shouldBePlaying && !m_isPipelinePlaying) {
         auto result = changePipelineState(GST_STATE_PLAYING);
@@ -496,11 +506,6 @@ void MediaPlayerPrivateGStreamerMSE::updateStates()
             GST_ERROR_OBJECT(pipeline(), "Setting the pipeline to PAUSED failed");
 
         shouldUpdatePlaybackState = result == ChangePipelineStateResult::Ok;
-    } else if (m_isEosWithNoBuffers) {
-        if (auto player = m_player.get()) {
-            // Trigger playback end detection in HTMLMediaElement.
-            player->timeChanged();
-        }
     }
 
     if (!shouldUpdatePlaybackState)
@@ -581,32 +586,21 @@ void MediaPlayerPrivateGStreamerMSE::emitStreams(const Vector<RefPtr<MediaSource
     webKitMediaSrcEmitStreams(WEBKIT_MEDIA_SRC(m_source.get()), playbackTracks);
 }
 
-void MediaPlayerPrivateGStreamerMSE::setEosWithNoBuffers(bool eosWithNoBuffers)
+void MediaPlayerPrivateGStreamerMSE::rebuildPipeline()
 {
-    m_isEosWithNoBuffers = eosWithNoBuffers;
-    // Parsebin will trigger an error, instruct MediaPlayerPrivateGStreamer to ignore it.
-    if (eosWithNoBuffers) {
-        // On GStreamer, EOS with no buffers causes a parsebin error here:
-        // https://github.com/GStreamer/gst-plugins-base/blob/1.18.6/gst/playback/gstparsebin.c#L3495
+    if (pipeline())
+        return;
 
-        m_ignoreErrors = true;
-
-        GST_DEBUG_OBJECT(pipeline(), "EOS with no buffers, setting pipeline to READY state.");
-        changePipelineState(GST_STATE_READY);
-
-        unsigned errorCount = m_queuedSyncErrors.loadFullyFenced();
-        if (errorCount) {
-            GST_WARNING_OBJECT(pipeline(), "%u errors pending to process happened while processing EOS with"
-                " no buffers and should be ignored, manually reporting EOS", errorCount);
-            didEnd();
-            // In the best case, m_ignoreErrors will be cleaned up (in the main thread) in MediaPlayerPrivateGStreamer::handleMessage()
-            // in the future, after the last pending error is processed on the main thread. In the worst case, didEnd() will trigger
-            // a pipeline teardown, which will trigger gst_bus_set_flushing() and the pending error message won't ever be processed
-            // by the main thread. That's not a problem, since the player itself will be destructed and nobody will care about the
-            // error count integrity anymore.
-        } else
-            m_ignoreErrors = false;
+    if (!m_mediaSourcePrivate || !m_mediaSourcePrivate->hasAllTracks()) [[unlikely]] {
+        GST_ERROR("Not all tracks are ready, aborting rebuild.");
+        ASSERT_NOT_REACHED();
+        return;
     }
+
+    GST_DEBUG("Re-building the pipeline");
+    m_isEndReached = false;
+    MediaPlayerPrivateGStreamer::load(m_url.string());
+    changePipelineState(GST_STATE_PAUSED);
 }
 
 void MediaPlayerPrivateGStreamerMSE::getSupportedTypes(HashSet<String>& types)

--- a/Source/WebCore/platform/graphics/gstreamer/mse/MediaPlayerPrivateGStreamerMSE.h
+++ b/Source/WebCore/platform/graphics/gstreamer/mse/MediaPlayerPrivateGStreamerMSE.h
@@ -85,11 +85,12 @@ public:
     void setInitialVideoSize(const FloatSize&);
 
     void didPreroll() override;
+    void didEnd() final;
 
     void startSource(const Vector<RefPtr<MediaSourceTrackGStreamer>>& tracks);
     WebKitMediaSrc* webKitMediaSrc() { return reinterpret_cast<WebKitMediaSrc*>(m_source.get()); }
 
-    void setEosWithNoBuffers(bool);
+    void rebuildPipeline();
 
 #if !RELEASE_LOG_DISABLED
     WTFLogChannel& logChannel() const final { return WebCore::LogMediaSource; }
@@ -134,7 +135,6 @@ private:
     Vector<RefPtr<MediaSourceTrackGStreamer>> m_tracks;
 
     bool m_isWaitingForPreroll = true;
-    bool m_isEosWithNoBuffers = false;
     MediaPlayer::ReadyState m_mediaSourceReadyState = MediaPlayer::ReadyState::HaveNothing;
     MediaPlayer::NetworkState m_mediaSourceNetworkState = MediaPlayer::NetworkState::Empty;
 

--- a/Source/WebCore/platform/graphics/gstreamer/mse/MediaSourcePrivateGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/mse/MediaSourcePrivateGStreamer.cpp
@@ -199,11 +199,12 @@ void MediaSourcePrivateGStreamer::markEndOfStream(EndOfStreamStatus endOfStreamS
     ASSERT(isMainThread());
 
     MediaSourcePrivate::markEndOfStream(endOfStreamStatus);
+
+#ifndef GST_DISABLE_GST_DEBUG
     RefPtr player = platformPlayer();
     if (!player)
         return;
 
-#ifndef GST_DISABLE_GST_DEBUG
     ASCIILiteral statusString;
     switch (endOfStreamStatus) {
     case EndOfStreamStatus::NoError:
@@ -216,15 +217,8 @@ void MediaSourcePrivateGStreamer::markEndOfStream(EndOfStreamStatus endOfStreamS
         statusString = "network-error"_s;
         break;
     }
-    GST_DEBUG_OBJECT(player->pipeline(), "Marking EOS, status is %s", statusString.characters());
+    GST_DEBUG_OBJECT(player->pipeline(), "Marked EOS, status is %s", statusString.characters());
 #endif
-    if (endOfStreamStatus == EndOfStreamStatus::NoError) {
-        auto bufferedRanges = buffered();
-        if (!bufferedRanges.length()) {
-            GST_DEBUG("EOS with no buffers");
-            player->setEosWithNoBuffers(true);
-        }
-    }
 }
 
 void MediaSourcePrivateGStreamer::unmarkEndOfStream()
@@ -234,7 +228,7 @@ void MediaSourcePrivateGStreamer::unmarkEndOfStream()
     if (!player)
         return;
 
-    player->setEosWithNoBuffers(false);
+    player->rebuildPipeline();
     MediaSourcePrivate::unmarkEndOfStream();
 }
 

--- a/Source/WebCore/platform/graphics/gstreamer/mse/SourceBufferPrivateGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/mse/SourceBufferPrivateGStreamer.cpp
@@ -200,7 +200,8 @@ void SourceBufferPrivateGStreamer::flush(TrackID trackId)
     if (!player)
         return;
     GST_DEBUG_OBJECT(player->pipeline(), "Source element has emitted tracks, let it handle the flush, which may cause a pipeline flush as well. trackId = '%" PRIu64 "'", track->id());
-    webKitMediaSrcFlush(player->webKitMediaSrc(), track->id());
+    if (auto source = player->webKitMediaSrc())
+        webKitMediaSrcFlush(source, track->id());
 }
 
 void SourceBufferPrivateGStreamer::enqueueSample(Ref<MediaSample>&& sample, TrackID trackId)

--- a/Source/WebCore/platform/graphics/gstreamer/mse/WebKitMediaSourceGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/mse/WebKitMediaSourceGStreamer.cpp
@@ -618,12 +618,19 @@ static void webKitMediaSrcLoop(void* userData)
             GST_DEBUG_OBJECT(pad, "First buffer on this pad was pushed (ret = %s).", gst_flow_get_name(result));
             dumpPipeline("first-frame-after"_s, stream);
         }
-IGNORE_WARNINGS_BEGIN("cast-align")
+        IGNORE_WARNINGS_BEGIN("cast-align");
     } else if (GST_IS_EVENT(object.get())) {
         // EOS events and other enqueued events are also sent unlocked so they can react to flushes if necessary.
         GRefPtr<GstEvent> event = GRefPtr<GstEvent>(GST_EVENT(object.leakRef()));
-IGNORE_WARNINGS_END
+        IGNORE_WARNINGS_END;
 
+        if (GST_EVENT_TYPE(event.get()) == GST_EVENT_EOS && !streamingMembers->hasPushedFirstBuffer) {
+            // parsebin emits errors if it receives EOS without prior buffer and those errors bubble
+            // up to our media player, leading to false-positive errors. Even if this parsebin
+            // behavior is acceptable in the general case, it is problematic for MSE.
+            GST_DEBUG_OBJECT(pad, "Ignoring EOS on non-prerolled pad");
+            return;
+        }
         streamingMembers.unlockEarly();
         GST_DEBUG_OBJECT(pad, "Pushing event downstream: %" GST_PTR_FORMAT, event.get());
         bool eventHandled = gst_pad_push_event(pad, GRefPtr<GstEvent>(event).leakRef());


### PR DESCRIPTION
#### 96f2c38a56fb640ae23a1c60b9f0e1ff58b8c551
<pre>
[GStreamer][MSE] Tear down the pipeline upon EOS notification and re-create it when the MediaSource un-marks its EOS flag
<a href="https://bugs.webkit.org/show_bug.cgi?id=313814">https://bugs.webkit.org/show_bug.cgi?id=313814</a>

Reviewed by Xabier Rodriguez-Calvar.

Without this patch the following sequence of events would lead to a GStreamer error in the MSE
playback pipeline where we would attempt to push a buffer downstream after EOS was previously
pushed:

- appendBuffer()
- let the segment play until EOS
- appendBuffer()
- play

The proposed solution is to dispose the internal MSE playback pipeline after EOS has been received.
If playback is requested again, the pipeline is re-created from scratch. The previous workarounds
related with &quot;setEosWithNoBuffers&quot; are then no longer needed and can be removed.

Test: media/media-source/media-source-real-play-after-eos.html

* LayoutTests/media/media-source/media-source-real-play-after-eos-expected.txt: Added.
* LayoutTests/media/media-source/media-source-real-play-after-eos.html: Added.
* Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp:
(WebCore::MediaPlayerPrivateGStreamer::tearDown):
(WebCore::MediaPlayerPrivateGStreamer::load):
(WebCore::MediaPlayerPrivateGStreamer::timeChanged):
(WebCore::MediaPlayerPrivateGStreamer::handleMessage):
(WebCore::MediaPlayerPrivateGStreamer::createGSTPlayBin):
(WebCore::MediaPlayerPrivateGStreamer::cdmInstanceAttached):
(WebCore::MediaPlayerPrivateGStreamer::cdmInstanceDetached):
(WebCore::MediaPlayerPrivateGStreamer::handleSyncErrorMessage): Deleted.
* Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.h:
* Source/WebCore/platform/graphics/gstreamer/TrackPrivateBaseGStreamer.cpp:
(WebCore::TrackPrivateBaseGStreamer::~TrackPrivateBaseGStreamer):
* Source/WebCore/platform/graphics/gstreamer/TrackPrivateBaseGStreamer.h:
* Source/WebCore/platform/graphics/gstreamer/mse/MediaPlayerPrivateGStreamerMSE.cpp:
(WebCore::MediaPlayerPrivateGStreamerMSE::load):
(WebCore::MediaPlayerPrivateGStreamerMSE::play):
(WebCore::MediaPlayerPrivateGStreamerMSE::pause):
(WebCore::MediaPlayerPrivateGStreamerMSE::seekToTarget):
(WebCore::MediaPlayerPrivateGStreamerMSE::doSeek):
(WebCore::MediaPlayerPrivateGStreamerMSE::didPreroll):
(WebCore::MediaPlayerPrivateGStreamerMSE::didEnd):
(WebCore::MediaPlayerPrivateGStreamerMSE::updateStates):
(WebCore::MediaPlayerPrivateGStreamerMSE::rebuildPipeline):
(WebCore::MediaPlayerPrivateGStreamerMSE::setEosWithNoBuffers): Deleted.
* Source/WebCore/platform/graphics/gstreamer/mse/MediaPlayerPrivateGStreamerMSE.h:
* Source/WebCore/platform/graphics/gstreamer/mse/MediaSourcePrivateGStreamer.cpp:
(WebCore::MediaSourcePrivateGStreamer::markEndOfStream):
(WebCore::MediaSourcePrivateGStreamer::unmarkEndOfStream):
* Source/WebCore/platform/graphics/gstreamer/mse/SourceBufferPrivateGStreamer.cpp:
(WebCore::SourceBufferPrivateGStreamer::flush):
* Source/WebCore/platform/graphics/gstreamer/mse/WebKitMediaSourceGStreamer.cpp:
(webKitMediaSrcLoop):

Canonical link: <a href="https://commits.webkit.org/312998@main">https://commits.webkit.org/312998@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6f3ed8a39ca5be64496b4d550a86a11aebe39565

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/161783 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/35257 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/28360 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/170686 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/118154 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/163652 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/35358 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/35258 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/125522 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/88438 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/164742 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/27835 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/145318 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/106118 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/26884 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/25399 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/18407 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/136577 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/23073 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/173175 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/20215 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/24714 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/133818 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/34931 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/29488 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/133823 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36142 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/34915 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/144868 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/96963 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/28356 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/21691 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/34425 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/101870 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/33925 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/34168 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/34074 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->