### PR TITLE
Remove MediaStrategy::nativeImageFromVideoFrame

### DIFF
--- a/Source/WebCore/Modules/mediastream/ImageCapture.cpp
+++ b/Source/WebCore/Modules/mediastream/ImageCapture.cpp
@@ -127,53 +127,12 @@ static ImageOrientation NODELETE videoFrameOrientation(const VideoFrame& videoFr
     return ImageOrientation::Orientation::OriginTopLeft;
 }
 
-static Ref<ImageBitmap> createImageBitmapViaDrawing(Ref<ImageBuffer>&& imageBuffer, VideoFrame& videoFrame)
-{
-    bool shouldDiscardAlpha = false;
-    imageBuffer->context().drawVideoFrame(videoFrame, { { }, imageBuffer->backendSize() }, videoFrameOrientation(videoFrame), shouldDiscardAlpha);
-
-    bool isOriginClean = true;
-    return ImageBitmap::create(WTF::move(imageBuffer), isOriginClean);
-}
-
 static Ref<ImageBitmap> createImageBitmapFromNativeImage(Ref<ImageBuffer>&& imageBuffer, NativeImage& nativeImage, ImageOrientation orientation)
 {
     imageBuffer->context().drawNativeImage(nativeImage, { { }, imageBuffer->backendSize() }, { { }, imageBuffer->backendSize() }, ImagePaintingOptions { orientation });
 
     bool isOriginClean = true;
     return ImageBitmap::create(WTF::move(imageBuffer), isOriginClean);
-}
-
-static void createImageBitmap(VideoFrame& videoFrame, CompletionHandler<void(RefPtr<ImageBitmap>&&)>&& completionHandler)
-{
-    IntSize size { static_cast<int>(videoFrame.presentationSize().width()), static_cast<int>(videoFrame.presentationSize().height()) };
-    if (videoFrame.has90DegreeRotation())
-        size = { size.height(), size.width() };
-    auto imageBuffer = ImageBuffer::create(size, RenderingMode::Unaccelerated, RenderingPurpose::Unspecified, 1, DestinationColorSpace::SRGB(), PixelFormat::BGRA8);
-    if (!imageBuffer) {
-        completionHandler({ });
-        return;
-    }
-
-    if (hasPlatformStrategies()) {
-        platformStrategies()->mediaStrategy()->nativeImageFromVideoFrame(videoFrame, [videoFrame = Ref { videoFrame }, imageBuffer = imageBuffer.releaseNonNull(), completionHandler = WTF::move(completionHandler)](auto&& nativeImage) mutable {
-            if (!nativeImage) {
-                completionHandler(createImageBitmapViaDrawing(WTF::move(imageBuffer), videoFrame));
-                return;
-            }
-
-            RefPtr image = WTF::move(*nativeImage);
-            if (!image) {
-                completionHandler({ });
-                return;
-            }
-
-            completionHandler(createImageBitmapFromNativeImage(WTF::move(imageBuffer), *image, videoFrameOrientation(videoFrame)));
-        });
-        return;
-    }
-
-    completionHandler(createImageBitmapViaDrawing(imageBuffer.releaseNonNull(), videoFrame));
 }
 
 static Exception createImageCaptureException()
