### PR TITLE
[JSC] Implement cycle-collector for RTT and RTTGroup

### DIFF
--- a/JSTests/wasm/stress/wasm-cycle-collect-dupe-on-insert.js
+++ b/JSTests/wasm/stress/wasm-cycle-collect-dupe-on-insert.js
@@ -1,0 +1,159 @@
+// Exercises the dupe-on-insert fallbacks in canonicalizeRecursionGroupImpl
+// and canonicalizeSingletonImpl. When a just-parsed candidate module
+// produces a rec-group or singleton structurally identical to one already
+// in the canonical table, the candidate is discarded. Historically the
+// discard path didn't break the candidate's self-display refs (and, for
+// groups, its m_group back-refs), leaking the candidate forever.
+//
+// Two modules with the SAME type signature are constructed back-to-back.
+// The second module's parse hits the dupe path. If dupe-on-insert leaks,
+// the canonical table grows monotonically with iterations; with the fix,
+// it stays bounded near baseline.
+
+function uleb128(value) {
+    const result = [];
+    do {
+        let byte = value & 0x7f;
+        value >>>= 7;
+        if (value !== 0) byte |= 0x80;
+        result.push(byte);
+    } while (value !== 0);
+    return result;
+}
+
+function sleb128(value) {
+    const result = [];
+    let more = true;
+    while (more) {
+        let byte = value & 0x7f;
+        value >>= 7;
+        if ((value === 0 && (byte & 0x40) === 0) ||
+            (value === -1 && (byte & 0x40) !== 0)) {
+            more = false;
+        } else {
+            byte |= 0x80;
+        }
+        result.push(byte);
+    }
+    return result;
+}
+
+function encodeSection(id, contents) {
+    return [id, ...uleb128(contents.length), ...contents];
+}
+
+const WASM_MAGIC = [0x00, 0x61, 0x73, 0x6d];
+const WASM_VERSION = [0x01, 0x00, 0x00, 0x00];
+const SEC_TYPE = 1;
+const TYPE_STRUCT = 0x5f;
+const TYPE_ARRAY = 0x5e;
+const TYPE_SUB = 0x50;
+const TYPE_REC = 0x4e;
+const REF_NULL = 0x63;
+const TYPE_I32 = 0x7f;
+const TYPE_I64 = 0x7e;
+const FIELD_IMMUTABLE = 0x00;
+
+// The uniqueness salt varies the shape per *pair*. Both modules in a pair
+// share the same salt so their types canonicalize identically -> the second
+// module's parse hits the dupe-on-insert path. Across pairs the salt varies
+// so we don't merely dedup against a single canonical entry held by the
+// first pair.
+function buildMutualRecGroupBytes(pairSalt) {
+    const low = pairSalt & 0xff;
+    const high = (pairSalt >> 8) & 0xff;
+    const i32Count = 1 + low;
+    const i64Count = 1 + high;
+    const totalStructFields = 1 + i32Count + i64Count;
+
+    const structBody = [TYPE_STRUCT, ...uleb128(totalStructFields)];
+    structBody.push(REF_NULL, ...sleb128(1), FIELD_IMMUTABLE);
+    for (let i = 0; i < i32Count; ++i)
+        structBody.push(TYPE_I32, FIELD_IMMUTABLE);
+    for (let i = 0; i < i64Count; ++i)
+        structBody.push(TYPE_I64, FIELD_IMMUTABLE);
+
+    const arrayBody = [TYPE_ARRAY, REF_NULL, ...sleb128(0), FIELD_IMMUTABLE];
+
+    const typeSectionBody = [
+        0x01, TYPE_REC, 0x02,
+        TYPE_SUB, 0x00, ...structBody,
+        TYPE_SUB, 0x00, ...arrayBody,
+    ];
+
+    return new Uint8Array([
+        ...WASM_MAGIC,
+        ...WASM_VERSION,
+        ...encodeSection(SEC_TYPE, typeSectionBody),
+    ]);
+}
+
+// Self-recursive singleton (struct with ref to self). Same uniqueness logic.
+function buildSelfRecursiveSingletonBytes(pairSalt) {
+    const low = pairSalt & 0xff;
+    const high = (pairSalt >> 8) & 0xff;
+    const i32Count = 1 + low;
+    const i64Count = 1 + high;
+    const totalFields = 1 + i32Count + i64Count;
+
+    const structBody = [TYPE_STRUCT, ...uleb128(totalFields)];
+    structBody.push(REF_NULL, ...sleb128(0), FIELD_IMMUTABLE);
+    for (let i = 0; i < i32Count; ++i)
+        structBody.push(TYPE_I32, FIELD_IMMUTABLE);
+    for (let i = 0; i < i64Count; ++i)
+        structBody.push(TYPE_I64, FIELD_IMMUTABLE);
+
+    const typeSectionBody = [
+        0x01, TYPE_REC, 0x01,
+        TYPE_SUB, 0x00, ...structBody,
+    ];
+
+    return new Uint8Array([
+        ...WASM_MAGIC,
+        ...WASM_VERSION,
+        ...encodeSection(SEC_TYPE, typeSectionBody),
+    ]);
+}
+
+if (typeof $vm === "undefined" || typeof $vm.wasmCanonicalTypeCount !== "function")
+    throw new Error("$vm.wasmCanonicalTypeCount() is required for this test");
+
+function churnPairs(builder, count, saltBase) {
+    for (let i = 0; i < count; ++i) {
+        const salt = saltBase + i;
+        // First module: NEW canonical entry.
+        const m1 = new WebAssembly.Module(builder(salt));
+        // Second module with identical type: dupe-on-insert path.
+        const m2 = new WebAssembly.Module(builder(salt));
+        void m1;
+        void m2;
+    }
+}
+
+function verifyReclamation(label, builder) {
+    const baseline = $vm.wasmCanonicalTypeCount();
+    const pairs = 200;
+    churnPairs(builder, pairs, 0);
+
+    // Drive GC to quiescence via gc() (sync full + sweep).
+    let after = $vm.wasmCanonicalTypeCount();
+    for (let round = 0; round < 20; ++round) {
+        const before = after;
+        if (typeof gc === "function") gc();
+        else if (typeof fullGC === "function") fullGC();
+        after = $vm.wasmCanonicalTypeCount();
+        if (after === before) break;
+    }
+
+    const grew = after - baseline;
+    const budget = Math.floor(pairs / 10);
+    if (grew > budget) {
+        throw new Error(
+            `[${label}] canonical table grew by ${grew} entries after ${pairs} dupe pairs ` +
+            `(baseline=${baseline}, after=${after}, budget=${budget}). ` +
+            `The dupe-on-insert path is probably leaking.`);
+    }
+}
+
+verifyReclamation("mutual rec-group", buildMutualRecGroupBytes);
+verifyReclamation("self-recursive singleton", buildSelfRecursiveSingletonBytes);

