### PR TITLE
Synchronous consecutive history.go() / history.back() calls are coalesced instead of queued

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/overlapping-navigations-and-traversals/same-document-traversal-cross-document-traversal-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/overlapping-navigations-and-traversals/same-document-traversal-cross-document-traversal-expected.txt
@@ -1,7 +1,4 @@
 
-
-Harness Error (TIMEOUT), message = null
-
-TIMEOUT traversals in the same (back) direction: queued up Test timed out
-NOTRUN traversals in the same (forward) direction: queued up
+PASS traversals in the same (back) direction: queued up
+PASS traversals in the same (forward) direction: queued up
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/overlapping-navigations-and-traversals/same-document-traversal-same-document-traversal-hashchange-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/overlapping-navigations-and-traversals/same-document-traversal-same-document-traversal-hashchange-expected.txt
@@ -2,7 +2,7 @@
 
 Harness Error (TIMEOUT), message = null
 
-FAIL same-document traversals in opposite directions: queued up assert_equals: newURL 1 expected "http://web-platform.test:8800/common/blank.html#1" but got "http://web-platform.test:8800/common/blank.html#3"
+PASS same-document traversals in opposite directions: queued up
 TIMEOUT same-document traversals in opposite directions, second traversal invalid at queuing time: queued up Test timed out
 NOTRUN same-document traversals in the same (back) direction: queue up
 NOTRUN same-document traversals in the same (forward) direction: queue up

--- a/LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/overlapping-navigations-and-traversals/same-document-traversal-same-document-traversal-pushstate-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/overlapping-navigations-and-traversals/same-document-traversal-same-document-traversal-pushstate-expected.txt
@@ -2,7 +2,7 @@
 
 Harness Error (TIMEOUT), message = null
 
-FAIL same-document traversals in opposite directions: queued up assert_equals: state 1 expected 1 but got 3
+PASS same-document traversals in opposite directions: queued up
 TIMEOUT same-document traversals in opposite directions, second traversal invalid at queuing time: queued up Test timed out
 NOTRUN same-document traversals in the same (back) direction: queue up
 NOTRUN same-document traversals in the same (forward) direction: queue up

--- a/LayoutTests/imported/w3c/web-platform-tests/html/browsers/history/the-history-interface/004-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/browsers/history/the-history-interface/004-expected.txt
@@ -1,6 +1,6 @@
 
 PASS .go commands should be queued until the thread has ended
 PASS browser needs to support hashchange events for this testcase
-FAIL queued .go commands should all be executed when the queue is processed assert_equals: the wrong number of queued commands were executed expected 2 but got 1
-FAIL history position should be calculated when executing, not when calling the .go command assert_equals: expected "" but got "bar"
+PASS queued .go commands should all be executed when the queue is processed
+PASS history position should be calculated when executing, not when calling the .go command
 

--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/overlapping-navigations-and-traversals/same-document-traversal-same-document-traversal-hashchange-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/overlapping-navigations-and-traversals/same-document-traversal-same-document-traversal-hashchange-expected.txt
@@ -1,9 +1,0 @@
-
-
-Harness Error (TIMEOUT), message = null
-
-FAIL same-document traversals in opposite directions: queued up assert_equals: newURL 1 expected "http://web-platform.test:8800/common/blank.html#1" but got "http://web-platform.test:8800/common/blank.html#3"
-TIMEOUT same-document traversals in opposite directions, second traversal invalid at queuing time: queued up Test timed out
-NOTRUN same-document traversals in the same (back) direction: queue up
-NOTRUN same-document traversals in the same (forward) direction: queue up
-

--- a/Source/WebCore/loader/NavigationScheduler.cpp
+++ b/Source/WebCore/loader/NavigationScheduler.cpp
@@ -101,6 +101,7 @@ public:
     virtual void didStopTimer(Frame&, NewLoadInProgress) { }
     virtual bool targetIsCurrentFrame() const { return true; }
     virtual bool isSameDocumentNavigation(Frame&) const { return false; }
+    virtual bool isHistoryNavigation() const { return false; }
 
     enum class ShouldCancel : uint8_t { No, Yes };
     virtual ShouldCancel adjustForNewBackForwardEntry() { return ShouldCancel::No; }
@@ -348,6 +349,8 @@ public:
         RefPtr currentItem = localFrame->loader().history().currentItem();
         return currentItem && historyItem->shouldDoSameDocumentNavigationTo(*currentItem);
     }
+
+    bool isHistoryNavigation() const final { return true; }
 
     ShouldCancel adjustForNewBackForwardEntry() final
     {
@@ -620,6 +623,7 @@ void NavigationScheduler::clear()
 {
     m_timer.stop();
     m_redirect = nullptr;
+    m_pendingHistoryNavigations.clear();
 }
 
 inline bool NavigationScheduler::shouldScheduleNavigation() const
@@ -807,6 +811,13 @@ void NavigationScheduler::scheduleHistoryNavigation(int steps)
         return;
     }
 
+    // Queue consecutive history navigations rather than cancel-and-replace, so each
+    // history.go() call results in its own traversal task. See whatwg/html#6927.
+    if ((m_redirect && m_redirect->isHistoryNavigation()) || !m_pendingHistoryNavigations.isEmpty()) {
+        m_pendingHistoryNavigations.append(makeUnique<ScheduledHistoryNavigation>(steps));
+        return;
+    }
+
     schedule(makeUnique<ScheduledHistoryNavigation>(steps));
 }
 
@@ -848,7 +859,20 @@ void NavigationScheduler::timerFired()
     std::unique_ptr<ScheduledNavigation> redirect = std::exchange(m_redirect, nullptr);
     LOG(History, "NavigationScheduler %p timerFired - firing redirect %p", this, redirect.get());
 
