### PR TITLE
Rename HTMLOrForeignElement to HTMLOrSVGOrMathMLElement

### DIFF
--- a/Source/WebCore/CMakeLists.txt
+++ b/Source/WebCore/CMakeLists.txt
@@ -1399,7 +1399,7 @@ set(WebCore_NON_SVG_IDL_FILES
     html/HTMLOptGroupElement.idl
     html/HTMLOptionElement.idl
     html/HTMLOptionsCollection.idl
-    html/HTMLOrForeignElement.idl
+    html/HTMLOrSVGOrMathMLElement.idl
     html/HTMLOutputElement.idl
     html/HTMLParagraphElement.idl
     html/HTMLParamElement.idl

--- a/Source/WebCore/DerivedSources-input.xcfilelist
+++ b/Source/WebCore/DerivedSources-input.xcfilelist
@@ -1687,7 +1687,7 @@ $(PROJECT_DIR)/html/HTMLObjectElement.idl
 $(PROJECT_DIR)/html/HTMLOptGroupElement.idl
 $(PROJECT_DIR)/html/HTMLOptionElement.idl
 $(PROJECT_DIR)/html/HTMLOptionsCollection.idl
-$(PROJECT_DIR)/html/HTMLOrForeignElement.idl
+$(PROJECT_DIR)/html/HTMLOrSVGOrMathMLElement.idl
 $(PROJECT_DIR)/html/HTMLOutputElement.idl
 $(PROJECT_DIR)/html/HTMLParagraphElement.idl
 $(PROJECT_DIR)/html/HTMLParamElement.idl

--- a/Source/WebCore/DerivedSources-output.xcfilelist
+++ b/Source/WebCore/DerivedSources-output.xcfilelist
@@ -1636,8 +1636,8 @@ $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSHTMLOptionElement.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSHTMLOptionElement.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSHTMLOptionsCollection.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSHTMLOptionsCollection.h
-$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSHTMLOrForeignElement.cpp
-$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSHTMLOrForeignElement.h
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSHTMLOrSVGOrMathMLElement.cpp
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSHTMLOrSVGOrMathMLElement.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSHTMLOutputElement.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSHTMLOutputElement.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSHTMLParagraphElement.cpp

--- a/Source/WebCore/DerivedSources.make
+++ b/Source/WebCore/DerivedSources.make
@@ -1355,7 +1355,7 @@ JS_BINDING_IDLS := \
     $(WebCore)/html/HTMLOptGroupElement.idl \
     $(WebCore)/html/HTMLOptionElement.idl \
     $(WebCore)/html/HTMLOptionsCollection.idl \
-    $(WebCore)/html/HTMLOrForeignElement.idl \
+    $(WebCore)/html/HTMLOrSVGOrMathMLElement.idl \
     $(WebCore)/html/HTMLOutputElement.idl \
     $(WebCore)/html/HTMLParagraphElement.idl \
     $(WebCore)/html/HTMLParamElement.idl \

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -4415,7 +4415,7 @@ JSHTMLObjectElement.cpp
 JSHTMLOptGroupElement.cpp
 JSHTMLOptionElement.cpp
 JSHTMLOptionsCollection.cpp
-JSHTMLOrForeignElement.cpp
+JSHTMLOrSVGOrMathMLElement.cpp
 JSHTMLOutputElement.cpp
 JSHTMLParagraphElement.cpp
 JSHTMLParamElement.cpp

--- a/Source/WebCore/html/HTMLElement.idl
+++ b/Source/WebCore/html/HTMLElement.idl
@@ -84,5 +84,5 @@ dictionary TogglePopoverOptions : ShowPopoverOptions {
 HTMLElement includes GlobalEventHandlers;
 HTMLElement includes DocumentAndElementEventHandlers;
 HTMLElement includes ElementContentEditable;
-HTMLElement includes HTMLOrForeignElement;
+HTMLElement includes HTMLOrSVGOrMathMLElement;
 HTMLElement includes ElementCSSInlineStyle;

--- a/Source/WebCore/html/HTMLOrSVGOrMathMLElement.idl
+++ b/Source/WebCore/html/HTMLOrSVGOrMathMLElement.idl
@@ -24,9 +24,7 @@
  */
 
 // https://html.spec.whatwg.org/multipage/dom.html#htmlorsvgelement
-// FIXME: update above link when this change has been implemented:
-// https://github.com/whatwg/html/issues/4702
-interface mixin HTMLOrForeignElement {
+interface mixin HTMLOrSVGOrMathMLElement {
     [SameObject] readonly attribute DOMStringMap dataset;
     attribute [AtomString] DOMString nonce; // intentionally no [CEReactions=Needed]
 

--- a/Source/WebCore/mathml/MathMLElement.idl
+++ b/Source/WebCore/mathml/MathMLElement.idl
@@ -33,5 +33,5 @@
 
 MathMLElement includes GlobalEventHandlers;
 MathMLElement includes DocumentAndElementEventHandlers;
-MathMLElement includes HTMLOrForeignElement;
+MathMLElement includes HTMLOrSVGOrMathMLElement;
 MathMLElement includes ElementCSSInlineStyle;

--- a/Source/WebCore/svg/SVGElement.idl
+++ b/Source/WebCore/svg/SVGElement.idl
@@ -33,5 +33,5 @@
 
 SVGElement includes GlobalEventHandlers;
 SVGElement includes DocumentAndElementEventHandlers;
-SVGElement includes HTMLOrForeignElement;
+SVGElement includes HTMLOrSVGOrMathMLElement;
 SVGElement includes ElementCSSInlineStyle;


### PR DESCRIPTION
#### 6f9391970562bda5feb7f440a2f10389586b6a09
<pre>
Rename HTMLOrForeignElement to HTMLOrSVGOrMathMLElement
<a href="https://bugs.webkit.org/show_bug.cgi?id=313970">https://bugs.webkit.org/show_bug.cgi?id=313970</a>

Reviewed by Anne van Kesteren.

See <a href="https://github.com/whatwg/html/pull/12416">https://github.com/whatwg/html/pull/12416</a>

* Source/WebCore/CMakeLists.txt:
* Source/WebCore/DerivedSources-input.xcfilelist:
* Source/WebCore/DerivedSources-output.xcfilelist:
* Source/WebCore/DerivedSources.make:
* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/html/HTMLElement.idl:
* Source/WebCore/html/HTMLOrSVGOrMathMLElement.idl: Renamed from Source/WebCore/html/HTMLOrForeignElement.idl.
* Source/WebCore/mathml/MathMLElement.idl:
* Source/WebCore/svg/SVGElement.idl:

Canonical link: <a href="https://commits.webkit.org/312609@main">https://commits.webkit.org/312609@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/07fdc89450225d68fb9c979b19e5f4aba712fcf4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/160504 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/33977 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/27078 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/169407 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/115570 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/162373 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/34078 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/33977 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/169407 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/115570 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/163462 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/26704 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/144177 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/169407 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/25756 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/24259 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk3-libwebrtc~~](https://ews-build.webkit.org/#/builders/173/builds/17126 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/135450 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/167/builds/21940 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/171886 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/18421 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/23580 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/171886 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/33651 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/28352 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/171886 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/33635 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/143735 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/95419 "Built successfully") | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/164/builds/27333 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/20549 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/33145 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/100017 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/32645 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/32889 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/32793 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->