### PR TITLE
Introduce time-based website data eviction

### DIFF
--- a/Source/WTF/wtf/Seconds.h
+++ b/Source/WTF/wtf/Seconds.h
@@ -51,6 +51,7 @@ public:
     
     constexpr double value() const { return m_value; }
     
+    constexpr double days() const { return m_value / (3600 * 24); }
     constexpr double minutes() const { return m_value / 60; }
     constexpr double seconds() const { return m_value; }
     constexpr double milliseconds() const { return seconds() * 1000; }
@@ -58,6 +59,7 @@ public:
     constexpr double nanoseconds() const { return microseconds() * 1000; }
 
     // Keep in mind that Seconds is held in double. If the value is not in range of 53bit integer, the result may not be precise.
+    template<typename T> T daysAs() const { static_assert(std::is_integral<T>::value); return clampToAccepting64<T>(days()); }
     template<typename T> T minutesAs() const { static_assert(std::is_integral<T>::value); return clampToAccepting64<T>(minutes()); }
     template<typename T> T secondsAs() const { static_assert(std::is_integral<T>::value); return clampToAccepting64<T>(seconds()); }
     template<typename T> T millisecondsAs() const { static_assert(std::is_integral<T>::value); return clampToAccepting64<T>(milliseconds()); }

--- a/Source/WebKit/NetworkProcess/NetworkSession.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkSession.cpp
@@ -135,7 +135,7 @@ static Ref<NetworkStorageManager> createNetworkStorageManager(NetworkProcess& ne
     String serviceWorkerStorageDirectory;
     serviceWorkerStorageDirectory = parameters.serviceWorkerRegistrationDirectory;
     SandboxExtension::consumePermanently(parameters.serviceWorkerRegistrationDirectoryExtensionHandle);
-    return NetworkStorageManager::create(networkProcess, parameters.sessionID, parameters.dataStoreIdentifier, connectionID, parameters.generalStorageDirectory, parameters.localStorageDirectory, parameters.indexedDBDirectory, parameters.cacheStorageDirectory, serviceWorkerStorageDirectory, parameters.perOriginStorageQuota, parameters.originQuotaRatio, parameters.totalQuotaRatio, parameters.standardVolumeCapacity, parameters.volumeCapacityOverride, parameters.unifiedOriginStorageLevel, parameters.storageSiteValidationEnabled);
+    return NetworkStorageManager::create(networkProcess, parameters.sessionID, parameters.dataStoreIdentifier, connectionID, parameters.generalStorageDirectory, parameters.localStorageDirectory, parameters.indexedDBDirectory, parameters.cacheStorageDirectory, serviceWorkerStorageDirectory, parameters.perOriginStorageQuota, parameters.originQuotaRatio, parameters.totalQuotaRatio, parameters.standardVolumeCapacity, parameters.volumeCapacityOverride, parameters.unifiedOriginStorageLevel, parameters.storageSiteValidationEnabled, parameters.shouldPerformTimeBasedEviction, parameters.timeBasedEvictionThreshold, parameters.lastModificationTimeUpdateIntervalOverride);
 }
 
 #if ENABLE(WEB_PUSH_NOTIFICATIONS)

--- a/Source/WebKit/NetworkProcess/NetworkSessionCreationParameters.h
+++ b/Source/WebKit/NetworkProcess/NetworkSessionCreationParameters.h
@@ -126,6 +126,9 @@ struct NetworkSessionCreationParameters {
     bool serviceWorkerProcessTerminationDelayEnabled { true };
     bool inspectionForServiceWorkersAllowed { true };
     bool storageSiteValidationEnabled { false };
+    bool shouldPerformTimeBasedEviction { false };
+    Seconds timeBasedEvictionThreshold { 180 * 24_h };
+    std::optional<Seconds> lastModificationTimeUpdateIntervalOverride;
 #if ENABLE(DECLARATIVE_WEB_PUSH)
     bool isDeclarativeWebPushEnabled { false };
 #endif

--- a/Source/WebKit/NetworkProcess/NetworkSessionCreationParameters.serialization.in
+++ b/Source/WebKit/NetworkProcess/NetworkSessionCreationParameters.serialization.in
@@ -100,6 +100,9 @@ enum class WebKit::AllowsCellularAccess : bool;
     bool serviceWorkerProcessTerminationDelayEnabled;
     bool inspectionForServiceWorkersAllowed;
     bool storageSiteValidationEnabled;
+    bool shouldPerformTimeBasedEviction;
+    Seconds timeBasedEvictionThreshold;
+    std::optional<Seconds> lastModificationTimeUpdateIntervalOverride;
 #if ENABLE(DECLARATIVE_WEB_PUSH)
     bool isDeclarativeWebPushEnabled;
 #endif

--- a/Source/WebKit/NetworkProcess/storage/NetworkStorageManager.cpp
+++ b/Source/WebKit/NetworkProcess/storage/NetworkStorageManager.cpp
@@ -162,9 +162,9 @@ String NetworkStorageManager::persistedFilePath(const WebCore::ClientOrigin& ori
     return FileSystem::pathByAppendingComponent(directory, persistedFileName);
 }
 
-Ref<NetworkStorageManager> NetworkStorageManager::create(NetworkProcess& process, PAL::SessionID sessionID, Markable<WTF::UUID> identifier, std::optional<IPC::Connection::UniqueID> connection, const String& path, const String& customLocalStoragePath, const String& customIDBStoragePath, const String& customCacheStoragePath, const String& customServiceWorkerStoragePath, uint64_t defaultOriginQuota, std::optional<double> originQuotaRatio, std::optional<double> totalQuotaRatio, std::optional<uint64_t> standardVolumeCapacity, std::optional<uint64_t> volumeCapacityOverride, UnifiedOriginStorageLevel level, bool storageSiteValidationEnabled)
+Ref<NetworkStorageManager> NetworkStorageManager::create(NetworkProcess& process, PAL::SessionID sessionID, Markable<WTF::UUID> identifier, std::optional<IPC::Connection::UniqueID> connection, const String& path, const String& customLocalStoragePath, const String& customIDBStoragePath, const String& customCacheStoragePath, const String& customServiceWorkerStoragePath, uint64_t defaultOriginQuota, std::optional<double> originQuotaRatio, std::optional<double> totalQuotaRatio, std::optional<uint64_t> standardVolumeCapacity, std::optional<uint64_t> volumeCapacityOverride, UnifiedOriginStorageLevel level, bool storageSiteValidationEnabled, bool shouldPerformTimeBasedEviction, Seconds timeBasedEvictionThreshold, std::optional<Seconds> lastModificationTimeUpdateIntervalOverride)
 {
-    return adoptRef(*new NetworkStorageManager(process, sessionID, identifier, connection, path, customLocalStoragePath, customIDBStoragePath, customCacheStoragePath, customServiceWorkerStoragePath, defaultOriginQuota, originQuotaRatio, totalQuotaRatio, standardVolumeCapacity, volumeCapacityOverride, level, storageSiteValidationEnabled));
+    return adoptRef(*new NetworkStorageManager(process, sessionID, identifier, connection, path, customLocalStoragePath, customIDBStoragePath, customCacheStoragePath, customServiceWorkerStoragePath, defaultOriginQuota, originQuotaRatio, totalQuotaRatio, standardVolumeCapacity, volumeCapacityOverride, level, storageSiteValidationEnabled, shouldPerformTimeBasedEviction, timeBasedEvictionThreshold, lastModificationTimeUpdateIntervalOverride));
 }
 
 static ASCIILiteral queueName(PAL::SessionID sessionID)
@@ -174,7 +174,7 @@ static ASCIILiteral queueName(PAL::SessionID sessionID)
     return "com.apple.WebKit.Storage.persistent"_s;
 }
 
-NetworkStorageManager::NetworkStorageManager(NetworkProcess& process, PAL::SessionID sessionID, Markable<WTF::UUID> identifier, std::optional<IPC::Connection::UniqueID> connection, const String& path, const String& customLocalStoragePath, const String& customIDBStoragePath, const String& customCacheStoragePath, const String& customServiceWorkerStoragePath, uint64_t defaultOriginQuota, std::optional<double> originQuotaRatio, std::optional<double> totalQuotaRatio, std::optional<uint64_t> standardVolumeCapacity, std::optional<uint64_t> volumeCapacityOverride, UnifiedOriginStorageLevel level, bool storageSiteValidationEnabled)
+NetworkStorageManager::NetworkStorageManager(NetworkProcess& process, PAL::SessionID sessionID, Markable<WTF::UUID> identifier, std::optional<IPC::Connection::UniqueID> connection, const String& path, const String& customLocalStoragePath, const String& customIDBStoragePath, const String& customCacheStoragePath, const String& customServiceWorkerStoragePath, uint64_t defaultOriginQuota, std::optional<double> originQuotaRatio, std::optional<double> totalQuotaRatio, std::optional<uint64_t> standardVolumeCapacity, std::optional<uint64_t> volumeCapacityOverride, UnifiedOriginStorageLevel level, bool storageSiteValidationEnabled, bool shouldPerformTimeBasedEviction, Seconds timeBasedEvictionThreshold, std::optional<Seconds> lastModificationTimeUpdateIntervalOverride)
     : m_process(process)
     , m_sessionID(sessionID)
     , m_queue(SuspendableWorkQueue::create(queueName(sessionID), SuspendableWorkQueue::QOS::Default, SuspendableWorkQueue::ShouldLog::Yes))
