### PR TITLE
Add tests for MessageChannel transfer of non-IPC-serializable types

### DIFF
--- a/LayoutTests/fast/message-channel/transfer-mediastreamtrack-expected.txt
+++ b/LayoutTests/fast/message-channel/transfer-mediastreamtrack-expected.txt
@@ -1,0 +1,5 @@
+Test that a MediaStreamTrack can be transferred through a MessageChannel in the same context.
+
+PASS: received a MediaStreamTrack
+PASS: track kind is audio
+

--- a/LayoutTests/fast/message-channel/transfer-mediastreamtrack.html
+++ b/LayoutTests/fast/message-channel/transfer-mediastreamtrack.html
@@ -1,0 +1,55 @@
+<body>
+<p>Test that a MediaStreamTrack can be transferred through a MessageChannel in the same context.</p>
+<pre id="log"></pre>
+<script>
+if (window.testRunner) {
+    testRunner.dumpAsText();
+    testRunner.waitUntilDone();
+}
+
+function log(msg) {
+    document.getElementById("log").textContent += msg + "\n";
+}
+
+async function runTest() {
+    const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
+    const track = stream.getAudioTracks()[0];
+
+    const channel = new MessageChannel();
+    let receivedTransfer = false;
+
+    channel.port2.onmessage = (event) => {
+        if (event.data === "done") {
+            if (!receivedTransfer)
+                log("FAIL: never received the MediaStreamTrack message");
+            if (window.testRunner)
+                testRunner.notifyDone();
+            return;
+        }
+
+        receivedTransfer = true;
+        const received = event.data;
+        if (received instanceof MediaStreamTrack)
+            log("PASS: received a MediaStreamTrack");
+        else
+            log("FAIL: expected a MediaStreamTrack, got " + received);
+
+        if (received.kind === "audio")
+            log("PASS: track kind is audio");
+        else
+            log("FAIL: expected kind 'audio', got '" + received.kind + "'");
+
+        received.stop();
+    };
+
+    channel.port1.postMessage(track, [track]);
+    channel.port1.postMessage("done");
+}
+
+runTest().catch(e => {
+    log("FAIL: " + e);
+    if (window.testRunner)
+        testRunner.notifyDone();
+});
+</script>
+</body>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/infrastructure/safe-passing-of-structured-data/messagechannel.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/infrastructure/safe-passing-of-structured-data/messagechannel.any-expected.txt
@@ -139,6 +139,8 @@ PASS Serializing OOB TypedArray throws
 PASS Serializing OOB DataView throws
 PASS ArrayBuffer
 PASS MessagePort
+PASS ImageBitmap
+PASS OffscreenCanvas
 PASS A detached ArrayBuffer cannot be transferred
 PASS A detached platform object cannot be transferred
 PASS Transferring a non-transferable platform object fails

--- a/LayoutTests/imported/w3c/web-platform-tests/html/infrastructure/safe-passing-of-structured-data/messagechannel.any.serviceworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/infrastructure/safe-passing-of-structured-data/messagechannel.any.serviceworker-expected.txt
@@ -124,6 +124,8 @@ PASS Serializing OOB TypedArray throws
 PASS Serializing OOB DataView throws
 PASS ArrayBuffer
 PASS MessagePort
+PASS ImageBitmap
+PASS OffscreenCanvas
 PASS A detached ArrayBuffer cannot be transferred
 PASS A detached platform object cannot be transferred
 PASS Transferring a non-transferable platform object fails

--- a/LayoutTests/imported/w3c/web-platform-tests/html/infrastructure/safe-passing-of-structured-data/messagechannel.any.sharedworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/infrastructure/safe-passing-of-structured-data/messagechannel.any.sharedworker-expected.txt
@@ -124,6 +124,8 @@ PASS Serializing OOB TypedArray throws
 PASS Serializing OOB DataView throws
 PASS ArrayBuffer
 PASS MessagePort
+PASS ImageBitmap
+PASS OffscreenCanvas
 PASS A detached ArrayBuffer cannot be transferred
 PASS A detached platform object cannot be transferred
 PASS Transferring a non-transferable platform object fails

--- a/LayoutTests/imported/w3c/web-platform-tests/html/infrastructure/safe-passing-of-structured-data/messagechannel.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/infrastructure/safe-passing-of-structured-data/messagechannel.any.worker-expected.txt
@@ -124,6 +124,8 @@ PASS Serializing OOB TypedArray throws
 PASS Serializing OOB DataView throws
 PASS ArrayBuffer
 PASS MessagePort