--- a/JSTests/wasm/stress/wasm-cycle-collect-intra-group-subtype.js
+++ b/JSTests/wasm/stress/wasm-cycle-collect-intra-group-subtype.js
@@ -1,0 +1,116 @@
+// Exercises the cycle collector's sweep ordering for a multi-member rec-group
+// that contains intra-group subtyping. This is the scenario where sweep must
+// not interleave clearDisplayRefsToMembersOf with setCanonicalGroup(nullptr):
+// the intra-group predicate `slot->canonicalGroup() == &deadGroup` must see
+// every target's original m_group back-pointer, or display slots pointing at
+// already-unlinked members get missed and dangle through ~RTT destruction.
+//
+// Shape (varied per iteration so each module gets a fresh canonical group):
+//   (rec
+//     (type $A (sub (struct (field i32))))
+//     (type $B (sub $A (struct (field i32) (field (ref null $A))))))
+// $B is a subtype of $A -- B's display contains A. Both are in the same
+// rec-group. After module drop, both should be reclaimable.
+
+function uleb128(value) {
+    const result = [];
+    do {
+        let byte = value & 0x7f;
+        value >>>= 7;
+        if (value !== 0) byte |= 0x80;
+        result.push(byte);
+    } while (value !== 0);
+    return result;
+}
+
+function sleb128(value) {
+    const result = [];
+    let more = true;
+    while (more) {
+        let byte = value & 0x7f;
+        value >>= 7;
+        if ((value === 0 && (byte & 0x40) === 0) ||
+            (value === -1 && (byte & 0x40) !== 0)) {
+            more = false;
+        } else {
+            byte |= 0x80;
+        }
+        result.push(byte);
+    }
+    return result;
+}
+
+function encodeSection(id, contents) {
+    return [id, ...uleb128(contents.length), ...contents];
+}
+
+const WASM_MAGIC = [0x00, 0x61, 0x73, 0x6d];
+const WASM_VERSION = [0x01, 0x00, 0x00, 0x00];
+
+const SEC_TYPE = 1;
+const TYPE_STRUCT = 0x5f;
+const TYPE_SUB = 0x50;
+const TYPE_REC = 0x4e;
+const REF_NULL = 0x63;
+const TYPE_I32 = 0x7f;
+const TYPE_I64 = 0x7e;
+const FIELD_IMMUTABLE = 0x00;
+
+function buildModuleBytes(iterationSalt) {
+    // Two-dimensional salt so each iteration produces a structurally
+    // distinct rec-group (no dedup masking).
+    const lowSalt = iterationSalt & 0xff;
+    const highSalt = (iterationSalt >> 8) & 0xff;
+    const i32Count = 1 + lowSalt;
+    const i64Count = 1 + highSalt;
+
+    // Type 0: $A = sub (open) struct { i32*i32Count, i64*i64Count }
+    const aFieldCount = i32Count + i64Count;
+    const aBody = [TYPE_STRUCT, ...uleb128(aFieldCount)];
+    for (let i = 0; i < i32Count; ++i)
+        aBody.push(TYPE_I32, FIELD_IMMUTABLE);
+    for (let i = 0; i < i64Count; ++i)
+        aBody.push(TYPE_I64, FIELD_IMMUTABLE);
+
+    // Type 1: $B = sub $A struct { ..., (ref null $A) }
+    //   B has A in its display chain; B's last field is a back-ref into the
+    //   same rec-group's type 0 (intra-group ref => TypeSlot anchors cycle).
+    const bFieldCount = i32Count + i64Count + 1;
+    const bBody = [TYPE_STRUCT, ...uleb128(bFieldCount)];
+    for (let i = 0; i < i32Count; ++i)
+        bBody.push(TYPE_I32, FIELD_IMMUTABLE);
+    for (let i = 0; i < i64Count; ++i)
+        bBody.push(TYPE_I64, FIELD_IMMUTABLE);
+    bBody.push(REF_NULL, ...sleb128(0), FIELD_IMMUTABLE);
+
+    const typeSectionBody = [
+        0x01,                         // 1 top-level entry (the rec group)
+        TYPE_REC,
+        0x02,                         // 2 types inside the rec group
+        TYPE_SUB, 0x00, ...aBody,     // A: 0 supertypes
+        TYPE_SUB, 0x01, ...sleb128(0), ...bBody, // B: 1 supertype = type 0 (A)
+    ];
+
+    return new Uint8Array([
+        ...WASM_MAGIC,
+        ...WASM_VERSION,
+        ...encodeSection(SEC_TYPE, typeSectionBody),
+    ]);
+}
+
+function churn(count, saltBase) {
+    for (let i = 0; i < count; ++i) {
+        const m = new WebAssembly.Module(buildModuleBytes(saltBase + i));
+        void m;
+    }
+}
+
+const batches = 10;
+const perBatch = 300;
+for (let b = 0; b < batches; ++b) {
+    churn(perBatch, b * perBatch);
+    if (typeof gc === "function")
+        gc();
+    else if (typeof fullGC === "function")
+        fullGC();
+}

--- a/JSTests/wasm/stress/wasm-cycle-collect-mutually-recursive-struct-array.js
+++ b/JSTests/wasm/stress/wasm-cycle-collect-mutually-recursive-struct-array.js
@@ -1,0 +1,121 @@
+// Exercises the cycle collector in Wasm::TypeInformation::tryCleanup for
+// multi-member recursion groups whose members mutually reference each other
+// via TypeSlot::rttAnchor. Before the collector landed, these leaked on
+// every module drop because hasOneRef() can never fire on a rec-group whose
+// members form an intra-group cycle.
+//
+// Each iteration builds a unique module whose type section is one rec-group
+// of the form:
+//   (rec
+//     (type $s (struct (field (ref null $a)) i32 ... i32))   ; iteration-specific field count
+//     (type $a (array  (ref null $s))))
+//
+// Varying the struct's trailing i32 field count per iteration forces a
+// fresh canonical rec-group entry each time. We churn many such modules
+// under repeated full GCs; if the collector fails, the canonical table
+// grows without bound and this test OOMs or times out. On success, the
+// jsc process stays within a reasonable memory budget.
+
+function uleb128(value) {
+    const result = [];
+    do {
+        let byte = value & 0x7f;
+        value >>>= 7;
+        if (value !== 0) byte |= 0x80;
+        result.push(byte);
+    } while (value !== 0);
+    return result;
+}
+
+function sleb128(value) {
+    const result = [];
+    let more = true;
+    while (more) {
+        let byte = value & 0x7f;
+        value >>= 7;
+        if ((value === 0 && (byte & 0x40) === 0) ||
+            (value === -1 && (byte & 0x40) !== 0)) {
+            more = false;
+        } else {
+            byte |= 0x80;
+        }
+        result.push(byte);
+    }
+    return result;
+}
+
+function encodeSection(id, contents) {
+    return [id, ...uleb128(contents.length), ...contents];
+}
+
+const WASM_MAGIC = [0x00, 0x61, 0x73, 0x6d];
+const WASM_VERSION = [0x01, 0x00, 0x00, 0x00];
+
+const SEC_TYPE = 1;
+const TYPE_STRUCT = 0x5f;
+const TYPE_ARRAY = 0x5e;
+const TYPE_SUB = 0x50;
+const TYPE_REC = 0x4e;
+const REF_NULL = 0x63; // (ref null ht) prefix; heap type follows as varint32
+const TYPE_I32 = 0x7f;
+const TYPE_I64 = 0x7e;
+const FIELD_IMMUTABLE = 0x00;
+
+function buildModuleBytes(iterationSalt) {
+    // 2-dimensional salt: low 8 bits drive i32-field count, next 8 bits
+    // drive i64-field count. Yields up to 256*256 structurally-unique
+    // rec-groups so canonicalization dedup can't bound the table and mask
+    // a broken collector.
+    const lowSalt = iterationSalt & 0xff;
+    const highSalt = (iterationSalt >> 8) & 0xff;
+    const i32Count = 1 + lowSalt;
+    const i64Count = 1 + highSalt;
+    const totalStructFields = 1 + i32Count + i64Count;
+
+    const structBody = [TYPE_STRUCT, ...uleb128(totalStructFields)];
+    structBody.push(REF_NULL, ...sleb128(1), FIELD_IMMUTABLE);
+    for (let i = 0; i < i32Count; ++i)
+        structBody.push(TYPE_I32, FIELD_IMMUTABLE);
+    for (let i = 0; i < i64Count; ++i)
+        structBody.push(TYPE_I64, FIELD_IMMUTABLE);
+
+    const arrayBody = [TYPE_ARRAY, REF_NULL, ...sleb128(0), FIELD_IMMUTABLE];
+
+    const typeSectionBody = [
+        0x01,           // 1 top-level entry (the rec group itself)
+        TYPE_REC,
+        0x02,           // 2 types inside the rec group
+        TYPE_SUB, 0x00, ...structBody, // struct @ 0, no supertypes
+        TYPE_SUB, 0x00, ...arrayBody,  // array @ 1, no supertypes
+    ];
+
+    return new Uint8Array([
+        ...WASM_MAGIC,
+        ...WASM_VERSION,
+        ...encodeSection(SEC_TYPE, typeSectionBody),
+    ]);
+}
+
+function churnModules(count, saltBase) {
+    for (let i = 0; i < count; ++i) {
+        const bytes = buildModuleBytes(saltBase + i);
+        const m = new WebAssembly.Module(bytes);
+        // Drop the strong ref to m immediately; only the intra-rec-group
+        // TypeSlot anchor cycle would keep the canonical entry alive if the
+        // collector fails.
+        void m;
+    }
+}
+
+// Use gc() (full + sync sweep) rather than fullGC() (full + deferred
+// sweep) so JSWebAssemblyModule::destroy -- which calls tryCleanup --
+// actually fires inside each GC call.
+const batches = 20;
+const perBatch = 500;
+for (let b = 0; b < batches; ++b) {
+    churnModules(perBatch, b * perBatch);
+    if (typeof gc === "function")
+        gc();
+    else if (typeof fullGC === "function")
+        fullGC();
+}

