### PR TITLE
Various build speed improvements

### DIFF
--- a/Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.h
+++ b/Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.h
@@ -34,6 +34,7 @@
 #include <WebCore/AXTextMarker.h>
 #include <WebCore/AXTextRun.h>
 #include <WebCore/AXTreeStore.h>
+#include <WebCore/AccessibilityObject.h>
 #include <WebCore/ColorHash.h>
 #include <WebCore/FrameIdentifier.h>
 #include <WebCore/RenderStyleConstants.h>

--- a/Source/WebCore/rendering/PathOperation.cpp
+++ b/Source/WebCore/rendering/PathOperation.cpp
@@ -103,6 +103,19 @@ std::optional<Path> ShapePathOperation::getPath(const TransformOperationData& da
     return Style::tryPath(shape(), data, zoom);
 }
 
+bool ShapePathOperation::operator==(const ShapePathOperation& other) const
+{
+    return m_shape == other.m_shape
+        && m_referenceBox == other.m_referenceBox;
+}
+
+bool ShapePathOperation::operator==(const PathOperation& other) const
+{
+    if (!isSameType(other))
+        return false;
+    return *this == uncheckedDowncast<ShapePathOperation>(other);
+}
+
 // MARK: - BoxPathOperation
 
 Ref<BoxPathOperation> BoxPathOperation::create(CSSBoxType referenceBox)
@@ -157,6 +170,18 @@ RefPtr<PathOperation> RayPathOperation::blend(const PathOperation* to, const Ble
 std::optional<Path> RayPathOperation::getPath(const TransformOperationData& data, Style::ZoomFactor zoom) const
 {
     return Style::tryPath(*ray(), data, zoom);
+}
+
+bool RayPathOperation::operator==(const RayPathOperation& other) const
+{
+    return m_ray == other.m_ray;
+}
+
+bool RayPathOperation::operator==(const PathOperation& other) const
+{
+    if (!isSameType(other))
+        return false;
+    return *this == uncheckedDowncast<RayPathOperation>(other);
 }
 
 } // namespace WebCore

--- a/Source/WebCore/rendering/PathOperation.h
+++ b/Source/WebCore/rendering/PathOperation.h
@@ -135,19 +135,10 @@ public:
 
     std::optional<Path> getPath(const TransformOperationData&, Style::ZoomFactor) const final;
 
-    bool operator==(const ShapePathOperation& other) const
-    {
-        return m_shape == other.m_shape
-            && m_referenceBox == other.m_referenceBox;
-    }
+    bool operator==(const ShapePathOperation&) const;
 
 private:
-    bool operator==(const PathOperation& other) const override
-    {
-        if (!isSameType(other))
-            return false;
-        return *this == uncheckedDowncast<ShapePathOperation>(other);
-    }
+    bool operator==(const PathOperation&) const override;
 
     ShapePathOperation(Style::BasicShape shape, CSSBoxType referenceBox)
         : PathOperation(Type::Shape, referenceBox)
@@ -201,18 +192,10 @@ public:
     double lengthForContainPath(const FloatRect& elementRect, double computedPathLength) const;
     std::optional<Path> getPath(const TransformOperationData&, Style::ZoomFactor) const final;
 
-    bool operator==(const RayPathOperation& other) const
-    {
-        return m_ray == other.m_ray;
-    }
+    bool operator==(const RayPathOperation&) const;
 
 private:
-    bool operator==(const PathOperation& other) const override
-    {
-        if (!isSameType(other))
-            return false;
-        return *this == uncheckedDowncast<RayPathOperation>(other);
-    }
+    bool operator==(const PathOperation&) const override;
 
     RayPathOperation(Style::RayFunction ray, CSSBoxType referenceBox)
         : PathOperation(Type::Ray, referenceBox)

--- a/Source/WebKit/Shared/SessionState.cpp
+++ b/Source/WebKit/Shared/SessionState.cpp
@@ -29,8 +29,19 @@
 #include "SessionStateConversion.h"
 #include <WebCore/BackForwardFrameItemIdentifier.h>
 #include <WebCore/BackForwardItemIdentifier.h>
