### PR TITLE
REGRESSION(310280@main): [iPhone] Fullscreen does not work on NFL.com

### DIFF
--- a/Source/WebCore/loader/MediaResourceLoader.cpp
+++ b/Source/WebCore/loader/MediaResourceLoader.cpp
@@ -44,6 +44,7 @@
 #include "OriginAccessPatterns.h"
 #include "SecurityOrigin.h"
 #include "Settings.h"
+#include <JavaScriptCore/RegularExpression.h>
 #include <WebCore/HTTPStatusCodes.h>
 #include <wtf/NeverDestroyed.h>
 #include <wtf/SortedArrayMap.h>
@@ -169,6 +170,8 @@ RefPtr<PlatformMediaResource> MediaResourceLoader::requestResource(ResourceReque
         return nullptr;
 
     Ref mediaResource = MediaResource::create(*this, WTF::move(resource));
+    if (document->quirks().shouldSuppressHLSSubtitles())
+        mediaResource->setShouldSuppressHLSSubtitles();
     m_resources.add(mediaResource.get());
 
     return mediaResource;
@@ -390,11 +393,48 @@ void MediaResource::dataSent(CachedResource& resource, unsigned long long bytesS
         client->dataSent(*this, bytesSent, totalBytesToBeSent);
 }
 
+void MediaResource::sendPartialPlaylistLine(String& line)
+{
+    if (!line.length())
+        return;
+
+    if (line.contains("EXT-X-MEDIA:TYPE=SUBTITLES"_s))
+        return;
+
+    RefPtr client = protect(*this)->client();
+    if (!client)
+        return;
+
+    static NeverDestroyed<JSC::Yarr::RegularExpression> subtitlesAttr("SUBTITLES=\"[^\"]*\",?"_s);
+    replace(line, subtitlesAttr, ""_s);
+
+    if (auto lineBuffer = utf8Buffer(line)) {
+        client->dataReceived(*this, *lineBuffer);
+        m_partialPlaylistByteCount += lineBuffer->size();
+
+        client->dataReceived(*this, SharedBuffer::create(Vector<uint8_t> {  FillWith { }, 1, '\n' }));
+        ++m_partialPlaylistByteCount;
+    }
+}
+
 void MediaResource::dataReceived(CachedResource& resource, const SharedBuffer& buffer)
 {
     assertIsMainThread();
 
     ASSERT_UNUSED(resource, &resource == m_resource);
+
+    if (m_shouldSuppressHLSSubtitles && resource.response().mimeType() == "application/x-mpegurl"_s) {
+        String partialPlaylist = makeString(m_partialPlaylistLine, String::fromUTF8(byteCast<char>(buffer.span())));
+        auto lines = partialPlaylist.split('\n');
+        if (lines.isEmpty())
+            return;
+
+        m_partialPlaylistLine = lines.takeLast();
+
+        for (auto& line : lines)
+            sendPartialPlaylistLine(line);
+        return;
+    }
 
     Ref protectedThis { *this };
     if (RefPtr client = this->client())
@@ -408,12 +448,30 @@ void MediaResource::notifyFinished(CachedResource& resource, const NetworkLoadMe
     ASSERT_UNUSED(resource, &resource == m_resource);
 
     Ref protectedThis { *this };
-    if (RefPtr client = this->client()) {
-        if (m_resource->loadFailedOrCanceled())
-            client->loadFailed(*this, m_resource->resourceError());
-        else
-            client->loadFinished(*this, metrics);
+    RefPtr client = protect(*this)->client();
+    if (!client)
+        return ensureShutdown();
+
+    if (m_resource->loadFailedOrCanceled()) {
+        client->loadFailed(*this, m_resource->resourceError());
+        return ensureShutdown();
     }
+
+    if (m_shouldSuppressHLSSubtitles && (!m_partialPlaylistLine.isEmpty() || m_partialPlaylistByteCount)) {
+        sendPartialPlaylistLine(m_partialPlaylistLine);
+
+        long long expectedLength = resource.response().expectedContentLength();
+        if (expectedLength > 0 && static_cast<size_t>(expectedLength) > m_partialPlaylistByteCount) {
+            auto remainingBytes = static_cast<size_t>(expectedLength) - m_partialPlaylistByteCount;
+            auto remainingBuffer = SharedBuffer::create(Vector<uint8_t> { FillWith { }, remainingBytes, '\n' });
+            client->dataReceived(*this, remainingBuffer);
+        }
+
+        m_partialPlaylistLine = { };
+        m_partialPlaylistByteCount = 0;
+    }
+
+    client->loadFinished(*this, metrics);
     ensureShutdown();
 }
 

--- a/Source/WebCore/loader/MediaResourceLoader.h
+++ b/Source/WebCore/loader/MediaResourceLoader.h
@@ -123,13 +123,21 @@ public:
     void dataReceived(CachedResource&, const SharedBuffer&) override;
     void notifyFinished(CachedResource&, const NetworkLoadMetrics&, LoadWillContinueInAnotherProcess) override;
 
+    void setShouldSuppressHLSSubtitles() { m_shouldSuppressHLSSubtitles = true; }
+
 private:
+
+    void sendPartialPlaylistLine(String&);
 
     MediaResource(MediaResourceLoader&, CachedResourceHandle<CachedRawResource>&&);
     void ensureShutdown();
     const Ref<MediaResourceLoader> m_loader;
     Atomic<bool> m_didPassAccessControlCheck { false };
     CachedResourceHandle<CachedRawResource> m_resource;
+
+    bool m_shouldSuppressHLSSubtitles { false };
+    size_t m_partialPlaylistByteCount { 0 };
+    String m_partialPlaylistLine;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/page/Quirks.cpp
+++ b/Source/WebCore/page/Quirks.cpp
@@ -1895,30 +1895,6 @@ bool Quirks::needsIPhoneUserAgent(const URL& url, UseDesktopClassBrowsing useDes
     return false;
 }
 
-bool Quirks::needsChromeForAndroidUserAgent(const URL& url)
-{
-#if PLATFORM(IOS_FAMILY)
-    // nfl.com rdar://171113872
-    if (url.host() == "www.nfl.com"_s && PAL::currentUserInterfaceIdiomIsSmallScreen())
-        return true;
-#else
-    UNUSED_PARAM(url);
-#endif
-    return false;
-}
-
-bool Quirks::needsMediaSourceEnabled(const URL& url)
-{
-#if PLATFORM(IOS_FAMILY)
-    // nfl.com rdar://171113872
-    if (url.host() == "www.nfl.com"_s && PAL::currentUserInterfaceIdiomIsSmallScreen())
-        return true;
-#else
-    UNUSED_PARAM(url);
-#endif
-    return false;
-}
-
 std::optional<String> Quirks::needsCustomUserAgentOverride(const URL& url, const String& applicationNameForUserAgent, const String& currentUserAgent)
 {
     auto hostDomain = RegistrableDomain(url);
@@ -2321,6 +2297,14 @@ bool Quirks::shouldLimitHLSPlaybackRate() const
     QUIRKS_EARLY_RETURN_IF_DISABLED_WITH_VALUE(false);
 
     return m_quirksData.quirkIsEnabled(QuirksData::SiteSpecificQuirk::ShouldLimitHLSPlaybackRate);
+}
+
+// nfl.com:
+bool Quirks::shouldSuppressHLSSubtitles() const
+{
+    QUIRKS_EARLY_RETURN_IF_DISABLED_WITH_VALUE(false);
+
+    return m_quirksData.quirkIsEnabled(QuirksData::SiteSpecificQuirk::ShouldSuppressHLSSubtitles);
 }
 
 // spotify.com rdar://140707449
@@ -3457,6 +3441,13 @@ static void NODELETE handleNBAQuirks(QuirksData& quirksData, const URL& /* quirk
 #endif
 }
 
+static void handleNFLQuirks(QuirksData& quirksData, const URL& /* quirksURL */, const String& quirksDomainString, const URL&  /* documentURL */)
+{
+    QUIRKS_EARLY_RETURN_IF_NOT_DOMAIN("nfl.com"_s);
+
+    quirksData.enableQuirk(QuirksData::SiteSpecificQuirk::ShouldSuppressHLSSubtitles);
+}
+
 static void handleNHLQuirks(QuirksData& quirksData, const URL& /* quirksURL */, const String& quirksDomainString, const URL&  /* documentURL */)
 {
     QUIRKS_EARLY_RETURN_IF_NOT_DOMAIN("nhl.com"_s);
@@ -3906,6 +3897,7 @@ void Quirks::determineRelevantQuirks()
         { "messenger"_s, &handleFacebookMessengerQuirks },
         { "netflix"_s, &handleNetflixQuirks },
         { "nba"_s, &handleNBAQuirks },
+        { "nfl"_s, &handleNFLQuirks },
         { "nhl"_s, &handleNHLQuirks },
 #if PLATFORM(IOS) || PLATFORM(VISION)
         { "nytimes"_s, &handleNYTimesQuirks },

--- a/Source/WebCore/page/Quirks.h
+++ b/Source/WebCore/page/Quirks.h
@@ -123,10 +123,7 @@ public:
     WEBCORE_EXPORT static bool needsIPadMiniUserAgent(const URL&);
     WEBCORE_EXPORT static bool NODELETE needsIPhoneUserAgent(const URL&, UseDesktopClassBrowsing = UseDesktopClassBrowsing::Unspecified);
     WEBCORE_EXPORT static bool NODELETE needsDesktopUserAgent(const URL&);
-    WEBCORE_EXPORT static bool NODELETE needsChromeForAndroidUserAgent(const URL&);
     WEBCORE_EXPORT static std::optional<String> needsCustomUserAgentOverride(const URL&, const String& applicationNameForUserAgent, const String& currentUserAgent);
-
-    WEBCORE_EXPORT static bool NODELETE needsMediaSourceEnabled(const URL&);
 
     WEBCORE_EXPORT static bool needsPartitionedCookies(const ResourceRequest&);
 
@@ -340,6 +337,7 @@ public:
     bool shouldComparareUsedValuesForBorderWidthForTriggeringTransitions() const;
 
     bool shouldLimitHLSPlaybackRate() const;
+    bool shouldSuppressHLSSubtitles() const;
 
     void determineRelevantQuirks();
 

--- a/Source/WebCore/page/QuirksData.h
+++ b/Source/WebCore/page/QuirksData.h
@@ -258,6 +258,7 @@ struct QuirksData {
 #endif
         ShouldLimitHLSPlaybackRate,
         ShouldDeferIntersectionObserversDuringResize,
+        ShouldSuppressHLSSubtitles,
 
         NumberOfQuirks
     };

--- a/Source/WebKit/UIProcess/ios/WebPageProxyIOS.mm
+++ b/Source/WebKit/UIProcess/ios/WebPageProxyIOS.mm
@@ -1581,16 +1581,8 @@ WebContentMode WebPageProxy::effectiveContentModeAfterAdjustingPolicies(API::Web
         if (auto selectors = Quirks::defaultVisibilityAdjustmentSelectors(request.url()))
             policies.setVisibilityAdjustmentSelectors({ WTF::move(*selectors) });
 
-        if (Quirks::needsMediaSourceEnabled(request.url()))
-            policies.setMediaSourcePolicy(WebsiteMediaSourcePolicy::Enable);
-
         if (Quirks::needsIPhoneUserAgent(request.url())) {
             applyIPhoneUserAgent();
-            return WebContentMode::Mobile;
-        }
-
-        if (Quirks::needsChromeForAndroidUserAgent(request.url())) {
-            policies.setCustomUserAgent("Mozilla/5.0 (Linux; Android 10; K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/138.0.0.0 Mobile Safari/537.36"_s);
             return WebContentMode::Mobile;
         }
     }


### PR DESCRIPTION
#### 332462f1fd529d194273cf93d4cccec905e586b9
<pre>
REGRESSION(310280@main): [iPhone] Fullscreen does not work on NFL.com
<a href="https://rdar.apple.com/154879148">rdar://154879148</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=313906">https://bugs.webkit.org/show_bug.cgi?id=313906</a>

Reviewed by Eric Carlson.

In 310280@main, NFL.com was quirked to report the Android UA, so that it would
have correct caption tracks. However, this broke the ability to enter fullscreen
as NFL.com expected Android devices to support the fullscreen API.

Change the caption quirk to instead directly address the root cause of the caption
bug: the NFL.com HLS streams list a subtitle track whose contents are entirely empty.
The presence of this track suppresses the discovery of embedded CEA-608 caption
information. On iPad, macOS, and Android, NFL.com parses these captions out of the
transport stream for each video, but on iPhone it depends upon the native player
extracting these captions.

Add a quirk that will edit the HLS playlist itself before it&apos;s delivered to
AVFoundation, to remove all references to the non-functional Subtitle track.

* Source/WebCore/loader/MediaResourceLoader.cpp:
(WebCore::MediaResourceLoader::requestResource):
(WebCore::MediaResource::sendPartialPlaylistLine):
(WebCore::MediaResource::dataReceived):
(WebCore::MediaResource::notifyFinished):
* Source/WebCore/loader/MediaResourceLoader.h:
(WebCore::MediaResource::setShouldSuppressHLSSubtitles):
* Source/WebCore/page/Quirks.cpp:
* Source/WebCore/page/Quirks.h:
* Source/WebCore/page/QuirksData.h:
* Source/WebKit/UIProcess/ios/WebPageProxyIOS.mm:
(WebKit::WebPageProxy::effectiveContentModeAfterAdjustingPolicies):

Canonical link: <a href="https://commits.webkit.org/312540@main">https://commits.webkit.org/312540@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cafdaa1a2e4084a9986ae61a704fa21f39c046be

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/160330 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/33803 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/26904 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/169232 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/115396 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/162199 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/33904 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/33803 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/124304 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/115396 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/163288 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/26544 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/144009 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/104903 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/25596 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/24098 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/16952 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/135289 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/21772 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/171710 "Built successfully") | | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/18068 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/23412 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/132558 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/33476 "Build is in progress. Recent messages:OS: Tahoe (26.2), Xcode: 26.2; Running apply-patch; Checked out pull request; Compiled WebKit (warnings)") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/28192 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/132581 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35831 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/33461 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/143567 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/95243 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/27191 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/20381 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/32970 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/99731 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/32471 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/32715 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/32619 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->