### PR TITLE
webgpu:api,validation,createTexture:depthOrArrayLayers_and_mipLevelCount_for_transient_attachments:* is failing

### DIFF
--- a/Source/WebCore/Modules/WebGPU/GPUTextureUsage.h
+++ b/Source/WebCore/Modules/WebGPU/GPUTextureUsage.h
@@ -35,11 +35,12 @@ namespace WebCore {
 using GPUTextureUsageFlags = uint32_t;
 class GPUTextureUsage : public RefCounted<GPUTextureUsage> {
 public:
-    static constexpr GPUFlagsConstant COPY_SRC          = 0x01;
-    static constexpr GPUFlagsConstant COPY_DST          = 0x02;
-    static constexpr GPUFlagsConstant TEXTURE_BINDING   = 0x04;
-    static constexpr GPUFlagsConstant STORAGE_BINDING   = 0x08;
-    static constexpr GPUFlagsConstant RENDER_ATTACHMENT = 0x10;
+    static constexpr GPUFlagsConstant COPY_SRC             = 0x01;
+    static constexpr GPUFlagsConstant COPY_DST             = 0x02;
+    static constexpr GPUFlagsConstant TEXTURE_BINDING      = 0x04;
+    static constexpr GPUFlagsConstant STORAGE_BINDING      = 0x08;
+    static constexpr GPUFlagsConstant RENDER_ATTACHMENT    = 0x10;
+    static constexpr GPUFlagsConstant TRANSIENT_ATTACHMENT = 0x20;
 };
 
 inline WebGPU::TextureUsageFlags convertTextureUsageFlagsToBacking(GPUTextureUsageFlags textureUsageFlags)
@@ -55,6 +56,8 @@ inline WebGPU::TextureUsageFlags convertTextureUsageFlagsToBacking(GPUTextureUsa
         result.add(WebGPU::TextureUsage::StorageBinding);
     if (textureUsageFlags & GPUTextureUsage::RENDER_ATTACHMENT)
         result.add(WebGPU::TextureUsage::RenderAttachment);
+    if (textureUsageFlags & GPUTextureUsage::TRANSIENT_ATTACHMENT)
+        result.add(WebGPU::TextureUsage::Transient);
     return result;
 }
 

--- a/Source/WebCore/Modules/WebGPU/GPUTextureUsage.idl
+++ b/Source/WebCore/Modules/WebGPU/GPUTextureUsage.idl
@@ -32,9 +32,10 @@ typedef [EnforceRange] unsigned long GPUTextureUsageFlags;
     SecureContext
 ]
 namespace GPUTextureUsage {
-    const GPUFlagsConstant COPY_SRC          = 0x01;
-    const GPUFlagsConstant COPY_DST          = 0x02;
-    const GPUFlagsConstant TEXTURE_BINDING   = 0x04;
-    const GPUFlagsConstant STORAGE_BINDING   = 0x08;
-    const GPUFlagsConstant RENDER_ATTACHMENT = 0x10;
+    const GPUFlagsConstant COPY_SRC             = 0x01;
+    const GPUFlagsConstant COPY_DST             = 0x02;
+    const GPUFlagsConstant TEXTURE_BINDING      = 0x04;
+    const GPUFlagsConstant STORAGE_BINDING      = 0x08;
+    const GPUFlagsConstant RENDER_ATTACHMENT    = 0x10;
+    const GPUFlagsConstant TRANSIENT_ATTACHMENT = 0x20;
 };

--- a/Source/WebCore/Modules/WebGPU/Implementation/WebGPUConvertToBackingContext.cpp
+++ b/Source/WebCore/Modules/WebGPU/Implementation/WebGPUConvertToBackingContext.cpp
@@ -814,6 +814,8 @@ WGPUTextureUsageFlags ConvertToBackingContext::convertTextureUsageFlagsToBacking
         result |= WGPUTextureUsage_StorageBinding;
     if (textureUsageFlags.contains(TextureUsage::RenderAttachment))
         result |= WGPUTextureUsage_RenderAttachment;
+    if (textureUsageFlags.contains(TextureUsage::Transient))
+        result |= WGPUTextureUsage_Transient;
     return result;
 }
 