@@ -194,7 +194,7 @@ NetworkStorageManager::NetworkStorageManager(NetworkProcess& process, PAL::Sessi
     m_pathNormalizedMainThread = FileSystem::lexicallyNormal(path);
     m_customIDBStoragePathNormalizedMainThread = FileSystem::lexicallyNormal(customIDBStoragePath);
 
-    workQueue().dispatch([this, weakThis = ThreadSafeWeakPtr { *this }, path = path.isolatedCopy(), customLocalStoragePath = crossThreadCopy(customLocalStoragePath), customIDBStoragePath = crossThreadCopy(customIDBStoragePath), customCacheStoragePath = crossThreadCopy(customCacheStoragePath), customServiceWorkerStoragePath = crossThreadCopy(customServiceWorkerStoragePath), defaultOriginQuota, originQuotaRatio, totalQuotaRatio, standardVolumeCapacity, volumeCapacityOverride, level, storageSiteValidationEnabled]() mutable {
+    workQueue().dispatch([this, weakThis = ThreadSafeWeakPtr { *this }, path = path.isolatedCopy(), customLocalStoragePath = crossThreadCopy(customLocalStoragePath), customIDBStoragePath = crossThreadCopy(customIDBStoragePath), customCacheStoragePath = crossThreadCopy(customCacheStoragePath), customServiceWorkerStoragePath = crossThreadCopy(customServiceWorkerStoragePath), defaultOriginQuota, originQuotaRatio, totalQuotaRatio, standardVolumeCapacity, volumeCapacityOverride, level, storageSiteValidationEnabled, shouldPerformTimeBasedEviction, timeBasedEvictionThreshold, lastModificationTimeUpdateIntervalOverride]() mutable {
         assertIsCurrent(workQueue());
 
         auto protectedThis = weakThis.get();
@@ -206,6 +206,7 @@ NetworkStorageManager::NetworkStorageManager(NetworkProcess& process, PAL::Sessi
         m_totalQuotaRatio = totalQuotaRatio;
         m_standardVolumeCapacity = standardVolumeCapacity;
         m_volumeCapacityOverride = volumeCapacityOverride;
+        m_lastModificationTimeUpdateIntervalOverride = lastModificationTimeUpdateIntervalOverride;
 #if PLATFORM(IOS_FAMILY)
         m_backupExclusionPeriod = defaultBackupExclusionPeriod;
 #endif
@@ -237,6 +238,8 @@ NetworkStorageManager::NetworkStorageManager(NetworkProcess& process, PAL::Sessi
 #endif
 
         IDBStorageManager::createVersionDirectoryIfNeeded(m_customIDBStoragePath);
+        if (shouldPerformTimeBasedEviction)
+            performTimeBasedEviction(timeBasedEvictionThreshold);
         RunLoop::mainSingleton().dispatch([protectedThis = WTF::move(protectedThis)] { });
     });
 }
@@ -381,7 +384,7 @@ void NetworkStorageManager::includeOriginInBackupIfNecessary(OriginStorageManage
 
 #endif
 
-void NetworkStorageManager::writeOriginToFileIfNecessary(const WebCore::ClientOrigin& origin, StorageAreaBase* storageArea)
+void NetworkStorageManager::writeOriginToFileIfNecessary(const WebCore::ClientOrigin& origin, ShouldUpdateOriginAccessTime shouldUpdateOriginAccessTime, StorageAreaBase* storageArea)
 {
     assertIsCurrent(workQueue());
     CheckedPtr manager = m_originStorageManagers.get(origin);
@@ -389,6 +392,11 @@ void NetworkStorageManager::writeOriginToFileIfNecessary(const WebCore::ClientOr
         return;
 
     if (manager->originFileCreationTimestamp()) {
+        if (shouldUpdateOriginAccessTime == ShouldUpdateOriginAccessTime::Yes) {
+            // Write operations will have origin access time updated via quota checks.
+            // This is needed for read operations for some storage types.
+            updateLastModificationTimeForOrigin(origin);
+        }
 #if PLATFORM(IOS_FAMILY)
         includeOriginInBackupIfNecessary(*manager);
 #endif
@@ -406,6 +414,8 @@ void NetworkStorageManager::writeOriginToFileIfNecessary(const WebCore::ClientOr
     bool didWrite = WebCore::StorageUtilities::writeOriginToFile(originFile, origin);
     auto timestamp = FileSystem::fileCreationTime(originFile);
     manager->setOriginFileCreationTimestamp(timestamp);
+    if (!didWrite && shouldUpdateOriginAccessTime == ShouldUpdateOriginAccessTime::Yes)
+        updateLastModificationTimeForOrigin(origin);
 #if PLATFORM(IOS_FAMILY)
     if (didWrite)
         FileSystem::setExcludedFromBackup(originDirectory, true);
@@ -538,10 +548,22 @@ void NetworkStorageManager::donePrepareForEviction(const std::optional<HashMap<W
     }
 
     m_totalUsage = totalUsage;
-    performEviction(WTF::move(originRecords));
+    performQuotaBasedEviction(WTF::move(originRecords));
 }
 
-void NetworkStorageManager::performEviction(HashMap<WebCore::SecurityOriginData, AccessRecord>&& originRecords)
+void NetworkStorageManager::performEvictionForOrigin(const WebCore::SecurityOriginData& topOrigin, const AccessRecord& record)
+{
+    for (auto& clientOrigin : record.clientOrigins) {
+        auto origin = WebCore::ClientOrigin { topOrigin, clientOrigin };
+        originStorageManager(origin)->deleteData(allManagedTypes(), -WallTime::infinity());
+        removeOriginStorageManagerIfPossible(origin);
+    }
+
+    if (m_totalUsage && record.usage)
+        m_totalUsage = *m_totalUsage - record.usage;
+}
+
+void NetworkStorageManager::performQuotaBasedEviction(HashMap<WebCore::SecurityOriginData, AccessRecord>&& originRecords)
 {
     assertIsCurrent(workQueue());
 
@@ -564,17 +586,58 @@ void NetworkStorageManager::performEviction(HashMap<WebCore::SecurityOriginData,
         if (record.isActive || valueOrDefault(record.isPersisted))
             continue;
 
-        for (auto& clientOrigin : record.clientOrigins) {
-            auto origin = WebCore::ClientOrigin { topOrigin, clientOrigin };
-            originStorageManager(origin)->deleteData(allManagedTypes(), -WallTime::infinity());
-            removeOriginStorageManagerIfPossible(origin);
-        }
-
-        m_totalUsage = *m_totalUsage - record.usage;
+        performEvictionForOrigin(topOrigin, record);
         deletedDomains.append(WebCore::RegistrableDomain { topOrigin });
     }
 
-    RELEASE_LOG(Storage, "%p - NetworkStorageManager::performEviction evicts %" PRIu64 " origins, current usage %" PRIu64 ", total quota %" PRIu64, this, static_cast<uint64_t>(deletedDomains.size()), valueOrDefault(m_totalUsage), *m_totalQuota);
+    RELEASE_LOG(Storage, "%p - NetworkStorageManager::performQuotaBasedEviction evicts %" PRIu64 " origins, current usage %" PRIu64 ", total quota %" PRIu64, this, static_cast<uint64_t>(deletedDomains.size()), valueOrDefault(m_totalUsage), *m_totalQuota);
+
+    if (!deletedDomains.isEmpty() && m_parentConnection)
+        IPC::Connection::send(*m_parentConnection, Messages::NetworkProcessProxy::DidPerformEvictionForDomains(m_sessionID, WTF::move(deletedDomains)), 0);
+}
+
+void NetworkStorageManager::performTimeBasedEviction(Seconds threshold)
+{
+    assertIsCurrent(workQueue());
+
+    RELEASE_LOG(Storage, "%p - NetworkStorageManager::performTimeBasedEviction started sessionID=%" PRIu64 " threshold=%.0f days", this, m_sessionID.toUInt64(), threshold.days());
+
+    auto startTime = MonotonicTime::now();
+    HashMap<WebCore::SecurityOriginData, AccessRecord> originRecords;
+    for (auto& origin : getAllOrigins()) {
+        auto accessTime = lastModificationTimeForOrigin(origin, originStorageManager(origin));
+
+        auto& record = originRecords.ensure(origin.topOrigin, [&] {
+            return AccessRecord { };
+        }).iterator->value;
+        if (record.lastAccessTime < accessTime)
+            record.lastAccessTime = accessTime;
+
+        record.clientOrigins.append(origin.clientOrigin);
+        bool removed = removeOriginStorageManagerIfPossible(origin);
+        if (!removed)
+            record.isActive = true;
+        if (!record.isPersisted && persistedInternal(WebCore::ClientOrigin { origin.topOrigin, origin.topOrigin }))
+            record.isPersisted = true;
+    }
+
+    auto cutoffTime = WallTime::now() - threshold;
+
+    Vector<WebCore::RegistrableDomain> deletedDomains;
+    for (auto& [topOrigin, record] : originRecords) {
+        if (record.isActive || valueOrDefault(record.isPersisted))
+            continue;
+
+        if (record.lastAccessTime >= cutoffTime)
+            continue;
+
+        performEvictionForOrigin(topOrigin, record);
+        deletedDomains.append(WebCore::RegistrableDomain { topOrigin });
+    }
+
+    auto elapsedTime = MonotonicTime::now() - startTime;
+    UNUSED_PARAM(elapsedTime);
+    RELEASE_LOG(Storage, "%p - NetworkStorageManager::performTimeBasedEviction sessionID=%" PRIu64 " threshold=%.0f days evicted %" PRIu64 " origins in %.2f ms", this, m_sessionID.toUInt64(), threshold.days(), static_cast<uint64_t>(deletedDomains.size()), elapsedTime.milliseconds());
 
     if (!deletedDomains.isEmpty() && m_parentConnection)
         IPC::Connection::send(*m_parentConnection, Messages::NetworkProcessProxy::DidPerformEvictionForDomains(m_sessionID, WTF::move(deletedDomains)), 0);
@@ -617,7 +680,7 @@ OriginQuotaManager::Parameters NetworkStorageManager::originQuotaManagerParamete
     return { roundedQuota, roundedStandardReportedQuota, WTF::move(increaseQuotaFunction), WTF::move(notifySpaceGrantedFunction) };
 }
 
-CheckedRef<OriginStorageManager> NetworkStorageManager::originStorageManager(const WebCore::ClientOrigin& origin, ShouldWriteOriginFile shouldWriteOriginFile)
+CheckedRef<OriginStorageManager> NetworkStorageManager::originStorageManager(const WebCore::ClientOrigin& origin, ShouldWriteOriginFile shouldWriteOriginFile, ShouldUpdateOriginAccessTime shouldUpdateOriginAccessTime)
 {
     assertIsCurrent(workQueue());
 
@@ -635,7 +698,7 @@ CheckedRef<OriginStorageManager> NetworkStorageManager::originStorageManager(con
     }).iterator->value;
 
     if (shouldWriteOriginFile == ShouldWriteOriginFile::Yes)
-        writeOriginToFileIfNecessary(origin);
+        writeOriginToFileIfNecessary(origin, shouldUpdateOriginAccessTime);
 
     return originStorageManager;
 }
@@ -664,17 +727,18 @@ void NetworkStorageManager::updateLastModificationTimeForOrigin(const WebCore::C
     assertIsCurrent(workQueue());
 
     auto currentTime = WallTime::now();
+    auto updateInterval = m_lastModificationTimeUpdateIntervalOverride.value_or(originLastModificationTimeUpdateInterval);
     auto iterator = m_lastModificationTimes.find(origin);
     if (iterator == m_lastModificationTimes.end())
         m_lastModificationTimes.set(origin, currentTime);
     else {
-        if (currentTime - iterator->value <= originLastModificationTimeUpdateInterval)
+        if (currentTime - iterator->value <= updateInterval)
             return;
         iterator->value = currentTime;
     }
 
-    m_lastModificationTimes.removeIf([&currentTime](auto& iterator) {
-        return currentTime - iterator.value > originLastModificationTimeUpdateInterval;
+    m_lastModificationTimes.removeIf([&currentTime, updateInterval](auto& iterator) {
+        return currentTime - iterator.value > updateInterval;
     });
 
     // This function must be called when origin is in use, i.e. OriginStorageManager exists.
@@ -912,7 +976,7 @@ void NetworkStorageManager::fileSystemGetDirectory(IPC::Connection& connection, 
     ASSERT(!RunLoop::isMain());
     MESSAGE_CHECK_COMPLETION(isSiteAllowedForConnection(connection.uniqueID(), WebCore::RegistrableDomain { origin.topOrigin }), connection, completionHandler(makeUnexpected(FileSystemStorageError::Unknown)));
 
-    Ref fileSystemStorageManager = originStorageManager(origin)->fileSystemStorageManager(*protect(m_fileSystemStorageHandleRegistry));
+    Ref fileSystemStorageManager = originStorageManager(origin, ShouldWriteOriginFile::Yes, ShouldUpdateOriginAccessTime::Yes)->fileSystemStorageManager(*protect(m_fileSystemStorageHandleRegistry));
     auto result = fileSystemStorageManager->getDirectory(connection.uniqueID());
     if (result)
         completionHandler(std::optional { result.value() });
@@ -1683,7 +1747,7 @@ void NetworkStorageManager::connectToStorageArea(IPC::Connection& connection, We
 
     if (RefPtr storageArea = m_storageAreaRegistry->getStorageArea(*resultIdentifier)) {
         completionHandler(*resultIdentifier, storageArea->allItems(), StorageAreaBase::nextMessageIdentifier());
-        writeOriginToFileIfNecessary(origin, storageArea.get());
+        writeOriginToFileIfNecessary(origin, ShouldUpdateOriginAccessTime::Yes, storageArea.get());
         return;
     }
 
@@ -1762,7 +1826,7 @@ void NetworkStorageManager::setItem(IPC::Connection& connection, StorageAreaIden
         allItems = storageArea->allItems();
     completionHandler(hasError, WTF::move(allItems));
 
-    writeOriginToFileIfNecessary(storageArea->origin(), storageArea.get());
+    writeOriginToFileIfNecessary(storageArea->origin(), ShouldUpdateOriginAccessTime::Yes, storageArea.get());
 }
 
 void NetworkStorageManager::removeItem(IPC::Connection& connection, StorageAreaIdentifier identifier, StorageAreaImplIdentifier implIdentifier, String&& key, String&& urlString, CompletionHandler<void(bool, HashMap<String, String>&&)>&& completionHandler)
@@ -1785,7 +1849,7 @@ void NetworkStorageManager::removeItem(IPC::Connection& connection, StorageAreaI
         allItems = storageArea->allItems();
     completionHandler(hasError, WTF::move(allItems));
 
-    writeOriginToFileIfNecessary(storageArea->origin(), storageArea.get());
+    writeOriginToFileIfNecessary(storageArea->origin(), ShouldUpdateOriginAccessTime::Yes, storageArea.get());
 }
 
 void NetworkStorageManager::clear(IPC::Connection& connection, StorageAreaIdentifier identifier, StorageAreaImplIdentifier implIdentifier, String&& urlString, CompletionHandler<void()>&& completionHandler)
@@ -1803,7 +1867,7 @@ void NetworkStorageManager::clear(IPC::Connection& connection, StorageAreaIdenti
     std::ignore = storageArea->clear(connection.uniqueID(), implIdentifier, WTF::move(urlString));
     completionHandler();
 
-    writeOriginToFileIfNecessary(storageArea->origin(), storageArea.get());
+    writeOriginToFileIfNecessary(storageArea->origin(), ShouldUpdateOriginAccessTime::Yes, storageArea.get());
 }
 
 void NetworkStorageManager::openDatabase(IPC::Connection& connection, const WebCore::IDBOpenRequestData& requestData)
@@ -2063,7 +2127,7 @@ void NetworkStorageManager::cacheStorageOpenCache(IPC::Connection& connection, c
 {
     MESSAGE_CHECK_COMPLETION(isSiteAllowedForConnection(connection.uniqueID(), WebCore::RegistrableDomain { origin.topOrigin }), connection, callback(makeUnexpected(WebCore::DOMCacheEngine::Error::Internal)));
 
-    protect(originStorageManager(origin)->cacheStorageManager(*m_cacheStorageRegistry, origin, m_queue.copyRef()))->openCache(cacheName, WTF::move(callback));
+    protect(originStorageManager(origin, ShouldWriteOriginFile::Yes, ShouldUpdateOriginAccessTime::Yes)->cacheStorageManager(*m_cacheStorageRegistry, origin, m_queue.copyRef()))->openCache(cacheName, WTF::move(callback));
 }
 
 void NetworkStorageManager::cacheStorageRemoveCache(WebCore::DOMCacheIdentifier cacheIdentifier, WebCore::DOMCacheEngine::RemoveCacheIdentifierCallback&& callback)

--- a/Source/WebKit/NetworkProcess/storage/NetworkStorageManager.h
+++ b/Source/WebKit/NetworkProcess/storage/NetworkStorageManager.h
@@ -105,7 +105,7 @@ class StorageAreaRegistry;
 class NetworkStorageManager final : public IPC::WorkQueueMessageReceiver<WTF::DestructionThread::MainRunLoop> {
     WTF_MAKE_TZONE_ALLOCATED(NetworkStorageManager);
 public:
-    static Ref<NetworkStorageManager> create(NetworkProcess&, PAL::SessionID, Markable<WTF::UUID>, std::optional<IPC::Connection::UniqueID>, const String& path, const String& customLocalStoragePath, const String& customIDBStoragePath, const String& customCacheStoragePath, const String& customServiceWorkerStoragePath, uint64_t defaultOriginQuota, std::optional<double> originQuotaRatio, std::optional<double> totalQuotaRatio, std::optional<uint64_t> standardVolumeCapacity, std::optional<uint64_t> volumeCapacityOverride, UnifiedOriginStorageLevel, bool storageSiteValidationEnabled);
+    static Ref<NetworkStorageManager> create(NetworkProcess&, PAL::SessionID, Markable<WTF::UUID>, std::optional<IPC::Connection::UniqueID>, const String& path, const String& customLocalStoragePath, const String& customIDBStoragePath, const String& customCacheStoragePath, const String& customServiceWorkerStoragePath, uint64_t defaultOriginQuota, std::optional<double> originQuotaRatio, std::optional<double> totalQuotaRatio, std::optional<uint64_t> standardVolumeCapacity, std::optional<uint64_t> volumeCapacityOverride, UnifiedOriginStorageLevel, bool storageSiteValidationEnabled, bool shouldPerformTimeBasedEviction, Seconds timeBasedEvictionThreshold, std::optional<Seconds> lastModificationTimeUpdateIntervalOverride);
     static bool canHandleTypes(OptionSet<WebsiteDataType>);
     static OptionSet<WebsiteDataType> allManagedTypes();
 
@@ -161,7 +161,7 @@ public:
     void queryCacheStorage(WebCore::ClientOrigin&&, WebCore::RetrieveRecordsOptions&&, String&&, CompletionHandler<void(std::optional<WebCore::DOMCacheEngine::Record>&&)>&&);
 
 private:
-    NetworkStorageManager(NetworkProcess&, PAL::SessionID, Markable<WTF::UUID>, std::optional<IPC::Connection::UniqueID>, const String& path, const String& customLocalStoragePath, const String& customIDBStoragePath, const String& customCacheStoragePath, const String& customServiceWorkerStoragePath, uint64_t defaultOriginQuota, std::optional<double> originQuotaRatio, std::optional<double> totalQuotaRatio, std::optional<uint64_t> standardVolumeCapacity, std::optional<uint64_t> volumeCapacityOverride, UnifiedOriginStorageLevel, bool storageSiteValidationEnabled);
+    NetworkStorageManager(NetworkProcess&, PAL::SessionID, Markable<WTF::UUID>, std::optional<IPC::Connection::UniqueID>, const String& path, const String& customLocalStoragePath, const String& customIDBStoragePath, const String& customCacheStoragePath, const String& customServiceWorkerStoragePath, uint64_t defaultOriginQuota, std::optional<double> originQuotaRatio, std::optional<double> totalQuotaRatio, std::optional<uint64_t> standardVolumeCapacity, std::optional<uint64_t> volumeCapacityOverride, UnifiedOriginStorageLevel, bool storageSiteValidationEnabled, bool shouldPerformTimeBasedEviction, Seconds timeBasedEvictionThreshold, std::optional<Seconds> lastModificationTimeUpdateIntervalOverride);
     ~NetworkStorageManager();
 
     std::optional<SharedPreferencesForWebProcess> NODELETE sharedPreferencesForWebProcess(IPC::Connection&) const;
@@ -169,9 +169,10 @@ private:
     bool NODELETE isStorageAreaTypeEnabled(IPC::Connection&, StorageAreaBase::StorageType) const;
     bool NODELETE useSQLiteMemoryBackingStore() const;
 
-    void writeOriginToFileIfNecessary(const WebCore::ClientOrigin&, StorageAreaBase* = nullptr);
+    enum class ShouldUpdateOriginAccessTime: bool { No, Yes };
+    void writeOriginToFileIfNecessary(const WebCore::ClientOrigin&, ShouldUpdateOriginAccessTime, StorageAreaBase* = nullptr);
     enum class ShouldWriteOriginFile : bool { No, Yes };
-    CheckedRef<OriginStorageManager> originStorageManager(const WebCore::ClientOrigin&, ShouldWriteOriginFile = ShouldWriteOriginFile::Yes);
+    CheckedRef<OriginStorageManager> originStorageManager(const WebCore::ClientOrigin&, ShouldWriteOriginFile = ShouldWriteOriginFile::Yes, ShouldUpdateOriginAccessTime = ShouldUpdateOriginAccessTime::No);
     bool removeOriginStorageManagerIfPossible(const WebCore::ClientOrigin&);
 
     void forEachClientOriginDirectoryUnderTopOrigin(const String& encodedTopOrigin, NOESCAPE const Function<void(const String&)>&);
@@ -289,7 +290,9 @@ private:
         WallTime lastAccessTime;
         Vector<WebCore::SecurityOriginData> clientOrigins;
     };
-    void performEviction(HashMap<WebCore::SecurityOriginData, AccessRecord>&&);
+    void performQuotaBasedEviction(HashMap<WebCore::SecurityOriginData, AccessRecord>&&);
+    void performTimeBasedEviction(Seconds threshold);
+    void performEvictionForOrigin(const WebCore::SecurityOriginData& topOrigin, const AccessRecord&);
     const SuspendableWorkQueue& workQueue() const WTF_RETURNS_CAPABILITY(m_queue.get()) { return m_queue; }
     SuspendableWorkQueue& workQueue() WTF_RETURNS_CAPABILITY(m_queue.get()) { return m_queue; }
     OriginQuotaManager::Parameters originQuotaManagerParameters(const WebCore::ClientOrigin&);
@@ -323,6 +326,7 @@ private:
     std::optional<double> m_totalQuotaRatio;
     std::optional<uint64_t> m_standardVolumeCapacity;
     std::optional<uint64_t> m_volumeCapacityOverride;
+    std::optional<Seconds> m_lastModificationTimeUpdateIntervalOverride;
     std::optional<uint64_t> m_totalUsage;
     std::optional<uint64_t> m_totalQuota;
     bool m_isEvictionScheduled { false };

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebsiteDataStoreConfiguration.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebsiteDataStoreConfiguration.h
@@ -53,6 +53,9 @@ WK_CLASS_AVAILABLE(macos(10.13), ios(11.0))
 @property (nonatomic) BOOL networkCacheSpeculativeValidationEnabled WK_API_AVAILABLE(macos(10.15.4), ios(13.4));
 @property (nonatomic) BOOL fastServerTrustEvaluationEnabled WK_API_AVAILABLE(macos(10.15.4), ios(13.4));
 @property (nonatomic) NSUInteger perOriginStorageQuota WK_API_AVAILABLE(macos(10.15.4), ios(13.4));
+@property (nonatomic) BOOL timeBasedEvictionEnabled;
+@property (nonatomic) NSTimeInterval timeBasedEvictionThreshold;
+@property (nonatomic, nullable, copy) NSNumber *lastModificationTimeUpdateIntervalOverride;
 @property (nonatomic, nullable, copy) NSNumber *originQuotaRatio WK_API_AVAILABLE(macos(14.0), ios(17.0));
 @property (nonatomic, nullable, copy) NSNumber *totalQuotaRatio WK_API_AVAILABLE(macos(14.0), ios(17.0));
 @property (nonatomic, nullable, copy) NSNumber *standardVolumeCapacity WK_API_AVAILABLE(macos(14.0), ios(17.0));

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebsiteDataStoreConfiguration.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebsiteDataStoreConfiguration.mm
@@ -502,6 +502,43 @@ static WebKit::UnifiedOriginStorageLevel NODELETE toUnifiedOriginStorageLevel(_W
     _configuration->setPerOriginStorageQuota(quota);
 }
 
+- (BOOL)timeBasedEvictionEnabled
+{
+    return _configuration->timeBasedEvictionEnabled();
+}
+
+- (void)setTimeBasedEvictionEnabled:(BOOL)enabled
+{
+    _configuration->setTimeBasedEvictionEnabled(enabled);
+}
+
+- (NSTimeInterval)timeBasedEvictionThreshold
+{
+    return _configuration->timeBasedEvictionThreshold().seconds();
+}
+
+- (void)setTimeBasedEvictionThreshold:(NSTimeInterval)seconds
+{
+    _configuration->setTimeBasedEvictionThreshold(Seconds(seconds));
+}
+
+- (NSNumber *)lastModificationTimeUpdateIntervalOverride
+{
+    auto interval = _configuration->lastModificationTimeUpdateIntervalOverride();
+    if (!interval)
+        return nil;
+
+    return [NSNumber numberWithDouble:interval->seconds()];
+}
+
+- (void)setLastModificationTimeUpdateIntervalOverride:(NSNumber *)seconds
+{
+    if (seconds)
+        _configuration->setLastModificationTimeUpdateIntervalOverride(Seconds([seconds doubleValue]));
+    else
+        _configuration->setLastModificationTimeUpdateIntervalOverride(std::nullopt);
+}
+
 - (NSNumber *)originQuotaRatio
 {
     auto ratio = _configuration->originQuotaRatio();

--- a/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.cpp
+++ b/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.cpp
@@ -1913,6 +1913,15 @@ bool WebsiteDataStore::trackingPreventionEnabled() const
     return m_trackingPreventionEnabled == TrackingPreventionEnabled::Yes;
 }
 
+bool WebsiteDataStore::shouldPerformTimeBasedEviction() const
+{
+    bool isBrowserOrRunningTest = false;
+#if PLATFORM(COCOA)
+    isBrowserOrRunningTest = isFullWebBrowserOrRunningTest();
+#endif
+    return isBrowserOrRunningTest && m_configuration->timeBasedEvictionEnabled() && !trackingPreventionEnabled();
+}
+
 bool WebsiteDataStore::resourceLoadStatisticsDebugMode() const
 {
     return m_trackingPreventionDebugMode;
@@ -2239,6 +2248,9 @@ WebsiteDataStoreParameters WebsiteDataStore::parameters()
     networkSessionParameters.serviceWorkerProcessTerminationDelayEnabled = m_configuration->serviceWorkerProcessTerminationDelayEnabled();
     networkSessionParameters.inspectionForServiceWorkersAllowed = m_inspectionForServiceWorkersAllowed;
     networkSessionParameters.storageSiteValidationEnabled = m_storageSiteValidationEnabled;
+    networkSessionParameters.shouldPerformTimeBasedEviction = shouldPerformTimeBasedEviction();
+    networkSessionParameters.timeBasedEvictionThreshold = m_configuration->timeBasedEvictionThreshold();
+    networkSessionParameters.lastModificationTimeUpdateIntervalOverride = m_configuration->lastModificationTimeUpdateIntervalOverride();
 #if ENABLE(DECLARATIVE_WEB_PUSH)
     networkSessionParameters.isDeclarativeWebPushEnabled = m_configuration->isDeclarativeWebPushEnabled();
 #endif

--- a/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.h
+++ b/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.h
@@ -187,6 +187,8 @@ public:
     bool storageSiteValidationEnabled() const { return m_storageSiteValidationEnabled; }
     void setStorageSiteValidationEnabled(bool);
 
+    bool shouldPerformTimeBasedEviction() const;
+
     uint64_t perOriginStorageQuota() const { return m_configuration->perOriginStorageQuota(); }
     std::optional<double> originQuotaRatio() { return m_configuration->originQuotaRatio(); }
 

--- a/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStoreConfiguration.cpp
+++ b/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStoreConfiguration.cpp
@@ -177,6 +177,10 @@ Ref<WebsiteDataStoreConfiguration> WebsiteDataStoreConfiguration::copy() const
     copy->m_webContentRestrictionsConfigurationFile = this->m_webContentRestrictionsConfigurationFile;
 #endif
     copy->m_additionalDomainsWithUserInteractionForTesting = this->m_additionalDomainsWithUserInteractionForTesting;
+    copy->m_timeBasedEvictionEnabled = this->m_timeBasedEvictionEnabled;
+    copy->m_timeBasedEvictionThreshold = this->m_timeBasedEvictionThreshold;
+    copy->m_lastModificationTimeUpdateIntervalOverride = this->m_lastModificationTimeUpdateIntervalOverride;
+    copy->m_defaultTrackingPreventionEnabledOverride = this->m_defaultTrackingPreventionEnabledOverride;
 
     return copy;
 }

--- a/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStoreConfiguration.h
+++ b/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStoreConfiguration.h
@@ -70,6 +70,13 @@ public:
     std::optional<double> originQuotaRatio() const { return m_originQuotaRatio; }
     void setOriginQuotaRatio(std::optional<double> ratio) { m_originQuotaRatio = ratio; }
 
+    bool timeBasedEvictionEnabled() const { return m_timeBasedEvictionEnabled; }
+    void setTimeBasedEvictionEnabled(bool enabled) { m_timeBasedEvictionEnabled = enabled; }
+    Seconds timeBasedEvictionThreshold() const { return m_timeBasedEvictionThreshold; }
+    void setTimeBasedEvictionThreshold(Seconds threshold) { m_timeBasedEvictionThreshold = threshold; }
+    std::optional<Seconds> lastModificationTimeUpdateIntervalOverride() const { return m_lastModificationTimeUpdateIntervalOverride; }
+    void setLastModificationTimeUpdateIntervalOverride(std::optional<Seconds> interval) { m_lastModificationTimeUpdateIntervalOverride = interval; }
+
     std::optional<double> totalQuotaRatio() const { return m_totalQuotaRatio; }
     void setTotalQuotaRatio(std::optional<double> ratio) { m_totalQuotaRatio = ratio; }
 
@@ -303,6 +310,9 @@ private:
     Directories m_directories;
     uint64_t m_perOriginStorageQuota;
     std::optional<double> m_originQuotaRatio;
+    bool m_timeBasedEvictionEnabled { false };
+    Seconds m_timeBasedEvictionThreshold { 180 * 24_h };
+    std::optional<Seconds> m_lastModificationTimeUpdateIntervalOverride;
     std::optional<double> m_totalQuotaRatio;
     std::optional<uint64_t> m_standardVolumeCapacity;
     std::optional<uint64_t> m_volumeCapacityOverride;

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKWebsiteDatastore.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKWebsiteDatastore.mm
@@ -1513,4 +1513,413 @@ TEST(StorageSiteValidation, StorageBlockingPolicyAllowAll)
     EXPECT_FALSE(webContentProcessTerminated);
 }
 
+TEST(TimeBasedEviction, Basic)
+{
+    RetainPtr uuid = adoptNS([[NSUUID alloc] initWithUUIDString:@"68753a44-4d6f-1226-9c60-0050e4c00068"]);
+    done = false;
+    [WKWebsiteDataStore _removeDataStoreWithIdentifier:uuid.get() completionHandler:^(NSError *error) {
+        done = true;
+    }];
+    TestWebKitAPI::Util::run(&done);
+
+    RetainPtr websiteDataStoreConfiguration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] initWithIdentifier:uuid.get()]);
+    [websiteDataStoreConfiguration setTimeBasedEvictionEnabled:YES];
+    [websiteDataStoreConfiguration setTimeBasedEvictionThreshold:2.0];
+    [websiteDataStoreConfiguration setDefaultTrackingPreventionEnabledOverride:@NO];
+
+    NSString *idbHTML = @"<script> \
+        var request = indexedDB.open('testDB'); \
+        request.onupgradeneeded = function(event) { \
+            event.target.result.createObjectStore('store'); \
+        }; \
+        request.onsuccess = function() { \
+            window.webkit.messageHandlers.testHandler.postMessage('done'); \
+        }; \
+        request.onerror = function() { \
+            window.webkit.messageHandlers.testHandler.postMessage('error'); \
+        }; \
+    </script>";
+
+    @autoreleasepool {
+        RetainPtr websiteDataStore = adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:websiteDataStoreConfiguration.get()]);
+        RetainPtr handler = adoptNS([[WKWebsiteDataStoreMessageHandler alloc] init]);
+        RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+        [[configuration userContentController] addScriptMessageHandler:handler.get() name:@"testHandler"];
+        [configuration setWebsiteDataStore:websiteDataStore.get()];
+        RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+
+        receivedScriptMessage = false;
+        [webView loadHTMLString:idbHTML baseURL:[NSURL URLWithString:@"https://example1.com/"]];
+        TestWebKitAPI::Util::run(&receivedScriptMessage);
+        EXPECT_WK_STREQ(@"done", [lastScriptMessage body]);
+
+        // Wait so example1.com data becomes stale.
+        TestWebKitAPI::Util::runFor(2_s);
+
+        // Load example2.com — its data will be fresh.
+        receivedScriptMessage = false;
+        [webView loadHTMLString:idbHTML baseURL:[NSURL URLWithString:@"https://example2.com/"]];
+        TestWebKitAPI::Util::run(&receivedScriptMessage);
+        EXPECT_WK_STREQ(@"done", [lastScriptMessage body]);
+
+        done = false;
+        [websiteDataStore fetchDataRecordsOfTypes:[WKWebsiteDataStore allWebsiteDataTypes] completionHandler:^(NSArray<WKWebsiteDataRecord *> *records) {
+            EXPECT_EQ(2u, records.count);
+            NSArray *sortedRecords = [records sortedArrayUsingComparator:^(WKWebsiteDataRecord *a, WKWebsiteDataRecord *b) {
+                return [a.displayName compare:b.displayName];
+            }];
+            EXPECT_WK_STREQ(@"example1.com", [sortedRecords[0] displayName]);
+            EXPECT_WK_STREQ(@"example2.com", [sortedRecords[1] displayName]);
+            done = true;
+        }];
+        TestWebKitAPI::Util::run(&done);
+    }
+
+    // Create a new data store — eviction runs on session initialization.
+    // example1.com should be evicted (stale), example2.com should remain (fresh).
+    RetainPtr websiteDataStore2 = adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:websiteDataStoreConfiguration.get()]);
+    done = false;
+    [websiteDataStore2 fetchDataRecordsOfTypes:[WKWebsiteDataStore allWebsiteDataTypes] completionHandler:^(NSArray<WKWebsiteDataRecord *> *records) {
+        EXPECT_EQ(1u, records.count);
+        EXPECT_WK_STREQ(@"example2.com", [[records firstObject] displayName]);
+        done = true;
+    }];
+    TestWebKitAPI::Util::run(&done);
+}
+
+TEST(TimeBasedEviction, IndexedDBReadUpdatesTimestamp)
+{
+    RetainPtr uuid = adoptNS([[NSUUID alloc] initWithUUIDString:@"68753a44-4d6f-1226-9c60-0050e4c00069"]);
+    done = false;
+    [WKWebsiteDataStore _removeDataStoreWithIdentifier:uuid.get() completionHandler:^(NSError *error) {
+        done = true;
+    }];
+    TestWebKitAPI::Util::run(&done);
+
+    RetainPtr websiteDataStoreConfiguration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] initWithIdentifier:uuid.get()]);
+    [websiteDataStoreConfiguration setTimeBasedEvictionEnabled:YES];
+    [websiteDataStoreConfiguration setTimeBasedEvictionThreshold:2.0];
+    [websiteDataStoreConfiguration setDefaultTrackingPreventionEnabledOverride:@NO];
+    [websiteDataStoreConfiguration setLastModificationTimeUpdateIntervalOverride:@0];
+
+    NSString *idbWriteHTML = @"<script> \
+        var request = indexedDB.open('testDB'); \
+        request.onupgradeneeded = function(event) { \
+            var store = event.target.result.createObjectStore('store'); \
+            store.put('value', 'key'); \
+        }; \
+        request.onsuccess = function() { \
+            window.webkit.messageHandlers.testHandler.postMessage('done'); \
+        }; \
+        request.onerror = function() { \
+            window.webkit.messageHandlers.testHandler.postMessage('error'); \
+        }; \
+    </script>";
+
+    NSString *idbReadHTML = @"<script> \
+        var request = indexedDB.open('testDB'); \
+        request.onsuccess = function() { \
+            window.webkit.messageHandlers.testHandler.postMessage('done'); \
+        }; \
+        request.onerror = function() { \
+            window.webkit.messageHandlers.testHandler.postMessage('error'); \
+        }; \
+    </script>";
+
+    @autoreleasepool {
+        RetainPtr websiteDataStore = adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:websiteDataStoreConfiguration.get()]);
+        RetainPtr handler = adoptNS([[WKWebsiteDataStoreMessageHandler alloc] init]);
+        RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+        [[configuration userContentController] addScriptMessageHandler:handler.get() name:@"testHandler"];
+        [configuration setWebsiteDataStore:websiteDataStore.get()];
+        RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+
+        // Write data for both origins.
+        receivedScriptMessage = false;
+        [webView loadHTMLString:idbWriteHTML baseURL:[NSURL URLWithString:@"https://example1.com/"]];
+        TestWebKitAPI::Util::run(&receivedScriptMessage);
+        EXPECT_WK_STREQ(@"done", [lastScriptMessage body]);
+
+        receivedScriptMessage = false;
+        [webView loadHTMLString:idbWriteHTML baseURL:[NSURL URLWithString:@"https://example2.com/"]];
+        TestWebKitAPI::Util::run(&receivedScriptMessage);
+        EXPECT_WK_STREQ(@"done", [lastScriptMessage body]);
+
+        // Wait so both origins' data becomes stale.
+        TestWebKitAPI::Util::runFor(2_s);
+
+        // Read from example1.com — this should update its modification timestamp.
+        receivedScriptMessage = false;
+        [webView loadHTMLString:idbReadHTML baseURL:[NSURL URLWithString:@"https://example1.com"]];
+        TestWebKitAPI::Util::run(&receivedScriptMessage);
+        EXPECT_WK_STREQ(@"done", [lastScriptMessage body]);
+
+        done = false;
+        [websiteDataStore fetchDataRecordsOfTypes:[WKWebsiteDataStore allWebsiteDataTypes] completionHandler:^(NSArray<WKWebsiteDataRecord *> *records) {
+            EXPECT_EQ(2u, records.count);
+            done = true;
+        }];
+        TestWebKitAPI::Util::run(&done);
+    }
+
+    // Create a new data store — eviction runs on session initialization.
+    // example2.com should be evicted (stale), example1.com should remain (read refreshed its timestamp).
+    RetainPtr websiteDataStore2 = adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:websiteDataStoreConfiguration.get()]);
+    done = false;
+    [websiteDataStore2 fetchDataRecordsOfTypes:[WKWebsiteDataStore allWebsiteDataTypes] completionHandler:^(NSArray<WKWebsiteDataRecord *> *records) {
+        EXPECT_EQ(1u, records.count);
+        EXPECT_WK_STREQ(@"example1.com", [[records firstObject] displayName]);
+        done = true;
+    }];
+    TestWebKitAPI::Util::run(&done);
+}
+
+TEST(TimeBasedEviction, LocalStorageReadUpdatesTimestamp)
+{
+    RetainPtr uuid = adoptNS([[NSUUID alloc] initWithUUIDString:@"68753a44-4d6f-1226-9c60-0050e4c0006a"]);
+    done = false;
+    [WKWebsiteDataStore _removeDataStoreWithIdentifier:uuid.get() completionHandler:^(NSError *error) {
+        done = true;
+    }];
+    TestWebKitAPI::Util::run(&done);
+
+    RetainPtr websiteDataStoreConfiguration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] initWithIdentifier:uuid.get()]);
+    [websiteDataStoreConfiguration setTimeBasedEvictionEnabled:YES];
+    [websiteDataStoreConfiguration setTimeBasedEvictionThreshold:2.0];
+    [websiteDataStoreConfiguration setDefaultTrackingPreventionEnabledOverride:@NO];
+    [websiteDataStoreConfiguration setLastModificationTimeUpdateIntervalOverride:@0];
+
+    NSString *localStorageWriteHTML = @"<script> \
+        localStorage.setItem('key', 'value'); \
+        window.webkit.messageHandlers.testHandler.postMessage('done'); \
+    </script>";
+
+    NSString *localStorageReadHTML = @"<script> \
+        var result = localStorage.getItem('key'); \
+        window.webkit.messageHandlers.testHandler.postMessage(result); \
+    </script>";
+
+    @autoreleasepool {
+        RetainPtr websiteDataStore = adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:websiteDataStoreConfiguration.get()]);
+        RetainPtr handler = adoptNS([[WKWebsiteDataStoreMessageHandler alloc] init]);
+        RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+        [[configuration userContentController] addScriptMessageHandler:handler.get() name:@"testHandler"];
+        [configuration setWebsiteDataStore:websiteDataStore.get()];
+        RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+
+        // Write data for both origins.
+        receivedScriptMessage = false;
+        [webView loadHTMLString:localStorageWriteHTML baseURL:[NSURL URLWithString:@"https://example1.com/"]];
+        TestWebKitAPI::Util::run(&receivedScriptMessage);
+        EXPECT_WK_STREQ(@"done", [lastScriptMessage body]);
+
+        receivedScriptMessage = false;
+        [webView loadHTMLString:localStorageWriteHTML baseURL:[NSURL URLWithString:@"https://example2.com/"]];
+        TestWebKitAPI::Util::run(&receivedScriptMessage);
+        EXPECT_WK_STREQ(@"done", [lastScriptMessage body]);
+
+        // Wait so both origins' data becomes stale.
+        TestWebKitAPI::Util::runFor(2_s);
+
+        // Read from example1.com — this should update its modification timestamp.
+        receivedScriptMessage = false;
+        [webView loadHTMLString:localStorageReadHTML baseURL:[NSURL URLWithString:@"https://example1.com/"]];
+        TestWebKitAPI::Util::run(&receivedScriptMessage);
+        EXPECT_WK_STREQ(@"value", [lastScriptMessage body]);
+
+        done = false;
+        [websiteDataStore fetchDataRecordsOfTypes:[WKWebsiteDataStore allWebsiteDataTypes] completionHandler:^(NSArray<WKWebsiteDataRecord *> *records) {
+            EXPECT_EQ(2u, records.count);
+            done = true;
+        }];
+        TestWebKitAPI::Util::run(&done);
+    }
+
+    // Create a new data store — eviction runs on session initialization.
+    // example2.com should be evicted (stale), example1.com should remain (read refreshed its timestamp).
+    RetainPtr websiteDataStore2 = adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:websiteDataStoreConfiguration.get()]);
+    done = false;
+    [websiteDataStore2 fetchDataRecordsOfTypes:[WKWebsiteDataStore allWebsiteDataTypes] completionHandler:^(NSArray<WKWebsiteDataRecord *> *records) {
+        EXPECT_EQ(1u, records.count);
+        EXPECT_WK_STREQ(@"example1.com", [[records firstObject] displayName]);
+        done = true;
+    }];
+    TestWebKitAPI::Util::run(&done);
+}
+
+TEST(TimeBasedEviction, CacheStorageReadUpdatesTimestamp)
+{
+    RetainPtr uuid = adoptNS([[NSUUID alloc] initWithUUIDString:@"68753a44-4d6f-1226-9c60-0050e4c0006b"]);
+    done = false;
+    [WKWebsiteDataStore _removeDataStoreWithIdentifier:uuid.get() completionHandler:^(NSError *error) {
+        done = true;
+    }];
+    TestWebKitAPI::Util::run(&done);
+
+    RetainPtr websiteDataStoreConfiguration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] initWithIdentifier:uuid.get()]);
+    [websiteDataStoreConfiguration setTimeBasedEvictionEnabled:YES];
+    [websiteDataStoreConfiguration setTimeBasedEvictionThreshold:2.0];
+    [websiteDataStoreConfiguration setDefaultTrackingPreventionEnabledOverride:@NO];
+    [websiteDataStoreConfiguration setLastModificationTimeUpdateIntervalOverride:@0];
+
+    NSString *cacheWriteHTML = @"<script> \
+        window.caches.open('test').then((cache) => { \
+            return cache.put('https://webkit.org/test', new Response('hello')); \
+        }).then(() => { \
+            window.webkit.messageHandlers.testHandler.postMessage('done'); \
+        }).catch(() => { \
+            window.webkit.messageHandlers.testHandler.postMessage('error'); \
+        }); \
+    </script>";
+
+    NSString *cacheReadHTML = @"<script> \
+        window.caches.open('test').then((cache) => { \
+            return cache.match('https://webkit.org/test'); \
+        }).then((response) => { \
+            window.webkit.messageHandlers.testHandler.postMessage(response ? 'done' : 'miss'); \
+        }).catch(() => { \
+            window.webkit.messageHandlers.testHandler.postMessage('error'); \
+        }); \
+    </script>";
+
+    @autoreleasepool {
+        RetainPtr websiteDataStore = adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:websiteDataStoreConfiguration.get()]);
+        RetainPtr handler = adoptNS([[WKWebsiteDataStoreMessageHandler alloc] init]);
+        RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+        [[configuration userContentController] addScriptMessageHandler:handler.get() name:@"testHandler"];
+        [configuration setWebsiteDataStore:websiteDataStore.get()];
+        RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+
+        // Write data for both origins.
+        receivedScriptMessage = false;
+        [webView loadHTMLString:cacheWriteHTML baseURL:[NSURL URLWithString:@"https://example1.com/"]];
+        TestWebKitAPI::Util::run(&receivedScriptMessage);
+        EXPECT_WK_STREQ(@"done", [lastScriptMessage body]);
+
+        receivedScriptMessage = false;
+        [webView loadHTMLString:cacheWriteHTML baseURL:[NSURL URLWithString:@"https://example2.com/"]];
+        TestWebKitAPI::Util::run(&receivedScriptMessage);
+        EXPECT_WK_STREQ(@"done", [lastScriptMessage body]);
+
+        // Wait so both origins' data becomes stale.
+        TestWebKitAPI::Util::runFor(2_s);
+
+        // Read from example1.com — this should update its modification timestamp.
+        receivedScriptMessage = false;
+        [webView loadHTMLString:cacheReadHTML baseURL:[NSURL URLWithString:@"https://example1.com/"]];
+        TestWebKitAPI::Util::run(&receivedScriptMessage);
+        EXPECT_WK_STREQ(@"done", [lastScriptMessage body]);
+
+        done = false;
+        [websiteDataStore fetchDataRecordsOfTypes:[WKWebsiteDataStore allWebsiteDataTypes] completionHandler:^(NSArray<WKWebsiteDataRecord *> *records) {
+            EXPECT_EQ(2u, records.count);
+            done = true;
+        }];
+        TestWebKitAPI::Util::run(&done);
+    }
+
+    // Create a new data store — eviction runs on session initialization.
+    // example2.com should be evicted (stale), example1.com should remain (read refreshed its timestamp).
+    RetainPtr websiteDataStore2 = adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:websiteDataStoreConfiguration.get()]);
+    done = false;
+    [websiteDataStore2 fetchDataRecordsOfTypes:[WKWebsiteDataStore allWebsiteDataTypes] completionHandler:^(NSArray<WKWebsiteDataRecord *> *records) {
+        EXPECT_EQ(1u, records.count);
+        EXPECT_WK_STREQ(@"example1.com", [[records firstObject] displayName]);
+        done = true;
+    }];
+    TestWebKitAPI::Util::run(&done);
+}
+
+TEST(TimeBasedEviction, FileSystemAPIReadUpdatesTimestamp)
+{
+    RetainPtr uuid = adoptNS([[NSUUID alloc] initWithUUIDString:@"68753a44-4d6f-1226-9c60-0050e4c0006c"]);
+    done = false;
+    [WKWebsiteDataStore _removeDataStoreWithIdentifier:uuid.get() completionHandler:^(NSError *error) {
+        done = true;
+    }];
+    TestWebKitAPI::Util::run(&done);
+
+    RetainPtr websiteDataStoreConfiguration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] initWithIdentifier:uuid.get()]);
+    [websiteDataStoreConfiguration setTimeBasedEvictionEnabled:YES];
+    [websiteDataStoreConfiguration setTimeBasedEvictionThreshold:2.0];
+    [websiteDataStoreConfiguration setDefaultTrackingPreventionEnabledOverride:@NO];
+    [websiteDataStoreConfiguration setLastModificationTimeUpdateIntervalOverride:@0];
+
+    NSString *fsWriteHTML = @"<script> \
+        async function write() { \
+            try { \
+                var root = await navigator.storage.getDirectory(); \
+                await root.getFileHandle('test.txt', { 'create' : true }); \
+                window.webkit.messageHandlers.testHandler.postMessage('done'); \
+            } catch(err) { \
+                window.webkit.messageHandlers.testHandler.postMessage('error: ' + err.message); \
+            } \
+        } \
+        write(); \
+    </script>";
+
+    NSString *fsReadHTML = @"<script> \
+        async function read() { \
+            try { \
+                var root = await navigator.storage.getDirectory(); \
+                await root.getFileHandle('test.txt', { 'create' : false }); \
+                window.webkit.messageHandlers.testHandler.postMessage('done'); \
+            } catch(err) { \
+                window.webkit.messageHandlers.testHandler.postMessage('error: ' + err.message); \
+            } \
+        } \
+        read(); \
+    </script>";
+
+    @autoreleasepool {
+        RetainPtr websiteDataStore = adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:websiteDataStoreConfiguration.get()]);
+        RetainPtr handler = adoptNS([[WKWebsiteDataStoreMessageHandler alloc] init]);
+        RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+        [[configuration userContentController] addScriptMessageHandler:handler.get() name:@"testHandler"];
+        [configuration setWebsiteDataStore:websiteDataStore.get()];
+        auto preferences = [configuration preferences];
+        preferences._fileSystemAccessEnabled = YES;
+        preferences._storageAPIEnabled = YES;
+        RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+
+        // Write data for both origins.
+        receivedScriptMessage = false;
+        [webView loadHTMLString:fsWriteHTML baseURL:[NSURL URLWithString:@"https://example1.com/"]];
+        TestWebKitAPI::Util::run(&receivedScriptMessage);
+        EXPECT_WK_STREQ(@"done", [lastScriptMessage body]);
+
+        receivedScriptMessage = false;
+        [webView loadHTMLString:fsWriteHTML baseURL:[NSURL URLWithString:@"https://example2.com/"]];
+        TestWebKitAPI::Util::run(&receivedScriptMessage);
+        EXPECT_WK_STREQ(@"done", [lastScriptMessage body]);
+
+        // Wait so both origins' data becomes stale.
+        TestWebKitAPI::Util::runFor(2_s);
+
+        // Read from example1.com — this should update its modification timestamp.
+        receivedScriptMessage = false;
+        [webView loadHTMLString:fsReadHTML baseURL:[NSURL URLWithString:@"https://example1.com/"]];
+        TestWebKitAPI::Util::run(&receivedScriptMessage);
+        EXPECT_WK_STREQ(@"done", [lastScriptMessage body]);
+
+        done = false;
+        [websiteDataStore fetchDataRecordsOfTypes:[WKWebsiteDataStore allWebsiteDataTypes] completionHandler:^(NSArray<WKWebsiteDataRecord *> *records) {
+            EXPECT_EQ(2u, records.count);
+            done = true;
+        }];
+        TestWebKitAPI::Util::run(&done);
+    }
+
+    // Create a new data store — eviction runs on session initialization.
+    // example2.com should be evicted (stale), example1.com should remain (read refreshed its timestamp).
+    RetainPtr websiteDataStore2 = adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:websiteDataStoreConfiguration.get()]);
+    done = false;
+    [websiteDataStore2 fetchDataRecordsOfTypes:[WKWebsiteDataStore allWebsiteDataTypes] completionHandler:^(NSArray<WKWebsiteDataRecord *> *records) {
+        EXPECT_EQ(1u, records.count);
+        EXPECT_WK_STREQ(@"example1.com", [[records firstObject] displayName]);
+        done = true;
+    }];
+    TestWebKitAPI::Util::run(&done);
+}
+
 } // namespace TestWebKitAPI


