### PR TITLE
[WebXR Layers] Add init and setter param validation for equirect layer

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/webxr/layers/xrEquirectLayer_paramValidation.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webxr/layers/xrEquirectLayer_paramValidation.https-expected.txt
@@ -1,0 +1,4 @@
+
+PASS Ensure XREquirectLayer init and setter parameters are validated - webgl
+PASS Ensure XREquirectLayer init and setter parameters are validated - webgl2
+

--- a/LayoutTests/imported/w3c/web-platform-tests/webxr/layers/xrEquirectLayer_paramValidation.https.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webxr/layers/xrEquirectLayer_paramValidation.https.html
@@ -1,0 +1,94 @@
+<!DOCTYPE html>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="../resources/webxr_util.js"></script>
+<script src="../resources/webxr_test_constants.js"></script>
+
+<script>
+
+  function testEquirectLayerParamValidation(xrSession, deviceController, t, { gl }) {
+    return xrSession.requestReferenceSpace('local').then((refSpace) => {
+      const binding = new XRWebGLBinding(xrSession, gl);
+      const baseInit = { space: refSpace, viewPixelWidth: 1, viewPixelHeight: 1, };
+
+      // Constructor params validation
+      t.step(() => {
+        const layer = binding.createEquirectLayer({ ...baseInit, radius: -1 });
+        assert_greater_than_equal(layer.radius, 0, "radius must be a non-negative value");
+      });
+
+      t.step(() => {
+        const layer = binding.createEquirectLayer({ ...baseInit, centralHorizontalAngle: -1 });
+        assert_greater_than_equal(layer.centralHorizontalAngle, 0, "centralHorizontalAngle must be a non-negative value");
+      });
+
+      t.step(() => {
+        const layer = binding.createEquirectLayer({ ...baseInit, centralHorizontalAngle: 3 * Math.PI });
+        assert_approx_equals(layer.centralHorizontalAngle, 2 * Math.PI, 1e-4, "centralHorizontalAngle must not exceed 2*pi");
+      });
+
+      t.step(() => {
+        const layer = binding.createEquirectLayer({ ...baseInit, upperVerticalAngle: 2 });
+        assert_approx_equals(layer.upperVerticalAngle, Math.PI / 2, 1e-4, "upperVerticalAngle must clamp to pi/2");
+      });
+
+      t.step(() => {
+        const layer = binding.createEquirectLayer({ ...baseInit, upperVerticalAngle: -2 });
+        assert_approx_equals(layer.upperVerticalAngle, -Math.PI / 2, 1e-4, "upperVerticalAngle must clamp to -pi/2");
+      });
+
+      t.step(() => {
+        const layer = binding.createEquirectLayer({ ...baseInit, lowerVerticalAngle: 2 });
+        assert_approx_equals(layer.lowerVerticalAngle, Math.PI / 2, 1e-4, "lowerVerticalAngle must clamp to pi/2");
+      });
+
+      t.step(() => {
+        const layer = binding.createEquirectLayer({ ...baseInit, lowerVerticalAngle: -2 });
+        assert_approx_equals(layer.lowerVerticalAngle, -Math.PI / 2, 1e-4, "lowerVerticalAngle must clamp to -pi/2");
+      });
+
+      // Setter validation
+      const layer = binding.createEquirectLayer({ ...baseInit });
+
+      t.step(() => {
+        layer.radius = -5;
+        assert_greater_than_equal(layer.radius, 0, "Setting negative radius must clamp to a non-negative value");
+      });
+
+      t.step(() => {
+        layer.centralHorizontalAngle = -1;
+        assert_greater_than_equal(layer.centralHorizontalAngle, 0, "Setting negative centralHorizontalAngle must clamp to a non-negative value");
+      });
+
+      t.step(() => {
+        layer.centralHorizontalAngle = 3 * Math.PI;
+        assert_approx_equals(layer.centralHorizontalAngle, 2 * Math.PI, 1e-4, "Setting centralHorizontalAngle must not exceed 2*pi");
+      });
+
+      t.step(() => {
+        layer.upperVerticalAngle = 2;
+        assert_approx_equals(layer.upperVerticalAngle, Math.PI / 2, 1e-4, "Setting upperVerticalAngle must clamp to pi/2");
+      });
+
+      t.step(() => {
+        layer.upperVerticalAngle = -2;
+        assert_approx_equals(layer.upperVerticalAngle, -Math.PI / 2, 1e-4, "Setting upperVerticalAngle must clamp to -pi/2");
+      });
+
+      t.step(() => {
+        layer.lowerVerticalAngle = 2;
+        assert_approx_equals(layer.lowerVerticalAngle, Math.PI / 2, 1e-4, "Setting lowerVerticalAngle must clamp to pi/2");
+      });
+
+      t.step(() => {
+        layer.lowerVerticalAngle = -2;
+        assert_approx_equals(layer.lowerVerticalAngle, -Math.PI / 2, 1e-4, "Setting lowerVerticalAngle must clamp to -pi/2");
+      });
+    });
+  }
+
+  xr_session_promise_test("Ensure XREquirectLayer init and setter parameters are validated",
+    testEquirectLayerParamValidation, TRACKED_IMMERSIVE_DEVICE, 'immersive-vr', { requiredFeatures: ['layers'] }
+);
+
+</script>

