### PR TITLE
[WebXR] Clean up review comments from 311589@main

### DIFF
--- a/Source/WebKit/UIProcess/XR/PlatformXRCoordinator.h
+++ b/Source/WebKit/UIProcess/XR/PlatformXRCoordinator.h
@@ -73,7 +73,7 @@ public:
 
 #if ENABLE(WEBXR_LAYERS)
     using CreateCompositionLayerCallback = CompletionHandler<void(std::optional<PlatformXR::LayerInfo>)>;
-    virtual void createCompositionLayer(PlatformXR::CompositionLayerType, WebCore::IntSize, PlatformXR::LayerLayout, CreateCompositionLayerCallback&&) { };
+    virtual void createCompositionLayer(PlatformXR::CompositionLayerType, WebCore::IntSize, PlatformXR::LayerLayout, CreateCompositionLayerCallback&&) = 0;
 #endif
 
     // Session creation/termination.

--- a/Source/WebKit/UIProcess/XR/PlatformXRSystem.cpp
+++ b/Source/WebKit/UIProcess/XR/PlatformXRSystem.cpp
@@ -443,13 +443,8 @@ PlatformXRCoordinator* PlatformXRSystem::xrCoordinator()
 }
 #endif // !USE(APPLE_INTERNAL_SDK) && !USE(OPENXR) && !PLATFORM(IOS) && !PLATFORM(VISION)
 
-#if ENABLE(WEBXR_LAYERS) && PLATFORM(VISION)
-void PlatformXRSystem::createCompositionLayer(IPC::Connection&, PlatformXR::CompositionLayerType, WebCore::IntSize, PlatformXR::LayerLayout, CompletionHandler<void(std::optional<PlatformXR::LayerInfo>)>&& reply)
-{
-    ASSERT_NOT_REACHED_WITH_MESSAGE("VisionOS does not support composition layers yet");
-    reply(std::nullopt);
-}
-#endif // ENABLE(WEBXR_LAYERS) && PLATFORM(VISION)
+/*
+*/
 
 } // namespace WebKit
 

--- a/Source/WebKit/UIProcess/XR/PlatformXRSystem.h
+++ b/Source/WebKit/UIProcess/XR/PlatformXRSystem.h
@@ -105,12 +105,7 @@ private:
     void submitFrame(IPC::Connection&);
 #endif
 #if ENABLE(WEBXR_LAYERS)
-#if !USE(OPENXR) && !defined(NDEBUG)
-#define XR_NORETURN [[noreturn]]
-#else
-#define XR_NORETURN
-#endif
-    XR_NORETURN void NODELETE createCompositionLayer(IPC::Connection&, PlatformXR::CompositionLayerType, WebCore::IntSize, PlatformXR::LayerLayout, CompletionHandler<void(std::optional<PlatformXR::LayerInfo>)>&&);
+    void NODELETE createCompositionLayer(IPC::Connection&, PlatformXR::CompositionLayerType, WebCore::IntSize, PlatformXR::LayerLayout, CompletionHandler<void(std::optional<PlatformXR::LayerInfo>)>&&);
 #endif
 #if ENABLE(WEBXR_HIT_TEST)
     void requestHitTestSource(const PlatformXR::HitTestOptions&, CompletionHandler<void(Expected<PlatformXR::HitTestSource, WebCore::ExceptionData>)>&&);

--- a/Source/WebKit/UIProcess/XR/xros/PlatformXRSystemXROS.mm
+++ b/Source/WebKit/UIProcess/XR/xros/PlatformXRSystemXROS.mm
@@ -46,6 +46,14 @@ PlatformXRCoordinator* PlatformXRSystem::xrCoordinator()
     return &xrCoordinator.get();
 }
 
+#if ENABLE(WEBXR_LAYERS)
+void PlatformXRSystem::createCompositionLayer(IPC::Connection&, PlatformXR::CompositionLayerType, WebCore::IntSize, PlatformXR::LayerLayout, CompletionHandler<void(std::optional<PlatformXR::LayerInfo>)>&& reply)
+{
+    RELEASE_LOG_ERROR(XR, "VisionOS does not support composition layers yet");
+    reply(std::nullopt);
+}
+#endif // ENABLE(WEBXR_LAYERS)
+
 } // namespace WebKit
 
 #endif // ENABLE(WEBXR) && USE(COMPOSITORXR)


### PR DESCRIPTION
#### 7d902079ddb0d4494bfbe7a63fe725f22b031d2b
<pre>
[WebXR] Clean up review comments from 311589@main
<a href="https://bugs.webkit.org/show_bug.cgi?id=313956">https://bugs.webkit.org/show_bug.cgi?id=313956</a>
<a href="https://rdar.apple.com/176162825">rdar://176162825</a>

Reviewed by Mike Wyrzykowski.

Refactor visionOS implementation of createCompositionLayer.
Remove the need for XR_NORETURN.

* Source/WebKit/UIProcess/XR/PlatformXRCoordinator.h:
(WebKit::PlatformXRCoordinator::createCompositionLayer): Deleted.
* Source/WebKit/UIProcess/XR/PlatformXRSystem.cpp:
(WebKit::PlatformXRSystem::createCompositionLayer): Deleted.
* Source/WebKit/UIProcess/XR/PlatformXRSystem.h:
* Source/WebKit/UIProcess/XR/xros/PlatformXRSystemXROS.mm:
(WebKit::PlatformXRSystem::createCompositionLayer):

Canonical link: <a href="https://commits.webkit.org/312582@main">https://commits.webkit.org/312582@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cae37f932e9895b7d6b66558239215c2f10f4cad

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/160244 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/33714 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/26818 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/169146 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/114625 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/d7c4cbd6-c02b-4fdf-ba2b-fca7b32710a6) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/33818 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/33716 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/124230 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/87148 "2 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/3a4616c6-316f-4071-80c5-1a52a78dd32f) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/163202 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/26475 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/143931 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/104829 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/60db0754-7b0a-4f11-adc2-2366c602292c) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/25528 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/24023 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/16866 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/135220 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/171624 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/17612 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/23334 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/132482 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/33390 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/28118 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/132508 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35853 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/33375 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/143489 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/91658 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/27128 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/20303 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/32884 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/99281 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/32382 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/32628 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/32532 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->