### PR TITLE
[JSC][WASM][Debugger] Update call_indirect trap test for corrected PC reporting

### DIFF
--- a/JSTests/wasm/debugger/resources/wasm/trap-out-of-bounds-call-indirect.js
+++ b/JSTests/wasm/debugger/resources/wasm/trap-out-of-bounds-call-indirect.js
@@ -23,8 +23,8 @@ var wasm = new Uint8Array([
     0x00,       // 0 local declarations
     0x41, 0x00, // [0x2f][0x30] i32.const 0  (call index)
     0x11, 0x00, 0x00, // [0x31][0x32][0x33] call_indirect type=0 table=0  <- OutOfBoundsCallIndirect
-                      //   PC advanced past 3-byte instruction; trap handler sees PC=[0x34]
-    0x1a,       // [0x34] drop  <- PC visible in debugger
+                      //   PC is captured before advancement; trap handler sees PC=[0x31]
+    0x1a,       // [0x34] drop  <- never reached
     0x41, 0x00, // [0x35][0x36] i32.const 0  (return value, never reached)
     0x0b,       // [0x37] end
 ]);

--- a/JSTests/wasm/debugger/tests/tests.py
+++ b/JSTests/wasm/debugger/tests/tests.py
@@ -1511,12 +1511,12 @@ class WasmOutOfBoundsCallIndirectTrapTestCase:
     def execute(self):
         for _ in range(10):
             self.session.cmd("c", patterns=["Process 1 stopped", "Out of bounds call_indirect"])
-            self.session.cmd("dis", patterns=["->  0x4000000000000034: drop"])
+            self.session.cmd("dis", patterns=["->  0x4000000000000031: call_indirect 0"])
 
         self.session.cmd(
             "bt",
             patterns=[
-                "frame #0: 0x4000000000000034",
+                "frame #0: 0x4000000000000031",
                 "frame #1: 0xc000000000000000",
             ]
         )


### PR DESCRIPTION
#### a5b9946d0662b8cafe8dbbd13c62c28e7eb93e21
<pre>
[JSC][WASM][Debugger] Update call_indirect trap test for corrected PC reporting
<a href="https://bugs.webkit.org/show_bug.cgi?id=313852">https://bugs.webkit.org/show_bug.cgi?id=313852</a>
<a href="https://rdar.apple.com/176052939">rdar://176052939</a>

Reviewed by Yusuke Suzuki.

714bf5b (&quot;Delay PC advancement until after operationCallMayThrow in IPInt&quot;)
moved advancePCByReg past operationCallMayThrow for call_indirect, which
changed the trap PC from 0x34 (drop — the post-advanced address) to 0x31
(call_indirect — the trapping instruction itself). This is correct behavior:
the debugger now shows the instruction that actually faulted.

Update WasmOutOfBoundsCallIndirectTrapTestCase and the resource file comment
to reflect the new addresses.

Pure test change, no new behavior added.

Canonical link: <a href="https://commits.webkit.org/312453@main">https://commits.webkit.org/312453@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cefda7e3a4b1e90470baafcb243f7de5c1351297

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/160017 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/33487 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/26591 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/168896 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/114398 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/33590 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/33489 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/124022 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/114398 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/162975 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/26288 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/143723 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/104637 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/25341 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/23812 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/16638 "Built successfully") | | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/20/builds/152073 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/135032 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/171377 "Built successfully") | | 
| [  ~~🛠 🧪 jsc-debug-arm64~~](https://ews-build.webkit.org/#/builders/171/builds/20854 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/23130 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/132286 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/33163 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/27894 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/132312 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/33148 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/143287 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/91298 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/24345 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/164/builds/26928 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/20100 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/192301 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/32657 "Built successfully") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/49468 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/32155 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/32401 "Built successfully") | | | | 
| | [❌ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/32305 "Failed to checkout and rebase branch from PR 64071") | | | | 
<!--EWS-Status-Bubble-End-->