### PR TITLE
[JSC][WASM][Debugger] Replace threadId(VM) with stable per-VM debugger ID

### DIFF
--- a/Source/JavaScriptCore/runtime/VM.cpp
+++ b/Source/JavaScriptCore/runtime/VM.cpp
@@ -487,8 +487,11 @@ WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
         requestEntryScopeService(EntryScopeService::TracePoints);
 
 #if ENABLE(WEBASSEMBLY_DEBUGGER)
-    if (Options::enableWasmDebugger()) [[unlikely]]
+    if (Options::enableWasmDebugger()) [[unlikely]] {
         m_debugState = makeUnique<Wasm::DebugState>();
+        static std::atomic<uint64_t> s_nextVMId { 1 };
+        m_debugState->vmDebugId = s_nextVMId.fetch_add(1, std::memory_order_relaxed);
+    }
 #endif
 
 #if ENABLE(JIT)

--- a/Source/JavaScriptCore/wasm/debugger/WasmDebugServerUtilities.h
+++ b/Source/JavaScriptCore/wasm/debugger/WasmDebugServerUtilities.h
@@ -257,6 +257,11 @@ struct DebugState {
     bool isStopped { false }; // FIXME: There is better design (rdar://174508321) for code efficiency.
     std::unique_ptr<StopData> stopData { nullptr };
 
+    // Unique VM identifier used as the thread ID in GDB RSP replies to LLDB
+    // (qThreadStopInfo, thread-pcs, etc.). Assigned once at DebugState construction;
+    // stable for the VM's lifetime regardless of which OS thread holds the JSLock.
+    uint64_t vmDebugId { 0 };
+
     // Step-into tracking (for step debugging behavior)
     StepIntoEvent stepIntoEvent;
 };