--- a/Source/WebCore/Modules/webxr/XREquirectLayer.cpp
+++ b/Source/WebCore/Modules/webxr/XREquirectLayer.cpp
@@ -25,6 +25,7 @@
 
 #include "config.h"
 #include "XREquirectLayer.h"
+#include <cmath>
 
 #if ENABLE(WEBXR_LAYERS)
 
@@ -33,6 +34,7 @@
 #include "WebXRSession.h"
 #include "XRLayerBacking.h"
 #include "XRWebGLBinding.h"
+#include <wtf/MathExtras.h>
 #include <wtf/Scope.h>
 #include <wtf/TZoneMallocInlines.h>
 
@@ -44,11 +46,13 @@ XREquirectLayer::XREquirectLayer(ScriptExecutionContext& scriptExecutionContext,
     : XRCompositionLayer(&scriptExecutionContext, session, WTF::move(backing), init)
     , m_space(init.space)
     , m_transform((init.transform) ? init.transform : WebXRRigidTransform::create())
-    , m_radius(init.radius)
-    , m_centralHorizontalAngle(init.centralHorizontalAngle)
-    , m_upperVerticalAngle(init.upperVerticalAngle)
-    , m_lowerVerticalAngle(init.lowerVerticalAngle)
 {
+    // Explicitly call setters to add validation.
+    setRadius(init.radius);
+    setCentralHorizontalAngle(init.centralHorizontalAngle);
+    setUpperVerticalAngle(init.upperVerticalAngle);
+    setLowerVerticalAngle(init.lowerVerticalAngle);
+
     setIsStatic(init.isStatic);
 }
 
@@ -81,6 +85,31 @@ void XREquirectLayer::setTransform(WebXRRigidTransform& transform)
         return;
 
     m_transform = transform;
+    setNeedsRedraw(true);
+}
+
+void XREquirectLayer::setRadius(float radius)
+{
+    m_radius = std::max(0.f, radius);
+    setNeedsRedraw(true);
+}
+
+void XREquirectLayer::setCentralHorizontalAngle(float angle)
+{
+    constexpr float twoPiFloat = static_cast<float>(std::numbers::pi * 2);
+    m_centralHorizontalAngle = std::clamp(angle, 0.f, twoPiFloat);
+    setNeedsRedraw(true);
+}
+
+void XREquirectLayer::setUpperVerticalAngle(float angle)
+{
+    m_upperVerticalAngle = std::clamp(angle, -piOverTwoFloat, piOverTwoFloat);
+    setNeedsRedraw(true);
+}
+
+void XREquirectLayer::setLowerVerticalAngle(float angle)
+{
+    m_lowerVerticalAngle = std::clamp(angle, -piOverTwoFloat, piOverTwoFloat);
     setNeedsRedraw(true);
 }
 

