### PR TITLE
Fix ASAN crash in CSSVariableData

### DIFF
--- a/LayoutTests/fast/css/variables/dashed-function-result-token-lifetime-expected.txt
+++ b/LayoutTests/fast/css/variables/dashed-function-result-token-lifetime-expected.txt
@@ -1,0 +1,1 @@
+PASS if no crash. Got: aaaa bbbb

--- a/LayoutTests/fast/css/variables/dashed-function-result-token-lifetime.html
+++ b/LayoutTests/fast/css/variables/dashed-function-result-token-lifetime.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<style>
+@function --f(--a) {
+  result: aaaa var(--a);
+}
+#target {
+  --x: --f(bbbb);
+}
+</style>
+<div id="target"></div>
+<script>
+if (window.testRunner)
+    testRunner.dumpAsText();
+var v = getComputedStyle(target).getPropertyValue('--x');
+document.write("PASS if no crash. Got: " + v);
+</script>

--- a/Source/WebCore/style/StyleSubstitutionResolver.cpp
+++ b/Source/WebCore/style/StyleSubstitutionResolver.cpp
@@ -339,7 +339,9 @@ bool SubstitutionResolver::substituteDashedFunction(StringView functionName, CSS
     if (guard.isCyclicContext())
         return false;
 
+    // Tokens reference resolvedResult's string backing; keep it alive until CSSVariableData re-captures.
     tokens.appendVector(resolvedResult->tokens());
+    m_intermediateCustomProperties.append(WTF::move(resolvedResult));
     return true;
 }
 
@@ -714,11 +716,13 @@ RefPtr<CSSVariableData> SubstitutionResolver::substitute(const CSSSubstitutionVa
     auto substitutedTokens = substituteTokenRange(value.m_data->tokenRange(), context);
     if (!substitutedTokens) {
         m_intermediateTokenStrings.clear();
+        m_intermediateCustomProperties.clear();
         return nullptr;
     }
 
     auto data = CSSVariableData::create(*substitutedTokens, m_isAttrTainted ? IsAttrTainted::Yes : IsAttrTainted::No, context);
     m_intermediateTokenStrings.clear();
+    m_intermediateCustomProperties.clear();
     return data;
 }
 

--- a/Source/WebCore/style/StyleSubstitutionResolver.h
+++ b/Source/WebCore/style/StyleSubstitutionResolver.h
@@ -84,6 +84,7 @@ private:
     Builder& m_styleBuilder;
     RefPtr<const CSSSubstitutionValue> m_substitutionValue;
     Vector<String> m_intermediateTokenStrings;
+    Vector<RefPtr<const CustomProperty>> m_intermediateCustomProperties;
     unsigned m_urlContextDepth { 0 };
     bool m_isAttrTainted { false };
     bool m_hasTaintedURL { false };


### PR DESCRIPTION
#### 4b97014ab4bea4fca336424d0b19e4b783ce2ee6
<pre>
Fix ASAN crash in CSSVariableData
<a href="https://bugs.webkit.org/show_bug.cgi?id=313848">https://bugs.webkit.org/show_bug.cgi?id=313848</a>
<a href="https://rdar.apple.com/174419283">rdar://174419283</a>

Reviewed by David Kilzer.

Keep the resolved CustomProperty alive in m_intermediateCustomProperties until
substitute() has constructed the new CSSVariableData, mirroring the existing
m_intermediateTokenStrings mechanism used for attr() tokenizer output.

* LayoutTests/fast/css/variables/dashed-function-result-token-lifetime-expected.txt: Added.
* LayoutTests/fast/css/variables/dashed-function-result-token-lifetime.html: Added.
* Source/WebCore/style/StyleSubstitutionResolver.cpp:
(WebCore::Style::SubstitutionResolver::substituteDashedFunction):
(WebCore::Style::SubstitutionResolver::substitute):
* Source/WebCore/style/StyleSubstitutionResolver.h:

Canonical link: <a href="https://commits.webkit.org/312494@main">https://commits.webkit.org/312494@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/16ecf8019d4df16cf7e34e3e4cda3f462a7fc415

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/160015 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/33485 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/26589 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/168894 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/114396 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/f9806a5a-0bcd-4854-9f67-3d05ea22d9a2) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/161884 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/33588 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/33487 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/124020 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/86986 "2 failures") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/5170cd52-8596-4ad5-883a-021e3010898b) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/162973 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/26273 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/143719 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/104635 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/eb75e7b2-c24d-4174-a82d-37893829c1dd) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/25326 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/23810 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/16636 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/135017 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/21488 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/171375 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/17383 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/23126 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/132283 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/33161 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/27892 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/132309 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/33146 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/143283 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/91296 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/24372 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/26923 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/20096 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/32655 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/99052 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/32153 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/32399 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/32303 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->