--- a/JSTests/wasm/stress/wasm-cycle-collect-observable.js
+++ b/JSTests/wasm/stress/wasm-cycle-collect-observable.js
@@ -1,0 +1,139 @@
+// Directly verifies that Wasm::TypeInformation::tryCleanup actually reclaims
+// canonical entries (as opposed to merely keeping memory bounded via
+// canonicalization dedup). Uses the $vm.wasmCanonicalTypeCount() helper to
+// observe the canonical table size before and after a batch of churn.
+//
+// Each iteration builds a structurally-UNIQUE rec-group, so there's no dedup
+// fallback -- if the cycle collector doesn't run, the table will grow
+// linearly with iterations. After a full GC, the table should drop back to
+// near the baseline.
+
+function uleb128(value) {
+    const result = [];
+    do {
+        let byte = value & 0x7f;
+        value >>>= 7;
+        if (value !== 0) byte |= 0x80;
+        result.push(byte);
+    } while (value !== 0);
+    return result;
+}
+
+function sleb128(value) {
+    const result = [];
+    let more = true;
+    while (more) {
+        let byte = value & 0x7f;
+        value >>= 7;
+        if ((value === 0 && (byte & 0x40) === 0) ||
+            (value === -1 && (byte & 0x40) !== 0)) {
+            more = false;
+        } else {
+            byte |= 0x80;
+        }
+        result.push(byte);
+    }
+    return result;
+}
+
+function encodeSection(id, contents) {
+    return [id, ...uleb128(contents.length), ...contents];
+}
+
+const WASM_MAGIC = [0x00, 0x61, 0x73, 0x6d];
+const WASM_VERSION = [0x01, 0x00, 0x00, 0x00];
+const SEC_TYPE = 1;
+const TYPE_STRUCT = 0x5f;
+const TYPE_ARRAY = 0x5e;
+const TYPE_SUB = 0x50;
+const TYPE_REC = 0x4e;
+const REF_NULL = 0x63;
+const TYPE_I32 = 0x7f;
+const TYPE_I64 = 0x7e;
+const FIELD_IMMUTABLE = 0x00;
+
+// Encode a 2-dimensional salt: low 8 bits drive i32-field count, next 8 bits
+// drive i64-field count. Unique across (lowSalt, highSalt) space, up to 256
+// * 256 combinations before wrapping.
+function buildModuleBytes(iter) {
+    const lowSalt = iter & 0xff;
+    const highSalt = (iter >> 8) & 0xff;
+    const i32Count = 1 + lowSalt;
+    const i64Count = 1 + highSalt;
+
+    // struct at index 0: 1 ref-to-array + i32Count i32 + i64Count i64
+    const totalStructFields = 1 + i32Count + i64Count;
+    const structBody = [TYPE_STRUCT, ...uleb128(totalStructFields)];
+    structBody.push(REF_NULL, ...sleb128(1), FIELD_IMMUTABLE);
+    for (let i = 0; i < i32Count; ++i)
+        structBody.push(TYPE_I32, FIELD_IMMUTABLE);
+    for (let i = 0; i < i64Count; ++i)
+        structBody.push(TYPE_I64, FIELD_IMMUTABLE);
+
+    // array at index 1: element = ref-to-struct
+    const arrayBody = [TYPE_ARRAY, REF_NULL, ...sleb128(0), FIELD_IMMUTABLE];
+
+    const typeSectionBody = [
+        0x01, TYPE_REC, 0x02,
+        TYPE_SUB, 0x00, ...structBody,
+        TYPE_SUB, 0x00, ...arrayBody,
+    ];
+
+    return new Uint8Array([
+        ...WASM_MAGIC,
+        ...WASM_VERSION,
+        ...encodeSection(SEC_TYPE, typeSectionBody),
+    ]);
+}
+
+if (typeof $vm === "undefined" || typeof $vm.wasmCanonicalTypeCount !== "function")
+    throw new Error("$vm.wasmCanonicalTypeCount() is required for this test");
+
+const baseline = $vm.wasmCanonicalTypeCount();
+const iterations = 500;
+
+// Churn inside a helper function so every local `m` goes out of scope when
+// the call returns -- stack / register conservative roots shouldn't pin any
+// module past the return. Without this, the JS GC conservatively holds onto
+// modules via in-frame references and fullGC() drains only a trickle per
+// call.
+function churnBatch(start, count) {
+    for (let i = 0; i < count; ++i) {
+        const m = new WebAssembly.Module(buildModuleBytes(start + i));
+        void m;
+    }
+}
+
+churnBatch(0, iterations);
+
+// Drive GC to quiescence. `gc()` (= collectNow(Sync, Full)) is the right
+// primitive here -- it runs a full collection AND sweeps synchronously, so
+// JSWebAssemblyModule::destroy (and therefore TypeInformation::tryCleanup)
+// actually fires inside the call. `fullGC()` alone runs the mark phase but
+// defers sweeping, which is why earlier versions of this test saw only a
+// handful of modules destroyed per call.
+let after = $vm.wasmCanonicalTypeCount();
+for (let round = 0; round < 20; ++round) {
+    const before = after;
+    if (typeof gc === "function")
+        gc();
+    else if (typeof fullGC === "function")
+        fullGC();
+    after = $vm.wasmCanonicalTypeCount();
+    if (after === before)
+        break;
+}
+
+const grew = after - baseline;
+
+// With working reclamation, `grew` should be a small constant. Without
+// reclamation, grew ~= iterations. Budget at one-tenth of iterations for a
+// conservative middle ground that catches regressions while tolerating a
+// few conservatively-rooted modules.
+const budget = Math.floor(iterations / 10);
+if (grew > budget) {
+    throw new Error(
+        `canonical table grew by ${grew} entries after churn of ${iterations} unique modules ` +
+        `(baseline=${baseline}, after=${after}, budget=${budget}). ` +
+        `This suggests Wasm::TypeInformation::tryCleanup is not reclaiming rec-groups.`);
+}

--- a/JSTests/wasm/stress/wasm-cycle-collect-parse-failure.js
+++ b/JSTests/wasm/stress/wasm-cycle-collect-parse-failure.js
@@ -1,0 +1,118 @@
+// Verifies that a parser failure AFTER RTT construction but BEFORE
+// canonicalization does not leak the partially-built RTT. Historically an
+// RTT wrote `this` into its self-display slot at construction, creating a
+// permanent refcount cycle; anything that failed validation between
+// tryCreate* and HashSet insertion leaked one RTT per failed parse. Now
+// the self-slot is deferred until canonicalization success, so the
+// candidate destructs cleanly when the parser unwinds.
+//
+// Strategy: construct a module whose type section is valid enough to
+// tryCreate a struct RTT, then hits a validation error later that causes
+// the parser to abandon the constructed RTT. Measure the canonical table
+// before and after many such failed parses; with the fix, nothing accrues
+// because the candidates were never canonicalized (and, critically, they
+// also don't leak).
+
+function uleb128(v) { const r = []; do { let b = v & 0x7f; v >>>= 7; if (v) b |= 0x80; r.push(b); } while (v); return r; }
+function sleb128(v) { const r = []; let more = true; while (more) { let b = v & 0x7f; v >>= 7; if ((v === 0 && (b & 0x40) === 0) || (v === -1 && (b & 0x40) !== 0)) more = false; else b |= 0x80; r.push(b); } return r; }
+function enc(id, c) { return [id, ...uleb128(c.length), ...c]; }
+
+const WASM_MAGIC = [0x00, 0x61, 0x73, 0x6d];
+const WASM_VERSION = [0x01, 0x00, 0x00, 0x00];
+const SEC_TYPE = 1;
+const SEC_FUNCTION = 3;
+const TYPE_STRUCT = 0x5f;
+const TYPE_SUB = 0x50;
+const TYPE_REC = 0x4e;
+const TYPE_I32 = 0x7f;
+const FIELD_IMMUTABLE = 0x00;
+
+// Builds a module whose type section starts a rec-group, successfully
+// tryCreate's a valid first struct RTT, then hits an invalid byte before
+// reaching the end of the rec-group. The parser must throw BEFORE
+// canonicalizeRecursionGroup runs -- which means the first struct's RTT
+// was constructed but never inserted into the canonical table. With the
+// self-slot-set-at-construction design, that RTT is permanently pinned by
+// its own self-display ref and leaks. With the deferred-self-slot design,
+// it has no self-cycle and destructs cleanly when the rec-group's
+// candidate Vector goes out of scope during parse-error unwind.
+//
+// Uniqueness across iterations: vary the struct's field count so the
+// discarded RTT is structurally distinct per iteration. If it were ever
+// to reach canonicalization (it shouldn't), each one would be unique.
+function buildFailingModule(salt) {
+    const i32Count = 1 + (salt & 0xff);
+    const structBody = [TYPE_STRUCT, ...uleb128(i32Count)];
+    for (let i = 0; i < i32Count; ++i)
+        structBody.push(TYPE_I32, FIELD_IMMUTABLE);
+
+    const typeSection = [
+        0x01,        // 1 top-level entry: the rec group
+        TYPE_REC,
+        0x02,        // 2 types -- but we'll only provide 1 + garbage
+        TYPE_SUB, 0x00, ...structBody,
+        0xFF,        // invalid byte where type 1's form-byte should be
+    ];
+
+    return new Uint8Array([
+        ...WASM_MAGIC, ...WASM_VERSION,
+        ...enc(SEC_TYPE, typeSection),
+    ]);
+}
+
+if (typeof $vm === "undefined" || typeof $vm.wasmCanonicalTypeCount !== "function")
+    throw new Error("$vm.wasmCanonicalTypeCount() required");
+
+const baseline = $vm.wasmCanonicalTypeCount();
+const iterations = 500;
+
+function churn() {
+    for (let i = 0; i < iterations; ++i) {
+        let threw = false;
+        try {
+            new WebAssembly.Module(buildFailingModule(i));
+        } catch (e) {
+            threw = true;
+        }
+        if (!threw)
+            throw new Error(`iteration ${i}: expected WebAssembly.CompileError, module parsed successfully`);
+    }
+}
+
+churn();
+
+// The failed parses canonicalized their type sections successfully before
+// the function section exploded. Trigger a tryCleanup by creating and
+// dropping a valid trivial module -- JSWebAssemblyModule::destroy invokes
+// the cycle collector, which should reclaim every canonicalized RTT with
+// no external holder (including all 256 from the churn above).
+function triggerCleanup() {
+    const trivial = new Uint8Array([...WASM_MAGIC, ...WASM_VERSION]);
+    for (let i = 0; i < 5; ++i) {
+        const m = new WebAssembly.Module(trivial);
+        void m;
+    }
+}
+triggerCleanup();
+
+// Drive GC to quiescence.
+let after = $vm.wasmCanonicalTypeCount();
+for (let round = 0; round < 20; ++round) {
+    const before = after;
+    if (typeof gc === "function") gc();
+    else if (typeof fullGC === "function") fullGC();
+    after = $vm.wasmCanonicalTypeCount();
+    if (after === before) break;
+}
+
+const grew = after - baseline;
+// With Option C (deferred self-slot), the cycle collector can reclaim
+// these canonicalized singletons because their only owners are the table
+// entry (+1) and the self-display slot (+1); trial-decrement leaves
+// virtualRefCount == 0 -> eligible. Before the cycle collector landed,
+// this test would leak all 256.
+if (grew > Math.floor(iterations / 10)) {
+    throw new Error(
+        `canonical table grew by ${grew} entries after ${iterations} failed parses ` +
+        `(baseline=${baseline}, after=${after}). Parse-failure RTTs are leaking.`);
+}

