### PR TITLE
[Cocoa] Crash in WeakPtr<PlatformSpeechSynthesizer>::get() under -[WebSpeechSynthesisWrapper availableVoicesDidChange]

### DIFF
--- a/LayoutTests/fast/speechsynthesis/mac/speech-synthesis-voices-changed-background-thread-expected.txt
+++ b/LayoutTests/fast/speechsynthesis/mac/speech-synthesis-voices-changed-background-thread-expected.txt
@@ -1,0 +1,1 @@
+PASS if no crash.

--- a/LayoutTests/fast/speechsynthesis/mac/speech-synthesis-voices-changed-background-thread.html
+++ b/LayoutTests/fast/speechsynthesis/mac/speech-synthesis-voices-changed-background-thread.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<script>
+if (window.testRunner) {
+    testRunner.dumpAsText();
+    testRunner.waitUntilDone();
+}
+
+// Create the platform speech wrapper in the UI process so it registers as an
+// observer for AVSpeechSynthesisAvailableVoicesDidChangeNotification.
+speechSynthesis.speak(new SpeechSynthesisUtterance(""));
+speechSynthesis.cancel();
+
+if (window.testRunner) {
+    testRunner.runUIScript(`
+        uiController.simulateAvailableSpeechVoicesDidChangeOnBackgroundThread(function() {
+            uiController.uiScriptComplete("");
+        });
+    `, function() {
+        document.body.textContent = "PASS if no crash.";
+        testRunner.notifyDone();
+    });
+} else
+    document.body.textContent = "This test requires WebKitTestRunner.";
+</script>

--- a/Source/WebCore/platform/cocoa/PlatformSpeechSynthesizerCocoa.mm
+++ b/Source/WebCore/platform/cocoa/PlatformSpeechSynthesizerCocoa.mm
@@ -103,7 +103,13 @@ static float getAVSpeechUtteranceMaximumSpeechRate()
 
 - (void)availableVoicesDidChange
 {
-    Ref { *m_synthesizerObject }->voicesDidChange();
+    // AVFoundation may post AVSpeechSynthesisAvailableVoicesDidChangeNotification from a
+    // background Swift concurrency thread. PlatformSpeechSynthesizer (and its WeakPtr) are
+    // main-thread objects, so hop to the main thread and null-check before dispatching.
+    ensureOnMainThread([retainedSelf = retainPtr(self)] {
+        if (RefPtr synthesizer = retainedSelf->m_synthesizerObject.get())
+            synthesizer->voicesDidChange();
+    });
 }
 
 #endif

--- a/Tools/TestRunnerShared/UIScriptContext/Bindings/UIScriptController.idl
+++ b/Tools/TestRunnerShared/UIScriptContext/Bindings/UIScriptController.idl
@@ -84,6 +84,7 @@ interface UIScriptController {
     undefined doAfterDoubleTapDelay(object callback);
 
     undefined simulateAccessibilitySettingsChangeNotification(object callback);
+    undefined simulateAvailableSpeechVoicesDidChangeOnBackgroundThread(object callback);
 
     // Interaction.
     // These functions post events asynchronously. The callback is fired when the events have been dispatched, but any

--- a/Tools/TestRunnerShared/UIScriptContext/UIScriptController.h
+++ b/Tools/TestRunnerShared/UIScriptContext/UIScriptController.h
@@ -351,6 +351,7 @@ public:
     // Accessibility
 
     virtual void simulateAccessibilitySettingsChangeNotification(JSValueRef) { notImplemented(); }
+    virtual void simulateAvailableSpeechVoicesDidChangeOnBackgroundThread(JSValueRef) { notImplemented(); }
     virtual void retrieveSpeakSelectionContent(JSValueRef) { notImplemented(); }
     virtual JSRetainPtr<JSStringRef> accessibilitySpeakSelectionContent() const { notImplemented(); return nullptr; }
     virtual JSObjectRef contentsOfUserInterfaceItem(JSStringRef) const { notImplemented(); return nullptr; }

--- a/Tools/WebKitTestRunner/cocoa/UIScriptControllerCocoa.h
+++ b/Tools/WebKitTestRunner/cocoa/UIScriptControllerCocoa.h
@@ -81,6 +81,8 @@ private:
 
     void completeTaskAsynchronouslyAfterActivityStateUpdate(unsigned callbackID);
 
+    void simulateAvailableSpeechVoicesDidChangeOnBackgroundThread(JSValueRef) override;
+
     unsigned long countOfUpdatesWithLayerChanges() const override;
 
 #if ENABLE(IMAGE_ANALYSIS)

--- a/Tools/WebKitTestRunner/cocoa/UIScriptControllerCocoa.mm
+++ b/Tools/WebKitTestRunner/cocoa/UIScriptControllerCocoa.mm
@@ -322,6 +322,20 @@ unsigned long UIScriptControllerCocoa::countOfUpdatesWithLayerChanges() const
     return webView()._countOfUpdatesWithLayerChanges;
 }
 
