### PR TITLE
Prune decoded frames for large animated images

### DIFF
--- a/LayoutTests/fast/images/large-animated-image-prunes-decoded-frames-expected.txt
+++ b/LayoutTests/fast/images/large-animated-image-prunes-decoded-frames-expected.txt
@@ -11,3 +11,4 @@ PASS frameBytes * 2 is >= decodedSizeAfterAnimation
 PASS successfullyParsed is true
 
 TEST COMPLETE
+

--- a/LayoutTests/fast/images/large-animated-image-prunes-decoded-frames-expected.txt
+++ b/LayoutTests/fast/images/large-animated-image-prunes-decoded-frames-expected.txt
@@ -1,0 +1,13 @@
+This tests that large animated images discard old decoded frames as they animate.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS internals.imageFrameIndex(image) is >= 0
+PASS internals.imageFrameIndex(image) is >= 1
+PASS internals.imageFrameIndex(image) is >= 2
+PASS decodedSizeAfterAnimation is >= frameBytes
+PASS decodedSizeAfterAnimation is <= frameBytes * 2
+PASS successfullyParsed is true
+
+TEST COMPLETE

--- a/LayoutTests/fast/images/large-animated-image-prunes-decoded-frames-expected.txt
+++ b/LayoutTests/fast/images/large-animated-image-prunes-decoded-frames-expected.txt
@@ -7,7 +7,7 @@ PASS internals.imageFrameIndex(image) is >= 0
 PASS internals.imageFrameIndex(image) is >= 1
 PASS internals.imageFrameIndex(image) is >= 2
 PASS decodedSizeAfterAnimation is >= frameBytes
-PASS decodedSizeAfterAnimation is <= frameBytes * 2
+PASS frameBytes * 2 is >= decodedSizeAfterAnimation
 PASS successfullyParsed is true
 
 TEST COMPLETE

--- a/LayoutTests/fast/images/large-animated-image-prunes-decoded-frames.html
+++ b/LayoutTests/fast/images/large-animated-image-prunes-decoded-frames.html
@@ -53,7 +53,7 @@
             if (window.internals) {
                 decodedSizeAfterAnimation = internals.imageDecodedSizeForTesting(image);
                 shouldBeGreaterThanOrEqual("decodedSizeAfterAnimation", "frameBytes");
-                shouldBeLessThanOrEqual("decodedSizeAfterAnimation", "frameBytes * 2");
+                shouldBeGreaterThanOrEqual("frameBytes * 2", "decodedSizeAfterAnimation");
             }
 
             finishJSTest();

--- a/LayoutTests/fast/images/large-animated-image-prunes-decoded-frames.html
+++ b/LayoutTests/fast/images/large-animated-image-prunes-decoded-frames.html
@@ -1,0 +1,66 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <script src="../../resources/js-test-pre.js"></script>
+</head>
+<body>
+    <img id="image">
+    <canvas id="canvas" width="100" height="100"></canvas>
+    <script>
+        function drawFrame(expectedFrameIndex, shouldWaitForNextFrame)
+        {
+            return new Promise((resolve) => {
+                let context = canvas.getContext("2d");
+                context.drawImage(image, 0, 0, 100, 100, 0, 0, canvas.width, canvas.height);
+
+                if (window.internals) {
+                    shouldBeGreaterThanOrEqual("internals.imageFrameIndex(image)", expectedFrameIndex.toString());
+                    if (shouldWaitForNextFrame)
+                        image.addEventListener("webkitImageFrameReady", resolve, { once: true });
+                    else
+                        resolve();
+                    return;
+                }
+
+                setTimeout(resolve, 40);
+            });
+        }
+
+        async function drawFrames()
+        {
+            await drawFrame(0, true);
+            await drawFrame(1, true);
+            await drawFrame(2, false);
+        }
+
+        description("This tests that large animated images discard old decoded frames as they animate.");
+        jsTestIsAsync = true;
+
+        var image = document.getElementById("image");
+        var canvas = document.getElementById("canvas");
+        var frameBytes = 400 * 400 * 4;
+        var decodedSizeAfterAnimation;
+
+        image.onload = async () => {
+            if (window.internals) {
+                internals.clearMemoryCache();
+                internals.settings.setAnimatedImageDebugCanvasDrawingEnabled(true);
+                internals.settings.setWebkitImageReadyEventEnabled(true);
+            }
+
+            await drawFrames();
+
+            if (window.internals) {
+                decodedSizeAfterAnimation = internals.imageDecodedSizeForTesting(image);
+                shouldBeGreaterThanOrEqual("decodedSizeAfterAnimation", "frameBytes");
+                shouldBeLessThanOrEqual("decodedSizeAfterAnimation", "frameBytes * 2");
+            }
+
+            finishJSTest();
+        };
+
+        image.src = "resources/animated-red-green-blue-400x400.gif";
+    </script>
+    <script src="../../resources/js-test-post.js"></script>
+</body>
+</html>

