### PR TITLE
Crash in StreamPipeToState::errorsMustBePropagatedForward

### DIFF
--- a/Source/WebCore/Modules/streams/StreamPipeToUtilities.cpp
+++ b/Source/WebCore/Modules/streams/StreamPipeToUtilities.cpp
@@ -302,6 +302,9 @@ void StreamPipeToState::handleSignal()
                     return nullptr;
 
                 auto value = internalWritableStream->abort(*globalObject, signal->reason().getValue());
+                if (!value)
+                    return nullptr;
+
                 auto* promise = uncheckedDowncast<JSC::JSPromise>(value);
                 if (!promise)
                     return nullptr;
@@ -407,6 +410,9 @@ void StreamPipeToState::errorsMustBePropagatedForward(JSDOMGlobalObject& globalO
 
                 Ref internalWritableStream = protectedThis->m_destination->internalWritableStream();
                 auto value = internalWritableStream->abort(*globalObject, error.get());
+                if (!value)
+                    return nullptr;
+
                 auto* promise = uncheckedDowncast<JSC::JSPromise>(value);
                 if (!promise) {
                     auto [result, deferred] = createPromiseAndWrapper(*globalObject);


### PR DESCRIPTION
#### 8c6a14a3b7892a91658114698a141d7ee543e220
<pre>
Crash in StreamPipeToState::errorsMustBePropagatedForward
<a href="https://bugs.webkit.org/show_bug.cgi?id=313907">https://bugs.webkit.org/show_bug.cgi?id=313907</a>
&lt;<a href="https://rdar.apple.com/175745036">rdar://175745036</a>&gt;

Reviewed by NOBODY (OOPS!).

Added a nullptr check before calling uncheckedDowncast.

No new tests since there is no reproduction for these crashes.

* Source/WebCore/Modules/streams/StreamPipeToUtilities.cpp:
(WebCore::StreamPipeToState::handleSignal):
(WebCore::StreamPipeToState::errorsMustBePropagatedForward):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8c6a14a3b7892a91658114698a141d7ee543e220

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/160117 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/33587 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/26691 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/169008 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/114498 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/3976f33f-2299-4f86-85f3-9a7105ccee9b) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/161986 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/33690 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/33589 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/124111 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/87046 "2 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/cf6205b3-a2a1-40eb-ab30-f2ff98d7f5cf) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/163075 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/26360 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/143819 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/104721 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/4a66ea9a-e265-4b28-9c7a-483b8261b2be) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/25413 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/23904 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/16738 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/135105 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/21582 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/171487 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/17485 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/23221 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/132371 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/33263 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/27990 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/132397 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/33248 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/143377 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/91448 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/27010 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/20190 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/32757 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/99154 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/32255 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/32501 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/32405 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->