--- a/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPU.serialization.in
+++ b/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPU.serialization.in
@@ -328,6 +328,7 @@ header: <WebCore/WebGPUTextureUsage.h>
     TextureBinding,
     StorageBinding,
     RenderAttachment,
+    Transient,
 };
 
 using WebCore::WebGPU::TextureUsageFlags = OptionSet<WebCore::WebGPU::TextureUsage>;

--- a/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUTextureUsage.h
+++ b/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUTextureUsage.h
@@ -37,6 +37,7 @@ enum class TextureUsage : uint8_t {
     TextureBinding   = 1 << 2,
     StorageBinding   = 1 << 3,
     RenderAttachment = 1 << 4,
+    Transient        = 1 << 5,
 };
 using TextureUsageFlags = OptionSet<TextureUsage>;
 

--- a/Source/WebCore/html/canvas/GPUCanvasContextCocoa.mm
+++ b/Source/WebCore/html/canvas/GPUCanvasContextCocoa.mm
@@ -429,6 +429,9 @@ ExceptionOr<void> GPUCanvasContextCocoa::configure(GPUCanvasConfiguration&& conf
         unconfigure();
     }
 
+    if (configuration.usage & GPUTextureUsage::TRANSIENT_ATTACHMENT)
+        return Exception { ExceptionCode::TypeError, "GPUCanvasContextCocoa::configure: Can not configure a canvas with a transient backing"_s };
+
     if (auto error = configuration.device->errorValidatingSupportedFormat(configuration.format))
         return Exception { ExceptionCode::TypeError, makeString("GPUCanvasContext.configure: Unsupported texture format: "_s, *error) };
 

--- a/Source/WebGPU/WebGPU/CommandEncoder.mm
+++ b/Source/WebGPU/WebGPU/CommandEncoder.mm
@@ -604,9 +604,12 @@ Ref<RenderPassEncoder> CommandEncoder::beginRenderPass(const WGPURenderPassDescr
             if (!(texture.usage() & WGPUTextureUsage_RenderAttachment) || !Texture::isColorRenderableFormat(textureFormat, m_device))
                 return RenderPassEncoder::createInvalid(*this, m_device, @"color attachment is not renderable");
 
-            if (!isRenderableTextureView(texture))
+            if (!isRenderableTextureView(texture, attachment.loadOp, attachment.storeOp))
                 return RenderPassEncoder::createInvalid(*this, m_device, @"texture view is not renderable");
         }
+        if (!isAllowableTextureView(texture, attachment.loadOp, attachment.storeOp))
+            return RenderPassEncoder::createInvalid(*this, m_device, @"texture view is not renderable");
+
         texture.setCommandEncoder(*this);
 
         id<MTLTexture> mtlTexture = texture.texture();