--- a/Source/WebCore/platform/graphics/BitmapImage.h
+++ b/Source/WebCore/platform/graphics/BitmapImage.h
@@ -93,6 +93,7 @@ public:
     void setMinimumDecodingDurationForTesting(Seconds duration) { m_source->setMinimumDecodingDurationForTesting(duration); }
     void setClearDecoderAfterAsyncFrameRequestForTesting(bool enabled) { m_source->setClearDecoderAfterAsyncFrameRequestForTesting(enabled); }
     void setHasHDRContentForTesting() { m_source->setHasHDRContentForTesting(); }
+    unsigned decodedSizeForTesting() const { return m_source->decodedSizeForTesting(); }
     unsigned decodeCountForTesting() const { return m_source->decodeCountForTesting(); }
     unsigned blankDrawCountForTesting() const { return m_source->blankDrawCountForTesting(); }
 

--- a/Source/WebCore/platform/graphics/BitmapImageSource.h
+++ b/Source/WebCore/platform/graphics/BitmapImageSource.h
@@ -63,6 +63,7 @@ public:
     bool isAnimationAllowed() const;
 
     // Decoding & animation
+    bool isLargeForDecoding() const final;
     bool isPendingDecodingAtIndex(unsigned index, SubsamplingLevel, const DecodingOptions&) const;
     void destroyNativeImageAtIndex(unsigned index, std::optional<DecodingDestination> = std::nullopt);
     void imageFrameAtIndexAvailable(unsigned index, ImageAnimatingState, DecodingStatus);
@@ -124,7 +125,6 @@ private:
 
     // Decoding
     DecodingDestination preferredDecodingDestination(GraphicsContext&, ImagePaintingOptions) const final;
-    bool isLargeForDecoding() const final;
     bool NODELETE isDecodingWorkQueueIdle() const;
     bool isCompatibleWithOptionsAtIndex(unsigned index, SubsamplingLevel, const DecodingOptions&) const;
     void stopDecodingWorkQueue() final;
@@ -200,6 +200,7 @@ private:
     long long expectedContentLength() const;
 
     // Testing support
+    unsigned decodedSizeForTesting() const final { return m_decodedSize; }
     unsigned decodeCountForTesting() const final { return m_decodeCountForTesting; }
     unsigned blankDrawCountForTesting() const final { return m_blankDrawCountForTesting; }
     void setMinimumDecodingDurationForTesting(Seconds) final;

--- a/Source/WebCore/platform/graphics/ImageFrameAnimator.cpp
+++ b/Source/WebCore/platform/graphics/ImageFrameAnimator.cpp
@@ -68,7 +68,7 @@ void ImageFrameAnimator::destroyDecodedData(bool destroyAll)
     static constexpr unsigned LargeAnimationCutoff = 30 * 1024 * 1024;
 
     Ref source = m_source.get();
-    if (source->decodedSize() < LargeAnimationCutoff)
+    if (!source->isLargeForDecoding() && source->decodedSize() < LargeAnimationCutoff)
         return;
 
     source->destroyDecodedData(destroyAll);

--- a/Source/WebCore/platform/graphics/ImageSource.h
+++ b/Source/WebCore/platform/graphics/ImageSource.h
@@ -124,6 +124,7 @@ public:
     virtual DecodingStatus frameDecodingStatusAtIndex(unsigned) const { RELEASE_ASSERT_NOT_REACHED(); return DecodingStatus::Invalid; }
 
     // Testing support
+    virtual unsigned decodedSizeForTesting() const { return 0; }
     virtual unsigned decodeCountForTesting() const { return 0; }
     virtual unsigned blankDrawCountForTesting() const { return 0; }
     virtual void setMinimumDecodingDurationForTesting(Seconds) { RELEASE_ASSERT_NOT_REACHED(); }

