### PR TITLE
[JSC] Make run-javascriptcore-tests work with CMake mac build

### DIFF
--- a/Tools/Scripts/run-jsc-stress-tests
+++ b/Tools/Scripts/run-jsc-stress-tests
@@ -2637,7 +2637,16 @@ def prepareBundle
         
         frameworkPath = frameworkFromJSCPath($jscPath)
         destinationFrameworkPath = Pathname.new(".vm") + "JavaScriptCore.framework"
-        $jscPath = destinationFrameworkPath + "Helpers" + "jsc"
+        # On Apple Cocoa CMake builds the jsc binary lives next to the
+        # framework rather than inside <framework>/Helpers/jsc as on Xcode
+        # builds. Detect that and stage jsc at .vm/jsc so we don't have to
+        # mutate the framework that .vm/JavaScriptCore.framework symlinks to.
+        jscOutsideFramework = frameworkPath && !File.file?(frameworkPath + "Helpers" + "jsc")
+        if jscOutsideFramework
+            $jscPath = Pathname.new(".vm") + "jsc"
+        else
+            $jscPath = destinationFrameworkPath + "Helpers" + "jsc"
+        end
         $testingFrameworkPath = Pathname.new("..") + destinationFrameworkPath
 
         if frameworkPath
@@ -2681,6 +2690,20 @@ def prepareBundle
                 rescue Exception
                     $stderr.puts "Warning: unable to create soft link, trying to copy."
                     FileUtils.cp_r source, destination
+                end
+            end
+
+            if jscOutsideFramework
+                jscDestination = Pathname.new(".vm") + "jsc"
+                if $copyVM
+                    FileUtils.cp originalJSCPath, jscDestination
+                else
+                    begin
+                        FileUtils.ln_s originalJSCPath, jscDestination
+                    rescue Exception
+                        $stderr.puts "Warning: unable to create soft link for jsc, trying to copy."
+                        FileUtils.cp originalJSCPath, jscDestination
+                    end
                 end
             end
 

--- a/Tools/Scripts/webkitdirs.pm
+++ b/Tools/Scripts/webkitdirs.pm
@@ -1189,6 +1189,8 @@ sub determineConfigurationProductDir
         } else {
             if (isGtk() or isWPE() or isJSCOnly() or shouldUseFlatpak() or shouldBuildForCrossTarget() or inCrossTargetEnvironment()) {
                 $configurationProductDir = "$baseProductDir/$portName/$configuration";
+            } elsif (isAppleCocoaWebKit() && isCMakeBuild()) {
+                $configurationProductDir = "$baseProductDir/cmake-mac/$configuration";
             } else {
                 $configurationProductDir = "$baseProductDir/$configuration";
             }
@@ -3123,6 +3125,21 @@ sub determineIsCMakeBuild()
 {
     return if defined($isCMakeBuild);
     $isCMakeBuild = checkForArgumentAndRemoveFromARGV("--cmake");
+    return if $isCMakeBuild;
+
+    # Auto-detect a CMake macOS build when no Xcode build is present at the
+    # expected path. The CMake macOS presets place artifacts under
+    # WebKitBuild/cmake-mac/<Configuration>; an Xcode build, if present,
+    # always wins to preserve existing workflows.
+    if (isAppleCocoaWebKit()) {
+        determineBaseProductDir();
+        determineConfiguration();
+        my $cmakeMacBuild = File::Spec->catdir($baseProductDir, "cmake-mac", $configuration);
+        my $xcodeBuild = File::Spec->catdir($baseProductDir, $configuration);
+        if (-f File::Spec->catfile($cmakeMacBuild, "CMakeCache.txt") && !-d $xcodeBuild) {
+            $isCMakeBuild = 1;
+        }
+    }
 }
 
 sub isCMakeBuild()


### PR DESCRIPTION
#### 73f72dd384ca73dd3e53f6d212805bef72938c0a
<pre>
[JSC] Make run-javascriptcore-tests work with CMake mac build
<a href="https://bugs.webkit.org/show_bug.cgi?id=313888">https://bugs.webkit.org/show_bug.cgi?id=313888</a>
<a href="https://rdar.apple.com/176081579">rdar://176081579</a>

Reviewed by Sosuke Suzuki.

Adjust harness so that we can just use run-javascriptcore-tests with
CMake Mac build JSC.

* Tools/Scripts/run-jsc-stress-tests:
* Tools/Scripts/webkitdirs.pm:
(determineConfigurationProductDir):
(determineIsCMakeBuild):

Canonical link: <a href="https://commits.webkit.org/312482@main">https://commits.webkit.org/312482@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9bfa15c9362d40c3fa31b899c9d0bef3be5474be

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/160089 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/33559 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/26663 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/168974 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/114470 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/161958 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/33662 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/33561 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/124085 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/87019 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/163047 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/26333 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/143793 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/104696 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/46090b4a-9b6b-402b-a47d-daa91c31fe1c) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/25386 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/23877 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/16710 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/152145 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/135078 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/21557 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/171454 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/20926 "Built successfully and passed tests") | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/23195 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/132346 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/33235 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/27960 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/132372 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/33220 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/143352 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/91398 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/24363 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/26984 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/20165 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/192452 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/32729 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/49483 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/32227 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/32473 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/32377 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->