### PR TITLE
[JSC][WASM][Debugger] Fix STW deadlocks when VM blocks in memory.atomic.wait or WebCore operations

### DIFF
--- a/JSTests/wasm/debugger/resources/wasm/memory-atomic-wait-no-timeout.js
+++ b/JSTests/wasm/debugger/resources/wasm/memory-atomic-wait-no-timeout.js
@@ -1,0 +1,69 @@
+// WASM debugger test for memory.atomic.wait32 with no timeout (infinite wait).
+//
+// A worker thread calls waiter() with timeout=-1, blocking indefinitely.
+// The main thread is idle (JSC forbids memory.atomic.wait on the main thread).
+// This exercises the STW deadlock fix: the debugger must be able to interrupt
+// a VM that is blocked inside memory.atomic.wait with an infinite timeout.
+//
+// Module layout (single function "waiter"):
+//   [0x2a] i32.const 0         ; address
+//   [0x2c] i32.const 0         ; expected value
+//   [0x2e] i64.const -1        ; timeout (-1 = wait indefinitely)
+//   [0x30] memory.atomic.wait32 align=2 offset=0
+//   [0x34] end
+//
+// Virtual addresses (worker compiles first → base 0x4000000000000000):
+//   memory.atomic.wait32 → 0x4000000000000030
+//   end                  → 0x4000000000000034
+
+var wasmBytes = new Uint8Array([
+    // [0x00] WASM header
+    0x00, 0x61, 0x73, 0x6d, // magic
+    0x01, 0x00, 0x00, 0x00, // version
+
+    // [0x08] Type section: (func [] -> [i32])
+    0x01, 0x05, 0x01, 0x60, 0x00, 0x01, 0x7f,
+
+    // [0x0f] Function section: 1 function of type 0
+    0x03, 0x02, 0x01, 0x00,
+
+    // [0x13] Memory section: 1 shared memory min=1 max=1
+    // flags=0x03: min+max+shared
+    0x05, 0x04, 0x01, 0x03, 0x01, 0x01,
+
+    // [0x19] Export section: "waiter" -> func 0
+    0x07, 0x0a, 0x01,
+    0x06, 0x77, 0x61, 0x69, 0x74, 0x65, 0x72, 0x00, 0x00, // "waiter", func 0
+
+    // [0x25] Code section
+    0x0a, 0x0e, 0x01,
+
+    // [0x28] Function 0 body: memory.atomic.wait32(addr=0, expected=0, timeout=-1)
+    0x0c, 0x00,             // body size=12, 0 locals
+    0x41, 0x00,             // [0x2a] i32.const 0   (address)
+    0x41, 0x00,             // [0x2c] i32.const 0   (expected)
+    0x42, 0x7f,             // [0x2e] i64.const -1  (timeout: wait indefinitely)
+    0xfe, 0x01, 0x02, 0x00, // [0x30] memory.atomic.wait32 align=2 offset=0
+    0x0b,                   // [0x34] end
+]);
+
+// Worker compiles and runs waiter() with an infinite timeout.
+// Bytes are inlined in the script string — the worker is the first to call
+// WebAssembly.Module(), so it gets base address 0x4000000000000000.
+$.agent.start(`
+    var module = new WebAssembly.Module(new Uint8Array([${Array.from(wasmBytes).join(',')}]));
+    var instance = new WebAssembly.Instance(module, {});
+    var waiter = instance.exports.waiter;
+    // FIXME: Even this is printed. The worker may still not be blocked before debugger attaches.
+    print("DEBUGGER_READY");
+    // Each call blocks indefinitely until notified or the debugger interrupts.
+    for (;;)
+        waiter();
+`);
+
+let iteration = 0;
+for (;;) {
+    iteration += 1;
+    if (iteration % 1e8 == 0)
+        print("Main iteration=", iteration);
+}

--- a/JSTests/wasm/debugger/resources/wasm/memory-atomic-wait.js
+++ b/JSTests/wasm/debugger/resources/wasm/memory-atomic-wait.js
@@ -1,0 +1,67 @@
+// WASM debugger test for memory.atomic.wait32.
+//
+// A worker thread loops calling waiter() with a 1 ns timeout, so the wait
+// returns immediately on every iteration and the breakpoint fires rapidly.
+// The main thread is idle (JSC forbids memory.atomic.wait on the main thread).
+//
+// Module layout (single function "waiter"):
+//   [0x2a] i32.const 0         ; address
+//   [0x2c] i32.const 0         ; expected value
+//   [0x2e] i64.const 1         ; timeout (1 nanosecond)
+//   [0x30] memory.atomic.wait32 align=2 offset=0
+//   [0x34] end
+//
+// Virtual addresses (worker compiles first → base 0x4000000000000000):
+//   memory.atomic.wait32 → 0x4000000000000030
+//   end                  → 0x4000000000000034
+
+var wasmBytes = new Uint8Array([
+    // [0x00] WASM header
+    0x00, 0x61, 0x73, 0x6d, // magic
+    0x01, 0x00, 0x00, 0x00, // version
+
+    // [0x08] Type section: (func [] -> [i32])
+    0x01, 0x05, 0x01, 0x60, 0x00, 0x01, 0x7f,
+
+    // [0x0f] Function section: 1 function of type 0
+    0x03, 0x02, 0x01, 0x00,
+
+    // [0x13] Memory section: 1 shared memory min=1 max=1
+    // flags=0x03: min+max+shared
+    0x05, 0x04, 0x01, 0x03, 0x01, 0x01,
+
+    // [0x19] Export section: "waiter" -> func 0
+    0x07, 0x0a, 0x01,
+    0x06, 0x77, 0x61, 0x69, 0x74, 0x65, 0x72, 0x00, 0x00, // "waiter", func 0
+
+    // [0x25] Code section
+    0x0a, 0x0e, 0x01,
+
+    // [0x28] Function 0 body: memory.atomic.wait32(addr=0, expected=0, timeout=1ns)
+    0x0c, 0x00,             // body size=12, 0 locals
+    0x41, 0x00,             // [0x2a] i32.const 0  (address)
+    0x41, 0x00,             // [0x2c] i32.const 0  (expected)
+    0x42, 0x01,             // [0x2e] i64.const 1  (timeout: 1 nanosecond)
+    0xfe, 0x01, 0x02, 0x00, // [0x30] memory.atomic.wait32 align=2 offset=0
+    0x0b,                   // [0x34] end
+]);
+
+// Worker compiles and runs waiter() in a tight loop.
+// Bytes are inlined in the script string — the worker is the first to call
+// WebAssembly.Module(), so it gets base address 0x4000000000000000.
+$.agent.start(`
+    var module = new WebAssembly.Module(new Uint8Array([${Array.from(wasmBytes).join(',')}]));
+    var instance = new WebAssembly.Instance(module, {});
+    var waiter = instance.exports.waiter;
+    print("DEBUGGER_READY");
+    // Loop rapidly: 1 ns timeout means wait returns immediately every call.
+    for (;;)
+        waiter();
+`);
+
+let iteration = 0;
+for (;;) {
+    iteration += 1;
+    if (iteration % 1e8 == 0)
+        print("Main iteration=", iteration);
+}

