### PR TITLE
[WebXR] Remove use of WeakPtr in PlatformXRCompositor

### DIFF
--- a/Source/WebKit/UIProcess/XR/xros/PlatformXRCompositor.h
+++ b/Source/WebKit/UIProcess/XR/xros/PlatformXRCompositor.h
@@ -13,6 +13,7 @@
 #import <WebCore/PageIdentifier.h>
 #import <WebCore/SecurityOriginData.h>
 #import <wtf/RetainPtr.h>
+#import <wtf/TZoneMalloc.h>
 #import <wtf/Threading.h>
 #import <wtf/Vector.h>
 #import <wtf/WeakObjCPtr.h>
@@ -39,24 +40,18 @@ class WebPageProxy;
 enum class PlatformXRSessionEndReason : uint8_t;
 }
 
-namespace WTF {
-// FIXME: rdar://175742141
-template<typename T> struct IsDeprecatedWeakRefSmartPointerException;
-template<> struct IsDeprecatedWeakRefSmartPointerException<WebKit::CompositorCoordinator> : std::true_type { }; // NOLINT
-}
-
 namespace WebCore {
 struct XRCanvasConfiguration;
 }
 
 namespace WebKit {
 
-class CompositorCoordinator final : public PlatformXRCoordinator, public CanMakeWeakPtr<CompositorCoordinator> {
-    WTF_DEPRECATED_MAKE_FAST_ALLOCATED(CompositorCoordinator);
+class CompositorCoordinator final : public PlatformXRCoordinator {
+    WTF_MAKE_TZONE_ALLOCATED(CompositorCoordinator);
 public:
-    CompositorCoordinator();
     virtual ~CompositorCoordinator() { }
 
+    static CompositorCoordinator* singleton();
     static bool isCompositorServicesAvailable();
 
     void getPrimaryDeviceInfo(WebPageProxy&, DeviceInfoCallback&&) override;
@@ -69,6 +64,10 @@ public:
     void submitFrame(WebPageProxy&) override;
 
 private:
+    friend class WTF::LazyNeverDestroyed<CompositorCoordinator>;
+
+    CompositorCoordinator();
+
     bool processEvent();
     void update();
     void render(cp_frame_t, cp_drawable_t, NSTimeInterval);

--- a/Source/WebKit/UIProcess/XR/xros/PlatformXRCompositor.mm
+++ b/Source/WebKit/UIProcess/XR/xros/PlatformXRCompositor.mm
@@ -23,6 +23,7 @@
 #import <WebCore/SecurityOriginData.h>
 #import <WebCore/TransformationMatrix.h>
 #import <pal/spi/cocoa/MetalSPI.h>
+#import <wtf/NeverDestroyed.h>
 #import <wtf/SystemTracing.h>
 
 #if HAVE(SPATIAL_CONTROLLERS)
@@ -31,6 +32,10 @@
 
 #import <pal/cocoa/ARKitSoftLink.h>
 #import <pal/cocoa/CompositorServicesSoftLink.h>
+
+namespace WebKit {
+WTF_MAKE_TZONE_ALLOCATED_IMPL(CompositorCoordinator);
+}
 
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 
@@ -72,6 +77,19 @@ using namespace PAL;
 bool CompositorCoordinator::isCompositorServicesAvailable()
 {
     return isCompositorServicesFrameworkAvailable();
+}
+
+CompositorCoordinator* CompositorCoordinator::singleton()
+{
+    if (!isCompositorServicesAvailable())
+        return nullptr;
+
+    static LazyNeverDestroyed<CompositorCoordinator> singleton;
+    static std::once_flag once;
+    std::call_once(once, [] {
+        singleton.construct();
+    });
+    return &singleton.get();
 }
 
 CompositorCoordinator::CompositorCoordinator()
@@ -178,17 +196,15 @@ void CompositorCoordinator::requestPermissionOnSessionFeatures(WebPageProxy& pag
         return;
     }
 
-    page.uiClient().requestPermissionOnXRSessionFeatures(page, securityOriginData, mode, filterOutUnsupportedFeatures(granted), filterOutUnsupportedFeatures(consentRequired), filterOutUnsupportedFeatures(consentOptional), filterOutUnsupportedFeatures(requiredFeaturesRequested), filterOutUnsupportedFeatures(optionalFeaturesRequested), [weakThis = WeakPtr { *this }, this, securityOriginData, callback = WTF::move(callback)](std::optional<Vector<PlatformXR::SessionFeature>> userGranted) mutable {
+    page.uiClient().requestPermissionOnXRSessionFeatures(page, securityOriginData, mode, filterOutUnsupportedFeatures(granted), filterOutUnsupportedFeatures(consentRequired), filterOutUnsupportedFeatures(consentOptional), filterOutUnsupportedFeatures(requiredFeaturesRequested), filterOutUnsupportedFeatures(optionalFeaturesRequested), [this, securityOriginData, callback = WTF::move(callback)](std::optional<Vector<PlatformXR::SessionFeature>> userGranted) mutable {
         if (userGranted)
             userGranted = filterOutUnsupportedFeatures(*userGranted);
 
 #if ENABLE(WEBXR_HANDS) && !PLATFORM(IOS_FAMILY_SIMULATOR)
-        if (weakThis) {
-            if (userGranted && userGranted->contains(PlatformXR::SessionFeature::HandTracking))
-                m_lastSecurityOriginGrantedHandTracking = securityOriginData;
-            else
-                m_lastSecurityOriginGrantedHandTracking = std::nullopt;
-        }
+        if (userGranted && userGranted->contains(PlatformXR::SessionFeature::HandTracking))
+            m_lastSecurityOriginGrantedHandTracking = securityOriginData;
+        else
+            m_lastSecurityOriginGrantedHandTracking = std::nullopt;
 #else
         UNUSED_PARAM(this);
 #endif
@@ -227,11 +243,11 @@ void CompositorCoordinator::startSession(WebPageProxy& page, WeakPtr<PlatformXRC
 
     m_sessionEventClient = WTF::move(sessionEventClient);
 
-    page.uiClient().startXRSession(page, requestedFeatures, WTF::move(init), [weakThis = WeakPtr { *this }, this, weakPage = WeakPtr { page }, pageIdentifier, securityOriginData, requestedFeatures](RetainPtr<id> cpLayer, UIViewController *viewController) mutable {
+    page.uiClient().startXRSession(page, requestedFeatures, WTF::move(init), [this, weakPage = WeakPtr { page }, pageIdentifier, securityOriginData, requestedFeatures](RetainPtr<id> cpLayer, UIViewController *viewController) mutable {
         ASSERT(RunLoop::isMain());
         ASSERT(!cpLayer || [cpLayer.get() isKindOfClass:getCP_OBJECT_cp_layer_rendererClassSingleton()]);
-        auto strongPage = weakPage;
-        if (!weakThis || !strongPage)
+        RefPtr strongPage = weakPage;
+        if (!strongPage)
             return;
 
         m_cpLayer = cpLayer.get();

--- a/Source/WebKit/UIProcess/XR/xros/PlatformXRSystemXROS.mm
+++ b/Source/WebKit/UIProcess/XR/xros/PlatformXRSystemXROS.mm
@@ -35,15 +35,7 @@ namespace WebKit {
 
 PlatformXRCoordinator* PlatformXRSystem::xrCoordinator()
 {
-    if (!CompositorCoordinator::isCompositorServicesAvailable())
-        return nullptr;
-
-    static LazyNeverDestroyed<CompositorCoordinator> xrCoordinator;
-    static std::once_flag once;
-    std::call_once(once, [] {
-        xrCoordinator.construct();
-    });
-    return &xrCoordinator.get();
+    return CompositorCoordinator::singleton();
 }
 
 #if ENABLE(WEBXR_LAYERS)


### PR DESCRIPTION
#### 1c3efb7fb8736d313583866d3d31922ce5e2b842
<pre>
[WebXR] Remove use of WeakPtr in PlatformXRCompositor
<a href="https://bugs.webkit.org/show_bug.cgi?id=313948">https://bugs.webkit.org/show_bug.cgi?id=313948</a>
<a href="https://rdar.apple.com/175742141">rdar://175742141</a>

Reviewed by Chris Dumez.

CompositorCoordinator is a LazyNeverDestroyed singleton, so
WeakPtr&lt;CompositorCoordinator&gt; is unnecessary. Add a static `singleton()` getter
and replace WeakPtr{*this} captures in callbacks with plain `this`
captures. Remove `CanMakeWeakPtr` and the deprecated exception.

Also replace WTF_DEPRECATED_MAKE_FAST_ALLOCATED with WTF_MAKE_TZONE_ALLOCATED,
and fix the startSession callback to properly promote WeakPtr&lt;WebPageProxy&gt; to
RefPtr.

* Source/WebKit/UIProcess/XR/xros/PlatformXRCompositor.h:
* Source/WebKit/UIProcess/XR/xros/PlatformXRCompositor.mm:
(WebKit::CompositorCoordinator::singleton):
(WebKit::CompositorCoordinator::requestPermissionOnSessionFeatures):
(WebKit::CompositorCoordinator::startSession):
* Source/WebKit/UIProcess/XR/xros/PlatformXRSystemXROS.mm:
(WebKit::PlatformXRSystem::xrCoordinator):

Canonical link: <a href="https://commits.webkit.org/312585@main">https://commits.webkit.org/312585@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4f4e53cb68602c37ad38da14ce62a632ae6a69c4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/160471 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/33944 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/27045 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/169374 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/115537 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/34045 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/33944 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/124426 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/115537 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/163429 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/26672 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/144149 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/105025 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/25724 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/24226 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk3-libwebrtc~~](https://ews-build.webkit.org/#/builders/173/builds/17093 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/135418 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/171852 "Built successfully") | | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/18281 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/23552 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/132686 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/33618 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/28320 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/132705 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35852 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/33602 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/143707 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/95384 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/27305 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/20521 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/33112 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/99937 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/32612 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/32856 "Built successfully") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/32760 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->