### PR TITLE
http/tests/inspector/network/copy-as-fetch.html cannot be run repeatedly

### DIFF
--- a/LayoutTests/http/tests/inspector/network/copy-as-fetch.html
+++ b/LayoutTests/http/tests/inspector/network/copy-as-fetch.html
@@ -72,11 +72,11 @@ function test()
         {name: "POSTRequestURLUTF8", expression: `createPOSTRequestWithUTF8()`},
         {name: "PUTRequestWithJSON", expression: `createPUTRequestWithJSON()`},
 
-        {name: "ReferrerPolicy.EmptyString", expression: `fetch("resources/url", {referrerPolicy: ""})`},
-        {name: "ReferrerPolicy.NoReferrer", expression: `fetch("resources/url", {referrerPolicy: "no-referrer"})`},
+        {name: "ReferrerPolicy.EmptyString", expression: `fetch("resources/url", {referrerPolicy: "", cache: "no-store"})`},
+        {name: "ReferrerPolicy.NoReferrer", expression: `fetch("resources/url", {referrerPolicy: "no-referrer", cache: "no-store"})`},
 
-        {name: "Integrity.Invalid", expression: `fetch("resources/data.txt?integrity=invalid", {integrity: "INVALID"})`},
-        {name: "Integrity.Valid", expression: `fetch("resources/data.txt?integrity=valid", {integrity: "sha256-qQCuhmp5o0z/of299BZBz6a+CBJGM2TPN53xY1PHXS8="})`},
+        {name: "Integrity.Invalid", expression: `fetch("resources/data.txt?integrity=invalid", {integrity: "INVALID", cache: "no-store"})`},
+        {name: "Integrity.Valid", expression: `fetch("resources/data.txt?integrity=valid", {integrity: "sha256-qQCuhmp5o0z/of299BZBz6a+CBJGM2TPN53xY1PHXS8=", cache: "no-store"})`},
     ].forEach(({name, expression}) => {
         suite.addTestCase({
             name: "WI.Resource.prototype.generateFetchCode." + name,
@@ -90,8 +90,10 @@ function test()
 
                 let fetchCode = resource.generateFetchCode();
 
-                // Strip inconsistent headers.
+                // Strip inconsistent and unrelated headers.
                 fetchCode = fetchCode.replace(/\s+"Accept-Language": ".+?",\n/, "\n");
+                fetchCode = fetchCode.replace(/\s+"Cache-Control": ".+?",\n/, "\n");
+                fetchCode = fetchCode.replace(/\s+"Pragma": ".+?",\n/, "\n");
                 fetchCode = fetchCode.replace(/\s+"Priority": ".+?",\n/, "\n");
                 fetchCode = fetchCode.replace(/("User-Agent": )(".+?")(,?\n)/, "$1<filtered>$3");
 


### PR DESCRIPTION
#### 3170735ecff6976d07ce447c8d2300dd1b9607e1
<pre>
http/tests/inspector/network/copy-as-fetch.html cannot be run repeatedly
<a href="https://bugs.webkit.org/show_bug.cgi?id=313831">https://bugs.webkit.org/show_bug.cgi?id=313831</a>
<a href="https://rdar.apple.com/176037138">rdar://176037138</a>

Reviewed by Qianlang Chen.

The copy-as-fetch inspector test fails when run multiple times in succession because
WebKit&apos;s memory cache serves responses from the first run. When a cached response is
used, the inspector doesn&apos;t capture full request details (headers, integrity, referrer),
causing generateFetchCode to produce incomplete output.

This change adds cache: &quot;no-store&quot; to the four fetch() calls in the test so the browser
bypasses caches entirely. This ensures the inspector always sees fresh network requests
with complete details, making the test repeatable. The test is exercising generateFetchCode
serialization, not caching behavior.

It also removes the Cache-Control and Pragma headers which are not relevant to the
feature being tested, and confound attempts to run this test in multiple iterations.

* LayoutTests/http/tests/inspector/network/copy-as-fetch.html:

Canonical link: <a href="https://commits.webkit.org/312754@main">https://commits.webkit.org/312754@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4faca7921e9779574e7b3d436de83e83c921b65c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/160922 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/34395 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/27496 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/169825 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/117182 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/e294e306-17db-4647-924d-181168aaa1e4) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/34496 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/34395 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/124819 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/117182 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/80eeb458-e0e8-4ef0-b991-31cc85095ccd) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/163881 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/27077 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/144546 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/105416 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/95339611-91a8-479b-9569-aaf7b76eaa20) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/26129 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/24633 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/17545 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/135823 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/22308 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/172308 "Built successfully") | | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/23949 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/133093 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/34069 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/28725 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/133103 "Found 1 new API test failure: TestWebKit:WebKit.WKPageCopySessionStateWithFiltering (failure)") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35957 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/34053 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/144103 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/95892 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/27682 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/20919 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/33564 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/33063 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/33307 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/33212 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->