### PR TITLE
Fix SharedArrayBuffer cloning and agent cluster IDs

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -6272,7 +6272,6 @@ imported/w3c/web-platform-tests/html/cross-origin-embedder-policy/reporting-subr
 imported/w3c/web-platform-tests/html/cross-origin-opener-policy/reporting/access-reporting/reporting-observer.html [ Skip ]
 imported/w3c/web-platform-tests/html/dom/render-blocking/remove-attr-unblocks-rendering.optional.html [ Skip ]
 imported/w3c/web-platform-tests/html/dom/self-origin.sub.html [ Skip ]
-imported/w3c/web-platform-tests/html/infrastructure/safe-passing-of-structured-data/shared-array-buffers/window-failure.https.html [ Skip ]
 imported/w3c/web-platform-tests/html/semantics/embedded-content/the-iframe-element/iframe_sandbox_navigation_download_allow_downloads.sub.tentative.html [ Skip ]
 imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/delay-load-event-until-move-to-empty-source.html [ Skip ]
 imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/image-loading-lazy-move-into-script-disabled-iframe.html [ Skip ]

--- a/LayoutTests/imported/w3c/web-platform-tests/html/cross-origin-embedder-policy/cross-origin-isolated-permission.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/cross-origin-embedder-policy/cross-origin-isolated-permission.https-expected.txt
@@ -11,10 +11,10 @@ PASS dedicated worker: scheme = https, value = undefined
 PASS dedicated worker: scheme = https, value = *
 PASS dedicated worker: scheme = https, value = self
 FAIL dedicated worker: scheme = https, value = (\) assert_equals: expected false but got true
-FAIL dedicated worker: scheme = data, value = undefined assert_equals: expected false but got true
-FAIL dedicated worker: scheme = data, value = * assert_equals: expected false but got true
-FAIL dedicated worker: scheme = data, value = self assert_equals: expected false but got true
-FAIL dedicated worker: scheme = data, value = (\) assert_equals: expected false but got true
+PASS dedicated worker: scheme = data, value = undefined
+PASS dedicated worker: scheme = data, value = *
+PASS dedicated worker: scheme = data, value = self
+PASS dedicated worker: scheme = data, value = (\)
 PASS dedicated worker: scheme = blob, value = undefined
 PASS dedicated worker: scheme = blob, value = *
 PASS dedicated worker: scheme = blob, value = self

--- a/LayoutTests/imported/w3c/web-platform-tests/html/infrastructure/safe-passing-of-structured-data/shared-array-buffers/identity-not-preserved.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/infrastructure/safe-passing-of-structured-data/shared-array-buffers/identity-not-preserved.https-expected.txt
@@ -1,5 +1,5 @@
 
-FAIL postMessaging to this window does not give back the same SharedArrayBuffer (but does use the same backing block) assert_equals: clonedView[0] ends up 5 expected 5 but got 0
+PASS postMessaging to this window does not give back the same SharedArrayBuffer (but does use the same backing block)
 PASS postMessaging to a worker and back does not give back the same SharedArrayBuffer
 PASS postMessaging to an iframe and back does not give back the same SharedArrayBuffer
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/infrastructure/safe-passing-of-structured-data/shared-array-buffers/window-failure.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/infrastructure/safe-passing-of-structured-data/shared-array-buffers/window-failure.https-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL SharedArrayBuffer and a cross-site <iframe> assert_unreached: Got a message event, expected a messageerror event Reached unreachable code
+PASS SharedArrayBuffer and a cross-site <iframe>
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/infrastructure/safe-passing-of-structured-data/shared-array-buffers/window-iframe-messagechannel.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/infrastructure/safe-passing-of-structured-data/shared-array-buffers/window-iframe-messagechannel.https-expected.txt
@@ -1,7 +1,6 @@
-ALERT: [object SharedArrayBuffer]
 
 PASS postMessaging to a same-origin iframe via MessageChannel allows them to see each others' modifications
-FAIL postMessaging to a same-site iframe via MessageChannel should fail assert_equals: expected "messageerror event received" but got "message event received"
-FAIL postMessaging to a cross-site iframe via MessageChannel should fail assert_equals: expected "messageerror event received" but got "message event received"
+PASS postMessaging to a same-site iframe via MessageChannel should fail
+PASS postMessaging to a cross-site iframe via MessageChannel should fail
 PASS postMessaging with a MessageChannel that's been cross-site should succeed
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/infrastructure/safe-passing-of-structured-data/shared-array-buffers/window-simple-success.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/infrastructure/safe-passing-of-structured-data/shared-array-buffers/window-simple-success.https-expected.txt
@@ -12,7 +12,7 @@ PASS postMessaging to a dedicated worker allows them to see each others' modific
 PASS postMessaging to a dedicated worker allows them to see each others' modifications with Float16Array
 PASS postMessaging to a dedicated worker allows them to see each others' modifications with Float32Array
 PASS postMessaging to a dedicated worker allows them to see each others' modifications with Float64Array
-FAIL postMessaging to a same-origin iframe allows them to see each others' modifications assert_equals: The window must see changes made in the iframe expected 2 but got 1
-FAIL postMessaging to a same-origin deeply-nested iframe allows them to see each others' modifications assert_equals: The window must see changes made in the nested iframe expected 2 but got 1
-FAIL postMessaging to a same-origin opened window allows them to see each others' modifications assert_equals: The window must see changes made in the popup window expected 2 but got 1
+PASS postMessaging to a same-origin iframe allows them to see each others' modifications
+PASS postMessaging to a same-origin deeply-nested iframe allows them to see each others' modifications
+PASS postMessaging to a same-origin opened window allows them to see each others' modifications
 