### PR DESCRIPTION
#### 4fb2a0985cf0d6956111bf749feaf75118b7f6de
<pre>
Introduce time-based website data eviction
<a href="https://bugs.webkit.org/show_bug.cgi?id=313865">https://bugs.webkit.org/show_bug.cgi?id=313865</a>
<a href="https://rdar.apple.com/175894273">rdar://175894273</a>

Reviewed by Ben Nham.

For users with ITP disabled, website data can accumulate indefinitely. Add a time-based eviction mechanism that deletes
data for origins not accessed within a configurable threshold (default 180 days). Eviction currently runs once at
session initialization, skipping active and persisted origins. The eviction currently only include types written by
Storage APIs (so not including cookies and credentials). The feature is currently gated on timeBasedEvictionEnabled,
which is off by default.

This patch includes a drive-by fix that we don&apos;t update modification timestamp of origins with LocalStorage operations
since they don&apos;t go through normal quota check (LocalStorage has its own quota).

Tests: TimeBasedEviction.Basic
       TimeBasedEviction.IndexedDBReadUpdatesTimestamp
       TimeBasedEviction.LocalStorageReadUpdatesTimestamp
       TimeBasedEviction.CacheStorageReadUpdatesTimestamp
       TimeBasedEviction.FileSystemAPIReadUpdatesTimestamp

