### PR TITLE
[WPT export friction] Run WPT lint via check-webkit-style

### DIFF
--- a/Tools/Scripts/webkitpy/layout_tests/controllers/layout_test_finder.py
+++ b/Tools/Scripts/webkitpy/layout_tests/controllers/layout_test_finder.py
@@ -32,6 +32,9 @@ from webkitpy.layout_tests.models.test import Test
 from webkitpy.thirdparty.wpt.manifest.sourcefile import SourceFile
 from webkitpy.w3c.common import TEMPLATED_TEST_HEADER
 
+IMPORTED_WPT_DIR = "imported/w3c/web-platform-tests"
+LOCAL_WPT_PATH = "http/wpt"
+
 supported_test_extensions = (
     ".htm",
     ".html",
@@ -445,8 +448,8 @@ class LayoutTestFinder(object):
                     and "websocket" in trimmed_path + variant
                 ),
                 is_wpt_test=(
-                    "imported/w3c/web-platform-tests/" in trimmed_path
-                    or "http/wpt/" in trimmed_path
+                    IMPORTED_WPT_DIR + "/" in trimmed_path
+                    or LOCAL_WPT_PATH + "/" in trimmed_path
                 ),
                 is_wpt_crash_test=self.is_wpt_crash_test(trimmed_path),
             )
@@ -611,11 +614,11 @@ class LayoutTestFinder(object):
 
     def is_wpt_crash_test(self, name):
         # This shouldn't exist, we should be reading the WPT manifest instead.
-        if "imported/w3c/web-platform-tests/" in name:
-            base_dir = self.fs.join(self.layout_tests_base_dir, "imported/w3c/web-platform-tests/")
+        if IMPORTED_WPT_DIR + "/" in name:
+            base_dir = self.fs.join(self.layout_tests_base_dir, *IMPORTED_WPT_DIR.split('/'))
             url_base = "/"
-        elif "http/wpt/" in name:
-            base_dir = self.fs.join(self.layout_tests_base_dir, "http/wpt/")
+        elif LOCAL_WPT_PATH + "/" in name:
+            base_dir = self.fs.join(self.layout_tests_base_dir, *LOCAL_WPT_PATH.split('/'))
             url_base = "/WebKit/"
         else:
             return False

--- a/Tools/Scripts/webkitpy/style/checker.py
+++ b/Tools/Scripts/webkitpy/style/checker.py
@@ -37,6 +37,7 @@ import re
 
 from webkitpy.common.host import Host
 from webkitpy.common.system.logutils import configure_logging as _configure_logging
+from webkitpy.layout_tests.controllers.layout_test_finder import IMPORTED_WPT_DIR
 from webkitpy.port.config import apple_additions
 from webkitpy.style.checkers.basexcconfig import BaseXcconfigChecker
 from webkitpy.style.checkers.common import categories as CommonCategories
@@ -65,6 +66,7 @@ from webkitpy.style.checkers.watchlist import WatchListChecker
 from webkitpy.style.checkers.xcodeproj import XcodeProjectFileChecker
 from webkitpy.style.checkers.xcscheme import XcodeSchemeChecker
 from webkitpy.style.checkers.xml import XMLChecker
+from webkitpy.style.checkers.wpt import wpt_lint_categories, run_wpt_lint
 from webkitpy.style.error_handlers import DefaultStyleErrorHandler
 from webkitpy.style.filter import FilterConfiguration
 from webkitpy.style.optparser import ArgumentParser