--- a/LayoutTests/imported/w3c/web-platform-tests/streams/transferable/deserialize-error.window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/streams/transferable/deserialize-error.window-expected.txt
@@ -1,6 +1,4 @@
 
-Harness Error (TIMEOUT), message = null
-
-TIMEOUT a WritableStream deserialization failure should result in a DataCloneError Test timed out
-TIMEOUT a ReadableStream deserialization failure should result in a DataCloneError Test timed out
+PASS a WritableStream deserialization failure should result in a DataCloneError
+PASS a ReadableStream deserialization failure should result in a DataCloneError
 

--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -5482,6 +5482,7 @@ imported/w3c/web-platform-tests/html/infrastructure/safe-passing-of-structured-d
 imported/w3c/web-platform-tests/html/infrastructure/safe-passing-of-structured-data/shared-array-buffers/nested-worker-success.https.html [ Skip ]
 imported/w3c/web-platform-tests/html/infrastructure/safe-passing-of-structured-data/shared-array-buffers/no-transferring.https.html [ Skip ]
 imported/w3c/web-platform-tests/html/infrastructure/safe-passing-of-structured-data/shared-array-buffers/serialization-via-history.https.html [ Skip ]
+imported/w3c/web-platform-tests/html/infrastructure/safe-passing-of-structured-data/shared-array-buffers/window-failure.https.html [ Skip ]
 imported/w3c/web-platform-tests/html/infrastructure/safe-passing-of-structured-data/shared-array-buffers/window-iframe-messagechannel.https.html [ Skip ]
 imported/w3c/web-platform-tests/html/infrastructure/safe-passing-of-structured-data/shared-array-buffers/window-messagechannel-success.https.html [ Skip ]
 imported/w3c/web-platform-tests/html/infrastructure/safe-passing-of-structured-data/shared-array-buffers/window-simple-success.https.html [ Skip ]

--- a/LayoutTests/platform/ios-site-isolation/TestExpectations
+++ b/LayoutTests/platform/ios-site-isolation/TestExpectations
@@ -257,6 +257,7 @@ imported/w3c/web-platform-tests/html/browsers/origin/cross-origin-objects/cross-
 imported/w3c/web-platform-tests/html/cross-origin-embedder-policy/cross-origin-isolated-permission.https.html [ Failure ]
 imported/w3c/web-platform-tests/html/infrastructure/safe-passing-of-structured-data/shared-array-buffers/broadcastchannel-success-and-failure.https.html [ Failure ]
 imported/w3c/web-platform-tests/html/infrastructure/safe-passing-of-structured-data/shared-array-buffers/nested-sharedworker-success.https.html [ Failure ]
+imported/w3c/web-platform-tests/html/infrastructure/safe-passing-of-structured-data/shared-array-buffers/window-failure.https.html [ Skip ]
 imported/w3c/web-platform-tests/html/infrastructure/safe-passing-of-structured-data/shared-array-buffers/window-iframe-messagechannel.https.html [ Failure ]
 imported/w3c/web-platform-tests/html/infrastructure/safe-passing-of-structured-data/shared-array-buffers/window-sharedworker-failure.https.html [ Failure ]
 imported/w3c/web-platform-tests/html/interaction/focus/focus-input-type-switch.html [ Failure ]

--- a/LayoutTests/platform/mac-site-isolation/TestExpectations
+++ b/LayoutTests/platform/mac-site-isolation/TestExpectations
@@ -260,6 +260,7 @@ imported/w3c/web-platform-tests/fetch/api/redirect/redirect-keepalive.any.html [
 imported/w3c/web-platform-tests/FileAPI/url/url-in-tags-revoke.window.html [ Failure ]
 imported/w3c/web-platform-tests/fullscreen/rendering/fullscreen-root-block-scroll.html [ Failure ]
 imported/w3c/web-platform-tests/html/browsers/browsing-the-web/history-traversal/pageswap/pageswap-replace-with-cross-origin-redirect.sub.html [ Failure ]
+imported/w3c/web-platform-tests/html/infrastructure/safe-passing-of-structured-data/shared-array-buffers/window-failure.https.html [ Skip ]
 imported/w3c/web-platform-tests/html/infrastructure/safe-passing-of-structured-data/shared-array-buffers/window-iframe-messagechannel.https.html [ Failure ]
 imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/image-loading-lazy-in-cross-origin-iframe-001.sub.html [ Failure ]
 imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/image-loading-lazy-in-cross-origin-iframe-002.sub.html [ Failure ]

--- a/LayoutTests/workers/sab/postMessage-clones-growable-expected.txt
+++ b/LayoutTests/workers/sab/postMessage-clones-growable-expected.txt
@@ -1,9 +1,16 @@
-Checks that window.postMessage throws DataCloneError for growable SharedArrayBuffers
+Checks that window.postMessage shares growable SharedArrayBuffers
 
 On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
 
 
-PASS window.postMessage(memory, '*') threw exception DataCloneError: The object can not be cloned..
+PASS memory[0] is 42
+PASS otherMemory[0] is 42
+PASS memory[0] is 43
+PASS otherMemory[0] is 43
+PASS memory.length is 1
+PASS otherMemory.length is 1
+PASS memory.length is 256
+PASS otherMemory.length is 256
 PASS successfullyParsed is true
 
 TEST COMPLETE

--- a/LayoutTests/workers/sab/postMessage-clones-growable.html
+++ b/LayoutTests/workers/sab/postMessage-clones-growable.html
@@ -5,12 +5,31 @@
 </head>
 <body>
 <script>
-description("Checks that window.postMessage throws DataCloneError for growable SharedArrayBuffers");
+description("Checks that window.postMessage shares growable SharedArrayBuffers");
+
+jsTestIsAsync = true;
 
 var sab = new SharedArrayBuffer(4, { maxByteLength: 1024 });
 var memory = new Int32Array(sab);
+var otherMemory;
 
-shouldThrow("window.postMessage(memory, '*')", "'DataCloneError: The object can not be cloned.'");
+window.addEventListener("message", function (event) {
+    otherMemory = new Int32Array(event.data);
+    memory[0] = 42;
+    shouldBe("memory[0]", "42");
+    shouldBe("otherMemory[0]", "42");
+    otherMemory[0] = 43;
+    shouldBe("memory[0]", "43");
+    shouldBe("otherMemory[0]", "43");
+    shouldBe("memory.length", "1");
+    shouldBe("otherMemory.length", "1");
+    sab.grow(1024);
+    shouldBe("memory.length", "256");
+    shouldBe("otherMemory.length", "256");
+    finishJSTest();
+});
+
+window.postMessage(sab, "*");
 </script>
 </body>
 </html>

--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -2159,6 +2159,7 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     platform/AudioSampleFormat.h
     platform/BoxExtents.h
     platform/BoxSides.h
+    platform/BrowsingContextGroupIdentifier.h
     platform/CPUMonitor.h
     platform/CaptionPreferencesDelegate.h
     platform/CaretAnimator.h

--- a/Source/WebCore/Modules/webaudio/AudioWorkletMessagingProxy.cpp
+++ b/Source/WebCore/Modules/webaudio/AudioWorkletMessagingProxy.cpp
@@ -61,7 +61,8 @@ static WorkletParameters generateWorkletParameters(AudioWorklet& worklet)
         document->referrerPolicy(),
         worklet.audioContext() ? !worklet.audioContext()->isOfflineContext() : false,
         document->advancedPrivacyProtections(),
-        document->noiseInjectionHashSalt()
+        document->noiseInjectionHashSalt(),
+        document->agentClusterID()
     };
 }
 

