### PR TITLE
[JSC] Simplify RegExp match array creation

### DIFF
--- a/Source/JavaScriptCore/runtime/RegExpMatchesArray.cpp
+++ b/Source/JavaScriptCore/runtime/RegExpMatchesArray.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2012-2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2012-2026 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -20,7 +20,7 @@
  * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
  * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
- * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. 
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
 #include "config.h"
@@ -72,6 +72,197 @@ JSArray* createEmptyRegExpMatchesArray(JSGlobalObject* globalObject, JSString* i
     array->putDirectWithoutBarrier(RegExpMatchesArrayGroupsPropertyOffset, jsUndefined());
     if (regExp->hasIndices())
         array->putDirectWithoutBarrier(RegExpMatchesArrayIndicesPropertyOffset, jsUndefined());
+    return array;
+}
+
+JSArray* createRegExpMatchesArrayWithGroupsOrIndices(VM& vm, JSGlobalObject* globalObject, JSString* input, RegExp* regExp, const MatchResult& result, std::span<const int> subpatternResults, unsigned numSubpatterns, bool hasNamedCaptures, bool createIndices)
+{
+    JSArray* array;
+    JSArray* indicesArray = nullptr;
+
+    // FIXME: This should handle array allocation errors gracefully.
+    // https://bugs.webkit.org/show_bug.cgi?id=155144
+
+    JSObject* groups = hasNamedCaptures ? constructEmptyObject(vm, globalObject->nullPrototypeObjectStructure()) : nullptr;
+    Structure* matchStructure = createIndices ? globalObject->regExpMatchesArrayWithIndicesStructure() : globalObject->regExpMatchesArrayStructure();
+
+    JSObject* indicesGroups = createIndices && hasNamedCaptures ? constructEmptyObject(vm, globalObject->nullPrototypeObjectStructure()) : nullptr;
+
+    auto setProperties = [&] () {
+        array->putDirectOffset(vm, RegExpMatchesArrayIndexPropertyOffset, jsNumber(result.start));
+        array->putDirectOffset(vm, RegExpMatchesArrayInputPropertyOffset, input);
+        array->putDirectOffset(vm, RegExpMatchesArrayGroupsPropertyOffset, hasNamedCaptures ? groups : jsUndefined());
+
+        ASSERT(!array->butterfly()->indexingHeader()->preCapacity(matchStructure));
+        auto capacity = matchStructure->outOfLineCapacity();
+        auto size = matchStructure->outOfLineSize();
+        gcSafeZeroMemory(static_cast<JSValue*>(array->butterfly()->base(0, capacity)), (capacity - size) * sizeof(JSValue));
+
+        if (createIndices) {
+            array->putDirectOffset(vm, RegExpMatchesArrayIndicesPropertyOffset, indicesArray);
+
+            Structure* indicesStructure = globalObject->regExpMatchesIndicesArrayStructure();
+
+            indicesArray->putDirectOffset(vm, RegExpMatchesIndicesGroupsPropertyOffset, indicesGroups ? indicesGroups : jsUndefined());
+
+            ASSERT(!indicesArray->butterfly()->indexingHeader()->preCapacity(indicesStructure));
+            auto indicesCapacity = indicesStructure->outOfLineCapacity();
+            auto indicesSize = indicesStructure->outOfLineSize();
+            gcSafeZeroMemory(static_cast<JSValue*>(indicesArray->butterfly()->base(0, indicesCapacity)), (indicesCapacity - indicesSize) * sizeof(JSValue));
+        }
+    };
+
+    auto createIndexArray = [&] (GCDeferralContext& deferralContext, int start, int end) {
+        ObjectInitializationScope scope(vm);
+
+        JSArray* result = JSArray::tryCreateUninitializedRestricted(scope, &deferralContext, globalObject->arrayStructureForIndexingTypeDuringAllocation(ArrayWithContiguous), 2);
+        result->initializeIndexWithoutBarrier(scope, 0, jsNumber(start));
+        result->initializeIndexWithoutBarrier(scope, 1, jsNumber(end));
+
+        return result;
+    };
+
+    if (globalObject->isHavingABadTime()) [[unlikely]] {
+        GCDeferralContext deferralContext(vm);
+        ObjectInitializationScope matchesArrayScope(vm);
+        ObjectInitializationScope indicesArrayScope(vm);
+        array = JSArray::tryCreateUninitializedRestricted(matchesArrayScope, &deferralContext, matchStructure, numSubpatterns + 1);
+
+        if (createIndices)
+            indicesArray = JSArray::tryCreateUninitializedRestricted(indicesArrayScope, &deferralContext, globalObject->regExpMatchesIndicesArrayStructure(), numSubpatterns + 1);
+
+        // FIXME: we should probably throw an out of memory error here, but
+        // when making this change we should check that all clients of this
+        // function will correctly handle an exception being thrown from here.
+        // https://bugs.webkit.org/show_bug.cgi?id=169786
+        RELEASE_ASSERT(array);
+
+        setProperties();
+
+        array->initializeIndexWithoutBarrier(matchesArrayScope, 0, jsSubstringOfResolved(vm, &deferralContext, input, result.start, result.end - result.start));
+
+        for (unsigned i = 1; i <= numSubpatterns; ++i) {
+            int start = subpatternResults[2 * i];
+            int end = subpatternResults[2 * i + 1];
+            JSValue value;
+            if (start >= 0 && end >= start)
+                value = jsSubstringOfResolved(vm, &deferralContext, input, start, end - start);
+            else
+                value = jsUndefined();
+            array->initializeIndexWithoutBarrier(matchesArrayScope, i, value);
+        }
+
+        if (createIndices) {
+            for (unsigned i = 0; i <= numSubpatterns; ++i) {
+                int start = subpatternResults[2 * i];
+                int end = subpatternResults[2 * i + 1];
+                JSValue value;
+                if (start >= 0 && end >= start)
+                    indicesArray->initializeIndexWithoutBarrier(indicesArrayScope, i, createIndexArray(deferralContext, start, end));
+                else
+                    indicesArray->initializeIndexWithoutBarrier(indicesArrayScope, i, jsUndefined());
+            }
+        }
+    } else {
+        GCDeferralContext deferralContext(vm);
+        ObjectInitializationScope matchesArrayScope(vm);
+        ObjectInitializationScope indicesArrayScope(vm);
+        array = tryCreateUninitializedRegExpMatchesArray(matchesArrayScope, &deferralContext, matchStructure, numSubpatterns + 1);
+
+        if (createIndices)
+            indicesArray = tryCreateUninitializedRegExpMatchesArray(indicesArrayScope, &deferralContext, globalObject->regExpMatchesIndicesArrayStructure(), numSubpatterns + 1);
+
+        // FIXME: we should probably throw an out of memory error here, but
+        // when making this change we should check that all clients of this
+        // function will correctly handle an exception being thrown from here.
+        // https://bugs.webkit.org/show_bug.cgi?id=169786
+        RELEASE_ASSERT(array);
+
+        setProperties();
+
+        array->initializeIndexWithoutBarrier(matchesArrayScope, 0, jsSubstringOfResolved(vm, &deferralContext, input, result.start, result.end - result.start), ArrayWithContiguous);
+
+        for (unsigned i = 1; i <= numSubpatterns; ++i) {
+            int start = subpatternResults[2 * i];
+            int end = subpatternResults[2 * i + 1];
+            JSValue value;
+            if (start >= 0 && end >= start)
+                value = jsSubstringOfResolved(vm, &deferralContext, input, start, end - start);
+            else
+                value = jsUndefined();
+            array->initializeIndexWithoutBarrier(matchesArrayScope, i, value, ArrayWithContiguous);
+        }
+
+        if (createIndices) {
+            for (unsigned i = 0; i <= numSubpatterns; ++i) {
+                int start = subpatternResults[2 * i];
+                int end = subpatternResults[2 * i + 1];
+                if (start >= 0 && end >= start)
+                    indicesArray->initializeIndexWithoutBarrier(indicesArrayScope, i, createIndexArray(deferralContext, start, end));
+                else
+                    indicesArray->initializeIndexWithoutBarrier(indicesArrayScope, i, jsUndefined());
+            }
+        }
+    }
+
+    // Now the object is safe to scan by GC.
+
+    // We initialize the groups and indices objects late as they could allocate, which with the current API could cause
+    // allocations.
+    if (hasNamedCaptures) {
+        for (unsigned i = 1; i <= numSubpatterns; ++i) {
+            String groupName = regExp->getCaptureGroupNameForSubpatternId(i);
+            if (!groupName.isEmpty()) {
+                auto captureIndex = regExp->subpatternIdForGroupName(groupName, subpatternResults);
+
+                JSValue value;
+                if (captureIndex > 0)
+                    value = array->getIndexQuickly(captureIndex);
+                else
+                    value = jsUndefined();
+                groups->putDirect(vm, Identifier::fromString(vm, groupName), value);
+
+                if (createIndices && captureIndex > 0)
+                    indicesGroups->putDirect(vm, Identifier::fromString(vm, groupName), indicesArray->getIndexQuickly(captureIndex));
+            }
+        }
+    }
+
+    return array;
+}
+
+JSArray* createRegExpMatchesArrayForPlainRegExpHavingABadTime(VM& vm, JSGlobalObject* globalObject, JSString* input, const MatchResult& result, std::span<const int> subpatternResults, unsigned numSubpatterns)
+{
+    Structure* matchStructure = globalObject->regExpMatchesArrayStructure();
+
+    GCDeferralContext deferralContext(vm);
+    ObjectInitializationScope matchesArrayScope(vm);
+
+    // FIXME: This should handle array allocation errors gracefully.
+    // https://bugs.webkit.org/show_bug.cgi?id=155144
+    JSArray* array = JSArray::tryCreateUninitializedRestricted(matchesArrayScope, &deferralContext, matchStructure, numSubpatterns + 1);
+    RELEASE_ASSERT(array);
+
+    array->putDirectOffset(vm, RegExpMatchesArrayIndexPropertyOffset, jsNumber(result.start));
+    array->putDirectOffset(vm, RegExpMatchesArrayInputPropertyOffset, input);
+    array->putDirectOffset(vm, RegExpMatchesArrayGroupsPropertyOffset, jsUndefined());
+
+    ASSERT(!array->butterfly()->indexingHeader()->preCapacity(matchStructure));
+    auto capacity = matchStructure->outOfLineCapacity();
+    auto size = matchStructure->outOfLineSize();
+    if (capacity > size) [[unlikely]]
+        gcSafeZeroMemory(static_cast<JSValue*>(array->butterfly()->base(0, capacity)), (capacity - size) * sizeof(JSValue));
+
+    array->initializeIndexWithoutBarrier(matchesArrayScope, 0, jsSubstringOfResolved(vm, &deferralContext, input, result.start, result.end - result.start));
+    for (unsigned i = 1; i <= numSubpatterns; ++i) {
+        int start = subpatternResults[2 * i];
+        int end = subpatternResults[2 * i + 1];
+        JSValue value = jsUndefined();
+        if (start >= 0 && end >= start)
+            value = jsSubstringOfResolved(vm, &deferralContext, input, start, end - start);
+        array->initializeIndexWithoutBarrier(matchesArrayScope, i, value);
+    }
+
     return array;
 }
 

