### PR TITLE
[AppKit Gestures] Occasional debug assertion crash when clicking in a PDF in an iframe

### DIFF
--- a/LayoutTests/fast/frames/hit-test-into-iframe-under-transformed-ancestor-expected.txt
+++ b/LayoutTests/fast/frames/hit-test-into-iframe-under-transformed-ancestor-expected.txt
@@ -1,0 +1,11 @@
+
+Tests that a point-based hit test descending into an iframe whose ancestor has a CSS transform does not trigger the rect-based-through-transform assertion in RenderLayer::hitTestList.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS hitNode is childInIframe
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/frames/hit-test-into-iframe-under-transformed-ancestor.html
+++ b/LayoutTests/fast/frames/hit-test-into-iframe-under-transformed-ancestor.html
@@ -1,0 +1,80 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <style>
+        body {
+            margin: 0;
+        }
+
+        .transformed-ancestor {
+            /* Forces hitTestLayerByApplyingTransform in the outer document when
+               the hit test descends through this layer. */
+            transform: scale(1);
+            position: absolute;
+            top: 50px;
+            left: 50px;
+            width: 400px;
+            height: 300px;
+        }
+
+        iframe {
+            display: block;
+            width: 400px;
+            height: 300px;
+            border: none;
+        }
+    </style>
+    <script src="../../resources/js-test.js"></script>
+    <script>
+        let hitNode;
+        let childInIframe;
+        window.addEventListener('load', () => {
+            description('Tests that a point-based hit test descending into an iframe whose ancestor has a CSS transform does not trigger the rect-based-through-transform assertion in RenderLayer::hitTestList.');
+
+            if (!window.internals) {
+                testFailed('This test requires window.internals.');
+                return;
+            }
+
+            const iframe = document.getElementsByTagName('iframe')[0];
+            const bounds = iframe.getBoundingClientRect();
+            childInIframe = iframe.contentDocument.getElementById('child');
+
+            // Aim the hit test at a point inside the iframe that's also inside
+            // the child <div>. Use a point-based request that allows descending
+            // into child frames but does NOT collect multiple elements.
+            hitNode = internals.nodeFromPointIncludingChildFrames(document, Math.floor(bounds.x + bounds.width / 2), Math.floor(bounds.y + bounds.height / 2));
+
+            // Before the fix, this whole sequence would have already asserted
+            // in RenderLayer::hitTestList. Surviving to this line is most of
+            // what the test is checking; we additionally assert that we landed
+            // in the iframe's child div rather than on the iframe itself.
+            shouldBe('hitNode', 'childInIframe');
+        }, false);
+    </script>
+</head>
+<body>
+    <div class="transformed-ancestor">
+        <iframe srcdoc="
+        <style>
+            html, body { margin: 0; width: 100%; height: 100%; }
+            /* A composited descendant forces hitTestList to run inside the
+               subframe, which is where the assertion used to fire. */
+            #child {
+                position: absolute;
+                top: 50px;
+                left: 50px;
+                width: 200px;
+                height: 150px;
+                background-color: green;
+                will-change: transform;
+            }
+        </style>
+        <body>
+            <div id='child'></div>
+        </body>
+        "></iframe>
+    </div>
+<div id="console"></div>
+</body>
+</html>

--- a/Source/WebCore/rendering/HitTestLocation.cpp
+++ b/Source/WebCore/rendering/HitTestLocation.cpp
@@ -34,12 +34,12 @@ HitTestLocation::HitTestLocation(const LayoutPoint& point)
 {
 }
 
-HitTestLocation::HitTestLocation(const FloatPoint& point, const FloatQuad& quad)
+HitTestLocation::HitTestLocation(const FloatPoint& point, const FloatQuad& quad, RectBased rectBased)
     : m_point { flooredLayoutPoint(point) }
     , m_boundingBox { quad.enclosingBoundingBox() }
     , m_transformedPoint { point }
     , m_transformedRect { quad }
-    , m_isRectBased { true }
+    , m_isRectBased { rectBased == RectBased::Yes }
     , m_isRectilinear { quad.isRectilinear() }
 {
 }

