### PR TITLE
[JSC] Implement static `import defer` semantics

### DIFF
--- a/JSTests/modules/import-defer-cycle-root-error.js
+++ b/JSTests/modules/import-defer-cycle-root-error.js
@@ -1,0 +1,22 @@
+//@ requireOptions("--useImportDefer=1")
+import { shouldBe } from "./resources/assert.js";
+
+// SCC {a, b}: a has TLA and rejects; b is the non-root member.
+// After the cycle root (a) fails asynchronously, accessing the deferred namespace of b
+// must rethrow a's evaluation error rather than silently succeeding, because Evaluate()
+// redirects to [[CycleRoot]].
+
+let importError;
+await import("./import-defer/cycle-a.js").catch(e => importError = e);
+shouldBe(typeof importError, "object");
+shouldBe(importError.someError, "tla-reject");
+
+const { nsB } = await import("./import-defer/cycle-b-exporter.js");
+
+let accessError;
+try {
+    nsB.value;
+} catch (e) {
+    accessError = e;
+}
+shouldBe(accessError, importError);

--- a/JSTests/modules/import-defer-evaluation.js
+++ b/JSTests/modules/import-defer-evaluation.js
@@ -1,0 +1,23 @@
+//@ requireOptions("--useImportDefer=1")
+import { shouldBe } from "./resources/assert.js";
+
+globalThis.deferEvaluations = [];
+
+import defer * as ns from "./import-defer/eval-tracker.js";
+
+shouldBe(globalThis.deferEvaluations.length, 0);
+
+// Symbol/`then` accesses must not trigger evaluation.
+ns[Symbol.toStringTag];
+ns.then;
+shouldBe(globalThis.deferEvaluations.length, 0);
+
+// First string access triggers synchronous evaluation.
+shouldBe(ns.value, 42);
+shouldBe(globalThis.deferEvaluations.length, 1);
+shouldBe(globalThis.deferEvaluations[0], "eval-tracker");
+
+// Subsequent accesses do not re-evaluate.
+shouldBe(ns.value, 42);
+Reflect.ownKeys(ns);
+shouldBe(globalThis.deferEvaluations.length, 1);

--- a/JSTests/modules/import-defer-ic-poly.js
+++ b/JSTests/modules/import-defer-ic-poly.js
@@ -1,0 +1,31 @@
+//@ requireOptions("--useImportDefer=1")
+import { shouldBe } from "./resources/assert.js";
+
+globalThis.deferEvaluations = [];
+
+import defer * as deferred from "./import-defer/eval-tracker.js";
+import * as eager from "./import-defer/dep.js";
+
+// Single accessor used polymorphically across a deferred namespace, an eager
+// namespace, and plain objects. The ModuleNamespaceLoad IC is keyed on the specific
+// namespace constant, so it must not confuse the receivers nor the deferred-vs-eager
+// trigger semantics.
+function readValue(obj) { return obj.value; }
+noInline(readValue);
+
+let plain = { value: 7 };
+let plain2 = { other: 1, value: 8 };
+
+// Warm up on the deferred namespace first; this triggers evaluation exactly once.
+for (let i = 0; i < testLoopCount; ++i)
+    shouldBe(readValue(deferred), 42);
+shouldBe(globalThis.deferEvaluations.length, 1);
+
+// Now go polymorphic. Evaluation must not run again, and each receiver keeps its value.
+for (let i = 0; i < testLoopCount; ++i) {
+    shouldBe(readValue(deferred), 42);
+    shouldBe(readValue(eager), 1);
+    shouldBe(readValue(plain), 7);
+    shouldBe(readValue(plain2), 8);
+}
+shouldBe(globalThis.deferEvaluations.length, 1);

--- a/JSTests/modules/import-defer-ic.js
+++ b/JSTests/modules/import-defer-ic.js
@@ -1,0 +1,32 @@
+//@ requireOptions("--useImportDefer=1")
+import { shouldBe } from "./resources/assert.js";
+
+globalThis.deferEvaluations = [];
+
+import defer * as ns from "./import-defer/eval-tracker.js";
+
+// Warm up the property access through all JIT tiers without triggering evaluation.
+function readSymbol(obj) { return obj[Symbol.toStringTag]; }
+noInline(readSymbol);
+for (let i = 0; i < testLoopCount; ++i)
+    shouldBe(readSymbol(ns), "Deferred Module");
+shouldBe(globalThis.deferEvaluations.length, 0);
+
+// First string-key access through the IC must still trigger evaluation exactly once.
+function readValue(obj) { return obj.value; }
+noInline(readValue);
+for (let i = 0; i < testLoopCount; ++i)
+    shouldBe(readValue(ns), 42);
+shouldBe(globalThis.deferEvaluations.length, 1);
+
+// Once the deferred module is evaluated, the warmed-up IC must keep returning the
+// same value while still bound to the same namespace constant.
+for (let i = 0; i < testLoopCount; ++i)
+    shouldBe(readValue(ns), 42);
+shouldBe(globalThis.deferEvaluations.length, 1);
+
+// "then" must continue to be filtered out even after the IC warms up.
+function readThen(obj) { return obj.then; }
+noInline(readThen);
+for (let i = 0; i < testLoopCount; ++i)
+    shouldBe(readThen(ns), undefined);

--- a/JSTests/modules/import-defer-mixed-phase.js
+++ b/JSTests/modules/import-defer-mixed-phase.js
@@ -1,0 +1,14 @@
+//@ requireOptions("--useImportDefer=1")
+import { shouldBe } from "./resources/assert.js";
+
+// Same specifier requested in both defer and evaluation phases. Per spec they are
+// separate ModuleRequest records; the evaluation-phase entry must drive evaluation
+// at its position in source order, after the eager middle dependency.
+import defer * as nsDefer from "./import-defer/mixed-dep.js";
+import "./import-defer/mixed-middle.js";
+import * as nsEager from "./import-defer/mixed-dep.js";
+
+shouldBe(JSON.stringify(globalThis.deferMixedEvaluations), JSON.stringify(["middle", "dep"]));
+shouldBe(nsDefer === nsEager, false);
+shouldBe(nsDefer.value, nsEager.value);
+shouldBe(globalThis.deferMixedEvaluations.length, 2);

--- a/JSTests/modules/import-defer-reentrancy.js
+++ b/JSTests/modules/import-defer-reentrancy.js
@@ -1,0 +1,8 @@
+//@ requireOptions("--useImportDefer=1")
+import { shouldBe } from "./resources/assert.js";
+
+import defer * as ns from "./import-defer/reentrant.js";
+
+// Trigger evaluation; reentrant.js will try to access its own deferred namespace while
+// its [[Status]] is EVALUATING. ReadyForSyncExecution must return false -> TypeError.
+shouldBe(ns.result instanceof TypeError, true);

--- a/JSTests/modules/import-defer-throws.js
+++ b/JSTests/modules/import-defer-throws.js
@@ -1,0 +1,21 @@
+//@ requireOptions("--useImportDefer=1")
+import { shouldBe } from "./resources/assert.js";
+
+import defer * as ns from "./import-defer/throws.js";
+
+function read(obj) {
+    try {
+        return obj.value;
+    } catch (e) {
+        return e;
+    }
+}
+noInline(read);
+
+// Every access must re-throw the cached [[EvaluationError]]; the IC must not cache a
+// successful binding load that bypasses the throw.
+let firstError = read(ns);
+shouldBe(typeof firstError, "object");
+shouldBe(firstError.someError, "deferred-throw");
+for (let i = 0; i < 1e4; ++i)
+    shouldBe(read(ns), firstError);

--- a/JSTests/modules/import-defer-tla.js
+++ b/JSTests/modules/import-defer-tla.js
@@ -1,0 +1,13 @@
+//@ requireOptions("--useImportDefer=1")
+import { shouldBe } from "./resources/assert.js";
+
+import defer * as ns from "./import-defer/tla-parent.js";
+
+// GatherAsynchronousTransitiveDependencies must have eagerly evaluated the TLA-bearing
+// dependency (and its sync deps) on the parent's async pipeline; the synchronous bits
+// behind the defer (tla-parent itself, sync-dep) remain unevaluated.
+shouldBe(JSON.stringify(globalThis.deferTLAEvaluations), JSON.stringify(["tla-dep-of-tla", "tla-child"]));
+
+// Touching the namespace synchronously evaluates the rest.
+shouldBe(ns.value, 1);
+shouldBe(JSON.stringify(globalThis.deferTLAEvaluations), JSON.stringify(["tla-dep-of-tla", "tla-child", "sync-dep", "tla-parent"]));

