### PR TITLE
[AppKit Gestures] Changing selection on PDFs that are <object> or <embed> sometimes does not work

### DIFF
--- a/Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm
+++ b/Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm
@@ -2561,6 +2561,10 @@ void WebPage::updateFocusBeforeSelectingTextAtLocation(const IntPoint& point)
 #if ENABLE(PDF_PLUGIN)
     if (RefPtr pluginView = pluginViewForFrame(frame.get()))
         pluginView->focusPluginElement();
+    else if (RefPtr pluginElement = dynamicDowncast<HTMLPlugInElement>(hitNode.get())) {
+        if (RefPtr pluginView = dynamicDowncast<PluginView>(pluginElement->pluginWidget()))
+            pluginView->focusPluginElement();
+    }
 #endif
 }
 

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -1925,14 +1925,21 @@ Ref<API::Array> WebPage::trackedRepaintRects()
 
 PluginView* WebPage::focusedPluginViewForFrame(LocalFrame& frame)
 {
-    auto* pluginDocument = dynamicDowncast<PluginDocument>(frame.document());
-    if (!pluginDocument)
+    if (auto* pluginDocument = dynamicDowncast<PluginDocument>(frame.document())) {
+        if (pluginDocument->focusedElement() != pluginDocument->pluginElement())
+            return nullptr;
+        return pluginViewForFrame(&frame);
+    }
+
+    RefPtr document = frame.document();
+    if (!document)
         return nullptr;
 
-    if (pluginDocument->focusedElement() != pluginDocument->pluginElement())
+    RefPtr pluginElement = dynamicDowncast<HTMLPlugInElement>(document->focusedElement());
+    if (!pluginElement)
         return nullptr;
 
-    return pluginViewForFrame(&frame);
+    return dynamicDowncast<PluginView>(pluginElement->pluginWidget());
 }
 
 PluginView* WebPage::pluginViewForFrame(LocalFrame* frame)

--- a/Source/WebKit/WebProcess/WebPage/WebPage.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.h
@@ -1734,7 +1734,7 @@ public:
     std::optional<double> cpuLimit() const { return m_cpuLimit; }
 
 #if ENABLE(PDF_PLUGIN)
-    static PluginView* NODELETE focusedPluginViewForFrame(WebCore::LocalFrame&);
+    static PluginView* focusedPluginViewForFrame(WebCore::LocalFrame&);
     static PluginView* NODELETE pluginViewForFrame(WebCore::LocalFrame*);
     PluginView* mainFramePlugIn() const;
 #endif

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/UnifiedPDFTests.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/UnifiedPDFTests.mm
@@ -812,36 +812,60 @@ UNIFIED_PDF_TEST(WebProcessShouldNotCrashWithUISideCompositingDisabled)
     EXPECT_FALSE([delegate webProcessCrashed]);
 }
 
-UNIFIED_PDF_TEST(SelectAllText)
+static void runSelectAllAndVerifySelectedTextMatches(NSString *expected, void (^loadContent)(TestWKWebView *webView))
 {
     RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600) configuration:configurationForWebViewTestingUnifiedPDF().get()]);
-    [webView synchronouslyLoadRequest:[NSURLRequest requestWithURL:[NSBundle.test_resourcesBundle URLForResource:@"test" withExtension:@"pdf"]]];
-
-    auto selectAllText = [](TestWKWebView *webView) {
-#if PLATFORM(IOS_FAMILY)
-        [webView selectTextInGranularity:UITextGranularityDocument atPoint:CGPointMake(100, 100)];
-#else
-        [[webView window] makeFirstResponder:webView];
-        [[webView window] makeKeyAndOrderFront:nil];
-        [[webView window] orderFrontRegardless];
-        [webView sendClickAtPoint:NSMakePoint(100, 100)];
-        [webView selectAll:nil];
-#endif
-    };
-
-    selectAllText(webView.get());
+    loadContent(webView.get());
     [webView waitForNextPresentationUpdate];
 
 #if PLATFORM(IOS_FAMILY)
-    RetainPtr contentView = [webView textInputContentView];
-    RetainPtr selectedText = [contentView selectedText];
+    [webView selectTextInGranularity:UITextGranularityDocument atPoint:CGPointMake(100, 100)];
+    [webView waitForNextPresentationUpdate];
+
+    RetainPtr selectedText = [[webView textInputContentView] selectedText];
 #else
+    [[NSPasteboard generalPasteboard] clearContents];
+
+    [[webView window] makeFirstResponder:webView.get()];
+    [[webView window] makeKeyAndOrderFront:nil];
+    [[webView window] orderFrontRegardless];
+
+    [webView sendClickAtPoint:NSMakePoint(100, 100)];
+    [webView selectAll:nil];
+    [webView waitForNextPresentationUpdate];
     [webView copy:nil];
     [webView waitForNextPresentationUpdate];
+
     RetainPtr selectedText = [[NSPasteboard generalPasteboard] stringForType:NSPasteboardTypeString];
 #endif
-    EXPECT_WK_STREQ(@"Test PDF Content\n555-555-1234", selectedText.get());
+
+    EXPECT_WK_STREQ(expected, selectedText.get());
 }
