### PR TITLE
[GTK MiniBrowser] Truncate title for menu items in UTF-8 code point boundary

### DIFF
--- a/Tools/MiniBrowser/gtk/BrowserWindow.c
+++ b/Tools/MiniBrowser/gtk/BrowserWindow.c
@@ -216,6 +216,29 @@ static void browserWindowHistoryItemActivated(BrowserWindow *window, GVariant *p
     webkit_web_view_go_to_back_forward_list_item(webView, item);
 }
 
+static char *truncateTitle(const char *title)
+{
+#define MAX_TITLE 50
+    if (g_utf8_strlen(title, -1) <= MAX_TITLE) {
+#if GTK_CHECK_VERSION(3, 98, 5)
+        return g_markup_escape_text(title, -1);
+#else
+        return g_strdup(title);
+#endif
+    }
+
+    const char *end = g_utf8_offset_to_pointer(title, MAX_TITLE - 1);
+    g_autofree char *truncatedTitle = g_strndup(title, end - title);
+    g_autofree char *ellipsizedTitle = g_strconcat(truncatedTitle, "\xE2\x80\xA6", NULL);
+
+#if GTK_CHECK_VERSION(3, 98, 5)
+    return g_markup_escape_text(ellipsizedTitle, -1);
+#else
+    return g_steal_pointer(&ellipsizedTitle);
+#endif
+#undef MAX_TITLE
+}
+
 static void browserWindowCreateBackForwardMenu(BrowserWindow *window, GList *list, gboolean isBack)
 {
     if (!list)
@@ -232,27 +255,7 @@ static void browserWindowCreateBackForwardMenu(BrowserWindow *window, GList *lis
         if (!title || !*title)
             title = webkit_back_forward_list_item_get_uri(item);
 
-        char *displayTitle;
-#define MAX_TITLE 100
-#if GTK_CHECK_VERSION(3, 98, 5)
-        char *escapedTitle = g_markup_escape_text(title, -1);
-        if (strlen(escapedTitle) > MAX_TITLE) {
-            displayTitle = g_strndup(escapedTitle, MAX_TITLE);
-            g_free(escapedTitle);
-            displayTitle[MAX_TITLE - 1] = 0xA6;
-            displayTitle[MAX_TITLE - 2] = 0x80;
-            displayTitle[MAX_TITLE - 3] = 0xE2;
-        } else
-            displayTitle = escapedTitle;
-#else
-        displayTitle = g_strndup(title, MIN(MAX_TITLE, strlen(title)));
-        if (strlen(title) > MAX_TITLE) {
-            displayTitle[MAX_TITLE - 1] = 0xA6;
-            displayTitle[MAX_TITLE - 2] = 0x80;
-            displayTitle[MAX_TITLE - 3] = 0xE2;
-        }
-#endif
-#undef MAX_TITLE
+        char *displayTitle = truncateTitle(title);
 
         char *actionName = g_strdup_printf("action-%" G_GUINT64_FORMAT, ++actionId);
         GSimpleAction *action = g_simple_action_new(actionName, NULL);


### PR DESCRIPTION
#### 9508413124c4897fbbb35f7ecb4b19aa7269d3dd
<pre>
[GTK MiniBrowser] Truncate title for menu items in UTF-8 code point boundary
<a href="https://bugs.webkit.org/show_bug.cgi?id=304962">https://bugs.webkit.org/show_bug.cgi?id=304962</a>

Reviewed by Carlos Garcia Campos.

g_menu_item_new reported a warning for an invalid UTF-8 string.

&gt; (MiniBrowser:21769): g_variant_new_string: assertion &apos;g_utf8_validate (string, -1, NULL)&apos; failed

Truncate the title in a code point boundary.

* Tools/MiniBrowser/gtk/BrowserWindow.c:
(truncateTitle):
(browserWindowCreateBackForwardMenu):

Canonical link: <a href="https://commits.webkit.org/312512@main">https://commits.webkit.org/312512@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d7849b486d9f32a4d212d42137630d5260c3e903

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/159932 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/33400 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/26506 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/168805 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/114313 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/161801 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/33504 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/33404 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/123950 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/86938 "1 flakes 9 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/162890 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/26205 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/143651 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/104569 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/25257 "Passed tests") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/23728 "Found 2 new API test failures: TestWebKitAPI.WKWebExtension.LoadFromZipArchiveWithoutParentDirectory, TestWebKitAPI.WKBackForwardList.BackForwardNavigationSkipsItemsWithoutUserGestureFragment (failure)") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/16553 "Built successfully") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/134949 "Found 1 new API test failure: TestWebKitAPI.WritingTools.CompositionWithMultipleChunks (failure)") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/21421 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/171290 "Built successfully") | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/23059 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/132217 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/33078 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/27813 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/132244 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/33063 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/143216 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/91197 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/24376 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/26862 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/20029 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/32572 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/32069 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/32316 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/32220 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->