--- a/JSTests/modules/import-defer-triggers.js
+++ b/JSTests/modules/import-defer-triggers.js
@@ -1,0 +1,29 @@
+//@ requireOptions("--useImportDefer=1")
+import { shouldBe } from "./resources/assert.js";
+
+globalThis.deferTriggerEvaluations ||= [];
+
+import defer * as nsHas from "./import-defer/trigger-has.js";
+import defer * as nsKeys from "./import-defer/trigger-keys.js";
+import defer * as nsDelete from "./import-defer/trigger-delete.js";
+import defer * as nsDefine from "./import-defer/trigger-define.js";
+import defer * as nsIndex from "./import-defer/trigger-index.js";
+
+shouldBe(globalThis.deferTriggerEvaluations.length, 0);
+
+shouldBe("foo" in nsHas, true);
+shouldBe(globalThis.deferTriggerEvaluations.includes("has"), true);
+
+shouldBe(Object.keys(nsKeys).includes("foo"), true);
+shouldBe(globalThis.deferTriggerEvaluations.includes("keys"), true);
+
+shouldBe(Reflect.deleteProperty(nsDelete, "foo"), false);
+shouldBe(globalThis.deferTriggerEvaluations.includes("delete"), true);
+
+shouldBe(Reflect.defineProperty(nsDefine, "foo", { value: 2 }), false);
+shouldBe(globalThis.deferTriggerEvaluations.includes("define"), true);
+
+shouldBe(nsIndex[0], undefined);
+shouldBe(globalThis.deferTriggerEvaluations.includes("index"), true);
+
+shouldBe(globalThis.deferTriggerEvaluations.length, 5);

--- a/JSTests/modules/import-defer.js
+++ b/JSTests/modules/import-defer.js
@@ -1,0 +1,17 @@
+//@ requireOptions("--useImportDefer=1")
+import { shouldBe } from "./resources/assert.js";
+
+import defer * as ns1 from "./import-defer/dep.js";
+import defer * as ns2 from "./import-defer/dep.js";
+import * as nsEager from "./import-defer/dep.js";
+import { reExportedDeferred } from "./import-defer/re-export.js";
+
+shouldBe(ns1, ns2);
+shouldBe(ns1, reExportedDeferred);
+shouldBe(ns1 === nsEager, false);
+shouldBe(Object.prototype.toString.call(ns1), "[object Deferred Module]");
+shouldBe(Object.prototype.toString.call(nsEager), "[object Module]");
+
+// "then" must not be visible on a deferred namespace and must not trigger evaluation.
+shouldBe(ns1.then, undefined);
+shouldBe(Reflect.has(ns1, "then"), false);

--- a/JSTests/modules/import-defer/cycle-a.js
+++ b/JSTests/modules/import-defer/cycle-a.js
@@ -1,0 +1,3 @@
+import "./cycle-b.js";
+await 0;
+throw { someError: "tla-reject" };

--- a/JSTests/modules/import-defer/cycle-b-exporter.js
+++ b/JSTests/modules/import-defer/cycle-b-exporter.js
@@ -1,0 +1,2 @@
+import defer * as nsB from "./cycle-b.js";
+export { nsB };

--- a/JSTests/modules/import-defer/cycle-b.js
+++ b/JSTests/modules/import-defer/cycle-b.js
@@ -1,0 +1,2 @@
+import "./cycle-a.js";
+export const value = 42;

--- a/JSTests/modules/import-defer/dep.js
+++ b/JSTests/modules/import-defer/dep.js
@@ -1,0 +1,2 @@
+export const value = 1;
+export function then() { }

--- a/JSTests/modules/import-defer/eval-tracker.js
+++ b/JSTests/modules/import-defer/eval-tracker.js
@@ -1,0 +1,2 @@
+globalThis.deferEvaluations.push("eval-tracker");
+export const value = 42;

--- a/JSTests/modules/import-defer/mixed-dep.js
+++ b/JSTests/modules/import-defer/mixed-dep.js
@@ -1,0 +1,2 @@
+(globalThis.deferMixedEvaluations ||= []).push("dep");
+export const value = 1;

--- a/JSTests/modules/import-defer/mixed-middle.js
+++ b/JSTests/modules/import-defer/mixed-middle.js
@@ -1,0 +1,1 @@
+(globalThis.deferMixedEvaluations ||= []).push("middle");

--- a/JSTests/modules/import-defer/re-export.js
+++ b/JSTests/modules/import-defer/re-export.js
@@ -1,0 +1,2 @@
+import defer * as reExportedDeferred from "./dep.js";
+export { reExportedDeferred };

--- a/JSTests/modules/import-defer/reentrant.js
+++ b/JSTests/modules/import-defer/reentrant.js
@@ -1,0 +1,9 @@
+import defer * as self from "./reentrant.js";
+let caught;
+try {
+    self.value;
+} catch (e) {
+    caught = e;
+}
+export const result = caught;
+export const value = 0;

--- a/JSTests/modules/import-defer/throws.js
+++ b/JSTests/modules/import-defer/throws.js
@@ -1,0 +1,2 @@
+export const value = 1;
+throw { someError: "deferred-throw" };

--- a/JSTests/modules/import-defer/tla-child.js
+++ b/JSTests/modules/import-defer/tla-child.js
@@ -1,0 +1,3 @@
+import "./tla-dep-of-tla.js";
+await 0;
+(globalThis.deferTLAEvaluations ||= []).push("tla-child");

--- a/JSTests/modules/import-defer/tla-dep-of-tla.js
+++ b/JSTests/modules/import-defer/tla-dep-of-tla.js
@@ -1,0 +1,1 @@
+(globalThis.deferTLAEvaluations ||= []).push("tla-dep-of-tla");

--- a/JSTests/modules/import-defer/tla-parent.js
+++ b/JSTests/modules/import-defer/tla-parent.js
@@ -1,0 +1,4 @@
+import "./tla-sync-dep.js";
+import "./tla-child.js";
+(globalThis.deferTLAEvaluations ||= []).push("tla-parent");
+export const value = 1;

--- a/JSTests/modules/import-defer/tla-sync-dep.js
+++ b/JSTests/modules/import-defer/tla-sync-dep.js
@@ -1,0 +1,1 @@
+(globalThis.deferTLAEvaluations ||= []).push("sync-dep");

--- a/JSTests/modules/import-defer/trigger-define.js
+++ b/JSTests/modules/import-defer/trigger-define.js
@@ -1,0 +1,2 @@
+(globalThis.deferTriggerEvaluations ||= []).push("define");
+export const foo = 1;

--- a/JSTests/modules/import-defer/trigger-delete.js
+++ b/JSTests/modules/import-defer/trigger-delete.js
@@ -1,0 +1,2 @@
+(globalThis.deferTriggerEvaluations ||= []).push("delete");
+export const foo = 1;

--- a/JSTests/modules/import-defer/trigger-has.js
+++ b/JSTests/modules/import-defer/trigger-has.js
@@ -1,0 +1,2 @@
+(globalThis.deferTriggerEvaluations ||= []).push("has");
+export const foo = 1;

--- a/JSTests/modules/import-defer/trigger-index.js
+++ b/JSTests/modules/import-defer/trigger-index.js
@@ -1,0 +1,2 @@
+(globalThis.deferTriggerEvaluations ||= []).push("index");
+export const foo = 1;

--- a/JSTests/modules/import-defer/trigger-keys.js
+++ b/JSTests/modules/import-defer/trigger-keys.js
@@ -1,0 +1,2 @@
+(globalThis.deferTriggerEvaluations ||= []).push("keys");
+export const foo = 1;

--- a/JSTests/test262/config.yaml
+++ b/JSTests/test262/config.yaml
@@ -8,18 +8,84 @@ flags:
   json-parse-with-source: useJSONSourceTextAccess
   iterator-sequencing: useIteratorSequencing
   explicit-resource-management: useExplicitResourceManagement
+  import-defer: useImportDefer
 skip:
   features:
     - callable-boundary-realms
     - FinalizationRegistry.prototype.cleanupSome
     - decorators
     - source-phase-imports
-    - import-defer
     - joint-iteration
     - Intl.Era-monthcode
     - await-dictionary
     - import-bytes
   paths:
