### PR TITLE
ASSERTION FAILED: m_wrapper from WebCore::JSEventListener::ensureJSFunction in Navigation::innerDispatchNavigateEvent

### DIFF
--- a/LayoutTests/navigation-api/navigation-navigate-event-after-gc-expected.txt
+++ b/LayoutTests/navigation-api/navigation-navigate-event-after-gc-expected.txt
@@ -1,0 +1,9 @@
+This test passes if it does not crash.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/navigation-api/navigation-navigate-event-after-gc.html
+++ b/LayoutTests/navigation-api/navigation-navigate-event-after-gc.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<script src="../resources/js-test.js"></script>
+<script src="../resources/gc.js"></script>
+<script>
+description("This test passes if it does not crash.");
+
+jsTestIsAsync = true;
+
+window.onload = () => {
+    let iframe = document.createElement("iframe");
+    iframe.src = "resources/navigate-with-intercept.html";
+
+    window.addEventListener("message", (e) => {
+        if (e.data !== "ready")
+            return;
+
+        // Remove the iframe so its frame detaches and JSDOMWindow is
+        // no longer a GC root.
+        iframe.remove();
+        iframe = null;
+
+        // Defer the GC to a new task so the current call stack (which may
+        // still hold transient references) is fully unwound.
+        setTimeout(() => {
+            gc();
+            gc();
+            gc();
+
+            finishJSTest();
+        }, 0);
+    });
+
+    document.body.appendChild(iframe);
+};
+</script>

--- a/LayoutTests/navigation-api/resources/navigate-with-intercept.html
+++ b/LayoutTests/navigation-api/resources/navigate-with-intercept.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<script>
+navigation.addEventListener("navigate", (e) => {
+    if (e.destination.sameDocument)
+        e.intercept({ handler: () => new Promise(() => { /* never resolves */ }) });
+});
+navigation.navigate("#test");
+parent.postMessage("ready", "*");
+</script>

--- a/Source/WebCore/page/Navigation.cpp
+++ b/Source/WebCore/page/Navigation.cpp
@@ -586,7 +586,7 @@ bool Navigation::hasEntriesAndEventsDisabled() const
 {
     RefPtr window = this->window();
     RefPtr document = window->document();
-    if (!document || !document->isFullyActive())
+    if (!document || !document->isFullyActive() || document->activeDOMObjectsAreStopped())
         return true;
     if (document->loader() && document->loader()->isInitialAboutBlank())
         return true;


### PR DESCRIPTION
#### 12876cfd8e3f0002b13048bc66d345e312f8f47e
<pre>
ASSERTION FAILED: m_wrapper from WebCore::JSEventListener::ensureJSFunction in Navigation::innerDispatchNavigateEvent
<a href="https://bugs.webkit.org/show_bug.cgi?id=310813">https://bugs.webkit.org/show_bug.cgi?id=310813</a>
<a href="https://rdar.apple.com/162816815">rdar://162816815</a>

Reviewed by NOBODY (OOPS!).

Do not try to dispatch the navigate event if the script execution context
is gone or stopped, to avoid tripping assertions due to the JS wrapper
being gone.

Test: navigation-api/navigation-navigate-event-after-gc.html

* LayoutTests/navigation-api/navigation-navigate-event-after-gc-expected.txt: Added.
* LayoutTests/navigation-api/navigation-navigate-event-after-gc.html: Added.
* LayoutTests/navigation-api/resources/navigate-with-intercept.html: Added.
* Source/WebCore/page/Navigation.cpp:
(WebCore::Navigation::hasEntriesAndEventsDisabled const):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/12876cfd8e3f0002b13048bc66d345e312f8f47e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/160460 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/159/builds/33933 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/27034 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/169363 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/115526 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/0e54f4b4-f5d5-4ca3-bdcf-1db9c949f535) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/162329 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/34034 "Built successfully") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/156/builds/33933 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/169363 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/115526 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/6c3ce148-5e48-4e7d-b715-ce7c6bed2ddf) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/163418 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/26661 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/144132 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/169363 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/7fa54269-280e-48cf-9013-491c0721509f) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/25713 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/156/builds/33933 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk3-libwebrtc~~](https://ews-build.webkit.org/#/builders/173/builds/17082 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/135407 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/167/builds/21895 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/171841 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/18254 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/23535 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/171841 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/33607 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/156/builds/33933 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/171841 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/33591 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/143690 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/95373 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/160/builds/33591 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/20504 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/33101 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/99917 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/32601 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/32845 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/32749 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->