### PR TITLE
[WPE] Send touch cancel event on losing touch capability

### DIFF
--- a/Source/WebKit/WPEPlatform/wpe/wayland/WPEWaylandSeat.cpp
+++ b/Source/WebKit/WPEPlatform/wpe/wayland/WPEWaylandSeat.cpp
@@ -521,6 +521,16 @@ const struct wl_seat_listener WaylandSeat::s_listener = {
             seat.m_touch.source = WPE_INPUT_SOURCE_TOUCHSCREEN;
             wl_touch_add_listener(seat.m_touch.object, &s_touchListener, data);
         } else if (!hasTouch && seat.m_touch.object) {
+            if (seat.m_touch.toplevel) {
+                if (GRefPtr<WPEView> view = wpeToplevelWaylandGetVisibleViewUnderTouch(seat.m_touch.toplevel.get())) {
+                    for (const auto& iter : seat.m_touch.points) {
+                        GRefPtr<WPEEvent> event = adoptGRef(wpe_event_touch_new(WPE_EVENT_TOUCH_CANCEL, view.get(), seat.m_touch.source, 0, seat.modifiers(),
+                            iter.key, iter.value.first, iter.value.second));
+                        wpe_view_event(view.get(), event.get());
+                    }
+                }
+            }
+
             wl_touch_release(seat.m_touch.object);
             seat.m_touch = { };
         }


### PR DESCRIPTION
#### 13af2406270cb62d608cc5468fe04368f9472165
<pre>
[WPE] Send touch cancel event on losing touch capability
<a href="https://bugs.webkit.org/show_bug.cgi?id=313976">https://bugs.webkit.org/show_bug.cgi?id=313976</a>

Reviewed by Carlos Garcia Campos.

Currently, when touch capability is lost, we reset all related data, but
do not notify the page. This may cause some UI elements, such as
buttons, to appear &quot;stuck&quot; in pressed state.

This change sends a touch cancel event for each touch point to let the
page update its state.

* Source/WebKit/WPEPlatform/wpe/wayland/WPEWaylandSeat.cpp:

Canonical link: <a href="https://commits.webkit.org/312604@main">https://commits.webkit.org/312604@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/016fdaa2b0c5ae75f35b47e900f0c1c877b8aea9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/160287 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/33760 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/26861 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/169189 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/115353 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/33861 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/33760 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/124269 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/87801 "1 flakes 2 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/163245 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/26508 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/143970 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/104868 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/25561 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/24058 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/16909 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/135253 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/171667 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/18025 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/23373 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/132519 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/33433 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/28152 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/132544 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35871 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/33418 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/143528 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/95203 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/27162 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/20342 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/32927 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/99688 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/32428 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/32672 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/32576 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->