### PR TITLE
[JSC] Add Array#concat DFG nodes

### DIFF
--- a/JSTests/stress/array-concat-intrinsic-cow-result.js
+++ b/JSTests/stress/array-concat-intrinsic-cow-result.js
@@ -1,0 +1,85 @@
+// Tests that Array.prototype.concat's COW (copy-on-write) result path is correctly modeled
+// in the DFG abstract interpreter. When one operand is empty and the other is a
+// CopyOnWrite-butterflied array, concatAppendArray takes a fast path that reuses the source
+// butterfly and returns a CopyOnWrite-indexed result. If the DFG's abstract result structure
+// set omits CopyOnWrite variants, downstream speculation on the result can OSR-exit
+// spuriously.
+
+function assert(cond, msg) {
+    if (!cond)
+        throw new Error("Bad: " + (msg || ""));
+}
+noInline(assert);
+
+function shallowEq(a, b) {
+    assert(a.length === b.length, "length " + a.length + " vs " + b.length);
+    for (let i = 0; i < a.length; i++)
+        assert(a[i] === b[i], "index " + i);
+}
+noInline(shallowEq);
+
+// Array literals like `[1, 2, 3]` produce CopyOnWriteArrayWithInt32 until written to. Keeping
+// them unmodified throughout the test preserves the COW state and exercises the COW
+// fast-path in concatAppendArray.
+function firstEmpty() {
+    return [].concat([1, 2, 3]);
+}
+noInline(firstEmpty);
+
+function secondEmpty() {
+    return [1, 2, 3].concat([]);
+}
+noInline(secondEmpty);
+
+function firstEmptyDouble() {
+    return [].concat([1.5, 2.5, 3.5]);
+}
+noInline(firstEmptyDouble);
+
+function secondEmptyDouble() {
+    return [1.5, 2.5, 3.5].concat([]);
+}
+noInline(secondEmptyDouble);
+
+function firstEmptyContiguous() {
+    return [].concat(["a", "b", "c"]);
+}
+noInline(firstEmptyContiguous);
+
+function secondEmptyContiguous() {
+    return ["a", "b", "c"].concat([]);
+}
+noInline(secondEmptyContiguous);
+
+// Also exercise a downstream use of the result — iterating and summing — so that any
+// speculation on the result's structure actually needs to be sound.
+function sumAfterConcat(producer) {
+    const arr = producer();
+    let out = 0;
+    for (let i = 0; i < arr.length; i++)
+        out = out + arr[i];
+    return out;
+}
+noInline(sumAfterConcat);
+
+for (let i = 0; i < testLoopCount; i++) {
+    shallowEq(firstEmpty(), [1, 2, 3]);
+    shallowEq(secondEmpty(), [1, 2, 3]);
+    shallowEq(firstEmptyDouble(), [1.5, 2.5, 3.5]);
+    shallowEq(secondEmptyDouble(), [1.5, 2.5, 3.5]);
+    shallowEq(firstEmptyContiguous(), ["a", "b", "c"]);
+    shallowEq(secondEmptyContiguous(), ["a", "b", "c"]);
+
+    assert(sumAfterConcat(firstEmpty) === 6, "sum firstEmpty");
+    assert(sumAfterConcat(secondEmpty) === 6, "sum secondEmpty");
+    assert(sumAfterConcat(firstEmptyDouble) === 7.5, "sum firstEmptyDouble");
+    assert(sumAfterConcat(secondEmptyDouble) === 7.5, "sum secondEmptyDouble");
+}
+
+// Mutate the result to confirm it is a distinct-enough array (COW or not, the observable
+// semantic is that writing to the result does not affect the source).
+const source = [10, 20, 30];
+const result = source.concat([]);
+result[0] = 999;
+assert(source[0] === 10, "source mutated");
+assert(result[0] === 999, "result didn't mutate");

--- a/JSTests/stress/array-concat-intrinsic-non-array-object.js
+++ b/JSTests/stress/array-concat-intrinsic-non-array-object.js
@@ -1,0 +1,59 @@
+// Regression test for a bug where tryConcatOneArgFast fell through to the JSArray
+// uncheckedDowncast branch for a non-array object argument, dereferencing a bogus butterfly
+// pointer and crashing.
+//
+// The fix: the non-array-object branch must return the concatAppendOne result directly
+// (RELEASE_AND_RETURN), not merely check the exception scope and fall through.
+
+function assert(cond, msg) {
+    if (!cond)
+        throw new Error("Bad: " + (msg || ""));
+}
+noInline(assert);
+
+function objConcat(a, b) { return a.concat(b); }
+noInline(objConcat);
+
+function runAll() {
+    // Plain object (not an array) — hits the non-array non-spreadable branch.
+    {
+        const plainObj = { foo: "bar" };
+        const r = objConcat([1, 2], plainObj);
+        assert(r.length === 3, "plain-object length " + r.length);
+        assert(r[0] === 1);
+        assert(r[1] === 2);
+        assert(r[2] === plainObj, "plain-object should be single-element-appended");
+    }
+
+    // Object with array-like shape but no Symbol.isConcatSpreadable — also non-spreadable.
+    {
+        const arrLike = { 0: "a", 1: "b", length: 2 };
+        const r = objConcat([10, 20], arrLike);
+        assert(r.length === 3);
+        assert(r[2] === arrLike, "array-like without spreadable must be appended, not spread");
+    }
+
+    // Object with prototype set to Array.prototype but not a JSArray — still non-spreadable
+    // per `arrayMissingIsConcatSpreadable` semantics (its prototype is array-prototype but
+    // isJSArray returns false, so we treat it as a non-array object).
+    {
+        const pseudoArr = Object.create(Array.prototype);
+        pseudoArr[0] = "x"; pseudoArr[1] = "y"; pseudoArr.length = 2;
+        const r = objConcat([1], pseudoArr);
+        assert(r.length === 2);
+        assert(r[1] === pseudoArr);
+    }
+
+    // Null and undefined arguments — primitives, not objects.
+    {
+        const r1 = objConcat([1, 2], null);
+        assert(r1.length === 3 && r1[2] === null);
+        const r2 = objConcat([1, 2], undefined);
+        assert(r2.length === 3 && r2[2] === undefined);
+    }
+}
+
+// Run at LLInt tier first (where the crash originally reproduced), then warm up through
+// Baseline/DFG/FTL to exercise every JIT path.
+for (let i = 0; i < testLoopCount; i++)
+    runAll();

