### PR TITLE
[TestWebKitAPI] macCatalyst build broken because PlatformWebView.h uses NSWindow unconditionally on Apple platforms

### DIFF
--- a/Tools/TestWebKitAPI/Helpers/PlatformWebView.h
+++ b/Tools/TestWebKitAPI/Helpers/PlatformWebView.h
@@ -41,13 +41,25 @@
 #if defined(__APPLE__) && !PLATFORM(GTK)
 #ifdef __OBJC__
 @class WKWebView;
+#if PLATFORM(MAC)
 @class NSWindow;
 #else
+@class UIWindow;
+#endif
+#else
 class WKWebView;
+#if PLATFORM(MAC)
 class NSWindow;
+#else
+class UIWindow;
+#endif
 #endif
 typedef WKWebView *PlatformWKView;
+#if PLATFORM(MAC)
 typedef NSWindow *PlatformWindow;
+#else
+typedef UIWindow *PlatformWindow;
+#endif
 #elif PLATFORM(GTK)
 typedef WKViewRef PlatformWKView;
 typedef GtkWidget *PlatformWindow;


### PR DESCRIPTION
#### 3eb40bee52b53b6c9b290c1d54fedf6bf22c5a19
<pre>
[TestWebKitAPI] macCatalyst build broken because PlatformWebView.h uses NSWindow unconditionally on Apple platforms
<a href="https://bugs.webkit.org/show_bug.cgi?id=313872">https://bugs.webkit.org/show_bug.cgi?id=313872</a>
<a href="https://rdar.apple.com/176070030">rdar://176070030</a>

Reviewed by Richard Robinson.

PlatformWebView.h forward-declares NSWindow and typedefs PlatformWindow
as NSWindow * under `#if defined(__APPLE__) &amp;&amp; !PLATFORM(GTK)`. This
condition is true on macCatalyst, but NSWindow is not available there.

This contradiction has been latent for a long time since nothing compiled
PlatformWebView.h for macCatalyst. The failure now surfaces during the
SwiftExplicitDependencyGeneratePcm build phase: the TestWebKitAPILibrary
module map declares `umbrella &quot;../Helpers&quot;`, which pulls in every header
under Tools/TestWebKitAPI/Helpers/. When this precompiled module is then
built for macCatalyst, the compiler sees the NSWindow forward declaration
and emits:

```
  error: &apos;NSWindow&apos; is unavailable: not available on macCatalyst
```

Originally, I wanted to change the outer guard to read PLATFORM(MAC),
but it was intentionally written that way in 168883@main to support the
GTK-on-macOS-clang build. Instead, to fix this bug, we add PLATFORM(MAC)
guards inside the block so that we can distinguish between NSWindow and
UIWindow as necessary.

* Tools/TestWebKitAPI/Helpers/PlatformWebView.h:

Canonical link: <a href="https://commits.webkit.org/312664@main">https://commits.webkit.org/312664@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/86112929b2e88bcd48f58be9bcac1bf1c381fc12

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/160061 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/33531 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/26635 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/168943 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/114442 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/64836acd-de92-45b3-879b-544de558c15f) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/161930 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/33634 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/33533 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/124059 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/87000 "2 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/1022aadd-56fc-4c45-827a-6feaf5fb0e36) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/163019 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/26305 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/143765 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/104673 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/fde71dbd-0439-4fab-9e1e-e72ce97987fb) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/25358 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/23847 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/16682 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/135049 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/21532 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/171424 "Built successfully") | | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/23170 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/132323 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/33207 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/27930 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/132349 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/33192 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/143327 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/91348 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/24451 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/26956 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/20140 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/32701 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/32199 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/32445 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/32349 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->