### PR TITLE
[Cocoa] Activate DisplayCaptureCapability before prompting for getDisplayMedia

### DIFF
--- a/Source/WebCore/page/MediaProducer.h
+++ b/Source/WebCore/page/MediaProducer.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 Apple Inc. All rights reserved.
+ * Copyright (C) 2014-2026 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -61,6 +61,8 @@ enum class MediaProducerMediaState : uint32_t {
     HasMutedSystemAudioCaptureDevice = 1 << 25,
     HasInterruptedSystemAudioCaptureDevice = 1 << 26,
     HasStreamingActivity = 1 << 27,
+    IsPromptingForWindowCapture = 1 << 28,
+    IsPromptingForScreenCapture = 1 << 29,
 };
 using MediaProducerMediaStateFlags = OptionSet<MediaProducerMediaState>;
 
@@ -97,6 +99,7 @@ public:
     static constexpr MediaStateFlags WindowCaptureMask = { MediaState::HasActiveWindowCaptureDevice, MediaState::HasMutedWindowCaptureDevice, MediaState::HasInterruptedWindowCaptureDevice };
     static constexpr MediaStateFlags ActiveDisplayCaptureMask = { MediaState::HasActiveScreenCaptureDevice, MediaState::HasActiveWindowCaptureDevice };
     static constexpr MediaStateFlags MutedDisplayCaptureMask = { MediaState::HasMutedScreenCaptureDevice, MediaState::HasMutedWindowCaptureDevice };
+    static constexpr MediaStateFlags IsPromptingForDisplayCaptureMask = { MediaState::IsPromptingForWindowCapture, MediaState::IsPromptingForScreenCapture };
     static constexpr MediaStateFlags DisplayCaptureMask = { ActiveDisplayCaptureMask | MutedDisplayCaptureMask };
 
     static constexpr MediaStateFlags SystemAudioCaptureMask = { MediaState::HasActiveSystemAudioCaptureDevice, MediaState::HasMutedSystemAudioCaptureDevice, MediaState::HasInterruptedSystemAudioCaptureDevice };
@@ -119,7 +122,9 @@ public:
         MediaState::HasInterruptedWindowCaptureDevice,
         MediaState::HasActiveSystemAudioCaptureDevice,
         MediaState::HasMutedSystemAudioCaptureDevice,
-        MediaState::HasInterruptedSystemAudioCaptureDevice
+        MediaState::HasInterruptedSystemAudioCaptureDevice,
+        MediaState::IsPromptingForWindowCapture,
+        MediaState::IsPromptingForScreenCapture,
     };
     static constexpr MediaStateFlags IsCapturingAudioMask = { MicrophoneCaptureMask | SystemAudioCaptureMask };
     static constexpr MediaStateFlags IsCapturingVideoMask = { VideoCaptureMask | DisplayCaptureMask };

--- a/Source/WebCore/page/MediaProducer.serialization.in
+++ b/Source/WebCore/page/MediaProducer.serialization.in
@@ -48,7 +48,9 @@
     HasActiveSystemAudioCaptureDevice,
     HasMutedSystemAudioCaptureDevice,
     HasInterruptedSystemAudioCaptureDevice,