@@ -183,13 +142,17 @@ static Exception createImageCaptureException()
 
 static void createImageBitmapOrException(VideoFrame& videoFrame, CompletionHandler<void(ExceptionOr<Ref<ImageBitmap>>&&)>&& callback)
 {
-    createImageBitmap(videoFrame, [callback = WTF::move(callback)](auto&& bitmap) mutable {
-        if (!bitmap) {
-            callback(createImageCaptureException());
-            return;
-        }
-        callback(bitmap.releaseNonNull());
-    });
+    auto nativeImage = videoFrame.copyNativeImage();
+    if (!nativeImage) {
+        callback(createImageCaptureException());
+        return;
+    }
+
+    IntSize size { static_cast<int>(videoFrame.presentationSize().width()), static_cast<int>(videoFrame.presentationSize().height()) };
+    if (videoFrame.has90DegreeRotation())
+        size = { size.height(), size.width() };
+    RefPtr imageBuffer = ImageBuffer::create(size, RenderingMode::Unaccelerated, RenderingPurpose::Unspecified, 1, DestinationColorSpace::SRGB(), PixelFormat::BGRA8);
+    callback(createImageBitmapFromNativeImage(imageBuffer.releaseNonNull(), *nativeImage, videoFrameOrientation(videoFrame)));
 }
 
 class ImageCaptureVideoFrameObserver : public RealtimeMediaSource::VideoFrameObserver, public ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<ImageCaptureVideoFrameObserver, WTF::DestructionThread::MainRunLoop> {

--- a/Source/WebCore/platform/MediaStrategy.h
+++ b/Source/WebCore/platform/MediaStrategy.h
@@ -74,7 +74,6 @@ public:
 #endif
 
 #if ENABLE(VIDEO)
-    virtual void nativeImageFromVideoFrame(const VideoFrame&, CompletionHandler<void(std::optional<RefPtr<NativeImage>>&&)>&&);
     virtual bool canDecodeExtendedType(PlatformMediaDecodingType, const ContentType&) { return false; }
     virtual void ensureCodecsSupportChecksInitialized() { }
 #endif
@@ -98,12 +97,5 @@ private:
     bool m_wirelessPlaybackMediaPlayerEnabled { false };
 #endif
 };
-
-#if ENABLE(VIDEO)
-inline void MediaStrategy::nativeImageFromVideoFrame(const VideoFrame&, CompletionHandler<void(std::optional<RefPtr<NativeImage>>&&)>&& completionHandler)
-{
-    completionHandler(std::nullopt);
-}
-#endif
 
 } // namespace WebCore

--- a/Source/WebCore/platform/VideoFrame.h
+++ b/Source/WebCore/platform/VideoFrame.h
@@ -116,7 +116,7 @@ public:
 
     void NODELETE initializeCharacteristics(MediaTime presentationTime, bool isMirrored, Rotation);
 
-    RefPtr<NativeImage> copyNativeImage() const;
+    WEBCORE_EXPORT RefPtr<NativeImage> copyNativeImage() const;
     const PlatformVideoColorSpace& colorSpace() const LIFETIME_BOUND { return m_colorSpace; }
 
     bool hasNoTransformation() const { return m_rotation == VideoFrameRotation::None && !m_isMirrored; }

--- a/Source/WebKit/GPUProcess/media/RemoteVideoFrameObjectHeap.cpp
+++ b/Source/WebKit/GPUProcess/media/RemoteVideoFrameObjectHeap.cpp
@@ -143,49 +143,6 @@ void RemoteVideoFrameObjectHeap::pixelBuffer(RemoteVideoFrameReadReference&& rea
     completionHandler(WTF::move(pixelBuffer));
 }
 
