### PR TITLE
[AppKit Gestures] Fix some correctness issues in a few AppKitGesturesTests tests

### DIFF
--- a/Tools/TestWebKitAPI/Tests/WebKit/WebPage/AppKitGesturesTests.swift
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WebPage/AppKitGesturesTests.swift
@@ -92,7 +92,7 @@ struct AppKitGesturesTests {
         }
 
         await recap.play { composer in
-            composer._wk_click(toBounds.center)
+            composer._wk_click(at: toBounds.center, for: .seconds(0.1))
 
             composer.advanceTime(0.1)
 
@@ -112,7 +112,11 @@ struct AppKitGesturesTests {
         #expect(firstRangeEditorState.postLayoutData != nil)
     }
 
-    @Test(arguments: [true, false])
+    @Test(
+        .disabled("This test is now correct, but it reveals a real issue causing it to now fail."),
+        .bug("rdar://176117750"),
+        arguments: [true, false]
+    )
     func clickingOnSelectedWordOpensContextMenu(contentEditable: Bool) async throws {
         try await loadHTML(contentEditable: contentEditable)
 
@@ -149,7 +153,7 @@ struct AppKitGesturesTests {
             with: implementation
         ) {
             await recap.play { composer in
-                composer._wk_click(crazyBoundsInScreenCoordinates.center)
+                composer._wk_click(at: crazyBoundsInScreenCoordinates.center, for: .seconds(0.1))
             }
 
             await future.wait()
@@ -184,9 +188,9 @@ struct AppKitGesturesTests {
         }
 
         await recap.play { composer in
-            composer._wk_click(crazyBoundsInScreenCoordinates.center)
+            composer._wk_click(at: crazyBoundsInScreenCoordinates.center, for: .seconds(0.1))
             composer.advanceTime(0.1)
-            composer._wk_click(crazyBoundsInScreenCoordinates.center)
+            composer._wk_click(at: crazyBoundsInScreenCoordinates.center, for: .seconds(0.1))
         }
 
         await page.waitForNextPresentationUpdate()
@@ -219,7 +223,7 @@ struct AppKitGesturesTests {
         }
 
         await recap.play { composer in
-            composer._wk_click(point)
+            composer._wk_click(at: point, for: .seconds(0.1))
         }
 
         await page.waitForNextPresentationUpdate()


### PR DESCRIPTION
#### 360f5c4d28b0f36af9d2487cd56c7fb1dceb1b6d
<pre>
[AppKit Gestures] Fix some correctness issues in a few AppKitGesturesTests tests
<a href="https://bugs.webkit.org/show_bug.cgi?id=313924">https://bugs.webkit.org/show_bug.cgi?id=313924</a>
<a href="https://rdar.apple.com/176119725">rdar://176119725</a>

Reviewed by Abrar Rahman Protyasha.

* Tools/TestWebKitAPI/Tests/WebKit/WebPage/AppKitGesturesTests.swift:
(AppKitGesturesTests.updatingTextRangeSelectionByUserInteractionUpdatesEditorState(_:)):
(AppKitGesturesTests.clickingOnSelectedWordOpensContextMenu(_:)):
(AppKitGesturesTests.doubleClickingInWordSelectsWord(_:)):
(AppKitGesturesTests.clickingInWordChangesSelection(_:)):

Canonical link: <a href="https://commits.webkit.org/312493@main">https://commits.webkit.org/312493@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5cbb43e1776cdadbb20a834743e3d5a8115b23e0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/160153 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/33623 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/26727 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/169053 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/114534 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/d6cb6acd-ee1f-4f13-8cbc-1952defde4de) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/162022 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/33726 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/33625 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/124150 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/87076 "1 flakes 2 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/82da3c9f-200e-4ec7-9467-e15d4cdf7a1f) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/163111 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/26393 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/143853 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/104751 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/fbb8d6b2-726a-4abc-b07b-ebc0a89b7503) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/25446 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/23939 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/16774 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/135138 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/21616 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/171529 "Built successfully") | | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/23256 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/132404 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/33299 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/28028 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/132430 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/33284 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/143411 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/91522 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/24371 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/27043 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/20225 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/32793 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/32291 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/32537 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/32441 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->