--- a/JSTests/wasm/stress/wasm-cycle-collect-self-recursive-singleton.js
+++ b/JSTests/wasm/stress/wasm-cycle-collect-self-recursive-singleton.js
@@ -1,0 +1,101 @@
+// Exercises the cycle collector in Wasm::TypeInformation::tryCleanup for
+// self-recursive singletons (rec-group of size 1 whose single type references
+// itself). Before the collector landed, the existing `hasOneRef()` predicate
+// in tryCleanup couldn't fire on such a singleton because the TypeSlot's
+// rttAnchor + the self-display slot each add a self-reference, keeping the
+// refcount at >= 2.
+//
+// Each iteration builds a module of shape:
+//   (rec (type $s (struct (field (ref null $s)) i32 ... i32)))
+// The trailing i32 field count varies per iteration so every iteration
+// produces a fresh canonical singleton.
+
+function uleb128(value) {
+    const result = [];
+    do {
+        let byte = value & 0x7f;
+        value >>>= 7;
+        if (value !== 0) byte |= 0x80;
+        result.push(byte);
+    } while (value !== 0);
+    return result;
+}
+
+function sleb128(value) {
+    const result = [];
+    let more = true;
+    while (more) {
+        let byte = value & 0x7f;
+        value >>= 7;
+        if ((value === 0 && (byte & 0x40) === 0) ||
+            (value === -1 && (byte & 0x40) !== 0)) {
+            more = false;
+        } else {
+            byte |= 0x80;
+        }
+        result.push(byte);
+    }
+    return result;
+}
+
+function encodeSection(id, contents) {
+    return [id, ...uleb128(contents.length), ...contents];
+}
+
+const WASM_MAGIC = [0x00, 0x61, 0x73, 0x6d];
+const WASM_VERSION = [0x01, 0x00, 0x00, 0x00];
+
+const SEC_TYPE = 1;
+const TYPE_STRUCT = 0x5f;
+const TYPE_SUB = 0x50;
+const TYPE_REC = 0x4e;
+const REF_NULL = 0x63;
+const TYPE_I32 = 0x7f;
+const TYPE_I64 = 0x7e;
+const FIELD_IMMUTABLE = 0x00;
+
+function buildModuleBytes(iterationSalt) {
+    const lowSalt = iterationSalt & 0xff;
+    const highSalt = (iterationSalt >> 8) & 0xff;
+    const i32Count = 1 + lowSalt;
+    const i64Count = 1 + highSalt;
+    const totalFields = 1 + i32Count + i64Count;
+
+    const structBody = [TYPE_STRUCT, ...uleb128(totalFields)];
+    // Self-reference: (ref null 0) where 0 is this very type's module index.
+    structBody.push(REF_NULL, ...sleb128(0), FIELD_IMMUTABLE);
+    for (let i = 0; i < i32Count; ++i)
+        structBody.push(TYPE_I32, FIELD_IMMUTABLE);
+    for (let i = 0; i < i64Count; ++i)
+        structBody.push(TYPE_I64, FIELD_IMMUTABLE);
+
+    const typeSectionBody = [
+        0x01,
+        TYPE_REC,
+        0x01, // 1 type inside rec
+        TYPE_SUB, 0x00, ...structBody,
+    ];
+
+    return new Uint8Array([
+        ...WASM_MAGIC,
+        ...WASM_VERSION,
+        ...encodeSection(SEC_TYPE, typeSectionBody),
+    ]);
+}
+
+function churnModules(count, saltBase) {
+    for (let i = 0; i < count; ++i) {
+        const m = new WebAssembly.Module(buildModuleBytes(saltBase + i));
+        void m;
+    }
+}
+
+const batches = 20;
+const perBatch = 500;
+for (let b = 0; b < batches; ++b) {
+    churnModules(perBatch, b * perBatch);
+    if (typeof gc === "function")
+        gc();
+    else if (typeof fullGC === "function")
+        fullGC();
+}

--- a/JSTests/wasm/stress/wasm-gc-realmless-structure.js
+++ b/JSTests/wasm/stress/wasm-gc-realmless-structure.js
@@ -1,6 +1,3 @@
-//@ requireOptions("--useWasmGC=1")
-//@ skip if !$isSupportedByHardware
-
 // Test that WasmGC objects work correctly with realmless structures (null realm).
 
 function makeWasmGCModule() {

--- a/Source/JavaScriptCore/runtime/OptionsList.h
+++ b/Source/JavaScriptCore/runtime/OptionsList.h
@@ -117,6 +117,7 @@ bool hasCapacityToUseLargeGigacage();
     v(Bool, debuggerTriggersBreakpointException, false, Normal, "Using the debugger statement will trigger an breakpoint exception (Useful when lldbing)"_s) \
     v(Bool, verboseWasmDebugger, false, Normal, nullptr) \
     v(Bool, enableWasmDebugger, false, Normal, nullptr) \
+    v(Bool, verboseWasmTypeCleanup, false, Normal, "Log per-invocation counts from Wasm::TypeInformation::tryCleanup (scanned / live / reclaimed)."_s) \
     v(Bool, dumpBytecodesBeforeGeneratorification, false, Normal, nullptr) \
     v(Unsigned, switchJumpTableAmountThreshold, 15, Normal, nullptr) \
     \

--- a/Source/JavaScriptCore/tools/JSDollarVM.cpp
+++ b/Source/JavaScriptCore/tools/JSDollarVM.cpp
@@ -94,6 +94,7 @@ WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 #include "WasmModuleInformation.h"
 #include "WasmStreamingCompiler.h"
 #include "WasmStreamingParser.h"
+#include "WasmTypeDefinition.h"
 #endif
 
 #if ENABLE(WEBASSEMBLY_DEBUGGER)
@@ -2210,6 +2211,7 @@ static JSC_DECLARE_HOST_FUNCTION(functionCurrentCPUTime);
 static JSC_DECLARE_HOST_FUNCTION(functionTotalGCTime);
 static JSC_DECLARE_HOST_FUNCTION(functionParseCount);
 static JSC_DECLARE_HOST_FUNCTION(functionIsWasmSupported);
+static JSC_DECLARE_HOST_FUNCTION(functionWasmCanonicalTypeCount);
 static JSC_DECLARE_HOST_FUNCTION(functionMake16BitStringIfPossible);
 static JSC_DECLARE_HOST_FUNCTION(functionGetStructureTransitionList);;
 static JSC_DECLARE_HOST_FUNCTION(functionGetConcurrently);
@@ -3892,6 +3894,16 @@ JSC_DEFINE_HOST_FUNCTION(functionIsWasmSupported, (JSGlobalObject*, CallFrame*))
     return JSValue::encode(jsBoolean(Wasm::isSupported()));
 }
 