--- a/JSTests/wasm/debugger/tests/tests.py
+++ b/JSTests/wasm/debugger/tests/tests.py
@@ -1335,6 +1335,46 @@ class MultiVMSameModuleDifferentFunctionsTestCase:
         )
 
 
+class MemoryAtomicWaitTestCase:
+    test_file = "resources/wasm/memory-atomic-wait.js"
+    extra_jsc_options = ["--useDollarVM=1"]
+
+    def execute(self):
+        self.session.cmd("th list", patterns=["thread #1", "thread #2"])
+
+        self.session.cmd("b 0x4000000000000030")
+        self.session.cmd(
+            "c",
+            patterns=[
+                "Process 1 stopped",
+                "stop reason = breakpoint",
+                "->  0x4000000000000030",
+            ],
+        )
+
+        self.session.cmd("si", patterns=["->  0x4000000000000034: end"])
+
+        self.session.cmd(
+            "c",
+            patterns=[
+                "Process 1 stopped",
+                "stop reason = breakpoint",
+                "->  0x4000000000000030: memory.atomic.wait32",
+            ],
+        )
+
+        self.session.cmd("br del -f", patterns=["All breakpoints removed. (1 breakpoint)"])
+
+
+class MemoryAtomicWaitNoTimeoutTestCase:
+    test_file = "resources/wasm/memory-atomic-wait-no-timeout.js"
+    extra_jsc_options = ["--useDollarVM=1"]
+
+    def execute(self):
+        self.session.cmd("th list", patterns=["thread #1", "thread #2"])
+        self.session.cmd("dis", patterns=["->  0x4000000000000030: memory.atomic.wait32 0"])
+
+
 class DoCatchThrowTestCase:
     test_file = "resources/swift-wasm/do-catch-throw/main.js"
 
