### PR TITLE
[JSC] Optimize FTL `Array#indexOf` / `Array#includes` string fast loop

### DIFF
--- a/JSTests/microbenchmarks/array-indexof-string-16bit-different-length.js
+++ b/JSTests/microbenchmarks/array-indexof-string-16bit-different-length.js
@@ -1,0 +1,22 @@
+// Array of 16-bit strings whose lengths all differ from the search element.
+// FTL fast loop should be able to reject each element on the length check
+// alone without bailing to the C++ slow path just because the element is 16-bit.
+
+function test(arr, key) {
+    return arr.indexOf(key);
+}
+noInline(test);
+
+let arr = [];
+for (let i = 0; i < 1000; ++i) {
+    // 16-bit string, length 5..14 (never 4)
+    arr.push("あ".repeat(5 + (i % 10)));
+}
+
+let key = "abcd"; // 8-bit, length 4
+let result = 0;
+for (let i = 0; i < 5e5; ++i)
+    result += test(arr, key);
+
+if (result !== -5e5)
+    throw new Error("bad result: " + result);

--- a/JSTests/microbenchmarks/array-indexof-string-8bit-different-length.js
+++ b/JSTests/microbenchmarks/array-indexof-string-8bit-different-length.js
@@ -1,0 +1,16 @@
+function test(arr, key) {
+    return arr.indexOf(key);
+}
+noInline(test);
+
+let arr = [];
+for (let i = 0; i < 1000; ++i)
+    arr.push("a".repeat(5 + (i % 10)));
+
+let key = "abcd";
+let result = 0;
+for (let i = 0; i < 5e5; ++i)
+    result += test(arr, key);
+
+if (result !== -5e5)
+    throw new Error("bad result: " + result);

--- a/Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp
+++ b/Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp
@@ -8597,8 +8597,8 @@ IGNORE_CLANG_WARNINGS_END
             LBasicBlock fastCheckElementString = m_out.newBlock();
             LBasicBlock fastPath = m_out.newBlock();
             LBasicBlock slowCheckElementRope = m_out.newBlock();
-            LBasicBlock slowCheckElement8Bit = m_out.newBlock();
             LBasicBlock compareStringLengths = m_out.newBlock();
+            LBasicBlock slowCheckElement8Bit = m_out.newBlock();
             LBasicBlock checkNonEmpty = m_out.newBlock();
             LBasicBlock loadBytes = m_out.newBlock();
             LBasicBlock compareBytesLoop = m_out.newBlock();
@@ -8645,37 +8645,37 @@ IGNORE_CLANG_WARNINGS_END
 
             m_out.appendTo(loopHeader, fastCheckElementEmpty);
             LValue index = m_out.phi(pointerType(), initialStartIndex);
-            m_out.branch(m_out.notEqual(index, length), unsure(fastCheckElementEmpty), unsure(notFound));
+            m_out.branch(m_out.notEqual(index, length), usually(fastCheckElementEmpty), rarely(notFound));
 
             m_out.appendTo(fastCheckElementEmpty, fastCheckElementCell);
             LValue element = m_out.load64(m_out.baseIndex(m_heaps.indexedContiguousProperties, storage, index));
-            m_out.branch(m_out.isZero64(element), unsure(loopNext), unsure(fastCheckElementCell));
+            m_out.branch(m_out.isZero64(element), rarely(loopNext), usually(fastCheckElementCell));
 
             m_out.appendTo(fastCheckElementCell, fastCheckElementString);
-            m_out.branch(isCell(element), unsure(fastCheckElementString), unsure(loopNext));
+            m_out.branch(isCell(element), usually(fastCheckElementString), rarely(loopNext));
 
             m_out.appendTo(fastCheckElementString, fastPath);
-            m_out.branch(isString(element), unsure(fastPath), unsure(loopNext));
+            m_out.branch(isString(element), usually(fastPath), rarely(loopNext));
 
             m_out.appendTo(fastPath, slowCheckElementRope);
             ValueFromBlock foundResult = isArrayIncludes ? m_out.anchor(m_out.constBool(true)) : m_out.anchor(index);
-            m_out.branch(m_out.equal(element, searchElement), unsure(continuation), unsure(slowCheckElementRope));
+            m_out.branch(m_out.equal(element, searchElement), rarely(continuation), usually(slowCheckElementRope));
 
-            m_out.appendTo(slowCheckElementRope, slowCheckElement8Bit);
-            m_out.branch(isRopeString(element), rarely(slowCase), usually(slowCheckElement8Bit));
+            m_out.appendTo(slowCheckElementRope, compareStringLengths);
+            m_out.branch(isRopeString(element), rarely(slowCase), usually(compareStringLengths));
 