@@ -445,6 +447,40 @@ _PATH_RULES_SPECIFIER = [
     ([  # Ignore whitespace issues in third party library esprima.js
      os.path.join('Source', 'WebInspectorUI', 'UserInterface', 'External', 'Esprima', 'esprima.js')],
      ["-whitespace/tab"]),
+
+    ([  # Import artifact written by Tools/Scripts/import-w3c-tests.
+      'w3c-import.log'],
+     ['-wpt/lint']),
+
+    ([  # WebKit's expectations.
+      '-expected.txt'],
+     ['-wpt/lint']),
+
+    ([  # Dummy .html files generated from .any.js templates by
+        # Tools/Scripts/import-w3c-tests (excluding those sharing the basename, see below).
+      '.any.window-module.html',
+      '.any.serviceworker.html',
+      '.any.serviceworker-module.html',
+      '.any.sharedworker.html',
+      '.any.sharedworker-module.html',
+      '.any.worker.html',
+      '.any.worker-module.html',
+      '.any.shadowrealm-in-window.html',
+      '.any.shadowrealm-in-shadowrealm.html',
+      '.any.shadowrealm-in-dedicatedworker.html',
+      '.any.shadowrealm-in-sharedworker.html',
+      '.any.shadowrealm-in-serviceworker.html',
+      '.any.shadowrealm-in-audioworklet.html'],
+     ['-wpt/lint/worker_collision']),
+
+    ([  # Templated test sources and their generated dummy .html counterparts.
+      '.any.js',
+      '.any.html',
+      '.window.js',
+      '.window.html',
+      '.worker.js',
+      '.worker.html'],
+     ['-wpt/lint/duplicate_basename_path', '-wpt/lint/worker_collision']),
 ]
 
 
@@ -631,6 +667,8 @@ def _all_categories():
     #        (which validate the consistency of the configuration
     #        settings against the known categories, etc).
     categories = categories.union(["pep8/W191", "pep8/W291", "pep8/E501", "pycodestyle/E501"])
+
+    categories = categories.union(wpt_lint_categories())
 
     if apple_additions():
         categories = categories.union(apple_additions().all_categories())
@@ -1273,3 +1311,14 @@ class StyleProcessor(ProcessorBase):
     def do_association_check(self, files, cwd, host=Host()):
         _log.debug("Running TestExpectations linter")
         TestExpectationsChecker.lint_test_expectations(files, self._configuration, cwd, self._increment_error_count, host=host)
+
+        wpt_dir = os.path.join('LayoutTests', *IMPORTED_WPT_DIR.split('/'))
+        wpt_paths = []
+        for abs_path in files:
+            rel_path = os.path.relpath(abs_path, cwd)
+            if rel_path.startswith(wpt_dir + os.sep):
+                wpt_rel = os.path.relpath(rel_path, wpt_dir)
+                wpt_paths.append(wpt_rel)
+        if wpt_paths:
+            wpt_repo_dir = os.path.join(cwd, wpt_dir)
+            run_wpt_lint(wpt_repo_dir, wpt_paths, self._configuration, self._increment_error_count)

