### PR TITLE
[TestWebKitAPI] macCatalyst build is broken (WebGLNoCrashOnOtherThreadAccess.mm:135:19: error: calling a private constructor of class '(anonymous namespace)::SetContextCGL')

### DIFF
--- a/Tools/TestWebKitAPI/Tests/WebKitLegacy/ios/WebGLNoCrashOnOtherThreadAccess.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitLegacy/ios/WebGLNoCrashOnOtherThreadAccess.mm
@@ -46,7 +46,7 @@ bool didFinishLoad;
 bool didFinishTest;
 
 #if PLATFORM(MAC) || PLATFORM(MACCATALYST)
-class SetContextCGL {
+struct SetContextCGL {
     SetContextCGL()
     {
         // TODO: implement properly. Skipped due to complicated instantiation.
@@ -59,7 +59,7 @@ class SetContextCGL {
     }
 };
 #else
-class SetContextCGL {
+struct SetContextCGL {
 
 };
 #endif


### PR DESCRIPTION
#### c4244328fc981124a8344e74fc665701e9c09dd2
<pre>
[TestWebKitAPI] macCatalyst build is broken (WebGLNoCrashOnOtherThreadAccess.mm:135:19: error: calling a private constructor of class &apos;(anonymous namespace)::SetContextCGL&apos;)
<a href="https://bugs.webkit.org/show_bug.cgi?id=313874">https://bugs.webkit.org/show_bug.cgi?id=313874</a>
<a href="https://rdar.apple.com/176071596">rdar://176071596</a>

Reviewed by Richard Robinson.

The build was broken with this error:

```
/Tools/TestWebKitAPI/Tests/WebKitLegacy/ios/WebGLNoCrashOnOtherThreadAccess.mm:135:19: error: calling a private constructor of class &apos;(anonymous namespace)::SetContextCGL&apos;
  135 |     SetContextCGL clientContextCGL1;
/Tools/TestWebKitAPI/Tests/WebKitLegacy/ios/WebGLNoCrashOnOtherThreadAccess.mm:50:5: note: implicitly declared private here
   50 |     SetContextCGL()
```

To fix this, we convert SetContextCGL to a struct, changing implicit
visibility.

* Tools/TestWebKitAPI/Tests/WebKitLegacy/ios/WebGLNoCrashOnOtherThreadAccess.mm:

Canonical link: <a href="https://commits.webkit.org/312708@main">https://commits.webkit.org/312708@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/25be3f4e18a72f2902c18833b642af8ffee4885e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/160807 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/34280 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/27381 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/169710 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/115873 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/162676 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/34381 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/34280 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/124723 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/88054 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/163766 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/26973 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/144444 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/105320 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/26025 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/24528 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/17430 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/135719 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/22207 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/172192 "Built successfully") | | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/23848 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/132987 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/33954 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/28620 "Found 8 new test failures: http/tests/site-isolation/inspector/console/message-from-iframe.html http/tests/site-isolation/inspector/console/message-from-worker.html http/tests/site-isolation/inspector/dom/getDocument-frame-target.html http/tests/site-isolation/inspector/page/override-user-agent-cross-origin-iframe.html http/tests/site-isolation/inspector/target/target-cross-origin-page-navigation.html http/tests/site-isolation/inspector/target/target.html http/tests/site-isolation/inspector/unit-tests/target-manager.html http/tests/site-isolation/inspector/worker/worker-in-cross-origin-iframe.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/132998 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/33938 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/144002 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/95759 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/24471 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/27591 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/20817 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/33449 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/32948 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/33192 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/33096 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->