### PR TITLE
[Win] Handle in flight requests when IndexedDB stopped

### DIFF
--- a/LayoutTests/http/tests/IndexedDB/resources/stop-during-request-dispatch-frame.html
+++ b/LayoutTests/http/tests/IndexedDB/resources/stop-during-request-dispatch-frame.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<script>
+var dbName = "stop-during-request-dispatch-db-" + Math.random();
+var openReq = indexedDB.open(dbName, 1);
+
+openReq.onupgradeneeded = function(e) {
+    var db = e.target.result;
+    var store = db.createObjectStore("store");
+    for (var i = 0; i < 10; i++)
+        store.put("value" + i, i);
+};
+
+openReq.onsuccess = function(e) {
+    var db = e.target.result;
+    var txn = db.transaction("store", "readonly");
+    var store = txn.objectStore("store");
+
+    var firstGet = store.get(0);
+    for (var i = 1; i < 10; i++)
+        store.get(i);
+
+    txn.commit();
+
+    firstGet.onsuccess = function() {
+        parent.postMessage("committed", "*");
+    };
+};
+
+openReq.onerror = function(e) {
+    parent.postMessage("error: " + e.target.error, "*");
+};
+</script>

--- a/LayoutTests/http/tests/IndexedDB/transaction-stop-during-request-dispatch-expected.txt
+++ b/LayoutTests/http/tests/IndexedDB/transaction-stop-during-request-dispatch-expected.txt
@@ -1,0 +1,3 @@
+
+PASS IDBTransaction should not leak when stopped while a request's event dispatch is in flight
+

--- a/LayoutTests/http/tests/IndexedDB/transaction-stop-during-request-dispatch.html
+++ b/LayoutTests/http/tests/IndexedDB/transaction-stop-during-request-dispatch.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<script src="/resources/gc.js"></script>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script>
+promise_test(async (test) => {
+    assert_true(!!window.internals, "Test requires internals API");
+
+    const gcCount = 100;
+
+    gc();
+    await new Promise(r => setTimeout(r, 50));
+    const baseline = internals.numberOfIDBTransactions();
+
+    let frame = await new Promise((resolve, reject) => {
+        function onMessage() {
+            window.removeEventListener("message", onMessage);
+            resolve(f);
+        }
+        window.addEventListener("message", onMessage);
+        let f = document.createElement('iframe');
+        f.src = "resources/stop-during-request-dispatch-frame.html";
+        document.body.appendChild(f);
+    });
+
+    frame.remove();
+    frame = null;
+
+    for (let i = 0; i < gcCount; i++) {
+        gc();
+        await new Promise(r => setTimeout(r, 50));
+        if (internals.numberOfIDBTransactions() <= baseline)
+            return;
+    }
+
+    let residual = internals.numberOfIDBTransactions() - baseline;
+    assert_equals(residual, 0,
+        "IDBTransaction objects not destroyed (" + residual + " still alive after GC)");
+
+}, "IDBTransaction should not leak when stopped while a request's event dispatch is in flight");
+
+</script>

--- a/Source/WebCore/Modules/indexeddb/IDBTransaction.cpp
+++ b/Source/WebCore/Modules/indexeddb/IDBTransaction.cpp
@@ -347,8 +347,16 @@ void IDBTransaction::stop()
 
     m_openRequests.clear();
 
-    if (isFinishedOrFinishing())
+    if (isFinishedOrFinishing()) {
+        if (m_currentlyCompletingRequest) {
+            // The request event will never be dispatched after context is stopped.
+            // Reset m_currentlyCompletingRequest so handleOperationsCompletedOnServer can drain remaining operations.
+            ++m_handledRequestResultsCount;
+            m_currentlyCompletingRequest = nullptr;
+            handleOperationsCompletedOnServer();
+        }
         return;
+    }
 
     abortInternal();
 }


### PR DESCRIPTION
#### da96423634924bb1d0e6bd764918016ddef42f36
<pre>
[Win] Handle in flight requests when IndexedDB stopped
<a href="https://bugs.webkit.org/show_bug.cgi?id=313931">https://bugs.webkit.org/show_bug.cgi?id=313931</a>

Reviewed by Sihui Liu.

If a request was being completed when stop() was called, we weren&apos;t
explicitly cleaning it up and running it&apos;s completion handlers.

Test case transaction-stop-during-request-dispatch.html highlights the issue:

1. iframe issues 10 get requests, calls txn.commit(), sets onsuccess on the
first request

2. From inside firstGet.onsuccess, iframe postMessages the parent — this queues
the parent&apos;s onmessage task

3. Handler returns -&gt; finishedDispatchEventForRequest clears
m_currentlyCompletingRequest, then handleOperationsCompletedOnServer
immediately sets it to get #1

4. Parent&apos;s onmessage (queued before step 3 finished) runs frame.remove() while
m_currentlyCompletingRequest = get #1

5. IDBTransaction::stop() runs with completion in flight — pre-fix path returns
early, retain cycle survives

Canonical link: <a href="https://commits.webkit.org/312647@main">https://commits.webkit.org/312647@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d7648e7e2d1347bc4c2ee717fc9482b539cbd456

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/160559 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/34032 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/27133 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/169462 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/115625 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/162428 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/34133 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/34032 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/124510 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/87933 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/163518 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/26751 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/144226 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/105110 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/25803 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/24306 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/17182 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/135497 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/21989 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/171941 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/18751 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/23629 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/132774 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/33706 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/28399 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/132789 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35897 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/33690 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/143784 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/95486 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/27382 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/20598 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/33201 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/100351 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/32700 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/32944 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/32848 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->