### PR TITLE
REGRESSION: PerformanceNavigationTiming.domInteractive and domContentLoadedEventEnd always return 0

### DIFF
--- a/LayoutTests/performance-api/performance-navigation-timing-document-event-timing-expected.txt
+++ b/LayoutTests/performance-api/performance-navigation-timing-document-event-timing-expected.txt
@@ -1,0 +1,19 @@
+PerformanceNavigationTiming document event timing attributes should be non-zero after load.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS entries.length is 1
+PASS nav.domInteractive is >= 1
+PASS nav.domContentLoadedEventStart is >= 1
+PASS nav.domContentLoadedEventEnd is >= 1
+PASS nav.domComplete is >= 1
+PASS nav.loadEventStart is >= 1
+PASS nav.domContentLoadedEventStart is >= nav.domInteractive
+PASS nav.domContentLoadedEventEnd is >= nav.domContentLoadedEventStart
+PASS nav.domComplete is >= nav.domContentLoadedEventEnd
+PASS nav.loadEventStart is >= nav.domComplete
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/performance-api/performance-navigation-timing-document-event-timing.html
+++ b/LayoutTests/performance-api/performance-navigation-timing-document-event-timing.html
@@ -1,0 +1,35 @@
+<!DOCTYPE HTML>
+<html>
+<head>
+<script src="../resources/js-test.js"></script>
+</head>
+<body>
+<script>
+
+window.jsTestIsAsync = true;
+description("PerformanceNavigationTiming document event timing attributes should be non-zero after load.");
+
+window.addEventListener("load", () => {
+    setTimeout(() => {
+        window.entries = performance.getEntriesByType("navigation");
+        shouldBe("entries.length", "1");
+
+        window.nav = entries[0];
+        shouldBeGreaterThanOrEqual("nav.domInteractive", "1");
+        shouldBeGreaterThanOrEqual("nav.domContentLoadedEventStart", "1");
+        shouldBeGreaterThanOrEqual("nav.domContentLoadedEventEnd", "1");
+        shouldBeGreaterThanOrEqual("nav.domComplete", "1");
+        shouldBeGreaterThanOrEqual("nav.loadEventStart", "1");
+
+        shouldBeGreaterThanOrEqual("nav.domContentLoadedEventStart", "nav.domInteractive");
+        shouldBeGreaterThanOrEqual("nav.domContentLoadedEventEnd", "nav.domContentLoadedEventStart");
+        shouldBeGreaterThanOrEqual("nav.domComplete", "nav.domContentLoadedEventEnd");
+        shouldBeGreaterThanOrEqual("nav.loadEventStart", "nav.domComplete");
+
+        finishJSTest();
+    }, 0);
+}, false);
+
+</script>
+</body>
+</html>

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -2024,15 +2024,14 @@ ExceptionOr<Ref<Element>> Document::createElementNS(const AtomString& namespaceU
     return createElementNS(namespaceURI, qualifiedName, { });
 }
 
-std::optional<DocumentEventTiming> Document::documentEventTimingFromNavigationTiming()
+DocumentEventTiming* Document::documentEventTimingFromNavigationTiming()
 {
     RefPtr window = this->window();
     if (!window)
-        return std::nullopt;
-    RefPtr navigationTiming = window->performance().navigationTiming();
-    if (!navigationTiming)
-        return std::nullopt;
-    return navigationTiming->documentEventTiming();
+        return nullptr;
+    if (auto* navigationTiming = window->performance().navigationTiming())
+        return &navigationTiming->documentEventTiming();
+    return nullptr;
 }
 
 void Document::setReadyState(ReadyState readyState)