+
+UNIFIED_PDF_TEST(SelectAllText)
+{
+    runSelectAllAndVerifySelectedTextMatches(@"Test PDF Content\n555-555-1234", ^(TestWKWebView *webView) {
+        [webView synchronouslyLoadRequest:[NSURLRequest requestWithURL:[NSBundle.test_resourcesBundle URLForResource:@"test" withExtension:@"pdf"]]];
+    });
+}
+
+#if PLATFORM(MAC)
+
+UNIFIED_PDF_TEST(SelectAllTextInEmbedHostedPDF)
+{
+    runSelectAllAndVerifySelectedTextMatches(@"Test PDF Content\n555-555-1234", ^(TestWKWebView *webView) {
+        [webView synchronouslyLoadHTMLString:@"<embed src='test.pdf' width='600' height='600'>"];
+    });
+}
+
+UNIFIED_PDF_TEST(SelectAllTextInObjectHostedPDF)
+{
+    runSelectAllAndVerifySelectedTextMatches(@"Test PDF Content\n555-555-1234", ^(TestWKWebView *webView) {
+        [webView synchronouslyLoadHTMLString:@"<object type='application/pdf' data='test.pdf' width='600' height='600'></object>"];
+    });
+}
+
+#endif // PLATFORM(MAC)
 
 #if PLATFORM(IOS_FAMILY)
 


### PR DESCRIPTION
#### fcffec75c21506c0bf8ba4fc89790ffd07c91f5a
<pre>
[AppKit Gestures] Changing selection on PDFs that are &lt;object&gt; or &lt;embed&gt; sometimes does not work
<a href="https://bugs.webkit.org/show_bug.cgi?id=313954">https://bugs.webkit.org/show_bug.cgi?id=313954</a>
<a href="https://rdar.apple.com/172055860">rdar://172055860</a>

Reviewed by Abrar Rahman Protyasha.

WKTextSelectionController results in `WebPage::setSelectionRange` and `WebPage::updateSelectionWithExtentPointAndBoundary`
being called when clicking and dragging to change a selection.

Those entry points in addition to `WebPage::updateFocusBeforeSelectingTextAtLocation`
look up the plugin via WebPage::focusedPluginViewForFrame(LocalFrame&amp;), which only
recognizes plugins whose host document is a PluginDocument.

PluginDocument is created only when a PDF is the main resource of a frame (see
DOMImplementation.cpp). `&lt;iframe src=&quot;.pdf&quot;&gt;` qualifies: the iframe&apos;s subframe
loads the PDF as its main resource, so its document is a PluginDocument.
`&lt;embed&gt;` and `&lt;object&gt;` do not: the plugin is an inline widget inside a regular
HTMLDocument, so the lookup returns nullptr, and this path falls through to
the generic HTML range-selection code, and the FrameSelection on an HTMLDocument
that only contains a widget node cannot produce a selection.

The synthetic-click path in WebPageCocoa already handles this case via
HTMLPlugInElement::pluginWidget(), which returns the PluginView uniformly for
all three hosting modes. Apply the same pattern to the two sites this bug
touches:

  * WebPage::focusedPluginViewForFrame: if the frame&apos;s document is not a
    PluginDocument, fall back to the document&apos;s focused element; if it is an
    HTMLPlugInElement whose pluginWidget() is a PluginView, return that. The
    existing PluginDocument branch is preserved.

  * WebPage::updateFocusBeforeSelectingTextAtLocation: when the hit-test lands
    on an HTMLPlugInElement (embed/object), call focusPluginElement() on its
    PluginView so the fallback above can find it on subsequent lookups. The
    iframe branch (pluginViewForFrame, which stays PluginDocument-only) is
    unchanged.

Widening focusedPluginViewForFrame does intentionally affect its other callers
as well. populateEditorStateIfNeeded and executeEditingCommand now route to
embed/object-hosted PDFs when they are focused, so editor state and editing
commands like Copy and SelectAll behave consistently with iframe-hosted PDFs.

Test: Tools/TestWebKitAPI/Tests/WebKit/WKWebView/UnifiedPDFTests.mm

* Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm:
(WebKit::WebPage::updateFocusBeforeSelectingTextAtLocation):
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::focusedPluginViewForFrame):
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/UnifiedPDFTests.mm:
(TestWebKitAPI::runSelectAllAndVerifySelectedTextMatches):
(TestWebKitAPI::UNIFIED_PDF_TEST):

Canonical link: <a href="https://commits.webkit.org/312734@main">https://commits.webkit.org/312734@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cbd78f31941867a6f31b54b0496f2d92c5d7632f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/160370 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/33843 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/26944 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/169273 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/115436 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/162239 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/33944 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/33843 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/124341 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/87837 "2 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/f05fe550-4fc0-444a-bbc7-5a6893a8132a) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/163328 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/26580 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/144047 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/104940 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/87ac7a38-43d7-4bb6-9665-0c23a84c0996) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/25632 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/24136 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/16992 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/135325 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/21810 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/171750 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/18108 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/23450 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/132598 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/33516 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/28230 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/132619 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35942 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/33501 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/143605 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/95283 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/27229 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/20419 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/33010 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/99771 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/32511 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/32755 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/32659 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->