### PR TITLE
[JSC] GreedyRegAlloc: Add loop-aware live range splitting (disabled by default)

### DIFF
--- a/JSTests/stress/regalloc-loop-splitting.js
+++ b/JSTests/stress/regalloc-loop-splitting.js
@@ -1,0 +1,41 @@
+//@ requireOptions("--airGreedyRegAllocSplitAroundLoops=true")
+
+// Exercises loop-aware live range splitting in the greedy register allocator.
+// Many variables live across a loop with a clobber call creating register pressure.
+
+function clobber(x) { return x | 0; }
+noInline(clobber);
+
+function test(p) {
+    let v0  = p + 0;
+    let v1  = p + 1;
+    let v2  = p + 2;
+    let v3  = p + 3;
+    let v4  = p + 4;
+    let v5  = p + 5;
+    let v6  = p + 6;
+    let v7  = p + 7;
+    let v8  = p + 8;
+    let v9  = p + 9;
+    let v10 = p + 10;
+    let v11 = p + 11;
+    let v12 = p + 12;
+    let v13 = p + 13;
+    let v14 = p + 14;
+    let v15 = p + 15;
+
+    let sum = 0;
+    for (let i = 0; i < 100; i++)
+        sum = clobber(sum + i);
+
+    return v0 + v1 + v2 + v3 + v4 + v5 + v6 + v7 +
+           v8 + v9 + v10 + v11 + v12 + v13 + v14 + v15 + sum;
+}
+noInline(test);
+
+let expected = 5086; // v-sum = 136, loop sum = 4950
+for (let i = 0; i < testLoopCount; i++) {
+    let result = test(1);
+    if (result !== expected)
+        throw "FAIL: expected " + expected + " but got " + result;
+}

--- a/Source/JavaScriptCore/JavaScriptCore.xcodeproj/project.pbxproj
+++ b/Source/JavaScriptCore/JavaScriptCore.xcodeproj/project.pbxproj
@@ -1583,6 +1583,7 @@
 		A40755D92D10CAE000DC55FF /* AirAllocateRegistersByGreedy.h in Headers */ = {isa = PBXBuildFile; fileRef = A40755D72D10CABA00DC55FF /* AirAllocateRegistersByGreedy.h */; };
 		A43531C12D6E40E200B01FE1 /* AirRegisterAllocatorStats.h in Headers */ = {isa = PBXBuildFile; fileRef = A43531C02D6E40E200B01FE1 /* AirRegisterAllocatorStats.h */; };
 		A4AC51DC2F35530600C06B89 /* AirPhaseStats.h in Headers */ = {isa = PBXBuildFile; fileRef = A4AC51DB2F35530600C06B89 /* AirPhaseStats.h */; };
+		A4C1EDBD2F913B7A007E4588 /* AirEnsureDedicatedLoopEntryExitBlocks.h in Headers */ = {isa = PBXBuildFile; fileRef = A4C1EDBA2F913B7A007E4588 /* AirEnsureDedicatedLoopEntryExitBlocks.h */; };
 		A4F6474C2F32D8E100CABA36 /* AirStackAllocatorStats.h in Headers */ = {isa = PBXBuildFile; fileRef = A4F6474B2F32D8C000CABA36 /* AirStackAllocatorStats.h */; };
 		A503FA1A188E0FB000110F14 /* JavaScriptCallFrame.h in Headers */ = {isa = PBXBuildFile; fileRef = A503FA14188E0FAF00110F14 /* JavaScriptCallFrame.h */; };
 		A503FA1E188E0FB000110F14 /* JSJavaScriptCallFramePrototype.h in Headers */ = {isa = PBXBuildFile; fileRef = A503FA18188E0FB000110F14 /* JSJavaScriptCallFramePrototype.h */; };
@@ -5290,6 +5291,8 @@
 		A40755D82D10CABA00DC55FF /* AirAllocateRegistersByGreedy.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = AirAllocateRegistersByGreedy.cpp; path = b3/air/AirAllocateRegistersByGreedy.cpp; sourceTree = "<group>"; };
 		A43531C02D6E40E200B01FE1 /* AirRegisterAllocatorStats.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = AirRegisterAllocatorStats.h; path = b3/air/AirRegisterAllocatorStats.h; sourceTree = "<group>"; };
 		A4AC51DB2F35530600C06B89 /* AirPhaseStats.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = AirPhaseStats.h; path = b3/air/AirPhaseStats.h; sourceTree = "<group>"; };
+		A4C1EDBA2F913B7A007E4588 /* AirEnsureDedicatedLoopEntryExitBlocks.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = AirEnsureDedicatedLoopEntryExitBlocks.h; path = b3/air/AirEnsureDedicatedLoopEntryExitBlocks.h; sourceTree = "<group>"; };
+		A4C1EDBB2F913B7A007E4588 /* AirEnsureDedicatedLoopEntryExitBlocks.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = AirEnsureDedicatedLoopEntryExitBlocks.cpp; path = b3/air/AirEnsureDedicatedLoopEntryExitBlocks.cpp; sourceTree = "<group>"; };
 		A4F6474B2F32D8C000CABA36 /* AirStackAllocatorStats.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = AirStackAllocatorStats.h; path = b3/air/AirStackAllocatorStats.h; sourceTree = "<group>"; };
 		A503FA13188E0FAF00110F14 /* JavaScriptCallFrame.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = JavaScriptCallFrame.cpp; sourceTree = "<group>"; };
 		A503FA14188E0FAF00110F14 /* JavaScriptCallFrame.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = JavaScriptCallFrame.h; sourceTree = "<group>"; };
@@ -7175,6 +7178,8 @@
 				0F4570371BE44C910062A629 /* AirEliminateDeadCode.h */,
 				0F6183231C45BF070072450B /* AirEmitShuffle.cpp */,
 				0F6183241C45BF070072450B /* AirEmitShuffle.h */,
+				A4C1EDBB2F913B7A007E4588 /* AirEnsureDedicatedLoopEntryExitBlocks.cpp */,
+				A4C1EDBA2F913B7A007E4588 /* AirEnsureDedicatedLoopEntryExitBlocks.h */,
 				0F4DE1CC1C4C1B54004D6C11 /* AirFixObviousSpills.cpp */,
 				0F4DE1CD1C4C1B54004D6C11 /* AirFixObviousSpills.h */,
 				262D85B41C0D650F006ACB61 /* AirFixPartialRegisterStalls.cpp */,
@@ -10974,6 +10979,7 @@
 				E3FB5BEC2F0886090016B5F5 /* AirDominators.h in Headers */,
 				0F4570391BE44C910062A629 /* AirEliminateDeadCode.h in Headers */,
 				0F61832D1C45BF070072450B /* AirEmitShuffle.h in Headers */,
+				A4C1EDBD2F913B7A007E4588 /* AirEnsureDedicatedLoopEntryExitBlocks.h in Headers */,
 				0F4DE1CF1C4C1B54004D6C11 /* AirFixObviousSpills.h in Headers */,
 				262D85B71C0D650F006ACB61 /* AirFixPartialRegisterStalls.h in Headers */,
 				0F2AC5671E8A0B790001EE3F /* AirFixSpillsAfterTerminals.h in Headers */,

--- a/Source/JavaScriptCore/Sources.txt
+++ b/Source/JavaScriptCore/Sources.txt
@@ -78,6 +78,7 @@ b3/air/AirCustom.cpp
 b3/air/AirDisassembler.cpp
 b3/air/AirEliminateDeadCode.cpp
 b3/air/AirEmitShuffle.cpp
+b3/air/AirEnsureDedicatedLoopEntryExitBlocks.cpp
 b3/air/AirFixObviousSpills.cpp
 b3/air/AirFixPartialRegisterStalls.cpp
 b3/air/AirFixSpillsAfterTerminals.cpp

--- a/Source/JavaScriptCore/b3/air/AirAllocateRegistersByGreedy.cpp
+++ b/Source/JavaScriptCore/b3/air/AirAllocateRegistersByGreedy.cpp
@@ -30,11 +30,15 @@
 
 #include "AirArgInlines.h"
 #include "AirCode.h"
+#include "AirDominators.h"
+#include "AirEmitShuffle.h"
+#include "AirEnsureDedicatedLoopEntryExitBlocks.h"
 #include "AirFixSpillsAfterTerminals.h"
-#include "AirPhaseInsertionSet.h"
 #include "AirInstInlines.h"
 #include "AirLiveness.h"
+#include "AirNaturalLoops.h"
 #include "AirPadInterference.h"
+#include "AirPhaseInsertionSet.h"
 #include "AirPhaseScope.h"
 #include "AirRegLiveness.h"
 #include "AirRegisterAllocatorStats.h"
@@ -71,6 +75,16 @@ public:
     Cost operator*(float scalar) const { return Cost(m_value * scalar); }
     Cost operator/(float scalar) const { return Cost(m_value / scalar); }
 
