### PR TITLE
Cherry-pick 311773@main (4a5a2da864a3). https://bugs.webkit.org/show_bug.cgi?id=312823

### DIFF
--- a/LayoutTests/ipc/register-mdns-name-unpaired-surrogate-crash-expected.txt
+++ b/LayoutTests/ipc/register-mdns-name-unpaired-surrogate-crash-expected.txt
@@ -1,0 +1,1 @@
+This test passes if the Networking process does not crash.

--- a/LayoutTests/ipc/register-mdns-name-unpaired-surrogate-crash.html
+++ b/LayoutTests/ipc/register-mdns-name-unpaired-surrogate-crash.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html><!-- webkit-test-runner [ IPCTestingAPIEnabled=true PeerConnectionEnabled=true ] -->
+<script>
+window.testRunner?.dumpAsText();
+window.testRunner?.waitUntilDone();
+import('./coreipc.js').then(({ CoreIPC }) => {
+    // 31 three-byte BMP code points followed by an unpaired high surrogate.
+    // simdutf::utf8_length_from_utf16 over-counts the trailing surrogate, yielding
+    // a length greater than characters.size() * 3.
+    const ipAddress = '\u0800'.repeat(31) + '\uD800';
+    CoreIPC.Networking.NetworkMDNSRegister.RegisterMDNSName(0, {
+        documentIdentifier: { object: { high: 1, low: 1 }, processIdentifier: 1 },
+        ipAddress
+    });
+    setTimeout(() => window.testRunner?.notifyDone(), 100);
+}).catch(() => window.testRunner?.notifyDone());
+</script>
+<body>
+<p>This test passes if the Networking process does not crash.</p>
+</body>

--- a/Source/WTF/wtf/text/StringImpl.h
+++ b/Source/WTF/wtf/text/StringImpl.h
@@ -1497,7 +1497,7 @@ inline Expected<std::invoke_result_t<Func, std::span<const char8_t>>, UTF8Conver
         return makeUnexpected(UTF8ConversionError::OutOfMemory);
 
     size_t bufferSize = characters.size() * 3;
-    bufferVector.grow(bufferSize);
+    bufferVector.resize(bufferSize);
     auto convertedSize = utf8ForCharactersIntoBuffer(characters, mode, bufferVector);
     if (!convertedSize)
         return makeUnexpected(convertedSize.error());

--- a/Source/WebCore/accessibility/AXLiveRegionManager.cpp
+++ b/Source/WebCore/accessibility/AXLiveRegionManager.cpp
@@ -179,19 +179,32 @@ void AXLiveRegionManager::handleLiveRegionChange(AccessibilityObject& object, An
     postAnnouncementForChange(object, oldSnapshot, newSnapshot);
 }
 