+JSC_DEFINE_HOST_FUNCTION(functionWasmCanonicalTypeCount, (JSGlobalObject*, CallFrame*))
+{
+    DollarVMAssertScope assertScope;
+#if ENABLE(WEBASSEMBLY)
+    return JSValue::encode(jsNumber(Wasm::TypeInformation::canonicalTypeCount()));
+#else
+    return JSValue::encode(jsNumber(0));
+#endif
+}
+
 JSC_DEFINE_HOST_FUNCTION(functionMake16BitStringIfPossible, (JSGlobalObject* globalObject, CallFrame* callFrame))
 {
     DollarVMAssertScope assertScope;
@@ -4530,6 +4542,7 @@ void JSDollarVM::finishCreation(VM& vm)
     addFunction(vm, alwaysAllow, "parseCount"_s, functionParseCount, 0);
 
     addFunction(vm, alwaysAllow, "isWasmSupported"_s, functionIsWasmSupported, 0);
+    addFunction(vm, alwaysAllow, "wasmCanonicalTypeCount"_s, functionWasmCanonicalTypeCount, 0);
     addFunction(vm, alwaysAllow, "make16BitStringIfPossible"_s, functionMake16BitStringIfPossible, 1);
 
     addFunction(vm, allowIfNotFuzz, "getStructureTransitionList"_s, functionGetStructureTransitionList, 1);

--- a/Source/JavaScriptCore/wasm/WasmTypeDefinition.cpp
+++ b/Source/JavaScriptCore/wasm/WasmTypeDefinition.cpp
@@ -32,12 +32,14 @@
 #include "JSWebAssemblyArray.h"
 #include "JSWebAssemblyException.h"
 #include "JSWebAssemblyStruct.h"
+#include "Options.h"
 #include "WasmCallee.h"
 #include "WasmFormat.h"
 #include "WasmTypeDefinitionInlines.h"
 #include "WasmTypeSectionState.h"
 #include "WebAssemblyFunctionBase.h"
 #include <wtf/CommaPrinter.h>
+#include <wtf/DataLog.h>
 #include <wtf/FastMalloc.h>
 #include <wtf/ReferenceWrapperVector.h>
 #include <wtf/StringPrintStream.h>
@@ -153,7 +155,7 @@ RTTGroup::~RTTGroup()
         rtt->setCanonicalGroup(nullptr, 0);
 }
 
-void RTT::rewriteInternalRefs(TypeSectionState* state, const Vector<Ref<const RTT>>& groupMembers, const RecursionGroup* recursionGroup)
+void RTT::rewriteInternalRefs(TypeSectionState* state, std::span<const Ref<const RTT>> groupMembers, const RecursionGroup* recursionGroup)
 {
     // Walk every ref-bearing TypeSlot in the payload. For each placeholder
     // Projection ref, rewrite the slot's Type::index to the canonical RTT
@@ -206,6 +208,26 @@ void RTT::clearReferencedRTTs()
     visitChildrenRTT([](TypeSlot& slot) {
         slot.rttAnchor = nullptr;
     });
+}
+
+void RTT::clearAllDisplayRefs()
+{
+    for (unsigned i = 0; i < (m_displaySizeExcludingThis + 1); ++i)
+        at(i) = nullptr;
+}
+
+void RTT::setSelfDisplaySlot() const
+{
+    ASSERT(!at(m_displaySizeExcludingThis));
+    const_cast<RTT*>(this)->at(m_displaySizeExcludingThis) = this;
+}
+
+void TypeInformation::breakCyclesForReclamation(const RTT& rtt)
+{
+    RTT& mutableRTT = const_cast<RTT&>(rtt);
+    mutableRTT.clearAllDisplayRefs();
+    mutableRTT.clearReferencedRTTs();
+    rtt.setCanonicalGroup(nullptr, 0);
 }
 
 void RTT::dump(PrintStream& out) const