@@ -1684,6 +1724,8 @@ ALL_TESTS = [
     SystemCallTestCase,
     MultiVMSameModuleSameFunctionTestCase,
     MultiVMSameModuleDifferentFunctionsTestCase,
+    MemoryAtomicWaitTestCase,
+    MemoryAtomicWaitNoTimeoutTestCase,
     DoCatchThrowTestCase,
     WasmWasmWasmCallStackTestCase,
     JsWasmJsWasmCallStackTestCase,

--- a/Source/JavaScriptCore/llint/InPlaceInterpreter64.asm
+++ b/Source/JavaScriptCore/llint/InPlaceInterpreter64.asm
@@ -10096,12 +10096,19 @@ ipintAtomicOp(_memory_atomic_wait32, macro()
     addq t1, t0
     storeq t0, (StackValueSize * 3)[sp] # replace pointer with pointer + offset
 
+    # Push callee/cfr/PC/MC for debugger; operands shift to args[4..7].
+    subq (StackValueSize * 4), sp
+    storeq ws0, (StackValueSize * 0)[sp]  # args[0] = IPIntCallee*
+    storeq cfr, (StackValueSize * 1)[sp]  # args[1] = cfr
+    storeq PC,  (StackValueSize * 2)[sp]  # args[2] = PC
+    storeq MC,  (StackValueSize * 3)[sp]  # args[3] = MC
+
     move sp, a1
 
     operationCall(macro() cCall2(_ipint_extern_memory_atomic_wait32) end)
     bilt r0, 0, _ipint_throw_OutOfBoundsMemoryAccess
 
-    addq (StackValueSize * 4), sp
+    addq (StackValueSize * 8), sp
 
     pushInt32(r0)
     loadb IPInt::AtomicMemoryAccessMetadata::instructionLength[MC], t0
@@ -10119,12 +10126,19 @@ ipintAtomicOp(_memory_atomic_wait64, macro()
     addq t1, t0
     storeq t0, (StackValueSize * 3)[sp] # replace pointer with pointer + offset
 
+    # Push callee/cfr/PC/MC for debugger; operands shift to args[4..7].
+    subq (StackValueSize * 4), sp
+    storeq ws0, (StackValueSize * 0)[sp]  # args[0] = IPIntCallee*
+    storeq cfr, (StackValueSize * 1)[sp]  # args[1] = cfr
+    storeq PC,  (StackValueSize * 2)[sp]  # args[2] = PC
+    storeq MC,  (StackValueSize * 3)[sp]  # args[3] = MC
+
     move sp, a1
 
     operationCall(macro() cCall2(_ipint_extern_memory_atomic_wait64) end)
     bilt r0, 0, _ipint_throw_OutOfBoundsMemoryAccess
 
-    addq (StackValueSize * 4), sp
+    addq (StackValueSize * 8), sp
 
     pushInt32(r0)
     loadb IPInt::AtomicMemoryAccessMetadata::instructionLength[MC], t0

--- a/Source/JavaScriptCore/runtime/StopTheWorldCallback.h
+++ b/Source/JavaScriptCore/runtime/StopTheWorldCallback.h
@@ -28,10 +28,19 @@
 #include <cstdint>
 #include <utility>
 #include <wtf/IterationStatus.h>
+#include <wtf/Seconds.h>
 
 namespace JSC {
 
 class VM;
+
+#if ENABLE(WEBASSEMBLY_DEBUGGER)
+// How often a VM blocked in a non-JSC operation (memory.atomic.wait, sync XHR, etc.)
+// wakes to check NeedStopTheWorld and participate in STW.
+// 50 ms is chosen to be as long as possible while remaining below the ~100 ms threshold
+// for human perception of responsiveness in a debugger driven by human interaction.
+inline constexpr Seconds DebuggerSTWCheckInterval { 0.05 };
+#endif
 
 using StopTheWorldStatus = std::pair<IterationStatus, VM*>;
 
@@ -56,6 +65,10 @@ enum class StopTheWorldEvent : uint8_t {
     //
     // The WASM program itself triggered a stop (breakpoint hit, trap, or dynamic module load).
     WasmProgramStop,
+    // A thread blocked in memory.atomic.wait32/64 cooperatively participating in STW.
+    // Unlike WasmProgramStop, clearStop() is skipped on resume so the stop data persists
+    // across multiple STW cycles while the wait is still in progress.
+    WasmAtomicsWaitBlocked,
     // Not a real stop: fired when the mutator reaches a call/throw site during step-into.
     // Signals the debugger thread to check whether a callee entry breakpoint was installed;
     // the mutator does not pause and wait for a debugger command.

--- a/Source/JavaScriptCore/runtime/VMManager.cpp
+++ b/Source/JavaScriptCore/runtime/VMManager.cpp
@@ -502,8 +502,13 @@ void VMManager::notifyVMStop(VM& vm, StopTheWorldEvent event)
         numberOfStoppedVMs = --m_numberOfStoppedVMs;
 
 #if ENABLE(WEBASSEMBLY_DEBUGGER)
-        if (Options::enableWasmDebugger()) [[unlikely]]
-            vm.debugState()->clearStop();
+        if (Options::enableWasmDebugger()) [[unlikely]] {
+            // WasmAtomicsWaitBlocked: thread is still sleeping inside memory.atomic.wait and
+            // may participate in multiple STW cycles. Keep stopData so each cycle shows the
+            // correct state; waitForSync() calls clearStop() when the wait ends.
+            if (event != StopTheWorldEvent::WasmAtomicsWaitBlocked)
+                vm.debugState()->clearStop();
+        }
 #endif
     }
 

--- a/Source/JavaScriptCore/runtime/VMManager.h
+++ b/Source/JavaScriptCore/runtime/VMManager.h
@@ -277,7 +277,7 @@ public:
     void notifyVMDestruction(VM&);
     void notifyVMActivation(VM&);
     void notifyVMDeactivation(VM&);
-    void notifyVMStop(VM&, StopTheWorldEvent);
+    JS_EXPORT_PRIVATE void notifyVMStop(VM&, StopTheWorldEvent);
 
     void handleVMDestructionWhileWorldStopped(VM&);
 

--- a/Source/JavaScriptCore/runtime/WaiterListManager.cpp
+++ b/Source/JavaScriptCore/runtime/WaiterListManager.cpp
@@ -32,10 +32,17 @@
 #include "JSLock.h"
 #include "JSObjectInlines.h"
 #include "ObjectConstructor.h"
+#include "Options.h"
+#include "VMManager.h"
+#include "VMTraps.h"
 #include <wtf/DataLog.h>
 #include <wtf/NeverDestroyed.h>
 #include <wtf/RawPointer.h>
 #include <wtf/TZoneMallocInlines.h>
+
+#if ENABLE(WEBASSEMBLY_DEBUGGER)
+#include "WasmDebugServerUtilities.h"
+#endif
 
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 
@@ -72,6 +79,39 @@ WaiterListManager& WaiterListManager::singleton()
     return manager;
 }
 
+static void waitForSync(Locker<Lock>& listLocker, VM& vm, Ref<Waiter>& syncWaiter, Ref<WaiterList>& list, MonotonicTime time)
+{
+    listLocker.assertIsHolding(list->lock);
+    while (syncWaiter->isOnList() && time.now() < time && !vm.hasTerminationRequest()) {
+#if ENABLE(WEBASSEMBLY_DEBUGGER)
+        // FIXME: rdar://176407534 This is a workaround. Ideally VMManager would maintain a registry of all
+        // blocking operations (atomics.wait, futex, etc.) and signal them directly on STW
+        // instead of relying on each site to poll NeedStopTheWorld at a fixed interval.
+        // Implementing that correctly is non-trivial due to registration races, lock ordering
+        // between VMManager and each waiter's list lock, and unregistration races on wait
+        // completion — worth a dedicated follow-up patch.
+        if (Options::enableWasmDebugger()) [[unlikely]] {
+            if (vm.traps().hasTrapBit(VMTraps::NeedStopTheWorld)) {
+                // Unlock to participate in STW. The waiter stays on the list —
+                // isOnList() and time guards handle all outcomes on the next iteration.
+                list->lock.unlock();
+                VMManager::singleton().notifyVMStop(vm, StopTheWorldEvent::WasmAtomicsWaitBlocked);
+                list->lock.lock();
+            }
+            auto cap = MonotonicTime::now() + DebuggerSTWCheckInterval;
+            syncWaiter->condition().waitUntil(list->lock, std::min(time, cap).approximate<WallTime>());
+            continue;
+        }
+#endif
+        syncWaiter->condition().waitUntil(list->lock, time.approximate<WallTime>());
+    }
+
+#if ENABLE(WEBASSEMBLY_DEBUGGER)
+    if (Options::enableWasmDebugger()) [[unlikely]]
+        vm.debugState()->clearStop();
+#endif
+}
+
 template <typename ValueType>
 WaiterListManager::WaitSyncResult WaiterListManager::waitSyncImpl(VM& vm, ValueType* ptr, ValueType expectedValue, Seconds timeout)
 {
@@ -89,8 +129,7 @@ WaiterListManager::WaitSyncResult WaiterListManager::waitSyncImpl(VM& vm, ValueT
         list->addLast(listLocker, syncWaiter);
         dataLogLnIf(WaiterListsManagerInternal::verbose, "<WaiterListManager> <Thread:", Thread::currentSingleton(), "> added a new SyncWaiter=", syncWaiter.get(), " to a waiterList for ptr ", RawPointer(ptr));
 
-        while (syncWaiter->isOnList() && time.now() < time && !vm.hasTerminationRequest())
-            syncWaiter->condition().waitUntil(list->lock, time.approximate<WallTime>());
+        waitForSync(listLocker, vm, syncWaiter, list, time);
 
         // At this point, syncWaiter should be either notified (dequeued) or timeout (not dequeued).
         bool didGetDequeued = !syncWaiter->isOnList();
@@ -351,7 +390,7 @@ Ref<WaiterList> WaiterListManager::findOrCreateList(void* ptr)
 {
     Locker waiterListsLocker { m_waiterListsLock };
     return m_waiterLists.ensure(ptr, [] {
-        return adoptRef(*new WaiterList()); 
+        return adoptRef(*new WaiterList());
     }).iterator->value.get();
 }
 

--- a/Source/JavaScriptCore/wasm/WasmIPIntSlowPaths.cpp
+++ b/Source/JavaScriptCore/wasm/WasmIPIntSlowPaths.cpp
@@ -1232,10 +1232,20 @@ WASM_IPINT_EXTERN_CPP_DECL(get_global_64, unsigned index)
 WASM_IPINT_EXTERN_CPP_DECL(memory_atomic_wait32, IPIntStackEntry* args)
 {
 #if CPU(ARM64) || CPU(X86_64)
-    uint8_t memoryIndex = args[0].i32;
-    uint64_t timeout = args[1].i64;
-    uint32_t value = args[2].i32;
-    uint64_t pointerWithOffset = args[3].i64;
+    uint8_t memoryIndex = args[4].i32;
+    uint64_t timeout = args[5].i64;
+    uint32_t value = args[6].i32;
+    uint64_t pointerWithOffset = args[7].i64;
+#if ENABLE(WEBASSEMBLY_DEBUGGER)
+    if (Options::enableWasmDebugger()) [[unlikely]] {
+        auto* callee = std::bit_cast<Wasm::IPIntCallee*>(args[0].i64);
+        auto* callFrame = std::bit_cast<CallFrame*>(args[1].i64);
+        auto* pc = std::bit_cast<uint8_t*>(args[2].i64);
+        auto* mc = std::bit_cast<uint8_t*>(args[3].i64);
+        auto* stack = args + 4; // wasm expression stack: [memoryIndex, timeout, value, pointer+offset]
+        instance->vm().debugState()->setAtomicsWaitStopData(callee, instance, callFrame, pc, mc, stack);
+    }
+#endif
     int32_t result = Wasm::memoryAtomicWait32(instance, pointerWithOffset, value, timeout, memoryIndex);
     WASM_RETURN_TWO(std::bit_cast<void*>(static_cast<intptr_t>(result)), nullptr);
 #else
@@ -1248,10 +1258,20 @@ WASM_IPINT_EXTERN_CPP_DECL(memory_atomic_wait32, IPIntStackEntry* args)
 WASM_IPINT_EXTERN_CPP_DECL(memory_atomic_wait64, IPIntStackEntry* args)
 {
 #if CPU(ARM64) || CPU(X86_64)
-    uint8_t memoryIndex = args[0].i32;
-    uint64_t timeout = args[1].i64;
-    uint64_t value = args[2].i64;
-    uint64_t pointerWithOffset = args[3].i64;
+    uint8_t memoryIndex = args[4].i32;
+    uint64_t timeout = args[5].i64;
+    uint64_t value = args[6].i64;
+    uint64_t pointerWithOffset = args[7].i64;
+#if ENABLE(WEBASSEMBLY_DEBUGGER)
+    if (Options::enableWasmDebugger()) [[unlikely]] {
+        auto* callee = std::bit_cast<Wasm::IPIntCallee*>(args[0].i64);
+        auto* callFrame = std::bit_cast<CallFrame*>(args[1].i64);
+        auto* pc = std::bit_cast<uint8_t*>(args[2].i64);
+        auto* mc = std::bit_cast<uint8_t*>(args[3].i64);
+        auto* stack = args + 4; // wasm expression stack: [memoryIndex, timeout, value, pointer+offset]
+        instance->vm().debugState()->setAtomicsWaitStopData(callee, instance, callFrame, pc, mc, stack);
+    }
+#endif
     int32_t result = Wasm::memoryAtomicWait64(instance, pointerWithOffset, value, timeout, memoryIndex);
     WASM_RETURN_TWO(std::bit_cast<void*>(static_cast<intptr_t>(result)), nullptr);
 #else

--- a/Source/JavaScriptCore/wasm/debugger/WasmDebugServer.cpp
+++ b/Source/JavaScriptCore/wasm/debugger/WasmDebugServer.cpp
@@ -60,6 +60,7 @@ WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 #include <wtf/Assertions.h>
 #include <wtf/DataLog.h>
 #include <wtf/HexNumber.h>
+#include <wtf/Lock.h>
 #include <wtf/NeverDestroyed.h>
 #include <wtf/Scope.h>
 #include <wtf/Threading.h>
@@ -83,6 +84,14 @@ DebugServer::DebugServer()
 
 bool DebugServer::start()
 {
+    // Guard against concurrent start() calls from $.agent.start() workers in the jsc shell
+    // and against the createAndBindServerSocket() race below.
+    static Lock initLock;
+    Locker locker { initLock };
+
+    if (isInService())
+        return true;
+
     if (!createAndBindServerSocket())
         return false;
 

--- a/Source/JavaScriptCore/wasm/debugger/WasmDebugServerUtilities.h
+++ b/Source/JavaScriptCore/wasm/debugger/WasmDebugServerUtilities.h
@@ -181,6 +181,12 @@ struct DebugState {
         stopData = makeUnique<StopData>(callee, instance, callFrame);
     }
 
+    void setAtomicsWaitStopData(IPIntCallee* callee, JSWebAssemblyInstance* instance, CallFrame* callFrame, uint8_t* pc, uint8_t* mc, IPInt::IPIntStackEntry* stack)
+    {
+        stopReason = Reason::Interrupted;
+        stopData = makeUnique<StopData>(VirtualAddress::toVirtual(instance, callee->functionIndex(), pc), *pc, pc, mc, stack, callee, instance, callFrame);
+    }
+
     void setBreakpointStopData(Breakpoint::Type type, VirtualAddress address, uint8_t originalBytecode, uint8_t* pc, uint8_t* mc, IPInt::IPIntStackEntry* stack, IPIntCallee* callee, JSWebAssemblyInstance* instance, CallFrame* callFrame)
     {
         switch (type) {
@@ -217,10 +223,23 @@ struct DebugState {
     }
     bool isStoppedAtBytecode() const
     {
-        bool result = stopData && stopData->pc;
-        if (result)
-            RELEASE_ASSERT(stopReason == Reason::Breakpoint || stopReason == Reason::Step || stopReason == Reason::WasmTrap);
+        bool result = stopData && !!stopData->pc;
+        if (result) {
+            // FIXME: Reason::Interrupted is only valid here because setAtomicsWaitStopData uses it.
+            // All other Interrupted stops have no stopData->pc. Consider introducing a dedicated
+            // Reason::AtomicsWaitBlocked to keep that case distinct and tighten this assertion.
+            RELEASE_ASSERT(stopReason == Reason::Breakpoint || stopReason == Reason::Step || stopReason == Reason::WasmTrap || stopReason == Reason::Interrupted);
+        }
         return result;
+    }
+    bool isAtomicsWaitStop() const
+    {
+        if (!isStoppedAtBytecode())
+            return false;
+        if (stopData->originalBytecode != OpType::ExtAtomic)
+            return false;
+        auto extOp = static_cast<ExtAtomicOpType>(*(stopData->pc + 1));
+        return extOp == ExtAtomicOpType::MemoryAtomicWait32 || extOp == ExtAtomicOpType::MemoryAtomicWait64;
     }
 
     // WHY-based helpers — determined by stopReason:

--- a/Source/JavaScriptCore/wasm/debugger/WasmExecutionHandler.cpp
+++ b/Source/JavaScriptCore/wasm/debugger/WasmExecutionHandler.cpp
@@ -184,6 +184,7 @@ ExecutionHandler::ResumeMode ExecutionHandler::stopCode(Locker<Lock>& locker, St
     case StopTheWorldEvent::VMStopped:
     case StopTheWorldEvent::VMCreated:
     case StopTheWorldEvent::VMActivated:
+    case StopTheWorldEvent::WasmAtomicsWaitBlocked:
         RELEASE_ASSERT(m_debuggerState == DebuggerState::InterruptRequested || m_debuggerState == DebuggerState::SwitchRequested);
         m_breakpointManager->clearAllOneTimeBreakpoints();
         notifyDebuggerOfStop();
@@ -418,7 +419,7 @@ void ExecutionHandler::step()
         // resuming all is the right behavior.
         resumeAll = true;
     } else if (state->isStoppedAtBytecode())
-        resumeAll = stepAtBreakpoint(locker, state);
+        resumeAll = stepAtBytecode(locker, state);
     else {
         RELEASE_ASSERT(state->isStoppedAtPrologue());
         setBreakpointAtEntry(state->stopData->instance, state->stopData->callee.get(), Breakpoint::Type::Step);
@@ -439,7 +440,7 @@ void ExecutionHandler::step()
     dataLogLnIf(Options::verboseWasmDebugger(), "[Debugger][Step] Code is stopped and debugger replied");
 }
 
-bool ExecutionHandler::stepAtBreakpoint(Locker<Lock>& locker, DebugState* state)
+bool ExecutionHandler::stepAtBytecode(Locker<Lock>& locker, DebugState* state)
 {
     RELEASE_ASSERT(state->isStoppedAtBytecode());
     auto& stopData = *state->stopData;
@@ -524,8 +525,9 @@ bool ExecutionHandler::stepAtBreakpoint(Locker<Lock>& locker, DebugState* state)
         m_debuggerContinue.wait(locker); // Wait for call/throw one-time breakpoint to be registered.
     }
 
-    // If no one-time breakpoints registered, then resume all.
-    return !m_breakpointManager->hasOneTimeBreakpoints();
+    // If no one-time breakpoints registered, or stopped at memory.atomic.wait (must resumeAll
+    // so notifier threads can run), then resume all VMs instead of using RunOne.
+    return !m_breakpointManager->hasOneTimeBreakpoints() || state->isAtomicsWaitStop();
 }
 
 void ExecutionHandler::setStepIntoBreakpointForCall(VM& callerVM, CalleeBits boxedCallee, JSWebAssemblyInstance* calleeInstance)

--- a/Source/JavaScriptCore/wasm/debugger/WasmExecutionHandler.h
+++ b/Source/JavaScriptCore/wasm/debugger/WasmExecutionHandler.h
@@ -137,7 +137,7 @@ private:
 
     void resumeImpl(Locker<Lock>&) WTF_REQUIRES_LOCK(m_lock);
 
-    bool stepAtBreakpoint(Locker<Lock>&, DebugState*) WTF_REQUIRES_LOCK(m_lock);
+    bool stepAtBytecode(Locker<Lock>&, DebugState*) WTF_REQUIRES_LOCK(m_lock);
 
     void sendStopReply(AbstractLocker&);
     void sendStopReplyForThread(AbstractLocker&, uint64_t threadId);

--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -3562,6 +3562,7 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     workers/WorkerOrWorkletThread.h
     workers/WorkerReportingProxy.h
     workers/WorkerRunLoop.h
+    workers/WorkerSTWParticipation.h
     workers/WorkerScriptLoader.h
     workers/WorkerScriptLoaderClient.h
     workers/WorkerThread.h

--- a/Source/WebCore/Modules/filesystem/WorkerFileSystemStorageConnection.cpp
+++ b/Source/WebCore/Modules/filesystem/WorkerFileSystemStorageConnection.cpp
@@ -32,6 +32,7 @@
 #include "FileSystemSyncAccessHandle.h"
 #include "WorkerGlobalScope.h"
 #include "WorkerLoaderProxy.h"
+#include "WorkerSTWParticipation.h"
 #include "WorkerThread.h"
 #include <wtf/Scope.h>
 
@@ -294,7 +295,8 @@ void WorkerFileSystemStorageConnection::createSyncAccessHandle(FileSystemHandleI
 
 void WorkerFileSystemStorageConnection::closeSyncAccessHandle(FileSystemHandleIdentifier identifier, FileSystemSyncAccessHandleIdentifier accessHandleIdentifier)
 {
-    if (!m_scope)
+    RefPtr scope = m_scope.get();
+    if (!scope)
         return;
 
     BinarySemaphore semaphore;
@@ -303,7 +305,7 @@ void WorkerFileSystemStorageConnection::closeSyncAccessHandle(FileSystemHandleId
             semaphore.signal();
         });
     });
-    semaphore.wait();
+    waitWithSTWParticipation(semaphore, scope->vm());
 }
 
 void WorkerFileSystemStorageConnection::closeSyncAccessHandle(FileSystemHandleIdentifier, FileSystemSyncAccessHandleIdentifier, EmptyCallback&&)
@@ -474,7 +476,8 @@ void WorkerFileSystemStorageConnection::move(FileSystemHandleIdentifier identifi
 
 std::optional<uint64_t> WorkerFileSystemStorageConnection::requestNewCapacityForSyncAccessHandle(FileSystemHandleIdentifier identifier, FileSystemSyncAccessHandleIdentifier accessHandleIdentifier, uint64_t newCapacity)
 {
-    if (!m_scope)
+    RefPtr scope = m_scope.get();
+    if (!scope)
         return std::nullopt;
 
     if (!m_mainThreadConnection)
@@ -489,7 +492,7 @@ std::optional<uint64_t> WorkerFileSystemStorageConnection::requestNewCapacityFor
         };
         mainThreadConnection->requestNewCapacityForSyncAccessHandle(identifier, accessHandleIdentifier, newCapacity, WTF::move(mainThreadCallback));
     });
-    semaphore.wait();
+    waitWithSTWParticipation(semaphore, scope->vm());
     return grantedCapacity;
 }
 

--- a/Source/WebCore/Modules/indexeddb/IDBTransaction.cpp
+++ b/Source/WebCore/Modules/indexeddb/IDBTransaction.cpp
@@ -1309,7 +1309,7 @@ void IDBTransaction::putOrAddOnServer(IDBClient::TransactionOperation& operation
     // workers currently write blobs to disk synchronously.
     // FIXME: https://bugs.webkit.org/show_bug.cgi?id=157958 - Make this asynchronous after refactoring allows it.
     if (!isMainThread()) {
-        auto idbValue = value->writeBlobsToDiskForIndexedDBSynchronously(isEphemeral);
+        auto idbValue = value->writeBlobsToDiskForIndexedDBSynchronously(isEphemeral, globalObject->vm());
         if (idbValue.data().data()) {
             auto indexKeys = generateIndexKeyMapForValueIsolatedCopy(*globalObject, objectStoreInfo, keyData, idbValue);
             m_database->connectionProxy().putOrAdd(operation, WTF::move(keyData), idbValue, indexKeys, overwriteMode);

--- a/Source/WebCore/Modules/websockets/WorkerThreadableWebSocketChannel.cpp
+++ b/Source/WebCore/Modules/websockets/WorkerThreadableWebSocketChannel.cpp
@@ -45,6 +45,7 @@
 #include "WorkerGlobalScope.h"
 #include "WorkerLoaderProxy.h"
 #include "WorkerRunLoop.h"
+#include "WorkerSTWParticipation.h"
 #include "WorkerThread.h"
 #include <JavaScriptCore/ArrayBuffer.h>
 #include <wtf/MainThread.h>
@@ -387,7 +388,7 @@ void WorkerThreadableWebSocketChannel::Bridge::initialize(WorkerGlobalScope& sco
         peer = mainThreadInitialize(context, workerThread.get(), workerContextIdentifier, WTF::move(workerClientWrapper), taskMode, WTF::move(provider));
         semaphore.signal();
     });
-    semaphore.wait();
+    waitWithSTWParticipation(semaphore, scope.vm());
 
     if (peer)
         m_workerClientWrapper->didCreateWebSocketChannel(peer.releaseNonNull());

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -3637,6 +3637,7 @@ workers/WorkerOrWorkletGlobalScope.cpp
 workers/WorkerOrWorkletScriptController.cpp
 workers/WorkerOrWorkletThread.cpp
 workers/WorkerRunLoop.cpp
+workers/WorkerSTWParticipation.cpp
 workers/WorkerScriptLoader.cpp
 workers/WorkerThread.cpp
 workers/service/ExtendableEvent.cpp

--- a/Source/WebCore/bindings/js/SerializedScriptValue.cpp
+++ b/Source/WebCore/bindings/js/SerializedScriptValue.cpp
@@ -85,6 +85,7 @@
 #include "WebCodecsEncodedAudioChunk.h"
 #include "WebCodecsEncodedVideoChunk.h"
 #include "WebCoreJSClientData.h"
+#include "WorkerSTWParticipation.h"
 #include <JavaScriptCore/APICast.h>
 #include <JavaScriptCore/ArrayConventions.h>
 #include <JavaScriptCore/BigIntObject.h>
@@ -7195,7 +7196,7 @@ void SerializedScriptValue::writeBlobsToDiskForIndexedDB(bool isEphemeral, Compl
     });
 }
 
-IDBValue SerializedScriptValue::writeBlobsToDiskForIndexedDBSynchronously(bool isEphemeral)
+IDBValue SerializedScriptValue::writeBlobsToDiskForIndexedDBSynchronously(bool isEphemeral, JSC::VM& vm)
 {
     ASSERT(!isMainThread());
 
@@ -7210,7 +7211,7 @@ IDBValue SerializedScriptValue::writeBlobsToDiskForIndexedDBSynchronously(bool i
             semaphore.signal();
         });
     });
-    semaphore.wait();
+    waitWithSTWParticipation(semaphore, vm);
 
     return value;
 }

--- a/Source/WebCore/bindings/js/SerializedScriptValue.h
+++ b/Source/WebCore/bindings/js/SerializedScriptValue.h
@@ -137,8 +137,7 @@ public:
     Vector<String> blobURLs() const;
     Vector<URLKeepingBlobAlive> blobHandles() const { return crossThreadCopy(m_internals.blobHandles); }
     void writeBlobsToDiskForIndexedDB(bool isEphemeral, CompletionHandler<void(IDBValue&&)>&&);
-    IDBValue writeBlobsToDiskForIndexedDBSynchronously(bool isEphemeral);
-
+    IDBValue writeBlobsToDiskForIndexedDBSynchronously(bool isEphemeral, JSC::VM&);
     WEBCORE_EXPORT static Ref<SerializedScriptValue> createFromWireBytes(Vector<uint8_t>&&);
     const Vector<uint8_t>& wireBytes() const LIFETIME_BOUND { return m_internals.data; }
 

--- a/Source/WebCore/workers/WorkerGlobalScope.cpp
+++ b/Source/WebCore/workers/WorkerGlobalScope.cpp
@@ -75,6 +75,7 @@
 #include "WorkerNavigator.h"
 #include "WorkerOrWorkletGlobalScope.h"
 #include "WorkerReportingProxy.h"
+#include "WorkerSTWParticipation.h"
 #include "WorkerSWClientConnection.h"
 #include "WorkerScriptLoader.h"
 #include "WorkerStorageConnection.h"
@@ -546,7 +547,7 @@ std::optional<Vector<uint8_t>> WorkerGlobalScope::serializeAndWrapCryptoKey(Cryp
         wrappedKey = context.serializeAndWrapCryptoKey(WTF::move(keyData));
         semaphore.signal();
     });
-    semaphore.wait();
+    waitWithSTWParticipation(semaphore, vm());
     return wrappedKey;
 }
 
