### PR TITLE
[macOS] TestWebKitAPI should use App sandbox

### DIFF
--- a/Tools/TestWebKitAPI/Scripts/process-entitlements.sh
+++ b/Tools/TestWebKitAPI/Scripts/process-entitlements.sh
@@ -50,6 +50,7 @@ function process_mac_testwebkitapi_entitlements()
     plistbuddy Add :com.apple.security.temporary-exception.sbpl array
     plistbuddy Add :com.apple.security.temporary-exception.sbpl:0 string '(allow mach-issue-extension (require-all (extension-class \"com.apple.webkit.extension.mach\")))'
     plistbuddy Add :com.apple.security.temporary-exception.sbpl:1 string '(allow iokit-issue-extension (require-all (extension-class \"com.apple.webkit.extension.iokit\")))'
+    plistbuddy Add :com.apple.security.temporary-exception.sbpl:2 string '(allow signal (target others))'
 
     if [[ "${WK_USE_RESTRICTED_ENTITLEMENTS}" == YES ]]
     then
@@ -59,6 +60,11 @@ function process_mac_testwebkitapi_entitlements()
         plistbuddy Add :com.apple.private.hid.client.event-filter bool YES
         plistbuddy Add :com.apple.private.hid.client.event-dispatch.internal bool YES
     fi
+
+    plistbuddy Add :com.apple.security.app-sandbox bool YES
+    plistbuddy Add :com.apple.security.network.client bool YES
+    plistbuddy Add :com.apple.security.network.server bool YES
+    plistbuddy Add :com.apple.security.temporary-exception.files.absolute-path.read-write string /private/tmp/
 }
 
 # ========================================


### PR DESCRIPTION
#### cd04595a86879b489b1bcfb8d633f2a0e58e46b8
<pre>
[macOS] TestWebKitAPI should use App sandbox
<a href="https://bugs.webkit.org/show_bug.cgi?id=313850">https://bugs.webkit.org/show_bug.cgi?id=313850</a>
<a href="https://rdar.apple.com/176052450">rdar://176052450</a>

Reviewed by NOBODY (OOPS!).

This will be a more realistic testing scenario.

* Tools/TestWebKitAPI/Scripts/process-entitlements.sh:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cd04595a86879b489b1bcfb8d633f2a0e58e46b8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/160140 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/33610 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/26714 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/169038 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/114521 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/9777c9e6-eb7e-4ccd-a593-1813ea806f81) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/162009 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/33713 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/33612 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/124137 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/87065 "1 flakes 2 failures") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/61816578-9b76-40d1-88b4-e4d8e6f64668) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/163098 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/26380 "Passed tests") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/143840 "Found 58 new API test failures: TestWebKitAPI.WKWebView.LocalStorageNullEntries, TestWebKitAPI.WebPushDBuiltInTest.TestPermissionsAfterNotificatonRequestPermission, TestWebKitAPI.WebKit.GlobalPreferenceChangesUsingDefaultsWriteWithSuspendedProcess, TestWebKitAPI.WebArchive.CookieAccessAfterLoadRequest, TestWebKitAPI.WebKit.WebsiteDataStoreCustomPathsWithPrewarming, TestWebKitAPI.WebPushDNavigatorTest.SubscribeFailureTest, TestWebKitAPI.IndexedDB.IDBObjectStoreInfoUpgradeToV2, TestWebKitAPI.WebPushDInjectedPushTest.HandleInjectedAESGCMPush, TestWebKitAPI.WebKit.GlobalPreferenceChangesUsingDefaultsWrite, TestWebKitAPI.WebPushDInjectedPushTest.HandleInjectedAES128GCMPush ... (failure)") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/104740 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/5287c024-5025-4bb7-8116-5b5bfa82fea0) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/25433 "Passed tests") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/23927 "Found 54 new API test failures: TestWebKitAPI.WKWebView.LocalStorageNullEntries, TestWebKitAPI.WebPushDBuiltInTest.TestPermissionsAfterNotificatonRequestPermission, TestWebKitAPI.WebKit.GlobalPreferenceChangesUsingDefaultsWriteWithSuspendedProcess, TestWebKitAPI.WebArchive.CookieAccessAfterLoadRequest, TestWebKitAPI.WebPushDNavigatorTest.SubscribeFailureTest, TestWebKitAPI.WebPushDInjectedPushTest.HandleInjectedAESGCMPush, TestWebKitAPI.WebKit.GlobalPreferenceChangesUsingDefaultsWrite, TestWebKitAPI.WebPushDInjectedPushTest.HandleInjectedAES128GCMPush, TestWebKitAPI.WebPushD.WKWebPushDaemonConnectionPushNotifications, TestWebKitAPI.WebKit.PrintFrame ... (failure)") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/16761 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/135125 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/21603 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/171513 "Built successfully") | | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/23243 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/132391 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/33286 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/28014 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/132417 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/33271 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/143398 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/91503 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/27031 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/20212 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/32780 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/32278 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/32524 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/32428 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->