+    # Dynamic import.defer() is not yet implemented.
+    - test/language/expressions/dynamic-import/import-defer
+    - test/language/import/import-defer/deferred-namespace-object/identity.js
+    - test/language/expressions/dynamic-import/catch/nested-arrow-import-catch-import-defer-specifier-tostring-abrupt-rejects.js
+    - test/language/expressions/dynamic-import/catch/nested-async-arrow-function-await-import-defer-specifier-tostring-abrupt-rejects.js
+    - test/language/expressions/dynamic-import/catch/nested-async-arrow-function-return-await-import-defer-specifier-tostring-abrupt-rejects.js
+    - test/language/expressions/dynamic-import/catch/nested-async-function-await-import-defer-specifier-tostring-abrupt-rejects.js
+    - test/language/expressions/dynamic-import/catch/nested-async-function-import-defer-specifier-tostring-abrupt-rejects.js
+    - test/language/expressions/dynamic-import/catch/nested-async-function-return-await-import-defer-specifier-tostring-abrupt-rejects.js
+    - test/language/expressions/dynamic-import/catch/nested-async-gen-await-import-defer-specifier-tostring-abrupt-rejects.js
+    - test/language/expressions/dynamic-import/catch/nested-async-gen-return-await-import-defer-specifier-tostring-abrupt-rejects.js
+    - test/language/expressions/dynamic-import/catch/nested-block-import-catch-import-defer-specifier-tostring-abrupt-rejects.js
+    - test/language/expressions/dynamic-import/catch/nested-block-labeled-import-defer-specifier-tostring-abrupt-rejects.js
+    - test/language/expressions/dynamic-import/catch/nested-do-while-import-defer-specifier-tostring-abrupt-rejects.js
+    - test/language/expressions/dynamic-import/catch/nested-else-import-catch-import-defer-specifier-tostring-abrupt-rejects.js
+    - test/language/expressions/dynamic-import/catch/nested-function-import-catch-import-defer-specifier-tostring-abrupt-rejects.js
+    - test/language/expressions/dynamic-import/catch/nested-if-import-catch-import-defer-specifier-tostring-abrupt-rejects.js
+    - test/language/expressions/dynamic-import/catch/nested-while-import-catch-import-defer-specifier-tostring-abrupt-rejects.js
+    - test/language/expressions/dynamic-import/catch/top-level-import-catch-import-defer-specifier-tostring-abrupt-rejects.js
+    - test/language/expressions/dynamic-import/syntax/valid/nested-arrow-assignment-expression-import-defer-empty-str-is-valid-assign-expr.js
+    - test/language/expressions/dynamic-import/syntax/valid/nested-arrow-assignment-expression-import-defer-script-code-valid.js
+    - test/language/expressions/dynamic-import/syntax/valid/nested-arrow-import-defer-empty-str-is-valid-assign-expr.js
+    - test/language/expressions/dynamic-import/syntax/valid/nested-arrow-import-defer-script-code-valid.js
+    - test/language/expressions/dynamic-import/syntax/valid/nested-async-arrow-function-await-import-defer-empty-str-is-valid-assign-expr.js
+    - test/language/expressions/dynamic-import/syntax/valid/nested-async-arrow-function-await-import-defer-script-code-valid.js
+    - test/language/expressions/dynamic-import/syntax/valid/nested-async-arrow-function-return-await-import-defer-empty-str-is-valid-assign-expr.js
+    - test/language/expressions/dynamic-import/syntax/valid/nested-async-arrow-function-return-await-import-defer-script-code-valid.js
+    - test/language/expressions/dynamic-import/syntax/valid/nested-async-function-await-import-defer-empty-str-is-valid-assign-expr.js
+    - test/language/expressions/dynamic-import/syntax/valid/nested-async-function-await-import-defer-script-code-valid.js
+    - test/language/expressions/dynamic-import/syntax/valid/nested-async-function-import-defer-empty-str-is-valid-assign-expr.js
+    - test/language/expressions/dynamic-import/syntax/valid/nested-async-function-import-defer-script-code-valid.js
+    - test/language/expressions/dynamic-import/syntax/valid/nested-async-function-return-await-import-defer-empty-str-is-valid-assign-expr.js
+    - test/language/expressions/dynamic-import/syntax/valid/nested-async-function-return-await-import-defer-script-code-valid.js
+    - test/language/expressions/dynamic-import/syntax/valid/nested-async-gen-await-import-defer-empty-str-is-valid-assign-expr.js
+    - test/language/expressions/dynamic-import/syntax/valid/nested-async-gen-await-import-defer-script-code-valid.js
+    - test/language/expressions/dynamic-import/syntax/valid/nested-block-import-defer-empty-str-is-valid-assign-expr.js
+    - test/language/expressions/dynamic-import/syntax/valid/nested-block-import-defer-script-code-valid.js
+    - test/language/expressions/dynamic-import/syntax/valid/nested-block-labeled-import-defer-empty-str-is-valid-assign-expr.js
+    - test/language/expressions/dynamic-import/syntax/valid/nested-block-labeled-import-defer-script-code-valid.js
+    - test/language/expressions/dynamic-import/syntax/valid/nested-do-while-import-defer-empty-str-is-valid-assign-expr.js
+    - test/language/expressions/dynamic-import/syntax/valid/nested-do-while-import-defer-script-code-valid.js
+    - test/language/expressions/dynamic-import/syntax/valid/nested-else-braceless-import-defer-empty-str-is-valid-assign-expr.js
+    - test/language/expressions/dynamic-import/syntax/valid/nested-else-braceless-import-defer-script-code-valid.js
+    - test/language/expressions/dynamic-import/syntax/valid/nested-else-import-defer-empty-str-is-valid-assign-expr.js
+    - test/language/expressions/dynamic-import/syntax/valid/nested-else-import-defer-script-code-valid.js
+    - test/language/expressions/dynamic-import/syntax/valid/nested-function-import-defer-empty-str-is-valid-assign-expr.js
+    - test/language/expressions/dynamic-import/syntax/valid/nested-function-import-defer-script-code-valid.js
+    - test/language/expressions/dynamic-import/syntax/valid/nested-function-return-import-defer-empty-str-is-valid-assign-expr.js
+    - test/language/expressions/dynamic-import/syntax/valid/nested-function-return-import-defer-script-code-valid.js
+    - test/language/expressions/dynamic-import/syntax/valid/nested-if-braceless-import-defer-empty-str-is-valid-assign-expr.js
+    - test/language/expressions/dynamic-import/syntax/valid/nested-if-braceless-import-defer-script-code-valid.js
+    - test/language/expressions/dynamic-import/syntax/valid/nested-if-import-defer-empty-str-is-valid-assign-expr.js
+    - test/language/expressions/dynamic-import/syntax/valid/nested-if-import-defer-script-code-valid.js
+    - test/language/expressions/dynamic-import/syntax/valid/nested-while-import-defer-empty-str-is-valid-assign-expr.js
+    - test/language/expressions/dynamic-import/syntax/valid/nested-while-import-defer-script-code-valid.js
+    - test/language/expressions/dynamic-import/syntax/valid/nested-with-expression-import-defer-empty-str-is-valid-assign-expr.js
+    - test/language/expressions/dynamic-import/syntax/valid/nested-with-expression-import-defer-script-code-valid.js
+    - test/language/expressions/dynamic-import/syntax/valid/nested-with-import-defer-empty-str-is-valid-assign-expr.js
+    - test/language/expressions/dynamic-import/syntax/valid/nested-with-import-defer-script-code-valid.js
+    - test/language/expressions/dynamic-import/syntax/valid/top-level-import-defer-empty-str-is-valid-assign-expr.js
+    - test/language/expressions/dynamic-import/syntax/valid/top-level-import-defer-script-code-valid.js
+    # Depends on the nonextensible-applies-to-private proposal which JSC has not implemented yet.
+    - test/language/import/import-defer/evaluation-triggers/ignore-private-name-access.js
+    # Incorrect tests, see https://github.com/tc39/test262/issues/4980
+    - test/language/import/import-defer/evaluation-triggers/ignore-super-property-set-exported.js
+    - test/language/import/import-defer/evaluation-triggers/ignore-super-property-set-not-exported.js
     - test/built-ins/Temporal/Instant/prototype/toZonedDateTimeISO
     - test/built-ins/Temporal/Now/plainDateISO
     - test/built-ins/Temporal/Now/plainDateTimeISO

