### PR TITLE
Web Inspector: Define which timeline events can be nested

### DIFF
--- a/Source/WebCore/inspector/agents/InspectorTimelineAgent.cpp
+++ b/Source/WebCore/inspector/agents/InspectorTimelineAgent.cpp
@@ -599,21 +599,41 @@ static Inspector::Protocol::Timeline::EventType NODELETE toProtocol(TimelineReco
     return Inspector::Protocol::Timeline::EventType::TimeStamp;
 }
 
+bool InspectorTimelineAgent::shouldNestUnder(TimelineRecordType type, TimelineRecordType previousType) const
+{
+    switch (type) {
+    case TimelineRecordType::FunctionCall:
+        return true;
+    case TimelineRecordType::TimerFire:
+    case TimelineRecordType::EventDispatch:
+    case TimelineRecordType::FireAnimationFrame:
+    case TimelineRecordType::ObserverCallback:
+        switch (previousType) {
+        case TimelineRecordType::EvaluateScript:
+        case TimelineRecordType::FunctionCall:
+            return true;
+        default:
+            return false;
+        }
+    default:
+        return false;
+    }
+}
+
 void InspectorTimelineAgent::addRecordToTimeline(Ref<JSON::Object>&& record, TimelineRecordType type)
 {
     record->setString("type"_s, Inspector::Protocol::Helpers::getEnumConstantValue(toProtocol(type)));
 
-    if (m_recordStack.isEmpty()) {
+    const TimelineRecordEntry* previousEntry = m_recordStack.isEmpty() ? nullptr : &m_recordStack.last();
+    if (previousEntry && shouldNestUnder(type, previousEntry->type)) {
+        // Nested paint records are an implementation detail and add no information not already contained in the parent.
+        if (type == TimelineRecordType::Paint && previousEntry->type == type)
+            return;
+        previousEntry->children->pushObject(WTF::move(record));
+    } else {
         // FIXME: runtimeCast is a hack. We do it because we can't build TimelineEvent directly now.
         auto recordObject = Inspector::Protocol::BindingTraits<Inspector::Protocol::Timeline::TimelineEvent>::runtimeCast(WTF::move(record));
         sendEvent(WTF::move(recordObject));
-    } else {
-        const TimelineRecordEntry& parent = m_recordStack.last();
-        // Nested paint records are an implementation detail and add no information not already contained in the parent.
-        if (type == TimelineRecordType::Paint && parent.type == type)
-            return;
-
-        parent.children->pushObject(WTF::move(record));
     }
 }
 

--- a/Source/WebCore/inspector/agents/InspectorTimelineAgent.h
+++ b/Source/WebCore/inspector/agents/InspectorTimelineAgent.h
@@ -196,6 +196,8 @@ private:
 
     void didCompleteRecordEntry(const TimelineRecordEntry&);
 
+    bool shouldNestUnder(TimelineRecordType type, TimelineRecordType previousType) const;
+
     void addRecordToTimeline(Ref<JSON::Object>&&, TimelineRecordType);
 
     const UniqueRef<Inspector::TimelineFrontendDispatcher> m_frontendDispatcher;


### PR DESCRIPTION
#### 5bbe8996939dc7bc4544cf4f675671b19037267c
<pre>
Web Inspector: Define which timeline events can be nested
<a href="https://bugs.webkit.org/show_bug.cgi?id=313959">https://bugs.webkit.org/show_bug.cgi?id=313959</a>

Reviewed by Devin Rousso.

Currently, any timeline event that occurs during a longer ongoing event
unconditionally becomes its child, regardless of whether they are
logically related.

This patch adds `InspectorTimelineAgent::shouldNestUnder()` method that
defines which events can be nested under which other events.

* Source/WebCore/inspector/agents/InspectorTimelineAgent.cpp:
(WebCore::InspectorTimelineAgent::shouldNestUnder const):
(WebCore::InspectorTimelineAgent::addRecordToTimeline):
* Source/WebCore/inspector/agents/InspectorTimelineAgent.h:

Canonical link: <a href="https://commits.webkit.org/312649@main">https://commits.webkit.org/312649@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a4e69745da89298e555b9f543b07de86006de5cf

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/160561 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/34034 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/27135 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/169464 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/115627 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/162430 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/34135 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/34034 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/124512 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/87934 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/163520 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/26756 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/144218 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/105112 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/25808 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/24309 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/17184 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/135502 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/21981 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/171943 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/18754 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/23621 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/132776 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/33708 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/28402 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/132791 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35898 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/33692 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/143776 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/95488 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/27383 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/20590 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/33203 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/100357 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/32702 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/32946 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/32850 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->