### PR TITLE
Resync `html/browsers/browsing-the-web/navigating-across-documents/initial-empty-document` from WPT Upstream

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/navigating-across-documents/initial-empty-document/iframe-nosrc-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/navigating-across-documents/initial-empty-document/iframe-nosrc-expected.txt
@@ -5,4 +5,5 @@ PASS location.assign
 PASS window.open
 FAIL link click assert_equals: history.length must not change after normal navigation on document loaded by iframe with no src expected 6 but got 7
 FAIL form submission assert_equals: history.length increases after normal navigation from  non-initial empty document expected 8 but got 7
+FAIL initial about:blank => non-initial about:blank (via location.href) => normal HTTP navigation assert_equals: history.length must not change after normal navigation on document loaded by iframe with no src expected 7 but got 8
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/navigating-across-documents/initial-empty-document/iframe-nosrc.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/navigating-across-documents/initial-empty-document/iframe-nosrc.html
@@ -175,4 +175,39 @@ promise_test(async t => {
   assert_equals(history.length, startingHistoryLength + 1,
     "history.length increases after normal navigation from  non-initial empty document");
 }, "form submission");
+
+// This test is very similar to the `location.href` test a few cases above, but
+// the difference is that instead of navigating from:
+//   initial about:blank Document => HTTP => HTTP
+// ... we navigate from:
+//   initial about:blank Document => (non-initial) about:blank Document => HTTP
+//
+// We do this to ensure/assert that an explicit navigation to about:blank
+// *after* the iframe has finished initializing, is counted as a normal
+// navigation away from the initial about:blank Document, and the "initial-ness"
+// of the initial about:blank Document is not carried over to the next
+// about:blank Document.
+promise_test(async t => {
+  const startingHistoryLength = history.length;
+  // Create an iframe with src not set, which will stay on the initial empty
+  // document.
+  const iframe = insertIframe(t);
+  assert_equals(history.length, startingHistoryLength,
+    "Inserting iframe with no src must not change history.length");
+
+  // Navigate away from the initial empty document through setting location.href
+  // to `about:blank`. This should do a replacement TO ANOTHER about:blank
+  // Document, which is not the initial about:blank Document.
+  iframe.contentWindow.location.href = 'about:blank';
+  await waitForLoad(t, iframe, 'about:blank');
+  assert_equals(history.length, startingHistoryLength,
+    "history.length must not change after normal navigation on document loaded by iframe with no src");
+
+  // Navigate again using the same method, but this time it shouldn't do a
+  // replacement since it's no longer on the initial empty document.
+  iframe.contentWindow.location.href = url2;
+  await waitForLoad(t, iframe, url2);
+  assert_equals(history.length, startingHistoryLength + 1,
+    "history.length increases after normal navigation from  non-initial empty document");
+}, "initial about:blank => non-initial about:blank (via location.href) => normal HTTP navigation");
 </script>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/navigating-across-documents/initial-empty-document/iframe-src-204-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/navigating-across-documents/initial-empty-document/iframe-src-204-expected.txt
@@ -5,4 +5,5 @@ PASS Navigating to a different document with location.assign
 PASS Navigating to a different document with window.open
 FAIL Navigating to a different document with link click assert_equals: history.length must not change after normal navigation on document loaded by iframe with no src expected 6 but got 7
 FAIL Navigating to a different document with form submission assert_equals: history.length increases after normal navigation from  non-initial empty document expected 8 but got 7
+PASS about:blank on top of 204 loads async
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/navigating-across-documents/initial-empty-document/iframe-src-204.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/navigating-across-documents/initial-empty-document/iframe-src-204.html
@@ -175,4 +175,24 @@ promise_test(async t => {
   assert_equals(history.length, startingHistoryLength + 1,
     "history.length increases after normal navigation from  non-initial empty document");
 }, "Navigating to a different document with form submission");