+    bool wasHistoryNavigation = redirect->isHistoryNavigation();
     redirect->fire(frame);
+
+    if (wasHistoryNavigation)
+        processNextPendingHistoryNavigation();
+}
+
+void NavigationScheduler::processNextPendingHistoryNavigation()
+{
+    if (m_redirect || m_pendingHistoryNavigations.isEmpty())
+        return;
+
+    m_redirect = m_pendingHistoryNavigations.takeFirst();
+    startTimer();
 }
 
 void NavigationScheduler::schedule(std::unique_ptr<ScheduledNavigation> redirect)
@@ -914,6 +938,7 @@ void NavigationScheduler::cancel(NewLoadInProgress newLoadInProgress)
     LOG(History, "NavigationScheduler %p cancel(newLoadInProgress=%d)", this, newLoadInProgress == NewLoadInProgress::Yes);
 
     m_timer.stop();
+    m_pendingHistoryNavigations.clear();
 
     if (auto redirect = std::exchange(m_redirect, nullptr))
         redirect->didStopTimer(protect(m_frame), newLoadInProgress);

--- a/Source/WebCore/loader/NavigationScheduler.h
+++ b/Source/WebCore/loader/NavigationScheduler.h
@@ -35,6 +35,7 @@
 #include <WebCore/Timer.h>
 #include <wtf/CanMakeWeakPtr.h>
 #include <wtf/CompletionHandler.h>
+#include <wtf/Deque.h>
 #include <wtf/Forward.h>
 #include <wtf/WeakRef.h>
 
@@ -86,12 +87,14 @@ private:
 
     void timerFired();
     void schedule(std::unique_ptr<ScheduledNavigation>);
+    void processNextPendingHistoryNavigation();
 
     static LockBackForwardList mustLockBackForwardList(Frame& targetFrame);
 
     WeakRef<Frame> m_frame;
     Timer m_timer;
     std::unique_ptr<ScheduledNavigation> m_redirect;
+    Deque<std::unique_ptr<ScheduledNavigation>> m_pendingHistoryNavigations;
 };
 
 } // namespace WebCore


### PR DESCRIPTION
#### 7503c5676f7b2fc7d2613cd006c2a46c79593bc0
<pre>
Synchronous consecutive history.go() / history.back() calls are coalesced instead of queued
<a href="https://bugs.webkit.org/show_bug.cgi?id=313808">https://bugs.webkit.org/show_bug.cgi?id=313808</a>

Reviewed by NOBODY (OOPS!).

When history.go(), history.back(), or history.forward() is called multiple times synchronously, NavigationScheduler::schedule() cancel-and-replaces the previous pending entry, so only the last call is processed. The HTML spec&apos;s &quot;traverse the history by a delta&quot; algorithm requires each call to queue an independent traversal task whose destination is computed against the index produced by the previous traversal. This is the &quot;Ignore first XDT/SDT&quot; cell of the Safari column in <a href="https://github.com/whatwg/html/issues/6927">https://github.com/whatwg/html/issues/6927</a> and a sub-case of webkit.org/b/229762.

Add a FIFO queue (m_pendingHistoryNavigations) for history navigations: if a history navigation is already pending or queued, append the new one instead of cancel-and-replacing. After a history navigation fires, drain the next queued entry into m_redirect and restart the timer, so each traversal runs as its own task with its destination recomputed at fire time. clear() and cancel() drain the queue alongside m_redirect.

No new tests (existing WPTs in the overlapping-navigations-and-traversals suite already cover this; their checked-in FAIL/TIMEOUT baselines are updated to reflect the new PASS results).

* LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/overlapping-navigations-and-traversals/same-document-traversal-cross-document-traversal-expected.txt: TIMEOUT/NOTRUN -&gt; PASS/PASS.
* LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/overlapping-navigations-and-traversals/same-document-traversal-same-document-traversal-hashchange-expected.txt: First subtest FAIL -&gt; PASS.
* LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/overlapping-navigations-and-traversals/same-document-traversal-same-document-traversal-pushstate-expected.txt: First subtest FAIL -&gt; PASS.
* Source/WebCore/loader/NavigationScheduler.cpp:
(WebCore::ScheduledNavigation::isHistoryNavigation const): Added (default false). ScheduledHistoryNavigation overrides this to return true.
(WebCore::NavigationScheduler::clear): Also clear the pending history navigation queue.
(WebCore::NavigationScheduler::scheduleHistoryNavigation): Queue the new navigation when a history navigation is already pending or queued, instead of cancel-and-replacing through schedule().
(WebCore::NavigationScheduler::timerFired): After firing a history navigation, drain the next queued entry via processNextPendingHistoryNavigation().
(WebCore::NavigationScheduler::processNextPendingHistoryNavigation): Added. Move the next queued navigation into m_redirect and start the timer.
(WebCore::NavigationScheduler::cancel): Also clear the pending history navigation queue.
* Source/WebCore/loader/NavigationScheduler.h: Add wtf/Deque.h include, m_pendingHistoryNavigations queue member, processNextPendingHistoryNavigation declaration.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3e27286b5dca0822a2939fd9328046200fd1d6f3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/160054 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/33524 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/26628 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/168936 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/114435 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/161923 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/33627 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/33526 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/124053 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/86997 "2 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/163012 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/26303 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/143757 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/104667 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/25356 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/23843 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/16675 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/135047 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/21524 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/171416 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/17422 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/23162 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/132317 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/33200 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/27926 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/132343 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/33185 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/143319 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/91336 "The change is no longer eligible for processing.") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/26954 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/20132 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/32694 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/99091 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/32192 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/32438 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/32342 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->