--- a/Tools/Scripts/webkitpy/style/checkers/wpt.py
+++ b/Tools/Scripts/webkitpy/style/checkers/wpt.py
@@ -1,0 +1,99 @@
+# Copyright (C) 2026 Apple Inc. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1.  Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+# 2.  Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS'' AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR
+# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+"""Runs the web-platform-tests linter against changed WPT files."""
+
+import importlib.util
+import inspect
+import os
+
+from webkitpy.layout_tests.controllers.layout_test_finder import IMPORTED_WPT_DIR
+from webkitpy.w3c.wpt_linter import WPTLinter
+
+
+class WPTLintRulesImportError(Exception):
+    """Raised when WPT's tools/lint/rules.py is present but cannot be loaded.
+
+    Loud-fail so that upstream WPT changes (e.g. new non-stdlib imports in
+    rules.py) are noticed promptly rather than silently dropping the per-rule
+    subcategories from check-webkit-style.
+    """
+
+
+def _load_wpt_lint_rules_module():
+    """Return the executed rules.py module, or None if the file is absent.
+
+    Raises WPTLintRulesImportError if the file is present but fails to load.
+    """
+    rules_path = os.path.join('LayoutTests', *IMPORTED_WPT_DIR.split('/'), 'tools', 'lint', 'rules.py')
+    if not os.path.exists(rules_path):
+        return None
+    try:
+        spec = importlib.util.spec_from_file_location('_wpt_lint_rules', rules_path)
+        if spec is None or spec.loader is None:
+            raise WPTLintRulesImportError('Unable to create import spec for %s' % rules_path)
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+        return module
+    except WPTLintRulesImportError:
+        raise
+    except Exception as e:
+        raise WPTLintRulesImportError(
+            'Failed to load WPT lint rules from %s: %s' % (rules_path, e)
+        ) from e
+
+
+def _normalize_rule_name(rule):
+    """Normalize WPT rule names to webkitpy.style categories.
+
+    For example "WORKER COLLISION" is transformed to "worker_collision".
+    """
+    return rule.lower().replace(' ', '_').replace('-', '_')
+
+
+def wpt_lint_categories():
+    """Return ``wpt/lint/<rule>`` categories derived from WPT's rules.py."""
+    categories = {'wpt/lint'}
+    module = _load_wpt_lint_rules_module()
+    if module is None:
+        return categories
+    for obj in vars(module).values():
+        if inspect.isclass(obj) and isinstance(getattr(obj, 'name', None), str):
+            categories.add('wpt/lint/' + _normalize_rule_name(obj.name))
+    return categories
+
+
+def run_wpt_lint(wpt_repo_dir, wpt_paths, configuration, increment_error_count):
+    """Run the WPT linter and report each error via the style configuration."""
+    for error in WPTLinter(wpt_repo_dir).lint(wpt_paths):
+        file_path = os.path.join('LayoutTests', *IMPORTED_WPT_DIR.split('/'), error['path'])
+        line_number = error['lineno'] if error['lineno'] is not None else '-'
+        category = 'wpt/lint/' + _normalize_rule_name(error['rule'])
+        if configuration.is_reportable(category=category, confidence_in_error=5, file_path=file_path):
+            configuration.write_style_error(
+                category=category,
+                confidence_in_error=5,
+                file_path=file_path,
+                line_number=line_number,
+                message='[%s] %s' % (error['rule'], error['message']),
+            )
+            increment_error_count()