+// Limit on the number of objects visited during snapshot building to prevent
+// web content from hanging the process with excessively large live regions.
+static constexpr size_t maximumSnapshotObjects = 512;
+
 LiveRegionSnapshot AXLiveRegionManager::buildLiveRegionSnapshot(AccessibilityObject& object) const
 {
     LiveRegionSnapshot snapshot;
     snapshot.liveRegionStatus = stringToLiveRegionStatus(object.liveRegionStatus());
     snapshot.liveRegionRelevant = stringToLiveRegionRelevant(object.liveRegionRelevant());
 
-    std::function<void(AccessibilityObject&)> buildObjectList = [this, &buildObjectList, &snapshot] (AccessibilityObject& object) {
+    size_t objectsVisited = 0;
+    std::function<void(AccessibilityObject&)> buildObjectList = [this, &buildObjectList, &snapshot, &objectsVisited] (AccessibilityObject& object) {
+        if (objectsVisited >= maximumSnapshotObjects)
+            return;
+        ++objectsVisited;
+
         // Treat atomic objects as one object, so when they change the entire subtree is announced.
         if (object.liveRegionAtomic()) {
             HashSet<AXID> descendants;
 
             // Collect all atomic-region descendants to detect when nodes are added/removed within the atomic region.
-            std::function<void(AccessibilityObject&)> collectDescendants = [&collectDescendants, &descendants] (AccessibilityObject& descendant) {
+            std::function<void(AccessibilityObject&)> collectDescendants = [&collectDescendants, &descendants, &objectsVisited] (AccessibilityObject& descendant) {
+                if (objectsVisited >= maximumSnapshotObjects)
+                    return;
+                ++objectsVisited;
+
                 descendants.add(descendant.objectID());
                 for (auto& child : descendant.unignoredChildren())
                     collectDescendants(downcast<AccessibilityObject>(child.get()));

--- a/Source/WebCore/style/values/primitives/StylePrimitiveNumericTypes+Conversions.h
+++ b/Source/WebCore/style/values/primitives/StylePrimitiveNumericTypes+Conversions.h
@@ -351,19 +351,27 @@ template<auto R, typename V> struct ToStyle<CSS::UnevaluatedCalc<CSS::AnglePerce
 
         ASSERT(simplifiedCalc->category() == CSS::Category::AnglePercentage || simplifiedCalc->category() == CSS::Category::Angle || simplifiedCalc->category() == CSS::Category::Percentage);
 
-        if (simplifiedCalc->category() == CSS::Category::Angle)
-            return canonicalize(CSS::AngleRaw<R, V> { To::Dimension::unit, simplifiedCalc->doubleValue(rest...) }, std::forward<Rest>(rest)...);
+        if (simplifiedCalc->category() == CSS::Category::Angle) {
+            auto doubleValue = simplifiedCalc->doubleValue(rest...);
+            return canonicalize(CSS::AngleRaw<R, V> { To::Dimension::unit, doubleValue }, std::forward<Rest>(rest)...);
+        }
 
         if (simplifiedCalc->category() == CSS::Category::Percentage) {
-            if (WTF::holdsAlternative<CSSCalc::Percentage>(simplifiedCalc->tree().root))
-                return canonicalize(CSS::PercentageRaw<R, V> { simplifiedCalc->doubleValue(rest...) }, std::forward<Rest>(rest)...);
+            if (WTF::holdsAlternative<CSSCalc::Percentage>(simplifiedCalc->tree().root)) {
+                auto doubleValue = simplifiedCalc->doubleValue(rest...);
+                return canonicalize(CSS::PercentageRaw<R, V> { doubleValue }, std::forward<Rest>(rest)...);
+            }
             return typename To::Calc { simplifiedCalc->createCalculationValue(std::forward<Rest>(rest)...) };
         }
 
-        if (!simplifiedCalc->tree().type.percentHint)
-            return canonicalize(CSS::AngleRaw<R, V> { To::Dimension::unit, simplifiedCalc->doubleValue(rest...) }, std::forward<Rest>(rest)...);
-        if (WTF::holdsAlternative<CSSCalc::Percentage>(simplifiedCalc->tree().root))
-            return canonicalize(CSS::PercentageRaw<R, V> { simplifiedCalc->doubleValue(rest...) }, std::forward<Rest>(rest)...);
+        if (!simplifiedCalc->tree().type.percentHint) {
+            auto doubleValue = simplifiedCalc->doubleValue(rest...);
+            return canonicalize(CSS::AngleRaw<R, V> { To::Dimension::unit, doubleValue }, std::forward<Rest>(rest)...);
+        }
+        if (WTF::holdsAlternative<CSSCalc::Percentage>(simplifiedCalc->tree().root)) {
+            auto doubleValue = simplifiedCalc->doubleValue(rest...);
+            return canonicalize(CSS::PercentageRaw<R, V> { doubleValue }, std::forward<Rest>(rest)...);
+        }
         return typename To::Calc { simplifiedCalc->createCalculationValue(std::forward<Rest>(rest)...) };
     }
 };
@@ -385,19 +393,27 @@ template<auto R, typename V> struct ToStyle<CSS::UnevaluatedCalc<CSS::LengthPerc
 
         ASSERT(simplifiedCalc->category() == CSS::Category::LengthPercentage || simplifiedCalc->category() == CSS::Category::Length || simplifiedCalc->category() == CSS::Category::Percentage);
 
-        if (simplifiedCalc->category() == CSS::Category::Length)
-            return canonicalize(CSS::LengthRaw<R, V> { To::Dimension::unit, simplifiedCalc->doubleValue(rest...) }, std::forward<Rest>(rest)...);
+        if (simplifiedCalc->category() == CSS::Category::Length) {
+            auto doubleValue = simplifiedCalc->doubleValue(rest...);
+            return canonicalize(CSS::LengthRaw<R, V> { To::Dimension::unit, doubleValue }, std::forward<Rest>(rest)...);
+        }
 
         if (simplifiedCalc->category() == CSS::Category::Percentage) {
-            if (WTF::holdsAlternative<CSSCalc::Percentage>(simplifiedCalc->tree().root))
-                return canonicalize(CSS::PercentageRaw<R, V> { simplifiedCalc->doubleValue(rest...) }, std::forward<Rest>(rest)...);
+            if (WTF::holdsAlternative<CSSCalc::Percentage>(simplifiedCalc->tree().root)) {
+                auto doubleValue = simplifiedCalc->doubleValue(rest...);
+                return canonicalize(CSS::PercentageRaw<R, V> { doubleValue }, std::forward<Rest>(rest)...);
+            }
             return typename To::Calc { simplifiedCalc->createCalculationValue(std::forward<Rest>(rest)...) };
         }
 
-        if (!simplifiedCalc->tree().type.percentHint)
-            return canonicalize(CSS::LengthRaw<R, V> { To::Dimension::unit, simplifiedCalc->doubleValue(rest...) }, std::forward<Rest>(rest)...);
-        if (WTF::holdsAlternative<CSSCalc::Percentage>(simplifiedCalc->tree().root))
-            return canonicalize(CSS::PercentageRaw<R, V> { simplifiedCalc->doubleValue(rest...) }, std::forward<Rest>(rest)...);
+        if (!simplifiedCalc->tree().type.percentHint) {
+            auto doubleValue = simplifiedCalc->doubleValue(rest...);
+            return canonicalize(CSS::LengthRaw<R, V> { To::Dimension::unit, doubleValue }, std::forward<Rest>(rest)...);
+        }
+        if (WTF::holdsAlternative<CSSCalc::Percentage>(simplifiedCalc->tree().root)) {
+            auto doubleValue = simplifiedCalc->doubleValue(rest...);
+            return canonicalize(CSS::PercentageRaw<R, V> { doubleValue }, std::forward<Rest>(rest)...);
+        }
         return typename To::Calc { simplifiedCalc->createCalculationValue(std::forward<Rest>(rest)...) };
     }
 };

--- a/Source/WebKit/NetworkProcess/cache/NetworkCacheStorage.cpp
+++ b/Source/WebKit/NetworkProcess/cache/NetworkCacheStorage.cpp
@@ -746,7 +746,7 @@ std::optional<BlobStorage::Blob> Storage::storeBodyAsBlob(WriteOperationIdentifi
 
     addWriteOperationActivity(identifier);
 
-    RunLoop::mainSingleton().dispatch([this, protectedThis = Ref { *this }, blob = WTF::move(blob), identifier] {
+    RunLoop::mainSingleton().dispatch([this, protectedThis = Ref { *this }, blob, identifier] {
         assertIsMainThread();
 
         auto* writeOperation = m_activeWriteOperations.get(identifier);


### PR DESCRIPTION
#### c03ce1b850ef71caf4ee1a5afd3a167969466305
<pre>
Cherry-pick 311773@main (4a5a2da864a3). <a href="https://bugs.webkit.org/show_bug.cgi?id=312823">https://bugs.webkit.org/show_bug.cgi?id=312823</a>

    AX: AXLiveRegionManager::buildLiveRegionSnapshot can hang when iterating giant live regions
    <a href="https://bugs.webkit.org/show_bug.cgi?id=312823">https://bugs.webkit.org/show_bug.cgi?id=312823</a>
    <a href="https://rdar.apple.com/175190959">rdar://175190959</a>

    Reviewed by Joshua Hoffman.

    Web developers can pack arbitrary amounts of content into a live region, causing
    buildLiveRegionSnapshot to walk an unbounded accessibility tree and hang the web
    content process. Add a shared counter (maximumSnapshotObjects = 512) that caps the
    total objects visited across both the main buildObjectList walk and the collectDescendants
    walk for atomic regions.

    * Source/WebCore/accessibility/AXLiveRegionManager.cpp:
    (WebCore::AXLiveRegionManager::buildLiveRegionSnapshot const):

    Canonical link: <a href="https://commits.webkit.org/311773@main">https://commits.webkit.org/311773@main</a>

Canonical link: <a href="https://commits.webkit.org/305877.466@webkitglib/2.52">https://commits.webkit.org/305877.466@webkitglib/2.52</a>
</pre>
----------------------------------------------------------------------
#### 6476b06fc3f21eb5afef074765c0f2c7517f28d2
<pre>
Cherry-pick 312200@main (a888adce0991). <a href="https://bugs.webkit.org/show_bug.cgi?id=313537">https://bugs.webkit.org/show_bug.cgi?id=313537</a>

    Fix use-after-move in Storage::storeBodyAsBlob()
    <a href="https://bugs.webkit.org/show_bug.cgi?id=313537">https://bugs.webkit.org/show_bug.cgi?id=313537</a>

    Reviewed by Anne van Kesteren.

    Fix use-after-move of `blob` in Storage::storeBodyAsBlob(). It was moved
    into the lambda capture and later on returned by the function.

    * Source/WebKit/NetworkProcess/cache/NetworkCacheStorage.cpp:
    (WebKit::NetworkCache::Storage::storeBodyAsBlob):

    Canonical link: <a href="https://commits.webkit.org/312200@main">https://commits.webkit.org/312200@main</a>

Canonical link: <a href="https://commits.webkit.org/305877.465@webkitglib/2.52">https://commits.webkit.org/305877.465@webkitglib/2.52</a>
</pre>
----------------------------------------------------------------------
#### e7d39c927b06026c29e458240ade9ec28cda5cac
<pre>
Cherry-pick 311969@main (f7956b81207f). <a href="https://bugs.webkit.org/show_bug.cgi?id=313092">https://bugs.webkit.org/show_bug.cgi?id=313092</a>

    Address Use-After-Move in primitives/StylePrimitiveNumericTypes+Conversions
    <a href="https://bugs.webkit.org/show_bug.cgi?id=313092">https://bugs.webkit.org/show_bug.cgi?id=313092</a>
    <a href="https://rdar.apple.com/175388744">rdar://175388744</a>

    Reviewed by Sam Weinig.

    This fixes a use-after-move where the use and forward are unsequenced.

    * Source/WebCore/style/values/primitives/StylePrimitiveNumericTypes+Conversions.h:

    Canonical link: <a href="https://commits.webkit.org/311969@main">https://commits.webkit.org/311969@main</a>

Canonical link: <a href="https://commits.webkit.org/305877.464@webkitglib/2.52">https://commits.webkit.org/305877.464@webkitglib/2.52</a>
</pre>
----------------------------------------------------------------------
#### 83368093edaf69b2f3d598bf66a085676a641fc7
<pre>
Cherry-pick 312057@main (fd0db67fd877). <a href="https://bugs.webkit.org/show_bug.cgi?id=313333">https://bugs.webkit.org/show_bug.cgi?id=313333</a>

    [WTF] Fix crash in utf8ForCharacters when string ends with unpaired surrogate
    <a href="https://bugs.webkit.org/show_bug.cgi?id=313333">https://bugs.webkit.org/show_bug.cgi?id=313333</a>
    <a href="https://rdar.apple.com/174924192">rdar://174924192</a>

    Reviewed by Yusuke Suzuki.

    Replace grow with resize so the buffer is set to exactly characters.size() * 3 bytes, satisfying the assert regardless of what simdutf estimated.

    Test: ipc/register-mdns-name-unpaired-surrogate-crash.html

    * LayoutTests/ipc/register-mdns-name-unpaired-surrogate-crash-expected.txt: Added.
    * LayoutTests/ipc/register-mdns-name-unpaired-surrogate-crash.html: Added.
    * Source/WTF/wtf/text/StringImpl.h:
    (WTF::StringImpl::tryGetUTF8ForCharacters):

    Canonical link: <a href="https://commits.webkit.org/312057@main">https://commits.webkit.org/312057@main</a>

Canonical link: <a href="https://commits.webkit.org/305877.463@webkitglib/2.52">https://commits.webkit.org/305877.463@webkitglib/2.52</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e81467445707d96ce060693daf4c0af6df596919

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/160252 "Passed style check") | [❌ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/33722 "Unable to build WebKit without PR, please check manually (failure)") | [❌ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/26826 "Unable to build WebKit without PR, please check manually (failure)") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/169154 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/114633 "The change is no longer eligible for processing.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/162121 "Passed tests") | [❌ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/33826 "Unable to build WebKit without PR, please check manually (failure)") | [❌ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/33724 "Unable to build WebKit without PR, please check manually (failure)") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/124240 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/114633 "The change is no longer eligible for processing.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/163210 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/155/builds/33826 "Unable to build WebKit without PR, please check manually (failure)") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/168/builds/26826 "Unable to build WebKit without PR, please check manually (failure)") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/104839 "Passed tests") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/155/builds/33826 "Unable to build WebKit without PR, please check manually (failure)") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/156/builds/33724 "Unable to build WebKit without PR, please check manually (failure)") | [❌ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/16874 "Unable to build WebKit without PR, please check manually (failure)") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/152308 "Built successfully and passed tests") | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/155/builds/33826 "Unable to build WebKit without PR, please check manually (failure)") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/168/builds/26826 "Unable to build WebKit without PR, please check manually (failure)") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/171632 "Unable to build WebKit without PR, please check manually (failure)") | 
| [❌ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/21089 "Found 1 new JSC stress test failure: wasm.yaml/wasm/stress/simd-exception-throwing-v128-clobbers-fp.js.wasm-no-wasm-jit (failure)") | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/18022 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/168/builds/26826 "Unable to build WebKit without PR, please check manually (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/2/builds/171632 "Unable to build WebKit without PR, please check manually (failure)") | 
| | [❌ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/33398 "Unable to build WebKit without PR, please check manually (failure)") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/156/builds/33724 "Unable to build WebKit without PR, please check manually (failure)") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/2/builds/171632 "Unable to build WebKit without PR, please check manually (failure)") | 
| | [❌ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/33383 "Unable to build WebKit without PR, please check manually (failure)") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/168/builds/26826 "Unable to build WebKit without PR, please check manually (failure)") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/91668 "The change is no longer eligible for processing.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/24416 "Built successfully and passed tests") | [❌ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/160/builds/33383 "Unable to build WebKit without PR, please check manually (failure)") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/168/builds/26826 "Unable to build WebKit without PR, please check manually (failure)") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/192651 "Built successfully") | 
| | [❌ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/32892 "Failed to compile WebKit") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/99686 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/49594 "Passed tests") | 
| | [❌ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/32390 "Failed to compile WebKit") | | | 
| | [❌ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/32636 "Unable to build WebKit without PR, please check manually (failure)") | | | 
| | [❌ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/32540 "Unable to build WebKit without PR, please check manually (failure)") | | | 
<!--EWS-Status-Bubble-End-->