### PR TITLE
Align WebAssembly.Memory & .Module with SharedArrayBuffer

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/serialization/memory/window-success.tentative.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/serialization/memory/window-success.tentative.https-expected.txt
@@ -1,5 +1,5 @@
 
 PASS postMessaging a shared WebAssembly.Memory to a dedicated worker
-FAIL postMessaging a shared WebAssembly.Memory to a same-origin iframe The object can not be cloned.
+PASS postMessaging a shared WebAssembly.Memory to a same-origin iframe
 PASS Cloning a shared WebAssembly.Memory through a MessageChannel
 

--- a/Source/WebCore/Modules/mediastream/RTCRtpScriptTransform.cpp
+++ b/Source/WebCore/Modules/mediastream/RTCRtpScriptTransform.cpp
@@ -55,7 +55,7 @@ ExceptionOr<Ref<RTCRtpScriptTransform>> RTCRtpScriptTransform::create(JSC::JSGlo
         return Exception { ExceptionCode::InvalidStateError, "Invalid context"_s };
 
     Vector<Ref<MessagePort>> transferredPorts;
-    auto serializedOptions = SerializedScriptValue::create(state, options, WTF::move(transfer), transferredPorts);
+    auto serializedOptions = SerializedScriptValue::create(state, options, WTF::move(transfer), transferredPorts, SerializationForStorage::No);
     if (serializedOptions.hasException())
         return serializedOptions.releaseException();
 

--- a/Source/WebCore/Modules/notifications/Notification.cpp
+++ b/Source/WebCore/Modules/notifications/Notification.cpp
@@ -91,7 +91,7 @@ static ExceptionOr<Ref<SerializedScriptValue>> createSerializedScriptValue(Scrip
         return Exception { ExceptionCode::TypeError, "Notification cannot be created without a global object"_s };
 
     Vector<Ref<MessagePort>> dummyPorts;
-    return SerializedScriptValue::create(*globalObject, value, { }, dummyPorts);
+    return SerializedScriptValue::create(*globalObject, value, { }, dummyPorts, SerializationForStorage::Yes);
 }
 
 ExceptionOr<Ref<Notification>> Notification::create(ScriptExecutionContext& context, String&& title, Options&& options)

--- a/Source/WebCore/Modules/webaudio/AudioWorkletNode.cpp
+++ b/Source/WebCore/Modules/webaudio/AudioWorkletNode.cpp
@@ -99,7 +99,7 @@ ExceptionOr<Ref<AudioWorkletNode>> AudioWorkletNode::create(JSC::JSGlobalObject&
     {
         auto lock = JSC::JSLockHolder { &globalObject };
         auto* jsOptions = convertDictionaryToJS(globalObject, downcast<JSDOMGlobalObject>(globalObject), options);
-        serializedOptions = SerializedScriptValue::create(globalObject, jsOptions, SerializationForStorage::No, SerializationErrorMode::NonThrowing, SerializationContext::WorkerPostMessage);
+        serializedOptions = SerializedScriptValue::create(globalObject, jsOptions, SerializationForStorage::No, SerializationErrorMode::NonThrowing);
         if (!serializedOptions)
             serializedOptions = SerializedScriptValue::nullValue();
     }

--- a/Source/WebCore/bindings/js/SerializedScriptValue.cpp
+++ b/Source/WebCore/bindings/js/SerializedScriptValue.cpp
@@ -2291,8 +2291,10 @@ private:
 #endif
 #if ENABLE(WEBASSEMBLY)
             if (JSWebAssemblyModule* module = dynamicDowncast<JSWebAssemblyModule>(obj)) {
-                if (m_context != SerializationContext::WorkerPostMessage && m_context != SerializationContext::WindowPostMessage)
-                    return false;
+                if (m_forStorage == SerializationForStorage::Yes) {
+                    code = SerializationReturnCode::DataCloneError;
+                    return true;
+                }
 
                 uint32_t index = m_wasmModules.size();
                 m_wasmModules.append(Ref { module->module() });
@@ -2302,11 +2304,11 @@ private:
                 return true;
             }
             if (JSWebAssemblyMemory* memory = dynamicDowncast<JSWebAssemblyMemory>(obj)) {
-                if (!JSC::Options::useSharedArrayBuffer() || memory->memory().sharingMode() != JSC::MemorySharingMode::Shared) {
+                if (m_forStorage == SerializationForStorage::Yes || memory->memory().sharingMode() != JSC::MemorySharingMode::Shared) {
                     code = SerializationReturnCode::DataCloneError;
                     return true;
                 }
-                if (m_context != SerializationContext::WorkerPostMessage) {
+                if (!isCrossOriginIsolatedContext(m_lexicalGlobalObject) && !JSC::Options::useSharedArrayBuffer()) {
                     code = SerializationReturnCode::DataCloneError;
                     return true;
                 }
@@ -5629,15 +5631,13 @@ private:
         }
 #if ENABLE(WEBASSEMBLY)
         case WasmModuleTag: {
-            if (m_majorVersion >= 12) {
-                // https://webassembly.github.io/spec/web-api/index.html#serialization
-                CachedStringRef agentClusterID;
-                bool agentClusterIDSuccessfullyRead = readStringData(agentClusterID);
-                if (!agentClusterIDSuccessfullyRead || agentClusterID->string() != agentClusterIDFromGlobalObject(*m_globalObject)) {
-                    SERIALIZE_TRACE("FAIL deserialize");
-                    fail();
-                    return JSValue();
-                }
+            // https://webassembly.github.io/spec/web-api/index.html#serialization
+            CachedStringRef agentClusterID;
+            bool agentClusterIDSuccessfullyRead = readStringData(agentClusterID);
+            if (!agentClusterIDSuccessfullyRead || agentClusterID->string() != agentClusterIDFromGlobalObject(*m_globalObject)) {
+                SERIALIZE_TRACE("FAIL deserialize");
+                fail();
+                return JSValue();
             }
             uint32_t index;
             bool indexSuccessfullyRead = read(index);
@@ -5649,18 +5649,16 @@ private:
             return JSC::JSWebAssemblyModule::create(m_lexicalGlobalObject->vm(), m_globalObject->webAssemblyModuleStructure(), m_wasmModules->at(index).copyRef());
         }
         case WasmMemoryTag: {
-            if (m_majorVersion >= 12) {
-                CachedStringRef agentClusterID;
-                bool agentClusterIDSuccessfullyRead = readStringData(agentClusterID);
-                if (!agentClusterIDSuccessfullyRead || agentClusterID->string() != agentClusterIDFromGlobalObject(*m_globalObject)) {
-                    SERIALIZE_TRACE("FAIL deserialize");
-                    fail();
-                    return JSValue();
-                }
+            CachedStringRef agentClusterID;
+            bool agentClusterIDSuccessfullyRead = readStringData(agentClusterID);
+            if (!agentClusterIDSuccessfullyRead || agentClusterID->string() != agentClusterIDFromGlobalObject(*m_globalObject)) {
+                SERIALIZE_TRACE("FAIL deserialize");
+                fail();
+                return JSValue();
             }
             uint32_t index;
             bool indexSuccessfullyRead = read(index);
-            if (!indexSuccessfullyRead || !m_wasmMemoryHandles || index >= m_wasmMemoryHandles->size() || !JSC::Options::useSharedArrayBuffer()) {
+            if (!indexSuccessfullyRead || !m_wasmMemoryHandles || index >= m_wasmMemoryHandles->size()) {
                 SERIALIZE_TRACE("FAIL deserialize");
                 fail();
                 return JSValue();
@@ -6964,7 +6962,7 @@ ExceptionOr<Ref<SerializedScriptValue>> SerializedScriptValue::create(JSGlobalOb
         , .inMemoryMessagePorts = WTF::move(inMemoryMessagePorts)
 #if ENABLE(WEBASSEMBLY)
         , .wasmModulesArray = wasmModules.isEmpty() ? nullptr : makeUnique<WasmModuleArray>(WTF::move(wasmModules))
-        , .wasmMemoryHandlesArray = context == SerializationContext::WorkerPostMessage ? makeUnique<WasmMemoryHandleArray>(wasmMemoryHandles) : nullptr
+        , .wasmMemoryHandlesArray = makeUnique<WasmMemoryHandleArray>(WTF::move(wasmMemoryHandles))
 #endif
         , .blobHandles = crossThreadCopy(WTF::move(blobHandles))
     }));
@@ -6989,7 +6987,7 @@ RefPtr<SerializedScriptValue> SerializedScriptValue::create(JSContextRef originC
     auto scope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
 
     JSValue value = toJS(lexicalGlobalObject, apiValue);
-    auto serializedValue = SerializedScriptValue::create(*lexicalGlobalObject, value);
+    auto serializedValue = SerializedScriptValue::create(*lexicalGlobalObject, value, SerializationForStorage::No);
     if (scope.exception()) [[unlikely]] {
         if (exception)
             *exception = toRef(lexicalGlobalObject, scope.exception()->value());

--- a/Source/WebCore/bindings/js/SerializedScriptValue.h
+++ b/Source/WebCore/bindings/js/SerializedScriptValue.h
@@ -71,8 +71,8 @@ template<typename> class ExceptionOr;
 
 enum class SerializationReturnCode;
 
-enum class SerializationErrorMode { NonThrowing, Throwing };
-enum class SerializationContext { Default, WorkerPostMessage, WindowPostMessage, CloneAcrossWorlds };
+enum class SerializationErrorMode : bool { NonThrowing, Throwing };
+enum class SerializationContext : bool { Default, CloneAcrossWorlds };
 enum class SerializationForStorage : bool { No, Yes };
 
 struct ErrorInformation {
@@ -91,8 +91,8 @@ DECLARE_ALLOCATOR_WITH_HEAP_IDENTIFIER(SerializedScriptValue);
 class SerializedScriptValue : public ThreadSafeRefCounted<SerializedScriptValue> {
     WTF_DEPRECATED_MAKE_FAST_ALLOCATED_WITH_HEAP_IDENTIFIER(SerializedScriptValue, SerializedScriptValue);
 public:
-    WEBCORE_EXPORT static ExceptionOr<Ref<SerializedScriptValue>> create(JSC::JSGlobalObject&, JSC::JSValue, Vector<JSC::Strong<JSC::JSObject>>&& transfer, Vector<Ref<MessagePort>>&, SerializationForStorage = SerializationForStorage::No, SerializationContext = SerializationContext::Default);
-    WEBCORE_EXPORT static RefPtr<SerializedScriptValue> create(JSC::JSGlobalObject&, JSC::JSValue, SerializationForStorage = SerializationForStorage::No, SerializationErrorMode = SerializationErrorMode::Throwing, SerializationContext = SerializationContext::Default);
+    WEBCORE_EXPORT static ExceptionOr<Ref<SerializedScriptValue>> create(JSC::JSGlobalObject&, JSC::JSValue, Vector<JSC::Strong<JSC::JSObject>>&& transfer, Vector<Ref<MessagePort>>&, SerializationForStorage, SerializationContext = SerializationContext::Default);
+    WEBCORE_EXPORT static RefPtr<SerializedScriptValue> create(JSC::JSGlobalObject&, JSC::JSValue, SerializationForStorage, SerializationErrorMode = SerializationErrorMode::Throwing, SerializationContext = SerializationContext::Default);
     WEBCORE_EXPORT static RefPtr<SerializedScriptValue> convert(JSC::JSGlobalObject&, JSC::JSValue);
 
     WEBCORE_EXPORT static RefPtr<SerializedScriptValue> create(StringView);

--- a/Source/WebCore/dom/BroadcastChannel.cpp
+++ b/Source/WebCore/dom/BroadcastChannel.cpp
@@ -197,7 +197,7 @@ ExceptionOr<void> BroadcastChannel::postMessage(JSC::JSGlobalObject& globalObjec
         return Exception { ExceptionCode::InvalidStateError, "This BroadcastChannel is closed"_s };
 
     Vector<Ref<MessagePort>> ports;
-    auto messageData = SerializedScriptValue::create(globalObject, message, { }, ports, SerializationForStorage::No, SerializationContext::WorkerPostMessage);
+    auto messageData = SerializedScriptValue::create(globalObject, message, { }, ports, SerializationForStorage::No);
     if (messageData.hasException())
         return messageData.releaseException();
     ASSERT(ports.isEmpty());

--- a/Source/WebCore/dom/MessagePort.cpp
+++ b/Source/WebCore/dom/MessagePort.cpp
@@ -154,7 +154,7 @@ ExceptionOr<void> MessagePort::postMessage(JSC::JSGlobalObject& globalObject, JS
     LOG(MessagePorts, "Attempting to post message to port %s (to be received by port %s)", m_identifier.logString().utf8().data(), m_remoteIdentifier.logString().utf8().data());
 
     Vector<Ref<MessagePort>> ports;
-    auto messageData = SerializedScriptValue::create(globalObject, messageValue, WTF::move(options.transfer), ports, SerializationForStorage::No, SerializationContext::WorkerPostMessage);
+    auto messageData = SerializedScriptValue::create(globalObject, messageValue, WTF::move(options.transfer), ports, SerializationForStorage::No);
     if (messageData.hasException())
         return messageData.releaseException();
 

--- a/Source/WebCore/page/LocalDOMWindow.cpp
+++ b/Source/WebCore/page/LocalDOMWindow.cpp
@@ -1034,7 +1034,7 @@ ExceptionOr<void> LocalDOMWindow::postMessage(JSC::JSGlobalObject& lexicalGlobal
         return targetSecurityOrigin.releaseException();
 
     Vector<Ref<MessagePort>> ports;
-    auto messageData = SerializedScriptValue::create(lexicalGlobalObject, messageValue, WTF::move(options.transfer), ports, SerializationForStorage::No, SerializationContext::WindowPostMessage);
+    auto messageData = SerializedScriptValue::create(lexicalGlobalObject, messageValue, WTF::move(options.transfer), ports, SerializationForStorage::No);
     if (messageData.hasException())
         return messageData.releaseException();
 

--- a/Source/WebCore/page/PerformanceMark.cpp
+++ b/Source/WebCore/page/PerformanceMark.cpp
@@ -79,7 +79,7 @@ ExceptionOr<Ref<PerformanceMark>> PerformanceMark::create(JSC::JSGlobalObject& g
     }
 
     Vector<Ref<MessagePort>> ignoredMessagePorts;
-    auto serializedDetail = SerializedScriptValue::create(globalObject, detail, { }, ignoredMessagePorts);
+    auto serializedDetail = SerializedScriptValue::create(globalObject, detail, { }, ignoredMessagePorts, SerializationForStorage::No);
     if (serializedDetail.hasException())
         return serializedDetail.releaseException();
 

--- a/Source/WebCore/page/PerformanceUserTiming.cpp
+++ b/Source/WebCore/page/PerformanceUserTiming.cpp
@@ -230,7 +230,7 @@ ExceptionOr<Ref<PerformanceMeasure>> PerformanceUserTiming::measure(JSC::JSGloba
         detail = JSC::jsNull();
 
     Vector<Ref<MessagePort>> ignoredMessagePorts;
-    auto serializedDetail = SerializedScriptValue::create(globalObject, detail, { }, ignoredMessagePorts);
+    auto serializedDetail = SerializedScriptValue::create(globalObject, detail, { }, ignoredMessagePorts, SerializationForStorage::No);
     if (serializedDetail.hasException())
         return serializedDetail.releaseException();
 

--- a/Source/WebCore/page/RemoteDOMWindow.cpp
+++ b/Source/WebCore/page/RemoteDOMWindow.cpp
@@ -115,7 +115,7 @@ ExceptionOr<void> RemoteDOMWindow::postMessage(JSC::JSGlobalObject& lexicalGloba
         target = origin->data();
 
     Vector<Ref<MessagePort>> ports;
-    auto messageData = SerializedScriptValue::create(lexicalGlobalObject, message, WTF::move(options.transfer), ports, SerializationForStorage::No, SerializationContext::WindowPostMessage);
+    auto messageData = SerializedScriptValue::create(lexicalGlobalObject, message, WTF::move(options.transfer), ports, SerializationForStorage::No);
     if (messageData.hasException())
         return messageData.releaseException();
 

--- a/Source/WebCore/page/WindowOrWorkerGlobalScope.cpp
+++ b/Source/WebCore/page/WindowOrWorkerGlobalScope.cpp
@@ -80,7 +80,7 @@ void WindowOrWorkerGlobalScope::reportError(JSDOMGlobalObject& globalObject, JSC
 ExceptionOr<JSC::JSValue> WindowOrWorkerGlobalScope::structuredClone(JSDOMGlobalObject& lexicalGlobalObject, JSDOMGlobalObject& relevantGlobalObject, JSC::JSValue value, StructuredSerializeOptions&& options)
 {
     Vector<Ref<MessagePort>> ports;
-    auto messageData = SerializedScriptValue::create(lexicalGlobalObject, value, WTF::move(options.transfer), ports, SerializationForStorage::No, SerializationContext::Default);
+    auto messageData = SerializedScriptValue::create(lexicalGlobalObject, value, WTF::move(options.transfer), ports, SerializationForStorage::No);
     if (messageData.hasException())
         return messageData.releaseException();
 

--- a/Source/WebCore/workers/DedicatedWorkerGlobalScope.cpp
+++ b/Source/WebCore/workers/DedicatedWorkerGlobalScope.cpp
@@ -95,7 +95,7 @@ ExceptionOr<void> DedicatedWorkerGlobalScope::postMessage(JSC::JSGlobalObject& s
 {
     Vector<Ref<MessagePort>> ports;
 
-    auto message = SerializedScriptValue::create(state, messageValue, WTF::move(options.transfer), ports, SerializationForStorage::No, SerializationContext::WorkerPostMessage);
+    auto message = SerializedScriptValue::create(state, messageValue, WTF::move(options.transfer), ports, SerializationForStorage::No);
     if (message.hasException())
         return message.releaseException();
 

--- a/Source/WebCore/workers/Worker.cpp
+++ b/Source/WebCore/workers/Worker.cpp
@@ -152,7 +152,7 @@ Worker::~Worker()
 ExceptionOr<void> Worker::postMessage(JSC::JSGlobalObject& globalObject, JSC::JSValue messageValue, StructuredSerializeOptions&& options)
 {
     Vector<Ref<MessagePort>> ports;
-    auto message = SerializedScriptValue::create(globalObject, messageValue, WTF::move(options.transfer), ports, SerializationForStorage::No, SerializationContext::WorkerPostMessage);
+    auto message = SerializedScriptValue::create(globalObject, messageValue, WTF::move(options.transfer), ports, SerializationForStorage::No);
     if (message.hasException())
         return message.releaseException();
 

--- a/Source/WebCore/workers/service/ServiceWorker.cpp
+++ b/Source/WebCore/workers/service/ServiceWorker.cpp
@@ -112,7 +112,7 @@ ExceptionOr<void> ServiceWorker::postMessage(JSC::JSGlobalObject& globalObject, 
         return Exception { ExceptionCode::InvalidStateError };
 
     Vector<Ref<MessagePort>> ports;
-    auto messageData = SerializedScriptValue::create(globalObject, messageValue, WTF::move(options.transfer), ports, SerializationForStorage::No, SerializationContext::WorkerPostMessage);
+    auto messageData = SerializedScriptValue::create(globalObject, messageValue, WTF::move(options.transfer), ports, SerializationForStorage::No);
     if (messageData.hasException())
         return messageData.releaseException();
 

--- a/Source/WebCore/workers/service/ServiceWorkerClient.cpp
+++ b/Source/WebCore/workers/service/ServiceWorkerClient.cpp
@@ -78,7 +78,7 @@ String ServiceWorkerClient::id() const
 ExceptionOr<void> ServiceWorkerClient::postMessage(JSC::JSGlobalObject& globalObject, JSC::JSValue messageValue, StructuredSerializeOptions&& options)
 {
     Vector<Ref<MessagePort>> ports;
-    auto messageData = SerializedScriptValue::create(globalObject, messageValue, WTF::move(options.transfer), ports, SerializationForStorage::No, SerializationContext::WorkerPostMessage);
+    auto messageData = SerializedScriptValue::create(globalObject, messageValue, WTF::move(options.transfer), ports, SerializationForStorage::No);
     if (messageData.hasException())
         return messageData.releaseException();
 


### PR DESCRIPTION
#### e871a6981d5839e513bdee6f967dbe4edb31bc5d
<pre>
Align WebAssembly.Memory &amp; .Module with SharedArrayBuffer
<a href="https://bugs.webkit.org/show_bug.cgi?id=313975">https://bugs.webkit.org/show_bug.cgi?id=313975</a>
<a href="https://rdar.apple.com/176792374">rdar://176792374</a>

Reviewed by Yusuke Suzuki.

The serializer&apos;s per-type gates for WebAssembly.Module and
WebAssembly.Memory were expressed in terms of SerializationContext that
hid two bugs:

* Notification&apos;s data serialization mistakenly passed
  SerializationForStorage::No even though the spec requires
  StructuredSerializeForStorage. The context-based gate was masking
  this by rejecting non-postMessage contexts in the generic-object
  fallback at objectStartState; switching the gate to the forStorage
  bit exposed that a WebAssembly.Module silently serialized
  successfully for a Notification instead of throwing DataCloneError.
  (If this change is not made an existing test regresses.)
* The wasmMemoryHandlesArray on the resulting SerializedScriptValue was
  only retained for SerializationContext::WorkerPostMessage, so a
  shared WebAssembly.Memory posted between same-origin same-process
  windows (same agent cluster) would be incorrectly dropped.
  (Fix demonstrated with the test progression.)

To address these we made these changes to SerializedScriptValue:

* WebAssembly.Module serialization: gate on m_forStorage == Yes (throws
  DataCloneError) instead of on context. Per spec the module is not
  storable but is structured-cloneable within an agent cluster.
* WebAssembly.Memory serialization: gate on m_forStorage == Yes and
  align the isolation gate with SharedArrayBuffer
  (cross-origin-isolated or the useSharedArrayBuffer option), not on a
  context value.
* Deserialization: drop the m_majorVersion &gt;= 12 gating as these
  objects were never stored to disk and drop the redundant
  !useSharedArrayBuffer() check for WasmMemoryTag (the agent-cluster-ID
  check subsumes it).
* SerializationContext is reduced from four values to { Default,
  CloneAcrossWorlds } -- WorkerPostMessage and WindowPostMessage no longer
  gate any serializer behavior after the above changes.

Canonical link: <a href="https://commits.webkit.org/313482@main">https://commits.webkit.org/313482@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4dda2cbb208f1e752f0286a6c87724c8245be7c2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/163246 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/36727 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/29944 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/172185 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/119693 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/82f18b2b-c88b-45d2-b898-2baf2bd84607) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/165115 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/37055 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/36728 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/126761 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/89359 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/8102cb7d-0c79-43ef-8580-fd7f7dd1f03f) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/166205 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/29035 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/146759 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/107328 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/0e696ad0-6fef-444a-95f7-ff8c8e99e389) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/28081 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/26709 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/19887 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/137974 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/24483 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/174688 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/26906 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/26138 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/135067 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/36397 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/30811 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/135059 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/37183 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/146278 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/99102 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/24842 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/30363 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/23122 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/35893 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/108312 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/35392 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/1147 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/35639 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/35539 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->