### PR TITLE
[Linux] Handle ENOSPC on NetworkProcess cache mmap writes

### DIFF
--- a/Source/WTF/wtf/FileSystem.cpp
+++ b/Source/WTF/wtf/FileSystem.cpp
@@ -40,6 +40,7 @@
 #include <wtf/text/StringBuilder.h>
 
 #if !OS(WINDOWS)
+#include <fcntl.h>
 #include <sys/mman.h>
 #include <sys/param.h>
 #include <sys/stat.h>
@@ -326,10 +327,27 @@ MappedFileData createMappedFileData(const String& path, size_t bytesSize, FileHa
     if (!handle)
         return { };
 
+    bool succeeded = false;
+    auto removeOrphanOnFailure = makeScopeExit([&] {
+        if (!succeeded)
+            FileSystem::deleteFile(path);
+    });
+
     if (!handle.truncate(bytesSize)) {
         RELEASE_LOG_FAULT(MemoryPressure, "Unable to truncate file");
         return { };
     }
+
+#if HAVE(FALLOCATE)
+    // Reserve real blocks so a later mmap'd memcpy() can't SIGBUS on ENOSPC.
+    // EOPNOTSUPP: filesystem doesn't support pre-allocation -> preserve old behavior.
+    // posix_fallocate is avoided because it falls back to zero-filling when pre-allocation
+    // is not supported by the FS.
+    if (fallocate(handle.platformHandle(), 0, 0, bytesSize) == -1 && errno != EOPNOTSUPP) {
+        RELEASE_LOG_ERROR(MemoryPressure, "Unable to reserve %zu bytes for cache file (errno=%d)", bytesSize, errno);
+        return { };
+    }
+#endif
 
     if (!FileSystem::makeSafeToUseMemoryMapForPath(path))
         return { };
@@ -341,6 +359,7 @@ MappedFileData createMappedFileData(const String& path, size_t bytesSize, FileHa
     if (outputHandle)
         *outputHandle = WTF::move(handle);
 
+    succeeded = true;
     return WTF::move(*mappedFile);
 }
 

--- a/Source/WTF/wtf/PlatformHave.h
+++ b/Source/WTF/wtf/PlatformHave.h
@@ -253,6 +253,10 @@
 #define HAVE_DLADDR 1
 #endif
 
+#if OS(LINUX)
+#define HAVE_FALLOCATE 1
+#endif
+
 #if OS(WINDOWS)
 #define HAVE_ISDEBUGGERPRESENT 1
 #endif


### PR DESCRIPTION
#### 15b0198087a9f0274fc73c1736e7a4678d6ea412
<pre>
[Linux] Handle ENOSPC on NetworkProcess cache mmap writes
<a href="https://bugs.webkit.org/show_bug.cgi?id=313815">https://bugs.webkit.org/show_bug.cgi?id=313815</a>

Reviewed by Adrian Perez de Castro.

If the filesystem runs out of space when the NetworkProcess is writing
into its cache, BlobStorage::add will get SIGBUS when memcpy&apos;ing into a
MAP_SHARED mapping.

By using fallocate immediately after ftruncate, we attempt to reserve
the blocks needed. This allows us to handle ENOSPC, returning an empty
MappedFileData, something already handled by skipping caching the entry.
If EOPNOTSUPP is received, we keep the existing behaviour and progress
-- which might or might not lead to a later SIGBUS.

Doing this exposed a latent leak in createMappedFileData, where files
would survive early returns on error scenarios. A scope guard now
ensures that files are unlinked in error scenarios, which ensures that
the corresponding read paths avoid reading from leftover orphan files.

A new HAVE(FALLOCATE) has been added, defined only in Linux. Darwin or
other systems would probably want their own analogous operation.

Tested manually by creating a small tmpfs, then pointing --profile-dir to
it and navigating. Before the fix, this would consistently trigger a
SIGBUS. After the fix, this logs an error mmapping but continues
unaffected.

* Source/WTF/wtf/FileSystem.cpp:
(WTF::FileSystemImpl::createMappedFileData):
* Source/WTF/wtf/PlatformHave.h:

Canonical link: <a href="https://commits.webkit.org/312611@main">https://commits.webkit.org/312611@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/aab0dc4cf022d593d0c85fedc11bb4e7632549a6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/160523 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/33996 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/27097 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/169426 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/115589 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/34097 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/33996 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/124477 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/115589 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/163481 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/26725 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/144198 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/105077 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/25777 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/24280 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/17145 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/152579 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/135471 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/21961 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/171905 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/21360 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/18470 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/23601 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/132742 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/33670 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/28373 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/132756 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35875 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/33654 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/143756 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/95438 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/27357 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/20570 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/192922 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/33164 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/100066 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/49678 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/32664 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/32908 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/32812 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->