--- a/JSTests/stress/array-concat-intrinsic-sparse-threshold.js
+++ b/JSTests/stress/array-concat-intrinsic-sparse-threshold.js
@@ -1,0 +1,50 @@
+// Tests that the ArrayConcatIntrinsic's fast path bails correctly for inputs that would
+// require ArrayStorage: the DFG operation returns empty, the JIT speculation-checks against
+// that and OSR-exits with ExoticObjectMode. After enough exits, subsequent compilations of
+// the same call site see the exit profile and decline the intrinsic, so execution proceeds
+// through the host function (which correctly handles large-size concat).
+
+function assert(cond, msg) {
+    if (!cond)
+        throw new Error("Bad: " + (msg || ""));
+}
+noInline(assert);
+
+function makeInt32(n) {
+    const a = [];
+    for (let i = 0; i < n; i++)
+        a.push(i | 0);
+    return a;
+}
+noInline(makeInt32);
+
+function doConcat(a, b) { return a.concat(b); }
+noInline(doConcat);
+
+for (let i = 0; i < testLoopCount; i++)
+    doConcat(makeInt32(2), makeInt32(2));
+
+{
+    const a = makeInt32(60000);
+    const b = makeInt32(30000);
+    const r = doConcat(a, b);
+    assert(r.length === 90000, "under-threshold length " + r.length);
+    assert(r[0] === 0 && r[59999] === 59999 && r[60000] === 0 && r[89999] === 29999,
+           "under-threshold contents");
+}
+
+{
+    const a = makeInt32(60000);
+    const b = makeInt32(60000);
+    for (let i = 0; i < 200; i++) {
+        const r = doConcat(a, b);
+        assert(r.length === 120000, "oversized length " + r.length);
+        assert(r[0] === 0 && r[59999] === 59999 && r[60000] === 0 && r[119999] === 59999,
+               "oversized contents");
+    }
+}
+
+for (let i = 0; i < testLoopCount; i++) {
+    const r = doConcat(makeInt32(2), makeInt32(3));
+    assert(r.length === 5, "post-threshold small length " + r.length);
+}

--- a/JSTests/stress/array-concat-intrinsic-spreadable-watchpoint.js
+++ b/JSTests/stress/array-concat-intrinsic-spreadable-watchpoint.js
@@ -1,0 +1,68 @@
+// Tests that Array.prototype.concat correctly handles invalidation of the
+// arrayIsConcatSpreadableWatchpointSet. The DFG intrinsic installs this watchpoint lazily;
+// any addition of Symbol.isConcatSpreadable to Array.prototype or Object.prototype must
+// invalidate compiled code so that subsequent compilations/executions produce spec-compliant
+// results.
+
+function assert(cond, msg) {
+    if (!cond)
+        throw new Error("Bad: " + (msg || ""));
+}
+noInline(assert);
+
+function shallowEq(a, b) {
+    assert(a.length === b.length, "length: " + a.length + " vs " + b.length);
+    for (let i = 0; i < a.length; i++)
+        assert(a[i] === b[i], "index " + i + ": " + a[i] + " vs " + b[i]);
+}
+noInline(shallowEq);
+
+function concatArr(a, b) { return a.concat(b); }
+noInline(concatArr);
+
+function concatOne(a, v) { return a.concat(v); }
+noInline(concatOne);
+
+// Phase 1: with the watchpoint still valid, warm up both shapes so the intrinsic fires
+// and fixup promotes to ArrayConcatArray / narrows to NotCellUse.
+for (let i = 0; i < testLoopCount; i++) {
+    shallowEq(concatArr([1, 2, 3], [4, 5]), [1, 2, 3, 4, 5]);
+    shallowEq(concatOne([1, 2], 42), [1, 2, 42]);
+}
+
+// Phase 2: invalidate arrayIsConcatSpreadableWatchpointSet by setting Symbol.isConcatSpreadable
+// on Array.prototype. Per ECMA-262 IsConcatSpreadable, the inherited value overrides the
+// default "IsArray" fallback. Setting it to `false` makes arrays no longer auto-spread —
+// the spec applies the check to both the receiver and each argument.
+Array.prototype[Symbol.isConcatSpreadable] = false;
+
+// After invalidation the cached compiled code is no longer valid. Runs must observe the
+// updated semantics: both the receiver and the argument are treated as single elements.
+for (let i = 0; i < testLoopCount; i++) {
+    let a = [1, 2, 3];
+    let b = [4, 5];
+    let r = concatArr(a, b);
+    // Expected: [a, b], length 2 — both receiver and argument are non-spreadable.
+    assert(r.length === 2, "after invalidation arr length " + r.length);
+    assert(r[0] === a, "after invalidation r[0] should be a");
+    assert(r[1] === b, "after invalidation r[1] should be b");
+
+    // For primitive args the result depends on the receiver's spreadability. With the
+    // receiver also non-spreadable (inherited false), result is [[1,2], 42] — length 2.
+    let r2 = concatOne([1, 2], 42);
+    assert(r2.length === 2, "after invalidation one length " + r2.length);
+    assert(Array.isArray(r2[0]) && r2[0][0] === 1 && r2[0][1] === 2, "r2[0] wrong");
+    assert(r2[1] === 42, "r2[1] wrong");
+}
+
+// Phase 3: set it back to the default (true) on Array.prototype. The watchpoint stays
+// invalidated (it's one-shot), but the per-instance override should propagate via the
+// prototype chain the same way.
+Array.prototype[Symbol.isConcatSpreadable] = true;
+for (let i = 0; i < testLoopCount; i++) {
+    shallowEq(concatArr([1, 2, 3], [4, 5]), [1, 2, 3, 4, 5]);
+    shallowEq(concatOne([1, 2], 42), [1, 2, 42]);
+}
+
+// Clean up to avoid leaking state to any subsequent test loader.
+delete Array.prototype[Symbol.isConcatSpreadable];

