### PR TITLE
[GStreamer] Assorted minor clean-ups

### DIFF
--- a/Source/WebCore/platform/graphics/gstreamer/eme/CDMProxyThunder.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/eme/CDMProxyThunder.cpp
@@ -88,7 +88,6 @@ bool CDMProxyThunder::decrypt(CDMProxyThunder::DecryptionContext& input, const G
         return false;
     }
 
-    GST_TRACE("decrypting");
     OpenCDMError errorCode;
 #if THUNDER_HAS_OCDM_DECRYPT_BUFFER
     RELEASE_ASSERT_WITH_MESSAGE(inputCaps, "Decryption attempted without input caps");

--- a/Source/WebCore/platform/graphics/gstreamer/eme/WebKitThunderParser.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/eme/WebKitThunderParser.cpp
@@ -140,7 +140,10 @@ static void webkitMediaThunderParserConstructed(GObject* object)
     G_OBJECT_CLASS(webkit_media_thunder_parser_parent_class)->constructed(object);
 
     auto self = WEBKIT_MEDIA_THUNDER_PARSER(object);
-    self->priv->parser = makeGStreamerElement("parsebin"_s, "inner-parser"_s);
+
+    static Atomic<uint32_t> nParsers = 0;
+    auto name = makeString("inner-parser-"_s, nParsers.exchangeAdd(1));
+    self->priv->parser = makeGStreamerElement("parsebin"_s, name);
 
     auto factories = gst_element_factory_list_get_elements(GST_ELEMENT_FACTORY_TYPE_DECRYPTOR, GST_RANK_MARGINAL);
     factories = g_list_sort(factories, gst_plugin_feature_rank_compare_func);
@@ -168,6 +171,7 @@ static void webkitMediaThunderParserConstructed(GObject* object)
         GValueArray* result;
 
         auto factories = gst_element_factory_list_get_elements(GST_ELEMENT_FACTORY_TYPE_DECODABLE, GST_RANK_MARGINAL);
