### PR TITLE
Reduce use of uncheckedDowncast for JS types in WebCore/

### DIFF
--- a/Source/WebCore/Modules/applepay/paymentrequest/ApplePayPaymentHandler.cpp
+++ b/Source/WebCore/Modules/applepay/paymentrequest/ApplePayPaymentHandler.cpp
@@ -994,7 +994,7 @@ template<typename T>
 static JSC::Strong<JSC::JSObject> toJSDictionary(JSC::JSGlobalObject& lexicalGlobalObject, const T& value)
 {
     JSC::JSLockHolder lock { &lexicalGlobalObject };
-    return { lexicalGlobalObject.vm(), asObject(toJS<IDLDictionary<T>>(lexicalGlobalObject, uncheckedDowncast<JSDOMGlobalObject>(lexicalGlobalObject), value)) };
+    return { lexicalGlobalObject.vm(), asObject(toJS<IDLDictionary<T>>(lexicalGlobalObject, downcast<JSDOMGlobalObject>(lexicalGlobalObject), value)) };
 }
 
 void ApplePayPaymentHandler::didAuthorizePayment(const Payment& payment)

--- a/Source/WebCore/Modules/fetch/FetchBodyOwner.cpp
+++ b/Source/WebCore/Modules/fetch/FetchBodyOwner.cpp
@@ -388,7 +388,7 @@ ExceptionOr<void> FetchBodyOwner::createReadableStream(JSC::JSGlobalObject& stat
 {
     ASSERT(!m_readableStreamSource);
 
-    auto& globalObject = uncheckedDowncast<JSDOMGlobalObject>(state);
+    auto& globalObject = downcast<JSDOMGlobalObject>(state);
     if (isDisturbed()) {
         auto streamOrException = ReadableStream::create(globalObject, { }, { });
         if (streamOrException.hasException()) [[unlikely]]
@@ -421,7 +421,7 @@ ExceptionOr<void> FetchBodyOwner::createReadableStream(JSC::JSGlobalObject& stat
     auto [fetchBodySource, readableStreamSource] = FetchBodySource::createNonByteSource(*this);
     m_readableStreamSource = WTF::move(fetchBodySource);
 
-    auto streamOrException = ReadableStream::create(uncheckedDowncast<JSDOMGlobalObject>(state), readableStreamSource);
+    auto streamOrException = ReadableStream::create(downcast<JSDOMGlobalObject>(state), readableStreamSource);
     if (streamOrException.hasException()) [[unlikely]] {
         m_readableStreamSource = nullptr;
         return streamOrException.releaseException();

--- a/Source/WebCore/Modules/fetch/FetchBodySource.cpp
+++ b/Source/WebCore/Modules/fetch/FetchBodySource.cpp
@@ -94,7 +94,7 @@ Ref<DOMPromise> FetchBodySource::cancel(JSDOMGlobalObject& globalObject, Readabl
 static JSDOMGlobalObject* globalObjectFromBodyOwner(RefPtr<FetchBodyOwner>&& bodyOwner)
 {
     RefPtr context = bodyOwner ? bodyOwner->scriptExecutionContext() : nullptr;
-    return uncheckedDowncast<JSDOMGlobalObject>(context->globalObject());
+    return downcast<JSDOMGlobalObject>(context->globalObject());
 }
 
 // FIXME: We should be able to take a FragmentedSharedBuffer

--- a/Source/WebCore/Modules/fetch/FetchRequest.cpp
+++ b/Source/WebCore/Modules/fetch/FetchRequest.cpp
@@ -308,7 +308,7 @@ ExceptionOr<void> FetchRequest::setBody(FetchRequest& request)
             return Exception { ExceptionCode::TypeError, makeString("Request has method '"_s, m_request.httpMethod(), "' and cannot have a body"_s) };
 
         RefPtr context = scriptExecutionContext();
-        auto* globalObject = context ? uncheckedDowncast<JSDOMGlobalObject>(context->globalObject()) : nullptr;
+        auto* globalObject = context ? downcast<JSDOMGlobalObject>(context->globalObject()) : nullptr;
         m_body = request.m_body->createProxy(*globalObject);
         request.setDisturbed();
     }

--- a/Source/WebCore/Modules/filesystem/FileSystemFileHandle.cpp
+++ b/Source/WebCore/Modules/filesystem/FileSystemFileHandle.cpp
@@ -146,7 +146,7 @@ void FileSystemFileHandle::createWritable(const CreateWritableOptions& options, 
             return promise.reject(Exception { ExceptionCode::InvalidStateError, "Context has stopped"_s });
         }
 
-        auto* globalObject = uncheckedDowncast<JSDOMGlobalObject>(context->globalObject());
+        auto* globalObject = downcast<JSDOMGlobalObject>(context->globalObject());
         if (!globalObject) {
             closeWritable(streamIdentifier, FileSystemWriteCloseReason::Aborted);
             return promise.reject(Exception { ExceptionCode::InvalidStateError, "Global object is invalid"_s });

--- a/Source/WebCore/Modules/filesystem/FileSystemWritableFileStream.cpp
+++ b/Source/WebCore/Modules/filesystem/FileSystemWritableFileStream.cpp
@@ -79,7 +79,7 @@ static JSC::JSValue convertChunk(JSC::JSGlobalObject& lexicalGlobalObject, JSDOM
 
 void FileSystemWritableFileStream::write(JSC::JSGlobalObject& lexicalGlobalObject, const ChunkType& data, DOMPromiseDeferred<void>&& promise)
 {
-    auto* globalObject = uncheckedDowncast<JSDOMGlobalObject>(&lexicalGlobalObject);
+    auto* globalObject = downcast<JSDOMGlobalObject>(&lexicalGlobalObject);
     RELEASE_ASSERT(globalObject);
 
     auto jsData = convertChunk(lexicalGlobalObject, *globalObject, data);
@@ -91,7 +91,7 @@ void FileSystemWritableFileStream::write(JSC::JSGlobalObject& lexicalGlobalObjec
     if (result.hasException())
         return promise.reject(result.releaseException());
 
-    auto* jsPromise = uncheckedDowncast<JSC::JSPromise>(result.returnValue());
+    auto* jsPromise = downcast<JSC::JSPromise>(result.returnValue());
     if (!jsPromise)
         return promise.reject(Exception { ExceptionCode::UnknownError, "Failed to complete write operation"_s });
 

--- a/Source/WebCore/Modules/mediastream/MediaStreamTrackProcessor.cpp
+++ b/Source/WebCore/Modules/mediastream/MediaStreamTrackProcessor.cpp
@@ -90,7 +90,7 @@ ExceptionOr<Ref<ReadableStream>> MediaStreamTrackProcessor::readable(JSC::JSGlob
     if (!m_readable) {
         if (!m_readableStreamSource)
             lazyInitialize(m_readableStreamSource, makeUniqueWithoutRefCountedCheck<Source>(*this));
-        auto readableOrException = ReadableStream::create(uncheckedDowncast<JSDOMGlobalObject>(globalObject), *m_readableStreamSource);
+        auto readableOrException = ReadableStream::create(downcast<JSDOMGlobalObject>(globalObject), *m_readableStreamSource);
         if (readableOrException.hasException()) {
             m_readableStreamSource->setAsCancelled();
             return readableOrException.releaseException();
@@ -256,7 +256,7 @@ void MediaStreamTrackProcessor::Source::enqueue(WebCodecsVideoFrame& frame, Scri
 {
     ASSERT(!m_isCancelled);
 
-    auto* globalObject = uncheckedDowncast<JSDOMGlobalObject>(context.globalObject());
+    auto* globalObject = downcast<JSDOMGlobalObject>(context.globalObject());
     if (!globalObject)
         return;
 

--- a/Source/WebCore/Modules/mediastream/RTCEncodedStreamProducer.cpp
+++ b/Source/WebCore/Modules/mediastream/RTCEncodedStreamProducer.cpp
@@ -52,7 +52,7 @@ RTCEncodedStreamProducer::~RTCEncodedStreamProducer() = default;
 
 ExceptionOr<Ref<RTCEncodedStreamProducer>> RTCEncodedStreamProducer::create(ScriptExecutionContext& context)
 {
-    auto* globalObject = uncheckedDowncast<JSDOMGlobalObject>(context.globalObject());
+    auto* globalObject = downcast<JSDOMGlobalObject>(context.globalObject());
     if (!globalObject)
         return Exception { ExceptionCode::InvalidStateError };
 
@@ -112,7 +112,7 @@ void RTCEncodedStreamProducer::enqueueFrame(Ref<RTCRtpTransformableFrame>&& fram
     if (!context)
         return;
 
-    auto* globalObject = uncheckedDowncast<JSDOMGlobalObject>(context->globalObject());
+    auto* globalObject = downcast<JSDOMGlobalObject>(context->globalObject());
     if (!globalObject)
         return;
 

--- a/Source/WebCore/Modules/mediastream/RTCPeerConnection.cpp
+++ b/Source/WebCore/Modules/mediastream/RTCPeerConnection.cpp
@@ -1093,7 +1093,7 @@ void RTCPeerConnection::generateCertificate(JSC::JSGlobalObject& lexicalGlobalOb
         promise.reject(parameters.releaseException());
         return;
     }
-    Ref document = downcast<Document>(*uncheckedDowncast<JSDOMGlobalObject>(lexicalGlobalObject).scriptExecutionContext());
+    Ref document = downcast<Document>(*downcast<JSDOMGlobalObject>(lexicalGlobalObject).scriptExecutionContext());
     PeerConnectionBackend::generateCertificate(document.get(), parameters.returnValue(), WTF::move(promise));
 }
 

--- a/Source/WebCore/Modules/mediastream/RTCRtpSFrameTransform.cpp
+++ b/Source/WebCore/Modules/mediastream/RTCRtpSFrameTransform.cpp
@@ -221,7 +221,7 @@ void transformFrame(Frame& frame, JSDOMGlobalObject& globalObject, RTCRtpSFrameT
 
 ExceptionOr<void> RTCRtpSFrameTransform::createStreams()
 {
-    auto* globalObject = scriptExecutionContext() ? uncheckedDowncast<JSDOMGlobalObject>(protect(scriptExecutionContext())->globalObject()) : nullptr;
+    auto* globalObject = scriptExecutionContext() ? downcast<JSDOMGlobalObject>(protect(scriptExecutionContext())->globalObject()) : nullptr;
     if (!globalObject)
         return Exception { ExceptionCode::InvalidStateError };
 
@@ -233,7 +233,7 @@ ExceptionOr<void> RTCRtpSFrameTransform::createStreams()
     auto writable = WritableStream::create(*globalObject, SimpleWritableStreamSink::create([transformer = m_transformer, readableStreamSource = m_readableStreamSource, weakThis = ThreadSafeWeakPtr { *this }](auto& context, auto value) -> ExceptionOr<void> {
         if (!context.globalObject())
             return Exception { ExceptionCode::InvalidStateError };
-        auto& globalObject = *uncheckedDowncast<JSDOMGlobalObject>(context.globalObject());
+        auto& globalObject = *downcast<JSDOMGlobalObject>(context.globalObject());
         auto scope = DECLARE_THROW_SCOPE(globalObject.vm());
 
         auto frameConversionResult = convert<IDLUnion<IDLArrayBuffer, IDLArrayBufferView, IDLInterface<RTCEncodedAudioFrame>, IDLInterface<RTCEncodedVideoFrame>>>(globalObject, value);

--- a/Source/WebCore/Modules/mediastream/RTCRtpScriptTransform.cpp
+++ b/Source/WebCore/Modules/mediastream/RTCRtpScriptTransform.cpp
@@ -49,7 +49,7 @@ ExceptionOr<Ref<RTCRtpScriptTransform>> RTCRtpScriptTransform::create(JSC::JSGlo
     if (!worker.scriptExecutionContext())
         return Exception { ExceptionCode::InvalidStateError, "Worker frame is detached"_s };
 
-    RefPtr context = uncheckedDowncast<JSDOMGlobalObject>(&state)->scriptExecutionContext();
+    RefPtr context = downcast<JSDOMGlobalObject>(&state)->scriptExecutionContext();
     if (!context)
         return Exception { ExceptionCode::InvalidStateError, "Invalid context"_s };
 

--- a/Source/WebCore/Modules/mediastream/RTCRtpScriptTransformer.cpp
+++ b/Source/WebCore/Modules/mediastream/RTCRtpScriptTransformer.cpp
@@ -45,7 +45,7 @@ ExceptionOr<Ref<RTCRtpScriptTransformer>> RTCRtpScriptTransformer::create(Script
     if (!context.globalObject())
         return Exception { ExceptionCode::InvalidStateError };
 
-    auto& globalObject = *uncheckedDowncast<JSDOMGlobalObject>(context.globalObject());
+    auto& globalObject = *downcast<JSDOMGlobalObject>(context.globalObject());
     JSC::JSLockHolder lock(globalObject.vm());
 
     auto producerOrException = RTCEncodedStreamProducer::create(context);

--- a/Source/WebCore/Modules/mediastream/VideoTrackGenerator.cpp
+++ b/Source/WebCore/Modules/mediastream/VideoTrackGenerator.cpp
@@ -46,7 +46,7 @@ ExceptionOr<Ref<VideoTrackGenerator>> VideoTrackGenerator::create(ScriptExecutio
 {
     auto source = Source::create(context.identifier());
     auto sink = Sink::create(Ref { source });
-    auto writableOrException = WritableStream::create(*uncheckedDowncast<JSDOMGlobalObject>(context.globalObject()), Ref { sink });
+    auto writableOrException = WritableStream::create(*downcast<JSDOMGlobalObject>(context.globalObject()), Ref { sink });
 
     if (writableOrException.hasException())
         return writableOrException.releaseException();

--- a/Source/WebCore/Modules/streams/ReadableStream.cpp
+++ b/Source/WebCore/Modules/streams/ReadableStream.cpp
@@ -136,7 +136,7 @@ ExceptionOr<Ref<ReadableStream>> ReadableStream::create(JSDOMGlobalObject& globa
 
 ExceptionOr<Ref<ReadableStream>> ReadableStream::createFromJSValues(JSC::JSGlobalObject& globalObject, JSC::JSValue underlyingSource, JSC::JSValue strategy, std::optional<double> highWaterMark)
 {
-    auto& jsDOMGlobalObject = uncheckedDowncast<JSDOMGlobalObject>(globalObject);
+    auto& jsDOMGlobalObject = downcast<JSDOMGlobalObject>(globalObject);
     RefPtr protectedContext { jsDOMGlobalObject.scriptExecutionContext() };
     auto result = InternalReadableStream::createFromUnderlyingSource(jsDOMGlobalObject, underlyingSource, strategy, highWaterMark);
     if (result.hasException())
@@ -358,7 +358,7 @@ void ReadableStream::cancel(Exception&& exception)
     }
 
     RefPtr context = scriptExecutionContext();
-    auto* globalObject = context ? uncheckedDowncast<JSDOMGlobalObject>(context->globalObject()): nullptr;
+    auto* globalObject = context ? downcast<JSDOMGlobalObject>(context->globalObject()): nullptr;
     if (!globalObject)
         return;
 
@@ -534,7 +534,7 @@ Ref<DOMPromise> ReadableStream::cancel(JSDOMGlobalObject& globalObject, JSC::JSV
             return promise;
         }
 
-        auto* jsPromise = uncheckedDowncast<JSC::JSPromise>(result);
+        auto* jsPromise = downcast<JSC::JSPromise>(result);
         if (!jsPromise)
             return promise;
 
@@ -693,7 +693,7 @@ void ReadableStream::teedBranchIsDestroyed(ReadableStream& teedBranch)
 JSDOMGlobalObject* ReadableStream::globalObject()
 {
     RefPtr context = scriptExecutionContext();
-    return context ? uncheckedDowncast<JSDOMGlobalObject>(context->globalObject()) : nullptr;
+    return context ? downcast<JSDOMGlobalObject>(context->globalObject()) : nullptr;
 }
 
 bool ReadableStream::isPulling() const
@@ -809,7 +809,7 @@ Ref<DOMPromise> ReadableStream::Iterator::returnSteps(JSDOMGlobalObject& globalO
 // https://streams.spec.whatwg.org/#rs-asynciterator
 ExceptionOr<Ref<ReadableStream::Iterator>> ReadableStream::createIterator(ScriptExecutionContext* context, std::optional<IteratorOptions>&& options)
 {
-    auto& globalObject = *uncheckedDowncast<JSDOMGlobalObject>(context->globalObject());
+    auto& globalObject = *downcast<JSDOMGlobalObject>(context->globalObject());
     auto readerOrException = ReadableStreamDefaultReader::create(globalObject, *this);
     if (readerOrException.hasException())
         return readerOrException.releaseException();

--- a/Source/WebCore/Modules/streams/ReadableStreamBYOBReader.cpp
+++ b/Source/WebCore/Modules/streams/ReadableStreamBYOBReader.cpp
@@ -279,7 +279,7 @@ WebCoreOpaqueRoot root(ReadableStreamBYOBReader* reader)
 
 bool JSReadableStreamBYOBReaderOwner::isReachableFromOpaqueRoots(JSC::Handle<JSC::Unknown> handle, void*, AbstractSlotVisitor& visitor, ASCIILiteral* reason)
 {
-    auto* jsReader = uncheckedDowncast<JSReadableStreamBYOBReader>(handle.slot()->asCell());
+    auto* jsReader = downcast<JSReadableStreamBYOBReader>(handle.slot()->asCell());
     SUPPRESS_UNCOUNTED_LOCAL auto& reader = jsReader->wrapped();
     SUPPRESS_UNCOUNTED_LOCAL if (reader.isReachableFromOpaqueRoots()) {
         if (reason) [[unlikely]]

--- a/Source/WebCore/Modules/streams/ReadableStreamDefaultReader.cpp
+++ b/Source/WebCore/Modules/streams/ReadableStreamDefaultReader.cpp
@@ -98,7 +98,7 @@ void ReadableStreamDefaultReader::read(JSDOMGlobalObject& globalObject, Ref<Read
 {
     if (RefPtr internalReader = this->internalDefaultReader()) {
         auto value = internalReader->readForBindings(globalObject);
-        auto* promise = uncheckedDowncast<JSC::JSPromise>(value);
+        auto* promise = downcast<JSC::JSPromise>(value);
         if (!promise)
             return;
 
@@ -385,7 +385,7 @@ WebCoreOpaqueRoot root(ReadableStreamDefaultReader* reader)
 
 bool JSReadableStreamDefaultReaderOwner::isReachableFromOpaqueRoots(JSC::Handle<JSC::Unknown> handle, void*, AbstractSlotVisitor& visitor, ASCIILiteral* reason)
 {
-    auto* jsReader = uncheckedDowncast<JSReadableStreamDefaultReader>(handle.slot()->asCell());
+    auto* jsReader = downcast<JSReadableStreamDefaultReader>(handle.slot()->asCell());
     SUPPRESS_UNCOUNTED_LOCAL auto& reader = jsReader->wrapped();
     SUPPRESS_UNCOUNTED_LOCAL if (reader.isReachableFromOpaqueRoots()) {
         if (reason) [[unlikely]]

--- a/Source/WebCore/Modules/streams/ReadableStreamToSharedBufferSink.cpp
+++ b/Source/WebCore/Modules/streams/ReadableStreamToSharedBufferSink.cpp
@@ -49,7 +49,7 @@ public:
     JSDOMGlobalObject* globalObject() final
     {
         RefPtr context = m_context.get();
-        return context ? uncheckedDowncast<JSDOMGlobalObject>(context->globalObject()): nullptr;
+        return context ? downcast<JSDOMGlobalObject>(context->globalObject()): nullptr;
     }
 
     ScriptExecutionContext* NODELETE context() const { return m_context.get(); }
@@ -115,7 +115,7 @@ ReadableStreamToSharedBufferSink::~ReadableStreamToSharedBufferSink() = default;
 void ReadableStreamToSharedBufferSink::pipeFrom(ReadableStream& stream)
 {
     RefPtr context = stream.scriptExecutionContext();
-    auto* globalObject = context ? uncheckedDowncast<JSDOMGlobalObject>(context->globalObject()): nullptr;
+    auto* globalObject = context ? downcast<JSDOMGlobalObject>(context->globalObject()): nullptr;
     if (!globalObject) {
         error(Exception { ExceptionCode::TypeError, "no global object"_s });
         return;

--- a/Source/WebCore/Modules/streams/StreamPipeToUtilities.cpp
+++ b/Source/WebCore/Modules/streams/StreamPipeToUtilities.cpp
@@ -253,7 +253,7 @@ static RefPtr<DOMPromise> cancelReadableStream(JSDOMGlobalObject& globalObject, 
     if (!value)
         return nullptr;
 
-    auto* promise = uncheckedDowncast<JSC::JSPromise>(value);
+    auto* promise = downcast<JSC::JSPromise>(value);
     if (!promise)
         return nullptr;
 
@@ -276,7 +276,7 @@ StreamPipeToState::~StreamPipeToState() = default;
 JSDOMGlobalObject* StreamPipeToState::globalObject()
 {
     RefPtr context = scriptExecutionContext();
-    return context ? uncheckedDowncast<JSDOMGlobalObject>(context->globalObject()) : nullptr;
+    return context ? downcast<JSDOMGlobalObject>(context->globalObject()) : nullptr;
 }
 
 void StreamPipeToState::handleSignal()
@@ -302,7 +302,7 @@ void StreamPipeToState::handleSignal()
                     return nullptr;
 
                 auto value = internalWritableStream->abort(*globalObject, signal->reason().getValue());
-                auto* promise = uncheckedDowncast<JSC::JSPromise>(value);
+                auto* promise = downcast<JSC::JSPromise>(value);
                 if (!promise)
                     return nullptr;
 
@@ -407,7 +407,7 @@ void StreamPipeToState::errorsMustBePropagatedForward(JSDOMGlobalObject& globalO
 
                 Ref internalWritableStream = protectedThis->m_destination->internalWritableStream();
                 auto value = internalWritableStream->abort(*globalObject, error.get());
-                auto* promise = uncheckedDowncast<JSC::JSPromise>(value);
+                auto* promise = downcast<JSC::JSPromise>(value);
                 if (!promise) {
                     auto [result, deferred] = createPromiseAndWrapper(*globalObject);
                     deferred->resolve();
@@ -555,7 +555,7 @@ void StreamPipeToState::closingMustBePropagatedBackward()
             };
 
             auto [result, deferred] = createPromiseAndWrapper(*globalObject);
-            auto* promise = uncheckedDowncast<JSC::JSPromise>(value);
+            auto* promise = downcast<JSC::JSPromise>(value);
             if (!promise)
                 deferred->rejectWithCallback(WTF::move(getError2), RejectAsHandled::Yes);
             else {

--- a/Source/WebCore/Modules/streams/StreamTeeUtilities.cpp
+++ b/Source/WebCore/Modules/streams/StreamTeeUtilities.cpp
@@ -156,7 +156,7 @@ public:
 
     JSDOMGlobalObject* globalObject()
     {
-        return m_context ? uncheckedDowncast<JSDOMGlobalObject>(protect(m_context)->globalObject()) : nullptr;
+        return m_context ? downcast<JSDOMGlobalObject>(protect(m_context)->globalObject()) : nullptr;
     }
 
     void queueMicrotaskWithValue(JSC::JSValue value, Function<void(JSC::JSValue)>&& task)
@@ -165,7 +165,7 @@ public:
         if (!context)
             return;
 
-        auto& globalObject = *uncheckedDowncast<JSDOMGlobalObject>(context->globalObject());
+        auto& globalObject = *downcast<JSDOMGlobalObject>(context->globalObject());
         protect(context->eventLoop())->queueMicrotask(globalObject.vm(), [task = WTF::move(task), value = JSC::Strong<JSC::Unknown> { globalObject.vm(), value }] {
             task(value.get());
         });

--- a/Source/WebCore/Modules/streams/StreamTransferUtilities.cpp
+++ b/Source/WebCore/Modules/streams/StreamTransferUtilities.cpp
@@ -189,7 +189,7 @@ private:
         if (!globalObject)
             return;
 
-        packAndPostMessage(*uncheckedDowncast<JSDOMGlobalObject>(globalObject), m_port.get(), "pull"_s, JSC::jsUndefined());
+        packAndPostMessage(*downcast<JSDOMGlobalObject>(globalObject), m_port.get(), "pull"_s, JSC::jsUndefined());
         pullFinished();
     }
     void doCancel(JSC::JSValue reason) final
@@ -199,7 +199,7 @@ private:
         if (!globalObject)
             return;
 
-        auto result = packAndPostMessageHandlingError(*uncheckedDowncast<JSDOMGlobalObject>(globalObject), m_port.get(), "error"_s, reason);
+        auto result = packAndPostMessageHandlingError(*downcast<JSDOMGlobalObject>(globalObject), m_port.get(), "error"_s, reason);
         if (result.hasException())
             cancelFinished(result.releaseException());
         else
@@ -311,7 +311,7 @@ private:
             return;
 
         if (!m_backpressurePromise) {
-            RefPtr backpressurePromise = DeferredPromise::create(*uncheckedDowncast<JSDOMGlobalObject>(globalObject), DeferredPromise::Mode::RetainPromiseOnResolve);
+            RefPtr backpressurePromise = DeferredPromise::create(*downcast<JSDOMGlobalObject>(globalObject), DeferredPromise::Mode::RetainPromiseOnResolve);
             if (!backpressurePromise)
                 return;
             backpressurePromise->resolve();
@@ -325,7 +325,7 @@ private:
                 return;
 
             RefPtr context = protectedThis->m_port->scriptExecutionContext();
-            auto* globalObject = context ? uncheckedDowncast<JSDOMGlobalObject>(context->globalObject()) : nullptr;
+            auto* globalObject = context ? downcast<JSDOMGlobalObject>(context->globalObject()) : nullptr;
             if (!globalObject)
                 return;
 

--- a/Source/WebCore/Modules/streams/TransformStream.cpp
+++ b/Source/WebCore/Modules/streams/TransformStream.cpp
@@ -62,12 +62,12 @@ ExceptionOr<Ref<TransformStream>> TransformStream::create(JSC::JSGlobalObject& g
     if (readableStrategy)
         readableStrategyValue = readableStrategy.get();
 
-    auto result = createInternalTransformStream(uncheckedDowncast<JSDOMGlobalObject>(globalObject), transformerValue, writableStrategyValue, readableStrategyValue);
+    auto result = createInternalTransformStream(downcast<JSDOMGlobalObject>(globalObject), transformerValue, writableStrategyValue, readableStrategyValue);
     if (result.hasException())
         return result.releaseException();
 
     auto transformResult = result.releaseReturnValue();
-    return adoptRef(*new TransformStream(uncheckedDowncast<JSDOMGlobalObject>(globalObject), transformResult.transform, WTF::move(transformResult.readable), WTF::move(transformResult.writable)));
+    return adoptRef(*new TransformStream(downcast<JSDOMGlobalObject>(globalObject), transformResult.transform, WTF::move(transformResult.readable), WTF::move(transformResult.writable)));
 }
 
 Ref<TransformStream> TransformStream::create(Ref<ReadableStream>&& readable, Ref<WritableStream>&& writable)

--- a/Source/WebCore/Modules/streams/WritableStream.cpp
+++ b/Source/WebCore/Modules/streams/WritableStream.cpp
@@ -79,7 +79,7 @@ ExceptionOr<Ref<InternalWritableStream>> WritableStream::createInternalWritableS
 
 ExceptionOr<Ref<WritableStream>> WritableStream::create(JSC::JSGlobalObject& globalObject, JSC::JSValue underlyingSink, JSC::JSValue strategy)
 {
-    auto result = InternalWritableStream::createFromUnderlyingSink(uncheckedDowncast<JSDOMGlobalObject>(globalObject), underlyingSink, strategy);
+    auto result = InternalWritableStream::createFromUnderlyingSink(downcast<JSDOMGlobalObject>(globalObject), underlyingSink, strategy);
     if (result.hasException())
         return result.releaseException();
 

--- a/Source/WebCore/Modules/webaudio/AudioWorkletNode.cpp
+++ b/Source/WebCore/Modules/webaudio/AudioWorkletNode.cpp
@@ -98,7 +98,7 @@ ExceptionOr<Ref<AudioWorkletNode>> AudioWorkletNode::create(JSC::JSGlobalObject&
     RefPtr<SerializedScriptValue> serializedOptions;
     {
         auto lock = JSC::JSLockHolder { &globalObject };
-        auto* jsOptions = convertDictionaryToJS(globalObject, uncheckedDowncast<JSDOMGlobalObject>(globalObject), options);
+        auto* jsOptions = convertDictionaryToJS(globalObject, downcast<JSDOMGlobalObject>(globalObject), options);
         serializedOptions = SerializedScriptValue::create(globalObject, jsOptions, SerializationForStorage::No, SerializationErrorMode::NonThrowing, SerializationContext::WorkerPostMessage);
         if (!serializedOptions)
             serializedOptions = SerializedScriptValue::nullValue();

--- a/Source/WebCore/Modules/webtransport/DatagramByteSource.cpp
+++ b/Source/WebCore/Modules/webtransport/DatagramByteSource.cpp
@@ -187,7 +187,7 @@ void DatagramByteSource::tryEnqueuing(JSC::ArrayBuffer& buffer, ReadableByteStre
 void DatagramByteSource::error(JSC::JSGlobalObject& globalObject, JSC::JSValue value)
 {
     if (RefPtr controller = m_controller) {
-        auto& jsDOMGlobalObject = uncheckedDowncast<JSDOMGlobalObject>(globalObject);
+        auto& jsDOMGlobalObject = downcast<JSDOMGlobalObject>(globalObject);
         controller->error(jsDOMGlobalObject, value);
     }
 }

--- a/Source/WebCore/Modules/webtransport/DatagramSink.cpp
+++ b/Source/WebCore/Modules/webtransport/DatagramSink.cpp
@@ -58,7 +58,7 @@ void DatagramSink::write(ScriptExecutionContext& context, JSC::JSValue value, DO
     if (m_isClosed)
         return promise.settle(Exception { ExceptionCode::InvalidStateError });
 
-    auto& globalObject = *uncheckedDowncast<JSDOMGlobalObject>(context.globalObject());
+    auto& globalObject = *downcast<JSDOMGlobalObject>(context.globalObject());
     auto scope = DECLARE_THROW_SCOPE(globalObject.vm());
 
     auto bufferSource = convert<IDLUnion<IDLArrayBuffer, IDLArrayBufferView>>(globalObject, value);

--- a/Source/WebCore/Modules/webtransport/WebTransport.cpp
+++ b/Source/WebCore/Modules/webtransport/WebTransport.cpp
@@ -97,7 +97,7 @@ ExceptionOr<Ref<WebTransport>> WebTransport::create(ScriptExecutionContext& cont
         ASSERT_NOT_REACHED();
         return Exception { ExceptionCode::InvalidStateError };
     }
-    auto& domGlobalObject = *uncheckedDowncast<JSDOMGlobalObject>(globalObject);
+    auto& domGlobalObject = *downcast<JSDOMGlobalObject>(globalObject);
 
     auto bidirectionalStreamSource = WebTransportBidirectionalStreamSource::create();
     auto incomingBidirectionalStreams = ReadableStream::create(domGlobalObject, bidirectionalStreamSource.copyRef());
@@ -233,7 +233,7 @@ void WebTransport::receiveIncomingUnidirectionalStream(WebTransportStreamIdentif
     if (!session)
         return;
 
-    auto& jsDOMGlobalObject = *uncheckedDowncast<JSDOMGlobalObject>(globalObject);
+    auto& jsDOMGlobalObject = *downcast<JSDOMGlobalObject>(globalObject);
     Ref incomingStream = WebTransportReceiveStreamSource::createIncomingDataSource(*this, identifier);
     auto stream = [&] {
         Locker<JSC::JSLock> locker(jsDOMGlobalObject.vm().apiLock());
@@ -283,7 +283,7 @@ void WebTransport::receiveBidirectionalStream(WebTransportStreamIdentifier ident
         return;
 
     Ref sink = WebTransportSendStreamSink::create(*this, identifier);
-    auto& jsDOMGlobalObject = *uncheckedDowncast<JSDOMGlobalObject>(globalObject);
+    auto& jsDOMGlobalObject = *downcast<JSDOMGlobalObject>(globalObject);
     Ref incomingStream = WebTransportReceiveStreamSource::createIncomingDataSource(*this, identifier);
     auto stream = WebCore::createBidirectionalStream(*this, *session, jsDOMGlobalObject, sink.copyRef(), incomingStream.copyRef());
     if (stream.hasException())
@@ -322,7 +322,7 @@ void WebTransport::streamReceiveError(WebTransportStreamIdentifier identifier, u
         return;
 
     if (RefPtr source = m_readStreamSources.get(identifier)) {
-        auto& jsDOMGlobalObject = *uncheckedDowncast<JSDOMGlobalObject>(globalObject);
+        auto& jsDOMGlobalObject = *downcast<JSDOMGlobalObject>(globalObject);
         auto error = WebTransportError::create(WebTransportErrorOptions {
             WebTransportErrorSource::Stream,
             static_cast<unsigned>(errorCode)
@@ -347,7 +347,7 @@ void WebTransport::streamSendError(WebTransportStreamIdentifier identifier, uint
         return;
 
     if (RefPtr sink = m_sendStreamSinks.get(identifier)) {
-        auto& jsDOMGlobalObject = *uncheckedDowncast<JSDOMGlobalObject>(globalObject);
+        auto& jsDOMGlobalObject = *downcast<JSDOMGlobalObject>(globalObject);
         auto error = WebTransportError::create(WebTransportErrorOptions {
             WebTransportErrorSource::Stream,
             static_cast<unsigned>(errorCode)
@@ -568,7 +568,7 @@ void WebTransport::createBidirectionalStream(ScriptExecutionContext& context, We
             return promise->reject(ExceptionCode::InvalidStateError);
 
         Ref sink = WebTransportSendStreamSink::create(protectedThis.get(), *identifier);
-        auto& jsDOMGlobalObject = *uncheckedDowncast<JSDOMGlobalObject>(globalObject);
+        auto& jsDOMGlobalObject = *downcast<JSDOMGlobalObject>(globalObject);
         Ref incomingStream = WebTransportReceiveStreamSource::createIncomingDataSource(protectedThis.get(), *identifier);
         auto stream = WebCore::createBidirectionalStream(protectedThis, *session, jsDOMGlobalObject, sink.copyRef(), incomingStream.copyRef());
         if (stream.hasException())
@@ -613,7 +613,7 @@ void WebTransport::createUnidirectionalStream(ScriptExecutionContext& context, W
             return promise->reject(ExceptionCode::InvalidStateError);
 
         Ref sink = WebTransportSendStreamSink::create(protectedThis.get(), *identifier);
-        auto& jsDOMGlobalObject = *uncheckedDowncast<JSDOMGlobalObject>(globalObject);
+        auto& jsDOMGlobalObject = *downcast<JSDOMGlobalObject>(globalObject);
         auto stream = [&] {
             Locker<JSC::JSLock> locker(jsDOMGlobalObject.vm().apiLock());
             return WebTransportSendStream::create(protectedThis, jsDOMGlobalObject, sink.copyRef());

--- a/Source/WebCore/Modules/webtransport/WebTransportBidirectionalStreamSource.cpp
+++ b/Source/WebCore/Modules/webtransport/WebTransportBidirectionalStreamSource.cpp
@@ -40,7 +40,7 @@ bool WebTransportBidirectionalStreamSource::receiveIncomingStream(JSC::JSGlobalO
 {
     if (m_isCancelled)
         return false;
-    auto& jsDOMGlobalObject = uncheckedDowncast<JSDOMGlobalObject>(globalObject);
+    auto& jsDOMGlobalObject = downcast<JSDOMGlobalObject>(globalObject);
     Locker<JSC::JSLock> locker(jsDOMGlobalObject.vm().apiLock());
     auto value = toJS(&globalObject, &jsDOMGlobalObject, stream.get());
     if (!controller().enqueue(value)) {

--- a/Source/WebCore/Modules/webtransport/WebTransportDatagramsWritable.cpp
+++ b/Source/WebCore/Modules/webtransport/WebTransportDatagramsWritable.cpp
@@ -47,7 +47,7 @@ ExceptionOr<Ref<WebTransportDatagramsWritable>> WebTransportDatagramsWritable::c
         ASSERT_NOT_REACHED();
         return Exception { ExceptionCode::InvalidStateError };
     }
-    auto& domGlobalObject = *uncheckedDowncast<JSDOMGlobalObject>(globalObject);
+    auto& domGlobalObject = *downcast<JSDOMGlobalObject>(globalObject);
 
     Ref datagramSink = DatagramSink::create(transport ? transport->session().get() : nullptr);
     auto internal = createInternalWritableStream(domGlobalObject, datagramSink.copyRef());

--- a/Source/WebCore/Modules/webtransport/WebTransportReceiveStreamSource.cpp
+++ b/Source/WebCore/Modules/webtransport/WebTransportReceiveStreamSource.cpp
@@ -51,7 +51,7 @@ bool WebTransportReceiveStreamSource::receiveIncomingStream(JSC::JSGlobalObject&
 {
     if (m_isCancelled || m_identifier)
         return false;
-    auto& jsDOMGlobalObject = uncheckedDowncast<JSDOMGlobalObject>(globalObject);
+    auto& jsDOMGlobalObject = downcast<JSDOMGlobalObject>(globalObject);
     Locker<JSC::JSLock> locker(jsDOMGlobalObject.vm().apiLock());
     auto value = toJS(&globalObject, &jsDOMGlobalObject, stream.get());
     if (!controller().enqueue(value)) {

--- a/Source/WebCore/Modules/webtransport/WebTransportSendStreamSink.cpp
+++ b/Source/WebCore/Modules/webtransport/WebTransportSendStreamSink.cpp
@@ -88,7 +88,7 @@ void WebTransportSendStreamSink::write(ScriptExecutionContext& context, JSC::JSV
     if (m_isClosed)
         return promise.reject(Exception { ExceptionCode::InvalidStateError });
 
-    auto& globalObject = *uncheckedDowncast<JSDOMGlobalObject>(context.globalObject());
+    auto& globalObject = *downcast<JSDOMGlobalObject>(context.globalObject());
     auto scope = DECLARE_THROW_SCOPE(globalObject.vm());
 
     auto bufferSource = convert<IDLUnion<IDLArrayBuffer, IDLArrayBufferView>>(globalObject, value);

--- a/Source/WebCore/bindings/js/CommonVM.cpp
+++ b/Source/WebCore/bindings/js/CommonVM.cpp
@@ -93,7 +93,7 @@ LocalFrame* lexicalFrameFromCommonVM()
 {
     JSC::VM& vm = commonVM();
     if (auto* topCallFrame = vm.topCallFrame) {
-        if (auto* globalObject = uncheckedDowncast<JSDOMGlobalObject>(topCallFrame->lexicalGlobalObject(vm))) {
+        if (auto* globalObject = downcast<JSDOMGlobalObject>(topCallFrame->lexicalGlobalObject(vm))) {
             if (auto* window = dynamicDowncast<JSDOMWindow>(globalObject)) {
                 if (auto* frame = window->wrapped().frame())
                     return dynamicDowncast<LocalFrame>(frame);

--- a/Source/WebCore/bindings/js/IDBBindingUtilities.cpp
+++ b/Source/WebCore/bindings/js/IDBBindingUtilities.cpp
@@ -83,27 +83,27 @@ static bool get(JSGlobalObject& lexicalGlobalObject, JSValue object, const Strin
         RETURN_IF_EXCEPTION(scope, false);
         return true;
     }
-    if (obj->inherits<JSBlob>() && (keyPathElement == "size"_s || keyPathElement == "type"_s)) {
+    if (auto* blob = dynamicDowncast<JSBlob>(*obj); blob && (keyPathElement == "size"_s || keyPathElement == "type"_s)) {
         if (keyPathElement == "size"_s) {
-            result = jsNumber(uncheckedDowncast<JSBlob>(obj)->wrapped().size());
+            result = jsNumber(blob->wrapped().size());
             return true;
         }
         if (keyPathElement == "type"_s) {
-            result = jsString(vm, uncheckedDowncast<JSBlob>(obj)->wrapped().type());
+            result = jsString(vm, blob->wrapped().type());
             return true;
         }
     }
-    if (obj->inherits<JSFile>()) {
+    if (auto* file = dynamicDowncast<JSFile>(*obj)) {
         if (keyPathElement == "name"_s) {
-            result = jsString(vm, uncheckedDowncast<JSFile>(obj)->wrapped().name());
+            result = jsString(vm, file->wrapped().name());
             return true;
         }
         if (keyPathElement == "lastModified"_s) {
-            result = jsNumber(protect(uncheckedDowncast<JSFile>(obj)->wrapped())->lastModified());
+            result = jsNumber(protect(file->wrapped())->lastModified());
             return true;
         }
         if (keyPathElement == "lastModifiedDate"_s) {
-            result = jsDate(lexicalGlobalObject, WallTime::fromRawSeconds(Seconds::fromMilliseconds(protect(uncheckedDowncast<JSFile>(obj)->wrapped())->lastModified()).value()));
+            result = jsDate(lexicalGlobalObject, WallTime::fromRawSeconds(Seconds::fromMilliseconds(protect(file->wrapped())->lastModified()).value()));
             return true;
         }
     }

--- a/Source/WebCore/bindings/js/InternalReadableStreamDefaultReader.cpp
+++ b/Source/WebCore/bindings/js/InternalReadableStreamDefaultReader.cpp
@@ -158,7 +158,7 @@ void InternalReadableStreamDefaultReader::onClosedPromiseRejection(Function<void
     if (result.hasException())
         return;
 
-    auto* promise = uncheckedDowncast<JSC::JSPromise>(result.returnValue());
+    auto* promise = downcast<JSC::JSPromise>(result.returnValue());
     if (!promise)
         return;
 
@@ -188,7 +188,7 @@ void InternalReadableStreamDefaultReader::onClosedPromiseResolution(Function<voi
     if (result.hasException())
         return;
 
-    auto* promise = uncheckedDowncast<JSC::JSPromise>(result.returnValue());
+    auto* promise = downcast<JSC::JSPromise>(result.returnValue());
     if (!promise)
         return;
 

--- a/Source/WebCore/bindings/js/InternalWritableStreamWriter.cpp
+++ b/Source/WebCore/bindings/js/InternalWritableStreamWriter.cpp
@@ -88,7 +88,7 @@ RefPtr<DOMPromise> writableStreamDefaultWriterCloseWithErrorPropagation(Internal
     if (result.hasException())
         return nullptr;
 
-    auto* promise = uncheckedDowncast<JSC::JSPromise>(result.returnValue());
+    auto* promise = downcast<JSC::JSPromise>(result.returnValue());
     if (!promise)
         return nullptr;
 
@@ -127,7 +127,7 @@ RefPtr<DOMPromise> writableStreamDefaultWriterWrite(InternalWritableStreamWriter
     if (result.hasException())
         return nullptr;
 
-    auto* promise = uncheckedDowncast<JSC::JSPromise>(result.returnValue());
+    auto* promise = downcast<JSC::JSPromise>(result.returnValue());
     if (!promise)
         return nullptr;
 
@@ -150,7 +150,7 @@ void InternalWritableStreamWriter::onClosedPromiseRejection(Function<void(JSDOMG
     if (result.hasException())
         return;
 
-    auto* promise = uncheckedDowncast<JSC::JSPromise>(result.returnValue());
+    auto* promise = downcast<JSC::JSPromise>(result.returnValue());
     if (!promise)
         return;
 
@@ -178,7 +178,7 @@ void InternalWritableStreamWriter::onClosedPromiseResolution(Function<void()>&& 
     if (result.hasException())
         return;
 
-    auto* promise = uncheckedDowncast<JSC::JSPromise>(result.returnValue());
+    auto* promise = downcast<JSC::JSPromise>(result.returnValue());
     if (!promise)
         return;
 
@@ -227,7 +227,7 @@ void InternalWritableStreamWriter::whenReady(Function<void (bool)>&& callback)
     if (result.hasException())
         return;
 
-    auto* promise = uncheckedDowncast<JSC::JSPromise>(result.returnValue());
+    auto* promise = downcast<JSC::JSPromise>(result.returnValue());
     if (!promise)
         return;
 

--- a/Source/WebCore/bindings/js/JSAbortSignalCustom.cpp
+++ b/Source/WebCore/bindings/js/JSAbortSignalCustom.cpp
@@ -33,7 +33,7 @@ namespace WebCore {
 
 bool JSAbortSignalOwner::isReachableFromOpaqueRoots(JSC::Handle<JSC::Unknown> handle, void*, JSC::AbstractSlotVisitor& visitor, ASCIILiteral* reason)
 {
-    auto& abortSignal = uncheckedDowncast<JSAbortSignal>(handle.slot()->asCell())->wrapped();
+    auto& abortSignal = downcast<JSAbortSignal>(handle.slot()->asCell())->wrapped();
     if (abortSignal.aborted())
         return false;
 

--- a/Source/WebCore/bindings/js/JSCSSRuleListCustom.cpp
+++ b/Source/WebCore/bindings/js/JSCSSRuleListCustom.cpp
@@ -38,7 +38,7 @@ using namespace JSC;
 
 bool JSCSSRuleListOwner::isReachableFromOpaqueRoots(JSC::Handle<JSC::Unknown> handle, void*, AbstractSlotVisitor& visitor, ASCIILiteral* reason)
 {
-    JSCSSRuleList* jsCSSRuleList = uncheckedDowncast<JSCSSRuleList>(handle.slot()->asCell());
+    JSCSSRuleList* jsCSSRuleList = downcast<JSCSSRuleList>(handle.slot()->asCell());
     if (!jsCSSRuleList->hasCustomProperties())
         return false;
 

--- a/Source/WebCore/bindings/js/JSCanvasRenderingContext2DCustom.cpp
+++ b/Source/WebCore/bindings/js/JSCanvasRenderingContext2DCustom.cpp
@@ -30,7 +30,7 @@ bool JSCanvasRenderingContext2DOwner::isReachableFromOpaqueRoots(JSC::Handle<JSC
     if (reason) [[unlikely]]
         *reason = "Canvas is opaque root"_s;
 
-    JSCanvasRenderingContext2D* jsCanvasRenderingContext = uncheckedDowncast<JSCanvasRenderingContext2D>(handle.slot()->asCell());
+    JSCanvasRenderingContext2D* jsCanvasRenderingContext = downcast<JSCanvasRenderingContext2D>(handle.slot()->asCell());
     return containsWebCoreOpaqueRoot(visitor, jsCanvasRenderingContext->wrapped().canvas());
 }
 

--- a/Source/WebCore/bindings/js/JSDOMBuiltinConstructor.h
+++ b/Source/WebCore/bindings/js/JSDOMBuiltinConstructor.h
@@ -90,14 +90,14 @@ template<typename JSClass> inline JSC::Structure* JSDOMBuiltinConstructor<JSClas
     auto scope = DECLARE_THROW_SCOPE(vm);
     auto* newTargetGlobalObject = JSC::getFunctionRealm(lexicalGlobalObject, newTarget);
     RETURN_IF_EXCEPTION(scope, nullptr);
-    auto* baseStructure = getDOMStructure<JSClass>(vm, *uncheckedDowncast<JSDOMGlobalObject>(newTargetGlobalObject));
+    auto* baseStructure = getDOMStructure<JSClass>(vm, *downcast<JSDOMGlobalObject>(newTargetGlobalObject));
     RELEASE_AND_RETURN(scope, JSC::InternalFunction::createSubclassStructure(lexicalGlobalObject, newTarget, baseStructure));
 }
 
 template<typename JSClass> inline JSC::EncodedJSValue JSC_HOST_CALL_ATTRIBUTES JSDOMBuiltinConstructor<JSClass>::construct(JSC::JSGlobalObject* lexicalGlobalObject, JSC::CallFrame* callFrame)
 {
     ASSERT(callFrame);
-    auto* castedThis = uncheckedDowncast<JSDOMBuiltinConstructor>(callFrame->jsCallee());
+    auto* castedThis = downcast<JSDOMBuiltinConstructor>(callFrame->jsCallee());
     auto* structure = castedThis->getDOMStructureForJSObject(lexicalGlobalObject, asObject(callFrame->newTarget()));
     if (!structure) [[unlikely]]
         return { };

--- a/Source/WebCore/bindings/js/JSDOMBuiltinConstructorBase.cpp
+++ b/Source/WebCore/bindings/js/JSDOMBuiltinConstructorBase.cpp
@@ -33,7 +33,7 @@ using namespace JSC;
 template<typename Visitor>
 void JSDOMBuiltinConstructorBase::visitChildrenImpl(JSC::JSCell* cell, Visitor& visitor)
 {
-    auto* thisObject = uncheckedDowncast<JSDOMBuiltinConstructorBase>(cell);
+    auto* thisObject = downcast<JSDOMBuiltinConstructorBase>(cell);
     ASSERT_GC_OBJECT_INHERITS(thisObject, info());
     Base::visitChildren(thisObject, visitor);
     visitor.append(thisObject->m_initializeFunction);

--- a/Source/WebCore/bindings/js/JSDOMConvertXPathNSResolver.h
+++ b/Source/WebCore/bindings/js/JSDOMConvertXPathNSResolver.h
@@ -51,11 +51,11 @@ template<> struct Converter<IDLInterface<XPathNSResolver>> : DefaultConverter<ID
             return Result::exception();
         }
 
-        auto object = asObject(value);
-        if (object->inherits<JSXPathNSResolver>())
-            return { uncheckedDowncast<JSXPathNSResolver>(*object).wrapped() };
+        auto* object = asObject(value);
+        if (auto* resolver = dynamicDowncast<JSXPathNSResolver>(*object))
+            return { resolver->wrapped() };
 
-        return { JSCustomXPathNSResolver::create(object, uncheckedDowncast<JSDOMGlobalObject>(&lexicalGlobalObject)) };
+        return { JSCustomXPathNSResolver::create(object, downcast<JSDOMGlobalObject>(&lexicalGlobalObject)) };
     }
 };
 

--- a/Source/WebCore/bindings/js/JSDOMExceptionHandling.cpp
+++ b/Source/WebCore/bindings/js/JSDOMExceptionHandling.cpp
@@ -117,7 +117,7 @@ void reportException(JSGlobalObject* lexicalGlobalObject, JSC::Exception* except
     scope.clearException();
     vm.clearLastException();
 
-    auto* globalObject = uncheckedDowncast<JSDOMGlobalObject>(lexicalGlobalObject);
+    auto* globalObject = downcast<JSDOMGlobalObject>(lexicalGlobalObject);
     if (auto* window = dynamicDowncast<JSDOMWindow>(globalObject)) {
         RefPtr localDOMWindow = dynamicDowncast<LocalDOMWindow>(window->wrapped());
         if (!localDOMWindow || !localDOMWindow->isCurrentlyDisplayedInFrame())

--- a/Source/WebCore/bindings/js/JSDOMGlobalObject.cpp
+++ b/Source/WebCore/bindings/js/JSDOMGlobalObject.cpp
@@ -220,7 +220,7 @@ JSC_DEFINE_HOST_FUNCTION(createWritableStreamFromInternal, (JSGlobalObject* glob
     ASSERT(callFrame->argumentCount() == 1);
     ASSERT(callFrame->uncheckedArgument(0).isObject());
 
-    auto* jsDOMGlobalObject = uncheckedDowncast<JSDOMGlobalObject>(globalObject);
+    auto* jsDOMGlobalObject = downcast<JSDOMGlobalObject>(globalObject);
     auto internalWritableStream = InternalWritableStream::fromObject(*jsDOMGlobalObject, *callFrame->uncheckedArgument(0).toObject(globalObject));
     return JSValue::encode(toJSNewlyCreated(globalObject, jsDOMGlobalObject, WritableStream::create(WTF::move(internalWritableStream))));
 }
@@ -234,7 +234,7 @@ JSC_DEFINE_HOST_FUNCTION(addAbortAlgorithmToSignal, (JSGlobalObject* globalObjec
     if (!abortSignal) [[unlikely]]
         return JSValue::encode(JSValue(JSC::JSValue::JSFalse));
 
-    auto* jsDOMGlobalObject = uncheckedDowncast<JSDOMGlobalObject>(globalObject);
+    auto* jsDOMGlobalObject = downcast<JSDOMGlobalObject>(globalObject);
     Ref<AbortAlgorithm> abortAlgorithm = JSAbortAlgorithm::create(callFrame->uncheckedArgument(1).getObject(), jsDOMGlobalObject);
 
     auto algorithmIdentifier = AbortSignal::addAbortAlgorithmToSignal(abortSignal->wrapped(), WTF::move(abortAlgorithm));
@@ -262,7 +262,7 @@ JSC_DEFINE_HOST_FUNCTION(isAbortSignal, (JSGlobalObject*, CallFrame* callFrame))
 
 JSC_DEFINE_HOST_FUNCTION(createAbortSignal, (JSGlobalObject* globalObject, CallFrame*))
 {
-    auto* jsDOMGlobalObject = uncheckedDowncast<JSDOMGlobalObject>(globalObject);
+    auto* jsDOMGlobalObject = downcast<JSDOMGlobalObject>(globalObject);
     return JSValue::encode(toJS(globalObject, jsDOMGlobalObject, AbortSignal::create(jsDOMGlobalObject->scriptExecutionContext())));
 }
 
@@ -417,7 +417,7 @@ bool JSDOMGlobalObject::canCompileStrings(JSGlobalObject* globalObject, Compilat
     VM& vm = globalObject->vm();
     auto throwScope = DECLARE_THROW_SCOPE(vm);
 
-    auto& thisObject = *uncheckedDowncast<JSDOMGlobalObject>(globalObject);
+    auto& thisObject = *downcast<JSDOMGlobalObject>(globalObject);
     CheckedPtr scriptExecutionContext = thisObject.scriptExecutionContext();
 
     auto result = canCompile(*scriptExecutionContext, compilationType, codeString, args);
@@ -435,7 +435,7 @@ bool JSDOMGlobalObject::canCompileStrings(JSGlobalObject* globalObject, Compilat
 
 Structure* JSDOMGlobalObject::trustedScriptStructure(JSGlobalObject* globalObject)
 {
-    auto& thisObject = *uncheckedDowncast<JSDOMGlobalObject>(globalObject);
+    auto& thisObject = *downcast<JSDOMGlobalObject>(globalObject);
 
     return getDOMStructure<JSTrustedScript>(globalObject->vm(), thisObject);
 }
@@ -443,7 +443,7 @@ Structure* JSDOMGlobalObject::trustedScriptStructure(JSGlobalObject* globalObjec
 template<typename Visitor>
 void JSDOMGlobalObject::visitChildrenImpl(JSCell* cell, Visitor& visitor)
 {
-    JSDOMGlobalObject* thisObject = uncheckedDowncast<JSDOMGlobalObject>(cell);
+    JSDOMGlobalObject* thisObject = downcast<JSDOMGlobalObject>(cell);
     ASSERT_GC_OBJECT_INHERITS(thisObject, info());
     Base::visitChildren(thisObject, visitor);
 
@@ -473,7 +473,7 @@ void JSDOMGlobalObject::promiseRejectionTracker(JSGlobalObject* jsGlobalObject, 
 {
     // https://html.spec.whatwg.org/multipage/webappapis.html#the-hostpromiserejectiontracker-implementation
 
-    auto& globalObject = *uncheckedDowncast<JSDOMGlobalObject>(jsGlobalObject);
+    auto& globalObject = *downcast<JSDOMGlobalObject>(jsGlobalObject);
     CheckedPtr context = globalObject.scriptExecutionContext();
     if (!context)
         return;
@@ -546,42 +546,42 @@ static JSC::JSPromise* handleResponseOnStreamingAction(JSC::JSGlobalObject* glob
     VM& vm = globalObject->vm();
     JSLockHolder lock(vm);
 
-    auto deferred = DeferredPromise::create(*uncheckedDowncast<JSDOMGlobalObject>(globalObject), DeferredPromise::Mode::RetainPromiseOnResolve);
+    auto deferred = DeferredPromise::create(*downcast<JSDOMGlobalObject>(globalObject), DeferredPromise::Mode::RetainPromiseOnResolve);
 
     auto inputResponse = JSFetchResponse::toWrapped(vm, source);
     if (!inputResponse) {
         deferred->reject(ExceptionCode::TypeError, "first argument must be an Response or Promise for Response"_s);
-        return uncheckedDowncast<JSC::JSPromise>(deferred->promise());
+        return downcast<JSC::JSPromise>(deferred->promise());
     }
 
     if (auto exception = inputResponse->loadingException()) {
         deferred->reject(*exception);
-        return uncheckedDowncast<JSC::JSPromise>(deferred->promise());
+        return downcast<JSC::JSPromise>(deferred->promise());
     }
 
     // 4. If response is not CORS-same-origin, reject returnValue with a TypeError and abort these substeps.
     // If response is opaque, content-type becomes "".
     if (!inputResponse->isCORSSameOrigin()) {
         deferred->reject(ExceptionCode::TypeError, "Response is not CORS-same-origin"_s);
-        return uncheckedDowncast<JSC::JSPromise>(deferred->promise());
+        return downcast<JSC::JSPromise>(deferred->promise());
     }
 
     // 3. If mimeType is not `application/wasm`, reject returnValue with a TypeError and abort these substeps.
     if (!inputResponse->hasWasmMIMEType()) {
         deferred->reject(ExceptionCode::TypeError, "Unexpected response MIME type. Expected 'application/wasm'"_s);
-        return uncheckedDowncast<JSC::JSPromise>(deferred->promise());
+        return downcast<JSC::JSPromise>(deferred->promise());
     }
 
     // 5. If response’s status is not an ok status, reject returnValue with a TypeError and abort these substeps.
     if (!inputResponse->ok()) {
         deferred->reject(ExceptionCode::TypeError, "Response has not returned OK status"_s);
-        return uncheckedDowncast<JSC::JSPromise>(deferred->promise());
+        return downcast<JSC::JSPromise>(deferred->promise());
     }
 
     // https://fetch.spec.whatwg.org/#concept-body-consume-body
     if (inputResponse->isDisturbedOrLocked()) {
         deferred->reject(ExceptionCode::TypeError, "Response is disturbed or locked"_s);
-        return uncheckedDowncast<JSC::JSPromise>(deferred->promise());
+        return downcast<JSC::JSPromise>(deferred->promise());
     }
 
     // FIXME: for efficiency, we should load blobs directly instead of going through the readableStream path.
@@ -589,11 +589,11 @@ static JSC::JSPromise* handleResponseOnStreamingAction(JSC::JSGlobalObject* glob
         auto streamOrException = inputResponse->readableStream(*globalObject);
         if (streamOrException.hasException()) [[unlikely]] {
             deferred->reject(streamOrException.releaseException());
-            return uncheckedDowncast<JSC::JSPromise>(deferred->promise());
+            return downcast<JSC::JSPromise>(deferred->promise());
         }
     }
 
-    auto compiler = JSC::Wasm::StreamingCompiler::create(vm, compilerMode, globalObject, uncheckedDowncast<JSC::JSPromise>(deferred->promise()), importObject, WTF::move(compileOptions), JSC::makeSource("handleResponseOnStreamingAction"_s, JSC::SourceOrigin(), JSC::SourceTaintedOrigin::Untainted), inputResponse->url());
+    auto compiler = JSC::Wasm::StreamingCompiler::create(vm, compilerMode, globalObject, downcast<JSC::JSPromise>(deferred->promise()), importObject, WTF::move(compileOptions), JSC::makeSource("handleResponseOnStreamingAction"_s, JSC::SourceOrigin(), JSC::SourceTaintedOrigin::Untainted), inputResponse->url());
 
     if (inputResponse->isBodyReceivedByChunk()) {
         inputResponse->consumeBodyReceivedByChunk([globalObject, compiler = WTF::move(compiler)](auto&& result) mutable {
@@ -631,7 +631,7 @@ static JSC::JSPromise* handleResponseOnStreamingAction(JSC::JSGlobalObject* glob
             else
                 compiler->finalize(globalObject);
         });
-        return uncheckedDowncast<JSC::JSPromise>(deferred->promise());
+        return downcast<JSC::JSPromise>(deferred->promise());
     }
 
     auto body = inputResponse->consumeBody();
@@ -644,7 +644,7 @@ static JSC::JSPromise* handleResponseOnStreamingAction(JSC::JSGlobalObject* glob
         compiler->finalize(globalObject);
     });
 
-    return uncheckedDowncast<JSC::JSPromise>(deferred->promise());
+    return downcast<JSC::JSPromise>(deferred->promise());
 }
 
 JSC::JSPromise* JSDOMGlobalObject::compileStreaming(JSC::JSGlobalObject* globalObject, JSC::JSValue source, std::optional<JSC::WebAssemblyCompileOptions>&& compileOptions)
@@ -662,17 +662,17 @@ JSC::JSPromise* JSDOMGlobalObject::instantiateStreaming(JSC::JSGlobalObject* glo
 
 static ScriptModuleLoader* scriptModuleLoader(JSDOMGlobalObject* globalObject)
 {
-    if (globalObject->inherits<JSDOMWindowBase>()) {
-        if (RefPtr document = uncheckedDowncast<JSDOMWindowBase>(globalObject)->wrapped().documentIfLocal())
+    if (auto* window = dynamicDowncast<JSDOMWindowBase>(*globalObject)) {
+        if (RefPtr document = window->wrapped().documentIfLocal())
             return &document->moduleLoader();
         return nullptr;
     }
-    if (globalObject->inherits<JSShadowRealmGlobalScopeBase>())
-        return &uncheckedDowncast<JSShadowRealmGlobalScopeBase>(globalObject)->wrapped().moduleLoader();
-    if (globalObject->inherits<JSWorkerGlobalScopeBase>())
-        return &uncheckedDowncast<JSWorkerGlobalScopeBase>(globalObject)->wrapped().moduleLoader();
-    if (globalObject->inherits<JSWorkletGlobalScopeBase>())
-        return &uncheckedDowncast<JSWorkletGlobalScopeBase>(globalObject)->wrapped().moduleLoader();
+    if (auto* globalScope = dynamicDowncast<JSShadowRealmGlobalScopeBase>(*globalObject))
+        return &globalScope->wrapped().moduleLoader();
+    if (auto* worker = dynamicDowncast<JSWorkerGlobalScopeBase>(*globalObject))
+        return &worker->wrapped().moduleLoader();
+    if (auto* worklet = dynamicDowncast<JSWorkletGlobalScopeBase>(*globalObject))
+        return &worklet->wrapped().moduleLoader();
     if (globalObject->inherits<JSIDBSerializationGlobalObject>())
         return nullptr;
 
@@ -683,7 +683,7 @@ static ScriptModuleLoader* scriptModuleLoader(JSDOMGlobalObject* globalObject)
 
 JSC::Identifier JSDOMGlobalObject::moduleLoaderResolve(JSC::JSGlobalObject* globalObject, JSC::JSModuleLoader* moduleLoader, JSC::JSValue moduleName, JSC::JSValue importerModuleKey, RefPtr<JSC::ScriptFetcher> scriptFetcher, bool useImportMap)
 {
-    JSDOMGlobalObject* thisObject = uncheckedDowncast<JSDOMGlobalObject>(globalObject);
+    JSDOMGlobalObject* thisObject = downcast<JSDOMGlobalObject>(globalObject);
     if (auto* loader = scriptModuleLoader(thisObject))
         return loader->resolve(globalObject, moduleLoader, moduleName, importerModuleKey, WTF::move(scriptFetcher), useImportMap);
     return { };
@@ -693,7 +693,7 @@ JSC::JSPromise* JSDOMGlobalObject::moduleLoaderFetch(JSC::JSGlobalObject* global
 {
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
-    JSDOMGlobalObject* thisObject = uncheckedDowncast<JSDOMGlobalObject>(globalObject);
+    JSDOMGlobalObject* thisObject = downcast<JSDOMGlobalObject>(globalObject);
     if (auto* loader = scriptModuleLoader(thisObject))
         RELEASE_AND_RETURN(scope, loader->fetch(globalObject, moduleLoader, moduleKey, WTF::move(parameters), WTF::move(scriptFetcher)));
     JSC::JSPromise* promise = JSC::JSPromise::create(vm, globalObject->promiseStructure());
@@ -704,7 +704,7 @@ JSC::JSPromise* JSDOMGlobalObject::moduleLoaderFetch(JSC::JSGlobalObject* global
 
 JSC::JSValue JSDOMGlobalObject::moduleLoaderEvaluate(JSC::JSGlobalObject* globalObject, JSC::JSModuleLoader* moduleLoader, JSC::JSValue moduleKey, JSC::JSValue moduleRecord, RefPtr<JSC::ScriptFetcher> scriptFetcher, JSC::JSValue awaitedValue, JSC::JSValue resumeMode)
 {
-    JSDOMGlobalObject* thisObject = uncheckedDowncast<JSDOMGlobalObject>(globalObject);
+    JSDOMGlobalObject* thisObject = downcast<JSDOMGlobalObject>(globalObject);
     if (auto* loader = scriptModuleLoader(thisObject))
         return loader->evaluate(globalObject, moduleLoader, moduleKey, moduleRecord, WTF::move(scriptFetcher), awaitedValue, resumeMode);
     return JSC::jsUndefined();
@@ -714,7 +714,7 @@ JSC::JSPromise* JSDOMGlobalObject::moduleLoaderImportModule(JSC::JSGlobalObject*
 {
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
-    JSDOMGlobalObject* thisObject = uncheckedDowncast<JSDOMGlobalObject>(globalObject);
+    JSDOMGlobalObject* thisObject = downcast<JSDOMGlobalObject>(globalObject);
     if (auto* loader = scriptModuleLoader(thisObject))
         RELEASE_AND_RETURN(scope, loader->importModule(globalObject, moduleLoader, moduleName, WTF::move(parameters), sourceOrigin));
     JSC::JSPromise* promise = JSC::JSPromise::create(vm, globalObject->promiseStructure());
@@ -725,7 +725,7 @@ JSC::JSPromise* JSDOMGlobalObject::moduleLoaderImportModule(JSC::JSGlobalObject*
 
 JSC::JSObject* JSDOMGlobalObject::moduleLoaderCreateImportMetaProperties(JSC::JSGlobalObject* globalObject, JSC::JSModuleLoader* moduleLoader, JSC::JSValue moduleKey, JSC::JSModuleRecord* moduleRecord, RefPtr<JSC::ScriptFetcher> scriptFetcher)
 {
-    JSDOMGlobalObject* thisObject = uncheckedDowncast<JSDOMGlobalObject>(globalObject);
+    JSDOMGlobalObject* thisObject = downcast<JSDOMGlobalObject>(globalObject);
     if (auto* loader = scriptModuleLoader(thisObject))
         return loader->createImportMetaProperties(globalObject, moduleLoader, moduleKey, moduleRecord, WTF::move(scriptFetcher));
     return JSC::constructEmptyObject(globalObject->vm(), globalObject->nullPrototypeObjectStructure());
@@ -735,7 +735,7 @@ JSC::JSGlobalObject* JSDOMGlobalObject::deriveShadowRealmGlobalObject(JSC::JSGlo
 {
     auto& vm = globalObject->vm();
 
-    auto domGlobalObject = uncheckedDowncast<JSDOMGlobalObject>(globalObject);
+    auto domGlobalObject = downcast<JSDOMGlobalObject>(globalObject);
     RefPtr context = domGlobalObject->scriptExecutionContext();
     if (RefPtr document = dynamicDowncast<Document>(context.get())) {
         // Same-origin iframes present a difficult circumstance because the
@@ -858,7 +858,7 @@ static JSDOMGlobalObject& callerGlobalObject(JSC::JSGlobalObject& lexicalGlobalO
                     // Figure out what to do here. We can probably get the global object
                     // from the top-most Wasm Instance. https://bugs.webkit.org/show_bug.cgi?id=165721
                     if (visitor->callee().isCell() && visitor->callee().asCell()->isObject())
-                        m_globalObject = uncheckedDowncast<JSObject>(visitor->callee().asCell())->realm();
+                        m_globalObject = downcast<JSObject>(visitor->callee().asCell())->realm();
                 }
                 return IterationStatus::Done;
             }
@@ -874,7 +874,7 @@ static JSDOMGlobalObject& callerGlobalObject(JSC::JSGlobalObject& lexicalGlobalO
         GetCallerGlobalObjectFunctor iter(skipFirstFrame);
         StackVisitor::visit(callFrame, vm, iter);
         if (iter.globalObject())
-            return *uncheckedDowncast<JSDOMGlobalObject>(iter.globalObject());
+            return *downcast<JSDOMGlobalObject>(iter.globalObject());
     }
 
     // In the case of legacyActiveGlobalObjectForAccessor, it is possible that vm.topCallFrame is nullptr when the script is evaluated as JSONP.
@@ -883,12 +883,12 @@ static JSDOMGlobalObject& callerGlobalObject(JSC::JSGlobalObject& lexicalGlobalO
     if (lookUpFromVMEntryScope) {
         if (vm.entryScope) {
             if (auto* result = vm.entryScope->globalObject())
-                return *uncheckedDowncast<JSDOMGlobalObject>(result);
+                return *downcast<JSDOMGlobalObject>(result);
         }
     }
 
     // If we cannot find JSGlobalObject in caller frames, we just return the current lexicalGlobalObject.
-    return uncheckedDowncast<JSDOMGlobalObject>(lexicalGlobalObject);
+    return downcast<JSDOMGlobalObject>(lexicalGlobalObject);
 }
 
 JSDOMGlobalObject& callerGlobalObject(JSC::JSGlobalObject& lexicalGlobalObject, JSC::CallFrame* callFrame)
@@ -913,9 +913,10 @@ bool JSDOMGlobalObject::allowsJSHandleCreation() const
     }
     if (!m_world->isNormal())
         return false;
-    if (!inherits<JSDOMWindow>())
+    auto* jsDOMWindow = dynamicDowncast<JSDOMWindow>(*this);
+    if (!jsDOMWindow)
         return false;
-    RefPtr localFrame = dynamicDowncast<LocalFrame>(uncheckedDowncast<JSDOMWindow>(this)->wrapped().frame());
+    RefPtr localFrame = dynamicDowncast<LocalFrame>(jsDOMWindow->wrapped().frame());
     if (!localFrame)
         return false;
     RefPtr documentLoader = localFrame->loader().loaderForWebsitePolicies();

--- a/Source/WebCore/bindings/js/JSDOMGlobalObjectInlines.h
+++ b/Source/WebCore/bindings/js/JSDOMGlobalObjectInlines.h
@@ -74,10 +74,9 @@ JSClass* toJSDOMGlobalObject(JSC::VM&, JSC::JSValue value)
     static_assert(std::is_base_of_v<JSDOMGlobalObject, JSClass>);
 
     if (auto* object = value.getObject()) {
-        if (object->type() == JSC::GlobalProxyType)
-            return dynamicDowncast<JSClass>(uncheckedDowncast<JSC::JSGlobalProxy>(object)->target());
-        if (object->inherits<JSClass>())
-            return uncheckedDowncast<JSClass>(object);
+        if (auto* proxy = dynamicDowncast<JSC::JSGlobalProxy>(*object))
+            return dynamicDowncast<JSClass>(proxy->target());
+        return dynamicDowncast<JSClass>(*object);
     }
 
     return nullptr;

--- a/Source/WebCore/bindings/js/JSDOMPromise.cpp
+++ b/Source/WebCore/bindings/js/JSDOMPromise.cpp
@@ -59,7 +59,7 @@ auto DOMPromise::whenPromiseIsSettled(JSDOMGlobalObject* globalObject, JSC::JSPr
         ASSERT(castedThis);
         // We exchange callback so that all captured variables are deallocated after the call. This is quicker than waiting for the handler function to be GCed.
         if (castedThis)
-            std::exchange(callback, { })(uncheckedDowncast<JSDOMGlobalObject>(globalObject), castedThis->status() == JSC::JSPromise::Status::Fulfilled, castedThis->result());
+            std::exchange(callback, { })(downcast<JSDOMGlobalObject>(globalObject), castedThis->status() == JSC::JSPromise::Status::Fulfilled, castedThis->result());
         return JSC::JSValue::encode(JSC::jsUndefined());
     });
 

--- a/Source/WebCore/bindings/js/JSDOMPromiseDeferred.cpp
+++ b/Source/WebCore/bindings/js/JSDOMPromiseDeferred.cpp
@@ -78,7 +78,7 @@ void DeferredPromise::callFunction(JSGlobalObject& lexicalGlobalObject, ResolveM
 
     auto handleExceptionIfNeeded = makeScopeExit([&] {
         if (scope.exception()) [[unlikely]]
-            handleUncaughtException(scope, uncheckedDowncast<JSDOMGlobalObject>(lexicalGlobalObject));
+            handleUncaughtException(scope, downcast<JSDOMGlobalObject>(lexicalGlobalObject));
     });
 
     if (activeDOMObjectsAreSuspended() || !ScriptDisallowedScope::isScriptAllowedInMainThread()) {
@@ -347,7 +347,7 @@ void DeferredPromise::handleUncaughtException(TopExceptionScope& scope, JSDOMGlo
 
 std::pair<Ref<DOMPromise>, Ref<DeferredPromise>> createPromiseAndWrapper(Document& document)
 {
-    auto& globalObject = *uncheckedDowncast<JSDOMGlobalObject>(document.globalObject());
+    auto& globalObject = *downcast<JSDOMGlobalObject>(document.globalObject());
     return createPromiseAndWrapper(globalObject);
 }
 
@@ -355,7 +355,7 @@ std::pair<Ref<DOMPromise>, Ref<DeferredPromise>> createPromiseAndWrapper(JSDOMGl
 {
     JSC::JSLockHolder lock(globalObject.vm());
     RefPtr deferredPromise = DeferredPromise::create(globalObject);
-    Ref domPromise = DOMPromise::create(globalObject, *uncheckedDowncast<JSC::JSPromise>(deferredPromise->promise()));
+    Ref domPromise = DOMPromise::create(globalObject, *downcast<JSC::JSPromise>(deferredPromise->promise()));
     return { WTF::move(domPromise), deferredPromise.releaseNonNull() };
 }
 

--- a/Source/WebCore/bindings/js/JSDOMWindowCustom.cpp
+++ b/Source/WebCore/bindings/js/JSDOMWindowCustom.cpp
@@ -198,7 +198,7 @@ bool JSDOMWindow::getOwnPropertySlot(JSObject* object, JSGlobalObject* lexicalGl
     if (std::optional<unsigned> index = parseIndex(propertyName))
         return getOwnPropertySlotByIndex(object, lexicalGlobalObject, index.value(), slot);
 
-    auto* thisObject = uncheckedDowncast<JSDOMWindow>(object);
+    auto* thisObject = downcast<JSDOMWindow>(object);
 
     ASSERT(lexicalGlobalObject->vm().currentThreadIsHoldingAPILock());
 
@@ -234,7 +234,7 @@ bool JSDOMWindow::getOwnPropertySlot(JSObject* object, JSGlobalObject* lexicalGl
 
 bool JSDOMWindow::getOwnPropertySlotByIndex(JSObject* object, JSGlobalObject* lexicalGlobalObject, unsigned index, PropertySlot& slot)
 {
-    auto* thisObject = uncheckedDowncast<JSDOMWindow>(object);
+    auto* thisObject = downcast<JSDOMWindow>(object);
     Ref window = thisObject->wrapped();
 
     // Indexed getters take precendence over regular properties, so caching would be invalid.
@@ -273,7 +273,7 @@ bool JSDOMWindow::put(JSCell* cell, JSGlobalObject* lexicalGlobalObject, Propert
     VM& vm = lexicalGlobalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    auto* thisObject = uncheckedDowncast<JSDOMWindow>(cell);
+    auto* thisObject = downcast<JSDOMWindow>(cell);
 
     String errorMessage;
     if (!BindingSecurity::shouldAllowAccessToDOMWindow(*lexicalGlobalObject, protect(thisObject->wrapped()), errorMessage)) {
@@ -296,7 +296,7 @@ bool JSDOMWindow::put(JSCell* cell, JSGlobalObject* lexicalGlobalObject, Propert
 bool JSDOMWindow::putByIndex(JSCell* cell, JSGlobalObject* lexicalGlobalObject, unsigned index, JSValue value, bool shouldThrow)
 {
     VM& vm = lexicalGlobalObject->vm();
-    auto* thisObject = uncheckedDowncast<JSDOMWindow>(cell);
+    auto* thisObject = downcast<JSDOMWindow>(cell);
     auto scope = DECLARE_THROW_SCOPE(vm);
 
     String errorMessage;
@@ -316,7 +316,7 @@ bool JSDOMWindow::putByIndex(JSCell* cell, JSGlobalObject* lexicalGlobalObject, 
 
 bool JSDOMWindow::deleteProperty(JSCell* cell, JSGlobalObject* lexicalGlobalObject, PropertyName propertyName, DeletePropertySlot& slot)
 {
-    auto* thisObject = uncheckedDowncast<JSDOMWindow>(cell);
+    auto* thisObject = downcast<JSDOMWindow>(cell);
     // Only allow deleting properties by frames in the same origin.
     if (!BindingSecurity::shouldAllowAccessToDOMWindow(lexicalGlobalObject, protect(thisObject->wrapped()), ThrowSecurityError))
         return false;
@@ -331,7 +331,7 @@ bool JSDOMWindow::deleteProperty(JSCell* cell, JSGlobalObject* lexicalGlobalObje
 
 bool JSDOMWindow::deletePropertyByIndex(JSCell* cell, JSGlobalObject* lexicalGlobalObject, unsigned propertyName)
 {
-    auto* thisObject = uncheckedDowncast<JSDOMWindow>(cell);
+    auto* thisObject = downcast<JSDOMWindow>(cell);
     // Only allow deleting properties by frames in the same origin.
     if (!BindingSecurity::shouldAllowAccessToDOMWindow(lexicalGlobalObject, protect(thisObject->wrapped()), ThrowSecurityError))
         return false;
@@ -344,7 +344,7 @@ bool JSDOMWindow::deletePropertyByIndex(JSCell* cell, JSGlobalObject* lexicalGlo
 
 void JSDOMWindow::analyzeHeap(JSCell* cell, HeapAnalyzer& analyzer)
 {
-    auto* thisObject = uncheckedDowncast<JSDOMWindow>(cell);
+    auto* thisObject = downcast<JSDOMWindow>(cell);
     Ref location = protect(thisObject->wrapped())->location();
     analyzer.setLabelForCell(cell, location->href());
 
@@ -419,7 +419,7 @@ static void addScopedChildrenIndexes(JSGlobalObject& lexicalGlobalObject, DOMWin
 // https://html.spec.whatwg.org/#windowproxy-ownpropertykeys
 void JSDOMWindow::getOwnPropertyNames(JSObject* object, JSGlobalObject* lexicalGlobalObject, PropertyNameArrayBuilder& propertyNames, DontEnumPropertiesMode mode)
 {
-    auto* thisObject = uncheckedDowncast<JSDOMWindow>(object);
+    auto* thisObject = downcast<JSDOMWindow>(object);
     Ref window = thisObject->wrapped();
 
     addScopedChildrenIndexes(*lexicalGlobalObject, window.get(), propertyNames);
@@ -437,7 +437,7 @@ bool JSDOMWindow::defineOwnProperty(JSC::JSObject* object, JSC::JSGlobalObject* 
     VM& vm = lexicalGlobalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    auto* thisObject = uncheckedDowncast<JSDOMWindow>(object);
+    auto* thisObject = downcast<JSDOMWindow>(object);
     // Only allow defining properties in this way by frames in the same origin, as it allows setters to be introduced.
     if (!BindingSecurity::shouldAllowAccessToDOMWindow(lexicalGlobalObject, protect(thisObject->wrapped()), ThrowSecurityError))
         return false;
@@ -454,7 +454,7 @@ bool JSDOMWindow::defineOwnProperty(JSC::JSObject* object, JSC::JSGlobalObject* 
 
 JSValue JSDOMWindow::getPrototype(JSObject* object, JSGlobalObject* lexicalGlobalObject)
 {
-    auto* thisObject = uncheckedDowncast<JSDOMWindow>(object);
+    auto* thisObject = downcast<JSDOMWindow>(object);
     if (!BindingSecurity::shouldAllowAccessToDOMWindow(lexicalGlobalObject, protect(thisObject->wrapped()), DoNotReportSecurityError))
         return jsNull();
 
@@ -616,10 +616,10 @@ DOMWindow* NODELETE JSDOMWindow::toWrapped(VM&, JSValue value)
     if (!value.isObject())
         return nullptr;
     JSObject* object = asObject(value);
-    if (object->inherits<JSDOMWindow>())
-        return &uncheckedDowncast<JSDOMWindow>(object)->wrapped();
-    if (object->inherits<JSWindowProxy>()) {
-        if (auto* jsDOMWindow = dynamicDowncast<JSDOMWindow>(uncheckedDowncast<JSWindowProxy>(object)->window()))
+    if (auto* jsDOMWindow = dynamicDowncast<JSDOMWindow>(*object))
+        return &jsDOMWindow->wrapped();
+    if (auto* windowProxy = dynamicDowncast<JSWindowProxy>(*object)) {
+        if (auto* jsDOMWindow = dynamicDowncast<JSDOMWindow>(windowProxy->window()))
             return &jsDOMWindow->wrapped();
     }
     return nullptr;
@@ -724,7 +724,7 @@ JSDOMWindow& mainWorldGlobalObject(LocalFrame& frame)
     // FIXME: What guarantees the result of jsWindowProxy() is non-null?
     // FIXME: What guarantees the result of window() is non-null?
     // FIXME: What guarantees the result of window() a JSDOMWindow?
-    return *uncheckedDowncast<JSDOMWindow>(protect(frame.windowProxy())->jsWindowProxy(mainThreadNormalWorldSingleton())->window());
+    return *downcast<JSDOMWindow>(protect(frame.windowProxy())->jsWindowProxy(mainThreadNormalWorldSingleton())->window());
 }
 
 } // namespace WebCore

--- a/Source/WebCore/bindings/js/JSDOMWindowProperties.cpp
+++ b/Source/WebCore/bindings/js/JSDOMWindowProperties.cpp
@@ -91,7 +91,7 @@ void JSDOMWindowProperties::finishCreation(JSGlobalObject& globalObject)
 
 bool JSDOMWindowProperties::getOwnPropertySlot(JSObject* object, JSGlobalObject* lexicalGlobalObject, PropertyName propertyName, PropertySlot& slot)
 {
-    auto* thisObject = uncheckedDowncast<JSDOMWindowProperties>(object);
+    auto* thisObject = downcast<JSDOMWindowProperties>(object);
     ASSERT_GC_OBJECT_INHERITS(thisObject, info());
 
     if (Base::getOwnPropertySlot(thisObject, lexicalGlobalObject, propertyName, slot))

--- a/Source/WebCore/bindings/js/JSDeprecatedCSSOMValueCustom.cpp
+++ b/Source/WebCore/bindings/js/JSDeprecatedCSSOMValueCustom.cpp
@@ -41,7 +41,7 @@ using namespace JSC;
 
 bool JSDeprecatedCSSOMValueOwner::isReachableFromOpaqueRoots(JSC::Handle<JSC::Unknown> handle, void*, AbstractSlotVisitor& visitor, ASCIILiteral* reason)
 {
-    JSDeprecatedCSSOMValue* jsCSSValue = uncheckedDowncast<JSDeprecatedCSSOMValue>(handle.slot()->asCell());
+    JSDeprecatedCSSOMValue* jsCSSValue = downcast<JSDeprecatedCSSOMValue>(handle.slot()->asCell());
     if (!jsCSSValue->hasCustomProperties())
         return false;
 

--- a/Source/WebCore/bindings/js/JSDocumentCustom.cpp
+++ b/Source/WebCore/bindings/js/JSDocumentCustom.cpp
@@ -100,7 +100,7 @@ DEFINE_VISIT_ADDITIONAL_CHILDREN_IN_GC_THREAD(JSDocument);
 void JSDocument::analyzeHeap(JSCell* cell, HeapAnalyzer& analyzer)
 {
     Base::analyzeHeap(cell, analyzer);
-    auto* thisObject = uncheckedDowncast<JSDocument>(cell);
+    auto* thisObject = downcast<JSDocument>(cell);
     analyzer.setLabelForCell(cell, thisObject->wrapped().url().string());
 }
 

--- a/Source/WebCore/bindings/js/JSErrorHandler.cpp
+++ b/Source/WebCore/bindings/js/JSErrorHandler.cpp
@@ -108,7 +108,7 @@ void JSErrorHandler::handleEvent(ScriptExecutionContext& scriptExecutionContext,
 
             {
                 auto scope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
-                auto* jsErrorEvent = uncheckedDowncast<JSErrorEvent>(toJS(globalObject, globalObject, *errorEvent));
+                auto* jsErrorEvent = downcast<JSErrorEvent>(toJS(globalObject, globalObject, *errorEvent));
                 if (auto* exception = scope.exception()) [[unlikely]] {
                     scope.clearException();
                     return exception;

--- a/Source/WebCore/bindings/js/JSEventListener.cpp
+++ b/Source/WebCore/bindings/js/JSEventListener.cpp
@@ -156,7 +156,7 @@ void JSEventListener::handleEvent(ScriptExecutionContext& scriptExecutionContext
         return;
 
     if (scriptExecutionContext.isDocument()) {
-        auto* window = uncheckedDowncast<JSDOMWindow>(globalObject);
+        auto* window = downcast<JSDOMWindow>(globalObject);
         RefPtr localDOMWindow = dynamicDowncast<LocalDOMWindow>(window->wrapped());
         if (!localDOMWindow || !localDOMWindow->isCurrentlyDisplayedInFrame())
             return;

--- a/Source/WebCore/bindings/js/JSEventTargetCustom.cpp
+++ b/Source/WebCore/bindings/js/JSEventTargetCustom.cpp
@@ -51,14 +51,14 @@ JSValue toJSNewlyCreated(JSGlobalObject*, JSDOMGlobalObject* globalObject, Ref<E
 
 EventTarget* NODELETE JSEventTarget::toWrapped(VM&, JSValue value)
 {
-    if (value.inherits<JSWindowProxy>())
-        return &uncheckedDowncast<JSWindowProxy>(asObject(value))->wrapped();
-    if (value.inherits<JSDOMWindow>())
-        return &uncheckedDowncast<JSDOMWindow>(asObject(value))->wrapped();
-    if (value.inherits<JSWorkerGlobalScope>())
-        return &uncheckedDowncast<JSWorkerGlobalScope>(asObject(value))->wrapped();
-    if (value.inherits<JSEventTarget>())
-        return &uncheckedDowncast<JSEventTarget>(asObject(value))->wrapped();
+    if (auto* windowProxy = dynamicDowncast<JSWindowProxy>(value))
+        return &windowProxy->wrapped();
+    if (auto* window = dynamicDowncast<JSDOMWindow>(value))
+        return &window->wrapped();
+    if (auto* workerGlobalScope = dynamicDowncast<JSWorkerGlobalScope>(value))
+        return &workerGlobalScope->wrapped();
+    if (auto* eventTarget = dynamicDowncast<JSEventTarget>(value))
+        return &eventTarget->wrapped();
     return nullptr;
 }
 

--- a/Source/WebCore/bindings/js/JSExecState.cpp
+++ b/Source/WebCore/bindings/js/JSExecState.cpp
@@ -60,9 +60,10 @@ JSC::JSValue evaluateHandlerFromAnyThread(JSC::JSGlobalObject* lexicalGlobalObje
 
 ScriptExecutionContext* executionContext(JSC::JSGlobalObject* globalObject)
 {
-    if (!globalObject || !globalObject->inherits<JSDOMGlobalObject>())
+    auto* domGlobalObject = dynamicDowncast<JSDOMGlobalObject>(globalObject);
+    if (!domGlobalObject)
         return nullptr;
-    return uncheckedDowncast<JSDOMGlobalObject>(globalObject)->scriptExecutionContext();
+    return domGlobalObject->scriptExecutionContext();
 }
 
 } // namespace WebCore

--- a/Source/WebCore/bindings/js/JSHTMLAllCollectionCustom.cpp
+++ b/Source/WebCore/bindings/js/JSHTMLAllCollectionCustom.cpp
@@ -46,7 +46,7 @@ JSC_DEFINE_HOST_FUNCTION(callJSHTMLAllCollection, (JSGlobalObject* lexicalGlobal
     VM& vm = lexicalGlobalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    auto* castedThis = uncheckedDowncast<JSHTMLAllCollection>(callFrame->jsCallee());
+    auto* castedThis = downcast<JSHTMLAllCollection>(callFrame->jsCallee());
     ASSERT(castedThis);
     auto& impl = castedThis->wrapped();
     if (callFrame->argument(0).isUndefined())

--- a/Source/WebCore/bindings/js/JSHTMLElementCustom.cpp
+++ b/Source/WebCore/bindings/js/JSHTMLElementCustom.cpp
@@ -54,7 +54,7 @@ EncodedJSValue constructJSHTMLElement(JSGlobalObject* lexicalGlobalObject, CallF
     VM& vm = lexicalGlobalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    auto* jsConstructor = uncheckedDowncast<JSDOMConstructorBase>(callFrame.jsCallee());
+    auto* jsConstructor = downcast<JSDOMConstructorBase>(callFrame.jsCallee());
     ASSERT(jsConstructor);
 
     CheckedPtr context = jsConstructor->scriptExecutionContext();
@@ -65,7 +65,7 @@ EncodedJSValue constructJSHTMLElement(JSGlobalObject* lexicalGlobalObject, CallF
     auto* newTarget = callFrame.newTarget().getObject();
     auto* functionGlobalObject = getFunctionRealm(lexicalGlobalObject, newTarget);
     RETURN_IF_EXCEPTION(scope, { });
-    auto* newTargetGlobalObject = uncheckedDowncast<JSDOMGlobalObject>(functionGlobalObject);
+    auto* newTargetGlobalObject = downcast<JSDOMGlobalObject>(functionGlobalObject);
     JSValue htmlElementConstructorValue = JSHTMLElement::getConstructor(vm, newTargetGlobalObject);
     if (newTarget == htmlElementConstructorValue)
         return throwVMTypeError(lexicalGlobalObject, scope, "new.target is not a valid custom element constructor"_s);

--- a/Source/WebCore/bindings/js/JSIDBRecordCustom.cpp
+++ b/Source/WebCore/bindings/js/JSIDBRecordCustom.cpp
@@ -33,12 +33,12 @@ namespace WebCore {
 
 JSC::JSValue JSIDBRecord::key(JSC::JSGlobalObject& lexicalGlobalObject) const
 {
-    return toJS<IDLIDBKeyData>(lexicalGlobalObject, uncheckedDowncast<JSDOMGlobalObject>(lexicalGlobalObject), wrapped().key());
+    return toJS<IDLIDBKeyData>(lexicalGlobalObject, downcast<JSDOMGlobalObject>(lexicalGlobalObject), wrapped().key());
 }
 
 JSC::JSValue JSIDBRecord::primaryKey(JSC::JSGlobalObject& lexicalGlobalObject) const
 {
-    return toJS<IDLIDBKeyData>(lexicalGlobalObject, uncheckedDowncast<JSDOMGlobalObject>(lexicalGlobalObject), wrapped().primaryKey());
+    return toJS<IDLIDBKeyData>(lexicalGlobalObject, downcast<JSDOMGlobalObject>(lexicalGlobalObject), wrapped().primaryKey());
 }
 
 JSC::JSValue JSIDBRecord::value(JSC::JSGlobalObject& lexicalGlobalObject) const

--- a/Source/WebCore/bindings/js/JSIDBRequestCustom.cpp
+++ b/Source/WebCore/bindings/js/JSIDBRequestCustom.cpp
@@ -63,22 +63,22 @@ JSC::JSValue JSIDBRequest::result(JSC::JSGlobalObject& lexicalGlobalObject) cons
         },
         [&](const Ref<IDBCursor>& cursor) {
             return cachedPropertyValue(throwScope, lexicalGlobalObject, *this, resultWrapper, [&](JSC::ThrowScope& throwScope) {
-                return toJS<IDLInterface<IDBCursor>>(lexicalGlobalObject, uncheckedDowncast<JSDOMGlobalObject>(lexicalGlobalObject), throwScope, cursor);
+                return toJS<IDLInterface<IDBCursor>>(lexicalGlobalObject, downcast<JSDOMGlobalObject>(lexicalGlobalObject), throwScope, cursor);
             });
         },
         [&](const Ref<IDBDatabase>& database) {
             return cachedPropertyValue(throwScope, lexicalGlobalObject, *this, resultWrapper, [&](JSC::ThrowScope& throwScope) {
-                return toJS<IDLInterface<IDBDatabase>>(lexicalGlobalObject, uncheckedDowncast<JSDOMGlobalObject>(lexicalGlobalObject), throwScope, database);
+                return toJS<IDLInterface<IDBDatabase>>(lexicalGlobalObject, downcast<JSDOMGlobalObject>(lexicalGlobalObject), throwScope, database);
             });
         },
         [&](const IDBKeyData& keyData) {
             return cachedPropertyValue(throwScope, lexicalGlobalObject, *this, resultWrapper, [&](JSC::ThrowScope&) {
-                return toJS<IDLIDBKeyData>(lexicalGlobalObject, uncheckedDowncast<JSDOMGlobalObject>(lexicalGlobalObject), keyData);
+                return toJS<IDLIDBKeyData>(lexicalGlobalObject, downcast<JSDOMGlobalObject>(lexicalGlobalObject), keyData);
             });
         },
         [&](const Vector<IDBKeyData>& keyDatas) {
             return cachedPropertyValue(throwScope, lexicalGlobalObject, *this, resultWrapper, [&](JSC::ThrowScope&) {
-                return toJS<IDLSequence<IDLIDBKeyData>>(lexicalGlobalObject, uncheckedDowncast<JSDOMGlobalObject>(lexicalGlobalObject), keyDatas);
+                return toJS<IDLSequence<IDLIDBKeyData>>(lexicalGlobalObject, downcast<JSDOMGlobalObject>(lexicalGlobalObject), keyDatas);
             });
         },
         [&](const IDBGetResult& getResult) {
@@ -94,7 +94,7 @@ JSC::JSValue JSIDBRequest::result(JSC::JSGlobalObject& lexicalGlobalObject) cons
                 auto& values = getAllResult.values();
                 auto& keyPath = getAllResult.keyPath();
 
-                auto* domGlobalObject = uncheckedDowncast<JSDOMGlobalObject>(&lexicalGlobalObject);
+                auto* domGlobalObject = downcast<JSDOMGlobalObject>(&lexicalGlobalObject);
 
                 JSC::MarkedArgumentBuffer list;
                 list.ensureCapacity(keys.size());

--- a/Source/WebCore/bindings/js/JSIntersectionObserverCustom.cpp
+++ b/Source/WebCore/bindings/js/JSIntersectionObserverCustom.cpp
@@ -44,7 +44,7 @@ DEFINE_VISIT_ADDITIONAL_CHILDREN_IN_GC_THREAD(JSIntersectionObserver);
 
 bool JSIntersectionObserverOwner::isReachableFromOpaqueRoots(JSC::Handle<JSC::Unknown> handle, void*, JSC::AbstractSlotVisitor& visitor, ASCIILiteral* reason)
 {
-    if (uncheckedDowncast<JSIntersectionObserver>(handle.slot()->asCell())->wrapped().isReachableFromOpaqueRoots(visitor)) {
+    if (downcast<JSIntersectionObserver>(handle.slot()->asCell())->wrapped().isReachableFromOpaqueRoots(visitor)) {
         if (reason) [[unlikely]]
             *reason = "Reachable from observed nodes"_s;
         return true;

--- a/Source/WebCore/bindings/js/JSKeyframeEffectCustom.cpp
+++ b/Source/WebCore/bindings/js/JSKeyframeEffectCustom.cpp
@@ -41,10 +41,10 @@ JSValue JSKeyframeEffect::getKeyframes(JSGlobalObject& lexicalGlobalObject, Call
 {
     auto lock = JSLockHolder { &lexicalGlobalObject };
 
-    if (!uncheckedDowncast<JSDOMGlobalObject>(&lexicalGlobalObject)->scriptExecutionContext()) [[unlikely]]
+    if (!downcast<JSDOMGlobalObject>(&lexicalGlobalObject)->scriptExecutionContext()) [[unlikely]]
         return jsUndefined();
 
-    auto& domGlobalObject = uncheckedDowncast<JSDOMGlobalObject>(lexicalGlobalObject);
+    auto& domGlobalObject = downcast<JSDOMGlobalObject>(lexicalGlobalObject);
     auto computedKeyframes = wrapped().getKeyframes();
     auto keyframeObjects = computedKeyframes.map([&](auto& computedKeyframe) -> Strong<JSObject> {
         auto keyframeObject = convertDictionaryToJS(lexicalGlobalObject, domGlobalObject, { computedKeyframe });

--- a/Source/WebCore/bindings/js/JSLazyEventListener.cpp
+++ b/Source/WebCore/bindings/js/JSLazyEventListener.cpp
@@ -176,9 +176,8 @@ JSObject* JSLazyEventListener::initializeJSFunction(ScriptExecutionContext& exec
         }
 
         if (listenerHasEventHandlerScope) {
-            ASSERT(wrapper()->inherits<JSHTMLElement>());
             // Add the event's home element to the scope (and the document, and the form - see JSHTMLElement::eventHandlerScope)
-            JSFunction* listenerAsFunction = uncheckedDowncast<JSFunction>(jsFunction);
+            JSFunction* listenerAsFunction = downcast<JSFunction>(jsFunction);
             listenerAsFunction->setScope(vm, uncheckedDowncast<JSHTMLElement>(wrapper())->pushEventHandlerScope(lexicalGlobalObject, listenerAsFunction->scope()));
         }
     }

--- a/Source/WebCore/bindings/js/JSMutationObserverCustom.cpp
+++ b/Source/WebCore/bindings/js/JSMutationObserverCustom.cpp
@@ -49,7 +49,7 @@ DEFINE_VISIT_ADDITIONAL_CHILDREN_IN_GC_THREAD(JSMutationObserver);
 
 bool JSMutationObserverOwner::isReachableFromOpaqueRoots(JSC::Handle<JSC::Unknown> handle, void*, AbstractSlotVisitor& visitor, ASCIILiteral* reason)
 {
-    if (uncheckedDowncast<JSMutationObserver>(handle.slot()->asCell())->wrapped().isReachableFromOpaqueRoots(visitor)) {
+    if (downcast<JSMutationObserver>(handle.slot()->asCell())->wrapped().isReachableFromOpaqueRoots(visitor)) {
         if (reason) [[unlikely]]
             *reason = "Reachable from observed nodes"_s;
         return true;

--- a/Source/WebCore/bindings/js/JSNodeCustom.cpp
+++ b/Source/WebCore/bindings/js/JSNodeCustom.cpp
@@ -69,7 +69,7 @@ using namespace HTMLNames;
 
 bool JSNodeOwner::isReachableFromOpaqueRoots(JSC::Handle<JSC::Unknown> handle, void*, AbstractSlotVisitor& visitor, ASCIILiteral* reason)
 {
-    SUPPRESS_UNCHECKED_LOCAL auto& node = uncheckedDowncast<JSNode>(handle.slot()->asCell())->wrapped();
+    SUPPRESS_UNCHECKED_LOCAL auto& node = downcast<JSNode>(handle.slot()->asCell())->wrapped();
     if (!node.isConnected()) {
         if (GCReachableRefMap::contains(node) || node.isInCustomElementReactionQueue()) {
             if (reason) [[unlikely]]

--- a/Source/WebCore/bindings/js/JSNodeListCustom.cpp
+++ b/Source/WebCore/bindings/js/JSNodeListCustom.cpp
@@ -41,7 +41,7 @@ using namespace JSC;
 
 bool JSNodeListOwner::isReachableFromOpaqueRoots(JSC::Handle<JSC::Unknown> handle, void*, AbstractSlotVisitor& visitor, ASCIILiteral* reason)
 {
-    JSNodeList* jsNodeList = uncheckedDowncast<JSNodeList>(handle.slot()->asCell());
+    JSNodeList* jsNodeList = downcast<JSNodeList>(handle.slot()->asCell());
     if (!jsNodeList->hasCustomProperties())
         return false;
 

--- a/Source/WebCore/bindings/js/JSOffscreenCanvasRenderingContext2DCustom.cpp
+++ b/Source/WebCore/bindings/js/JSOffscreenCanvasRenderingContext2DCustom.cpp
@@ -37,7 +37,7 @@ bool JSOffscreenCanvasRenderingContext2DOwner::isReachableFromOpaqueRoots(JSC::H
     if (reason) [[unlikely]]
         *reason = "Canvas is opaque root"_s;
 
-    auto* jsOffscreenCanvasRenderingContext = uncheckedDowncast<JSOffscreenCanvasRenderingContext2D>(handle.slot()->asCell());
+    auto* jsOffscreenCanvasRenderingContext = downcast<JSOffscreenCanvasRenderingContext2D>(handle.slot()->asCell());
     return containsWebCoreOpaqueRoot(visitor, jsOffscreenCanvasRenderingContext->wrapped().canvas());
 }
 

--- a/Source/WebCore/bindings/js/JSPaintRenderingContext2DCustom.cpp
+++ b/Source/WebCore/bindings/js/JSPaintRenderingContext2DCustom.cpp
@@ -43,7 +43,7 @@ bool JSPaintRenderingContext2DOwner::isReachableFromOpaqueRoots(JSC::Handle<JSC:
     if (reason) [[unlikely]]
         *reason = "Canvas is opaque root"_s;
 
-    auto* jsPaintRenderingContext = uncheckedDowncast<JSPaintRenderingContext2D>(handle.slot()->asCell());
+    auto* jsPaintRenderingContext = downcast<JSPaintRenderingContext2D>(handle.slot()->asCell());
     return containsWebCoreOpaqueRoot(visitor, jsPaintRenderingContext->wrapped().canvas());
 }
 

--- a/Source/WebCore/bindings/js/JSPerformanceObserverCustom.cpp
+++ b/Source/WebCore/bindings/js/JSPerformanceObserverCustom.cpp
@@ -44,7 +44,7 @@ bool JSPerformanceObserverOwner::isReachableFromOpaqueRoots(JSC::Handle<JSC::Unk
     if (reason) [[unlikely]]
         *reason = "Registered PerformanceObserver callback"_s;
 
-    return uncheckedDowncast<JSPerformanceObserver>(handle.slot()->asCell())->wrapped().isRegistered();
+    return downcast<JSPerformanceObserver>(handle.slot()->asCell())->wrapped().isRegistered();
 }
 
 }

--- a/Source/WebCore/bindings/js/JSPluginElementFunctions.cpp
+++ b/Source/WebCore/bindings/js/JSPluginElementFunctions.cpp
@@ -127,7 +127,7 @@ bool pluginElementCustomPut(JSHTMLElement* element, JSGlobalObject* lexicalGloba
 
 JSC_DEFINE_HOST_FUNCTION(callPlugin, (JSGlobalObject* lexicalGlobalObject, CallFrame* callFrame))
 {
-    JSHTMLElement* element = uncheckedDowncast<JSHTMLElement>(callFrame->jsCallee());
+    JSHTMLElement* element = downcast<JSHTMLElement>(callFrame->jsCallee());
 
     // Get the plug-in script object.
     JSObject* scriptObject = pluginScriptObject(lexicalGlobalObject, element);

--- a/Source/WebCore/bindings/js/JSPopStateEventCustom.cpp
+++ b/Source/WebCore/bindings/js/JSPopStateEventCustom.cpp
@@ -55,7 +55,7 @@ JSValue JSPopStateEvent::state(JSGlobalObject& lexicalGlobalObject) const
 
         // Share the same deserialization with history.state when the state is the current one.
         if (history->isSameAsCurrentState(event.serializedState())) {
-            auto* jsHistory = uncheckedDowncast<JSHistory>(toJS(&lexicalGlobalObject, realm(), *history).asCell());
+            auto* jsHistory = downcast<JSHistory>(toJS(&lexicalGlobalObject, realm(), *history).asCell());
             return jsHistory->state(lexicalGlobalObject);
         }
 

--- a/Source/WebCore/bindings/js/JSResizeObserverCustom.cpp
+++ b/Source/WebCore/bindings/js/JSResizeObserverCustom.cpp
@@ -58,7 +58,7 @@ DEFINE_VISIT_ADDITIONAL_CHILDREN_IN_GC_THREAD(JSResizeObserver);
 
 bool JSResizeObserverOwner::isReachableFromOpaqueRoots(JSC::Handle<JSC::Unknown> handle, void*, JSC::AbstractSlotVisitor& visitor, ASCIILiteral* reason)
 {
-    if (uncheckedDowncast<JSResizeObserver>(handle.slot()->asCell())->wrapped().isReachableFromOpaqueRoots(visitor)) {
+    if (downcast<JSResizeObserver>(handle.slot()->asCell())->wrapped().isReachableFromOpaqueRoots(visitor)) {
         if (reason) [[unlikely]]
             *reason = "Reachable from observed nodes"_s;
         return true;

--- a/Source/WebCore/bindings/js/JSTextTrackCueCustom.cpp
+++ b/Source/WebCore/bindings/js/JSTextTrackCueCustom.cpp
@@ -41,7 +41,7 @@ using namespace JSC;
 
 bool JSTextTrackCueOwner::isReachableFromOpaqueRoots(JSC::Handle<JSC::Unknown> handle, void*, AbstractSlotVisitor& visitor, ASCIILiteral* reason)
 {
-    JSTextTrackCue* jsTextTrackCue = uncheckedDowncast<JSTextTrackCue>(handle.slot()->asCell());
+    JSTextTrackCue* jsTextTrackCue = downcast<JSTextTrackCue>(handle.slot()->asCell());
     TextTrackCue& textTrackCue = jsTextTrackCue->wrapped();
 
     if (!textTrackCue.isContextStopped() && textTrackCue.hasPendingActivity()) {

--- a/Source/WebCore/bindings/js/JSUndoItemCustom.cpp
+++ b/Source/WebCore/bindings/js/JSUndoItemCustom.cpp
@@ -45,7 +45,7 @@ bool JSUndoItemOwner::isReachableFromOpaqueRoots(JSC::Handle<JSC::Unknown> handl
     if (reason) [[unlikely]]
         *reason = "Document is an opaque root."_s;
 
-    SUPPRESS_UNCHECKED_LOCAL auto* documentForUndoItem = uncheckedDowncast<JSUndoItem>(handle.slot()->asCell())->wrapped().document();
+    SUPPRESS_UNCHECKED_LOCAL auto* documentForUndoItem = downcast<JSUndoItem>(handle.slot()->asCell())->wrapped().document();
     return containsWebCoreOpaqueRoot(visitor, documentForUndoItem);
 }
 

--- a/Source/WebCore/bindings/js/JSWebAnimationCustom.cpp
+++ b/Source/WebCore/bindings/js/JSWebAnimationCustom.cpp
@@ -44,7 +44,7 @@ EncodedJSValue constructJSWebAnimation(JSGlobalObject* lexicalGlobalObject, Call
     VM& vm = lexicalGlobalObject->vm();
     auto throwScope = DECLARE_THROW_SCOPE(vm);
     UNUSED_PARAM(throwScope);
-    auto* jsConstructor = uncheckedDowncast<JSDOMConstructorBase>(callFrame.jsCallee());
+    auto* jsConstructor = downcast<JSDOMConstructorBase>(callFrame.jsCallee());
     ASSERT(jsConstructor);
     CheckedPtr context = jsConstructor->scriptExecutionContext();
     if (!context) [[unlikely]]

--- a/Source/WebCore/bindings/js/JSWindowProxy.cpp
+++ b/Source/WebCore/bindings/js/JSWindowProxy.cpp
@@ -150,7 +150,7 @@ void JSWindowProxy::attachDebugger(JSC::Debugger* debugger)
 DOMWindow& JSWindowProxy::wrapped() const
 {
     auto* window = this->window();
-    return uncheckedDowncast<JSDOMWindowBase>(window)->wrapped();
+    return downcast<JSDOMWindowBase>(window)->wrapped();
 }
 
 JSValue toJS(JSGlobalObject* lexicalGlobalObject, WindowProxy& windowProxy)
@@ -169,8 +169,8 @@ WindowProxy* JSWindowProxy::toWrapped(VM&, JSValue value)
     if (!value.isObject())
         return nullptr;
     JSObject* object = asObject(value);
-    if (object->inherits<JSWindowProxy>())
-        return uncheckedDowncast<JSWindowProxy>(object)->windowProxy();
+    if (auto* windowProxy = dynamicDowncast<JSWindowProxy>(*object))
+        return windowProxy->windowProxy();
     return nullptr;
 }
 

--- a/Source/WebCore/bindings/js/JSWindowProxy.h
+++ b/Source/WebCore/bindings/js/JSWindowProxy.h
@@ -53,7 +53,7 @@ public:
 
     DECLARE_INFO;
 
-    JSDOMGlobalObject* window() const { return uncheckedDowncast<JSDOMGlobalObject>(target()); }
+    JSDOMGlobalObject* window() const { return downcast<JSDOMGlobalObject>(target()); }
 
     void setWindow(JSC::VM&, JSDOMGlobalObject&);
     void setWindow(DOMWindow&);

--- a/Source/WebCore/bindings/js/ScriptCachedFrameData.cpp
+++ b/Source/WebCore/bindings/js/ScriptCachedFrameData.cpp
@@ -56,7 +56,7 @@ ScriptCachedFrameData::ScriptCachedFrameData(LocalFrame& frame)
     JSLockHolder lock(commonVM());
 
     for (auto windowProxy : frame.windowProxy().jsWindowProxiesAsVector()) {
-        auto* window = uncheckedDowncast<JSDOMWindow>(windowProxy->window());
+        auto* window = downcast<JSDOMWindow>(windowProxy->window());
         m_windows.add(windowProxy->world(), Strong<JSDOMWindow>(window->vm(), window));
         window->setConsoleClient(nullptr);
     }

--- a/Source/WebCore/bindings/js/ScriptController.cpp
+++ b/Source/WebCore/bindings/js/ScriptController.cpp
@@ -335,7 +335,7 @@ void ScriptController::initScriptForWindowProxy(JSWindowProxy& windowProxy)
     JSC::VM& vm = world->vm();
     auto scope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
 
-    uncheckedDowncast<JSDOMWindow>(windowProxy.window())->updateDocument();
+    downcast<JSDOMWindow>(windowProxy.window())->updateDocument();
     EXCEPTION_ASSERT_UNUSED(scope, !scope.exception());
 
     windowProxy.window()->setConsoleClient(m_frame->console());
@@ -515,7 +515,7 @@ void ScriptController::updateDocument()
     RefPtr document = m_frame->document();
     for (auto& jsWindowProxy : protect(windowProxy())->jsWindowProxiesAsVector()) {
         JSLockHolder lock(jsWindowProxy->world().vm());
-        uncheckedDowncast<JSDOMWindow>(jsWindowProxy->window())->updateDocument();
+        downcast<JSDOMWindow>(jsWindowProxy->window())->updateDocument();
         if (document)
             document->addMicrotaskGlobalObject(jsWindowProxy->window());
     }

--- a/Source/WebCore/bindings/js/ScriptModuleLoader.cpp
+++ b/Source/WebCore/bindings/js/ScriptModuleLoader.cpp
@@ -185,7 +185,7 @@ static void rejectWithFetchError(ScriptExecutionContext& context, Ref<DeferredPr
     context.eventLoop().queueTask(TaskSource::Networking, [deferred = WTF::move(deferred), ec, message = WTF::move(message)]() {
         deferred->rejectWithCallback([&] (JSDOMGlobalObject& jsGlobalObject) {
             JSC::VM& vm = jsGlobalObject.vm();
-            JSC::JSObject* error = uncheckedDowncast<JSC::JSObject>(createDOMException(&jsGlobalObject, ec, message));
+            JSC::JSObject* error = downcast<JSC::JSObject>(createDOMException(&jsGlobalObject, ec, message));
             ASSERT(error);
             error->putDirect(vm, vm.propertyNames->builtinNames().moduleFetchFailureKindPrivateName(), JSC::jsNumber(std::to_underlying(ModuleFetchFailureKind::WasFetchError)));
             return error;
@@ -197,7 +197,7 @@ JSC::JSPromise* ScriptModuleLoader::fetch(JSC::JSGlobalObject* jsGlobalObject, J
 {
     JSC::VM& vm = jsGlobalObject->vm();
 
-    auto& globalObject = *uncheckedDowncast<JSDOMGlobalObject>(jsGlobalObject);
+    auto& globalObject = *downcast<JSDOMGlobalObject>(jsGlobalObject);
     auto* jsPromise = JSC::JSPromise::create(vm, globalObject.promiseStructure());
     RELEASE_ASSERT(jsPromise);
     if (!m_context)
@@ -323,7 +323,7 @@ JSC::JSPromise* ScriptModuleLoader::importModule(JSC::JSGlobalObject* jsGlobalOb
 {
     JSC::VM& vm = jsGlobalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
-    auto& globalObject = *uncheckedDowncast<JSDOMGlobalObject>(jsGlobalObject);
+    auto& globalObject = *downcast<JSDOMGlobalObject>(jsGlobalObject);
 
     if (!m_context)
         return nullptr;

--- a/Source/WebCore/bindings/js/SerializedScriptValue.cpp
+++ b/Source/WebCore/bindings/js/SerializedScriptValue.cpp
@@ -665,9 +665,9 @@ enum class ImageBitmapSerializationFlags : uint8_t {
 #if ENABLE(WEBASSEMBLY)
 static String agentClusterIDFromGlobalObject(JSGlobalObject& globalObject)
 {
-    if (!globalObject.inherits<JSDOMGlobalObject>())
-        return JSDOMGlobalObject::defaultAgentClusterID();
-    return uncheckedDowncast<JSDOMGlobalObject>(&globalObject)->agentClusterID();
+    if (auto* domGlobalObject = dynamicDowncast<JSDOMGlobalObject>(globalObject))
+        return domGlobalObject->agentClusterID();
+    return JSDOMGlobalObject::defaultAgentClusterID();
 }
 #endif
 
@@ -1374,7 +1374,7 @@ private:
         if (input.isEmpty())
             return;
 
-        auto* globalObject = uncheckedDowncast<JSDOMGlobalObject>(m_lexicalGlobalObject);
+        auto* globalObject = downcast<JSDOMGlobalObject>(m_lexicalGlobalObject);
         for (size_t i = 0; i < input.size(); ++i) {
             if (auto* object = toJSOrNull(globalObject, input[i]).getObject())
                 result.add(object, i);
@@ -1545,7 +1545,7 @@ private:
             return;
         }
 #endif
-        dumpHeapBigIntData(uncheckedDowncast<JSBigInt>(value));
+        dumpHeapBigIntData(downcast<JSBigInt>(value));
     }
 
 #if USE(BIGINT32)
@@ -1596,8 +1596,8 @@ private:
     {
         auto& vm = m_lexicalGlobalObject->vm();
         auto* globalObject = m_lexicalGlobalObject;
-        if (globalObject->inherits<JSDOMGlobalObject>())
-            return toJS(globalObject, uncheckedDowncast<JSDOMGlobalObject>(globalObject), arrayBuffer);
+        if (auto* domGlobalObject = dynamicDowncast<JSDOMGlobalObject>(*globalObject))
+            return toJS(globalObject, domGlobalObject, arrayBuffer);
 
         if (auto* buffer = arrayBuffer.m_wrapper.get())
             return buffer;
@@ -1685,7 +1685,7 @@ private:
         else
             write(DOMPointReadOnlyTag);
 
-        dumpDOMPoint(protect(uncheckedDowncast<JSDOMPointReadOnly>(obj)->wrapped()));
+        dumpDOMPoint(protect(downcast<JSDOMPointReadOnly>(obj)->wrapped()));
     }
 
     void dumpDOMRect(JSObject* obj)
@@ -1695,7 +1695,7 @@ private:
         else
             write(DOMRectReadOnlyTag);
 
-        Ref rect = uncheckedDowncast<JSDOMRectReadOnly>(obj)->wrapped();
+        Ref rect = downcast<JSDOMRectReadOnly>(obj)->wrapped();
         write(rect->x());
         write(rect->y());
         write(rect->width());
@@ -1709,7 +1709,7 @@ private:
         else
             write(DOMMatrixReadOnlyTag);
 
-        Ref matrix = uncheckedDowncast<JSDOMMatrixReadOnly>(obj)->wrapped();
+        Ref matrix = downcast<JSDOMMatrixReadOnly>(obj)->wrapped();
         bool is2D = matrix->is2D();
         write(is2D);
         if (is2D) {
@@ -1743,7 +1743,7 @@ private:
     {
         write(DOMQuadTag);
 
-        Ref quad = uncheckedDowncast<JSDOMQuad>(obj)->wrapped();
+        Ref quad = downcast<JSDOMQuad>(obj)->wrapped();
         dumpDOMPoint(quad->p1());
         dumpDOMPoint(quad->p2());
         dumpDOMPoint(quad->p3());
@@ -1752,7 +1752,7 @@ private:
 
     void dumpImageBitmap(JSObject* obj, SerializationReturnCode& code)
     {
-        Ref imageBitmap = uncheckedDowncast<JSImageBitmap>(obj)->wrapped();
+        Ref imageBitmap = downcast<JSImageBitmap>(obj)->wrapped();
         auto index = m_transferredImageBitmaps.find(obj);
         if (index != m_transferredImageBitmaps.end()) {
             write(ImageBitmapTransferTag);
@@ -1820,7 +1820,7 @@ private:
         } else if (m_context == SerializationContext::CloneAcrossWorlds) {
             write(InMemoryOffscreenCanvasTag);
             write(static_cast<uint32_t>(m_inMemoryOffscreenCanvases.size()));
-            m_inMemoryOffscreenCanvases.append(protect(uncheckedDowncast<JSOffscreenCanvas>(obj)->wrapped()));
+            m_inMemoryOffscreenCanvases.append(protect(downcast<JSOffscreenCanvas>(obj)->wrapped()));
             return;
         }
 
@@ -1842,7 +1842,7 @@ private:
     }
     void dumpRTCEncodedAudioFrame(JSObject* obj)
     {
-        Ref frame = uncheckedDowncast<JSRTCEncodedAudioFrame>(obj)->wrapped();
+        Ref frame = downcast<JSRTCEncodedAudioFrame>(obj)->wrapped();
 
         auto index = m_serializedRTCEncodedAudioFrames.find(frame.ptr());
         if (index == notFound) {
@@ -1855,7 +1855,7 @@ private:
     }
     void dumpRTCEncodedVideoFrame(JSObject* obj)
     {
-        Ref frame = uncheckedDowncast<JSRTCEncodedVideoFrame>(obj)->wrapped();
+        Ref frame = downcast<JSRTCEncodedVideoFrame>(obj)->wrapped();
 
         auto index = m_serializedRTCEncodedVideoFrames.find(frame.ptr());
         if (index == notFound) {
@@ -1906,7 +1906,7 @@ private:
 #if ENABLE(WEB_CODECS)
     void dumpWebCodecsEncodedVideoChunk(JSObject* obj)
     {
-        Ref videoChunk = uncheckedDowncast<JSWebCodecsEncodedVideoChunk>(obj)->wrapped();
+        Ref videoChunk = downcast<JSWebCodecsEncodedVideoChunk>(obj)->wrapped();
 
         auto index = m_serializedVideoChunks.find(&videoChunk->storage());
         if (index == notFound) {
@@ -1920,7 +1920,7 @@ private:
 
     bool dumpWebCodecsVideoFrame(JSObject* obj)
     {
-        Ref videoFrame = uncheckedDowncast<JSWebCodecsVideoFrame>(obj)->wrapped();
+        Ref videoFrame = downcast<JSWebCodecsVideoFrame>(obj)->wrapped();
         if (videoFrame->isDetached())
             return false;
 
@@ -1936,7 +1936,7 @@ private:
 
     void dumpWebCodecsEncodedAudioChunk(JSObject* obj)
     {
-        Ref audioChunk = uncheckedDowncast<JSWebCodecsEncodedAudioChunk>(obj)->wrapped();
+        Ref audioChunk = downcast<JSWebCodecsEncodedAudioChunk>(obj)->wrapped();
 
         auto index = m_serializedAudioChunks.find(&audioChunk->storage());
         if (index == notFound) {
@@ -1950,7 +1950,7 @@ private:
 
     bool dumpWebCodecsAudioData(JSObject* obj)
     {
-        Ref audioData = uncheckedDowncast<JSWebCodecsAudioData>(obj)->wrapped();
+        Ref audioData = downcast<JSWebCodecsAudioData>(obj)->wrapped();
         if (audioData->isDetached())
             return false;
 
@@ -1970,7 +1970,7 @@ private:
         auto index = m_transferredMediaStreamTracks.find(obj);
         if (index == m_transferredMediaStreamTracks.end()) {
             bool shouldAllowMediaStreamTrackSerialization = [&] {
-                RefPtr context = uncheckedDowncast<JSDOMGlobalObject>(m_lexicalGlobalObject)->scriptExecutionContext();
+                RefPtr context = downcast<JSDOMGlobalObject>(m_lexicalGlobalObject)->scriptExecutionContext();
                 RefPtr document = dynamicDowncast<Document>(context);
                 return document && document->quirks().shouldAllowMediaStreamTrackSerializationQuirk();
             }();
@@ -1979,7 +1979,7 @@ private:
                 return;
             }
 
-            m_serializedMediaStreamTracks.append(protect(uncheckedDowncast<JSMediaStreamTrack>(obj)->wrapped())->clone());
+            m_serializedMediaStreamTracks.append(protect(downcast<JSMediaStreamTrack>(obj)->wrapped())->clone());
             index = m_transferredMediaStreamTracks.add(obj, m_transferredMediaStreamTracks.size()).iterator;
         }
 
@@ -2164,7 +2164,7 @@ private:
                 } else if (m_context == SerializationContext::CloneAcrossWorlds) {
                     write(InMemoryMessagePortTag);
                     write(static_cast<uint32_t>(m_inMemoryMessagePorts.size()));
-                    m_inMemoryMessagePorts.append(protect(uncheckedDowncast<JSMessagePort>(obj)->wrapped()));
+                    m_inMemoryMessagePorts.append(protect(downcast<JSMessagePort>(obj)->wrapped()));
                     return true;
                 }
                 // MessagePort object could not be found in transferred message ports
@@ -3088,7 +3088,7 @@ SerializationReturnCode CloneSerializer::serialize(JSValue in)
                 ASSERT(inValue.isObject());
                 if (inputObjectStack.size() > maximumFilterRecursion)
                     return SerializationReturnCode::StackOverflowError;
-                JSMap* inMap = uncheckedDowncast<JSMap>(inValue);
+                JSMap* inMap = downcast<JSMap>(inValue);
                 if (!addToObjectPoolIfNotDupe<MapObjectTag>(inMap))
                     break;
                 write(MapObjectTag);
@@ -3134,7 +3134,7 @@ SerializationReturnCode CloneSerializer::serialize(JSValue in)
                 ASSERT(inValue.isObject());
                 if (inputObjectStack.size() > maximumFilterRecursion)
                     return SerializationReturnCode::StackOverflowError;
-                JSSet* inSet = uncheckedDowncast<JSSet>(inValue);
+                JSSet* inSet = downcast<JSSet>(inValue);
                 if (!addToObjectPoolIfNotDupe<SetObjectTag>(inSet))
                     break;
                 write(SetObjectTag);
@@ -4023,7 +4023,7 @@ private:
         auto makeArrayBufferView = [&](auto&& view) -> bool {
             if (!view)
                 return false;
-            arrayBufferView = toJS(m_lexicalGlobalObject, uncheckedDowncast<JSDOMGlobalObject>(m_globalObject), view.releaseNonNull());
+            arrayBufferView = toJS(m_lexicalGlobalObject, downcast<JSDOMGlobalObject>(m_globalObject), view.releaseNonNull());
             return true;
         };
 
@@ -4579,7 +4579,7 @@ private:
     {
         if (!m_isDOMGlobalObject)
             return { };
-        return toJS(m_lexicalGlobalObject, uncheckedDowncast<JSDOMGlobalObject>(m_globalObject), std::forward<T>(nativeObj));
+        return toJS(m_lexicalGlobalObject, downcast<JSDOMGlobalObject>(m_globalObject), std::forward<T>(nativeObj));
     }
 
     template<class T>
@@ -4600,7 +4600,7 @@ private:
 
         if (!m_isDOMGlobalObject)
             return { };
-        return toJSNewlyCreated(m_lexicalGlobalObject, uncheckedDowncast<JSDOMGlobalObject>(m_globalObject), T::create(x, y, z, w));
+        return toJSNewlyCreated(m_lexicalGlobalObject, downcast<JSDOMGlobalObject>(m_globalObject), T::create(x, y, z, w));
     }
 
     template<class T>
@@ -4633,7 +4633,7 @@ private:
             TransformationMatrix matrix(m11, m12, m21, m22, m41, m42);
             if (!m_isDOMGlobalObject)
                 return { };
-            return toJSNewlyCreated(m_lexicalGlobalObject, uncheckedDowncast<JSDOMGlobalObject>(m_globalObject), T::create(WTF::move(matrix), DOMMatrixReadOnly::Is2D::Yes));
+            return toJSNewlyCreated(m_lexicalGlobalObject, downcast<JSDOMGlobalObject>(m_globalObject), T::create(WTF::move(matrix), DOMMatrixReadOnly::Is2D::Yes));
         } else {
             double m11;
             if (!read(m11))
@@ -4687,7 +4687,7 @@ private:
             TransformationMatrix matrix(m11, m12, m13, m14, m21, m22, m23, m24, m31, m32, m33, m34, m41, m42, m43, m44);
             if (!m_isDOMGlobalObject)
                 return { };
-            return toJSNewlyCreated(m_lexicalGlobalObject, uncheckedDowncast<JSDOMGlobalObject>(m_globalObject), T::create(WTF::move(matrix), DOMMatrixReadOnly::Is2D::No));
+            return toJSNewlyCreated(m_lexicalGlobalObject, downcast<JSDOMGlobalObject>(m_globalObject), T::create(WTF::move(matrix), DOMMatrixReadOnly::Is2D::No));
         }
     }
 
@@ -4709,7 +4709,7 @@ private:
 
         if (!m_isDOMGlobalObject)
             return { };
-        return toJSNewlyCreated(m_lexicalGlobalObject, uncheckedDowncast<JSDOMGlobalObject>(m_globalObject), T::create(x, y, width, height));
+        return toJSNewlyCreated(m_lexicalGlobalObject, downcast<JSDOMGlobalObject>(m_globalObject), T::create(x, y, width, height));
     }
 
     std::optional<DOMPointInit> NODELETE readDOMPointInit()
@@ -4744,7 +4744,7 @@ private:
 
         if (!m_isDOMGlobalObject)
             return { };
-        return toJSNewlyCreated(m_lexicalGlobalObject, uncheckedDowncast<JSDOMGlobalObject>(m_globalObject), DOMQuad::create(p1.value(), p2.value(), p3.value(), p4.value()));
+        return toJSNewlyCreated(m_lexicalGlobalObject, downcast<JSDOMGlobalObject>(m_globalObject), DOMQuad::create(p1.value(), p2.value(), p3.value(), p4.value()));
     }
 
     JSValue readTransferredImageBitmap()
@@ -4846,7 +4846,7 @@ private:
             return JSC::constructEmptyObject(m_lexicalGlobalObject, m_globalObject->objectPrototype());
 
         auto rtcCertificate = RTCCertificate::create(SecurityOrigin::createFromString(origin->string()), expires, WTF::move(fingerprints), certificate->takeString(), keyedMaterial->takeString());
-        return toJSNewlyCreated(m_lexicalGlobalObject, uncheckedDowncast<JSDOMGlobalObject>(m_globalObject), WTF::move(rtcCertificate));
+        return toJSNewlyCreated(m_lexicalGlobalObject, downcast<JSDOMGlobalObject>(m_globalObject), WTF::move(rtcCertificate));
     }
 
     JSValue readRTCDataChannel()
@@ -4913,7 +4913,7 @@ private:
 
         auto addResult = m_readableStreams.add(readableStreamIndex, nullptr);
         if (addResult.isNewEntry) {
-            auto readableStreamOrError = ReadableStream::runTransferReceivingSteps(*uncheckedDowncast<JSDOMGlobalObject>(m_lexicalGlobalObject), { m_messagePorts.at(messagePortIndex).get() });
+            auto readableStreamOrError = ReadableStream::runTransferReceivingSteps(*downcast<JSDOMGlobalObject>(m_lexicalGlobalObject), { m_messagePorts.at(messagePortIndex).get() });
             if (readableStreamOrError.hasException()) {
                 SERIALIZE_TRACE("FAIL creating readable stream");
                 fail();
@@ -4940,7 +4940,7 @@ private:
 
         auto addResult = m_writableStreams.add(writableStreamIndex, nullptr);
         if (addResult.isNewEntry) {
-            auto writableStreamOrError = WritableStream::runTransferReceivingSteps(*uncheckedDowncast<JSDOMGlobalObject>(m_lexicalGlobalObject), { m_messagePorts.at(messagePortIndex).get() });
+            auto writableStreamOrError = WritableStream::runTransferReceivingSteps(*downcast<JSDOMGlobalObject>(m_lexicalGlobalObject), { m_messagePorts.at(messagePortIndex).get() });
             if (writableStreamOrError.hasException()) {
                 SERIALIZE_TRACE("FAIL creating writable stream");
                 fail();
@@ -4967,7 +4967,7 @@ private:
 
         auto addResult = m_transformStreams.add(transformStreamIndex, nullptr);
         if (addResult.isNewEntry) {
-            auto transformStreamOrError = TransformStream::runTransferReceivingSteps(*uncheckedDowncast<JSDOMGlobalObject>(m_lexicalGlobalObject), { m_messagePorts.at(messagePortsIndex).get(), m_messagePorts.at(messagePortsIndex + 1).get() });
+            auto transformStreamOrError = TransformStream::runTransferReceivingSteps(*downcast<JSDOMGlobalObject>(m_lexicalGlobalObject), { m_messagePorts.at(messagePortsIndex).get(), m_messagePorts.at(messagePortsIndex + 1).get() });
             if (transformStreamOrError.hasException()) {
                 SERIALIZE_TRACE("FAIL creating writable stream");
                 fail();
@@ -5303,7 +5303,7 @@ private:
                 return JSValue();
             if (!m_canCreateDOMObject)
                 return jsNull();
-            return toJS(m_lexicalGlobalObject, uncheckedDowncast<JSDOMGlobalObject>(m_globalObject), file.releaseNonNull());
+            return toJS(m_lexicalGlobalObject, downcast<JSDOMGlobalObject>(m_globalObject), file.releaseNonNull());
         }
         case FileListTag: {
             unsigned length = 0;
@@ -6840,19 +6840,19 @@ ExceptionOr<Ref<SerializedScriptValue>> SerializedScriptValue::create(JSGlobalOb
     });
 #endif
     for (auto& readableStream : readableStreams) {
-        auto detachedOrException = readableStream->runTransferSteps(uncheckedDowncast<JSDOMGlobalObject>(lexicalGlobalObject));
+        auto detachedOrException = readableStream->runTransferSteps(downcast<JSDOMGlobalObject>(lexicalGlobalObject));
         if (detachedOrException.hasException())
             return detachedOrException.releaseException();
         messagePorts.append(detachedOrException.releaseReturnValue().readableStreamPort);
     }
     for (auto& writableStream : writableStreams) {
-        auto detachedOrException = writableStream->runTransferSteps(uncheckedDowncast<JSDOMGlobalObject>(lexicalGlobalObject));
+        auto detachedOrException = writableStream->runTransferSteps(downcast<JSDOMGlobalObject>(lexicalGlobalObject));
         if (detachedOrException.hasException())
             return detachedOrException.releaseException();
         messagePorts.append(detachedOrException.releaseReturnValue().writableStreamPort);
     }
     for (auto& transformStream : transformStreams) {
-        auto detachedOrException = transformStream->runTransferSteps(uncheckedDowncast<JSDOMGlobalObject>(lexicalGlobalObject));
+        auto detachedOrException = transformStream->runTransferSteps(downcast<JSDOMGlobalObject>(lexicalGlobalObject));
         if (detachedOrException.hasException())
             return detachedOrException.releaseException();
         auto detachedTransform = detachedOrException.releaseReturnValue();

--- a/Source/WebCore/bindings/js/StructuredClone.cpp
+++ b/Source/WebCore/bindings/js/StructuredClone.cpp
@@ -106,9 +106,7 @@ JSC_DEFINE_HOST_FUNCTION(structuredCloneForStream, (JSGlobalObject* globalObject
         return JSValue::encode(JSArrayBuffer::create(globalObject->vm(), globalObject->arrayBufferStructure(ArrayBufferSharingMode::Default), result.releaseNonNull()));
     }
 
-    if (value.inherits<JSArrayBufferView>()) {
-        auto* bufferView = uncheckedDowncast<JSArrayBufferView>(value);
-        ASSERT(bufferView);
+    if (auto* bufferView = dynamicDowncast<JSArrayBufferView>(value)) {
 
         auto* buffer = bufferView->unsharedBuffer();
         if (!buffer || buffer->isDetached()) [[unlikely]] {

--- a/Source/WebCore/bindings/js/WebCoreJSClientData.cpp
+++ b/Source/WebCore/bindings/js/WebCoreJSClientData.cpp
@@ -226,7 +226,7 @@ String JSVMClientData::overrideSourceURL(const JSC::StackFrame& frame, const Str
     if (!globalObject->inherits<JSDOMWindowBase>())
         return nullString();
 
-    RefPtr document = uncheckedDowncast<JSDOMWindowBase>(globalObject)->wrapped().documentIfLocal();
+    RefPtr document = downcast<JSDOMWindowBase>(globalObject)->wrapped().documentIfLocal();
     if (!document)
         return nullString();
 

--- a/Source/WebCore/bindings/js/WebCoreTypedArrayController.cpp
+++ b/Source/WebCore/bindings/js/WebCoreTypedArrayController.cpp
@@ -43,12 +43,12 @@ WebCoreTypedArrayController::~WebCoreTypedArrayController() = default;
 
 JSC::JSArrayBuffer* WebCoreTypedArrayController::toJS(JSC::JSGlobalObject* lexicalGlobalObject, JSC::JSGlobalObject* globalObject, JSC::ArrayBuffer& buffer)
 {
-    return uncheckedDowncast<JSC::JSArrayBuffer>(WebCore::toJS(lexicalGlobalObject, uncheckedDowncast<JSDOMGlobalObject>(globalObject), buffer));
+    return downcast<JSC::JSArrayBuffer>(WebCore::toJS(lexicalGlobalObject, downcast<JSDOMGlobalObject>(globalObject), buffer));
 }
 
 void WebCoreTypedArrayController::registerWrapper(JSC::JSGlobalObject* globalObject, JSC::ArrayBuffer& native, JSC::JSArrayBuffer& wrapper)
 {
-    cacheWrapper(uncheckedDowncast<JSDOMGlobalObject>(globalObject)->world(), &native, &wrapper);
+    cacheWrapper(downcast<JSDOMGlobalObject>(globalObject)->world(), &native, &wrapper);
 }
 
 bool WebCoreTypedArrayController::isAtomicsWaitAllowedOnCurrentThread()
@@ -60,7 +60,7 @@ bool WebCoreTypedArrayController::JSArrayBufferOwner::isReachableFromOpaqueRoots
 {
     if (reason) [[unlikely]]
         *reason = "ArrayBuffer is opaque root"_s;
-    auto& wrapper = *uncheckedDowncast<JSC::JSArrayBuffer>(handle.slot()->asCell());
+    auto& wrapper = *downcast<JSC::JSArrayBuffer>(handle.slot()->asCell());
     return visitor.containsOpaqueRoot(wrapper.impl());
 }
 

--- a/Source/WebCore/bridge/objc/objc_utility.mm
+++ b/Source/WebCore/bridge/objc/objc_utility.mm
@@ -107,7 +107,7 @@ ObjcValue convertValueToObjcValue(JSGlobalObject* lexicalGlobalObject, JSValue v
 
             JSGlobalObject* globalObject = 0;
             if (value.isObject() && asObject(value)->isGlobalObject())
-                globalObject = uncheckedDowncast<JSGlobalObject>(asObject(value));
+                globalObject = downcast<JSGlobalObject>(asObject(value));
 
             if (!globalObject)
                 globalObject = originGlobalObject;

--- a/Source/WebCore/bridge/runtime_object.cpp
+++ b/Source/WebCore/bridge/runtime_object.cpp
@@ -273,7 +273,7 @@ JSC_DEFINE_HOST_FUNCTION(callRuntimeConstructor, (JSGlobalObject* globalObject, 
     instance->end();
     
     ASSERT(result);
-    return JSValue::encode(result.isObject() ? uncheckedDowncast<JSObject>(result.asCell()) : constructor);
+    return JSValue::encode(result.isObject() ? downcast<JSObject>(result.asCell()) : constructor);
 }
 
 CallData RuntimeObject::getConstructData(JSCell* cell)

--- a/Source/WebCore/css/CSSStyleSheetObservableArray.cpp
+++ b/Source/WebCore/css/CSSStyleSheetObservableArray.cpp
@@ -88,7 +88,7 @@ JSC::JSValue CSSStyleSheetObservableArray::valueAt(JSC::JSGlobalObject* lexicalG
 {
     if (index >= m_sheets.size())
         return JSC::jsUndefined();
-    return toJS(lexicalGlobalObject, uncheckedDowncast<JSDOMGlobalObject>(lexicalGlobalObject), m_sheets[index]);
+    return toJS(lexicalGlobalObject, downcast<JSDOMGlobalObject>(lexicalGlobalObject), m_sheets[index]);
 }
 
 ExceptionOr<void> CSSStyleSheetObservableArray::setSheets(Vector<Ref<CSSStyleSheet>>&& sheets)

--- a/Source/WebCore/dom/AbortSignal.cpp
+++ b/Source/WebCore/dom/AbortSignal.cpp
@@ -68,7 +68,7 @@ Ref<AbortSignal> AbortSignal::timeout(ScriptExecutionContext& context, uint64_t 
     auto action = [signal](ScriptExecutionContext& context) mutable {
         signal->setHasActiveTimeoutTimer(false);
 
-        auto* globalObject = uncheckedDowncast<JSDOMGlobalObject>(context.globalObject());
+        auto* globalObject = downcast<JSDOMGlobalObject>(context.globalObject());
         if (!globalObject)
             return;
 
@@ -142,7 +142,7 @@ void AbortSignal::signalAbort(JSC::JSValue reason)
     if (!context)
         return;
 
-    auto* globalObject = uncheckedDowncast<JSDOMGlobalObject>(context->globalObject());
+    auto* globalObject = downcast<JSDOMGlobalObject>(context->globalObject());
     if (!globalObject)
         return;
 

--- a/Source/WebCore/dom/Element.cpp
+++ b/Source/WebCore/dom/Element.cpp
@@ -3479,7 +3479,7 @@ RefPtr<ShadowRoot> Element::shadowRootForBindings(JSC::JSGlobalObject& lexicalGl
         return nullptr;
     if (shadow->mode() == ShadowRootMode::Open)
         return shadow;
-    if (uncheckedDowncast<JSDOMGlobalObject>(&lexicalGlobalObject)->world().shadowRootIsAlwaysOpen())
+    if (downcast<JSDOMGlobalObject>(&lexicalGlobalObject)->world().shadowRootIsAlwaysOpen())
         return shadow;
     return nullptr;
 }

--- a/Source/WebCore/dom/Event.cpp
+++ b/Source/WebCore/dom/Event.cpp
@@ -165,7 +165,7 @@ Vector<Ref<EventTarget>> Event::composedPath(JSC::JSGlobalObject& lexicalGlobalO
 {
     if (!m_eventPath)
         return Vector<Ref<EventTarget>>();
-    if (uncheckedDowncast<JSDOMGlobalObject>(&lexicalGlobalObject)->world().shadowRootIsAlwaysOpen())
+    if (downcast<JSDOMGlobalObject>(&lexicalGlobalObject)->world().shadowRootIsAlwaysOpen())
         return m_eventPath->computePathTreatingAllShadowRootsAsOpen();
     return m_eventPath->computePathUnclosedToTarget(*protect(currentTarget()));
 }

--- a/Source/WebCore/dom/MessageEvent.cpp
+++ b/Source/WebCore/dom/MessageEvent.cpp
@@ -93,7 +93,7 @@ auto MessageEvent::create(JSC::JSGlobalObject& globalObject, Ref<SerializedScrip
 
     auto& eventType = didFail ? eventNames().messageerrorEvent : eventNames().messageEvent;
     Ref event = adoptRef(*new MessageEvent(eventType, MessageEvent::JSValueTag { }, WTF::move(origin), lastEventId, WTF::move(source), WTF::move(ports)));
-    JSC::Strong<JSC::JSObject> strongWrapper(vm, uncheckedDowncast<JSC::JSObject>(toJS(&globalObject, uncheckedDowncast<JSDOMGlobalObject>(&globalObject), event.get())));
+    JSC::Strong<JSC::JSObject> strongWrapper(vm, downcast<JSC::JSObject>(toJS(&globalObject, downcast<JSDOMGlobalObject>(&globalObject), event.get())));
     event->jsData().set(globalObject, strongWrapper.get(), deserialized);
 
     return MessageEventWithStrongData { event, WTF::move(strongWrapper) };
@@ -156,7 +156,7 @@ void MessageEvent::initMessageEvent(JSC::JSGlobalObject& globalObject, const Ato
         Locker locker { m_concurrentDataAccessLock };
         m_data = JSValueTag { };
     }
-    auto* domGlobalObject = uncheckedDowncast<JSDOMGlobalObject>(&globalObject);
+    auto* domGlobalObject = downcast<JSDOMGlobalObject>(&globalObject);
     auto* wrapper = toJS(&globalObject, domGlobalObject, *this).getObject();
     m_jsData.set(globalObject, wrapper, data);
     m_cachedData.clear();

--- a/Source/WebCore/dom/MessagePort.cpp
+++ b/Source/WebCore/dom/MessagePort.cpp
@@ -288,7 +288,7 @@ void MessagePort::dispatchMessages()
 
             if (pendingActivity->object().m_messageHandler) {
                 ASSERT(message.transferredPorts.isEmpty());
-                pendingActivity->object().m_messageHandler(*uncheckedDowncast<JSDOMGlobalObject>(globalObject), message.message.releaseNonNull().get());
+                pendingActivity->object().m_messageHandler(*downcast<JSDOMGlobalObject>(globalObject), message.message.releaseNonNull().get());
                 continue;
             }
 

--- a/Source/WebCore/dom/UserGestureIndicator.cpp
+++ b/Source/WebCore/dom/UserGestureIndicator.cpp
@@ -163,7 +163,7 @@ WTF_MAKE_COMPACT_TZONE_ALLOCATED_IMPL(UserGestureInitiatedMicrotaskDispatcher);
 
 RefPtr<JSC::MicrotaskDispatcher> UserGestureToken::createMicrotaskDispatcher(JSC::VM&, JSC::JSGlobalObject* globalObject)
 {
-    auto* domGlobalObject = uncheckedDowncast<JSDOMGlobalObject>(globalObject);
+    auto* domGlobalObject = downcast<JSDOMGlobalObject>(globalObject);
     RefPtr context = domGlobalObject->scriptExecutionContext();
     if (!context) [[unlikely]]
         return nullptr;

--- a/Source/WebCore/fileapi/Blob.cpp
+++ b/Source/WebCore/fileapi/Blob.cpp
@@ -518,7 +518,7 @@ ExceptionOr<Ref<ReadableStream>> Blob::stream()
         return promise;
     };
 
-    return ReadableStream::createReadableByteStream(*uncheckedDowncast<JSDOMGlobalObject>(globalObject), WTF::move(pullAlgorithm), WTF::move(cancelAlgorithm), {
+    return ReadableStream::createReadableByteStream(*downcast<JSDOMGlobalObject>(globalObject), WTF::move(pullAlgorithm), WTF::move(cancelAlgorithm), {
         .isSourceReachableFromOpaqueRoot = ReadableStream::IsSourceReachableFromOpaqueRoot::Yes
     });
 }

--- a/Source/WebCore/inspector/CommandLineAPIHost.cpp
+++ b/Source/WebCore/inspector/CommandLineAPIHost.cpp
@@ -165,7 +165,7 @@ CommandLineAPIHost::EventListenersRecord CommandLineAPIHost::getEventListeners(J
 #if ENABLE(WEB_RTC)
 void CommandLineAPIHost::gatherRTCLogs(JSGlobalObject& globalObject, RefPtr<RTCLogsCallback>&& callback)
 {
-    RefPtr document = dynamicDowncast<Document>(uncheckedDowncast<JSDOMGlobalObject>(&globalObject)->scriptExecutionContext());
+    RefPtr document = dynamicDowncast<Document>(downcast<JSDOMGlobalObject>(&globalObject)->scriptExecutionContext());
     if (!document)
         return;
 

--- a/Source/WebCore/inspector/CommandLineAPIModule.cpp
+++ b/Source/WebCore/inspector/CommandLineAPIModule.cpp
@@ -50,7 +50,7 @@ CommandLineAPIModule::CommandLineAPIModule()
 
 JSFunction* CommandLineAPIModule::injectModuleFunction(JSC::JSGlobalObject* lexicalGlobalObject) const
 {
-    if (auto* globalObject = uncheckedDowncast<JSDOMGlobalObject>(lexicalGlobalObject))
+    if (auto* globalObject = downcast<JSDOMGlobalObject>(lexicalGlobalObject))
         return globalObject->builtinInternalFunctions().commandLineAPIModuleSource().m_injectModuleFunction.get();
 
     WTFLogAlways("Attempted to get `injectModule` function from `CommandLineAPIModule` for non-`JSDOMGlobalObject`.");
@@ -65,7 +65,7 @@ JSValue CommandLineAPIModule::host(InjectedScriptManager* injectedScriptManager,
     RefPtr commandLineAPIHost = pageInjectedScriptManager->commandLineAPIHost();
     ASSERT(commandLineAPIHost);
 
-    JSDOMGlobalObject* globalObject = uncheckedDowncast<JSDOMGlobalObject>(lexicalGlobalObject);
+    JSDOMGlobalObject* globalObject = downcast<JSDOMGlobalObject>(lexicalGlobalObject);
     return commandLineAPIHost->wrapper(lexicalGlobalObject, globalObject);
 }
 

--- a/Source/WebCore/inspector/agents/page/PageAuditAgent.cpp
+++ b/Source/WebCore/inspector/agents/page/PageAuditAgent.cpp
@@ -89,7 +89,7 @@ void PageAuditAgent::populateAuditObject(JSC::JSGlobalObject* lexicalGlobalObjec
     if (!lexicalGlobalObject)
         return;
 
-    if (auto* globalObject = uncheckedDowncast<JSDOMGlobalObject>(lexicalGlobalObject)) {
+    if (auto* globalObject = downcast<JSDOMGlobalObject>(lexicalGlobalObject)) {
         JSC::VM& vm = globalObject->vm();
         JSC::JSLockHolder lock(vm);
 

--- a/Source/WebCore/page/LocalDOMWindow.cpp
+++ b/Source/WebCore/page/LocalDOMWindow.cpp
@@ -853,7 +853,7 @@ bool LocalDOMWindow::shouldHaveWebKitNamespaceForWorld(DOMWrapperWorld& world, J
     if (world.allowNodeSerialization())
         return true;
 
-    if (uncheckedDowncast<JSDOMGlobalObject>(globalObject)->allowsJSHandleCreation())
+    if (downcast<JSDOMGlobalObject>(globalObject)->allowsJSHandleCreation())
         return true;
 
     RefPtr frame = this->frame();

--- a/Source/WebCore/page/Navigation.cpp
+++ b/Source/WebCore/page/Navigation.cpp
@@ -307,8 +307,8 @@ static Ref<DOMPromise> createDOMPromise(const DeferredPromise& deferredPromise)
     Locker<JSC::JSLock> locker(commonVM().apiLock());
 
     auto promiseValue = deferredPromise.promise();
-    auto& jsPromise = *uncheckedDowncast<JSC::JSPromise>(promiseValue);
-    auto& globalObject = *uncheckedDowncast<JSDOMGlobalObject>(jsPromise.realm());
+    auto& jsPromise = *downcast<JSC::JSPromise>(promiseValue);
+    auto& globalObject = *downcast<JSDOMGlobalObject>(jsPromise.realm());
 
     return DOMPromise::create(globalObject, jsPromise);
 }
@@ -973,7 +973,7 @@ public:
     static Ref<PromiseSettlementObserver> create(Document& document)
     {
         ASSERT(document.isFullyActive());
-        auto* globalObject = uncheckedDowncast<JSDOMGlobalObject>(document.globalObject());
+        auto* globalObject = downcast<JSDOMGlobalObject>(document.globalObject());
         JSC::JSLockHolder locker(globalObject->vm());
         RefPtr wrapper = DeferredPromise::create(*globalObject, DeferredPromise::Mode::RetainPromiseOnResolve);
         return adoptRef(*new PromiseSettlementObserver(wrapper.releaseNonNull()));
@@ -1067,7 +1067,7 @@ void Navigation::setupInterceptionState(NavigateEvent& event, NavigationNavigati
     }
 
     {
-        auto& domGlobalObject = *uncheckedDowncast<JSDOMGlobalObject>(document.globalObject());
+        auto& domGlobalObject = *downcast<JSDOMGlobalObject>(document.globalObject());
         JSC::JSLockHolder locker(domGlobalObject.vm());
         m_transition = NavigationTransition::create(navigationType, *fromNavigationHistoryEntry, DeferredPromise::create(domGlobalObject, DeferredPromise::Mode::RetainPromiseOnResolve).releaseNonNull());
     }

--- a/Source/WebCore/page/NavigationTransition.cpp
+++ b/Source/WebCore/page/NavigationTransition.cpp
@@ -64,7 +64,7 @@ void NavigationTransition::rejectPromise(JSC::JSValue exceptionObject)
 DOMPromise& NavigationTransition::finished()
 {
     if (!m_finishedDOMPromise) {
-        auto& promise = *uncheckedDowncast<JSC::JSPromise>(m_finished->promise());
+        auto& promise = *downcast<JSC::JSPromise>(m_finished->promise());
         m_finishedDOMPromise = DOMPromise::create(*m_finished->globalObject(), promise);
     }
 

--- a/Source/WebCore/page/UserMessageHandler.cpp
+++ b/Source/WebCore/page/UserMessageHandler.cpp
@@ -56,7 +56,7 @@ static bool passesSameOriginCheck(JSC::JSGlobalObject& globalObject, RefPtr<Loca
     Ref frameSecurityOrigin = document->securityOrigin();
     if (!globalObject.inherits<JSDOMGlobalObject>())
         return false;
-    RefPtr scriptExecutionContext = uncheckedDowncast<JSDOMGlobalObject>(globalObject).scriptExecutionContext();
+    RefPtr scriptExecutionContext = downcast<JSDOMGlobalObject>(globalObject).scriptExecutionContext();
     if (!scriptExecutionContext)
         return false;
     RefPtr securityOrigin = scriptExecutionContext->securityOrigin();

--- a/Source/WebCore/page/WebKitNamespace.cpp
+++ b/Source/WebCore/page/WebKitNamespace.cpp
@@ -87,7 +87,7 @@ JSC::JSValue WebKitNamespace::evaluateScript(JSC::JSGlobalObject& globalObject, 
 {
     if (!globalObject.inherits<JSDOMGlobalObject>())
         return JSC::jsNull();
-    Ref world = uncheckedDowncast<JSDOMGlobalObject>(&globalObject)->world();
+    Ref world = downcast<JSDOMGlobalObject>(&globalObject)->world();
     RefPtr frame = this->frame();
     if (!frame)
         return JSC::jsNull();

--- a/Source/WebCore/platform/mac/SerializedPlatformDataCueMac.mm
+++ b/Source/WebCore/platform/mac/SerializedPlatformDataCueMac.mm
@@ -134,7 +134,7 @@ static JSValue *jsValueWithDataInContext(NSData *data, JSContext *context)
 
     auto* lexicalGlobalObject = toJS([context JSGlobalContextRef]);
     // FIXME: It is a layering violation to use the JSDOMGlobalObject type in the platform directory.
-    JSC::JSValue array = dataArray ? toJS(lexicalGlobalObject, uncheckedDowncast<JSDOMGlobalObject>(lexicalGlobalObject), *dataArray) : JSC::jsNull();
+    JSC::JSValue array = dataArray ? toJS(lexicalGlobalObject, downcast<JSDOMGlobalObject>(lexicalGlobalObject), *dataArray) : JSC::jsNull();
 
     return [JSValue valueWithJSValueRef:toRef(lexicalGlobalObject, array) inContext:context];
 }

--- a/Source/WebCore/testing/Internals.cpp
+++ b/Source/WebCore/testing/Internals.cpp
@@ -2988,7 +2988,7 @@ String Internals::parserMetaData(JSC::JSValue code)
         StackVisitor::visit(callFrame, vm, iter);
         executable = iter.codeBlock()->ownerExecutable();
     } else if (code.isCallable())
-        executable = uncheckedDowncast<JSFunction>(code.toObject(globalObject))->jsExecutable();
+        executable = downcast<JSFunction>(code.toObject(globalObject))->jsExecutable();
     else
         return String();
 

--- a/Source/WebCore/testing/js/WebCoreTestSupport.cpp
+++ b/Source/WebCore/testing/js/WebCoreTestSupport.cpp
@@ -78,7 +78,7 @@ void injectInternalsObject(JSContextRef context)
     VM& vm = lexicalGlobalObject->vm();
     auto scope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
     JSLockHolder lock(vm);
-    JSDOMGlobalObject* globalObject = uncheckedDowncast<JSDOMGlobalObject>(lexicalGlobalObject);
+    JSDOMGlobalObject* globalObject = downcast<JSDOMGlobalObject>(lexicalGlobalObject);
     if (RefPtr document = dynamicDowncast<Document>(*globalObject->scriptExecutionContext())) {
         globalObject->putDirect(vm, Identifier::fromString(vm, Internals::internalsId), toJS(lexicalGlobalObject, globalObject, Internals::create(*document)));
         Options::useDollarVM() = true;
@@ -91,7 +91,7 @@ void resetInternalsObject(JSContextRef context)
 {
     JSGlobalObject* lexicalGlobalObject = toJS(context);
     JSLockHolder lock(lexicalGlobalObject);
-    JSDOMGlobalObject* globalObject = uncheckedDowncast<JSDOMGlobalObject>(lexicalGlobalObject);
+    JSDOMGlobalObject* globalObject = downcast<JSDOMGlobalObject>(lexicalGlobalObject);
     Ref document = downcast<Document>(*globalObject->scriptExecutionContext());
     RefPtr page = document->page();
     RELEASE_ASSERT_WITH_MESSAGE(page, "Frame or Page is nullptr when Document is in a bad state");

--- a/Source/WebCore/workers/WorkerOrWorkletScriptController.cpp
+++ b/Source/WebCore/workers/WorkerOrWorkletScriptController.cpp
@@ -306,7 +306,7 @@ JSC::JSValue WorkerOrWorkletScriptController::evaluateModule(const URL& sourceUR
     } else if (moduleRecord.inherits<JSC::SyntheticModuleRecord>())
         InspectorInstrumentation::willEvaluateScript(*globalScope, sourceURL.string(), 1, 1);
     else {
-        auto* jsModuleRecord = uncheckedDowncast<JSModuleRecord>(&moduleRecord);
+        auto* jsModuleRecord = downcast<JSModuleRecord>(&moduleRecord);
         const auto& jsSourceCode = jsModuleRecord->sourceCode();
         InspectorInstrumentation::willEvaluateScript(*globalScope, sourceURL.string(), jsSourceCode.firstLine().oneBasedInt(), jsSourceCode.startColumn().oneBasedInt());
     }
@@ -525,7 +525,7 @@ void WorkerOrWorkletScriptController::loadAndEvaluateModule(const URL& moduleURL
             RETURN_IF_EXCEPTION(scope, { });
             scriptFetcher->notifyLoadCompleted(*moduleKey.impl());
 
-            RefPtr context = downcast<WorkerOrWorkletGlobalScope>(uncheckedDowncast<JSDOMGlobalObject>(globalObject)->scriptExecutionContext());
+            RefPtr context = downcast<WorkerOrWorkletGlobalScope>(downcast<JSDOMGlobalObject>(globalObject)->scriptExecutionContext());
             if (!context || !context->script()) {
                 task->run(std::nullopt);
                 return JSValue::encode(jsUndefined());

--- a/Source/WebCore/workers/service/ExtendableMessageEvent.cpp
+++ b/Source/WebCore/workers/service/ExtendableMessageEvent.cpp
@@ -45,7 +45,7 @@ static JSC::Strong<JSC::JSObject> createWrapperAndSetData(JSC::JSGlobalObject& g
     JSC::Strong<JSC::Unknown> strongData(vm, value);
 
     Locker<JSC::JSLock> locker(vm.apiLock());
-    JSC::Strong<JSC::JSObject> strongWrapper(vm, uncheckedDowncast<JSC::JSObject>(toJSNewlyCreated<IDLInterface<ExtendableMessageEvent>>(globalObject,  uncheckedDowncast<JSDOMGlobalObject>(globalObject), Ref { event })));
+    JSC::Strong<JSC::JSObject> strongWrapper(vm, downcast<JSC::JSObject>(toJSNewlyCreated<IDLInterface<ExtendableMessageEvent>>(globalObject,  downcast<JSDOMGlobalObject>(globalObject), Ref { event })));
     event.data().set(globalObject, strongWrapper.get(), value);
 
     return strongWrapper;

--- a/Source/WebCore/workers/service/FetchEvent.cpp
+++ b/Source/WebCore/workers/service/FetchEvent.cpp
@@ -61,9 +61,9 @@ static inline Ref<DOMPromise> retrieveHandledPromise(JSC::JSGlobalObject& global
 
     JSC::JSLockHolder lock(globalObject.vm());
 
-    auto& jsDOMGlobalObject = uncheckedDowncast<JSDOMGlobalObject>(globalObject);
+    auto& jsDOMGlobalObject = downcast<JSDOMGlobalObject>(globalObject);
     auto deferredPromise = DeferredPromise::create(jsDOMGlobalObject);
-    return DOMPromise::create(jsDOMGlobalObject, *uncheckedDowncast<JSC::JSPromise>(deferredPromise->promise()));
+    return DOMPromise::create(jsDOMGlobalObject, *downcast<JSC::JSPromise>(deferredPromise->promise()));
 }
 
 FetchEvent::FetchEvent(JSC::JSGlobalObject& globalObject, const AtomString& type, Init&& initializer, IsTrusted isTrusted)

--- a/Source/WebCore/workers/service/InstallEvent.cpp
+++ b/Source/WebCore/workers/service/InstallEvent.cpp
@@ -171,7 +171,7 @@ static ExceptionOr<ServiceWorkerRoute> convertServiceWorkerRule(RouterRule&& rul
 // https://w3c.github.io/ServiceWorker/#dom-installevent-addroutes
 void InstallEvent::addRoutes(JSC::JSGlobalObject& globalObject, Variant<RouterRule, Vector<RouterRule>>&& rules, Ref<DeferredPromise>&& promise)
 {
-    auto& jsDOMGlobalObject = uncheckedDowncast<JSDOMGlobalObject>(globalObject);
+    auto& jsDOMGlobalObject = downcast<JSDOMGlobalObject>(globalObject);
     RefPtr serviceWorkerGlobalScope = dynamicDowncast<ServiceWorkerGlobalScope>(jsDOMGlobalObject.scriptExecutionContext());
 
     auto rulesVector = switchOn(WTF::move(rules), [](RouterRule&& rule) -> Vector<RouterRule> {
@@ -205,7 +205,7 @@ void InstallEvent::addRoutes(JSC::JSGlobalObject& globalObject, Variant<RouterRu
 
     RefPtr delayPromise = DeferredPromise::create(jsDOMGlobalObject);
     if (delayPromise) {
-        auto& jsPromise = *uncheckedDowncast<JSC::JSPromise>(delayPromise->promise());
+        auto& jsPromise = *downcast<JSC::JSPromise>(delayPromise->promise());
         waitUntil(DOMPromise::create(jsDOMGlobalObject, jsPromise));
     }
 

--- a/Source/WebCore/workers/service/ServiceWorkerRegistration.cpp
+++ b/Source/WebCore/workers/service/ServiceWorkerRegistration.cpp
@@ -332,7 +332,7 @@ void ServiceWorkerRegistration::showNotification(ScriptExecutionContext& context
 
         if (RefPtr pushEvent = serviceWorkerGlobalScope->pushEvent()) {
             auto& globalObject = *promise->globalObject();
-            auto& jsPromise = *uncheckedDowncast<JSC::JSPromise>(promise->promise());
+            auto& jsPromise = *downcast<JSC::JSPromise>(promise->promise());
             pushEvent->waitUntil(DOMPromise::create(globalObject, jsPromise));
         }
 

--- a/Source/WebCore/workers/service/context/ServiceWorkerFetch.cpp
+++ b/Source/WebCore/workers/service/context/ServiceWorkerFetch.cpp
@@ -197,7 +197,7 @@ void dispatchFetchEvent(Ref<Client>&& client, ServiceWorkerGlobalScope& globalSc
         fetchRequest->setNavigationPreloadIdentifier(fetchIdentifier);
 
 
-    auto& jsDOMGlobalObject = *uncheckedDowncast<JSDOMGlobalObject>(globalScope.globalObject());
+    auto& jsDOMGlobalObject = *downcast<JSDOMGlobalObject>(globalScope.globalObject());
     JSC::JSLockHolder lock(jsDOMGlobalObject.vm());
 
     auto* promise = JSC::JSPromise::create(jsDOMGlobalObject.vm(), jsDOMGlobalObject.promiseStructure());

--- a/Source/WebCore/worklets/PaintWorkletGlobalScope.cpp
+++ b/Source/WebCore/worklets/PaintWorkletGlobalScope.cpp
@@ -140,7 +140,7 @@ ExceptionOr<void> PaintWorkletGlobalScope::registerPaint(JSC::JSGlobalObject& gl
         if (paintValue.isUndefined())
             return Exception { ExceptionCode::TypeError, "The class must have a paint method"_s };
 
-        auto paintCallback = convert<IDLCallbackFunction<JSCSSPaintCallback>>(globalObject, paintValue, uncheckedDowncast<JSDOMGlobalObject>(globalObject));
+        auto paintCallback = convert<IDLCallbackFunction<JSCSSPaintCallback>>(globalObject, paintValue, downcast<JSDOMGlobalObject>(globalObject));
         if (paintCallback.hasException(scope)) [[unlikely]]
             return Exception { ExceptionCode::ExistingExceptionError };
 

--- a/Source/WebKit/WebProcess/Extensions/Bindings/JSWebExtensionWrapper.cpp
+++ b/Source/WebKit/WebProcess/Extensions/Bindings/JSWebExtensionWrapper.cpp
@@ -114,7 +114,7 @@ JSValueRef callWithArguments(JSObjectRef callbackFunction, JSRetainPtr<JSGlobalC
         return nil;
 
     auto* globalObject = toJS(globalContext.get());
-    RefPtr context = globalObject ? uncheckedDowncast<JSDOMGlobalObject>(globalObject)->scriptExecutionContext() : nullptr;
+    RefPtr context = globalObject ? downcast<JSDOMGlobalObject>(globalObject)->scriptExecutionContext() : nullptr;
     if (!context || context->activeDOMObjectsAreStopped())
         return nil;
 

--- a/Source/WebKit/WebProcess/WebPage/WebFrame.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebFrame.cpp
@@ -1184,7 +1184,7 @@ String WebFrame::counterValue(JSObjectRef element)
     if (!toJS(element)->inherits<JSElement>())
         return String();
 
-    Ref coreElement = uncheckedDowncast<JSElement>(toJS(element))->wrapped();
+    Ref coreElement = downcast<JSElement>(toJS(element))->wrapped();
     return counterValueForElement(coreElement.ptr());
 }
 
@@ -1572,7 +1572,7 @@ static Ref<WebKitJSHandle> createJSHandle(Node& node)
     Ref document = node.document();
     auto* lexicalGlobalObject = document->globalObject();
     RELEASE_ASSERT(lexicalGlobalObject->template inherits<JSDOMGlobalObject>());
-    auto* domGlobalObject = uncheckedDowncast<JSDOMGlobalObject>(lexicalGlobalObject);
+    auto* domGlobalObject = downcast<JSDOMGlobalObject>(lexicalGlobalObject);
     JSLockHolder locker { lexicalGlobalObject };
     return WebKitJSHandle::create(toJS(lexicalGlobalObject, domGlobalObject, node).toObject(lexicalGlobalObject));
 }


### PR DESCRIPTION
#### 952b3b16274da2a3983b683ab74957ec9eb1935a
<pre>
Reduce use of uncheckedDowncast for JS types in WebCore/
<a href="https://bugs.webkit.org/show_bug.cgi?id=313941">https://bugs.webkit.org/show_bug.cgi?id=313941</a>

Reviewed by Dan Glastonbury and Anne van Kesteren.

Reduce use of uncheckedDowncast for JS types in WebCore/. Use safer
downcast &amp; dynamicDowncast instead. This tested as performance neutral
on Speedometer 3.

Canonical link: <a href="https://commits.webkit.org/312505@main">https://commits.webkit.org/312505@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e2357c2e3e49834f1661d57f6e0c61facada010e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/160199 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/33669 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/26773 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/169101 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/114580 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/162068 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/33772 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/33671 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/124187 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/87113 "1 flakes 2 failures") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/163157 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/26429 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/143889 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/104786 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/25482 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/23978 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/16820 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/135174 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/21652 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/171577 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/17567 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/23292 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/132438 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/33345 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/28072 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/132464 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35813 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/33330 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/143447 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/91606 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/27081 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/20261 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/32839 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/99236 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/32337 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/32583 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/32487 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->