### PR TITLE
[AppKit Gestures] Unable to invoke context menus on highlighted text via click

### DIFF
--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
@@ -2329,11 +2329,15 @@ inline OptionSet<WebKit::FindOptions> toFindOptions(WKFindConfiguration *configu
 static RetainPtr<NSDictionary> dictionaryRepresentationForEditorState(const WebKit::EditorState& state)
 {
     if (!state.hasPostLayoutData())
-        return @{ @"post-layout-data" : @NO };
+        return @{
+            @"post-layout-data" : @NO,
+            @"selection-type": @(static_cast<NSInteger>(state.selectionType)),
+        };
 
     auto& postLayoutData = *state.postLayoutData;
     return @{
         @"post-layout-data" : @YES,
+        @"selection-type": @(static_cast<NSInteger>(state.selectionType)),
         @"bold": postLayoutData.typingAttributes.contains(WebKit::TypingAttribute::Bold) ? @YES : @NO,
         @"italic": postLayoutData.typingAttributes.contains(WebKit::TypingAttribute::Italics) ? @YES : @NO,
         @"underline": postLayoutData.typingAttributes.contains(WebKit::TypingAttribute::Underline) ? @YES : @NO,

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewConfiguration+Extras.swift
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewConfiguration+Extras.swift
@@ -73,6 +73,10 @@ extension WKWebViewConfiguration {
         if let processPool = wrapped.processPool {
             self.processPool = processPool
         }
+
+        #if os(macOS)
+        self._requiresUserActionForEditingControlsManager = wrapped.requiresUserActionForEditingControlsManager
+        #endif
     }
 }
 

--- a/Source/WebKit/UIProcess/API/Swift/WebPage+Configuration.swift
+++ b/Source/WebKit/UIProcess/API/Swift/WebPage+Configuration.swift
@@ -167,6 +167,12 @@ extension WebPage {
         /// The process pool to use for the page, used for testing.
         @_spi(Testing)
         public var processPool: WKProcessPool? = nil
+
+        #if os(macOS)
+        /// If `false`, the editor state is always forced to update.
+        @_spi(Testing)
+        public var requiresUserActionForEditingControlsManager: Bool = false
+        #endif
     }
 }
 

--- a/Source/WebKit/UIProcess/API/Swift/WebPage.swift
+++ b/Source/WebKit/UIProcess/API/Swift/WebPage.swift
@@ -419,6 +419,9 @@ final public class WebPage {
     @ObservationIgnored
     private var indefiniteNavigations: [UUID: AsyncThrowingStream<NavigationEvent, any Error>.Continuation] = [:]
 
+    @ObservationIgnored
+    private var editorStateSnapshotsContinuations: [UUID: AsyncStream<EditorStateSnapshot>.Continuation] = [:]
+
     /// Loads the web content that the specified URL references and navigates to that content.
     ///
     /// Use this method to load a page from a local or network-based URL. For example, you might use this method
@@ -674,8 +677,28 @@ final public class WebPage {
     public func setMicrophoneCaptureState(_ state: WKMediaCaptureState) async {
         await backingWebView.setMicrophoneCaptureState(state)
     }
+}
 
-    // MARK: Helper functions
+// MARK: Helper functions
+
+extension WebPage {
+    private struct KeyValueObservations: ~Copyable {
+        var contents: [PartialKeyPath<WebPage>: NSKeyValueObservation] = [:]
+
+        deinit {
+            for (_, observation) in contents {
+                observation.invalidate()
+            }
+        }
+    }
+
+    func addEditorStateUpdate(_ newEditorState: [AnyHashable: Any]) {
+        let snapshot = EditorStateSnapshot(newEditorState)
+
+        for continuation in editorStateSnapshotsContinuations.values {
+            continuation.yield(snapshot)
+        }
+    }
 
     func addNavigationEvent(_ event: Result<NavigationEvent, any Error>, for cocoaNavigation: WKNavigation?) {
         if let cocoaNavigation {
@@ -798,24 +821,105 @@ extension WebPage.FullscreenState {
     }
 }
 
-extension WebPage {
-    private struct KeyValueObservations: ~Copyable {
-        var contents: [PartialKeyPath<WebPage>: NSKeyValueObservation] = [:]
+// MARK: Testing
 
-        deinit {
-            for (_, observation) in contents {
-                observation.invalidate()
-            }
+extension WebPage {
+    /// Represents details about the current editor state.
+    @_spi(Testing)
+    public struct EditorStateSnapshot: Sendable, Equatable {
+        /// The post-layout data associated with an editor state.
+        @_spi(Testing)
+        public struct PostLayoutData: Sendable, Equatable {
+            /// The current selection is bold.
+            @_spi(Testing)
+            public let bold: Bool
+
+            /// The current selection is italic.
+            @_spi(Testing)
+            public let italic: Bool
+
+            /// The current selection is underlined.
+            @_spi(Testing)
+            public let underline: Bool
+
+            /// The text alignment of the current selection.
+            @_spi(Testing)
+            public let textAlignment: NSTextAlignment
+
+            /// The CSS color string of the current selection.
+            @_spi(Testing)
+            public let textColor: Swift.String
         }
-    }
-}
 
-extension WebPage {
+        /// A type of selection.
+        @_spi(Testing)
+        public enum SelectionType: Int, Sendable, Equatable {
+            /// No selection.
+            case none
+
+            /// A caret selection.
+            case caret
+
+            /// A range selection.
+            case range
+        }
+
+        /// The current type of selection.
+        @_spi(Testing)
+        public let selectionType: SelectionType
+
+        /// The post-layout data of the editor state, if any.
+        @_spi(Testing)
+        public let postLayoutData: PostLayoutData?
+    }
+
     // SPI for testing.
     // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
     @_spi(Testing)
     public func terminateWebContentProcess() {
         backingWebView._killWebContentProcess()
+    }
+
+    /// An indefinite sequence of editor state snapshot changes for this page.
+    @_spi(Testing)
+    public func editorStateSnapshots() -> some AsyncSequence<EditorStateSnapshot, Never> & Sendable {
+        let id = UUID()
+
+        let (stream, continuation) = AsyncStream.makeStream(of: EditorStateSnapshot.self)
+        continuation.onTermination = { [weak self] termination in
+            guard let self else {
+                return
+            }
+            Task { @MainActor in
+                editorStateSnapshotsContinuations[id] = nil
+            }
+        }
+
+        editorStateSnapshotsContinuations[id] = continuation
+        return stream
+    }
+}
+
+extension WebPage.EditorStateSnapshot {
+    init(_ dictionary: [AnyHashable: Any]) {
+        // The Objective-C interface this is converting from is not able to express at compile-time that this is guaranteed.
+        // swift-format-ignore: NeverForceUnwrap
+        self.selectionType = SelectionType(rawValue: dictionary["selection-type"] as! SelectionType.RawValue)!
+
+        guard let postLayoutData = dictionary["post-layout-data"] as? Bool, postLayoutData else {
+            self.postLayoutData = nil
+            return
+        }
+
+        // The Objective-C interface this is converting from is not able to express at compile-time that these are guaranteed.
+        // swift-format-ignore: NeverForceUnwrap
+        self.postLayoutData = .init(
+            bold: dictionary["bold"] as! Bool,
+            italic: dictionary["italic"] as! Bool,
+            underline: dictionary["underline"] as! Bool,
+            textAlignment: NSTextAlignment(rawValue: dictionary["text-alignment"] as! Int)!,
+            textColor: dictionary["text-color"] as! String
+        )
     }
 }
 

--- a/Source/WebKit/UIProcess/Cocoa/WKUIDelegateAdapter.swift
+++ b/Source/WebKit/UIProcess/Cocoa/WKUIDelegateAdapter.swift
@@ -147,6 +147,12 @@ final class WKUIDelegateAdapter: NSObject, WKUIDelegatePrivate {
     func _webView(_ webView: WKWebView!, geometryDidChange geometry: WKScrollGeometry) {
         owner?.backingWebView.geometryDidChange(WKScrollGeometryAdapter(geometry))
     }
+
+    // swift-format-ignore: NoLeadingUnderscores
+    @objc(_webView:editorStateDidChange:)
+    func _webView(_ webView: WKWebView, editorStateDidChange editorState: [AnyHashable: Any]) {
+        owner?.addEditorStateUpdate(editorState)
+    }
 }
 
 #endif

--- a/Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm
+++ b/Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm
@@ -2402,6 +2402,8 @@ bool WebPage::shouldAllowSingleClickToChangeSelection(WebCore::Node& targetNode,
 
 void WebPage::selectWithGesture(const IntPoint& point, GestureType gestureType, GestureRecognizerState gestureState, bool isInteractingWithFocusedElement, CompletionHandler<void(const WebCore::IntPoint&, GestureType, GestureRecognizerState, OptionSet<SelectionFlags>)>&& completionHandler)
 {
+    SetForScope userIsInteractingChange { m_userIsInteracting, true };
+
     if (gestureState == GestureRecognizerState::Began)
         updateFocusBeforeSelectingTextAtLocation(point);
 
@@ -2761,6 +2763,8 @@ void WebPage::setSelectionRange(WebCore::IntPoint point, WebCore::TextGranularit
 
 void WebPage::updateSelectionWithExtentPointAndBoundary(WebCore::IntPoint point, WebCore::TextGranularity granularity, bool isInteractingWithFocusedElement, TextInteractionSource source, CompletionHandler<void(bool)>&& callback)
 {
+    SetForScope userIsInteractingChange { m_userIsInteracting, true };
+
     RefPtr frame = m_page->focusController().focusedOrMainFrame();
     if (!frame)
         return callback(false);
@@ -2864,6 +2868,8 @@ void WebPage::updateSelectionWithExtentPoint(WebCore::IntPoint point, bool isInt
 
 void WebPage::selectTextWithGranularityAtPoint(WebCore::IntPoint point, WebCore::TextGranularity granularity, bool isInteractingWithFocusedElement, CompletionHandler<void()>&& completionHandler)
 {
+    SetForScope userIsInteractingChange { m_userIsInteracting, true };
+
 #if PLATFORM(IOS_FAMILY)
     if (!m_potentialTapNode) {
         setSelectionRange(point, granularity, isInteractingWithFocusedElement);

--- a/Tools/TestWebKitAPI/Helpers/cocoa/Foundation+Extras.swift
+++ b/Tools/TestWebKitAPI/Helpers/cocoa/Foundation+Extras.swift
@@ -21,7 +21,10 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
 // THE POSSIBILITY OF SUCH DAMAGE.
 
+public import CoreGraphics
 import Foundation
+private import Synchronization
+
 import struct Foundation.URL
 import struct Swift.String
 
@@ -78,4 +81,123 @@ extension StringProtocol {
 
         return start..<end
     }
+}
+
+extension CGRect {
+    /// The center point of this rect.
+    public var center: CGPoint {
+        .init(x: midX, y: midY)
+    }
+}
+
+/// A type used to model an asynchronous promise, via a Semaphore-like interface.
+public struct Future: Sendable, ~Copyable {
+    private enum State {
+        case initial
+        case waiting(CheckedContinuation<Void, Never>)
+        case signaled
+    }
+
+    private let state = Mutex<State>(.initial)
+
+    /// Create a new Future.
+    public init() {
+    }
+
+    /// Resolves the promise of this Future.
+    public func signal() {
+        let continuation = state.withLock { state -> CheckedContinuation<Void, Never>? in
+            defer {
+                state = .signaled
+            }
+
+            if case .waiting(let continuation) = state {
+                return continuation
+            }
+
+            return nil
+        }
+        continuation?.resume()
+    }
+
+    /// Waits for the promise of this Future to be resolved.
+    public func wait() async {
+        await withCheckedContinuation { continuation in
+            let resumeImmediately = state.withLock { state in
+                switch state {
+                case .signaled:
+                    return true
+
+                case .initial:
+                    state = .waiting(continuation)
+                    return false
+
+                case .waiting:
+                    preconditionFailure("Future only supports a single waiter")
+                }
+            }
+
+            if resumeImmediately {
+                continuation.resume()
+            }
+        }
+    }
+}
+
+/// Temporarily replaces the implementation of an Objective-C class method with a custom block implementation for the lifetime of `body`.
+///
+/// For example, given a type
+///
+/// ```swift
+/// @objc public class MyObjectiveCType: NSObject {
+///     dynamic class func add(a: Int, b: Int) -> Int {
+///         a + b
+///     }
+/// }
+/// ```
+///
+/// then the implementation of `add` can be temporarily replaced:
+///
+/// ```swift
+/// let newImplementation = @convention(block) (MyObjectiveCType.Type, Int, Int) -> Int = { _, a, b in
+///     a - b
+/// }
+///
+/// let result = withSwizzledObjectiveCClassMethod(
+///     class: MyObjectiveCType.self,
+///     replacing: #selector(MyObjectiveCType.add(a:b:)),
+///     with: newImplementation
+/// ) {
+///     MyObjectiveCType.add(a: 5, b: 3)
+/// }
+///
+/// // result is now `2`.
+/// ```
+///
+/// - Parameters:
+///   - class: The class whose selector should be replaced.
+///   - selector: The selector to be replaced.
+///   - implementationBlock: A block that will be used as the new implementation.
+///   - body: The code to execute with the replaced implementation.
+/// - Throws: Any error thrown by `body`.
+/// - Returns: The return value of `body`.
+/// - Note: The signature of `implementationBlock` must match exactly; if it does not, undefined behavior will occur.
+@discardableResult
+nonisolated(nonsending) public func withSwizzledObjectiveCClassMethod<Result, Failure>(
+    class: AnyClass,
+    replacing selector: Selector,
+    with implementationBlock: Any,
+    perform body: nonisolated(nonsending) () async throws(Failure) -> sending Result
+) async throws(Failure) -> sending Result where Result: ~Copyable, Failure: Error {
+    guard let method = unsafe class_getClassMethod(`class`, selector) else {
+        preconditionFailure("failed to get class method")
+    }
+
+    let originalImplementation = unsafe method_setImplementation(method, imp_implementationWithBlock(implementationBlock))
+
+    defer {
+        unsafe method_setImplementation(method, originalImplementation)
+    }
+
+    return try await body()
 }

--- a/Tools/TestWebKitAPI/Helpers/cocoa/JavaScriptMessages.swift
+++ b/Tools/TestWebKitAPI/Helpers/cocoa/JavaScriptMessages.swift
@@ -31,8 +31,8 @@ public enum JavaScriptMessages {
 }
 
 extension JavaScriptMessages {
-    /// Gets the bounding client rect of the current selection.
-    public struct SelectionBoundingClientRect: WebPage.JavaScriptExpression {
+    /// Gets the bounding client rect of an element.
+    public struct BoundingClientRect: WebPage.JavaScriptExpression {
         // Protocol conformance.
         // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
         public typealias Output = DOMRect
@@ -41,21 +41,50 @@ extension JavaScriptMessages {
         // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
         public static var expression: String {
             """
-            const selection = window.getSelection();
+            const range = document.createRange();
 
-            const range = selection.getRangeAt(0);
+            if (selection.kind === "range") {
+                const baseNode = document.getElementById(selection.base.container).firstChild;
+                const extentNode = document.getElementById(selection.extent.container).firstChild;
+                range.setStart(baseNode, selection.base.offset)
+                range.setEnd(extentNode, selection.extent.offset);
+            } else {
+                const node = document.getElementById(selection.position.container).firstChild;
+                range.setStart(node, selection.position.offset)
+                range.setEnd(node, selection.position.offset);
+            }
+
             return range.getBoundingClientRect().toJSON();
             """
         }
 
-        /// Create a new `SelectionBoundingClientRect`.
-        public init() {
+        private let selection: JavaScriptSelection
+
+        /// Create a `BoundingClientRect` expression from the given selection.
+        ///
+        /// - Parameter selection: The selection that will be set.
+        public init(_ selection: JavaScriptSelection) {
+            self.selection = selection
+        }
+
+        /// A convenience initializer for a range selection.
+        ///
+        /// - Parameters:
+        ///   - container: The container the range is relative to.
+        ///   - range: The range of the selection within the container.
+        public init(in container: String, range: Range<Int>) {
+            self.selection = .range(
+                base: .init(in: container, at: range.lowerBound),
+                extent: .init(in: container, at: range.upperBound),
+            )
         }
 
         // Protocol conformance.
         // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
         public func encoded() -> [String: Any?] {
-            [:]
+            [
+                "selection": selection.encoded()
+            ]
         }
     }
 }

--- a/Tools/TestWebKitAPI/Tests/WebKit/WebPage/AppKitGesturesTests.swift
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WebPage/AppKitGesturesTests.swift
@@ -24,7 +24,7 @@
 #if HAVE_APPKIT_GESTURES_SUPPORT
 
 import Foundation
-@_spi(WebKitAdditions_Testing) import WebKit
+@_spi(WebKitAdditions_Testing) @_spi(Testing) import WebKit
 import SwiftUI
 import struct Swift.String
 import struct _Concurrency.Task
@@ -32,6 +32,7 @@ private import struct TestWebKitAPILibrary.DOMRect
 import Testing
 private import TestWebKitAPILibrary
 private import Recap
+private import AppKit_Private.NSMenu_Private
 
 private actor Recap {
     static let shared = Recap()
@@ -48,6 +49,233 @@ private actor Recap {
         await RCPInlinePlayer.play(eventStream, options: .init())
     }
 }
+
+@MainActor
+@Suite(.serialized)
+struct AppKitGesturesTests {
+    private static let text = "Here's to the crazy ones."
+
+    private let recap = Recap.shared
+
+    private let page: WebPage = {
+        var configuration = WebPage.Configuration()
+        configuration.requiresUserActionForEditingControlsManager = true
+        return WebPage(configuration: configuration)
+    }()
+
+    private let window: NSWindow
+
+    init() async throws {
+        let contentSize = NSSize(width: 800, height: 600)
+
+        self.window = NSWindow(size: contentSize) { [page] in
+            WebView(page)
+        }
+
+        self.window.setFrameOrigin(.zero)
+        NSApp.activate(ignoringOtherApps: true)
+        self.window.makeKeyAndOrderFront(nil)
+    }
+
+    @Test(arguments: [true, false])
+    func updatingTextRangeSelectionByUserInteractionUpdatesEditorState(contentEditable: Bool) async throws {
+        try await loadHTML(contentEditable: contentEditable)
+
+        let toBounds = try await screenBoundsOfText("to")
+        let crazyBounds = try await screenBoundsOfText("crazy")
+
+        let editorStateSnapshots = page.editorStateSnapshots()
+
+        // Recap requires this test to be ran within an app host.
+        guard NSApp.isActive else {
+            return
+        }
+
+        await recap.play { composer in
+            composer._wk_click(toBounds.center)
+
+            composer.advanceTime(0.1)
+
+            composer.drag(withStart: toBounds.center, end: crazyBounds.center, duration: 1)
+
+            composer.advanceTime(0.1)
+
+            composer._wk_mouseUp()
+        }
+
+        let firstRangeEditorState = try await #require(
+            editorStateSnapshots.first { @Sendable state in
+                state.selectionType == .range
+            }
+        )
+
+        #expect(firstRangeEditorState.postLayoutData != nil)
+    }
+
+    @Test(arguments: [true, false])
+    func clickingOnSelectedWordOpensContextMenu(contentEditable: Bool) async throws {
+        try await loadHTML(contentEditable: contentEditable)
+
+        let crazyRange = try #require(Self.text.utf16Range(of: "crazy"))
+        let crazySelection = JavaScriptSelection.range(
+            base: .init(in: "div", at: crazyRange.lowerBound),
+            extent: .init(in: "div", at: crazyRange.upperBound)
+        )
+        try await page.callJavaScript(JavaScriptMessages.SetSelection(crazySelection))
+
+        let crazyBoundsInScreenCoordinates = try await screenBoundsOfText("crazy")
+
+        await page.waitForNextPresentationUpdate()
+
+        // Recap requires this test to be ran within an app host.
+        guard NSApp.isActive else {
+            return
+        }
+
+        let future = Future()
+
+        let implementation: @convention(block) (NSMenu.Type, NSMenu, _NSViewMenuContext, NSView, (@convention(block) () -> Void)?) -> Void =
+            { _, menu, context, view, completion in
+                completion?()
+
+                #expect(view is WKWebView)
+
+                future.signal()
+            }
+
+        await withSwizzledObjectiveCClassMethod(
+            class: NSMenu.self,
+            replacing: #selector(NSMenu._popUpContextMenu(_:with:for:) as (NSMenu, _NSViewMenuContext, NSView) async -> Void),
+            with: implementation
+        ) {
+            await recap.play { composer in
+                composer._wk_click(crazyBoundsInScreenCoordinates.center)
+            }
+
+            await future.wait()
+        }
+
+        await page.waitForNextPresentationUpdate()
+
+        let newSelection = try await page.callJavaScript(JavaScriptMessages.GetSelection())
+
+        #expect(newSelection == crazySelection)
+    }
+
+    @Test(arguments: [true, false])
+    func doubleClickingInWordSelectsWord(contentEditable: Bool) async throws {
+        try await loadHTML(contentEditable: contentEditable)
+
+        let crazyRange = try #require(Self.text.utf16Range(of: "crazy"))
+        let crazySelection = JavaScriptSelection.range(
+            base: .init(in: "div", at: crazyRange.lowerBound),
+            extent: .init(in: "div", at: crazyRange.upperBound)
+        )
+
+        let crazyBoundsInScreenCoordinates = try await screenBoundsOfText("crazy")
+
+        try await page.callJavaScript(JavaScriptMessages.SetSelection(in: "div", offset: 0))
+
+        await page.waitForNextPresentationUpdate()
+
+        // Recap requires this test to be ran within an app host.
+        guard NSApp.isActive else {
+            return
+        }
+
+        await recap.play { composer in
+            composer._wk_click(crazyBoundsInScreenCoordinates.center)
+            composer.advanceTime(0.1)
+            composer._wk_click(crazyBoundsInScreenCoordinates.center)
+        }
+
+        await page.waitForNextPresentationUpdate()
+
+        let newSelection = try await page.callJavaScript(JavaScriptMessages.GetSelection())
+
+        #expect(newSelection == crazySelection)
+    }
+
+    @Test(arguments: [0.1, 0.5, 0.9])
+    func clickingInWordChangesSelection(fractionOfWordToClick: Double) async throws {
+        try await loadHTML(contentEditable: true)
+
+        let crazyRange = try #require(Self.text.utf16Range(of: "crazy"))
+
+        let crazyBoundsInScreenCoordinates = try await screenBoundsOfText("crazy")
+
+        let point = CGPoint(
+            x: crazyBoundsInScreenCoordinates.origin.x + (crazyBoundsInScreenCoordinates.size.width * fractionOfWordToClick),
+            y: crazyBoundsInScreenCoordinates.midY
+        )
+
+        try await page.callJavaScript(JavaScriptMessages.SetSelection(in: "div", offset: 0))
+
+        await page.waitForNextPresentationUpdate()
+
+        // Recap requires this test to be ran within an app host.
+        guard NSApp.isActive else {
+            return
+        }
+
+        await recap.play { composer in
+            composer._wk_click(point)
+        }
+
+        await page.waitForNextPresentationUpdate()
+
+        // This is a rough approximation of the heuristic the implementation uses.
+        let offset = fractionOfWordToClick < 0.2 ? crazyRange.lowerBound : crazyRange.upperBound
+
+        let newSelection = try await page.callJavaScript(JavaScriptMessages.GetSelection())
+        #expect(newSelection == .collapsed(.init(in: "div", at: offset)))
+    }
+
+    @Test
+    func clickingChangesSelection() async throws {
+        try await loadHTML(contentEditable: true)
+
+        let crazyRange = try #require(Self.text.utf16Range(of: "crazy"))
+        try await page.callJavaScript(JavaScriptMessages.SetSelection(in: "div", range: crazyRange))
+
+        let crazyBoundsInViewportCoordinates = try await CGRect(
+            page.callJavaScript(JavaScriptMessages.BoundingClientRect(in: "div", range: crazyRange))
+        )
+
+        let contentHeight = try #require(window.contentViewController?.view.frame.height)
+
+        let crazyBoundsInAppKitCoordinates = CGRect(
+            x: crazyBoundsInViewportCoordinates.minX,
+            y: contentHeight - crazyBoundsInViewportCoordinates.maxY,
+            width: crazyBoundsInViewportCoordinates.width,
+            height: crazyBoundsInViewportCoordinates.height,
+        )
+
+        try await page.callJavaScript(JavaScriptMessages.SetSelection(in: "div", offset: 0))
+
+        let waitForSelectionChange = """
+            return await new Promise(resolve => {
+                document.addEventListener("selectionchange", () => {
+                    const offset = window.getSelection().focusOffset;
+                    resolve(offset);
+                });
+            });
+            """
+
+        async let newSelection = page.callJavaScript(waitForSelectionChange) as? Int
+
+        // Ensure the JS `selectionchange` event listener is installed before performing the click.
+        await Task.yield()
+
+        page.click(at: crazyBoundsInAppKitCoordinates.center)
+
+        let selection = try await newSelection
+        let expected = "Here's to the cra".count
+        #expect(selection == expected)
+    }
+}
+
+// MARK: Helpers
 
 @MainActor
 private func convertToCoreGraphicsScreenCoordinates(rectInViewportCoordinates: DOMRect, window: NSWindow) -> CGRect {
@@ -80,170 +308,28 @@ private func convertToCoreGraphicsScreenCoordinates(rectInViewportCoordinates: D
     return inCoreGraphicsScreenCoordinates
 }
 
-@MainActor
-@Suite(.serialized)
-struct AppKitGesturesTests {
-    private static let text = "Here's to the crazy ones."
-
-    private static let html = """
-        <div id="div" contenteditable style="font-size: 30px;">\(text)</div>
-        """
-
-    private let recap = Recap.shared
-    private let page = WebPage()
-    private let window: NSWindow
-
-    init() async throws {
-        try await self.page.load(html: Self.html).wait()
-
-        let contentSize = NSSize(width: 800, height: 600)
-
-        self.window = NSWindow(size: contentSize) { [page] in
-            WebView(page)
-        }
-
-        self.window.setFrameOrigin(.zero)
-        NSApp.activate(ignoringOtherApps: true)
-        self.window.makeKeyAndOrderFront(nil)
-    }
-
-    @Test
-    func doubleClickingInWordSelectsWord() async throws {
-        let crazyRange = try #require(Self.text.utf16Range(of: "crazy"))
-        let crazySelection = JavaScriptSelection.range(
-            base: .init(in: "div", at: crazyRange.lowerBound),
-            extent: .init(in: "div", at: crazyRange.upperBound)
-        )
-        try await page.callJavaScript(JavaScriptMessages.SetSelection(crazySelection))
-
-        let crazyBoundsInViewportCoordinates = try await page.callJavaScript(JavaScriptMessages.SelectionBoundingClientRect())
-
-        let crazyBoundsInScreenCoordinates = convertToCoreGraphicsScreenCoordinates(
-            rectInViewportCoordinates: crazyBoundsInViewportCoordinates,
-            window: window
-        )
-
-        let point = CGPoint(
-            x: crazyBoundsInScreenCoordinates.midX,
-            y: crazyBoundsInScreenCoordinates.midY
-        )
-
-        try await page.callJavaScript(JavaScriptMessages.SetSelection(in: "div", offset: 0))
-
-        await page.waitForNextPresentationUpdate()
-
-        // Recap requires this test to be ran within an app host.
-        guard NSApp.isActive else {
-            return
-        }
-
-        await recap.play { composer in
-            composer._wk_click(point)
-            composer.advanceTime(0.1)
-            composer._wk_click(point)
-        }
-
-        await page.waitForNextPresentationUpdate()
-
-        let newSelection = try await page.callJavaScript(JavaScriptMessages.GetSelection())
-
-        #expect(newSelection == crazySelection)
-    }
-
-    @Test(arguments: [0.1, 0.5, 0.9])
-    func clickingInWordChangesSelection(fractionOfWordToClick: Double) async throws {
-        let crazyRange = try #require(Self.text.utf16Range(of: "crazy"))
-        try await page.callJavaScript(JavaScriptMessages.SetSelection(in: "div", range: crazyRange))
-
-        let crazyBoundsInViewportCoordinates = try await page.callJavaScript(JavaScriptMessages.SelectionBoundingClientRect())
-
-        let crazyBoundsInScreenCoordinates = convertToCoreGraphicsScreenCoordinates(
-            rectInViewportCoordinates: crazyBoundsInViewportCoordinates,
-            window: window
-        )
-
-        let point = CGPoint(
-            x: crazyBoundsInScreenCoordinates.origin.x + (crazyBoundsInScreenCoordinates.size.width * fractionOfWordToClick),
-            y: crazyBoundsInScreenCoordinates.midY
-        )
-
-        try await page.callJavaScript(JavaScriptMessages.SetSelection(in: "div", offset: 0))
-
-        await page.waitForNextPresentationUpdate()
-
-        // Recap requires this test to be ran within an app host.
-        guard NSApp.isActive else {
-            return
-        }
-
-        await recap.play { composer in
-            composer._wk_click(point)
-        }
-
-        await page.waitForNextPresentationUpdate()
-
-        // This is a rough approximation of the heuristic the implementation uses.
-        let offset = fractionOfWordToClick < 0.2 ? crazyRange.lowerBound : crazyRange.upperBound
-
-        let newSelection = try await page.callJavaScript(JavaScriptMessages.GetSelection())
-        #expect(newSelection == .collapsed(.init(in: "div", at: offset)))
-    }
-
-    @Test
-    func clickingChangesSelection() async throws {
-        let page = WebPage()
-
-        let text = "Here's to the crazy ones."
+extension AppKitGesturesTests {
+    private func loadHTML(contentEditable: Bool) async throws {
         let html = """
-            <div id="div" contenteditable style="font-size: 30px;">\(text)</div>
+            <div \(contentEditable ? "contenteditable" : "") id="div" style="font-size: 30px;">\(Self.text)</div>
             """
 
         try await page.load(html: html).wait()
+    }
 
-        let contentSize = NSSize(width: 800, height: 600)
+    private func screenBoundsOfText(_ text: String) async throws -> CGRect {
+        let range = try #require(Self.text.utf16Range(of: text))
 
-        let window = NSWindow(size: contentSize) {
-            WebView(page)
-        }
-
-        window.setFrameOrigin(.zero)
-        window.makeKeyAndOrderFront(nil)
-
-        let crazyRange = try #require(text.utf16Range(of: "crazy"))
-        try await page.callJavaScript(JavaScriptMessages.SetSelection(in: "div", range: crazyRange))
-
-        let crazyBoundsInViewportCoordinates = try await CGRect(page.callJavaScript(JavaScriptMessages.SelectionBoundingClientRect()))
-
-        let crazyBoundsInAppKitCoordinates = CGRect(
-            x: crazyBoundsInViewportCoordinates.minX,
-            y: contentSize.height - crazyBoundsInViewportCoordinates.maxY,
-            width: crazyBoundsInViewportCoordinates.width,
-            height: crazyBoundsInViewportCoordinates.height,
+        let viewportCoordinates = try await page.callJavaScript(
+            JavaScriptMessages.BoundingClientRect(in: "div", range: range)
         )
 
-        let middleOfCrazy = CGPoint(x: crazyBoundsInAppKitCoordinates.midX, y: crazyBoundsInAppKitCoordinates.midY)
+        let screenCoordinates = convertToCoreGraphicsScreenCoordinates(
+            rectInViewportCoordinates: viewportCoordinates,
+            window: window
+        )
 
-        try await page.callJavaScript(JavaScriptMessages.SetSelection(in: "div", offset: 0))
-
-        let waitForSelectionChange = """
-            return await new Promise(resolve => {
-                document.addEventListener("selectionchange", () => {
-                    const offset = window.getSelection().focusOffset;
-                    resolve(offset);
-                });
-            });
-            """
-
-        async let newSelection = page.callJavaScript(waitForSelectionChange) as? Int
-
-        // Ensure the JS `selectionchange` event listener is installed before performing the click.
-        await Task.yield()
-
-        page.click(at: middleOfCrazy)
-
-        let selection = try await newSelection
-        let expected = "Here's to the cra".count
-        #expect(selection == expected)
+        return screenCoordinates
     }
 }
 

--- a/Tools/TestWebKitAPI/Tests/WebKit/WebPage/JavaScriptExpressionTests.swift
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WebPage/JavaScriptExpressionTests.swift
@@ -145,7 +145,7 @@ struct JavaScriptExpressionTests {
 
         try await page.callJavaScript(JavaScriptMessages.SetSelection(selection))
 
-        let rect = try await page.callJavaScript(JavaScriptMessages.SelectionBoundingClientRect())
+        let rect = try await page.callJavaScript(JavaScriptMessages.BoundingClientRect(selection))
 
         #expect(rect.x > 0)
         #expect(rect.y > 0)
@@ -158,9 +158,11 @@ struct JavaScriptExpressionTests {
         let page = WebPage()
         try await page.load(html: Self.html).wait()
 
-        try await page.callJavaScript(JavaScriptMessages.SetSelection(.collapsed(.init(in: "div", at: 0))))
+        let selection: JavaScriptSelection = .collapsed(.init(in: "div", at: 0))
 
-        let rect = try await page.callJavaScript(JavaScriptMessages.SelectionBoundingClientRect())
+        try await page.callJavaScript(JavaScriptMessages.SetSelection(selection))
+
+        let rect = try await page.callJavaScript(JavaScriptMessages.BoundingClientRect(selection))
 
         #expect(rect.width == 0)
         #expect(rect.height > 0)


### PR DESCRIPTION
#### 620a1ea677f50d3d9af23ff22bedeee59eccc356
<pre>
[AppKit Gestures] Unable to invoke context menus on highlighted text via click
<a href="https://bugs.webkit.org/show_bug.cgi?id=313861">https://bugs.webkit.org/show_bug.cgi?id=313861</a>
<a href="https://rdar.apple.com/175290015">rdar://175290015</a>

Reviewed by Abrar Rahman Protyasha.

In `WKTextSelectionController`, the `if !hasSelection || !editorState.hasPostLayoutAndVisualData()` predicate
was evaluating to `true` because the editor state had no post-layout data. As a result, the system didn&apos;t try
to invoke a context menu.

This issue was happening only in Safari, and only in non-contenteditable regions, and only when there
is no prior user interaction, because:

1. In non-Safari clients, `m_requiresUserActionForEditingControlsManager` is set to `false`, meaning that
`WebPage::shouldAvoidComputingPostLayoutDataForEditorState` always returns `false` and therefore the editor
state is always updated. This is not true for Safari.

2. In contenteditable regions, there is a focused element, and so `m_userInteractionsSincePageTransition.add(UserInteractionFlag::FocusedElement);`
gets invoked, and `WebPage::shouldAvoidComputingPostLayoutDataForEditorState` once again returns false.

Therefore, in order for a non-contenteditable region in Safari to have its editor state updated, a user interaction
must happen. This was not happening in most of the cases in WKTextSelectionController, since several WebPage
functions like `WebPage::updateSelectionWithExtentPointAndBoundary` did not properly attribute user interaction.

Fix by updating the relevant methods to add a missing

```
SetForScope userIsInteractingChange { m_userIsInteracting, true };
```

Tests: Tools/TestWebKitAPI/Helpers/cocoa/Foundation+Extras.swift
       Tools/TestWebKitAPI/Helpers/cocoa/JavaScriptMessages.swift
       Tools/TestWebKitAPI/Tests/WebKit/WebPage/AppKitGesturesTests.swift
       Tools/TestWebKitAPI/Tests/WebKit/WebPage/JavaScriptExpressionTests.swift

* Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm:
(dictionaryRepresentationForEditorState):
* Source/WebKit/UIProcess/API/Cocoa/WKWebViewConfiguration+Extras.swift:
* Source/WebKit/UIProcess/API/Swift/WebPage+Configuration.swift:
(Configuration.requiresUserActionForEditingControlsManager):
* Source/WebKit/UIProcess/API/Swift/WebPage.swift:
(editorStateSnapshotsContinuations):
(KeyValueObservations.contents):
(addEditorStateUpdate(_:)):
(editorStateSnapshots):
(WebPage.terminateWebContentProcess): Deleted.
* Source/WebKit/UIProcess/Cocoa/WKUIDelegateAdapter.swift:
(WKUIDelegateAdapter._webView(_:editorStateDidChange:)):
* Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm:
(WebKit::WebPage::selectWithGesture):
(WebKit::WebPage::updateSelectionWithExtentPointAndBoundary):
(WebKit::WebPage::selectTextWithGranularityAtPoint):
* Tools/TestWebKitAPI/Helpers/cocoa/Foundation+Extras.swift:
(CGRect.center):
(State.signal):
(State.wait):
* Tools/TestWebKitAPI/Helpers/cocoa/JavaScriptMessages.swift:
(BoundingClientRect.expression):
(BoundingClientRect.encoded):
(SelectionBoundingClientRect.expression): Deleted.
(SelectionBoundingClientRect.encoded): Deleted.
* Tools/TestWebKitAPI/Tests/WebKit/WebPage/AppKitGesturesTests.swift:
(AppKitGesturesTests.updatingTextRangeSelectionByUserInteractionUpdatesEditorState(_:)):
(AppKitGesturesTests.clickingOnSelectedWordOpensContextMenu(_:)):
(AppKitGesturesTests.doubleClickingInWordSelectsWord(_:)):
(AppKitGesturesTests.clickingInWordChangesSelection(_:)):
(AppKitGesturesTests.clickingChangesSelection):
(convertToCoreGraphicsScreenCoordinates(_:window:)):
(AppKitGesturesTests.loadHTML(_:)):
(AppKitGesturesTests.screenBoundsOfText(_:)):
(AppKitGesturesTests.doubleClickingInWordSelectsWord): Deleted.
* Tools/TestWebKitAPI/Tests/WebKit/WebPage/JavaScriptExpressionTests.swift:
(JavaScriptExpressionTests.selectionBoundingClientRectReturnsNonEmptyRectForRangeSelection):
(JavaScriptExpressionTests.selectionBoundingClientRectReturnsZeroWidthRectForCollapsedSelection):

Canonical link: <a href="https://commits.webkit.org/312469@main">https://commits.webkit.org/312469@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/aa191c968d47b22fa6ce864f0eb5687a0059f862

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/160052 "5 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/33522 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/26626 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/168933 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/114433 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/161921 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/33625 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/33524 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/124052 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/114433 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/163010 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/26300 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/143755 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/104666 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/25353 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/23840 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/16673 "Built successfully") | | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/152108 "Build is in progress. Recent messages:") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/135044 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/21522 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/171413 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/17420 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/23160 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/132316 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/33198 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/27923 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/132342 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35795 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/33183 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/143317 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/91333 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/26953 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/20130 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/32692 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/99089 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/32190 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/32436 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/32340 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->