--- a/Source/WebCore/Modules/webxr/XREquirectLayer.h
+++ b/Source/WebCore/Modules/webxr/XREquirectLayer.h
@@ -57,13 +57,13 @@ public:
     void setTransform(WebXRRigidTransform&);
 
     float radius() const { return m_radius; }
-    void setRadius(float radius) { m_radius = radius; setNeedsRedraw(true); }
+    void setRadius(float);
     float centralHorizontalAngle() const { return m_centralHorizontalAngle; }
-    void setCentralHorizontalAngle(float angle) { m_centralHorizontalAngle = angle; setNeedsRedraw(true); }
+    void setCentralHorizontalAngle(float);
     float upperVerticalAngle() const { return m_upperVerticalAngle; }
-    void setUpperVerticalAngle(float angle) { m_upperVerticalAngle = angle; setNeedsRedraw(true); }
+    void setUpperVerticalAngle(float);
     float lowerVerticalAngle() const { return m_lowerVerticalAngle; }
-    void setLowerVerticalAngle(float angle) { m_lowerVerticalAngle = angle; setNeedsRedraw(true); }
+    void setLowerVerticalAngle(float);
 
 private:
     XREquirectLayer(ScriptExecutionContext&, WebXRSession&, Ref<XRLayerBacking>&&, const XREquirectLayerInit&);


### PR DESCRIPTION
#### 6c4c4b8f1ceaa3118b98418de778d8fc72f60f9c
<pre>
[WebXR Layers] Add init and setter param validation for equirect layer
<a href="https://bugs.webkit.org/show_bug.cgi?id=313958">https://bugs.webkit.org/show_bug.cgi?id=313958</a>

Reviewed by Dan Glastonbury.

The equirect layer is defined by a set of values that define its shape.
They can be specified at construction time in the init structure and/or
modified later using the layer setters.

Those values must be validated as not every value is valid. Specs do not
have an explicit validation phase for them but they do specify the
limits so we&apos;ll have to add some clamping

Test: imported/w3c/web-platform-tests/webxr/layers/xrEquirectLayer_paramValidation.https.html

* LayoutTests/imported/w3c/web-platform-tests/webxr/layers/xrEquirectLayer_paramValidation.https-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/webxr/layers/xrEquirectLayer_paramValidation.https.html: Added.
* Source/WebCore/Modules/webxr/XREquirectLayer.cpp:
(WebCore::XREquirectLayer::XREquirectLayer):
(WebCore::XREquirectLayer::setRadius):
(WebCore::XREquirectLayer::setCentralHorizontalAngle):
(WebCore::XREquirectLayer::setUpperVerticalAngle):
(WebCore::XREquirectLayer::setLowerVerticalAngle):
* Source/WebCore/Modules/webxr/XREquirectLayer.h:
(WebCore::XREquirectLayer::setRadius): Deleted.
(WebCore::XREquirectLayer::setCentralHorizontalAngle): Deleted.
(WebCore::XREquirectLayer::setUpperVerticalAngle): Deleted.
(WebCore::XREquirectLayer::setLowerVerticalAngle): Deleted.

Canonical link: <a href="https://commits.webkit.org/312595@main">https://commits.webkit.org/312595@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4f0b6b593cac0ca702bfc64f9ed3eb047bdbb141

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/160259 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/33731 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/26833 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/169161 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/114640 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/162128 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/33833 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/33732 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/124245 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/87796 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/163217 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/26487 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/143948 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/104844 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/25540 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/24035 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/16881 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/135232 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/21711 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/171639 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/17697 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/23351 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/132495 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/33405 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/28129 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/132521 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35863 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/33390 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/143506 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/91680 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/27137 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/20320 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/32899 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/99364 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/32397 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/32644 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/32547 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->