@@ -2045,7 +2044,7 @@ void Document::setReadyState(ReadyState readyState)
         if (!m_eventTiming.domLoading) {
             auto now = MonotonicTime::now();
             m_eventTiming.domLoading = now;
-            if (auto eventTiming = documentEventTimingFromNavigationTiming())
+            if (auto* eventTiming = documentEventTimingFromNavigationTiming())
                 eventTiming->domLoading = now;
             // We do this here instead of in the Document constructor because monotonicTimestamp() is 0 when the Document constructor is running.
             if (!url().isEmpty())
@@ -2057,7 +2056,7 @@ void Document::setReadyState(ReadyState readyState)
         if (!m_eventTiming.domComplete) {
             auto now = MonotonicTime::now();
             m_eventTiming.domComplete = now;
-            if (auto eventTiming = documentEventTimingFromNavigationTiming())
+            if (auto* eventTiming = documentEventTimingFromNavigationTiming())
                 eventTiming->domComplete = now;
             WTFEmitSignpost(this, NavigationAndPaintTiming, "domComplete");
         }
@@ -2066,7 +2065,7 @@ void Document::setReadyState(ReadyState readyState)
         if (!m_eventTiming.domInteractive) {
             auto now = MonotonicTime::now();
             m_eventTiming.domInteractive = now;
-            if (auto eventTiming = documentEventTimingFromNavigationTiming())
+            if (auto* eventTiming = documentEventTimingFromNavigationTiming())
                 eventTiming->domInteractive = now;
             WTFEmitSignpost(this, NavigationAndPaintTiming, "domInteractive");
         }
@@ -8109,7 +8108,7 @@ void Document::finishedParsing()
     if (!m_eventTiming.domContentLoadedEventStart) {
         auto now = MonotonicTime::now();
         m_eventTiming.domContentLoadedEventStart = now;
-        if (auto eventTiming = documentEventTimingFromNavigationTiming())
+        if (auto* eventTiming = documentEventTimingFromNavigationTiming())
             eventTiming->domContentLoadedEventStart = now;
         WTFEmitSignpost(this, NavigationAndPaintTiming, "domContentLoadedEventBegin");
     }
@@ -8125,7 +8124,7 @@ void Document::finishedParsing()
     if (!m_eventTiming.domContentLoadedEventEnd) {
         auto now = MonotonicTime::now();
         m_eventTiming.domContentLoadedEventEnd = now;
-        if (auto eventTiming = documentEventTimingFromNavigationTiming())
+        if (auto* eventTiming = documentEventTimingFromNavigationTiming())
             eventTiming->domContentLoadedEventEnd = now;
         WTFEmitSignpost(this, NavigationAndPaintTiming, "domContentLoadedEventEnd");
     }

--- a/Source/WebCore/dom/Document.h
+++ b/Source/WebCore/dom/Document.h
@@ -2140,7 +2140,7 @@ private:
     void createRenderTree();
     void detachParser();
 
-    std::optional<DocumentEventTiming> documentEventTimingFromNavigationTiming();
+    DocumentEventTiming* documentEventTimingFromNavigationTiming();
 
     // ScriptExecutionContext
     CSSFontSelector* cssFontSelector() final;


### PR DESCRIPTION
#### 2d4afb4d2ec54e094e22d269c5ed230c83ea79d7
<pre>
REGRESSION: PerformanceNavigationTiming.domInteractive and domContentLoadedEventEnd always return 0
<a href="https://bugs.webkit.org/show_bug.cgi?id=312861">https://bugs.webkit.org/show_bug.cgi?id=312861</a>
<a href="https://rdar.apple.com/175739835">rdar://175739835</a>

Reviewed by Ryosuke Niwa.

308683@main changed Document::documentEventTimingFromNavigationTiming() to return
std::optional&lt;DocumentEventTiming&gt; instead of DocumentEventTiming*. This caused all
call sites to modify a local copy of DocumentEventTiming that was immediately discarded,
rather than the actual DocumentEventTiming owned by the PerformanceNavigationTiming object.

As a result, domInteractive, domContentLoadedEventStart, domContentLoadedEventEnd, and
domComplete were always reported as 0 via the Navigation Timing Level 2 API.

Fix by returning a raw pointer again, using a local auto* for the navigationTiming
to avoid the LIFETIME_BOUND warning that motivated the original change.

Test: performance-api/performance-navigation-timing-document-event-timing.html

* LayoutTests/performance-api/performance-navigation-timing-document-event-timing-expected.txt: Added.
* LayoutTests/performance-api/performance-navigation-timing-document-event-timing.html: Added.
* Source/WebCore/dom/Document.cpp:
(WebCore::Document::documentEventTimingFromNavigationTiming):
(WebCore::Document::setReadyState):
(WebCore::Document::finishedParsing):
* Source/WebCore/dom/Document.h:

Canonical link: <a href="https://commits.webkit.org/312500@main">https://commits.webkit.org/312500@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a02b46ea85c0ba86523b75d6a067d21bd1559fa9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/160207 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/33677 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/26781 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/169109 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/114588 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/925dc944-a4a3-4ae7-b4de-55cf490c3453) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/162076 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/33781 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/33679 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/124196 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/87121 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/c4df9fb8-bd58-4600-815d-5da3043eb3d2) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/163165 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/26438 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/143900 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/104795 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/850ffd62-4ef3-4401-a506-651b164aaf24) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/25491 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/23986 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/16829 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/135183 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/21663 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/171585 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/17575 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/23303 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/132448 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/33353 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/28081 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/132474 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35810 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/33338 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/143458 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/91614 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/27092 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/20272 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/32847 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/99244 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/32345 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/32591 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/32495 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->