@@ -481,11 +503,11 @@ struct GroupLookup {
 
 // Singleton lookup: only matches the entry's own RTT at projection index 0.
 struct SingletonSelfRef {
-    SUPPRESS_UNCOUNTED_MEMBER const RTT* self;
+    SUPPRESS_UNCOUNTED_MEMBER const RTT& self;
     std::optional<size_t> operator()(const RTT* rtt) const
     {
-        if (rtt == self)
-            return size_t { 0 };
+        if (rtt == &self)
+            return 0;
         return std::nullopt;
     }
 };
@@ -666,15 +688,12 @@ bool CanonicalRecursionGroupEntry::operator==(const CanonicalRecursionGroupEntry
 
 unsigned CanonicalSingletonEntryHash::hash(const CanonicalSingletonEntry& entry)
 {
-    ASSERT(entry.rtt);
-    return hashRTTForRecGroup(*entry.rtt, SingletonSelfRef { entry.rtt.get() });
+    return hashRTTForRecGroup(entry.rtt.get(), SingletonSelfRef { entry.rtt.get() });
 }
 
 bool CanonicalSingletonEntryHash::equal(const CanonicalSingletonEntry& a, const CanonicalSingletonEntry& b)
 {
-    if (!a.rtt || !b.rtt)
-        return a.rtt == b.rtt;
-    return equalRTTsForRecGroup(*a.rtt, SingletonSelfRef { a.rtt.get() }, *b.rtt, SingletonSelfRef { b.rtt.get() });
+    return equalRTTsForRecGroup(a.rtt.get(), SingletonSelfRef { a.rtt.get() }, b.rtt.get(), SingletonSelfRef { b.rtt.get() });
 }
 
 bool CanonicalSingletonEntry::operator==(const CanonicalSingletonEntry& other) const
@@ -715,68 +734,45 @@ Vector<Ref<const RTT>> TypeInformation::canonicalizeRecursionGroupImpl(TypeSecti
     // The loop/HashSet logic below is correct for any size >= 1.
     ASSERT(!candidateRTTs.isEmpty());
 
-    Locker locker { m_lock };
-
-    // Rewrite internal Projection refs to canonical RTT pointers
-    // (self-references among the candidate RTTs themselves). Non-recursive
-    // RTTs have no placeholder-tagged refs in their payloads, so skip the
-    // rewrite walk entirely for them.
-    for (auto& rtt : candidateRTTs) {
-        if (rtt->hasRecursiveReference())
-            const_cast<RTT&>(rtt.get()).rewriteInternalRefs(state, candidateRTTs, recursionGroup);
+    auto candidateGroup = RTTGroup::create(WTF::move(candidateRTTs));
+    for (uint32_t i = 0; i < candidateGroup->size(); ++i) {
+        auto& rtt = candidateGroup->at(i);
+        // Resolve placeholder Projection refs to bare canonical RTT
+        // pointers. Pass candidateGroup->rtts(), not the moved-from
+        // candidateRTTs.
+        if (rtt.hasRecursiveReference())
+            const_cast<RTT&>(rtt).rewriteInternalRefs(state, candidateGroup->rtts().span(), recursionGroup);
+        rtt.setSelfDisplaySlot();
+        rtt.setCanonicalGroup(candidateGroup.ptr(), i);
     }
 
-    // Wrap the candidate RTTs in an RTTGroup and tag each member's
-    // canonicalGroup() back-pointer. Hash/equal can then O(1)-detect
-    // intra-group refs via rtt->canonicalGroup() == candidateGroup.get().
-    // If the candidate matches an existing canonical entry, the inserted
-    // Ref is dropped; our local candidateGroup keeps the RTTs alive while
-    // we break the intra-group rttAnchor cycles created by
-    // rewriteInternalRefs so they can actually be freed. RTTGroup's
-    // destructor then nulls each member's back-pointer for safety.
-    auto candidateGroup = RTTGroup::create(WTF::move(candidateRTTs));
-    for (uint32_t i = 0; i < candidateGroup->size(); ++i)
-        candidateGroup->at(i).setCanonicalGroup(candidateGroup.ptr(), i);
-
+    Locker locker { m_lock };
     CanonicalRecursionGroupEntry candidate { candidateGroup.copyRef() };
     auto addResult = m_canonicalRecursionGroups.add(WTF::move(candidate));
-
     if (!addResult.isNewEntry) {
-        for (auto& rtt : candidateGroup->rtts())
-            const_cast<RTT&>(rtt.get()).clearReferencedRTTs();
+        for (const Ref<const RTT>& member : candidateGroup->rtts())
+            breakCyclesForReclamation(member.get());
     }
-    // After add, addResult.iterator->group is either the existing canonical
-    // group or the just-inserted candidate group (both have equivalent rtts).
     return addResult.iterator->group->rtts();
 }
 
 Ref<const RTT> TypeInformation::canonicalizeSingletonImpl(TypeSectionState* state, const RecursionGroup* recursionGroup, Ref<const RTT>&& candidate)
 {
-    // Rewrite intra-group placeholder refs to the candidate RTT* so the
-    // singleton hash/equal can detect self-refs via pointer identity.
-    // Non-recursive payloads have nothing to rewrite; skip the walk.
-    bool hasRecursiveReference = candidate->hasRecursiveReference();
-    if (hasRecursiveReference) {
-        // rewriteInternalRefs consults the Vector<Ref<const RTT>>& to map
-        // projection indices to RTT pointers. A singleton's only valid
-        // projection index is 0, pointing at the candidate itself.
-        Vector<Ref<const RTT>> groupMembers;
+    // Rewrite self-ref placeholders to the candidate RTT so hash/equal can
+    // detect self-refs by pointer identity.
+    if (candidate->hasRecursiveReference()) {
+        Vector<Ref<const RTT>, 1> groupMembers;
         groupMembers.append(candidate.copyRef());
-        const_cast<RTT&>(candidate.get()).rewriteInternalRefs(state, groupMembers, recursionGroup);
+        const_cast<RTT&>(candidate.get()).rewriteInternalRefs(state, groupMembers.span(), recursionGroup);
     }
+    candidate->setSelfDisplaySlot();
 
     Locker locker { m_lock };
-    // Retain an external ref across HashSet::add so we can break the
-    // self-cycle that rewriteInternalRefs wrote into the candidate's
-    // TypeSlot anchors if the candidate is discarded as a duplicate. Only
-    // needed when the candidate actually went through rewriteInternalRefs
-    // (recursive case); non-recursive singletons have no self-refs to break.
-    Ref<const RTT> retainer = candidate.copyRef();
-    CanonicalSingletonEntry entry { WTF::move(candidate) };
+    CanonicalSingletonEntry entry { candidate.copyRef() };
     auto addResult = m_canonicalSingletonGroups.add(WTF::move(entry));
-    if (!addResult.isNewEntry && hasRecursiveReference)
-        const_cast<RTT&>(retainer.get()).clearReferencedRTTs();
-    return Ref<const RTT> { *addResult.iterator->rtt };
+    if (!addResult.isNewEntry)
+        breakCyclesForReclamation(candidate.get());
+    return addResult.iterator->rtt.copyRef();
 }
 
 Ref<const RTT> TypeInformation::canonicalizeStandaloneRTT(Ref<const RTT>&& candidate)
@@ -855,26 +851,156 @@ void TypeInformation::tryCleanup()
     auto& info = singleton();
     Locker locker { info.m_lock };
 
-    bool changed = false;
-    do {
-        changed = false;
-        info.m_canonicalSingletonGroups.removeIf([&](const CanonicalSingletonEntry& entry) {
-            if (entry.rtt && entry.rtt->hasOneRef()) {
-                changed = true;
-                return true;
-            }
-            return false;
-        });
-    } while (changed);
+    // Bacon-Rajan synchronous cycle collection. Snapshot -> trial-decrement
+    // internal edges -> restore via BFS from roots -> sweep zeros.
 
-    // Multi-member m_canonicalRecursionGroups: skipped. Members anchor each
-    // other through TypeSlot::rttAnchor (rewriteInternalRefs builds the
-    // cycles intentionally), so per-member hasOneRef() never fires. A
-    // correct collector would have to detect that the entire group's
-    // external refcount is zero and drop all members atomically; not worth
-    // the complexity until profiling justifies it. Also, if singleton case
-    // includes recursion, then it is also leaking.
-    // FIXME: Implement group-level reclamation. https://bugs.webkit.org/show_bug.cgi?id=313185
+    auto forEachCandidateGroup = [&](auto&& cb) {
+        for (const auto& entry : info.m_canonicalRecursionGroups)
+            cb(entry.group.get());
+    };
+    auto forEachCandidateRTT = [&](auto&& cb) {
+        forEachCandidateGroup([&](auto& group) {
+            for (const auto& rtt : group.rtts())
+                cb(rtt.get());
+        });
+        for (const auto& entry : info.m_canonicalSingletonGroups)
+            cb(entry.rtt.get());
+    };
+
+    // Phase 1: snapshot refCount() into scratch.
+    forEachCandidateGroup([](const RTTGroup& group) {
+        group.setVirtualRefCount(group.refCount());
+    });
+    forEachCandidateRTT([](const RTT& rtt) {
+        rtt.setVirtualRefCount(rtt.refCount());
+    });
+
+    auto decRTT = [](const RTT* tgt) {
+        if (!tgt)
+            return;
+        ASSERT(tgt->virtualRefCount() > 0);
+        tgt->setVirtualRefCount(tgt->virtualRefCount() - 1);
+    };
+    auto decGroup = [](const RTTGroup* tgt) {
+        if (!tgt)
+            return;
+        ASSERT(tgt->virtualRefCount() > 0);
+        tgt->setVirtualRefCount(tgt->virtualRefCount() - 1);
+    };
+
+    auto decEdgesFromRTT = [&](const RTT& rtt) {
+        decGroup(rtt.canonicalGroup());
+        rtt.forEachPayloadRTTRef(decRTT);
+        for (unsigned i = 0; i <= rtt.displaySizeExcludingThis(); ++i)
+            decRTT(rtt.displayEntry(i));
+    };
+
+    // Phase 2: trial-decrement every internal structural edge.
+    // Unlike original Bacon-Rajan, we do not need tri-color graph traversal since
+    // all RTTs and groups are reachable from m_canonicalRecursionGroups and m_canonicalSingletonGroups.
+
+    // Visit each group and RTT, perform trial-decrement for each edge.
+    // This edge includes edges from m_canonicalRecursionGroups / m_canonicalSingletonGroups.
+    for (const auto& entry : info.m_canonicalRecursionGroups) {
+        const RTTGroup& group = entry.group.get();
+        decGroup(&group);
+        for (const auto& rtt : group.rtts()) {
+            decRTT(rtt.ptr());
+            decEdgesFromRTT(rtt.get());
+        }
+    }
+    for (const auto& entry : info.m_canonicalSingletonGroups) {
+        decRTT(entry.rtt.ptr());
+        decEdgesFromRTT(entry.rtt.get());
+    }
+
+    // Phase 3: transitive-closure restore from any object still > 0.
+    Vector<const RTT*, 16> rttWorklist;
+    Vector<const RTTGroup*, 16> groupWorklist;
+
+    // After trial-decrement, if group / RTT are still non-zero count,
+    // this indicates that they are actually referenced outside of this registry.
+    forEachCandidateRTT([&](const RTT& rtt) {
+        if (rtt.virtualRefCount() > 0)
+            rttWorklist.append(&rtt);
+    });
+    forEachCandidateGroup([&](const RTTGroup& group) {
+        if (group.virtualRefCount() > 0)
+            groupWorklist.append(&group);
+    });
+
+    // Then restore virtualRefCount non-zero which are reachable from the above really live RTTs and groups.
+    auto incRTT = [&](const RTT* tgt) {
+        if (!tgt)
+            return;
+        bool wasZero = !tgt->virtualRefCount();
+        tgt->setVirtualRefCount(tgt->virtualRefCount() + 1);
+        if (wasZero)
+            rttWorklist.append(tgt);
+    };
+    auto incGroup = [&](const RTTGroup* tgt) {
+        if (!tgt)
+            return;
+        bool wasZero = !tgt->virtualRefCount();
+        tgt->setVirtualRefCount(tgt->virtualRefCount() + 1);
+        if (wasZero)
+            groupWorklist.append(tgt);
+    };
+
+    while (!rttWorklist.isEmpty() || !groupWorklist.isEmpty()) {
+        while (!groupWorklist.isEmpty()) {
+            const RTTGroup* group = groupWorklist.takeLast();
+            for (const auto& rtt : group->rtts())
+                incRTT(rtt.ptr());
+        }
+        while (!rttWorklist.isEmpty()) {
+            const RTT* rtt = rttWorklist.takeLast();
+            incGroup(rtt->canonicalGroup());
+            rtt->forEachPayloadRTTRef(incRTT);
+            for (unsigned i = 0; i <= rtt->displaySizeExcludingThis(); ++i)
+                incRTT(rtt->displayEntry(i));
+        }
+    }
+
+    // Phase 4: sweep objects whose virtualRefCount stayed 0.
+    size_t groupsBeforeSweep = info.m_canonicalRecursionGroups.size();
+    size_t singletonsBeforeSweep = info.m_canonicalSingletonGroups.size();
+    info.m_canonicalRecursionGroups.removeIf([&](const CanonicalRecursionGroupEntry& entry) {
+        const RTTGroup& group = entry.group.get();
+        if (group.virtualRefCount() > 0)
+            return false;
+        // Clear intra-group display / payload / m_group refs so the natural
+        // destructor cascade can drive each member's refcount to 0 once the
+        // table entry drops.
+        for (const auto& member : group.rtts())
+            breakCyclesForReclamation(member.get());
+        return true;
+    });
+
+    info.m_canonicalSingletonGroups.removeIf([&](const CanonicalSingletonEntry& entry) {
+        if (entry.rtt->virtualRefCount() > 0)
+            return false;
+        breakCyclesForReclamation(entry.rtt.get());
+        return true;
+    });
+
+    if (Options::verboseWasmTypeCleanup()) [[unlikely]] {
+        size_t groupsAfter = info.m_canonicalRecursionGroups.size();
+        size_t singletonsAfter = info.m_canonicalSingletonGroups.size();
+        dataLogLn("[Wasm::TypeInformation::tryCleanup] groups scanned=", groupsBeforeSweep,
+            " reclaimed=", groupsBeforeSweep - groupsAfter,
+            " live=", groupsAfter,
+            " | singletons scanned=", singletonsBeforeSweep,
+            " reclaimed=", singletonsBeforeSweep - singletonsAfter,
+            " live=", singletonsAfter);
+    }
+}
+
+size_t TypeInformation::canonicalTypeCount()
+{
+    auto& info = singleton();
+    Locker locker { info.m_lock };
+    return info.m_canonicalRecursionGroups.size() + info.m_canonicalSingletonGroups.size();
 }
 
 bool NODELETE Type::definitelyIsCellOrNull() const

--- a/Source/JavaScriptCore/wasm/WasmTypeDefinition.h
+++ b/Source/JavaScriptCore/wasm/WasmTypeDefinition.h
@@ -588,6 +588,15 @@ public:
             cb(slot);
     }
 
+    template<typename Callback>
+    void forEachPayloadRTTRef(Callback&& cb) const
+    {
+        for (const TypeSlot& slot : m_signature) {
+            if (slot.rttAnchor)
+                cb(slot.rttAnchor.get());
+        }
+    }
+
 private:
     std::span<const TypeSlot> signatureSpan() const LIFETIME_BOUND { return m_signature.span(); }
 
@@ -644,6 +653,15 @@ public:
         }
     }
 