+void UIScriptControllerCocoa::simulateAvailableSpeechVoicesDidChangeOnBackgroundThread(JSValueRef callback)
+{
+    unsigned callbackID = m_context->prepareForAsyncTask(callback, CallbackTypeNonPersistent);
+
+    dispatch_async(globalDispatchQueueSingleton(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), makeBlockPtr([this, protectedThis = Ref { *this }, callbackID] {
+        [[NSNotificationCenter defaultCenter] postNotificationName:@"AVSpeechSynthesisAvailableVoicesDidChangeNotification" object:nil];
+        dispatch_async(mainDispatchQueueSingleton(), makeBlockPtr([this, protectedThis, callbackID] {
+            if (!m_context)
+                return;
+            m_context->asyncTaskComplete(callbackID);
+        }).get());
+    }).get());
+}
+
 #if ENABLE(IMAGE_ANALYSIS)
 
 uint64_t UIScriptControllerCocoa::currentImageAnalysisRequestID() const


### PR DESCRIPTION
#### 28838f616b1d327c59413bcf0d2956d560a68522
<pre>
[Cocoa] Crash in WeakPtr&lt;PlatformSpeechSynthesizer&gt;::get() under -[WebSpeechSynthesisWrapper availableVoicesDidChange]
&lt;<a href="https://bugs.webkit.org/show_bug.cgi?id=313950">https://bugs.webkit.org/show_bug.cgi?id=313950</a>&gt;
&lt;<a href="https://rdar.apple.com/173555693">rdar://173555693</a>&gt;

Reviewed by Tyler Wilcock.

AVFoundation&apos;s `VoiceDatabaseClient` now posts
`AVSpeechSynthesisAvailableVoicesDidChangeNotification` from a
Swift concurrency cooperative thread rather than the main thread.
The `WebSpeechSynthesisWrapper` observer dereferenced its
`WeakPtr&lt;PlatformSpeechSynthesizer&gt;` directly in the notification
handler, tripping the `WeakPtr` threading assertion
(`ASSERT_WITH_SECURITY_IMPLICATION(canSafelyBeUsed())`) and
crashing the UI process.

Fix by ensuring the code runs on the main thread before accessing the
`WeakPtr` and null-checking it there since the owning
`PlatformSpeechSynthesizer` may have been destroyed by the time
the dispatched task runs.

Add a `UIScriptController` hook that posts the notification from a
background dispatch queue so the regression is covered by a layout test.

Test: fast/speechsynthesis/mac/speech-synthesis-voices-changed-background-thread.html

* LayoutTests/fast/speechsynthesis/mac/speech-synthesis-voices-changed-background-thread-expected.txt: Add.
* LayoutTests/fast/speechsynthesis/mac/speech-synthesis-voices-changed-background-thread.html: Add.
* Source/WebCore/platform/cocoa/PlatformSpeechSynthesizerCocoa.mm:
(-[WebSpeechSynthesisWrapper availableVoicesDidChange]):
* Tools/TestRunnerShared/UIScriptContext/Bindings/UIScriptController.idl:
* Tools/TestRunnerShared/UIScriptContext/UIScriptController.h:
(WTR::UIScriptController::simulateAvailableSpeechVoicesDidChangeOnBackgroundThread):
* Tools/WebKitTestRunner/cocoa/UIScriptControllerCocoa.h:
* Tools/WebKitTestRunner/cocoa/UIScriptControllerCocoa.mm:
(WTR::UIScriptControllerCocoa::simulateAvailableSpeechVoicesDidChangeOnBackgroundThread):

Canonical link: <a href="https://commits.webkit.org/312522@main">https://commits.webkit.org/312522@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/89055602b4d224d589f977cbe614267a36118de0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/160220 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/33690 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/26794 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/169122 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/114601 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/983f567a-6b96-4c40-b805-66ceb9c3d7ac) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/162089 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/33794 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/33692 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/124205 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/87125 "1 flakes 2 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/66f42977-5ccc-4e7e-a553-3364055e1b47) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/163178 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/26450 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/143909 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/104804 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/6006e748-4fba-4981-88f2-775a3cfc207d) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/25503 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/23999 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/16842 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/135195 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/21672 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/171598 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/17588 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/23312 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/132458 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/33366 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/28094 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/132484 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/33351 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/143467 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/91629 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/24380 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/27101 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/20281 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/32860 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/99257 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/32358 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/32604 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/32508 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->