+PASS ImageBitmap
+PASS OffscreenCanvas
 PASS A detached ArrayBuffer cannot be transferred
 PASS A detached platform object cannot be transferred
 PASS Transferring a non-transferable platform object fails

--- a/LayoutTests/imported/w3c/web-platform-tests/html/infrastructure/safe-passing-of-structured-data/transfer-audiodata-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/infrastructure/safe-passing-of-structured-data/transfer-audiodata-expected.txt
@@ -1,0 +1,3 @@
+
+PASS AudioData can be transferred through a MessageChannel
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/infrastructure/safe-passing-of-structured-data/transfer-audiodata.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/infrastructure/safe-passing-of-structured-data/transfer-audiodata.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>MessageChannel transfer of AudioData</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script>
+promise_test(async t => {
+    const audioData = new AudioData({
+        data: new Float32Array([0.1, 0.2, 0.3, 0.4]),
+        format: "f32",
+        sampleRate: 44100,
+        numberOfFrames: 4,
+        numberOfChannels: 1,
+        timestamp: 0
+    });
+
+    const channel = new MessageChannel();
+    const received = new Promise(resolve => {
+        channel.port2.onmessage = e => resolve(e.data);
+    });
+
+    channel.port1.postMessage(audioData, [audioData]);
+
+    const copy = await received;
+    assert_true(copy instanceof AudioData);
+    assert_equals(copy.numberOfFrames, 4);
+    assert_equals(copy.numberOfChannels, 1);
+    assert_equals(copy.sampleRate, 44100);
+    copy.close();
+}, "AudioData can be transferred through a MessageChannel");
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/infrastructure/safe-passing-of-structured-data/transfer-mediasourcehandle-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/infrastructure/safe-passing-of-structured-data/transfer-mediasourcehandle-expected.txt
@@ -1,0 +1,3 @@
+
+PASS MediaSourceHandle can be transferred through a MessageChannel
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/infrastructure/safe-passing-of-structured-data/transfer-mediasourcehandle.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/infrastructure/safe-passing-of-structured-data/transfer-mediasourcehandle.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>MessageChannel transfer of MediaSourceHandle</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script>
+promise_test(async t => {
+    const worker = new Worker(URL.createObjectURL(new Blob([`
+        const ms = new ManagedMediaSource();
+        const handle = ms.handle;
+        self.postMessage(handle, [handle]);
+    `], { type: "text/javascript" })));
+
+    const handle = await new Promise((resolve, reject) => {
+        worker.onmessage = e => resolve(e.data);
+        worker.onerror = e => { e.preventDefault(); reject(e.message); };
+    });
+    worker.terminate();
+
+    const channel = new MessageChannel();
+    const received = new Promise(resolve => {
+        channel.port2.onmessage = e => resolve(e.data);
+    });
+
+    channel.port1.postMessage(handle, [handle]);
+
+    const copy = await received;
+    assert_true(copy instanceof MediaSourceHandle);
+}, "MediaSourceHandle can be transferred through a MessageChannel");
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/infrastructure/safe-passing-of-structured-data/transfer-videoframe-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/infrastructure/safe-passing-of-structured-data/transfer-videoframe-expected.txt
@@ -1,0 +1,3 @@
+
+PASS VideoFrame can be transferred through a MessageChannel
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/infrastructure/safe-passing-of-structured-data/transfer-videoframe.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/infrastructure/safe-passing-of-structured-data/transfer-videoframe.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>MessageChannel transfer of VideoFrame</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script>
+promise_test(async t => {
+    const canvas = new OffscreenCanvas(2, 2);
+    const ctx = canvas.getContext("2d");
+    ctx.fillRect(0, 0, 2, 2);
+    const frame = new VideoFrame(canvas, { timestamp: 0 });
+
+    const channel = new MessageChannel();
+    const received = new Promise(resolve => {
+        channel.port2.onmessage = e => resolve(e.data);
+    });
+
+    channel.port1.postMessage(frame, [frame]);
+
+    const copy = await received;
+    assert_true(copy instanceof VideoFrame);
+    assert_equals(copy.codedWidth, 2);
+    assert_equals(copy.codedHeight, 2);
+    copy.close();
+}, "VideoFrame can be transferred through a MessageChannel");
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/infrastructure/safe-passing-of-structured-data/window-postmessage.window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/infrastructure/safe-passing-of-structured-data/window-postmessage.window-expected.txt
@@ -139,6 +139,8 @@ PASS Serializing OOB TypedArray throws
 PASS Serializing OOB DataView throws
 PASS ArrayBuffer
 PASS MessagePort
