### PR TITLE
Smooth scroll in viewport with scroll-snap fails on iOS

### DIFF
--- a/LayoutTests/fast/scrolling/ios/scroll-into-view-smooth-after-snap-expected.txt
+++ b/LayoutTests/fast/scrolling/ios/scroll-into-view-smooth-after-snap-expected.txt
@@ -1,0 +1,16 @@
+top
+bottom
+After a programmatic scrollIntoView to a snap point, the user should be able to drag back to the original snap point without a stale cached snap index forcing a re-snap.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS document.scrollingElement.scrollTop is 0
+PASS document.scrollingElement.scrollTop is 800
+PASS document.scrollingElement.scrollTop is 800
+PASS document.scrollingElement.scrollTop is 0
+PASS document.scrollingElement.scrollTop is 0
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/scrolling/ios/scroll-into-view-smooth-after-snap.html
+++ b/LayoutTests/fast/scrolling/ios/scroll-into-view-smooth-after-snap.html
@@ -1,0 +1,77 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ useFlexibleViewport=true ] -->
+<html>
+<head>
+<meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no">
+<script src="../../../resources/js-test.js"></script>
+<script src="../../../resources/ui-helper.js"></script>
+<style>
+html {
+    scroll-snap-type: y mandatory;
+}
+
+body {
+  margin: 0;
+}
+
+.block {
+    height: 800px;
+    box-sizing: border-box;
+    border: 1px solid black;
+    scroll-snap-align: start;
+}
+</style>
+
+<body onload="runTest()">
+    <div class="block" id="top">top</div>
+    <div class="block" id="bottom">bottom</div>
+    <div id="console"></div>
+</body>
+
+<script>
+jsTestIsAsync = true;
+
+async function runTest()
+{
+    description("After a programmatic scrollIntoView to a snap point, the user should be able to drag back to the original snap point without a stale cached snap index forcing a re-snap.");
+
+    if (!window.testRunner) {
+        finishJSTest();
+        return;
+    }
+
+    await UIHelper.delayFor(0);
+    shouldBe("document.scrollingElement.scrollTop", "0");
+
+    document.getElementById("bottom").scrollIntoView({ block: "start" });
+    await UIHelper.waitForTargetScrollAnimationToSettle(document.scrollingElement);
+    shouldBe("document.scrollingElement.scrollTop", "800");
+
+    const xOffset = 150;
+    const yOffset = 800;
+    // The event coordinates here ensure that -scrollViewWillEndDragging:withVelocity:... is called with zero velocity.
+    // This is a small scroll that keeps us at the second snap point.
+    await UIHelper.sendEventStream(new UIHelper.EventStreamBuilder()
+        .begin(xOffset, yOffset + 50)
+        .move(xOffset, yOffset + 55, 0.01)
+        .move(xOffset, yOffset + 60, 0.01)
+        .move(xOffset + 1, yOffset + 60, 0.01)
+        .move(xOffset - 1, yOffset + 60, 0.01)
+        .move(xOffset, yOffset + 60, 0.01)
+        .end()
+        .takeResult());
+
+    await UIHelper.waitForTargetScrollAnimationToSettle(document.scrollingElement);
+    shouldBe("document.scrollingElement.scrollTop", "800");
+
+    document.getElementById("top").scrollIntoView({ behavior: "smooth", block: "start" });
+    await UIHelper.waitForTargetScrollAnimationToSettle(document.scrollingElement);
+    shouldBe("document.scrollingElement.scrollTop", "0");
+
+    await UIHelper.ensurePresentationUpdate();
+
+    shouldBe("document.scrollingElement.scrollTop", "0");
+
+    finishJSTest();
+}
+</script>
+</html>

