### PR TITLE
[JSC] Unroll zero-fill for `NewButterflyWithSize` with small constant length

### DIFF
--- a/JSTests/microbenchmarks/new-array-constant-size-zero-fill-16.js
+++ b/JSTests/microbenchmarks/new-array-constant-size-zero-fill-16.js
@@ -1,0 +1,11 @@
+//@ skip if $model == "Apple Watch Series 3" # added by mark-jsc-stress-test.py
+function foo() {
+    return new Array(16);
+}
+
+function bar() {
+    for (var i = 0; i < 100000000; ++i)
+        foo();
+}
+
+bar();

--- a/JSTests/microbenchmarks/new-array-constant-size-zero-fill-4.js
+++ b/JSTests/microbenchmarks/new-array-constant-size-zero-fill-4.js
@@ -1,0 +1,11 @@
+//@ skip if $model == "Apple Watch Series 3" # added by mark-jsc-stress-test.py
+function foo() {
+    return new Array(4);
+}
+
+function bar() {
+    for (var i = 0; i < 100000000; ++i)
+        foo();
+}
+
+bar();

--- a/JSTests/microbenchmarks/new-array-constant-size-zero-fill-8.js
+++ b/JSTests/microbenchmarks/new-array-constant-size-zero-fill-8.js
@@ -1,0 +1,11 @@
+//@ skip if $model == "Apple Watch Series 3" # added by mark-jsc-stress-test.py
+function foo() {
+    return new Array(8);
+}
+
+function bar() {
+    for (var i = 0; i < 100000000; ++i)
+        foo();
+}
+
+bar();

--- a/JSTests/stress/new-array-constant-size-zero-fill.js
+++ b/JSTests/stress/new-array-constant-size-zero-fill.js
@@ -1,0 +1,88 @@
+//@ requireOptions("--useConcurrentJIT=0")
+
+function shouldBe(a, b) {
+    if (a !== b)
+        throw new Error("expected " + b + " but got " + a);
+}
+
+function shouldBeArrayOfHoles(arr, length) {
+    shouldBe(arr.length, length);
+    for (var i = 0; i < length; ++i) {
+        shouldBe(i in arr, false);
+        shouldBe(arr[i], undefined);
+    }
+}
+
+// Sizes that exercise the unrolled path (<= 16) and the loop fallback (> 16).
+function make0()    { return new Array(0); }
+function make1()    { return new Array(1); }
+function make2()    { return new Array(2); }
+function make3()    { return new Array(3); }
+function make7()    { return new Array(7); }
+function make8()    { return new Array(8); }
+function make15()   { return new Array(15); }
+function make16()   { return new Array(16); }
+function make17()   { return new Array(17); }
+function make32()   { return new Array(32); }
+function make100()  { return new Array(100); }
+function make999()  { return new Array(999); }
+
+var fns = [
+    [make0, 0],
+    [make1, 1],
+    [make2, 2],
+    [make3, 3],
+    [make7, 7],
+    [make8, 8],
+    [make15, 15],
+    [make16, 16],
+    [make17, 17],
+    [make32, 32],
+    [make100, 100],
+    [make999, 999],
+];
+
+for (var i = 0; i < testLoopCount; ++i) {
+    for (var j = 0; j < fns.length; ++j) {
+        var [fn, len] = fns[j];
+        shouldBeArrayOfHoles(fn(), len);
+    }
+}
+
+// Force ArrayWithDouble indexing via the array allocation profile, then
+// allocate fresh constant-sized arrays through the same call site to make sure
+// the (newly canonical) PNaN bit pattern is still treated as a hole.
+function makeProfiled(seed) {
+    var a = new Array(8);
+    for (var i = 0; i < 8; ++i)
+        a[i] = i + seed + 0.5; // doubles
+    return a;
+}
+for (var i = 0; i < testLoopCount; ++i)
+    makeProfiled(i);
+
+function freshAfterDoubleProfile(len) {
+    return new Array(len);
+}
+for (var i = 0; i < testLoopCount; ++i) {
+    var a = freshAfterDoubleProfile(8);
+    shouldBe(a.length, 8);
+    for (var k = 0; k < 8; ++k) {
+        shouldBe(k in a, false);
+        shouldBe(a[k], undefined);
+    }
+}
+
+// Mutate after creation to confirm storage is writable.
+function mutate() {
+    var a = new Array(8);
+    for (var i = 0; i < 8; ++i)
+        a[i] = i * 2;
+    return a;
+}
+for (var i = 0; i < testLoopCount; ++i) {
+    var a = mutate();
+    shouldBe(a.length, 8);
+    for (var k = 0; k < 8; ++k)
+        shouldBe(a[k], k * 2);
+}

