### PR TITLE
StabilityTracer: Crash in CachedMatchFinder

### DIFF
--- a/Source/WebCore/editing/CachedMatchFinder.cpp
+++ b/Source/WebCore/editing/CachedMatchFinder.cpp
@@ -361,7 +361,7 @@ auto CachedMatchFinder::textForScope(ContainerNode& scope, FindOptions options) 
     Vector<TextRun> runs;
     for (; !it.atEnd(); it.advance()) {
         auto textRunRange = it.range();
-        runs.append(TextRun { static_cast<unsigned>(builder.length()), textRunRange, &textRunRange.start.container->treeScope().rootNode() });
+        runs.append(TextRun { static_cast<unsigned>(builder.length()), textRunRange });
         auto text = it.text();
         if (text.is8Bit()) {
             for (auto character : text.span8())

--- a/Source/WebCore/editing/CachedMatchFinder.h
+++ b/Source/WebCore/editing/CachedMatchFinder.h
@@ -27,7 +27,6 @@
 
 #include "FindOptions.h"
 #include "SimpleRange.h"
-#include <wtf/CheckedPtr.h>
 #include <wtf/Function.h>
 #include <wtf/TZoneMalloc.h>
 #include <wtf/Vector.h>
@@ -52,7 +51,6 @@ private:
     struct TextRun {
         unsigned offset;
         SimpleRange range;
-        CheckedPtr<ContainerNode> scopeRoot;
     };
 
     struct TextRunCache {


### PR DESCRIPTION
#### 78fdd82849f9b7badbed5d1f4053f25ee28d8288
<pre>
StabilityTracer: Crash in CachedMatchFinder
<a href="https://bugs.webkit.org/show_bug.cgi?id=313912">https://bugs.webkit.org/show_bug.cgi?id=313912</a>
<a href="https://rdar.apple.com/175960648">rdar://175960648</a>

Reviewed by NOBODY (OOPS!).

CachedMatchFinder::bufferForOptions() replaces the current contents of cache.runs
with new TextRuns. The currently stored TextRuns in cache.runs are destroyed. So
their CheckedPtr&lt;ContainerNode&gt; scopeRoot members are destroyed. When a CheckedPtr
is destroyed, it calls decrementCheckedPtrCount(), which decrements the count that
is stored on the target object (in this case ContainerNode).

The crash occurs in decrementCheckedPtrCount() and is caused by pointer
authentication and not by crashDueToCheckedPtrToDeadObject(). This likely means
that the crash is caused by accessing the target object even though it has already
been destroyed. Pointer authentication is catching that the object was destroyed
even before decrementCheckedPtrCount() realizes this by checking the count. This
means that the CheckedPtr is outliving the ContainerNode itself.

This can be fixed by making scopeRoot a WeakPtr. But scopeRoot isn&apos;t even used.
So the best fix is to remove it.

* Source/WebCore/editing/CachedMatchFinder.cpp:
(WebCore::CachedMatchFinder::textForScope):
* Source/WebCore/editing/CachedMatchFinder.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/78fdd82849f9b7badbed5d1f4053f25ee28d8288

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/160134 "Failed to checkout and rebase branch from PR 64116") | [❌ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/33604 "Failed to checkout and rebase branch from PR 64116") | [❌ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/26708 "Failed to checkout and rebase branch from PR 64116") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/169030 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/114515 "Failed to checkout and rebase branch from PR 64116") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/8fd29366-d160-4848-a6c8-b12c6dd8c81f) 
| [❌ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/162003 "Failed to checkout and rebase branch from PR 64116") | [❌ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/33707 "Failed to checkout and rebase branch from PR 64116") | [❌ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/33606 "Failed to checkout and rebase branch from PR 64116") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/169030 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/59/builds/114515 "Failed to checkout and rebase branch from PR 64116") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/dcbec0e1-9bdf-4da8-af4e-76a312a0d2cc) 
| [❌ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/163092 "Failed to checkout and rebase branch from PR 64116") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/155/builds/33707 "Failed to checkout and rebase branch from PR 64116") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/168/builds/26708 "Failed to checkout and rebase branch from PR 64116") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/169030 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/15f22d65-a7f0-40e4-85ee-83dac0a4e32c) 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/155/builds/33707 "Failed to checkout and rebase branch from PR 64116") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/156/builds/33606 "Failed to checkout and rebase branch from PR 64116") | [❌ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/16755 "Failed to checkout and rebase branch from PR 64116") | | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/155/builds/33707 "Failed to checkout and rebase branch from PR 64116") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/168/builds/26708 "Failed to checkout and rebase branch from PR 64116") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/171506 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [❌ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/17502 "Failed to checkout and rebase branch from PR 64116") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/168/builds/26708 "Failed to checkout and rebase branch from PR 64116") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/171506 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [❌ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/33280 "Failed to checkout and rebase branch from PR 64116") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/156/builds/33606 "Failed to checkout and rebase branch from PR 64116") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/171506 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [❌ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/33265 "Failed to checkout and rebase branch from PR 64116") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/168/builds/26708 "Failed to checkout and rebase branch from PR 64116") | [❌ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/91487 "Failed to checkout and rebase branch from PR 64116") | | 
| | [❌ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/160/builds/33265 "Failed to checkout and rebase branch from PR 64116") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/168/builds/26708 "Failed to checkout and rebase branch from PR 64116") | | | 
| | [❌ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/32774 "Failed to checkout and rebase branch from PR 64116") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/99171 "Failed to checkout and rebase branch from PR 64116") | | | 
| | [❌ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/32272 "Failed to checkout and rebase branch from PR 64116") | | | | 
| | [❌ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/32518 "Failed to checkout and rebase branch from PR 64116") | | | | 
| | [❌ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/32422 "Failed to checkout and rebase branch from PR 64116") | | | | 
<!--EWS-Status-Bubble-End-->