### PR TITLE
[libpas] Support a soft failable allocation limit

### DIFF
--- a/Source/JavaScriptCore/runtime/Options.cpp
+++ b/Source/JavaScriptCore/runtime/Options.cpp
@@ -380,6 +380,8 @@ bool Options::isAvailable(Options::ID id, Options::Availability availability)
     if (id == maxSingleAllocationSizeID)
         return true;
 #endif
+    if (id == softFailableAllocationLimitID)
+        return true;
     if (id == traceLLIntExecutionID)
         return !!LLINT_TRACING;
     if (id == traceLLIntSlowPathID)
@@ -941,6 +943,8 @@ void Options::notifyOptionsChanged()
     else
         fastSetMaxSingleAllocationSize(std::numeric_limits<size_t>::max());
 #endif
+
+    fastSetSoftFailableAllocationLimit(Options::softFailableAllocationLimit());
 
     if (Options::useZombieMode()) {
         Options::sweepSynchronously() = true;

--- a/Source/JavaScriptCore/runtime/OptionsList.h
+++ b/Source/JavaScriptCore/runtime/OptionsList.h
@@ -419,6 +419,7 @@ bool hasCapacityToUseLargeGigacage();
     v(Bool, useImmortalObjects, false, Normal, "debugging option to keep all objects alive forever"_s) \
     v(Bool, sweepSynchronously, false, Normal, "debugging option to sweep all dead objects synchronously at GC end before resuming mutator"_s) \
     v(Unsigned, maxSingleAllocationSize, 0, Configurable, "debugging option to limit individual allocations to a max size (0 = limit not set, N = limit size in bytes)"_s) \
+    v(Size, softFailableAllocationLimit, std::numeric_limits<size_t>::max(), Configurable, "soft limit (in bytes of memory obtained from the OS by libpas): once crossed, libpas slow-path allocations from failable callers (tryFastMalloc and friends) that would need new OS pages fail; once tripped, per-thread local allocators are drained on the slow path so future allocations re-enter the slow path. Non-failable paths still grow past this limit. For OOM testing."_s) \
     \
     v(GCLogLevel, logGC, GCLogging::None, Normal, "debugging option to log GC activity (0 = None, 1 = Basic, 2 = Verbose)"_s) \
     v(Bool, useGC, true, Normal, nullptr) \

--- a/Source/WTF/wtf/FastMalloc.cpp
+++ b/Source/WTF/wtf/FastMalloc.cpp
@@ -94,6 +94,11 @@ void fastSetMaxSingleAllocationSize(size_t size)
 
 #endif // !defined(NDEBUG)
 
+void fastSetSoftFailableAllocationLimit(size_t size)
+{
+    bmalloc::api::setSoftFailableAllocationLimit(size);
+}
+
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 
 char* fastStrDup(const char* src)

--- a/Source/WTF/wtf/FastMalloc.h
+++ b/Source/WTF/wtf/FastMalloc.h
@@ -129,6 +129,8 @@ namespace WTF {
 WTF_EXPORT_PRIVATE void fastSetMaxSingleAllocationSize(size_t);
 #endif
 
+WTF_EXPORT_PRIVATE void fastSetSoftFailableAllocationLimit(size_t);
+
 WTF_EXPORT_PRIVATE bool isFastMallocEnabled();
 
 // These functions call CRASH() if an allocation fails.
@@ -389,6 +391,8 @@ WTF_EXPORT_PRIVATE void* mallocArray(Kind, size_t numElements, size_t elementSiz
 #if !defined(NDEBUG)
 using WTF::fastSetMaxSingleAllocationSize;
 #endif
+
+using WTF::fastSetSoftFailableAllocationLimit;
 
 template<typename T>
 struct AllowCompactPointers : std::false_type { };

--- a/Source/bmalloc/bmalloc/bmalloc.cpp
+++ b/Source/bmalloc/bmalloc/bmalloc.cpp
@@ -36,6 +36,7 @@
 #include "pas_platform.h"
 #include "pas_probabilistic_guard_malloc_allocator.h"
 #include "pas_scavenger.h"
+#include "pas_page_malloc.h"
 #include "pas_thread_local_cache.h"
 #include "pas_mte_config.h"
 #endif
@@ -208,6 +209,15 @@ void forceEnablePGM(uint16_t guardMallocRate)
     pas_probabilistic_guard_malloc_initialize_pgm_as_enabled(guardMallocRate);
 #else
     BUNUSED_PARAM(guardMallocRate);
+#endif
+}
+
+void setSoftFailableAllocationLimit(size_t size)
+{
+#if BUSE(LIBPAS)
+    pas_set_soft_failable_allocation_limit(size);
+#else
+    BUNUSED_PARAM(size);
 #endif
 }
 

--- a/Source/bmalloc/bmalloc/bmalloc.h
+++ b/Source/bmalloc/bmalloc/bmalloc.h
@@ -318,6 +318,12 @@ BEXPORT void enableMiniMode(bool forceMiniMode = false);
 BEXPORT void disableScavenger();
 BEXPORT void forceEnablePGM(uint16_t guardMallocRate);
 
+// For OOM testing. When set below SIZE_MAX, failable libpas allocations (e.g. tryFastMalloc-
+// driven paths) that would require libpas to obtain new pages from the OS will fail once
+// libpas has obtained at least this many bytes from the OS. This is a soft limit:
+// non-failable paths continue to grow past it.
+BEXPORT void setSoftFailableAllocationLimit(size_t);
+
 #if BENABLE(MALLOC_SIZE)
 inline size_t mallocSize(const void* object)
 {

--- a/Source/bmalloc/libpas/src/libpas/jit_heap_config.c
+++ b/Source/bmalloc/libpas/src/libpas/jit_heap_config.c
@@ -59,10 +59,12 @@ pas_simple_large_free_heap jit_fresh_memory_heap = PAS_SIMPLE_LARGE_FREE_HEAP_IN
 
 static pas_aligned_allocation_result fresh_memory_aligned_allocator(size_t size,
                                                                     pas_alignment alignment,
+                                                                    bool is_failable,
                                                                     void *arg)
 {
     PAS_UNUSED_PARAM(size);
     PAS_UNUSED_PARAM(alignment);
+    PAS_UNUSED_PARAM(is_failable);
     PAS_ASSERT(!arg);
     return pas_aligned_allocation_result_create_empty();
 }
@@ -77,25 +79,25 @@ static void initialize_fresh_memory_config(pas_large_free_heap_config* config)
     config->deallocator_arg = NULL;
 }
 
-static pas_allocation_result allocate_from_fresh(size_t size, pas_alignment alignment)
+static pas_allocation_result allocate_from_fresh(size_t size, pas_alignment alignment, bool is_failable)
 {
     pas_large_free_heap_config config;
 
     pas_heap_lock_assert_held();
 
     initialize_fresh_memory_config(&config);
-    return pas_simple_large_free_heap_try_allocate(&jit_fresh_memory_heap, size, alignment, &config);
+    return pas_simple_large_free_heap_try_allocate(&jit_fresh_memory_heap, size, alignment, is_failable, &config);
 }
 
 static pas_allocation_result page_provider(
-    size_t size, pas_alignment alignment, const char* name,
+    size_t size, pas_alignment alignment, bool is_failable, const char* name,
     pas_heap* heap, pas_physical_memory_transaction* transaction, void* arg)
 {
     PAS_UNUSED_PARAM(name);
     PAS_UNUSED_PARAM(heap);
     PAS_UNUSED_PARAM(transaction);
     PAS_ASSERT(!arg);
-    return allocate_from_fresh(size, alignment);
+    return allocate_from_fresh(size, alignment, is_failable);
 }
 
 pas_large_heap_physical_page_sharing_cache jit_large_fresh_memory_heap = {
@@ -149,7 +151,7 @@ void* jit_small_segregated_allocate_page(
     PAS_UNUSED_PARAM(heap);
     PAS_UNUSED_PARAM(transaction);
     return (void*)allocate_from_fresh(
-        JIT_SMALL_PAGE_SIZE, pas_alignment_create_traditional(JIT_SMALL_PAGE_SIZE)).begin;
+        JIT_SMALL_PAGE_SIZE, pas_alignment_create_traditional(JIT_SMALL_PAGE_SIZE), true).begin;
 }
 
 pas_page_base* jit_small_segregated_create_page_header(
@@ -182,7 +184,7 @@ void* jit_small_bitfit_allocate_page(
     PAS_UNUSED_PARAM(heap);
     PAS_UNUSED_PARAM(transaction);
     return (void*)allocate_from_fresh(
-        JIT_SMALL_PAGE_SIZE, pas_alignment_create_traditional(JIT_SMALL_PAGE_SIZE)).begin;
+        JIT_SMALL_PAGE_SIZE, pas_alignment_create_traditional(JIT_SMALL_PAGE_SIZE), true).begin;
 }
 
 pas_page_base* jit_small_bitfit_create_page_header(
@@ -205,7 +207,7 @@ void* jit_medium_bitfit_allocate_page(
     PAS_UNUSED_PARAM(heap);
     PAS_UNUSED_PARAM(transaction);
     return (void*)allocate_from_fresh(
-        JIT_MEDIUM_PAGE_SIZE, pas_alignment_create_traditional(JIT_MEDIUM_PAGE_SIZE)).begin;
+        JIT_MEDIUM_PAGE_SIZE, pas_alignment_create_traditional(JIT_MEDIUM_PAGE_SIZE), true).begin;
 }
 
 pas_page_base* jit_medium_bitfit_create_page_header(
@@ -233,7 +235,7 @@ void jit_medium_destroy_page_header(
 }
 
 pas_aligned_allocation_result jit_aligned_allocator(
-    size_t size, pas_alignment alignment, pas_large_heap* large_heap, const pas_heap_config* config)
+    size_t size, pas_alignment alignment, bool is_failable, pas_large_heap* large_heap, const pas_heap_config* config)
 {
     pas_aligned_allocation_result result;
     size_t aligned_size;
@@ -241,13 +243,13 @@ pas_aligned_allocation_result jit_aligned_allocator(
 
     PAS_UNUSED_PARAM(large_heap);
     PAS_UNUSED_PARAM(config);
-    
+
     pas_zero_memory(&result, sizeof(result));
 
     aligned_size = pas_round_up_to_power_of_2(size, alignment.alignment);
 
     allocation_result = pas_large_heap_physical_page_sharing_cache_try_allocate_with_alignment(
-        &jit_large_fresh_memory_heap, aligned_size, alignment, config, false);
+        &jit_large_fresh_memory_heap, aligned_size, alignment, is_failable, config, false);
     if (!allocation_result.did_succeed)
         return result;
 

--- a/Source/bmalloc/libpas/src/libpas/jit_heap_config.h
+++ b/Source/bmalloc/libpas/src/libpas/jit_heap_config.h
@@ -106,7 +106,7 @@ jit_heap_config_fast_megapage_kind(uintptr_t begin)
 
 static PAS_ALWAYS_INLINE pas_page_base* jit_heap_config_page_header(uintptr_t begin);
 PAS_API pas_aligned_allocation_result jit_aligned_allocator(
-    size_t size, pas_alignment alignment, pas_large_heap* large_heap, const pas_heap_config* config);
+    size_t size, pas_alignment alignment, bool is_failable, pas_large_heap* large_heap, const pas_heap_config* config);
 PAS_API void* jit_prepare_to_enumerate(pas_enumerator* enumerator);
 
 PAS_HEAP_CONFIG_SPECIALIZATION_DECLARATIONS(jit_heap_config);

--- a/Source/bmalloc/libpas/src/libpas/pas_aligned_allocator.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_aligned_allocator.h
@@ -33,6 +33,7 @@ PAS_BEGIN_EXTERN_C;
 
 typedef pas_aligned_allocation_result (*pas_aligned_allocator)(size_t size,
                                                                pas_alignment alignment,
+                                                               bool is_failable,
                                                                void* arg);
 
 PAS_END_EXTERN_C;

--- a/Source/bmalloc/libpas/src/libpas/pas_bootstrap_free_heap.c
+++ b/Source/bmalloc/libpas/src/libpas/pas_bootstrap_free_heap.c
@@ -37,6 +37,7 @@
 
 static pas_aligned_allocation_result bootstrap_source_allocate_aligned(size_t size,
                                                                        pas_alignment alignment,
+                                                                       bool is_failable,
                                                                        void* arg)
 {
     PAS_UNUSED_PARAM(arg);
@@ -45,7 +46,7 @@ static pas_aligned_allocation_result bootstrap_source_allocate_aligned(size_t si
     if (verbose)
         pas_log("bootstrap heap allocating %zu\n", size);
 
-    pas_aligned_allocation_result retval = pas_enumerable_page_malloc_try_allocate_without_deallocating_padding(size, alignment, false);
+    pas_aligned_allocation_result retval = pas_enumerable_page_malloc_try_allocate_without_deallocating_padding(size, alignment, false, is_failable);
 
     if (verbose)
         pas_log("bootstrap heap done allocating, returning %p.\n", retval.result);

--- a/Source/bmalloc/libpas/src/libpas/pas_bootstrap_heap_page_provider.c
+++ b/Source/bmalloc/libpas/src/libpas/pas_bootstrap_heap_page_provider.c
@@ -34,6 +34,7 @@
 pas_allocation_result pas_bootstrap_heap_page_provider(
     size_t size,
     pas_alignment alignment,
+    bool is_failable,
     const char* name,
     pas_heap* heap,
     pas_physical_memory_transaction* transaction,
@@ -48,7 +49,7 @@ pas_allocation_result pas_bootstrap_heap_page_provider(
         pas_log("bootstreap heap page-provider allocating %zu for %s\n", size, name);
 
     pas_allocation_result retval = pas_bootstrap_free_heap_try_allocate_with_alignment(
-        size, alignment, name, pas_delegate_allocation);
+        size, alignment, is_failable, name, pas_delegate_allocation);
 
     if (verbose)
         pas_log("bootstrap heap page-provider done allocating\n");

--- a/Source/bmalloc/libpas/src/libpas/pas_bootstrap_heap_page_provider.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_bootstrap_heap_page_provider.h
@@ -33,6 +33,7 @@ PAS_BEGIN_EXTERN_C;
 PAS_API pas_allocation_result pas_bootstrap_heap_page_provider(
     size_t size,
     pas_alignment alignment,
+    bool is_failable,
     const char* name,
     pas_heap* heap,
     pas_physical_memory_transaction* transaction,

--- a/Source/bmalloc/libpas/src/libpas/pas_compact_bootstrap_free_heap.c
+++ b/Source/bmalloc/libpas/src/libpas/pas_compact_bootstrap_free_heap.c
@@ -39,10 +39,12 @@
 static pas_aligned_allocation_result compact_bootstrap_source_allocate_aligned(
     size_t size,
     pas_alignment alignment,
+    bool is_failable,
     void* arg)
 {
     PAS_ASSERT(!arg);
     PAS_ASSERT(!alignment.alignment_begin);
+    PAS_UNUSED_PARAM(is_failable);
     static const bool verbose = PAS_SHOULD_LOG(PAS_LOG_BOOTSTRAP_HEAPS);
 
     if (verbose)

--- a/Source/bmalloc/libpas/src/libpas/pas_compact_heap_reservation.c
+++ b/Source/bmalloc/libpas/src/libpas/pas_compact_heap_reservation.c
@@ -72,7 +72,7 @@ pas_aligned_allocation_result pas_compact_heap_reservation_try_allocate(size_t s
         PAS_ASSERT(page_result.result);
 #else
         page_result = pas_page_malloc_try_allocate_without_deallocating_padding(
-            pas_compact_heap_reservation_size, pas_alignment_create_trivial(), false);
+            pas_compact_heap_reservation_size, pas_alignment_create_trivial(), false, false);
         PAS_ASSERT(!page_result.left_padding_size);
         PAS_ASSERT(!page_result.right_padding_size);
         PAS_ASSERT(page_result.result);

--- a/Source/bmalloc/libpas/src/libpas/pas_create_basic_heap_page_caches_with_reserved_memory.c
+++ b/Source/bmalloc/libpas/src/libpas/pas_create_basic_heap_page_caches_with_reserved_memory.c
@@ -40,6 +40,7 @@
 static pas_allocation_result allocate_from_compact_megapages(
     size_t size,
     pas_alignment alignment,
+    bool is_failable,
     const char* name,
     pas_heap* heap,
     pas_physical_memory_transaction* transaction,
@@ -49,6 +50,7 @@ static pas_allocation_result allocate_from_compact_megapages(
 
     PAS_UNUSED_PARAM(name);
     PAS_UNUSED_PARAM(arg);
+    PAS_UNUSED_PARAM(is_failable);
     PAS_ASSERT(heap);
     PAS_ASSERT(transaction);
     PAS_ASSERT(!alignment.alignment_begin);
@@ -63,6 +65,7 @@ static pas_allocation_result allocate_from_compact_megapages(
 static pas_allocation_result allocate_from_megapages(
     size_t size,
     pas_alignment alignment,
+    bool is_failable,
     const char* name,
     pas_heap* heap,
     pas_physical_memory_transaction* transaction,
@@ -72,6 +75,7 @@ static pas_allocation_result allocate_from_megapages(
     pas_megapage_cache_size cache_size = (pas_megapage_cache_size)(uintptr_t)arg;
 
     PAS_UNUSED_PARAM(name);
+    PAS_UNUSED_PARAM(is_failable);
     PAS_ASSERT(heap);
     PAS_ASSERT(transaction);
     PAS_ASSERT(!alignment.alignment_begin);

--- a/Source/bmalloc/libpas/src/libpas/pas_enumerable_page_malloc.c
+++ b/Source/bmalloc/libpas/src/libpas/pas_enumerable_page_malloc.c
@@ -35,11 +35,11 @@ pas_enumerable_range_list pas_enumerable_page_malloc_page_list;
 
 pas_aligned_allocation_result
 pas_enumerable_page_malloc_try_allocate_without_deallocating_padding(
-    size_t size, pas_alignment alignment, bool may_contain_small_or_medium)
+    size_t size, pas_alignment alignment, bool may_contain_small_or_medium, bool is_failable)
 {
     pas_aligned_allocation_result result;
 
-    result = pas_page_malloc_try_allocate_without_deallocating_padding(size, alignment, may_contain_small_or_medium);
+    result = pas_page_malloc_try_allocate_without_deallocating_padding(size, alignment, may_contain_small_or_medium, is_failable);
 
     if (result.result) {
         pas_enumerable_range_list_append(

--- a/Source/bmalloc/libpas/src/libpas/pas_enumerable_page_malloc.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_enumerable_page_malloc.h
@@ -37,7 +37,7 @@ PAS_API extern pas_enumerable_range_list pas_enumerable_page_malloc_page_list;
 /* It's assumed that whatever is returned from this is never deallocated, but may be decommitted. */
 PAS_API pas_aligned_allocation_result
 pas_enumerable_page_malloc_try_allocate_without_deallocating_padding(
-    size_t size, pas_alignment alignment, bool may_contain_small_or_medium);
+    size_t size, pas_alignment alignment, bool may_contain_small_or_medium, bool is_failable);
 
 PAS_END_EXTERN_C;
 

--- a/Source/bmalloc/libpas/src/libpas/pas_enumerator_region.c
+++ b/Source/bmalloc/libpas/src/libpas/pas_enumerator_region.c
@@ -52,7 +52,7 @@ void* pas_enumerator_region_allocate(pas_enumerator_region** region_ptr,
         PAS_ASSERT_WITH_DETAIL(pas_is_aligned(allocation_size, PAS_INTERNAL_MIN_ALIGN));
 
         allocation_result = pas_page_malloc_try_allocate_without_deallocating_padding(
-            allocation_size, pas_alignment_create_trivial(), false);
+            allocation_size, pas_alignment_create_trivial(), false, false);
 
         PAS_ASSERT_WITH_DETAIL(allocation_result.result);
         PAS_ASSERT_WITH_DETAIL(allocation_result.result == allocation_result.left_padding);

--- a/Source/bmalloc/libpas/src/libpas/pas_fast_large_free_heap.c
+++ b/Source/bmalloc/libpas/src/libpas/pas_fast_large_free_heap.c
@@ -413,6 +413,7 @@ static PAS_ALWAYS_INLINE void initialize_generic_heap_config(
 pas_allocation_result pas_fast_large_free_heap_try_allocate(pas_fast_large_free_heap* heap,
                                                             size_t size,
                                                             pas_alignment alignment,
+                                                            bool is_failable,
                                                             pas_large_free_heap_config* config)
 {
     static const bool verbose = PAS_SHOULD_LOG(PAS_LOG_LARGE_HEAPS);
@@ -422,7 +423,7 @@ pas_allocation_result pas_fast_large_free_heap_try_allocate(pas_fast_large_free_
     initialize_generic_heap_config(&generic_heap_config);
     return pas_generic_large_free_heap_try_allocate(
         (pas_generic_large_free_heap*)heap,
-        size, alignment, config,
+        size, alignment, is_failable, config,
         &generic_heap_config);
 }
 

--- a/Source/bmalloc/libpas/src/libpas/pas_fast_large_free_heap.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_fast_large_free_heap.h
@@ -65,6 +65,7 @@ PAS_API pas_allocation_result
 pas_fast_large_free_heap_try_allocate(pas_fast_large_free_heap* heap,
                                       size_t size,
                                       pas_alignment alignment,
+                                      bool is_failable,
                                       pas_large_free_heap_config* config);
 
 PAS_API void pas_fast_large_free_heap_deallocate(pas_fast_large_free_heap* heap,

--- a/Source/bmalloc/libpas/src/libpas/pas_fast_megapage_cache.c
+++ b/Source/bmalloc/libpas/src/libpas/pas_fast_megapage_cache.c
@@ -64,12 +64,13 @@ void* pas_fast_megapage_cache_try_allocate(
     const pas_page_base_config* config,
     pas_fast_megapage_kind kind,
     bool should_zero,
+    bool is_failable,
     pas_heap* heap,
     pas_physical_memory_transaction* transaction)
 {
     pas_megapage_cache_config cache_config;
     table_set_by_index_data data;
-    
+
     data.table = table;
     data.kind = kind;
 
@@ -81,8 +82,8 @@ void* pas_fast_megapage_cache_try_allocate(
     cache_config.table_set_by_index = table_set_by_index;
     cache_config.table_set_by_index_arg = &data;
     cache_config.should_zero = should_zero;
-    
-    return pas_megapage_cache_try_allocate(cache, &cache_config, heap, transaction);
+
+    return pas_megapage_cache_try_allocate(cache, &cache_config, is_failable, heap, transaction);
 }
 
 PAS_END_EXTERN_C;

--- a/Source/bmalloc/libpas/src/libpas/pas_fast_megapage_cache.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_fast_megapage_cache.h
@@ -50,6 +50,7 @@ PAS_API void* pas_fast_megapage_cache_try_allocate(
     const pas_page_base_config* config,
     pas_fast_megapage_kind kind,
     bool should_zero,
+    bool is_failable,
     pas_heap* heap,
     pas_physical_memory_transaction* transaction);
 

--- a/Source/bmalloc/libpas/src/libpas/pas_generic_large_free_heap.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_generic_large_free_heap.h
@@ -174,6 +174,7 @@ pas_generic_large_free_heap_try_allocate(
     pas_generic_large_free_heap* heap,
     size_t size,
     pas_alignment alignment,
+    bool is_failable,
     pas_large_free_heap_config* config,
     pas_generic_large_free_heap_config* generic_heap_config)
 {
@@ -225,7 +226,7 @@ pas_generic_large_free_heap_try_allocate(
             generic_heap_config->dump(heap);
         }
         
-        page_allocation = config->aligned_allocator(size, alignment, config->aligned_allocator_arg);
+        page_allocation = config->aligned_allocator(size, alignment, is_failable, config->aligned_allocator_arg);
         if (!page_allocation.result) {
             if (PAS_GENERIC_LARGE_FREE_HEAP_VERBOSE >= 2)
                 pas_log("Returning failure.\n");

--- a/Source/bmalloc/libpas/src/libpas/pas_heap_config.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_heap_config.h
@@ -72,6 +72,7 @@ typedef pas_page_base* (*pas_heap_config_page_header_func)(uintptr_t begin);
 typedef pas_aligned_allocation_result (*pas_heap_config_aligned_allocator)(
     size_t size,
     pas_alignment alignment,
+    bool is_failable,
     pas_large_heap* large_heap,
     const pas_heap_config* config);
 typedef void* (*pas_heap_config_prepare_to_enumerate)(pas_enumerator* enumerator);

--- a/Source/bmalloc/libpas/src/libpas/pas_heap_config_utils.c
+++ b/Source/bmalloc/libpas/src/libpas/pas_heap_config_utils.c
@@ -45,12 +45,13 @@ pas_aligned_allocation_result
 pas_heap_config_utils_allocate_aligned(
     size_t size,
     pas_alignment alignment,
+    bool is_failable,
     pas_large_heap* large_heap,
     const pas_heap_config* config,
     bool should_zero)
 {
     static const bool verbose = false;
-    
+
     pas_large_heap_physical_page_sharing_cache* cache;
     pas_aligned_allocation_result result;
     pas_allocation_result allocation_result;
@@ -61,7 +62,7 @@ pas_heap_config_utils_allocate_aligned(
     PAS_UNUSED_PARAM(config);
 
     pas_zero_memory(&result, sizeof(result));
-    
+
     aligned_size = pas_round_up_to_power_of_2(size, alignment.alignment);
 
     runtime_config = (pas_basic_heap_runtime_config*)
@@ -70,10 +71,10 @@ pas_heap_config_utils_allocate_aligned(
         cache = &runtime_config->page_caches->megapage_large_heap_cache;
     else
         cache = &runtime_config->page_caches->large_heap_cache;
-    
+
     allocation_result =
         pas_large_heap_physical_page_sharing_cache_try_allocate_with_alignment(
-            cache, aligned_size, alignment, config, should_zero);
+            cache, aligned_size, alignment, is_failable, config, should_zero);
     if (!allocation_result.did_succeed)
         return result;
 

--- a/Source/bmalloc/libpas/src/libpas/pas_heap_config_utils.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_heap_config_utils.h
@@ -429,6 +429,7 @@ typedef struct {
     PAS_API pas_aligned_allocation_result name ## _aligned_allocator( \
         size_t size, \
         pas_alignment alignment, \
+        bool is_failable, \
         pas_large_heap* large_heap, \
         const pas_heap_config* config); \
     PAS_HEAP_CONFIG_SPECIALIZATION_DECLARATIONS(name ## _heap_config); \

--- a/Source/bmalloc/libpas/src/libpas/pas_heap_config_utils_inlines.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_heap_config_utils_inlines.h
@@ -40,6 +40,7 @@ PAS_API pas_aligned_allocation_result
 pas_heap_config_utils_allocate_aligned(
     size_t size,
     pas_alignment alignment,
+    bool is_failable,
     pas_large_heap* large_heap,
     const pas_heap_config* config,
     bool should_zero);
@@ -162,6 +163,7 @@ typedef struct {
             page_config.base.page_config_ptr, \
             megapage_kind, \
             arguments.allocate_page_should_zero, \
+            false, \
             pas_heap_for_segregated_heap(heap), \
             transaction); \
         \
@@ -193,6 +195,7 @@ typedef struct {
             page_config.base.page_config_ptr, \
             pas_small_other_fast_megapage_kind, \
             arguments.allocate_page_should_zero, \
+            false, \
             pas_heap_for_segregated_heap(heap), \
             transaction); \
         \
@@ -222,6 +225,7 @@ typedef struct {
             megapage_cache, \
             page_config.base.page_config_ptr, \
             arguments.allocate_page_should_zero, \
+            false, \
             pas_heap_for_segregated_heap(heap), \
             transaction); \
         \
@@ -251,6 +255,7 @@ typedef struct {
             megapage_cache, \
             page_config.base.page_config_ptr, \
             arguments.allocate_page_should_zero, \
+            false, \
             pas_heap_for_segregated_heap(heap), \
             transaction); \
         \
@@ -280,6 +285,7 @@ typedef struct {
             megapage_cache, \
             page_config.base.page_config_ptr, \
             arguments.allocate_page_should_zero, \
+            false, \
             pas_heap_for_segregated_heap(heap), \
             transaction); \
         \
@@ -289,11 +295,12 @@ typedef struct {
     pas_aligned_allocation_result name ## _aligned_allocator( \
         size_t size, \
         pas_alignment alignment, \
+        bool is_failable, \
         pas_large_heap* large_heap, \
         const pas_heap_config* config) \
     { \
         return pas_heap_config_utils_allocate_aligned( \
-            size, alignment, large_heap, config, \
+            size, alignment, is_failable, large_heap, config, \
             ((pas_basic_heap_config_definitions_arguments){__VA_ARGS__}).allocate_page_should_zero); \
     } \
     \

--- a/Source/bmalloc/libpas/src/libpas/pas_heap_page_provider.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_heap_page_provider.h
@@ -41,6 +41,7 @@ typedef struct pas_physical_memory_transaction pas_physical_memory_transaction;
 typedef pas_allocation_result (*pas_heap_page_provider)(
     size_t size,
     pas_alignment alignment,
+    bool is_failable,
     const char* name,
     pas_heap* heap, /* Can be NULL. */
     pas_physical_memory_transaction* transaction, /* Can be NULL. */

--- a/Source/bmalloc/libpas/src/libpas/pas_large_free_heap_helpers.c
+++ b/Source/bmalloc/libpas/src/libpas/pas_large_free_heap_helpers.c
@@ -43,6 +43,7 @@ static const bool verbose = PAS_SHOULD_LOG(PAS_LOG_LARGE_HEAPS);
 
 static pas_aligned_allocation_result large_utility_aligned_allocator(size_t size,
                                                                      pas_alignment alignment,
+                                                                     bool is_failable,
                                                                      void* arg)
 {
     size_t page_size;
@@ -68,6 +69,7 @@ static pas_aligned_allocation_result large_utility_aligned_allocator(size_t size
 
     allocation_result = memory_source(
         aligned_size, aligned_alignment,
+        is_failable,
         "pas_large_utility_free_heap/chunk",
         pas_delegate_allocation);
 
@@ -125,7 +127,7 @@ void* pas_large_free_heap_helpers_try_allocate_with_alignment(
     pas_heap_lock_assert_held();
     initialize_config(&config, memory_source);
     alignment = pas_alignment_round_up(alignment, PAS_INTERNAL_MIN_ALIGN);
-    result = pas_fast_large_free_heap_try_allocate(heap, size, alignment, &config);
+    result = pas_fast_large_free_heap_try_allocate(heap, size, alignment, false, &config);
     pas_did_allocate(
         (void*)result.begin, size, pas_large_utility_free_heap_kind, name, pas_object_allocation);
     if (result.did_succeed) {

--- a/Source/bmalloc/libpas/src/libpas/pas_large_free_heap_helpers.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_large_free_heap_helpers.h
@@ -42,6 +42,7 @@ PAS_API extern bool pas_large_utility_free_heap_talks_to_large_sharing_pool;
 typedef pas_allocation_result (*pas_large_free_heap_helpers_memory_source)(
     size_t size,
     pas_alignment alignment,
+    bool is_failable,
     const char* name,
     pas_allocation_kind allocation_kind);
 

--- a/Source/bmalloc/libpas/src/libpas/pas_large_heap.c
+++ b/Source/bmalloc/libpas/src/libpas/pas_large_heap.c
@@ -66,15 +66,16 @@ typedef struct {
 
 static pas_aligned_allocation_result aligned_allocator(size_t size,
                                                        pas_alignment alignment,
+                                                       bool is_failable,
                                                        void* arg)
 {
     aligned_allocator_data* data;
-    
+
     data = arg;
-    
+
     PAS_ASSERT(data);
-    
-    return data->aligned_allocator(size, alignment, data->heap, data->config);
+
+    return data->aligned_allocator(size, alignment, is_failable, data->heap, data->config);
 }
 
 static void initialize_config(pas_large_free_heap_config* config,
@@ -104,36 +105,37 @@ static pas_allocation_result allocate_impl(pas_large_heap* heap,
                                            pas_physical_memory_transaction* transaction)
 {
     static const bool verbose = PAS_SHOULD_LOG(PAS_LOG_LARGE_HEAPS);
-    
+
     pas_allocation_result result;
     const pas_heap_type* type;
     pas_large_free_heap_config config;
     aligned_allocator_data data;
-    
+
     PAS_ASSERT(pas_is_power_of_2(*alignment));
     pas_heap_lock_assert_held();
-    
+
     type = pas_heap_for_large_heap(heap)->type;
-    
+
     if (!*size)
         *size = heap_config->get_type_size(type);
-    
+
     *alignment = PAS_MAX(*alignment, heap_config->get_type_alignment(type));
     *alignment = PAS_MAX(*alignment, heap_config->large_alignment);
-    
+
     *size = pas_round_up_to_power_of_2(*size, *alignment);
-    
+
     if (verbose) {
         pas_log("large heap allocating large object of size %zu\n", *size);
         pas_log("large heap cartesian tree minimum = %p, num mapped bytes = %zu\n", pas_cartesian_tree_minimum(&heap->free_heap.tree), heap->free_heap.num_mapped_bytes);
     }
-    
+
     initialize_config(&config, &data, heap, heap_config);
-    
+
     result = pas_fast_large_free_heap_try_allocate(
         &heap->free_heap,
         *size,
         pas_alignment_create_traditional(*alignment),
+        true,
         &config);
     
     if (!result.did_succeed)

--- a/Source/bmalloc/libpas/src/libpas/pas_large_heap_physical_page_sharing_cache.c
+++ b/Source/bmalloc/libpas/src/libpas/pas_large_heap_physical_page_sharing_cache.c
@@ -48,6 +48,7 @@ typedef struct {
 
 static pas_aligned_allocation_result large_aligned_allocator(size_t size,
                                                              pas_alignment alignment,
+                                                             bool is_failable,
                                                              void* arg)
 {
     static const bool verbose = false;
@@ -97,6 +98,7 @@ static pas_aligned_allocation_result large_aligned_allocator(size_t size,
     
     allocation_result = data->cache->provider(
         aligned_size, aligned_alignment,
+        is_failable,
         "pas_large_heap_physical_page_sharing_cache/chunk",
         NULL, NULL,
         data->cache->provider_arg);
@@ -162,18 +164,19 @@ pas_large_heap_physical_page_sharing_cache_try_allocate_with_alignment(
     pas_large_heap_physical_page_sharing_cache* cache,
     size_t size,
     pas_alignment alignment,
+    bool is_failable,
     const pas_heap_config* heap_config,
     bool should_zero)
 {
     static const bool verbose = false;
-    
+
     aligned_allocator_data data;
     pas_large_free_heap_config config;
-    
+
     data.cache = cache;
     data.config = heap_config;
     data.should_zero = should_zero;
-    
+
     config.type_size = 1;
     config.min_alignment = 1;
     config.aligned_allocator = large_aligned_allocator;
@@ -185,8 +188,8 @@ pas_large_heap_physical_page_sharing_cache_try_allocate_with_alignment(
         pas_log("Allocating large heap physical cache out of simple free heap %p\n",
                 &cache->free_heap);
     }
-    
-    return pas_simple_large_free_heap_try_allocate(&cache->free_heap, size, alignment, &config);
+
+    return pas_simple_large_free_heap_try_allocate(&cache->free_heap, size, alignment, is_failable, &config);
 }
 
 #endif /* LIBPAS_ENABLED */

--- a/Source/bmalloc/libpas/src/libpas/pas_large_heap_physical_page_sharing_cache.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_large_heap_physical_page_sharing_cache.h
@@ -73,6 +73,7 @@ pas_large_heap_physical_page_sharing_cache_try_allocate_with_alignment(
     pas_large_heap_physical_page_sharing_cache* cache,
     size_t size,
     pas_alignment alignment,
+    bool is_failable,
     const pas_heap_config* config,
     bool should_zero);
 

--- a/Source/bmalloc/libpas/src/libpas/pas_local_allocator_inlines.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_local_allocator_inlines.h
@@ -32,6 +32,7 @@
 #include "pas_config.h"
 #include "pas_full_alloc_bits_inlines.h"
 #include "pas_mte.h"
+#include "pas_page_malloc.h"
 #include "pas_scavenger.h"
 #include "pas_segregated_exclusive_view_inlines.h"
 #include "pas_segregated_heap_inlines.h"
@@ -999,9 +1000,9 @@ pas_local_allocator_try_allocate_small_segregated_slow_impl(
     pas_allocator_counts* counts)
 {
     PAS_ASSERT(!pas_system_heap_should_supplant_bmalloc(config.kind));
-    
+
     pas_local_allocator_commit_if_necessary(allocator, config);
-    
+
     for (;;) {
         pas_allocation_result result;
         bool refill_result;
@@ -1019,10 +1020,18 @@ pas_local_allocator_try_allocate_small_segregated_slow_impl(
 
         if (!refill_result)
             return pas_allocation_result_create_failure();
-        
+
         result = pas_local_allocator_try_allocate_inline_cases(allocator, allocation_mode, config);
-        if (result.did_succeed)
+        if (result.did_succeed) {
+            /* Gate 2: once the soft failable-allocation limit has been crossed, drain the bump
+               region so future allocations on this thread re-enter the slow path and get a fresh
+               chance to be gated by Gate 1 in pas_page_malloc_try_map_pages. */
+            if (pas_past_soft_failable_allocation_limit()) {
+                allocator->remaining = 0;
+                allocator->payload_end = 0;
+            }
             return result;
+        }
     }
 }
 
@@ -1145,8 +1154,15 @@ pas_local_allocator_try_allocate_slow_impl(pas_local_allocator* allocator,
             return pas_allocation_result_create_failure();
 
         result = config.specialized_local_allocator_try_allocate_inline_cases(allocator, allocation_mode);
-        if (result.did_succeed)
+        if (result.did_succeed) {
+            /* Gate 2: once the soft failable-allocation limit has been crossed, drain the bump
+               region so future allocations on this thread re-enter the slow path. */
+            if (pas_past_soft_failable_allocation_limit()) {
+                allocator->remaining = 0;
+                allocator->payload_end = 0;
+            }
             return result;
+        }
 
         if (verbose) {
             pas_log("Relooping in try_allocate_slow with kind = %s\n",

--- a/Source/bmalloc/libpas/src/libpas/pas_medium_megapage_cache.c
+++ b/Source/bmalloc/libpas/src/libpas/pas_medium_megapage_cache.c
@@ -38,6 +38,7 @@ void* pas_medium_megapage_cache_try_allocate(
     pas_megapage_cache* cache,
     const pas_page_base_config* config,
     bool should_zero,
+    bool is_failable,
     pas_heap* heap,
     pas_physical_memory_transaction* transaction)
 {
@@ -51,8 +52,8 @@ void* pas_medium_megapage_cache_try_allocate(
     cache_config.table_set_by_index = NULL;
     cache_config.table_set_by_index_arg = NULL;
     cache_config.should_zero = should_zero;
-    
-    return pas_megapage_cache_try_allocate(cache, &cache_config, heap, transaction);
+
+    return pas_megapage_cache_try_allocate(cache, &cache_config, is_failable, heap, transaction);
 }
 
 #endif /* LIBPAS_ENABLED */

--- a/Source/bmalloc/libpas/src/libpas/pas_medium_megapage_cache.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_medium_megapage_cache.h
@@ -44,6 +44,7 @@ PAS_API void* pas_medium_megapage_cache_try_allocate(
     pas_megapage_cache* cache,
     const pas_page_base_config* config,
     bool should_zero,
+    bool is_failable,
     pas_heap* heap,
     pas_physical_memory_transaction* transaction);
 

--- a/Source/bmalloc/libpas/src/libpas/pas_megapage_cache.c
+++ b/Source/bmalloc/libpas/src/libpas/pas_megapage_cache.c
@@ -46,6 +46,7 @@ typedef struct {
 
 static pas_aligned_allocation_result megapage_cache_allocate_aligned(size_t size,
                                                                      pas_alignment alignment,
+                                                                     bool is_failable,
                                                                      void* arg)
 {
     megapage_cache_allocate_aligned_data* data;
@@ -95,6 +96,7 @@ static pas_aligned_allocation_result megapage_cache_allocate_aligned(size_t size
     
     bootstrap_result = cache->provider(
         new_size, new_alignment,
+        is_failable,
         "pas_megapage_cache/chunk",
         data->heap,
         data->transaction,
@@ -182,6 +184,7 @@ void pas_megapage_cache_construct(pas_megapage_cache* cache,
 
 void* pas_megapage_cache_try_allocate(pas_megapage_cache* cache,
                                       pas_megapage_cache_config* cache_config,
+                                      bool is_failable,
                                       pas_heap* heap,
                                       pas_physical_memory_transaction* transaction)
 {
@@ -195,7 +198,7 @@ void* pas_megapage_cache_try_allocate(pas_megapage_cache* cache,
     data.cache_config = cache_config;
     data.heap = heap;
     data.transaction = transaction;
-    
+
     pas_zero_memory(&config, sizeof(config));
     config.type_size = 1;
     config.min_alignment = 1;
@@ -203,11 +206,12 @@ void* pas_megapage_cache_try_allocate(pas_megapage_cache* cache,
     config.aligned_allocator_arg = &data;
     config.deallocator = NULL;
     config.deallocator_arg = NULL;
-    
+
     result = pas_simple_large_free_heap_try_allocate(
         &cache->free_heap,
         cache_config->allocation_size,
         cache_config->allocation_alignment,
+        is_failable,
         &config);
     
     if (!result.did_succeed)

--- a/Source/bmalloc/libpas/src/libpas/pas_megapage_cache.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_megapage_cache.h
@@ -80,6 +80,7 @@ PAS_API void pas_megapage_cache_construct(pas_megapage_cache* cache,
 
 PAS_API void* pas_megapage_cache_try_allocate(pas_megapage_cache* cache,
                                               pas_megapage_cache_config* cache_config,
+                                              bool is_failable,
                                               pas_heap* heap,
                                               pas_physical_memory_transaction* transaction);
 

--- a/Source/bmalloc/libpas/src/libpas/pas_page_malloc.c
+++ b/Source/bmalloc/libpas/src/libpas/pas_page_malloc.c
@@ -31,6 +31,7 @@
 
 #include <errno.h>
 #include <math.h>
+#include <stdint.h>
 #include <stdio.h>
 #include <string.h>
 #if !PAS_OS(WINDOWS)
@@ -55,6 +56,13 @@
 size_t pas_page_malloc_num_allocated_bytes;
 size_t pas_page_malloc_cached_alignment;
 size_t pas_page_malloc_cached_alignment_shift;
+
+size_t pas_soft_failable_allocation_limit = SIZE_MAX;
+
+void pas_set_soft_failable_allocation_limit(size_t size)
+{
+    pas_soft_failable_allocation_limit = size;
+}
 
 #if defined(MADV_ZERO) && PAS_OS(DARWIN)
 #define PAS_USE_MADV_ZERO 1
@@ -164,8 +172,10 @@ PAS_NEVER_INLINE size_t pas_page_malloc_alignment_shift_slow(void)
 }
 
 static void*
-pas_page_malloc_try_map_pages(size_t size, bool may_contain_small_or_medium)
+pas_page_malloc_try_map_pages(size_t size, bool may_contain_small_or_medium, bool is_failable)
 {
+    if (is_failable && pas_past_soft_failable_allocation_limit())
+        return NULL;
 
 #if PAS_OS(WINDOWS)
     PAS_PROFILE(PAGE_ALLOCATION, size, may_contain_small_or_medium, PAS_VM_TAG);
@@ -205,7 +215,7 @@ pas_page_malloc_try_map_pages(size_t size, bool may_contain_small_or_medium)
 
 pas_aligned_allocation_result
 pas_page_malloc_try_allocate_without_deallocating_padding(
-    size_t size, pas_alignment alignment, bool may_contain_small_or_medium)
+    size_t size, pas_alignment alignment, bool may_contain_small_or_medium, bool is_failable)
 {
     static const bool verbose = PAS_SHOULD_LOG(PAS_LOG_OTHER);
     
@@ -240,7 +250,7 @@ pas_page_malloc_try_allocate_without_deallocating_padding(
             return result;
     }
 
-    mmap_result = pas_page_malloc_try_map_pages(mapped_size, may_contain_small_or_medium);
+    mmap_result = pas_page_malloc_try_map_pages(mapped_size, may_contain_small_or_medium, is_failable);
     if (!mmap_result)
         return result;
 

--- a/Source/bmalloc/libpas/src/libpas/pas_page_malloc.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_page_malloc.h
@@ -40,6 +40,20 @@ PAS_API extern size_t pas_page_malloc_cached_alignment_shift;
 PAS_API extern bool pas_page_malloc_decommit_zero_fill;
 #endif /* PAS_OS(DARWIN) */
 
+/* When pas_page_malloc_num_allocated_bytes reaches this limit, failable page
+   allocations (is_failable=true) return NULL instead of obtaining new memory from the
+   OS. This is a soft limit: non-failable paths (bootstrap, scavenger metadata, the
+   non-try_ entries like bmalloc_allocate) continue to grow past it. Default is
+   SIZE_MAX, which disables the limit. */
+PAS_API extern size_t pas_soft_failable_allocation_limit;
+
+PAS_API void pas_set_soft_failable_allocation_limit(size_t size);
+
+static inline bool pas_past_soft_failable_allocation_limit(void)
+{
+    return pas_page_malloc_num_allocated_bytes >= pas_soft_failable_allocation_limit;
+}
+
 PAS_API PAS_NEVER_INLINE size_t pas_page_malloc_alignment_slow(void);
 
 static inline size_t pas_page_malloc_alignment(void)
@@ -60,7 +74,7 @@ static inline size_t pas_page_malloc_alignment_shift(void)
 
 PAS_API pas_aligned_allocation_result
 pas_page_malloc_try_allocate_without_deallocating_padding(
-    size_t size, pas_alignment alignment, bool may_contain_small_or_medium);
+    size_t size, pas_alignment alignment, bool may_contain_small_or_medium, bool is_failable);
 
 PAS_API void pas_page_malloc_deallocate(void* base, size_t size);
 

--- a/Source/bmalloc/libpas/src/libpas/pas_reserved_memory_provider.c
+++ b/Source/bmalloc/libpas/src/libpas/pas_reserved_memory_provider.c
@@ -31,10 +31,12 @@
 
 static pas_aligned_allocation_result null_aligned_allocator(size_t size,
                                                             pas_alignment alignment,
+                                                            bool is_failable,
                                                             void* arg)
 {
     PAS_UNUSED_PARAM(size);
     PAS_UNUSED_PARAM(alignment);
+    PAS_UNUSED_PARAM(is_failable);
     PAS_UNUSED_PARAM(arg);
     return pas_aligned_allocation_result_create_empty();
 }
@@ -67,6 +69,7 @@ void pas_reserved_memory_provider_construct(
 pas_allocation_result pas_reserved_memory_provider_try_allocate(
     size_t size,
     pas_alignment alignment,
+    bool is_failable,
     const char* name,
     pas_heap* heap,
     pas_physical_memory_transaction* transaction,
@@ -84,7 +87,7 @@ pas_allocation_result pas_reserved_memory_provider_try_allocate(
     initialize_config(&config);
 
     return pas_simple_large_free_heap_try_allocate(
-        &provider->free_heap, size, alignment, &config);
+        &provider->free_heap, size, alignment, is_failable, &config);
 }
 
 #endif /* LIBPAS_ENABLED */

--- a/Source/bmalloc/libpas/src/libpas/pas_reserved_memory_provider.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_reserved_memory_provider.h
@@ -46,6 +46,7 @@ PAS_API void pas_reserved_memory_provider_construct(
 PAS_API pas_allocation_result pas_reserved_memory_provider_try_allocate(
     size_t size,
     pas_alignment alignment,
+    bool is_failable,
     const char* name,
     pas_heap* heap,
     pas_physical_memory_transaction* transaction,

--- a/Source/bmalloc/libpas/src/libpas/pas_simple_free_heap_declarations.def
+++ b/Source/bmalloc/libpas/src/libpas/pas_simple_free_heap_declarations.def
@@ -58,6 +58,7 @@ PAS_API pas_allocation_result
 PAS_SIMPLE_FREE_HEAP_ID(_try_allocate_with_manual_alignment)(
     size_t size,
     pas_alignment alignment,
+    bool is_failable,
     const char* name,
     pas_allocation_kind allocation_kind);
 
@@ -65,6 +66,7 @@ PAS_API pas_allocation_result
 PAS_SIMPLE_FREE_HEAP_ID(_try_allocate_with_alignment)(
     size_t size,
     pas_alignment alignment,
+    bool is_failable,
     const char* name,
     pas_allocation_kind allocation_kind);
 

--- a/Source/bmalloc/libpas/src/libpas/pas_simple_free_heap_definitions.def
+++ b/Source/bmalloc/libpas/src/libpas/pas_simple_free_heap_definitions.def
@@ -35,7 +35,7 @@ pas_allocation_result PAS_SIMPLE_FREE_HEAP_ID(_try_allocate)(
     pas_allocation_kind allocation_kind)
 {
     return PAS_SIMPLE_FREE_HEAP_ID(_try_allocate_with_alignment)(
-        size, pas_alignment_create_trivial(), name, allocation_kind);
+        size, pas_alignment_create_trivial(), false, name, allocation_kind);
 }
 
 pas_allocation_result PAS_SIMPLE_FREE_HEAP_ID(_allocate)(
@@ -51,12 +51,13 @@ pas_allocation_result
 PAS_SIMPLE_FREE_HEAP_ID(_try_allocate_with_manual_alignment)(
     size_t size,
     pas_alignment alignment,
+    bool is_failable,
     const char* name,
     pas_allocation_kind allocation_kind)
 {
     return pas_simple_free_heap_helpers_try_allocate_with_manual_alignment(
         &PAS_SIMPLE_FREE_HEAP_NAME, initialize_config, PAS_SIMPLE_FREE_HEAP_ID(_kind),
-        size, alignment, name, allocation_kind,
+        size, alignment, is_failable, name, allocation_kind,
         &PAS_SIMPLE_FREE_HEAP_ID(_num_allocated_object_bytes),
         &PAS_SIMPLE_FREE_HEAP_ID(_num_allocated_object_bytes_peak));
 }
@@ -65,13 +66,14 @@ pas_allocation_result
 PAS_SIMPLE_FREE_HEAP_ID(_try_allocate_with_alignment)(
     size_t size,
     pas_alignment alignment,
+    bool is_failable,
     const char* name,
     pas_allocation_kind allocation_kind)
 {
     alignment = pas_alignment_round_up(alignment, PAS_INTERNAL_MIN_ALIGN);
 
     return PAS_SIMPLE_FREE_HEAP_ID(_try_allocate_with_manual_alignment)(
-        size, alignment, name, allocation_kind);
+        size, alignment, is_failable, name, allocation_kind);
 }
 
 pas_allocation_result PAS_SIMPLE_FREE_HEAP_ID(_allocate_with_manual_alignment)(
@@ -82,7 +84,7 @@ pas_allocation_result PAS_SIMPLE_FREE_HEAP_ID(_allocate_with_manual_alignment)(
 {
     pas_allocation_result result =
         PAS_SIMPLE_FREE_HEAP_ID(_try_allocate_with_manual_alignment)(
-            size, alignment, name, allocation_kind);
+            size, alignment, false, name, allocation_kind);
     PAS_ASSERT(result.did_succeed);
     PAS_ASSERT(result.begin);
     return result;
@@ -96,7 +98,7 @@ pas_allocation_result PAS_SIMPLE_FREE_HEAP_ID(_allocate_with_alignment)(
 {
     pas_allocation_result result =
         PAS_SIMPLE_FREE_HEAP_ID(_try_allocate_with_alignment)(
-            size, alignment, name, allocation_kind);
+            size, alignment, false, name, allocation_kind);
     PAS_ASSERT(result.did_succeed);
     PAS_ASSERT(result.begin);
     return result;

--- a/Source/bmalloc/libpas/src/libpas/pas_simple_free_heap_helpers.c
+++ b/Source/bmalloc/libpas/src/libpas/pas_simple_free_heap_helpers.c
@@ -45,16 +45,17 @@ pas_simple_free_heap_helpers_try_allocate_with_manual_alignment(
     pas_heap_kind heap_kind,
     size_t size,
     pas_alignment alignment,
+    bool is_failable,
     const char* name,
     pas_allocation_kind allocation_kind,
     size_t* num_allocated_object_bytes,
     size_t* num_allocated_object_bytes_peak)
 {
     static const bool exaggerate_cost = false;
-    
+
     pas_large_free_heap_config config;
     pas_allocation_result result;
-    
+
     pas_heap_lock_assert_held();
 
     if (verbose) {
@@ -67,10 +68,11 @@ pas_simple_free_heap_helpers_try_allocate_with_manual_alignment(
        use the size that the user passed. Anything else would result in us forever forgetting
        about that that alignment slop, since the caller will pass their original size when
        freeing the object later. */
-    
+
     initialize_config(&config);
     result = pas_simple_large_free_heap_try_allocate(free_heap,
                                                      size, alignment,
+                                                     is_failable,
                                                      &config);
     if (verbose)
         pas_log("Simple allocated %p with size %zu\n", (void*)result.begin, size);
@@ -83,12 +85,13 @@ pas_simple_free_heap_helpers_try_allocate_with_manual_alignment(
 
         result = pas_simple_large_free_heap_try_allocate(free_heap,
                                                          size, alignment,
+                                                         is_failable,
                                                          &config);
     }
-    
+
     pas_did_allocate(
         (void*)result.begin, size, heap_kind, name, allocation_kind);
-    
+
     if (result.did_succeed && allocation_kind == pas_object_allocation) {
         (*num_allocated_object_bytes) += size;
         *num_allocated_object_bytes_peak = PAS_MAX(

--- a/Source/bmalloc/libpas/src/libpas/pas_simple_free_heap_helpers.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_simple_free_heap_helpers.h
@@ -45,6 +45,7 @@ pas_simple_free_heap_helpers_try_allocate_with_manual_alignment(
     pas_heap_kind heap_kind,
     size_t size,
     pas_alignment alignment,
+    bool is_failable,
     const char* name,
     pas_allocation_kind allocation_kind,
     size_t* num_allocated_object_bytes,

--- a/Source/bmalloc/libpas/src/libpas/pas_simple_large_free_heap.c
+++ b/Source/bmalloc/libpas/src/libpas/pas_simple_large_free_heap.c
@@ -391,13 +391,14 @@ static void merge_physical(pas_simple_large_free_heap* heap,
 static pas_allocation_result try_allocate_without_fixing(pas_simple_large_free_heap* heap,
                                                          size_t size,
                                                          pas_alignment alignment,
+                                                         bool is_failable,
                                                          pas_large_free_heap_config* config)
 {
     pas_generic_large_free_heap_config generic_heap_config;
     initialize_generic_heap_config(&generic_heap_config);
     return pas_generic_large_free_heap_try_allocate(
         (pas_generic_large_free_heap*)heap,
-        size, alignment, config,
+        size, alignment, is_failable, config,
         &generic_heap_config);
 }
 
@@ -429,6 +430,7 @@ static void fix_free_list_if_necessary(pas_simple_large_free_heap* heap,
         heap,
         new_capacity * sizeof(pas_large_free),
         pas_alignment_create_traditional(sizeof(void*)),
+        false,
         config).begin;
     PAS_ASSERT(new_free_list);
 
@@ -467,12 +469,13 @@ static void fix_free_list_if_necessary(pas_simple_large_free_heap* heap,
 pas_allocation_result pas_simple_large_free_heap_try_allocate(pas_simple_large_free_heap* heap,
                                                               size_t size,
                                                               pas_alignment alignment,
+                                                              bool is_failable,
                                                               pas_large_free_heap_config* config)
 {
     pas_allocation_result result;
-    
-    result = try_allocate_without_fixing(heap, size, alignment, config);
-    
+
+    result = try_allocate_without_fixing(heap, size, alignment, is_failable, config);
+
     fix_free_list_if_necessary(heap, config);
     
     if (verbose) {

--- a/Source/bmalloc/libpas/src/libpas/pas_simple_large_free_heap.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_simple_large_free_heap.h
@@ -62,6 +62,7 @@ PAS_API pas_allocation_result
 pas_simple_large_free_heap_try_allocate(pas_simple_large_free_heap* heap,
                                         size_t size,
                                         pas_alignment alignment,
+                                        bool is_failable,
                                         pas_large_free_heap_config* config);
 
 PAS_API void pas_simple_large_free_heap_deallocate(pas_simple_large_free_heap* heap,

--- a/Source/bmalloc/libpas/src/libpas/pas_small_medium_bootstrap_free_heap.c
+++ b/Source/bmalloc/libpas/src/libpas/pas_small_medium_bootstrap_free_heap.c
@@ -37,6 +37,7 @@
 
 static pas_aligned_allocation_result bootstrap_source_allocate_aligned(size_t size,
                                                                        pas_alignment alignment,
+                                                                       bool is_failable,
                                                                        void* arg)
 {
     PAS_UNUSED_PARAM(arg);
@@ -45,7 +46,7 @@ static pas_aligned_allocation_result bootstrap_source_allocate_aligned(size_t si
     if (verbose)
         pas_log("small/medium bootstrap heap allocating %zu\n", size);
 
-    pas_aligned_allocation_result retval = pas_enumerable_page_malloc_try_allocate_without_deallocating_padding(size, alignment, true);
+    pas_aligned_allocation_result retval = pas_enumerable_page_malloc_try_allocate_without_deallocating_padding(size, alignment, true, is_failable);
 
     if (verbose)
         pas_log("small/medium bootstrap heap done allocating, returning %p.\n", retval.result);

--- a/Source/bmalloc/libpas/src/libpas/pas_small_medium_bootstrap_heap_page_provider.c
+++ b/Source/bmalloc/libpas/src/libpas/pas_small_medium_bootstrap_heap_page_provider.c
@@ -36,6 +36,7 @@
 pas_allocation_result pas_small_medium_bootstrap_heap_page_provider(
     size_t size,
     pas_alignment alignment,
+    bool is_failable,
     const char* name,
     pas_heap* heap,
     pas_physical_memory_transaction* transaction,
@@ -52,7 +53,7 @@ pas_allocation_result pas_small_medium_bootstrap_heap_page_provider(
     PAS_PROFILE(SMALL_MEDIUM_BOOTSTRAP_ALLOCATION, heap, size, alignment, name, arg);
 
     pas_allocation_result retval = pas_small_medium_bootstrap_free_heap_try_allocate_with_alignment(
-        size, alignment, name, pas_delegate_allocation);
+        size, alignment, is_failable, name, pas_delegate_allocation);
 
     if (verbose)
         pas_log("small/medium bootstrap heap page-provider done allocating\n");

--- a/Source/bmalloc/libpas/src/libpas/pas_small_medium_bootstrap_heap_page_provider.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_small_medium_bootstrap_heap_page_provider.h
@@ -33,6 +33,7 @@ PAS_BEGIN_EXTERN_C;
 PAS_API pas_allocation_result pas_small_medium_bootstrap_heap_page_provider(
     size_t size,
     pas_alignment alignment,
+    bool is_failable,
     const char* name,
     pas_heap* heap,
     pas_physical_memory_transaction* transaction,

--- a/Source/bmalloc/libpas/src/libpas/pas_utility_heap_config.c
+++ b/Source/bmalloc/libpas/src/libpas/pas_utility_heap_config.c
@@ -51,6 +51,7 @@ void* pas_utility_heap_allocate_page(
     return (void*)pas_compact_bootstrap_free_heap_try_allocate_with_alignment(
         PAS_SMALL_PAGE_DEFAULT_SIZE,
         pas_alignment_create_traditional(PAS_SMALL_PAGE_DEFAULT_SIZE),
+        true,
         "pas_utility_heap/page",
         pas_delegate_allocation).begin;
 }

--- a/Source/bmalloc/libpas/src/test/BmallocTests.cpp
+++ b/Source/bmalloc/libpas/src/test/BmallocTests.cpp
@@ -27,6 +27,7 @@
 #include "bmalloc_heap.h"
 #include "bmalloc_heap_config.h"
 #include "pas_internal_config.h"
+#include "pas_page_malloc.h"
 
 #include <array>
 #include <cstdlib>
@@ -175,6 +176,32 @@ void testBmallocSmallIndexOverlap()
     CHECK(mem2);
 }
 
+void testSoftFailableAllocationLimitBlocksFailableLargeAllocations()
+{
+    // Set limit below current allocated bytes. Any failable allocation that triggers a
+    // new OS page request should return NULL. Non-failable (bmalloc_allocate) would still
+    // succeed because its path passes is_failable=false.
+    size_t before = pas_page_malloc_num_allocated_bytes;
+    pas_set_soft_failable_allocation_limit(before ? before - 1 : 1);
+
+    // Issue a large failable allocation that's too big to be served from existing free lists,
+    // so it must request new OS pages.
+    const size_t kBigSize = 256 * 1024 * 1024;
+    void* mem = bmalloc_try_allocate(kBigSize, pas_non_compact_allocation_mode);
+    CHECK(!mem);
+
+    // Restore the limit so other tests are unaffected.
+    pas_set_soft_failable_allocation_limit(SIZE_MAX);
+}
+
+void testSoftFailableAllocationLimitDisabledAllowsAllocation()
+{
+    // With default (SIZE_MAX) limit, failable allocations should succeed normally.
+    pas_set_soft_failable_allocation_limit(SIZE_MAX);
+    void* mem = bmalloc_try_allocate(1024, pas_non_compact_allocation_mode);
+    CHECK(mem);
+}
+
 } // anonymous namespace
 
 void addBmallocTests()
@@ -186,4 +213,6 @@ void addBmallocTests()
     ADD_TEST(testBmallocForceBitfitAfterAlloc());
     ADD_TEST(testBmallocDisableAllocationsAboveMTETaggingCeiling());
     ADD_TEST(testBmallocSmallIndexOverlap());
+    ADD_TEST(testSoftFailableAllocationLimitDisabledAllowsAllocation());
+    ADD_TEST(testSoftFailableAllocationLimitBlocksFailableLargeAllocations());
 }

--- a/Source/bmalloc/libpas/src/test/LargeFreeHeapTests.cpp
+++ b/Source/bmalloc/libpas/src/test/LargeFreeHeapTests.cpp
@@ -212,8 +212,9 @@ ostream& operator<<(ostream& out, const Free& free)
     return out;
 }
 
-pas_aligned_allocation_result allocatorAdapter(size_t size, pas_alignment alignment, void* arg)
+pas_aligned_allocation_result allocatorAdapter(size_t size, pas_alignment alignment, bool is_failable, void* arg)
 {
+    PAS_UNUSED_PARAM(is_failable);
     const function<pas_aligned_allocation_result(size_t size, pas_alignment alignment)>* allocator =
         reinterpret_cast<const function<pas_aligned_allocation_result(size_t size, pas_alignment alignment)>*>(arg);
     return (*allocator)(size, alignment);
@@ -285,7 +286,7 @@ void testLargeFreeHeapImpl(HeapType* heap,
             cout << "    Allocating size = " << action.size
                  << ", alignment = " << pas_string_stream_get_string(&stream) << endl;
             pas_string_stream_destruct(&stream);
-            CHECK_EQUAL(allocateFunc(heap, action.size, action.alignment, &config).begin,
+            CHECK_EQUAL(allocateFunc(heap, action.size, action.alignment, false, &config).begin,
                         action.result);
             break;
         }
@@ -371,7 +372,7 @@ void testBootstrapHeap(const vector<Action>& actions,
 {
     static constexpr size_t slabSize = 1lu << 20;
     void* slabPtr = pas_page_malloc_try_allocate_without_deallocating_padding(
-        slabSize, alignSimple(slabSize), false).result;
+        slabSize, alignSimple(slabSize), false, false).result;
     CHECK(slabPtr);
     uintptr_t slab = reinterpret_cast<uintptr_t>(slabPtr);
     


### PR DESCRIPTION
#### cdc8a2811ec967818ef85e1337b17f8fffc15d33
<pre>
[libpas] Support a soft failable allocation limit
<a href="https://bugs.webkit.org/show_bug.cgi?id=313942">https://bugs.webkit.org/show_bug.cgi?id=313942</a>
<a href="https://rdar.apple.com/176146714">rdar://176146714</a>

Reviewed by NOBODY (OOPS!).

WIP, the goal is to enable OOM testing without checks in the fast paths
of libpas so we can test in Release builds without perf impact.

Explanation of why this fixes the bug (OOPS!).

No new tests (OOPS!).

* Source/JavaScriptCore/runtime/Options.cpp:
(JSC::Options::isAvailable):
(JSC::Options::notifyOptionsChanged):
* Source/JavaScriptCore/runtime/OptionsList.h:
* Source/WTF/wtf/FastMalloc.cpp:
(WTF::fastSetSoftFailableAllocationLimit):
* Source/WTF/wtf/FastMalloc.h:
* Source/bmalloc/bmalloc/bmalloc.cpp:
(bmalloc::api::setSoftFailableAllocationLimit):
* Source/bmalloc/bmalloc/bmalloc.h:
* Source/bmalloc/libpas/src/libpas/jit_heap_config.c:
(fresh_memory_aligned_allocator):
(allocate_from_fresh):
(page_provider):
(jit_small_segregated_allocate_page):
(jit_small_bitfit_allocate_page):
(jit_medium_bitfit_allocate_page):
(jit_aligned_allocator):
* Source/bmalloc/libpas/src/libpas/jit_heap_config.h:
* Source/bmalloc/libpas/src/libpas/pas_aligned_allocator.h:
* Source/bmalloc/libpas/src/libpas/pas_bootstrap_free_heap.c:
(bootstrap_source_allocate_aligned):
* Source/bmalloc/libpas/src/libpas/pas_bootstrap_heap_page_provider.c:
(pas_bootstrap_heap_page_provider):
* Source/bmalloc/libpas/src/libpas/pas_bootstrap_heap_page_provider.h:
* Source/bmalloc/libpas/src/libpas/pas_compact_bootstrap_free_heap.c:
(compact_bootstrap_source_allocate_aligned):
* Source/bmalloc/libpas/src/libpas/pas_compact_heap_reservation.c:
(pas_compact_heap_reservation_try_allocate):
* Source/bmalloc/libpas/src/libpas/pas_create_basic_heap_page_caches_with_reserved_memory.c:
(allocate_from_compact_megapages):
(allocate_from_megapages):
* Source/bmalloc/libpas/src/libpas/pas_enumerable_page_malloc.c:
(pas_enumerable_page_malloc_try_allocate_without_deallocating_padding):
* Source/bmalloc/libpas/src/libpas/pas_enumerable_page_malloc.h:
* Source/bmalloc/libpas/src/libpas/pas_enumerator_region.c:
(pas_enumerator_region_allocate):
* Source/bmalloc/libpas/src/libpas/pas_fast_large_free_heap.c:
(pas_fast_large_free_heap_try_allocate):
* Source/bmalloc/libpas/src/libpas/pas_fast_large_free_heap.h:
* Source/bmalloc/libpas/src/libpas/pas_fast_megapage_cache.c:
(pas_fast_megapage_cache_try_allocate):
* Source/bmalloc/libpas/src/libpas/pas_fast_megapage_cache.h:
* Source/bmalloc/libpas/src/libpas/pas_generic_large_free_heap.h:
(pas_generic_large_free_heap_try_allocate):
* Source/bmalloc/libpas/src/libpas/pas_heap_config.h:
* Source/bmalloc/libpas/src/libpas/pas_heap_config_utils.c:
(pas_heap_config_utils_allocate_aligned):
* Source/bmalloc/libpas/src/libpas/pas_heap_config_utils.h:
* Source/bmalloc/libpas/src/libpas/pas_heap_config_utils_inlines.h:
* Source/bmalloc/libpas/src/libpas/pas_heap_page_provider.h:
* Source/bmalloc/libpas/src/libpas/pas_large_free_heap_helpers.c:
(large_utility_aligned_allocator):
(pas_large_free_heap_helpers_try_allocate_with_alignment):
* Source/bmalloc/libpas/src/libpas/pas_large_free_heap_helpers.h:
* Source/bmalloc/libpas/src/libpas/pas_large_heap.c:
(aligned_allocator):
(allocate_impl):
* Source/bmalloc/libpas/src/libpas/pas_large_heap_physical_page_sharing_cache.c:
(large_aligned_allocator):
(pas_large_heap_physical_page_sharing_cache_try_allocate_with_alignment):
* Source/bmalloc/libpas/src/libpas/pas_large_heap_physical_page_sharing_cache.h:
* Source/bmalloc/libpas/src/libpas/pas_local_allocator_inlines.h:
(pas_local_allocator_try_allocate_small_segregated_slow_impl):
(pas_local_allocator_try_allocate_slow_impl):
* Source/bmalloc/libpas/src/libpas/pas_medium_megapage_cache.c:
(pas_medium_megapage_cache_try_allocate):
* Source/bmalloc/libpas/src/libpas/pas_medium_megapage_cache.h:
* Source/bmalloc/libpas/src/libpas/pas_megapage_cache.c:
(megapage_cache_allocate_aligned):
(pas_megapage_cache_try_allocate):
* Source/bmalloc/libpas/src/libpas/pas_megapage_cache.h:
* Source/bmalloc/libpas/src/libpas/pas_page_malloc.c:
(pas_set_soft_failable_allocation_limit):
(pas_page_malloc_try_map_pages):
(pas_page_malloc_try_allocate_without_deallocating_padding):
* Source/bmalloc/libpas/src/libpas/pas_page_malloc.h:
(pas_past_soft_failable_allocation_limit):
* Source/bmalloc/libpas/src/libpas/pas_reserved_memory_provider.c:
(null_aligned_allocator):
(pas_reserved_memory_provider_try_allocate):
* Source/bmalloc/libpas/src/libpas/pas_reserved_memory_provider.h:
* Source/bmalloc/libpas/src/libpas/pas_simple_free_heap_declarations.def:
* Source/bmalloc/libpas/src/libpas/pas_simple_free_heap_definitions.def:
* Source/bmalloc/libpas/src/libpas/pas_simple_free_heap_helpers.c:
(pas_simple_free_heap_helpers_try_allocate_with_manual_alignment):
* Source/bmalloc/libpas/src/libpas/pas_simple_free_heap_helpers.h:
* Source/bmalloc/libpas/src/libpas/pas_simple_large_free_heap.c:
(try_allocate_without_fixing):
(fix_free_list_if_necessary):
(pas_simple_large_free_heap_try_allocate):
* Source/bmalloc/libpas/src/libpas/pas_simple_large_free_heap.h:
* Source/bmalloc/libpas/src/libpas/pas_small_medium_bootstrap_free_heap.c:
(bootstrap_source_allocate_aligned):
* Source/bmalloc/libpas/src/libpas/pas_small_medium_bootstrap_heap_page_provider.c:
(pas_small_medium_bootstrap_heap_page_provider):
* Source/bmalloc/libpas/src/libpas/pas_small_medium_bootstrap_heap_page_provider.h:
* Source/bmalloc/libpas/src/libpas/pas_utility_heap_config.c:
(pas_utility_heap_allocate_page):
* Source/bmalloc/libpas/src/test/BmallocTests.cpp:
(std::testSoftFailableAllocationLimitBlocksFailableLargeAllocations):
(std::testSoftFailableAllocationLimitDisabledAllowsAllocation):
(addBmallocTests):
* Source/bmalloc/libpas/src/test/LargeFreeHeapTests.cpp:
(std::allocatorAdapter):
(std::testLargeFreeHeapImpl):
(std::testBootstrapHeap):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cdc8a2811ec967818ef85e1337b17f8fffc15d33

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/160194 "2 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/33664 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/26768 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/169096 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/114575 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/5b56e3bd-93fb-4b6e-91af-cfc155347eba) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/33767 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/33666 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/124189 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/87114 "2 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/0c9d769c-1159-442b-bd5f-9fef1c733283) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/163152 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/26433 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/143888 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/104788 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/55e2d3f3-a528-4dbb-9ad4-4045f35d877f) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/25486 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/23979 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/16815 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/152250 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/135178 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/21651 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/171572 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/21031 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/17562 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/23291 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/132443 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/33340 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/28073 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/132469 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/33325 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/143446 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/91600 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/27084 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/20260 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/192557 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/32834 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/99231 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/49527 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/32332 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/32578 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/32482 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->