--- a/Source/JavaScriptCore/runtime/RegExpMatchesArray.h
+++ b/Source/JavaScriptCore/runtime/RegExpMatchesArray.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2008-2021 Apple Inc. All rights reserved.
+ *  Copyright (C) 2008-2026 Apple Inc. All rights reserved.
  *
  *  This library is free software; you can redistribute it and/or
  *  modify it under the terms of the GNU Lesser General Public
@@ -36,6 +36,9 @@ static constexpr PropertyOffset RegExpMatchesArrayGroupsPropertyOffset = firstOu
 static constexpr PropertyOffset RegExpMatchesArrayIndicesPropertyOffset = firstOutOfLineOffset + 3;
 static constexpr PropertyOffset RegExpMatchesIndicesGroupsPropertyOffset = firstOutOfLineOffset;
 
+JSArray* createRegExpMatchesArrayWithGroupsOrIndices(VM&, JSGlobalObject*, JSString* input, RegExp*, const MatchResult&, std::span<const int> subpatternResults, unsigned numSubpatterns, bool hasNamedCaptures, bool createIndices);
+JSArray* createRegExpMatchesArrayForPlainRegExpHavingABadTime(VM&, JSGlobalObject*, JSString*, const MatchResult&, std::span<const int> subpatternResults, unsigned numSubpatterns);
+
 ALWAYS_INLINE JSArray* tryCreateUninitializedRegExpMatchesArray(ObjectInitializationScope& scope, GCDeferralContext* deferralContext, Structure* structure, unsigned initialLength)
 {
     VM& vm = scope.vm();
@@ -60,178 +63,67 @@ ALWAYS_INLINE JSArray* tryCreateUninitializedRegExpMatchesArray(ObjectInitializa
     return result;
 }
 
-ALWAYS_INLINE JSArray* createRegExpMatchesArray(
-    VM& vm, JSGlobalObject* globalObject, JSString* input, StringView inputValue,
-    RegExp* regExp, unsigned startOffset, MatchResult& result)
+ALWAYS_INLINE JSArray* createRegExpMatchesArrayForPlainRegExp(VM& vm, JSGlobalObject* globalObject, JSString* input, const MatchResult& result, std::span<const int> subpatternResults, unsigned numSubpatterns)
+{
+    Structure* matchStructure = globalObject->regExpMatchesArrayStructure();
+
+    GCDeferralContext deferralContext(vm);
+    ObjectInitializationScope matchesArrayScope(vm);
+
+    // FIXME: This should handle array allocation errors gracefully.
+    // https://bugs.webkit.org/show_bug.cgi?id=155144
+    JSArray* array = tryCreateUninitializedRegExpMatchesArray(matchesArrayScope, &deferralContext, matchStructure, numSubpatterns + 1);
+    RELEASE_ASSERT(array);
+
+    array->putDirectOffset(vm, RegExpMatchesArrayIndexPropertyOffset, jsNumber(result.start));
+    array->putDirectOffset(vm, RegExpMatchesArrayInputPropertyOffset, input);
+    array->putDirectOffset(vm, RegExpMatchesArrayGroupsPropertyOffset, jsUndefined());
+
+    ASSERT(!array->butterfly()->indexingHeader()->preCapacity(matchStructure));
+    auto capacity = matchStructure->outOfLineCapacity();
+    auto size = matchStructure->outOfLineSize();
+    if (capacity > size) [[unlikely]]
+        gcSafeZeroMemory(static_cast<JSValue*>(array->butterfly()->base(0, capacity)), (capacity - size) * sizeof(JSValue));
+
+    array->initializeIndexWithoutBarrier(matchesArrayScope, 0, jsSubstringOfResolved(vm, &deferralContext, input, result.start, result.end - result.start), ArrayWithContiguous);
+    for (unsigned i = 1; i <= numSubpatterns; ++i) {
+        int start = subpatternResults[2 * i];
+        int end = subpatternResults[2 * i + 1];
+        JSValue value = jsUndefined();
+        if (start >= 0 && end >= start)
+            value = jsSubstringOfResolved(vm, &deferralContext, input, start, end - start);
+        array->initializeIndexWithoutBarrier(matchesArrayScope, i, value, ArrayWithContiguous);
+    }
+
+    return array;
+}
+
+ALWAYS_INLINE JSArray* createRegExpMatchesArray(VM& vm, JSGlobalObject* globalObject, JSString* input, StringView inputValue, RegExp* regExp, unsigned startOffset, MatchResult& result)
 {
     if constexpr (validateDFGDoesGC)
         vm.verifyCanGC();
 
-    int position = regExp->matchInline<Yarr::MatchFrom::VMThread>(globalObject, vm, inputValue, startOffset, regExp->ovectorSpan());
+    auto subpatternResults = regExp->ovectorSpan();
+    int position = regExp->matchInline<Yarr::MatchFrom::VMThread>(globalObject, vm, inputValue, startOffset, subpatternResults);
     if (position == -1) {
         result = MatchResult::failed();
         return nullptr;
     }
 
-    auto subpatternResults = regExp->ovectorSpan();
     result.start = position;
     result.end = subpatternResults[1];
-    
-    JSArray* array;
-    JSArray* indicesArray = nullptr;
 
-    // FIXME: This should handle array allocation errors gracefully.
-    // https://bugs.webkit.org/show_bug.cgi?id=155144
-    
     unsigned numSubpatterns = regExp->numSubpatterns();
     bool hasNamedCaptures = regExp->hasNamedCaptures();
     bool createIndices = regExp->hasIndices();
-    JSObject* groups = hasNamedCaptures ? constructEmptyObject(vm, globalObject->nullPrototypeObjectStructure()) : nullptr;
-    Structure* matchStructure = createIndices ? globalObject->regExpMatchesArrayWithIndicesStructure() : globalObject->regExpMatchesArrayStructure();
 
-    JSObject* indicesGroups = createIndices && hasNamedCaptures ? constructEmptyObject(vm, globalObject->nullPrototypeObjectStructure()) : nullptr;
-
-    auto setProperties = [&] () {
-        array->putDirectOffset(vm, RegExpMatchesArrayIndexPropertyOffset, jsNumber(result.start));
-        array->putDirectOffset(vm, RegExpMatchesArrayInputPropertyOffset, input);
-        array->putDirectOffset(vm, RegExpMatchesArrayGroupsPropertyOffset, hasNamedCaptures ? groups : jsUndefined());
-
-        ASSERT(!array->butterfly()->indexingHeader()->preCapacity(matchStructure));
-        auto capacity = matchStructure->outOfLineCapacity();
-        auto size = matchStructure->outOfLineSize();
-        gcSafeZeroMemory(static_cast<JSValue*>(array->butterfly()->base(0, capacity)), (capacity - size) * sizeof(JSValue));
-
-        if (createIndices) {
-            array->putDirectOffset(vm, RegExpMatchesArrayIndicesPropertyOffset, indicesArray);
-
-            Structure* indicesStructure = globalObject->regExpMatchesIndicesArrayStructure();
-
-            indicesArray->putDirectOffset(vm, RegExpMatchesIndicesGroupsPropertyOffset, indicesGroups ? indicesGroups : jsUndefined());
-
-            ASSERT(!indicesArray->butterfly()->indexingHeader()->preCapacity(indicesStructure));
-            auto indicesCapacity = indicesStructure->outOfLineCapacity();
-            auto indicesSize = indicesStructure->outOfLineSize();
-            gcSafeZeroMemory(static_cast<JSValue*>(indicesArray->butterfly()->base(0, indicesCapacity)), (indicesCapacity - indicesSize) * sizeof(JSValue));
-        }
-    };
-
-    auto createIndexArray = [&] (GCDeferralContext& deferralContext, int start, int end) {
-        ObjectInitializationScope scope(vm);
-
-        JSArray* result = JSArray::tryCreateUninitializedRestricted(scope, &deferralContext, globalObject->arrayStructureForIndexingTypeDuringAllocation(ArrayWithContiguous), 2);
-        result->initializeIndexWithoutBarrier(scope, 0, jsNumber(start));
-        result->initializeIndexWithoutBarrier(scope, 1, jsNumber(end));
-        
-        return result;
-    };
-
-    if (globalObject->isHavingABadTime()) [[unlikely]] {
-        GCDeferralContext deferralContext(vm);
-        ObjectInitializationScope matchesArrayScope(vm);
-        ObjectInitializationScope indicesArrayScope(vm);
-        array = JSArray::tryCreateUninitializedRestricted(matchesArrayScope, &deferralContext, matchStructure, numSubpatterns + 1);
-
-        if (createIndices)
-            indicesArray = JSArray::tryCreateUninitializedRestricted(indicesArrayScope, &deferralContext, globalObject->regExpMatchesIndicesArrayStructure(), numSubpatterns + 1);
-
-        // FIXME: we should probably throw an out of memory error here, but
-        // when making this change we should check that all clients of this
-        // function will correctly handle an exception being thrown from here.
-        // https://bugs.webkit.org/show_bug.cgi?id=169786
-        RELEASE_ASSERT(array);
-
-        setProperties();
-        
-        array->initializeIndexWithoutBarrier(matchesArrayScope, 0, jsSubstringOfResolved(vm, &deferralContext, input, result.start, result.end - result.start));
-
-        for (unsigned i = 1; i <= numSubpatterns; ++i) {
-            int start = subpatternResults[2 * i];
-            int end = subpatternResults[2 * i + 1];
-            JSValue value;
-            if (start >= 0 && end >= start)
-                value = jsSubstringOfResolved(vm, &deferralContext, input, start, end - start);
-            else
-                value = jsUndefined();
-            array->initializeIndexWithoutBarrier(matchesArrayScope, i, value);
-        }
-
-        if (createIndices) {
-            for (unsigned i = 0; i <= numSubpatterns; ++i) {
-                int start = subpatternResults[2 * i];
-                int end = subpatternResults[2 * i + 1];
-                JSValue value;
-                if (start >= 0 && end >= start)
-                    indicesArray->initializeIndexWithoutBarrier(indicesArrayScope, i, createIndexArray(deferralContext, start, end));
-                else
-                    indicesArray->initializeIndexWithoutBarrier(indicesArrayScope, i, jsUndefined());
-            }
-        }
-    } else {
-        GCDeferralContext deferralContext(vm);
-        ObjectInitializationScope matchesArrayScope(vm);
-        ObjectInitializationScope indicesArrayScope(vm);
-        array = tryCreateUninitializedRegExpMatchesArray(matchesArrayScope, &deferralContext, matchStructure, numSubpatterns + 1);
-
-        if (createIndices)
-            indicesArray = tryCreateUninitializedRegExpMatchesArray(indicesArrayScope, &deferralContext, globalObject->regExpMatchesIndicesArrayStructure(), numSubpatterns + 1);
-
-        // FIXME: we should probably throw an out of memory error here, but
-        // when making this change we should check that all clients of this
-        // function will correctly handle an exception being thrown from here.
-        // https://bugs.webkit.org/show_bug.cgi?id=169786
-        RELEASE_ASSERT(array);
-        
-        setProperties();
-        
-        array->initializeIndexWithoutBarrier(matchesArrayScope, 0, jsSubstringOfResolved(vm, &deferralContext, input, result.start, result.end - result.start), ArrayWithContiguous);
-        
-        for (unsigned i = 1; i <= numSubpatterns; ++i) {
-            int start = subpatternResults[2 * i];
-            int end = subpatternResults[2 * i + 1];
-            JSValue value;
-            if (start >= 0 && end >= start)
-                value = jsSubstringOfResolved(vm, &deferralContext, input, start, end - start);
-            else
-                value = jsUndefined();
-            array->initializeIndexWithoutBarrier(matchesArrayScope, i, value, ArrayWithContiguous);
-        }
-
-        if (createIndices) {
-            for (unsigned i = 0; i <= numSubpatterns; ++i) {
-                int start = subpatternResults[2 * i];
-                int end = subpatternResults[2 * i + 1];
-                if (start >= 0 && end >= start)
-                    indicesArray->initializeIndexWithoutBarrier(indicesArrayScope, i, createIndexArray(deferralContext, start, end));
-                else
-                    indicesArray->initializeIndexWithoutBarrier(indicesArrayScope, i, jsUndefined());
-            }
-        }
+    if (!hasNamedCaptures && !createIndices) [[likely]] {
+        if (globalObject->isHavingABadTime()) [[unlikely]]
+            return createRegExpMatchesArrayForPlainRegExpHavingABadTime(vm, globalObject, input, result, subpatternResults, numSubpatterns);
+        return createRegExpMatchesArrayForPlainRegExp(vm, globalObject, input, result, subpatternResults, numSubpatterns);
     }
 
-    // Now the object is safe to scan by GC.
-
-    // We initialize the groups and indices objects late as they could allocate, which with the current API could cause
-    // allocations.
-    if (hasNamedCaptures) {
-        for (unsigned i = 1; i <= numSubpatterns; ++i) {
-            String groupName = regExp->getCaptureGroupNameForSubpatternId(i);
-            if (!groupName.isEmpty()) {
-                auto captureIndex = regExp->subpatternIdForGroupName(groupName, subpatternResults);
-
-                JSValue value;
-                if (captureIndex > 0)
-                    value = array->getIndexQuickly(captureIndex);
-                else
-                    value = jsUndefined();
-                groups->putDirect(vm, Identifier::fromString(vm, groupName), value);
-
-                if (createIndices && captureIndex > 0)
-                    indicesGroups->putDirect(vm, Identifier::fromString(vm, groupName), indicesArray->getIndexQuickly(captureIndex));
-            }
-        }
-    }
-
-    return array;
+    return createRegExpMatchesArrayWithGroupsOrIndices(vm, globalObject, input, regExp, result, subpatternResults, numSubpatterns, hasNamedCaptures, createIndices);
 }
 
 JSArray* createEmptyRegExpMatchesArray(JSGlobalObject*, JSString*, RegExp*);


### PR DESCRIPTION
#### a8f761f1946a8c7e44f4049494b101565252a820
<pre>
[JSC] Simplify RegExp match array creation
<a href="https://bugs.webkit.org/show_bug.cgi?id=313913">https://bugs.webkit.org/show_bug.cgi?id=313913</a>
<a href="https://rdar.apple.com/176109334">rdar://176109334</a>

Reviewed by Yijia Huang.

Simplify RegExp match array creation for non complicated cases (not
having indice and not having named captures). We also move haveABadTime
case out-of-line code too.

* Source/JavaScriptCore/runtime/RegExpMatchesArray.cpp:
(JSC::createRegExpMatchesArrayWithGroupsOrIndices):
(JSC::createRegExpMatchesArrayForPlainRegExpHavingABadTime):
* Source/JavaScriptCore/runtime/RegExpMatchesArray.h:
(JSC::createRegExpMatchesArrayForPlainRegExp):
(JSC::createRegExpMatchesArray):

Canonical link: <a href="https://commits.webkit.org/312530@main">https://commits.webkit.org/312530@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b4e9199cdc6f7490df9c7390df05dab13517d540

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/160133 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/33603 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/26707 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/169029 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/114514 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/dd2dee19-63b7-4413-947d-9b0d861c9b7e) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/33706 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/33605 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/124127 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/87061 "1 flakes 2 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/be8eb1f9-2b7f-4467-ac4b-60e280daa721) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/163091 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/26375 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/143834 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/104736 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/defc0ffc-7e49-40ed-ab2d-583cb6c359d9) 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/25428 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-position/fixed-z-index-blend.html (failure)") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/23922 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/16754 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/152189 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/135120 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/21597 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/171504 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/20970 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/17501 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/23237 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/132387 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/33279 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/28008 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/132413 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/33264 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/143392 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/91486 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/24384 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/27026 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/20206 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/192496 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/32773 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/99170 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/49499 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/32271 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/32517 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/32421 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->