-void RemoteVideoFrameObjectHeap::convertFrameBuffer(SharedVideoFrame&& sharedVideoFrame, CompletionHandler<void(WebCore::DestinationColorSpace)>&& callback)
-{
-    DestinationColorSpace destinationColorSpace { DestinationColorSpace::SRGB().platformColorSpace() };
-    auto scope = makeScopeExit([&callback, &destinationColorSpace] { callback(destinationColorSpace); });
-
-    RefPtr<VideoFrame> frame;
-    Ref connection = m_connection;
-
-    if (std::holds_alternative<RemoteVideoFrameReadReference>(sharedVideoFrame.buffer))
-        frame = get(WTF::move(std::get<RemoteVideoFrameReadReference>(sharedVideoFrame.buffer)));
-    else
-        frame = m_sharedVideoFrameReader.read(WTF::move(sharedVideoFrame));
-
-    if (!frame) {
-        connection->send(Messages::RemoteVideoFrameObjectHeapProxyProcessor::NewConvertedVideoFrameBuffer { { } }, 0);
-        return;
-    }
-
-    RetainPtr<CVPixelBufferRef> buffer = frame->pixelBuffer();
-    destinationColorSpace = DestinationColorSpace(createCGColorSpaceForCVPixelBuffer(buffer.get()));
-
-    if (CVPixelBufferGetPixelFormatType(buffer.get()) != kCVPixelFormatType_32BGRA) {
-        Locker locker { m_pixelBufferConformerLock };
-        if (!m_pixelBufferConformer)
-            m_pixelBufferConformer = makeUnique<WebCore::PixelBufferConformerCV>(kCVPixelFormatType_32BGRA);
-
-        auto convertedBuffer = m_pixelBufferConformer->convert(buffer.get());
-        if (!convertedBuffer) {
-            RELEASE_LOG_ERROR(WebRTC, "RemoteVideoFrameObjectHeap::convertFrameBuffer conformer failed");
-            connection->send(Messages::RemoteVideoFrameObjectHeapProxyProcessor::NewConvertedVideoFrameBuffer { { } }, 0);
-            return;
-        }
-        buffer = WTF::move(convertedBuffer);
-    }
-
-    bool canSendIOSurface = false;
-    auto result = m_sharedVideoFrameWriter.writeBuffer(buffer.get(),
-        [&](auto& semaphore) { connection->send(Messages::RemoteVideoFrameObjectHeapProxyProcessor::SetSharedVideoFrameSemaphore { semaphore }, 0); },
-        [&](auto&& handle) { connection->send(Messages::RemoteVideoFrameObjectHeapProxyProcessor::SetSharedVideoFrameMemory { WTF::move(handle) }, 0); },
-        canSendIOSurface);
-    connection->send(Messages::RemoteVideoFrameObjectHeapProxyProcessor::NewConvertedVideoFrameBuffer { WTF::move(result) }, 0);
-}
-
 void RemoteVideoFrameObjectHeap::setSharedVideoFrameSemaphore(IPC::Semaphore&& semaphore)
 {
     m_sharedVideoFrameReader.setSemaphore(WTF::move(semaphore));

--- a/Source/WebKit/GPUProcess/media/RemoteVideoFrameObjectHeap.h
+++ b/Source/WebKit/GPUProcess/media/RemoteVideoFrameObjectHeap.h
@@ -71,7 +71,6 @@ private:
 #if PLATFORM(COCOA)
     void getVideoFrameBuffer(RemoteVideoFrameReadReference&&, bool canSendIOSurface);
     void pixelBuffer(RemoteVideoFrameReadReference&&, CompletionHandler<void(RetainPtr<CVPixelBufferRef>)>&&);
-    void convertFrameBuffer(SharedVideoFrame&&, CompletionHandler<void(WebCore::DestinationColorSpace)>&&);
     void setSharedVideoFrameSemaphore(IPC::Semaphore&&);
     void setSharedVideoFrameMemory(WebCore::SharedMemory::Handle&&);
 

--- a/Source/WebKit/GPUProcess/media/RemoteVideoFrameObjectHeap.messages.in
+++ b/Source/WebKit/GPUProcess/media/RemoteVideoFrameObjectHeap.messages.in
@@ -33,7 +33,6 @@ messages -> RemoteVideoFrameObjectHeap {
     PixelBuffer(WebKit::RemoteVideoFrameReadReference read) -> (RetainPtr<CVPixelBufferRef> result) Synchronous
     SetSharedVideoFrameSemaphore(IPC::Semaphore semaphore)
     SetSharedVideoFrameMemory(WebCore::SharedMemory::Handle storageHandle)
-    ConvertFrameBuffer(struct WebKit::SharedVideoFrame frame) -> (WebCore::DestinationColorSpace space) Synchronous
 #endif
     ReleaseVideoFrame(WebKit::RemoteVideoFrameWriteReference write) AllowedWhenWaitingForSyncReply
 }

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextGLProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextGLProxy.cpp
@@ -258,7 +258,7 @@ RefPtr<Image> RemoteGraphicsContextGLProxy::videoFrameToImage(WebCore::VideoFram
 #if PLATFORM(COCOA)
     RefPtr<NativeImage> nativeImage;
     callOnMainRunLoopAndWait([&] {
-        nativeImage = protect(m_videoFrameObjectHeapProxy)->getNativeImage(frame);
+        nativeImage = frame.copyNativeImage();
     });
     return BitmapImage::create(WTF::move(nativeImage));
 #else

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteQueueProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteQueueProxy.cpp
@@ -173,13 +173,7 @@ void RemoteQueueProxy::setLabelInternal(const String& label)
 
 RefPtr<WebCore::NativeImage> RemoteQueueProxy::getNativeImage(WebCore::VideoFrame& videoFrame)
 {
-    RefPtr<WebCore::NativeImage> nativeImage;
-#if ENABLE(VIDEO) && PLATFORM(COCOA) && ENABLE(WEB_CODECS)
-    callOnMainRunLoopAndWait([&nativeImage, videoFrame = protect(videoFrame), videoFrameHeap = protect(m_videoFrameObjectHeapProxy)] {
-        nativeImage = videoFrameHeap->getNativeImage(videoFrame);
-    });
-#endif
-    return nativeImage;
+    return videoFrame.copyNativeImage();
 }
 
 

--- a/Source/WebKit/WebProcess/GPU/media/AudioVideoRendererRemote.cpp
+++ b/Source/WebKit/WebProcess/GPU/media/AudioVideoRendererRemote.cpp
@@ -401,7 +401,7 @@ RefPtr<NativeImage> AudioVideoRendererRemote::currentNativeImage() const
         return nullptr;
     ASSERT(gpuProcessConnection);
 
-    return protect(gpuProcessConnection->videoFrameObjectHeapProxy())->getNativeImage(*videoFrame);
+    return videoFrame->copyNativeImage();
 #else
     ASSERT_NOT_REACHED();
     return nullptr;

--- a/Source/WebKit/WebProcess/GPU/media/RemoteMediaPlayerManager.cpp
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteMediaPlayerManager.cpp
@@ -263,7 +263,7 @@ void RemoteMediaPlayerManager::setUseGPUProcess(bool useGPUProcess)
             return protect(WebProcess::singleton().ensureGPUProcessConnection())->sampleBufferDisplayLayerManager().createLayer(client);
         });
         WebCore::MediaPlayerPrivateMediaStreamAVFObjC::setNativeImageCreator([](auto& videoFrame) {
-            return protect(WebProcess::singleton().ensureGPUProcessConnection())->videoFrameObjectHeapProxy().getNativeImage(videoFrame);
+            return videoFrame.copyNativeImage();
         });
     }
 #endif