--- a/Source/WebCore/testing/Internals.cpp
+++ b/Source/WebCore/testing/Internals.cpp
@@ -1275,6 +1275,12 @@ void Internals::setClearDecoderAfterAsyncFrameRequestForTesting(HTMLImageElement
         bitmapImage->setClearDecoderAfterAsyncFrameRequestForTesting(enabled);
 }
 
+unsigned Internals::imageDecodedSizeForTesting(HTMLImageElement& element)
+{
+    auto* bitmapImage = bitmapImageFromImageElement(element);
+    return bitmapImage ? bitmapImage->decodedSizeForTesting() : 0;
+}
+
 unsigned Internals::imageDecodeCount(HTMLImageElement& element)
 {
     auto* bitmapImage = bitmapImageFromImageElement(element);

--- a/Source/WebCore/testing/Internals.h
+++ b/Source/WebCore/testing/Internals.h
@@ -280,6 +280,7 @@ public:
     void pauseImageAnimation(HTMLImageElement&);
     unsigned NODELETE imagePendingDecodePromisesCountForTesting(HTMLImageElement&);
     void setClearDecoderAfterAsyncFrameRequestForTesting(HTMLImageElement&, bool enabled);
+    unsigned imageDecodedSizeForTesting(HTMLImageElement&);
     unsigned imageDecodeCount(HTMLImageElement&);
     unsigned imageBlankDrawCount(HTMLImageElement&);
     AtomString imageLastDecodingOptions(HTMLImageElement&);

--- a/Source/WebCore/testing/Internals.idl
+++ b/Source/WebCore/testing/Internals.idl
@@ -768,6 +768,7 @@ enum ContentsFormat {
     [Conditional=ACCESSIBILITY_ANIMATION_CONTROL] undefined pauseImageAnimation(HTMLImageElement element);
     unsigned long imagePendingDecodePromisesCountForTesting(HTMLImageElement element);
     undefined setClearDecoderAfterAsyncFrameRequestForTesting(HTMLImageElement element, boolean enabled);
+    unsigned long imageDecodedSizeForTesting(HTMLImageElement element);
     unsigned long imageDecodeCount(HTMLImageElement element);
     unsigned long imageBlankDrawCount(HTMLImageElement element);
     DOMString imageLastDecodingOptions(HTMLImageElement element);


### PR DESCRIPTION
## Summary
- Prune decoded animation frames for images that already qualify as large for decoding, instead of waiting until decoded frame data reaches 30 MB.
- Expose decoded image size through Internals testing hooks.
- Add a regression test that verifies a large animated image keeps only the primary/current decoded frames while it animates.

## Root cause
`BitmapImageSource::isLargeForDecoding()` treats animated images over 100 KB per frame as large, but `ImageFrameAnimator::destroyDecodedData()` only discarded old decoded animation frames after the total decoded size reached 30 MB. Several moderate or large animated images could therefore retain multiple decoded frames at the same time.

## Validation
- `git diff --check`
- `Tools/Scripts/check-webkit-style --diff-files Source/WebCore/platform/graphics/ImageFrameAnimator.cpp Source/WebCore/platform/graphics/ImageSource.h Source/WebCore/platform/graphics/BitmapImageSource.h Source/WebCore/platform/graphics/BitmapImage.h Source/WebCore/testing/Internals.h Source/WebCore/testing/Internals.idl Source/WebCore/testing/Internals.cpp LayoutTests/fast/images/large-animated-image-prunes-decoded-frames.html LayoutTests/fast/images/large-animated-image-prunes-decoded-frames-expected.txt`
- `Tools/Scripts/run-webkit-tests fast/images/large-animated-image-prunes-decoded-frames.html` did not run in this sparse checkout because the runner could not resolve the WebKit build directory (`Tools/Scripts/webkit-build-directory --configuration --release --mac`).<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0d8d4f2fddc381611ca70400cfbd503738eeba98

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/161633 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/35107 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/28210 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/170536 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/118004 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/163502 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/35208 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/35108 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/125396 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/88323 "2 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/164592 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/27698 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/145178 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/105992 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/26747 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/25260 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/18257 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/136440 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/22934 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/173024 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/20065 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/24575 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/133686 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/34781 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/29354 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/133691 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/34765 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/144729 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/96726 "The change is no longer eligible for processing.") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/28223 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/21549 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/34275 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/101720 "Built successfully") | | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/33775 "Build is in progress. Recent messages:OS: Tahoe (26.2), Xcode: 26.2; Skipping applying patch since patch_id isn't provided; Checked out pull request; Running compile-webkit") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/34018 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/33924 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->