+        factories = g_list_sort(factories, gst_plugin_feature_rank_compare_func);
         auto list = gst_element_factory_list_filter(factories, caps, GST_PAD_SINK, gst_caps_is_fixed(caps));
         result = g_value_array_new(g_list_length(list));
         for (GList* tmp = list; tmp; tmp = tmp->next) {

--- a/Source/WebCore/platform/graphics/gstreamer/mse/AppendPipeline.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/mse/AppendPipeline.cpp
@@ -371,7 +371,7 @@ GstPadProbeReturn AppendPipeline::appsrcEndOfAppendCheckerProbe(GstPadProbeInfo*
     }
 
     GST_TRACE_OBJECT(pipeline(), "Posting end-of-append task to the main thread");
-    dumpBinToDotFile(m_pipeline, "end-of-append"_s);
+    dumpBinToDotFile(m_pipeline, makeString(unsafeSpan(GST_ELEMENT_NAME(m_pipeline.get())), "-end-of-append"_s));
     m_taskQueue.enqueueTask([this]() {
         handleEndOfAppend();
     });

--- a/Source/WebCore/platform/graphics/gstreamer/mse/MediaPlayerPrivateGStreamerMSE.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/mse/MediaPlayerPrivateGStreamerMSE.cpp
@@ -28,25 +28,17 @@
 
 #if ENABLE(VIDEO) && USE(GSTREAMER) && ENABLE(MEDIA_SOURCE)
 
-#include "AppendPipeline.h"
 #include "AudioTrackPrivateGStreamer.h"
 #include "GStreamerCommon.h"
 #include "GStreamerRegistryScannerMSE.h"
 #include "InbandTextTrackPrivateGStreamer.h"
-#include "MIMETypeRegistry.h"
-#include "MediaDescription.h"
 #include "MediaPlayer.h"
+#include "MediaSourcePrivateClient.h"
 #include "MediaSourceTrackGStreamer.h"
 #include "SourceBufferPrivateGStreamer.h"
-#include "TimeRanges.h"
 #include "VideoTrackPrivateGStreamer.h"
 #include "WebKitMediaSourceGStreamer.h"
 
-#include <gst/app/gstappsink.h>
-#include <gst/app/gstappsrc.h>
-#include <gst/gst.h>
-#include <gst/pbutils/pbutils.h>
-#include <gst/video/video.h>
 #include <wtf/Condition.h>
 #include <wtf/HashSet.h>
 #include <wtf/NativePromise.h>

--- a/Source/WebCore/platform/graphics/gstreamer/mse/WebKitMediaSourceGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/mse/WebKitMediaSourceGStreamer.cpp
@@ -26,11 +26,10 @@
 
 #if ENABLE(VIDEO) && ENABLE(MEDIA_SOURCE) && USE(GSTREAMER)
 
-#include "GStreamerCommon.h"
+#include "MediaSourcePrivateClient.h"
 #include "MediaSourceTrackGStreamer.h"
 #include "VideoTrackPrivateGStreamer.h"
 #include <cassert>
-#include <gst/gst.h>
 #include <wtf/Condition.h>
 #include <wtf/DataMutex.h>
 #include <wtf/HashMap.h>
@@ -120,7 +119,6 @@ struct WebKitMediaSrcPadClass {
 
 namespace WTF {
 
-WTF_DEFINE_GREF_TRAITS(WebKitMediaSrc, gst_object_ref_sink, gst_object_unref, g_object_is_floating)
 WTF_DEFINE_GREF_TRAITS_INLINE(WebKitMediaSrcPad, gst_object_ref_sink, gst_object_unref, g_object_is_floating)
 
 } // namespace WTF

--- a/Source/WebCore/platform/graphics/gstreamer/mse/WebKitMediaSourceGStreamer.h
+++ b/Source/WebCore/platform/graphics/gstreamer/mse/WebKitMediaSourceGStreamer.h
@@ -26,33 +26,25 @@
 #if ENABLE(VIDEO) && ENABLE(MEDIA_SOURCE) && USE(GSTREAMER)
 
 #include "GStreamerCommon.h"
-#include "MediaPlayer.h"
-#include "MediaSource.h"
-#include "MediaSourcePrivate.h"
-#include "SourceBufferPrivate.h"
-#include "SourceBufferPrivateClient.h"
-#include "SourceBufferPrivateGStreamer.h"
+#include <wtf/Forward.h>
 
 namespace WebCore {
-
 class MediaPlayerPrivateGStreamerMSE;
-
+class MediaSourceTrackGStreamer;
 } // namespace WebCore
 
-G_BEGIN_DECLS
-
-#define WEBKIT_TYPE_MEDIA_SRC            (webkit_media_src_get_type ())
-#define WEBKIT_MEDIA_SRC(obj)            (G_TYPE_CHECK_INSTANCE_CAST ((obj), WEBKIT_TYPE_MEDIA_SRC, WebKitMediaSrc))
-#define WEBKIT_MEDIA_SRC_CLASS(klass)    (G_TYPE_CHECK_CLASS_CAST ((klass), WEBKIT_TYPE_MEDIA_SRC, WebKitMediaSrcClass))
-#define WEBKIT_IS_MEDIA_SRC(obj)         (G_TYPE_CHECK_INSTANCE_TYPE ((obj), WEBKIT_TYPE_MEDIA_SRC))
-#define WEBKIT_IS_MEDIA_SRC_CLASS(klass) (G_TYPE_CHECK_CLASS_TYPE ((klass), WEBKIT_TYPE_MEDIA_SRC))
+#define WEBKIT_TYPE_MEDIA_SRC            (webkit_media_src_get_type())
+#define WEBKIT_MEDIA_SRC(obj)            (G_TYPE_CHECK_INSTANCE_CAST((obj), WEBKIT_TYPE_MEDIA_SRC, WebKitMediaSrc))
+#define WEBKIT_MEDIA_SRC_CLASS(klass)    (G_TYPE_CHECK_CLASS_CAST((klass), WEBKIT_TYPE_MEDIA_SRC, WebKitMediaSrcClass))
+#define WEBKIT_IS_MEDIA_SRC(obj)         (G_TYPE_CHECK_INSTANCE_TYPE((obj), WEBKIT_TYPE_MEDIA_SRC))
+#define WEBKIT_IS_MEDIA_SRC_CLASS(klass) (G_TYPE_CHECK_CLASS_TYPE((klass), WEBKIT_TYPE_MEDIA_SRC))
 
 struct WebKitMediaSrcPrivate;
 
 struct WebKitMediaSrc {
     GstElement parent;
 
-    WebKitMediaSrcPrivate *priv;
+    WebKitMediaSrcPrivate* priv;
 };
 
 struct WebKitMediaSrcClass {
@@ -61,16 +53,10 @@ struct WebKitMediaSrcClass {
 
 GType webkit_media_src_get_type(void);
 
-void webKitMediaSrcEmitStreams(WebKitMediaSrc* source, const Vector<RefPtr<WebCore::MediaSourceTrackGStreamer>>& tracks);
+void webKitMediaSrcEmitStreams(WebKitMediaSrc*, const Vector<RefPtr<WebCore::MediaSourceTrackGStreamer>>&);
 
-void webKitMediaSrcFlush(WebKitMediaSrc*, TrackID streamId);
+void webKitMediaSrcFlush(WebKitMediaSrc*, TrackID);
 
 void webKitMediaSrcSetPlayer(WebKitMediaSrc*, ThreadSafeWeakPtr<WebCore::MediaPlayerPrivateGStreamerMSE>&&);
 
-G_END_DECLS
-
-namespace WTF {
-WTF_DECLARE_GREF_TRAITS(WebKitMediaSrc);
-} // namespace WTF
-
-#endif // USE(GSTREAMER)
+#endif // ENABLE(VIDEO) && ENABLE(MEDIA_SOURCE) && USE(GSTREAMER)


### PR DESCRIPTION
#### 450d297f1b8b58aeeaec6c00602cdae0bd335de9
<pre>
[GStreamer] Assorted minor clean-ups
<a href="https://bugs.webkit.org/show_bug.cgi?id=313885">https://bugs.webkit.org/show_bug.cgi?id=313885</a>

Reviewed by Xabier Rodriguez-Calvar.

* Source/WebCore/platform/graphics/gstreamer/eme/CDMProxyThunder.cpp:
(WebCore::CDMProxyThunder::decrypt): Remove un-needed GST_TRACE call, there is one already in the
decryptor.
* Source/WebCore/platform/graphics/gstreamer/eme/WebKitThunderParser.cpp:
(webkitMediaThunderParserConstructed): Give meaningful names to the internal parsebin element, to
ease debugging. Also sort element factories by rank, same as for decryptors.
* Source/WebCore/platform/graphics/gstreamer/mse/AppendPipeline.cpp:
(WebCore::AppendPipeline::appsrcEndOfAppendCheckerProbe): Give meaningful name to end-of-append dot
files.
* Source/WebCore/platform/graphics/gstreamer/mse/MediaPlayerPrivateGStreamerMSE.cpp: Remove
un-necessary header includes.
* Source/WebCore/platform/graphics/gstreamer/mse/WebKitMediaSourceGStreamer.cpp: Ditto and also
remove un-used GRefPtr traits for WebKitMediaSrc.
* Source/WebCore/platform/graphics/gstreamer/mse/WebKitMediaSourceGStreamer.h: Improve WebKit coding
style compliance.

Canonical link: <a href="https://commits.webkit.org/312602@main">https://commits.webkit.org/312602@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2eca97043e07219f2b38973ecd304e09c259c06f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/160509 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/33982 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/27083 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/169412 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/115575 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/162378 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/34083 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/33982 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/124462 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/115575 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/163467 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/26709 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/144179 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/105062 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/25761 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/24265 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/17131 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/135455 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/21942 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/171891 "Built successfully") | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/18437 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/23582 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/132724 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/33656 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/28358 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/132740 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35866 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/33640 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/143737 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/95424 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/27337 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/20551 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/33150 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/100027 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/32650 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/32894 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/32798 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->