--- a/Source/JavaScriptCore/wasm/debugger/WasmExecutionHandler.cpp
+++ b/Source/JavaScriptCore/wasm/debugger/WasmExecutionHandler.cpp
@@ -113,7 +113,6 @@ void ExecutionHandler::stopTheWorld(VM& debuggee, StopTheWorldEvent event)
 
         switch (event) {
         case StopTheWorldEvent::WasmStepIntoSiteReached:
-            RELEASE_ASSERT(Thread::currentSingleton().uid() == threadId(*m_debuggee));
             RELEASE_ASSERT(m_debuggee == info.targetVM && info.worldMode == VMManager::Mode::RunOne);
             break;
         case StopTheWorldEvent::WasmProgramStop:
@@ -168,8 +167,6 @@ DebuggerTrapStatus ExecutionHandler::handleDebuggerTrapIfNeeded(CallFrame* callF
 
 ExecutionHandler::ResumeMode ExecutionHandler::stopCode(Locker<Lock>& locker, StopTheWorldEvent event)
 {
-    RELEASE_ASSERT(Thread::currentSingleton().uid() == threadId(*m_debuggee));
-
     dataLogLnIf(Options::verboseWasmDebugger(), "[Code][Stop] Start with event:", event);
 
     auto notifyDebuggerOfStop = [&]() WTF_REQUIRES_LOCK(m_lock) {
@@ -343,11 +340,11 @@ void ExecutionHandler::notifyDebuggerOfNewModule(VM& vm)
     stopTheWorld(vm, StopTheWorldEvent::WasmProgramStop);
 }
 
-static inline VM* findVM(uint64_t threadId)
+static inline VM* findVM(uint64_t vmDebugId)
 {
     VM* result = nullptr;
     VMManager::forEachVM([&](VM& vm) {
-        if (vm.debugState()->isStopped && threadId == ExecutionHandler::threadId(vm)) {
+        if (vm.debugState()->isStopped && vmDebugId == vm.debugState()->vmDebugId) {
             result = &vm;
             return IterationStatus::Done;
         }
@@ -356,13 +353,13 @@ static inline VM* findVM(uint64_t threadId)
     return result;
 }
 
-void ExecutionHandler::switchTarget(uint64_t threadId)
+void ExecutionHandler::switchTarget(uint64_t vmDebugId)
 {
     RELEASE_ASSERT(Thread::currentSingleton().uid() == debugServerThreadId());
 
     Locker locker { m_lock };
 
-    VM* newDebuggee = findVM(threadId);
+    VM* newDebuggee = findVM(vmDebugId);
     dataLogLnIf(Options::verboseWasmDebugger(), "[Code][SwitchVM] current debuggee=", RawPointer(m_debuggee), " new debuggee=", RawPointer(newDebuggee));
 
     if (m_debuggee == newDebuggee)
@@ -539,7 +536,6 @@ void ExecutionHandler::setStepIntoBreakpointForCall(VM& callerVM, CalleeBits box
     [&]() {
         Locker locker { m_lock };
 
-        RELEASE_ASSERT(Thread::currentSingleton().uid() == threadId(*m_debuggee));
         RELEASE_ASSERT(m_debuggee == &callerVM);
         dataLogLnIf(Options::verboseWasmDebugger(), "[Code][StepIntoEvent] Start for call");
         RELEASE_ASSERT(m_debuggerState == DebuggerState::StepRequested);
@@ -568,7 +564,6 @@ void ExecutionHandler::setStepIntoBreakpointForThrow(VM& throwVM)
     [&]() {
         Locker locker { m_lock };
 
-        RELEASE_ASSERT(Thread::currentSingleton().uid() == threadId(*m_debuggee));
         RELEASE_ASSERT(m_debuggee == &throwVM);
         dataLogLnIf(Options::verboseWasmDebugger(), "[Code][StepIntoEvent] Start for throw");
         RELEASE_ASSERT(m_debuggerState == DebuggerState::StepRequested);
@@ -718,11 +713,11 @@ void ExecutionHandler::handleThreadStopInfo(StringView packet)
     // Format: qThreadStopInfo<thread-id-in-hex>
     // Parse the thread ID
     StringView threadIdStr = packet.substring(strlen("qThreadStopInfo"));
-    uint64_t threadId = parseHex(threadIdStr);
-    dataLogLnIf(Options::verboseWasmDebugger(), "[Debugger] Handling qThreadStopInfo for thread: ", threadId);
+    uint64_t vmDebugId = parseHex(threadIdStr);
+    dataLogLnIf(Options::verboseWasmDebugger(), "[Debugger] Handling qThreadStopInfo for thread: ", vmDebugId);
 
     Locker locker { m_lock };
-    sendStopReplyForThread(locker, threadId);
+    sendStopReplyForThread(locker, vmDebugId);
 }
 
 static uint64_t NODELETE getStopPC(const DebugState& state)
@@ -733,7 +728,7 @@ static uint64_t NODELETE getStopPC(const DebugState& state)
     return state.stopData->address;
 }
 
-static String getThreadName(const DebugState& state, uint64_t threadId)
+static String getThreadName(const DebugState& state, uint64_t vmDebugId)
 {
     StringView stateName;
     if (state.isStoppedAtPrologue())
@@ -744,11 +739,11 @@ static String getThreadName(const DebugState& state, uint64_t threadId)
         RELEASE_ASSERT(state.isStoppedAtSystemCall());
         stateName = "system-call"_s;
     }
-    return makeString(stateName, " tid:0x"_s, hex(threadId, Lowercase));
+    return makeString(stateName, " tid:0x"_s, hex(vmDebugId, Lowercase));
 }
 
 struct ThreadInfo {
-    uint64_t threadId;
+    uint64_t vmDebugId;
     uint64_t pc;
     String name;
     StringView stopReason;
@@ -756,21 +751,21 @@ struct ThreadInfo {
 
 void ExecutionHandler::sendStopReply(AbstractLocker& locker) WTF_REQUIRES_LOCK(m_lock)
 {
-    sendStopReplyForThread(locker, threadId(*m_debuggee));
+    sendStopReplyForThread(locker, m_debuggee->debugState()->vmDebugId);
 }
 
-void ExecutionHandler::sendStopReplyForThread(AbstractLocker& locker, uint64_t threadId) WTF_REQUIRES_LOCK(m_lock)
+void ExecutionHandler::sendStopReplyForThread(AbstractLocker& locker, uint64_t vmDebugId) WTF_REQUIRES_LOCK(m_lock)
 {
-    VM* vm = findVM(threadId);
+    VM* vm = findVM(vmDebugId);
     if (!vm) {
-        dataLogLnIf(Options::verboseWasmDebugger(), "[Debugger] sendStopReplyForThread: thread ", threadId, " not found");
+        dataLogLnIf(Options::verboseWasmDebugger(), "[Debugger] sendStopReplyForThread: thread ", vmDebugId, " not found");
         sendErrorReply(ProtocolError::InvalidAddress);
         return;
     }
 
     DebugState* state = vm->debugState();
     if (!state) {
-        dataLogLnIf(Options::verboseWasmDebugger(), "[Debugger] sendStopReplyForThread: thread ", threadId, " not found");
+        dataLogLnIf(Options::verboseWasmDebugger(), "[Debugger] sendStopReplyForThread: thread ", vmDebugId, " not found");
         sendErrorReply(ProtocolError::InvalidAddress);
         return;
     }
@@ -783,9 +778,9 @@ void ExecutionHandler::sendStopReplyForThread(AbstractLocker& locker, uint64_t t
         auto* state = vm.debugState();
         if (!state->isStopped)
             return IterationStatus::Continue;
-        uint64_t tid = ExecutionHandler::threadId(vm);
+        uint64_t tid = vm.debugState()->vmDebugId;
         allThreads.append({ tid, getStopPC(*state), getThreadName(*state, tid), stopReasonToInfo(*state).reasonSuffix });
-        if (tid == threadId)
+        if (tid == vmDebugId)
             std::swap(allThreads[0], allThreads.last());
         return IterationStatus::Continue;
     });
@@ -795,7 +790,7 @@ void ExecutionHandler::sendStopReplyForThread(AbstractLocker& locker, uint64_t t
     // actually triggered the stop event (breakpoint/step/trap/interrupt/new-module-load).
     // Passive threads get signal 0 so LLDB's ShouldSelect() returns false for them, allowing
     // the event thread to win thread selection in HandleProcessStateChangedEvent.
-    bool isPassiveThread = state->stopReason == DebugState::Reason::Interrupted && m_debuggee && threadId != ExecutionHandler::threadId(*m_debuggee);
+    bool isPassiveThread = state->stopReason == DebugState::Reason::Interrupted && m_debuggee && vmDebugId != m_debuggee->debugState()->vmDebugId;
     auto stopInfo = isPassiveThread
         ? StopReasonInfo { signalStopString(0), "signal"_s }
         : stopReasonToInfo(*state);
@@ -803,15 +798,15 @@ void ExecutionHandler::sendStopReplyForThread(AbstractLocker& locker, uint64_t t
     // Build packet with target thread
     StringBuilder reply;
     reply.append(stopInfo.reasonString);
-    reply.append("thread:"_s, hex(threadId, Lowercase), ';');
-    reply.append("name:"_s, getThreadName(*state, threadId), ';');
+    reply.append("thread:"_s, hex(vmDebugId, Lowercase), ';');
+    reply.append("name:"_s, getThreadName(*state, vmDebugId), ';');
 
     // All thread IDs
     reply.append("threads:"_s);
     for (size_t i = 0; i < allThreads.size(); ++i) {
         if (i > 0)
             reply.append(',');
-        reply.append(hex(allThreads[i].threadId, Lowercase));
+        reply.append(hex(allThreads[i].vmDebugId, Lowercase));
     }
     reply.append(';');
 
@@ -860,7 +855,7 @@ void ExecutionHandler::sendStopReplyForThread(AbstractLocker& locker, uint64_t t
         reply.append(';');
     }
 
-    dataLogLnIf(Options::verboseWasmDebugger(), "[Debugger] Sending stop reply: target thread="_s, hex(threadId), ", total threads="_s, allThreads.size(), ", packet="_s, reply.toString());
+    dataLogLnIf(Options::verboseWasmDebugger(), "[Debugger] Sending stop reply: target thread="_s, hex(vmDebugId), ", total threads="_s, allThreads.size(), ", packet="_s, reply.toString());
     sendReplyImpl(locker, reply.toString());
 }
 
@@ -920,12 +915,6 @@ void ExecutionHandler::reset()
 void ExecutionHandler::sendReplyOK() { m_debugServer.sendReplyOK(); }
 void ExecutionHandler::sendErrorReply(ProtocolError error) { m_debugServer.sendErrorReply(error); }
 
-uint64_t ExecutionHandler::threadId(const VM& vm)
-{
-    auto uid = vm.ownerThreadUID();
-    // nullopt when JSLock was never acquired (e.g. during VM construction); fall back to current thread.
-    return uid.value_or(Thread::currentSingleton().uid());
-}
 
 DebugState* ExecutionHandler::debuggeeState() const { return m_debuggee->debugState(); }
 
@@ -941,16 +930,17 @@ bool ExecutionHandler::hasBreakpoints() const
     return m_breakpointManager && m_breakpointManager->hasBreakpoints();
 }
 
-String ExecutionHandler::callStackStringFor(uint64_t threadId)
+String ExecutionHandler::callStackStringFor(uint64_t vmDebugId)
 {
     Locker locker { m_lock };
 
     VM* targetVM = m_debuggee;
-    if (this->threadId(*targetVM) != threadId)
-        targetVM = findVM(threadId);
+    RELEASE_ASSERT(targetVM);
+    if (targetVM->debugState()->vmDebugId != vmDebugId)
+        targetVM = findVM(vmDebugId);
 
     if (!targetVM) {
-        dataLogLnIf(Options::verboseWasmDebugger(), "[ExecutionHandler] callStackStringFor: thread ", threadId, " not found");
+        dataLogLnIf(Options::verboseWasmDebugger(), "[ExecutionHandler] callStackStringFor: thread ", vmDebugId, " not found");
         return String();
     }
 

--- a/Source/JavaScriptCore/wasm/debugger/WasmExecutionHandler.h
+++ b/Source/JavaScriptCore/wasm/debugger/WasmExecutionHandler.h
@@ -99,7 +99,6 @@ public:
 
     bool hasBreakpoints() const;
 
-    JS_EXPORT_PRIVATE static uint64_t threadId(const VM&);
     uint64_t debugServerThreadId() const
     {
         RELEASE_ASSERT(m_debugServerThreadId.has_value());

--- a/Source/JavaScriptCore/wasm/debugger/tests/ExecutionHandlerTest.cpp
+++ b/Source/JavaScriptCore/wasm/debugger/tests/ExecutionHandlerTest.cpp
@@ -134,8 +134,7 @@ static void resume()
 
 static void switchTarget(VM* newDebuggee)
 {
-    uint64_t threadId = ExecutionHandler::threadId(*newDebuggee);
-    executionHandler->switchTarget(threadId);
+    executionHandler->switchTarget(newDebuggee->debugState()->vmDebugId);
     validateStop();
     CHECK(executionHandler->debuggeeVM() == newDebuggee, "Switch to new debuggee failed");
 }


### PR DESCRIPTION
#### dd5e59aaf56e79bb26cba625579c2e1aef4d694d
<pre>
[JSC][WASM][Debugger] Replace threadId(VM) with stable per-VM debugger ID
<a href="https://bugs.webkit.org/show_bug.cgi?id=313911">https://bugs.webkit.org/show_bug.cgi?id=313911</a>
<a href="https://rdar.apple.com/176106671">rdar://176106671</a>

Reviewed by NOBODY (OOPS!).

The WASM debugger used ownerThreadUID() as the thread ID in GDB RSP replies
to LLDB (qThreadStopInfo, thread-pcs, etc.). This value reflects whichever
OS thread currently holds the JSLock — when a Worker VM&apos;s JSLock transfers
to a different thread (e.g. after memory.atomic.wait completes and another
task acquires the VM), the thread ID changes between consecutive stop replies.
LLDB then fails to find the VM in subsequent qThreadStopInfo queries.

Fix: introduce DebugState::vmDebugId — a unique per-VM identifier assigned
once from an atomic counter (s_nextVMId) when DebugState is created during
VM construction, and never changes for the VM&apos;s lifetime.

Replace all uses of ExecutionHandler::threadId(VM&amp;) with direct access to
vm.debugState()-&gt;vmDebugId. Remove threadId() entirely since it was the
sole source of the instability. Remove the RELEASE_ASSERTs that compared
Thread::currentSingleton().uid() against threadId() — those comparisons
were checking OS thread identity which is no longer meaningful as the
debugger thread ID.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/dd5e59aaf56e79bb26cba625579c2e1aef4d694d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/160128 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/33598 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/26702 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/169022 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/114509 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/4e3a5a20-5b94-4100-bc37-a839f82aeb3f) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/33701 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/33600 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/124123 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/87057 "2 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/8b374385-9eb4-4e27-ba15-a7f47a6c74d3) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/163086 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/26370 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/143830 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/104732 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/454ee059-e03d-4224-9334-9ec94d1b189b) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/25423 "Passed tests") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/23916 "Found 1 new API test failure: TestWebKitAPI.WebKit.InterruptionBetweenSameProcessPages (failure)") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/16749 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/152184 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/135115 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/21593 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/171499 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/20965 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/17496 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/23233 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/132382 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/33274 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/28003 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/132408 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/33259 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/143388 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/91471 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/27021 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/20202 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/192491 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/32768 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/99165 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/49496 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/32266 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/32512 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/32416 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->