--- a/Source/WebCore/bindings/js/JSDOMGlobalObject.cpp
+++ b/Source/WebCore/bindings/js/JSDOMGlobalObject.cpp
@@ -56,7 +56,6 @@
 #include "JSWorkletGlobalScope.h"
 #include "JSWritableStream.h"
 #include "LocalDOMWindow.h"
-#include "ProcessIdentifier.h"
 #include "RejectedPromiseTracker.h"
 #include "ScriptController.h"
 #include "ScriptModuleLoader.h"
@@ -778,20 +777,6 @@ JSC::JSGlobalObject* JSDOMGlobalObject::deriveShadowRealmGlobalObject(JSC::JSGlo
         context->addMicrotaskGlobalObject(wrapper);
 
     return wrapper;
-}
-
-String JSDOMGlobalObject::defaultAgentClusterID()
-{
-    return makeString(Process::identifier().toUInt64(), "-default"_s);
-}
-
-String JSDOMGlobalObject::agentClusterID() const
-{
-    if (auto* workerGlobalScope = dynamicDowncast<WorkerGlobalScope>(scriptExecutionContext())) {
-        ASSERT(!workerGlobalScope->agentClusterID().isEmpty());
-        return workerGlobalScope->agentClusterID();
-    }
-    return defaultAgentClusterID();
 }
 
 JSC::JSObject* JSDOMGlobalObject::readableStreamByteStrategySize()

--- a/Source/WebCore/bindings/js/JSDOMGlobalObject.h
+++ b/Source/WebCore/bindings/js/JSDOMGlobalObject.h
@@ -87,10 +87,6 @@ public:
     static bool canCompileStrings(JSC::JSGlobalObject*, JSC::CompilationType, String, const JSC::ArgList&);
     static JSC::Structure* trustedScriptStructure(JSC::JSGlobalObject*);
 
-    // https://tc39.es/ecma262/#sec-agent-clusters
-    String agentClusterID() const;
-    static String defaultAgentClusterID();
-
     // Make binding code generation easier.
     JSDOMGlobalObject* realm() { return this; }
 

--- a/Source/WebCore/bindings/js/SerializedScriptValue.cpp
+++ b/Source/WebCore/bindings/js/SerializedScriptValue.cpp
@@ -31,7 +31,6 @@
 #include "ByteArrayPixelBuffer.h"
 #include "ClientOrigin.h"
 #include "ContextDestructionObserverInlines.h"
-#include "CrossOriginMode.h"
 #include "CryptoKeyAES.h"
 #include "CryptoKeyEC.h"
 #include "CryptoKeyHMAC.h"
@@ -673,14 +672,26 @@ enum class ImageBitmapSerializationFlags : uint8_t {
             dataLogLn("TRACE ", __VA_ARGS__, " @ ", __LINE__); \
     } while (false)
 
-#if ENABLE(WEBASSEMBLY)
 static String agentClusterIDFromGlobalObject(JSGlobalObject& globalObject)
 {
-    if (auto* domGlobalObject = dynamicDowncast<JSDOMGlobalObject>(globalObject))
-        return domGlobalObject->agentClusterID();
-    return JSDOMGlobalObject::defaultAgentClusterID();
+    auto& domGlobalObject = downcast<JSDOMGlobalObject>(globalObject);
+    RefPtr context = domGlobalObject.scriptExecutionContext();
+    ASSERT(context);
+    if (!context)
+        return nullString();
+    auto result = context->agentClusterID();
+    ASSERT(!result.isNull());
+    return result;
 }
-#endif
+
+static bool isCrossOriginIsolatedContext(JSGlobalObject* globalObject)
+{
+    auto* domGlobalObject = dynamicDowncast<JSDOMGlobalObject>(globalObject);
+    if (!domGlobalObject)
+        return false;
+    RefPtr context = domGlobalObject->scriptExecutionContext();
+    return context && context->crossOriginIsolated();
+}
 
 const uint32_t currentKeyFormatVersion = 1;
 