--- a/JSTests/stress/array-concat-intrinsic.js
+++ b/JSTests/stress/array-concat-intrinsic.js
@@ -1,0 +1,143 @@
+function assert(b, ...m) {
+    if (!b)
+        throw new Error("Bad: ", ...m);
+}
+noInline(assert);
+
+function shallowEq(a, b) {
+    assert(a.length === b.length, a, b);
+    for (let i = 0; i < a.length; i++)
+        assert(a[i] === b[i], a, b);
+}
+noInline(shallowEq);
+
+function runConcat(a, b) {
+    return a.concat(b);
+}
+noInline(runConcat);
+
+// Warm up and verify across a variety of indexing types.
+function testBasic() {
+    // Int32 + Int32
+    shallowEq(runConcat([1, 2, 3], [4, 5, 6]), [1, 2, 3, 4, 5, 6]);
+    // Int32 + Double
+    shallowEq(runConcat([1, 2, 3], [4.5, 5.5, 6.5]), [1, 2, 3, 4.5, 5.5, 6.5]);
+    // Double + Int32
+    shallowEq(runConcat([1.5, 2.5, 3.5], [4, 5, 6]), [1.5, 2.5, 3.5, 4, 5, 6]);
+    // Double + Double
+    shallowEq(runConcat([1.5, 2.5], [3.5, 4.5]), [1.5, 2.5, 3.5, 4.5]);
+    // Contiguous + Contiguous
+    shallowEq(runConcat(["a", "b"], ["c", "d"]), ["a", "b", "c", "d"]);
+    // Contiguous + Int32 (promoted to Contiguous)
+    shallowEq(runConcat(["a"], [1, 2]), ["a", 1, 2]);
+    // Empty + Int32
+    shallowEq(runConcat([], [1, 2, 3]), [1, 2, 3]);
+    // Int32 + Empty
+    shallowEq(runConcat([1, 2, 3], []), [1, 2, 3]);
+    // Empty + Empty
+    shallowEq(runConcat([], []), []);
+}
+
+for (let i = 0; i < testLoopCount; i++) {
+    testBasic();
+}
+
+// Invalidation tests: setting Symbol.isConcatSpreadable or subclassing must not break correctness.
+function testSpeciesInvalidation() {
+    class MyArray extends Array {
+        static get [Symbol.species]() {
+            return Array;
+        }
+    }
+    const arr = new MyArray(1, 2, 3);
+    // This goes through the host function because the receiver isn't an original Array structure.
+    const r = arr.concat([4, 5]);
+    shallowEq([...r], [1, 2, 3, 4, 5]);
+}
+testSpeciesInvalidation();
+
+// Mutate Symbol.isConcatSpreadable on an instance — the intrinsic watchpoint should fire.
+function testIsConcatSpreadable() {
+    const a = [1, 2, 3];
+    const b = [4, 5];
+    // Baseline result before any spreading override.
+    shallowEq(a.concat(b), [1, 2, 3, 4, 5]);
+    b[Symbol.isConcatSpreadable] = false;
+    // After the override, b should be concatenated as an element, not spread.
+    const r = a.concat(b);
+    assert(r.length === 4);
+    assert(r[0] === 1);
+    assert(r[3] === b);
+}
+testIsConcatSpreadable();
+
+// COW (copy-on-write) arrays as operands.
+function testCOW() {
+    function makeCOW() { return [1, 2, 3]; }
+    noInline(makeCOW);
+    const a = makeCOW();
+    const b = makeCOW();
+    shallowEq(runConcat(a, b), [1, 2, 3, 1, 2, 3]);
+}
+for (let i = 0; i < testLoopCount; i++) {
+    testCOW();
+}
+
+// Larger arrays exercising the memcpy fast path.
+function testLarge() {
+    const a = new Array(100);
+    const b = new Array(100);
+    for (let i = 0; i < 100; i++) { a[i] = i; b[i] = 100 + i; }
+    const r = runConcat(a, b);
+    assert(r.length === 200);
+    for (let i = 0; i < 100; i++) {
+        assert(r[i] === i);
+        assert(r[100 + i] === 100 + i);
+    }
+}
+for (let i = 0; i < testLoopCount; i++) {
+    testLarge();
+}
+
+// array.concat(primitive) — should hit the ArrayConcatAppendOne fast path.
+function appendInt(a) { return a.concat(42); }
+function appendDouble(a) { return a.concat(3.14); }
+function appendString(a) { return a.concat("x"); }
+function appendBool(a) { return a.concat(true); }
+function appendNull(a) { return a.concat(null); }
+function appendUndef(a) { return a.concat(undefined); }
+noInline(appendInt); noInline(appendDouble); noInline(appendString);
+noInline(appendBool); noInline(appendNull); noInline(appendUndef);
+
+for (let i = 0; i < testLoopCount; i++) {
+    shallowEq(appendInt([1, 2, 3]), [1, 2, 3, 42]);
+    shallowEq(appendDouble([1.5, 2.5]), [1.5, 2.5, 3.14]);
+    shallowEq(appendString(["a", "b"]), ["a", "b", "x"]);
+    shallowEq(appendBool([1, 2]), [1, 2, true]);
+    shallowEq(appendNull([1]), [1, null]);
+
+    const r = appendUndef([1, 2]);
+    assert(r.length === 3);
+    assert(r[2] === undefined);
+}
+
+// Polymorphic argument (sometimes array, sometimes primitive) — intrinsic should bail and the
+// host function handles it correctly.
+function polyConcat(a, b) { return a.concat(b); }
+noInline(polyConcat);
+for (let i = 0; i < testLoopCount; i++) {
+    const even = (i & 1) === 0;
+    const r = polyConcat([1, 2, 3], even ? [4, 5] : 42);
+    if (even) shallowEq(r, [1, 2, 3, 4, 5]);
+    else shallowEq(r, [1, 2, 3, 42]);
+}
+
+// Non-array object argument — intrinsic should bail, host function handles.
+function objConcat(a, b) { return a.concat(b); }
+noInline(objConcat);
+const plainObj = { foo: "bar" };
+for (let i = 0; i < testLoopCount; i++) {
+    const r = objConcat([1, 2], plainObj);
+    assert(r.length === 3);
+    assert(r[2] === plainObj);
+}

--- a/Source/JavaScriptCore/dfg/DFGAbstractInterpreterInlines.h
+++ b/Source/JavaScriptCore/dfg/DFGAbstractInterpreterInlines.h
@@ -3305,6 +3305,11 @@ bool AbstractInterpreter<AbstractStateType>::executeEffects(unsigned clobberLimi
         break;
     }
 
+    case ArrayConcatArray:
+    case ArrayConcatAppendOne:
+        setTypeForNode(node, SpecArray);
+        break;
+
     case ArraySplice:
         clobberWorld();
         makeBytecodeTopForNode(node);

--- a/Source/JavaScriptCore/dfg/DFGBackwardsPropagationPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGBackwardsPropagationPhase.cpp
@@ -393,7 +393,13 @@ private:
             break;
         }
 