+    template<typename Callback>
+    void forEachPayloadRTTRef(Callback&& cb) const
+    {
+        for (const StructFieldEntry& entry : m_fields) {
+            if (entry.rttAnchor)
+                cb(entry.rttAnchor.get());
+        }
+    }
+
 private:
     std::span<const StructFieldEntry> fieldsSpan() const LIFETIME_BOUND { return m_fields.span(); }
 
@@ -684,6 +702,13 @@ public:
         cb(slot);
         m_elementType.type = StorageType(slot.type);
         m_elementTypeAnchor = WTF::move(slot.rttAnchor);
+    }
+
+    template<typename Callback>
+    void forEachPayloadRTTRef(Callback&& cb) const
+    {
+        if (m_elementTypeAnchor)
+            cb(m_elementTypeAnchor.get());
     }
 
 private:
@@ -854,22 +879,45 @@ public:
         RELEASE_ASSERT_NOT_REACHED();
     }
 
+    template<typename Callback>
+    void forEachPayloadRTTRef(Callback&& cb) const
+    {
+        switch (m_kind) {
+        case RTTKind::Function:
+            std::get<RTTFunctionPayload>(m_payload).forEachPayloadRTTRef(std::forward<Callback>(cb));
+            return;
+        case RTTKind::Struct:
+            std::get<RTTStructPayload>(m_payload).forEachPayloadRTTRef(std::forward<Callback>(cb));
+            return;
+        case RTTKind::Array:
+            std::get<RTTArrayPayload>(m_payload).forEachPayloadRTTRef(std::forward<Callback>(cb));
+            return;
+        }
+        RELEASE_ASSERT_NOT_REACHED();
+    }
+
     // Rewrite internal recgroup refs in this RTT's payload to canonical RTT
     // pointers. Called during canonicalizeRecursionGroup before the candidate
     // RTTs are exposed: any Type ref whose index is a Projection of
     // recursionGroup is replaced with groupMembers[projectionIndex] (i.e.,
     // a self-reference in the post-canonicalization group). After this all
     // refs in payload are uniformly RTT* form.
-    void rewriteInternalRefs(TypeSectionState*, const Vector<Ref<const RTT>>& groupMembers, const RecursionGroup*);
+    void rewriteInternalRefs(TypeSectionState*, std::span<const Ref<const RTT>> groupMembers, const RecursionGroup*);
 
-    // Drop all RTT anchors added by rewriteInternalRefs (and by
-    // typeDefinitionFor* for external refs). Used when a freshly built
-    // candidate RTT turns out to duplicate an existing canonical entry
-    // during canonicalization: nulling each TypeSlot's rttAnchor breaks the
-    // intra-recgroup refcount cycle so the discarded candidate can actually
-    // be freed. Never call on a committed canonical RTT -- doing so would
-    // re-introduce the UAF rewriteInternalRefs guards against.
+    // Drop all RTT anchors. Called on the dupe-on-insert candidate and on
+    // sweep-eligible canonical RTTs. Never call on a still-reachable
+    // canonical RTT -- re-introduces the UAF rewriteInternalRefs guards.
     void clearReferencedRTTs();
+
+    // Null every display slot. Sweep-time helper; breaks self- and
+    // sibling-display cycles before the destructor cascade runs.
+    void clearAllDisplayRefs();
+
+    // Write `this` into span()[m_displaySizeExcludingThis]. Called exactly
+    // once per RTT after successful canonicalization; deferring this write
+    // until canonicalization means parse failures and dupe losers never
+    // establish a self-reference cycle and can destruct cleanly.
+    void setSelfDisplaySlot() const;
 
     // Set during canonicalization (under TypeInformation::m_lock) to identify
     // membership in a canonical recursion group without scanning the group's
@@ -882,8 +930,11 @@ public:
         m_group = group;
         m_canonicalIndexInGroup = indexInGroup;
     }
-    const RTTGroup* canonicalGroup() const { return m_group; }
+    const RTTGroup* canonicalGroup() const { return m_group.get(); }
     uint32_t canonicalIndexInGroup() const { return m_canonicalIndexInGroup; }
+
+    uint32_t virtualRefCount() const { return m_virtualRefCount; }
+    void setVirtualRefCount(uint32_t value) const { m_virtualRefCount = value; }
 
     static constexpr ptrdiff_t offsetOfKind() { return OBJECT_OFFSETOF(RTT, m_kind); }
     static constexpr ptrdiff_t offsetOfDisplaySizeExcludingThis() { return OBJECT_OFFSETOF(RTT, m_displaySizeExcludingThis); }
@@ -894,6 +945,13 @@ private:
     // initializer list so the Variant is never observed in an unset state
     // (no std::monostate alternative). Defined inline so each tryCreate*
     // call site instantiates the matching specialization.
+    // Display layout: span()[0..m_displaySizeExcludingThis-1] is the
+    // ancestor chain; span()[m_displaySizeExcludingThis] is the self-slot,
+    // left nullptr by the constructor and written only by
+    // setSelfDisplaySlot() after canonicalization. Subtype constructor
+    // copies supertype's ancestor slots and explicitly writes &supertype
+    // as its own supertype-identity slot, because the supertype may still
+    // be a non-canonical sibling at construction time.
     template<typename Payload>
     RTT(RTTKind kind, bool isFinalType, StructFieldCount fieldCount, Payload&& payload)
         : TrailingArrayType(std::max(1u, inlinedDisplaySize))
@@ -903,7 +961,6 @@ private:
         , m_fieldCount(fieldCount)
         , m_payload(std::forward<Payload>(payload))
     {
-        at(0) = this;
     }
     template<typename Payload>
     RTT(RTTKind kind, const RTT& supertype, bool isFinalType, StructFieldCount fieldCount, Payload&& payload)
@@ -914,19 +971,18 @@ private:
         , m_fieldCount(fieldCount)
         , m_payload(std::forward<Payload>(payload))
     {
-        unsigned actualDisplaySize = supertype.displaySizeExcludingThis() + 2;
-        ASSERT(actualDisplaySize == (m_displaySizeExcludingThis + 1));
-        for (size_t i = 0; i < actualDisplaySize - 1; ++i)
+        for (size_t i = 0; i < supertype.displaySizeExcludingThis(); ++i)
             span()[i] = supertype.span()[i];
-        at(m_displaySizeExcludingThis) = this;
+        at(supertype.displaySizeExcludingThis()) = &supertype;
     }
 
     const RTTKind m_kind;
     const bool m_isFinalType { false };
     const unsigned m_displaySizeExcludingThis { };
     const StructFieldCount m_fieldCount { 0 };
-    SUPPRESS_UNCOUNTED_MEMBER mutable const RTTGroup* m_group { nullptr };
+    mutable RefPtr<const RTTGroup> m_group { nullptr };
     mutable uint32_t m_canonicalIndexInGroup { 0 };
+    mutable uint32_t m_virtualRefCount { 0 };
 #if ENABLE(JIT)
     // Cache for the JS->Wasm IC entrypoint. Function-kind only; null for
     // struct/array. Lazy-initialized under m_jitCodeLock; once set, the IC
@@ -960,12 +1016,16 @@ public:
     size_t size() const { return m_rtts.size(); }
     const RTT& at(size_t i) const LIFETIME_BOUND { return m_rtts[i]; }
 
+    uint32_t virtualRefCount() const { return m_virtualRefCount; }
+    void setVirtualRefCount(uint32_t value) const { m_virtualRefCount = value; }
+
 private:
     explicit RTTGroup(Vector<Ref<const RTT>>&& rtts)
         : m_rtts(WTF::move(rtts))
     { }
 
     Vector<Ref<const RTT>> m_rtts;