+    // Subtract other from this cost, clamping to zero. Skips non-finite values
+    // since an inf cost has lost precision and inf - inf = NaN.
+    void subtractSaturating(Cost other)
+    {
+        if (std::isfinite(m_value)) {
+            m_value -= other.m_value;
+            m_value = std::max(m_value, 0.0f);
+        }
+    }
+
     friend auto operator<=>(const Cost&, const Cost&) = default;
 
 private:
@@ -86,16 +100,21 @@ static constexpr SpillCost maxSpillableSpillCost { std::numeric_limits<float>::m
 static_assert(unspillableCost > fastTmpSpillCost);
 static_assert(unspillableCost > maxSpillableSpillCost);
 
+static constexpr unsigned maxLoopSplitDepth = 32;
+static constexpr UseDefCost zeroCostEpsilon { 1e-6f };
+
 // Phase constants used for the PhaseInsertionSet. Ensures that the fixup and spill/fill instructions
 // inserted in a particular gap end up in the correct order.
 // "MoveTo" = value flows toward the original tmp (or its spill slot).
 // "MoveFrom" = value flows away from the original tmp (or its spill slot).
 enum InsertionPhase : unsigned {
     SpillMoveTo,
+    AroundLoopExitFixup,
     ClobberMoveTo,
     IntraBlockMoveTo,
     IntraBlockMoveFrom,
     ClobberMoveFrom,
+    AroundLoopEntryFixup,
     SpillMoveFrom,
 };
 
@@ -235,7 +254,17 @@ public:
         return m_size;
     }
 
-    bool NODELETE overlaps(LiveRange& other)
+    bool NODELETE contains(Point point) const
+    {
+        for (auto& interval : m_intervals) {
+            if (interval.end() <= point)
+                continue;
+            return interval.begin() <= point;
+        }
+        return false;
+    }
+
+    bool NODELETE overlaps(const LiveRange& other) const
     {
         auto otherIter = other.intervals().begin();
         auto otherEnd = other.intervals().end();
@@ -700,6 +729,7 @@ struct TmpData {
     LiveRange liveRange;
     Coalescables coalescables;
     UseDefCost useDefCost { 0 };
+    UseDefCost cumulativeFixupCost { 0 };
     uint32_t spillSlotTableIndex { 0 };
     uint32_t splitAroundClobbersMetadataIndex : 31 { 0 };
     uint32_t hasColdUse : 1 { 0 };
@@ -707,6 +737,11 @@ struct TmpData {
     Spillability spillability { Spillability::Spillable };
     Reg preferredReg;
     Reg assigned;
+};
+
+struct LoopData {
+    LiveRange range;
+    LiveRange boundary;
 };
 
 class UseDefList {
@@ -781,6 +816,24 @@ struct IntraBlockSplitMetadata {
 
     Tmp originalTmp;
     Vector<Split> splits;
+};
+
+// AroundLoopSplitMetadata tracks a Tmp that has been split at a loop boundary.
+// The original Tmp covers the non-loop portion and the split Tmp covers the loop portion.
+struct AroundLoopSplitMetadata {
+    AroundLoopSplitMetadata(Tmp originalTmp, const NaturalLoop* loop)
+        : originalTmp(originalTmp)
+        , loop(loop) { }
+
+    void dump(PrintStream& out) const
+    {
+        out.print(originalTmp, " : AroundLoop(BB", *loop->header(), ") { ", loopTmp, " loopHasDef=", loopHasDef, " } ");
+    }
+
+    Tmp originalTmp;
+    Tmp loopTmp;
+    bool loopHasDef { false };
+    const NaturalLoop* loop { nullptr };
 };
 
 class GreedyAllocator {
@@ -881,7 +934,9 @@ public:
         });
         out.println("AroundClobbers splits:\n", listDump(m_aroundClobbersMetadata, "\n"));
         out.println("IntraBlock splits:\n", listDump(m_intraBlockMetadata, "\n"));
+        out.println("AroundLoop splits:\n", listDump(m_aroundLoopMetadata, "\n"));
         out.println("SpillSlotTable: ", pointerListDump(m_spillSlotTable));
+        out.println("Loops: ", pointerDump(m_naturalLoops.get()));
         out.println("Stats (GP):", m_stats[GP]);
         out.println("Stats (FP):", m_stats[FP]);
     }
@@ -942,14 +997,37 @@ private:
         m_stats[GP].numInsts += (tailPosition + 1) / PointOffsets::PointsPerInst;
     }
 
-    BasicBlock* findBlockContainingPoint(Point point)
+    void forEachBlockInLiveRange(const LiveRange& liveRange, const Invocable<IterationStatus(BasicBlock*)> auto& func)
+    {
+        for (auto& interval : liveRange.intervals()) {
+            size_t blockIdx = findBlockIndexContainingPoint(interval.begin());
+            while (true) {
+                BasicBlock* block = m_code[blockIdx];
+                if (func(block) == IterationStatus::Done)
+                    return;
+                Point nextHead = m_tailPoints[blockIdx] + 1;
+                if (nextHead >= interval.end())
+                    break;
+                do {
+                    ++blockIdx;
+                } while (!m_code[blockIdx]);
+            };
+        }
+    }
+
+    size_t findBlockIndexContainingPoint(Point point)
     {
         auto iter = std::lower_bound(m_tailPoints.begin(), m_tailPoints.end(), point);
         ASSERT(iter != m_tailPoints.end()); // Should ask only about legal instruction boundaries.
         size_t blockIndex = std::distance(m_tailPoints.begin(), iter);
-        BasicBlock* block = m_code[blockIndex];
-        ASSERT(positionOfHead(block) <= point && point <= positionOfTail(block));
-        return block;
+        ASSERT(m_code[blockIndex]);
+        ASSERT(positionOfHead(m_code[blockIndex]) <= point && point <= m_tailPoints[blockIndex]);
+        return blockIndex;
+    }
+
+    BasicBlock* findBlockContainingPoint(Point point)
+    {
+        return m_code[findBlockIndexContainingPoint(point)];
     }
 
     Point NODELETE positionOfHead(BasicBlock* block) const
@@ -2017,14 +2095,8 @@ private:
                     m_stats[bank].numGroupMovesCoalesced++;
                     float freq = adjustedBlockFrequency(block);
                     TmpData& tmpData = m_map.get<bank>(tmp);
-                    // Avoid computing NaN which can happen when tmpData.useDefCost is inf and freq or 2*freq is Inf.
-                    // And if useDefCost became Inf (usually due high nesting depth) subtracting not necessarily the right thing anyway.
-                    if (std::isfinite(tmpData.useDefCost.value())) {
-                        tmpData.useDefCost -= UseDefCost(freq); // For args[0]
-                        tmpData.useDefCost -= UseDefCost(freq); // For args[1]
-                        if (tmpData.useDefCost < UseDefCost(0))
-                            tmpData.useDefCost = UseDefCost(0);
-                    }
+                    tmpData.useDefCost.subtractSaturating(UseDefCost(freq)); // For args[0]
+                    tmpData.useDefCost.subtractSaturating(UseDefCost(freq)); // For args[1]
                 }
             }
         }
@@ -2119,6 +2191,8 @@ private:
         TmpData& originalData = m_map[originalTmp];
         ensureSpillSlotTableEntry(originalData);
         m_map[splitTmp].spillSlotTableIndex = originalData.spillSlotTableIndex;
+        if (m_hasUseDefLists)
+            m_useDefLists.resize(m_code);
         return splitTmp;
     }
 
@@ -2413,7 +2487,212 @@ private:
         ASSERT(tmpData.spillCost() != unspillableCost); // Should have evicted.
         if (trySplitAroundClobbers<bank>(tmp, tmpData))
             return true;
+        if (trySplitAroundLoop<bank>(tmp, tmpData))
+            return true;
         return trySplitIntraBlock<bank>(tmp, tmpData);