+#include <WebCore/SerializedScriptValue.h>
 
 namespace WebKit {
+
+FrameState::~FrameState()
+{
+    RELEASE_ASSERT(RunLoop::isMain());
+}
+
+FrameState::FrameState()
+{
+    RELEASE_ASSERT(RunLoop::isMain());
+}
 
 FrameState::FrameState(String&& urlString, String&& originalURLString, String&& referrer, AtomString&& target, std::optional<WebCore::FrameIdentifier> frameID, std::optional<Vector<uint8_t>>&& stateObjectData, int64_t documentSequenceNumber, int64_t itemSequenceNumber, std::optional<WTF::UUID> navigationAPIKey, WebCore::IntPoint scrollPosition, bool shouldRestoreScrollPosition, float pageScaleFactor, std::optional<HTTPBody>&& httpBody, std::optional<WebCore::BackForwardItemIdentifier> itemID, std::optional<WebCore::BackForwardFrameItemIdentifier> frameItemID, bool hasCachedPage, String&& title, WebCore::ShouldOpenExternalURLsPolicy shouldOpenExternalURLsPolicy, RefPtr<WebCore::SerializedScriptValue>&& sessionStateObject, bool wasCreatedByJSWithoutUserInteraction, bool wasRestoredFromSession,  std::optional<WebCore::PolicyContainer>&& policyContainer,
 #if PLATFORM(IOS_FAMILY)

--- a/Source/WebKit/Shared/SessionState.h
+++ b/Source/WebKit/Shared/SessionState.h
@@ -33,7 +33,6 @@
 #include <WebCore/FrameLoaderTypes.h>
 #include <WebCore/IntRect.h>
 #include <WebCore/PolicyContainer.h>
-#include <WebCore/SerializedScriptValue.h>
 #include <wtf/ArgumentCoder.h>
 #include <wtf/RefCounted.h>
 #include <wtf/RunLoop.h>
@@ -46,6 +45,10 @@
 namespace IPC {
 class Decoder;
 class Encoder;
+}
+
+namespace WebCore {
+class SerializedScriptValue;
 }
 
 namespace WebKit {
@@ -76,7 +79,7 @@ public:
     }
 
     // This is used to help debug <rdar://problem/48634553>.
-    ~FrameState() { RELEASE_ASSERT(RunLoop::isMain()); }
+    ~FrameState();
 
     Ref<FrameState> copy();
 
@@ -131,7 +134,7 @@ public:
 
 private:
     // This is used to help debug <rdar://problem/48634553>.
-    FrameState() { RELEASE_ASSERT(RunLoop::isMain()); }
+    FrameState();
 
     FrameState(String&& urlString, String&& originalURLString, String&& referrer, AtomString&& target, std::optional<WebCore::FrameIdentifier>, std::optional<Vector<uint8_t>>&& stateObjectData, int64_t documentSequenceNumber, int64_t itemSequenceNumber, std::optional<WTF::UUID> navigationAPIKey, WebCore::IntPoint scrollPosition, bool shouldRestoreScrollPosition, float pageScaleFactor, std::optional<HTTPBody>&&, std::optional<WebCore::BackForwardItemIdentifier>, std::optional<WebCore::BackForwardFrameItemIdentifier>, bool hasCachedPage, String&& title, WebCore::ShouldOpenExternalURLsPolicy, RefPtr<WebCore::SerializedScriptValue>&& sessionStateObject, bool wasCreatedByJSWithoutUserInteraction, bool wasRestoredFromSession,  std::optional<WebCore::PolicyContainer>&&,
 #if PLATFORM(IOS_FAMILY)

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -8869,7 +8869,7 @@ struct WebCore::WrappedCryptoKey {
 };
 
 #if PLATFORM(IOS_FAMILY)
-using WebCore::RenderThemeIOS::CSSValueToSystemColorMap = HashMap<WebCore::CSSValueKey, WebCore::Color>
+using WebCore::CSSValueToSystemColorMap = HashMap<WebCore::CSSValueKey, WebCore::Color>
 #endif
 
 enum class WebCore::WorkerThreadMode : bool

--- a/Source/WebKit/Shared/WebProcessCreationParameters.h
+++ b/Source/WebKit/Shared/WebProcessCreationParameters.h
@@ -55,7 +55,8 @@
 #endif
 
 #if PLATFORM(IOS_FAMILY)
-#include <WebCore/RenderThemeIOS.h>
+#include <WebCore/CSSValueKey.h>
+#include <WebCore/ColorHash.h>
 #include <pal/system/ios/UserInterfaceIdiom.h>
 #endif
 
@@ -73,6 +74,12 @@
 namespace API {
 class Data;
 }
+
+#if PLATFORM(IOS_FAMILY)
+namespace WebCore {
+using CSSValueToSystemColorMap = HashMap<CSSValueKey, Color>;
+}
+#endif
 
 namespace WebKit {
 
@@ -216,7 +223,7 @@ struct WebProcessCreationParameters {
 #if PLATFORM(IOS_FAMILY)
     PAL::UserInterfaceIdiom currentUserInterfaceIdiom { PAL::UserInterfaceIdiom::Default };
     bool supportsPictureInPicture { false };
-    WebCore::RenderThemeIOS::CSSValueToSystemColorMap cssValueToSystemColorMap;
+    WebCore::CSSValueToSystemColorMap cssValueToSystemColorMap;
     WebCore::Color focusRingColor;
     String localizedDeviceModel;
     String contentSizeCategory;

--- a/Source/WebKit/Shared/WebProcessCreationParameters.serialization.in
+++ b/Source/WebKit/Shared/WebProcessCreationParameters.serialization.in
@@ -164,7 +164,7 @@ using WebCore::SystemSettings::State = WebCore::SystemSettingsState;
 #if PLATFORM(IOS_FAMILY)
     PAL::UserInterfaceIdiom currentUserInterfaceIdiom;
     bool supportsPictureInPicture;
-    WebCore::RenderThemeIOS::CSSValueToSystemColorMap cssValueToSystemColorMap;
+    WebCore::CSSValueToSystemColorMap cssValueToSystemColorMap;
     WebCore::Color focusRingColor;
     String localizedDeviceModel;
     String contentSizeCategory;

--- a/Source/WebKit/UIProcess/Cocoa/WebProcessPoolCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/WebProcessPoolCocoa.mm
@@ -125,6 +125,7 @@
 #endif
 
 #if PLATFORM(IOS_FAMILY)
+#import <WebCore/RenderThemeIOS.h>
 #import <pal/spi/ios/GraphicsServicesSPI.h>
 #import <pal/spi/ios/MobileGestaltSPI.h>
 #endif

--- a/Source/WebKit/UIProcess/ProcessActivityGroup.cpp
+++ b/Source/WebKit/UIProcess/ProcessActivityGroup.cpp
@@ -26,6 +26,8 @@
 #include "config.h"
 #include "ProcessActivityGroup.h"
 
+#include "WebProcessProxy.h"
+
 namespace WebKit {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(ProcessActivityGroup);
@@ -87,6 +89,11 @@ void ProcessActivityGroup::activityTimedOut()
 Ref<ProcessActivityGroup> ProcessActivityGroupContext::foregroundProcessActivityGroup(ASCIILiteral name, std::optional<Seconds> timeout)
 {
     return ProcessActivityGroup::create(*this, name, ProcessThrottlerActivityType::Foreground, timeout);
+}
+
+Vector<Ref<WebProcessProxy>> ProcessActivityGroupContext::activityTargets()
+{
+    return { };
 }
 
 void ProcessActivityGroupContext::addProcessActivityGroup(ProcessActivityGroup& activityGroup)

--- a/Source/WebKit/UIProcess/ProcessActivityGroup.h
+++ b/Source/WebKit/UIProcess/ProcessActivityGroup.h
@@ -26,7 +26,6 @@
 #pragma once
 
 #include "ProcessThrottler.h"
-#include "WebProcessProxy.h"
 
 #include <WebCore/ProcessIdentifier.h>
 #include <wtf/RunLoop.h>
@@ -34,6 +33,7 @@
 namespace WebKit {
 
 class ProcessActivityGroup;
+class WebProcessProxy;
 
 class ProcessActivityGroupContext
 : public CanMakeWeakPtr<ProcessActivityGroupContext>
@@ -47,7 +47,7 @@ public:
 
     Ref<ProcessActivityGroup> foregroundProcessActivityGroup(ASCIILiteral name, std::optional<Seconds> timeout = std::nullopt);
 
-    virtual Vector<Ref<WebProcessProxy>> activityTargets() { return { }; }
+    virtual Vector<Ref<WebProcessProxy>> activityTargets();
 
     void didAddActivityTarget(WebProcessProxy&);
     void didRemoveActivityTarget(WebProcessProxy&);

--- a/Source/WebKit/WebProcess/WebCoreSupport/SessionStateConversion.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/SessionStateConversion.cpp
@@ -30,6 +30,7 @@
 #include <WebCore/BlobData.h>
 #include <WebCore/FormData.h>
 #include <WebCore/HistoryItem.h>
+#include <WebCore/SerializedScriptValue.h>
 #include <wtf/FileSystem.h>
 
 namespace WebKit {

--- a/Source/WebKit/WebProcess/cocoa/WebProcessCocoa.mm
+++ b/Source/WebKit/WebProcess/cocoa/WebProcessCocoa.mm
@@ -146,6 +146,7 @@
 #if PLATFORM(IOS_FAMILY)
 #import "AccessibilityUtilitiesSPI.h"
 #import "UIKitSPI.h"
+#import <WebCore/RenderThemeIOS.h>
 #import <wtf/spi/darwin/MemoryStatusSPI.h>
 #endif
 


### PR DESCRIPTION
#### 2b861656bd50d9ea7ea3ef518559e9ac9d683d72
<pre>
Various build speed improvements
<a href="https://bugs.webkit.org/show_bug.cgi?id=313934">https://bugs.webkit.org/show_bug.cgi?id=313934</a>
<a href="https://rdar.apple.com/176137158">rdar://176137158</a>

Reviewed by Richard Robinson.

Three miscellaneous build speed improvements:
1. PathOperation.h was expensive because of the mpark::* template instantiations
   in the various operator==. Move those to the .cpp file

2. WebProcessProxy.h was expensive becaused it pulled in WebProcessCreationParameters.h,
   which, on iOS, pulled in lots of style-related headers via RenderThemeIOS.h.
   Instead, forware-declare CSSValueToSystemColorMap.

3. SessionState.h pulled in SerializedScriptValue.h which was expensive; fix by
   forward-declaring SerializedScriptValue.

* Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.h:
* Source/WebCore/rendering/PathOperation.cpp:
(WebCore::ShapePathOperation::operator== const):
(WebCore::RayPathOperation::operator== const):
* Source/WebCore/rendering/PathOperation.h:
* Source/WebKit/Shared/SessionState.cpp:
(WebKit::FrameState::~FrameState):
(WebKit::FrameState::FrameState):
* Source/WebKit/Shared/SessionState.h:
(WebKit::FrameState::~FrameState): Deleted.
(WebKit::FrameState::FrameState): Deleted.
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:
* Source/WebKit/Shared/WebProcessCreationParameters.h:
* Source/WebKit/Shared/WebProcessCreationParameters.serialization.in:
* Source/WebKit/UIProcess/Cocoa/WebProcessPoolCocoa.mm:
* Source/WebKit/UIProcess/ProcessActivityGroup.cpp:
(WebKit::ProcessActivityGroupContext::activityTargets):
* Source/WebKit/UIProcess/ProcessActivityGroup.h:
(WebKit::ProcessActivityGroupContext::activityTargets): Deleted.
* Source/WebKit/WebProcess/WebCoreSupport/SessionStateConversion.cpp:
* Source/WebKit/WebProcess/cocoa/WebProcessCocoa.mm:

Canonical link: <a href="https://commits.webkit.org/312492@main">https://commits.webkit.org/312492@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a2ca92c9a8522e294b94c0a4fae162066a05c83a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/160178 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/33648 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/26752 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/169080 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/114559 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/cf31de5c-9a07-4638-9833-63f4301a1eae) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/162047 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/33751 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/33650 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/124171 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/87097 "2 flakes 2 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/aad503bc-829b-4870-bc58-7dd547d4e398) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/163136 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/26414 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/143873 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/104770 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/a6f9ba11-1a9e-4a64-996c-76ca496e1690) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/25467 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/23961 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/16799 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/135159 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/21636 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/171556 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/17546 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/23276 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/132423 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/33324 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/28053 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/132449 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35804 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/33309 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/143431 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/91577 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/27065 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/20245 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/32818 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/99215 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/32316 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/32562 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/32466 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->