### PR TITLE
REGRESSION(312305@main): [macOS] 5 http/tests/inspector tests are constant TIMEOUTs

### DIFF
--- a/Source/WebInspectorUI/Scripts/copy-user-interface-resources.pl
+++ b/Source/WebInspectorUI/Scripts/copy-user-interface-resources.pl
@@ -25,6 +25,7 @@
 
 use warnings;
 use English;
+use Cwd qw(abs_path);
 use File::Basename qw(dirname);
 use File::Copy qw(copy);
 use File::Path qw(make_path remove_tree);
@@ -80,7 +81,8 @@ sub readInputFileList()
     my @files;
     while (my $line = <$fh>) {
         chomp $line;
-        push @files, $line;
+        my $resolved = abs_path($line);
+        push @files, ($resolved ? $resolved : $line);
     }
     close($fh);
     return @files;
@@ -89,6 +91,7 @@ sub readInputFileList()
 sub copyFilesFromList($$\@)
 {
     my ($sourcePrefix, $destRoot, $fileListRef) = @_;
+    $sourcePrefix = abs_path($sourcePrefix) || $sourcePrefix;
     $sourcePrefix .= '/' unless $sourcePrefix =~ /\/$/;
     for my $file (@$fileListRef) {
         next unless index($file, $sourcePrefix) == 0;


### PR DESCRIPTION
#### 8fdb43bdab381cbea67645149d448c540ab6edc2
<pre>
REGRESSION(312305@main): [macOS] 5 http/tests/inspector tests are constant TIMEOUTs
<a href="https://bugs.webkit.org/show_bug.cgi?id=313791">https://bugs.webkit.org/show_bug.cgi?id=313791</a>
&lt;<a href="https://rdar.apple.com/175978103">rdar://175978103</a>&gt;

Reviewed by Elliott Williams.

Tests were failing in some build environments because the content of the WebInspectorUI
was not reliably copied to the target location. The switch to using xcfilelists caused
the specific paths to differ on build systems that used symlinks to different volumes
for storing build products.

Both readInputFileList and copyFilesFromList now resolve symlinks via Cwd::abs_path before
comparing paths. On Internal SDK builds, the source tree is mounted through a sandbox, so
$ENV{&apos;SRCROOT&apos;} and the Xcode-resolved xcfilelist entries can refer to the same files
through different symlink chains. Without resolution, the index() prefix match silently
fails and no files are copied.

* Source/WebInspectorUI/Scripts/copy-user-interface-resources.pl:
(readInputFileList): Pass path through `Cwd::abs_path` before adding to comparison list.
(copyFilesFromList): Ditto.

Canonical link: <a href="https://commits.webkit.org/312450@main">https://commits.webkit.org/312450@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b88bb7667187e23c44d34cc3f406d07ae534d559

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/159960 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/33428 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/26534 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/168836 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/114341 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/69f091df-836c-45fa-8279-0aa00450d0b7) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/33532 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/33432 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/123974 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/86955 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/9ae0bb2d-6d20-49a2-8193-96dd6f05db4d) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/162918 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/26231 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/143672 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/104591 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/1633b0f3-8987-4ebd-9a87-065ee70744c3) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/25283 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/23757 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/16581 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/134975 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/21442 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/171320 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/17328 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/23080 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/132238 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/33106 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/27840 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/132265 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35788 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/33091 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/143237 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/91241 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/26885 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/20050 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/32600 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/98997 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/32097 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/32344 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/32248 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->