### PR TITLE
[WebXR] Replace use of callOnMainThread in PlatformXRCompositor

### DIFF
--- a/Source/WebKit/UIProcess/XR/xros/PlatformXRCompositor.mm
+++ b/Source/WebKit/UIProcess/XR/xros/PlatformXRCompositor.mm
@@ -442,7 +442,7 @@ void CompositorCoordinator::update()
     }
 
     // FIXME: rdar://175742010
-    callOnMainThread([this, isRenderingStalled]() { // NOLINT
+    callOnMainRunLoop([this, isRenderingStalled]() {
         if (!m_terminationPending && isRenderingStalled) {
             if (RefPtr<WebPageProxy> page = m_sessionPage.get())
                 terminateSession(*page, PlatformXRSessionEndReason::NoFrameUpdateScheduled);
@@ -605,7 +605,7 @@ void CompositorCoordinator::render(cp_frame_t frame, cp_drawable_t drawable, NST
         tracePoint(WebXRCPFrameStartSubmissionEnd);
 
         // FIXME: rdar://175742010
-        callOnMainThread([callback = WTF::move(m_onFrameUpdate), frameData = WTF::move(frameData)]() mutable { // NOLINT
+        callOnMainRunLoop([callback = WTF::move(m_onFrameUpdate), frameData = WTF::move(frameData)]() mutable {
             callback(WTF::move(frameData));
         });
 


### PR DESCRIPTION
#### ec316926e89ba89cbed99778a635281c877290f5
<pre>
[WebXR] Replace use of callOnMainThread in PlatformXRCompositor
<a href="https://bugs.webkit.org/show_bug.cgi?id=313947">https://bugs.webkit.org/show_bug.cgi?id=313947</a>
<a href="https://rdar.apple.com/175742010">rdar://175742010</a>

Reviewed by Chris Dumez.

Style checker complains about the use of callOnMainThread. Replaced with
callOnMainRunLoop, which is identical on visionOS.

* Source/WebKit/UIProcess/XR/xros/PlatformXRCompositor.mm:
(WebKit::CompositorCoordinator::update):
(WebKit::CompositorCoordinator::render):

Canonical link: <a href="https://commits.webkit.org/312499@main">https://commits.webkit.org/312499@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d7641e265545fc5ebf22d89f63f006ffd60c0471

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/160209 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/33679 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/26783 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/169111 "Built successfully") | [❌ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/114590 "Failed to checkout and rebase branch from PR 64140") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/18b59ccb-85d8-45a3-8897-3f7ffd1fdc76) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/33783 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/33681 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/124197 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/59/builds/114590 "Failed to checkout and rebase branch from PR 64140") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/ceeed823-de34-4712-9464-6cd2c872f321) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/163167 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/26441 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/143899 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/104796 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/4423416a-d57f-465a-a757-eedaa90e5187) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/25494 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/23988 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/16831 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/135186 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/171587 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/17577 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/23302 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/132449 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/33355 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/28083 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/132475 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35809 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/33340 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/143457 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/91616 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/27093 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/20271 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/32849 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/99246 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/32347 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/32593 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/32497 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->