--- a/Source/JavaScriptCore/parser/ModuleAnalyzer.cpp
+++ b/Source/JavaScriptCore/parser/ModuleAnalyzer.cpp
@@ -41,11 +41,10 @@ ModuleAnalyzer::ModuleAnalyzer(JSGlobalObject* globalObject, const Identifier& m
 {
 }
 
-void ModuleAnalyzer::appendRequestedModule(const Identifier& specifier, RefPtr<ScriptFetchParameters>&& attributes)
+void ModuleAnalyzer::appendRequestedModule(const Identifier& specifier, RefPtr<ScriptFetchParameters>&& attributes, AbstractModuleRecord::ModulePhase phase)
 {
-    auto result = m_requestedModules.add(specifier.impl());
-    if (result.isNewEntry)
-        moduleRecord()->appendRequestedModule(specifier, WTF::move(attributes));
+    if (m_requestedModules[phase].add(specifier.impl()).isNewEntry)
+        moduleRecord()->appendRequestedModule(specifier, WTF::move(attributes), phase);
 }
 
 void ModuleAnalyzer::exportVariable(ModuleProgramNode& moduleProgramNode, const RefPtr<UniquedStringImpl>& localName, const VariableEnvironmentEntry& variable)
@@ -84,8 +83,12 @@ void ModuleAnalyzer::exportVariable(ModuleProgramNode& moduleProgramNode, const 
         // export { namespace }
         //
         // Sec 15.2.1.16.1 step 11-a-ii-2-b https://tc39.github.io/ecma262/#sec-parsemodule
-        for (auto& exportName : moduleProgramNode.moduleScopeData().exportedBindings().get(localName.get()))
-            moduleRecord()->addExportEntry(JSModuleRecord::ExportEntry::createNamespace(Identifier::fromUid(m_vm, exportName.get()), importEntry.moduleRequest));
+        for (auto& exportName : moduleProgramNode.moduleScopeData().exportedBindings().get(localName.get())) {
+            if (importEntry.phase == AbstractModuleRecord::ModulePhase::Defer)
+                moduleRecord()->addExportEntry(JSModuleRecord::ExportEntry::createLocal(Identifier::fromUid(m_vm, exportName.get()), Identifier::fromUid(m_vm, localName.get())));
+            else
+                moduleRecord()->addExportEntry(JSModuleRecord::ExportEntry::createNamespace(Identifier::fromUid(m_vm, exportName.get()), importEntry.moduleRequest));
+        }
         return;
     }
 

--- a/Source/JavaScriptCore/parser/ModuleAnalyzer.h
+++ b/Source/JavaScriptCore/parser/ModuleAnalyzer.h
@@ -28,6 +28,7 @@
 #include "ErrorType.h"
 #include "JSModuleRecord.h"
 #include "Nodes.h"
+#include <wtf/EnumeratedArray.h>
 
 namespace JSC {
 
@@ -47,7 +48,7 @@ public:
 
     JSModuleRecord* moduleRecord() { return m_moduleRecord; }
 
-    void appendRequestedModule(const Identifier&, RefPtr<ScriptFetchParameters>&&);
+    void appendRequestedModule(const Identifier&, RefPtr<ScriptFetchParameters>&&, AbstractModuleRecord::ModulePhase = AbstractModuleRecord::ModulePhase::Evaluation);
 
     void fail(std::tuple<ErrorType, String>&& errorMessage) { m_errorMessage = errorMessage; }
 
@@ -56,7 +57,7 @@ private:
 
     VM& m_vm;
     JSModuleRecord* m_moduleRecord;
-    IdentifierSet m_requestedModules;
+    EnumeratedArray<AbstractModuleRecord::ModulePhase, IdentifierSet, AbstractModuleRecord::ModulePhase::Defer> m_requestedModules;
     std::tuple<ErrorType, String> m_errorMessage;
 };
 

--- a/Source/JavaScriptCore/parser/NodesAnalyzeModule.cpp
+++ b/Source/JavaScriptCore/parser/NodesAnalyzeModule.cpp
@@ -83,11 +83,13 @@ bool ImportDeclarationNode::analyzeModule(ModuleAnalyzer& analyzer)
         return false;
     }
 
