### PR TITLE
[Tahoe Debug] TestWebKitAPI.WebKit.WKNavigationResponseDownloadAttribute is flaky failure

### DIFF
--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKNavigationResponse.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKNavigationResponse.mm
@@ -208,41 +208,19 @@ TEST(WebKit, WKNavigationResponsePDFType)
 
 @end
 
-// FIXME when rdar://170575820 is resolved.
-#if PLATFORM(MAC) && __MAC_OS_X_VERSION_MIN_REQUIRED >= 260000
-TEST(WebKit, DISABLED_WKNavigationResponseDownloadAttribute)
-#else
 TEST(WebKit, WKNavigationResponseDownloadAttribute)
-#endif
 {
     auto getDownloadResponse = [] (RetainPtr<NSString> body) -> RetainPtr<WKNavigationResponse> {
         using namespace TestWebKitAPI;
-        HTTPServer server([body](Connection connection) {
-            connection.receiveHTTPRequest([=](Vector<char>&&) {
-                unsigned bodyLength = [body length];
-                NSString *firstResponse = [NSString stringWithFormat:
-                    @"HTTP/1.1 200 OK\r\n"
-                    "Content-Length: %d\r\n\r\n"
-                    "%@",
-                    bodyLength,
-                    body.get()
-                ];
-                connection.send(firstResponse, [=] {
-                    connection.receiveHTTPRequest([=](Vector<char>&&) {
-                        NSString *secondResponse = @"HTTP/1.1 200 OK\r\n"
-                            "Content-Length: 6\r\n"
-                            "Content-Disposition: attachment; filename=fromHeader.txt;\r\n\r\n"
-                            "Hello!";
-                        connection.send(secondResponse);
-                    });
-                });
-            });
+        HTTPServer server({
+            { "/"_s, { String(body.get()) } },
+            { "/fromHref.txt"_s, { { { "Content-Disposition"_s, "attachment; filename=fromHeader.txt;"_s } }, "Hello!"_s } },
         });
         RetainPtr delegate = adoptNS([NavigationResponseTestDelegate new]);
         RetainPtr webView = adoptNS([WKWebView new]);
         [webView setNavigationDelegate:delegate.get()];
 
-        [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:[NSString stringWithFormat:@"http://127.0.0.1:%d/", server.port()]]]];
+        [webView loadRequest:server.request()];
         [delegate waitForNavigationFinishedCallback];
 
         [webView evaluateJavaScript:@"document.getElementById('link').click();" completionHandler:nil];


### PR DESCRIPTION
#### 34e048130ef74dbb1941e69ecab9b4d3dba211a7
<pre>
[Tahoe Debug] TestWebKitAPI.WebKit.WKNavigationResponseDownloadAttribute is flaky failure
<a href="https://bugs.webkit.org/show_bug.cgi?id=308071">https://bugs.webkit.org/show_bug.cgi?id=308071</a>
<a href="https://rdar.apple.com/170575820">rdar://170575820</a>

Reviewed by Per Arne Vollan.

The test&apos;s HTTP server used connection-based sequential request handling,
expecting both the initial page load and the link click navigation to
arrive on the same TCP connection. When the browser opened a new
connection for the second request, the server would serve the HTML body
instead of the Content-Disposition response, producing a suggestedFilename
of &quot;fromHref.txt.html&quot; instead of &quot;fromHeader.txt&quot;.

Switch to path-based routing so each URL gets the correct response
regardless of which connection the request arrives on. Also remove the
DISABLED_ guard for macOS 26+ since this fixes the underlying flakiness.

* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKNavigationResponse.mm:
(TEST(WebKit, WKNavigationResponseDownloadAttribute)):

Canonical link: <a href="https://commits.webkit.org/312583@main">https://commits.webkit.org/312583@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d85ff9e98f19ce3b1577b8425ea57b7f82440680

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/160210 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/33680 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/26784 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/169112 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/114591 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/0a29e571-87bb-44a0-8fc0-f27006356c1f) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/162079 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/33784 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/33682 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/124198 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/87120 "1 flakes 2 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/af9d5a07-10fe-4edc-bb0a-d1e110d7351e) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/163168 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/26442 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/143901 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/104797 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/b1b82890-0f1d-4e44-bb80-bc993715a0a9) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/25495 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/23989 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/16832 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/135187 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/21664 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/171588 "Built successfully") | | 
| | | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/23304 "Found 1 new test failure: imported/w3c/web-platform-tests/css/selectors/invalidation/media-pseudo-classes-in-has.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/132450 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/33356 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/28084 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/132476 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/33341 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/143459 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/91617 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/24413 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/27094 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/20273 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/32850 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/32348 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/32594 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/32498 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->