+    mutable uint32_t m_virtualRefCount { 0 };
 };
 
 // Isorecursive canonical recursion-group entry. Wraps an owning Ref to the
@@ -1000,9 +1060,11 @@ struct CanonicalRecursionGroupEntryHash {
 // structural content, with self-refs detected by pointer equality against
 // the entry's own RTT. Mirrors V8's canonical_singleton_groups_.
 struct CanonicalSingletonEntry {
-    RefPtr<const RTT> rtt;
+    Ref<const RTT> rtt;
 
-    CanonicalSingletonEntry() = default;
+    CanonicalSingletonEntry()
+        : rtt(WTF::HashTableEmptyValue)
+    { }
     explicit CanonicalSingletonEntry(Ref<const RTT>&& r)
         : rtt(WTF::move(r))
     { }
@@ -1039,6 +1101,8 @@ template<> struct HashTraits<JSC::Wasm::CanonicalRecursionGroupEntry> : SimpleCl
 };
 template<> struct HashTraits<JSC::Wasm::CanonicalSingletonEntry> : SimpleClassHashTraits<JSC::Wasm::CanonicalSingletonEntry> {
     static constexpr bool emptyValueIsZero = true;
+    static constexpr bool hasIsEmptyValueFunction = true;
+    static bool isEmptyValue(const JSC::Wasm::CanonicalSingletonEntry& value) { return value.rtt.isHashTableEmptyValue(); }
 };
 
 } // namespace WTF
@@ -1081,6 +1145,9 @@ public:
     static RefPtr<const RTT> tryGetRTT(TypeIndex);
 
     static void tryCleanup();
+
+    // Total canonical entries currently retained. Used by tests.
+    static size_t canonicalTypeCount();
 
 private:
     static Ref<const RTT> typeDefinitionForFunction(const Vector<Type, 16>& returnTypes, const Vector<Type, 16>& argumentTypes);
@@ -1133,6 +1200,11 @@ private:
     Ref<const RTT> canonicalizeSingletonImpl(TypeSectionState*, const RecursionGroup*, Ref<const RTT>&&);
     Ref<const RTT> canonicalizeStandaloneRTTImpl(Ref<const RTT>&&);
     static RefPtr<const RTT> extractExternalRTT(Type);
+
+    // Null every cycle-forming ref on `rtt` (display, payload, m_group) so
+    // its refcount can cascade to 0. Used by tryCleanup's sweep and the
+    // dupe-on-insert fallbacks.
+    static void breakCyclesForReclamation(const RTT&);
 
     // Returns true iff `type` is a ref whose index encodes a parser-time
     // placeholder Projection (i.e. an unresolved intra-recgroup reference).


### PR DESCRIPTION
#### 5d2b2254f73f00fbcc457624d85f46381c1586b3
<pre>
[JSC] Implement cycle-collector for RTT and RTTGroup
<a href="https://bugs.webkit.org/show_bug.cgi?id=313881">https://bugs.webkit.org/show_bug.cgi?id=313881</a>
<a href="https://rdar.apple.com/176076792">rdar://176076792</a>

Reviewed by Yijia Huang.

This patch implements traditional Bacon-Rajan cycle collector for Wasm
RTT and RTTGroup. This is cheap and easy since we do this only when
TypeInformation::tryCleanup is explicitly called (instead of recording
all deref-ed RefCounted as PURPLE as a potential root of cycle).

Because TypeInformation lists all RTTs and RTTGroups, we do not need to
have tri-color graph traversal. So we can just perform as follows.

1. Traverse all of them and snapshot the refCount as
   virtualRefCount.
2. Do trial-decrement: deref (virtualRefCount) from each edge.
3. Checking virtualRefCount after (2). If it is non-zero, this means
   that this RTT / RTTGroup is retained outside of TypeInformation
   registry. Thus they are really alive. Otherwise, it is actually dead.
4. From non-zero virtualRefCount, traverse the graph and virtually ref
   the each edge. If RTT or RTTGroup becomes non-zero newly, then we
   push it to the worklist. This basically marks all RTTs / RTTGroups
   reachable from (3).
5. Finally, list all of RTTs and RTTGroups, if they are zero
   virtualRefCount, break cycles and drop it from registry. Then they
   will be destroyed.

Tests: JSTests/stress/wasm-cycle-collect-dupe-on-insert.js
       JSTests/stress/wasm-cycle-collect-intra-group-subtype.js
       JSTests/stress/wasm-cycle-collect-mutually-recursive-struct-array.js
       JSTests/stress/wasm-cycle-collect-observable.js
       JSTests/stress/wasm-cycle-collect-parse-failure.js
       JSTests/stress/wasm-cycle-collect-self-recursive-singleton.js

* JSTests/wasm/stress/wasm-cycle-collect-dupe-on-insert.js: Added.
(uleb128):
(sleb128):
(encodeSection):
(buildMutualRecGroupBytes):
(buildSelfRecursiveSingletonBytes):
(churnPairs):
(verifyReclamation):
* JSTests/wasm/stress/wasm-cycle-collect-intra-group-subtype.js: Added.
(uleb128):
(sleb128):
(encodeSection):
(buildModuleBytes):
(churn):
* JSTests/wasm/stress/wasm-cycle-collect-mutually-recursive-struct-array.js: Added.
(uleb128):
(sleb128):
(encodeSection):
(buildModuleBytes):
(churnModules):
* JSTests/wasm/stress/wasm-cycle-collect-observable.js: Added.
(uleb128):
(sleb128):
(encodeSection):
(buildModuleBytes):
(churnBatch):
* JSTests/wasm/stress/wasm-cycle-collect-parse-failure.js: Added.
(uleb128):
(sleb128):
(enc):
(buildFailingModule):
(churn):
(triggerCleanup):
(grew.Math.floor):
* JSTests/wasm/stress/wasm-cycle-collect-self-recursive-singleton.js: Added.
(uleb128):
(sleb128):
(encodeSection):
(buildModuleBytes):
(churnModules):
* JSTests/wasm/stress/wasm-gc-realmless-structure.js: Renamed from JSTests/stress/wasm-gc-realmless-structure.js.
* Source/JavaScriptCore/runtime/OptionsList.h:
* Source/JavaScriptCore/tools/JSDollarVM.cpp:
(JSC::JSC_DEFINE_HOST_FUNCTION):
(JSC::JSDollarVM::finishCreation):
* Source/JavaScriptCore/wasm/WasmTypeDefinition.cpp:
(JSC::Wasm::RTT::rewriteInternalRefs):
(JSC::Wasm::RTT::clearAllDisplayRefs):
(JSC::Wasm::RTT::setSelfDisplaySlot const):
(JSC::Wasm::TypeInformation::breakCyclesForReclamation):
(JSC::Wasm::SingletonSelfRef::operator() const):
(JSC::Wasm::CanonicalSingletonEntryHash::hash):
(JSC::Wasm::CanonicalSingletonEntryHash::equal):
(JSC::Wasm::TypeInformation::canonicalizeRecursionGroupImpl):
(JSC::Wasm::TypeInformation::canonicalizeSingletonImpl):
(JSC::Wasm::TypeInformation::tryCleanup):
(JSC::Wasm::TypeInformation::canonicalTypeCount):
* Source/JavaScriptCore/wasm/WasmTypeDefinition.h:
(JSC::Wasm::RTTFunctionPayload::forEachPayloadRTTRef const):
(JSC::Wasm::RTTStructPayload::forEachPayloadRTTRef const):
(JSC::Wasm::RTTArrayPayload::forEachPayloadRTTRef const):
(JSC::Wasm::CanonicalSingletonEntry::CanonicalSingletonEntry):
(WTF::HashTraits&lt;JSC::Wasm::CanonicalSingletonEntry&gt;::isEmptyValue):

Canonical link: <a href="https://commits.webkit.org/312485@main">https://commits.webkit.org/312485@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/462b0afca1407479d72d04260ed575f2e4b38248

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/160078 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/33548 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/26652 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/168962 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/114459 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/3ffb0c0b-f1f5-4762-b9ec-73719ef90ac5) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/161947 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/33651 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/33550 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/124076 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/87012 "2 failures") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/c69cfb54-b313-4e27-a82f-67e838e107ba) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/163036 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/26322 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/143780 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/104688 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/8ddbeff5-b92d-4c82-8bd4-2658051b2f41) 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/25375 "Found 1 new test failure: imported/w3c/web-platform-tests/css/selectors/has-specificity.html (failure)") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/23866 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/16699 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/152134 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/135067 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/21545 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/171442 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/20915 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/17446 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/23183 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/132337 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/33224 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/27950 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/132363 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/33209 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/143340 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/91382 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/24365 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/26974 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/20153 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/192442 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/32718 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/99115 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/49482 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/32216 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/32462 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/32366 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->