-    analyzer.appendRequestedModule(m_moduleName->moduleName(), WTF::move(result.value()));
+    auto phase = m_type == ImportType::Deferred ? AbstractModuleRecord::ModulePhase::Defer : AbstractModuleRecord::ModulePhase::Evaluation;
+    analyzer.appendRequestedModule(m_moduleName->moduleName(), WTF::move(result.value()), phase);
     for (auto* specifier : m_specifierList->specifiers()) {
         analyzer.moduleRecord()->addImportEntry(JSModuleRecord::ImportEntry {
             specifier->importedName() == analyzer.vm().propertyNames->starNamespacePrivateName
                 ? JSModuleRecord::ImportEntryType::Namespace : JSModuleRecord::ImportEntryType::Single,
+            phase,
             m_moduleName->moduleName(),
             specifier->importedName(),
             specifier->localName(),

--- a/Source/JavaScriptCore/runtime/AbstractModuleRecord.cpp
+++ b/Source/JavaScriptCore/runtime/AbstractModuleRecord.cpp
@@ -91,6 +91,7 @@ void AbstractModuleRecord::visitChildrenImpl(JSCell* cell, Visitor& visitor)
     Base::visitChildren(thisObject, visitor);
     visitor.append(thisObject->m_moduleEnvironment);
     visitor.append(thisObject->m_moduleNamespaceObject);
+    visitor.append(thisObject->m_deferredNamespaceObject);
     visitor.append(thisObject->m_cycleRoot);
     visitor.append(thisObject->m_topLevelCapability);
     visitor.append(thisObject->m_asyncCapability);
@@ -134,9 +135,9 @@ bool AbstractModuleRecord::ModuleRequest::operator==(const ModuleRequest& other)
     return true;
 }
 
-void AbstractModuleRecord::appendRequestedModule(const Identifier& moduleName, RefPtr<ScriptFetchParameters>&& attributes)
+void AbstractModuleRecord::appendRequestedModule(const Identifier& moduleName, RefPtr<ScriptFetchParameters>&& attributes, ModulePhase phase)
 {
-    m_requestedModules.append({ moduleName, WTF::move(attributes) });
+    m_requestedModules.append({ moduleName, WTF::move(attributes), phase });
 }
 
 void AbstractModuleRecord::addStarExportEntry(const Identifier& moduleName)
@@ -792,7 +793,7 @@ auto AbstractModuleRecord::resolveExport(JSGlobalObject* globalObject, const Ide
     RELEASE_AND_RETURN(scope, resolveExportImpl(globalObject, ResolveQuery(this, exportName.impl())));
 }
 
-JSModuleNamespaceObject* AbstractModuleRecord::getModuleNamespace(JSGlobalObject* globalObject)
+JSModuleNamespaceObject* AbstractModuleRecord::getModuleNamespace(JSGlobalObject* globalObject, ModulePhase phase)
 {
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
@@ -803,7 +804,10 @@ JSModuleNamespaceObject* AbstractModuleRecord::getModuleNamespace(JSGlobalObject
 #endif
 
     // https://tc39.es/ecma262/#sec-getmodulenamespace
-    if (m_moduleNamespaceObject)
+    if (phase == ModulePhase::Defer) {
+        if (m_deferredNamespaceObject)
+            return m_deferredNamespaceObject.get();
+    } else if (m_moduleNamespaceObject)
         return m_moduleNamespaceObject.get();
 
     // Spec performs GetExportedNames() then per-name ResolveExport(), which walks the
@@ -916,8 +920,13 @@ JSModuleNamespaceObject* AbstractModuleRecord::getModuleNamespace(JSGlobalObject
         }
     }
 
-    auto* moduleNamespaceObject = JSModuleNamespaceObject::create(globalObject, globalObject->moduleNamespaceObjectStructure(), this, WTF::move(resolutions));
+    auto* moduleNamespaceObject = JSModuleNamespaceObject::create(globalObject, globalObject->moduleNamespaceObjectStructure(), this, WTF::move(resolutions), phase == ModulePhase::Defer);
     RETURN_IF_EXCEPTION(scope, nullptr);
+
+    if (phase == ModulePhase::Defer) {
+        m_deferredNamespaceObject.set(vm, this, moduleNamespaceObject);
+        return moduleNamespaceObject;
+    }
 
     // Materialize *namespace* slot with module namespace object unless the module environment is not yet materialized, in which case we'll do it in setModuleEnvironment
     if (m_moduleEnvironment) {
@@ -930,6 +939,108 @@ JSModuleNamespaceObject* AbstractModuleRecord::getModuleNamespace(JSGlobalObject
     m_moduleNamespaceObject.set(vm, this, moduleNamespaceObject);
 
     return moduleNamespaceObject;
+}
+
+// https://tc39.es/proposal-defer-import-eval/#sec-GatherAsynchronousTransitiveDependencies
+void AbstractModuleRecord::gatherAsynchronousTransitiveDependencies(WTF::OrderedHashSet<AbstractModuleRecord*>& result, UncheckedKeyHashSet<AbstractModuleRecord*>& seen)
+{
+    // The spec text is recursive; we use an explicit work list to avoid native stack overflow on
+    // deep graphs. Children are pushed in reverse to preserve the spec's pre-order discovery order.
+    Vector<AbstractModuleRecord*, 8> stack;
+    stack.append(this);
+    while (!stack.isEmpty()) {
+        AbstractModuleRecord* module = stack.takeLast();
+        // 3. If seen contains module, return result.
+        // 4. Append module to seen.
+        if (!seen.add(module).isNewEntry)
+            continue;
+        // 5. If module is not a Cyclic Module Record, return result.
+        auto* cyclic = dynamicDowncast<CyclicModuleRecord>(module);
+        if (!cyclic)
+            continue;
+        // 6. If module.[[Status]] is either EVALUATING or EVALUATED, return result.
+        if (cyclic->status() == CyclicModuleRecord::Status::Evaluating || cyclic->status() == CyclicModuleRecord::Status::Evaluated)
+            continue;
+        // 7. If module.[[HasTLA]] is true, then
+        if (cyclic->hasTLA()) {
+            // 7.a. Append module to result.
+            result.add(module);
+            // 7.b. Return result.
+            continue;
+        }
+        // 8. For each ModuleRequest Record request of module.[[RequestedModules]], do
+        //   8.a. Let requiredModule be GetImportedModule(module, request).
+        //   8.b. Let additionalModules be GatherAsynchronousTransitiveDependencies(requiredModule, seen).
+        //   8.c. For each Module Record m of additionalModules, do
+        //     8.c.i. If result does not contain m, then append m to result.
+        for (auto& request : cyclic->requestedModules() | std::views::reverse)
+            stack.append(JSModuleLoader::getImportedModule(cyclic, request));
+    }
+    // 9. Return result.
+}
+
+// https://tc39.es/proposal-defer-import-eval/#sec-ReadyForSyncExecution
+bool AbstractModuleRecord::readyForSyncExecution()
+{
+    // The spec text is recursive; we use an explicit work list to avoid native stack overflow on deep graphs.
+    UncheckedKeyHashSet<AbstractModuleRecord*> seen;
+    Vector<AbstractModuleRecord*, 8> stack;
+    stack.append(this);
+    while (!stack.isEmpty()) {
+        AbstractModuleRecord* module = stack.takeLast();
+        // 1. If module is not a Cyclic Module Record, return true.
+        auto* cyclic = dynamicDowncast<CyclicModuleRecord>(module);
+        if (!cyclic)
+            continue;
+        // 3. If seen contains module, return true.
+        // 4. Append module to seen.
+        if (!seen.add(module).isNewEntry)
+            continue;
+        // 5. If module.[[Status]] is EVALUATED, return true.
+        if (cyclic->status() == CyclicModuleRecord::Status::Evaluated)
+            continue;
+        // 6. If module.[[Status]] is either EVALUATING or EVALUATING-ASYNC, return false.
+        if (cyclic->status() == CyclicModuleRecord::Status::Evaluating || cyclic->status() == CyclicModuleRecord::Status::EvaluatingAsync)
+            return false;
+        // 7. Assert: module.[[Status]] is LINKED.
+        ASSERT(cyclic->status() == CyclicModuleRecord::Status::Linked);
+        // 8. If module.[[HasTLA]] is true, return false.
+        if (cyclic->hasTLA())
+            return false;
+        // 9. For each ModuleRequest Record request of module.[[RequestedModules]], do
+        //   9.a. Let requiredModule be GetImportedModule(module, request).
+        //   9.b. If ReadyForSyncExecution(requiredModule, seen) is false, return false.
+        for (const ModuleRequest& request : cyclic->requestedModules())
+            stack.append(JSModuleLoader::getImportedModule(cyclic, request));
+    }
+    // 10. Return true.
+    return true;
+}
+
+// https://tc39.es/proposal-defer-import-eval/#sec-EvaluateModuleSync
+void AbstractModuleRecord::evaluateSync(JSGlobalObject* globalObject)
+{
+    VM& vm = globalObject->vm();
+    auto scope = DECLARE_THROW_SCOPE(vm);
+    // 1. If ReadyForSyncExecution(module) is false, throw a TypeError exception.
+    if (!readyForSyncExecution()) {
+        throwTypeError(globalObject, scope, "Unable to synchronously evaluate deferred module"_s);
+        return;
+    }
+    // 2. Let promise be ! module.Evaluate().
+    JSPromise* promise = evaluate(globalObject);
+    RETURN_IF_EXCEPTION(scope, void());
+    // 3. Assert: promise.[[PromiseState]] is either FULFILLED or REJECTED.
+    ASSERT(promise->status() != JSPromise::Status::Pending);
+    // 4. If promise.[[PromiseState]] is REJECTED, then
+    if (promise->status() == JSPromise::Status::Rejected) {
+        // 4.a. If promise.[[PromiseIsHandled]] is false, perform HostPromiseRejectionTracker(promise, "handle").
+        // 4.b. Set promise.[[PromiseIsHandled]] to true.
+        promise->markAsHandled();
+        // 4.c. Return ThrowCompletion(promise.[[PromiseResult]]).
+        throwException(globalObject, scope, promise->result());
+    }
+    // 5. Return UNUSED.
 }
 
 JSPromise* AbstractModuleRecord::asyncCapability() const
@@ -1084,44 +1195,62 @@ unsigned AbstractModuleRecord::innerModuleEvaluation(JSGlobalObject* globalObjec
     ++index;
     // 10. Append module to stack.
     stack.append(module);
+    // https://tc39.es/proposal-defer-import-eval/#sec-innermoduleevaluation
+    // 10. Let evaluationList be a new empty List.
+    WTF::OrderedHashSet<AbstractModuleRecord*> evaluationList;
     // 11. For each ModuleRequest Record request of module.[[RequestedModules]], do
     for (const ModuleRequest& request : module->requestedModules()) {
         // 11.a. Let requiredModule be GetImportedModule(module, request).
         AbstractModuleRecord* requiredModule = JSModuleLoader::getImportedModule(module, request);
+        // 11.b. If request.[[Phase]] is defer, then
+        if (request.m_phase == ModulePhase::Defer) [[unlikely]] {
+            // 11.b.i. Let additionalModules be GatherAsynchronousTransitiveDependencies(requiredModule).
+            // 11.b.ii. For each Module Record additionalModule of additionalModules, do
+            //   11.b.ii.1. If evaluationList does not contain additionalModule, then append additionalModule to evaluationList.
+            UncheckedKeyHashSet<AbstractModuleRecord*> seen;
+            requiredModule->gatherAsynchronousTransitiveDependencies(evaluationList, seen);
+        } else {
+            // 11.c. Else if evaluationList does not contain requiredModule, then
+            //   11.c.i. Append requiredModule to evaluationList.
+            evaluationList.add(requiredModule);
+        }
+    }
+    // 12. For each Module Record requiredModule of evaluationList, do
+    for (AbstractModuleRecord* requiredModule : evaluationList) {
         checkSafeToRecurse(globalObject, scope);
         RETURN_IF_EXCEPTION(scope, invalid);
-        // 11.b. Set index to ? InnerModuleEvaluation(requiredModule, stack, index).
+        // 12.a. Set index to ? InnerModuleEvaluation(requiredModule, stack, index).
         unsigned result = requiredModule->innerModuleEvaluation(globalObject, stack, index);
         RETURN_IF_EXCEPTION(scope, invalid);
         index = result;
-        // 11.c. If requiredModule is a Cyclic Module Record, then
+        // 12.b. If requiredModule is a Cyclic Module Record, then
         if (auto* cyclic = dynamicDowncast<CyclicModuleRecord>(requiredModule)) {
-            // 11.c.i. Assert: requiredModule.[[Status]] is one of EVALUATING, EVALUATING-ASYNC, or EVALUATED.
+            // 12.b.i. Assert: requiredModule.[[Status]] is one of EVALUATING, EVALUATING-ASYNC, or EVALUATED.
             ASSERT(cyclic->status() == Status::Evaluating || cyclic->status() == Status::EvaluatingAsync || cyclic->status() == Status::Evaluated);
-            // 11.c.ii. Assert: requiredModule.[[Status]] is EVALUATING if and only if stack contains requiredModule.
+            // 12.b.ii. Assert: requiredModule.[[Status]] is EVALUATING if and only if stack contains requiredModule.
             ASSERT(stack.contains(requiredModule) == (cyclic->status() == Status::Evaluating));
-            // 11.c.iii. If requiredModule.[[Status]] is EVALUATING, then
+            // 12.b.iii. If requiredModule.[[Status]] is EVALUATING, then
             if (cyclic->status() == Status::Evaluating) {
-                // 11.c.iii.1. Set module.[[DFSAncestorIndex]] to min(module.[[DFSAncestorIndex]], requiredModule.[[DFSAncestorIndex]]).
+                // 12.b.iii.1. Set module.[[DFSAncestorIndex]] to min(module.[[DFSAncestorIndex]], requiredModule.[[DFSAncestorIndex]]).
                 module->setDFSAncestorIndex(std::min(module->dfsAncestorIndex(), cyclic->dfsAncestorIndex()));
-            // 11.c.iv. Else,
+            // 12.b.iv. Else,
             } else {
-                // 11.c.iv.1. Set requiredModule to requiredModule.[[CycleRoot]].
+                // 12.b.iv.1. Set requiredModule to requiredModule.[[CycleRoot]].
                 cyclic = requiredModule->cycleRoot();
                 requiredModule = cyclic;
-                // 11.c.iv.2. Assert: requiredModule.[[Status]] is either EVALUATING-ASYNC or EVALUATED.
+                // 12.b.iv.2. Assert: requiredModule.[[Status]] is either EVALUATING-ASYNC or EVALUATED.
                 ASSERT(cyclic->status() == Status::EvaluatingAsync || cyclic->status() == Status::Evaluated);
-                // 11.c.iv.3. If requiredModule.[[EvaluationError]] is not empty, return ? requiredModule.[[EvaluationError]].
+                // 12.b.iv.3. If requiredModule.[[EvaluationError]] is not empty, return ? requiredModule.[[EvaluationError]].
                 if (JSValue error = cyclic->evaluationError()) {
                     scope.throwException(globalObject, error);
                     return invalid;
                 }
             }
-            // 11.c.v. If requiredModule.[[AsyncEvaluationOrder]] is an integer, then
+            // 12.b.v. If requiredModule.[[AsyncEvaluationOrder]] is an integer, then
             if (cyclic->asyncEvaluationOrder().hasOrder()) {
-                // 11.c.v.1. Set module.[[PendingAsyncDependencies]] to module.[[PendingAsyncDependencies]] + 1.
+                // 12.b.v.1. Set module.[[PendingAsyncDependencies]] to module.[[PendingAsyncDependencies]] + 1.
                 module->setPendingAsyncDependencies(module->pendingAsyncDependencies().value() + 1);
-                // 11.c.v.2. Append module to requiredModule.[[AsyncParentModules]].
+                // 12.b.v.2. Append module to requiredModule.[[AsyncParentModules]].
                 cyclic->appendAsyncParentModule(vm, module);
             }
         }

--- a/Source/JavaScriptCore/runtime/AbstractModuleRecord.h
+++ b/Source/JavaScriptCore/runtime/AbstractModuleRecord.h
@@ -94,9 +94,12 @@ public:
         Identifier localName;
     };
 
+    enum class ModulePhase : uint8_t { Evaluation, Defer };
+
     enum class ImportEntryType { Single, Namespace };
     struct ImportEntry {
         ImportEntryType type;
+        ModulePhase phase { ModulePhase::Evaluation };
         Identifier moduleRequest;
         Identifier importName;
         Identifier localName;
@@ -109,6 +112,7 @@ public:
     struct ModuleRequest {
         Identifier m_specifier;
         RefPtr<ScriptFetchParameters> m_attributes;
+        ModulePhase m_phase { ModulePhase::Evaluation };
 
         ScriptFetchParameters::Type type(ScriptFetchParameters::Type fallback = ScriptFetchParameters::Type::JavaScript) const;
         bool operator==(const ModuleRequest&) const;
@@ -122,7 +126,7 @@ public:
 
     DECLARE_EXPORT_INFO;
 
-    void appendRequestedModule(const Identifier&, RefPtr<ScriptFetchParameters>&&);
+    void appendRequestedModule(const Identifier&, RefPtr<ScriptFetchParameters>&&, ModulePhase = ModulePhase::Evaluation);
     void addStarExportEntry(const Identifier&);
     void addImportEntry(const ImportEntry&);
     void addExportEntry(const ExportEntry&);
@@ -195,7 +199,11 @@ public:
 
     AbstractModuleRecord* hostResolveImportedModule(JSGlobalObject*, const Identifier& moduleName);
 
-    JSModuleNamespaceObject* getModuleNamespace(JSGlobalObject*);
+    JSModuleNamespaceObject* getModuleNamespace(JSGlobalObject*, ModulePhase = ModulePhase::Evaluation);
+
+    void gatherAsynchronousTransitiveDependencies(WTF::OrderedHashSet<AbstractModuleRecord*>& result, UncheckedKeyHashSet<AbstractModuleRecord*>& seen);
+    bool readyForSyncExecution();
+    void evaluateSync(JSGlobalObject*);
 
     JSPromise* asyncCapability() const;
     void asyncCapability(VM&, JSPromise*);
@@ -266,6 +274,7 @@ private:
     Vector<ModuleRequest> m_requestedModules;
 
     WriteBarrier<JSModuleNamespaceObject> m_moduleNamespaceObject;
+    WriteBarrier<JSModuleNamespaceObject> m_deferredNamespaceObject;
 
     WriteBarrier<JSPromise> m_asyncCapability;
 

--- a/Source/JavaScriptCore/runtime/CyclicModuleRecord.cpp
+++ b/Source/JavaScriptCore/runtime/CyclicModuleRecord.cpp
@@ -167,8 +167,8 @@ void CyclicModuleRecord::initializeEnvironment(JSGlobalObject* globalObject, Ref
 #endif
             // 7.b. If in.[[ImportName]] is NAMESPACE-OBJECT, then
             if (in.type == ImportEntryType::Namespace) {
-                // 7.b.i. Let namespace be GetModuleNamespace(importedModule).
-                JSModuleNamespaceObject* ns = importedModule->getModuleNamespace(globalObject);
+                // 7.b.i. Let namespace be GetModuleNamespace(importedModule, in.[[Phase]]).
+                JSModuleNamespaceObject* ns = importedModule->getModuleNamespace(globalObject, in.phase);
                 RETURN_IF_EXCEPTION(scope, void());
                 // 7.b.ii. Perform ! env.CreateImmutableBinding(in.[[LocalName]], true).
                 // 7.b.iii. Perform ! env.InitializeBinding(in.[[LocalName]], namespace).

--- a/Source/JavaScriptCore/runtime/JSModuleNamespaceObject.cpp
+++ b/Source/JavaScriptCore/runtime/JSModuleNamespaceObject.cpp
@@ -27,6 +27,7 @@
 #include "JSModuleNamespaceObject.h"
 
 #include "AbstractModuleRecord.h"
+#include "CyclicModuleRecord.h"
 #include "JSCInlines.h"
 #include "JSModuleEnvironment.h"
 
@@ -34,10 +35,11 @@ namespace JSC {
 
 const ClassInfo JSModuleNamespaceObject::s_info = { "ModuleNamespaceObject"_s, &Base::s_info, nullptr, nullptr, CREATE_METHOD_TABLE(JSModuleNamespaceObject) };
 
-JSModuleNamespaceObject::JSModuleNamespaceObject(VM& vm, Structure* structure, AbstractModuleRecord* moduleRecord, Vector<std::pair<Identifier, AbstractModuleRecord::Resolution>>&& resolutions)
+JSModuleNamespaceObject::JSModuleNamespaceObject(VM& vm, Structure* structure, AbstractModuleRecord* moduleRecord, Vector<std::pair<Identifier, AbstractModuleRecord::Resolution>>&& resolutions, bool isDeferred)
     : Base(vm, structure)
     , m_exports()
     , m_moduleRecord(moduleRecord, WriteBarrierEarlyInit)
+    , m_isDeferred(isDeferred)
 {
     // http://www.ecma-international.org/ecma-262/6.0/#sec-module-namespace-exotic-objects
     // Quoted from the spec:
@@ -63,7 +65,7 @@ void JSModuleNamespaceObject::finishCreation(JSGlobalObject* globalObject)
     auto scope = DECLARE_THROW_SCOPE(vm);
     Base::finishCreation(vm);
     ASSERT(inherits(info()));
-    putDirect(vm, vm.propertyNames->toStringTagSymbol, jsNontrivialString(vm, "Module"_s), PropertyAttribute::DontEnum | PropertyAttribute::DontDelete | PropertyAttribute::ReadOnly);
+    putDirect(vm, vm.propertyNames->toStringTagSymbol, jsNontrivialString(vm, m_isDeferred ? "Deferred Module"_s : "Module"_s), PropertyAttribute::DontEnum | PropertyAttribute::DontDelete | PropertyAttribute::ReadOnly);
 
     // http://www.ecma-international.org/ecma-262/6.0/#sec-module-namespace-exotic-objects-getprototypeof
     // http://www.ecma-international.org/ecma-262/6.0/#sec-module-namespace-exotic-objects-setprototypeof-v
@@ -92,6 +94,34 @@ void JSModuleNamespaceObject::visitChildrenImpl(JSCell* cell, Visitor& visitor)
 
 DEFINE_VISIT_CHILDREN(JSModuleNamespaceObject);
 
+// https://tc39.es/proposal-defer-import-eval/#sec-IsSymbolLikeNamespaceKey
+ALWAYS_INLINE bool JSModuleNamespaceObject::isSymbolLikeNamespaceKey(VM& vm, PropertyName propertyName)
+{
+    return propertyName.isSymbol() || (m_isDeferred && propertyName == vm.propertyNames->then);
+}
+
+// https://tc39.es/proposal-defer-import-eval/#sec-GetModuleExportsList
+// The spec returns O.[[Exports]] after triggering evaluation; here we only perform the
+// evaluation side effect since callers already have direct access to m_exports.
+void JSModuleNamespaceObject::ensureDeferredNamespaceEvaluation(JSGlobalObject* globalObject)
+{
+    // 1. If O.[[Deferred]] is true, then
+    ASSERT(m_isDeferred);
+    // Fast path: if the module's cycle has already successfully evaluated, EvaluateModuleSync would
+    // observe a fulfilled promise and return without throwing, so we can skip the work entirely.
+    // We must consult [[CycleRoot]] here because Evaluate() redirects to it; for a non-root SCC
+    // member, status/evaluationError on the module itself may not reflect the cycle's outcome.
+    if (auto* cyclic = dynamicDowncast<CyclicModuleRecord>(m_moduleRecord.get())) {
+        CyclicModuleRecord* root = cyclic->cycleRoot() ? cyclic->cycleRoot() : cyclic;
+        if (root->status() == CyclicModuleRecord::Status::Evaluated && !root->evaluationError())
+            return;
+    }
+    //   1.a. Let m be O.[[Module]].
+    //   1.b. Perform ? EvaluateModuleSync(m).
+    m_moduleRecord->evaluateSync(globalObject);
+    // 2. Return O.[[Exports]].
+}
+
 static JSValue getValue(JSModuleEnvironment* environment, PropertyName localName, ScopeOffset& scopeOffset)
 {
     SymbolTable* symbolTable = environment->symbolTable();
@@ -113,13 +143,17 @@ bool JSModuleNamespaceObject::getOwnPropertySlotCommon(JSGlobalObject* globalObj
 
     // http://www.ecma-international.org/ecma-262/6.0/#sec-module-namespace-exotic-objects-getownproperty-p
 
-    // step 1.
-    // If the property name is a symbol, we don't look into the imported bindings.
+    // 1. If IsSymbolLikeNamespaceKey(P, O) is true, then return ! Ordinary{Get,GetOwnProperty,HasProperty}(O, P, ...).
     // It may return the descriptor with writable: true, but namespace objects does not allow it in [[Set]] / [[DefineOwnProperty]] side.
-    if (propertyName.isSymbol())
+    if (isSymbolLikeNamespaceKey(vm, propertyName))
         return Base::getOwnPropertySlot(this, globalObject, propertyName, slot);
 
     slot.setIsTaintedByOpaqueObject();
+
+    if (m_isDeferred && slot.internalMethodType() != PropertySlot::InternalMethodType::VMInquiry) [[unlikely]] {
+        ensureDeferredNamespaceEvaluation(globalObject);
+        RETURN_IF_EXCEPTION(scope, false);
+    }
 
     auto iterator = m_exports.find(propertyName.uid());
     if (iterator == m_exports.end())
@@ -205,9 +239,16 @@ bool JSModuleNamespaceObject::putByIndex(JSCell*, JSGlobalObject* globalObject, 
 bool JSModuleNamespaceObject::deleteProperty(JSCell* cell, JSGlobalObject* globalObject, PropertyName propertyName, DeletePropertySlot& slot)
 {
     // https://tc39.es/ecma262/#sec-module-namespace-exotic-objects-delete-p
+    VM& vm = globalObject->vm();
+    auto scope = DECLARE_THROW_SCOPE(vm);
     JSModuleNamespaceObject* thisObject = uncheckedDowncast<JSModuleNamespaceObject>(cell);
-    if (propertyName.isSymbol())
-        return Base::deleteProperty(thisObject, globalObject, propertyName, slot);
+    if (thisObject->isSymbolLikeNamespaceKey(vm, propertyName))
+        RELEASE_AND_RETURN(scope, Base::deleteProperty(thisObject, globalObject, propertyName, slot));
+
+    if (thisObject->m_isDeferred) [[unlikely]] {
+        thisObject->ensureDeferredNamespaceEvaluation(globalObject);
+        RETURN_IF_EXCEPTION(scope, false);
+    }
 
     return !thisObject->m_exports.contains(propertyName.uid());
 }
@@ -215,7 +256,12 @@ bool JSModuleNamespaceObject::deleteProperty(JSCell* cell, JSGlobalObject* globa
 bool JSModuleNamespaceObject::deletePropertyByIndex(JSCell* cell, JSGlobalObject* globalObject, unsigned propertyName)
 {
     VM& vm = globalObject->vm();
+    auto scope = DECLARE_THROW_SCOPE(vm);
     JSModuleNamespaceObject* thisObject = uncheckedDowncast<JSModuleNamespaceObject>(cell);
+    if (thisObject->m_isDeferred) [[unlikely]] {
+        thisObject->ensureDeferredNamespaceEvaluation(globalObject);
+        RETURN_IF_EXCEPTION(scope, false);
+    }
     return !thisObject->m_exports.contains(Identifier::from(vm, propertyName).impl());
 }
 
@@ -226,6 +272,10 @@ void JSModuleNamespaceObject::getOwnPropertyNames(JSObject* cell, JSGlobalObject
 
     // https://tc39.es/ecma262/#sec-module-namespace-exotic-objects-ownpropertykeys
     JSModuleNamespaceObject* thisObject = uncheckedDowncast<JSModuleNamespaceObject>(cell);
+    if (thisObject->m_isDeferred) [[unlikely]] {
+        thisObject->ensureDeferredNamespaceEvaluation(globalObject);
+        RETURN_IF_EXCEPTION(scope, void());
+    }
     for (const auto& name : thisObject->m_exports.keys()) {
         if (mode == DontEnumPropertiesMode::Exclude) {
             // Perform [[GetOwnProperty]] to throw ReferenceError if binding is uninitialized.
@@ -250,8 +300,8 @@ bool JSModuleNamespaceObject::defineOwnProperty(JSObject* cell, JSGlobalObject* 
 
     JSModuleNamespaceObject* thisObject = uncheckedDowncast<JSModuleNamespaceObject>(cell);
 
-    // 1. If Type(P) is Symbol, return OrdinaryDefineOwnProperty(O, P, Desc).
-    if (propertyName.isSymbol())
+    // 1. If IsSymbolLikeNamespaceKey(P, O) is true, return ! OrdinaryDefineOwnProperty(O, P, Desc).
+    if (thisObject->isSymbolLikeNamespaceKey(vm, propertyName))
         RELEASE_AND_RETURN(scope, Base::defineOwnProperty(thisObject, globalObject, propertyName, descriptor, shouldThrow));
 
     // 2. Let current be ? O.[[GetOwnProperty]](P).

--- a/Source/JavaScriptCore/runtime/JSModuleNamespaceObject.h
+++ b/Source/JavaScriptCore/runtime/JSModuleNamespaceObject.h
@@ -45,10 +45,10 @@ public:
         return vm.moduleNamespaceObjectSpace<mode>();
     }
 
-    static JSModuleNamespaceObject* create(JSGlobalObject* globalObject, Structure* structure, AbstractModuleRecord* moduleRecord, Vector<std::pair<Identifier, AbstractModuleRecord::Resolution>>&& resolutions)
+    static JSModuleNamespaceObject* create(JSGlobalObject* globalObject, Structure* structure, AbstractModuleRecord* moduleRecord, Vector<std::pair<Identifier, AbstractModuleRecord::Resolution>>&& resolutions, bool isDeferred = false)
     {
         VM& vm = getVM(globalObject);
-        JSModuleNamespaceObject* object = new (NotNull, allocateCell<JSModuleNamespaceObject>(vm)) JSModuleNamespaceObject(vm, structure, moduleRecord, WTF::move(resolutions));
+        JSModuleNamespaceObject* object = new (NotNull, allocateCell<JSModuleNamespaceObject>(vm)) JSModuleNamespaceObject(vm, structure, moduleRecord, WTF::move(resolutions), isDeferred);
         object->finishCreation(globalObject);
         return object;
     }
@@ -71,9 +71,11 @@ public:
     AbstractModuleRecord* moduleRecord() LIFETIME_BOUND { return m_moduleRecord.get(); }
 
 private:
-    JS_EXPORT_PRIVATE JSModuleNamespaceObject(VM&, Structure*, AbstractModuleRecord*, Vector<std::pair<Identifier, AbstractModuleRecord::Resolution>>&&);
+    JS_EXPORT_PRIVATE JSModuleNamespaceObject(VM&, Structure*, AbstractModuleRecord*, Vector<std::pair<Identifier, AbstractModuleRecord::Resolution>>&&, bool isDeferred);
     JS_EXPORT_PRIVATE void finishCreation(JSGlobalObject*);
     bool getOwnPropertySlotCommon(JSGlobalObject*, PropertyName, PropertySlot&);
+    ALWAYS_INLINE bool isSymbolLikeNamespaceKey(VM&, PropertyName);
+    void ensureDeferredNamespaceEvaluation(JSGlobalObject*);
 
     struct ExportEntry {
         Identifier localName;
@@ -84,6 +86,7 @@ private:
 
     ExportMap m_exports;
     WriteBarrier<AbstractModuleRecord> m_moduleRecord;
+    const bool m_isDeferred;
 
     friend size_t cellSize(JSCell*);
 };

--- a/Source/JavaScriptCore/wasm/js/JSWebAssemblyInstance.cpp
+++ b/Source/JavaScriptCore/wasm/js/JSWebAssemblyInstance.cpp
@@ -347,6 +347,7 @@ JSWebAssemblyInstance* JSWebAssemblyInstance::tryCreate(VM& vm, Structure* insta
                 moduleRecord->appendRequestedModule(moduleName, nullptr);
             moduleRecord->addImportEntry(WebAssemblyModuleRecord::ImportEntry {
                 WebAssemblyModuleRecord::ImportEntryType::Single,
+                WebAssemblyModuleRecord::ModulePhase::Evaluation,
                 moduleName,
                 fieldName,
                 Identifier::fromUid(PrivateName(PrivateName::Description, "WebAssemblyImportName"_s)),


### PR DESCRIPTION
#### de45366f4ebac2ecf43ee0e8e831e5506573d353
<pre>
[JSC] Implement static `import defer` semantics
<a href="https://bugs.webkit.org/show_bug.cgi?id=313827">https://bugs.webkit.org/show_bug.cgi?id=313827</a>

Reviewed by Yusuke Suzuki.

This implements the runtime semantics of the static `import defer * as ns`
form of the Deferred Module Evaluation proposal[1] on top of the new
C++ module loader. Loading and linking are unchanged; only evaluation is
deferred until the namespace object is touched via a non-symbol-like key.

Dynamic `import.defer()` is intentionally left for a follow-up; the
corresponding test262 entries are skipped in config.yaml.

The feature remains gated behind `--useImportDefer`.

[1] <a href="https://tc39.es/proposal-defer-import-eval/">https://tc39.es/proposal-defer-import-eval/</a>

* JSTests/modules/import-defer-cycle-root-error.js: Added.
(catch):
* JSTests/modules/import-defer-evaluation.js: Added.
* JSTests/modules/import-defer-ic.js: Added.
(readSymbol):
(readValue):
(readThen):
* JSTests/modules/import-defer-throws.js: Added.
(read):
* JSTests/modules/import-defer.js: Added.
* JSTests/modules/import-defer/cycle-a.js: Added.
* JSTests/modules/import-defer/cycle-b-exporter.js: Added.
* JSTests/modules/import-defer/cycle-b.js: Added.
* JSTests/modules/import-defer/dep.js: Added.
(export.then):
* JSTests/modules/import-defer/eval-tracker.js: Added.
* JSTests/modules/import-defer/re-export.js: Added.
* JSTests/modules/import-defer/throws.js: Added.
* JSTests/test262/config.yaml:
* Source/JavaScriptCore/parser/ModuleAnalyzer.cpp:
(JSC::ModuleAnalyzer::appendRequestedModule):
(JSC::ModuleAnalyzer::exportVariable):
* Source/JavaScriptCore/parser/ModuleAnalyzer.h:
* Source/JavaScriptCore/parser/NodesAnalyzeModule.cpp:
(JSC::ImportDeclarationNode::analyzeModule):
* Source/JavaScriptCore/runtime/AbstractModuleRecord.cpp:
(JSC::AbstractModuleRecord::visitChildrenImpl):
(JSC::AbstractModuleRecord::appendRequestedModule):
(JSC::AbstractModuleRecord::getModuleNamespace):
(JSC::AbstractModuleRecord::gatherAsynchronousTransitiveDependencies):
(JSC::AbstractModuleRecord::readyForSyncExecution):
(JSC::AbstractModuleRecord::evaluateSync):
(JSC::AbstractModuleRecord::innerModuleEvaluation):
* Source/JavaScriptCore/runtime/AbstractModuleRecord.h:
* Source/JavaScriptCore/runtime/CyclicModuleRecord.cpp:
(JSC::CyclicModuleRecord::initializeEnvironment):
* Source/JavaScriptCore/runtime/JSModuleNamespaceObject.cpp:
(JSC::JSModuleNamespaceObject::finishCreation):
(JSC::JSModuleNamespaceObject::isSymbolLikeNamespaceKey):
(JSC::JSModuleNamespaceObject::ensureDeferredNamespaceEvaluation):
(JSC::JSModuleNamespaceObject::getOwnPropertySlotCommon):
(JSC::JSModuleNamespaceObject::deleteProperty):
(JSC::JSModuleNamespaceObject::deletePropertyByIndex):
(JSC::JSModuleNamespaceObject::getOwnPropertyNames):
(JSC::JSModuleNamespaceObject::defineOwnProperty):
* Source/JavaScriptCore/runtime/JSModuleNamespaceObject.h:
* Source/JavaScriptCore/wasm/js/JSWebAssemblyInstance.cpp:
(JSC::JSWebAssemblyInstance::tryCreate):

Canonical link: <a href="https://commits.webkit.org/313139@main">https://commits.webkit.org/313139@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/91f1bbb05fad0410b6d66847151c2832c898cf4a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/162183 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/35659 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/28775 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/171091 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/118556 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/35763 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/35660 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/125867 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/88728 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/165142 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/28199 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/145689 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/106445 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/27246 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/25760 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/18812 "Built successfully") | 
| [⏳ 🛠 🧪 jsc ](https://ews-build.webkit.org/#/builders/JSC-Tests-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/136947 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/23428 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/173585 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/23022 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/20938 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/25071 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/134166 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/35333 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/29848 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/134167 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36226 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/35316 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/145224 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/97523 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/28701 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/22052 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/194583 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/34826 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/102578 "Built successfully") | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/50180 "Found 1 new JSC stress test failure: stress/regexp-dot-star-enclosure-contains-capturing-terms-out-of-stack.js.bytecode-cache (failure)") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/34327 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/34572 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/34475 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->