### PR TITLE
Digital Credentials:

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/digital-credentials/digital-credential-user-agent-allows-protocol.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/digital-credentials/digital-credential-user-agent-allows-protocol.https-expected.txt
@@ -1,3 +1,7 @@
 
 PASS User agent does not allow invalid protocol identifiers.
+FAIL userAgentAllowsProtocol() returns true for "openid4vp-v1-unsigned". assert_true: Expected true for valid presentation protocol "openid4vp-v1-unsigned". expected true got false
+FAIL userAgentAllowsProtocol() returns true for "openid4vp-v1-signed". assert_true: Expected true for valid presentation protocol "openid4vp-v1-signed". expected true got false
+FAIL userAgentAllowsProtocol() returns true for "openid4vp-v1-multisigned". assert_true: Expected true for valid presentation protocol "openid4vp-v1-multisigned". expected true got false
+PASS userAgentAllowsProtocol() returns true for "org-iso-mdoc".
 

--- a/LayoutTests/imported/w3c/web-platform-tests/digital-credentials/digital-credential-user-agent-allows-protocol.https.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/digital-credentials/digital-credential-user-agent-allows-protocol.https.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <title>Tests for DigitalCredential's userAgentAllowsProtocol() static method.</title>
-<link rel="help" href="https://github.com/w3c-fedid/digital-credentials/pull/221" />
+<link rel="help" href="https://w3c-fedid.github.io/digital-credentials/#dom-digitalcredential-useragentallowsprotocol" />
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 
@@ -15,5 +15,21 @@
       assert_equals(result, false, `Incorrect result for ${invalidIdentifier}.`);
     }
   }, "User agent does not allow invalid protocol identifiers.");
+
+  const validPresentationProtocols = [
+    "openid4vp-v1-unsigned",
+    "openid4vp-v1-signed",
+    "openid4vp-v1-multisigned",
+    "org-iso-mdoc",
+  ];
+
+  for (const protocol of validPresentationProtocols) {
+    test(() => {
+      assert_true(
+        DigitalCredential.userAgentAllowsProtocol(protocol),
+        `Expected true for valid presentation protocol "${protocol}".`
+      );
+    }, `userAgentAllowsProtocol() returns true for "${protocol}".`);
+  }
 
 </script>

--- a/Source/WebCore/Modules/identity/CredentialRequestCoordinator.cpp
+++ b/Source/WebCore/Modules/identity/CredentialRequestCoordinator.cpp
@@ -46,6 +46,7 @@
 #include "JSValueInWrappedObjectInlines.h"
 #include "Page.h"
 #include "SecurityOriginData.h"
+#include "TaskSource.h"
 #include <JavaScriptCore/JSObject.h>
 #include <Logging.h>
 #include <wtf/TZoneMallocInlines.h>