--- a/Source/WebCore/page/LocalFrameView.cpp
+++ b/Source/WebCore/page/LocalFrameView.cpp
@@ -3291,7 +3291,7 @@ void LocalFrameView::setScrollOffsetWithOptions(const ScrollOffset& scrollOffset
     if (page && page->isMonitoringWheelEvents())
         scrollAnimator().setWheelEventTestMonitor(page->wheelEventTestMonitor());
 
-    ScrollOffset snappedOffset = ceiledIntPoint(scrollAnimator().scrollOffsetAdjustedForSnapping(scrollOffset, options.snapPointSelectionMethod));
+    auto snappedOffset = ceiledIntPoint(scrollAnimator().scrollOffsetAdjustedForSnapping(scrollOffset, options.snapPointSelectionMethod));
     auto snappedPosition = scrollPositionFromOffset(snappedOffset);
 
     if (options.animated == ScrollIsAnimated::Yes)

--- a/Source/WebCore/page/scrolling/ScrollingStateScrollingNode.cpp
+++ b/Source/WebCore/page/scrolling/ScrollingStateScrollingNode.cpp
@@ -119,6 +119,8 @@ ScrollingStateScrollingNode::ScrollingStateScrollingNode(const ScrollingStateScr
     , m_scrollPosition(stateNode.scrollPosition())
     , m_scrollOrigin(stateNode.scrollOrigin())
     , m_snapOffsetsInfo(stateNode.m_snapOffsetsInfo)
+    // m_currentHorizontalSnapPointIndex is not currently copied.
+    // m_currentVerticalSnapPointIndex is not currently copied.
 #if PLATFORM(MAC) || USE(COORDINATED_GRAPHICS_ASYNC_SCROLLBAR)
     , m_scrollbarHoverState(stateNode.scrollbarHoverState())
 #endif
@@ -263,7 +265,7 @@ void ScrollingStateScrollingNode::setCurrentVerticalSnapPointIndex(std::optional
 {
     if (m_currentVerticalSnapPointIndex == index)
         return;
-    
+
     m_currentVerticalSnapPointIndex = index;
     setPropertyChanged(Property::CurrentVerticalSnapOffsetIndex);
 }

--- a/Source/WebCore/page/scrolling/ScrollingTree.cpp
+++ b/Source/WebCore/page/scrolling/ScrollingTree.cpp
@@ -309,7 +309,7 @@ void ScrollingTree::scrollingTreeNodeDidScroll(ScrollingTreeScrollingNode& node,
 
 void ScrollingTree::mainFrameViewportChangedViaDelegatedScrolling(const FloatPoint& scrollPosition, const FloatRect& layoutViewport, double)
 {
-    LOG_WITH_STREAM(Scrolling, stream << "ScrollingTree::viewportChangedViaDelegatedScrolling - layoutViewport " << layoutViewport);
+    LOG_WITH_STREAM(Scrolling, stream << "ScrollingTree::mainFrameViewportChangedViaDelegatedScrolling - layoutViewport " << layoutViewport);
     
     if (RefPtr rootNode = m_rootNode)
         rootNode->wasScrolledByDelegatedScrolling(scrollPosition, layoutViewport);

--- a/Source/WebCore/platform/ScrollAnimator.cpp
+++ b/Source/WebCore/platform/ScrollAnimator.cpp
@@ -441,10 +441,13 @@ FloatPoint ScrollAnimator::scrollOffsetAdjustedForSnapping(const FloatPoint& off
     if (!m_scrollController.usesScrollSnap())
         return offset;
 
-    return {
+    auto result = FloatPoint {
         scrollOffsetAdjustedForSnapping(ScrollEventAxis::Horizontal, offset, method),
         scrollOffsetAdjustedForSnapping(ScrollEventAxis::Vertical, offset, method)
     };
+
+    LOG_WITH_STREAM(ScrollSnap, stream << "ScrollAnimator::scrollOffsetAdjustedForSnapping() - offset " << offset << " adjusted to  " << result);
+    return result;
 }
 
 float ScrollAnimator::scrollOffsetAdjustedForSnapping(ScrollEventAxis axis, const FloatPoint& newOffset, ScrollSnapPointSelectionMethod method) const

--- a/Source/WebKit/Shared/RemoteLayerTree/RemoteScrollingCoordinatorTransaction.cpp
+++ b/Source/WebKit/Shared/RemoteLayerTree/RemoteScrollingCoordinatorTransaction.cpp
@@ -97,9 +97,13 @@ static void dump(TextStream& ts, const ScrollingStateScrollingNode& node, bool c
     if (!changedPropertiesOnly || node.hasChangedProperty(ScrollingStateNode::Property::SnapOffsetsInfo)) {
         ts.dumpProperty("horizontal snap offsets"_s, node.snapOffsetsInfo().horizontalSnapOffsets);
         ts.dumpProperty("vertical snap offsets"_s, node.snapOffsetsInfo().verticalSnapOffsets);
-        ts.dumpProperty("current horizontal snap point index"_s, node.currentHorizontalSnapPointIndex());
-        ts.dumpProperty("current vertical snap point index"_s, node.currentVerticalSnapPointIndex());
     }
+
+    if (!changedPropertiesOnly || node.hasChangedProperty(ScrollingStateNode::Property::CurrentHorizontalSnapOffsetIndex))
+        ts.dumpProperty("current horizontal snap point index"_s, node.currentHorizontalSnapPointIndex());
+
+    if (!changedPropertiesOnly || node.hasChangedProperty(ScrollingStateNode::Property::CurrentVerticalSnapOffsetIndex))
+        ts.dumpProperty("current vertical snap point index"_s, node.currentVerticalSnapPointIndex());
 
 #if ENABLE(SCROLLING_THREAD)
     if (!changedPropertiesOnly || node.hasChangedProperty(ScrollingStateNode::Property::ReasonsForSynchronousScrolling))

--- a/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm
+++ b/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm
@@ -753,26 +753,32 @@ static WebCore::Color scrollViewBackgroundColor(WKWebView *webView, AllowPageBac
     return CGPointMake(-combinedUnobscuredAndScrollViewInset.left, -combinedUnobscuredAndScrollViewInset.top);
 }
 
-- (CGPoint)_contentOffsetAdjustedForObscuredInset:(CGPoint)point
+- (CGPoint)_contentOffset:(CGPoint)point adjustedForObscuredInsets:(UIEdgeInsets)insets
 {
     CGPoint result = point;
-    UIEdgeInsets contentInset = [self _computedObscuredInset];
-
-    result.x -= contentInset.left;
-    result.y -= contentInset.top;
+    result.x -= insets.left;
+    result.y -= insets.top;
 
     return result;
 }
 
-- (CGPoint)_scrollOffsetAdjustedForObscuredInset:(CGPoint)contentOffset
+- (CGPoint)_scrollOffset:(CGPoint)point adjustedForObscuredInsets:(UIEdgeInsets)insets
 {
-    CGPoint result = contentOffset;
-    UIEdgeInsets contentInset = [self _computedObscuredInset];
-
-    result.x += contentInset.left;
-    result.y += contentInset.top;
+    CGPoint result = point;
+    result.x += insets.left;
+    result.y += insets.top;
 
     return result;
+}
+
+- (CGPoint)_contentOffsetAdjustedForObscuredInset:(CGPoint)scrollOffset
+{
+    return [self _contentOffset:scrollOffset adjustedForObscuredInsets:[self _computedObscuredInset]];
+}
+
+- (CGPoint)_scrollOffsetAdjustedForObscuredInset:(CGPoint)contentOffset
+{
+    return [self _scrollOffset:contentOffset adjustedForObscuredInsets:[self _computedObscuredInset]];
 }
 
 - (UIRectEdge)_effectiveObscuredInsetEdgesAffectedBySafeArea
@@ -2069,8 +2075,12 @@ static WebCore::FloatPoint constrainContentOffset(WebCore::FloatPoint contentOff
     _page->scheduleAccessibilityFrameGeometryUpdate();
 #endif
 
-    if (CheckedPtr coordinator = _page->scrollingCoordinatorProxy())
+    if (CheckedPtr coordinator = downcast<WebKit::RemoteScrollingCoordinatorProxyIOS>(_page->scrollingCoordinatorProxy())) {
         coordinator->setRootNodeIsInUserScroll(false);
+
+        auto scrollOffset = [self _scrollOffsetAdjustedForObscuredInset:scrollView.contentOffset];
+        coordinator->updateSnapIndicesForMainFrameOffset(scrollOffset, contentZoomScale(self));
+    }
 }
 
 - (void)scrollViewWillEndDragging:(UIScrollView *)scrollView withVelocity:(CGPoint)velocity targetContentOffset:(inout CGPoint *)targetContentOffset
@@ -2088,20 +2098,26 @@ static WebCore::FloatPoint constrainContentOffset(WebCore::FloatPoint contentOff
     }
 
     if (CheckedPtr coordinator = downcast<WebKit::RemoteScrollingCoordinatorProxyIOS>(_page->scrollingCoordinatorProxy())) {
-        // FIXME: Here, I'm finding the maximum horizontal/vertical scroll offsets. There's probably a better way to do this.
-        CGSize maxScrollOffsets = CGSizeMake(scrollView.contentSize.width - scrollView.bounds.size.width, scrollView.contentSize.height - scrollView.bounds.size.height);
-
-        UIEdgeInsets obscuredInset;
-
+        UIEdgeInsets obscuredInsets;
         id<WKUIDelegatePrivate> uiDelegatePrivate = static_cast<id <WKUIDelegatePrivate>>([self UIDelegate]);
         if ([uiDelegatePrivate respondsToSelector:@selector(_webView:finalObscuredInsetsForScrollView:withVelocity:targetContentOffset:)])
-            obscuredInset = [uiDelegatePrivate _webView:self finalObscuredInsetsForScrollView:scrollView withVelocity:velocity targetContentOffset:targetContentOffset];
+            obscuredInsets = [uiDelegatePrivate _webView:self finalObscuredInsetsForScrollView:scrollView withVelocity:velocity targetContentOffset:targetContentOffset];
         else
-            obscuredInset = [self _computedObscuredInset];
+            obscuredInsets = [self _computedObscuredInset];
 
-        CGRect unobscuredRect = UIEdgeInsetsInsetRect(self.bounds, obscuredInset);
+        // FIXME: Here, we're finding the maximum horizontal/vertical scroll offsets. There's probably a better way to do this.
+        CGSize maxContentOffset = CGSizeMake(scrollView.contentSize.width + obscuredInsets.right - scrollView.bounds.size.width, scrollView.contentSize.height + obscuredInsets.bottom - scrollView.bounds.size.height);
+        CGSize maxScrollOffset = CGSizeMake(maxContentOffset.width + obscuredInsets.left, maxContentOffset.height + obscuredInsets.top);
 
-        coordinator->adjustTargetContentOffsetForSnapping(maxScrollOffsets, velocity, unobscuredRect.origin.y, scrollView.contentOffset, targetContentOffset);
+        auto zoomScale = contentZoomScale(self);
+
+        // Add insets.
+        auto adjustedOffset = [self _scrollOffset:*targetContentOffset adjustedForObscuredInsets:obscuredInsets];
+        auto currentOffset = [self _scrollOffset:scrollView.contentOffset adjustedForObscuredInsets:obscuredInsets];
+        auto adjustedScrollOffset = coordinator->adjustTargetScrollOffsetForSnapping(maxScrollOffset, zoomScale, velocity, currentOffset, adjustedOffset);
+
+        // Subtract insets.
+        *targetContentOffset = [self _contentOffset:adjustedScrollOffset adjustedForObscuredInsets:obscuredInsets];
     }
 }
 
@@ -3018,19 +3034,21 @@ static bool scrollViewCanScroll(UIScrollView *scrollView)
     if (viewStability.isEmpty()) {
         CheckedPtr coordinator = downcast<WebKit::RemoteScrollingCoordinatorProxyIOS>(_page->scrollingCoordinatorProxy());
         if (coordinator && coordinator->hasActiveSnapPoint()) {
-            CGPoint currentPoint = [_scrollView contentOffset];
-            CGPoint activePoint = coordinator->nearestActiveContentInsetAdjustedSnapOffset(unobscuredRect.origin.y, currentPoint);
+            CGPoint currentScrollOffset = [self _scrollOffsetAdjustedForObscuredInset:[_scrollView contentOffset]];
+            CGPoint snappedScrollOffset = coordinator->scrollOffsetSnappedToNearestSnapPoint(currentScrollOffset, scaleFactor);
 
-            if (!CGPointEqualToPoint(activePoint, currentPoint)) {
+            if (!CGPointEqualToPoint(snappedScrollOffset, currentScrollOffset)) {
+                LOG_WITH_STREAM(Scrolling, stream << "_createVisibleContentRectUpdate: scroll snap adjusted scroll offset from " << currentScrollOffset << " to " << snappedScrollOffset);
+                CGPoint snappedContentOffset = [self _contentOffsetAdjustedForObscuredInset:snappedScrollOffset];
                 RetainPtr<WKScrollView> strongScrollView = _scrollView;
-                RunLoop::mainSingleton().dispatch([strongScrollView, activePoint] {
-                    [strongScrollView setContentOffset:activePoint animated:NO];
+                RunLoop::mainSingleton().dispatch([strongScrollView, snappedContentOffset] {
+                    [strongScrollView setContentOffset:snappedContentOffset animated:NO];
                 });
             }
         }
     }
 
-    MonotonicTime timestamp = MonotonicTime::now();
+    auto timestamp = MonotonicTime::now();
     WebCore::VelocityData velocityData;
     bool inStableState = viewStability.isEmpty();
     if (!inStableState)

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingCoordinatorProxy.cpp
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingCoordinatorProxy.cpp
@@ -489,8 +489,6 @@ void RemoteScrollingCoordinatorProxy::sendUIStateChangedIfNecessary()
 
 void RemoteScrollingCoordinatorProxy::resetStateAfterProcessExited()
 {
-    m_currentHorizontalSnapPointIndex = 0;
-    m_currentVerticalSnapPointIndex = 0;
     m_uiState.reset();
 }
 

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingCoordinatorProxy.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingCoordinatorProxy.h
@@ -229,8 +229,6 @@ private:
 protected:
     WebCore::ScrollRequestData m_scrollRequestData;
     RemoteScrollingUIState m_uiState;
-    std::optional<unsigned> m_currentHorizontalSnapPointIndex;
-    std::optional<unsigned> m_currentVerticalSnapPointIndex;
     bool m_waitingForDidScrollReply { false };
     HashSet<WebCore::PlatformLayerIdentifier> m_layersWithScrollingRelations;
 };

--- a/Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteScrollingCoordinatorProxyIOS.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteScrollingCoordinatorProxyIOS.h
@@ -61,9 +61,11 @@ public:
     bool shouldSetScrollViewDecelerationRateFast() const;
     void setRootNodeIsInUserScroll(bool) override;
 
-    void adjustTargetContentOffsetForSnapping(CGSize maxScrollDimensions, CGPoint velocity, CGFloat topInset, CGPoint currentContentOffset, CGPoint* targetContentOffset);
+    CGPoint adjustTargetScrollOffsetForSnapping(CGSize maxScrollOffset, CGFloat zoomScale, CGPoint velocity, CGPoint currentScrollOffset, CGPoint targetScrollOffset);
     bool hasActiveSnapPoint() const;
-    CGPoint nearestActiveContentInsetAdjustedSnapOffset(CGFloat topInset, const CGPoint&) const;
+    CGPoint scrollOffsetSnappedToNearestSnapPoint(CGPoint scrollOffset, CGFloat zoomScale) const;
+
+    void updateSnapIndicesForMainFrameOffset(CGPoint scrollOffset, CGFloat zoomScale);
 
 #if ENABLE(OVERLAY_REGIONS_IN_EVENT_REGION)
     void updateOverlayRegions(const Vector<WebCore::PlatformLayerIdentifier>& destroyedLayers = { }) override;
@@ -108,8 +110,7 @@ private:
 
     WebCore::FloatRect currentLayoutViewport() const;
 
-    bool shouldSnapForMainFrameScrolling(WebCore::ScrollEventAxis) const;
-    std::pair<float, std::optional<unsigned>> closestSnapOffsetForMainFrameScrolling(WebCore::ScrollEventAxis, float currentScrollOffset, WebCore::FloatPoint scrollDestination, float velocity) const;
+    std::pair<float, std::optional<unsigned>> closestSnapOffsetForMainFrameScrolling(WebCore::ScrollEventAxis, CGFloat zoomScale, CGFloat currentScrollOffset, WebCore::FloatPoint scrollDestination, float velocity) const;
 
 #if ENABLE(THREADED_ANIMATIONS)
     void updateTimeDependentAnimationStacks();

--- a/Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteScrollingCoordinatorProxyIOS.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteScrollingCoordinatorProxyIOS.mm
@@ -634,32 +634,44 @@ void RemoteScrollingCoordinatorProxyIOS::scrollingTreeNodeDidEndScroll(Scrolling
     sendUIStateChangedIfNecessary();
 }
 
-void RemoteScrollingCoordinatorProxyIOS::adjustTargetContentOffsetForSnapping(CGSize maxScrollOffsets, CGPoint velocity, CGFloat topInset, CGPoint currentContentOffset, CGPoint* targetContentOffset)
+static bool shouldSnapForMainFrameScrolling(ScrollingTreeScrollingNode& node, ScrollEventAxis axis)
 {
+    return node.snapOffsetsInfo().offsetsForAxis(axis).size();
+}
+
+CGPoint RemoteScrollingCoordinatorProxyIOS::adjustTargetScrollOffsetForSnapping(CGSize maxScrollOffset, CGFloat zoomScale, CGPoint velocity, CGPoint currentScrollOffset, CGPoint targetScrollOffset)
+{
+    RefPtr rootNode = scrollingTree().rootNode();
+    if (!rootNode)
+        return targetScrollOffset;
+
     // The bounds checking with maxScrollOffsets is to ensure that we won't interfere with rubber-banding when scrolling to the edge of the page.
-    if (shouldSnapForMainFrameScrolling(WebCore::ScrollEventAxis::Horizontal)) {
-        float potentialSnapPosition;
-        std::tie(potentialSnapPosition, m_currentHorizontalSnapPointIndex) = closestSnapOffsetForMainFrameScrolling(WebCore::ScrollEventAxis::Horizontal, currentContentOffset.x, FloatPoint(*targetContentOffset), velocity.x);
-        if (targetContentOffset->x > 0 && targetContentOffset->x < maxScrollOffsets.width)
-            targetContentOffset->x = std::min<float>(maxScrollOffsets.width, potentialSnapPosition);
+    if (shouldSnapForMainFrameScrolling(*rootNode, WebCore::ScrollEventAxis::Horizontal)) {
+        auto [potentialSnapPosition, snapIndex] = closestSnapOffsetForMainFrameScrolling(WebCore::ScrollEventAxis::Horizontal, zoomScale, currentScrollOffset.x, targetScrollOffset, velocity.x);
+        if (targetScrollOffset.x > 0 && targetScrollOffset.x < maxScrollOffset.width)
+            targetScrollOffset.x = std::min<float>(potentialSnapPosition, maxScrollOffset.width);
+
+        rootNode->setCurrentHorizontalSnapPointIndex(snapIndex);
     }
 
-    if (shouldSnapForMainFrameScrolling(WebCore::ScrollEventAxis::Vertical)) {
-        float potentialSnapPosition;
-        FloatPoint projectedOffset { *targetContentOffset };
-        projectedOffset.move(0, topInset);
-        std::tie(potentialSnapPosition, m_currentVerticalSnapPointIndex) = closestSnapOffsetForMainFrameScrolling(WebCore::ScrollEventAxis::Vertical, currentContentOffset.y + topInset, WTF::move(projectedOffset), velocity.y);
-        if (m_currentVerticalSnapPointIndex)
-            potentialSnapPosition -= topInset;
+    if (shouldSnapForMainFrameScrolling(*rootNode, WebCore::ScrollEventAxis::Vertical)) {
+        auto [potentialSnapPosition, snapIndex] = closestSnapOffsetForMainFrameScrolling(WebCore::ScrollEventAxis::Vertical, zoomScale, currentScrollOffset.y, targetScrollOffset, velocity.y);
+        if (targetScrollOffset.y > 0 && targetScrollOffset.y < maxScrollOffset.height)
+            targetScrollOffset.y = std::min<float>(potentialSnapPosition, maxScrollOffset.height);
 
-        if (targetContentOffset->y > 0 && targetContentOffset->y < maxScrollOffsets.height)
-            targetContentOffset->y = std::min<float>(maxScrollOffsets.height, potentialSnapPosition);
+        rootNode->setCurrentVerticalSnapPointIndex(snapIndex);
     }
+
+    return targetScrollOffset;
 }
 
 bool RemoteScrollingCoordinatorProxyIOS::shouldSetScrollViewDecelerationRateFast() const
 {
-    return shouldSnapForMainFrameScrolling(ScrollEventAxis::Horizontal) || shouldSnapForMainFrameScrolling(ScrollEventAxis::Vertical);
+    RefPtr rootNode = scrollingTree().rootNode();
+    if (!rootNode)
+        return false;
+
+    return shouldSnapForMainFrameScrolling(*rootNode, ScrollEventAxis::Horizontal) || shouldSnapForMainFrameScrolling(*rootNode, ScrollEventAxis::Vertical);
 }
 
 void RemoteScrollingCoordinatorProxyIOS::setRootNodeIsInUserScroll(bool value)
@@ -677,21 +689,11 @@ void RemoteScrollingCoordinatorProxyIOS::setRootNodeIsInUserScroll(bool value)
     sendUIStateChangedIfNecessary();
 }
 
-bool RemoteScrollingCoordinatorProxyIOS::shouldSnapForMainFrameScrolling(ScrollEventAxis axis) const
-{
-    RefPtr rootNode = scrollingTree().rootNode();
-    if (rootNode)
-        return rootNode->snapOffsetsInfo().offsetsForAxis(axis).size();
-
-    return false;
-}
-
-std::pair<float, std::optional<unsigned>> RemoteScrollingCoordinatorProxyIOS::closestSnapOffsetForMainFrameScrolling(ScrollEventAxis axis, float currentScrollOffset, FloatPoint scrollDestination, float velocity) const
+std::pair<float, std::optional<unsigned>> RemoteScrollingCoordinatorProxyIOS::closestSnapOffsetForMainFrameScrolling(ScrollEventAxis axis, CGFloat zoomScale, CGFloat currentScrollOffset, FloatPoint scrollDestination, float velocity) const
 {
     RefPtr rootNode = scrollingTree().rootNode();
     const auto& snapOffsetsInfo = rootNode->snapOffsetsInfo();
 
-    auto zoomScale = [protect(webPageProxy())->cocoaView() scrollView].zoomScale;
     scrollDestination.scale(1.0 / zoomScale);
     float scaledCurrentScrollOffset = currentScrollOffset / zoomScale;
     auto [rawClosestSnapOffset, newIndex] = snapOffsetsInfo.closestSnapOffset(axis, rootNode->layoutViewport().size(), scrollDestination, velocity, scaledCurrentScrollOffset);
@@ -710,37 +712,52 @@ bool RemoteScrollingCoordinatorProxyIOS::hasActiveSnapPoint() const
     if (horizontal.isEmpty() && vertical.isEmpty())
         return false;
 
-    if ((!horizontal.isEmpty() && m_currentHorizontalSnapPointIndex >= horizontal.size())
-        || (!vertical.isEmpty() && m_currentVerticalSnapPointIndex >= vertical.size())) {
+    if ((!horizontal.isEmpty() && rootNode->currentHorizontalSnapPointIndex() >= horizontal.size())
+        || (!vertical.isEmpty() && rootNode->currentVerticalSnapPointIndex() >= vertical.size())) {
         return false;
     }
     
     return true;
 }
-    
-CGPoint RemoteScrollingCoordinatorProxyIOS::nearestActiveContentInsetAdjustedSnapOffset(CGFloat topInset, const CGPoint& currentPoint) const
+
+CGPoint RemoteScrollingCoordinatorProxyIOS::scrollOffsetSnappedToNearestSnapPoint(CGPoint currentScrollOffset, CGFloat zoomScale) const
 {
-    CGPoint activePoint = currentPoint;
+    ASSERT(hasActiveSnapPoint());
 
     RefPtr rootNode = scrollingTree().rootNode();
     if (!rootNode)
-        return CGPointZero;
+        return currentScrollOffset;
 
     const auto& horizontal = rootNode->snapOffsetsInfo().horizontalSnapOffsets;
     const auto& vertical = rootNode->snapOffsetsInfo().verticalSnapOffsets;
-    auto zoomScale = [protect(webPageProxy())->cocoaView() scrollView].zoomScale;
 
     // The bounds checking with maxScrollOffsets is to ensure that we won't interfere with rubber-banding when scrolling to the edge of the page.
-    if (!horizontal.isEmpty() && m_currentHorizontalSnapPointIndex && *m_currentHorizontalSnapPointIndex < horizontal.size())
-        activePoint.x = horizontal[*m_currentHorizontalSnapPointIndex].offset * zoomScale;
+    auto currentHorizontalSnapIndex = rootNode->currentHorizontalSnapPointIndex();
+    if (!horizontal.isEmpty() && currentHorizontalSnapIndex && *currentHorizontalSnapIndex < horizontal.size())
+        currentScrollOffset.x = horizontal[*currentHorizontalSnapIndex].offset * zoomScale;
 
-    if (!vertical.isEmpty() && m_currentVerticalSnapPointIndex && *m_currentVerticalSnapPointIndex < vertical.size()) {
-        float potentialSnapPosition = vertical[*m_currentVerticalSnapPointIndex].offset * zoomScale;
-        potentialSnapPosition -= topInset;
-        activePoint.y = potentialSnapPosition;
+    auto currentVerticalSnapIndex = rootNode->currentVerticalSnapPointIndex();
+    if (!vertical.isEmpty() && currentVerticalSnapIndex && *currentVerticalSnapIndex < vertical.size())
+        currentScrollOffset.y = vertical[*currentVerticalSnapIndex].offset * zoomScale;
+
+    return currentScrollOffset;
+}
+
+void RemoteScrollingCoordinatorProxyIOS::updateSnapIndicesForMainFrameOffset(CGPoint scrollOffset, CGFloat zoomScale)
+{
+    RefPtr rootNode = scrollingTree().rootNode();
+    if (!rootNode)
+        return;
+
+    if (shouldSnapForMainFrameScrolling(*rootNode, WebCore::ScrollEventAxis::Horizontal)) {
+        auto [potentialSnapPosition, snapIndex] = closestSnapOffsetForMainFrameScrolling(WebCore::ScrollEventAxis::Horizontal, zoomScale, scrollOffset.x, scrollOffset, 0);
+        rootNode->setCurrentHorizontalSnapPointIndex(snapIndex);
     }
 
-    return activePoint;
+    if (shouldSnapForMainFrameScrolling(*rootNode, WebCore::ScrollEventAxis::Vertical)) {
+        auto [potentialSnapPosition, snapIndex] = closestSnapOffsetForMainFrameScrolling(WebCore::ScrollEventAxis::Vertical, zoomScale, scrollOffset.y, scrollOffset, 0);
+        rootNode->setCurrentVerticalSnapPointIndex(snapIndex);
+    }
 }
 
 void RemoteScrollingCoordinatorProxyIOS::displayDidRefresh(PlatformDisplayID displayID)

--- a/Source/WebKit/UIProcess/RemoteLayerTree/ios/ScrollingTreeScrollingNodeDelegateIOS.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/ios/ScrollingTreeScrollingNodeDelegateIOS.mm
@@ -118,8 +118,8 @@
     }
 
     Ref scrollingNode = scrollingTreeNodeDelegate->scrollingNode();
-    std::optional<unsigned> originalHorizontalSnapPosition = scrollingNode->currentHorizontalSnapPointIndex();
-    std::optional<unsigned> originalVerticalSnapPosition = scrollingNode->currentVerticalSnapPointIndex();
+    auto originalHorizontalSnapPosition = scrollingNode->currentHorizontalSnapPointIndex();
+    auto originalVerticalSnapPosition = scrollingNode->currentVerticalSnapPointIndex();
 
     WebCore::FloatSize viewportSize(static_cast<float>(CGRectGetWidth([scrollView bounds])), static_cast<float>(CGRectGetHeight([scrollView bounds])));
     const auto& snapOffsetsInfo = scrollingNode->snapOffsetsInfo();


### PR DESCRIPTION
#### 5c74a3cb95df09bad3c953b1d828bac5e48d6668
<pre>
Smooth scroll in viewport with scroll-snap fails on iOS
<a href="https://bugs.webkit.org/show_bug.cgi?id=245722">https://bugs.webkit.org/show_bug.cgi?id=245722</a>
<a href="https://rdar.apple.com/100727098">rdar://100727098</a>

Reviewed by Abrar Rahman Protyasha.

On iOS, after a programmatic scroll, a user scroll could snap the scroll offset back
to an earlier, stale snap point. This made combinations of scroll snap and
programmatics scrolling very unreliable.

The active snap points are maintained in the UI process independently from the web
process. It&apos;s unclear if this is the correct design, but changing that at present
would be too risky. The comments in ScrollingStateScrollingNode, and logging fixes
make this design choice more clear.

The bug was that the active snap point was only updated in `-[WKWebView
scrollViewWillEndDragging:...]` and not after other scrolls, so a snap point was
chosen after dragging, then the programmatic scroll moved the content offset
elsewhere, then the next `-_updateVisibleContentRects` would jump back to the stale
snap point. The fix is to update the active snap index in `-_didFinishScrolling:`.

Some other clean up was also done; RemoteScrollingCoordinatorProxyIOS now takes all
arguments as scrollOffsets (already adjusted for insets), and takes zoomScale as an
argument.

The functions to map between contentOffset and scrollOffset are factored into
two-argument verions for call sites that need to pass custom insets.

Test: fast/scrolling/ios/scroll-into-view-smooth-after-snap.html

* LayoutTests/fast/scrolling/ios/scroll-into-view-smooth-after-snap-expected.txt: Added.
* LayoutTests/fast/scrolling/ios/scroll-into-view-smooth-after-snap.html: Added.
* Source/WebCore/page/LocalFrameView.cpp:
(WebCore::LocalFrameView::setScrollOffsetWithOptions):
* Source/WebCore/page/scrolling/ScrollingStateScrollingNode.cpp:
(WebCore::ScrollingStateScrollingNode::ScrollingStateScrollingNode):
(WebCore::ScrollingStateScrollingNode::setCurrentVerticalSnapPointIndex):
* Source/WebCore/page/scrolling/ScrollingTree.cpp:
(WebCore::ScrollingTree::mainFrameViewportChangedViaDelegatedScrolling):
* Source/WebCore/platform/ScrollAnimator.cpp:
(WebCore::ScrollAnimator::scrollOffsetAdjustedForSnapping const):
* Source/WebKit/Shared/RemoteLayerTree/RemoteScrollingCoordinatorTransaction.cpp:
(WebKit::dump):
* Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm:
(-[WKWebView _contentOffset:adjustedForObscuredInsets:]):
(-[WKWebView _scrollOffset:adjustedForObscuredInsets:]):
(-[WKWebView _contentOffsetAdjustedForObscuredInset:]):
(-[WKWebView _scrollOffsetAdjustedForObscuredInset:]):
(-[WKWebView _didFinishScrolling:]):
(-[WKWebView scrollViewWillEndDragging:withVelocity:targetContentOffset:]):
(-[WKWebView _createVisibleContentRectUpdate]):
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingCoordinatorProxy.cpp:
(WebKit::RemoteScrollingCoordinatorProxy::resetStateAfterProcessExited):
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingCoordinatorProxy.h:
* Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteScrollingCoordinatorProxyIOS.h:
* Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteScrollingCoordinatorProxyIOS.mm:
(WebKit::shouldSnapForMainFrameScrolling):
(WebKit::RemoteScrollingCoordinatorProxyIOS::adjustTargetScrollOffsetForSnapping):
(WebKit::RemoteScrollingCoordinatorProxyIOS::shouldSetScrollViewDecelerationRateFast const):
(WebKit::RemoteScrollingCoordinatorProxyIOS::closestSnapOffsetForMainFrameScrolling const):
(WebKit::RemoteScrollingCoordinatorProxyIOS::hasActiveSnapPoint const):
(WebKit::RemoteScrollingCoordinatorProxyIOS::scrollOffsetSnappedToNearestSnapPoint const):
(WebKit::RemoteScrollingCoordinatorProxyIOS::updateSnapIndicesForMainFrameOffset):
(WebKit::RemoteScrollingCoordinatorProxyIOS::adjustTargetContentOffsetForSnapping): Deleted.
(WebKit::RemoteScrollingCoordinatorProxyIOS::shouldSnapForMainFrameScrolling const): Deleted.
(WebKit::RemoteScrollingCoordinatorProxyIOS::nearestActiveContentInsetAdjustedSnapOffset const): Deleted.
* Source/WebKit/UIProcess/RemoteLayerTree/ios/ScrollingTreeScrollingNodeDelegateIOS.mm:
(-[WKScrollingNodeScrollViewDelegate scrollViewWillEndDragging:withVelocity:targetContentOffset:]):

Canonical link: <a href="https://commits.webkit.org/312558@main">https://commits.webkit.org/312558@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/34f9cc4d194e1b2caae99af39ced4a535ce0cf23

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/160119 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/33589 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/26693 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/169011 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/114500 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/2585f0b4-f98a-4f2a-b344-182335cec495) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/161988 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/33692 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/33591 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/124114 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/87047 "2 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/765a2d69-f9a1-4915-b882-510c730681ec) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/163077 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/26362 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/143820 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/104723 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/577dd9ed-59f6-41cd-b0f2-f22444b66b44) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/25415 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/23905 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/16740 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/135107 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/21583 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/171489 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/17487 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/23222 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/132373 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/33265 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/27992 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/132399 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35843 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/33250 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/143378 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/91455 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/27012 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/20191 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/32759 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/99156 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/32257 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/32503 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/32407 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->