--- a/Source/WebKit/WebProcess/GPU/media/WebMediaStrategy.cpp
+++ b/Source/WebKit/WebProcess/GPU/media/WebMediaStrategy.cpp
@@ -178,12 +178,4 @@ void WebMediaStrategy::enableMockMediaSource()
 }
 #endif
 
-#if PLATFORM(COCOA) && ENABLE(VIDEO)
-void WebMediaStrategy::nativeImageFromVideoFrame(const WebCore::VideoFrame& frame, CompletionHandler<void(std::optional<RefPtr<WebCore::NativeImage>>&&)>&& completionHandler)
-{
-    // FIXME: Move out of sync IPC.
-    completionHandler(protect(protect(WebProcess::singleton().ensureGPUProcessConnection())->videoFrameObjectHeapProxy())->getNativeImage(frame));
-}
-#endif
-
 } // namespace WebKit

--- a/Source/WebKit/WebProcess/GPU/media/WebMediaStrategy.h
+++ b/Source/WebKit/WebProcess/GPU/media/WebMediaStrategy.h
@@ -56,9 +56,6 @@ private:
 #if ENABLE(MEDIA_SOURCE)
     void enableMockMediaSource() final;
 #endif
-#if PLATFORM(COCOA) && ENABLE(VIDEO)
-    void nativeImageFromVideoFrame(const WebCore::VideoFrame&, CompletionHandler<void(std::optional<RefPtr<WebCore::NativeImage>>&&)>&&) final;
-#endif
 
 #if ENABLE(GPU_PROCESS)
     std::atomic<bool> m_useGPUProcess { false };