@@ -563,7 +564,7 @@ std::optional<Vector<uint8_t>> WorkerGlobalScope::unwrapCryptoKey(const Vector<u
         key = context.unwrapCryptoKey(wrappedKey);
         semaphore.signal();
     });
-    semaphore.wait();
+    waitWithSTWParticipation(semaphore, vm());
     return key;
 }
 

--- a/Source/WebCore/workers/WorkerNotificationClient.cpp
+++ b/Source/WebCore/workers/WorkerNotificationClient.cpp
@@ -32,6 +32,7 @@
 #include "NotificationResources.h"
 #include "WorkerGlobalScope.h"
 #include "WorkerLoaderProxy.h"
+#include "WorkerSTWParticipation.h"
 #include "WorkerThread.h"
 #include <wtf/threads/BinarySemaphore.h>
 
@@ -105,7 +106,7 @@ auto WorkerNotificationClient::checkPermission(ScriptExecutionContext*) -> Permi
             permission = client->checkPermission(&context);
         semaphore.signal();
     });
-    semaphore.wait();
+    waitWithSTWParticipation(semaphore, Ref { m_workerScope.get() }->vm());
     return permission;
 }
 

--- a/Source/WebCore/workers/WorkerRunLoop.cpp
+++ b/Source/WebCore/workers/WorkerRunLoop.cpp
@@ -1,11 +1,11 @@
 /*
  * Copyright (C) 2009 Google Inc. All rights reserved.
  * Copyright (C) 2016-2024 Apple Inc. All rights reserved.
- * 
+ *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are
  * met:
- * 
+ *
  *     * Redistributions of source code must retain the above copyright
  * notice, this list of conditions and the following disclaimer.
  *     * Redistributions in binary form must reproduce the above
@@ -15,7 +15,7 @@
  *     * Neither the name of Google Inc. nor the names of its
  * contributors may be used to endorse or promote products derived from
  * this software without specific prior written permission.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
  * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
  * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
@@ -28,7 +28,7 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
- 
+
 #include "config.h"
 #include "WorkerRunLoop.h"
 
@@ -47,7 +47,10 @@
 #include "WorkerThread.h"
 #include <JavaScriptCore/JSCJSValueInlines.h>
 #include <JavaScriptCore/JSRunLoopTimer.h>
+#include <JavaScriptCore/Options.h>
 #include <JavaScriptCore/TopExceptionScope.h>
+#include <JavaScriptCore/VMManager.h>
+#include <JavaScriptCore/VMTraps.h>
 #include <wtf/AutodrainedPool.h>
 #include <wtf/TZoneMallocInlines.h>
 
@@ -304,12 +307,29 @@ WorkerDedicatedRunLoop::RunInModeResult WorkerDedicatedRunLoop::runInMode(Worker
     if (script) {
         script->releaseHeapAccess();
         script->addTimerSetNotification(timerAddedTask);
+
+#if ENABLE(WEBASSEMBLY_DEBUGGER)
+        // Apply the STW check cap last so it overrides all platform-specific timeouts.
+        // Zero overhead when the WASM debugger is disabled.
+        if (JSC::Options::enableWasmDebugger()) [[unlikely]]
+            timeoutDelay = std::min(timeoutDelay, JSC::DebuggerSTWCheckInterval);
+#endif
     }
     MessageQueueWaitResult result;
     auto task = m_messageQueue.waitForMessageFilteredWithTimeout(result, predicate, timeoutDelay);
     if (script) {
         script->acquireHeapAccess();
         script->removeTimerSetNotification(timerAddedTask);
+
+#if ENABLE(WEBASSEMBLY_DEBUGGER)
+        // Heap access is released above; participate in STW if needed while it remains released.
+        // Check regardless of result — NeedStopTheWorld may be set even when a message arrived.
+        if (JSC::Options::enableWasmDebugger()) [[unlikely]] {
+            JSC::VM& vm = script->vm();
+            if (vm.traps().hasTrapBit(JSC::VMTraps::NeedStopTheWorld))
+                JSC::VMManager::singleton().notifyVMStop(vm, JSC::StopTheWorldEvent::VMStopped);
+        }
+#endif
     }
 
     RunInModeResult runInModeResult;

--- a/Source/WebCore/workers/WorkerSTWParticipation.cpp
+++ b/Source/WebCore/workers/WorkerSTWParticipation.cpp
@@ -1,0 +1,52 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED OF ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "WorkerSTWParticipation.h"
+
+#include <JavaScriptCore/Options.h>
+#include <JavaScriptCore/VM.h>
+#include <JavaScriptCore/VMManager.h>
+#include <JavaScriptCore/VMTraps.h>
+
+namespace WebCore {
+
+void waitWithSTWParticipation(WTF::BinarySemaphore& semaphore, JSC::VM& vm)
+{
+#if ENABLE(WEBASSEMBLY_DEBUGGER)
+    if (JSC::Options::enableWasmDebugger()) [[unlikely]] {
+        while (!semaphore.waitFor(JSC::DebuggerSTWCheckInterval)) {
+            if (vm.traps().hasTrapBit(JSC::VMTraps::NeedStopTheWorld))
+                JSC::VMManager::singleton().notifyVMStop(vm, JSC::StopTheWorldEvent::VMStopped);
+        }
+        return;
+    }
+#else
+    UNUSED_PARAM(vm);
+#endif
+    semaphore.wait();
+}
+
+} // namespace WebCore

--- a/Source/WebCore/workers/WorkerSTWParticipation.h
+++ b/Source/WebCore/workers/WorkerSTWParticipation.h
@@ -1,0 +1,36 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <wtf/threads/BinarySemaphore.h>
+
+namespace JSC { class VM; }
+
+namespace WebCore {
+
+void waitWithSTWParticipation(WTF::BinarySemaphore&, JSC::VM&);
+
+} // namespace WebCore


### PR DESCRIPTION
#### da1f31b2f4318b5a53ecf09aadafb85fbc8413d4
<pre>
[JSC][WASM][Debugger] Fix STW deadlocks when VM blocks in memory.atomic.wait or WebCore operations
<a href="https://rdar.apple.com/176042013">rdar://176042013</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=313838">https://bugs.webkit.org/show_bug.cgi?id=313838</a>

Reviewed by Mark Lam.

Worker threads that block while the VM is entered (vm.isEntered()==true)
prevent the WASM debugger&apos;s Stop-The-World protocol from completing: the VM
never reaches a JSC trap check point to call notifyVMStop(), hanging the
STW count indefinitely.

This patch fixes two categories of blocking operations:

1. memory.atomic.wait32/64 (JSC/WASM)

WaiterListManager::waitForSync() now polls every kDebuggerSTWCheckInterval
(50ms) and calls notifyVMStop(WasmAtomicsWaitBlocked) if NeedStopTheWorld
is set. WasmAtomicsWaitBlocked skips clearStop() so stop data persists
across multiple STW cycles; waitForSync() calls clearStop() on exit.
Stop data (callee/cfr/PC/MC/stack) is threaded from the asm through the
slow path stack frame. stepAtBytecode() handles the atomics-wait case
with resumeAll so notifier threads can run.

2. WebCore blocking operations (six sites)

Adds waitWithSTWParticipation() (WorkerSTWParticipation.h): a drop-in
replacement for BinarySemaphore::wait() that polls every 50ms and calls
notifyVMStop(VMStopped) if NeedStopTheWorld is set. Applied to:
- SubtleCrypto.wrapKey / unwrapKey (WorkerGlobalScope)
- Notification.permission check (WorkerNotificationClient)
- IndexedDB blob disk write, worker path (SerializedScriptValue)
- WebSocket peer initialization (WorkerThreadableWebSocketChannel)
- FileSystemSyncAccessHandle close/resize (WorkerFileSystemStorageConnection)
WorkerDedicatedRunLoop::runInMode() caps timeoutDelay to 50ms and checks
NeedStopTheWorld after each wait, covering sync XHR and any operation
that drives the worker run loop synchronously.

Also fixes DebugServer::start() idempotency: worker VMs in the jsc shell
re-enter start() via jsc.cpp&apos;s per-VM init path, corrupting m_serverSocket;
the isInService() guard prevents this.

Two new debugger tests: MemoryAtomicWaitTestCase (1ns timeout, breakpoint
+ step) and MemoryAtomicWaitNoTimeoutTestCase (infinite wait, process
interrupt verifies the STW fix).

Canonical link: <a href="https://commits.webkit.org/312813@main">https://commits.webkit.org/312813@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9f97a6aeefd24f47236e0f8e12748225906df61a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/161013 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/34486 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/27587 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/169916 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/117273 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/162882 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/34587 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/34486 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/124895 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/117273 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/163972 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/27160 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/144634 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/105492 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/26209 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/24709 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/17636 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/153069 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/135903 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/22396 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/172399 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/21851 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/19420 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/24037 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/133172 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/34160 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/28944 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/133182 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/34144 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/144191 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/95983 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/24504 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/27747 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/21009 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/193412 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/33655 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/101080 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/49809 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/33154 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/33398 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/33303 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->