### PR TITLE
[Build Speed] Reduce the cost of Threading.h

### DIFF
--- a/Source/JavaScriptCore/runtime/BufferMemoryHandle.h
+++ b/Source/JavaScriptCore/runtime/BufferMemoryHandle.h
@@ -34,11 +34,13 @@
 #include <wtf/CagedPtr.h>
 #include <wtf/Expected.h>
 #include <wtf/Function.h>
+#include <wtf/Lock.h>
 #include <wtf/RAMSize.h>
 #include <wtf/RefCounted.h>
 #include <wtf/RefPtr.h>
 #include <wtf/StdSet.h>
 #include <wtf/TZoneMalloc.h>
+#include <wtf/ThreadSafeWeakHashSet.h>
 #include <wtf/Vector.h>
 #include <wtf/WeakPtr.h>
 

--- a/Source/WTF/SaferCPPExpectations/ForwardDeclCheckerExpectations
+++ b/Source/WTF/SaferCPPExpectations/ForwardDeclCheckerExpectations
@@ -1,0 +1,1 @@
+wtf/NativePromise.h

--- a/Source/WTF/WTF.xcodeproj/project.pbxproj
+++ b/Source/WTF/WTF.xcodeproj/project.pbxproj
@@ -115,6 +115,8 @@
 		46335BEE2E778B1300860374 /* DispatchOSObject.h in Headers */ = {isa = PBXBuildFile; fileRef = 46335BED2E778B1300860374 /* DispatchOSObject.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		46335BEF2E778B1300860375 /* NetworkOSObject.h in Headers */ = {isa = PBXBuildFile; fileRef = 46335BEE2E778B1300860375 /* NetworkOSObject.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		463CCFBC2B251D77009AB04E /* SingleThreadIntegralWrapper.h in Headers */ = {isa = PBXBuildFile; fileRef = 463CCFBB2B251D77009AB04E /* SingleThreadIntegralWrapper.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		463CCFBD2B251D78009AB04E /* CurrentThread.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 463CCFBE2B251D78009AB04E /* CurrentThread.cpp */; };
+		463CCFBF2B251D78009AB04E /* CurrentThread.h in Headers */ = {isa = PBXBuildFile; fileRef = 463CCFC02B251D78009AB04E /* CurrentThread.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		46449E8B2822E5680005A8BC /* WeakHashCountedSet.h in Headers */ = {isa = PBXBuildFile; fileRef = 46449E8A2822E5670005A8BC /* WeakHashCountedSet.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		465005D82CD2840A00950C5F /* MallocSpan.h in Headers */ = {isa = PBXBuildFile; fileRef = 465005D72CD2840A00950C5F /* MallocSpan.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		4655743627F5FC4A002D5522 /* ASCIILiteralCocoa.mm in Sources */ = {isa = PBXBuildFile; fileRef = 4655743527F5FC4A002D5522 /* ASCIILiteralCocoa.mm */; };
@@ -415,6 +417,7 @@
 		DD3DC8E027A4BF8E007E5B61 /* ListHashSet.h in Headers */ = {isa = PBXBuildFile; fileRef = A8A472C1151A825A004123FF /* ListHashSet.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		DD3DC8E127A4BF8E007E5B61 /* LoggingHashID.h in Headers */ = {isa = PBXBuildFile; fileRef = 0F30BA8C1E78708E002CA847 /* LoggingHashID.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		DD3DC8E227A4BF8E007E5B61 /* ThreadingPrimitives.h in Headers */ = {isa = PBXBuildFile; fileRef = A8A47335151A825B004123FF /* ThreadingPrimitives.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		463CCFC12B251D79009AB04E /* ThreadingEnums.h in Headers */ = {isa = PBXBuildFile; fileRef = 463CCFC22B251D79009AB04E /* ThreadingEnums.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		DD3DC8E327A4BF8E007E5B61 /* DataLog.h in Headers */ = {isa = PBXBuildFile; fileRef = A8A47278151A825A004123FF /* DataLog.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		DD3DC8E427A4BF8E007E5B61 /* HashCountedSet.h in Headers */ = {isa = PBXBuildFile; fileRef = A8A472B3151A825A004123FF /* HashCountedSet.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		DD3DC8E527A4BF8E007E5B61 /* WeakHashMap.h in Headers */ = {isa = PBXBuildFile; fileRef = 9BE153352671F00F00C7D096 /* WeakHashMap.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -1347,6 +1350,8 @@
 		46335BED2E778B1300860374 /* DispatchOSObject.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = DispatchOSObject.h; sourceTree = "<group>"; };
 		46335BEE2E778B1300860375 /* NetworkOSObject.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = NetworkOSObject.h; sourceTree = "<group>"; };
 		463CCFBB2B251D77009AB04E /* SingleThreadIntegralWrapper.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SingleThreadIntegralWrapper.h; sourceTree = "<group>"; };
+		463CCFBE2B251D78009AB04E /* CurrentThread.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = CurrentThread.cpp; sourceTree = "<group>"; };
+		463CCFC02B251D78009AB04E /* CurrentThread.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CurrentThread.h; sourceTree = "<group>"; };
 		46449E8A2822E5670005A8BC /* WeakHashCountedSet.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WeakHashCountedSet.h; sourceTree = "<group>"; };
 		465005D72CD2840A00950C5F /* MallocSpan.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MallocSpan.h; sourceTree = "<group>"; };
 		4655743527F5FC4A002D5522 /* ASCIILiteralCocoa.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = ASCIILiteralCocoa.mm; sourceTree = "<group>"; };
@@ -1677,6 +1682,7 @@
 		A8A4732E151A825B004123FF /* WTFString.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WTFString.h; sourceTree = "<group>"; };
 		A8A47332151A825B004123FF /* Threading.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Threading.cpp; sourceTree = "<group>"; };
 		A8A47333151A825B004123FF /* Threading.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Threading.h; sourceTree = "<group>"; };
+		463CCFC22B251D79009AB04E /* ThreadingEnums.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ThreadingEnums.h; sourceTree = "<group>"; };
 		A8A47335151A825B004123FF /* ThreadingPrimitives.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ThreadingPrimitives.h; sourceTree = "<group>"; };
 		A8A4733A151A825B004123FF /* BinarySemaphore.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = BinarySemaphore.cpp; sourceTree = "<group>"; };
 		A8A4733B151A825B004123FF /* BinarySemaphore.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BinarySemaphore.h; sourceTree = "<group>"; };
@@ -2424,6 +2430,8 @@
 				A8A47274151A825A004123FF /* CryptographicallyRandomNumber.h */,
 				E15556F318A0CC18006F48FB /* CryptographicUtilities.cpp */,
 				E15556F418A0CC18006F48FB /* CryptographicUtilities.h */,
+				463CCFBE2B251D78009AB04E /* CurrentThread.cpp */,
+				463CCFC02B251D78009AB04E /* CurrentThread.h */,
 				A8A47275151A825A004123FF /* CurrentTime.cpp */,
 				A8A47277151A825A004123FF /* DataLog.cpp */,
 				A8A47278151A825A004123FF /* DataLog.h */,
@@ -2784,6 +2792,7 @@
 				E311FB161F0A568B003C08DE /* ThreadGroup.h */,
 				A8A47332151A825B004123FF /* Threading.cpp */,
 				A8A47333151A825B004123FF /* Threading.h */,
+				463CCFC22B251D79009AB04E /* ThreadingEnums.h */,
 				A8A47335151A825B004123FF /* ThreadingPrimitives.h */,
 				5311BD5B1EA822F900525281 /* ThreadMessage.cpp */,
 				5311BD591EA81A9600525281 /* ThreadMessage.h */,
@@ -3574,6 +3583,7 @@
 				DD3DC8B727A4BF8E007E5B61 /* CryptographicUtilities.h in Headers */,
 				DDF307E127C086DF006A526F /* CString.h in Headers */,
 				CDD4AC7A2D9C309A00D11414 /* CStringView.h in Headers */,
+				463CCFBF2B251D78009AB04E /* CurrentThread.h in Headers */,
 				DD3DC8E327A4BF8E007E5B61 /* DataLog.h in Headers */,
 				DD4901E927B4748A00D7E50D /* DataMutex.h in Headers */,
 				DD3DC94227A4BF8E007E5B61 /* DataRef.h in Headers */,
@@ -3959,6 +3969,7 @@
 				DD3DC8AB27A4BF8E007E5B61 /* ThreadAssertions.h in Headers */,
 				DD3DC87327A4BF8E007E5B61 /* ThreadGroup.h in Headers */,
 				DD3DC8A327A4BF8E007E5B61 /* Threading.h in Headers */,
+				463CCFC12B251D79009AB04E /* ThreadingEnums.h in Headers */,
 				DD3DC8E227A4BF8E007E5B61 /* ThreadingPrimitives.h in Headers */,
 				DD3DC92227A4BF8E007E5B61 /* ThreadMessage.h in Headers */,
 				DD3DC96927A4BF8E007E5B61 /* ThreadSafeRefCounted.h in Headers */,
@@ -4500,6 +4511,7 @@
 				E15556F518A0CC18006F48FB /* CryptographicUtilities.cpp in Sources */,
 				A8A47439151A825B004123FF /* CString.cpp in Sources */,
 				CDD4AC792D9C309A00D11414 /* CStringView.cpp in Sources */,
+				463CCFBD2B251D78009AB04E /* CurrentThread.cpp in Sources */,
 				A8A4739C151A825B004123FF /* CurrentTime.cpp in Sources */,
 				A8A4739E151A825B004123FF /* DataLog.cpp in Sources */,
 				A8A473A0151A825B004123FF /* DateMath.cpp in Sources */,

--- a/Source/WTF/wtf/AutomaticThread.h
+++ b/Source/WTF/wtf/AutomaticThread.h
@@ -30,9 +30,10 @@
 #include <wtf/CheckedPtr.h>
 #include <wtf/Condition.h>
 #include <wtf/Lock.h>
+#include <wtf/StackAllocation.h>
 #include <wtf/TZoneMalloc.h>
 #include <wtf/ThreadSafeRefCounted.h>
-#include <wtf/Threading.h>
+#include <wtf/ThreadingEnums.h>
 #include <wtf/Vector.h>
 
 namespace WTF {

--- a/Source/WTF/wtf/CMakeLists.txt
+++ b/Source/WTF/wtf/CMakeLists.txt
@@ -74,6 +74,7 @@ set(WTF_PUBLIC_HEADERS
     CrossThreadTaskHandler.h
     CryptographicUtilities.h
     CryptographicallyRandomNumber.h
+    CurrentThread.h
     DataLog.h
     DataMutex.h
     DataRef.h
@@ -365,6 +366,7 @@ set(WTF_PUBLIC_HEADERS
     ThreadSanitizerSupport.h
     ThreadSpecific.h
     Threading.h
+    ThreadingEnums.h
     ThreadingPrimitives.h
     TimeWithDynamicClockType.h
     TimingScope.h
@@ -546,6 +548,7 @@ set(WTF_SOURCES
     CrossThreadTaskHandler.cpp
     CryptographicUtilities.cpp
     CryptographicallyRandomNumber.cpp
+    CurrentThread.cpp
     CurrentTime.cpp
     DataLog.cpp
     DateMath.cpp

--- a/Source/WTF/wtf/CheckedRef.h
+++ b/Source/WTF/wtf/CheckedRef.h
@@ -35,10 +35,6 @@
 #include <wtf/TypeTraits.h>
 #include <wtf/UniqueRef.h>
 
-#if ASSERT_ENABLED
-#include <wtf/Threading.h>
-#endif
-
 namespace WTF {
 
 #define USING_CAN_MAKE_CHECKEDPTR(BASE) \

--- a/Source/WTF/wtf/CrossThreadTaskHandler.cpp
+++ b/Source/WTF/wtf/CrossThreadTaskHandler.cpp
@@ -27,6 +27,7 @@
 #include <wtf/CrossThreadTaskHandler.h>
 
 #include <wtf/AutodrainedPool.h>
+#include <wtf/Threading.h>
 
 namespace WTF {
 

--- a/Source/WTF/wtf/CrossThreadTaskHandler.h
+++ b/Source/WTF/wtf/CrossThreadTaskHandler.h
@@ -28,7 +28,6 @@
 #include <wtf/CrossThreadQueue.h>
 #include <wtf/CrossThreadTask.h>
 #include <wtf/Lock.h>
-#include <wtf/Threading.h>
 
 namespace WTF {
 

--- a/Source/WTF/wtf/CurrentThread.cpp
+++ b/Source/WTF/wtf/CurrentThread.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020 Apple Inc. All rights reserved.
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -23,34 +23,21 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#pragma once
+#include "config.h"
+#include <wtf/CurrentThread.h>
 
-#if ENABLE(MEDIA_SESSION)
-
-#include <wtf/text/WTFString.h>
-
-namespace WebCore {
-
-struct MediaPositionState {
-    double duration = std::numeric_limits<double>::infinity();
-    double playbackRate = 1;
-    double position = 0;
-
-    String toJSONString() const;
-
-    friend bool operator==(const MediaPositionState&, const MediaPositionState&) = default;
-};
-
-}
+#include <wtf/Threading.h>
 
 namespace WTF {
 
-template<typename> struct LogArgument;
+uint32_t currentThreadID()
+{
+    return Thread::currentSingleton().uid();
+}
 
-template<> struct LogArgument<WebCore::MediaPositionState> {
-    static String toString(const WebCore::MediaPositionState& state) { return state.toJSONString(); }
-};
+bool currentThreadMayBeGCThread()
+{
+    return Thread::mayBeGCThread();
+}
 
 } // namespace WTF
-
-#endif // ENABLE(MEDIA_SESSION)

--- a/Source/WTF/wtf/CurrentThread.h
+++ b/Source/WTF/wtf/CurrentThread.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020 Apple Inc. All rights reserved.
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -25,32 +25,15 @@
 
 #pragma once
 
-#if ENABLE(MEDIA_SESSION)
-
-#include <wtf/text/WTFString.h>
-
-namespace WebCore {
-
-struct MediaPositionState {
-    double duration = std::numeric_limits<double>::infinity();
-    double playbackRate = 1;
-    double position = 0;
-
-    String toJSONString() const;
-
-    friend bool operator==(const MediaPositionState&, const MediaPositionState&) = default;
-};
-
-}
+#include <cstdint>
+#include <wtf/ExportMacros.h>
 
 namespace WTF {
 
-template<typename> struct LogArgument;
-
-template<> struct LogArgument<WebCore::MediaPositionState> {
-    static String toString(const WebCore::MediaPositionState& state) { return state.toJSONString(); }
-};
+WTF_EXPORT_PRIVATE uint32_t currentThreadID();
+WTF_EXPORT_PRIVATE bool currentThreadMayBeGCThread();
 
 } // namespace WTF
 
-#endif // ENABLE(MEDIA_SESSION)
+using WTF::currentThreadID;
+using WTF::currentThreadMayBeGCThread;

--- a/Source/WTF/wtf/DataLog.cpp
+++ b/Source/WTF/wtf/DataLog.cpp
@@ -26,13 +26,14 @@
 #include "config.h"
 #include <wtf/DataLog.h>
 
+#include <mutex>
 #include <stdarg.h>
 #include <string.h>
 #include <wtf/Assertions.h>
 #include <wtf/FilePrintStream.h>
 #include <wtf/LockedPrintStream.h>
 #include <wtf/ProcessID.h>
-#include <mutex>
+#include <wtf/text/StringCommon.h>
 
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 

--- a/Source/WTF/wtf/DataMutex.h
+++ b/Source/WTF/wtf/DataMutex.h
@@ -20,9 +20,10 @@
 
 #pragma once
 
+#include <wtf/CurrentThread.h>
+#include <wtf/Function.h>
 #include <wtf/Lock.h>
 #include <wtf/ThreadSanitizerSupport.h>
-#include <wtf/Threading.h>
 
 namespace WTF {
 
@@ -59,7 +60,7 @@ private:
     Lock m_mutex;
     T m_data WTF_GUARDED_BY_LOCK(m_mutex);
 #if ENABLE_DATA_MUTEX_CHECKS
-    Thread* m_currentMutexHolder { nullptr };
+    uint32_t m_currentMutexHolder { 0 };
 #endif
 };
 
@@ -123,11 +124,11 @@ private:
 
     void lock() WTF_ACQUIRES_LOCK(m_dataMutex.m_mutex)
     {
-        DATA_MUTEX_CHECK(m_dataMutex.m_currentMutexHolder != &Thread::currentSingleton()); // Thread attempted recursive lock on non-recursive lock.
+        DATA_MUTEX_CHECK(m_dataMutex.m_currentMutexHolder != currentThreadID());
         mutex().lock();
         m_isLocked = true;
 #if ENABLE_DATA_MUTEX_CHECKS
-        m_dataMutex.m_currentMutexHolder = &Thread::currentSingleton();
+        m_dataMutex.m_currentMutexHolder = currentThreadID();
 #endif
     }
 
@@ -136,7 +137,7 @@ private:
         DATA_MUTEX_CHECK(mutex().isHeld());
         assertIsHeld(m_dataMutex.m_mutex);
 #if ENABLE_DATA_MUTEX_CHECKS
-        m_dataMutex.m_currentMutexHolder = nullptr;
+        m_dataMutex.m_currentMutexHolder = 0;
 #endif
         m_isLocked = false;
         mutex().unlock();

--- a/Source/WTF/wtf/FileSystem.cpp
+++ b/Source/WTF/wtf/FileSystem.cpp
@@ -29,6 +29,7 @@
 
 #include <wtf/CryptographicallyRandomNumber.h>
 #include <wtf/FileHandle.h>
+#include <wtf/Function.h>
 #include <wtf/HexNumber.h>
 #include <wtf/Logging.h>
 #include <wtf/MappedFileData.h>

--- a/Source/WTF/wtf/NativePromise.h
+++ b/Source/WTF/wtf/NativePromise.h
@@ -38,6 +38,7 @@
 #include <wtf/Expected.h>
 #include <wtf/FastMalloc.h>
 #include <wtf/Forward.h>
+#include <wtf/Function.h>
 #include <wtf/FunctionDispatcher.h>
 #include <wtf/Lock.h>
 #include <wtf/Locker.h>
@@ -45,7 +46,6 @@
 #include <wtf/Ref.h>
 #include <wtf/RefCountedAndCanMakeWeakPtr.h>
 #include <wtf/RefPtr.h>
-#include <wtf/RunLoop.h>
 #include <wtf/ThreadSafeRefCounted.h>
 #include <wtf/TypeTraits.h>
 #include <wtf/Vector.h>

--- a/Source/WTF/wtf/ParallelHelperPool.h
+++ b/Source/WTF/wtf/ParallelHelperPool.h
@@ -33,7 +33,6 @@
 #include <wtf/SharedTask.h>
 #include <wtf/TZoneMalloc.h>
 #include <wtf/ThreadSafeRefCounted.h>
-#include <wtf/Threading.h>
 #include <wtf/Vector.h>
 #include <wtf/WeakRandom.h>
 #include <wtf/text/CString.h>

--- a/Source/WTF/wtf/RecursiveLockAdapter.h
+++ b/Source/WTF/wtf/RecursiveLockAdapter.h
@@ -25,8 +25,8 @@
 
 #pragma once
 
+#include <wtf/CurrentThread.h>
 #include <wtf/Lock.h>
-#include <wtf/Threading.h>
 
 namespace WTF {
 
@@ -40,7 +40,7 @@ public:
     // which doesn't support analysis.
     void lock() WTF_IGNORES_THREAD_SAFETY_ANALYSIS
     {
-        auto currentThreadUID = Thread::currentSingleton().uid();
+        auto currentThreadUID = currentThreadID();
         if (currentThreadUID == m_ownerThreadUID) {
             m_recursionCount++;
             return;
@@ -69,7 +69,7 @@ public:
     // which doesn't support analysis.
     bool tryLock() WTF_IGNORES_THREAD_SAFETY_ANALYSIS
     {
-        auto currentThreadUID = Thread::currentSingleton().uid();
+        auto currentThreadUID = currentThreadID();
         if (currentThreadUID == m_ownerThreadUID) {
             m_recursionCount++;
             return true;
@@ -90,7 +90,7 @@ public:
         return m_lock.isLocked();
     }
 
-    bool isOwner() const { return m_ownerThreadUID == Thread::currentSingleton().uid(); }
+    bool isOwner() const { return m_ownerThreadUID == currentThreadID(); }
     
 private:
     uint32_t m_ownerThreadUID { 0 };

--- a/Source/WTF/wtf/RunLoop.cpp
+++ b/Source/WTF/wtf/RunLoop.cpp
@@ -29,6 +29,7 @@
 #include <wtf/NeverDestroyed.h>
 #include <wtf/Ref.h>
 #include <wtf/StdLibExtras.h>
+#include <wtf/ThreadSpecific.h>
 #include <wtf/text/StringBuilder.h>
 #include <wtf/threads/BinarySemaphore.h>
 
@@ -101,7 +102,7 @@ RunLoop* RunLoop::webIfExists()
 }
 #endif
 
-Ref<RunLoop> RunLoop::create(ASCIILiteral threadName, ThreadType threadType, Thread::QOS qos)
+Ref<RunLoop> RunLoop::create(ASCIILiteral threadName, ThreadType threadType, ThreadQOS qos)
 {
     RefPtr<RunLoop> runLoop;
     BinarySemaphore semaphore;

--- a/Source/WTF/wtf/RunLoop.h
+++ b/Source/WTF/wtf/RunLoop.h
@@ -39,8 +39,7 @@
 #include <wtf/RetainPtr.h>
 #include <wtf/Seconds.h>
 #include <wtf/ThreadSafetyAnalysis.h>
-#include <wtf/ThreadSpecific.h>
-#include <wtf/Threading.h>
+#include <wtf/ThreadingEnums.h>
 #include <wtf/ThreadingPrimitives.h>
 #include <wtf/TypeTraits.h>
 #include <wtf/WeakHashSet.h>
@@ -60,6 +59,8 @@
 #endif
 
 namespace WTF {
+
+template<typename, CanBeGCThread> class ThreadSpecific;
 
 #if USE(GLIB_EVENT_LOOP)
 class ActivityObserver;
@@ -99,7 +100,7 @@ public:
     WTF_EXPORT_PRIVATE static RunLoop& webSingleton();
     WTF_EXPORT_PRIVATE static RunLoop* webIfExists();
 #endif
-    WTF_EXPORT_PRIVATE static Ref<RunLoop> create(ASCIILiteral threadName, ThreadType = ThreadType::Unknown, Thread::QOS = Thread::QOS::UserInitiated);
+    WTF_EXPORT_PRIVATE static Ref<RunLoop> create(ASCIILiteral threadName, ThreadType = ThreadType::Unknown, ThreadQOS = ThreadQOS::UserInitiated);
 
     static bool isMain() { return mainSingleton().isCurrent(); }
     WTF_EXPORT_PRIVATE bool isCurrent() const final;
@@ -290,7 +291,7 @@ public:
 
 private:
     class Holder;
-    static ThreadSpecific<Holder>& runLoopHolder();
+    static ThreadSpecific<Holder, CanBeGCThread::False>& runLoopHolder();
 
     RunLoop();
 

--- a/Source/WTF/wtf/SequesteredAllocator.h
+++ b/Source/WTF/wtf/SequesteredAllocator.h
@@ -402,7 +402,7 @@ public:
         ASSERT(!m_alive);
         m_alive = true;
         m_liveAllocations = 0;
-        dataLogLnIf(verbose, "Allocator ", id(), " in thread ", Thread::currentSingleton(),
+        dataLogLnIf(verbose, "Allocator ", id(), " in thread ", currentThreadID(),
             ": starting lifetime");
     }
 
@@ -423,7 +423,7 @@ public:
             m_decommitQueue.decommit();
 
         dataLogLnIf(verbose, "Allocator ", id(), " in thread ",
-            Thread::currentSingleton(), " ended lifetime: ", m_totalAllocatedBytes, "B allocated");
+            currentThreadID(), " ended lifetime: ", m_totalAllocatedBytes, "B allocated");
 
         if constexpr (verbose)
             m_totalAllocatedBytes = 0;

--- a/Source/WTF/wtf/SequesteredAutomaticThread.h
+++ b/Source/WTF/wtf/SequesteredAutomaticThread.h
@@ -36,7 +36,6 @@
 #include <wtf/SequesteredImmortalHeap.h>
 #include <wtf/TZoneMalloc.h>
 #include <wtf/ThreadSafeRefCounted.h>
-#include <wtf/Threading.h>
 #include <wtf/Vector.h>
 
 #if USE(PROTECTED_JIT_STACKS)

--- a/Source/WTF/wtf/SequesteredImmortalHeap.h
+++ b/Source/WTF/wtf/SequesteredImmortalHeap.h
@@ -41,11 +41,11 @@
 #include <wtf/Assertions.h>
 #include <wtf/Atomics.h>
 #include <wtf/Compiler.h>
+#include <wtf/CurrentThread.h>
 #include <wtf/DataLog.h>
 #include <wtf/DoublyLinkedList.h>
 #include <wtf/Lock.h>
 #include <wtf/PageBlock.h>
-#include <wtf/Threading.h>
 
 #if OS(DARWIN)
 #include <pthread/tsd_private.h>
@@ -374,7 +374,7 @@ public:
         _pthread_setspecific_direct(key, reinterpret_cast<void*>(slot));
         pthread_key_init_np(key, nullptr);
 
-        dataLogLnIf(verbose, "SequesteredImmortalHeap: thread (", Thread::currentSingleton(), ") allocated slot ", slotIndex, " (", slot, ")");
+        dataLogLnIf(verbose, "SequesteredImmortalHeap: thread (", currentThreadID(), ") allocated slot ", slotIndex, " (", slot, ")");
         return slot;
     }
 
@@ -448,7 +448,7 @@ private:
 
         // Cannot use dataLog here as it takes a lock
         if constexpr (verbose)
-            SAFE_FPRINTF(stderr, "SequesteredImmortalHeap: initialized by thread (%u)\n", Thread::currentSingleton().uid());
+            SAFE_FPRINTF(stderr, "SequesteredImmortalHeap: initialized by thread (%u)\n", currentThreadID());
     }
 
     void installScavenger();

--- a/Source/WTF/wtf/SingleThreadIntegralWrapper.h
+++ b/Source/WTF/wtf/SingleThreadIntegralWrapper.h
@@ -25,7 +25,10 @@
 
 #pragma once
 
-#include <wtf/Threading.h>
+#include <wtf/Assertions.h>
+#if ASSERT_ENABLED && !USE(WEB_THREAD)
+#include <wtf/CurrentThread.h>
+#endif
 
 namespace WTF {
 
@@ -51,14 +54,14 @@ public:
 
 private:
 #if ASSERT_ENABLED && !USE(WEB_THREAD)
-    void assertThread() const { ASSERT(m_thread.ptr() == &Thread::currentSingleton()); }
+    void assertThread() const { ASSERT(m_creationThread == currentThreadID()); }
 #else
     constexpr void assertThread() const { }
 #endif
 
     IntegralType m_value;
 #if ASSERT_ENABLED && !USE(WEB_THREAD)
-    const Ref<Thread> m_thread;
+    uint32_t m_creationThread;
 #endif
 };
 
@@ -66,7 +69,7 @@ template <typename IntegralType>
 inline SingleThreadIntegralWrapper<IntegralType>::SingleThreadIntegralWrapper(IntegralType value)
     : m_value { value }
 #if ASSERT_ENABLED && !USE(WEB_THREAD)
-    , m_thread { Thread::currentSingleton() }
+    , m_creationThread { currentThreadID() }
 #endif
 { }
 

--- a/Source/WTF/wtf/ThreadSpecific.h
+++ b/Source/WTF/wtf/ThreadSpecific.h
@@ -45,6 +45,7 @@
 #include <wtf/MainThread.h>
 #include <wtf/Noncopyable.h>
 #include <wtf/Threading.h>
+#include <wtf/ThreadingEnums.h>
 
 // X11 headers define a bunch of macros with common terms, interfering with WebCore and WTF enum values.
 // As a workaround, we explicitly undef them here.
@@ -56,11 +57,6 @@
 #endif
 
 namespace WTF {
-
-enum class CanBeGCThread {
-    False,
-    True
-};
 
 template<typename T, CanBeGCThread canBeGCThread = CanBeGCThread::False> class ThreadSpecific {
     WTF_MAKE_NONCOPYABLE(ThreadSpecific);

--- a/Source/WTF/wtf/Threading.h
+++ b/Source/WTF/wtf/Threading.h
@@ -51,6 +51,7 @@
 #include <wtf/ThreadSafeRefCounted.h>
 #include <wtf/ThreadSafeWeakHashSet.h>
 #include <wtf/ThreadSafeWeakPtr.h>
+#include <wtf/ThreadingEnums.h>
 #include <wtf/Vector.h>
 #include <wtf/WordLock.h>
 #include <wtf/text/AtomStringTable.h>
@@ -85,22 +86,6 @@ class PrintStream;
 
 WTF_EXPORT_PRIVATE void initialize();
 
-enum class GCThreadType : uint8_t {
-    None = 0,
-    Main,
-    Helper,
-};
-
-enum class ThreadType : uint8_t {
-    Unknown = 0,
-    JavaScript,
-    Compiler,
-    GarbageCollection,
-    Network,
-    Graphics,
-    Audio,
-};
-
 class ThreadSuspendLocker {
     WTF_MAKE_NONCOPYABLE(ThreadSuspendLocker);
 public:
@@ -131,19 +116,8 @@ public:
 
     WTF_EXPORT_PRIVATE ~Thread();
 
-    enum class QOS {
-        UserInteractive,
-        UserInitiated,
-        Default,
-        Utility,
-        Background
-    };
-
-    enum class SchedulingPolicy : uint8_t {
-        Other = 0,
-        FIFO,
-        Realtime,
-    };
+    using QOS = ThreadQOS;
+    using SchedulingPolicy = ThreadSchedulingPolicy;
 
     // These are not necessarily the system defaults, but they are what WebKit
     // chooses to be the default for newly created WTF::Threads

--- a/Source/WTF/wtf/ThreadingEnums.h
+++ b/Source/WTF/wtf/ThreadingEnums.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020 Apple Inc. All rights reserved.
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -25,32 +25,49 @@
 
 #pragma once
 
-#if ENABLE(MEDIA_SESSION)
-
-#include <wtf/text/WTFString.h>
-
-namespace WebCore {
-
-struct MediaPositionState {
-    double duration = std::numeric_limits<double>::infinity();
-    double playbackRate = 1;
-    double position = 0;
-
-    String toJSONString() const;
-
-    friend bool operator==(const MediaPositionState&, const MediaPositionState&) = default;
-};
-
-}
+#include <cstdint>
 
 namespace WTF {
 
-template<typename> struct LogArgument;
+enum class CanBeGCThread {
+    False,
+    True
+};
 
-template<> struct LogArgument<WebCore::MediaPositionState> {
-    static String toString(const WebCore::MediaPositionState& state) { return state.toJSONString(); }
+enum class GCThreadType : uint8_t {
+    None = 0,
+    Main,
+    Helper,
+};
+
+enum class ThreadType : uint8_t {
+    Unknown = 0,
+    JavaScript,
+    Compiler,
+    GarbageCollection,
+    Network,
+    Graphics,
+    Audio,
+};
+
+enum class ThreadQOS {
+    UserInteractive,
+    UserInitiated,
+    Default,
+    Utility,
+    Background
+};
+
+enum class ThreadSchedulingPolicy : uint8_t {
+    Other = 0,
+    FIFO,
+    Realtime,
 };
 
 } // namespace WTF
 
-#endif // ENABLE(MEDIA_SESSION)
+using WTF::CanBeGCThread;
+using WTF::GCThreadType;
+using WTF::ThreadQOS;
+using WTF::ThreadSchedulingPolicy;
+using WTF::ThreadType;

--- a/Source/WTF/wtf/WeakPtr.h
+++ b/Source/WTF/wtf/WeakPtr.h
@@ -29,6 +29,7 @@
 #include <type_traits>
 #include <wtf/CanMakeWeakPtr.h>
 #include <wtf/CompactRefPtrTuple.h>
+#include <wtf/CurrentThread.h>
 #include <wtf/GetPtr.h>
 #include <wtf/Packed.h>
 #include <wtf/SwiftBridging.h>
@@ -219,7 +220,7 @@ private:
         return !m_impl
             || !m_shouldEnableAssertions
             || m_impl->threadAssertion().isCurrent()
-            || Thread::mayBeGCThread();
+            || currentThreadMayBeGCThread();
     }
 #endif
 

--- a/Source/WTF/wtf/WeakPtrImpl.h
+++ b/Source/WTF/wtf/WeakPtrImpl.h
@@ -30,7 +30,6 @@
 #include <wtf/SingleThreadIntegralWrapper.h>
 #include <wtf/ThreadAssertions.h>
 #include <wtf/ThreadSafeRefCounted.h>
-#include <wtf/Threading.h>
 #include <wtf/TypeCasts.h>
 
 namespace WTF {

--- a/Source/WTF/wtf/WeakRef.h
+++ b/Source/WTF/wtf/WeakRef.h
@@ -25,11 +25,11 @@
 
 #pragma once
 
+#include <wtf/CurrentThread.h>
 #include <wtf/GetPtr.h>
 #include <wtf/HashTraits.h>
 #include <wtf/SingleThreadIntegralWrapper.h>
 #include <wtf/ThreadSafeRefCounted.h>
-#include <wtf/Threading.h>
 #include <wtf/TypeCasts.h>
 #include <wtf/TypeTraits.h>
 #include <wtf/WeakPtrImpl.h>
@@ -138,7 +138,7 @@ private:
         return !m_impl
             || !m_shouldEnableAssertions
             || m_impl->threadAssertion().isCurrent()
-            || Thread::mayBeGCThread();
+            || currentThreadMayBeGCThread();
     }
 #endif
 

--- a/Source/WTF/wtf/WorkQueue.h
+++ b/Source/WTF/wtf/WorkQueue.h
@@ -30,7 +30,9 @@
 #include <wtf/Forward.h>
 #include <wtf/FunctionDispatcher.h>
 #include <wtf/Seconds.h>
-#include <wtf/Threading.h>
+#include <wtf/ThreadAssertions.h>
+#include <wtf/ThreadSafeRefCounted.h>
+#include <wtf/ThreadingEnums.h>
 
 #if USE(COCOA_EVENT_LOOP)
 #include <wtf/darwin/DispatchOSObject.h>
@@ -42,7 +44,7 @@ namespace WTF {
 
 class WorkQueueBase : protected ThreadLike {
 public:
-    using QOS = Thread::QOS;
+    using QOS = ThreadQOS;
 
     WTF_EXPORT_PRIVATE virtual ~WorkQueueBase();
 

--- a/Source/WTF/wtf/generic/WorkQueueGeneric.cpp
+++ b/Source/WTF/wtf/generic/WorkQueueGeneric.cpp
@@ -30,6 +30,7 @@
 #include "config.h"
 #include <wtf/WorkQueue.h>
 
+#include <wtf/CurrentThread.h>
 #include <wtf/threads/BinarySemaphore.h>
 
 namespace WTF {
@@ -45,7 +46,7 @@ void WorkQueueBase::platformInitialize(ASCIILiteral name, Type, QOS qos)
     m_runLoop = RunLoop::create(name, ThreadType::Unknown, qos);
     BinarySemaphore semaphore;
     m_runLoop->dispatch([&] {
-        m_threadID = Thread::currentSingleton().uid();
+        m_threadID = currentThreadID();
         semaphore.signal();
     });
     semaphore.wait();

--- a/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUExternalTexture.h
+++ b/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUExternalTexture.h
@@ -28,6 +28,7 @@
 #include <wtf/Platform.h>
 #include <wtf/Ref.h>
 #include <wtf/RefCounted.h>
+#include <wtf/ThreadSafeWeakPtr.h>
 #include <wtf/WeakPtr.h>
 #include <wtf/text/WTFString.h>
 

--- a/Source/WebCore/Modules/webaudio/AudioDestinationNode.cpp
+++ b/Source/WebCore/Modules/webaudio/AudioDestinationNode.cpp
@@ -65,7 +65,7 @@ void AudioDestinationNode::renderQuantum(AudioBus& destinationBus, size_t number
     // This will take care of all AudioNodes because they all process within this scope.
     DenormalDisabler denormalDisabler;
     
-    context().setAudioThread(Thread::currentSingleton());
+    context().setAudioThread(currentThreadID());
 
     // For performance reasons, we forbid heap allocations while doing rendering on the audio thread.
     // Heap allocations that cannot be avoided or have not been fixed yet can be allowed using

--- a/Source/WebCore/Modules/webaudio/BaseAudioContext.h
+++ b/Source/WebCore/Modules/webaudio/BaseAudioContext.h
@@ -37,13 +37,13 @@
 #include "OscillatorType.h"
 #include "PeriodicWaveConstraints.h"
 #include <atomic>
+#include <wtf/CurrentThread.h>
 #include <wtf/Forward.h>
 #include <wtf/LoggerHelper.h>
 #include <wtf/MainThread.h>
 #include <wtf/RecursiveLockAdapter.h>
 #include <wtf/RobinHoodHashMap.h>
 #include <wtf/ThreadSafeRefCounted.h>
-#include <wtf/Threading.h>
 
 namespace JSC {
 class ArrayBuffer;
@@ -188,8 +188,8 @@ public:
     // Thread Safety and Graph Locking:
     //
     
-    void setAudioThread(Thread& thread) { m_audioThreadUID = thread.uid(); } // FIXME: check either not initialized or the same
-    bool isAudioThread() const { return m_audioThreadUID == Thread::currentSingleton().uid(); }
+    void setAudioThread(uint32_t threadUID) { m_audioThreadUID = threadUID; } // FIXME: check either not initialized or the same
+    bool isAudioThread() const { return m_audioThreadUID == currentThreadID(); }
 
     // Returns true only after the audio thread has been started and then shutdown.
     bool isAudioThreadFinished() const { return m_isAudioThreadFinished; }

--- a/Source/WebCore/Modules/webaudio/GainNode.h
+++ b/Source/WebCore/Modules/webaudio/GainNode.h
@@ -27,7 +27,6 @@
 #include "AudioNode.h"
 #include "AudioParam.h"
 #include "GainOptions.h"
-#include <wtf/Threading.h>
 
 namespace WebCore {
 

--- a/Source/WebCore/Modules/webaudio/OfflineAudioDestinationNode.h
+++ b/Source/WebCore/Modules/webaudio/OfflineAudioDestinationNode.h
@@ -27,7 +27,10 @@
 
 #include "AudioDestinationNode.h"
 #include <wtf/RefPtr.h>
-#include <wtf/Threading.h>
+
+namespace WTF {
+class Thread;
+}
 
 namespace WebCore {
 
@@ -73,7 +76,7 @@ private:
     const Ref<AudioBus> m_renderBus;
     
     // Rendering thread.
-    RefPtr<Thread> m_renderThread;
+    RefPtr<WTF::Thread> m_renderThread;
     size_t m_framesToProcess;
     size_t m_destinationOffset { 0 };
     bool m_startedRendering { false };

--- a/Source/WebCore/Modules/webdatabase/DatabaseContext.h
+++ b/Source/WebCore/Modules/webdatabase/DatabaseContext.h
@@ -33,10 +33,6 @@
 #include <wtf/RefPtr.h>
 #include <wtf/ThreadSafeRefCounted.h>
 
-#if PLATFORM(IOS_FAMILY)
-#include <wtf/Threading.h>
-#endif
-
 namespace WebCore {
 
 class Database;

--- a/Source/WebCore/Modules/webdatabase/DatabaseDetails.h
+++ b/Source/WebCore/Modules/webdatabase/DatabaseDetails.h
@@ -28,8 +28,8 @@
 
 #pragma once
 
+#include <wtf/CurrentThread.h>
 #include <wtf/Markable.h>
-#include <wtf/Threading.h>
 #include <wtf/WallTime.h>
 #include <wtf/text/WTFString.h>
 
@@ -56,7 +56,7 @@ public:
     std::optional<WallTime> creationTime() const { return m_creationTime; }
     std::optional<WallTime> modificationTime() const { return m_modificationTime; }
 #if ASSERT_ENABLED
-    Thread& thread() const { return m_thread.get(); }
+    uint32_t threadID() const { return m_threadID; }
 #endif
 
 private:
@@ -67,7 +67,7 @@ private:
     Markable<WallTime> m_creationTime;
     Markable<WallTime> m_modificationTime;
 #if ASSERT_ENABLED
-    Ref<Thread> m_thread { Thread::currentSingleton() };
+    uint32_t m_threadID { currentThreadID() };
 #endif
 };
 

--- a/Source/WebCore/Modules/webdatabase/DatabaseManager.cpp
+++ b/Source/WebCore/Modules/webdatabase/DatabaseManager.cpp
@@ -261,7 +261,7 @@ DatabaseDetails DatabaseManager::detailsForNameAndOrigin(const String& name, Sec
         Locker locker { m_proposedDatabasesLock };
         for (auto* proposedDatabase : m_proposedDatabases) {
             if (proposedDatabase->details().name() == name && proposedDatabase->origin().equal(origin)) {
-                ASSERT(&proposedDatabase->details().thread() == &Thread::currentSingleton() || isMainThread());
+                ASSERT(proposedDatabase->details().threadID() == currentThreadID() || isMainThread());
                 return proposedDatabase->details();
             }
         }

--- a/Source/WebCore/PAL/pal/system/mac/SystemSleepListenerMac.h
+++ b/Source/WebCore/PAL/pal/system/mac/SystemSleepListenerMac.h
@@ -29,6 +29,7 @@
 
 #include <pal/system/SystemSleepListener.h>
 #include <wtf/CheckedRef.h>
+#include <wtf/RetainPtr.h>
 #include <wtf/TZoneMalloc.h>
 #include <wtf/WeakPtr.h>
 

--- a/Source/WebCore/SaferCPPExpectations/ForwardDeclCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/ForwardDeclCheckerExpectations
@@ -48,6 +48,7 @@ layout/formattingContexts/inline/InlineFormattingContext.h
 layout/formattingContexts/inline/InlineItemsBuilder.cpp
 layout/formattingContexts/inline/InlineLine.h
 [ iOS ] page/cocoa/ContentChangeObserver.h
+page/Page.h
 page/scrolling/ScrollingStateNode.h
 [ Mac ] page/scrolling/ScrollingStateScrollingNode.cpp
 platform/PODRedBlackTree.h

--- a/Source/WebCore/accessibility/AXCrossProcessSearch.cpp
+++ b/Source/WebCore/accessibility/AXCrossProcessSearch.cpp
@@ -38,6 +38,7 @@
 #include <wtf/MonotonicTime.h>
 #include <wtf/RefCounted.h>
 #include <wtf/StdLibExtras.h>
+#include <wtf/Threading.h>
 #include <wtf/threads/BinarySemaphore.h>
 
 #if PLATFORM(COCOA)

--- a/Source/WebCore/bindings/js/JSCallbackData.cpp
+++ b/Source/WebCore/bindings/js/JSCallbackData.cpp
@@ -53,7 +53,7 @@ JSCallbackData::JSCallbackData(JSC::JSObject* callback, JSDOMGlobalObject* globa
 JSCallbackData::~JSCallbackData()
 {
 #if !PLATFORM(IOS_FAMILY)
-    ASSERT(m_thread.ptr() == &Thread::currentSingleton());
+    ASSERT(m_threadID == currentThreadID());
 #endif
 }
 

--- a/Source/WebCore/bindings/js/JSCallbackData.h
+++ b/Source/WebCore/bindings/js/JSCallbackData.h
@@ -32,9 +32,9 @@
 #include <JavaScriptCore/PropertyName.h>
 #include <JavaScriptCore/Weak.h>
 #include <JavaScriptCore/WeakHandleOwner.h>
+#include <wtf/CurrentThread.h>
 #include <wtf/NakedPtr.h>
 #include <wtf/TZoneMalloc.h>
-#include <wtf/Threading.h>
 
 namespace JSC {
 class JSObject;
@@ -80,7 +80,7 @@ private:
     JSC::Weak<JSC::JSObject> m_callback;
 
 #if ASSERT_ENABLED
-    const Ref<Thread> m_thread { Thread::currentSingleton() };
+    const uint32_t m_threadID { currentThreadID() };
 #endif
 };
 

--- a/Source/WebCore/css/CSSFontFeatureValue.h
+++ b/Source/WebCore/css/CSSFontFeatureValue.h
@@ -28,6 +28,7 @@
 
 #include "CSSValue.h"
 #include "FontTaggedSettings.h"
+#include <wtf/Function.h>
 
 namespace WebCore {
 

--- a/Source/WebCore/css/CSSRule.h
+++ b/Source/WebCore/css/CSSRule.h
@@ -26,6 +26,7 @@
 #include <WebCore/StyleRuleType.h>
 #include <wtf/RefCountedAndCanMakeWeakPtr.h>
 #include <wtf/TypeCasts.h>
+#include <wtf/text/WTFString.h>
 
 namespace WebCore {
 

--- a/Source/WebCore/dom/ActiveDOMObject.cpp
+++ b/Source/WebCore/dom/ActiveDOMObject.cpp
@@ -73,7 +73,7 @@ ActiveDOMObject::ActiveDOMObject(Document& document)
 
 ActiveDOMObject::~ActiveDOMObject()
 {
-    ASSERT(canCurrentThreadAccessThreadLocalData(m_creationThread));
+    ASSERT(m_creationThreadID == currentThreadID());
 
     // ActiveDOMObject may be inherited by a sub-class whose life-cycle
     // exceeds that of the associated ScriptExecutionContext. In those cases,

--- a/Source/WebCore/dom/ActiveDOMObject.h
+++ b/Source/WebCore/dom/ActiveDOMObject.h
@@ -31,10 +31,10 @@
 #include <wtf/AbstractRefCounted.h>
 #include <wtf/Assertions.h>
 #include <wtf/CancellableTask.h>
+#include <wtf/CurrentThread.h>
 #include <wtf/Forward.h>
 #include <wtf/Function.h>
 #include <wtf/RefCounted.h>
-#include <wtf/Threading.h>
 
 namespace WebCore {
 
@@ -162,7 +162,7 @@ private:
     uint64_t m_pendingActivityInstanceCount { 0 };
 #if ASSERT_ENABLED
     bool m_suspendIfNeededWasCalled { false };
-    const Ref<Thread> m_creationThread { Thread::currentSingleton() };
+    const uint32_t m_creationThreadID { currentThreadID() };
 #endif
 
     friend class ActiveDOMObjectEventDispatchTask;

--- a/Source/WebCore/dom/EventListenerMap.h
+++ b/Source/WebCore/dom/EventListenerMap.h
@@ -40,11 +40,11 @@
 #include <wtf/Assertions.h>
 #include <wtf/CheckedArithmetic.h>
 #include <wtf/Compiler.h>
+#include <wtf/CurrentThread.h>
 #include <wtf/Forward.h>
 #include <wtf/Lock.h>
 #include <wtf/Locker.h>
 #include <wtf/Platform.h>
-#include <wtf/Threading.h>
 #include <wtf/Vector.h>
 #include <wtf/text/AtomString.h>
 
@@ -121,13 +121,13 @@ private:
             return;
 #endif
         if (!m_threadUID) {
-            ASSERT(!Thread::mayBeGCThread());
-            m_threadUID = Thread::currentSingleton().uid();
+            ASSERT(!currentThreadMayBeGCThread());
+            m_threadUID = currentThreadID();
             return;
         }
-        if (m_threadUID == Thread::currentSingleton().uid()) [[likely]]
+        if (m_threadUID == currentThreadID()) [[likely]]
             return;
-        RELEASE_ASSERT(Thread::mayBeGCThread());
+        RELEASE_ASSERT(currentThreadMayBeGCThread());
     }
 
     Vector<std::pair<AtomString, EventListenerVector>, 0, CrashOnOverflow, 4> m_entries;

--- a/Source/WebCore/dom/NameNodeList.h
+++ b/Source/WebCore/dom/NameNodeList.h
@@ -24,6 +24,7 @@
 #pragma once
 
 #include "LiveNodeList.h"
+#include <wtf/text/AtomString.h>
 
 namespace WebCore {
 

--- a/Source/WebCore/html/Allowlist.h
+++ b/Source/WebCore/html/Allowlist.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include <WebCore/SecurityOriginData.h>
+#include <wtf/HashSet.h>
 
 namespace WebCore {
 

--- a/Source/WebCore/html/canvas/CanvasRenderingContext.cpp
+++ b/Source/WebCore/html/canvas/CanvasRenderingContext.cpp
@@ -73,7 +73,7 @@ Lock& CanvasRenderingContext::instancesLock()
 CanvasRenderingContext::CanvasRenderingContext(CanvasBase& canvas, Type type)
     : m_canvas(canvas)
     , m_type(type)
-    , m_owningThreadUID(Thread::currentSingleton().uid())
+    , m_owningThreadUID(currentThreadID())
 {
     Locker locker { instancesLock() };
     instances().add(this);

--- a/Source/WebCore/html/canvas/CanvasRenderingContext.h
+++ b/Source/WebCore/html/canvas/CanvasRenderingContext.h
@@ -30,6 +30,7 @@
 #include "ImageBuffer.h"
 #include "ScriptWrappable.h"
 #include <wtf/CheckedRef.h>
+#include <wtf/CurrentThread.h>
 #include <wtf/Forward.h>
 #include <wtf/Lock.h>
 #include <wtf/Noncopyable.h>
@@ -137,7 +138,7 @@ public:
 #if ENABLE(RESOURCE_USAGE)
     size_t NODELETE externalMemoryCost() const;
 #endif
-    bool isContextThread() const { return m_owningThreadUID == Thread::currentSingleton().uid(); }
+    bool isContextThread() const { return m_owningThreadUID == currentThreadID(); }
 
 protected:
     enum class Type : uint8_t {

--- a/Source/WebCore/loader/ResourceMonitorPersistence.cpp
+++ b/Source/WebCore/loader/ResourceMonitorPersistence.cpp
@@ -29,6 +29,7 @@
 #include "Logging.h"
 #include "SQLiteStatement.h"
 #include <wtf/FileSystem.h>
+#include <wtf/MainThread.h>
 #include <wtf/Seconds.h>
 #include <wtf/StdLibExtras.h>
 #include <wtf/text/MakeString.h>

--- a/Source/WebCore/page/ElementTargetingTypes.h
+++ b/Source/WebCore/page/ElementTargetingTypes.h
@@ -32,6 +32,7 @@
 #include <WebCore/RectEdges.h>
 #include <WebCore/RenderStyleConstants.h>
 #include <WebCore/ScriptExecutionContextIdentifier.h>
+#include <wtf/HashSet.h>
 #include <wtf/RefCounted.h>
 #include <wtf/URLHash.h>
 #include <wtf/Vector.h>

--- a/Source/WebCore/page/Page.h
+++ b/Source/WebCore/page/Page.h
@@ -20,7 +20,6 @@
 
 #pragma once
 
-#include <JavaScriptCore/Debugger.h>
 #include <WebCore/ActivityState.h>
 #include <WebCore/AnimationFrameRate.h>
 #include <WebCore/BackForwardFrameItemIdentifier.h>
@@ -81,6 +80,7 @@
 #endif
 
 namespace JSC {
+class Debugger;
 class JSGlobalObject;
 }
 

--- a/Source/WebCore/page/scrolling/ScrollingCoordinator.h
+++ b/Source/WebCore/page/scrolling/ScrollingCoordinator.h
@@ -38,7 +38,6 @@
 #include <wtf/Forward.h>
 #include <wtf/TZoneMalloc.h>
 #include <wtf/ThreadSafeRefCounted.h>
-#include <wtf/Threading.h>
 #include <wtf/TypeCasts.h>
 
 namespace WTF {

--- a/Source/WebCore/page/scrolling/ScrollingTree.h
+++ b/Source/WebCore/page/scrolling/ScrollingTree.h
@@ -47,6 +47,7 @@
 #include <wtf/MonotonicTime.h>
 #include <wtf/TZoneMalloc.h>
 #include <wtf/ThreadSafeRefCounted.h>
+#include <wtf/ThreadSafeWeakHashSet.h>
 #include <wtf/TypeCasts.h>
 
 namespace WebCore {

--- a/Source/WebCore/page/scrolling/mac/ScrollerMac.h
+++ b/Source/WebCore/page/scrolling/mac/ScrollerMac.h
@@ -32,6 +32,7 @@
 #include <WebCore/UserInterfaceLayoutDirection.h>
 #include <wtf/RecursiveLockAdapter.h>
 #include <wtf/RetainPtr.h>
+#include <wtf/ThreadSafeWeakPtr.h>
 
 OBJC_CLASS CALayer;
 OBJC_CLASS NSColor;

--- a/Source/WebCore/platform/OrientationNotifier.h
+++ b/Source/WebCore/platform/OrientationNotifier.h
@@ -27,6 +27,7 @@
 
 #include <WebCore/IntDegrees.h>
 #include <wtf/AbstractThreadSafeRefCountedAndCanMakeWeakPtr.h>
+#include <wtf/ThreadSafeWeakHashSet.h>
 #include <wtf/WeakHashSet.h>
 #include <wtf/WeakPtr.h>
 

--- a/Source/WebCore/platform/ScrollSnapAnimatorState.h
+++ b/Source/WebCore/platform/ScrollSnapAnimatorState.h
@@ -32,6 +32,7 @@
 #include <WebCore/ScrollAnimationMomentum.h>
 #include <WebCore/ScrollSnapOffsetsInfo.h>
 #include <WebCore/ScrollTypes.h>
+#include <wtf/HashSet.h>
 #include <wtf/MonotonicTime.h>
 #include <wtf/TZoneMalloc.h>
 

--- a/Source/WebCore/platform/Supplementable.h
+++ b/Source/WebCore/platform/Supplementable.h
@@ -27,13 +27,10 @@
 #define Supplementable_h
 
 #include <wtf/Assertions.h>
+#include <wtf/CurrentThread.h>
 #include <wtf/HashMap.h>
 #include <wtf/MainThread.h>
 #include <wtf/text/ASCIILiteral.h>
-
-#if ASSERT_ENABLED
-#include <wtf/Threading.h>
-#endif
 
 namespace WebCore {
 
@@ -149,14 +146,14 @@ class Supplementable {
 public:
     void provideSupplement(ASCIILiteral key, std::unique_ptr<Supplement<T>> supplement)
     {
-        ASSERT(canCurrentThreadAccessThreadLocalData(m_thread));
+        ASSERT(m_creationThreadID == currentThreadID());
         ASSERT(!m_supplements.get(key));
         m_supplements.add(key, WTF::move(supplement));
     }
 
     Supplement<T>* requireSupplement(ASCIILiteral key)
     {
-        ASSERT(canCurrentThreadAccessThreadLocalData(m_thread));
+        ASSERT(m_creationThreadID == currentThreadID());
         return m_supplements.get(key);
     }
 
@@ -169,7 +166,7 @@ private:
     using SupplementMap = HashMap<ASCIILiteral, std::unique_ptr<Supplement<T>>>;
     SupplementMap m_supplements;
 #if ASSERT_ENABLED
-    const Ref<Thread> m_thread { Thread::currentSingleton() };
+    const uint32_t m_creationThreadID { currentThreadID() };
 #endif
 };
 

--- a/Source/WebCore/platform/Timer.cpp
+++ b/Source/WebCore/platform/Timer.cpp
@@ -35,6 +35,7 @@
 #include <wtf/MainThread.h>
 #include <wtf/RuntimeApplicationChecks.h>
 #include <wtf/TZoneMallocInlines.h>
+#include <wtf/Threading.h>
 #include <wtf/Vector.h>
 
 #if PLATFORM(IOS_FAMILY)
@@ -275,7 +276,9 @@ struct SameSizeAsTimer {
 #if CPU(ADDRESS32)
     uint8_t bitfields;
 #endif
-    void* pointer;
+#if ASSERT_ENABLED
+    uint32_t threadID;
+#endif
 };
 
 static_assert(sizeof(Timer) == sizeof(SameSizeAsTimer), "Timer should stay small");
@@ -293,10 +296,25 @@ TimerBase::TimerBase()
 #endif
 }
 
+bool TimerBase::canAccessOnCurrentThread() const
+{
+#if ASSERT_ENABLED
+#if USE(WEB_THREAD)
+    if (m_creationThreadID == currentThreadID())
+        return true;
+    return WebThreadIsCurrent() || pthread_main_np();
+#else
+    return m_creationThreadID == currentThreadID();
+#endif
+#else
+    return true;
+#endif
+}
+
 TimerBase::~TimerBase()
 {
-    ASSERT(canCurrentThreadAccessThreadLocalData(m_thread));
-    RELEASE_ASSERT(canCurrentThreadAccessThreadLocalData(m_thread) || shouldSuppressThreadSafetyCheck());
+    ASSERT(canAccessOnCurrentThread());
+    RELEASE_ASSERT(canAccessOnCurrentThread() || shouldSuppressThreadSafetyCheck());
     stop();
     ASSERT(!inHeap());
     if (auto* item = m_heapItemWithBitfields.pointer())
@@ -306,7 +324,7 @@ TimerBase::~TimerBase()
 
 void TimerBase::start(Seconds nextFireInterval, Seconds repeatInterval)
 {
-    ASSERT(canCurrentThreadAccessThreadLocalData(m_thread));
+    ASSERT(canAccessOnCurrentThread());
 
     m_repeatInterval = repeatInterval;
     setNextFireTime(MonotonicTime::now() + nextFireInterval);
@@ -314,7 +332,7 @@ void TimerBase::start(Seconds nextFireInterval, Seconds repeatInterval)
 
 void TimerBase::stopSlowCase()
 {
-    ASSERT(canCurrentThreadAccessThreadLocalData(m_thread));
+    ASSERT(canAccessOnCurrentThread());
 
     m_repeatInterval = 0_s;
     setNextFireTime(MonotonicTime { });
@@ -513,8 +531,8 @@ void TimerBase::setNextFireTime(MonotonicTime newTime)
 #if USE(WEB_THREAD)
     RELEASE_ASSERT(WebThreadIsLockedOrDisabledInMainOrWebThread());
 #endif
-    ASSERT(canCurrentThreadAccessThreadLocalData(m_thread));
-    RELEASE_ASSERT(canCurrentThreadAccessThreadLocalData(m_thread) || shouldSuppressThreadSafetyCheck());
+    ASSERT(canAccessOnCurrentThread());
+    RELEASE_ASSERT(canAccessOnCurrentThread() || shouldSuppressThreadSafetyCheck());
     bool timerHasBeenDeleted = m_unalignedNextFireTime.isNaN();
     RELEASE_ASSERT_WITH_SECURITY_IMPLICATION(!timerHasBeenDeleted);
 

--- a/Source/WebCore/platform/Timer.h
+++ b/Source/WebCore/platform/Timer.h
@@ -30,6 +30,7 @@
 #include <wtf/AbstractCanMakeCheckedPtr.h>
 #include <wtf/CheckedRef.h>
 #include <wtf/CompactRefPtrTuple.h>
+#include <wtf/CurrentThread.h>
 #include <wtf/Function.h>
 #include <wtf/MonotonicTime.h>
 #include <wtf/Noncopyable.h>
@@ -37,7 +38,6 @@
 #include <wtf/RunLoop.h>
 #include <wtf/Seconds.h>
 #include <wtf/TZoneMalloc.h>
-#include <wtf/Threading.h>
 #include <wtf/TypeTraits.h>
 #include <wtf/Vector.h>
 #include <wtf/WeakPtr.h>
@@ -61,7 +61,6 @@ public:
     WEBCORE_EXPORT TimerBase();
     WEBCORE_EXPORT virtual ~TimerBase();
 
-    // TimerBase's destructor inspects Ref<Thread> m_thread, which won't work if we are moved-from.
     TimerBase(TimerBase&&) = delete;
     TimerBase& NODELETE operator=(TimerBase&&) = delete;
 
@@ -113,6 +112,7 @@ private:
     bool inHeap() const { return m_heapItemWithBitfields.pointer() && m_heapItemWithBitfields.pointer()->isInHeap(); }
 
     bool NODELETE hasValidHeapPosition() const;
+    WEBCORE_EXPORT bool canAccessOnCurrentThread() const;
     void updateHeapIfNeeded(MonotonicTime oldTime);
 
     void heapDecreaseKey();
@@ -129,7 +129,9 @@ private:
     Seconds m_repeatInterval; // 0 if not repeating
 
     CompactRefPtrTuple<ThreadTimerHeapItem, uint8_t> m_heapItemWithBitfields;
-    const Ref<Thread> m_thread { Thread::currentSingleton() };
+#if ASSERT_ENABLED
+    const uint32_t m_creationThreadID { currentThreadID() };
+#endif
 
     friend class ThreadTimers;
     friend class TimerHeapLessThanFunction;
@@ -200,12 +202,7 @@ inline void TimerBase::stop()
 
 inline bool TimerBase::isActive() const
 {
-    // FIXME: Write this in terms of USE(WEB_THREAD) instead of PLATFORM(IOS_FAMILY).
-#if !PLATFORM(IOS_FAMILY)
-    ASSERT(m_thread.ptr() == &Thread::currentSingleton());
-#else
-    ASSERT(WebThreadIsCurrent() || pthread_main_np() || m_thread.ptr() == &Thread::currentSingleton());
-#endif // PLATFORM(IOS_FAMILY)
+    ASSERT(canAccessOnCurrentThread());
     return static_cast<bool>(nextFireTime());
 }
 

--- a/Source/WebCore/platform/audio/HRTFDatabaseLoader.cpp
+++ b/Source/WebCore/platform/audio/HRTFDatabaseLoader.cpp
@@ -36,6 +36,7 @@
 #include <wtf/HashMap.h>
 #include <wtf/MainThread.h>
 #include <wtf/NeverDestroyed.h>
+#include <wtf/Threading.h>
 
 namespace WebCore {
 

--- a/Source/WebCore/platform/audio/HRTFDatabaseLoader.h
+++ b/Source/WebCore/platform/audio/HRTFDatabaseLoader.h
@@ -34,7 +34,10 @@
 #include <wtf/Lock.h>
 #include <wtf/RefPtr.h>
 #include <wtf/ThreadSafeWeakPtr.h>
-#include <wtf/Threading.h>
+
+namespace WTF {
+class Thread;
+}
 
 namespace WebCore {
 
@@ -76,7 +79,7 @@ private:
 
     // Holding a m_threadLock is required when accessing m_databaseLoaderThread.
     Lock m_threadLock;
-    RefPtr<Thread> m_databaseLoaderThread WTF_GUARDED_BY_LOCK(m_threadLock);
+    RefPtr<WTF::Thread> m_databaseLoaderThread WTF_GUARDED_BY_LOCK(m_threadLock);
 
     float m_databaseSampleRate;
 };

--- a/Source/WebCore/platform/audio/RealtimeAudioThread.cpp
+++ b/Source/WebCore/platform/audio/RealtimeAudioThread.cpp
@@ -27,6 +27,7 @@
 #include "RealtimeAudioThread.h"
 
 #include <wtf/MonotonicTime.h>
+#include <wtf/Threading.h>
 
 namespace WebCore {
 

--- a/Source/WebCore/platform/audio/RealtimeAudioThread.h
+++ b/Source/WebCore/platform/audio/RealtimeAudioThread.h
@@ -25,10 +25,16 @@
 
 #pragma once
 
-#include <wtf/Threading.h>
+#include <wtf/Forward.h>
+#include <wtf/Ref.h>
+#include <wtf/Seconds.h>
+
+namespace WTF {
+class Thread;
+}
 
 namespace WebCore {
 
-WEBCORE_EXPORT Ref<Thread> createMaybeRealtimeAudioThread(ASCIILiteral threadName, Function<void()>&&, Seconds renderingQuantumDuration);
+WEBCORE_EXPORT Ref<WTF::Thread> createMaybeRealtimeAudioThread(ASCIILiteral threadName, Function<void()>&&, Seconds renderingQuantumDuration);
 
 }

--- a/Source/WebCore/platform/audio/ReverbConvolver.cpp
+++ b/Source/WebCore/platform/audio/ReverbConvolver.cpp
@@ -36,6 +36,7 @@
 #include "AudioBus.h"
 #include <mutex>
 #include <wtf/TZoneMallocInlines.h>
+#include <wtf/Threading.h>
 
 namespace WebCore {
 

--- a/Source/WebCore/platform/audio/ReverbConvolver.h
+++ b/Source/WebCore/platform/audio/ReverbConvolver.h
@@ -36,9 +36,13 @@
 #include <memory>
 #include <wtf/Condition.h>
 #include <wtf/Lock.h>
+#include <wtf/RefPtr.h>
 #include <wtf/TZoneMalloc.h>
-#include <wtf/Threading.h>
 #include <wtf/Vector.h>
+
+namespace WTF {
+class Thread;
+}
 
 namespace WebCore {
 
@@ -86,7 +90,7 @@ private:
 
     // Background thread and synchronization
     bool m_useBackgroundThreads;
-    const RefPtr<Thread> m_backgroundThread;
+    const RefPtr<WTF::Thread> m_backgroundThread;
     bool m_wantsToExit { false };
     bool m_moreInputBuffered { false };
     mutable Lock m_backgroundThreadLock;

--- a/Source/WebCore/platform/audio/ios/MediaSessionHelperIOS.h
+++ b/Source/WebCore/platform/audio/ios/MediaSessionHelperIOS.h
@@ -31,6 +31,7 @@
 #include <WebCore/MediaPlaybackTarget.h>
 #include <wtf/AbstractRefCountedAndCanMakeWeakPtr.h>
 #include <wtf/ProcessID.h>
+#include <wtf/ThreadSafeWeakPtr.h>
 #include <wtf/WeakHashSet.h>
 
 namespace WebCore {

--- a/Source/WebCore/platform/encryptedmedia/CDMProxy.h
+++ b/Source/WebCore/platform/encryptedmedia/CDMProxy.h
@@ -41,6 +41,7 @@
 #include <wtf/HashSet.h>
 #include <wtf/Lock.h>
 #include <wtf/TZoneMalloc.h>
+#include <wtf/ThreadSafeWeakPtr.h>
 #include <wtf/WeakPtr.h>
 
 #if ENABLE(THUNDER)

--- a/Source/WebCore/platform/graphics/AudioVideoRenderer.h
+++ b/Source/WebCore/platform/graphics/AudioVideoRenderer.h
@@ -37,6 +37,7 @@
 #include <wtf/AbstractThreadSafeRefCountedAndCanMakeWeakPtr.h>
 #include <wtf/CompletionHandler.h>
 #include <wtf/MediaTime.h>
+#include <wtf/MonotonicTime.h>
 #include <wtf/NativePromise.h>
 #include <wtf/ObjectIdentifier.h>
 

--- a/Source/WebCore/platform/graphics/FontCascadeFonts.cpp
+++ b/Source/WebCore/platform/graphics/FontCascadeFonts.cpp
@@ -110,7 +110,7 @@ FontCascadeFonts::FontCascadeFonts()
 {
 #if ASSERT_ENABLED
     if (!isMainThread())
-        m_thread = Thread::currentSingleton();
+        m_creationThreadID = currentThreadID();
 #endif
 }
 
@@ -533,7 +533,7 @@ static RefPtr<GlyphPage> glyphPageFromFontRanges(unsigned pageNumber, const Font
 
 GlyphData FontCascadeFonts::glyphDataForCharacter(char32_t c, const FontCascadeDescription& description, FontSelector* fontSelector, FontVariant variant, ResolvedEmojiPolicy resolvedEmojiPolicy)
 {
-    ASSERT(m_thread ? m_thread->ptr() == &Thread::currentSingleton() : isMainThread());
+    ASSERT(m_creationThreadID ? *m_creationThreadID == currentThreadID() : isMainThread());
     ASSERT(variant != FontVariant::Auto);
 
     if (variant != FontVariant::Normal)

--- a/Source/WebCore/platform/graphics/FontCascadeFonts.h
+++ b/Source/WebCore/platform/graphics/FontCascadeFonts.h
@@ -28,6 +28,7 @@
 #include <WebCore/GlyphPage.h>
 #include <WebCore/TextMeasurementCache.h>
 #include <WebCore/TextRun.h>
+#include <wtf/CurrentThread.h>
 #include <wtf/EnumeratedArray.h>
 #include <wtf/Forward.h>
 #include <wtf/HashFunctions.h>
@@ -198,7 +199,7 @@ private:
     bool m_isForPlatformFont { false };
     TriState m_canTakeFixedPitchFastContentMeasuring : 2 { TriState::Indeterminate };
 #if ASSERT_ENABLED
-    std::optional<Ref<Thread>> m_thread;
+    std::optional<uint32_t> m_creationThreadID;
 #endif
 };
 
@@ -218,7 +219,7 @@ inline bool FontCascadeFonts::canTakeFixedPitchFastContentMeasuring(const FontCa
 
 inline const Font& FontCascadeFonts::primaryFont(const FontCascadeDescription& description, FontSelector* fontSelector)
 {
-    ASSERT(m_thread ? m_thread->ptr() == &Thread::currentSingleton() : isMainThread());
+    ASSERT(m_creationThreadID ? *m_creationThreadID == currentThreadID() : isMainThread());
     if (!m_cachedPrimaryFont) {
         // CSS Fonts 4 §5.2: "The first available font [...] is defined to be the first font for which
         // the character U+0020 (space) is not excluded by a unicode-range [...]. Note: it does not

--- a/Source/WebCore/platform/graphics/SourceBufferPrivate.cpp
+++ b/Source/WebCore/platform/graphics/SourceBufferPrivate.cpp
@@ -46,6 +46,7 @@
 #include <wtf/MainThread.h>
 #include <wtf/MediaTime.h>
 #include <wtf/StringPrintStream.h>
+#include <wtf/Threading.h>
 
 namespace WebCore {
 

--- a/Source/WebCore/platform/graphics/avfoundation/AudioVideoRendererAVFObjC.h
+++ b/Source/WebCore/platform/graphics/avfoundation/AudioVideoRendererAVFObjC.h
@@ -30,10 +30,13 @@
 #include <WebCore/ProcessIdentity.h>
 #include <WebCore/TrackInfo.h>
 #include <WebCore/WebAVSampleBufferListener.h>
+#include <wtf/Deque.h>
 #include <wtf/Forward.h>
 #include <wtf/Function.h>
 #include <wtf/HashMap.h>
 #include <wtf/LoggerHelper.h>
+#include <wtf/MonotonicTime.h>
+#include <wtf/RetainPtr.h>
 #include <wtf/StdUnorderedMap.h>
 #include <wtf/ThreadSafeWeakPtr.h>
 

--- a/Source/WebCore/platform/graphics/avfoundation/objc/CDMSessionAVFoundationObjC.h
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/CDMSessionAVFoundationObjC.h
@@ -29,6 +29,7 @@
 #include <wtf/RefCountedAndCanMakeWeakPtr.h>
 #include <wtf/RetainPtr.h>
 #include <wtf/TZoneMalloc.h>
+#include <wtf/ThreadSafeWeakPtr.h>
 #include <wtf/WeakPtr.h>
 #include <wtf/text/WTFString.h>
 

--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.h
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.h
@@ -39,6 +39,7 @@
 #include <wtf/HashMap.h>
 #include <wtf/LoggerHelper.h>
 #include <wtf/MediaTime.h>
+#include <wtf/MonotonicTime.h>
 #include <wtf/NativePromise.h>
 #include <wtf/ThreadSafeRefCounted.h>
 #include <wtf/ThreadSafeWeakPtr.h>

--- a/Source/WebCore/platform/graphics/transforms/TransformOperation.h
+++ b/Source/WebCore/platform/graphics/transforms/TransformOperation.h
@@ -29,6 +29,7 @@
 #include <WebCore/TransformationMatrix.h>
 #include <wtf/Forward.h>
 #include <wtf/RefCounted.h>
+#include <wtf/ThreadSafeRefCounted.h>
 #include <wtf/TypeCasts.h>
 
 namespace WebCore {

--- a/Source/WebCore/platform/ios/LegacyTileCache.h
+++ b/Source/WebCore/platform/ios/LegacyTileCache.h
@@ -34,7 +34,6 @@
 #include <wtf/Lock.h>
 #include <wtf/Noncopyable.h>
 #include <wtf/RetainPtr.h>
-#include <wtf/Threading.h>
 #include <wtf/Vector.h>
 #include <wtf/WeakPtr.h>
 

--- a/Source/WebCore/platform/ios/LegacyTileLayerPool.h
+++ b/Source/WebCore/platform/ios/LegacyTileLayerPool.h
@@ -35,7 +35,6 @@
 #include <wtf/HashMap.h>
 #include <wtf/Lock.h>
 #include <wtf/RetainPtr.h>
-#include <wtf/Threading.h>
 #include <wtf/Vector.h>
 
 @class LegacyTileLayer;

--- a/Source/WebCore/platform/mediastream/MediaStreamTrackPrivate.cpp
+++ b/Source/WebCore/platform/mediastream/MediaStreamTrackPrivate.cpp
@@ -38,6 +38,7 @@
 #include <wtf/CrossThreadCopier.h>
 #include <wtf/NativePromise.h>
 #include <wtf/TZoneMallocInlines.h>
+#include <wtf/Threading.h>
 #include <wtf/UUID.h>
 
 #if PLATFORM(COCOA)

--- a/Source/WebCore/platform/mediastream/RealtimeMediaSource.h
+++ b/Source/WebCore/platform/mediastream/RealtimeMediaSource.h
@@ -55,6 +55,7 @@
 #include <wtf/Forward.h>
 #include <wtf/Lock.h>
 #include <wtf/LoggerHelper.h>
+#include <wtf/MonotonicTime.h>
 #include <wtf/NativePromise.h>
 #include <wtf/ThreadSafeRefCounted.h>
 #include <wtf/Vector.h>

--- a/Source/WebCore/platform/mediastream/gstreamer/GStreamerCapturer.h
+++ b/Source/WebCore/platform/mediastream/gstreamer/GStreamerCapturer.h
@@ -29,7 +29,7 @@
 #include "PipeWireCaptureDevice.h"
 
 #include <wtf/Lock.h>
-#include <wtf/ThreadSafeRefCounted.h>
+#include <wtf/ThreadSafeWeakPtr.h>
 #include <wtf/WeakHashSet.h>
 
 namespace WebCore {

--- a/Source/WebCore/platform/network/curl/CurlContext.h
+++ b/Source/WebCore/platform/network/curl/CurlContext.h
@@ -36,7 +36,6 @@
 #include <wtf/Noncopyable.h>
 #include <wtf/Seconds.h>
 #include <wtf/TZoneMalloc.h>
-#include <wtf/Threading.h>
 #include <wtf/URL.h>
 
 #if OS(WINDOWS)

--- a/Source/WebCore/platform/network/curl/CurlRequestScheduler.cpp
+++ b/Source/WebCore/platform/network/curl/CurlRequestScheduler.cpp
@@ -28,6 +28,7 @@
 #include "config.h"
 #include "CurlRequestScheduler.h"
 #include <wtf/TZoneMallocInlines.h>
+#include <wtf/Threading.h>
 
 #if USE(CURL)
 
@@ -42,6 +43,11 @@ CurlRequestScheduler::CurlRequestScheduler(long maxConnects, long maxTotalConnec
     , m_maxTotalConnections(maxTotalConnections)
     , m_maxHostConnections(maxHostConnections)
 {
+}
+
+CurlRequestScheduler::~CurlRequestScheduler()
+{
+    stopThread();
 }
 
 bool CurlRequestScheduler::add(CurlRequestSchedulerClient* client)

--- a/Source/WebCore/platform/network/curl/CurlRequestScheduler.h
+++ b/Source/WebCore/platform/network/curl/CurlRequestScheduler.h
@@ -31,8 +31,12 @@
 #include <wtf/HashMap.h>
 #include <wtf/Lock.h>
 #include <wtf/Noncopyable.h>
+#include <wtf/RefPtr.h>
 #include <wtf/TZoneMalloc.h>
-#include <wtf/Threading.h>
+
+namespace WTF {
+class Thread;
+}
 
 namespace WebCore {
 
@@ -44,7 +48,7 @@ class CurlRequestScheduler {
     friend NeverDestroyed<CurlRequestScheduler>;
 public:
     CurlRequestScheduler(long maxConnects, long maxTotalConnections, long maxHostConnections);
-    ~CurlRequestScheduler() { stopThread(); }
+    ~CurlRequestScheduler();
 
     bool add(CurlRequestSchedulerClient*);
     void cancel(CurlRequestSchedulerClient*);
@@ -67,7 +71,7 @@ private:
     void finalizeTransfer(CurlRequestSchedulerClient*, Function<void()>);
 
     Lock m_mutex;
-    RefPtr<Thread> m_thread;
+    RefPtr<WTF::Thread> m_thread;
     bool m_runThread { false };
 
     Vector<Function<void()>> m_taskQueue;

--- a/Source/WebCore/platform/network/curl/CurlStreamScheduler.cpp
+++ b/Source/WebCore/platform/network/curl/CurlStreamScheduler.cpp
@@ -26,6 +26,7 @@
 #include "config.h"
 #include "CurlStreamScheduler.h"
 #include <wtf/TZoneMallocInlines.h>
+#include <wtf/Threading.h>
 
 #if USE(CURL)
 

--- a/Source/WebCore/platform/network/curl/CurlStreamScheduler.h
+++ b/Source/WebCore/platform/network/curl/CurlStreamScheduler.h
@@ -28,7 +28,12 @@
 #include "CurlStream.h"
 #include <wtf/Function.h>
 #include <wtf/HashMap.h>
+#include <wtf/RefPtr.h>
 #include <wtf/TZoneMalloc.h>
+
+namespace WTF {
+class Thread;
+}
 
 namespace WebCore {
 
@@ -55,7 +60,7 @@ private:
     void workerThread();
 
     Lock m_mutex;
-    RefPtr<Thread> m_thread;
+    RefPtr<WTF::Thread> m_thread;
     bool m_runThread { false };
 
     CurlStreamID m_currentStreamID = 1;

--- a/Source/WebCore/platform/sql/SQLiteDatabase.cpp
+++ b/Source/WebCore/platform/sql/SQLiteDatabase.cpp
@@ -41,7 +41,6 @@
 #include <wtf/Lock.h>
 #include <wtf/Scope.h>
 #include <wtf/TZoneMallocInlines.h>
-#include <wtf/Threading.h>
 #include <wtf/text/CString.h>
 #include <wtf/text/MakeString.h>
 
@@ -135,7 +134,7 @@ bool SQLiteDatabase::open(const String& filename, OpenMode openMode, OptionSet<O
         if (!m_db)
             return;
 
-        m_openingThread = nullptr;
+        m_openingThreadID = 0;
         m_openErrorMessage = sqlite3_errmsg(m_db);
         m_openError = sqlite3_errcode(m_db);
         close();
@@ -178,7 +177,7 @@ bool SQLiteDatabase::open(const String& filename, OpenMode openMode, OptionSet<O
 
     overrideUnauthorizedFunctions();
 
-    m_openingThread = Thread::currentSingleton();
+    m_openingThreadID = currentThreadID();
     if (sqlite3_extended_result_codes(m_db, 1) != SQLITE_OK)
         return false;
 
@@ -297,7 +296,7 @@ void SQLiteDatabase::close()
         ASSERT_WITH_MESSAGE(!m_statementCount, "All SQLiteTransaction objects should be destroyed before closing the database");
 
         // FIXME: This is being called on the main thread during JS GC. <rdar://problem/5739818>
-        // ASSERT(m_openingThread == &Thread::currentSingleton());
+        // ASSERT(m_openingThreadID == currentThreadID());
         sqlite3* db = m_db;
         {
             Locker locker { m_databaseClosingMutex };

--- a/Source/WebCore/platform/sql/SQLiteDatabase.h
+++ b/Source/WebCore/platform/sql/SQLiteDatabase.h
@@ -29,12 +29,12 @@
 #include <functional>
 #include <sqlite3.h>
 #include <wtf/CheckedRef.h>
+#include <wtf/CurrentThread.h>
 #include <wtf/Expected.h>
 #include <wtf/Lock.h>
 #include <wtf/OptionSet.h>
 #include <wtf/Platform.h>
 #include <wtf/TZoneMalloc.h>
-#include <wtf/Threading.h>
 #include <wtf/UniqueRef.h>
 #include <wtf/text/CString.h>
 #include <wtf/text/WTFString.h>
@@ -131,7 +131,7 @@ public:
     sqlite3* sqlite3Handle() const LIFETIME_BOUND
     {
 #if !PLATFORM(IOS_FAMILY)
-        ASSERT(m_sharable || m_openingThread == &Thread::currentSingleton() || !m_db);
+        ASSERT(m_sharable || m_openingThreadID == currentThreadID() || !m_db);
 #endif
         return m_db;
     }
@@ -195,7 +195,7 @@ private:
     RefPtr<DatabaseAuthorizer> m_authorizer WTF_GUARDED_BY_LOCK(m_authorizerLock);
 
     Lock m_lockingMutex;
-    RefPtr<Thread> m_openingThread { nullptr };
+    uint32_t m_openingThreadID { 0 };
 
     Lock m_databaseClosingMutex;
 

--- a/Source/WebCore/platform/video-codecs/cocoa/WebRTCVideoDecoderVTB.mm
+++ b/Source/WebCore/platform/video-codecs/cocoa/WebRTCVideoDecoderVTB.mm
@@ -30,6 +30,7 @@
 
 #import "MediaReorderQueue.h"
 #import <WebCore/CMUtilities.h>
+#import <wtf/ThreadSafeWeakPtr.h>
 #import <wtf/cf/TypeCastsCF.h>
 
 #import "CoreVideoSoftLink.h"

--- a/Source/WebCore/workers/WorkerOrWorkletThread.h
+++ b/Source/WebCore/workers/WorkerOrWorkletThread.h
@@ -35,6 +35,7 @@
 #include <wtf/ThreadSafeRefCounted.h>
 #include <wtf/ThreadSafeWeakHashSet.h>
 #include <wtf/ThreadSafeWeakPtr.h>
+#include <wtf/Threading.h>
 #include <wtf/threads/BinarySemaphore.h>
 
 namespace WTF {

--- a/Source/WebCore/workers/service/ExtendableEvent.h
+++ b/Source/WebCore/workers/service/ExtendableEvent.h
@@ -27,6 +27,7 @@
 
 #include <WebCore/Event.h>
 #include <WebCore/ExtendableEventInit.h>
+#include <wtf/HashSet.h>
 #include <wtf/WeakPtr.h>
 
 namespace WebCore {

--- a/Source/WebCore/workers/service/ServiceWorkerContainer.cpp
+++ b/Source/WebCore/workers/service/ServiceWorkerContainer.cpp
@@ -107,7 +107,7 @@ ServiceWorkerContainer::ServiceWorkerContainer(ScriptExecutionContext* context, 
 
 ServiceWorkerContainer::~ServiceWorkerContainer()
 {
-    ASSERT(m_creationThread.ptr() == &Thread::currentSingleton());
+    ASSERT(m_creationThreadID == currentThreadID());
 }
 
 ScriptExecutionContext* ServiceWorkerContainer::scriptExecutionContext() const
@@ -312,7 +312,7 @@ void ServiceWorkerContainer::updateRegistration(const URL& scopeURL, const URL& 
 
 void ServiceWorkerContainer::scheduleJob(Ref<ServiceWorkerJob>&& job)
 {
-    ASSERT(m_creationThread.ptr() == &Thread::currentSingleton());
+    ASSERT(m_creationThreadID == currentThreadID());
     RefPtr swConnection = m_swConnection;
     ASSERT(swConnection);
     ASSERT(!isStopped());
@@ -412,7 +412,7 @@ void ServiceWorkerContainer::startMessages()
 
 void ServiceWorkerContainer::jobFailedWithException(ServiceWorkerJob& job, const Exception& exception)
 {
-    ASSERT(m_creationThread.ptr() == &Thread::currentSingleton());
+    ASSERT(m_creationThreadID == currentThreadID());
 
     auto guard = makeScopeExit([this, protectedThis = Ref { *this }, job = Ref { job }] {
         destroyJob(job);
@@ -430,7 +430,7 @@ void ServiceWorkerContainer::jobFailedWithException(ServiceWorkerJob& job, const
 
 void ServiceWorkerContainer::queueTaskToFireUpdateFoundEvent(ServiceWorkerRegistrationIdentifier identifier)
 {
-    ASSERT(m_creationThread.ptr() == &Thread::currentSingleton());
+    ASSERT(m_creationThreadID == currentThreadID());
 
     if (RefPtr registration = m_registrations.get(identifier))
         registration->queueTaskToFireUpdateFoundEvent();
@@ -438,7 +438,7 @@ void ServiceWorkerContainer::queueTaskToFireUpdateFoundEvent(ServiceWorkerRegist
 
 void ServiceWorkerContainer::jobResolvedWithRegistration(ServiceWorkerJob& job, ServiceWorkerRegistrationData&& data, ShouldNotifyWhenResolved shouldNotifyWhenResolved)
 {
-    ASSERT(m_creationThread.ptr() == &Thread::currentSingleton());
+    ASSERT(m_creationThreadID == currentThreadID());
 
     if (job.data().type == ServiceWorkerJobType::Register) {
         CONTAINER_RELEASE_LOG("jobResolvedWithRegistration: Registration job %" PRIu64 " succeeded", job.identifier().toUInt64());
@@ -523,7 +523,7 @@ void ServiceWorkerContainer::notifyRegistrationIsSettled(const ServiceWorkerRegi
 
 void ServiceWorkerContainer::jobResolvedWithUnregistrationResult(ServiceWorkerJob& job, bool unregistrationResult)
 {
-    ASSERT(m_creationThread.ptr() == &Thread::currentSingleton());
+    ASSERT(m_creationThreadID == currentThreadID());
 
     auto guard = makeScopeExit([this, protectedThis = Ref { *this }, job = Ref { job }] {
         destroyJob(job);
@@ -543,7 +543,7 @@ void ServiceWorkerContainer::jobResolvedWithUnregistrationResult(ServiceWorkerJo
 
 void ServiceWorkerContainer::startScriptFetchForJob(ServiceWorkerJob& job, FetchOptions::Cache cachePolicy)
 {
-    ASSERT(m_creationThread.ptr() == &Thread::currentSingleton());
+    ASSERT(m_creationThreadID == currentThreadID());
 
     CONTAINER_RELEASE_LOG("startScriptFetchForJob: Starting script fetch for job %" PRIu64, job.identifier().toUInt64());
 
@@ -560,7 +560,7 @@ void ServiceWorkerContainer::startScriptFetchForJob(ServiceWorkerJob& job, Fetch
 
 void ServiceWorkerContainer::jobFinishedLoadingScript(ServiceWorkerJob& job, WorkerFetchResult&& fetchResult)
 {
-    ASSERT(m_creationThread.ptr() == &Thread::currentSingleton());
+    ASSERT(m_creationThreadID == currentThreadID());
 
     CONTAINER_RELEASE_LOG("jobFinishedLoadingScript: Successfuly finished fetching script for job %" PRIu64, job.identifier().toUInt64());
 
@@ -569,7 +569,7 @@ void ServiceWorkerContainer::jobFinishedLoadingScript(ServiceWorkerJob& job, Wor
 
 void ServiceWorkerContainer::jobFailedLoadingScript(ServiceWorkerJob& job, const ResourceError& error, Exception&& exception)
 {
-    ASSERT(m_creationThread.ptr() == &Thread::currentSingleton());
+    ASSERT(m_creationThreadID == currentThreadID());
 
     CONTAINER_RELEASE_LOG_ERROR("jobFinishedLoadingScript: Failed to fetch script for job %" PRIu64 ", error: %s", job.identifier().toUInt64(), error.localizedDescription().utf8().data());
 
@@ -591,7 +591,7 @@ void ServiceWorkerContainer::notifyFailedFetchingScript(ServiceWorkerJob& job, c
 
 void ServiceWorkerContainer::destroyJob(ServiceWorkerJob& job)
 {
-    ASSERT(m_creationThread.ptr() == &Thread::currentSingleton());
+    ASSERT(m_creationThreadID == currentThreadID());
     ASSERT(m_jobMap.contains(job.identifier()));
 
     bool isRegisterJob = job.data().type == ServiceWorkerJobType::Register;
@@ -620,7 +620,7 @@ SWClientConnection& ServiceWorkerContainer::ensureSWClientConnection()
 
 void ServiceWorkerContainer::addRegistration(ServiceWorkerRegistration& registration)
 {
-    ASSERT(m_creationThread.ptr() == &Thread::currentSingleton());
+    ASSERT(m_creationThreadID == currentThreadID());
 
     protect(ensureSWClientConnection())->addServiceWorkerRegistrationInServer(registration.identifier());
     m_registrations.add(registration.identifier(), registration);
@@ -628,7 +628,7 @@ void ServiceWorkerContainer::addRegistration(ServiceWorkerRegistration& registra
 
 void ServiceWorkerContainer::removeRegistration(ServiceWorkerRegistration& registration)
 {
-    ASSERT(m_creationThread.ptr() == &Thread::currentSingleton());
+    ASSERT(m_creationThreadID == currentThreadID());
 
     Ref { *m_swConnection }->removeServiceWorkerRegistrationInServer(registration.identifier());
     m_registrations.remove(registration.identifier());
@@ -703,7 +703,7 @@ void ServiceWorkerContainer::getNotifications(const URL& serviceWorkerRegistrati
 
 void ServiceWorkerContainer::queueTaskToDispatchControllerChangeEvent()
 {
-    ASSERT(m_creationThread.ptr() == &Thread::currentSingleton());
+    ASSERT(m_creationThreadID == currentThreadID());
 
     queueTaskToDispatchEvent(*this, TaskSource::DOMManipulation, Event::create(eventNames().controllerchangeEvent, Event::CanBubble::No, Event::IsCancelable::No));
 }
@@ -726,7 +726,7 @@ void ServiceWorkerContainer::stop()
 
 ServiceWorkerOrClientIdentifier ServiceWorkerContainer::contextIdentifier()
 {
-    ASSERT(m_creationThread.ptr() == &Thread::currentSingleton());
+    ASSERT(m_creationThreadID == currentThreadID());
     ASSERT(scriptExecutionContext());
     if (RefPtr serviceWorkerGlobal = dynamicDowncast<ServiceWorkerGlobalScope>(*scriptExecutionContext()))
         return serviceWorkerGlobal->thread()->identifier();

--- a/Source/WebCore/workers/service/ServiceWorkerContainer.h
+++ b/Source/WebCore/workers/service/ServiceWorkerContainer.h
@@ -40,8 +40,8 @@
 #include "ServiceWorkerRegistration.h"
 #include "ServiceWorkerRegistrationOptions.h"
 #include "WorkerType.h"
+#include <wtf/CurrentThread.h>
 #include <wtf/Forward.h>
-#include <wtf/Threading.h>
 
 namespace WebCore {
 
@@ -171,7 +171,7 @@ private:
     HashMap<ServiceWorkerRegistrationIdentifier, WeakRef<ServiceWorkerRegistration, WeakPtrImplWithEventTargetData>> m_registrations;
 
 #if ASSERT_ENABLED
-    const Ref<Thread> m_creationThread { Thread::currentSingleton() };
+    const uint32_t m_creationThreadID { currentThreadID() };
 #endif
 
     uint64_t m_lastOngoingSettledRegistrationIdentifier { 0 };

--- a/Source/WebCore/workers/service/ServiceWorkerJob.cpp
+++ b/Source/WebCore/workers/service/ServiceWorkerJob.cpp
@@ -59,7 +59,7 @@ ServiceWorkerJob::ServiceWorkerJob(ServiceWorkerJobClient& client, Ref<DeferredP
 
 ServiceWorkerJob::~ServiceWorkerJob()
 {
-    ASSERT(m_creationThread.ptr() == &Thread::currentSingleton());
+    ASSERT(m_creationThreadID == currentThreadID());
 }
 
 Ref<DeferredPromise> ServiceWorkerJob::takePromise()
@@ -69,7 +69,7 @@ Ref<DeferredPromise> ServiceWorkerJob::takePromise()
 
 void ServiceWorkerJob::failedWithException(const Exception& exception)
 {
-    ASSERT(m_creationThread.ptr() == &Thread::currentSingleton());
+    ASSERT(m_creationThreadID == currentThreadID());
     ASSERT(!m_completed);
 
     m_completed = true;
@@ -79,7 +79,7 @@ void ServiceWorkerJob::failedWithException(const Exception& exception)
 
 void ServiceWorkerJob::resolvedWithRegistration(ServiceWorkerRegistrationData&& data, ShouldNotifyWhenResolved shouldNotifyWhenResolved)
 {
-    ASSERT(m_creationThread.ptr() == &Thread::currentSingleton());
+    ASSERT(m_creationThreadID == currentThreadID());
     ASSERT(!m_completed);
 
     m_completed = true;
@@ -89,7 +89,7 @@ void ServiceWorkerJob::resolvedWithRegistration(ServiceWorkerRegistrationData&& 
 
 void ServiceWorkerJob::resolvedWithUnregistrationResult(bool unregistrationResult)
 {
-    ASSERT(m_creationThread.ptr() == &Thread::currentSingleton());
+    ASSERT(m_creationThreadID == currentThreadID());
     ASSERT(!m_completed);
 
     m_completed = true;
@@ -99,7 +99,7 @@ void ServiceWorkerJob::resolvedWithUnregistrationResult(bool unregistrationResul
 
 void ServiceWorkerJob::startScriptFetch(FetchOptions::Cache cachePolicy)
 {
-    ASSERT(m_creationThread.ptr() == &Thread::currentSingleton());
+    ASSERT(m_creationThreadID == currentThreadID());
     ASSERT(!m_completed);
 
     if (RefPtr client = m_client.get())
@@ -126,7 +126,7 @@ static FetchOptions scriptFetchOptions(FetchOptions::Cache cachePolicy, FetchOpt
 
 void ServiceWorkerJob::fetchScriptWithContext(ScriptExecutionContext& context, FetchOptions::Cache cachePolicy)
 {
-    ASSERT(m_creationThread.ptr() == &Thread::currentSingleton());
+    ASSERT(m_creationThreadID == currentThreadID());
     ASSERT(!m_completed);
 
     auto source = m_jobData.workerType == WorkerType::Module ? WorkerScriptLoader::Source::ModuleScript : WorkerScriptLoader::Source::ClassicWorkerScript;
@@ -166,7 +166,7 @@ ResourceError ServiceWorkerJob::validateServiceWorkerResponse(const ServiceWorke
 
 void ServiceWorkerJob::didReceiveResponse(ScriptExecutionContextIdentifier, std::optional<ResourceLoaderIdentifier>, const ResourceResponse& response)
 {
-    ASSERT(m_creationThread.ptr() == &Thread::currentSingleton());
+    ASSERT(m_creationThreadID == currentThreadID());
     ASSERT(!m_completed);
     ASSERT(m_scriptLoader);
 
@@ -185,7 +185,7 @@ void ServiceWorkerJob::didReceiveResponse(ScriptExecutionContextIdentifier, std:
 
 void ServiceWorkerJob::notifyFinished(std::optional<ScriptExecutionContextIdentifier>)
 {
-    ASSERT(m_creationThread.ptr() == &Thread::currentSingleton());
+    ASSERT(m_creationThreadID == currentThreadID());
     ASSERT(m_scriptLoader);
 
     auto scriptLoader = std::exchange(m_scriptLoader, { });

--- a/Source/WebCore/workers/service/ServiceWorkerJob.h
+++ b/Source/WebCore/workers/service/ServiceWorkerJob.h
@@ -34,11 +34,11 @@
 #include <WebCore/WorkerScriptLoader.h>
 #include <WebCore/WorkerScriptLoaderClient.h>
 #include <wtf/CompletionHandler.h>
+#include <wtf/CurrentThread.h>
 #include <wtf/RefPtr.h>
 #include <wtf/RunLoop.h>
 #include <wtf/TZoneMalloc.h>
 #include <wtf/ThreadSafeRefCounted.h>
-#include <wtf/Threading.h>
 
 namespace WebCore {
 
@@ -94,7 +94,7 @@ private:
     RefPtr<WorkerScriptLoader> m_scriptLoader;
 
 #if ASSERT_ENABLED
-    const Ref<Thread> m_creationThread { Thread::currentSingleton() };
+    const uint32_t m_creationThreadID { currentThreadID() };
 #endif
 };
 

--- a/Source/WebCore/workers/service/context/ServiceWorkerFetch.h
+++ b/Source/WebCore/workers/service/context/ServiceWorkerFetch.h
@@ -31,6 +31,7 @@
 #include <WebCore/ServiceWorkerTypes.h>
 #include <wtf/Ref.h>
 #include <wtf/ThreadSafeRefCounted.h>
+#include <wtf/ThreadSafeWeakPtr.h>
 
 namespace WebCore {
 class FetchEvent;

--- a/Source/WebCore/workers/service/server/SWServer.h
+++ b/Source/WebCore/workers/service/server/SWServer.h
@@ -51,7 +51,6 @@
 #include <wtf/RunLoop.h>
 #include <wtf/TZoneMalloc.h>
 #include <wtf/ThreadSafeRefCounted.h>
-#include <wtf/Threading.h>
 #include <wtf/URLHash.h>
 #include <wtf/UniqueRef.h>
 #include <wtf/WeakPtr.h>

--- a/Source/WebGPU/WebGPU/BindGroupLayout.h
+++ b/Source/WebGPU/WebGPU/BindGroupLayout.h
@@ -29,6 +29,7 @@
 #import <wtf/EnumeratedArray.h>
 #import <wtf/FastMalloc.h>
 #import <wtf/HashMap.h>
+#import <wtf/HashSet.h>
 #import <wtf/HashTraits.h>
 #import <wtf/Ref.h>
 #import <wtf/RefCountedAndCanMakeWeakPtr.h>

--- a/Source/WebGPU/WebGPU/BindableResource.h
+++ b/Source/WebGPU/WebGPU/BindableResource.h
@@ -32,6 +32,7 @@
 #import <wtf/GenericHashKey.h>
 #import <wtf/HashFunctions.h>
 #import <wtf/HashMap.h>
+#import <wtf/HashSet.h>
 #import <wtf/Hasher.h>
 #import <wtf/OptionSet.h>
 #import <wtf/RefPtr.h>

--- a/Source/WebGPU/WebGPU/CommandBuffer.h
+++ b/Source/WebGPU/WebGPU/CommandBuffer.h
@@ -31,6 +31,7 @@
 #import <wtf/RefCountedAndCanMakeWeakPtr.h>
 #import <wtf/SwiftBridging.h>
 #import <wtf/TZoneMalloc.h>
+#import <wtf/ThreadSafeWeakPtr.h>
 #import <wtf/WeakPtr.h>
 #import <wtf/threads/BinarySemaphore.h>
 

--- a/Source/WebGPU/WebGPU/Instance.h
+++ b/Source/WebGPU/WebGPU/Instance.h
@@ -30,11 +30,13 @@
 #import <wtf/CompletionHandler.h>
 #import <wtf/Deque.h>
 #import <wtf/FastMalloc.h>
+#import <wtf/HashMap.h>
 #import <wtf/Lock.h>
 #import <wtf/MachSendRight.h>
 #import <wtf/Ref.h>
 #import <wtf/TZoneMalloc.h>
 #import <wtf/ThreadSafeRefCounted.h>
+#import <wtf/ThreadSafeWeakPtr.h>
 #import <wtf/ThreadSafetyAnalysis.h>
 #import <wtf/WeakObjCPtr.h>
 #import <wtf/WeakPtr.h>

--- a/Source/WebGPU/WebGPU/Queue.h
+++ b/Source/WebGPU/WebGPU/Queue.h
@@ -34,6 +34,7 @@
 #import <wtf/SwiftBridging.h>
 #import <wtf/TZoneMalloc.h>
 #import <wtf/ThreadSafeRefCounted.h>
+#import <wtf/ThreadSafeWeakPtr.h>
 #import <wtf/Vector.h>
 #import <wtf/WeakPtr.h>
 

--- a/Source/WebGPU/WebGPU/RenderBundle.h
+++ b/Source/WebGPU/WebGPU/RenderBundle.h
@@ -27,6 +27,7 @@
 
 #import "BindableResource.h"
 #import <wtf/FastMalloc.h>
+#import <wtf/HashSet.h>
 #import <wtf/Ref.h>
 #import <wtf/RefCounted.h>
 #import <wtf/TZoneMalloc.h>

--- a/Source/WebGPU/WebGPU/RenderBundleEncoder.h
+++ b/Source/WebGPU/WebGPU/RenderBundleEncoder.h
@@ -30,6 +30,7 @@
 #import <wtf/FastMalloc.h>
 #import <wtf/Function.h>
 #import <wtf/HashMap.h>
+#import <wtf/HashSet.h>
 #import <wtf/Ref.h>
 #import <wtf/RefCounted.h>
 #import <wtf/TZoneMallocInlines.h>

--- a/Source/WebGPU/WebGPU/XRSubImage.h
+++ b/Source/WebGPU/WebGPU/XRSubImage.h
@@ -28,7 +28,9 @@
 #import <utility>
 #import <wtf/CompletionHandler.h>
 #import <wtf/FastMalloc.h>
+#import <wtf/HashMap.h>
 #import <wtf/Ref.h>
+#import <wtf/ThreadSafeWeakPtr.h>
 #import <wtf/WeakPtr.h>
 #include <wtf/RefCountedAndCanMakeWeakPtr.h>
 

--- a/Source/WebKit/NetworkProcess/cache/NetworkCacheIOChannelGLib.cpp
+++ b/Source/WebKit/NetworkProcess/cache/NetworkCacheIOChannelGLib.cpp
@@ -29,6 +29,7 @@
 #include "NetworkCacheFileSystem.h"
 #include <wtf/MainThread.h>
 #include <wtf/RunLoop.h>
+#include <wtf/Threading.h>
 #include <wtf/glib/GUniquePtr.h>
 #include <wtf/glib/RunLoopSourcePriority.h>
 

--- a/Source/WebKit/Platform/IPC/Connection.cpp
+++ b/Source/WebKit/Platform/IPC/Connection.cpp
@@ -45,6 +45,7 @@
 #include <wtf/RuntimeApplicationChecks.h>
 #include <wtf/Scope.h>
 #include <wtf/SystemTracing.h>
+#include <wtf/Threading.h>
 #include <wtf/WTFProcess.h>
 #include <wtf/text/WTFString.h>
 #include <wtf/threads/BinarySemaphore.h>

--- a/Source/WebKit/Platform/IPC/Connection.h
+++ b/Source/WebKit/Platform/IPC/Connection.h
@@ -65,7 +65,7 @@
 #include <wtf/ThreadAssertions.h>
 #include <wtf/ThreadSafeWeakPtr.h>
 #include <wtf/ThreadSafetyAnalysis.h>
-#include <wtf/Threading.h>
+#include <wtf/ThreadingEnums.h>
 #include <wtf/UniqueRef.h>
 #include <wtf/WorkQueue.h>
 #include <wtf/text/ASCIILiteral.h>
@@ -96,6 +96,10 @@
 #if ENABLE(IPC_TESTING_API)
 #include "MessageObserver.h"
 #endif
+
+namespace WTF {
+class Thread;
+}
 
 namespace IPC {
 
@@ -349,7 +353,7 @@ public:
     static pid_t remoteProcessID(GSocket*);
 #endif
 
-    static Ref<Connection> createServerConnection(Identifier&&, Thread::QOS = Thread::QOS::Default);
+    static Ref<Connection> createServerConnection(Identifier&&, ThreadQOS = ThreadQOS::Default);
     static Ref<Connection> createClientConnection(Identifier&&);
 
     struct ConnectionIdentifierPair {
@@ -436,8 +440,8 @@ public:
     template<typename T, typename C> std::optional<AsyncReplyID> sendWithAsyncReply(T&& message, C&& completionHandler, uint64_t destinationID = 0, OptionSet<SendOption> = { }); // Thread-safe, but the reply will be called on the Connection's dispatcher
     template<typename PC = NoOpPromiseConverter, typename T, typename Promise = typename ConvertedPromise<PC, typename T::Promise>::Type> Ref<Promise> sendWithPromisedReply(T&& message, uint64_t destinationID = 0, OptionSet<SendOption> = { }); // Thread-safe.
     template<typename T, typename C> std::optional<AsyncReplyID> sendWithAsyncReplyOnDispatcher(T&& message, GuaranteedSerialFunctionDispatcher&, C&& completionHandler, uint64_t destinationID = 0, OptionSet<SendOption> = { }); // Thread-safe.
-    template<typename T> Error send(T&& message, uint64_t destinationID, OptionSet<SendOption> sendOptions = { }, std::optional<Thread::QOS> qos = std::nullopt); // Thread-safe.
-    template<typename T> static Error send(UniqueID, T&& message, uint64_t destinationID, OptionSet<SendOption> sendOptions = { }, std::optional<Thread::QOS> qos = std::nullopt); // Thread-safe.
+    template<typename T> Error send(T&& message, uint64_t destinationID, OptionSet<SendOption> sendOptions = { }, std::optional<ThreadQOS> qos = std::nullopt); // Thread-safe.
+    template<typename T> static Error send(UniqueID, T&& message, uint64_t destinationID, OptionSet<SendOption> sendOptions = { }, std::optional<ThreadQOS> qos = std::nullopt); // Thread-safe.
 
     // Sync senders should check the SendSyncResult for true/false in case they need to know if the result was really received.
     // Sync senders should hold on to the SendSyncResult in case they reference the contents of the reply via DataRefererence / ArrayReference.
@@ -464,7 +468,7 @@ public:
 
     // Thread-safe.
     template<typename T, typename RawValue>
-    Error send(T&& message, const ObjectIdentifierGenericBase<RawValue>& destinationID, OptionSet<SendOption> sendOptions = { }, std::optional<Thread::QOS> qos = std::nullopt)
+    Error send(T&& message, const ObjectIdentifierGenericBase<RawValue>& destinationID, OptionSet<SendOption> sendOptions = { }, std::optional<ThreadQOS> qos = std::nullopt)
     {
         return send<T>(std::forward<T>(message), destinationID.toUInt64(), sendOptions, qos);
     }
@@ -483,10 +487,10 @@ public:
         return waitForAndDispatchImmediately<T>(destinationID.toUInt64(), timeout, waitForOptions);
     }
 
-    Error sendMessage(UniqueRef<Encoder>&&, OptionSet<SendOption> sendOptions, std::optional<Thread::QOS> = std::nullopt);
+    Error sendMessage(UniqueRef<Encoder>&&, OptionSet<SendOption> sendOptions, std::optional<ThreadQOS> = std::nullopt);
 
     using AsyncReplyHandler = ConnectionAsyncReplyHandler;
-    Error sendMessageWithAsyncReply(UniqueRef<Encoder>&&, AsyncReplyHandler, OptionSet<SendOption> sendOptions, std::optional<Thread::QOS> = std::nullopt);
+    Error sendMessageWithAsyncReply(UniqueRef<Encoder>&&, AsyncReplyHandler, OptionSet<SendOption> sendOptions, std::optional<ThreadQOS> = std::nullopt);
     std::pair<UniqueRef<Encoder>, SyncRequestID> createSyncMessageEncoder(MessageName, uint64_t destinationID);
     DecoderOrError sendSyncMessage(SyncRequestID, UniqueRef<Encoder>&&, Timeout, OptionSet<SendSyncOption> sendSyncOptions);
     Error sendSyncReply(UniqueRef<Encoder>&&);
@@ -567,7 +571,7 @@ public:
 #endif
 
 private:
-    Connection(Identifier&&, bool isServer, Thread::QOS = Thread::QOS::Default);
+    Connection(Identifier&&, bool isServer, ThreadQOS = ThreadQOS::Default);
     Connection();
     void platformInitialize(Identifier&&);
     bool NODELETE platformPrepareForOpen();
@@ -584,7 +588,7 @@ private:
     template<typename T, typename C> static AsyncReplyHandlerWithDispatcher makeAsyncReplyHandlerWithDispatcher(C&& completionHandler, GuaranteedSerialFunctionDispatcher&);
     template<typename T, typename PC, typename Promise> static AsyncReplyHandlerWithDispatcher makeAsyncReplyHandlerWithDispatcher(typename Promise::Producer&&);
 
-    Error sendMessageWithAsyncReplyWithDispatcher(UniqueRef<Encoder>&&, AsyncReplyHandlerWithDispatcher&&, OptionSet<SendOption> sendOptions, std::optional<Thread::QOS> = std::nullopt);
+    Error sendMessageWithAsyncReplyWithDispatcher(UniqueRef<Encoder>&&, AsyncReplyHandlerWithDispatcher&&, OptionSet<SendOption> sendOptions, std::optional<ThreadQOS> = std::nullopt);
     // Utility methods to avoid code duplication.
     template<typename T, typename C> static CompletionHandler<void(Connection*, Decoder*)> makeAsyncReplyCompletionHandler(C&& completionHandler, ThreadLikeAssertion);
     template<typename T> static CompletionHandler<void(Decoder*)> makeAsyncReplyCompletionHandler(typename T::Promise::Producer&&, ThreadLikeAssertion);
@@ -626,7 +630,7 @@ private:
 
     Timeout NODELETE timeoutRespectingIgnoreTimeoutsForTesting(Timeout) const;
 
-    Error sendMessageImpl(UniqueRef<Encoder>&&, OptionSet<SendOption> sendOptions, std::optional<Thread::QOS> = std::nullopt);
+    Error sendMessageImpl(UniqueRef<Encoder>&&, OptionSet<SendOption> sendOptions, std::optional<ThreadQOS> = std::nullopt);
 
 #if PLATFORM(COCOA)
     enum class SendMessageResult : uint8_t { Success, Failure, MessageTooLarge };
@@ -847,7 +851,7 @@ private:
 } SWIFT_SHARED_REFERENCE(refConnection, derefConnection);
 
 template<typename T>
-Error Connection::send(T&& message, uint64_t destinationID, OptionSet<SendOption> sendOptions, std::optional<Thread::QOS> qos)
+Error Connection::send(T&& message, uint64_t destinationID, OptionSet<SendOption> sendOptions, std::optional<ThreadQOS> qos)
 {
     static_assert(!T::isSync, "Async message expected");
 
@@ -858,7 +862,7 @@ Error Connection::send(T&& message, uint64_t destinationID, OptionSet<SendOption
 }
 
 template<typename T>
-Error Connection::send(UniqueID connectionID, T&& message, uint64_t destinationID, OptionSet<SendOption> sendOptions, std::optional<Thread::QOS> qos)
+Error Connection::send(UniqueID connectionID, T&& message, uint64_t destinationID, OptionSet<SendOption> sendOptions, std::optional<ThreadQOS> qos)
 {
     RefPtr connection = Connection::connection(connectionID);
     if (!connection)

--- a/Source/WebKit/Platform/IPC/StreamClientConnection.h
+++ b/Source/WebKit/Platform/IPC/StreamClientConnection.h
@@ -37,7 +37,6 @@
 #include <wtf/Scope.h>
 #include <wtf/SystemTracing.h>
 #include <wtf/TZoneMalloc.h>
-#include <wtf/Threading.h>
 
 namespace WebKit {
 namespace IPCTestingAPI {

--- a/Source/WebKit/Platform/IPC/StreamServerConnection.h
+++ b/Source/WebKit/Platform/IPC/StreamServerConnection.h
@@ -33,7 +33,6 @@
 #include "StreamServerConnectionBuffer.h"
 #include <wtf/Deque.h>
 #include <wtf/Lock.h>
-#include <wtf/Threading.h>
 
 namespace IPC {
 

--- a/Source/WebKit/Platform/IPC/unix/ConnectionUnix.cpp
+++ b/Source/WebKit/Platform/IPC/unix/ConnectionUnix.cpp
@@ -43,6 +43,7 @@
 #include <wtf/SafeStrerror.h>
 #include <wtf/StdLibExtras.h>
 #include <wtf/TZoneMallocInlines.h>
+#include <wtf/Threading.h>
 #include <wtf/UniStdExtras.h>
 
 #if OS(DARWIN)

--- a/Source/WebKit/Shared/EntryPointUtilities/Cocoa/XPCService/XPCServiceEntryPoint.h
+++ b/Source/WebKit/Shared/EntryPointUtilities/Cocoa/XPCService/XPCServiceEntryPoint.h
@@ -32,6 +32,7 @@
 #import <JavaScriptCore/ExecutableAllocator.h>
 #import <wtf/CompletionHandler.h>
 #import <wtf/OSObjectPtr.h>
+#import <wtf/Threading.h>
 #import <wtf/WTFProcess.h>
 #import <wtf/cocoa/RuntimeApplicationChecksCocoa.h>
 

--- a/Source/WebKit/Shared/WebGPU/WebGPUConvertFromBackingContext.h
+++ b/Source/WebKit/Shared/WebGPU/WebGPUConvertFromBackingContext.h
@@ -44,6 +44,7 @@
 #include <WebCore/WebGPURenderPassTimestampWrites.h>
 #include <optional>
 #include <wtf/RefCounted.h>
+#include <wtf/ThreadSafeWeakPtr.h>
 
 #if ENABLE(VIDEO) && PLATFORM(COCOA)
 typedef struct CF_BRIDGED_TYPE(id) __CVBuffer* CVPixelBufferRef;

--- a/Source/WebKit/UIProcess/Automation/BidiSessionAgent.h
+++ b/Source/WebKit/UIProcess/Automation/BidiSessionAgent.h
@@ -31,6 +31,8 @@
 #include "WebDriverBidiBackendDispatchers.h"
 #include <JavaScriptCore/InspectorBackendDispatcher.h>
 #include <wtf/Forward.h>
+#include <wtf/HashMap.h>
+#include <wtf/HashSet.h>
 #include <wtf/TZoneMalloc.h>
 #include <wtf/WeakPtr.h>
 #include <wtf/text/AtomString.h>

--- a/Source/WebKit/UIProcess/SpeechRecognitionRemoteRealtimeMediaSourceManager.h
+++ b/Source/WebKit/UIProcess/SpeechRecognitionRemoteRealtimeMediaSourceManager.h
@@ -31,6 +31,7 @@
 #include "MessageSender.h"
 #include <WebCore/RealtimeMediaSourceIdentifier.h>
 #include <wtf/TZoneMalloc.h>
+#include <wtf/ThreadSafeWeakPtr.h>
 #include <wtf/WeakRef.h>
 
 #if PLATFORM(COCOA)

--- a/Source/WebKit/UIProcess/WebAuthentication/fido/FidoService.h
+++ b/Source/WebKit/UIProcess/WebAuthentication/fido/FidoService.h
@@ -29,6 +29,7 @@
 
 #include "AuthenticatorTransportService.h"
 #include "CtapDriver.h"
+#include <wtf/HashSet.h>
 #include <wtf/RetainPtr.h>
 #include <wtf/UniqueRef.h>
 

--- a/Source/WebKit/UIProcess/glib/DisplayVBlankMonitorThreaded.h
+++ b/Source/WebKit/UIProcess/glib/DisplayVBlankMonitorThreaded.h
@@ -29,7 +29,12 @@
 #include <wtf/Condition.h>
 #include <wtf/Function.h>
 #include <wtf/Lock.h>
+#include <wtf/RefPtr.h>
 #include <wtf/RunLoop.h>
+
+namespace WTF {
+class Thread;
+}
 
 namespace WebKit {
 class DisplayVBlankMonitorThreaded;
@@ -64,7 +69,7 @@ private:
     bool startThreadIfNeeded();
     void destroyThreadTimerFired();
 
-    RefPtr<Thread> m_thread;
+    RefPtr<WTF::Thread> m_thread;
     Lock m_lock;
     Condition m_condition;
     State m_state WTF_GUARDED_BY_LOCK(m_lock) { State::Stop };

--- a/Source/WebKit/WebProcess/GPU/media/RemoteMediaPlayerMIMETypeCache.h
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteMediaPlayerMIMETypeCache.h
@@ -33,6 +33,7 @@
 #include <wtf/HashMap.h>
 #include <wtf/HashSet.h>
 #include <wtf/TZoneMalloc.h>
+#include <wtf/ThreadSafeWeakPtr.h>
 #include <wtf/WeakPtr.h>
 #include <wtf/text/StringHash.h>
 

--- a/Source/WebKit/WebProcess/GPU/webrtc/AudioMediaStreamTrackRendererInternalUnitManager.cpp
+++ b/Source/WebKit/WebProcess/GPU/webrtc/AudioMediaStreamTrackRendererInternalUnitManager.cpp
@@ -46,6 +46,7 @@
 #include <wtf/Identified.h>
 #include <wtf/RefCountedAndCanMakeWeakPtr.h>
 #include <wtf/TZoneMallocInlines.h>
+#include <wtf/Threading.h>
 
 namespace WebKit {
 

--- a/Source/WebKit/WebProcess/Network/WebSocketChannel.h
+++ b/Source/WebKit/WebProcess/Network/WebSocketChannel.h
@@ -34,6 +34,7 @@
 #include <WebCore/ThreadableWebSocketChannel.h>
 #include <WebCore/WebSocketChannelInspector.h>
 #include <WebCore/WebSocketFrame.h>
+#include <wtf/ThreadSafeWeakPtr.h>
 #include <wtf/WeakPtr.h>
 
 namespace IPC {

--- a/Source/WebKitLegacy/mac/WebCoreSupport/WebNotificationClient.h
+++ b/Source/WebKitLegacy/mac/WebCoreSupport/WebNotificationClient.h
@@ -29,6 +29,7 @@
 #import <WebCore/NotificationData.h>
 #import <WebCore/SecurityOriginData.h>
 #import <wtf/HashMap.h>
+#import <wtf/HashSet.h>
 #import <wtf/RefPtr.h>
 #import <wtf/RetainPtr.h>
 #import <wtf/TZoneMalloc.h>

--- a/Tools/TestWebKitAPI/Tests/IPC/ConnectionTests.cpp
+++ b/Tools/TestWebKitAPI/Tests/IPC/ConnectionTests.cpp
@@ -27,6 +27,7 @@
 
 #include "IPCTestUtilities.h"
 #include "Helpers/Test.h"
+#include <wtf/Threading.h>
 #include <wtf/threads/BinarySemaphore.h>
 
 

--- a/Tools/TestWebKitAPI/Tests/WTF/WorkQueue.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/WorkQueue.cpp
@@ -26,15 +26,16 @@
 #include "config.h"
 
 #include "Helpers/Test.h"
-#include <wtf/Condition.h>
-#include <wtf/Lock.h>
-#include <wtf/RunLoop.h>
-#include <wtf/Vector.h>
-#include <wtf/WorkQueue.h>
 #include <chrono>
 #include <memory>
 #include <string>
 #include <thread>
+#include <wtf/Condition.h>
+#include <wtf/Lock.h>
+#include <wtf/RunLoop.h>
+#include <wtf/Threading.h>
+#include <wtf/Vector.h>
+#include <wtf/WorkQueue.h>
 
 namespace TestWebKitAPI {
 

--- a/Tools/TestWebKitAPI/Tests/WebCore/CARingBufferTest.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/CARingBufferTest.cpp
@@ -33,6 +33,7 @@
 #include <atomic>
 #include <wtf/MainThread.h>
 #include <wtf/Scope.h>
+#include <wtf/Threading.h>
 
 using namespace WebCore;
 

--- a/Tools/TestWebKitAPI/Tests/WebCore/IntPointTests.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/IntPointTests.cpp
@@ -33,6 +33,10 @@
 #include <CoreGraphics/CoreGraphics.h>
 #endif
 
+#if PLATFORM(WIN)
+#include <windows.h>
+#endif
+
 namespace TestWebKitAPI {
 
 static void testGetAndSet(WebCore::IntPoint point)

--- a/Tools/TestWebKitAPI/Tests/WebCore/SerializedScriptValue.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/SerializedScriptValue.cpp
@@ -32,6 +32,7 @@
 #include <WebCore/ParsedContentRange.h>
 #include <WebCore/ProcessIdentifier.h>
 #include <WebCore/ThreadSafeDataBuffer.h>
+#include <wtf/Threading.h>
 #include <wtf/text/WTFString.h>
 
 using namespace WebCore;

--- a/Tools/TestWebKitAPI/Tests/WebCore/cocoa/TestGraphicsContextGLCocoa.mm
+++ b/Tools/TestWebKitAPI/Tests/WebCore/cocoa/TestGraphicsContextGLCocoa.mm
@@ -40,6 +40,7 @@
 #import <wtf/MemoryFootprint.h>
 #import <wtf/StdLibExtras.h>
 #import <wtf/TZoneMallocInlines.h>
+#import <wtf/Threading.h>
 
 namespace TestWebKitAPI {
 

--- a/Tools/TestWebKitAPI/Tests/WebCore/cocoa/WebCoreDecompressionSessionTests.mm
+++ b/Tools/TestWebKitAPI/Tests/WebCore/cocoa/WebCoreDecompressionSessionTests.mm
@@ -31,6 +31,7 @@
 #include <WebCore/CMUtilities.h>
 #include <WebCore/WebCoreDecompressionSession.h>
 #include <wtf/NativePromise.h>
+#include <wtf/RunLoop.h>
 
 #include <pal/cf/CoreMediaSoftLink.h>
 

--- a/Tools/TestWebKitAPI/Tests/WebCore/cocoa/XMLParsing.mm
+++ b/Tools/TestWebKitAPI/Tests/WebCore/cocoa/XMLParsing.mm
@@ -31,6 +31,7 @@
 #include <WebCore/ProcessIdentifier.h>
 #include <WebCoreTestSupport/WebCoreTestSupport.h>
 #include <libxml/parser.h>
+#include <wtf/Threading.h>
 
 namespace TestWebKitAPI {
 


### PR DESCRIPTION
#### f5e0197a95fb6c966535fd1fa9d8db6ffc1964e2
<pre>
[Build Speed] Reduce the cost of Threading.h
<a href="https://rdar.apple.com/176072258">rdar://176072258</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=313876">https://bugs.webkit.org/show_bug.cgi?id=313876</a>

Reviewed by Mike Wyrzykowski.

Threading.h pulls in ~252K lines transitively and was included by 1821
translation units. Many of those includes existed solely for thread
identity assertions — headers storing a Ref member just to
compare against Thread::currentSingleton() in debug builds.

Introduce two lightweight headers to break these dependencies:

- CurrentThread.h (~30 lines): provides currentThreadID() returning a
uint32_t (backed by Thread::uid()), and currentThreadMayBeGCThread().
Headers that only need thread identity checks can include this instead
of Threading.h.
- ThreadingEnums.h: provides GCThreadType, ThreadType, ThreadQOS,
ThreadSchedulingPolicy, and CanBeGCThread enums that were previously
defined inside Threading.h and Thread. Threading.h now includes
ThreadingEnums.h and uses &apos;using&apos; aliases for backward compatibility.

Convert headers throughout WTF, WebCore, and WebKit from storing
Ref/RefPtr for identity assertions to storing a uint32_t
thread ID initialized via currentThreadID(). This eliminates the
Threading.h dependency from high-traffic headers including:

- SingleThreadIntegralWrapper.h, WeakPtrImpl.h (affects every TU)
- Timer.h, Supplementable.h (affects most WebCore TUs via Document.h)
- RunLoop.h, WorkQueue.h, NativePromise.h, Connection.h (IPC/event loop)
- ActiveDOMObject.h, EventListenerMap.h (DOM infrastructure)
- DataMutex.h, RecursiveLockAdapter.h, AutomaticThread.h (WTF utilities)

Also forward-declare JSC::Debugger in Page.h (was including Debugger.h
which pulled in the full JSC VM.h → Threading.h chain), and forward-
declare WTF::Thread in headers that store RefPtr without
dereferencing it.

ClangBuildAnalyzer results:
- Threading.h: 231s / 1821 includes → 36s / 1123 includes

Canonical link: <a href="https://commits.webkit.org/312759@main">https://commits.webkit.org/312759@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3b036b2d71830a563d9568682ed32a2809616331

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/160966 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/34439 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/27540 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/169869 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/117226 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/162835 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/34540 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/34439 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/124861 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/117226 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/163925 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/27125 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/144596 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/105458 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/26176 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/24677 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/17589 "Built successfully") | | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/20/builds/153022 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/135870 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/22358 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/172352 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/21804 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/19373 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/23999 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/133142 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/34113 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/28770 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/133152 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35959 "Built successfully and passed tests") | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/34097 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/144153 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/95936 "Built successfully") | | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/160/builds/34097 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/20971 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/193365 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/33608 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/101033 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/49791 "Passed tests") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/33107 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/33351 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/33256 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->