+    }
+
+    void analyzeLoop(const NaturalLoop& loop)
+    {
+        // Collect boundary points for fast live-range-crosses-loop-boundary checks.
+        Vector<Point, 16> boundaryPoints;
+
+        BasicBlock* header = loop.header();
+        for (BasicBlock* pred : header->predecessors()) {
+            if (m_naturalLoops->belongsTo(pred, loop))
+                continue; // Back-edge predecessor, skip.
+            // ensureDedicatedLoopEntryExitBlocks() guarantees non-critical entry edges and dedicated exit blocks.
+            ASSERT(pred->numSuccessors() == 1 && pred->successor(0).block() == header);
+            boundaryPoints.append(positionOfTail(pred));
+        }
+
+        for (unsigned i = 0; i < loop.size(); i++) {
+            BasicBlock* loopBlock = loop.at(i);
+            for (auto& succ : loopBlock->successors()) {
+                if (m_naturalLoops->belongsTo(succ.block(), loop))
+                    continue;
+#if ASSERT_ENABLED
+                // ensureDedicatedLoopEntryExitBlocks() ensured the exit successor has only loop
+                // predecessors so it's safe to emit the fixup code in the successor block.
+                for (BasicBlock* exitPred : succ.block()->predecessors())
+                    ASSERT(m_naturalLoops->belongsTo(exitPred, loop));
+#endif
+                boundaryPoints.append(positionOfHead(succ.block()));
+            }
+        }
+
+        LoopData& loopData = m_loopData[loop.index()];
+        ASSERT(!loopData.range.size() && !loopData.boundary.size());
+
+        std::ranges::sort(boundaryPoints);
+        removeRepeatedElements(boundaryPoints);
+        LiveRange& boundary = loopData.boundary;
+        for (Point point : boundaryPoints)
+            boundary.append(Interval(point));
+
+        Vector<Interval, 32> loopIntervals;
+        for (unsigned i = 0; i < loop.size(); i++) {
+            auto block = loop.at(i);
+            loopIntervals.constructAndAppend(positionOfHead(block), positionOfTail(block) + 1);
+        }
+        std::ranges::sort(loopIntervals, [](const Interval& a, const Interval& b) {
+            return a.begin() < b.begin();
+        });
+        LiveRange& loopRange = loopData.range;
+        for (auto& interval : loopIntervals)
+            loopRange.append(interval);
+    }
+
+    void ensureLoopAnalysis()
+    {
+        if (m_naturalLoops)
+            return;
+        m_dominators = makeUnique<Dominators>(m_code);
+        m_naturalLoops = makeUnique<NaturalLoops>(m_code, *m_dominators);
+        m_loopData.resize(m_naturalLoops->numLoops());
+
+        for (unsigned i = 0; i < m_naturalLoops->numLoops(); i++)
+            analyzeLoop(m_naturalLoops->loop(i));
+    }
+
+    // Pick the outermost loop that meaningfully reduces the live range when split out.
+    // Returns the chosen loop and the non-loop remainder, or {nullptr, {}} if none qualifies.
+    std::pair<const NaturalLoop*, LiveRange> chooseLoopForSplit(const LiveRange& liveRange)
+    {
+        const NaturalLoop* resultLoop = nullptr;
+        LiveRange resultNonLoopRange;
+
+        BitVector visitedLoops;
+        Vector<const NaturalLoop*, 16> nestedLoops;
+        forEachBlockInLiveRange(liveRange, [&](BasicBlock* block) {
+            nestedLoops.shrink(0);
+            for (const NaturalLoop* loop = m_naturalLoops->innerMostLoopOf(block); loop; loop = m_naturalLoops->innerMostOuterLoop(*loop)) {
+                if (visitedLoops.get(loop->index()))
+                    break;
+                nestedLoops.append(loop);
+            }
+
+            // Iterate from outer-most to inner-most
+            for (auto* loop : std::views::reverse(nestedLoops)) {
+                ASSERT(!visitedLoops.get(loop->index()));
+                visitedLoops.set(loop->index());
+
+                auto& loopData = m_loopData[loop->index()];
+                if (liveRange.overlaps(loopData.boundary)) {
+                    // Skip loops that are too large relative to the live range since they are unlikely to improve allocation progress.
+                    if (loopData.range.size() > liveRange.size() * Options::airGreedyRegAllocLoopSplitMaxLoopFraction())
+                        continue;
+                    resultLoop = loop;
+                    resultNonLoopRange = LiveRange::subtract(liveRange, loopData.range);
+                    return IterationStatus::Done;
+                }
+            }
+            return IterationStatus::Continue;
+        });
+        return { resultLoop, WTF::move(resultNonLoopRange) };
+    }
+
+    template<Bank bank>
+    bool trySplitAroundLoop(Tmp tmp, TmpData& tmpData)
+    {
+        if (!Options::airGreedyRegAllocSplitAroundLoops())
+            return false;
+
+        // Clobber fixup references originalTmp which would be stale after loop splitting.
+        if (tmpData.splitAroundClobbersMetadataIndex)
+            return false;
+        if (tmpData.liveRange.size() < splitMinRangeSize)
+            return false;
+        if (isConstDef<bank>(tmp))
+            return false;
+        if (isLiveRangeBlockLocal(tmpData.liveRange))
+            return false;
+
+        ensureLoopAnalysis();
+        if (!m_naturalLoops->numLoops())
+            return false;
+
+        auto [loop, nonLoopRange] = chooseLoopForSplit(tmpData.liveRange);
+        if (!loop)
+            return false;
+
+        if (m_naturalLoops->loopDepth(loop->header()) > maxLoopSplitDepth)
+            return false;
+
+        auto findFirstLoopPredecessor = [this](const NaturalLoop* loop) -> BasicBlock* {
+            BasicBlock* header = loop->header();
+            for (BasicBlock* pred : header->predecessors()) {
+                if (!m_naturalLoops->belongsTo(pred, *loop))
+                    return pred;
+            }
+            ASSERT_NOT_REACHED();
+            return nullptr;
+        };
+
+        // Estimate the fixup cost: each loop invocation pays one entry + one exit move.
+        // If the cumulative fixup cost across sibling loop splits of this tmp exceeds useDefCost, bail.
+        BasicBlock* entryBlock = findFirstLoopPredecessor(loop);
+        UseDefCost fixupCost(2 * adjustedBlockFrequency(entryBlock));
+        UseDefCost totalFixupCost = tmpData.cumulativeFixupCost;
+        totalFixupCost += fixupCost;
+        if (totalFixupCost > tmpData.useDefCost)
+            return false;
+        tmpData.cumulativeFixupCost += fixupCost;
+
+        ensureUseDefLists();
+
+        Tmp loopTmp = addSplitTmp(tmp, UseDefCost(0), { });
+        // Note: addSplitTmp() may have resized m_map, invalidating the tmpData parameter.
+        TmpData& originalData = m_map.get<bank>(tmp);
+        TmpData& loopData = m_map.get<bank>(loopTmp);
+        loopData.liveRange = LiveRange::subtract(originalData.liveRange, nonLoopRange);
+        ASSERT(loopData.liveRange.size());
+
+        bool loopHasDef = false;
+        size_t cursor = 0;
+        for (Interval interval : loopData.liveRange.intervals()) {
+            do {
+                interval = forEachUseDefWithin(tmp, interval, cursor, [&](Point point, Inst& inst, BasicBlock& block) {
+                    inst.forEachTmp([&](Tmp& t, Arg::Role role, Bank, Width) {
+                        if (t != tmp)
+                            return;
+                        t = loopTmp;
+                        if (Arg::isAnyDef(role))
+                            loopHasDef = true;
+                        if (Arg::isColdUse(role))
+                            loopData.hasColdUse = true;
+                        else
+                            loopData.useDefCost += UseDefCost(block.frequency());
+                        m_useDefLists[loopTmp].add(point);
+                    });
+                });
+            } while (interval);
+        }
+
+        // originalTmp no longer live within the loop.
+        originalData.liveRange = WTF::move(nonLoopRange);
+        originalData.useDefCost.subtractSaturating(loopData.useDefCost);
+
+        m_aroundLoopMetadata.constructAndAppend(tmp, loop);
+        AroundLoopSplitMetadata& metadata = m_aroundLoopMetadata.last();
+        metadata.loopTmp = loopTmp;
+        metadata.loopHasDef = loopHasDef;
+
+        // Spill zero-cost sides directly — a register would just carry a value nothing reads,
+        // while still requiring fixup moves at loop boundaries. Epsilon handles FP rounding.
+        auto enqueueOrSpill = [&](Tmp t, TmpData& data) {
+            if (data.useDefCost < zeroCostEpsilon) {
+                spill(t, data);
+                m_stats[bank].numSplitAroundLoopZeroCostSpilled++;
+            } else
+                setStageAndEnqueue(t, data, Stage::TryAllocate);
+        };
+        enqueueOrSpill(loopTmp, loopData);
+        enqueueOrSpill(tmp, originalData);
+
+        m_stats[bank].numSplitAroundLoop++;
+        dataLogLnIf(verbose(), "Split (around loop): ", tmp, " -> loopTmp=", loopTmp, " header=BB", loop->header(), " loopHasDef=", loopHasDef);
+        return true;
     }
 
     template<Bank bank>