-            
+        case ArrayConcatArray:
+        case ArrayConcatAppendOne: {
+            node->child1()->mergeFlags(NodeBytecodeUsesAsValue);
+            node->child2()->mergeFlags(NodeBytecodeUsesAsValue);
+            break;
+        }
+
         case UInt32ToNumber: {
             node->child1()->mergeFlags(flags);
             break;

--- a/Source/JavaScriptCore/dfg/DFGByteCodeParser.cpp
+++ b/Source/JavaScriptCore/dfg/DFGByteCodeParser.cpp
@@ -2820,6 +2820,66 @@ auto ByteCodeParser::handleIntrinsicCall(Node* callee, Operand resultOperand, Ca
             return CallOptimizationResult::Inlined;
         }
 
+        case ArrayConcatIntrinsic: {
+            if (argumentCountIncludingThis != 2)
+                return CallOptimizationResult::DidNothing;
+
+            if (m_inlineStackTop->m_exitProfile.hasExitSite(m_currentIndex, BadConstantCache)
+                || m_inlineStackTop->m_exitProfile.hasExitSite(m_currentIndex, BadCache)
+                || m_inlineStackTop->m_exitProfile.hasExitSite(m_currentIndex, BadType)
+                || m_inlineStackTop->m_exitProfile.hasExitSite(m_currentIndex, ExoticObjectMode))
+                return CallOptimizationResult::DidNothing;
+
+            ArrayMode arrayMode = getArrayMode(Array::Read);
+            if (!arrayMode.isJSArray())
+                return CallOptimizationResult::DidNothing;
+
+            if (!arrayMode.isJSArrayWithOriginalStructure())
+                return CallOptimizationResult::DidNothing;
+
+            switch (arrayMode.type()) {
+            case Array::Double:
+            case Array::Int32:
+            case Array::Contiguous: {
+                JSGlobalObject* globalObject = m_graph.globalObjectFor(currentNodeOrigin().semantic);
+                if (globalObject->arraySpeciesWatchpointSet().state() != IsWatched
+                    || !globalObject->havingABadTimeWatchpointSet().isStillValid()
+                    || globalObject->arrayPrototypeChainIsSaneWatchpointSet().state() != IsWatched
+                    || globalObject->arrayIsConcatSpreadableWatchpointSet().state() != IsWatched)
+                    return CallOptimizationResult::DidNothing;
+
+                m_graph.watchpoints().addLazily(globalObject->arraySpeciesWatchpointSet());
+                m_graph.watchpoints().addLazily(globalObject->havingABadTimeWatchpointSet());
+                m_graph.watchpoints().addLazily(globalObject->arrayPrototypeChainIsSaneWatchpointSet());
+                m_graph.watchpoints().addLazily(globalObject->arrayIsConcatSpreadableWatchpointSet());
+
+                insertChecks();
+
+                Node* receiver = get(virtualRegisterForArgumentIncludingThis(0, registerOffset));
+                Node* argument = get(virtualRegisterForArgumentIncludingThis(1, registerOffset));
+
+                StructureSet receiverStructureSet;
+                receiverStructureSet.add(globalObject->originalArrayStructureForIndexingType(ArrayWithUndecided));
+                receiverStructureSet.add(globalObject->originalArrayStructureForIndexingType(ArrayWithInt32));
+                receiverStructureSet.add(globalObject->originalArrayStructureForIndexingType(ArrayWithContiguous));
+                receiverStructureSet.add(globalObject->originalArrayStructureForIndexingType(ArrayWithDouble));
+                receiverStructureSet.add(globalObject->originalArrayStructureForIndexingType(CopyOnWriteArrayWithInt32));
+                receiverStructureSet.add(globalObject->originalArrayStructureForIndexingType(CopyOnWriteArrayWithContiguous));
+                receiverStructureSet.add(globalObject->originalArrayStructureForIndexingType(CopyOnWriteArrayWithDouble));
+                addToGraph(CheckStructure, OpInfo(m_graph.addStructureSet(receiverStructureSet)), receiver);
+
+                Node* node = addToGraph(ArrayConcatAppendOne, OpInfo(), OpInfo(prediction), receiver, argument);
+                setResult(node);
+                return CallOptimizationResult::Inlined;
+            }
+            default:
+                return CallOptimizationResult::DidNothing;
+            }
+
+            RELEASE_ASSERT_NOT_REACHED();
+            return CallOptimizationResult::DidNothing;
+        }
+
         case ArrayIncludesIntrinsic:
         case ArrayIndexOfIntrinsic: {
             if (argumentCountIncludingThis < 2)

--- a/Source/JavaScriptCore/dfg/DFGClobberize.h
+++ b/Source/JavaScriptCore/dfg/DFGClobberize.h
@@ -703,6 +703,22 @@ void clobberize(Graph& graph, Node* node, const ReadFunctor& read, const WriteFu
         write(HeapObjectCount);
         return;
 
+    case ArrayConcatArray:
+    case ArrayConcatAppendOne: {
+        read(MiscFields);
+        read(JSCell_indexingType);
+        read(JSCell_structureID);
+        read(JSObject_butterfly);
+        read(Butterfly_publicLength);
+        read(IndexedDoubleProperties);
+        read(IndexedInt32Properties);
+        read(IndexedContiguousProperties);
+        read(IndexedArrayStorageProperties);
+        read(HeapObjectCount);
+        write(HeapObjectCount);
+        return;
+    }
+
     case ArrayIncludes:
     case ArrayIndexOf: {
         // FIXME: Should support a CSE rule.

--- a/Source/JavaScriptCore/dfg/DFGCloneHelper.h
+++ b/Source/JavaScriptCore/dfg/DFGCloneHelper.h
@@ -163,6 +163,8 @@ BasicBlock* CloneHelper::cloneBlock(BasicBlock* const block, const CustomizeSucc
     CLONE_STATUS(ArrayPop, Common) \
     CLONE_STATUS(ArrayPush, Common) \
     CLONE_STATUS(ArraySlice, Common) \
+    CLONE_STATUS(ArrayConcatArray, Common) \
+    CLONE_STATUS(ArrayConcatAppendOne, Common) \
     CLONE_STATUS(ArraySplice, Common) \
     CLONE_STATUS(Arrayify, Common) \
     CLONE_STATUS(ArrayifyToStructure, Common) \

--- a/Source/JavaScriptCore/dfg/DFGDoesGC.cpp
+++ b/Source/JavaScriptCore/dfg/DFGDoesGC.cpp
@@ -460,6 +460,8 @@ bool doesGC(Graph& graph, Node* node)
     case CallDOMGetter:
     case CallDOM:
     case ArraySlice:
+    case ArrayConcatArray:
+    case ArrayConcatAppendOne:
     case ArrayIncludes:
     case ArrayIndexOf:
     case ParseInt: // We might resolve a rope even though we don't clobber anything.

--- a/Source/JavaScriptCore/dfg/DFGFixupPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGFixupPhase.cpp
@@ -1721,6 +1721,32 @@ private:
             break;
         }
 
+        case ArrayConcatArray: {
+            fixEdge<KnownCellUse>(node->child1());
+            fixEdge<KnownCellUse>(node->child2());
+            break;
+        }
+
+        case ArrayConcatAppendOne: {
+            fixEdge<KnownCellUse>(node->child1());
+            SpeculatedType argPrediction = node->child2()->prediction();
+            if (isArraySpeculation(argPrediction)) {
+                JSGlobalObject* globalObject = m_graph.globalObjectFor(node->origin.semantic);
+                StructureSet structureSet;
+                structureSet.add(globalObject->originalArrayStructureForIndexingType(ArrayWithUndecided));
+                structureSet.add(globalObject->originalArrayStructureForIndexingType(ArrayWithInt32));
+                structureSet.add(globalObject->originalArrayStructureForIndexingType(ArrayWithContiguous));
+                structureSet.add(globalObject->originalArrayStructureForIndexingType(ArrayWithDouble));
+                structureSet.add(globalObject->originalArrayStructureForIndexingType(CopyOnWriteArrayWithInt32));
+                structureSet.add(globalObject->originalArrayStructureForIndexingType(CopyOnWriteArrayWithContiguous));
+                structureSet.add(globalObject->originalArrayStructureForIndexingType(CopyOnWriteArrayWithDouble));
+                m_insertionSet.insertNode(m_indexInBlock, SpecNone, CheckStructure, node->origin, OpInfo(m_graph.addStructureSet(structureSet)), Edge(node->child2().node(), CellUse));
+                node->setOpAndDefaultFlags(ArrayConcatArray);
+                fixEdge<KnownCellUse>(node->child2());
+            }
+            break;
+        }
+
         case ArraySplice: {
             fixEdge<ArrayUse>(m_graph.child(node, 0));
             fixEdge<Int32Use>(m_graph.child(node, 1));

--- a/Source/JavaScriptCore/dfg/DFGNodeType.h
+++ b/Source/JavaScriptCore/dfg/DFGNodeType.h
@@ -343,6 +343,8 @@ namespace JSC { namespace DFG {
     macro(ArrayPush, NodeResultJS | NodeMustGenerate | NodeHasVarArgs) \
     macro(ArrayPop, NodeResultJS | NodeMustGenerate) \
     macro(ArraySlice, NodeResultJS | NodeMustGenerate | NodeHasVarArgs) \
+    macro(ArrayConcatArray, NodeResultJS | NodeMustGenerate) \
+    macro(ArrayConcatAppendOne, NodeResultJS | NodeMustGenerate) \
     macro(ArrayIncludes, NodeResultBoolean | NodeHasVarArgs) \
     macro(ArrayIndexOf, NodeResultInt32 | NodeHasVarArgs) \
     macro(ArraySplice, NodeResultJS | NodeMustGenerate | NodeHasVarArgs) \

--- a/Source/JavaScriptCore/dfg/DFGOperations.cpp
+++ b/Source/JavaScriptCore/dfg/DFGOperations.cpp
@@ -1403,6 +1403,25 @@ JSC_DEFINE_JIT_OPERATION(operationArraySpliceIgnoreResult, EncodedJSValue, (JSGl
     OPERATION_RETURN(scope, result);
 }
 
+JSC_DEFINE_JIT_OPERATION(operationArrayConcatArray, JSArray*, (JSGlobalObject* globalObject, JSArray* firstArray, JSArray* secondArray))
+{
+    VM& vm = globalObject->vm();
+    CallFrame* callFrame = DECLARE_CALL_FRAME(vm);
+    JITOperationPrologueCallFrameTracer tracer(vm, callFrame);
+    auto scope = DECLARE_THROW_SCOPE(vm);
+    OPERATION_RETURN(scope, tryConcatAppendArrayFastWithWatchpoints(globalObject, vm, firstArray, secondArray));
+}
+
+JSC_DEFINE_JIT_OPERATION(operationArrayConcatAppendOne, JSArray*, (JSGlobalObject* globalObject, JSArray* firstArray, EncodedJSValue encodedSecond))
+{
+    VM& vm = globalObject->vm();
+    CallFrame* callFrame = DECLARE_CALL_FRAME(vm);
+    JITOperationPrologueCallFrameTracer tracer(vm, callFrame);
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
+    OPERATION_RETURN(scope, tryConcatOneArgFast(globalObject, vm, firstArray, JSValue::decode(encodedSecond)));
+}
+
 JSC_DEFINE_JIT_OPERATION(operationRegExpExecString, EncodedJSValue, (JSGlobalObject* globalObject, RegExpObject* regExpObject, JSString* argument))
 {
     SuperSamplerScope superSamplerScope(false);

--- a/Source/JavaScriptCore/dfg/DFGOperations.h
+++ b/Source/JavaScriptCore/dfg/DFGOperations.h
@@ -218,6 +218,8 @@ JSC_DECLARE_JIT_OPERATION(operationArrayPop, EncodedJSValue, (JSGlobalObject*, J
 JSC_DECLARE_JIT_OPERATION(operationArrayPopAndRecoverLength, EncodedJSValue, (JSGlobalObject*, JSArray*));
 JSC_DECLARE_JIT_OPERATION(operationArraySplice, EncodedJSValue, (JSGlobalObject*, JSArray*, int32_t start, int32_t deleteCount, EncodedJSValue*, unsigned));
 JSC_DECLARE_JIT_OPERATION(operationArraySpliceIgnoreResult, EncodedJSValue, (JSGlobalObject*, JSArray*, int32_t start, int32_t deleteCount, EncodedJSValue*, unsigned));
+JSC_DECLARE_JIT_OPERATION(operationArrayConcatArray, JSArray*, (JSGlobalObject*, JSArray*, JSArray*));
+JSC_DECLARE_JIT_OPERATION(operationArrayConcatAppendOne, JSArray*, (JSGlobalObject*, JSArray*, EncodedJSValue));
 JSC_DECLARE_JIT_OPERATION(operationRegExpExecString, EncodedJSValue, (JSGlobalObject*, RegExpObject*, JSString*));
 JSC_DECLARE_JIT_OPERATION(operationRegExpExec, EncodedJSValue, (JSGlobalObject*, RegExpObject*, EncodedJSValue));
 JSC_DECLARE_JIT_OPERATION(operationRegExpExecGeneric, EncodedJSValue, (JSGlobalObject*, EncodedJSValue, EncodedJSValue));

--- a/Source/JavaScriptCore/dfg/DFGPredictionPropagationPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGPredictionPropagationPhase.cpp
@@ -1365,6 +1365,8 @@ private:
             break;
             
         case ArraySlice:
+        case ArrayConcatArray:
+        case ArrayConcatAppendOne:
         case NewArrayWithSpread:
         case NewArray:
         case NewArrayWithSize:

--- a/Source/JavaScriptCore/dfg/DFGSafeToExecute.h
+++ b/Source/JavaScriptCore/dfg/DFGSafeToExecute.h
@@ -361,6 +361,8 @@ bool safeToExecute(AbstractStateType& state, Graph& graph, Node* node, bool igno
         return state.forNode(node->child1()).isType(SpecObject);
 
     case ArraySlice:
+    case ArrayConcatArray:
+    case ArrayConcatAppendOne:
     case ArrayIncludes:
     case ArrayIndexOf: {
         // You could plausibly move this code around as long as you proved the

--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp
@@ -9991,6 +9991,38 @@ void SpeculativeJIT::compileArraySlice(Node* node)
     cellResult(resultGPR, node);
 }
 
+void SpeculativeJIT::compileArrayConcatArray(Node* node)
+{
+    SpeculateCellOperand firstArray(this, node->child1());
+    SpeculateCellOperand secondArray(this, node->child2());
+
+    GPRReg firstArrayGPR = firstArray.gpr();
+    GPRReg secondArrayGPR = secondArray.gpr();
+
+    flushRegisters();
+    GPRFlushedCallResult result(this);
+    GPRReg resultGPR = result.gpr();
+    callOperation(operationArrayConcatArray, resultGPR, LinkableConstant::globalObject(*this, node), firstArrayGPR, secondArrayGPR);
+    speculationCheck(ExoticObjectMode, JSValueSource(), nullptr, branchTestPtr(Zero, resultGPR));
+    cellResult(resultGPR, node);
+}
+
+void SpeculativeJIT::compileArrayConcatAppendOne(Node* node)
+{
+    SpeculateCellOperand firstArray(this, node->child1());
+    JSValueOperand second(this, node->child2());
+
+    GPRReg firstArrayGPR = firstArray.gpr();
+    JSValueRegs secondRegs = second.jsValueRegs();
+
+    flushRegisters();
+    GPRFlushedCallResult result(this);
+    GPRReg resultGPR = result.gpr();
+    callOperation(operationArrayConcatAppendOne, resultGPR, LinkableConstant::globalObject(*this, node), firstArrayGPR, secondRegs);
+    speculationCheck(ExoticObjectMode, JSValueSource(), nullptr, branchTestPtr(Zero, resultGPR));
+    cellResult(resultGPR, node);
+}
+
 void SpeculativeJIT::compileArraySplice(Node* node)
 {
     unsigned refCount = node->refCount();

--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.h
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.h
@@ -1683,6 +1683,8 @@ public:
     void compileNewArray(Node*);
     void compileNewArrayWithSpread(Node*);
     void compileArraySlice(Node*);
+    void compileArrayConcatArray(Node*);
+    void compileArrayConcatAppendOne(Node*);
     void compileArraySplice(Node*);
     void compileArrayIndexOfOrArrayIncludes(Node*);
     void compileArrayPush(Node*);

--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT32_64.cpp
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT32_64.cpp
@@ -2946,6 +2946,16 @@ void SpeculativeJIT::compile(Node* node)
         break;
     }
 
+    case ArrayConcatArray: {
+        compileArrayConcatArray(node);
+        break;
+    }
+
+    case ArrayConcatAppendOne: {
+        compileArrayConcatAppendOne(node);
+        break;
+    }
+
     case ArraySplice: {
         compileArraySplice(node);
         break;

--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT64.cpp
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT64.cpp
@@ -4246,6 +4246,16 @@ void SpeculativeJIT::compile(Node* node)
         break;
     }
 
+    case ArrayConcatArray: {
+        compileArrayConcatArray(node);
+        break;
+    }
+
+    case ArrayConcatAppendOne: {
+        compileArrayConcatAppendOne(node);
+        break;
+    }
+
     case ArraySplice: {
         compileArraySplice(node);
         break;

--- a/Source/JavaScriptCore/ftl/FTLCapabilities.cpp
+++ b/Source/JavaScriptCore/ftl/FTLCapabilities.cpp
@@ -438,6 +438,8 @@ inline CapabilityLevel canCompile(Node* node)
     case CallDOM:
     case CallDOMGetter:
     case ArraySlice:
+    case ArrayConcatArray:
+    case ArrayConcatAppendOne:
     case ArraySplice:
     case ArrayIncludes:
     case ArrayIndexOf:

--- a/Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp
+++ b/Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp
@@ -1183,6 +1183,12 @@ private:
         case ArraySlice:
             compileArraySlice();
             break;
+        case ArrayConcatArray:
+            compileArrayConcatArray();
+            break;
+        case ArrayConcatAppendOne:
+            compileArrayConcatAppendOne();
+            break;
         case ArraySplice:
             compileArraySplice();
             break;
@@ -8425,6 +8431,26 @@ IGNORE_CLANG_WARNINGS_END
 
         mutatorFence();
         setJSValue(arrayResult.array);
+    }
+
+    void compileArrayConcatArray()
+    {
+        JSGlobalObject* globalObject = m_graph.globalObjectFor(m_origin.semantic);
+        LValue firstArray = lowCell(m_node->child1());
+        LValue secondArray = lowCell(m_node->child2());
+        LValue result = vmCall(pointerType(), operationArrayConcatArray, weakPointer(globalObject), firstArray, secondArray);
+        speculate(ExoticObjectMode, noValue(), nullptr, m_out.isNull(result));
+        setJSValue(result);
+    }
+
+    void compileArrayConcatAppendOne()
+    {
+        JSGlobalObject* globalObject = m_graph.globalObjectFor(m_origin.semantic);
+        LValue firstArray = lowCell(m_node->child1());
+        LValue second = lowJSValue(m_node->child2());
+        LValue result = vmCall(pointerType(), operationArrayConcatAppendOne, weakPointer(globalObject), firstArray, second);
+        speculate(ExoticObjectMode, noValue(), nullptr, m_out.isNull(result));
+        setJSValue(result);
     }
 
     void compileArraySplice()

--- a/Source/JavaScriptCore/runtime/ArrayPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/ArrayPrototype.cpp
@@ -103,7 +103,7 @@ void ArrayPrototype::finishCreation(VM& vm, JSGlobalObject* globalObject)
     putDirectWithoutTransition(vm, vm.propertyNames->iteratorSymbol, globalObject->arrayProtoValuesFunction(), static_cast<unsigned>(PropertyAttribute::DontEnum));
 
     JSC_NATIVE_FUNCTION_WITHOUT_TRANSITION(vm.propertyNames->toLocaleString, arrayProtoFuncToLocaleString, static_cast<unsigned>(PropertyAttribute::DontEnum), 0, ImplementationVisibility::Public);
-    JSC_NATIVE_FUNCTION_WITHOUT_TRANSITION(vm.propertyNames->builtinNames().concatPublicName(), arrayProtoFuncConcat, static_cast<unsigned>(PropertyAttribute::DontEnum), 1, ImplementationVisibility::Public);
+    JSC_NATIVE_INTRINSIC_FUNCTION_WITHOUT_TRANSITION(vm.propertyNames->builtinNames().concatPublicName(), arrayProtoFuncConcat, static_cast<unsigned>(PropertyAttribute::DontEnum), 1, ImplementationVisibility::Public, ArrayConcatIntrinsic);
     JSC_NATIVE_FUNCTION_WITHOUT_TRANSITION(vm.propertyNames->fill, arrayProtoFuncFill, static_cast<unsigned>(PropertyAttribute::DontEnum), 1, ImplementationVisibility::Public);
     JSC_NATIVE_FUNCTION_WITHOUT_TRANSITION(vm.propertyNames->join, arrayProtoFuncJoin, static_cast<unsigned>(PropertyAttribute::DontEnum), 1, ImplementationVisibility::Public);
     JSC_NATIVE_INTRINSIC_FUNCTION_WITHOUT_TRANSITION("pop"_s, arrayProtoFuncPop, static_cast<unsigned>(PropertyAttribute::DontEnum), 0, ImplementationVisibility::Public, ArrayPopIntrinsic);
@@ -1456,7 +1456,7 @@ JSC_DEFINE_HOST_FUNCTION(arrayProtoFuncLastIndexOf, (JSGlobalObject* globalObjec
     return JSValue::encode(jsNumber(-1));
 }
 
-static JSArray* concatAppendOne(JSGlobalObject* globalObject, VM& vm, JSArray* first, JSValue second)
+static JSArray* tryConcatAppendOneNonArray(JSGlobalObject* globalObject, VM& vm, JSArray* first, JSValue second)
 {
     auto scope = DECLARE_THROW_SCOPE(vm);
 
@@ -1510,9 +1510,12 @@ static JSArray* concatAppendOne(JSGlobalObject* globalObject, VM& vm, JSArray* f
     return result;
 }
 
-static JSArray* concatAppendArray(JSGlobalObject* globalObject, VM& vm, JSArray* firstArray, JSArray* secondArray)
+JSArray* tryConcatAppendArrayFastWithWatchpoints(JSGlobalObject* globalObject, VM& vm, JSArray* firstArray, JSArray* secondArray)
 {
     auto scope = DECLARE_THROW_SCOPE(vm);
+
+    ASSERT(!globalObject->isHavingABadTime());
+    ASSERT(firstArray->canFastCopy(secondArray));
 
     Butterfly* firstButterfly = firstArray->butterfly();
     Butterfly* secondButterfly = secondArray->butterfly();
@@ -1522,60 +1525,36 @@ static JSArray* concatAppendArray(JSGlobalObject* globalObject, VM& vm, JSArray*
 
     CheckedUint32 checkedResultSize = firstArraySize;
     checkedResultSize += secondArraySize;
-
-    if (checkedResultSize.hasOverflowed()) [[unlikely]] {
-        throwOutOfMemoryError(globalObject, scope);
-        return { };
-    }
+    if (checkedResultSize.hasOverflowed() || checkedResultSize.value() >= MIN_SPARSE_ARRAY_INDEX) [[unlikely]]
+        return nullptr;
 
     unsigned resultSize = checkedResultSize;
+
     IndexingType firstType = firstArray->indexingType();
     IndexingType secondType = secondArray->indexingType();
-    bool allowPromotion = true;
-    IndexingType type = firstArray->mergeIndexingTypeForCopying(secondType, allowPromotion);
-    if (type == NonArray || !firstArray->canFastCopy(secondArray) || resultSize >= MIN_SPARSE_ARRAY_INDEX) {
-        JSArray* result = constructEmptyArray(globalObject, nullptr, resultSize);
-        RETURN_IF_EXCEPTION(scope, { });
+    IndexingType type = firstArray->mergeIndexingTypeForCopying(secondType, /* allowPromotion */ true);
+    ASSERT(type != NonArray);
 
-        bool success = moveArrayElements<ArrayFillMode::Empty>(globalObject, vm, result, 0, firstArray, firstArraySize);
-        EXCEPTION_ASSERT(!scope.exception() == success);
-        if (!success) [[unlikely]]
-            return { };
-        success = moveArrayElements<ArrayFillMode::Empty>(globalObject, vm, result, firstArraySize, secondArray, secondArraySize);
-        EXCEPTION_ASSERT(!scope.exception() == success);
-        if (!success) [[unlikely]]
-            return { };
+    if (!resultSize)
+        RELEASE_AND_RETURN(scope, constructEmptyArray(globalObject, nullptr));
 
-        return result;
-    }
-
-    if (!globalObject->isHavingABadTime()) [[likely]] {
-        if (!resultSize)
-            RELEASE_AND_RETURN(scope, constructEmptyArray(globalObject, nullptr));
-
-        if (!secondArraySize) {
-            if (isCopyOnWrite(firstArray->indexingMode()))
-                return JSArray::createWithButterfly(vm, nullptr, globalObject->originalArrayStructureForIndexingType(firstArray->indexingMode()), firstArray->butterfly());
-        } else if (!firstArraySize) {
-            if (isCopyOnWrite(secondArray->indexingMode()))
-                return JSArray::createWithButterfly(vm, nullptr, globalObject->originalArrayStructureForIndexingType(secondArray->indexingMode()), secondArray->butterfly());
-        }
-    }
+    if (!secondArraySize && isCopyOnWrite(firstArray->indexingMode()))
+        return JSArray::createWithButterfly(vm, nullptr, globalObject->originalArrayStructureForIndexingType(firstArray->indexingMode()), firstButterfly);
+    if (!firstArraySize && isCopyOnWrite(secondArray->indexingMode()))
+        return JSArray::createWithButterfly(vm, nullptr, globalObject->originalArrayStructureForIndexingType(secondArray->indexingMode()), secondButterfly);
 
     Structure* resultStructure = globalObject->arrayStructureForIndexingTypeDuringAllocation(type);
-    if (hasAnyArrayStorage(resultStructure->indexingType())) [[unlikely]]
-        return { };
+    ASSERT(!hasAnyArrayStorage(resultStructure->indexingType()));
 
-    ASSERT(!globalObject->isHavingABadTime());
     auto vectorLength = Butterfly::optimalContiguousVectorLength(resultStructure, resultSize);
     if (vectorLength > MAX_STORAGE_VECTOR_LENGTH) [[unlikely]]
-        return { };
+        return nullptr;
 
     ASSERT(!resultStructure->outOfLineCapacity());
     void* memory = vm.auxiliarySpace().allocate(vm, Butterfly::totalSize(0, 0, true, vectorLength * sizeof(EncodedJSValue)), nullptr, AllocationFailureMode::ReturnNull);
     if (!memory) [[unlikely]] {
         throwOutOfMemoryError(globalObject, scope);
-        return { };
+        return nullptr;
     }
     auto* butterfly = Butterfly::fromBase(memory, 0, 0);
     butterfly->setVectorLength(vectorLength);
@@ -1602,6 +1581,34 @@ static JSArray* concatAppendArray(JSGlobalObject* globalObject, VM& vm, JSArray*
     return JSArray::createWithButterfly(vm, nullptr, resultStructure, butterfly);
 }
 
+JSArray* tryConcatOneArgFast(JSGlobalObject* globalObject, VM& vm, JSArray* firstArray, JSValue argumentValue)
+{
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
+    ASSERT(!globalObject->isHavingABadTime());
+
+    if (!argumentValue.isObject()) {
+        if (firstArray->length() >= MIN_SPARSE_ARRAY_INDEX) [[unlikely]]
+            return nullptr;
+        RELEASE_AND_RETURN(scope, tryConcatAppendOneNonArray(globalObject, vm, firstArray, argumentValue));
+    }
+
+    JSObject* argumentObject = asObject(argumentValue);
+    if (!arrayMissingIsConcatSpreadable(vm, argumentObject)) [[unlikely]]
+        return nullptr;
+
+    if (!isJSArray(argumentObject)) {
+        if (firstArray->length() >= MIN_SPARSE_ARRAY_INDEX) [[unlikely]]
+            return nullptr;
+        RELEASE_AND_RETURN(scope, tryConcatAppendOneNonArray(globalObject, vm, firstArray, argumentValue));
+    }
+
+    JSArray* secondArray = uncheckedDowncast<JSArray>(argumentObject);
+    if (!firstArray->canFastCopy(secondArray)) [[unlikely]]
+        return nullptr;
+    RELEASE_AND_RETURN(scope, tryConcatAppendArrayFastWithWatchpoints(globalObject, vm, firstArray, secondArray));
+}
+
 JSC_DEFINE_HOST_FUNCTION(arrayProtoFuncConcat, (JSGlobalObject* globalObject, CallFrame* callFrame))
 {
     VM& vm = globalObject->vm();
@@ -1623,33 +1630,14 @@ JSC_DEFINE_HOST_FUNCTION(arrayProtoFuncConcat, (JSGlobalObject* globalObject, Ca
         JSValue argumentValue = callFrame->uncheckedArgument(0);
         if (isJSArray(thisValue)) [[likely]] {
             auto* firstArray = uncheckedDowncast<JSArray>(thisValue);
-            if (arrayMissingIsConcatSpreadable(vm, firstArray) && arraySpeciesWatchpointIsValid(vm, firstArray)) [[likely]] {
+            if (!globalObject->isHavingABadTime() && arrayMissingIsConcatSpreadable(vm, firstArray) && arraySpeciesWatchpointIsValid(vm, firstArray) && !firstArray->mayInterceptIndexedAccesses()) [[likely]] {
                 // This code assumes that neither array has set Symbol.isConcatSpreadable. If the first array
                 // has indexed accessors then one of those accessors might change the value of Symbol.isConcatSpreadable
                 // on the second argument.
-                if (!firstArray->mayInterceptIndexedAccesses()) [[likely]] {
-                    if (!argumentValue.isObject()) {
-                        auto* result = concatAppendOne(globalObject, vm, firstArray, argumentValue);
-                        RETURN_IF_EXCEPTION(scope, { });
-                        if (result) [[likely]]
-                            return JSValue::encode(result);
-                    } else {
-                        auto* argumentObject = uncheckedDowncast<JSObject>(argumentValue);
-                        if (arrayMissingIsConcatSpreadable(vm, argumentObject)) [[likely]] {
-                            if (!isJSArray(argumentObject)) {
-                                auto* result = concatAppendOne(globalObject, vm, firstArray, argumentValue);
-                                RETURN_IF_EXCEPTION(scope, { });
-                                if (result) [[likely]]
-                                    return JSValue::encode(result);
-                            } else {
-                                auto* result = concatAppendArray(globalObject, vm, firstArray, uncheckedDowncast<JSArray>(argumentValue));
-                                RETURN_IF_EXCEPTION(scope, { });
-                                if (result) [[likely]]
-                                    return JSValue::encode(result);
-                            }
-                        }
-                    }
-                }
+                JSArray* result = tryConcatOneArgFast(globalObject, vm, firstArray, argumentValue);
+                RETURN_IF_EXCEPTION(scope, { });
+                if (result) [[likely]]
+                    return JSValue::encode(result);
             }
         }
     }

--- a/Source/JavaScriptCore/runtime/ArrayPrototype.h
+++ b/Source/JavaScriptCore/runtime/ArrayPrototype.h
@@ -49,4 +49,7 @@ STATIC_ASSERT_ISO_SUBSPACE_SHARABLE(ArrayPrototype, ArrayPrototype::Base);
 JSC_DECLARE_HOST_FUNCTION(arrayProtoFuncToString);
 JSC_DECLARE_HOST_FUNCTION(arrayProtoFuncValues);
 
+JSArray* tryConcatAppendArrayFastWithWatchpoints(JSGlobalObject*, VM&, JSArray* firstArray, JSArray* secondArray);
+JSArray* tryConcatOneArgFast(JSGlobalObject*, VM&, JSArray* firstArray, JSValue argument);
+
 } // namespace JSC

--- a/Source/JavaScriptCore/runtime/Intrinsic.h
+++ b/Source/JavaScriptCore/runtime/Intrinsic.h
@@ -54,6 +54,7 @@ namespace JSC {
     macro(TanhIntrinsic) \
     macro(ArrayPushIntrinsic) \
     macro(ArrayPopIntrinsic) \
+    macro(ArrayConcatIntrinsic) \
     macro(ArraySliceIntrinsic) \
     macro(ArraySpliceIntrinsic) \
     macro(ArrayIncludesIntrinsic) \


### PR DESCRIPTION
#### 94e35cf4d86c0d426751c9e46ce9a8f853dfea64
<pre>
[JSC] Add Array#concat DFG nodes
<a href="https://bugs.webkit.org/show_bug.cgi?id=313926">https://bugs.webkit.org/show_bug.cgi?id=313926</a>
<a href="https://rdar.apple.com/176122830">rdar://176122830</a>

Reviewed by Yijia Huang.

This patch adds Array#concat handling in DFG / FTL.

1. Initially we emit ArrayConcatAppendOne DFG node. This is because we
   have no idea whether second input is Array or not at this point yet.
2. In fixup phase, we check prediction, and we may convert
   ArrayConcatAppendOne to ArrayConcatArray, which is more optimized for
   `array.concat(array)` case.
3. Add DFG operation, which can return nullptr when it has complicated
   side-effects, like @@isConcatSpreadable for the second argument. When
   we found these cases, we just return nullptr. And then DFG / FTL will
   do OSR exit via ExoticObjectMode.
4. We set necessary watchpoints in DFG so that operation code skips many
   checks.

Tests: JSTests/stress/array-concat-intrinsic-cow-result.js
       JSTests/stress/array-concat-intrinsic-non-array-object.js
       JSTests/stress/array-concat-intrinsic-sparse-threshold.js
       JSTests/stress/array-concat-intrinsic-spreadable-watchpoint.js
       JSTests/stress/array-concat-intrinsic.js

* JSTests/stress/array-concat-intrinsic-cow-result.js: Added.
(assert):
(shallowEq):
(firstEmpty):
(secondEmpty):
(firstEmptyDouble):
(secondEmptyDouble):
(firstEmptyContiguous):
(secondEmptyContiguous):
(sumAfterConcat):
* JSTests/stress/array-concat-intrinsic-non-array-object.js: Added.
(assert):
(objConcat):
(runAll):
* JSTests/stress/array-concat-intrinsic-sparse-threshold.js: Added.
(assert):
(makeInt32):
(doConcat):
* JSTests/stress/array-concat-intrinsic-spreadable-watchpoint.js: Added.
(assert):
(shallowEq):
(concatArr):
(concatOne):
* JSTests/stress/array-concat-intrinsic.js: Added.
(assert):
(shallowEq):
(runConcat):
(testBasic):
(testSpeciesInvalidation.MyArray.get Symbol):
(testSpeciesInvalidation.MyArray):
(testSpeciesInvalidation):
(testIsConcatSpreadable):
(testCOW.makeCOW):
(testCOW):
(testLarge):
(appendInt):
(appendDouble):
(appendString):
(appendBool):
(appendNull):
(appendUndef):
(polyConcat):
(objConcat):
* Source/JavaScriptCore/dfg/DFGAbstractInterpreterInlines.h:
(JSC::DFG::AbstractInterpreter&lt;AbstractStateType&gt;::executeEffects):
* Source/JavaScriptCore/dfg/DFGBackwardsPropagationPhase.cpp:
(JSC::DFG::BackwardsPropagationPhase::propagate):
* Source/JavaScriptCore/dfg/DFGByteCodeParser.cpp:
(JSC::DFG::ByteCodeParser::handleIntrinsicCall):
* Source/JavaScriptCore/dfg/DFGClobberize.h:
(JSC::DFG::clobberize):
* Source/JavaScriptCore/dfg/DFGCloneHelper.h:
* Source/JavaScriptCore/dfg/DFGDoesGC.cpp:
(JSC::DFG::doesGC):
* Source/JavaScriptCore/dfg/DFGFixupPhase.cpp:
(JSC::DFG::FixupPhase::fixupNode):
* Source/JavaScriptCore/dfg/DFGNodeType.h:
* Source/JavaScriptCore/dfg/DFGOperations.cpp:
(JSC::DFG::JSC_DEFINE_JIT_OPERATION):
* Source/JavaScriptCore/dfg/DFGOperations.h:
* Source/JavaScriptCore/dfg/DFGPredictionPropagationPhase.cpp:
* Source/JavaScriptCore/dfg/DFGSafeToExecute.h:
(JSC::DFG::safeToExecute):
* Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp:
* Source/JavaScriptCore/dfg/DFGSpeculativeJIT.h:
* Source/JavaScriptCore/dfg/DFGSpeculativeJIT32_64.cpp:
(JSC::DFG::SpeculativeJIT::compile):
* Source/JavaScriptCore/dfg/DFGSpeculativeJIT64.cpp:
(JSC::DFG::SpeculativeJIT::compile):
* Source/JavaScriptCore/ftl/FTLCapabilities.cpp:
(JSC::FTL::canCompile):
* Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp:
(JSC::FTL::DFG::LowerDFGToB3::compileNode):
(JSC::FTL::DFG::LowerDFGToB3::compileArrayConcatArray):
(JSC::FTL::DFG::LowerDFGToB3::compileArrayConcatAppendOne):
* Source/JavaScriptCore/runtime/ArrayPrototype.cpp:
(JSC::ArrayPrototype::finishCreation):
(JSC::tryConcatAppendOneNonArray):
(JSC::tryConcatAppendArrayFastWithWatchpoints):
(JSC::tryConcatOneArgFast):
(JSC::JSC_DEFINE_HOST_FUNCTION):
(JSC::concatAppendOne): Deleted.
(JSC::concatAppendArray): Deleted.
* Source/JavaScriptCore/runtime/ArrayPrototype.h:
* Source/JavaScriptCore/runtime/Intrinsic.h:

Canonical link: <a href="https://commits.webkit.org/312543@main">https://commits.webkit.org/312543@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/480b4b667c63c02e2723f70c444107a3b4badd51

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/160161 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/33631 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/26735 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/169062 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/114542 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/dde8b5c7-a11d-4efb-9783-69afe10138a3) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/33734 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/33633 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/124157 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/87084 "2 flakes 2 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/3309bb60-ff2c-4805-8a0e-fbe98588c8ea) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/163119 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/26402 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/143861 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/104758 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/59e5a1d4-2ed6-4b59-b091-8d93357b3e1f) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/25455 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/23947 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/16782 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/152217 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/135147 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/21624 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/171538 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/20998 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/17529 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/23264 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/132411 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/33307 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/28037 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/132437 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/33292 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/143419 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/91540 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/24389 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/27053 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/20233 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/192524 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/32801 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/99198 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/49512 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/32299 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/32545 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/32449 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->