@@ -71,7 +72,8 @@ CredentialRequestCoordinator::CredentialRequestCoordinator(Ref<CredentialRequest
 CredentialRequestCoordinator::InteractionStateGuard::InteractionStateGuard(CredentialRequestCoordinator& coordinator)
     : m_coordinator(coordinator)
 {
-    ASSERT(coordinator.interactionState() == InteractionState::Requesting);
+    ASSERT(coordinator.interactionState() == InteractionState::Requesting
+        || coordinator.interactionState() == InteractionState::Aborting);
 }
 
 CredentialRequestCoordinator::InteractionStateGuard::~InteractionStateGuard()
@@ -126,8 +128,12 @@ CredentialPromise* CredentialRequestCoordinator::currentPromise()
 
 void CredentialRequestCoordinator::prepareCredentialRequests(const Document& document, CredentialPromise&& promise, Vector<UnvalidatedDigitalCredentialRequest>&& unvalidatedRequests, RefPtr<AbortSignal> signal)
 {
-    if (m_interactionState != InteractionState::Idle)
-        return promise.reject(ExceptionCode::NotAllowedError, "A credential request is already in progress."_s);
+    if (m_interactionState != InteractionState::Idle) {
+        queueTaskKeepingObjectAlive(*this, TaskSource::DOMManipulation, [promise = makeUnique<CredentialPromise>(WTF::move(promise))](auto&) mutable {
+            promise->reject(ExceptionCode::NotAllowedError, "A credential request is already in progress."_s);
+        });
+        return;
+    }
 
     ASSERT(!m_currentPromise);
     setInteractionState(InteractionState::Requesting);
@@ -206,18 +212,37 @@ void CredentialRequestCoordinator::initiateTheCredentialRequest(Expected<Digital
     if (responseData.responseDataJSON.isEmpty())
         return rejectTheCredentialRequestWith(Exception { ExceptionCode::NotAllowedError, "The user cancelled the credential request."_s });
 
-    auto parsedObject = parseDigitalCredentialsResponseData(responseData.responseDataJSON);
+    clearAbortAlgorithm();
+    queueTaskKeepingObjectAlive(*this, TaskSource::DOMManipulation, [responseDataJSON = responseData.responseDataJSON, protocol = responseData.protocol](auto& coordinator) mutable {
+        if (!coordinator.hasCurrentPromise()) {
+            coordinator.setInteractionState(InteractionState::Idle);
+            return;
+        }
 
-    if (parsedObject.hasException())
-        return rejectTheCredentialRequestWith(parsedObject.releaseException());
+        auto parsedObject = coordinator.parseDigitalCredentialsResponseData(responseDataJSON);
 
-    if (!parsedObject.returnValue())
-        return rejectTheCredentialRequestWith(Exception { ExceptionCode::TypeError, "No parsed object."_s });
+        if (parsedObject.hasException()) {
+            auto promise = WTF::move(coordinator.m_currentPromise);
+            promise->reject(parsedObject.releaseException());
+            coordinator.setInteractionState(InteractionState::Idle);
+            return;
+        }
 
-    auto returnValue = parsedObject.releaseReturnValue();
-    Ref credential = DigitalCredential::create({ returnValue->vm(), returnValue }, responseData.protocol);
+        if (!parsedObject.returnValue()) {
+            auto promise = WTF::move(coordinator.m_currentPromise);
+            promise->reject(Exception { ExceptionCode::TypeError, "Parsed JSON data is not an object."_s });
+            coordinator.setInteractionState(InteractionState::Idle);
+            return;
+        }
 
-    rejectTheCredentialRequestWith(credential.ptr());
+        auto returnValue = parsedObject.releaseReturnValue();
+        Ref credential = DigitalCredential::create({ returnValue->vm(), returnValue }, protocol);
+
+        auto promise = WTF::move(coordinator.m_currentPromise);
+        promise->resolve(credential.ptr());
+
+        coordinator.setInteractionState(InteractionState::Idle);
+    });
 }
 
 ExceptionOr<JSC::JSObject*> CredentialRequestCoordinator::parseDigitalCredentialsResponseData(const String& responseDataJSON) const
@@ -256,29 +281,22 @@ ExceptionOr<JSC::JSObject*> CredentialRequestCoordinator::parseDigitalCredential
     return parsedJSON.getObject();
 }
 
-void CredentialRequestCoordinator::rejectTheCredentialRequestWith(ExceptionOr<RefPtr<BasicCredential>>&& result)
+void CredentialRequestCoordinator::rejectTheCredentialRequestWith(Exception&& error)
 {
-    clearAbortAlgorithm();
-
-    auto promise = WTF::move(m_currentPromise);
-    m_currentPromise.reset();
-
     ASSERT(m_interactionState == InteractionState::Requesting || m_interactionState == InteractionState::Aborting);
 
-    m_client->dismissDigitalCredentialsChooser([weakThis = WeakPtr { *this }, promise = WTF::move(promise), result = WTF::move(result)](bool success) mutable {
-        if (!success)
-            LOG(DigitalCredentials, "Failed to dismiss the credentials picker.");
+    clearAbortAlgorithm();
 
-        if (auto* rawThis = weakThis.get())
-            rawThis->setInteractionState(InteractionState::Idle);
-
-        if (!promise)
+    queueTaskKeepingObjectAlive(*this, TaskSource::DOMManipulation, [error = WTF::move(error)](auto& coordinator) mutable {
+        if (!coordinator.hasCurrentPromise()) {
+            coordinator.setInteractionState(InteractionState::Idle);
             return;
+        }
 
-        if (result.hasException())
-            promise->reject(result.releaseException());
-        else
-            promise->resolve(result.releaseReturnValue().get());
+        auto promise = WTF::move(coordinator.m_currentPromise);
+        promise->reject(WTF::move(error));
+
+        coordinator.setInteractionState(InteractionState::Idle);
     });
 }
 
@@ -299,31 +317,29 @@ void CredentialRequestCoordinator::abortTheCredentialRequest(ExceptionOr<JSC::JS
 {
     clearAbortAlgorithm();
     if (m_interactionState == InteractionState::Idle) {
-        // No UI teardown needed. Settle (defensively) and return.
         if (m_currentPromise) {
-            if (reason.hasException())
-                m_currentPromise->reject(reason.releaseException());
-            else
-                m_currentPromise->rejectType<IDLAny>(reason.releaseReturnValue());
-            m_currentPromise.reset();
+            queueTaskKeepingObjectAlive(*this, TaskSource::DOMManipulation, [reason = WTF::move(reason)](auto& coordinator) mutable {
+                if (!coordinator.hasCurrentPromise())
+                    return;
+                auto promise = WTF::move(coordinator.m_currentPromise);
+                if (reason.hasException())
+                    promise->reject(reason.releaseException());
+                else
+                    promise->template rejectType<IDLAny>(reason.releaseReturnValue());
+            });
         }
         return;
     }
 
-    if (m_interactionState == InteractionState::Aborting) {
-        ASSERT(!m_currentPromise);
+    if (m_interactionState == InteractionState::Aborting)
         return;
-    }
 
     if (m_interactionState != InteractionState::Requesting) {
-        LOG(DigitalCredentials, "Cannot abort the credentials picker when it is not presenting.");
+        LOG(DigitalCredentials, "Cannot abort the credential request when it is not requesting.");
         return;
     }
 
     setInteractionState(InteractionState::Aborting);
-
-    auto promise = WTF::move(m_currentPromise);
-    m_currentPromise.reset();
 
     std::optional<Exception> abortException;
     std::optional<JSC::Strong<JSC::Unknown>> protectedReason;
@@ -344,23 +360,31 @@ void CredentialRequestCoordinator::abortTheCredentialRequest(ExceptionOr<JSC::JS
     }
 
     m_client->dismissDigitalCredentialsChooser(
-        [weakThis = WeakPtr { *this }, promise = WTF::move(promise), abortException = WTF::move(abortException), protectedReason = WTF::move(protectedReason)](bool success) mutable {
+        [weakThis = WeakPtr { *this }, abortException = WTF::move(abortException), protectedReason = WTF::move(protectedReason)](bool success) mutable {
             if (!success)
-                LOG(DigitalCredentials, "Failed to dismiss the credentials picker.");
+                LOG(DigitalCredentials, "Failed to dismiss the credentials chooser.");
 
-            if (auto* rawThis = weakThis.get())
-                rawThis->setInteractionState(InteractionState::Idle);
-
-            if (!promise)
+            RefPtr protectedThis = weakThis.get();
+            if (!protectedThis)
                 return;
 
-            if (abortException)
-                return promise->reject(WTF::move(*abortException));
+            queueTaskKeepingObjectAlive(*protectedThis, TaskSource::DOMManipulation, [abortException = WTF::move(abortException), protectedReason = WTF::move(protectedReason)](auto& coordinator) mutable {
+                if (!coordinator.hasCurrentPromise()) {
+                    coordinator.setInteractionState(InteractionState::Idle);
+                    return;
+                }
 
-            if (protectedReason)
-                return promise->rejectType<IDLAny>(protectedReason->get());
+                auto promise = WTF::move(coordinator.m_currentPromise);
 
-            promise->reject(ExceptionCode::AbortError);
+                if (abortException)
+                    promise->reject(WTF::move(*abortException));
+                else if (protectedReason)
+                    promise->template rejectType<IDLAny>(protectedReason->get());
+                else
+                    promise->reject(ExceptionCode::AbortError);
+
+                coordinator.setInteractionState(InteractionState::Idle);
+            });
         });
 }
 
@@ -368,6 +392,7 @@ void CredentialRequestCoordinator::contextDestroyed()
 {
     LOG(DigitalCredentials, "The context we were observing got destroyed");
     abortTheCredentialRequest(Exception { ExceptionCode::AbortError, "script execution context was destroyed."_s });
+    ActiveDOMObject::contextDestroyed();
 };
 
 CredentialRequestCoordinator::~CredentialRequestCoordinator()

--- a/Source/WebCore/Modules/identity/CredentialRequestCoordinator.cpp
+++ b/Source/WebCore/Modules/identity/CredentialRequestCoordinator.cpp
@@ -127,7 +127,7 @@ CredentialPromise* CredentialRequestCoordinator::currentPromise()
 void CredentialRequestCoordinator::prepareCredentialRequests(const Document& document, CredentialPromise&& promise, Vector<UnvalidatedDigitalCredentialRequest>&& unvalidatedRequests, RefPtr<AbortSignal> signal)
 {
     if (m_interactionState != InteractionState::Idle)
-        return promise.reject(ExceptionCode::InvalidStateError, "A credential picker operation is already in progress."_s);
+        return promise.reject(ExceptionCode::NotAllowedError, "A credential request is already in progress."_s);
 
     ASSERT(!m_currentPromise);
     setInteractionState(InteractionState::Requesting);

--- a/Source/WebCore/Modules/identity/CredentialRequestCoordinator.cpp
+++ b/Source/WebCore/Modules/identity/CredentialRequestCoordinator.cpp
@@ -204,7 +204,7 @@ void CredentialRequestCoordinator::initiateTheCredentialRequest(Expected<Digital
     auto& responseData = responseOrException.value();
 
     if (responseData.responseDataJSON.isEmpty())
-        return rejectTheCredentialRequestWith(Exception { ExceptionCode::AbortError, "User aborted the operation."_s });
+        return rejectTheCredentialRequestWith(Exception { ExceptionCode::NotAllowedError, "The user cancelled the credential request."_s });
 
     auto parsedObject = parseDigitalCredentialsResponseData(responseData.responseDataJSON);
 

--- a/Source/WebCore/Modules/identity/CredentialRequestCoordinator.cpp
+++ b/Source/WebCore/Modules/identity/CredentialRequestCoordinator.cpp
@@ -68,49 +68,49 @@ CredentialRequestCoordinator::CredentialRequestCoordinator(Ref<CredentialRequest
 {
 }
 
-CredentialRequestCoordinator::PickerStateGuard::PickerStateGuard(CredentialRequestCoordinator& coordinator)
+CredentialRequestCoordinator::InteractionStateGuard::InteractionStateGuard(CredentialRequestCoordinator& coordinator)
     : m_coordinator(coordinator)
 {
-    ASSERT(coordinator.currentState() == PickerState::Presenting);
+    ASSERT(coordinator.interactionState() == InteractionState::Requesting);
 }
 
-CredentialRequestCoordinator::PickerStateGuard::~PickerStateGuard()
+CredentialRequestCoordinator::InteractionStateGuard::~InteractionStateGuard()
 {
     if (!m_active)
         return;
 
-    ASSERT(m_coordinator->currentState() == PickerState::Presenting
-        || m_coordinator->currentState() == PickerState::Aborting);
+    ASSERT(m_coordinator->interactionState() == InteractionState::Requesting
+        || m_coordinator->interactionState() == InteractionState::Aborting);
 
-    m_coordinator->setState(PickerState::Idle);
+    m_coordinator->setInteractionState(InteractionState::Idle);
 }
 
-CredentialRequestCoordinator::PickerState CredentialRequestCoordinator::currentState() const
+CredentialRequestCoordinator::InteractionState CredentialRequestCoordinator::interactionState() const
 {
-    return m_state;
+    return m_interactionState;
 }
 
-bool CredentialRequestCoordinator::canTransitionTo(PickerState newState) const
+bool CredentialRequestCoordinator::canTransitionTo(InteractionState newState) const
 {
-    switch (m_state) {
-    case PickerState::Idle:
-        return newState == PickerState::Presenting;
-    case PickerState::Presenting:
-        return newState == PickerState::Aborting || newState == PickerState::Idle;
-    case PickerState::Aborting:
-        return newState == PickerState::Idle;
+    switch (m_interactionState) {
+    case InteractionState::Idle:
+        return newState == InteractionState::Requesting;
+    case InteractionState::Requesting:
+        return newState == InteractionState::Aborting || newState == InteractionState::Idle;
+    case InteractionState::Aborting:
+        return newState == InteractionState::Idle;
     }
     ASSERT_NOT_REACHED();
     return false;
 }
 
-void CredentialRequestCoordinator::setState(PickerState newState)
+void CredentialRequestCoordinator::setInteractionState(InteractionState newState)
 {
-    if (m_state == newState)
+    if (m_interactionState == newState)
         return;
 
     ASSERT(canTransitionTo(newState));
-    m_state = newState;
+    m_interactionState = newState;
 }
 
 void CredentialRequestCoordinator::setCurrentPromise(CredentialPromise&& promise)
@@ -124,9 +124,9 @@ CredentialPromise* CredentialRequestCoordinator::currentPromise()
     return m_currentPromise.get();
 }
 
-void CredentialRequestCoordinator::prepareCredentialRequest(const Document& document, CredentialPromise&& promise, Vector<UnvalidatedDigitalCredentialRequest>&& unvalidatedRequests, RefPtr<AbortSignal> signal)
+void CredentialRequestCoordinator::prepareCredentialRequests(const Document& document, CredentialPromise&& promise, Vector<UnvalidatedDigitalCredentialRequest>&& unvalidatedRequests, RefPtr<AbortSignal> signal)
 {
-    if (m_state != PickerState::Idle)
+    if (m_interactionState != InteractionState::Idle)
         return promise.reject(ExceptionCode::InvalidStateError, "A credential picker operation is already in progress."_s);
 
     if (!m_page)
@@ -150,7 +150,7 @@ void CredentialRequestCoordinator::prepareCredentialRequest(const Document& docu
             if (!weakThis)
                 return;
             LOG(DigitalCredentials, "Credential picker was aborted by AbortSignal");
-            weakThis->abortPicker(ExceptionOr<JSC::JSValue> { WTF::move(reason) });
+            weakThis->abortTheCredentialRequest(ExceptionOr<JSC::JSValue> { WTF::move(reason) });
         });
     }
 
@@ -163,29 +163,29 @@ void CredentialRequestCoordinator::prepareCredentialRequest(const Document& docu
     if (requestDataAndRawRequests.hasException())
         return promise.reject(requestDataAndRawRequests.releaseException());
 
-    setState(PickerState::Presenting);
+    setInteractionState(InteractionState::Requesting);
     observeContext(protect(document.scriptExecutionContext()).get());
 
     auto [requestData, rawRequests] = requestDataAndRawRequests.releaseReturnValue();
 
-    m_client->showDigitalCredentialsPicker(
+    m_client->showDigitalCredentialsChooser(
         WTF::move(rawRequests),
         requestData,
         [weakThis = WeakPtr { *this }, signal](Expected<DigitalCredentialsResponseData, ExceptionData>&& responseOrException) {
             if (RefPtr protectedThis = weakThis.get())
-                protectedThis->handleDigitalCredentialsPickerResult(WTF::move(responseOrException), signal);
+                protectedThis->initiateTheCredentialRequest(WTF::move(responseOrException), signal);
         });
 }
 
-void CredentialRequestCoordinator::handleDigitalCredentialsPickerResult(Expected<DigitalCredentialsResponseData, ExceptionData>&& responseOrException, RefPtr<AbortSignal> signal)
+void CredentialRequestCoordinator::initiateTheCredentialRequest(Expected<DigitalCredentialsResponseData, ExceptionData>&& responseOrException, RefPtr<AbortSignal> signal)
 {
     if (signal && signal->aborted()) {
         LOG(DigitalCredentials, "Credential picker result received after AbortSignal aborted");
-        abortPicker(ExceptionOr<JSC::JSValue> { signal->reason().getValue() });
+        abortTheCredentialRequest(ExceptionOr<JSC::JSValue> { signal->reason().getValue() });
         return;
     }
 
-    PickerStateGuard guard(*this);
+    InteractionStateGuard guard(*this);
 
     if (!m_currentPromise) {
         LOG(DigitalCredentials, "No current promise in coordinator.");
@@ -196,25 +196,25 @@ void CredentialRequestCoordinator::handleDigitalCredentialsPickerResult(Expected
     guard.deactivate();
 
     if (!responseOrException)
-        return dismissPickerAndSettle(responseOrException.error().toException());
+        return rejectTheCredentialRequestWith(responseOrException.error().toException());
 
     auto& responseData = responseOrException.value();
 
     if (responseData.responseDataJSON.isEmpty())
-        return dismissPickerAndSettle(Exception { ExceptionCode::AbortError, "User aborted the operation."_s });
+        return rejectTheCredentialRequestWith(Exception { ExceptionCode::AbortError, "User aborted the operation."_s });
 
     auto parsedObject = parseDigitalCredentialsResponseData(responseData.responseDataJSON);
 
     if (parsedObject.hasException())
-        return dismissPickerAndSettle(parsedObject.releaseException());
+        return rejectTheCredentialRequestWith(parsedObject.releaseException());
 
     if (!parsedObject.returnValue())
-        return dismissPickerAndSettle(Exception { ExceptionCode::TypeError, "No parsed object."_s });
+        return rejectTheCredentialRequestWith(Exception { ExceptionCode::TypeError, "No parsed object."_s });
 
     auto returnValue = parsedObject.releaseReturnValue();
     Ref credential = DigitalCredential::create({ returnValue->vm(), returnValue }, responseData.protocol);
 
-    dismissPickerAndSettle(credential.ptr());
+    rejectTheCredentialRequestWith(credential.ptr());
 }
 
 ExceptionOr<JSC::JSObject*> CredentialRequestCoordinator::parseDigitalCredentialsResponseData(const String& responseDataJSON) const
@@ -253,21 +253,21 @@ ExceptionOr<JSC::JSObject*> CredentialRequestCoordinator::parseDigitalCredential
     return parsedJSON.getObject();
 }
 
-void CredentialRequestCoordinator::dismissPickerAndSettle(ExceptionOr<RefPtr<BasicCredential>>&& result)
+void CredentialRequestCoordinator::rejectTheCredentialRequestWith(ExceptionOr<RefPtr<BasicCredential>>&& result)
 {
     clearAbortAlgorithm();
 
     auto promise = WTF::move(m_currentPromise);
     m_currentPromise.reset();
 
-    ASSERT(m_state == PickerState::Presenting || m_state == PickerState::Aborting);
+    ASSERT(m_interactionState == InteractionState::Requesting || m_interactionState == InteractionState::Aborting);
 
-    m_client->dismissDigitalCredentialsPicker([weakThis = WeakPtr { *this }, promise = WTF::move(promise), result = WTF::move(result)](bool success) mutable {
+    m_client->dismissDigitalCredentialsChooser([weakThis = WeakPtr { *this }, promise = WTF::move(promise), result = WTF::move(result)](bool success) mutable {
         if (!success)
             LOG(DigitalCredentials, "Failed to dismiss the credentials picker.");
 
         if (auto* rawThis = weakThis.get())
-            rawThis->setState(PickerState::Idle);
+            rawThis->setInteractionState(InteractionState::Idle);
 
         if (!promise)
             return;
@@ -292,10 +292,10 @@ void CredentialRequestCoordinator::clearAbortAlgorithm()
     m_abortSignal = nullptr;
 }
 
-void CredentialRequestCoordinator::abortPicker(ExceptionOr<JSC::JSValue>&& reason)
+void CredentialRequestCoordinator::abortTheCredentialRequest(ExceptionOr<JSC::JSValue>&& reason)
 {
     clearAbortAlgorithm();
-    if (m_state == PickerState::Idle) {
+    if (m_interactionState == InteractionState::Idle) {
         // No UI teardown needed. Settle (defensively) and return.
         if (m_currentPromise) {
             if (reason.hasException())
@@ -307,17 +307,17 @@ void CredentialRequestCoordinator::abortPicker(ExceptionOr<JSC::JSValue>&& reaso
         return;
     }
 
-    if (m_state == PickerState::Aborting) {
+    if (m_interactionState == InteractionState::Aborting) {
         ASSERT(!m_currentPromise);
         return;
     }
 
-    if (m_state != PickerState::Presenting) {
+    if (m_interactionState != InteractionState::Requesting) {
         LOG(DigitalCredentials, "Cannot abort the credentials picker when it is not presenting.");
         return;
     }
 
-    setState(PickerState::Aborting);
+    setInteractionState(InteractionState::Aborting);
 
     auto promise = WTF::move(m_currentPromise);
     m_currentPromise.reset();
@@ -340,13 +340,13 @@ void CredentialRequestCoordinator::abortPicker(ExceptionOr<JSC::JSValue>&& reaso
         }
     }
 
-    m_client->dismissDigitalCredentialsPicker(
+    m_client->dismissDigitalCredentialsChooser(
         [weakThis = WeakPtr { *this }, promise = WTF::move(promise), abortException = WTF::move(abortException), protectedReason = WTF::move(protectedReason)](bool success) mutable {
             if (!success)
                 LOG(DigitalCredentials, "Failed to dismiss the credentials picker.");
 
             if (auto* rawThis = weakThis.get())
-                rawThis->setState(PickerState::Idle);
+                rawThis->setInteractionState(InteractionState::Idle);
 
             if (!promise)
                 return;
@@ -364,7 +364,7 @@ void CredentialRequestCoordinator::abortPicker(ExceptionOr<JSC::JSValue>&& reaso
 void CredentialRequestCoordinator::contextDestroyed()
 {
     LOG(DigitalCredentials, "The context we were observing got destroyed");
-    abortPicker(Exception { ExceptionCode::AbortError, "script execution context was destroyed."_s });
+    abortTheCredentialRequest(Exception { ExceptionCode::AbortError, "script execution context was destroyed."_s });
 };
 
 CredentialRequestCoordinator::~CredentialRequestCoordinator()

--- a/Source/WebCore/Modules/identity/CredentialRequestCoordinator.cpp
+++ b/Source/WebCore/Modules/identity/CredentialRequestCoordinator.cpp
@@ -129,8 +129,12 @@ void CredentialRequestCoordinator::prepareCredentialRequests(const Document& doc
     if (m_interactionState != InteractionState::Idle)
         return promise.reject(ExceptionCode::InvalidStateError, "A credential picker operation is already in progress."_s);
 
+    ASSERT(!m_currentPromise);
+    setInteractionState(InteractionState::Requesting);
+    setCurrentPromise(WTF::move(promise));
+
     if (!m_page)
-        return promise.reject(ExceptionCode::AbortError, "Page was destroyed."_s);
+        return rejectTheCredentialRequestWith(Exception { ExceptionCode::AbortError, "Page was destroyed."_s });
 
     auto validatedRequestsOrException = m_client->validateAndParseDigitalCredentialRequests(
         protect(document.topOrigin()),
@@ -138,18 +142,20 @@ void CredentialRequestCoordinator::prepareCredentialRequests(const Document& doc
         unvalidatedRequests);
 
     if (validatedRequestsOrException.hasException())
-        return promise.reject(validatedRequestsOrException.releaseException());
+        return rejectTheCredentialRequestWith(validatedRequestsOrException.releaseException());
 
-    setCurrentPromise(WTF::move(promise));
+    auto validatedCredentialRequests = validatedRequestsOrException.releaseReturnValue();
+
+    if (validatedCredentialRequests.isEmpty())
+        return rejectTheCredentialRequestWith(Exception { ExceptionCode::TypeError, "No supported credential requests after validation."_s });
 
     if (signal) {
-        // CredentialsContainer handled rejecting pre-aborted signal
         ASSERT(!signal->aborted());
         m_abortSignal = signal;
         m_abortAlgorithmIdentifier = signal->addAlgorithm([weakThis = WeakPtr { *this }, signal = RefPtr { signal }](JSC::JSValue reason) {
             if (!weakThis)
                 return;
-            LOG(DigitalCredentials, "Credential picker was aborted by AbortSignal");
+            LOG(DigitalCredentials, "Credential request was aborted by AbortSignal");
             weakThis->abortTheCredentialRequest(ExceptionOr<JSC::JSValue> { WTF::move(reason) });
         });
     }
@@ -157,13 +163,10 @@ void CredentialRequestCoordinator::prepareCredentialRequests(const Document& doc
     if (signal && signal->aborted())
         return;
 
-    auto validatedCredentialRequests = validatedRequestsOrException.releaseReturnValue();
-
     auto requestDataAndRawRequests = DigitalCredentialsRequestDataBuilder::build(validatedCredentialRequests, document, WTF::move(unvalidatedRequests));
     if (requestDataAndRawRequests.hasException())
-        return promise.reject(requestDataAndRawRequests.releaseException());
+        return rejectTheCredentialRequestWith(requestDataAndRawRequests.releaseException());
 
-    setInteractionState(InteractionState::Requesting);
     observeContext(protect(document.scriptExecutionContext()).get());
 
     auto [requestData, rawRequests] = requestDataAndRawRequests.releaseReturnValue();

--- a/Source/WebCore/Modules/identity/CredentialRequestCoordinator.h
+++ b/Source/WebCore/Modules/identity/CredentialRequestCoordinator.h
@@ -67,7 +67,7 @@ public:
     void contextDestroyed() final;
 
 private:
-    void rejectTheCredentialRequestWith(ExceptionOr<RefPtr<BasicCredential>>&&);
+    void rejectTheCredentialRequestWith(Exception&&);
     void clearAbortAlgorithm();
 
     class InteractionStateGuard final {

--- a/Source/WebCore/Modules/identity/CredentialRequestCoordinator.h
+++ b/Source/WebCore/Modules/identity/CredentialRequestCoordinator.h
@@ -57,8 +57,8 @@ class CredentialRequestCoordinator final : public RefCounted<CredentialRequestCo
 
 public:
     static Ref<CredentialRequestCoordinator> create(Ref<CredentialRequestCoordinatorClient>&&, Page&);
-    WEBCORE_EXPORT void prepareCredentialRequest(const Document&, CredentialPromise&&, Vector<UnvalidatedDigitalCredentialRequest>&&, RefPtr<AbortSignal>);
-    WEBCORE_EXPORT void abortPicker(ExceptionOr<JSC::JSValue>&&);
+    WEBCORE_EXPORT void prepareCredentialRequests(const Document&, CredentialPromise&&, Vector<UnvalidatedDigitalCredentialRequest>&&, RefPtr<AbortSignal>);
+    WEBCORE_EXPORT void abortTheCredentialRequest(ExceptionOr<JSC::JSValue>&&);
     ~CredentialRequestCoordinator();
 
     void ref() const final { RefCounted::ref(); }
@@ -67,45 +67,45 @@ public:
     void contextDestroyed() final;
 
 private:
-    void dismissPickerAndSettle(ExceptionOr<RefPtr<BasicCredential>>&&);
+    void rejectTheCredentialRequestWith(ExceptionOr<RefPtr<BasicCredential>>&&);
     void clearAbortAlgorithm();
 
-    class PickerStateGuard final {
+    class InteractionStateGuard final {
     public:
-        explicit PickerStateGuard(CredentialRequestCoordinator&);
-        PickerStateGuard(const PickerStateGuard&) = delete;
-        PickerStateGuard& operator=(const PickerStateGuard&) = delete;
+        explicit InteractionStateGuard(CredentialRequestCoordinator&);
+        InteractionStateGuard(const InteractionStateGuard&) = delete;
+        InteractionStateGuard& operator=(const InteractionStateGuard&) = delete;
         void deactivate() { m_active = false; }
 
-        PickerStateGuard(PickerStateGuard&&) noexcept = delete;
-        PickerStateGuard& operator=(PickerStateGuard&&) noexcept = delete;
+        InteractionStateGuard(InteractionStateGuard&&) noexcept = delete;
+        InteractionStateGuard& operator=(InteractionStateGuard&&) noexcept = delete;
 
-        ~PickerStateGuard();
+        ~InteractionStateGuard();
 
     private:
         WeakRef<CredentialRequestCoordinator> m_coordinator;
         bool m_active { true };
-    }; // class PickerStateGuard
+    }; // class InteractionStateGuard
 
-    enum class PickerState : uint8_t {
+    enum class InteractionState : uint8_t {
         Idle,
-        Presenting,
+        Requesting,
         Aborting
-    }; // enum class PickerState
+    }; // enum class InteractionState
 
-    bool NODELETE canTransitionTo(PickerState) const;
-    PickerState NODELETE currentState() const;
-    void NODELETE setState(PickerState);
+    bool NODELETE canTransitionTo(InteractionState) const;
+    InteractionState NODELETE interactionState() const;
+    void NODELETE setInteractionState(InteractionState);
     bool hasCurrentPromise() const { return !!m_currentPromise; }
     void setCurrentPromise(CredentialPromise&&);
     CredentialPromise* NODELETE currentPromise();
 
     ExceptionOr<JSC::JSObject*> parseDigitalCredentialsResponseData(const String&) const;
-    void handleDigitalCredentialsPickerResult(Expected<DigitalCredentialsResponseData, ExceptionData>&& responseOrException, RefPtr<AbortSignal>);
+    void initiateTheCredentialRequest(Expected<DigitalCredentialsResponseData, ExceptionData>&& responseOrException, RefPtr<AbortSignal>);
 
     explicit CredentialRequestCoordinator(Ref<CredentialRequestCoordinatorClient>&&, Page&);
     const Ref<CredentialRequestCoordinatorClient> m_client;
-    PickerState m_state { PickerState::Idle };
+    InteractionState m_interactionState { InteractionState::Idle };
     RefPtr<AbortSignal> m_abortSignal;
     std::unique_ptr<CredentialPromise> m_currentPromise;
     std::optional<uint32_t> m_abortAlgorithmIdentifier;

--- a/Source/WebCore/Modules/identity/CredentialRequestCoordinatorClient.h
+++ b/Source/WebCore/Modules/identity/CredentialRequestCoordinatorClient.h
@@ -52,8 +52,8 @@ class CredentialRequestCoordinatorClient : public RefCounted<CredentialRequestCo
 public:
     CredentialRequestCoordinatorClient() = default;
     virtual ~CredentialRequestCoordinatorClient() = default;
-    virtual void showDigitalCredentialsPicker(DigitalCredentialsRawRequests&&, const DigitalCredentialsRequestData&, CompletionHandler<void(Expected<DigitalCredentialsResponseData, ExceptionData>&&)>&&) = 0;
-    virtual void dismissDigitalCredentialsPicker(CompletionHandler<void(bool)>&&) = 0;
+    virtual void showDigitalCredentialsChooser(DigitalCredentialsRawRequests&&, const DigitalCredentialsRequestData&, CompletionHandler<void(Expected<DigitalCredentialsResponseData, ExceptionData>&&)>&&) = 0;
+    virtual void dismissDigitalCredentialsChooser(CompletionHandler<void(bool)>&&) = 0;
     virtual ExceptionOr<Vector<ValidatedDigitalCredentialRequest>> validateAndParseDigitalCredentialRequests(const SecurityOrigin&, const Document&, const Vector<UnvalidatedDigitalCredentialRequest>&) = 0;
 
     void ref() const { RefCounted::ref(); }

--- a/Source/WebCore/Modules/identity/DigitalCredential.cpp
+++ b/Source/WebCore/Modules/identity/DigitalCredential.cpp
@@ -180,7 +180,7 @@ void DigitalCredential::discoverFromExternalSource(const Document& document, Cre
     }
 
     Ref coordinator = page->credentialRequestCoordinator();
-    coordinator->prepareCredentialRequest(document, WTF::move(promise), presentationRequestsOrException.releaseReturnValue(), options.signal);
+    coordinator->prepareCredentialRequests(document, WTF::move(promise), presentationRequestsOrException.releaseReturnValue(), options.signal);
 }
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/identity/dummy/DummyCredentialRequestCoordinatorClient.cpp
+++ b/Source/WebCore/Modules/identity/dummy/DummyCredentialRequestCoordinatorClient.cpp
@@ -45,12 +45,12 @@ Ref<DummyCredentialRequestCoordinatorClient> DummyCredentialRequestCoordinatorCl
     return adoptRef(*new DummyCredentialRequestCoordinatorClient);
 }
 
-void DummyCredentialRequestCoordinatorClient::showDigitalCredentialsPicker(DigitalCredentialsRawRequests&&, const DigitalCredentialsRequestData&, CompletionHandler<void(Expected<DigitalCredentialsResponseData, ExceptionData>&&)>&& completionHandler)
+void DummyCredentialRequestCoordinatorClient::showDigitalCredentialsChooser(DigitalCredentialsRawRequests&&, const DigitalCredentialsRequestData&, CompletionHandler<void(Expected<DigitalCredentialsResponseData, ExceptionData>&&)>&& completionHandler)
 {
     completionHandler(makeUnexpected(WebCore::ExceptionData { WebCore::ExceptionCode::NotSupportedError, "Empty client."_s }));
 }
 
-void DummyCredentialRequestCoordinatorClient::dismissDigitalCredentialsPicker(CompletionHandler<void(bool)>&& completionHandler)
+void DummyCredentialRequestCoordinatorClient::dismissDigitalCredentialsChooser(CompletionHandler<void(bool)>&& completionHandler)
 {
     completionHandler(false);
 }

--- a/Source/WebCore/Modules/identity/dummy/DummyCredentialRequestCoordinatorClient.h
+++ b/Source/WebCore/Modules/identity/dummy/DummyCredentialRequestCoordinatorClient.h
@@ -45,8 +45,8 @@ public:
     static Ref<DummyCredentialRequestCoordinatorClient> create();
 
 private:
-    void showDigitalCredentialsPicker(DigitalCredentialsRawRequests&&, const DigitalCredentialsRequestData&, CompletionHandler<void(Expected<DigitalCredentialsResponseData, ExceptionData>&&)>&&);
-    void dismissDigitalCredentialsPicker(CompletionHandler<void(bool)>&&) final;
+    void showDigitalCredentialsChooser(DigitalCredentialsRawRequests&&, const DigitalCredentialsRequestData&, CompletionHandler<void(Expected<DigitalCredentialsResponseData, ExceptionData>&&)>&&);
+    void dismissDigitalCredentialsChooser(CompletionHandler<void(bool)>&&) final;
     ExceptionOr<Vector<ValidatedDigitalCredentialRequest>> validateAndParseDigitalCredentialRequests(const SecurityOrigin&, const Document&, const Vector<UnvalidatedDigitalCredentialRequest>&) final;
 };
 

--- a/Source/WebCore/loader/EmptyClients.cpp
+++ b/Source/WebCore/loader/EmptyClients.cpp
@@ -497,14 +497,14 @@ public:
         return adoptRef(*new EmptyCredentialRequestCoordinatorClient);
     }
 
-    void showDigitalCredentialsPicker(DigitalCredentialsRawRequests&&, const DigitalCredentialsRequestData&, CompletionHandler<void(Expected<DigitalCredentialsResponseData, ExceptionData>&&)>&& completionHandler)
+    void showDigitalCredentialsChooser(DigitalCredentialsRawRequests&&, const DigitalCredentialsRequestData&, CompletionHandler<void(Expected<DigitalCredentialsResponseData, ExceptionData>&&)>&& completionHandler)
     {
         callOnMainThread([completionHandler = WTF::move(completionHandler)]() mutable {
             completionHandler(makeUnexpected(ExceptionData { ExceptionCode::NotSupportedError, "Empty client."_s }));
         });
     }
 
-    void dismissDigitalCredentialsPicker(CompletionHandler<void(bool)>&& completionHandler) final
+    void dismissDigitalCredentialsChooser(CompletionHandler<void(bool)>&& completionHandler) final
     {
         callOnMainThread([completionHandler = WTF::move(completionHandler)]() mutable {
             completionHandler(false);

--- a/Source/WebCore/page/Chrome.cpp
+++ b/Source/WebCore/page/Chrome.cpp
@@ -458,14 +458,14 @@ void Chrome::showContactPicker(ContactsRequestData&& requestData, CompletionHand
 }
 
 #if ENABLE(WEB_AUTHN)
-void Chrome::showDigitalCredentialsPicker(const DigitalCredentialsRequestData& requestData, WTF::CompletionHandler<void(Expected<WebCore::DigitalCredentialsResponseData, WebCore::ExceptionData>&&)>&& callback)
+void Chrome::showDigitalCredentialsChooser(const DigitalCredentialsRequestData& requestData, WTF::CompletionHandler<void(Expected<WebCore::DigitalCredentialsResponseData, WebCore::ExceptionData>&&)>&& callback)
 {
-    m_client->showDigitalCredentialsPicker(requestData, WTF::move(callback));
+    m_client->showDigitalCredentialsChooser(requestData, WTF::move(callback));
 }
 
-void Chrome::dismissDigitalCredentialsPicker(CompletionHandler<void(bool)>&& callback)
+void Chrome::dismissDigitalCredentialsChooser(CompletionHandler<void(bool)>&& callback)
 {
-    m_client->dismissDigitalCredentialsPicker(WTF::move(callback));
+    m_client->dismissDigitalCredentialsChooser(WTF::move(callback));
 }
 #endif
 

--- a/Source/WebCore/page/Chrome.h
+++ b/Source/WebCore/page/Chrome.h
@@ -210,8 +210,8 @@ public:
     void showContactPicker(ContactsRequestData&&, CompletionHandler<void(std::optional<Vector<ContactInfo>>&&)>&&);
 
 #if ENABLE(WEB_AUTHN)
-    void showDigitalCredentialsPicker(const DigitalCredentialsRequestData&, WTF::CompletionHandler<void(Expected<WebCore::DigitalCredentialsResponseData, WebCore::ExceptionData>&&)>&&);
-    void dismissDigitalCredentialsPicker(CompletionHandler<void(bool)>&&);
+    void showDigitalCredentialsChooser(const DigitalCredentialsRequestData&, WTF::CompletionHandler<void(Expected<WebCore::DigitalCredentialsResponseData, WebCore::ExceptionData>&&)>&&);
+    void dismissDigitalCredentialsChooser(CompletionHandler<void(bool)>&&);
 #endif
 
     void loadIconForFiles(const Vector<String>&, FileIconLoader&);

--- a/Source/WebCore/page/ChromeClient.h
+++ b/Source/WebCore/page/ChromeClient.h
@@ -426,12 +426,12 @@ public:
     virtual void showContactPicker(ContactsRequestData&&, CompletionHandler<void(std::optional<Vector<ContactInfo>>&&)>&& callback) { callback(std::nullopt); }
 
 #if ENABLE(WEB_AUTHN)
-    virtual void showDigitalCredentialsPicker(const DigitalCredentialsRequestData&, CompletionHandler<void(Expected<DigitalCredentialsResponseData, ExceptionData>&&)>&& completionHandler)
+    virtual void showDigitalCredentialsChooser(const DigitalCredentialsRequestData&, CompletionHandler<void(Expected<DigitalCredentialsResponseData, ExceptionData>&&)>&& completionHandler)
     {
         completionHandler(makeUnexpected(ExceptionData { ExceptionCode::NotSupportedError, "Digital credentials are not supported."_s }));
     }
 
-    virtual void dismissDigitalCredentialsPicker(CompletionHandler<void(bool)>&& completionHandler)
+    virtual void dismissDigitalCredentialsChooser(CompletionHandler<void(bool)>&& completionHandler)
     {
         completionHandler(false);
     }

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
@@ -349,15 +349,15 @@ RetainPtr<NSError> nsErrorFromExceptionDetails(const std::optional<WebCore::Exce
 WK_OBJECT_DISABLE_DISABLE_KVC_IVAR_ACCESS;
 
 #if ENABLE(WEB_AUTHN)
-- (void)_showDigitalCredentialsPicker:(const WebCore::DigitalCredentialsRequestData&)requestData completionHandler:(WTF::CompletionHandler<void(Expected<WebCore::DigitalCredentialsResponseData, WebCore::ExceptionData>&&)>&&)completionHandler
+- (void)_showDigitalCredentialsChooser:(const WebCore::DigitalCredentialsRequestData&)requestData completionHandler:(WTF::CompletionHandler<void(Expected<WebCore::DigitalCredentialsResponseData, WebCore::ExceptionData>&&)>&&)completionHandler
 {
-    LOG(DigitalCredentials, "Did not show digital credentials picker because it is not implemented.");
-    completionHandler(makeUnexpected(WebCore::ExceptionData { WebCore::ExceptionCode::NotSupportedError, "Digital credentials picker not implemented."_s }));
+    LOG(DigitalCredentials, "Did not show digital credentials chooser because it is not implemented.");
+    completionHandler(makeUnexpected(WebCore::ExceptionData { WebCore::ExceptionCode::NotSupportedError, "Digital credentials chooser not implemented."_s }));
 }
 
-- (void)_dismissDigitalCredentialsPicker:(WTF::CompletionHandler<void(bool)>&&)completionHandler
+- (void)_dismissDigitalCredentialsChooser:(WTF::CompletionHandler<void(bool)>&&)completionHandler
 {
-    LOG(DigitalCredentials, "Did not dismiss digital credentials picker because it is not implemented.");
+    LOG(DigitalCredentials, "Did not dismiss digital credentials chooser because it is not implemented.");
     completionHandler(false);
 }
 #endif // ENABLE(WEB_AUTHN)

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h
@@ -645,8 +645,8 @@ struct PerWebProcessState {
 - (void)_didAccessBackForwardList NS_DIRECT;
 
 #if ENABLE(WEB_AUTHN)
-- (void)_showDigitalCredentialsPicker:(const WebCore::DigitalCredentialsRequestData&)requestData completionHandler:(WTF::CompletionHandler<void(Expected<WebCore::DigitalCredentialsResponseData, WebCore::ExceptionData>&&)>&&)completionHandler;
-- (void)_dismissDigitalCredentialsPicker:(WTF::CompletionHandler<void(bool)>&&)completionHandler;
+- (void)_showDigitalCredentialsChooser:(const WebCore::DigitalCredentialsRequestData&)requestData completionHandler:(WTF::CompletionHandler<void(Expected<WebCore::DigitalCredentialsResponseData, WebCore::ExceptionData>&&)>&&)completionHandler;
+- (void)_dismissDigitalCredentialsChooser:(WTF::CompletionHandler<void(bool)>&&)completionHandler;
 #endif
 
 #if ENABLE(CONTENT_INSET_BACKGROUND_FILL)

--- a/Source/WebKit/UIProcess/DigitalCredentials/WKDigitalCredentialsPicker.mm
+++ b/Source/WebKit/UIProcess/DigitalCredentials/WKDigitalCredentialsPicker.mm
@@ -385,7 +385,7 @@ static RetainPtr<NSArray<NSArray<WKIdentityDocumentPresentmentRequestAuthenticat
 {
     if (!response && !error) {
         LOG(DigitalCredentials, "No response or error from document provider.");
-        WebCore::ExceptionData exceptionData = { ExceptionCode::UnknownError, "No response from document provider."_s };
+        WebCore::ExceptionData exceptionData = { ExceptionCode::OperationError, "No response from document provider."_s };
         [self completeWith:makeUnexpected(exceptionData)];
         return;
     }
@@ -439,12 +439,9 @@ static RetainPtr<NSArray<NSArray<WKIdentityDocumentPresentmentRequestAuthenticat
     case WKIdentityDocumentPresentmentErrorRequestInProgress:
         exceptionData = { ExceptionCode::InvalidStateError, "Request already in progress."_s };
         break;
-    case WKIdentityDocumentPresentmentErrorCancelled:
-        exceptionData = { ExceptionCode::AbortError, "Request was cancelled."_s };
-        break;
     default:
         LOG(DigitalCredentials, "The error code was not in the case statement? %zd.", error.code);
-        exceptionData = { ExceptionCode::UnknownError, "Some other error."_s };
+        exceptionData = { ExceptionCode::OperationError, "The credential request failed."_s };
         RetainPtr debugDescription = error.userInfo[NSDebugDescriptionErrorKey] ?: error.userInfo[NSLocalizedDescriptionKey];
         LOG(DigitalCredentials, "Internal error: %@", debugDescription ? debugDescription.get() : @"Unknown error with no description.");
         break;
@@ -457,9 +454,7 @@ static RetainPtr<NSArray<NSArray<WKIdentityDocumentPresentmentRequestAuthenticat
             consoleMessage = makeString(consoleMessage, " ("_s, String(debugDescription.get()), ")"_s);
 
         auto targetFrameID = page->focusedFrame() ? page->focusedFrame()->frameID() : page->mainFrame()->frameID();
-        auto logLevel = exceptionData.code == ExceptionCode::AbortError ? MessageLevel::Warning : MessageLevel::Error;
-
-        page->addConsoleMessage(targetFrameID, MessageSource::JS, logLevel, makeString("Digital Credential request failed: "_s, consoleMessage));
+        page->addConsoleMessage(targetFrameID, MessageSource::JS, MessageLevel::Error, makeString("Digital Credential request failed: "_s, consoleMessage));
     }
 
     [self completeWith:makeUnexpected(exceptionData)];

--- a/Source/WebKit/UIProcess/PageClient.h
+++ b/Source/WebKit/UIProcess/PageClient.h
@@ -340,11 +340,11 @@ public:
     virtual bool showShareSheet(WebCore::ShareDataWithParsedURL&&, WTF::CompletionHandler<void (bool)>&&) { return false; }
     virtual void showContactPicker(WebCore::ContactsRequestData&&, WTF::CompletionHandler<void(std::optional<Vector<WebCore::ContactInfo>>&&)>&& completionHandler) { completionHandler(std::nullopt); }
 
-    virtual void showDigitalCredentialsPicker(const WebCore::DigitalCredentialsRequestData&, WTF::CompletionHandler<void(Expected<WebCore::DigitalCredentialsResponseData, WebCore::ExceptionData>&&)>&& completionHandler)
+    virtual void showDigitalCredentialsChooser(const WebCore::DigitalCredentialsRequestData&, WTF::CompletionHandler<void(Expected<WebCore::DigitalCredentialsResponseData, WebCore::ExceptionData>&&)>&& completionHandler)
     {
         completionHandler(makeUnexpected(WebCore::ExceptionData { WebCore::ExceptionCode::NotSupportedError, "Digital credentials are not supported."_s }));
     }
-    virtual void dismissDigitalCredentialsPicker(WTF::CompletionHandler<void(bool)>&& completionHandler) { completionHandler(true); }
+    virtual void dismissDigitalCredentialsChooser(WTF::CompletionHandler<void(bool)>&& completionHandler) { completionHandler(true); }
     virtual void dismissAnyOpenPicker() { }
 
     virtual void didChangeContentSize(const WebCore::IntSize&) = 0;

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -10422,11 +10422,11 @@ void WebPageProxy::showContactPicker(IPC::Connection& connection, ContactsReques
 }
 
 #if ENABLE(WEB_AUTHN)
-void WebPageProxy::showDigitalCredentialsPicker(IPC::Connection& connection, const WebCore::DigitalCredentialsRequestData& requestData, CompletionHandler<void(Expected<WebCore::DigitalCredentialsResponseData, WebCore::ExceptionData>&&)>&& completionHandler)
+void WebPageProxy::showDigitalCredentialsChooser(IPC::Connection& connection, const WebCore::DigitalCredentialsRequestData& requestData, CompletionHandler<void(Expected<WebCore::DigitalCredentialsResponseData, WebCore::ExceptionData>&&)>&& completionHandler)
 {
     WTF::switchOn(requestData,
         [&](const auto& requestData) {
-            LOG(DigitalCredentials, "WebPageProxy::showDigitalCredentialsPicker() - UIProcess: received IPC from WebProcess for origin: %s", requestData.topOrigin.toString().utf8().data());
+            LOG(DigitalCredentials, "WebPageProxy::showDigitalCredentialsChooser() - UIProcess: received IPC from WebProcess for origin: %s", requestData.topOrigin.toString().utf8().data());
             MESSAGE_CHECK_COMPLETION_BASE(
                 protect(preferences())->digitalCredentialsEnabled(),
                 connection,
@@ -10440,8 +10440,8 @@ void WebPageProxy::showDigitalCredentialsPicker(IPC::Connection& connection, con
                 completionHandler(makeUnexpected(WebCore::ExceptionData { WebCore::ExceptionCode::SecurityError, "Digital credentials request is not same-origin with top-level navigable."_s }))
             );
 
-            LOG(DigitalCredentials, "WebPageProxy::showDigitalCredentialsPicker() - UIProcess: passing to pageClient to present picker UI");
-            protect(pageClient())->showDigitalCredentialsPicker(requestData, WTF::move(completionHandler));
+            LOG(DigitalCredentials, "WebPageProxy::showDigitalCredentialsChooser() - UIProcess: passing to pageClient to present chooser UI");
+            protect(pageClient())->showDigitalCredentialsChooser(requestData, WTF::move(completionHandler));
 #else
             completionHandler(makeUnexpected(WebCore::ExceptionData { WebCore::ExceptionCode::NotSupportedError, "Digital credentials UI is not supported."_s }));
 #endif
@@ -10457,7 +10457,7 @@ void WebPageProxy::fetchRawDigitalCredentialRequests(CompletionHandler<void(WebC
 #endif
 }
 
-void WebPageProxy::dismissDigitalCredentialsPicker(IPC::Connection& connection, CompletionHandler<void(bool)>&& completionHandler)
+void WebPageProxy::dismissDigitalCredentialsChooser(IPC::Connection& connection, CompletionHandler<void(bool)>&& completionHandler)
 {
     MESSAGE_CHECK_COMPLETION_BASE(
         protect(preferences())->digitalCredentialsEnabled(),
@@ -10465,7 +10465,7 @@ void WebPageProxy::dismissDigitalCredentialsPicker(IPC::Connection& connection, 
         completionHandler(false)
     );
 #if ENABLE(WEB_AUTHN)
-    protect(pageClient())->dismissDigitalCredentialsPicker(WTF::move(completionHandler));
+    protect(pageClient())->dismissDigitalCredentialsChooser(WTF::move(completionHandler));
 #else
     completionHandler(false);
 #endif

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -2381,9 +2381,9 @@ public:
     void setMockWebAuthenticationConfiguration(WebCore::MockWebAuthenticationConfiguration&&);
 
     // Digital Credentials API
-    void dismissDigitalCredentialsPicker(IPC::Connection&, CompletionHandler<void(bool)>&&);
+    void dismissDigitalCredentialsChooser(IPC::Connection&, CompletionHandler<void(bool)>&&);
     void fetchRawDigitalCredentialRequests(CompletionHandler<void(WebCore::DigitalCredentialsRawRequests)>&&);
-    void showDigitalCredentialsPicker(IPC::Connection&, const WebCore::DigitalCredentialsRequestData&, CompletionHandler<void(Expected<WebCore::DigitalCredentialsResponseData, WebCore::ExceptionData>&&)>&&);
+    void showDigitalCredentialsChooser(IPC::Connection&, const WebCore::DigitalCredentialsRequestData&, CompletionHandler<void(Expected<WebCore::DigitalCredentialsResponseData, WebCore::ExceptionData>&&)>&&);
 #endif
 
     using TextManipulationItemCallback = Function<void(const Vector<WebCore::TextManipulationItem>&)>;

--- a/Source/WebKit/UIProcess/WebPageProxy.messages.in
+++ b/Source/WebKit/UIProcess/WebPageProxy.messages.in
@@ -84,12 +84,12 @@ messages -> WebPageProxy {
 
 #if ENABLE(WEB_AUTHN)
 #if ENABLE(ISO18013_DOCUMENT_REQUEST_INFO)
-    [EnabledBy=DigitalCredentialsEnabled] ShowDigitalCredentialsPicker(Variant<WebCore::DigitalCredentialsMobileDocumentRequestData, WebCore::DigitalCredentialsMobileDocumentRequestDataWithRequestInfo> requestData) -> (Expected<WebCore::DigitalCredentialsResponseData, WebCore::ExceptionData> response)
+    [EnabledBy=DigitalCredentialsEnabled] ShowDigitalCredentialsChooser(Variant<WebCore::DigitalCredentialsMobileDocumentRequestData, WebCore::DigitalCredentialsMobileDocumentRequestDataWithRequestInfo> requestData) -> (Expected<WebCore::DigitalCredentialsResponseData, WebCore::ExceptionData> response)
 #endif
 #if !ENABLE(ISO18013_DOCUMENT_REQUEST_INFO)
-    [EnabledBy=DigitalCredentialsEnabled] ShowDigitalCredentialsPicker(Variant<WebCore::DigitalCredentialsMobileDocumentRequestData> requestData) -> (Expected<WebCore::DigitalCredentialsResponseData, WebCore::ExceptionData> response)
+    [EnabledBy=DigitalCredentialsEnabled] ShowDigitalCredentialsChooser(Variant<WebCore::DigitalCredentialsMobileDocumentRequestData> requestData) -> (Expected<WebCore::DigitalCredentialsResponseData, WebCore::ExceptionData> response)
 #endif
-    [EnabledBy=DigitalCredentialsEnabled] DismissDigitalCredentialsPicker() -> (bool didDismiss)
+    [EnabledBy=DigitalCredentialsEnabled] DismissDigitalCredentialsChooser() -> (bool didDismiss)
 #endif
 
     PrintFrame(WebCore::FrameIdentifier frameID, String title, WebCore::FloatSize pdfFirstPageSize) -> () Synchronous

--- a/Source/WebKit/UIProcess/ios/PageClientImplIOS.h
+++ b/Source/WebKit/UIProcess/ios/PageClientImplIOS.h
@@ -223,8 +223,8 @@ private:
     void showContactPicker(WebCore::ContactsRequestData&&, WTF::CompletionHandler<void(std::optional<Vector<WebCore::ContactInfo>>&&)>&&) override;
 
 #if ENABLE(WEB_AUTHN)
-    void showDigitalCredentialsPicker(const WebCore::DigitalCredentialsRequestData&, WTF::CompletionHandler<void(Expected<WebCore::DigitalCredentialsResponseData, WebCore::ExceptionData>&&)>&&) override;
-    void dismissDigitalCredentialsPicker(WTF::CompletionHandler<void(bool)>&&) override;
+    void showDigitalCredentialsChooser(const WebCore::DigitalCredentialsRequestData&, WTF::CompletionHandler<void(Expected<WebCore::DigitalCredentialsResponseData, WebCore::ExceptionData>&&)>&&) override;
+    void dismissDigitalCredentialsChooser(WTF::CompletionHandler<void(bool)>&&) override;
 #endif
 
     void dismissAnyOpenPicker() override;

--- a/Source/WebKit/UIProcess/ios/PageClientImplIOS.mm
+++ b/Source/WebKit/UIProcess/ios/PageClientImplIOS.mm
@@ -850,14 +850,14 @@ void PageClientImpl::showContactPicker(WebCore::ContactsRequestData&& requestDat
 }
 
 #if ENABLE(WEB_AUTHN)
-void PageClientImpl::showDigitalCredentialsPicker(const WebCore::DigitalCredentialsRequestData& requestData, WTF::CompletionHandler<void(Expected<WebCore::DigitalCredentialsResponseData, WebCore::ExceptionData>&&)>&& completionHandler)
+void PageClientImpl::showDigitalCredentialsChooser(const WebCore::DigitalCredentialsRequestData& requestData, WTF::CompletionHandler<void(Expected<WebCore::DigitalCredentialsResponseData, WebCore::ExceptionData>&&)>&& completionHandler)
 {
-    [contentView() _showDigitalCredentialsPicker:requestData completionHandler:WTF::move(completionHandler)];
+    [contentView() _showDigitalCredentialsChooser:requestData completionHandler:WTF::move(completionHandler)];
 }
 
-void PageClientImpl::dismissDigitalCredentialsPicker(CompletionHandler<void(bool)>&& completionHandler)
+void PageClientImpl::dismissDigitalCredentialsChooser(CompletionHandler<void(bool)>&& completionHandler)
 {
-    [contentView() _dismissDigitalCredentialsPicker:WTF::move(completionHandler)];
+    [contentView() _dismissDigitalCredentialsChooser:WTF::move(completionHandler)];
 }
 #endif
 

--- a/Source/WebKit/UIProcess/ios/WKContentViewInteraction.h
+++ b/Source/WebKit/UIProcess/ios/WKContentViewInteraction.h
@@ -859,8 +859,8 @@ FOR_EACH_PRIVATE_WKCONTENTVIEW_ACTION(DECLARE_WKCONTENTVIEW_ACTION_FOR_WEB_VIEW)
 - (void)_showContactPicker:(const WebCore::ContactsRequestData&)requestData completionHandler:(WTF::CompletionHandler<void(std::optional<Vector<WebCore::ContactInfo>>&&)>&&)completionHandler;
 
 #if ENABLE(WEB_AUTHN)
-- (void)_showDigitalCredentialsPicker:(const WebCore::DigitalCredentialsRequestData&)requestData completionHandler:(WTF::CompletionHandler<void(Expected<WebCore::DigitalCredentialsResponseData, WebCore::ExceptionData>&&)>&&)completionHandler;
-- (void)_dismissDigitalCredentialsPicker:(CompletionHandler<void(bool)>&&)completionHandler;
+- (void)_showDigitalCredentialsChooser:(const WebCore::DigitalCredentialsRequestData&)requestData completionHandler:(WTF::CompletionHandler<void(Expected<WebCore::DigitalCredentialsResponseData, WebCore::ExceptionData>&&)>&&)completionHandler;
+- (void)_dismissDigitalCredentialsChooser:(CompletionHandler<void(bool)>&&)completionHandler;
 #endif
 
 - (NSArray<NSString *> *)filePickerAcceptedTypeIdentifiers;

--- a/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
+++ b/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
@@ -9904,13 +9904,13 @@ static bool canUseQuickboardControllerFor(UITextContentType type)
 #endif // HAVE(SHARE_SHEET_UI)
 
 #if ENABLE(WEB_AUTHN)
-- (void)_showDigitalCredentialsPicker:(const WebCore::DigitalCredentialsRequestData&)requestData completionHandler:(WTF::CompletionHandler<void(Expected<WebCore::DigitalCredentialsResponseData, WebCore::ExceptionData>&&)>&&)completionHandler
+- (void)_showDigitalCredentialsChooser:(const WebCore::DigitalCredentialsRequestData&)requestData completionHandler:(WTF::CompletionHandler<void(Expected<WebCore::DigitalCredentialsResponseData, WebCore::ExceptionData>&&)>&&)completionHandler
 {
     _digitalCredentialsPicker = adoptNS([[WKDigitalCredentialsPicker alloc] initWithView:self.webView page:_page.get()]);
     [_digitalCredentialsPicker presentWithRequestData:requestData completionHandler:WTF::move(completionHandler)];
 }
 
-- (void)_dismissDigitalCredentialsPicker:(WTF::CompletionHandler<void(bool)>&&)completionHandler
+- (void)_dismissDigitalCredentialsChooser:(WTF::CompletionHandler<void(bool)>&&)completionHandler
 {
     if (!_digitalCredentialsPicker) {
         LOG(DigitalCredentials, "Digital credentials picker is not presented.");

--- a/Source/WebKit/UIProcess/mac/PageClientImplMac.h
+++ b/Source/WebKit/UIProcess/mac/PageClientImplMac.h
@@ -126,8 +126,8 @@ private:
     bool showShareSheet(WebCore::ShareDataWithParsedURL&&, WTF::CompletionHandler<void(bool)>&&) override;
 
 #if ENABLE(WEB_AUTHN)
-    void showDigitalCredentialsPicker(const WebCore::DigitalCredentialsRequestData&, WTF::CompletionHandler<void(Expected<WebCore::DigitalCredentialsResponseData, WebCore::ExceptionData>&&)>&&) override;
-    void dismissDigitalCredentialsPicker(WTF::CompletionHandler<void(bool)>&&) override;
+    void showDigitalCredentialsChooser(const WebCore::DigitalCredentialsRequestData&, WTF::CompletionHandler<void(Expected<WebCore::DigitalCredentialsResponseData, WebCore::ExceptionData>&&)>&&) override;
+    void dismissDigitalCredentialsChooser(WTF::CompletionHandler<void(bool)>&&) override;
 #endif
 
     WebCore::FloatRect convertToDeviceSpace(const WebCore::FloatRect&) override;

--- a/Source/WebKit/UIProcess/mac/PageClientImplMac.mm
+++ b/Source/WebKit/UIProcess/mac/PageClientImplMac.mm
@@ -699,14 +699,14 @@ bool PageClientImpl::showShareSheet(ShareDataWithParsedURL&& shareData, WTF::Com
 }
 
 #if ENABLE(WEB_AUTHN)
-void PageClientImpl::showDigitalCredentialsPicker(const WebCore::DigitalCredentialsRequestData& requestData, WTF::CompletionHandler<void(Expected<WebCore::DigitalCredentialsResponseData, WebCore::ExceptionData>&&)>&& completionHandler)
+void PageClientImpl::showDigitalCredentialsChooser(const WebCore::DigitalCredentialsRequestData& requestData, WTF::CompletionHandler<void(Expected<WebCore::DigitalCredentialsResponseData, WebCore::ExceptionData>&&)>&& completionHandler)
 {
-    protect(m_impl)->showDigitalCredentialsPicker(requestData, WTF::move(completionHandler), webView().get());
+    protect(m_impl)->showDigitalCredentialsChooser(requestData, WTF::move(completionHandler), webView().get());
 }
 
-void PageClientImpl::dismissDigitalCredentialsPicker(WTF::CompletionHandler<void(bool)>&& completionHandler)
+void PageClientImpl::dismissDigitalCredentialsChooser(WTF::CompletionHandler<void(bool)>&& completionHandler)
 {
-    protect(m_impl)->dismissDigitalCredentialsPicker(WTF::move(completionHandler), webView().get());
+    protect(m_impl)->dismissDigitalCredentialsChooser(WTF::move(completionHandler), webView().get());
 }
 #endif
 

--- a/Source/WebKit/UIProcess/mac/WebViewImpl.h
+++ b/Source/WebKit/UIProcess/mac/WebViewImpl.h
@@ -581,8 +581,8 @@ public:
     void shareSheetDidDismiss(WKShareSheet *);
 
 #if ENABLE(WEB_AUTHN)
-    void showDigitalCredentialsPicker(const WebCore::DigitalCredentialsRequestData&, WTF::CompletionHandler<void(Expected<WebCore::DigitalCredentialsResponseData, WebCore::ExceptionData>&&)>&&, WKWebView*);
-    void dismissDigitalCredentialsPicker(WTF::CompletionHandler<void(bool)>&&, WKWebView*);
+    void showDigitalCredentialsChooser(const WebCore::DigitalCredentialsRequestData&, WTF::CompletionHandler<void(Expected<WebCore::DigitalCredentialsResponseData, WebCore::ExceptionData>&&)>&&, WKWebView*);
+    void dismissDigitalCredentialsChooser(WTF::CompletionHandler<void(bool)>&&, WKWebView*);
 #endif
 
     _WKRemoteObjectRegistry *remoteObjectRegistry();

--- a/Source/WebKit/UIProcess/mac/WebViewImpl.mm
+++ b/Source/WebKit/UIProcess/mac/WebViewImpl.mm
@@ -3065,7 +3065,7 @@ void WebViewImpl::shareSheetDidDismiss(WKShareSheet *shareSheet)
 }
 
 #if ENABLE(WEB_AUTHN)
-void WebViewImpl::showDigitalCredentialsPicker(const WebCore::DigitalCredentialsRequestData& requestData, CompletionHandler<void(Expected<WebCore::DigitalCredentialsResponseData, WebCore::ExceptionData>&&)>&& completionHandler, WKWebView* webView)
+void WebViewImpl::showDigitalCredentialsChooser(const WebCore::DigitalCredentialsRequestData& requestData, CompletionHandler<void(Expected<WebCore::DigitalCredentialsResponseData, WebCore::ExceptionData>&&)>&& completionHandler, WKWebView* webView)
 {
     if (!_digitalCredentialsPicker)
         _digitalCredentialsPicker = adoptNS([[WKDigitalCredentialsPicker alloc] initWithView:webView page:m_page.ptr()]);
@@ -3073,7 +3073,7 @@ void WebViewImpl::showDigitalCredentialsPicker(const WebCore::DigitalCredentials
     [_digitalCredentialsPicker presentWithRequestData:requestData completionHandler:WTF::move(completionHandler)];
 }
 
-void WebViewImpl::dismissDigitalCredentialsPicker(CompletionHandler<void(bool)>&& completionHandler, WKWebView* webView)
+void WebViewImpl::dismissDigitalCredentialsChooser(CompletionHandler<void(bool)>&& completionHandler, WKWebView* webView)
 {
     if (!_digitalCredentialsPicker) {
         LOG(DigitalCredentials, "Digital credentials picker is not being presented.");

--- a/Source/WebKit/WebProcess/DigitalCredentials/DigitalCredentialsCoordinator.cpp
+++ b/Source/WebKit/WebProcess/DigitalCredentials/DigitalCredentialsCoordinator.cpp
@@ -61,7 +61,7 @@ Ref<DigitalCredentialsCoordinator> DigitalCredentialsCoordinator::create(WebPage
     return adoptRef(*new DigitalCredentialsCoordinator(webPage));
 }
 
-void DigitalCredentialsCoordinator::showDigitalCredentialsPicker(WebCore::DigitalCredentialsRawRequests&& rawRequests, const WebCore::DigitalCredentialsRequestData& request, WTF::CompletionHandler<void(Expected<WebCore::DigitalCredentialsResponseData, WebCore::ExceptionData>&&)>&& completionHandler)
+void DigitalCredentialsCoordinator::showDigitalCredentialsChooser(WebCore::DigitalCredentialsRawRequests&& rawRequests, const WebCore::DigitalCredentialsRequestData& request, WTF::CompletionHandler<void(Expected<WebCore::DigitalCredentialsResponseData, WebCore::ExceptionData>&&)>&& completionHandler)
 {
     WTF::switchOn(m_rawRequests, [](auto& cachedRawRequests) {
         ASSERT(cachedRawRequests.isEmpty());
@@ -69,7 +69,7 @@ void DigitalCredentialsCoordinator::showDigitalCredentialsPicker(WebCore::Digita
     m_rawRequests = WTF::move(rawRequests);
 
     if (RefPtr page = m_page.get()) {
-        page->showDigitalCredentialsPicker(request, [weakThis = WeakPtr { *this }, completionHandler = WTF::move(completionHandler)](Expected<WebCore::DigitalCredentialsResponseData, WebCore::ExceptionData>&& responseOrException) mutable {
+        page->showDigitalCredentialsChooser(request, [weakThis = WeakPtr { *this }, completionHandler = WTF::move(completionHandler)](Expected<WebCore::DigitalCredentialsResponseData, WebCore::ExceptionData>&& responseOrException) mutable {
             RefPtr protectedThis = weakThis.get();
             if (!protectedThis)
                 return completionHandler(makeUnexpected(WebCore::ExceptionData { WebCore::ExceptionCode::AbortError, "The coordinator is no longer available."_s }));
@@ -93,13 +93,13 @@ ExceptionOr<Vector<WebCore::ValidatedDigitalCredentialRequest>> DigitalCredentia
     return WTF::move(results);
 }
 
-void DigitalCredentialsCoordinator::dismissDigitalCredentialsPicker(CompletionHandler<void(bool)>&& completionHandler)
+void DigitalCredentialsCoordinator::dismissDigitalCredentialsChooser(CompletionHandler<void(bool)>&& completionHandler)
 {
     WTF::switchOn(m_rawRequests, [](auto& rawRequests) {
         rawRequests.clear();
     });
     if (RefPtr page = m_page.get())
-        page->dismissDigitalCredentialsPicker(WTF::move(completionHandler));
+        page->dismissDigitalCredentialsChooser(WTF::move(completionHandler));
     else
         completionHandler(false);
 }

--- a/Source/WebKit/WebProcess/DigitalCredentials/DigitalCredentialsCoordinator.h
+++ b/Source/WebKit/WebProcess/DigitalCredentials/DigitalCredentialsCoordinator.h
@@ -59,8 +59,8 @@ public:
     void ref() const final { RefCounted::ref(); }
     void deref() const final { RefCounted::deref(); }
 
-    void showDigitalCredentialsPicker(WebCore::DigitalCredentialsRawRequests&&, const WebCore::DigitalCredentialsRequestData&, CompletionHandler<void(Expected<WebCore::DigitalCredentialsResponseData, WebCore::ExceptionData>&&)>&&) final;
-    void dismissDigitalCredentialsPicker(CompletionHandler<void(bool)>&&) final;
+    void showDigitalCredentialsChooser(WebCore::DigitalCredentialsRawRequests&&, const WebCore::DigitalCredentialsRequestData&, CompletionHandler<void(Expected<WebCore::DigitalCredentialsResponseData, WebCore::ExceptionData>&&)>&&) final;
+    void dismissDigitalCredentialsChooser(CompletionHandler<void(bool)>&&) final;
     WebCore::ExceptionOr<Vector<WebCore::ValidatedDigitalCredentialRequest>> validateAndParseDigitalCredentialRequests(const WebCore::SecurityOrigin&, const WebCore::Document&, const Vector<WebCore::UnvalidatedDigitalCredentialRequest>&) final;
     void provideRawDigitalCredentialRequests(CompletionHandler<void(WebCore::DigitalCredentialsRawRequests&&)>&&);
 

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp
@@ -1048,16 +1048,16 @@ void WebChromeClient::showContactPicker(WebCore::ContactsRequestData&& requestDa
 }
 
 #if ENABLE(WEB_AUTHN)
-void WebChromeClient::showDigitalCredentialsPicker(const WebCore::DigitalCredentialsRequestData& requestData, WTF::CompletionHandler<void(Expected<WebCore::DigitalCredentialsResponseData, WebCore::ExceptionData>&&)>&& callback)
+void WebChromeClient::showDigitalCredentialsChooser(const WebCore::DigitalCredentialsRequestData& requestData, WTF::CompletionHandler<void(Expected<WebCore::DigitalCredentialsResponseData, WebCore::ExceptionData>&&)>&& callback)
 {
     if (RefPtr page = m_page.get())
-        page->showDigitalCredentialsPicker(requestData, WTF::move(callback));
+        page->showDigitalCredentialsChooser(requestData, WTF::move(callback));
 }
 
-void WebChromeClient::dismissDigitalCredentialsPicker(WTF::CompletionHandler<void(bool)>&& completionHandler)
+void WebChromeClient::dismissDigitalCredentialsChooser(WTF::CompletionHandler<void(bool)>&& completionHandler)
 {
     if (RefPtr page = m_page.get())
-        page->dismissDigitalCredentialsPicker(WTF::move(completionHandler));
+        page->dismissDigitalCredentialsChooser(WTF::move(completionHandler));
 }
 #endif
 

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.h
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.h
@@ -476,8 +476,8 @@ private:
     void setUserIsInteracting(bool) final;
 
 #if ENABLE(WEB_AUTHN)
-    void showDigitalCredentialsPicker(const WebCore::DigitalCredentialsRequestData&, WTF::CompletionHandler<void(Expected<WebCore::DigitalCredentialsResponseData, WebCore::ExceptionData>&&)>&&) final;
-    void dismissDigitalCredentialsPicker(WTF::CompletionHandler<void(bool)>&&) final;
+    void showDigitalCredentialsChooser(const WebCore::DigitalCredentialsRequestData&, WTF::CompletionHandler<void(Expected<WebCore::DigitalCredentialsResponseData, WebCore::ExceptionData>&&)>&&) final;
+    void dismissDigitalCredentialsChooser(WTF::CompletionHandler<void(bool)>&&) final;
     void setMockWebAuthenticationConfiguration(const WebCore::MockWebAuthenticationConfiguration&) final;
 #endif
 

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -8760,14 +8760,14 @@ void WebPage::showContactPicker(WebCore::ContactsRequestData&& requestData, Comp
 }
 
 #if ENABLE(WEB_AUTHN)
-void WebPage::showDigitalCredentialsPicker(const WebCore::DigitalCredentialsRequestData& requestData, CompletionHandler<void(Expected<WebCore::DigitalCredentialsResponseData, WebCore::ExceptionData>&&)>&& completionHandler)
+void WebPage::showDigitalCredentialsChooser(const WebCore::DigitalCredentialsRequestData& requestData, CompletionHandler<void(Expected<WebCore::DigitalCredentialsResponseData, WebCore::ExceptionData>&&)>&& completionHandler)
 {
-    sendWithAsyncReply(Messages::WebPageProxy::ShowDigitalCredentialsPicker(requestData), WTF::move(completionHandler));
+    sendWithAsyncReply(Messages::WebPageProxy::ShowDigitalCredentialsChooser(requestData), WTF::move(completionHandler));
 }
 
-void WebPage::dismissDigitalCredentialsPicker(CompletionHandler<void(bool)>&& completionHandler)
+void WebPage::dismissDigitalCredentialsChooser(CompletionHandler<void(bool)>&& completionHandler)
 {
-    sendWithAsyncReply(Messages::WebPageProxy::DismissDigitalCredentialsPicker(), WTF::move(completionHandler));
+    sendWithAsyncReply(Messages::WebPageProxy::DismissDigitalCredentialsChooser(), WTF::move(completionHandler));
 }
 #endif
 

--- a/Source/WebKit/WebProcess/WebPage/WebPage.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.h
@@ -1793,8 +1793,8 @@ public:
     void showContactPicker(WebCore::ContactsRequestData&&, CompletionHandler<void(std::optional<Vector<WebCore::ContactInfo>>&&)>&&);
 
 #if ENABLE(WEB_AUTHN)
-    void showDigitalCredentialsPicker(const WebCore::DigitalCredentialsRequestData&, CompletionHandler<void(Expected<WebCore::DigitalCredentialsResponseData, WebCore::ExceptionData>&&)>&&);
-    void dismissDigitalCredentialsPicker(CompletionHandler<void(bool)>&&);
+    void showDigitalCredentialsChooser(const WebCore::DigitalCredentialsRequestData&, CompletionHandler<void(Expected<WebCore::DigitalCredentialsResponseData, WebCore::ExceptionData>&&)>&&);
+    void dismissDigitalCredentialsChooser(CompletionHandler<void(bool)>&&);
 #endif
 
 #if ENABLE(ATTACHMENT_ELEMENT)


### PR DESCRIPTION
#### c2ab2a775047a470a1e280633ff9cae0646dac2d
<pre>
Digital Credentials: reject and resolve paths must queue a global task per spec
<a href="https://bugs.webkit.org/show_bug.cgi?id=313736">https://bugs.webkit.org/show_bug.cgi?id=313736</a>
Include a Radar link (OOPS!).

Reviewed by NOBODY (OOPS!).

Queue promise settlement as global tasks on the DOM manipulation task source per spec. rejectTheCredentialRequestWith now takes Exception&amp;&amp; (not ExceptionOr&lt;RefPtr&gt;), no longer dismisses the chooser (only abortTheCredentialRequest dismisses), and queues rejection via queueTaskKeepingObjectAlive. Success path in initiateTheCredentialRequest moves JSON parsing and credential creation inside the queued task, matching spec step 3.5.3. InteractionStateGuard permits Aborting state. Call ActiveDOMObject::contextDestroyed() in override.

* Source/WebCore/Modules/identity/CredentialRequestCoordinator.cpp:
(WebCore::CredentialRequestCoordinator::InteractionStateGuard::InteractionStateGuard):
(WebCore::CredentialRequestCoordinator::prepareCredentialRequests):
(WebCore::CredentialRequestCoordinator::initiateTheCredentialRequest):
(WebCore::CredentialRequestCoordinator::rejectTheCredentialRequestWith):
(WebCore::CredentialRequestCoordinator::abortTheCredentialRequest):
(WebCore::CredentialRequestCoordinator::contextDestroyed):
* Source/WebCore/Modules/identity/CredentialRequestCoordinator.h:
</pre>
----------------------------------------------------------------------
#### 6c7357cf6be480ffa162471fbd6fa0a8dd38421c
<pre>
Digital Credentials: fix DOMException mapping for platform-cancelled and unknown errors in WKDigitalCredentialsPicker
<a href="https://bugs.webkit.org/show_bug.cgi?id=311722">https://bugs.webkit.org/show_bug.cgi?id=311722</a>
<a href="https://rdar.apple.com/174308268">rdar://174308268</a>

Reviewed by NOBODY (OOPS!).

Map platform-cancelled and unknown errors to OperationError per spec. WKIdentityDocumentPresentmentErrorCancelled now falls through to the default OperationError case since platform cancellation is distinct from user cancellation (NotAllowedError) and AbortSignal cancellation (AbortError). The default/unknown case changes from UnknownError to OperationError, which is the spec&apos;s catch-all for operation-specific failures.

* Source/WebKit/UIProcess/DigitalCredentials/WKDigitalCredentialsPicker.mm:
(-[WKDigitalCredentialsPicker handlePresentmentCompletionWithResponse:error:]):
(-[WKDigitalCredentialsPicker handleNSError:]):
</pre>
----------------------------------------------------------------------
#### 8c5ece2203b56950a9b44e12a9932ca75d69ccc9
<pre>
Digital Credentials: user cancel should reject with NotAllowedError, not AbortError
<a href="https://bugs.webkit.org/show_bug.cgi?id=313735">https://bugs.webkit.org/show_bug.cgi?id=313735</a>
Include a Radar link (OOPS!).

Reviewed by NOBODY (OOPS!).

Reject with NotAllowedError (not AbortError) when the user cancels the credential chooser, per spec &apos;initiate the credential request&apos; step 3c. AbortError is reserved for AbortSignal-driven cancellation. Test coverage requires mock credential provider (Bug
  285651)

* Source/WebCore/Modules/identity/CredentialRequestCoordinator.cpp:
(WebCore::CredentialRequestCoordinator::initiateTheCredentialRequest):
</pre>
----------------------------------------------------------------------
#### c437962ea166f2a26f22673f937f72c6d2f949ff
<pre>
Digital Credentials: prepare credential requests rejects with wrong error code and synchronously instead of queuing a task
<a href="https://bugs.webkit.org/show_bug.cgi?id=311790">https://bugs.webkit.org/show_bug.cgi?id=311790</a>
<a href="https://rdar.apple.com/174895437">rdar://174895437</a>

Reviewed by NOBODY (OOPS!).

Reject with NotAllowedError (not InvalidStateError) when a credential request is already in progress, per spec &apos;prepare credential requests&apos; step 2.

* Source/WebCore/Modules/identity/CredentialRequestCoordinator.cpp:
(WebCore::CredentialRequestCoordinator::prepareCredentialRequests):
</pre>
----------------------------------------------------------------------
#### b4c3973418cf07454c471c32886e6b99f88e8366
<pre>
Digital Credentials: CredentialRequestCoordinator should transition to Presenting state before setting promise
<a href="https://bugs.webkit.org/show_bug.cgi?id=309625">https://bugs.webkit.org/show_bug.cgi?id=309625</a>
<a href="https://rdar.apple.com/172236892">rdar://172236892</a>

Reviewed by NOBODY (OOPS!).

Explanation of why this fixes the bug (OOPS!).

No new tests (OOPS!).

* Source/WebCore/Modules/identity/CredentialRequestCoordinator.cpp:
(WebCore::CredentialRequestCoordinator::prepareCredentialRequests):
</pre>
----------------------------------------------------------------------
#### 3c207dd12782ce9bbb2b30c80ed7de6bb366719d
<pre>
Digital Credentials: align CredentialRequestCoordinator method names with spec algorithm names
<a href="https://bugs.webkit.org/show_bug.cgi?id=313737">https://bugs.webkit.org/show_bug.cgi?id=313737</a>
<a href="https://rdar.apple.com/176128667">rdar://176128667</a>

Reviewed by NOBODY (OOPS!).

Rename methods, enums, and state machine terminology to match the
Digital Credentials API spec algorithm names. This makes it trivial
to cross-reference between spec and implementation.

Renames:
- PickerState → InteractionState (idle/requesting/aborting)
- prepareCredentialRequest → prepareCredentialRequests
- abortPicker → abortTheCredentialRequest
- dismissPickerAndSettle → rejectTheCredentialRequestWith
- handleDigitalCredentialsPickerResult → initiateTheCredentialRequest
- showDigitalCredentialsPicker → showDigitalCredentialsChooser
- dismissDigitalCredentialsPicker → dismissDigitalCredentialsChooser

Pure mechanical rename — no behavioral changes.

* Source/WebCore/Modules/identity/CredentialRequestCoordinator.cpp:
(WebCore::CredentialRequestCoordinator::InteractionStateGuard::InteractionStateGuard):
(WebCore::CredentialRequestCoordinator::InteractionStateGuard::~InteractionStateGuard):
(WebCore::CredentialRequestCoordinator::interactionState const):
(WebCore::CredentialRequestCoordinator::canTransitionTo const):
(WebCore::CredentialRequestCoordinator::setInteractionState):
(WebCore::CredentialRequestCoordinator::prepareCredentialRequests):
(WebCore::CredentialRequestCoordinator::initiateTheCredentialRequest):
(WebCore::CredentialRequestCoordinator::rejectTheCredentialRequestWith):
(WebCore::CredentialRequestCoordinator::abortTheCredentialRequest):
(WebCore::CredentialRequestCoordinator::contextDestroyed):
(WebCore::CredentialRequestCoordinator::PickerStateGuard::PickerStateGuard): Deleted.
(WebCore::CredentialRequestCoordinator::PickerStateGuard::~PickerStateGuard): Deleted.
(WebCore::CredentialRequestCoordinator::currentState const): Deleted.
(WebCore::CredentialRequestCoordinator::setState): Deleted.
(WebCore::CredentialRequestCoordinator::prepareCredentialRequest): Deleted.
(WebCore::CredentialRequestCoordinator::handleDigitalCredentialsPickerResult): Deleted.
(WebCore::CredentialRequestCoordinator::dismissPickerAndSettle): Deleted.
(WebCore::CredentialRequestCoordinator::abortPicker): Deleted.
* Source/WebCore/Modules/identity/CredentialRequestCoordinator.h:
* Source/WebCore/Modules/identity/CredentialRequestCoordinatorClient.h:
* Source/WebCore/Modules/identity/DigitalCredential.cpp:
(WebCore::DigitalCredential::discoverFromExternalSource):
* Source/WebCore/Modules/identity/dummy/DummyCredentialRequestCoordinatorClient.cpp:
(WebCore::DummyCredentialRequestCoordinatorClient::showDigitalCredentialsChooser):
(WebCore::DummyCredentialRequestCoordinatorClient::dismissDigitalCredentialsChooser):
(WebCore::DummyCredentialRequestCoordinatorClient::showDigitalCredentialsPicker): Deleted.
(WebCore::DummyCredentialRequestCoordinatorClient::dismissDigitalCredentialsPicker): Deleted.
* Source/WebCore/Modules/identity/dummy/DummyCredentialRequestCoordinatorClient.h:
* Source/WebCore/loader/EmptyClients.cpp:
* Source/WebCore/page/Chrome.cpp:
(WebCore::Chrome::showDigitalCredentialsChooser):
(WebCore::Chrome::dismissDigitalCredentialsChooser):
(WebCore::Chrome::showDigitalCredentialsPicker): Deleted.
(WebCore::Chrome::dismissDigitalCredentialsPicker): Deleted.
* Source/WebCore/page/Chrome.h:
* Source/WebCore/page/ChromeClient.h:
(WebCore::ChromeClient::showDigitalCredentialsChooser):
(WebCore::ChromeClient::dismissDigitalCredentialsChooser):
(WebCore::ChromeClient::showDigitalCredentialsPicker): Deleted.
(WebCore::ChromeClient::dismissDigitalCredentialsPicker): Deleted.
* Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm:
(-[WKWebView _showDigitalCredentialsChooser:completionHandler:]):
(-[WKWebView _dismissDigitalCredentialsChooser:]):
(-[WKWebView _showDigitalCredentialsPicker:completionHandler:]): Deleted.
(-[WKWebView _dismissDigitalCredentialsPicker:]): Deleted.
* Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h:
* Source/WebKit/UIProcess/PageClient.h:
(WebKit::PageClient::showDigitalCredentialsChooser):
(WebKit::PageClient::dismissDigitalCredentialsChooser):
(WebKit::PageClient::showDigitalCredentialsPicker): Deleted.
(WebKit::PageClient::dismissDigitalCredentialsPicker): Deleted.
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::showDigitalCredentialsChooser):
(WebKit::WebPageProxy::dismissDigitalCredentialsChooser):
(WebKit::WebPageProxy::showDigitalCredentialsPicker): Deleted.
(WebKit::WebPageProxy::dismissDigitalCredentialsPicker): Deleted.
* Source/WebKit/UIProcess/WebPageProxy.h:
* Source/WebKit/UIProcess/WebPageProxy.messages.in:
* Source/WebKit/UIProcess/ios/PageClientImplIOS.h:
* Source/WebKit/UIProcess/ios/PageClientImplIOS.mm:
(WebKit::PageClientImpl::showDigitalCredentialsChooser):
(WebKit::PageClientImpl::dismissDigitalCredentialsChooser):
(WebKit::PageClientImpl::showDigitalCredentialsPicker): Deleted.
(WebKit::PageClientImpl::dismissDigitalCredentialsPicker): Deleted.
* Source/WebKit/UIProcess/ios/WKContentViewInteraction.h:
* Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm:
(-[WKContentView _showDigitalCredentialsChooser:completionHandler:]):
(-[WKContentView _dismissDigitalCredentialsChooser:]):
(-[WKContentView _showDigitalCredentialsPicker:completionHandler:]): Deleted.
(-[WKContentView _dismissDigitalCredentialsPicker:]): Deleted.
* Source/WebKit/UIProcess/mac/PageClientImplMac.h:
* Source/WebKit/UIProcess/mac/PageClientImplMac.mm:
(WebKit::PageClientImpl::showDigitalCredentialsChooser):
(WebKit::PageClientImpl::dismissDigitalCredentialsChooser):
(WebKit::PageClientImpl::showDigitalCredentialsPicker): Deleted.
(WebKit::PageClientImpl::dismissDigitalCredentialsPicker): Deleted.
* Source/WebKit/UIProcess/mac/WebViewImpl.h:
* Source/WebKit/UIProcess/mac/WebViewImpl.mm:
(WebKit::WebViewImpl::showDigitalCredentialsChooser):
(WebKit::WebViewImpl::dismissDigitalCredentialsChooser):
(WebKit::WebViewImpl::showDigitalCredentialsPicker): Deleted.
(WebKit::WebViewImpl::dismissDigitalCredentialsPicker): Deleted.
* Source/WebKit/WebProcess/DigitalCredentials/DigitalCredentialsCoordinator.cpp:
(WebKit::DigitalCredentialsCoordinator::showDigitalCredentialsChooser):
(WebKit::DigitalCredentialsCoordinator::dismissDigitalCredentialsChooser):
(WebKit::DigitalCredentialsCoordinator::showDigitalCredentialsPicker): Deleted.
(WebKit::DigitalCredentialsCoordinator::dismissDigitalCredentialsPicker): Deleted.
* Source/WebKit/WebProcess/DigitalCredentials/DigitalCredentialsCoordinator.h:
* Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp:
(WebKit::WebChromeClient::showDigitalCredentialsChooser):
(WebKit::WebChromeClient::dismissDigitalCredentialsChooser):
(WebKit::WebChromeClient::showDigitalCredentialsPicker): Deleted.
(WebKit::WebChromeClient::dismissDigitalCredentialsPicker): Deleted.
* Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.h:
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::showDigitalCredentialsChooser):
(WebKit::WebPage::dismissDigitalCredentialsChooser):
(WebKit::WebPage::showDigitalCredentialsPicker): Deleted.
(WebKit::WebPage::dismissDigitalCredentialsPicker): Deleted.
* Source/WebKit/WebProcess/WebPage/WebPage.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c2ab2a775047a470a1e280633ff9cae0646dac2d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/160235 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/33705 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/26809 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/169137 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/114616 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/4f893b15-936e-49f9-aebf-d7a137da919d) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/162104 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/33809 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/33707 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/124221 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/87139 "2 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/9a1ae0d1-7786-4351-98ef-5c9ec4108f74) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/163193 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/26467 "Found 1 new test failure: http/wpt/identity/formats/ISO18013/mobiledocument.https.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/143924 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/104820 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/f0dfc320-fe55-495a-8761-3167cd7a9f0e) 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/25520 "Found 3 new test failures: imported/w3c/web-platform-tests/digital-credentials/get.tentative.https.html imported/w3c/web-platform-tests/digital-credentials/non-fully-active.https.html imported/w3c/web-platform-tests/digital-credentials/user-activation-get.https.html (failure)") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/24013 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/16857 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/135212 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/21687 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/171613 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/17603 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/23327 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/132473 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/33381 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/28108 "Found 2 new test failures: http/wpt/identity/formats/ISO18013/mobiledocument.https.html imported/w3c/web-platform-tests/digital-credentials/non-fully-active.https.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/132499 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/33366 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/143482 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/91649 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/27116 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/20296 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/32875 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/99272 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/32373 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/32619 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/32523 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->