+
+promise_test(async t => {
+  // The ready state is asserted to be what it is currently Blink, Gecko, WebKit
+  const iframe = insertIframeWith204Src(t);
+  assert_equals(iframe.contentDocument.readyState, "complete");
+
+  let loaded = false;
+  iframe.onload = () => loaded = true;
+
+  iframe.src = "about:blank";
+  assert_false(loaded, "No sync load event");
+  assert_equals(iframe.contentDocument.readyState, "complete");
+
+  await Promise.resolve();
+  assert_false(loaded, "No load event after microtask checkpoint");
+
+  await waitForLoad(t, iframe, "about:blank");
+  assert_true(loaded, "Iframe loaded eventually");
+  assert_equals(iframe.contentDocument.readyState, "complete");
+}, "about:blank on top of 204 loads async");
 </script>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/navigating-across-documents/initial-empty-document/iframe-src-aboutblank-navigate-immediately-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/navigating-across-documents/initial-empty-document/iframe-src-aboutblank-navigate-immediately-expected.txt
@@ -1,5 +1,5 @@
 
-PASS Navigating to a different document with src
+PASS Navigating away from the initial about:blank Document to a different one, with src
 PASS Navigating to a different document with location.href
 PASS Navigating to a different document with location.assign
 PASS Navigating to a different document with window.open