--- a/Tools/Scripts/webkitpy/style/checkers/wpt_unittest.py
+++ b/Tools/Scripts/webkitpy/style/checkers/wpt_unittest.py
@@ -1,0 +1,164 @@
+# Copyright (C) 2026 Apple Inc. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1.  Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+# 2.  Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS'' AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR
+# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+import os
+import tempfile
+import textwrap
+import unittest
+from unittest.mock import MagicMock, patch
+
+from webkitpy.style.checkers.wpt import (
+    WPTLintRulesImportError,
+    _load_wpt_lint_rules_module,
+    _normalize_rule_name,
+    run_wpt_lint,
+    wpt_lint_categories,
+)
+
+
+class RunWPTLintTest(unittest.TestCase):
+    @patch('webkitpy.style.checkers.wpt.WPTLinter')
+    def test_no_errors(self, MockLinter):
+        mock_instance = MagicMock()
+        mock_instance.lint.return_value = iter([])
+        MockLinter.return_value = mock_instance
+
+        configuration = MagicMock()
+        increment = MagicMock()
+
+        run_wpt_lint('/wpt', ['css/test.html'], configuration, increment)
+
+        mock_instance.lint.assert_called_once_with(['css/test.html'])
+        configuration.write_style_error.assert_not_called()
+        increment.assert_not_called()
+
+    @patch('webkitpy.style.checkers.wpt.WPTLinter')
+    def test_reports_each_error(self, MockLinter):
+        mock_instance = MagicMock()
+        mock_instance.lint.return_value = iter([
+            {'path': 'css/a.html', 'lineno': 12, 'rule': 'TRAILING WHITESPACE', 'message': 'trailing'},
+            {'path': 'css/b.html', 'lineno': None, 'rule': 'PARSE-FAILED', 'message': 'parse failed'},
+        ])
+        MockLinter.return_value = mock_instance
+
+        configuration = MagicMock()
+        configuration.is_reportable.return_value = True
+        increment = MagicMock()
+
+        run_wpt_lint('/wpt', ['css/a.html', 'css/b.html'], configuration, increment)
+
+        self.assertEqual(configuration.write_style_error.call_count, 2)
+        self.assertEqual(increment.call_count, 2)
+
+        first_call = configuration.write_style_error.call_args_list[0]
+        self.assertEqual(first_call.kwargs['category'], 'wpt/lint/trailing_whitespace')
+        self.assertEqual(first_call.kwargs['confidence_in_error'], 5)
+        self.assertEqual(first_call.kwargs['line_number'], 12)
+        self.assertIn('TRAILING WHITESPACE', first_call.kwargs['message'])
+        self.assertIn('trailing', first_call.kwargs['message'])
+        self.assertTrue(first_call.kwargs['file_path'].endswith('css/a.html'))
+
+        second_call = configuration.write_style_error.call_args_list[1]
+        self.assertEqual(second_call.kwargs['category'], 'wpt/lint/parse_failed')
+        self.assertEqual(second_call.kwargs['line_number'], '-')
+
+    @patch('webkitpy.style.checkers.wpt.WPTLinter')
+    def test_filtered_out_errors_are_not_counted(self, MockLinter):
+        mock_instance = MagicMock()
+        mock_instance.lint.return_value = iter([
+            {'path': 'css/a.html', 'lineno': 1, 'rule': 'DUPLICATE-BASENAME-PATH', 'message': 'm'},
+        ])
+        MockLinter.return_value = mock_instance
+
+        configuration = MagicMock()
+        configuration.is_reportable.return_value = False
+        increment = MagicMock()
+
+        run_wpt_lint('/wpt', ['css/a.html'], configuration, increment)
+
+        configuration.is_reportable.assert_called_once()
+        self.assertEqual(
+            configuration.is_reportable.call_args.kwargs['category'],
+            'wpt/lint/duplicate_basename_path')
+        configuration.write_style_error.assert_not_called()
+        increment.assert_not_called()
+
+
+class NormalizeRuleNameTest(unittest.TestCase):
+    def test_spaces_and_hyphens_become_underscores(self):
+        self.assertEqual(_normalize_rule_name('WORKER COLLISION'), 'worker_collision')
+        self.assertEqual(_normalize_rule_name('DUPLICATE-BASENAME-PATH'), 'duplicate_basename_path')
+        self.assertEqual(_normalize_rule_name('MISSING-LINK'), 'missing_link')
+        self.assertEqual(_normalize_rule_name('MOJOM-JS'), 'mojom_js')
+        self.assertEqual(_normalize_rule_name('GITIGNORE'), 'gitignore')
+
+
+class WPTLintCategoriesTest(unittest.TestCase):
+    def test_happy_path_contains_known_rules(self):
+        categories = wpt_lint_categories()
+        self.assertIn('wpt/lint', categories)
+        self.assertIn('wpt/lint/duplicate_basename_path', categories)
+        self.assertIn('wpt/lint/worker_collision', categories)
+
+    @patch('webkitpy.style.checkers.wpt.os.path.exists', return_value=False)
+    def test_rules_file_absent_returns_only_coarse_category(self, _mock_exists):
+        self.assertEqual(wpt_lint_categories(), {'wpt/lint'})
+
+    def test_broken_rules_file_raises(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            rules_dir = os.path.join(tmpdir, 'tools', 'lint')
+            os.makedirs(rules_dir)
+            with open(os.path.join(rules_dir, 'rules.py'), 'w') as f:
+                f.write('this is not valid python (\n')
+
+            # Patch IMPORTED_WPT_DIR to be relative from LayoutTests to tmpdir
+            layout_tests_dir = 'LayoutTests'
+            rel_from_layout_tests = os.path.relpath(tmpdir, layout_tests_dir)
+            with patch('webkitpy.style.checkers.wpt.IMPORTED_WPT_DIR', rel_from_layout_tests):
+                self.assertRaises(WPTLintRulesImportError, _load_wpt_lint_rules_module)
+
+
+class LoadWPTLintRulesModuleTest(unittest.TestCase):
+    def test_executes_stub_rules_module(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            rules_dir = os.path.join(tmpdir, 'tools', 'lint')
+            os.makedirs(rules_dir)
+            with open(os.path.join(rules_dir, 'rules.py'), 'w') as f:
+                f.write(textwrap.dedent("""
+                    class Rule:
+                        pass
+
+                    class A(Rule):
+                        name = "FOO BAR"
+
+                    class B(Rule):
+                        name = "BAZ-QUX"
+                """))
+
+            # Patch IMPORTED_WPT_DIR to be relative from LayoutTests to tmpdir
+            layout_tests_dir = 'LayoutTests'
+            rel_from_layout_tests = os.path.relpath(tmpdir, layout_tests_dir)
+            with patch('webkitpy.style.checkers.wpt.IMPORTED_WPT_DIR', rel_from_layout_tests):
+                categories = wpt_lint_categories()
+
+        self.assertIn('wpt/lint/foo_bar', categories)
+        self.assertIn('wpt/lint/baz_qux', categories)

--- a/Tools/Scripts/webkitpy/w3c/test_exporter.py
+++ b/Tools/Scripts/webkitpy/w3c/test_exporter.py
@@ -366,7 +366,12 @@ class WebPlatformTestExporter(object):
             self._filesystem.remove(git_patch_file)
 
         if self._options.use_linter:
-            lint_errors = self._linter.lint()
+            lint_errors = 0
+            for error in self._linter.lint():
+                _log.error("[%s] %s:%s %s",
+                           error['rule'], error['path'],
+                           error['lineno'] or '?', error['message'])
+                lint_errors += 1
             if lint_errors:
                 _log.error(f'The wpt linter detected {lint_errors} linting error(s). Please address the above errors before attempting to export changes to the web-platform-test repository.')
                 self.delete_local_branch(is_success=False)

--- a/Tools/Scripts/webkitpy/w3c/test_exporter_unittest.py
+++ b/Tools/Scripts/webkitpy/w3c/test_exporter_unittest.py
@@ -90,7 +90,7 @@ class TestExporterTest(testing.PathTestCase):
 
         def lint(self):
             self.calls.append('lint')
-            return 0
+            return iter([])
 
     def test_export(self):
         with OutputCapture(level=logging.INFO) as captured, bmocks.Bugzilla(self.BUGZILLA_URL.split('://')[1], issues=bmocks.ISSUES, environment=wkmocks.Environment(

--- a/Tools/Scripts/webkitpy/w3c/wpt_linter.py
+++ b/Tools/Scripts/webkitpy/w3c/wpt_linter.py
@@ -24,13 +24,46 @@
  This script is a wrapper for the web-platform-tests linter
 """
 
+import json
+import logging
+import os
 import subprocess
+import tempfile
+
+_log = logging.getLogger(__name__)
 
 
 class WPTLinter(object):
-    def __init__(self, repository_directory, filesystem):
+    def __init__(self, repository_directory):
         self.wpt_path = repository_directory
 
-    def lint(self):
-        proc = subprocess.Popen(['./wpt', 'lint'], cwd=self.wpt_path)
-        return proc.wait()
+    def lint(self, paths=None):
+        """Yield each ``./wpt lint --json`` error dict."""
+        cmd = ['./wpt', 'lint', '--json', '--repo-root', '.']
+
+        if paths is not None:
+            paths_file = None
+            try:
+                with tempfile.NamedTemporaryFile(mode='w', suffix='.txt', delete=False) as f:
+                    paths_file = f.name
+                    for path in paths:
+                        f.write(path + '\n')
+                cmd.extend(['--paths-file', paths_file])
+                yield from self._run_lint(cmd)
+            finally:
+                if paths_file and os.path.exists(paths_file):
+                    os.unlink(paths_file)
+        else:
+            yield from self._run_lint(cmd)
+
+    def _run_lint(self, cmd):
+        _log.debug('Running WPT linter: %s (cwd=%s)', ' '.join(cmd), self.wpt_path)
+        result = subprocess.run(cmd, cwd=self.wpt_path, capture_output=True)
+        if result.stderr:
+            raise RuntimeError(
+                'WPT linter wrote to stderr:\n' + result.stderr.decode('utf-8', 'replace')
+            )
+        for line in result.stdout.splitlines():
+            if not line.strip():
+                continue
+            yield json.loads(line)


### PR DESCRIPTION
#### 1c2ce5ed31e54021f3cd06a3f3b3c149a50cc8e8
<pre>
[WPT export friction] Run WPT lint via check-webkit-style
<a href="https://bugs.webkit.org/show_bug.cgi?id=257853">https://bugs.webkit.org/show_bug.cgi?id=257853</a>
<a href="https://rdar.apple.com/110843279">rdar://110843279</a>

Reviewed by Simon Fraser.

Integrate the WPT linter into check-webkit-style so that WPT lint
errors are reported as wpt/lint/&lt;rule&gt; style categories
(e.g. wpt/lint/trailing_whitespace). Individual rules can be
suppressed with the standard --filter mechanism, and errors appear
inline alongside other style violations.

The available rule names are derived dynamically from the upstream WPT
tools/lint/rules.py file. Path-based filter rules suppress known false
positives for WebKit-specific import artifacts: w3c-import.log,
-expected.txt, and the generated .html shims that import-w3c-tests
creates from templated test sources (.any.js, .window.js, .worker.js).

WPTLinter.lint() now yields structured error dicts (from --json
output) instead of returning a return code, which both
check-webkit-style and the WPT test exporter consume.

* Tools/Scripts/webkitpy/layout_tests/controllers/layout_test_finder.py:
(LayoutTestFinder):
(LayoutTestFinder.is_wpt_crash_test):
* Tools/Scripts/webkitpy/style/checker.py:
(_all_categories):
(StyleProcessor.do_association_check):
* Tools/Scripts/webkitpy/style/checkers/wpt.py: Added.
(WPTLintRulesImportError):
(_load_wpt_lint_rules_module):
(_normalize_rule_name):
(wpt_lint_categories):
(run_wpt_lint):
* Tools/Scripts/webkitpy/style/checkers/wpt_unittest.py: Added.
(RunWPTLintTest):
(RunWPTLintTest.test_no_errors):
(RunWPTLintTest.test_reports_each_error):
(RunWPTLintTest.test_filtered_out_errors_are_not_counted):
(NormalizeRuleNameTest):
(NormalizeRuleNameTest.test_spaces_and_hyphens_become_underscores):
(WPTLintCategoriesTest):
(WPTLintCategoriesTest.test_happy_path_contains_known_rules):
(WPTLintCategoriesTest.test_rules_file_absent_returns_only_coarse_category):
(WPTLintCategoriesTest.test_broken_rules_file_raises):
(LoadWPTLintRulesModuleTest):
(LoadWPTLintRulesModuleTest.test_executes_stub_rules_module):
* Tools/Scripts/webkitpy/w3c/test_exporter.py:
(WebPlatformTestExporter.do_export):
* Tools/Scripts/webkitpy/w3c/test_exporter_unittest.py:
(TestExporterTest.MockWPTLinter.lint):
* Tools/Scripts/webkitpy/w3c/wpt_linter.py:
(WPTLinter.__init__):
(WPTLinter.lint):
(WPTLinter):
(WPTLinter._run_lint):

Co-Authored-By: Simon Fraser &lt;simon.fraser@apple.com&gt;
Canonical link: <a href="https://commits.webkit.org/312533@main">https://commits.webkit.org/312533@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/78c5c6bf387c7811405def523a6908b01f9ffde9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/160021 "4 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/33491 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/26595 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/168900 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/114402 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/161890 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/33594 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/33493 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/124026 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/86985 "2 failures") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/162979 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/26276 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/143724 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/104641 "Passed tests") | | ⏳ 🛠 vision-apple 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/159341 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/25329 "Passed tests") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/23814 "Found 2 new API test failures: TestWebKitAPI.WKWebExtension.LoadFromMacAppExtensionBundle, TestWebKitAPI.ParserYieldTokenTests.AsyncScriptRunsWhenFetched (failure)") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/16642 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/135020 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/21493 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/171381 "Built successfully") | | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/23131 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/132289 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/33167 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/27896 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/132315 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35829 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/33152 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/143288 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/91302 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/26931 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/20101 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/32661 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/32159 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/32405 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/32309 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->