@@ -2495,7 +2774,7 @@ private:
         // might spill or be assigned another register.
         for (Interval hole : holeRange.intervals()) {
             BasicBlock* block = findBlockContainingPoint(hole.begin());
-            float freq = 2 * adjustedBlockFrequency(block);
+            UseDefCost freq(2 * adjustedBlockFrequency(block));
             // padInterference() ensures this.
             // FIXME: reconsider that, see https://bugs.webkit.org/show_bug.cgi?id=288122
             ASSERT(hole.begin() > positionOfHead(block));
@@ -3012,6 +3291,25 @@ private:
             insertSplitAroundClobbersFixupCode(m_aroundClobbersMetadata[i]);
         for (auto& metadata : m_intraBlockMetadata)
             insertSplitIntraBlockFixupCode(metadata);
+
+        if (Options::airGreedyRegAllocSplitAroundLoops()) {
+            HashMap<Tmp, unsigned> loopTmpToMetadataIndex;
+            for (unsigned index = 0; index < m_aroundLoopMetadata.size(); index++)
+                loopTmpToMetadataIndex.add(m_aroundLoopMetadata[index].loopTmp, index);
+
+            // Loop fixups for different Tmps may introduce register cycles. Use Shuffle to deal with potential register conflicts.
+            HashMap<BasicBlock*, Vector<ShufflePair>> loopEntryFixups;
+            HashMap<BasicBlock*, Vector<ShufflePair>> loopExitFixups;
+
+            for (auto& metadata : m_aroundLoopMetadata)
+                insertSplitAroundLoopFixupCode(metadata, loopTmpToMetadataIndex, loopEntryFixups, loopExitFixups);
+
+            for (auto& [block, shufflePairs] : loopEntryFixups)
+                m_insertionSets[block].insertInst(block->size() - 1, AroundLoopEntryFixup, createShuffle(block->at(block->size() - 1).origin, shufflePairs));
+            for (auto& [block, shufflePairs] : loopExitFixups)
+                m_insertionSets[block].insertInst(0, AroundLoopExitFixup, createShuffle(block->at(0).origin, shufflePairs));
+        }
+
         for (BasicBlock* block : m_code)
             m_insertionSets[block].execute(block);
     }
@@ -3088,6 +3386,111 @@ private:
                 m_stats[bank].numSplitIntraBlockStore++;
             }
         }
+    }
+
+    void insertSplitAroundLoopFixupCode(AroundLoopSplitMetadata& metadata, const HashMap<Tmp, unsigned>& loopTmpToMetadataIndex, HashMap<BasicBlock*, Vector<ShufflePair>>& entryFixups, HashMap<BasicBlock*, Vector<ShufflePair>>& exitFixups)
+    {
+        Tmp nonLoopTmp = metadata.originalTmp;
+        Tmp loopTmp = metadata.loopTmp;
+        const NaturalLoop& loop = *metadata.loop;
+        BasicBlock* header = loop.header();
+
+        Bank bank = nonLoopTmp.bank();
+        if (spillSlot(loopTmp))
+            m_stats[bank].numSplitAroundLoopLoopSpilled++;
+        if (spillSlot(nonLoopTmp))
+            m_stats[bank].numSplitAroundLoopNonLoopSpilled++;
+        if (spillSlot(loopTmp) && spillSlot(nonLoopTmp))
+            m_stats[bank].numSplitAroundLoopBothSpilled++;
+
+        auto argFor = [&](Tmp tmp) -> Arg {
+            StackSlot* spilled = spillSlot(tmp);
+            if (spilled)
+                return Arg::stack(spilled);
+            return tmp;
+        };
+        Arg nonLoopArg = argFor(nonLoopTmp);
+        Arg loopArg = argFor(loopTmp);
+
+        LiveRange& loopLiveRange = m_map[loopTmp].liveRange;
+        Width width = canonicalWidth(m_tmpWidth.requiredWidth(nonLoopTmp));
+
+        // Entry fixup: if either tmp got a register and the loop tmp is live at the header,
+        // transfer nonLoopTmp to loopTmp at the end of each entry edge.
+        if (nonLoopArg != loopArg && loopLiveRange.contains(positionOfHead(header))) {
+            for (BasicBlock* pred : header->predecessors()) {
+                if (m_naturalLoops->belongsTo(pred, loop))
+                    continue; // Skip back-edge predecessors.
+                // ensureDedicatedLoopEntryExitBlocks() guarantees non-critical entry edges.
+                ASSERT(pred->numSuccessors() == 1 && pred->successor(0).block() == header);
+                ASSERT(!nonLoopArg.isStack() || !loopArg.isStack());
+                entryFixups.ensure(pred, [] {
+                    return Vector<ShufflePair>();
+                }).iterator->value.append(ShufflePair(nonLoopArg, loopArg, width));
+            }
+        }
+
+        // Exit fixup: on each exit edge, transfer loopTmp to the destination nonLoopTmp.
+        // For nested loop splits, traverse outward to find the right destination.
+        IndexSet<BasicBlock*> visitedExitSuccessors;
+        for (unsigned i = 0; i < loop.size(); i++) {
+            BasicBlock* loopBlock = loop.at(i);
+            // If loopTmp isn't live at the exiting block then this block is within a nested loop that
+            // was also split. The inner fixup will handle this multi-level loop exit.
+            if (!loopLiveRange.contains(positionOfTail(loopBlock)))
+                continue;
+            for (auto& succ : loopBlock->successors()) {
+                if (m_naturalLoops->belongsTo(succ.block(), loop))
+                    continue;
+                if (!visitedExitSuccessors.add(succ.block()))
+                    continue; // Already inserted fixup for this exit successor.
+#if ASSERT_ENABLED
+                // ensureDedicatedLoopEntryExitBlocks() ensured the exit successor has only loop
+                // predecessors so it's safe to emit the fixup code in the successor block.
+                for (BasicBlock* exitPred : succ.block()->predecessors())
+                    ASSERT(m_naturalLoops->belongsTo(exitPred, loop));
+#endif
+                Point exitHead = positionOfHead(succ.block());
+                // Find the nonLoopTmp that carries the value into succ block by traversing splits outward.
+                Tmp traverseLoopTmp = loopTmp;
+                std::optional<unsigned> destSplitIndex;
+                bool anyDefsToRegisters = false;
+                while (true) {
+                    auto it = loopTmpToMetadataIndex.find(traverseLoopTmp);
+                    if (it == loopTmpToMetadataIndex.end()) {
+                        ASSERT(traverseLoopTmp != loopTmp);
+                        destSplitIndex = std::nullopt;
+                        break;
+                    }
+                    destSplitIndex = it->value;
+                    auto& splitMetadata = m_aroundLoopMetadata[*destSplitIndex];
+                    ASSERT(splitMetadata.loopTmp == traverseLoopTmp);
+                    TmpData& loopTmpData = m_map[traverseLoopTmp];
+                    anyDefsToRegisters |= loopTmpData.assigned && splitMetadata.loopHasDef;
+
+                    if (m_map[splitMetadata.originalTmp].liveRange.contains(exitHead))
+                        break;
+                    traverseLoopTmp = splitMetadata.originalTmp;
+                }
+
+                // There won't be a destSplitIndex if the original range wasn't live out of this loop. In that case,
+                // no exit fixup is needed.
+                if (destSplitIndex.has_value()) {
+                    Tmp destTmp = m_aroundLoopMetadata[*destSplitIndex].originalTmp;
+                    Arg destArg = argFor(destTmp);
+                    // If both sides spilled and the loop never wrote to a register, the
+                    // shared spill slot already holds the correct value.
+                    bool spillSlotAlreadyCoherent = destArg.isStack() && !anyDefsToRegisters;
+                    if (loopArg != destArg && !spillSlotAlreadyCoherent) {
+                        ASSERT(!loopArg.isStack() || !destArg.isStack());
+                        exitFixups.ensure(succ.block(), [] {
+                            return Vector<ShufflePair>();
+                        }).iterator->value.append(ShufflePair(loopArg, destArg, width));
+                    }
+                }
+            }
+        }
+        dataLogLnIf(verbose(), "AroundLoop fixup: nonLoop=", nonLoopTmp, " loop=", loopTmp, " header=BB", *header);
     }
 
     bool NODELETE mayBeCoalescable(Inst& inst)
@@ -3181,6 +3584,7 @@ private:
     TmpMap<UseDefList> m_useDefLists;
     Vector<AroundClobbersSplitMetadata> m_aroundClobbersMetadata;
     Vector<IntraBlockSplitMetadata> m_intraBlockMetadata;
+    Vector<AroundLoopSplitMetadata> m_aroundLoopMetadata;
     Vector<StackSlot*> m_spillSlotTable;
     IndexMap<Reg, RegisterRange> m_regRanges;
     GenerationalSet<uint8_t, SaVector> m_visited;
@@ -3193,6 +3597,9 @@ private:
     std::array<bool, numBanks> m_didSpill { };
     bool m_needsEmitSpillCode { false };
     bool m_hasUseDefLists { false };
+    std::unique_ptr<Dominators> m_dominators;
+    std::unique_ptr<NaturalLoops> m_naturalLoops;
+    Vector<LoopData> m_loopData;
 };
 
 } // namespace JSC::B3::Air::Greedy
@@ -3200,6 +3607,8 @@ private:
 void allocateRegistersByGreedy(Code& code)
 {
     PhaseScope phaseScope(code, "allocateRegistersByGreedy"_s);
+    if (Options::airGreedyRegAllocSplitAroundLoops())
+        ensureDedicatedLoopEntryExitBlocks(code);
     Greedy::GreedyAllocator allocator(code);
     allocator.run();
 }

--- a/Source/JavaScriptCore/b3/air/AirCode.cpp
+++ b/Source/JavaScriptCore/b3/air/AirCode.cpp
@@ -48,6 +48,8 @@ const char* const tierName = "Air ";
 
 WTF_MAKE_SEQUESTERED_ARENA_ALLOCATED_IMPL(CFG);
 WTF_MAKE_SEQUESTERED_ARENA_ALLOCATED_IMPL(Code);
