### PR TITLE
REGRESSION(312316@main): [macOS Debug] ASSERTION FAILED: m_customLocalStoragePath.isEmpty() == m_rootPath.isEmpty()

### DIFF
--- a/Source/WebKit/NetworkProcess/storage/OriginStorageManager.cpp
+++ b/Source/WebKit/NetworkProcess/storage/OriginStorageManager.cpp
@@ -518,7 +518,6 @@ String OriginStorageManager::StorageBucket::resolvedLocalStoragePath()
         return m_resolvedLocalStoragePath;
 
     if (m_level == UnifiedOriginStorageLevel::None) {
-        ASSERT(m_customLocalStoragePath.isEmpty() == m_rootPath.isEmpty());
         m_resolvedLocalStoragePath = m_customLocalStoragePath;
     } else if (!m_rootPath.isEmpty()) {
         auto localStorageDirectory = typeStoragePath(StorageType::LocalStorage);
@@ -546,7 +545,6 @@ String OriginStorageManager::StorageBucket::resolvedIDBStoragePath()
         return m_resolvedIDBStoragePath;
 
     if (m_level == UnifiedOriginStorageLevel::None) {
-        ASSERT(m_customIDBStoragePath.isEmpty() == m_rootPath.isEmpty());
         m_resolvedIDBStoragePath = m_customIDBStoragePath;
     } else {
         auto idbStoragePath = typeStoragePath(StorageType::IndexedDB);
@@ -570,7 +568,6 @@ String OriginStorageManager::StorageBucket::resolvedCacheStoragePath()
     switch (m_level) {
     case UnifiedOriginStorageLevel::None:
     case UnifiedOriginStorageLevel::Basic:
-        ASSERT(m_customCacheStoragePath.isEmpty() == m_rootPath.isEmpty());
         m_resolvedCacheStoragePath = m_customCacheStoragePath;
         break;
     case UnifiedOriginStorageLevel::Standard:

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WebsiteDataStoreCustomPaths.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WebsiteDataStoreCustomPaths.mm
@@ -270,22 +270,12 @@ static void runWebsiteDataStoreCustomPaths(ShouldEnableProcessPrewarming shouldE
     EXPECT_FALSE([WKWebsiteDataStore _defaultDataStoreExists]);
 }
 
-// FIXME when webkit.org/b/313786 is resolved.
-#if PLATFORM(MAC) && !defined(NDEBUG)
-TEST(WebKit, DISABLED_WebsiteDataStoreCustomPathsWithoutPrewarming)
-#else
 TEST(WebKit, WebsiteDataStoreCustomPathsWithoutPrewarming)
-#endif
 {
     runWebsiteDataStoreCustomPaths(ShouldEnableProcessPrewarming::No);
 }
 
-// FIXME when webkit.org/b/313786 is resolved.
-#if PLATFORM(MAC) && !defined(NDEBUG)
-TEST(WebKit, DISABLED_WebsiteDataStoreCustomPathsWithPrewarming)
-#else
 TEST(WebKit, WebsiteDataStoreCustomPathsWithPrewarming)
-#endif
 {
     runWebsiteDataStoreCustomPaths(ShouldEnableProcessPrewarming::Yes);
 }


### PR DESCRIPTION
#### d30f4a7b6c1b967a4340e7c63a7b9e628da694cf
<pre>
REGRESSION(<a href="https://commits.webkit.org/312316@main">312316@main</a>): [macOS Debug] ASSERTION FAILED: m_customLocalStoragePath.isEmpty() == m_rootPath.isEmpty()
<a href="https://bugs.webkit.org/show_bug.cgi?id=313786">https://bugs.webkit.org/show_bug.cgi?id=313786</a>
<a href="https://rdar.apple.com/175981209">rdar://175981209</a>

Reviewed by NOBODY (OOPS!).

The assertions in resolvedLocalStoragePath(), resolvedIDBStoragePath(), and
resolvedCacheStoragePath() check that `m_customStoragePath.isEmpty() == m_rootPath.isEmpty()`.

This is wrong when unifiedOriginStorageLevel is None: it is valid to have custom per-type
storage paths without a unified root directory, which is the entire point of
UnifiedOriginStorageLevelNone with individually configured storage paths.

It is unclear why these tests started failing recently and only on EWS bots (not
reproducible locally or on post-commit bots) but I doubt this is caused by <a href="https://commits.webkit.org/312316@main">312316@main</a>
since those tests do not involve extensions.

Test: Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WebsiteDataStoreCustomPaths.mm

* Source/WebKit/NetworkProcess/storage/OriginStorageManager.cpp:
(WebKit::OriginStorageManager::StorageBucket::resolvedLocalStoragePath):
(WebKit::OriginStorageManager::StorageBucket::resolvedIDBStoragePath):
(WebKit::OriginStorageManager::StorageBucket::resolvedCacheStoragePath):
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WebsiteDataStoreCustomPaths.mm:
(TEST(WebKit, WebsiteDataStoreCustomPathsWithoutPrewarming)):
(TEST(WebKit, WebsiteDataStoreCustomPathsWithPrewarming)):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d30f4a7b6c1b967a4340e7c63a7b9e628da694cf

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/160139 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/33609 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/26713 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/169035 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/114520 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/8a90b272-e25e-40cc-b96e-ab4a0abb3cff) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/162008 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/33712 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/33611 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/124133 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/87063 "2 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/66851173-7687-4dbf-a45f-a0d55a69fb9d) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/163097 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/26379 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/143839 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/104738 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/3b5945dd-59a9-4d13-bd18-0f1e1f56e8cc) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/25432 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/23926 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/16760 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/135124 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/21602 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/171511 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/17507 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/23242 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/132390 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/33285 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/28013 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/132416 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/33270 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/143397 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/91497 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/27028 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/20211 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/32779 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/99176 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/32277 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/32523 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/32427 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->