### PR TITLE
Drop event not firing when dragging file from MacOS Mail app

### DIFF
--- a/Source/WebKit/UIProcess/mac/WebViewImpl.mm
+++ b/Source/WebKit/UIProcess/mac/WebViewImpl.mm
@@ -4493,6 +4493,13 @@ static void performDragWithLegacyFiles(WebPageProxy& page, Box<Vector<String>>&&
     });
 }
 
+// rdar://70315587.
+#if ASSERT_ENABLED
+static constexpr auto filePromiseFulfillmentTimeout = 100_ms;
+#else
+static constexpr auto filePromiseFulfillmentTimeout = 3_s;
+#endif
+
 static bool handleLegacyFilesPromisePasteboard(id<NSDraggingInfo> draggingInfo, Box<WebCore::DragData>&& dragData, WebPageProxy& page, RetainPtr<NSView<WebViewImplDelegate>> view)
 {
     // FIXME: legacyFilesPromisePasteboardTypeSingleton() contains UTIs, not path names. Also, it's not
@@ -4510,28 +4517,62 @@ static bool handleLegacyFilesPromisePasteboard(id<NSDraggingInfo> draggingInfo, 
     auto fileNames = Box<Vector<String>>::create();
     RetainPtr dropDestination = [NSURL fileURLWithPath:dropDestinationPath.get() isDirectory:YES];
     String pasteboardName = draggingInfo.draggingPasteboard.name;
+
+    auto promiseCompleted = Box<bool>::create(false);
+
+    auto performFallbackDragOperation = [promiseCompleted, weakPage = WeakPtr { page }, dragData, pasteboardName = pasteboardName.isolatedCopy()] mutable {
+        if (*promiseCompleted)
+            return;
+        *promiseCompleted = true;
+        RefPtr protectedPage = weakPage.get();
+        if (!protectedPage)
+            return;
+        RELEASE_LOG(DragAndDrop, "File promise was not fulfilled; falling back to default drag operation.");
+        SandboxExtension::Handle sandboxExtensionHandle;
+        Vector<SandboxExtension::Handle> sandboxExtensionForUpload;
+        protectedPage->performDragOperation(*dragData, pasteboardName, WTF::move(sandboxExtensionHandle), WTF::move(sandboxExtensionForUpload));
+    };
+
+    bool foundReceivers = false;
     [draggingInfo enumerateDraggingItemsWithOptions:0 forView:view.get() classes:@[NSFilePromiseReceiver.class] searchOptions:@{ } usingBlock:makeBlockPtr([
         pasteboardName,
         dropDestination,
         fileNames,
         fileCount,
         dragData,
-        protectedPage = protect(page)
+        weakPage = WeakPtr { page },
+        promiseCompleted,
+        performFallbackDragOperation,
+        &foundReceivers
     ](NSDraggingItem *draggingItem, NSInteger idx, BOOL *stop) {
+        foundReceivers = true;
         RetainPtr queue = adoptNS([NSOperationQueue new]);
-        BlockPtr readerBlock = makeBlockPtr([protectedPage, fileNames, fileCount, dragData, pasteboardName = pasteboardName.isolatedCopy()](NSURL *fileURL, NSError *errorOrNil) mutable {
-            if (errorOrNil)
+        BlockPtr readerBlock = makeBlockPtr([weakPage, fileNames, fileCount, dragData, pasteboardName = pasteboardName.isolatedCopy(), promiseCompleted, performFallbackDragOperation](NSURL *fileURL, NSError *errorOrNil) mutable {
+            if (errorOrNil) {
+                RunLoop::mainSingleton().dispatch(WTF::move(performFallbackDragOperation));
                 return;
+            }
 
-            RunLoop::mainSingleton().dispatch([protectedPage, path = protect(fileURL.path), fileNames, fileCount, dragData, pasteboardName] mutable {
+            RunLoop::mainSingleton().dispatch([weakPage, path = protect(fileURL.path), fileNames, fileCount, dragData, pasteboardName, promiseCompleted] mutable {
+                if (*promiseCompleted)
+                    return;
                 fileNames->append(path.get());
                 if (fileNames->size() != fileCount)
                     return;
-                performDragWithLegacyFiles(protectedPage, WTF::move(fileNames), WTF::move(dragData), pasteboardName);
+                *promiseCompleted = true;
+                RefPtr protectedPage = weakPage.get();
+                if (!protectedPage)
+                    return;
+                performDragWithLegacyFiles(*protectedPage, WTF::move(fileNames), WTF::move(dragData), pasteboardName);
             });
         });
         [protect(draggingItem.item) receivePromisedFilesAtDestination:dropDestination.get() options:@{ } operationQueue:queue.get() reader:readerBlock.get()];
     }).get()];
+
+    if (!foundReceivers)
+        return false;
+
+    RunLoop::mainSingleton().dispatchAfter(filePromiseFulfillmentTimeout, WTF::move(performFallbackDragOperation));
 
     return true;
 }

--- a/Tools/TestWebKitAPI/Helpers/cocoa/DragAndDropSimulator.h
+++ b/Tools/TestWebKitAPI/Helpers/cocoa/DragAndDropSimulator.h
@@ -144,10 +144,13 @@ typedef NSDictionary<NSNumber *, NSValue *> *ProgressToCGPointValueMap;
 @property (nonatomic, strong) NSPasteboard *externalDragPasteboard;
 @property (nonatomic, strong) NSImage *externalDragImage;
 @property (nonatomic, readonly) NSArray<NSURL *> *externalPromisedFiles;
+@property (nonatomic, readonly) BOOL useUnfulfilledPromises;
+@property (nonatomic, readonly) NSArray<NSString *> *unfulfilledPromiseTypeIdentifiers;
 @property (nonatomic, copy) dispatch_block_t willBeginDraggingHandler;
 @property (nonatomic, copy) dispatch_block_t willEndDraggingHandler;
 
 - (void)writePromisedFiles:(NSArray<NSURL *> *)fileURLs;
+- (void)writeUnfulfilledPromisedFiles:(NSArray<NSString *> *)typeIdentifiers;
 - (void)writeFiles:(NSArray<NSURL *> *)fileURLs;
 - (NSArray<NSURL *> *)receivePromisedFiles;
 

--- a/Tools/TestWebKitAPI/Helpers/mac/DragAndDropSimulatorMac.mm
+++ b/Tools/TestWebKitAPI/Helpers/mac/DragAndDropSimulatorMac.mm
@@ -89,6 +89,7 @@ static RetainPtr<NSImage> defaultExternalDragImage()
     RetainPtr<NSPasteboard> _externalDragPasteboard;
     RetainPtr<NSImage> _externalDragImage;
     RetainPtr<NSArray<NSURL *>> _externalPromisedFiles;
+    RetainPtr<NSArray<NSString *>> _unfulfilledPromiseTypeIdentifiers;
     RetainPtr<NSMutableArray<_WKAttachment *>> _insertedAttachments;
     RetainPtr<NSMutableArray<_WKAttachment *>> _removedAttachments;
     RetainPtr<NSMutableArray<NSURL *>> _filePromiseDestinationURLs;
@@ -101,6 +102,7 @@ static RetainPtr<NSImage> defaultExternalDragImage()
     double _progress;
     bool _doneWaitingForDraggingSession;
     bool _doneWaitingForDrop;
+    bool _useUnfulfilledPromises;
 }
 
 @synthesize currentDragOperation = _currentDragOperation;
@@ -390,9 +392,21 @@ static RetainPtr<NSImage> defaultExternalDragImage()
     return _externalPromisedFiles.get();
 }
 
+- (BOOL)useUnfulfilledPromises
+{
+    return _useUnfulfilledPromises;
+}
+
+- (NSArray<NSString *> *)unfulfilledPromiseTypeIdentifiers
+{
+    return _unfulfilledPromiseTypeIdentifiers.get();
+}
+
 - (void)clearExternalDragInformation
 {
     _externalPromisedFiles = nil;
+    _unfulfilledPromiseTypeIdentifiers = nil;
+    _useUnfulfilledPromises = NO;
     _externalDragImage = nil;
     _externalDragPasteboard = nil;
 }
@@ -450,6 +464,15 @@ static BOOL getFilePathsAndTypeIdentifiers(NSArray<NSURL *> *fileURLs, NSArray<N
     [_externalDragPasteboard declareTypes:@[NSFilesPromisePboardType, NSFilenamesPboardType] owner:nil];
     [_externalDragPasteboard setPropertyList:types forType:NSFilesPromisePboardType];
     [_externalDragPasteboard setPropertyList:names forType:NSFilenamesPboardType];
+}
+
+- (void)writeUnfulfilledPromisedFiles:(NSArray<NSString *> *)typeIdentifiers
+{
+    _useUnfulfilledPromises = YES;
+    _unfulfilledPromiseTypeIdentifiers = typeIdentifiers;
+    _externalDragPasteboard = [NSPasteboard pasteboardWithUniqueName];
+    [_externalDragPasteboard declareTypes:@[NSFilesPromisePboardType] owner:nil];
+    [_externalDragPasteboard setPropertyList:typeIdentifiers forType:NSFilesPromisePboardType];
 }
 
 - (void)writeFiles:(NSArray<NSURL *> *)fileURLs

--- a/Tools/TestWebKitAPI/Helpers/mac/TestDraggingInfo.mm
+++ b/Tools/TestWebKitAPI/Helpers/mac/TestDraggingInfo.mm
@@ -96,8 +96,9 @@
         return;
     }
 
+    BOOL useUnfulfilledPromises = [_dragAndDropSimulator useUnfulfilledPromises];
     RetainPtr externalPromisedFiles = [_dragAndDropSimulator externalPromisedFiles];
-    if (!externalPromisedFiles)
+    if (!externalPromisedFiles && !useUnfulfilledPromises)
         return;
 
     BOOL stop = NO;
@@ -106,6 +107,26 @@
             continue;
 
         RetainPtr promisedTypeIdentifiers = dynamic_objc_cast<NSArray>([_pasteboard propertyListForType:NSFilesPromisePboardType]);
+
+        if (useUnfulfilledPromises) {
+            NSUInteger itemIndex = 0;
+            for (NSString *typeIdentifier in promisedTypeIdentifiers.get()) {
+                RetainPtr receiver = adoptNS([[UnfulfilledTestFilePromiseReceiver alloc] initWithTypeIdentifier:typeIdentifier]);
+                [receiver setDraggingSource:_source.get().get()];
+
+#if HAVE(DRAGGING_ITEM_INIT_WITH_PASTEBOARD_ITEM)
+                RetainPtr item = adoptNS([[NSDraggingItem alloc] _initWithPasteboardItem:receiver.get() localItem:nil]);
+#else
+                RetainPtr item = adoptNS([[NSDraggingItem alloc] _initWithItem:receiver.get()]);
+#endif
+                block(item.get(), itemIndex, &stop);
+                if (stop)
+                    break;
+                itemIndex++;
+            }
+            return;
+        }
+
         RELEASE_ASSERT([promisedTypeIdentifiers count] == [externalPromisedFiles count]);
 
         for (id object in promisedTypeIdentifiers.get())

--- a/Tools/TestWebKitAPI/Helpers/mac/TestFilePromiseReceiver.h
+++ b/Tools/TestWebKitAPI/Helpers/mac/TestFilePromiseReceiver.h
@@ -38,4 +38,13 @@
 
 @end
 
+@interface UnfulfilledTestFilePromiseReceiver : NSFilePromiseReceiver
+
+- (instancetype)initWithTypeIdentifier:(NSString *)promisedTypeIdentifier NS_DESIGNATED_INITIALIZER;
+- (instancetype)init NS_UNAVAILABLE;
+
+@property (nonatomic, weak) id draggingSource;
+
+@end
+
 #endif

--- a/Tools/TestWebKitAPI/Helpers/mac/TestFilePromiseReceiver.mm
+++ b/Tools/TestWebKitAPI/Helpers/mac/TestFilePromiseReceiver.mm
@@ -132,4 +132,46 @@ static NSURL *copyFile(NSURL *sourceURL, NSURL *destinationDirectory, NSError **
 
 @end
 
+@implementation UnfulfilledTestFilePromiseReceiver {
+    RetainPtr<NSString> _promisedTypeIdentifier;
+    WeakObjCPtr<id> _draggingSource;
+}
+
+- (instancetype)initWithTypeIdentifier:(NSString *)promisedTypeIdentifier
+{
+    if (!(self = [super init]))
+        return nil;
+
+    _promisedTypeIdentifier = adoptNS([promisedTypeIdentifier copy]);
+    return self;
+}
+
+- (NSArray<NSString *> *)fileTypes
+{
+    return @[ _promisedTypeIdentifier.get() ];
+}
+
+- (NSArray<NSString *> *)fileNames
+{
+    return @[ ];
+}
+
+- (id)draggingSource
+{
+    return _draggingSource.get().unsafeGet();
+}
+
+- (void)setDraggingSource:(id)draggingSource
+{
+    _draggingSource = draggingSource;
+}
+
+- (void)receivePromisedFilesAtDestination:(NSURL *)destinationDirectory options:(NSDictionary *)options operationQueue:(NSOperationQueue *)queue reader:(void (^)(NSURL *, NSError *))reader
+{
+    // Intentionally never call the reader block, simulating apps like Mail.app
+    // where the file promise is advertised but never fulfilled.
+}
+
+@end
+
 #endif // PLATFORM(MAC)

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/mac/DragAndDropTestsMac.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/mac/DragAndDropTestsMac.mm
@@ -266,6 +266,31 @@ TEST(DragAndDropTests, DragPromisedImageFileIntoFileUpload)
     EXPECT_WK_STREQ(UTTypeGIF.identifier, filePromiseReceiver.fileTypes.firstObject);
 }
 
+TEST(DragAndDropTests, DropEventFiresWhenFilePromiseIsNeverFulfilled)
+{
+    RetainPtr simulator = adoptNS([[DragAndDropSimulator alloc] initWithWebViewFrame:NSMakeRect(0, 0, 400, 400)]);
+    auto *webView = [simulator webView];
+    [webView synchronouslyLoadTestPageNamed:@"dump-datatransfer-types"];
+
+    [simulator writeUnfulfilledPromisedFiles:@[ @"com.apple.mail.email" ]];
+    [simulator runFrom:CGPointMake(0, 0) to:CGPointMake(375, 375)];
+
+    TestWebKitAPI::Util::waitForConditionWithLogging([&] () -> bool {
+        return [webView stringByEvaluatingJavaScript:@"output.value"].length > 0;
+    }, 2, @"Expected drop event to fire via timeout fallback.");
+
+    NSString *s = [webView stringByEvaluatingJavaScript:@"output.value"];
+    BOOL success = TestWebKitAPI::Util::jsonMatchesExpectedValues(s, @{
+        @"dragover" : @{
+            @"Files": @""
+        },
+        @"drop": @{
+            @"Files": @""
+        }
+    });
+    EXPECT_TRUE(success);
+}
+
 TEST(DragAndDropTests, ReadURLWhenDroppingPromisedWebLoc)
 {
     RetainPtr simulator = adoptNS([[DragAndDropSimulator alloc] initWithWebViewFrame:NSMakeRect(0, 0, 400, 400)]);


### PR DESCRIPTION
#### c803a86d9df98f9d6d7c48d35f8b73b64ca68750
<pre>
Drop event not firing when dragging file from MacOS Mail app
<a href="https://bugs.webkit.org/show_bug.cgi?id=217726">https://bugs.webkit.org/show_bug.cgi?id=217726</a>
<a href="https://rdar.apple.com/70315587">rdar://70315587</a>

Reviewed by NOBODY (OOPS!).

The problem: The drop down event never fires when dragging
an .eml file from the Mail app to a web page.
Mail puts an NSFilePromiseReceiver on the pasteboard
and WebKit calls receivePromisedFilesAtDestination:
on it, but the reader block is never invoked because
the drag session finalizes before Mail can fulfill
the promise. The function returns treu, so WebKit
never falls through to deliver the drop event to
the page.

The fix: Add a timeout fallback to handleLegacyFilesPromisePasteboard.
After calling receivePromisedFilesAtDestination:,
schedule a fallback via dispatchAfter. If the promise
resolves normally (Finder, Photos), the fallback is
a no-op. If it never resolves (Mail), the fallback
never fires performDragOperation so the drop event
reaches the page. If it errors, the fallback fires immediately.
Also return false when no NSFilePromiseReceiver objects
are found so the caller can try other pasteboard handlers.
All closures use WeakPtr to avoid extending WebPageProxy
lifetime.

The fix uses a timeout because there is no AppKit
API to detect that a file promise will never be fulfilled.
It only fires for the broken case and is strictly better
than the current behaviour where the drop is silently
swallowed.

Tests: Tools/TestWebKitAPI/Helpers/cocoa/DragAndDropSimulator.h
       Tools/TestWebKitAPI/Helpers/mac/DragAndDropSimulatorMac.mm
       Tools/TestWebKitAPI/Helpers/mac/TestDraggingInfo.mm
       Tools/TestWebKitAPI/Helpers/mac/TestFilePromiseReceiver.h
       Tools/TestWebKitAPI/Helpers/mac/TestFilePromiseReceiver.mm
       Tools/TestWebKitAPI/Tests/WebKit/WKWebView/mac/DragAndDropTestsMac.mm

* Source/WebKit/UIProcess/mac/WebViewImpl.mm:
(WebKit::handleLegacyFilesPromisePasteboard):
* Tools/TestWebKitAPI/Helpers/cocoa/DragAndDropSimulator.h:
* Tools/TestWebKitAPI/Helpers/mac/DragAndDropSimulatorMac.mm:
(-[DragAndDropSimulator useUnfulfilledPromises]):
(-[DragAndDropSimulator unfulfilledPromiseTypeIdentifiers]):
(-[DragAndDropSimulator clearExternalDragInformation]):
(-[DragAndDropSimulator writeUnfulfilledPromisedFiles:]):
* Tools/TestWebKitAPI/Helpers/mac/TestDraggingInfo.mm:
(-[TestDraggingInfo enumerateDraggingItemsWithOptions:forView:classes:searchOptions:usingBlock:]):
* Tools/TestWebKitAPI/Helpers/mac/TestFilePromiseReceiver.h:
* Tools/TestWebKitAPI/Helpers/mac/TestFilePromiseReceiver.mm:
(-[UnfulfilledTestFilePromiseReceiver initWithTypeIdentifier:]):
(-[UnfulfilledTestFilePromiseReceiver fileTypes]):
(-[UnfulfilledTestFilePromiseReceiver fileNames]):
(-[UnfulfilledTestFilePromiseReceiver draggingSource]):
(-[UnfulfilledTestFilePromiseReceiver setDraggingSource:]):
(-[UnfulfilledTestFilePromiseReceiver receivePromisedFilesAtDestination:options:operationQueue:reader:]):
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/mac/DragAndDropTestsMac.mm:
(TEST(DragAndDropTests, DropEventFiresWhenFilePromiseIsNeverFulfilled)):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c803a86d9df98f9d6d7c48d35f8b73b64ca68750

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/159998 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/33468 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/26572 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/168876 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/114379 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/cbc9086b-1c7c-4215-b452-42130f09b701) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/161867 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/33571 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/33470 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/124003 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/86977 "1 flakes 2 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/40fe144b-e377-4e19-b680-0ef11ad73ab3) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/162956 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/26254 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/143698 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/104619 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/f904cad9-f244-48ba-8922-8e7fe64b9062) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/25307 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/23793 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/16619 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/134998 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/21467 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/171358 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/17366 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/23105 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/132269 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/33144 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/27875 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/132295 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/33129 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/143262 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/91279 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/26908 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/20075 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/32638 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/99035 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/32136 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/32382 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/32286 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->