* Source/WTF/wtf/Seconds.h:
* Source/WebKit/NetworkProcess/NetworkSession.cpp:
(WebKit::createNetworkStorageManager):
* Source/WebKit/NetworkProcess/NetworkSessionCreationParameters.h:
* Source/WebKit/NetworkProcess/NetworkSessionCreationParameters.serialization.in:
* Source/WebKit/NetworkProcess/storage/NetworkStorageManager.cpp:
(WebKit::NetworkStorageManager::create):
(WebKit::NetworkStorageManager::NetworkStorageManager):
(WebKit::NetworkStorageManager::writeOriginToFileIfNecessary):
(WebKit::NetworkStorageManager::donePrepareForEviction):
(WebKit::NetworkStorageManager::performEvictionForOrigin):
(WebKit::NetworkStorageManager::performQuotaBasedEviction):
(WebKit::NetworkStorageManager::performTimeBasedEviction):
(WebKit::NetworkStorageManager::originStorageManager):
(WebKit::NetworkStorageManager::updateLastModificationTimeForOrigin):
(WebKit::NetworkStorageManager::fileSystemGetDirectory):
(WebKit::NetworkStorageManager::connectToStorageArea):
(WebKit::NetworkStorageManager::setItem):
(WebKit::NetworkStorageManager::removeItem):
(WebKit::NetworkStorageManager::clear):
(WebKit::NetworkStorageManager::cacheStorageOpenCache):
(WebKit::NetworkStorageManager::performEviction): Deleted.
* Source/WebKit/NetworkProcess/storage/NetworkStorageManager.h:
* Source/WebKit/UIProcess/API/Cocoa/_WKWebsiteDataStoreConfiguration.h:
* Source/WebKit/UIProcess/API/Cocoa/_WKWebsiteDataStoreConfiguration.mm:
(-[_WKWebsiteDataStoreConfiguration timeBasedEvictionEnabled]):
(-[_WKWebsiteDataStoreConfiguration setTimeBasedEvictionEnabled:]):
(-[_WKWebsiteDataStoreConfiguration timeBasedEvictionThreshold]):
(-[_WKWebsiteDataStoreConfiguration setTimeBasedEvictionThreshold:]):
(-[_WKWebsiteDataStoreConfiguration lastModificationTimeUpdateIntervalOverride]):
(-[_WKWebsiteDataStoreConfiguration setLastModificationTimeUpdateIntervalOverride:]):
* Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.cpp:
(WebKit::WebsiteDataStore::shouldPerformTimeBasedEviction const):
(WebKit::WebsiteDataStore::parameters):
* Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.h:
* Source/WebKit/UIProcess/WebsiteData/WebsiteDataStoreConfiguration.cpp:
(WebKit::WebsiteDataStoreConfiguration::copy const):
* Source/WebKit/UIProcess/WebsiteData/WebsiteDataStoreConfiguration.h:
(WebKit::WebsiteDataStoreConfiguration::timeBasedEvictionEnabled const):
(WebKit::WebsiteDataStoreConfiguration::setTimeBasedEvictionEnabled):
(WebKit::WebsiteDataStoreConfiguration::timeBasedEvictionThreshold const):
(WebKit::WebsiteDataStoreConfiguration::setTimeBasedEvictionThreshold):
(WebKit::WebsiteDataStoreConfiguration::lastModificationTimeUpdateIntervalOverride const):
(WebKit::WebsiteDataStoreConfiguration::setLastModificationTimeUpdateIntervalOverride):
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKWebsiteDatastore.mm:
(TestWebKitAPI::(TimeBasedEviction, Basic)):
(TestWebKitAPI::(TimeBasedEviction, IndexedDBReadUpdatesTimestamp)):
(TestWebKitAPI::(TimeBasedEviction, LocalStorageReadUpdatesTimestamp)):
(TestWebKitAPI::(TimeBasedEviction, CacheStorageReadUpdatesTimestamp)):
(TestWebKitAPI::(TimeBasedEviction, FileSystemAPIReadUpdatesTimestamp)):

Canonical link: <a href="https://commits.webkit.org/312741@main">https://commits.webkit.org/312741@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3fe01408980b7b762ce2491119a4381601d5f501

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/160676 "4 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/34149 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/27250 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/169579 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/115742 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/dabb4d58-5f58-48ee-a1ea-4f238ed59269) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/162545 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/34250 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/34149 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/124606 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/87980 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/2e11812a-49e2-44fc-8aa4-ba774824ce22) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/163635 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/26853 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/144337 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/105204 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/8b7fd791-ec59-493f-b3cc-bc77b056bce9) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/25905 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/24409 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/17299 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/152732 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/135599 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/22100 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/172059 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/21514 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/18962 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/23740 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/132873 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/33823 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/28501 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/132886 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35945 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/33807 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/143895 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/95616 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/27484 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/20710 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/193075 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/33318 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/100570 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/49725 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/32817 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/33061 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/32965 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->