+PASS ImageBitmap
+PASS OffscreenCanvas
 PASS A detached ArrayBuffer cannot be transferred
 PASS A detached platform object cannot be transferred
 PASS Transferring a non-transferable platform object fails

--- a/LayoutTests/imported/w3c/web-platform-tests/html/webappapis/structured-clone/structured-clone-battery-of-tests-with-transferables.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/webappapis/structured-clone/structured-clone-battery-of-tests-with-transferables.js
@@ -19,7 +19,29 @@ structuredCloneBatteryOfTests.push({
   }
 });
 
-// TODO: ImageBitmap
+structuredCloneBatteryOfTests.push({
+  description: 'ImageBitmap',
+  async f(runner) {
+    const canvas = new OffscreenCanvas(10, 10);
+    const ctx = canvas.getContext("2d");
+    ctx.fillStyle = "red";
+    ctx.fillRect(0, 0, 10, 10);
+    const bitmap = await createImageBitmap(canvas);
+    const copy = await runner.structuredClone(bitmap, [bitmap]);
+    assert_equals(copy.width, 10);
+    assert_equals(copy.height, 10);
+  }
+});
+
+structuredCloneBatteryOfTests.push({
+  description: 'OffscreenCanvas',
+  async f(runner) {
+    const canvas = new OffscreenCanvas(10, 10);
+    const copy = await runner.structuredClone(canvas, [canvas]);
+    assert_equals(copy.width, 10);
+    assert_equals(copy.height, 10);
+  }
+});
 
 structuredCloneBatteryOfTests.push({
   description: 'A detached ArrayBuffer cannot be transferred',

--- a/LayoutTests/imported/w3c/web-platform-tests/html/webappapis/structured-clone/structured-clone.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/webappapis/structured-clone/structured-clone.any-expected.txt
@@ -139,6 +139,8 @@ PASS Serializing OOB TypedArray throws
 PASS Serializing OOB DataView throws
 PASS ArrayBuffer
 PASS MessagePort
+PASS ImageBitmap
+PASS OffscreenCanvas
 PASS A detached ArrayBuffer cannot be transferred
 PASS A detached platform object cannot be transferred
 PASS Transferring a non-transferable platform object fails

--- a/LayoutTests/imported/w3c/web-platform-tests/html/webappapis/structured-clone/structured-clone.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/webappapis/structured-clone/structured-clone.any.worker-expected.txt
@@ -124,6 +124,8 @@ PASS Serializing OOB TypedArray throws
 PASS Serializing OOB DataView throws
 PASS ArrayBuffer
 PASS MessagePort
+PASS ImageBitmap
+PASS OffscreenCanvas
 PASS A detached ArrayBuffer cannot be transferred
 PASS A detached platform object cannot be transferred
 PASS Transferring a non-transferable platform object fails

--- a/LayoutTests/imported/w3c/web-platform-tests/workers/semantics/structured-clone/dedicated-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/workers/semantics/structured-clone/dedicated-expected.txt
@@ -139,6 +139,8 @@ PASS Serializing OOB TypedArray throws
 PASS Serializing OOB DataView throws
 PASS ArrayBuffer
 PASS MessagePort
+PASS ImageBitmap
+PASS OffscreenCanvas
 PASS A detached ArrayBuffer cannot be transferred
 PASS A detached platform object cannot be transferred
 PASS Transferring a non-transferable platform object fails

--- a/LayoutTests/imported/w3c/web-platform-tests/workers/semantics/structured-clone/shared-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/workers/semantics/structured-clone/shared-expected.txt
@@ -139,6 +139,8 @@ PASS Serializing OOB TypedArray throws
 PASS Serializing OOB DataView throws
 PASS ArrayBuffer
 PASS MessagePort
+PASS ImageBitmap
+PASS OffscreenCanvas
 PASS A detached ArrayBuffer cannot be transferred
 PASS A detached platform object cannot be transferred
 PASS Transferring a non-transferable platform object fails

--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -3938,6 +3938,9 @@ fast/images/low-memory-decode.html [ Skip ]
 # Lockdown Mode does not apply
 fast/speechsynthesis/lockdown-mode [ Skip ]
 
+# ManagedMediaSource is not supported
+imported/w3c/web-platform-tests/html/infrastructure/safe-passing-of-structured-data/transfer-mediasourcehandle.html [ Skip ]
+
 #////////////////////////////////////////////////////////////////////////////////////////
 # End of UNSUPPORTED tests.
 #////////////////////////////////////////////////////////////////////////////////////////

--- a/LayoutTests/platform/mac/TestExpectations
+++ b/LayoutTests/platform/mac/TestExpectations
@@ -2362,6 +2362,8 @@ webkit.org/b/299322 imported/w3c/web-platform-tests/uievents/mouse/mouse_boundar
 
 [ x86_64 ] imported/w3c/web-platform-tests/svg/fonts/font-size-adjust-scale-text.svg [ Failure Pass ]
 
+webkit.org/b/314491 [ x86_64 ] imported/w3c/web-platform-tests/html/infrastructure/safe-passing-of-structured-data/messagechannel.any.serviceworker.html [ Pass Crash ]
+
 webkit.org/b/300337 fast/images/imagebitmap-memory.html [ Pass ImageOnlyFailure ]
 
 # webkit.org/b/300715

--- a/LayoutTests/platform/win/TestExpectations
+++ b/LayoutTests/platform/win/TestExpectations
@@ -4681,3 +4681,5 @@ fast/canvas/offscreen-webgl-transfer-after-navigation-crash.html [ Skip ] # Flak
 webkit.org/b/312135 fast/animation/request-video-frame-callback-in-isolated-world-with-javascript-disabled.html [ Timeout ]
 
 webkit.org/b/312924 fast/webcodecs/resetting-audio-decoder-with-zero-size-crash.html [ Skip ]
+
+fast/message-channel/transfer-mediastreamtrack.html [ Skip ]


### PR DESCRIPTION
#### 0650787ae1535343d9609fa86776ce11d434b53e
<pre>
Add tests for MessageChannel transfer of non-IPC-serializable types
<a href="https://bugs.webkit.org/show_bug.cgi?id=313953">https://bugs.webkit.org/show_bug.cgi?id=313953</a>
<a href="https://rdar.apple.com/problem/176161982">rdar://problem/176161982</a>

Additional tests for the MessageChannel Site Isolation fix in
<a href="https://bugs.webkit.org/show_bug.cgi?id=313692.">https://bugs.webkit.org/show_bug.cgi?id=313692.</a>

Reviewed by Anne van Kesteren.

* LayoutTests/fast/message-channel/transfer-mediastreamtrack-expected.txt: Added.
* LayoutTests/fast/message-channel/transfer-mediastreamtrack.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/infrastructure/safe-passing-of-structured-data/messagechannel.any-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/infrastructure/safe-passing-of-structured-data/messagechannel.any.serviceworker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/infrastructure/safe-passing-of-structured-data/messagechannel.any.sharedworker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/infrastructure/safe-passing-of-structured-data/messagechannel.any.worker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/infrastructure/safe-passing-of-structured-data/transfer-audiodata-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/infrastructure/safe-passing-of-structured-data/transfer-audiodata.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/infrastructure/safe-passing-of-structured-data/transfer-mediasourcehandle-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/infrastructure/safe-passing-of-structured-data/transfer-mediasourcehandle.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/infrastructure/safe-passing-of-structured-data/transfer-videoframe-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/infrastructure/safe-passing-of-structured-data/transfer-videoframe.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/infrastructure/safe-passing-of-structured-data/window-postmessage.window-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/webappapis/structured-clone/structured-clone-battery-of-tests-with-transferables.js:
(structuredCloneBatteryOfTests.push.async f):
* LayoutTests/imported/w3c/web-platform-tests/html/webappapis/structured-clone/structured-clone.any-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/webappapis/structured-clone/structured-clone.any.worker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/workers/semantics/structured-clone/dedicated-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/workers/semantics/structured-clone/shared-expected.txt:
* LayoutTests/platform/glib/TestExpectations:
* LayoutTests/platform/mac/TestExpectations:
* LayoutTests/platform/win/TestExpectations:

Canonical link: <a href="https://commits.webkit.org/312959@main">https://commits.webkit.org/312959@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/15d7ae1f34aca7f921fd69ce8bb05ba3e8b845fe

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/161636 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/35110 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/28213 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/170539 "Failed to checkout and rebase branch from PR 64155") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/118007 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/35211 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/35111 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/5/builds/170539 "Failed to checkout and rebase branch from PR 64155") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/118007 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/164595 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/27703 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/145190 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/5/builds/170539 "Failed to checkout and rebase branch from PR 64155") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/26752 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/25263 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/18260 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/136445 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/167/builds/22946 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/173027 "Built successfully") | | 
| | | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/24587 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/133690 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/34784 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/29357 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/133695 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/34768 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/144741 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/96730 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/24556 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/164/builds/28226 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/21561 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/34278 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/33778 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/34021 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/33927 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->