--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp
@@ -15334,12 +15334,20 @@ void SpeculativeJIT::compileNewButterflyWithSize(Node* node)
     static_assert(Butterfly::offsetOfPublicLength() + static_cast<ptrdiff_t>(sizeof(uint32_t)) == Butterfly::offsetOfVectorLength());
     storePair32(sizeGPR, sizeGPR, storageGPR, TrustedImm32(Butterfly::offsetOfPublicLength()));
 
-    if (hasDouble(indexingMode))
-        moveTrustedValue(jsNaN(), scratchRegs);
-    else
-        moveTrustedValue(JSValue(), scratchRegs);
+    constexpr unsigned zeroFillUnrollLimit = 16;
+    if (butterflyLength <= zeroFillUnrollLimit) {
+        if (hasDouble(indexingMode))
+            emitFillStorageWithDoubleEmpty(storageGPR, 0, butterflyLength, scratchGPR);
+        else
+            emitFillStorageWithJSEmpty(storageGPR, 0, butterflyLength, scratchGPR);
+    } else {
+        if (hasDouble(indexingMode))
+            moveTrustedValue(jsNaN(), scratchRegs);
+        else
+            moveTrustedValue(JSValue(), scratchRegs);
 
-    emitInitializeButterfly(storageGPR, sizeGPR, scratchRegs, sizeGPR);
+        emitInitializeButterfly(storageGPR, sizeGPR, scratchRegs, sizeGPR);
+    }
     storageResult(storageGPR, node);
 }
 


### PR DESCRIPTION
#### 1de12d99d9edd9ff4f5dfcc77b07f729c93267ac
<pre>
[JSC] Unroll zero-fill for `NewButterflyWithSize` with small constant length
<a href="https://bugs.webkit.org/show_bug.cgi?id=313825">https://bugs.webkit.org/show_bug.cgi?id=313825</a>

Reviewed by Yusuke Suzuki.

`NewButterflyWithSize` is inserted by DFGConstantFoldingPhase from
`new Array(N)` where N is a small Int32 constant. Even though the length
is known at compile time, `compileNewButterflyWithSize` still emitted a
runtime hole-fill loop via `emitInitializeButterfly`.

This patch reuses `emitFillStorageWithJSEmpty` /
`emitFillStorageWithDoubleEmpty` (the same helpers the recently landed
`NewTypedArray` constant-size unroll uses) when `butterflyLength` is
within the unroll budget (16 words). On ARM64 the loop body collapses
into `stp xzr, xzr` pairs.

Microbenchmark (DFG only, JSC_useFTLJIT=false):

                                             baseline                  patched
new-array-constant-size-zero-fill-4    341.2569+-7.7353          328.1310+-6.3353          might be 1.0400x faster
new-array-constant-size-zero-fill-8    504.6251+-6.3335     ^    442.1297+-17.8307       ^ definitely 1.1414x faster
new-array-constant-size-zero-fill-16   844.2062+-22.6756    ^    679.9115+-17.8603       ^ definitely 1.2416x faster

&lt;geometric&gt;                            525.7819+-3.3028     ^    461.9929+-5.6665        ^ definitely 1.1381x faster

Tests: JSTests/microbenchmarks/new-array-constant-size-zero-fill-16.js
       JSTests/microbenchmarks/new-array-constant-size-zero-fill-4.js
       JSTests/microbenchmarks/new-array-constant-size-zero-fill-8.js
       JSTests/stress/new-array-constant-size-zero-fill.js

* JSTests/microbenchmarks/new-array-constant-size-zero-fill-16.js: Added.
(foo):
(bar):
* JSTests/microbenchmarks/new-array-constant-size-zero-fill-4.js: Added.
(foo):
(bar):
* JSTests/microbenchmarks/new-array-constant-size-zero-fill-8.js: Added.
(foo):
(bar):
* JSTests/stress/new-array-constant-size-zero-fill.js: Added.
(shouldBe):
(shouldBeArrayOfHoles):
(make0):
(make1):
(make2):
(make3):
(make7):
(make8):
(make15):
(make16):
(make17):
(make32):
(make100):
(make999):
(makeProfiled):
(freshAfterDoubleProfile):
(mutate):
* Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp:

Canonical link: <a href="https://commits.webkit.org/312496@main">https://commits.webkit.org/312496@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/88415c391f8b3841bd26050aa5132250f3b15386

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/159966 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/33435 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/26540 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/168843 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/114347 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/33539 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/33438 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/123979 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/86958 "2 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/162924 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/26230 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/143677 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/104596 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/25282 "Passed tests") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/23762 "Found 1 new API test failure: TestWebKitAPI.WKBackForwardList.BackForwardNavigationSkipsItemsWithoutUserGestureFragment (failure)") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/16587 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/152022 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/134974 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/21447 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/171326 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/20803 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/17334 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/23085 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/132246 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/33112 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/27844 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/132268 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35808 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/33097 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/143242 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/91247 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/26886 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/20055 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/192250 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/32606 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/99003 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/49447 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/32104 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/32350 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/32254 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->