--- a/LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/navigating-across-documents/initial-empty-document/iframe-src-aboutblank-navigate-immediately.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/navigating-across-documents/initial-empty-document/iframe-src-aboutblank-navigate-immediately.html
@@ -16,32 +16,42 @@ const url1 = "/common/blank.html?1";
 
 promise_test(async t => {
   const startingHistoryLength = history.length;
-  // Create an iframe with src set to about:blank. This would trigger a
-  // navigation to a non-initial about:blank document.
+  // Create an iframe with src set to about:blank. Per the HTML Standard, this
+  // stays on the "initial about:blank Document" [1], because the "process the
+  // iframe attributes" algorithm [2] catches the "about:blank" navigation and
+  // fires a special synchronous `load` event at the initial about:blank
+  // Document, instead of replacing it with a non-initial, second about:blank
+  // Document. This is documented in the note at the end of [3].
+  //
+  // [1]: https://html.spec.whatwg.org/#is-initial-about:blank.
+  // [2]: https://html.spec.whatwg.org/#process-the-iframe-attributes
+  // [3]: https://html.spec.whatwg.org/#completely-finish-loading
   const iframe = insertIframeWithAboutBlankSrc(t);
   assert_equals(history.length, startingHistoryLength,
     "Inserting iframe with src='about:blank' must not change history.length");
 
-  // Trigger a navigation to url1 through the iframe's src attribute.
-  // The iframe should still be on the initial empty document, and the
-  // navigation should do replacement.
+  // Trigger a navigation from the initial about:blank Document, to url1 through
+  // the iframe's src attribute. Because we're navigating from the initial
+  // about:blank Document, the navigation should be a replacement.
   iframe.src = url1;
+
   // Wait for the latest navigation to finish.
   await waitForLoad(t, iframe, url1);
   assert_equals(history.length, startingHistoryLength,
-    "history.length must not change after normal navigation on initial empty document");
-}, "Navigating to a different document with src");
+    "history.length must not change after normal navigation from initial " +
+    "about:blank Document");
+}, "Navigating away from the initial about:blank Document to a different " +
+    "one, with src");
 
 promise_test(async t => {
   const startingHistoryLength = history.length;
-  // Create an iframe with src set to about:blank but navigate away from it immediately below.
   const iframe = insertIframeWithAboutBlankSrc(t);
   assert_equals(history.length, startingHistoryLength,
     "Inserting iframe with src='about:blank' must not change history.length");
 
-  // Navigate away from the initial empty document through setting
-  // location.href. The iframe should still be on the initial empty document,
-  // and the navigation should do replacement.
+  // Trigger a navigation from the initial about:blank Document, to url1 through
+  // location.href. Because we're navigating from the initial about:blank
+  // Document, the navigation should be a replacement.
   iframe.contentWindow.location.href = url1;
   await waitForLoad(t, iframe, url1);
   assert_equals(history.length, startingHistoryLength,
@@ -50,14 +60,13 @@ promise_test(async t => {
 
 promise_test(async t => {
   const startingHistoryLength = history.length;
-  // Create an iframe with src set to about:blank but navigate away from it immediately below.
   const iframe = insertIframeWithAboutBlankSrc(t);
   assert_equals(history.length, startingHistoryLength,
     "Inserting iframe with src='about:blank' must not change history.length");
 
-  // Navigate away from the initial empty document through location.assign().
-  // The iframe should still be on the initial empty document, and the
-  // navigation should do replacement.
+  // Trigger a navigation from the initial about:blank Document, to url1 through
+  // location.assign(). Because we're navigating from the initial about:blank
+  // Document, the navigation should be a replacement.
   iframe.contentWindow.location.assign(url1);
   await waitForLoad(t, iframe, url1);
   assert_equals(history.length, startingHistoryLength,
@@ -66,14 +75,13 @@ promise_test(async t => {
 
 promise_test(async t => {
   const startingHistoryLength = history.length;
-  // Create an iframe with src set to about:blank but navigate away from it immediately below.
   const iframe = insertIframeWithAboutBlankSrc(t);
   assert_equals(history.length, startingHistoryLength,
     "Inserting iframe with src='about:blank' must not change history.length");
 
-  // Navigate away from the initial empty document through window.open().
-  // The iframe should still be on the initial empty document, and the
-  // navigation should do replacement.
+  // Trigger a navigation from the initial about:blank Document, to url1 through
+  // window.open(). Because we're navigating from the initial about:blank
+  // Document, the navigation should be a replacement.
   iframe.contentWindow.open(url1, "_self");
   await waitForLoad(t, iframe, url1);
   assert_equals(history.length, startingHistoryLength,
@@ -82,14 +90,13 @@ promise_test(async t => {
 
 promise_test(async t => {
   const startingHistoryLength = history.length;
-  // Create an iframe with src set to about:blank but navigate away from it immediately below.
   const iframe = insertIframeWithAboutBlankSrc(t);
   assert_equals(history.length, startingHistoryLength,
     "Inserting iframe with src='about:blank' must not change history.length");
 
-  // Navigate away from the initial empty document through clicking an <a>
-  // element. The iframe should still be on the initial empty document, and the
-  // navigation should do replacement.
+  // Trigger a navigation from the initial about:blank Document, to url1 through
+  // clicking an `<a>` element. Because we're navigating from the initial
+  // about:blank Document, the navigation should be a replacement.
   const a = iframe.contentDocument.createElement("a");
   a.href = url1;
   iframe.contentDocument.body.appendChild(a);
@@ -101,14 +108,13 @@ promise_test(async t => {
 
 promise_test(async t => {
   const startingHistoryLength = history.length;
-  // Create an iframe with src set to about:blank but navigate away from it immediately below.
   const iframe = insertIframeWithAboutBlankSrc(t);
   assert_equals(history.length, startingHistoryLength,
     "Inserting iframe with src='about:blank' must not change history.length");
 
-  // Navigate away from the initial empty document through form submission.
-  // The iframe should still be on the initial empty document, and the
-  // navigation should do replacement.
+  // Trigger a navigation from the initial about:blank Document, to url1 through
+  // a form submission. Because we're navigating from the initial about:blank
+  // Document, the navigation should be a replacement.
   const form = iframe.contentDocument.createElement("form");
   form.action = "/common/blank.html";
   iframe.contentDocument.body.appendChild(form);

--- a/LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/navigating-across-documents/initial-empty-document/load-event-iframe-element.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/navigating-across-documents/initial-empty-document/load-event-iframe-element.html
@@ -16,6 +16,7 @@ promise_test(async t => {
   });
   document.body.appendChild(iframe);
   assert_equals(loadCount, 1);
+  assert_equals(iframe.contentDocument.location.href, "about:blank");
 }, "load event fires synchronously on <iframe> element created with no src");
 
 promise_test(async t => {
@@ -27,6 +28,7 @@ promise_test(async t => {
   });
   document.body.appendChild(iframe);
   assert_equals(loadCount, 1);
+  assert_equals(iframe.contentDocument.location.href, "about:blank");
 }, "load event fires synchronously on <iframe> element created with src=''");
 
 promise_test(async t => {
@@ -38,6 +40,7 @@ promise_test(async t => {
   });
   document.body.appendChild(iframe);
   assert_equals(loadCount, 1);
+  assert_equals(iframe.contentDocument.location.href, "about:blank");
 }, "load event fires synchronously on <iframe> element created with src='about:blank'");
 
 promise_test(async t => {
@@ -49,6 +52,7 @@ promise_test(async t => {
   });
   document.body.appendChild(iframe);
   assert_equals(loadCount, 1);
+  assert_equals(iframe.contentDocument.location.href, "about:blank#foo");
 }, "load event fires synchronously on <iframe> element created with src='about:blank#foo'");
 
 promise_test(async t => {
@@ -60,5 +64,6 @@ promise_test(async t => {
   });
   document.body.appendChild(iframe);
   assert_equals(loadCount, 1);
+  assert_equals(iframe.contentDocument.location.href, "about:blank?foo");
 }, "load event fires synchronously on <iframe> element created with src='about:blank?foo'");
 </script>


### PR DESCRIPTION
#### 5739385239be6f14b6290137e2bae12cd08eea1b
<pre>
Resync `html/browsers/browsing-the-web/navigating-across-documents/initial-empty-document` from WPT Upstream
<a href="https://bugs.webkit.org/show_bug.cgi?id=313875">https://bugs.webkit.org/show_bug.cgi?id=313875</a>
<a href="https://rdar.apple.com/176071977">rdar://176071977</a>

Reviewed by Vitor Roriz.

Upstream commit: <a href="https://github.com/web-platform-tests/wpt/commit/b5c9f918d85130ae29eccebc2e205e328a424adc">https://github.com/web-platform-tests/wpt/commit/b5c9f918d85130ae29eccebc2e205e328a424adc</a>

* LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/navigating-across-documents/initial-empty-document/iframe-nosrc-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/navigating-across-documents/initial-empty-document/iframe-nosrc.html:
* LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/navigating-across-documents/initial-empty-document/iframe-src-204-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/navigating-across-documents/initial-empty-document/iframe-src-204.html:
* LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/navigating-across-documents/initial-empty-document/iframe-src-aboutblank-navigate-immediately-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/navigating-across-documents/initial-empty-document/iframe-src-aboutblank-navigate-immediately.html:
* LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/navigating-across-documents/initial-empty-document/load-event-iframe-element.html:
* LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/navigating-across-documents/initial-empty-document/resources/helpers.js:
(window.insertIframeWithAboutBlankSrcWaitForLoad.async t):

Canonical link: <a href="https://commits.webkit.org/312474@main">https://commits.webkit.org/312474@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/02c476e08d36992deb7dc1311c00f0a766c71421

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/160068 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/33538 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/26642 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/168951 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/114449 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/75837f38-daf8-48e5-aa9e-b6ac6b9c0e0a) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/33641 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/33540 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/124064 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/87005 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/bdc524d9-d43f-4fdf-927e-584d6a18a5dd) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/163026 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/26312 "Passed tests") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/143761 "Found 1 new API test failure: TestWebKitAPI.Preconnect.HTTPS (failure)") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/104677 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/fbc91cb0-5007-4f76-bef4-6e7a3e05bbad) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/25365 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/23855 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/16689 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/135056 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/21528 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/171431 "Built successfully") | | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/23166 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/132329 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/33214 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/27938 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/132355 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35798 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/33199 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/143323 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/91362 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/26964 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/20136 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/32708 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/32206 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/32452 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/32356 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->