@@ -661,7 +664,7 @@ Ref<RenderPassEncoder> CommandEncoder::beginRenderPass(const WGPURenderPassDescr
                 return RenderPassEncoder::createInvalid(*this, m_device, @"resolve target created from different device");
             resolveTarget.setCommandEncoder(*this);
             id<MTLTexture> resolveTexture = resolveTarget.texture();
-            if (mtlTexture.sampleCount == 1 || resolveTexture.sampleCount != 1 || isMultisampleTexture(resolveTexture) || !isMultisampleTexture(mtlTexture) || !isRenderableTextureView(resolveTarget) || mtlTexture.pixelFormat != resolveTexture.pixelFormat || !Texture::supportsResolve(resolveTarget.format(), m_device))
+            if (mtlTexture.sampleCount == 1 || resolveTexture.sampleCount != 1 || isMultisampleTexture(resolveTexture) || !isMultisampleTexture(mtlTexture) || !isRenderableTextureView(resolveTarget, attachment.loadOp, attachment.storeOp) || mtlTexture.pixelFormat != resolveTexture.pixelFormat || !Texture::supportsResolve(resolveTarget.format(), m_device))
                 return RenderPassEncoder::createInvalid(*this, m_device, @"resolve target is invalid");
 
             mtlAttachment.resolveTexture = resolveTexture;
@@ -707,9 +710,12 @@ Ref<RenderPassEncoder> CommandEncoder::beginRenderPass(const WGPURenderPassDescr
             if (textureView.arrayLayerCount() > 1 || textureView.mipLevelCount() > 1)
                 return RenderPassEncoder::createInvalid(*this, m_device, @"depth stencil texture has more than one array layer or mip level");
 
-            if (!Texture::isDepthStencilRenderableFormat(textureView.format(), m_device) || !isRenderableTextureView(textureView))
+            if (!Texture::isDepthStencilRenderableFormat(textureView.format(), m_device) || !isRenderableTextureView(textureView, attachment->depthLoadOp, attachment->depthStoreOp))
                 return RenderPassEncoder::createInvalid(*this, m_device, @"depth stencil texture is not renderable");
         }
+
+        if (!isAllowableTextureView(textureView, attachment->depthLoadOp, attachment->depthStoreOp))
+            return RenderPassEncoder::createInvalid(*this, m_device, @"depth stencil texture is not renderable");
 
         depthReadOnly = attachment->depthReadOnly;
         if (hasDepthComponent) {

--- a/Source/WebGPU/WebGPU/CommandEncoder.swift
+++ b/Source/WebGPU/WebGPU/CommandEncoder.swift
@@ -1179,7 +1179,7 @@ extension WebGPU.CommandEncoder {
                         return WebGPU.RenderPassEncoder.createInvalid(self, m_device.ptr(), "color attachment is not renderable")
                     }
 
-                    if !WebGPU.isRenderableTextureView(texture) {
+                    if !WebGPU.isRenderableTextureView(texture, attachment.loadOp, attachment.storeOp) {
                         return WebGPU.RenderPassEncoder.createInvalid(self, m_device.ptr(), "texture view is not renderable")
                     }
                 }
@@ -1267,7 +1267,7 @@ extension WebGPU.CommandEncoder {
                         || resolveTexture.sampleCount != 1
                         || isMultisampleTexture(texture: resolveTexture)
                         || !isMultisampleTexture(texture: mtlTexture)
-                        || !WebGPU.isRenderableTextureView(resolveTarget)
+                        || !WebGPU.isRenderableTextureView(resolveTarget, attachment.loadOp, attachment.storeOp)
                         || mtlTexture.pixelFormat != resolveTexture.pixelFormat
                         || !WebGPU.Texture.supportsResolve(resolveTarget.format(), m_device.ptr())
                     {
@@ -1339,7 +1339,7 @@ extension WebGPU.CommandEncoder {
                 if !WebGPU.Texture.isDepthStencilRenderableFormat(
                     textureView.format(),
                     m_device.ptr()
-                ) || !WebGPU.isRenderableTextureView(textureView) {
+                ) || !WebGPU.isRenderableTextureView(textureView, attachment.depthLoadOp, attachment.depthStoreOp) {
                     return WebGPU.RenderPassEncoder.createInvalid(self, m_device.ptr(), "depth stencil texture is not renderable")
                 }
             }

--- a/Source/WebGPU/WebGPU/Device.mm
+++ b/Source/WebGPU/WebGPU/Device.mm
@@ -711,9 +711,8 @@ id<MTLRenderPipelineState> Device::indexBufferClampPipeline(MTLIndexType indexTy
     {
         device MTLDrawIndexedPrimitivesIndirectArguments& indexedOutput = wkindexedOutput.args;
         ushort indexBufferValue = indexBuffer[min(indexId, data[indexCountMinusOne])];
-        ushort vertexIndex = data[primitiveRestart] + indexBufferValue;
-        bool negativeCondition = indexedOutput.baseVertex + data[primitiveRestart] < indexedOutput.baseVertex;
-        if (negativeCondition || (vertexIndex + indexedOutput.baseVertex >= data[vertexCount] + data[primitiveRestart])) {
+        uint vertexIndex = uint((ushort)(data[primitiveRestart]) + indexBufferValue);
+        if (addsat(vertexIndex, indexedOutput.baseVertex) >= data[vertexCount] + data[primitiveRestart]) {
             indexedOutput.indexCount = 0u;
             indexedOutput.instanceCount = 0u;
             indexedOutput.indexStart = 0u;

--- a/Source/WebGPU/WebGPU/Texture.mm
+++ b/Source/WebGPU/WebGPU/Texture.mm
@@ -2030,6 +2030,18 @@ NSString *Device::errorValidatingTextureCreation(const WGPUTextureDescriptor& de
             return @"createTexture: !textureViewFormatCompatible(descriptor.format, viewFormat)";
     }
 
+    if (descriptor.usage & WGPUTextureUsage_Transient) {
+        if (descriptor.usage != (WGPUTextureUsage_Transient | WGPUTextureUsage_RenderAttachment))
+            return @"createTexture: descriptor usage must be exactly Transient | Render_Attachment when using Transient textures";
+        if (descriptor.dimension != WGPUTextureDimension_2D)
+            return @"createTexture: descriptor dimension must be 2D when using Transient textures";
+        if (descriptor.mipLevelCount != 1)
+            return @"createTexture: descriptor mipLevelCount must be 1 when using Transient textures";
+
+        if (descriptor.size.depthOrArrayLayers != 1)
+            return @"createTexture: descriptor.size.depthOrArrayLayers must be 1 when using Transient textures";
+    }
+
     return nil;
 }
 
@@ -2891,8 +2903,10 @@ std::optional<MTLPixelFormat> Texture::stencilOnlyAspectMetalFormat(WGPUTextureF
     }
 }
 
-static MTLStorageMode NODELETE storageMode(bool deviceHasUnifiedMemory, bool supportsNonPrivateDepthStencilTextures)
+static MTLStorageMode NODELETE storageMode(bool deviceHasUnifiedMemory, bool supportsNonPrivateDepthStencilTextures, WGPUTextureUsageFlags usage)
 {
+    if (usage & WGPUTextureUsage_Transient)
+        return MTLStorageModeMemoryless;
 
     // FIXME: only perform this check if the texture is a depth/stencil texture.
     if (!supportsNonPrivateDepthStencilTextures)
@@ -2976,7 +2990,7 @@ Ref<Texture> Device::createTexture(const WGPUTextureDescriptor& descriptor)
 
     textureDescriptor.sampleCount = descriptor.sampleCount;
 
-    textureDescriptor.storageMode = storageMode(hasUnifiedMemory(), baseCapabilities().supportsNonPrivateDepthStencilTextures);
+    textureDescriptor.storageMode = storageMode(hasUnifiedMemory(), baseCapabilities().supportsNonPrivateDepthStencilTextures, descriptor.usage);
 
     // FIXME(PERFORMANCE): Consider write-combining CPU cache mode.
     // FIXME(PERFORMANCE): Consider implementing hazard tracking ourself.
@@ -3321,7 +3335,7 @@ Ref<TextureView> Texture::createView(const WGPUTextureViewDescriptor& inputDescr
 
     auto slices = NSMakeRange(descriptor->baseArrayLayer, descriptor->arrayLayerCount);
 
-    id<MTLTexture> texture = [m_texture newTextureViewWithPixelFormat:resolvedPixelFormat(pixelFormat, m_texture.pixelFormat) textureType:textureType levels:levels slices:slices];
+    id<MTLTexture> texture = m_texture.storageMode == MTLStorageModeMemoryless ? m_texture : [m_texture newTextureViewWithPixelFormat:resolvedPixelFormat(pixelFormat, m_texture.pixelFormat) textureType:textureType levels:levels slices:slices];
     if (!texture)
         return TextureView::createInvalid(*this, device.get());
 

--- a/Source/WebGPU/WebGPU/TextureOrTextureView.h
+++ b/Source/WebGPU/WebGPU/TextureOrTextureView.h
@@ -103,9 +103,24 @@ private:
     RefPtr<TextureView> m_view;
 };
 
-static bool isRenderableTextureView(const auto& texture)
+static bool isRenderableTextureView(const auto& texture, WGPULoadOp loadOp, WGPUStoreOp storeOp)
 {
+    if (texture.usage() & WGPUTextureUsage_Transient) {
+        if (loadOp != WGPULoadOp_Clear || storeOp != WGPUStoreOp_Discard)
+            return false;
+    }
+
     return (texture.usage() & WGPUTextureUsage_RenderAttachment) && (texture.is2DTexture() || texture.is2DArrayTexture() || texture.is3DTexture()) && texture.mipLevelCount() == 1 && texture.arrayLayerCount() <= 1;
+}
+
+static bool isAllowableTextureView(const auto& texture, WGPULoadOp loadOp, WGPUStoreOp storeOp)
+{
+    if (texture.usage() & WGPUTextureUsage_Transient) {
+        if (loadOp != WGPULoadOp_Clear || storeOp != WGPUStoreOp_Discard)
+            return false;
+    }
+
+    return true;
 }
 
 }

--- a/Source/WebGPU/WebGPU/WebGPU.h
+++ b/Source/WebGPU/WebGPU/WebGPU.h
@@ -777,6 +777,7 @@ typedef enum WGPUTextureUsage {
     WGPUTextureUsage_TextureBinding = 0x00000004,
     WGPUTextureUsage_StorageBinding = 0x00000008,
     WGPUTextureUsage_RenderAttachment = 0x00000010,
+    WGPUTextureUsage_Transient = 0x00000020,
     WGPUTextureUsage_Force32 = 0x7FFFFFFF
 } WGPUTextureUsage WGPU_ENUM_ATTRIBUTE;
 typedef WGPUFlags WGPUTextureUsageFlags WGPU_ENUM_ATTRIBUTE;


### PR DESCRIPTION
#### f6959b074943547121ec9b005e1832e395b0c060
<pre>
webgpu:api,validation,createTexture:depthOrArrayLayers_and_mipLevelCount_for_transient_attachments:* is failing
<a href="https://bugs.webkit.org/show_bug.cgi?id=313945">https://bugs.webkit.org/show_bug.cgi?id=313945</a>
<a href="https://rdar.apple.com/176147461">rdar://176147461</a>

Reviewed by Tadeu Zagallo.

Add support for transient attachments, which are beneficial for helping reduce jetsams on iOS due to memory pressure.

Prior to this change, <a href="https://gpuweb.github.io/cts/standalone/?q=webgpu">https://gpuweb.github.io/cts/standalone/?q=webgpu</a>:api,validation,createTexture:depthOrArrayLayers_and_mipLevelCount_for_transient_attachments:*
would print &quot;TRANSIENT_ATTACHMENT is not supported&quot;

WKTR treats both skipped and passing tests as &apos;PASS&apos; so -expected.txt files did not change.

* Source/WebCore/Modules/WebGPU/GPUTextureUsage.h:
(WebCore::convertTextureUsageFlagsToBacking):
* Source/WebCore/Modules/WebGPU/GPUTextureUsage.idl:
* Source/WebCore/Modules/WebGPU/Implementation/WebGPUConvertToBackingContext.cpp:
(WebCore::WebGPU::ConvertToBackingContext::convertTextureUsageFlagsToBacking):
* Source/WebCore/Modules/WebGPU/InternalAPI/WebGPU.serialization.in:
* Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUTextureUsage.h:
* Source/WebCore/html/canvas/GPUCanvasContextCocoa.mm:
(WebCore::GPUCanvasContextCocoa::configure):
* Source/WebGPU/WebGPU/CommandEncoder.mm:
(WebGPU::CommandEncoder::beginRenderPass):
* Source/WebGPU/WebGPU/CommandEncoder.swift:
(WebGPU.beginRenderPass(_:)):
* Source/WebGPU/WebGPU/Device.mm:
(WebGPU::Device::indexBufferClampPipeline):
* Source/WebGPU/WebGPU/Texture.mm:
(WebGPU::Device::errorValidatingTextureCreation):
(WebGPU::storageMode):
(WebGPU::Device::createTexture):
(WebGPU::Texture::createView):
* Source/WebGPU/WebGPU/TextureOrTextureView.h:
(WebGPU::isRenderableTextureView):
(WebGPU::isAllowableTextureView):
* Source/WebGPU/WebGPU/WebGPU.h:

Canonical link: <a href="https://commits.webkit.org/312699@main">https://commits.webkit.org/312699@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/385107f90326dd53de4e361fa3d2715cbb0903bc

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/160205 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/33675 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/26779 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/169107 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/114586 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/162074 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/33779 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/33677 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/124191 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/87119 "2 flakes 2 failures") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/163163 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/26435 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/143897 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/104790 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/25488 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/23984 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/16827 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/135180 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/21660 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/171583 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/17573 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/23300 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/132444 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/33351 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/28079 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/132470 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35920 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/33336 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/143455 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/91612 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/27089 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/20269 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/32845 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/99242 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/32343 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/32589 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/32493 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->