-    HasStreamingActivity
+    HasStreamingActivity,
+    IsPromptingForWindowCapture,
+    IsPromptingForScreenCapture,
 }
 
 [OptionSet] enum class WebCore::MediaProducerMutedState : uint8_t {

--- a/Source/WebKit/UIProcess/Cocoa/UserMediaPermissionRequestProxyCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/UserMediaPermissionRequestProxyCocoa.mm
@@ -49,8 +49,10 @@ void UserMediaPermissionRequestProxyCocoa::invalidate()
 {
 #if ENABLE(MEDIA_STREAM)
     if (m_hasPendingGetDisplayMediaPrompt) {
-        if (RefPtr page = manager()->page())
+        if (RefPtr page = manager()->page()) {
+            page->setIsPromptingForGetDisplayMedia({ });
             DisplayCaptureSessionManager::singleton().cancelGetDisplayMediaPrompt(*page);
+        }
         m_hasPendingGetDisplayMediaPrompt = false;
     }
 #endif
@@ -67,12 +69,28 @@ void UserMediaPermissionRequestProxyCocoa::promptForGetDisplayMedia(UserMediaDis
     if (!page)
         return;
 
+    WebCore::MediaProducerMediaStateFlags promptFlags;
+    switch (promptType) {
+    case UserMediaDisplayCapturePromptType::Window:
+        promptFlags.add(WebCore::MediaProducerMediaState::IsPromptingForWindowCapture);
+        break;
+    case UserMediaDisplayCapturePromptType::Screen:
+        promptFlags.add(WebCore::MediaProducerMediaState::IsPromptingForScreenCapture);
+        break;
+    case UserMediaDisplayCapturePromptType::UserChoose:
+        promptFlags.add({ WebCore::MediaProducerMediaState::IsPromptingForWindowCapture, WebCore::MediaProducerMediaState::IsPromptingForScreenCapture });
+        break;
+    }
+
+    page->setIsPromptingForGetDisplayMedia(promptFlags);
+
     m_hasPendingGetDisplayMediaPrompt = true;
-    DisplayCaptureSessionManager::singleton().promptForGetDisplayMedia(promptType, *page, topLevelDocumentSecurityOrigin().data(), [protectedThis = Ref { *this }](std::optional<CaptureDevice> device) mutable {
+    DisplayCaptureSessionManager::singleton().promptForGetDisplayMedia(promptType, *page, topLevelDocumentSecurityOrigin().data(), [protectedThis = Ref { *this }, page = WTF::move(page)](std::optional<CaptureDevice> device) mutable {
 
         protectedThis->m_hasPendingGetDisplayMediaPrompt = false;
 
         if (!device) {
+            page->setIsPromptingForGetDisplayMedia({ });
             protectedThis->deny(UserMediaPermissionRequestProxy::UserMediaAccessDenialReason::PermissionDenied);
             return;
         }

--- a/Source/WebKit/UIProcess/Cocoa/WebPageProxyCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/WebPageProxyCocoa.mm
@@ -1388,7 +1388,7 @@ bool WebPageProxy::shouldActivateDisplayCaptureCapability() const
     if (!isViewVisible())
         return false;
 
-    return internals().mediaState.containsAny(MediaProducer::DisplayCaptureMask);
+    return internals().mediaState.containsAny(MediaProducer::DisplayCaptureMask | MediaProducer::IsPromptingForDisplayCaptureMask);
 }
 
 bool WebPageProxy::shouldDeactivateDisplayCaptureCapability() const
@@ -1397,7 +1397,7 @@ bool WebPageProxy::shouldDeactivateDisplayCaptureCapability() const
     if (!displayCaptureCapability || !displayCaptureCapability->isActivatingOrActive())
         return false;
 
-    if (internals().mediaState & WebCore::MediaProducer::DisplayCaptureMask)
+    if (internals().mediaState.containsAny(MediaProducer::DisplayCaptureMask | MediaProducer::IsPromptingForDisplayCaptureMask))
         return false;
 
     return true;

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -15381,8 +15381,25 @@ void WebPageProxy::didEndViewGesture()
         pageClient->didEndViewGesture();
 }
 
+void WebPageProxy::setIsPromptingForGetDisplayMedia(WebCore::MediaProducerMediaStateFlags state)
+{
+    auto isPrompting = state.containsAny(WebCore::MediaProducer::IsPromptingForDisplayCaptureMask);
+    internals().mainFrameMediaState.remove(MediaProducer::IsPromptingForDisplayCaptureMask);
+    if (isPrompting)
+        internals().mainFrameMediaState.add(state & WebCore::MediaProducer::IsPromptingForDisplayCaptureMask);
+
+    updatePlayingMediaDidChange(isPrompting ? CanDelayNotification::No : CanDelayNotification::Yes);
+}
+
 void WebPageProxy::isPlayingMediaDidChange(MediaProducerMediaStateFlags newState)
 {
+    // Preserve IsPromptingForWindow/ScreenCapture until display capture actually begins, preventing
+    // premature capability deactivation between prompt approval and the first isPlayingMediaDidChange
+    // with DisplayCaptureMask set. The prompting state is cleared directly in the denial/cancel path,
+    // and in invalidate() when the page is torn down while a prompt is pending.
+    if (internals().mainFrameMediaState.containsAny(MediaProducer::IsPromptingForDisplayCaptureMask) && !newState.containsAny(MediaProducer::DisplayCaptureMask))
+        newState.add(internals().mainFrameMediaState & MediaProducer::IsPromptingForDisplayCaptureMask);
+
 #if PLATFORM(IOS_FAMILY)
     if (!m_legacyMainFrameProcess->throttler().shouldBeRunnable())
         return;

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -2090,6 +2090,7 @@ public:
     bool NODELETE hasMediaStreaming() const;
     void isPlayingMediaDidChange(WebCore::MediaProducerMediaStateFlags);
     void updateReportedMediaCaptureState();
+    void setIsPromptingForGetDisplayMedia(WebCore::MediaProducerMediaStateFlags);
 
     enum class CanDelayNotification : bool { No, Yes };
     void updatePlayingMediaDidChange(CanDelayNotification = CanDelayNotification::No);


### PR DESCRIPTION
#### 9ccf6f3b2a35010f3959e1a8d4b2353d70367d14
<pre>
[Cocoa] Activate DisplayCaptureCapability before prompting for getDisplayMedia
<a href="https://bugs.webkit.org/show_bug.cgi?id=313843">https://bugs.webkit.org/show_bug.cgi?id=313843</a>
<a href="https://rdar.apple.com/176044721">rdar://176044721</a>

Reviewed by Jer Noble.

Activate the display capture endowment while a getDisplayMedia() permission prompt is pending.

Track whether a getDisplayMedia() prompt is in progress with two new MediaProducerMediaState
bits: IsPromptingForWindowCapture and IsPromptingForScreenCapture. Include these bits in
the display capture capability activation/deactivation checks so the endowment is held for
the full duration of the prompt, not just once capture begins. Clear the prompting state
on denial, cancellation, and page invalidation, preserve it across transient media state
updates until DisplayCaptureMask is set.

Tested manually.

* Source/WebCore/page/MediaProducer.h:
* Source/WebCore/page/MediaProducer.serialization.in:
* Source/WebKit/UIProcess/Cocoa/UserMediaPermissionRequestProxyCocoa.mm:
(WebKit::UserMediaPermissionRequestProxyCocoa::invalidate):
(WebKit::UserMediaPermissionRequestProxyCocoa::promptForGetDisplayMedia):
* Source/WebKit/UIProcess/Cocoa/WebPageProxyCocoa.mm:
(WebKit::WebPageProxy::shouldActivateDisplayCaptureCapability const):
(WebKit::WebPageProxy::shouldDeactivateDisplayCaptureCapability const):
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::setIsPromptingForGetDisplayMedia):
(WebKit::WebPageProxy::isPlayingMediaDidChange):
* Source/WebKit/UIProcess/WebPageProxy.h:

Canonical link: <a href="https://commits.webkit.org/312477@main">https://commits.webkit.org/312477@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3306ccea23b1c1edc2535737d768cf5c7591e7ad

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/159994 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/33464 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/26568 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/168872 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/114375 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/161863 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/33567 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/33466 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/124001 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/86975 "1 flakes 2 failures") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/162952 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/26258 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/143700 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/104617 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/25311 "Passed tests") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/23791 "Found 2 new API test failures: TestWebKitAPI.WKInspectorExtension.EvaluateScriptInExtensionTabCanReturnPromises, TestWebKitAPI.WKBackForwardList.BackForwardNavigationSkipsItemsWithoutUserGestureFragment (failure)") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/16615 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/135002 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/21469 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/171354 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/17362 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/23107 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/132268 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/33140 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/27872 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/132294 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35801 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/33125 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/143264 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/91275 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/26910 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/20077 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/32634 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/99031 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/32132 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/32378 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/32282 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->