### PR TITLE
Skip array-prototype-concat-of-long-spliced-arrays(2).js in lockdown mode

### DIFF
--- a/JSTests/stress/array-prototype-concat-of-long-spliced-arrays.js
+++ b/JSTests/stress/array-prototype-concat-of-long-spliced-arrays.js
@@ -1,5 +1,5 @@
 //@ exclusive!
-//@ $skipModes << :lockdown if $memoryLimited  or $buildType == "debug"
+//@ $skipModes << :lockdown
 
 function shouldEqual(actual, expected) {
     if (actual != expected) {

--- a/JSTests/stress/array-prototype-concat-of-long-spliced-arrays2.js
+++ b/JSTests/stress/array-prototype-concat-of-long-spliced-arrays2.js
@@ -1,5 +1,5 @@
 //@ exclusive!
-//@ $skipModes << :lockdown if $memoryLimited or $buildType == "debug"
+//@ $skipModes << :lockdown
 
 function shouldEqual(actual, expected) {
     if (actual != expected) {


### PR DESCRIPTION
#### 07ed242e9726710558ec6e4983242f91cc21cc5a
<pre>
Skip array-prototype-concat-of-long-spliced-arrays(2).js in lockdown mode
<a href="https://bugs.webkit.org/show_bug.cgi?id=313937">https://bugs.webkit.org/show_bug.cgi?id=313937</a>
<a href="https://rdar.apple.com/176144091">rdar://176144091</a>

Reviewed by Yusuke Suzuki.

These two stress tests are by far the slowest in the JSC stress suite,
each taking ~165s of wall-clock time in lockdown mode (~330s combined).
In every other configuration they complete in 170-450ms.

Lockdown mode (--useJIT=false --alwaysHaveABadTime --useZombieMode
--allowDoubleShape=false --libpasForcePGMWithRate=15) adds no unique
coverage for the bug these tests guard, which lives in the C++
arrayProtoFuncConcat overflow check. That host function runs identically
regardless of JIT/LLInt/PGM/zombie-mode state. The 17 remaining stress
configurations (default, bytecode-cache, mini-mode, no-llint, no-ftl,
dfg-eager, ftl-eager, etc.) continue to exercise the same throw path.

run-jsc-stress-tests --filter run goes from 360.86s to 12.77s wall-clock
with all 36 remaining mode/test combinations.

Canonical link: <a href="https://commits.webkit.org/312519@main">https://commits.webkit.org/312519@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/43f23db4ad32929b4484ef3f286eb3b202ef70e0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/160191 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/33661 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/26765 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/169093 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/114572 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/cecacf62-1af9-4be1-ade8-07d515d17ea0) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/33764 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/33663 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/124181 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/87108 "2 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/25f7d6fe-9556-471c-832f-1f8e923621ac) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/163149 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/26424 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/143883 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/104780 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/c346ef2b-54cb-480d-9dc2-053429ba216c) 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/25477 "Found 1 new test failure: imported/w3c/web-platform-tests/navigation-api/navigate-event/signal-abort-window-stop.html (failure)") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/23971 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/16812 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/152247 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/135169 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/171569 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/21028 "Built successfully and passed tests") | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/23286 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/132433 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/33337 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/28065 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/132459 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/33322 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/143441 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/91597 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/24378 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/27076 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/20255 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/192554 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/32831 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/49526 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/32329 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/32575 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/32479 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->