--- a/Source/WebCore/rendering/HitTestLocation.h
+++ b/Source/WebCore/rendering/HitTestLocation.h
@@ -28,9 +28,11 @@ namespace WebCore {
 
 class HitTestLocation {
 public:
+    enum class RectBased : bool { No, Yes };
+
     WEBCORE_EXPORT HitTestLocation();
     HitTestLocation(const LayoutPoint&);
-    HitTestLocation(const FloatPoint&, const FloatQuad&);
+    HitTestLocation(const FloatPoint&, const FloatQuad&, RectBased = RectBased::Yes);
 
     HitTestLocation(const LayoutRect&);
 

--- a/Source/WebCore/rendering/RenderLayer.cpp
+++ b/Source/WebCore/rendering/RenderLayer.cpp
@@ -4970,7 +4970,7 @@ RenderLayer::HitLayer RenderLayer::hitTestLayerByApplyingTransform(RenderLayer* 
         newHitTestLocation = HitTestLocation(localPoint, localPointQuad);
     } else {
         auto localPointQuad = newTransformState->boundsOfMappedQuad();
-        newHitTestLocation = HitTestLocation(localPoint, FloatRect { localPointQuad });
+        newHitTestLocation = HitTestLocation(localPoint, FloatRect { localPointQuad }, HitTestLocation::RectBased::No);
     }
 
     // Now do a hit test with the root layer shifted to be us.

--- a/Source/WebCore/testing/Internals.cpp
+++ b/Source/WebCore/testing/Internals.cpp
@@ -2951,6 +2951,27 @@ ExceptionOr<RefPtr<NodeList>> Internals::nodesFromRect(Document& document, int c
     return RefPtr<NodeList> { StaticNodeList::create(WTF::move(matches)) };
 }
 
+ExceptionOr<RefPtr<Node>> Internals::nodeFromPointIncludingChildFrames(Document& document, int x, int y) const
+{
+    if (!document.frame() || !document.frame()->view())
+        return Exception { ExceptionCode::InvalidAccessError };
+
+    document.updateLayout(LayoutOptions::IgnorePendingStylesheets);
+
+    auto* localFrame = document.frame();
+    if (!localFrame)
+        return RefPtr<Node> { };
+
+    constexpr OptionSet<HitTestRequest::Type> hitType {
+        HitTestRequest::Type::ReadOnly,
+        HitTestRequest::Type::Active,
+        HitTestRequest::Type::DisallowUserAgentShadowContent,
+        HitTestRequest::Type::AllowChildFrameContent,
+    };
+    auto result = localFrame->eventHandler().hitTestResultAtPoint(IntPoint(x, y), hitType);
+    return RefPtr<Node> { result.innerNode() };
+}
+
 class GetCallerCodeBlockFunctor {
 public:
     GetCallerCodeBlockFunctor()

--- a/Source/WebCore/testing/Internals.h
+++ b/Source/WebCore/testing/Internals.h
@@ -486,6 +486,8 @@ public:
 
     ExceptionOr<RefPtr<NodeList>> nodesFromRect(Document&, int x, int y, unsigned topPadding, unsigned rightPadding, unsigned bottomPadding, unsigned leftPadding, bool ignoreClipping, bool allowUserAgentShadowContent, bool allowChildFrameContent) const;
 
+    ExceptionOr<RefPtr<Node>> nodeFromPointIncludingChildFrames(Document&, int x, int y) const;
+
     String parserMetaData(JSC::JSValue = JSC::JSValue::JSUndefined);
 
     void updateEditorUINowIfScheduled();

--- a/Source/WebCore/testing/Internals.idl
+++ b/Source/WebCore/testing/Internals.idl
@@ -716,6 +716,8 @@ enum ContentsFormat {
         unsigned long topPadding, unsigned long rightPadding, unsigned long bottomPadding, unsigned long leftPadding,
         boolean ignoreClipping, boolean allowShadowContent, boolean allowChildFrameContent);
 
+    Node? nodeFromPointIncludingChildFrames(Document document, long x, long y);
+
     // Calling parserMetaData() with no arguments gets the metadata for the script of the current scope.
     DOMString parserMetaData(optional any func);
 
@@ -826,7 +828,7 @@ enum ContentsFormat {
     boolean scrollbarUsingDarkAppearance(optional Node? node = null);
     DOMString horizontalScrollbarState(optional Node? node = null);
     DOMString verticalScrollbarState(optional Node? node = null);
-    
+
     DOMString scrollbarsControllerTypeForNode(optional Node? node = null);
 
     DOMString scrollingStateTreeAsText();
@@ -1439,7 +1441,7 @@ enum ContentsFormat {
 
     unsigned long createSleepDisabler(DOMString reason, boolean display);
     boolean destroySleepDisabler(unsigned long identifier);
-    
+
     [Conditional=APP_HIGHLIGHTS] readonly attribute sequence<DOMString> appHighlightContextMenuItemTitles;
     [Conditional=APP_HIGHLIGHTS] unsigned long numberOfAppHighlights();
 
@@ -1498,7 +1500,7 @@ enum ContentsFormat {
     undefined setHistoryTotalStateObjectPayloadLimitOverride(unsigned long limit);
 
     readonly attribute boolean isVisuallyNonEmpty;
-    
+
     boolean isUsingUISideCompositing();
 
     DOMString getComputedLabel(Element element);


### PR DESCRIPTION
#### f0569fd3c773e9d49e11e6da35b341beb0871068
<pre>
[AppKit Gestures] Occasional debug assertion crash when clicking in a PDF in an iframe
<a href="https://bugs.webkit.org/show_bug.cgi?id=313952">https://bugs.webkit.org/show_bug.cgi?id=313952</a>
<a href="https://rdar.apple.com/176157296">rdar://176157296</a>

Reviewed by Simon Fraser.

296407@main changed the `else` branch of `RenderLayer::hitTestLayerByApplyingTransform` to construct
the transformed `HitTestLocation` from an inverse-mapped quad via `HitTestLocation(FloatPoint, FloatQuad)`,
so that a 1x1 screen-space query through a transformed layer is not scaled up into the local coordinate
space (e.g. `transform: scale(100)` no longer yields a 100x100 effective hit area).

Unfortunately the only 2-argument constructor that accepts a quad unconditionally sets
`m_isRectBased = true`. That changed the meaning of the post-transform location from &quot;same point,
just mapped&quot; to &quot;rect-based hit test&quot;, even when the caller never asked for a rect-based test and
therefore did not pass `HitTestRequest::Type::CollectMultipleElements`. Callers like
`EventHandler::hitTestResultAtPoint` (used for `nodeRespondingToClickEvents`) start a point-based
hit test with `AllowVisibleChildFrameContentOnly` (or `AllowChildFrameContent`) set but *not*
`CollectMultipleElements`. Once the hit test descends through a transformed ancestor, the `HitTestLocation`
picked up `m_isRectBased = true`; the rect-based flag was then propagated across the iframe boundary by
 `RenderWidget::nodeAtPoint` via the copy-with-offset constructor (which mirrors `m_isRectBased`
 from its source), and the assertion

```
ASSERT(!result.isRectBasedTest() || request.resultIsElementList());
```

in `RenderLayer::hitTestList` (and the matching assert in `HitTestResult::addNodeToListBasedTestResultCommon`)
fires as soon as the subframe&apos;s layer tree has any child layers for `hitTestList` to iterate over.
This reliably reproduces on a PDF hosted in an iframe that sits under a transformed ancestor.

Fix by giving `HitTestLocation` a new constructor parameter to allow callers to explicitly set the rect-basedness,
and use it from the `else` branch of `hitTestLayerByApplyingTransform` so point-based hit tests remain
point-based through transforms while still using the inverse-mapped quad for intersection accuracy.
(The `if` branch (caller-initiated rect-based test) is left alone.)

Test: fast/frames/hit-test-into-iframe-under-transformed-ancestor.html

* LayoutTests/fast/frames/hit-test-into-iframe-under-transformed-ancestor-expected.txt: Added.
* LayoutTests/fast/frames/hit-test-into-iframe-under-transformed-ancestor.html: Added.
* Source/WebCore/testing/Internals.cpp:
(WebCore::Internals::nodeFromPointIncludingChildFrames const):
* Source/WebCore/testing/Internals.h:
* Source/WebCore/testing/Internals.idl:

Add a test helper that issues the same point-based, child-frame-descending hit test (ReadOnly
| Active | DisallowUserAgentShadowContent | AllowChildFrameContent, no CollectMultipleElements)
used by the reproducible path.

* Source/WebCore/rendering/HitTestLocation.cpp:
(WebCore::HitTestLocation::HitTestLocation):
* Source/WebCore/rendering/HitTestLocation.h:
* Source/WebCore/rendering/RenderLayer.cpp:
(WebCore::RenderLayer::hitTestLayerByApplyingTransform):

Pass `RectBased::No` in the `else` branch so a point-based hit test stays point-based after
being mapped through an ancestor transform, while still retaining the inverse-transformed
bounding quad for intersection accuracy.

Canonical link: <a href="https://commits.webkit.org/312538@main">https://commits.webkit.org/312538@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4b5afe3f613c946f5ae01ef53f67aed89a95df9a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/160228 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/33698 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/26802 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/169130 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/114609 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/162097 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/33802 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/33700 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/124215 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/87132 "1 flakes 2 failures") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/163186 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/26460 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/143919 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/104814 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/25513 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/24007 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/16850 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/135205 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/21682 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/171606 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/17596 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/23322 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/132467 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/33374 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/28102 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/132493 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35832 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/33359 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/143477 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/91639 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/27112 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/20291 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/32868 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/99265 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/32366 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/32612 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/32516 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->