--- a/Source/WebKit/WebProcess/GPU/media/cocoa/MediaPlayerPrivateRemoteCocoa.mm
+++ b/Source/WebKit/WebProcess/GPU/media/cocoa/MediaPlayerPrivateRemoteCocoa.mm
@@ -67,7 +67,7 @@ RefPtr<NativeImage> MediaPlayerPrivateRemote::nativeImageForCurrentTime()
     if (!videoFrame)
         return nullptr;
 
-    return protect(protect(WebProcess::singleton().ensureGPUProcessConnection())->videoFrameObjectHeapProxy())->getNativeImage(*videoFrame);
+    return videoFrame->copyNativeImage();
 }
 
 WebCore::DestinationColorSpace MediaPlayerPrivateRemote::colorSpace()

--- a/Source/WebKit/WebProcess/GPU/webrtc/RemoteVideoFrameObjectHeapProxy.h
+++ b/Source/WebKit/WebProcess/GPU/webrtc/RemoteVideoFrameObjectHeapProxy.h
@@ -50,7 +50,6 @@ public:
 
 #if PLATFORM(COCOA)
     void getVideoFrameBuffer(const RemoteVideoFrameProxy& proxy, bool canUseIOSurface, RemoteVideoFrameObjectHeapProxyProcessor::Callback&& callback) { m_processor->getVideoFrameBuffer(proxy, canUseIOSurface, WTF::move(callback)); }
-    RefPtr<WebCore::NativeImage> getNativeImage(const WebCore::VideoFrame& frame) { return m_processor->getNativeImage(frame); }
 #endif
 
 private:

--- a/Source/WebKit/WebProcess/GPU/webrtc/RemoteVideoFrameObjectHeapProxyProcessor.cpp
+++ b/Source/WebKit/WebProcess/GPU/webrtc/RemoteVideoFrameObjectHeapProxyProcessor.cpp
@@ -148,33 +148,6 @@ void RemoteVideoFrameObjectHeapProxyProcessor::newConvertedVideoFrameBuffer(std:
     m_conversionSemaphore.signal();
 }
 
-RefPtr<NativeImage> RemoteVideoFrameObjectHeapProxyProcessor::getNativeImage(const WebCore::VideoFrame& videoFrame)
-{
-    Ref connection = WebProcess::singleton().ensureGPUProcessConnection().connection();
-
-    if (m_sharedVideoFrameWriter.isDisabled())
-        m_sharedVideoFrameWriter = { };
-
-    auto frame = m_sharedVideoFrameWriter.write(videoFrame,
-        [&](auto& semaphore) { connection->send(Messages::RemoteVideoFrameObjectHeap::SetSharedVideoFrameSemaphore { semaphore }, 0); },
-        [&](auto&& handle) { connection->send(Messages::RemoteVideoFrameObjectHeap::SetSharedVideoFrameMemory { WTF::move(handle) }, 0); });
-    if (!frame)
-        return nullptr;
-
-    auto sendResult = connection->sendSync(Messages::RemoteVideoFrameObjectHeap::ConvertFrameBuffer { WTF::move(*frame) }, 0, GPUProcessConnection::defaultTimeout);
-    if (!sendResult.succeeded()) {
-        m_sharedVideoFrameWriter.disable();
-        return nullptr;
-    }
-
-    auto [destinationColorSpace] = sendResult.takeReplyOr(DestinationColorSpace { DestinationColorSpace::SRGB().platformColorSpace() });
-
-    m_conversionSemaphore.wait();
-
-    RetainPtr pixelBuffer = std::exchange(m_convertedBuffer, { });
-    return pixelBuffer ? NativeImage::create(createImageFrom32BGRAPixelBuffer(WTF::move(pixelBuffer), RetainPtr { destinationColorSpace.platformColorSpace() }.get())) : nullptr;
-}
-
 }
 
 #endif

--- a/Source/WebKit/WebProcess/GPU/webrtc/RemoteVideoFrameObjectHeapProxyProcessor.h
+++ b/Source/WebKit/WebProcess/GPU/webrtc/RemoteVideoFrameObjectHeapProxyProcessor.h
@@ -62,7 +62,6 @@ public:
 
     using Callback = Function<void(RetainPtr<CVPixelBufferRef>&&)>;
     void getVideoFrameBuffer(const RemoteVideoFrameProxy&, bool canUseIOSurfce, Callback&&);