+WTF_MAKE_SEQUESTERED_ARENA_ALLOCATED_IMPL(Dominators);
+WTF_MAKE_SEQUESTERED_ARENA_ALLOCATED_IMPL(NaturalLoops);
 
 static void defaultPrologueGenerator(CCallHelpers& jit, Code& code)
 {

--- a/Source/JavaScriptCore/b3/air/AirCode.h
+++ b/Source/JavaScriptCore/b3/air/AirCode.h
@@ -310,7 +310,7 @@ public:
     const SparseCollection<Special>& specials() const LIFETIME_BOUND { return m_specials; }
     SparseCollection<Special>& specials() LIFETIME_BOUND { return m_specials; }
 
-    void addFastTmp(Tmp);
+    JS_EXPORT_PRIVATE void addFastTmp(Tmp);
 
     template<typename Functor>
     void forEachFastTmp(const Functor& functor) const

--- a/Source/JavaScriptCore/b3/air/AirEnsureDedicatedLoopEntryExitBlocks.cpp
+++ b/Source/JavaScriptCore/b3/air/AirEnsureDedicatedLoopEntryExitBlocks.cpp
@@ -1,0 +1,147 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "AirEnsureDedicatedLoopEntryExitBlocks.h"
+
+#if ENABLE(B3_JIT)
+
+#include "AirBlockInsertionSet.h"
+#include "AirCode.h"
+#include "AirNaturalLoops.h"
+
+namespace JSC { namespace B3 { namespace Air {
+
+void ensureDedicatedLoopEntryExitBlocks(Code& code)
+{
+    Dominators dominators(code);
+    NaturalLoops loops(code, dominators);
+
+    unsigned originalBlockCount = code.size();
+
+    BlockInsertionSet insertionSet(code);
+
+    // Pass 1: Ensure dedicated exit blocks.
+    //
+    // For each loop L, each exit successor S must have all its predecessors inside L.
+    // When S has mixed predecessors (some in L, some not), we insert a pad block between
+    // L's predecessors and S.
+    //
+    // We use innerMostLoopOf(pred) == L to assign each predecessor to exactly one loop.
+    // This means inner loops claim their own predecessors, and outer loops only redirect
+    // predecessors that aren't in any inner loop. This works because pad blocks inserted
+    // for inner loops become exit successors of outer loops in the allocator's recomputed
+    // NaturalLoops, with all their predecessors inside the outer loop by containment.
+    for (unsigned loopIndex = loops.numLoops(); loopIndex--;) {
+        const NaturalLoop& loop = loops.loop(loopIndex);
+
+        for (unsigned i = 0; i < loop.size(); i++) {
+            for (auto& succ : loop.at(i)->successors()) {
+                BasicBlock* exitBlock = succ.block();
+                // Skip new pad blocks since the exit edges they replaced have already been handled.
+                // And we can't query loops on them since they didn't exist when loops was computed.
+                if (exitBlock->index() >= originalBlockCount)
+                    continue;
+                if (loops.belongsTo(exitBlock, loop))
+                    continue;
+
+                // Only redirect predecessors whose innermost loop is L. Inner
+                // loops handle their own predecessors and create their own pads.
+                Vector<BasicBlock*, 8> loopPreds;
+                for (BasicBlock* pred : exitBlock->predecessors()) {
+                    if (pred->index() < originalBlockCount && loops.innerMostLoopOf(pred) == &loop)
+                        loopPreds.append(pred);
+                }
+                if (loopPreds.isEmpty())
+                    continue;
+                // All predecessors are already in this loop — exit is already dedicated.
+                if (loopPreds.size() == exitBlock->numPredecessors())
+                    continue;
+
+                BasicBlock* pad = insertionSet.insertBefore(exitBlock, exitBlock->frequency());
+                pad->append(Jump, exitBlock->at(0).origin);
+                pad->setSuccessors(FrequentedBlock(exitBlock));
+                for (BasicBlock* loopPred : loopPreds) {
+                    for (BasicBlock*& target : loopPred->successorBlocks()) {
+                        if (target == exitBlock)
+                            target = pad;
+                    }
+                    pad->addPredecessor(loopPred);
+                    exitBlock->removePredecessor(loopPred);
+                }
+                exitBlock->addPredecessor(pad);
+            }
+        }
+    }
+
+    // Pass 2: Ensure non-critical entry edges.
+    //
+    // If any non-back-edge predecessor of a loop header has multiple successors (critical
+    // entry edge), redirect all non-back-edge predecessors through a pre-header block.
+    // This runs after the exit pass so entry mutations can't affect exit analysis. Exit
+    // pads from pass 1 may be predecessors of a loop header (when an exit successor is
+    // another loop's header), but belongsTo correctly identifies them as non-back-edge
+    // predecessors since they aren't in the frozen NaturalLoops.
+    for (unsigned loopIndex = loops.numLoops(); loopIndex--;) {
+        const NaturalLoop& loop = loops.loop(loopIndex);
+        BasicBlock* header = loop.header();
+
+        Vector<BasicBlock*, 4> entryPreds;
+        bool needsPreHeader = false;
+        for (BasicBlock* pred : header->predecessors()) {
+            // Skip pad blocks from the exit pass — they may be back-edge predecessors
+            // (inner loop exiting to this header) and always have a single successor,
+            // so they can't create critical entry edges.
+            if (pred->index() >= originalBlockCount)
+                continue;
+            if (loops.belongsTo(pred, loop))
+                continue;
+            entryPreds.append(pred);
+            if (pred->numSuccessors() > 1)
+                needsPreHeader = true;
+        }
+        if (!needsPreHeader)
+            continue;
+
+        BasicBlock* preHeader = insertionSet.insertBefore(header, header->frequency());
+        preHeader->append(Jump, header->at(0).origin);
+        preHeader->setSuccessors(FrequentedBlock(header));
+        for (BasicBlock* pred : entryPreds) {
+            for (BasicBlock*& target : pred->successorBlocks()) {
+                if (target == header)
+                    target = preHeader;
+            }
+            preHeader->addPredecessor(pred);
+            header->removePredecessor(pred);
+        }
+        header->addPredecessor(preHeader);
+    }
+
+    insertionSet.execute();
+}
+
+} } } // namespace JSC::B3::Air
+
+#endif // ENABLE(B3_JIT)

--- a/Source/JavaScriptCore/b3/air/AirEnsureDedicatedLoopEntryExitBlocks.h
+++ b/Source/JavaScriptCore/b3/air/AirEnsureDedicatedLoopEntryExitBlocks.h
@@ -1,0 +1,52 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if ENABLE(B3_JIT)
+
+namespace JSC { namespace B3 { namespace Air {
+
+class Code;
+
+// Ensures every natural loop has dedicated entry and exit blocks so that fixup code
+// (e.g. register transfer shuffles for live range splitting) can be inserted at loop
+// boundaries. Specifically:
+//
+// - Entry: if any non-back-edge predecessor of the loop header has multiple successors
+//   (critical entry edge), all non-back-edge predecessors are redirected through a
+//   dedicated pre-header block.
+//
+// - Exit: if any exit successor has predecessors from outside the loop (mixed
+//   predecessors), all loop predecessors of that exit successor are redirected through
+//   a dedicated exit block.
+//
+// Unneeded blocks (where no fixup was inserted) are cleaned up by simplifyCFG later.
+
+void ensureDedicatedLoopEntryExitBlocks(Code&);
+
+} } } // namespace JSC::B3::Air
+
+#endif // ENABLE(B3_JIT)

--- a/Source/JavaScriptCore/b3/air/AirRegisterAllocatorStats.h
+++ b/Source/JavaScriptCore/b3/air/AirRegisterAllocatorStats.h
@@ -60,6 +60,11 @@ namespace JSC { namespace B3 { namespace Air {
     macro(numSplitIntraBlockClusterTmpsSpilled) \
     macro(numSplitIntraBlockLoad)               \
     macro(numSplitIntraBlockStore)              \
+    macro(numSplitAroundLoop)                   \
+    macro(numSplitAroundLoopBothSpilled)        \
+    macro(numSplitAroundLoopLoopSpilled)        \
+    macro(numSplitAroundLoopNonLoopSpilled)     \
+    macro(numSplitAroundLoopZeroCostSpilled)    \
     macro(numGroupTmpsCoalesced)                \
     macro(numGroupsCreated)                     \
     macro(numGroupMovesCoalesced)               \

--- a/Source/JavaScriptCore/b3/air/testair.cpp
+++ b/Source/JavaScriptCore/b3/air/testair.cpp
@@ -46,6 +46,7 @@
 #include <wtf/DataLog.h>
 #include <wtf/Lock.h>
 #include <wtf/NumberOfCores.h>
+#include <wtf/SetForScope.h>
 #include <wtf/StdMap.h>
 #include <wtf/Threading.h>
 #include <wtf/WTFProcess.h>
@@ -2960,6 +2961,325 @@ void testStorePairClobberMemoryLoad()
 #endif
 #endif
 
+// Test loop-aware live range splitting.
+// Fast tmps create register pressure to steer which side spills.
+// 18 of 32 combinations tested (excludes infeasible and redundant cases).
+template<bool nonLoopSpilled, bool loopSpilled, bool hasDef, bool liveAtHeader, bool liveAtExit>
+void testSplitAroundLoop()
+{
+    unsigned numRegs = 8;
+    unsigned numAcrossLoopTmps = 4;
+
+    // Fast tmps steer which side spills by consuming registers in specific regions.
+    unsigned numFastTmpsOutsideLoop = 0;
+    unsigned numFastTmpsInsideLoop = 0;
+
+    if (nonLoopSpilled)
+        numFastTmpsOutsideLoop = numRegs - 1;
+    if (loopSpilled)
+        numFastTmpsInsideLoop = numRegs - 1;
+
+    B3::Procedure proc;
+    Code& code = proc.code();
+
+    {
+        Vector<Reg> allRegs = code.regsInPriorityOrder(GP);
+        for (size_t i = numRegs; i < allRegs.size(); ++i)
+            code.pinRegister(allRegs[i]);
+    }
+
+    BasicBlock* root = code.addBlock();
+    BasicBlock* header = code.addBlock(10.0);
+    BasicBlock* body = code.addBlock(10.0);
+    BasicBlock* exit = code.addBlock();
+
+    Vector<Tmp> tmps;
+    for (unsigned i = 0; i < numAcrossLoopTmps; ++i)
+        tmps.append(code.newTmp(GP));
+
+    Vector<Tmp> fastTmpsOutside;
+    for (unsigned i = 0; i < numFastTmpsOutsideLoop; ++i) {
+        Tmp ft = code.newTmp(GP);
+        code.addFastTmp(ft);
+        fastTmpsOutside.append(ft);
+    }
+    Vector<Tmp> fastTmpsInside;
+    for (unsigned i = 0; i < numFastTmpsInsideLoop; ++i) {
+        Tmp ft = code.newTmp(GP);
+        code.addFastTmp(ft);
+        fastTmpsInside.append(ft);
+    }
+
+    Tmp counter = code.newTmp(GP);
+    Tmp sum = code.newTmp(GP);
+
+    // Root: define tmps, optional pre-loop use, fast tmps, counter.
+    root->append(Move, nullptr, Arg::imm(0), sum);
+    for (unsigned i = 0; i < numAcrossLoopTmps; ++i)
+        loadConstant(root, static_cast<intptr_t>(i + 1), tmps[i]);
+    if (!liveAtHeader) {
+        // Pre-loop use creates a separate range not connected to the loop.
+        for (unsigned i = 0; i < numAcrossLoopTmps; ++i)
+            root->append(Add64, nullptr, tmps[i], sum);
+    }
+    for (unsigned i = 0; i < numFastTmpsOutsideLoop; ++i)
+        loadConstant(root, static_cast<intptr_t>(100 + i), fastTmpsOutside[i]);
+    for (unsigned i = 0; i < numFastTmpsOutsideLoop; ++i)
+        root->append(Add64, nullptr, fastTmpsOutside[i], sum);
+    loadConstant(root, static_cast<intptr_t>(5), counter);
+    root->append(Jump, nullptr);
+    root->setSuccessors(header);
+
+    // Header: branch to body or exit.
+    header->append(Branch32, nullptr, Arg::relCond(MacroAssembler::GreaterThan), counter, Arg::imm(0));
+    header->setSuccessors(body, exit);
+
+    // Body: fast tmps, optional fresh def, read tmps, optional modify, decrement.
+    for (unsigned i = 0; i < numFastTmpsInsideLoop; ++i)
+        body->append(Move, nullptr, counter, fastTmpsInside[i]);
+
+    if (!liveAtHeader) {
+        // Fresh def not connected to pre-loop range.
+        for (unsigned i = 0; i < numAcrossLoopTmps; ++i) {
+            body->append(Move, nullptr, counter, tmps[i]);
+            body->append(Add64, nullptr, Arg::imm(i + 1), tmps[i]);
+        }
+    }
+
+    for (unsigned i = 0; i < numAcrossLoopTmps; ++i)
+        body->append(Add64, nullptr, tmps[i], sum);
+
+    if (hasDef) {
+        for (unsigned i = 0; i < numAcrossLoopTmps; ++i)
+            body->append(Add64, nullptr, counter, tmps[i]);
+    }
+
+    for (unsigned i = 0; i < numFastTmpsInsideLoop; ++i)
+        body->append(Add64, nullptr, fastTmpsInside[i], sum);
+
+    body->append(Sub32, nullptr, Arg::imm(1), counter);
+    body->append(Jump, nullptr);
+    body->setSuccessors(header);
+
+    // Exit: optional redef, read tmps, fast tmps, return sum.
+    if (!liveAtExit) {
+        // Post-loop redef creates a separate range not connected to the loop.
+        for (unsigned i = 0; i < numAcrossLoopTmps; ++i)
+            loadConstant(exit, static_cast<intptr_t>(i + 1), tmps[i]);
+    }
+    for (unsigned i = 0; i < numAcrossLoopTmps; ++i)
+        exit->append(Add64, nullptr, tmps[i], sum);
+    for (unsigned i = 0; i < numFastTmpsOutsideLoop; ++i)
+        loadConstant(exit, static_cast<intptr_t>(200 + i), fastTmpsOutside[i]);
+    for (unsigned i = 0; i < numFastTmpsOutsideLoop; ++i)
+        exit->append(Add64, nullptr, fastTmpsOutside[i], sum);
+    exit->append(Move, nullptr, sum, Tmp(GPRInfo::returnValueGPR));
+    exit->append(Ret64, nullptr, Tmp(GPRInfo::returnValueGPR));
+
+    // Compute expected result.
+    int64_t expected = 0;
+
+    for (unsigned i = 0; i < numFastTmpsOutsideLoop; ++i)
+        expected += static_cast<int64_t>(100 + i);
+
+    if (!liveAtHeader) {
+        for (unsigned i = 0; i < numAcrossLoopTmps; ++i)
+            expected += static_cast<int64_t>(i + 1);
+    }
+
+    {
+        int64_t tmpVals[4];
+        for (unsigned i = 0; i < numAcrossLoopTmps; ++i)
+            tmpVals[i] = static_cast<int64_t>(i + 1);
+
+        for (int c = 5; c >= 1; --c) {
+            if (!liveAtHeader) {
+                for (unsigned i = 0; i < numAcrossLoopTmps; ++i)
+                    tmpVals[i] = c + static_cast<int64_t>(i + 1);
+            }
+            for (unsigned i = 0; i < numAcrossLoopTmps; ++i)
+                expected += tmpVals[i];
+            if (hasDef) {
+                for (unsigned i = 0; i < numAcrossLoopTmps; ++i)
+                    tmpVals[i] += c;
+            }
+            for (unsigned i = 0; i < numFastTmpsInsideLoop; ++i)
+                expected += c;
+        }
+
+        if (liveAtExit) {
+            for (unsigned i = 0; i < numAcrossLoopTmps; ++i)
+                expected += tmpVals[i];
+        }
+    }
+
+    if (!liveAtExit) {
+        for (unsigned i = 0; i < numAcrossLoopTmps; ++i)
+            expected += static_cast<int64_t>(i + 1);
+    }
+
+    for (unsigned i = 0; i < numFastTmpsOutsideLoop; ++i)
+        expected += static_cast<int64_t>(200 + i);
+
+    auto runResult = compileAndRun<int64_t>(proc);
+    CHECK(runResult == expected);
+}
+
+void testSplitAroundLoopNoInLoopUses()
+{
+    // Tmps defined before loop, not used inside, used after. loopTmp has zero cost and spills.
+    B3::Procedure proc;
+    Code& code = proc.code();
+
+    unsigned numRegs = 8;
+    unsigned numAcrossLoopTmps = 4;
+    unsigned numFastTmpsInsideLoop = numRegs - 1;
+
+    {
+        Vector<Reg> allRegs = code.regsInPriorityOrder(GP);
+        for (size_t i = numRegs; i < allRegs.size(); ++i)
+            code.pinRegister(allRegs[i]);
+    }
+
+    BasicBlock* root = code.addBlock();
+    BasicBlock* header = code.addBlock(10.0);
+    BasicBlock* body = code.addBlock(10.0);
+    BasicBlock* exit = code.addBlock();
+
+    Vector<Tmp> tmps;
+    for (unsigned i = 0; i < numAcrossLoopTmps; ++i) {
+        Tmp tmp = code.newTmp(GP);
+        tmps.append(tmp);
+        loadConstant(root, static_cast<intptr_t>(i + 1), tmp);
+    }
+
+    Vector<Tmp> fastTmpsInside;
+    for (unsigned i = 0; i < numFastTmpsInsideLoop; ++i) {
+        Tmp ft = code.newTmp(GP);
+        code.addFastTmp(ft);
+        fastTmpsInside.append(ft);
+    }
+
+    Tmp counter = code.newTmp(GP);
+    Tmp sum = code.newTmp(GP);
+    root->append(Move, nullptr, Arg::imm(0), sum);
+    loadConstant(root, static_cast<intptr_t>(5), counter);
+    root->append(Jump, nullptr);
+    root->setSuccessors(header);
+
+    header->append(Branch32, nullptr, Arg::relCond(MacroAssembler::GreaterThan), counter, Arg::imm(0));
+    header->setSuccessors(body, exit);
+
+    for (unsigned i = 0; i < numFastTmpsInsideLoop; ++i)
+        body->append(Move, nullptr, counter, fastTmpsInside[i]);
+    for (unsigned i = 0; i < numFastTmpsInsideLoop; ++i)
+        body->append(Add64, nullptr, fastTmpsInside[i], sum);
+    body->append(Sub32, nullptr, Arg::imm(1), counter);
+    body->append(Jump, nullptr);
+    body->setSuccessors(header);
+
+    for (unsigned i = 0; i < numAcrossLoopTmps; ++i)
+        exit->append(Add64, nullptr, tmps[i], sum);
+    exit->append(Move, nullptr, sum, Tmp(GPRInfo::returnValueGPR));
+    exit->append(Ret64, nullptr, Tmp(GPRInfo::returnValueGPR));
+
+    // 7*(5+4+3+2+1) + (1+2+3+4) = 105 + 10 = 115
+    CHECK(compileAndRun<int64_t>(proc) == 115);
+}
+
+template<bool criticalEntry>
+void testSplitAroundLoopCriticalEdge()
+{
+    // criticalEntry=true: root→header AND root→altExit (critical entry edge).
+    // criticalEntry=false: exit has predecessors from both loop and non-loop (critical exit edge).
+    // Loop splitting is prevented by the critical edge; verify correctness without it.
+
+    B3::Procedure proc;
+    Code& code = proc.code();
+
+    unsigned numRegs = 8;
+    unsigned numAcrossLoopTmps = 4;
+    unsigned numFastTmps = numRegs - 1;
+
+    {
+        Vector<Reg> allRegs = code.regsInPriorityOrder(GP);
+        for (size_t i = numRegs; i < allRegs.size(); ++i)
+            code.pinRegister(allRegs[i]);
+    }
+
+    BasicBlock* root = code.addBlock();
+    BasicBlock* header = code.addBlock(10.0);
+    BasicBlock* body = code.addBlock(10.0);
+    BasicBlock* exit = code.addBlock();
+
+    Vector<Tmp> tmps;
+    for (unsigned i = 0; i < numAcrossLoopTmps; ++i) {
+        Tmp tmp = code.newTmp(GP);
+        tmps.append(tmp);
+        loadConstant(root, static_cast<intptr_t>(i + 1), tmp);
+    }
+
+    Vector<Tmp> fastTmps;
+    for (unsigned i = 0; i < numFastTmps; ++i) {
+        Tmp ft = code.newTmp(GP);
+        code.addFastTmp(ft);
+        fastTmps.append(ft);
+        loadConstant(root, static_cast<intptr_t>(100 + i), ft);
+    }
+
+    Tmp counter = code.newTmp(GP);
+    Tmp arg = code.newTmp(GP);
+    Tmp sum = code.newTmp(GP);
+    root->append(Move, nullptr, Arg::imm(0), sum);
+    for (unsigned i = 0; i < numFastTmps; ++i)
+        root->append(Add64, nullptr, fastTmps[i], sum);
+    root->append(Move, nullptr, Tmp(GPRInfo::argumentGPR0), arg);
+    loadConstant(root, static_cast<intptr_t>(5), counter);
+
+    if (criticalEntry) {
+        // root→header AND root→altExit: critical entry edge.
+        BasicBlock* altExit = code.addBlock();
+        root->append(Branch32, nullptr, Arg::relCond(MacroAssembler::GreaterThan), arg, Arg::imm(0));
+        root->setSuccessors(header, altExit);
+        altExit->append(Move, nullptr, Arg::imm(0), Tmp(GPRInfo::returnValueGPR));
+        for (unsigned i = 0; i < numAcrossLoopTmps; ++i)
+            altExit->append(Add64, nullptr, tmps[i], Tmp(GPRInfo::returnValueGPR));
+        altExit->append(Ret64, nullptr, Tmp(GPRInfo::returnValueGPR));
+    } else {
+        // root→preheader→header, root→exit: exit has non-loop predecessor.
+        BasicBlock* preheader = code.addBlock();
+        root->append(Branch32, nullptr, Arg::relCond(MacroAssembler::GreaterThan), arg, Arg::imm(0));
+        root->setSuccessors(preheader, exit);
+        preheader->append(Jump, nullptr);
+        preheader->setSuccessors(header);
+    }
+
+    header->append(Branch32, nullptr, Arg::relCond(MacroAssembler::GreaterThan), counter, Arg::imm(0));
+    header->setSuccessors(body, exit);
+
+    for (unsigned i = 0; i < numAcrossLoopTmps; ++i)
+        body->append(Add64, nullptr, tmps[i], sum);
+    body->append(Sub32, nullptr, Arg::imm(1), counter);
+    body->append(Jump, nullptr);
+    body->setSuccessors(header);
+
+    for (unsigned i = 0; i < numFastTmps; ++i)
+        loadConstant(exit, static_cast<intptr_t>(200 + i), fastTmps[i]);
+    for (unsigned i = 0; i < numFastTmps; ++i)
+        exit->append(Add64, nullptr, fastTmps[i], sum);
+
+    for (unsigned i = 0; i < numAcrossLoopTmps; ++i)
+        exit->append(Add64, nullptr, tmps[i], sum);
+    exit->append(Move, nullptr, sum, Tmp(GPRInfo::returnValueGPR));
+    exit->append(Ret64, nullptr, Tmp(GPRInfo::returnValueGPR));
+
+    // arg=1: 721 (pre fast) + 50 (loop) + 10 (tmps) + 1421 (post fast) = 2202
+    // arg=0: altExit returns 10, or exit returns 2152 (no loop iterations)
+    auto compilation = compile(proc);
+    CHECK(invoke<int64_t>(*compilation, static_cast<int64_t>(1)) == 2202);
+    CHECK(invoke<int64_t>(*compilation, static_cast<int64_t>(0)) == (criticalEntry ? 10 : 2152));
+}
+
 #define PREFIX "O", Options::defaultB3OptLevel(), ": "
 
 #define RUN(test) do {                                 \
@@ -2981,6 +3301,38 @@ void run(const char* filter)
     auto shouldRun = [&] (const char* testName) -> bool {
         return !filter || WTF::findIgnoringASCIICaseWithoutLength(testName, filter) != WTF::notFound;
     };
+
+    auto dispatchTasks = [&] {
+        Lock lock;
+
+        Vector<Ref<Thread>> threads;
+        for (unsigned i = filter ? 1 : WTF::numberOfProcessorCores(); i--;) {
+            threads.append(
+                Thread::create(
+                    "testair thread"_s,
+                    [&] () {
+                        for (;;) {
+                            RefPtr<SharedTask<void()>> task;
+                            {
+                                Locker locker { lock };
+                                if (tasks.isEmpty())
+                                    return;
+                                task = tasks.takeFirst();
+                            }
+#if USE(PROTECTED_JIT)
+                            // Must be constructed before we allocate anything using SequesteredArenaMalloc
+                            ArenaLifetime arenaLifetime;
+#endif
+                            task->run();
+                        }
+                    }));
+        }
+
+        for (auto& thread : threads)
+            thread->waitForCompletion();
+    };
+
+    bool anyTestsScheduled = false;
 
     RUN(testSimple());
 
@@ -3088,36 +3440,50 @@ void run(const char* filter)
 #endif
 #endif
 
-    if (tasks.isEmpty())
-        usage();
-
-    Lock lock;
-
-    Vector<Ref<Thread>> threads;
-    for (unsigned i = filter ? 1 : WTF::numberOfProcessorCores(); i--;) {
-        threads.append(
-            Thread::create(
-                "testair thread"_s,
-                [&] () {
-                    for (;;) {
-                        RefPtr<SharedTask<void()>> task;
-                        {
-                            Locker locker { lock };
-                            if (tasks.isEmpty())
-                                return;
-                            task = tasks.takeFirst();
-                        }
-#if USE(PROTECTED_JIT)
-                        // Must be constructed before we allocate anything using SequesteredArenaMalloc
-                        ArenaLifetime arenaLifetime;
-#endif
-                        task->run();
-                    }
-                }));
+    if (!tasks.isEmpty()) {
+        anyTestsScheduled = true;
+        dispatchTasks();
     }
 
-    for (auto& thread : threads)
-        thread->waitForCompletion();
+    // Batch 2: loop-aware live range splitting enabled.
+    {
+        SetForScope splitAroundLoopsScope(Options::airGreedyRegAllocSplitAroundLoops(), true);
+        SetForScope loopFractionScope(Options::airGreedyRegAllocLoopSplitMaxLoopFraction(), 1.0);
+
+        // testSplitAroundLoop<nonLoopSpilled, loopSpilled, hasDef, liveAtHeader, liveAtExit>()
+        RUN((testSplitAroundLoop<false, true,  false, true,  true>()));
+        RUN((testSplitAroundLoop<false, true,  true,  true,  true>()));
+        RUN((testSplitAroundLoop<false, true,  false, true,  false>()));
+        RUN((testSplitAroundLoop<false, true,  true,  true,  false>()));
+        RUN((testSplitAroundLoop<false, false, false, true,  true>()));
+        RUN((testSplitAroundLoop<false, false, true,  true,  true>()));
+        RUN((testSplitAroundLoop<false, false, false, true,  false>()));
+        RUN((testSplitAroundLoop<false, false, true,  true,  false>()));
+        RUN((testSplitAroundLoop<true,  false, false, true,  true>()));
+        RUN((testSplitAroundLoop<true,  false, true,  true,  true>()));
+        RUN((testSplitAroundLoop<true,  false, false, true,  false>()));
+        RUN((testSplitAroundLoop<true,  false, true,  true,  false>()));
+        RUN((testSplitAroundLoop<false, true,  true,  false, true>()));
+        RUN((testSplitAroundLoop<false, true,  true,  false, false>()));
+        RUN((testSplitAroundLoop<false, false, true,  false, true>()));
+        RUN((testSplitAroundLoop<false, false, true,  false, false>()));
+        RUN((testSplitAroundLoop<true,  false, true,  false, true>()));
+        RUN((testSplitAroundLoop<true,  true,  true,  true,  true>()));
+
+        // Loop-aware splitting: standalone tests.
+        RUN(testSplitAroundLoopNoInLoopUses());
+        RUN((testSplitAroundLoopCriticalEdge<true>()));
+        RUN((testSplitAroundLoopCriticalEdge<false>()));
+
+        if (!tasks.isEmpty()) {
+            anyTestsScheduled = true;
+            dispatchTasks();
+        }
+    }
+
+    if (!anyTestsScheduled)
+        usage();
+
     crashLock.lock();
     crashLock.unlock();
 }

--- a/Source/JavaScriptCore/runtime/OptionsList.h
+++ b/Source/JavaScriptCore/runtime/OptionsList.h
@@ -512,6 +512,8 @@ bool hasCapacityToUseLargeGigacage();
     v(OptionString, airGreedyRegAllocDumpFunction, nullptr, Normal, "dump greedy register allocator state and IR for functions matching this substring"_s) \
     v(Bool, airUseGreedyRegAlloc, true, Normal, nullptr) \
     v(Double, airGreedyRegAllocSplitMultiplier, 2.0, Normal, nullptr) \
+    v(Bool, airGreedyRegAllocSplitAroundLoops, false, Normal, nullptr) \
+    v(Double, airGreedyRegAllocLoopSplitMaxLoopFraction, 0.75, Normal, nullptr) \
     v(Bool, airGreedyRegAllocSpillsEverything, false, Normal, nullptr) \
     v(Bool, airDumpPhaseStats, false, Normal, nullptr) \
     v(Bool, airValidateGreedRegAlloc, ASSERT_ENABLED, Normal, nullptr) \


### PR DESCRIPTION
#### 899099b0cc049f98cb5be085e0e1b82a7533c4c0
<pre>
[JSC] GreedyRegAlloc: Add loop-aware live range splitting (disabled by default)
<a href="https://bugs.webkit.org/show_bug.cgi?id=312905">https://bugs.webkit.org/show_bug.cgi?id=312905</a>
<a href="https://rdar.apple.com/175260380">rdar://175260380</a>

Reviewed by Keith Miller.

Add loop-aware live range splitting to the greedy register allocator.
When a tmp&apos;s live range crosses a loop boundary, split it into a loop
portion and a non-loop portion. This allows the two portions to be
allocated independently, reducing interference between the loop body
and the surrounding code. For example, a tmp live across a loop but
unused inside it can be split so that the loop portion is spilled,
freeing a register for the loop body. Similarly, a tmp that conflicts
with others outside the loop may get a register inside it after
splitting.

A new CFG normalization pass (ensureDedicatedLoopEntryExitBlocks)
ensures non-critical entry edges and dedicated exit blocks so that
fixup code can be safely inserted at loop boundaries. Entry/exit
fixups use Shuffle instructions to handle potential register cycles
when multiple tmps are split around the same loop.

The feature is off by default (airGreedyRegAllocSplitAroundLoops).
The mechanism is working and passes tests, but improvements to the
splitting policy and integration with the allocator&apos;s priority-driven
allocation order are needed to realize the potential.

Test: Source/JavaScriptCore/b3/air/testair.cpp
      JSTests/stress/regalloc-loop-splitting.js

* JSTests/stress/regalloc-loop-splitting.js: Added.
(clobber):
(test):
* Source/JavaScriptCore/JavaScriptCore.xcodeproj/project.pbxproj:
* Source/JavaScriptCore/Sources.txt:
* Source/JavaScriptCore/b3/air/AirAllocateRegistersByGreedy.cpp:
(JSC::B3::Air::Greedy::Cost::subtractSaturating):
(JSC::B3::Air::Greedy::LiveRange::contains const):
(JSC::B3::Air::Greedy::LiveRange::overlaps const):
(JSC::B3::Air::Greedy::AroundLoopSplitMetadata::AroundLoopSplitMetadata):
(JSC::B3::Air::Greedy::AroundLoopSplitMetadata::dump const):
(JSC::B3::Air::Greedy::GreedyAllocator::dump const):
(JSC::B3::Air::Greedy::GreedyAllocator::forEachBlockInLiveRange):
(JSC::B3::Air::Greedy::GreedyAllocator::findBlockIndexContainingPoint):
(JSC::B3::Air::Greedy::GreedyAllocator::findBlockContainingPoint):
(JSC::B3::Air::Greedy::GreedyAllocator::rewriteCoalescedTmps):
(JSC::B3::Air::Greedy::GreedyAllocator::addSplitTmp):
(JSC::B3::Air::Greedy::GreedyAllocator::trySplit):
(JSC::B3::Air::Greedy::GreedyAllocator::analyzeLoop):
(JSC::B3::Air::Greedy::GreedyAllocator::ensureLoopAnalysis):
(JSC::B3::Air::Greedy::GreedyAllocator::chooseLoopForSplit):
(JSC::B3::Air::Greedy::GreedyAllocator::trySplitAroundLoop):
(JSC::B3::Air::Greedy::GreedyAllocator::trySplitAroundClobbers):
(JSC::B3::Air::Greedy::GreedyAllocator::insertFixupCode):
(JSC::B3::Air::Greedy::GreedyAllocator::insertSplitAroundLoopFixupCode):
(JSC::B3::Air::allocateRegistersByGreedy):
(JSC::B3::Air::Greedy::LiveRange::overlaps): Deleted.
* Source/JavaScriptCore/b3/air/AirCode.cpp:
* Source/JavaScriptCore/b3/air/AirCode.h:
* Source/JavaScriptCore/b3/air/AirEnsureDedicatedLoopEntryExitBlocks.cpp: Added.
(JSC::B3::Air::ensureDedicatedLoopEntryExitBlocks):
* Source/JavaScriptCore/b3/air/AirEnsureDedicatedLoopEntryExitBlocks.h: Added.
* Source/JavaScriptCore/b3/air/AirRegisterAllocatorStats.h:
* Source/JavaScriptCore/b3/air/testair.cpp:
* Source/JavaScriptCore/runtime/OptionsList.h:

Canonical link: <a href="https://commits.webkit.org/312693@main">https://commits.webkit.org/312693@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d5fd1d56a244bb9e67c0ab3bac42f51c5627f1f6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/160587 "2 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/34060 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/27161 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/169490 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/115653 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/fc112cb4-0fab-448e-91cf-75dc9dcb255a) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/34161 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/34060 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/124539 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/87947 "1 flakes 1 failures") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/567fa7a1-2df8-4ec5-8a4a-9b3b06adb84d) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/163546 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/26787 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/144256 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/105139 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/75b0e840-f58e-4829-ba71-bf6a50b4d7c1) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/25839 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/24338 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/17210 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/152643 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/135533 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/22019 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/172045 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/21424 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/18829 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/23659 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/132869 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/33734 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/28431 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/132882 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/33718 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/143814 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/95522 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/24467 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/27414 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/20628 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/192986 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/33229 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/100432 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/49696 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/32728 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/32972 "Built successfully") | | | | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/32876 "Build is in progress. Recent messages:OS: Tahoe (26.2), Xcode: 26.2; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (warnings)") | | | | 
<!--EWS-Status-Bubble-End-->