-            m_out.appendTo(slowCheckElement8Bit, compareStringLengths);
+            m_out.appendTo(compareStringLengths, slowCheckElement8Bit);
             LValue elementImpl = m_out.loadPtr(element, m_heaps.JSString_value);
-            m_out.branch(m_out.testIsZero32(m_out.load32(elementImpl, m_heaps.StringImpl_hashAndFlags), m_out.constInt32(StringImpl::flagIs8Bit())), unsure(slowCase), unsure(compareStringLengths));
-
-            m_out.appendTo(compareStringLengths, loopNext);
             LValue elementLength = m_out.load32(elementImpl, m_heaps.StringImpl_length);
             m_out.branch(
                 m_out.notEqual(elementLength, m_out.load32(searchElementImpl, m_heaps.StringImpl_length)),
-                unsure(loopNext), unsure(checkNonEmpty));
+                unsure(loopNext), unsure(slowCheckElement8Bit));
+
+            m_out.appendTo(slowCheckElement8Bit, checkNonEmpty);
+            m_out.branch(m_out.testIsZero32(m_out.load32(elementImpl, m_heaps.StringImpl_hashAndFlags), m_out.constInt32(StringImpl::flagIs8Bit())), rarely(slowCase), usually(checkNonEmpty));
 
             m_out.appendTo(checkNonEmpty, loadBytes);
-            m_out.branch(m_out.isZero32(elementLength), unsure(continuation), unsure(loadBytes));
+            m_out.branch(m_out.isZero32(elementLength), rarely(continuation), usually(loadBytes));
 
             m_out.appendTo(loadBytes, compareBytesLoop);
             LValue elementData = m_out.loadPtr(elementImpl, m_heaps.StringImpl_data);


### PR DESCRIPTION
#### 6846e1b56c4bc4ddd76bf051f21007aa18b45696
<pre>
[JSC] Optimize FTL `Array#indexOf` / `Array#includes` string fast loop
<a href="https://bugs.webkit.org/show_bug.cgi?id=313904">https://bugs.webkit.org/show_bug.cgi?id=313904</a>

Reviewed by Yusuke Suzuki.

The FTL StringUse loop in compileArrayIndexOfOrArrayIncludes used unsure()
for every branch in the per-element check chain. B3 ended up placing
loopNext / notFound / continuation between the element load and the cell /
string / rope checks, so the hot path took 2-3 taken forward branches per
iteration. This made the FTL inline loop ~1.5x slower than the DFG inline
loop and even slower than the operationArrayIndexOfString slow path.

This patch:

1. Adds usually()/rarely() hints so B3 lays out the per-element checks as
   a straight-line fall-through sequence.
2. Compares lengths before testing the element&apos;s 8-bit flag (matching DFG),
   so 16-bit elements with mismatching lengths stay in the fast loop
   instead of bailing to the C++ slow path.

                                                       TipOfTree                  Patched

    array-indexof-string-8bit-different-length     573.6901+-21.8263    ^    340.6605+-21.3438       ^ definitely 1.6841x faster
    array-indexof-string-16bit-different-length    404.8519+-3.2210     ^    347.9345+-23.4201       ^ definitely 1.1636x faster

Tests: JSTests/microbenchmarks/array-indexof-string-16bit-different-length.js
       JSTests/microbenchmarks/array-indexof-string-8bit-different-length.js

* JSTests/microbenchmarks/array-indexof-string-16bit-different-length.js: Added.
(test):
* JSTests/microbenchmarks/array-indexof-string-8bit-different-length.js: Added.
(test):
* Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp:
(JSC::FTL::DFG::LowerDFGToB3::compileArrayIndexOfOrArrayIncludes):

Canonical link: <a href="https://commits.webkit.org/312963@main">https://commits.webkit.org/312963@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/14c219544995c6ab6bc3fd2523b1bd83d00cb52b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/160360 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/33833 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/26934 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/169263 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/115426 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/33934 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/33833 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/124333 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/87831 "1 flakes 2 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/163318 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/26582 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/144038 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/104932 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/25634 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/24128 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/16982 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/152416 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/135327 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/21801 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/171740 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/21197 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/18098 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/23441 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/132590 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/33506 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/28222 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/132611 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36119 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/33491 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/143596 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/95273 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/27216 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/20410 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/192759 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/33000 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/99761 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/49627 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/32501 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/32745 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/32649 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->