-    RefPtr<WebCore::NativeImage> getNativeImage(const WebCore::VideoFrame&);
 
     ThreadSafeWeakPtrControlBlock& controlBlock() const final { return IPC::WorkQueueMessageReceiver<WTF::DestructionThread::MainRunLoop>::controlBlock(); }
     uint32_t weakRefCount() const final { return IPC::WorkQueueMessageReceiver<WTF::DestructionThread::MainRunLoop>::weakRefCount(); }


### PR DESCRIPTION
#### fc097880cafe13566cb0908fa521f5d1314c0637
<pre>
Remove MediaStrategy::nativeImageFromVideoFrame
<a href="https://rdar.apple.com/176176418">rdar://176176418</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=313964">https://bugs.webkit.org/show_bug.cgi?id=313964</a>

Reviewed by NOBODY (OOPS!).

Current implement of MediaStrategy::nativeImageFromVideoFrame requires an IPC call.
We can instead just use VideoFrame::copytoNativeImage which does not always require a sync IPC call so we use this instead.
It allows simplifying implementation (we use just one code path).

Covered by existing tests.

* Source/WebCore/Modules/mediastream/ImageCapture.cpp:
(WebCore::createImageBitmap):
(WebCore::createImageBitmapViaDrawing): Deleted.
* Source/WebCore/platform/MediaStrategy.h:
(WebCore::MediaStrategy::nativeImageFromVideoFrame): Deleted.
* Source/WebCore/platform/VideoFrame.h:
* Source/WebKit/GPUProcess/media/RemoteVideoFrameObjectHeap.cpp:
(WebKit::RemoteVideoFrameObjectHeap::convertFrameBuffer): Deleted.
* Source/WebKit/GPUProcess/media/RemoteVideoFrameObjectHeap.h:
* Source/WebKit/GPUProcess/media/RemoteVideoFrameObjectHeap.messages.in:
* Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextGLProxy.cpp:
(WebKit::RemoteGraphicsContextGLProxy::videoFrameToImage):
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteQueueProxy.cpp:
(WebKit::WebGPU::RemoteQueueProxy::getNativeImage):
* Source/WebKit/WebProcess/GPU/media/AudioVideoRendererRemote.cpp:
(WebKit::AudioVideoRendererRemote::currentNativeImage const):
* Source/WebKit/WebProcess/GPU/media/RemoteMediaPlayerManager.cpp:
(WebKit::RemoteMediaPlayerManager::setUseGPUProcess):
* Source/WebKit/WebProcess/GPU/media/WebMediaStrategy.cpp:
(WebKit::WebMediaStrategy::nativeImageFromVideoFrame): Deleted.
* Source/WebKit/WebProcess/GPU/media/WebMediaStrategy.h:
* Source/WebKit/WebProcess/GPU/media/cocoa/MediaPlayerPrivateRemoteCocoa.mm:
(WebKit::MediaPlayerPrivateRemote::nativeImageForCurrentTime):
* Source/WebKit/WebProcess/GPU/webrtc/RemoteVideoFrameObjectHeapProxy.h:
(WebKit::RemoteVideoFrameObjectHeapProxy::getVideoFrameBuffer):
(WebKit::RemoteVideoFrameObjectHeapProxy::getNativeImage): Deleted.
* Source/WebKit/WebProcess/GPU/webrtc/RemoteVideoFrameObjectHeapProxyProcessor.cpp:
(WebKit::RemoteVideoFrameObjectHeapProxyProcessor::getNativeImage): Deleted.
* Source/WebKit/WebProcess/GPU/webrtc/RemoteVideoFrameObjectHeapProxyProcessor.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/784befb9b6df9a4fc34a3a0578cfdf2f86a10376

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/160283 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/33756 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/26857 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/169185 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/115082 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/6e4ba5a1-8a1b-4892-be84-47d18a971551) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/162152 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/33857 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/33756 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/124265 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/115082 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/0b8ee587-1562-4844-a82e-8585db40e2e4) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/163241 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/26504 "Found 60 new test failures: compositing/backing/backing-store-attachment-animating-outside-viewport.html fast/canvas/webgl/tex-image-and-sub-image-2d-with-video-rgb565.html fast/canvas/webgl/tex-image-and-sub-image-2d-with-video-rgba4444.html fast/canvas/webgl/tex-image-and-sub-image-2d-with-video-rgba5551.html fast/events/touch/ios/touch-event-regions-layer-tree/mousemove-mouseup.html fast/forms/ios/drag-range-track.html http/tests/app-privacy-report/user-attribution-cors-preflight-redirect.html webgl/1.0.x/conformance/extensions/oes-texture-float-with-video.html webgl/1.0.x/conformance/extensions/oes-texture-half-float-with-video.html webgl/1.0.x/conformance/textures/misc/texture-npot-video.html ... (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/143967 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/104864 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/f279c506-30c9-42e8-aacc-7e71be66934f) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/25557 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/24054 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/16905 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/135249 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/21730 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/171663 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/17980 "Built successfully") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/23370 "Found 60 new test failures: fast/canvas/canvas-createPattern-video-loading.html fast/canvas/canvas-createPattern-video-modify.html fast/canvas/webgl/tex-image-and-sub-image-2d-with-video-rgb565.html fast/canvas/webgl/tex-image-and-sub-image-2d-with-video-rgba4444.html fast/canvas/webgl/tex-image-and-sub-image-2d-with-video-rgba5551.html fast/css/sticky/sticky-top-margins.html fast/scrolling/mac/stateless-user-scroll-scrollend.html http/tests/performance/performance-resource-timing-cross-origin-media.html imported/w3c/web-platform-tests/css/css-scroll-snap/scroll-margin-overflow-ancestor.html imported/w3c/web-platform-tests/css/selectors/invalidation/has-pseudo-element.html ... (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/132517 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/33429 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/28148 "Found 60 new test failures: accessibility/mac/input-replacevalue-userinfo.html fast/canvas/canvas-createPattern-video-loading.html fast/canvas/canvas-createPattern-video-modify.html fast/canvas/webgl/tex-image-and-sub-image-2d-with-video-rgb565.html fast/canvas/webgl/tex-image-and-sub-image-2d-with-video-rgba4444.html fast/canvas/webgl/tex-image-and-sub-image-2d-with-video-rgba5551.html fast/forms/select/mac-wk2/inactive-appearance.html imported/w3c/web-platform-tests/IndexedDB/interleaved-cursors-small.any.serviceworker.html imported/w3c/web-platform-tests/IndexedDB/interleaved-cursors-small.any.sharedworker.html imported/w3c/web-platform-tests/IndexedDB/interleaved-cursors-small.any.worker.html ... (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/132542 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/33414 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/143525 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/94574 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/27156 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/20339 "Found 60 new test failures: fast/canvas/canvas-createPattern-video-loading.html fast/canvas/canvas-createPattern-video-modify.html fast/canvas/webgl/tex-image-and-sub-image-2d-with-video-rgb565.html fast/canvas/webgl/tex-image-and-sub-image-2d-with-video-rgba4444.html fast/canvas/webgl/tex-image-and-sub-image-2d-with-video-rgba5551.html fast/ruby/annotation-clipped-first-line.html fast/ruby/annotation-with-line-gap.html imported/w3c/web-platform-tests/css/css-cascade/scope-overlapping-has.html imported/w3c/web-platform-tests/css/selectors/has-specificity.html imported/w3c/web-platform-tests/css/selectors/invalidation/has-complexity.html ... (failure)") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/32923 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/99642 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/32424 "Built successfully") | | | | 
| | [❌ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/32668 "Hash 784befb9 for PR 64165 does not build (failure)") | | | | 
| | [❌ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/32572 "Hash 784befb9 for PR 64165 does not build (failure)") | | | | 
<!--EWS-Status-Bubble-End-->