### PR TITLE
Digital Credentials: CredentialRequestCoordinator should transition to Requesting state before setting promise

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/digital-credentials/get.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/digital-credentials/get.https-expected.txt
@@ -19,4 +19,5 @@ FAIL navigator.credentials.get() with one unknown protocol with malformed data a
 PASS navigator.credentials.get() with only bogus requests should reject with TypeError.
 FAIL navigator.credentials.get() with good requests at the start and end should skip the bogus ones and not fail. promise_rejects_dom: function "function() { throw e; }" threw object "TypeError: Type error" that is not a DOMException AbortError: property "code" is equal to undefined, expected 20
 FAIL navigator.credentials.get() with bogus requests at both ends should skip them and not fail. promise_rejects_dom: function "function() { throw e; }" threw object "TypeError: Type error" that is not a DOMException AbortError: property "code" is equal to undefined, expected 20
+PASS navigator.credentials.get() returns coordinator to idle after mid-flight abort.
 

--- a/Source/WebCore/Modules/identity/CredentialRequestCoordinator.cpp
+++ b/Source/WebCore/Modules/identity/CredentialRequestCoordinator.cpp
@@ -116,6 +116,7 @@ void CredentialRequestCoordinator::setInteractionState(InteractionState newState
 
 void CredentialRequestCoordinator::setCurrentPromise(CredentialPromise&& promise)
 {
+    ASSERT(m_interactionState == InteractionState::Requesting);
     ASSERT(!m_currentPromise);
     m_currentPromise = makeUnique<CredentialPromise>(WTF::move(promise));
 }
@@ -130,8 +131,12 @@ void CredentialRequestCoordinator::prepareCredentialRequests(const Document& doc
     if (m_interactionState != InteractionState::Idle)
         return promise.reject(ExceptionCode::InvalidStateError, "A credential request is already in progress."_s);
 
+    ASSERT(!m_currentPromise);
+    setInteractionState(InteractionState::Requesting);
+    setCurrentPromise(WTF::move(promise));
+
     if (!m_page)
-        return promise.reject(ExceptionCode::AbortError, "Page was destroyed."_s);
+        return rejectTheCredentialRequestWith(Exception { ExceptionCode::AbortError, "Page was destroyed."_s });
 
     auto validatedRequestsOrException = m_client->validateAndParseDigitalCredentialRequests(
         protect(document.topOrigin()),
@@ -139,12 +144,11 @@ void CredentialRequestCoordinator::prepareCredentialRequests(const Document& doc
         unvalidatedRequests);
 
     if (validatedRequestsOrException.hasException())
-        return promise.reject(validatedRequestsOrException.releaseException());
+        return rejectTheCredentialRequestWith(validatedRequestsOrException.releaseException());
 
-    setCurrentPromise(WTF::move(promise));
+    auto validatedCredentialRequests = validatedRequestsOrException.releaseReturnValue();
 
     if (signal) {
-        // CredentialsContainer handled rejecting pre-aborted signal
         ASSERT(!signal->aborted());
         m_abortSignal = signal;
         m_abortAlgorithmIdentifier = signal->addAlgorithm([weakThis = WeakPtr { *this }, signal = protect(signal)](JSC::JSValue reason) {
@@ -156,22 +160,17 @@ void CredentialRequestCoordinator::prepareCredentialRequests(const Document& doc
     }
 
     if (signal && signal->aborted())
-        return;
+        return rejectTheCredentialRequestWith(Exception { ExceptionCode::AbortError, "Signal was already aborted."_s });
 
-    auto validatedCredentialRequests = validatedRequestsOrException.releaseReturnValue();
     initiateTheCredentialRequest(document, WTF::move(validatedCredentialRequests), WTF::move(unvalidatedRequests), signal);
 }
 
 void CredentialRequestCoordinator::initiateTheCredentialRequest(const Document& document, Vector<ValidatedDigitalCredentialRequest>&& validatedRequests, Vector<UnvalidatedDigitalCredentialRequest>&& unvalidatedRequests, RefPtr<AbortSignal> signal)
 {
     auto requestDataAndRawRequests = DigitalCredentialsRequestDataBuilder::build(validatedRequests, document, WTF::move(unvalidatedRequests));
-    if (requestDataAndRawRequests.hasException()) {
-        if (auto* promise = currentPromise())
-            promise->reject(requestDataAndRawRequests.releaseException());
-        return;
-    }
+    if (requestDataAndRawRequests.hasException())
+        return rejectTheCredentialRequestWith(requestDataAndRawRequests.releaseException());
 
-    setInteractionState(InteractionState::Requesting);
     observeContext(protect(document.scriptExecutionContext()).get());
 
     auto [requestData, rawRequests] = requestDataAndRawRequests.releaseReturnValue();
@@ -261,6 +260,17 @@ ExceptionOr<JSC::JSObject*> CredentialRequestCoordinator::parseDigitalCredential
     return parsedJSON.getObject();
 }
 
+// https://w3c-fedid.github.io/digital-credentials/#dfn-reject-the-credential-request-with
+void CredentialRequestCoordinator::rejectTheCredentialRequestWith(Exception&& exception)
+{
+    ASSERT(m_interactionState != InteractionState::Idle);
+    ASSERT(m_currentPromise);
+    clearAbortAlgorithm();
+    m_currentPromise->reject(WTF::move(exception));
+    m_currentPromise.reset();
+    setInteractionState(InteractionState::Idle);
+}
+
 void CredentialRequestCoordinator::settleTheCredentialRequest(ExceptionOr<RefPtr<BasicCredential>>&& result)
 {
     clearAbortAlgorithm();
@@ -304,14 +314,7 @@ void CredentialRequestCoordinator::abortTheCredentialRequest(ExceptionOr<JSC::JS
 {
     clearAbortAlgorithm();
     if (m_interactionState == InteractionState::Idle) {
-        // No UI teardown needed. Settle (defensively) and return.
-        if (m_currentPromise) {
-            if (reason.hasException())
-                m_currentPromise->reject(reason.releaseException());
-            else
-                m_currentPromise->rejectType<IDLAny>(reason.releaseReturnValue());
-            m_currentPromise.reset();
-        }
+        ASSERT(!m_currentPromise);
         return;
     }
 

--- a/Source/WebCore/Modules/identity/CredentialRequestCoordinator.h
+++ b/Source/WebCore/Modules/identity/CredentialRequestCoordinator.h
@@ -68,6 +68,7 @@ public:
 
 private:
     void settleTheCredentialRequest(ExceptionOr<RefPtr<BasicCredential>>&&);
+    void rejectTheCredentialRequestWith(Exception&&);
     void clearAbortAlgorithm();
 
     class InteractionStateGuard final {


### PR DESCRIPTION
#### 828871706d95b1ff892567e281a37f0d9a278f21
<pre>
Digital Credentials: CredentialRequestCoordinator should transition to Requesting state before setting promise
<a href="https://bugs.webkit.org/show_bug.cgi?id=309625">https://bugs.webkit.org/show_bug.cgi?id=309625</a>
<a href="https://rdar.apple.com/172236892">rdar://172236892</a>

Reviewed by Anne van Kesteren.

Maintain the invariant that the interaction state is &apos;idle&apos; iff no
current promise is set. Set the state and promise as an atomic pair at
the top of prepareCredentialRequests (after the idle check), and route
error paths through a new rejectTheCredentialRequestWith helper that
implements §6.5 &quot;Reject the credential request with&quot;:
<a href="https://w3c-fedid.github.io/digital-credentials/#dfn-reject-the-credential-request-with">https://w3c-fedid.github.io/digital-credentials/#dfn-reject-the-credential-request-with</a>

Covered by existing digital-credentials tests.

* Source/WebCore/Modules/identity/CredentialRequestCoordinator.cpp:
(WebCore::CredentialRequestCoordinator::setCurrentPromise):
(WebCore::CredentialRequestCoordinator::prepareCredentialRequests):
(WebCore::CredentialRequestCoordinator::initiateTheCredentialRequest):
(WebCore::CredentialRequestCoordinator::rejectTheCredentialRequestWith):
(WebCore::CredentialRequestCoordinator::abortTheCredentialRequest):
* Source/WebCore/Modules/identity/CredentialRequestCoordinator.h:

Canonical link: <a href="https://commits.webkit.org/315893@main">https://commits.webkit.org/315893@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/54fe55a56d5503de66d766c07ed0e46db1af16a8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/170152 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/44075 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/37491 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/179514 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/127864 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/23b9a0cd-2a64-4c40-9bb5-c4196efba480) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/172018 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/45319 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/43707 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/132638 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/93477 "14 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/5d92f92c-4186-4c05-9a0e-964858d8a962) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/173111 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/35826 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/153072 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/113140 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/4ea0aee1-43b6-4a51-9439-7f839fba1d7a) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/34415 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/32774 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/28210 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/144898 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/32470 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/182111 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/34900 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/36942 "Found 1 new test failure: http/tests/site-isolation/frame-index.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/141091 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/43732 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/140916 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38001 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/44421 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/29454 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/108790 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/36186 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/116301 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/42931 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/7553 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/42323 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/42577 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/42466 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->