### PR TITLE
-webkit-text-fill-color has weird interaction with text-decoration-color

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -873,7 +873,6 @@ imported/w3c/web-platform-tests/speculation-rules/prefetch/redirect-to-prefetch-
 
 # Newly imported WPT ref tests failures.
 imported/w3c/web-platform-tests/compat/webkit-box-rtl-flex.html [ ImageOnlyFailure ]
-imported/w3c/web-platform-tests/compat/webkit-text-fill-color-property-005.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/compat/webkit-box-horizontal-rtl-variants.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/compat/webkit-box-horizontal-reverse-variants.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/encoding/eof-utf-8-one.html [ ImageOnlyFailure ]

--- a/LayoutTests/fast/text/text-decoration-currentcolor-fill-color-expected.html
+++ b/LayoutTests/fast/text/text-decoration-currentcolor-fill-color-expected.html
@@ -7,6 +7,7 @@ div {
 }
 a {
     color: transparent;
+    text-decoration-color: #551a8b;
 }
 </style>
 <div><a href="">PASS if underline is visible</a></div>

--- a/Source/WebCore/style/computed/StyleComputedStyleProperties+GettersCustomInlines.h
+++ b/Source/WebCore/style/computed/StyleComputedStyleProperties+GettersCustomInlines.h
@@ -334,7 +334,7 @@ inline WebCore::Color ColorPropertyTraits<PropertyNameConstant<CSSPropertyTextDe
                     return strokeColor;
             }
         }
-        return style.textFillColor().resolveColor(style.color());
+        return style.color();
     }
     return result.resolveColor(style.color());
 }
@@ -355,7 +355,7 @@ inline WebCore::Color ColorPropertyTraits<PropertyNameConstant<CSSPropertyTextDe
                     return strokeColor;
             }
         }
-        return style.visitedLinkTextFillColor().resolveColor(style.visitedLinkColor());
+        return style.visitedLinkColor();
     }
     return result.resolveColor(style.visitedLinkColor());
 }


### PR DESCRIPTION
#### 8a932317598d80019be6d615162ff57e18df5de6
<pre>
-webkit-text-fill-color has weird interaction with text-decoration-color
<a href="https://bugs.webkit.org/show_bug.cgi?id=193028">https://bugs.webkit.org/show_bug.cgi?id=193028</a>
<a href="https://rdar.apple.com/47010945">rdar://47010945</a>

Reviewed by Antti Koivisto.

Make text-decoration-color: currentcolor (default) use color instead of
-webkit-text-fill-color as required by the CSS specifications.

The change to fast/text/text-decoration-currentcolor-fill-color.html
requires some justification. 227884@main added it as follows for an
internal UI regression:

    &lt;style&gt;
    div {
        background-color: red;
        -webkit-background-clip: text;
        -webkit-text-fill-color: transparent;
    }
    &lt;/style&gt;
    &lt;div&gt;&lt;a href=&quot;&quot;&gt;PASS if no underline&lt;/a&gt;&lt;/div&gt;

The idea was that the underline would be hidden as it gets its color
from -webkit-text-fill-color. Today however that shows an underline,
suggesting the internal UI regression was resolved in some other way.

282060@main subsequently changed the test and might be the cause for
the test showing an underline, but given that the original behavior is
in violation of the specifications and there was no other fallout, we
should align with the specifications.

Canonical link: <a href="https://commits.webkit.org/312789@main">https://commits.webkit.org/312789@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/19533ebcf0e86f1d957729ec48f57688d35be6b8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/160876 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/34349 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/27450 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/169779 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/117027 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/ccf2cac7-7fb1-4a8e-99e8-174ffee0d92f) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/162745 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/34450 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/34349 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/124778 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/117027 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/3f9f04eb-2b99-4e5e-aa72-9c848f55e99a) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/163835 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/27036 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/144513 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/105375 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/10ef55cb-9f11-4b98-8aee-1cdf18b8d2da) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/26088 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/24590 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/17499 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/135782 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/22275 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/172262 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/19283 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/23916 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/133048 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/34023 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/28683 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/133059 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35983 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/34007 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/144070 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/95846 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/27657 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/20885 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/33518 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/100943 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/33017 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/33261 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/33166 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->