@@ -2204,23 +2215,20 @@ private:
                         code = SerializationReturnCode::DataCloneError;
                         return true;
                     }
-                    bool isCrossOriginIsolated = ScriptExecutionContext::crossOriginMode() == CrossOriginMode::Isolated;
-                    if (m_context == SerializationContext::WorkerPostMessage && (isCrossOriginIsolated || JSC::Options::useSharedArrayBuffer())) {
+                    if (isCrossOriginIsolatedContext(m_lexicalGlobalObject) || JSC::Options::useSharedArrayBuffer()) {
                         uint32_t index = m_sharedBuffers.size();
                         ArrayBufferContents contents;
                         if (arrayBuffer->shareWith(contents)) {
                             appendObjectPoolTag(SharedArrayBufferTag);
                             write(SharedArrayBufferTag);
+                            write(agentClusterIDFromGlobalObject(*m_lexicalGlobalObject));
                             m_sharedBuffers.append(WTF::move(contents));
                             write(index);
                             return true;
                         }
                     }
-                    if (m_context != SerializationContext::WindowPostMessage || !isCrossOriginIsolated) {
-                        code = SerializationReturnCode::DataCloneError;
-                        return true;
-                    }
-                    // FIXME: WindowPostMessage should share SharedArrayBuffer when cross-origin isolated, not fall through to a non-shared copy.
+                    code = SerializationReturnCode::DataCloneError;
+                    return true;
                 }
                 
                 if (arrayBuffer->isResizableOrGrowableShared()) {
@@ -5716,9 +5724,12 @@ private:
         }
         case SharedArrayBufferTag: {
             // https://html.spec.whatwg.org/multipage/structured-data.html#structureddeserialize
+            CachedStringRef agentClusterID;
+            bool agentClusterIDSuccessfullyRead = readStringData(agentClusterID);
             uint32_t index = UINT_MAX;
             bool indexSuccessfullyRead = read(index);
-            if (!indexSuccessfullyRead || !m_sharedBuffers || index >= m_sharedBuffers->size() || !JSC::Options::useSharedArrayBuffer()) {
+            if (!agentClusterIDSuccessfullyRead || agentClusterID->string() != agentClusterIDFromGlobalObject(*m_globalObject)
+                || !indexSuccessfullyRead || !m_sharedBuffers || index >= m_sharedBuffers->size()) {
                 SERIALIZE_TRACE("FAIL deserialize");
                 fail();
                 return JSValue();
@@ -6991,7 +7002,7 @@ ExceptionOr<Ref<SerializedScriptValue>> SerializedScriptValue::create(JSGlobalOb
     });
 #endif
 
-    Ref result = adoptRef(*new SerializedScriptValue(WTF::move(buffer), WTF::move(blobHandles), arrayBufferContentsArray.releaseReturnValue(), context == SerializationContext::WorkerPostMessage ? WTF::move(sharedBuffers) : nullptr, WTF::move(detachedImageBitmaps)
+    Ref result = adoptRef(*new SerializedScriptValue(WTF::move(buffer), WTF::move(blobHandles), arrayBufferContentsArray.releaseReturnValue(), WTF::move(sharedBuffers), WTF::move(detachedImageBitmaps)
 #if ENABLE(OFFSCREEN_CANVAS_IN_WORKERS)
                 , WTF::move(detachedCanvases)
                 , WTF::move(inMemoryOffscreenCanvases)

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -218,6 +218,7 @@
 #include "OpportunisticTaskScheduler.h"
 #include "OrientationNotifier.h"
 #include "OwnerPermissionsPolicyData.h"
+#include "Page.h"
 #include "PageGroup.h"
 #include "PageRevealEvent.h"
 #include "PageSwapEvent.h"
@@ -300,6 +301,7 @@
 #include "ServiceWorkerProvider.h"
 #include "Settings.h"
 #include "ShadowRoot.h"
+#include "Site.h"
 #include "SleepDisabler.h"
 #include "SocketProvider.h"
 #include "SpeculationRules.h"
@@ -8430,6 +8432,24 @@ bool Document::isSecureContext() const
     }
 
     return isDocumentSecure(*this);
+}
+
+bool Document::crossOriginIsolated() const
+{
+    RefPtr mainDocument = mainFrameDocument();
+    if (!mainDocument)
+        return false;
+    return mainDocument->crossOriginOpenerPolicy().value == CrossOriginOpenerPolicyValue::SameOriginPlusCOEP;
+}
+
+String Document::agentClusterID() const
+{
+    Ref origin = securityOrigin();
+    auto& data = origin->data();
+    auto browsingContextGroupIdentifier = page() && page()->browsingContextGroupIdentifier() ? page()->browsingContextGroupIdentifier()->toUInt64() : 0;
+    if (crossOriginIsolated())
+        return makeString(browsingContextGroupIdentifier, "-coi-"_s, data.toString());
+    return makeString(browsingContextGroupIdentifier, '-', Site(data).toString());
 }
 
 void Document::updateURLForPushOrReplaceState(const URL& url)

--- a/Source/WebCore/dom/Document.h
+++ b/Source/WebCore/dom/Document.h
@@ -1437,6 +1437,8 @@ public:
 
     bool isContextThread() const final;
     bool isSecureContext() const final;
+    bool NODELETE crossOriginIsolated() const final;
+    String agentClusterID() const final;
     bool isJSExecutionForbidden() const final { return false; }
 
     void queueTaskToDispatchEventOnWindow(LocalDOMWindow&, TaskSource, Ref<Event>&&);

--- a/Source/WebCore/dom/EmptyScriptExecutionContext.h
+++ b/Source/WebCore/dom/EmptyScriptExecutionContext.h
@@ -52,6 +52,7 @@ public:
 
     bool isSecureContext() const final { return false; }
     bool isJSExecutionForbidden() const final { return false; }
+    String agentClusterID() const final { return nullString(); }
     EventLoopTaskGroup& eventLoop() final
     {
         ASSERT_NOT_REACHED();

--- a/Source/WebCore/dom/ScriptExecutionContext.cpp
+++ b/Source/WebCore/dom/ScriptExecutionContext.cpp
@@ -68,6 +68,7 @@
 #include "ScriptDisallowedScope.h"
 #include "ScriptExecutionContextInlines.h"
 #include "ScriptTrackingPrivacyCategory.h"
+#include "SecurityOrigin.h"
 #include "ServiceWorker.h"
 #include "ServiceWorkerGlobalScope.h"
 #include "ServiceWorkerProvider.h"

--- a/Source/WebCore/dom/ScriptExecutionContext.h
+++ b/Source/WebCore/dom/ScriptExecutionContext.h
@@ -239,6 +239,9 @@ public:
     WEBCORE_EXPORT static void NODELETE setCrossOriginMode(CrossOriginMode);
     static CrossOriginMode NODELETE crossOriginMode();
 
+    virtual bool NODELETE crossOriginIsolated() const { return false; }
+    virtual String agentClusterID() const = 0;
+
     WEBCORE_EXPORT void NODELETE ref();
     WEBCORE_EXPORT void deref();
 

--- a/Source/WebCore/loader/EmptyClients.cpp
+++ b/Source/WebCore/loader/EmptyClients.cpp
@@ -1254,6 +1254,7 @@ PageConfiguration pageConfigurationWithEmptyClients(std::optional<PageIdentifier
 {
     PageConfiguration pageConfiguration {
         identifier,
+        std::nullopt,
         sessionID,
         makeUniqueRef<EmptyEditorClient>(),
         adoptRef(*new EmptySocketProvider),

--- a/Source/WebCore/page/LocalDOMWindow.cpp
+++ b/Source/WebCore/page/LocalDOMWindow.cpp
@@ -2009,8 +2009,8 @@ bool LocalDOMWindow::isSecureContext() const
 
 bool LocalDOMWindow::crossOriginIsolated() const
 {
-    ASSERT(ScriptExecutionContext::crossOriginMode() == CrossOriginMode::Shared || !document() || !document()->mainFrameDocument() || document()->mainFrameDocument()->crossOriginOpenerPolicy().value == CrossOriginOpenerPolicyValue::SameOriginPlusCOEP);
-    return ScriptExecutionContext::crossOriginMode() == CrossOriginMode::Isolated;
+    auto* document = this->document();
+    return document && document->crossOriginIsolated();
 }
 
 static void didAddStorageEventListener(LocalDOMWindow& window)

--- a/Source/WebCore/page/Page.cpp
+++ b/Source/WebCore/page/Page.cpp
@@ -389,6 +389,7 @@ WTF_MAKE_STRUCT_TZONE_ALLOCATED_IMPL(Page::Internals);
 Page::Page(PageConfiguration&& pageConfiguration)
     : m_internals(makeUniqueRef<Internals>())
     , m_identifier(pageConfiguration.identifier)
+    , m_browsingContextGroupIdentifier(pageConfiguration.browsingContextGroupIdentifier)
     , m_chrome(makeUniqueRef<Chrome>(*this, WTF::move(pageConfiguration.chromeClient)))
     , m_dragCaretController(makeUniqueRef<DragCaretController>())
 #if ENABLE(DRAG_SUPPORT)

--- a/Source/WebCore/page/Page.h
+++ b/Source/WebCore/page/Page.h
@@ -24,6 +24,7 @@
 #include <WebCore/AnimationFrameRate.h>
 #include <WebCore/BackForwardFrameItemIdentifier.h>
 #include <WebCore/BoxExtents.h>
+#include <WebCore/BrowsingContextGroupIdentifier.h>
 #include <WebCore/Color.h>
 #include <WebCore/DocumentEnums.h>
 #include <WebCore/FindOptions.h>
@@ -397,6 +398,8 @@ public:
 
     // Utility pages (e.g. SVG image pages) don't have an identifier currently.
     std::optional<PageIdentifier> identifier() const { return m_identifier; }
+
+    std::optional<BrowsingContextGroupIdentifier> browsingContextGroupIdentifier() const { return m_browsingContextGroupIdentifier; }
 
     void willEnterBackForwardCache();
 
@@ -1479,6 +1482,7 @@ private:
     const UniqueRef<Internals> m_internals;
 
     std::optional<PageIdentifier> m_identifier;
+    std::optional<BrowsingContextGroupIdentifier> m_browsingContextGroupIdentifier;
     const UniqueRef<Chrome> m_chrome;
     const UniqueRef<DragCaretController> m_dragCaretController;
 

--- a/Source/WebCore/page/PageConfiguration.cpp
+++ b/Source/WebCore/page/PageConfiguration.cpp
@@ -76,6 +76,7 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(PageConfiguration);
 
 PageConfiguration::PageConfiguration(
     std::optional<PageIdentifier> identifier,
+    std::optional<BrowsingContextGroupIdentifier> browsingContextGroupIdentifier,
     PAL::SessionID sessionID,
     UniqueRef<EditorClient>&& editorClient,
     Ref<SocketProvider>&& socketProvider,
@@ -108,6 +109,7 @@ PageConfiguration::PageConfiguration(
 #endif
 )
     : identifier(identifier)
+    , browsingContextGroupIdentifier(browsingContextGroupIdentifier)
     , sessionID(sessionID)
     , chromeClient(WTF::move(chromeClient))
 #if ENABLE(CONTEXT_MENUS)

--- a/Source/WebCore/page/PageConfiguration.h
+++ b/Source/WebCore/page/PageConfiguration.h
@@ -25,6 +25,7 @@
 
 #pragma once
 
+#include <WebCore/BrowsingContextGroupIdentifier.h>
 #include <WebCore/ContentSecurityPolicy.h>
 #include <WebCore/FrameIdentifier.h>
 #include <WebCore/PageIdentifier.h>
@@ -120,6 +121,7 @@ public:
 
     WEBCORE_EXPORT PageConfiguration(
         std::optional<PageIdentifier>,
+        std::optional<BrowsingContextGroupIdentifier>,
         PAL::SessionID,
         UniqueRef<EditorClient>&&,
         Ref<SocketProvider>&&,
@@ -155,6 +157,7 @@ public:
     PageConfiguration(PageConfiguration&&);
 
     std::optional<PageIdentifier> identifier;
+    std::optional<BrowsingContextGroupIdentifier> browsingContextGroupIdentifier;
     PAL::SessionID sessionID;
     std::unique_ptr<AlternativeTextClient> alternativeTextClient;
     UniqueRef<ChromeClient> chromeClient;

--- a/Source/WebCore/platform/BrowsingContextGroupIdentifier.h
+++ b/Source/WebCore/platform/BrowsingContextGroupIdentifier.h
@@ -1,0 +1,35 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <wtf/ObjectIdentifier.h>
+
+namespace WebCore {
+
+struct BrowsingContextGroupIdentifierType;
+using BrowsingContextGroupIdentifier = ObjectIdentifier<BrowsingContextGroupIdentifierType>;
+
+}

--- a/Source/WebCore/workers/WorkerGlobalScope.cpp
+++ b/Source/WebCore/workers/WorkerGlobalScope.cpp
@@ -741,7 +741,7 @@ void WorkerGlobalScope::clearDecodedScriptData()
 
 bool WorkerGlobalScope::crossOriginIsolated() const
 {
-    return ScriptExecutionContext::crossOriginMode() == CrossOriginMode::Isolated;
+    return crossOriginEmbedderPolicy().value == CrossOriginEmbedderPolicyValue::RequireCORP;
 }
 
 void WorkerGlobalScope::updateSourceProviderBuffers(const ScriptBuffer& mainScript, const HashMap<URL, ScriptBuffer>& importedScripts)

--- a/Source/WebCore/workers/WorkerGlobalScope.h
+++ b/Source/WebCore/workers/WorkerGlobalScope.h
@@ -136,7 +136,7 @@ public:
     void clearInterval(int timeoutId);
 
     bool isSecureContext() const final;
-    bool NODELETE crossOriginIsolated() const;
+    bool NODELETE crossOriginIsolated() const final;
 
     WorkerNavigator* optionalNavigator() const { return m_navigator.get(); }
     WorkerLocation* optionalLocation() const { return m_location.get(); }
@@ -177,7 +177,7 @@ public:
 
     WorkerClient* workerClient() LIFETIME_BOUND { return m_workerClient.get(); }
 
-    const String& agentClusterID() const LIFETIME_BOUND { return m_agentClusterID; }
+    String agentClusterID() const final { return m_agentClusterID; }
 
     void reportErrorToWorkerObject(const String&);
 

--- a/Source/WebCore/workers/WorkerMessagingProxy.cpp
+++ b/Source/WebCore/workers/WorkerMessagingProxy.cpp
@@ -161,11 +161,7 @@ void WorkerMessagingProxy::startWorkerGlobalScope(const URL& scriptURL, PAL::Ses
 
     bool isOnline = parentWorkerGlobalScope ? parentWorkerGlobalScope->isOnline() : platformStrategies()->loaderStrategy()->isOnLine();
 
-    String agentClusterID;
-    if (parentWorkerGlobalScope)
-        agentClusterID = parentWorkerGlobalScope->agentClusterID();
-    else
-        agentClusterID = JSDOMGlobalObject::defaultAgentClusterID();
+    auto agentClusterID = scriptExecutionContext->agentClusterID();
 
     m_scriptURL = scriptURL;
 

--- a/Source/WebCore/worklets/WorkletGlobalScope.cpp
+++ b/Source/WebCore/worklets/WorkletGlobalScope.cpp
@@ -58,6 +58,7 @@ WorkletGlobalScope::WorkletGlobalScope(WorkerOrWorkletThread& thread, Ref<JSC::V
     , m_url(parameters.windowURL)
     , m_jsRuntimeFlags(parameters.jsRuntimeFlags)
     , m_settingsValues(parameters.settingsValues)
+    , m_agentClusterID(parameters.agentClusterID)
 {
     ++gNumberOfWorkletGlobalScopes;
 
@@ -74,6 +75,7 @@ WorkletGlobalScope::WorkletGlobalScope(Document& document, Ref<JSC::VM>&& vm, Sc
     , m_jsRuntimeFlags(document.settings().javaScriptRuntimeFlags())
     , m_code(WTF::move(code))
     , m_settingsValues(document.settingsValues().isolatedCopy())
+    , m_agentClusterID(document.agentClusterID())
 {
     ++gNumberOfWorkletGlobalScopes;
 

--- a/Source/WebCore/worklets/WorkletGlobalScope.h
+++ b/Source/WebCore/worklets/WorkletGlobalScope.h
@@ -80,6 +80,8 @@ public:
 
     bool isSecureContext() const final { return false; }
 
+    String agentClusterID() const final { return m_agentClusterID; }
+
     JSC::RuntimeFlags jsRuntimeFlags() const { return m_jsRuntimeFlags; }
 
     void prepareForDestruction() override;
@@ -124,6 +126,7 @@ private:
     const RefPtr<WorkerMessagePortChannelProvider> m_messagePortChannelProvider;
 
     SettingsValues m_settingsValues;
+    String m_agentClusterID;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/worklets/WorkletParameters.h
+++ b/Source/WebCore/worklets/WorkletParameters.h
@@ -44,9 +44,10 @@ struct WorkletParameters {
     bool isAudioContextRealTime;
     OptionSet<AdvancedPrivacyProtections> advancedPrivacyProtections;
     std::optional<uint64_t> noiseInjectionHashSalt;
+    String agentClusterID;
 
-    WorkletParameters isolatedCopy() const & { return { windowURL.isolatedCopy(), jsRuntimeFlags, sampleRate, identifier.isolatedCopy(), sessionID, settingsValues.isolatedCopy(), referrerPolicy, isAudioContextRealTime, advancedPrivacyProtections, noiseInjectionHashSalt }; }
-    WorkletParameters isolatedCopy() && { return { WTF::move(windowURL).isolatedCopy(), jsRuntimeFlags, sampleRate, WTF::move(identifier).isolatedCopy(), sessionID, WTF::move(settingsValues).isolatedCopy(), referrerPolicy, isAudioContextRealTime, advancedPrivacyProtections, WTF::move(noiseInjectionHashSalt) }; }
+    WorkletParameters isolatedCopy() const & { return { windowURL.isolatedCopy(), jsRuntimeFlags, sampleRate, identifier.isolatedCopy(), sessionID, settingsValues.isolatedCopy(), referrerPolicy, isAudioContextRealTime, advancedPrivacyProtections, noiseInjectionHashSalt, agentClusterID.isolatedCopy() }; }
+    WorkletParameters isolatedCopy() && { return { WTF::move(windowURL).isolatedCopy(), jsRuntimeFlags, sampleRate, WTF::move(identifier).isolatedCopy(), sessionID, WTF::move(settingsValues).isolatedCopy(), referrerPolicy, isAudioContextRealTime, advancedPrivacyProtections, WTF::move(noiseInjectionHashSalt), WTF::move(agentClusterID).isolatedCopy() }; }
 };
 
 } // namespace WebCore

--- a/Source/WebKit/Scripts/webkit/messages.py
+++ b/Source/WebKit/Scripts/webkit/messages.py
@@ -429,6 +429,7 @@ def serialized_identifiers():
         'WebCore::BackForwardFrameItemIdentifierID',
         'WebCore::BackForwardItemIdentifierID',
         'WebCore::BackgroundFetchRecordIdentifier',
+        'WebCore::BrowsingContextGroupIdentifier',
         'WebCore::DOMCacheIdentifierID',
         'WebCore::DictationContext',
         'WebCore::NodeIdentifier',

--- a/Source/WebKit/Scripts/webkit/tests/MessageArgumentDescriptions.cpp
+++ b/Source/WebKit/Scripts/webkit/tests/MessageArgumentDescriptions.cpp
@@ -474,6 +474,7 @@ Vector<ASCIILiteral> serializedIdentifiers()
         "WebCore::BackForwardFrameItemIdentifierID"_s,
         "WebCore::BackForwardItemIdentifierID"_s,
         "WebCore::BackgroundFetchRecordIdentifier"_s,
+        "WebCore::BrowsingContextGroupIdentifier"_s,
         "WebCore::DOMCacheIdentifierID"_s,
         "WebCore::DictationContext"_s,
         "WebCore::NodeIdentifier"_s,

--- a/Source/WebKit/Shared/WTFArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WTFArgumentCoders.serialization.in
@@ -121,6 +121,7 @@ template: struct WebCore::AttributedStringTextTableIDType
 #endif
 template: struct WebCore::BackForwardFrameItemIdentifierType
 template: struct WebCore::BackForwardItemIdentifierType
+template: struct WebCore::BrowsingContextGroupIdentifierType
 template: struct WebCore::DictationContextType
 template: struct WebCore::FrameIdentifierType
 template: struct WebCore::HTMLMediaElementType

--- a/Source/WebKit/Shared/WebPageCreationParameters.h
+++ b/Source/WebKit/Shared/WebPageCreationParameters.h
@@ -38,6 +38,7 @@
 #include "WebPageGroupData.h"
 #include "WebPageProxyIdentifier.h"
 #include "WebPreferencesStore.h"
+#include <WebCore/BrowsingContextGroupIdentifier.h>
 #include "WebURLSchemeHandlerIdentifier.h"
 #include "WebsitePoliciesData.h"
 #include <WebCore/ActivityState.h>
@@ -121,6 +122,7 @@ struct WebPageCreationParameters {
     DrawingAreaIdentifier drawingAreaIdentifier;
     WebPageProxyIdentifier webPageProxyIdentifier;
     WebPageGroupData pageGroupData;
+    std::optional<WebCore::BrowsingContextGroupIdentifier> browsingContextGroupIdentifier;
 
     bool isEditable { false };
 

--- a/Source/WebKit/Shared/WebPageCreationParameters.serialization.in
+++ b/Source/WebKit/Shared/WebPageCreationParameters.serialization.in
@@ -36,6 +36,7 @@ enum class WebCore::UserInterfaceLayoutDirection : bool;
     WebKit::DrawingAreaIdentifier drawingAreaIdentifier;
     WebKit::WebPageProxyIdentifier webPageProxyIdentifier;
     WebKit::WebPageGroupData pageGroupData;
+    std::optional<WebCore::BrowsingContextGroupIdentifier> browsingContextGroupIdentifier;
 
     bool isEditable;
 

--- a/Source/WebKit/UIProcess/BrowsingContextGroup.h
+++ b/Source/WebKit/UIProcess/BrowsingContextGroup.h
@@ -28,6 +28,7 @@
 #include "EnhancedSecurity.h"
 #include "LoadedWebArchive.h"
 #include "WebProcessProxy.h"
+#include <WebCore/BrowsingContextGroupIdentifier.h>
 #include <WebCore/Site.h>
 #include <wtf/CompletionHandler.h>
 #include <wtf/RefCountedAndCanMakeWeakPtr.h>
@@ -62,6 +63,8 @@ public:
     static Ref<BrowsingContextGroup> create() { return adoptRef(*new BrowsingContextGroup()); }
     ~BrowsingContextGroup();
 
+    WebCore::BrowsingContextGroupIdentifier identifier() const { return m_identifier; }
+
     void sharedProcessForSite(WebsiteDataStore&, API::WebsitePolicies*, const WebPreferences&, const WebCore::Site&, const WebCore::Site& mainFrameSite, WebProcessProxy::LockdownMode, EnhancedSecurity, API::PageConfiguration&, IsMainFrame, CompletionHandler<void(FrameProcess*)>&&);
     Ref<FrameProcess> ensureProcessForSite(const WebCore::Site&, const WebCore::Site& mainFrameSite, WebProcessProxy&, const WebPreferences&, LoadedWebArchive = LoadedWebArchive::No, BrowsingContextGroupUpdate = BrowsingContextGroupUpdate::AddProcessAndInjectBrowsingContext);
     RefPtr<FrameProcess> processForSite(const WebCore::Site&);
@@ -88,6 +91,8 @@ public:
 
 private:
     BrowsingContextGroup();
+
+    WebCore::BrowsingContextGroupIdentifier m_identifier { WebCore::BrowsingContextGroupIdentifier::generate() };
 
     WeakPtr<FrameProcess> m_sharedProcess;
     HashSet<WebCore::Site> m_sharedProcessSites;

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -13130,6 +13130,7 @@ WebPageCreationParameters WebPageProxy::creationParameters(WebProcessProxy& proc
         .drawingAreaIdentifier = drawingArea.identifier(),
         .webPageProxyIdentifier = identifier(),
         .pageGroupData = m_pageGroup->data(),
+        .browsingContextGroupIdentifier = m_browsingContextGroup->identifier(),
         .visitedLinkTableID = m_visitedLinkStore->identifier(),
         .userContentControllerParameters = m_userContentController->parametersForProcess(process),
         .mainFrameIdentifier = mainFrameIdentifier,

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -790,6 +790,7 @@ WebPage::WebPage(PageIdentifier pageID, WebPageCreationParameters&& parameters)
 
     PageConfiguration pageConfiguration(
         pageID,
+        parameters.browsingContextGroupIdentifier,
         WebProcess::singleton().sessionID(),
         makeUniqueRef<WebEditorClient>(*this),
         WebSocketProvider::create(parameters.webPageProxyIdentifier),

--- a/Source/WebKitLegacy/mac/WebView/WebView.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebView.mm
@@ -1478,6 +1478,7 @@ static void WebKitInitializeGamepadProviderIfNecessary()
     auto storageProvider = PageStorageSessionProvider::create();
     WebCore::PageConfiguration pageConfiguration(
         WebCore::PageIdentifier::generate(),
+        std::nullopt,
         [[self preferences] privateBrowsingEnabled] ? PAL::SessionID::legacyPrivateSessionID() : PAL::SessionID::defaultSessionID(),
         makeUniqueRef<WebEditorClient>(self),
         LegacySocketProvider::create(),
@@ -1743,6 +1744,7 @@ static void WebKitInitializeGamepadProviderIfNecessary()
     auto storageProvider = PageStorageSessionProvider::create();
     WebCore::PageConfiguration pageConfiguration(
         WebCore::PageIdentifier::generate(),
+        std::nullopt,
         [[self preferences] privateBrowsingEnabled] ? PAL::SessionID::legacyPrivateSessionID() : PAL::SessionID::defaultSessionID(),
         makeUniqueRef<WebEditorClient>(self),
         LegacySocketProvider::create(),


### PR DESCRIPTION
#### 78c6c2fe52eae2c42a4772ebc315d75048a57aad
<pre>
Fix SharedArrayBuffer cloning and agent cluster IDs
<a href="https://bugs.webkit.org/show_bug.cgi?id=313972">https://bugs.webkit.org/show_bug.cgi?id=313972</a>

Reviewed by Chris Dumez.

Introduce BrowsingContextGroupIdentifier to correctly scope agent
cluster IDs. Previously we used Process::identifier() as an
approximation, but multiple browsing context groups can share a
process and BroadcastChannel is not scoped to a browsing context group.

Make ScriptExecutionContext::agentClusterID() pure virtual. Document
computes it from the BCG identifier + origin/site. Dedicated workers
and worklets inherit it from their creator. Shared/service workers
always have a unique agent cluster ID.

Also re-enables sharing of growable SharedArrayBuffers, which was
slightly broken by r310998.

Canonical link: <a href="https://commits.webkit.org/312800@main">https://commits.webkit.org/312800@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/938add5103c05d5a0efd0557cf2d01c8f058a47c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/161101 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/34574 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/27675 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/170004 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/117361 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/162970 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/34675 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/34575 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/124962 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/117361 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/164060 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/27239 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/144711 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/105559 "Passed tests") | | ⏳ 🛠 vision-apple 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/160421 "Passed tests") | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/26288 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/24787 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/17724 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/135982 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/22472 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/172487 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/19508 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/24113 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/133241 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/34248 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/28880 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/133251 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35990 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/34232 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/144267 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/96071 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/27800 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/21085 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/33743 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/101168 "Build is in progress. Recent messages:OS: Tahoe (26.3.1), Xcode: 26.2; Checked out pull request; Found 32433 issues") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/33242 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/33486 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/33391 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->