### PR TITLE
[AutoFill Debugging] Add an extra newline between large containers with visible borders or background colors when extracting markdown

### DIFF
--- a/LayoutTests/fast/text-extraction/debug-text-extraction-markdown-expected.txt
+++ b/LayoutTests/fast/text-extraction/debug-text-extraction-markdown-expected.txt
@@ -1,3 +1,5 @@
+Hello world
+
 Here’s to the crazy ones. The misfits. The rebels. The troublemakers. The round pegs in the square holes.
 [T\[e\]st link](https://www.apple.com/)
 You can quote them, disagree with them, glorify or vilify them. About the only thing you can’t do is ignore them. Because they change things.
@@ -6,6 +8,7 @@ This is a list:
 - foo
 - bar
 - baz
+
 On [sale](https://webkit.org/) for
 £10.99 This ~~text~~ has a ~~line through it~~. The price ~~was \~\~$50~~
 ~~CSS linethrough~~ normal text
@@ -13,3 +16,14 @@ On [sale](https://webkit.org/) for
 ~~both semantic and CSS~~
 ~~[A link](https://www.apple.com/)~~
 ![A linked image](file:///fake/linked-image.png) [](https://www.example.com/)
+
+Information
+
+40
+First
+
+3
+Second
+
+15
+Third

--- a/LayoutTests/fast/text-extraction/debug-text-extraction-markdown.html
+++ b/LayoutTests/fast/text-extraction/debug-text-extraction-markdown.html
@@ -9,35 +9,107 @@ body.done {
     white-space: pre-wrap;
 }
 
+body {
+    font-family: system-ui;
+}
+
 .linethrough {
     text-decoration: line-through;
+}
+
+section.background {
+    border-radius: 1em;
+    padding: 1em;
+    background-color: #efefef;
+}
+
+section + section {
+    margin-top: 1em;
+}
+
+section.bordered {
+    border: 1px solid #eee;
+    border-radius: 1em;
+    padding: 1em;
+}
+
+.stats {
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    gap: 1rem;
+    margin-top: 1rem;
+}
+
+.card {
+    min-width: 150px;
+    min-height: 100px;
+    background: white;
+    padding: 1rem;
+    border-radius: 4px;
+    text-align: center;
+    border: 1px solid #e0e0e0;
+}
+
+.number {
+    font-size: 2rem;
+    font-weight: bold;
+    color: #2d5016;
+    margin-bottom: 0.6em;
+}
+
+.label {
+    color: #666;
+    font-size: 1.2rem;
+    margin-top: 0.5rem;
 }
 </style>
 <script src="../../resources/ui-helper.js"></script>
 </head>
 <body>
-<p>Here’s to the crazy ones. The misfits. The rebels. The troublemakers. The round pegs in the square holes.</p>
-<a href="https://www.apple.com">T[e]st link</a>
-<div>You can quote them, disagree with them, glorify or vilify them. About the only thing you can’t do is ignore them. Because they change things.</div>
-<img src="file:///fake/image.png" alt="Purposefully broken image"></img>
-<p>This is a list:</p>
-<ul>
-    <li>foo</li>
-    <li>bar</li>
-    <li>baz</li>
-</ul>
-On <a href="https://webkit.org">sale</a> for
-<p>
-    <sup>£</sup>
-    10
-    <sup>99</sup>
-    This <strike>text</strike> has a <del>line through it</del>. The price <s>was ~~$50</s>
-</p>
-<p><span class="linethrough">CSS linethrough</span> normal text</p>
-<p class="linethrough">Linethrough <span>also linethrough</span></p>
-<p><del class="linethrough">both semantic and CSS</del></p>
-<p class="linethrough"><a href="https://www.apple.com">A link</a></p>
-<a href="https://www.example.com"><img src="file:///fake/linked-image.png" alt="A linked image"></a>
+<h1>Hello world</h1>
+<section class="background">
+    <p>Here’s to the crazy ones. The misfits. The rebels. The troublemakers. The round pegs in the square holes.</p>
+    <a href="https://www.apple.com">T[e]st link</a>
+    <div>You can quote them, disagree with them, glorify or vilify them. About the only thing you can’t do is ignore them. Because they change things.</div>
+    <img src="file:///fake/image.png" alt="Purposefully broken image"></img>
+    <p>This is a list:</p>
+    <ul>
+        <li>foo</li>
+        <li>bar</li>
+        <li>baz</li>
+    </ul>
+</section>
+<section class="bordered">
+    On <a href="https://webkit.org">sale</a> for
+    <p>
+        <sup>£</sup>
+        10
+        <sup>99</sup>
+        This <strike>text</strike> has a <del>line through it</del>. The price <s>was ~~$50</s>
+    </p>
+    <p><span class="linethrough">CSS linethrough</span> normal text</p>
+    <p class="linethrough">Linethrough <span>also linethrough</span></p>
+    <p><del class="linethrough">both semantic and CSS</del></p>
+    <p class="linethrough"><a href="https://www.apple.com">A link</a></p>
+    <a href="https://www.example.com"><img src="file:///fake/linked-image.png" alt="A linked image"></a>
+</section>
+<section class="background">
+    <h3>Information</h3>
+    <div class="stats">
+        <div class="card">
+            <div class="number">40</div>
+            <div class="label">First</div>
+        </div>
+        <div class="card">
+            <div class="number">3</div>
+            <div class="label">Second</div>
+        </div>
+        <div class="card">
+            <div class="number">15</div>
+            <div class="label">Third</div>
+        </div>
+    </div>
+</section>
 <script>
 addEventListener("load", async () => {
     if (!window.testRunner)

--- a/LayoutTests/fast/text-extraction/debug-text-extraction-shorten-urls-expected.txt
+++ b/LayoutTests/fast/text-extraction/debug-text-extraction-shorten-urls-expected.txt
@@ -50,6 +50,7 @@ root
 [Plain link \(2\)](example.com/2)
 [Plain link \(3\)](example.com/3)
 [Local file](/test/cat.png)
+
 ![SVG data URL](image)
 ![PNG data URL](image2)
 ![Long image path](vacation-2024-summer-beach.jpg)

--- a/Source/WebCore/page/text-extraction/TextExtraction.cpp
+++ b/Source/WebCore/page/text-extraction/TextExtraction.cpp
@@ -282,6 +282,8 @@ struct TraversalContext {
     WeakHashSet<Node, WeakPtrImplWithEventTargetData> additionalContainersToCollect;
     unsigned inAdditionalContainerToCollectCount { 0 };
     Vector<bool, 1> hasOverflowItemsStack;
+    Vector<unsigned, 2> visualBlockContainerStack { 0 };
+    unsigned nextVisualBlockContainerNumber { 1 };
     unsigned onlyCollectTextAndLinksCount { 0 };
     bool mergeParagraphs { false };
     bool skipNearlyTransparentContent { false };
@@ -292,6 +294,11 @@ struct TraversalContext {
     inline bool NODELETE shouldIncludeNodeWithRect(const FloatRect& rect) const
     {
         return !rectInRootView || rectInRootView->intersects(rect);
+    }
+
+    unsigned currentVisualBlockContainerNumber() const
+    {
+        return visualBlockContainerStack.isEmpty() ? 0 : visualBlockContainerStack.last();
     }
 
     void pushEnclosingBlock(const Node& node)
@@ -838,6 +845,18 @@ static bool areSameOrigin(Document& document, Document& other)
     return protect(document.securityOrigin())->isSameOriginAs(protect(other.securityOrigin()));
 }
 
+static bool isVisuallyDistinctContainer(const RenderStyle& style, const FloatRect& rect, const FloatRect&)
+{
+    bool hasEnclosingBorder = style.border().hasVisibleBorder() && style.usedBorderTopWidth() && style.usedBorderRightWidth() && style.usedBorderBottomWidth() && style.usedBorderLeftWidth();
+    bool hasVisualStyling = style.hasBackground() || style.hasOutline() || !style.boxShadow().isNone() || style.hasExplicitlySetBorderRadius() || hasEnclosingBorder;
+    if (!hasVisualStyling)
+        return false;
+
+    static constexpr auto minimumWidth = 150;
+    static constexpr auto minimumHeight = 90;
+    return rect.width() >= minimumWidth && rect.height() >= minimumHeight;
+}
+
 static inline void extractRecursive(Node& node, Item& parentItem, TraversalContext& context)
 {
     if (context.nodesToSkip.contains(node))
@@ -851,7 +870,18 @@ static inline void extractRecursive(Node& node, Item& parentItem, TraversalConte
     if (isAdditionalContainerToCollect)
         context.inAdditionalContainerToCollectCount++;
 
+    bool pushedVisualBlockContainer = false;
+    if (CheckedPtr renderer = node.renderer()) {
+        auto nodeBounds = rootViewBounds(node);
+        if (isBlock && isVisuallyDistinctContainer(protect(renderer->style()).get(), nodeBounds, parentItem.rectInRootView)) {
+            context.visualBlockContainerStack.append(context.nextVisualBlockContainerNumber++);
+            pushedVisualBlockContainer = true;
+        }
+    }
+
     auto extractionScope = makeScopeExit([&] {
+        if (pushedVisualBlockContainer)
+            context.visualBlockContainerStack.removeLast();
         if (isAdditionalContainerToCollect)
             context.inAdditionalContainerToCollectCount--;
         if (isBlock)
@@ -1066,6 +1096,9 @@ static inline void extractRecursive(Node& node, Item& parentItem, TraversalConte
 
     if (auto* renderer = node.renderer(); renderer && item)
         item->hasLineThrough = renderer->style().textDecorationLineInEffect().hasLineThrough();
+
+    if (item)
+        item->visualBlockContainerNumber = context.currentVisualBlockContainerNumber();
 
     ASSERT_IMPLIES(isScrollable, item);
 

--- a/Source/WebCore/page/text-extraction/TextExtractionTypes.h
+++ b/Source/WebCore/page/text-extraction/TextExtractionTypes.h
@@ -219,6 +219,7 @@ struct Item {
     String title;
     HashMap<String, String> clientAttributes;
     unsigned enclosingBlockNumber { 0 };
+    unsigned visualBlockContainerNumber { 0 };
     bool hasLineThrough { false };
 
     template<typename T> bool hasData() const

--- a/Source/WebKit/Shared/TextExtractionToStringConversion.cpp
+++ b/Source/WebKit/Shared/TextExtractionToStringConversion.cpp
@@ -354,6 +354,7 @@ struct TextExtractionLine {
     unsigned indentLevel { 0 };
     unsigned enclosingBlockNumber { 0 };
     unsigned superscriptLevel { 0 };
+    unsigned visualBlockContainerNumber { 0 };
 };
 
 static bool shouldEmitFullStopBetweenLines(const TextExtractionLine& previous, const String& previousText, const TextExtractionLine& line, const String& text)
@@ -458,28 +459,31 @@ public:
         String previousText;
         StringBuilder buffer;
         for (auto&& [text, line] : WTF::move(m_lines)) {
-            auto separator = [&] -> std::optional<char> {
+            auto separator = [&] -> std::optional<String> {
                 if (!previousLine)
                     return std::nullopt;
+
+                if (useMarkdownOutput() && previousLine->visualBlockContainerNumber != line.visualBlockContainerNumber)
+                    return "\n\n"_s;
 
                 if (shouldJoinWithPreviousLine(*previousLine, previousText, line, text))
                     return std::nullopt;
 
                 if (shouldEmitFullStopBetweenLines(*previousLine, previousText, line, text))
-                    return '.';
+                    return "."_s;
 
                 if (previousLine->enclosingBlockNumber == line.enclosingBlockNumber) {
                     if (shouldEmitExtraSpace(previousText[previousText.length() - 1], text[0]))
-                        return ' ';
+                        return " "_s;
 
                     return std::nullopt;
                 }
 
-                return '\n';
+                return "\n"_s;
             }();
 
             if (separator)
-                buffer.append(*separator);
+                buffer.append(WTF::move(*separator));
 
             previousLine = { WTF::move(line) };
             previousText = { text };
@@ -499,7 +503,7 @@ public:
         if (components.isEmpty())
             return;
 
-        auto [lineIndex, indentLevel, enclosingBlockNumber, superscriptLevel] = line;
+        auto [lineIndex, indentLevel, enclosingBlockNumber, superscriptLevel, visualBlockContainerNumber] = line;
         if (lineIndex >= m_lines.size()) {
             ASSERT_NOT_REACHED();
             return;
@@ -1597,7 +1601,7 @@ static void addPartsForItem(const TextExtraction::Item& item, std::optional<Node
 
                 if (aggregator.includeSelectOptions()) {
                     for (auto& option : selectData.options) {
-                        auto optionLine = TextExtractionLine { aggregator.advanceToNextLine(), line.indentLevel + 1 };
+                        auto optionLine = TextExtractionLine { aggregator.advanceToNextLine(), line.indentLevel + 1, line.enclosingBlockNumber, line.superscriptLevel, line.visualBlockContainerNumber };
                         if (option.isSelected)
                             aggregator.addResult(optionLine, { makeString("<option value='"_s, escapeStringForHTML(option.value), "' selected>"_s, escapeStringForHTML(option.label), "</option>"_s) });
                         else
@@ -1605,14 +1609,14 @@ static void addPartsForItem(const TextExtraction::Item& item, std::optional<Node
                     }
                 }
 
-                aggregator.addResult({ aggregator.advanceToNextLine(), line.indentLevel }, { makeString("</select>"_s) });
+                aggregator.addResult({ aggregator.advanceToNextLine(), line.indentLevel, line.enclosingBlockNumber, line.superscriptLevel, line.visualBlockContainerNumber }, { makeString("</select>"_s) });
             } else if (!aggregator.useMarkdownOutput()) {
                 parts.append("select"_s);
                 parts.appendVector(partsForItem(item, aggregator, includeRectForParentItem));
 
                 if (aggregator.includeSelectOptions()) {
                     for (auto& option : selectData.options) {
-                        auto optionLine = TextExtractionLine { aggregator.advanceToNextLine(), line.indentLevel + 1 };
+                        auto optionLine = TextExtractionLine { aggregator.advanceToNextLine(), line.indentLevel + 1, line.enclosingBlockNumber, line.superscriptLevel, line.visualBlockContainerNumber };
                         Vector<String> optionParts { "option"_s };
                         if (option.isSelected)
                             optionParts.append("selected"_s);
@@ -1766,7 +1770,7 @@ static void addTextRepresentationRecursive(const TextExtraction::Item& item, std
 
     auto includeRectForParentItem = omitChildTextNode ? IncludeRectForParentItem::Yes : IncludeRectForParentItem::No;
 
-    TextExtractionLine line { aggregator.advanceToNextLine(), depth, item.enclosingBlockNumber, aggregator.superscriptLevel() };
+    TextExtractionLine line { aggregator.advanceToNextLine(), depth, item.enclosingBlockNumber, aggregator.superscriptLevel(), item.visualBlockContainerNumber };
     addPartsForItem(item, std::optional { identifier }, line, aggregator, includeRectForParentItem, hasAdjacentLinkAfter);
 
     auto closingTagName = [&] -> String {

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -6919,6 +6919,7 @@ header: <WebCore/TextExtractionTypes.h>
     String title;
     HashMap<String, String> clientAttributes;
     unsigned enclosingBlockNumber;
+    unsigned visualBlockContainerNumber;
     bool hasLineThrough;
 };
 


### PR DESCRIPTION
#### 7e0e4d371e4f2dc823362d9abbd9d514564016f1
<pre>
[AutoFill Debugging] Add an extra newline between large containers with visible borders or background colors when extracting markdown
<a href="https://bugs.webkit.org/show_bug.cgi?id=313978">https://bugs.webkit.org/show_bug.cgi?id=313978</a>
<a href="https://rdar.apple.com/175370880">rdar://175370880</a>

Reviewed by Abrar Rahman Protyasha.

Add a heuristic to detect large (with an arbitrary threshold of at least 150 by 90) block-level
containers with visible borders, backgrounds, or drop-shadows, and automatically insert extra
newlines before or after visible text in these containers.

* LayoutTests/fast/text-extraction/debug-text-extraction-markdown-expected.txt:
* LayoutTests/fast/text-extraction/debug-text-extraction-markdown.html:
* LayoutTests/fast/text-extraction/debug-text-extraction-shorten-urls-expected.txt:
* Source/WebCore/page/text-extraction/TextExtraction.cpp:
(WebCore::TextExtraction::TraversalContext::currentVisualBlockContainerNumber const):
(WebCore::TextExtraction::isVisuallyDistinctContainer):

Add the detection heuristic here.

(WebCore::TextExtraction::extractRecursive):
* Source/WebCore/page/text-extraction/TextExtractionTypes.h:
* Source/WebKit/Shared/TextExtractionToStringConversion.cpp:
(WebKit::TextExtractionAggregator::takeResults):

Add 2 newlines as a separator between text that spans across large visible container boundaries.

(WebKit::TextExtractionAggregator::addResult):
(WebKit::addPartsForItem):
(WebKit::addTextRepresentationRecursive):
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:

Canonical link: <a href="https://commits.webkit.org/312546@main">https://commits.webkit.org/312546@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c100ae558fbcfc5b9d46131015fd02b7b445de1f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/160308 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/33781 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/26882 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/169210 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/115374 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/b4352d9f-208c-4d38-95f7-905ae8d033dd) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/162177 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/33882 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/33781 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/124285 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/87815 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/4c21914b-c8c4-46f2-b6a4-6264cc536a6f) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/163266 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/26524 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/143988 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/104884 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/dc4537ff-443f-4f4b-ac99-5669b79604f7) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/25576 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/24078 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/16930 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/135269 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/21751 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/171688 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/18046 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/23391 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/132536 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/33454 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/28172 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/132560 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35835 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/33439 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/143546 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/95221 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/27176 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/20360 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/32948 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/99709 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/32449 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/32693 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/32597 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->