### PR TITLE
[JSC][WASM][Debugger] Use VMIdentifier as stable per-VM thread ID for GDB RSP replies

### DIFF
--- a/Source/JavaScriptCore/wasm/debugger/WasmExecutionHandler.cpp
+++ b/Source/JavaScriptCore/wasm/debugger/WasmExecutionHandler.cpp
@@ -113,7 +113,6 @@ void ExecutionHandler::stopTheWorld(VM& debuggee, StopTheWorldEvent event)
 
         switch (event) {
         case StopTheWorldEvent::WasmStepIntoSiteReached:
-            RELEASE_ASSERT(Thread::currentSingleton().uid() == threadId(*m_debuggee));
             RELEASE_ASSERT(m_debuggee == info.targetVM && info.worldMode == VMManager::Mode::RunOne);
             break;
         case StopTheWorldEvent::WasmProgramStop:
@@ -168,8 +167,6 @@ DebuggerTrapStatus ExecutionHandler::handleDebuggerTrapIfNeeded(CallFrame* callF
 
 ExecutionHandler::ResumeMode ExecutionHandler::stopCode(Locker<Lock>& locker, StopTheWorldEvent event)
 {
-    RELEASE_ASSERT(Thread::currentSingleton().uid() == threadId(*m_debuggee));
-
     dataLogLnIf(Options::verboseWasmDebugger(), "[Code][Stop] Start with event:", event);
 
     auto notifyDebuggerOfStop = [&]() WTF_REQUIRES_LOCK(m_lock) {
@@ -343,11 +340,11 @@ void ExecutionHandler::notifyDebuggerOfNewModule(VM& vm)
     stopTheWorld(vm, StopTheWorldEvent::WasmProgramStop);
 }
 
-static inline VM* findVM(uint64_t threadId)
+static inline VM* findVM(uint64_t vmId)
 {
     VM* result = nullptr;
     VMManager::forEachVM([&](VM& vm) {
-        if (vm.debugState()->isStopped && threadId == ExecutionHandler::threadId(vm)) {
+        if (vm.debugState()->isStopped && vmId == vm.identifier().toRawValue()) {
             result = &vm;
             return IterationStatus::Done;
         }
@@ -356,13 +353,13 @@ static inline VM* findVM(uint64_t threadId)
     return result;
 }
 
-void ExecutionHandler::switchTarget(uint64_t threadId)
+void ExecutionHandler::switchTarget(uint64_t vmId)
 {
     RELEASE_ASSERT(Thread::currentSingleton().uid() == debugServerThreadId());
 
     Locker locker { m_lock };
 
-    VM* newDebuggee = findVM(threadId);
+    VM* newDebuggee = findVM(vmId);
     dataLogLnIf(Options::verboseWasmDebugger(), "[Code][SwitchVM] current debuggee=", RawPointer(m_debuggee), " new debuggee=", RawPointer(newDebuggee));
 
     if (m_debuggee == newDebuggee)
@@ -539,7 +536,6 @@ void ExecutionHandler::setStepIntoBreakpointForCall(VM& callerVM, CalleeBits box
     [&]() {
         Locker locker { m_lock };
 
-        RELEASE_ASSERT(Thread::currentSingleton().uid() == threadId(*m_debuggee));
         RELEASE_ASSERT(m_debuggee == &callerVM);
         dataLogLnIf(Options::verboseWasmDebugger(), "[Code][StepIntoEvent] Start for call");
         RELEASE_ASSERT(m_debuggerState == DebuggerState::StepRequested);
@@ -568,7 +564,6 @@ void ExecutionHandler::setStepIntoBreakpointForThrow(VM& throwVM)
     [&]() {
         Locker locker { m_lock };
 
-        RELEASE_ASSERT(Thread::currentSingleton().uid() == threadId(*m_debuggee));
         RELEASE_ASSERT(m_debuggee == &throwVM);
         dataLogLnIf(Options::verboseWasmDebugger(), "[Code][StepIntoEvent] Start for throw");
         RELEASE_ASSERT(m_debuggerState == DebuggerState::StepRequested);
@@ -718,11 +713,11 @@ void ExecutionHandler::handleThreadStopInfo(StringView packet)
     // Format: qThreadStopInfo<thread-id-in-hex>
     // Parse the thread ID
     StringView threadIdStr = packet.substring(strlen("qThreadStopInfo"));
-    uint64_t threadId = parseHex(threadIdStr);
-    dataLogLnIf(Options::verboseWasmDebugger(), "[Debugger] Handling qThreadStopInfo for thread: ", threadId);
+    uint64_t vmId = parseHex(threadIdStr);
+    dataLogLnIf(Options::verboseWasmDebugger(), "[Debugger] Handling qThreadStopInfo for thread: ", vmId);
 
     Locker locker { m_lock };
-    sendStopReplyForThread(locker, threadId);
+    sendStopReplyForThread(locker, vmId);
 }
 
 static uint64_t NODELETE getStopPC(const DebugState& state)
@@ -733,7 +728,7 @@ static uint64_t NODELETE getStopPC(const DebugState& state)
     return state.stopData->address;
 }
 
-static String getThreadName(const DebugState& state, uint64_t threadId)
+static String getThreadName(const DebugState& state, uint64_t vmId)
 {
     StringView stateName;
     if (state.isStoppedAtPrologue())
@@ -744,11 +739,11 @@ static String getThreadName(const DebugState& state, uint64_t threadId)
         RELEASE_ASSERT(state.isStoppedAtSystemCall());
         stateName = "system-call"_s;
     }
-    return makeString(stateName, " tid:0x"_s, hex(threadId, Lowercase));
+    return makeString(stateName, " tid:0x"_s, hex(vmId, Lowercase));
 }
 
 struct ThreadInfo {
-    uint64_t threadId;
+    uint64_t vmId;
     uint64_t pc;
     String name;
     StringView stopReason;
@@ -756,21 +751,21 @@ struct ThreadInfo {
 
 void ExecutionHandler::sendStopReply(AbstractLocker& locker) WTF_REQUIRES_LOCK(m_lock)
 {
-    sendStopReplyForThread(locker, threadId(*m_debuggee));
+    sendStopReplyForThread(locker, m_debuggee->identifier().toRawValue());
 }
 
-void ExecutionHandler::sendStopReplyForThread(AbstractLocker& locker, uint64_t threadId) WTF_REQUIRES_LOCK(m_lock)
+void ExecutionHandler::sendStopReplyForThread(AbstractLocker& locker, uint64_t vmId) WTF_REQUIRES_LOCK(m_lock)
 {
-    VM* vm = findVM(threadId);
+    VM* vm = findVM(vmId);
     if (!vm) {
-        dataLogLnIf(Options::verboseWasmDebugger(), "[Debugger] sendStopReplyForThread: thread ", threadId, " not found");
+        dataLogLnIf(Options::verboseWasmDebugger(), "[Debugger] sendStopReplyForThread: thread ", vmId, " not found");
         sendErrorReply(ProtocolError::InvalidAddress);
         return;
     }
 
     DebugState* state = vm->debugState();
     if (!state) {
-        dataLogLnIf(Options::verboseWasmDebugger(), "[Debugger] sendStopReplyForThread: thread ", threadId, " not found");
+        dataLogLnIf(Options::verboseWasmDebugger(), "[Debugger] sendStopReplyForThread: thread ", vmId, " not found");
         sendErrorReply(ProtocolError::InvalidAddress);
         return;
     }
@@ -783,9 +778,9 @@ void ExecutionHandler::sendStopReplyForThread(AbstractLocker& locker, uint64_t t
         auto* state = vm.debugState();
         if (!state->isStopped)
             return IterationStatus::Continue;
-        uint64_t tid = ExecutionHandler::threadId(vm);
+        uint64_t tid = vm.identifier().toRawValue();
         allThreads.append({ tid, getStopPC(*state), getThreadName(*state, tid), stopReasonToInfo(*state).reasonSuffix });
-        if (tid == threadId)
+        if (tid == vmId)
             std::swap(allThreads[0], allThreads.last());
         return IterationStatus::Continue;
     });
@@ -795,7 +790,7 @@ void ExecutionHandler::sendStopReplyForThread(AbstractLocker& locker, uint64_t t
     // actually triggered the stop event (breakpoint/step/trap/interrupt/new-module-load).
     // Passive threads get signal 0 so LLDB's ShouldSelect() returns false for them, allowing
     // the event thread to win thread selection in HandleProcessStateChangedEvent.
-    bool isPassiveThread = state->stopReason == DebugState::Reason::Interrupted && m_debuggee && threadId != ExecutionHandler::threadId(*m_debuggee);
+    bool isPassiveThread = state->stopReason == DebugState::Reason::Interrupted && m_debuggee && vmId != m_debuggee->identifier().toRawValue();
     auto stopInfo = isPassiveThread
         ? StopReasonInfo { signalStopString(0), "signal"_s }
         : stopReasonToInfo(*state);
@@ -803,15 +798,15 @@ void ExecutionHandler::sendStopReplyForThread(AbstractLocker& locker, uint64_t t
     // Build packet with target thread
     StringBuilder reply;
     reply.append(stopInfo.reasonString);
-    reply.append("thread:"_s, hex(threadId, Lowercase), ';');
-    reply.append("name:"_s, getThreadName(*state, threadId), ';');
+    reply.append("thread:"_s, hex(vmId, Lowercase), ';');
+    reply.append("name:"_s, getThreadName(*state, vmId), ';');
 
     // All thread IDs
     reply.append("threads:"_s);
     for (size_t i = 0; i < allThreads.size(); ++i) {
         if (i > 0)
             reply.append(',');
-        reply.append(hex(allThreads[i].threadId, Lowercase));
+        reply.append(hex(allThreads[i].vmId, Lowercase));
     }
     reply.append(';');
 
@@ -860,7 +855,7 @@ void ExecutionHandler::sendStopReplyForThread(AbstractLocker& locker, uint64_t t
         reply.append(';');
     }
 
-    dataLogLnIf(Options::verboseWasmDebugger(), "[Debugger] Sending stop reply: target thread="_s, hex(threadId), ", total threads="_s, allThreads.size(), ", packet="_s, reply.toString());
+    dataLogLnIf(Options::verboseWasmDebugger(), "[Debugger] Sending stop reply: target thread="_s, hex(vmId), ", total threads="_s, allThreads.size(), ", packet="_s, reply.toString());
     sendReplyImpl(locker, reply.toString());
 }
 
@@ -920,12 +915,6 @@ void ExecutionHandler::reset()
 void ExecutionHandler::sendReplyOK() { m_debugServer.sendReplyOK(); }
 void ExecutionHandler::sendErrorReply(ProtocolError error) { m_debugServer.sendErrorReply(error); }
 
-uint64_t ExecutionHandler::threadId(const VM& vm)
-{
-    auto uid = vm.ownerThreadUID();
-    // nullopt when JSLock was never acquired (e.g. during VM construction); fall back to current thread.
-    return uid.value_or(Thread::currentSingleton().uid());
-}
 
 DebugState* ExecutionHandler::debuggeeState() const { return m_debuggee->debugState(); }
 
@@ -941,16 +930,17 @@ bool ExecutionHandler::hasBreakpoints() const
     return m_breakpointManager && m_breakpointManager->hasBreakpoints();
 }
 
-String ExecutionHandler::callStackStringFor(uint64_t threadId)
+String ExecutionHandler::callStackStringFor(uint64_t vmId)
 {
     Locker locker { m_lock };
 
     VM* targetVM = m_debuggee;
-    if (this->threadId(*targetVM) != threadId)
-        targetVM = findVM(threadId);
+    RELEASE_ASSERT(targetVM);
+    if (targetVM->identifier().toRawValue() != vmId)
+        targetVM = findVM(vmId);
 
     if (!targetVM) {
-        dataLogLnIf(Options::verboseWasmDebugger(), "[ExecutionHandler] callStackStringFor: thread ", threadId, " not found");
+        dataLogLnIf(Options::verboseWasmDebugger(), "[ExecutionHandler] callStackStringFor: thread ", vmId, " not found");
         return String();
     }
 

--- a/Source/JavaScriptCore/wasm/debugger/WasmExecutionHandler.h
+++ b/Source/JavaScriptCore/wasm/debugger/WasmExecutionHandler.h
@@ -99,7 +99,6 @@ public:
 
     bool hasBreakpoints() const;
 
-    JS_EXPORT_PRIVATE static uint64_t threadId(const VM&);
     uint64_t debugServerThreadId() const
     {
         RELEASE_ASSERT(m_debugServerThreadId.has_value());

--- a/Source/JavaScriptCore/wasm/debugger/tests/ExecutionHandlerTest.cpp
+++ b/Source/JavaScriptCore/wasm/debugger/tests/ExecutionHandlerTest.cpp
@@ -134,8 +134,7 @@ static void resume()
 
 static void switchTarget(VM* newDebuggee)
 {
-    uint64_t threadId = ExecutionHandler::threadId(*newDebuggee);
-    executionHandler->switchTarget(threadId);
+    executionHandler->switchTarget(newDebuggee->identifier().toRawValue());
     validateStop();
     CHECK(executionHandler->debuggeeVM() == newDebuggee, "Switch to new debuggee failed");
 }


### PR DESCRIPTION
#### f475b7aaf0ec8173fc791e5739c290240f64ec2c
<pre>
[JSC][WASM][Debugger] Use VMIdentifier as stable per-VM thread ID for GDB RSP replies
<a href="https://bugs.webkit.org/show_bug.cgi?id=313911">https://bugs.webkit.org/show_bug.cgi?id=313911</a>
<a href="https://rdar.apple.com/176106671">rdar://176106671</a>

Reviewed by Mark Lam.

The WASM debugger used ownerThreadUID() as the thread ID in GDB RSP replies
to LLDB (qThreadStopInfo, thread-pcs, etc.). This value reflects whichever
OS thread currently holds the JSLock — when a Worker VM&apos;s JSLock transfers
to a different thread (e.g. after memory.atomic.wait completes and another
task acquires the VM), the thread ID changes between consecutive stop replies.
LLDB then fails to find the VM in subsequent qThreadStopInfo queries.

Fix: use vm.identifier().toRawValue() — the existing VMIdentifier assigned
to every VM at construction, a sequential uint64 that is stable for the
VM&apos;s lifetime regardless of which OS thread holds the JSLock.

Replace all uses of ExecutionHandler::threadId(VM&amp;) with direct access to
vm.identifier().toRawValue(). Remove threadId() entirely since it was the
sole source of the instability. Remove the RELEASE_ASSERTs that compared
Thread::currentSingleton().uid() against threadId() — those comparisons
were checking OS thread identity which is no longer meaningful as the
debugger thread ID.

Canonical link: <a href="https://commits.webkit.org/312529@main">https://commits.webkit.org/312529@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c6bd01928a04d01fb325e1451faa0b0efe247fad

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/160298 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/33771 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/26872 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/169200 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/115364 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/6b941dea-4a4b-4ce3-932f-b7fefb877e76) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/33872 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/33771 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/124279 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/115364 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/3ce32a17-ab04-4b1a-b4d0-ec63ccdb69a5) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/163256 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/26517 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/143976 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/104878 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/1c2cdab4-d89c-4124-9c40-615076a3722e) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/25569 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/24066 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/16920 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/152354 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/135262 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/21739 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/171678 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/21135 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/18036 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/23379 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/132530 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/33444 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/28161 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/132554 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35825 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/33429 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/143534 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/95211 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/27165 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/20348 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/192697 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/32938 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/99699 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/49606 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/32439 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/32683 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/32587 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->