### PR TITLE
macCatalyst engineering builds are broken (-Wobjc-property-no-attribute in VKCImageAnalyzerRequestVIConfiguration.h)

### DIFF
--- a/Source/WebCore/PAL/pal/spi/cocoa/VisionKitCoreSPI.h
+++ b/Source/WebCore/PAL/pal/spi/cocoa/VisionKitCoreSPI.h
@@ -45,7 +45,11 @@ DECLARE_SYSTEM_HEADER
 IGNORE_WARNINGS_BEGIN("undef")
 #import <VisionKitCore/VKImageAnalysis_WebKit.h>
 IGNORE_WARNINGS_END
+
+// FIXME: Remove this after rdar://150529276 is resolved.
+IGNORE_WARNINGS_BEGIN("objc-property-no-attribute")
 #import <VisionKitCore/VisionKitCore.h>
+IGNORE_WARNINGS_END
 
 #else
 


### PR DESCRIPTION
#### 9383551f3b49b9cad7a18d0b35b83e852e99eedc
<pre>
macCatalyst engineering builds are broken (-Wobjc-property-no-attribute in VKCImageAnalyzerRequestVIConfiguration.h)
<a href="https://bugs.webkit.org/show_bug.cgi?id=313870">https://bugs.webkit.org/show_bug.cgi?id=313870</a>
<a href="https://rdar.apple.com/167728365">rdar://167728365</a>

Reviewed by Richard Robinson.

The macCatalyst build is broken with the following error:

```
In file included from /Source/WebKit/Platform/cocoa/ImageAnalysisUtilities.mm:27:
In file included from /Source/WebKit/Platform/cocoa/ImageAnalysisUtilities.h:30:
In file included from /Build/Release-maccatalyst/usr/local/include/pal/spi/cocoa/VisionKitCoreSPI.h:48:
In file included from /SDK/Path/To/VisionKitCore.h:32:
/SDK/Path/To/VKCImageAnalyzerRequestVIConfiguration.h:26:1: error: no &apos;assign&apos;, &apos;retain&apos;, or &apos;copy&apos; attribute is specified - &apos;assign&apos; is assumed [-Werror,-Wobjc-property-no-attribute]
   26 | @property (nonatomic) NSNumber *isScreenshotsVLUAuthorized;
```

This is a bug in the SDK header, and the `DECLARE_SYSTEM_HEADER pragma`
in this file should suppress it, but -Wobjc-property-no-attribute
appears to not be suppressed by #pragma clang system_header in this
context.

To work around this issue, we wrap the VisionKitCore.h import in
`IGNORE_WARNINGS_BEGIN/END`, matching the existing pattern two lines
above for the &quot;undef&quot; warning around VKImageAnalysis_WebKit.h.

* Source/WebCore/PAL/pal/spi/cocoa/VisionKitCoreSPI.h:

Canonical link: <a href="https://commits.webkit.org/312662@main">https://commits.webkit.org/312662@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/86212882771cc853abc5147bb38312132a27d53d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/160063 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/33533 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/26637 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/168946 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/114444 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/161932 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/33636 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/33535 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/124060 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/87001 "2 failures") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/163021 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/26307 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/143768 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/104674 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/25360 "Passed tests") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/23849 "Found 2 new API test failures: TestWebKitAPI.WebKit.InterruptionBetweenSameProcessPages, TestWebKitAPI.WKWebExtensionAPIDeclarativeNetRequest.RemoveDynamicRules (failure)") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/16684 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/135051 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/21534 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/171426 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/17431 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/23172 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/132324 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/33209 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/27932 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/132350 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/33194 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/143329 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/91353 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/24450 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/26958 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/20142 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/32703 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/99100 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/32201 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/32447 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/32351 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->