### PR TITLE
[JSC] test 262 fail: test/staging/sm/TypedArray/constructor-buffer-sequence.js

### DIFF
--- a/JSTests/stress/typedarray-constructor-allocatetypedarray-before-isdetachedbuffer-prototype-getter-detach.js
+++ b/JSTests/stress/typedarray-constructor-allocatetypedarray-before-isdetachedbuffer-prototype-getter-detach.js
@@ -1,0 +1,78 @@
+// The original is https://github.com/tc39/test262/blob/d0c1b4555b03dd404873fd6422a4b5da00136500/test/staging/sm/TypedArray/constructor-buffer-sequence.js
+
+function shouldThrow(caseName, fn, expectedErrorCtor, expectedErrorMessage) {
+    if (!caseName)
+        throw new Error(`must specify test case name`);
+
+    const expected = `${expectedErrorCtor.name}(${expectedErrorMessage})`;
+    try {
+        fn();
+        throw new Error(`${caseName}: Expected to throw ${expected}, but succeeded`);
+    } catch (e) {
+        const actual = `${e.name}(${e.message})`;
+        if (!(e instanceof expectedErrorCtor) || e.message !== expectedErrorMessage)
+            throw new Error(`${caseName}: Expected ${expected} but got ${actual}`);
+    }
+}
+
+const otherGlobal = $.createRealm().global;
+
+function* createBuffers(lengths = [0, 8]) {
+    for (const length of lengths) {
+        const buffer = new ArrayBuffer(length);
+        yield {
+            buffer,
+            detach: () => $.detachArrayBuffer(buffer),
+        };
+    }
+
+    for (const length of lengths) {
+        const buffer = new otherGlobal.ArrayBuffer(length);
+        yield {
+            buffer,
+            detach: () => otherGlobal.$.detachArrayBuffer(buffer),
+        };
+    }
+}
+
+class ExpectedError extends Error { }
+
+function ConstructorWithThrowingPrototype(detach) {
+    return Object.defineProperty(function () { }.bind(null), "prototype", {
+        get() {
+            if (detach)
+                detach();
+            throw new ExpectedError();
+        }
+    });
+}
+
+const TEST_TARGET = [
+    BigInt64Array,
+    BigUint64Array,
+    Float16Array,
+    Float32Array,
+    Float64Array,
+    Int16Array,
+    Int32Array,
+    Int8Array,
+    Uint16Array,
+    Uint32Array,
+    Uint8Array,
+    Uint8ClampedArray,
+];
+
+for (const Ctor of TEST_TARGET) {
+    const label = Ctor.name;
+
+    for (const { buffer, detach } of createBuffers()) {
+        // the step 7-a |AllocateTypedArray| of https://tc39.es/ecma262/2026/#sec-typedarray
+        // should be executed before the step 6 |IsDetachedBuffer(buffer)| of https://tc39.es/ecma262/2026/#sec-initializetypedarrayfromarraybuffer
+        //
+        // Variant: if the buffer is detached in |AllocateTypedArray|.
+        const constructor = ConstructorWithThrowingPrototype(detach);
+        shouldThrow(label, () => {
+            Reflect.construct(Ctor, [buffer, 0, 0], constructor);
+        }, ExpectedError, '');
+    }
+}

--- a/JSTests/stress/typedarray-constructor-allocatetypedarray-before-isdetachedbuffer.js
+++ b/JSTests/stress/typedarray-constructor-allocatetypedarray-before-isdetachedbuffer.js
@@ -1,0 +1,76 @@
+// The original is https://github.com/tc39/test262/blob/d0c1b4555b03dd404873fd6422a4b5da00136500/test/staging/sm/TypedArray/constructor-buffer-sequence.js
+
+function shouldThrow(caseName, fn, expectedErrorCtor, expectedErrorMessage) {
+    if (!caseName)
+        throw new Error(`must specify test case name`);
+
+    const expected = `${expectedErrorCtor.name}(${expectedErrorMessage})`;
+    try {
+        fn();
+        throw new Error(`${caseName}: Expected to throw ${expected}, but succeeded`);
+    } catch (e) {
+        const actual = `${e.name}(${e.message})`;
+        if (!(e instanceof expectedErrorCtor) || e.message !== expectedErrorMessage)
+            throw new Error(`${caseName}: Expected ${expected} but got ${actual}`);
+    }
+}
+
+const otherGlobal = $.createRealm().global;
+
+function* createBuffers(lengths = [0, 8]) {
+    for (const length of lengths) {
+        const buffer = new ArrayBuffer(length);
+        yield {
+            buffer,
+            detach: () => $.detachArrayBuffer(buffer),
+        };
+    }
+
+    for (const length of lengths) {
+        const buffer = new otherGlobal.ArrayBuffer(length);
+        yield {
+            buffer,
+            detach: () => otherGlobal.$.detachArrayBuffer(buffer),
+        };
+    }
+}
+
+class ExpectedError extends Error { }
+
+function ConstructorWithThrowingPrototype(detach) {
+    return Object.defineProperty(function () { }.bind(null), "prototype", {
+        get() {
+            if (detach)
+                detach();
+            throw new ExpectedError();
+        }
+    });
+}
+
+const TEST_TARGET = [
+    BigInt64Array,
+    BigUint64Array,
+    Float16Array,
+    Float32Array,
+    Float64Array,
+    Int16Array,
+    Int32Array,
+    Int8Array,
+    Uint16Array,
+    Uint32Array,
+    Uint8Array,
+    Uint8ClampedArray,
+];
+
+for (const Ctor of TEST_TARGET) {
+    const label = Ctor.name;
+
+    for (const { buffer } of createBuffers()) {
+        // the step 7-a |AllocateTypedArray| of https://tc39.es/ecma262/2026/#sec-typedarray
+        // should be executed before the step 6 |IsDetachedBuffer(buffer)| of https://tc39.es/ecma262/2026/#sec-initializetypedarrayfromarraybuffer
+        const constructor = ConstructorWithThrowingPrototype();
+        shouldThrow(label, () => {
+            Reflect.construct(Ctor, [buffer, 0, 0], constructor);
+        }, ExpectedError, '');
+    }
+}

--- a/JSTests/stress/typedarray-constructor-allocatetypedarray-before-toindex-byteoffset.js
+++ b/JSTests/stress/typedarray-constructor-allocatetypedarray-before-toindex-byteoffset.js
@@ -1,0 +1,84 @@
+// The original is https://github.com/tc39/test262/blob/d0c1b4555b03dd404873fd6422a4b5da00136500/test/staging/sm/TypedArray/constructor-buffer-sequence.js
+
+function shouldThrow(caseName, fn, expectedErrorCtor, expectedErrorMessage) {
+    if (!caseName)
+        throw new Error(`must specify test case name`);
+
+    const expected = `${expectedErrorCtor.name}(${expectedErrorMessage})`;
+    try {
+        fn();
+        throw new Error(`${caseName}: Expected to throw ${expected}, but succeeded`);
+    } catch (e) {
+        const actual = `${e.name}(${e.message})`;
+        if (!(e instanceof expectedErrorCtor) || e.message !== expectedErrorMessage)
+            throw new Error(`${caseName}: Expected ${expected} but got ${actual}`);
+    }
+}
+
+const otherGlobal = $.createRealm().global;
+
+function* createBuffers(lengths = [0, 8]) {
+    for (const length of lengths) {
+        const buffer = new ArrayBuffer(length);
+        yield {
+            buffer,
+            detach: () => $.detachArrayBuffer(buffer),
+        };
+    }
+
+    for (const length of lengths) {
+        const buffer = new otherGlobal.ArrayBuffer(length);
+        yield {
+            buffer,
+            detach: () => otherGlobal.$.detachArrayBuffer(buffer),
+        };
+    }
+}
+
+const poisonedValue = new Proxy({}, new Proxy({}, {
+    get() {
+        // Throws an exception when any proxy trap is invoked.
+        throw new Error("Poisoned Value");
+    }
+}));
+
+class ExpectedError extends Error { }
+
+function ConstructorWithThrowingPrototype(detach) {
+    return Object.defineProperty(function () { }.bind(null), "prototype", {
+        get() {
+            if (detach)
+                detach();
+            throw new ExpectedError();
+        }
+    });
+}
+
+const TEST_TARGET = [
+    BigInt64Array,
+    BigUint64Array,
+    Float16Array,
+    Float32Array,
+    Float64Array,
+    Int16Array,
+    Int32Array,
+    Int8Array,
+    Uint16Array,
+    Uint32Array,
+    Uint8Array,
+    Uint8ClampedArray,
+];
+
+for (const Ctor of TEST_TARGET) {
+    const label = Ctor.name;
+
+    for (const { buffer } of createBuffers()) {
+        const constructor = ConstructorWithThrowingPrototype();
+
+        // the step 7-a |AllocateTypedArray| of https://tc39.es/ecma262/2026/#sec-typedarray
+        // should be executed before the step 2 |ToIndex(byteOffset)| of https://tc39.es/ecma262/2026/#sec-initializetypedarrayfromarraybuffer
+        shouldThrow(label, () => {
+            Reflect.construct(Ctor, [buffer, poisonedValue, 0], constructor);
+        }, ExpectedError, '');
+    }
+}

--- a/JSTests/stress/typedarray-constructor-allocatetypedarray-before-toindex-length.js
+++ b/JSTests/stress/typedarray-constructor-allocatetypedarray-before-toindex-length.js
@@ -1,0 +1,84 @@
+// The original is https://github.com/tc39/test262/blob/d0c1b4555b03dd404873fd6422a4b5da00136500/test/staging/sm/TypedArray/constructor-buffer-sequence.js
+
+function shouldThrow(caseName, fn, expectedErrorCtor, expectedErrorMessage) {
+    if (!caseName)
+        throw new Error(`must specify test case name`);
+
+    const expected = `${expectedErrorCtor.name}(${expectedErrorMessage})`;
+    try {
+        fn();
+        throw new Error(`${caseName}: Expected to throw ${expected}, but succeeded`);
+    } catch (e) {
+        const actual = `${e.name}(${e.message})`;
+        if (!(e instanceof expectedErrorCtor) || e.message !== expectedErrorMessage)
+            throw new Error(`${caseName}: Expected ${expected} but got ${actual}`);
+    }
+}
+
+const otherGlobal = $.createRealm().global;
+
+const poisonedValue = new Proxy({}, new Proxy({}, {
+    get() {
+        // Throws an exception when any proxy trap is invoked.
+        throw new Error("Poisoned Value");
+    }
+}));
+
+class ExpectedError extends Error { }
+
+function* createBuffers(lengths = [0, 8]) {
+    for (const length of lengths) {
+        const buffer = new ArrayBuffer(length);
+        yield {
+            buffer,
+            detach: () => $.detachArrayBuffer(buffer),
+        };
+    }
+
+    for (const length of lengths) {
+        const buffer = new otherGlobal.ArrayBuffer(length);
+        yield {
+            buffer,
+            detach: () => otherGlobal.$.detachArrayBuffer(buffer),
+        };
+    }
+}
+
+function ConstructorWithThrowingPrototype(detach) {
+    return Object.defineProperty(function(){}.bind(null), "prototype", {
+        get() {
+            if (detach)
+                detach();
+            throw new ExpectedError();
+        }
+    });
+}
+
+const TEST_TARGET = [
+    BigInt64Array,
+    BigUint64Array,
+    Float16Array,
+    Float32Array,
+    Float64Array,
+    Int16Array,
+    Int32Array,
+    Int8Array,
+    Uint16Array,
+    Uint32Array,
+    Uint8Array,
+    Uint8ClampedArray,
+];
+
+for (const Ctor of TEST_TARGET) {
+    const label = Ctor.name;
+
+    for (const { buffer } of createBuffers()) {
+        const constructor = ConstructorWithThrowingPrototype();
+
+        // the step 7-a |AllocateTypedArray| of https://tc39.es/ecma262/2026/#sec-typedarray
+        // should be executed before the step 5-a |ToIndex(length)| of https://tc39.es/ecma262/2026/#sec-initializetypedarrayfromarraybuffer
+        shouldThrow(label, () => {
+            Reflect.construct(Ctor, [buffer, 0, poisonedValue], constructor)
+        }, ExpectedError, '');
+    }
+}

--- a/JSTests/stress/typedarray-constructor-byteoffset-modulo-elementsize-before-isdetachedbuffer-weird-byteoffset.js
+++ b/JSTests/stress/typedarray-constructor-byteoffset-modulo-elementsize-before-isdetachedbuffer-weird-byteoffset.js
@@ -1,0 +1,86 @@
+// The original is https://github.com/tc39/test262/blob/d0c1b4555b03dd404873fd6422a4b5da00136500/test/staging/sm/TypedArray/constructor-buffer-sequence.js
+
+function assert(ok, message = '') {
+    if (!ok)
+        throw new Error(`Assertion!: ${message}`); 
+}
+
+function shouldThrow(caseName, fn, expectedErrorCtor, expectedErrorMessage) {
+    if (!caseName)
+        throw new Error(`must specify test case name`);
+
+    const expected = `${expectedErrorCtor.name}(${expectedErrorMessage})`;
+    try {
+        fn();
+        throw new Error(`${caseName}: Expected to throw ${expected}, but succeeded`);
+    } catch (e) {
+        const actual = `${e.name}(${e.message})`;
+        if (!(e instanceof expectedErrorCtor) || e.message !== expectedErrorMessage)
+            throw new Error(`${caseName}: Expected ${expected} but got ${actual}`);
+    }
+}
+
+const otherGlobal = $.createRealm().global;
+
+function* createBuffers(lengths = [0, 8]) {
+    for (const length of lengths) {
+        const buffer = new ArrayBuffer(length);
+        yield {
+            buffer,
+            detach: () => $.detachArrayBuffer(buffer),
+        };
+    }
+
+    for (const length of lengths) {
+        const buffer = new otherGlobal.ArrayBuffer(length);
+        yield {
+            buffer,
+            detach: () => otherGlobal.$.detachArrayBuffer(buffer),
+        };
+    }
+}
+
+function ValueReturning(value, detach) {
+    return {
+        valueOf() {
+            if (detach)
+                detach();
+            return value;
+        }
+    };
+}
+
+const TEST_TARGET = [
+    BigInt64Array,
+    BigUint64Array,
+    Float16Array,
+    Float32Array,
+    Float64Array,
+    Int16Array,
+    Int32Array,
+    // Int8Array,
+    Uint16Array,
+    Uint32Array,
+    // Uint8Array,
+    // Uint8ClampedArray,
+];
+
+for (const Ctor of TEST_TARGET) {
+    const label = Ctor.name;
+
+    assert(Ctor.BYTES_PER_ELEMENT !== 1, `${label}: |byteOffset % 1| is always 0. We cannot test what we want to test`);
+
+    for (const { buffer, detach } of createBuffers()) {
+        const byteOffset = ValueReturning(1, detach);
+
+        // https://tc39.es/ecma262/2026/#sec-initializetypedarrayfromarraybuffer
+        //
+        // the step 3 |offset modulo elementSize ≠ 0| should be executed before the step 6 |IsDetachedBuffer(buffer)|.
+        //
+        // Variant: The step 2 |ToIndex(byteOffset)| detach the buffer.
+        shouldThrow(label, () => {
+            new Ctor(buffer, byteOffset, 0);
+        }, RangeError, "byteOffset modulo TypedArray.BYTES_PER_ELEMENT must be 0");
+    }
+}
+

--- a/JSTests/stress/typedarray-constructor-byteoffset-modulo-elementsize-before-isdetachedbuffer.js
+++ b/JSTests/stress/typedarray-constructor-byteoffset-modulo-elementsize-before-isdetachedbuffer.js
@@ -1,0 +1,83 @@
+// The original is https://github.com/tc39/test262/blob/d0c1b4555b03dd404873fd6422a4b5da00136500/test/staging/sm/TypedArray/constructor-buffer-sequence.js
+
+function assert(ok, message = '') {
+    if (!ok)
+        throw new Error(`Assertion!: ${message}`); 
+}
+
+function shouldThrow(caseName, fn, expectedErrorCtor, expectedErrorMessage) {
+    if (!caseName)
+        throw new Error(`must specify test case name`);
+
+    const expected = `${expectedErrorCtor.name}(${expectedErrorMessage})`;
+    try {
+        fn();
+        throw new Error(`${caseName}: Expected to throw ${expected}, but succeeded`);
+    } catch (e) {
+        const actual = `${e.name}(${e.message})`;
+        if (!(e instanceof expectedErrorCtor) || e.message !== expectedErrorMessage)
+            throw new Error(`${caseName}: Expected ${expected} but got ${actual}`);
+    }
+}
+
+const otherGlobal = $.createRealm().global;
+
+function* createBuffers(lengths = [0, 8]) {
+    for (const length of lengths) {
+        const buffer = new ArrayBuffer(length);
+        yield {
+            buffer,
+            detach: () => $.detachArrayBuffer(buffer),
+        };
+    }
+
+    for (const length of lengths) {
+        const buffer = new otherGlobal.ArrayBuffer(length);
+        yield {
+            buffer,
+            detach: () => otherGlobal.$.detachArrayBuffer(buffer),
+        };
+    }
+}
+
+function ValueReturning(value, detach) {
+    return {
+        valueOf() {
+            if (detach)
+                detach();
+            return value;
+        }
+    };
+}
+
+const TEST_TARGET = [
+    BigInt64Array,
+    BigUint64Array,
+    Float16Array,
+    Float32Array,
+    Float64Array,
+    Int16Array,
+    Int32Array,
+    // Int8Array,
+    Uint16Array,
+    Uint32Array,
+    // Uint8Array,
+    // Uint8ClampedArray,
+];
+
+for (const Ctor of TEST_TARGET) {
+    const label = Ctor.name;
+
+    assert(Ctor.BYTES_PER_ELEMENT !== 1, `${label}: |byteOffset % 1| is always 0. We cannot test what we want to test`);
+
+    for (const { buffer, detach } of createBuffers()) {
+        detach();
+
+        // https://tc39.es/ecma262/2026/#sec-initializetypedarrayfromarraybuffer
+        //
+        // the step 3 |offset modulo elementSize ≠ 0| should be executed before the step 6 |IsDetachedBuffer(buffer)|.
+        shouldThrow(label, () => {
+            new Ctor(buffer, 1, 0);
+        }, RangeError, "byteOffset modulo TypedArray.BYTES_PER_ELEMENT must be 0");
+    }
+}

--- a/JSTests/stress/typedarray-constructor-byteoffset-modulo-elementsize-before-toindex-length.js
+++ b/JSTests/stress/typedarray-constructor-byteoffset-modulo-elementsize-before-toindex-length.js
@@ -1,0 +1,78 @@
+// The original is https://github.com/tc39/test262/blob/d0c1b4555b03dd404873fd6422a4b5da00136500/test/staging/sm/TypedArray/constructor-buffer-sequence.js
+
+function assert(ok, message = '') {
+    if (!ok)
+        throw new Error(`Assertion!: ${message}`); 
+}
+
+function shouldThrow(caseName, fn, expectedErrorCtor, expectedErrorMessage) {
+    if (!caseName)
+        throw new Error(`must specify test case name`);
+
+    const expected = `${expectedErrorCtor.name}(${expectedErrorMessage})`;
+    try {
+        fn();
+        throw new Error(`${caseName}: Expected to throw ${expected}, but succeeded`);
+    } catch (e) {
+        const actual = `${e.name}(${e.message})`;
+        if (!(e instanceof expectedErrorCtor) || e.message !== expectedErrorMessage)
+            throw new Error(`${caseName}: Expected ${expected} but got ${actual}`);
+    }
+}
+
+const otherGlobal = $.createRealm().global;
+
+const poisonedValue = new Proxy({}, new Proxy({}, {
+    get() {
+        // Throws an exception when any proxy trap is invoked.
+        throw new Error("Poisoned Value");
+    }
+}));
+
+function* createBuffers(lengths = [0, 8]) {
+    for (const length of lengths) {
+        const buffer = new ArrayBuffer(length);
+        yield {
+            buffer,
+            detach: () => $.detachArrayBuffer(buffer),
+        };
+    }
+
+    for (const length of lengths) {
+        const buffer = new otherGlobal.ArrayBuffer(length);
+        yield {
+            buffer,
+            detach: () => otherGlobal.$.detachArrayBuffer(buffer),
+        };
+    }
+}
+
+const TEST_TARGET = [
+    BigInt64Array,
+    BigUint64Array,
+    Float16Array,
+    Float32Array,
+    Float64Array,
+    Int16Array,
+    Int32Array,
+    // Int8Array,
+    Uint16Array,
+    Uint32Array,
+    // Uint8Array,
+    // Uint8ClampedArray,
+];
+
+for (const Ctor of TEST_TARGET) {
+    const label = Ctor.name;
+
+    assert(Ctor.BYTES_PER_ELEMENT !== 1, `${label}: |byteOffset % 1| is always 0. We cannot test what we want to test`);
+
+    for (const { buffer } of createBuffers()) {
+        // https://tc39.es/ecma262/2026/#sec-initializetypedarrayfromarraybuffer
+        //
+        // the step 3 |offset modulo elementSize ≠ 0| should be executed before the step 5.a |ToIndex(length)|.
+        shouldThrow(label, () => {
+            new Ctor(buffer, 1, poisonedValue);
+        }, RangeError, 'byteOffset modulo TypedArray.BYTES_PER_ELEMENT must be 0');
+    }
+}

--- a/JSTests/stress/typedarray-constructor-isdetachbuffer-before-bufferbytelength-modulo-elementsize-weird-byteoffset-detach.js
+++ b/JSTests/stress/typedarray-constructor-isdetachbuffer-before-bufferbytelength-modulo-elementsize-weird-byteoffset-detach.js
@@ -1,0 +1,85 @@
+// The original is https://github.com/tc39/test262/blob/d0c1b4555b03dd404873fd6422a4b5da00136500/test/staging/sm/TypedArray/constructor-buffer-sequence.js
+
+function assert(ok, message = '') {
+    if (!ok)
+        throw new Error(`Assertion!: ${message}`); 
+}
+
+function shouldThrow(caseName, fn, expectedErrorCtor, expectedErrorMessage) {
+    if (!caseName)
+        throw new Error(`must specify test case name`);
+
+    const expected = `${expectedErrorCtor.name}(${expectedErrorMessage})`;
+    try {
+        fn();
+        throw new Error(`${caseName}: Expected to throw ${expected}, but succeeded`);
+    } catch (e) {
+        const actual = `${e.name}(${e.message})`;
+        if (!(e instanceof expectedErrorCtor) || e.message !== expectedErrorMessage)
+            throw new Error(`${caseName}: Expected ${expected} but got ${actual}`);
+    }
+}
+
+const otherGlobal = $.createRealm().global;
+
+function* createBuffers(lengths = [0, 8]) {
+    for (const length of lengths) {
+        const buffer = new ArrayBuffer(length);
+        yield {
+            buffer,
+            detach: () => $.detachArrayBuffer(buffer),
+        };
+    }
+
+    for (const length of lengths) {
+        const buffer = new otherGlobal.ArrayBuffer(length);
+        yield {
+            buffer,
+            detach: () => otherGlobal.$.detachArrayBuffer(buffer),
+        };
+    }
+}
+
+function ValueReturning(value, detach) {
+    return {
+        valueOf() {
+            if (detach)
+                detach();
+            return value;
+        }
+    };
+}
+
+const TEST_TARGET = [
+    BigInt64Array,
+    BigUint64Array,
+    Float16Array,
+    Float32Array,
+    Float64Array,
+    Int16Array,
+    Int32Array,
+    //Int8Array,
+    Uint16Array,
+    Uint32Array,
+    //Uint8Array,
+    //Uint8ClampedArray,
+];
+
+for (const Ctor of TEST_TARGET) {
+    const label = Ctor.name;
+    assert(Ctor.BYTES_PER_ELEMENT !== 1, `${label}: |bufferByteLength % 1| is always 0. We cannot test what we want to test`);
+
+    // https://tc39.es/ecma262/2026/#sec-initializetypedarrayfromarraybuffer
+    // the step 6 |IsDetachedBuffer(buffer)| should be executed
+    // before the step 9-a-i |bufferByteLength modulo elementSize ≠ 0|.
+    //
+    // Variant: the step 2 |ToIndex(byteOffset)| detach the buffer.
+    for (const { buffer, detach } of createBuffers([1, 9])) {
+        const byteOffset = ValueReturning(0, detach);
+
+        shouldThrow(label, () => {
+            new Ctor(buffer, byteOffset);
+        }, TypeError, "Buffer is already detached");
+    }
+}
+

--- a/JSTests/stress/typedarray-constructor-isdetachbuffer-before-bufferbytelength-modulo-elementsize.js
+++ b/JSTests/stress/typedarray-constructor-isdetachbuffer-before-bufferbytelength-modulo-elementsize.js
@@ -1,0 +1,73 @@
+// The original is https://github.com/tc39/test262/blob/d0c1b4555b03dd404873fd6422a4b5da00136500/test/staging/sm/TypedArray/constructor-buffer-sequence.js
+
+function assert(ok, message = '') {
+    if (!ok)
+        throw new Error(`Assertion!: ${message}`); 
+}
+
+function shouldThrow(caseName, fn, expectedErrorCtor, expectedErrorMessage) {
+    if (!caseName)
+        throw new Error(`must specify test case name`);
+
+    const expected = `${expectedErrorCtor.name}(${expectedErrorMessage})`;
+    try {
+        fn();
+        throw new Error(`${caseName}: Expected to throw ${expected}, but succeeded`);
+    } catch (e) {
+        const actual = `${e.name}(${e.message})`;
+        if (!(e instanceof expectedErrorCtor) || e.message !== expectedErrorMessage)
+            throw new Error(`${caseName}: Expected ${expected} but got ${actual}`);
+    }
+}
+
+const otherGlobal = $.createRealm().global;
+
+function* createBuffers(lengths = [0, 8]) {
+    for (const length of lengths) {
+        const buffer = new ArrayBuffer(length);
+        yield {
+            buffer,
+            detach: () => $.detachArrayBuffer(buffer),
+        };
+    }
+
+    for (const length of lengths) {
+        const buffer = new otherGlobal.ArrayBuffer(length);
+        yield {
+            buffer,
+            detach: () => otherGlobal.$.detachArrayBuffer(buffer),
+        };
+    }
+}
+
+const TEST_TARGET = [
+    BigInt64Array,
+    BigUint64Array,
+    Float16Array,
+    Float32Array,
+    Float64Array,
+    Int16Array,
+    Int32Array,
+    //Int8Array,
+    Uint16Array,
+    Uint32Array,
+    //Uint8Array,
+    //Uint8ClampedArray,
+];
+
+for (const Ctor of TEST_TARGET) {
+    const label = Ctor.name;
+    assert(Ctor.BYTES_PER_ELEMENT !== 1, `${label}: |bufferByteLength % 1| is always 0. We cannot test what we want to test`);
+
+    // https://tc39.es/ecma262/2026/#sec-initializetypedarrayfromarraybuffer
+    // the step 6 |IsDetachedBuffer(buffer)| should be executed
+    // before the step 9-a-i |bufferByteLength modulo elementSize ≠ 0|.
+    for (const { buffer, detach } of createBuffers([1, 9])) {
+        detach();
+
+        shouldThrow(label, () => {
+            new Ctor(buffer, 0);
+        }, TypeError, "Buffer is already detached");
+    }
+}
+

--- a/JSTests/stress/typedarray-constructor-isdetachbuffer-before-newbytelength-lt-0-weird-byteoffset.js
+++ b/JSTests/stress/typedarray-constructor-isdetachbuffer-before-newbytelength-lt-0-weird-byteoffset.js
@@ -1,0 +1,87 @@
+// The original is https://github.com/tc39/test262/blob/d0c1b4555b03dd404873fd6422a4b5da00136500/test/staging/sm/TypedArray/constructor-buffer-sequence.js
+
+function assert(ok, message = '') {
+    if (!ok)
+        throw new Error(`Assertion!: ${message}`); 
+}
+
+function shouldThrow(caseName, fn, expectedErrorCtor, expectedErrorMessage) {
+    if (!caseName)
+        throw new Error(`must specify test case name`);
+
+    const expected = `${expectedErrorCtor.name}(${expectedErrorMessage})`;
+    try {
+        fn();
+        throw new Error(`${caseName}: Expected to throw ${expected}, but succeeded`);
+    } catch (e) {
+        const actual = `${e.name}(${e.message})`;
+        if (!(e instanceof expectedErrorCtor) || e.message !== expectedErrorMessage)
+            throw new Error(`${caseName}: Expected ${expected} but got ${actual}`);
+    }
+}
+
+const otherGlobal = $.createRealm().global;
+
+function* createBuffers(lengths = [0, 8]) {
+    for (const length of lengths) {
+        const buffer = new ArrayBuffer(length);
+        yield {
+            buffer,
+            detach: () => $.detachArrayBuffer(buffer),
+        };
+    }
+
+    for (const length of lengths) {
+        const buffer = new otherGlobal.ArrayBuffer(length);
+        yield {
+            buffer,
+            detach: () => otherGlobal.$.detachArrayBuffer(buffer),
+        };
+    }
+}
+
+function ValueReturning(value, detach) {
+    return {
+        valueOf() {
+            if (detach)
+                detach();
+            return value;
+        }
+    };
+}
+
+const TEST_TARGET = [
+    BigInt64Array,
+    BigUint64Array,
+    Float16Array,
+    Float32Array,
+    Float64Array,
+    Int16Array,
+    Int32Array,
+    Int8Array,
+    Uint16Array,
+    Uint32Array,
+    Uint8Array,
+    Uint8ClampedArray,
+];
+
+for (const Ctor of TEST_TARGET) {
+    const label = Ctor.name;
+
+    const byteOffset = 64;
+
+    // https://tc39.es/ecma262/2026/#sec-initializetypedarrayfromarraybuffer
+    // the step 6 |IsDetachedBuffer(buffer)| should be executed
+    // before the step 9-a-iii |newByteLength < 0|.
+    //
+    // Variant: the step 2 |ToIndex(byteOffset)| detach the buffer.
+    for (const { buffer, detach } of createBuffers()) {
+        assert(buffer.byteLength - byteOffset < 0, `${label}: newByteLength |bufferByteLength - offset| condition is expected`);
+
+        const weirdByteOffset = ValueReturning(byteOffset, detach);
+        shouldThrow(label, () => {
+            new Ctor(buffer, weirdByteOffset);
+        }, TypeError, "Buffer is already detached");
+    }
+}
+

--- a/JSTests/stress/typedarray-constructor-isdetachbuffer-before-newbytelength-lt-0.js
+++ b/JSTests/stress/typedarray-constructor-isdetachbuffer-before-newbytelength-lt-0.js
@@ -1,0 +1,112 @@
+// The original is https://github.com/tc39/test262/blob/d0c1b4555b03dd404873fd6422a4b5da00136500/test/staging/sm/TypedArray/constructor-buffer-sequence.js
+
+function assert(ok, message = '') {
+    if (!ok)
+        throw new Error(`Assertion!: ${message}`); 
+}
+
+function shouldThrow(caseName, fn, expectedErrorCtor, expectedErrorMessage) {
+    if (!caseName)
+        throw new Error(`must specify test case name`);
+
+    const expected = `${expectedErrorCtor.name}(${expectedErrorMessage})`;
+    try {
+        fn();
+        throw new Error(`${caseName}: Expected to throw ${expected}, but succeeded`);
+    } catch (e) {
+        const actual = `${e.name}(${e.message})`;
+        if (!(e instanceof expectedErrorCtor) || e.message !== expectedErrorMessage)
+            throw new Error(`${caseName}: Expected ${expected} but got ${actual}`);
+    }
+}
+
+const otherGlobal = $.createRealm().global;
+
+const poisonedValue = new Proxy({}, new Proxy({}, {
+    get() {
+        // Throws an exception when any proxy trap is invoked.
+        throw new Error("Poisoned Value");
+    }
+}));
+
+function* createBuffers(lengths = [0, 8]) {
+    for (const length of lengths) {
+        const buffer = new ArrayBuffer(length);
+        yield {
+            buffer,
+            detach: () => $.detachArrayBuffer(buffer),
+        };
+    }
+
+    for (const length of lengths) {
+        const buffer = new otherGlobal.ArrayBuffer(length);
+        yield {
+            buffer,
+            detach: () => otherGlobal.$.detachArrayBuffer(buffer),
+        };
+    }
+}
+
+function ConstructorWithThrowingPrototype(detach) {
+    return Object.defineProperty(function(){}.bind(null), "prototype", {
+        get() {
+            if (detach)
+                detach();
+            throw new ExpectedError();
+        }
+    });
+}
+
+function ValueThrowing(detach) {
+    return {
+        valueOf() {
+            if (detach)
+                detach();
+            throw new ExpectedError();
+        }
+    };
+}
+
+function ValueReturning(value, detach) {
+    return {
+        valueOf() {
+            if (detach)
+                detach();
+            return value;
+        }
+    };
+}
+
+const TEST_TARGET = [
+    BigInt64Array,
+    BigUint64Array,
+    Float16Array,
+    Float32Array,
+    Float64Array,
+    Int16Array,
+    Int32Array,
+    Int8Array,
+    Uint16Array,
+    Uint32Array,
+    Uint8Array,
+    Uint8ClampedArray,
+];
+
+for (const Ctor of TEST_TARGET) {
+    const label = Ctor.name;
+
+    const byteOffset = 64;
+
+    // https://tc39.es/ecma262/2026/#sec-initializetypedarrayfromarraybuffer
+    // the step 6 |IsDetachedBuffer(buffer)| should be executed
+    // before the step 9-a-iii |newByteLength < 0|.
+    for (const { buffer, detach } of createBuffers()) {
+        assert(buffer.byteLength - byteOffset < 0, `${label}: newByteLength |bufferByteLength - offset| condition is expected`);
+
+        detach();
+
+        shouldThrow(label, () => {
+            new Ctor(buffer, byteOffset);
+        }, TypeError, "Buffer is already detached");
+    }
+}

--- a/JSTests/stress/typedarray-constructor-isdetachbuffer-before-offset+newbytelength-gt-bufferbytelength-byteoffset-too-large.js
+++ b/JSTests/stress/typedarray-constructor-isdetachbuffer-before-offset+newbytelength-gt-bufferbytelength-byteoffset-too-large.js
@@ -1,0 +1,119 @@
+// The original is https://github.com/tc39/test262/blob/d0c1b4555b03dd404873fd6422a4b5da00136500/test/staging/sm/TypedArray/constructor-buffer-sequence.js
+
+function assert(ok, message = '') {
+    if (!ok)
+        throw new Error(`Assertion!: ${message}`); 
+}
+
+function shouldThrow(caseName, fn, expectedErrorCtor, expectedErrorMessage) {
+    if (!caseName)
+        throw new Error(`must specify test case name`);
+
+    const expected = `${expectedErrorCtor.name}(${expectedErrorMessage})`;
+    try {
+        fn();
+        throw new Error(`${caseName}: Expected to throw ${expected}, but succeeded`);
+    } catch (e) {
+        const actual = `${e.name}(${e.message})`;
+        if (!(e instanceof expectedErrorCtor) || e.message !== expectedErrorMessage)
+            throw new Error(`${caseName}: Expected ${expected} but got ${actual}`);
+    }
+}
+
+const otherGlobal = $.createRealm().global;
+
+const poisonedValue = new Proxy({}, new Proxy({}, {
+    get() {
+        // Throws an exception when any proxy trap is invoked.
+        throw new Error("Poisoned Value");
+    }
+}));
+
+function* createBuffers(lengths = [0, 8]) {
+    for (const length of lengths) {
+        const buffer = new ArrayBuffer(length);
+        yield {
+            buffer,
+            detach: () => $.detachArrayBuffer(buffer),
+        };
+    }
+
+    for (const length of lengths) {
+        const buffer = new otherGlobal.ArrayBuffer(length);
+        yield {
+            buffer,
+            detach: () => otherGlobal.$.detachArrayBuffer(buffer),
+        };
+    }
+}
+
+function ConstructorWithThrowingPrototype(detach) {
+    return Object.defineProperty(function(){}.bind(null), "prototype", {
+        get() {
+            if (detach)
+                detach();
+            throw new ExpectedError();
+        }
+    });
+}
+
+function ValueThrowing(detach) {
+    return {
+        valueOf() {
+            if (detach)
+                detach();
+            throw new ExpectedError();
+        }
+    };
+}
+
+function ValueReturning(value, detach) {
+    return {
+        valueOf() {
+            if (detach)
+                detach();
+            return value;
+        }
+    };
+}
+
+
+const TEST_TARGET = [
+    BigInt64Array,
+    BigUint64Array,
+    Float16Array,
+    Float32Array,
+    Float64Array,
+    Int16Array,
+    Int32Array,
+    Int8Array,
+    Uint16Array,
+    Uint32Array,
+    Uint8Array,
+    Uint8ClampedArray,
+];
+
+for (const Ctor of TEST_TARGET) {
+    const label = Ctor.name;
+
+    const byteOffset = 64;
+    const length = 0;
+
+    // https://tc39.es/ecma262/2026/#sec-initializetypedarrayfromarraybuffer
+    // the step 6 |IsDetachedBuffer(buffer)| should be executed
+    // before the step 9-b-ii |offset+newByteLength > bufferByteLength|.
+    //
+    // Variant: The given byteOffset is too large.
+    for (const { buffer, detach } of createBuffers()) {
+        {
+            // the step 9-b-i
+            const newByteLength = length * Ctor.BYTES_PER_ELEMENT;
+            assert((byteOffset + newByteLength) > buffer.byteLength, `${label}: |offset+newByteLength > bufferByteLength| is expected`);
+        }
+
+        const weirdLength = ValueReturning(length, detach);;
+        shouldThrow(label, () => {
+            new Ctor(buffer, byteOffset, weirdLength);
+        }, TypeError, "Buffer is already detached");
+    }
+}

--- a/JSTests/stress/typedarray-constructor-isdetachbuffer-before-offset+newbytelength-gt-bufferbytelength-length-too-large.js
+++ b/JSTests/stress/typedarray-constructor-isdetachbuffer-before-offset+newbytelength-gt-bufferbytelength-length-too-large.js
@@ -1,0 +1,98 @@
+// The original is https://github.com/tc39/test262/blob/d0c1b4555b03dd404873fd6422a4b5da00136500/test/staging/sm/TypedArray/constructor-buffer-sequence.js
+
+function assert(ok, message = '') {
+    if (!ok)
+        throw new Error(`Assertion!: ${message}`); 
+}
+
+function shouldThrow(caseName, fn, expectedErrorCtor, expectedErrorMessage) {
+    if (!caseName)
+        throw new Error(`must specify test case name`);
+
+    const expected = `${expectedErrorCtor.name}(${expectedErrorMessage})`;
+    try {
+        fn();
+        throw new Error(`${caseName}: Expected to throw ${expected}, but succeeded`);
+    } catch (e) {
+        const actual = `${e.name}(${e.message})`;
+        if (!(e instanceof expectedErrorCtor) || e.message !== expectedErrorMessage)
+            throw new Error(`${caseName}: Expected ${expected} but got ${actual}`);
+    }
+}
+
+const otherGlobal = $.createRealm().global;
+
+const poisonedValue = new Proxy({}, new Proxy({}, {
+    get() {
+        // Throws an exception when any proxy trap is invoked.
+        throw new Error("Poisoned Value");
+    }
+}));
+
+function* createBuffers(lengths = [0, 8]) {
+    for (const length of lengths) {
+        const buffer = new ArrayBuffer(length);
+        yield {
+            buffer,
+            detach: () => $.detachArrayBuffer(buffer),
+        };
+    }
+
+    for (const length of lengths) {
+        const buffer = new otherGlobal.ArrayBuffer(length);
+        yield {
+            buffer,
+            detach: () => otherGlobal.$.detachArrayBuffer(buffer),
+        };
+    }
+}
+
+function ValueReturning(value, detach) {
+    return {
+        valueOf() {
+            if (detach)
+                detach();
+            return value;
+        }
+    };
+}
+
+const TEST_TARGET = [
+    BigInt64Array,
+    BigUint64Array,
+    Float16Array,
+    Float32Array,
+    Float64Array,
+    Int16Array,
+    Int32Array,
+    Int8Array,
+    Uint16Array,
+    Uint32Array,
+    Uint8Array,
+    Uint8ClampedArray,
+];
+
+for (const Ctor of TEST_TARGET) {
+    const label = Ctor.name;
+
+    const byteOffset = 0;
+    const length = 64;
+
+    // https://tc39.es/ecma262/2026/#sec-initializetypedarrayfromarraybuffer
+    // the step 6 |IsDetachedBuffer(buffer)| should be executed
+    // before the step 9-b-ii |offset+newByteLength > bufferByteLength|.
+    //
+    // Variant: The given length is too large
+    for (const { buffer, detach } of createBuffers()) {
+        {
+            // the step 9-b-i
+            const newByteLength = length * Ctor.BYTES_PER_ELEMENT;
+            assert((byteOffset + newByteLength) > buffer.byteLength, `${label}: |offset+newByteLength > bufferByteLength| is expected`);
+        }
+
+        const weirdLength = ValueReturning(length, detach);;
+        shouldThrow(label, () => {
+            new Ctor(buffer, byteOffset, weirdLength);
+        }, TypeError, "Buffer is already detached");
+    }
+}

--- a/JSTests/stress/typedarray-constructor-toindex-byteoffset-before-isdetachedbuffer-weird-byteoffset-detach.js
+++ b/JSTests/stress/typedarray-constructor-toindex-byteoffset-before-isdetachedbuffer-weird-byteoffset-detach.js
@@ -1,0 +1,79 @@
+// The original is https://github.com/tc39/test262/blob/d0c1b4555b03dd404873fd6422a4b5da00136500/test/staging/sm/TypedArray/constructor-buffer-sequence.js
+
+function shouldThrow(caseName, fn, expectedErrorCtor, expectedErrorMessage) {
+    if (!caseName)
+        throw new Error(`must specify test case name`);
+
+    const expected = `${expectedErrorCtor.name}(${expectedErrorMessage})`;
+    try {
+        fn();
+        throw new Error(`${caseName}: Expected to throw ${expected}, but succeeded`);
+    } catch (e) {
+        const actual = `${e.name}(${e.message})`;
+        if (!(e instanceof expectedErrorCtor) || e.message !== expectedErrorMessage)
+            throw new Error(`${caseName}: Expected ${expected} but got ${actual}`);
+    }
+}
+
+const otherGlobal = $.createRealm().global;
+
+class ExpectedError extends Error { }
+
+function* createBuffers(lengths = [0, 8]) {
+    for (const length of lengths) {
+        const buffer = new ArrayBuffer(length);
+        yield {
+            buffer,
+            detach: () => $.detachArrayBuffer(buffer),
+        };
+    }
+
+    for (const length of lengths) {
+        const buffer = new otherGlobal.ArrayBuffer(length);
+        yield {
+            buffer,
+            detach: () => otherGlobal.$.detachArrayBuffer(buffer),
+        };
+    }
+}
+
+function ValueThrowing(detach) {
+    return {
+        valueOf() {
+            if (detach)
+                detach();
+            throw new ExpectedError();
+        }
+    };
+}
+
+const TEST_TARGET = [
+    BigInt64Array,
+    BigUint64Array,
+    Float16Array,
+    Float32Array,
+    Float64Array,
+    Int16Array,
+    Int32Array,
+    Int8Array,
+    Uint16Array,
+    Uint32Array,
+    Uint8Array,
+    Uint8ClampedArray,
+];
+
+for (const Ctor of TEST_TARGET) {
+    const label = Ctor.name;
+
+    // https://tc39.es/ecma262/2026/#sec-initializetypedarrayfromarraybuffer
+    // Ensure the step 2 |ToIndex(byteOffset)| should be executed before step 6 |IsDetachedBuffer(buffer)|.
+    //
+    // Variant: ToIndex(byteOffset) detach the buffer.
+    for (const { buffer, detach } of createBuffers()) {
+        const byteOffset = ValueThrowing(detach);
+
+        shouldThrow(label, () => {
+            new Ctor(buffer, byteOffset, 0)
+        }, ExpectedError, '');
+    }
+}

--- a/JSTests/stress/typedarray-constructor-toindex-byteoffset-before-isdetachedbuffer.js
+++ b/JSTests/stress/typedarray-constructor-toindex-byteoffset-before-isdetachedbuffer.js
@@ -1,0 +1,78 @@
+// The original is https://github.com/tc39/test262/blob/d0c1b4555b03dd404873fd6422a4b5da00136500/test/staging/sm/TypedArray/constructor-buffer-sequence.js
+
+function shouldThrow(caseName, fn, expectedErrorCtor, expectedErrorMessage) {
+    if (!caseName)
+        throw new Error(`must specify test case name`);
+
+    const expected = `${expectedErrorCtor.name}(${expectedErrorMessage})`;
+    try {
+        fn();
+        throw new Error(`${caseName}: Expected to throw ${expected}, but succeeded`);
+    } catch (e) {
+        const actual = `${e.name}(${e.message})`;
+        if (!(e instanceof expectedErrorCtor) || e.message !== expectedErrorMessage)
+            throw new Error(`${caseName}: Expected ${expected} but got ${actual}`);
+    }
+}
+
+const otherGlobal = $.createRealm().global;
+
+class ExpectedError extends Error { }
+
+function* createBuffers(lengths = [0, 8]) {
+    for (const length of lengths) {
+        const buffer = new ArrayBuffer(length);
+        yield {
+            buffer,
+            detach: () => $.detachArrayBuffer(buffer),
+        };
+    }
+
+    for (const length of lengths) {
+        const buffer = new otherGlobal.ArrayBuffer(length);
+        yield {
+            buffer,
+            detach: () => otherGlobal.$.detachArrayBuffer(buffer),
+        };
+    }
+}
+
+function ValueThrowing(detach) {
+    return {
+        valueOf() {
+            if (detach)
+                detach();
+            throw new ExpectedError();
+        }
+    };
+}
+
+const TEST_TARGET = [
+    BigInt64Array,
+    BigUint64Array,
+    Float16Array,
+    Float32Array,
+    Float64Array,
+    Int16Array,
+    Int32Array,
+    Int8Array,
+    Uint16Array,
+    Uint32Array,
+    Uint8Array,
+    Uint8ClampedArray,
+];
+
+for (const Ctor of TEST_TARGET) {
+    const label = Ctor.name;
+
+    for (const { buffer, detach } of createBuffers()) {
+        detach();
+        const byteOffset = ValueThrowing();
+
+        // https://tc39.es/ecma262/2026/#sec-initializetypedarrayfromarraybuffer
+        // Ensure the step 2 |ToIndex(byteOffset)| should be executed before step 6 |IsDetachedBuffer(buffer)|.
+        shouldThrow(label, () => {
+            new Ctor(buffer, byteOffset, 0);
+        }, ExpectedError, '');
+    }
+}

--- a/JSTests/stress/typedarray-constructor-toindex-byteoffset-detach-buffer.js
+++ b/JSTests/stress/typedarray-constructor-toindex-byteoffset-detach-buffer.js
@@ -1,0 +1,76 @@
+// The original is https://github.com/tc39/test262/blob/d0c1b4555b03dd404873fd6422a4b5da00136500/test/staging/sm/TypedArray/constructor-buffer-sequence.js
+
+function shouldThrow(caseName, fn, expectedErrorCtor, expectedErrorMessage) {
+    if (!caseName)
+        throw new Error(`must specify test case name`);
+
+    const expected = `${expectedErrorCtor.name}(${expectedErrorMessage})`;
+    try {
+        fn();
+        throw new Error(`${caseName}: Expected to throw ${expected}, but succeeded`);
+    } catch (e) {
+        const actual = `${e.name}(${e.message})`;
+        if (!(e instanceof expectedErrorCtor) || e.message !== expectedErrorMessage)
+            throw new Error(`${caseName}: Expected ${expected} but got ${actual}`);
+    }
+}
+
+const otherGlobal = $.createRealm().global;
+
+function* createBuffers(lengths = [0, 8]) {
+    for (const length of lengths) {
+        const buffer = new ArrayBuffer(length);
+        yield {
+            buffer,
+            detach: () => $.detachArrayBuffer(buffer),
+        };
+    }
+
+    for (const length of lengths) {
+        const buffer = new otherGlobal.ArrayBuffer(length);
+        yield {
+            buffer,
+            detach: () => otherGlobal.$.detachArrayBuffer(buffer),
+        };
+    }
+}
+
+function ValueReturning(value, detach) {
+    return {
+        valueOf() {
+            if (detach)
+                detach();
+            return value;
+        }
+    };
+}
+
+
+const TEST_TARGET = [
+    BigInt64Array,
+    BigUint64Array,
+    Float16Array,
+    Float32Array,
+    Float64Array,
+    Int16Array,
+    Int32Array,
+    Int8Array,
+    Uint16Array,
+    Uint32Array,
+    Uint8Array,
+    Uint8ClampedArray,
+];
+for (const Ctor of TEST_TARGET) {
+    const label = Ctor.name;
+
+    // if the step 2 |ToIndex(byteOffset)| detaches the array buffer,
+    // the step 6 |IsDetachedBuffer(buffer)| should catch it.
+    // https://tc39.es/ecma262/2026/#sec-initializetypedarrayfromarraybuffer
+    for (const { buffer, detach } of createBuffers()) {
+        const byteOffset = ValueReturning(0, detach);
+
+        shouldThrow(label, () => {
+            new Ctor(buffer, byteOffset, 0)
+        }, TypeError, 'Buffer is already detached');
+    }
+}

--- a/JSTests/stress/typedarray-constructor-toindex-length-before-isdetachedbuffer-weird-byteoffset-detach.js
+++ b/JSTests/stress/typedarray-constructor-toindex-length-before-isdetachedbuffer-weird-byteoffset-detach.js
@@ -1,0 +1,90 @@
+// The original is https://github.com/tc39/test262/blob/d0c1b4555b03dd404873fd6422a4b5da00136500/test/staging/sm/TypedArray/constructor-buffer-sequence.js
+
+function shouldThrow(caseName, fn, expectedErrorCtor, expectedErrorMessage) {
+    if (!caseName)
+        throw new Error(`must specify test case name`);
+
+    const expected = `${expectedErrorCtor.name}(${expectedErrorMessage})`;
+    try {
+        fn();
+        throw new Error(`${caseName}: Expected to throw ${expected}, but succeeded`);
+    } catch (e) {
+        const actual = `${e.name}(${e.message})`;
+        if (!(e instanceof expectedErrorCtor) || e.message !== expectedErrorMessage)
+            throw new Error(`${caseName}: Expected ${expected} but got ${actual}`);
+    }
+}
+
+const otherGlobal = $.createRealm().global;
+
+class ExpectedError extends Error { }
+
+function* createBuffers(lengths = [0, 8]) {
+    for (const length of lengths) {
+        const buffer = new ArrayBuffer(length);
+        yield {
+            buffer,
+            detach: () => $.detachArrayBuffer(buffer),
+        };
+    }
+
+    for (const length of lengths) {
+        const buffer = new otherGlobal.ArrayBuffer(length);
+        yield {
+            buffer,
+            detach: () => otherGlobal.$.detachArrayBuffer(buffer),
+        };
+    }
+}
+
+function ValueThrowing(detach) {
+    return {
+        valueOf() {
+            if (detach)
+                detach();
+            throw new ExpectedError();
+        }
+    };
+}
+
+function ValueReturning(value, detach) {
+    return {
+        valueOf() {
+            if (detach)
+                detach();
+            return value;
+        }
+    };
+}
+
+const TEST_TARGET = [
+    BigInt64Array,
+    BigUint64Array,
+    Float16Array,
+    Float32Array,
+    Float64Array,
+    Int16Array,
+    Int32Array,
+    Int8Array,
+    Uint16Array,
+    Uint32Array,
+    Uint8Array,
+    Uint8ClampedArray,
+];
+
+for (const Ctor of TEST_TARGET) {
+    const label = Ctor.name;
+
+    for (const { buffer, detach } of createBuffers()) {
+        const byteOffset = ValueReturning(0, detach);
+        const length = ValueThrowing();
+
+        // https://tc39.es/ecma262/2026/#sec-initializetypedarrayfromarraybuffer
+        // the step 5.a |ToIndex(length)| should be executed before step 6 |IsDetachedBuffer(buffer)|.
+        //
+        // Variant: the step 2 |ToIndex(byteOffset)| detach the buffer.
+        shouldThrow(label, () => {
+            new Ctor(buffer, byteOffset, length);
+        }, ExpectedError, '');
+    }
+}

--- a/JSTests/stress/typedarray-constructor-toindex-length-before-isdetachedbuffer-weird-length-detach.js
+++ b/JSTests/stress/typedarray-constructor-toindex-length-before-isdetachedbuffer-weird-length-detach.js
@@ -1,0 +1,80 @@
+// The original is https://github.com/tc39/test262/blob/d0c1b4555b03dd404873fd6422a4b5da00136500/test/staging/sm/TypedArray/constructor-buffer-sequence.js
+
+function shouldThrow(caseName, fn, expectedErrorCtor, expectedErrorMessage) {
+    if (!caseName)
+        throw new Error(`must specify test case name`);
+
+    const expected = `${expectedErrorCtor.name}(${expectedErrorMessage})`;
+    try {
+        fn();
+        throw new Error(`${caseName}: Expected to throw ${expected}, but succeeded`);
+    } catch (e) {
+        const actual = `${e.name}(${e.message})`;
+        if (!(e instanceof expectedErrorCtor) || e.message !== expectedErrorMessage)
+            throw new Error(`${caseName}: Expected ${expected} but got ${actual}`);
+    }
+}
+
+const otherGlobal = $.createRealm().global;
+
+class ExpectedError extends Error { }
+
+function* createBuffers(lengths = [0, 8]) {
+    for (const length of lengths) {
+        const buffer = new ArrayBuffer(length);
+        yield {
+            buffer,
+            detach: () => $.detachArrayBuffer(buffer),
+        };
+    }
+
+    for (const length of lengths) {
+        const buffer = new otherGlobal.ArrayBuffer(length);
+        yield {
+            buffer,
+            detach: () => otherGlobal.$.detachArrayBuffer(buffer),
+        };
+    }
+}
+
+function ValueThrowing(detach) {
+    return {
+        valueOf() {
+            if (detach)
+                detach();
+            throw new ExpectedError();
+        }
+    };
+}
+
+const TEST_TARGET = [
+    BigInt64Array,
+    BigUint64Array,
+    Float16Array,
+    Float32Array,
+    Float64Array,
+    Int16Array,
+    Int32Array,
+    Int8Array,
+    Uint16Array,
+    Uint32Array,
+    Uint8Array,
+    Uint8ClampedArray,
+];
+
+for (const Ctor of TEST_TARGET) {
+    const label = Ctor.name;
+
+    for (const { buffer, detach } of createBuffers()) {
+        const byteOffset = 0;
+        const length = ValueThrowing(detach);
+
+        // https://tc39.es/ecma262/2026/#sec-initializetypedarrayfromarraybuffer
+        // the step 5.a |ToIndex(length)| should be executed before the step 6 |IsDetachedBuffer(buffer)|.
+        //
+        // Variant: the step 5.a |ToIndex(length)| detach the buffer.
+        shouldThrow(label, () => {
+            new Ctor(buffer, byteOffset, length);
+        }, ExpectedError, '');
+    }
+}

--- a/JSTests/stress/typedarray-constructor-toindex-length-before-isdetachedbuffer.js
+++ b/JSTests/stress/typedarray-constructor-toindex-length-before-isdetachedbuffer.js
@@ -1,0 +1,78 @@
+// The original is https://github.com/tc39/test262/blob/d0c1b4555b03dd404873fd6422a4b5da00136500/test/staging/sm/TypedArray/constructor-buffer-sequence.js
+
+function shouldThrow(caseName, fn, expectedErrorCtor, expectedErrorMessage) {
+    if (!caseName)
+        throw new Error(`must specify test case name`);
+
+    const expected = `${expectedErrorCtor.name}(${expectedErrorMessage})`;
+    try {
+        fn();
+        throw new Error(`${caseName}: Expected to throw ${expected}, but succeeded`);
+    } catch (e) {
+        const actual = `${e.name}(${e.message})`;
+        if (!(e instanceof expectedErrorCtor) || e.message !== expectedErrorMessage)
+            throw new Error(`${caseName}: Expected ${expected} but got ${actual}`);
+    }
+}
+
+const otherGlobal = $.createRealm().global;
+
+class ExpectedError extends Error { }
+
+function* createBuffers(lengths = [0, 8]) {
+    for (const length of lengths) {
+        const buffer = new ArrayBuffer(length);
+        yield {
+            buffer,
+            detach: () => $.detachArrayBuffer(buffer),
+        };
+    }
+
+    for (const length of lengths) {
+        const buffer = new otherGlobal.ArrayBuffer(length);
+        yield {
+            buffer,
+            detach: () => otherGlobal.$.detachArrayBuffer(buffer),
+        };
+    }
+}
+
+function ValueThrowing(detach) {
+    return {
+        valueOf() {
+            if (detach)
+                detach();
+            throw new ExpectedError();
+        }
+    };
+}
+
+const TEST_TARGET = [
+    BigInt64Array,
+    BigUint64Array,
+    Float16Array,
+    Float32Array,
+    Float64Array,
+    Int16Array,
+    Int32Array,
+    Int8Array,
+    Uint16Array,
+    Uint32Array,
+    Uint8Array,
+    Uint8ClampedArray,
+];
+
+for (const Ctor of TEST_TARGET) {
+    const label = Ctor.name;
+
+    for (const { buffer, detach } of createBuffers()) {
+        detach();
+        const length = ValueThrowing();
+
+        // https://tc39.es/ecma262/2026/#sec-initializetypedarrayfromarraybuffer
+        // the step 5.a |ToIndex(length)| should be executed before the step 6 |IsDetachedBuffer(buffer)|.
+        shouldThrow(label, () => {
+            new Ctor(buffer, 0, length);
+        }, ExpectedError, '');
+    }
+}

--- a/JSTests/stress/typedarray-constructor-toindex-length-detach-buffer.js
+++ b/JSTests/stress/typedarray-constructor-toindex-length-detach-buffer.js
@@ -1,0 +1,77 @@
+// The original is https://github.com/tc39/test262/blob/d0c1b4555b03dd404873fd6422a4b5da00136500/test/staging/sm/TypedArray/constructor-buffer-sequence.js
+
+function shouldThrow(caseName, fn, expectedErrorCtor, expectedErrorMessage) {
+    if (!caseName)
+        throw new Error(`must specify test case name`);
+
+    const expected = `${expectedErrorCtor.name}(${expectedErrorMessage})`;
+    try {
+        fn();
+        throw new Error(`${caseName}: Expected to throw ${expected}, but succeeded`);
+    } catch (e) {
+        const actual = `${e.name}(${e.message})`;
+        if (!(e instanceof expectedErrorCtor) || e.message !== expectedErrorMessage)
+            throw new Error(`${caseName}: Expected ${expected} but got ${actual}`);
+    }
+}
+
+const otherGlobal = $.createRealm().global;
+
+class ExpectedError extends Error { }
+
+function* createBuffers(lengths = [0, 8]) {
+    for (const length of lengths) {
+        const buffer = new ArrayBuffer(length);
+        yield {
+            buffer,
+            detach: () => $.detachArrayBuffer(buffer),
+        };
+    }
+
+    for (const length of lengths) {
+        const buffer = new otherGlobal.ArrayBuffer(length);
+        yield {
+            buffer,
+            detach: () => otherGlobal.$.detachArrayBuffer(buffer),
+        };
+    }
+}
+
+function ValueReturning(value, detach) {
+    return {
+        valueOf() {
+            if (detach)
+                detach();
+            return value;
+        }
+    };
+}
+
+const TEST_TARGET = [
+    BigInt64Array,
+    BigUint64Array,
+    Float16Array,
+    Float32Array,
+    Float64Array,
+    Int16Array,
+    Int32Array,
+    Int8Array,
+    Uint16Array,
+    Uint32Array,
+    Uint8Array,
+    Uint8ClampedArray,
+];
+
+for (const Ctor of TEST_TARGET) {
+    const label = Ctor.name;
+
+    for (const { buffer, detach } of createBuffers()) {
+        // https://tc39.es/ecma262/2026/#sec-initializetypedarrayfromarraybuffer
+        // If the step 5-a |ToIndex(length)| of detach the buffer,
+        // the step 6 |IsDetachedBuffer(buffer)| should catch it.
+        const length = ValueReturning(0, detach);
+        shouldThrow(label, () => {
+            new Ctor(buffer, 0, length);
+        }, TypeError, 'Buffer is already detached');
+    }
+}

--- a/JSTests/test262/expectations.yaml
+++ b/JSTests/test262/expectations.yaml
@@ -894,9 +894,6 @@ test/staging/sm/RegExp/unicode-braced.js:
 test/staging/sm/RegExp/unicode-class-braced.js:
   default: 'SyntaxError: Invalid regular expression: regular expression too large'
   strict mode: 'SyntaxError: Invalid regular expression: regular expression too large'
-test/staging/sm/TypedArray/constructor-buffer-sequence.js:
-  default: 'Test262Error: Expected a ExpectedError but got a Error'
-  strict mode: 'Test262Error: Expected a ExpectedError but got a Error'
 test/staging/sm/TypedArray/slice-memcpy.js:
   default: 'Test262Error: Actual [1, 2, 1, 2, 3, 4] and expected [1, 2, 1, 2, 1, 2] should have the same contents. '
   strict mode: 'Test262Error: Actual [1, 2, 1, 2, 3, 4] and expected [1, 2, 1, 2, 1, 2] should have the same contents. '

--- a/LayoutTests/fast/canvas/webgl/data-view-test-expected.txt
+++ b/LayoutTests/fast/canvas/webgl/data-view-test-expected.txt
@@ -27,10 +27,10 @@ PASS view = new DataView(arrayBuffer, 1, 2) threw exception RangeError: Length o
 PASS view = new DataView(arrayBuffer, 2, 1) threw exception RangeError: Length out of range of buffer.
 
 Test for constructor throwing wrong byteoffset exception
-PASS view = new Int32Array(new ArrayBuffer(100), 1, 1) threw exception RangeError: Byte offset is not aligned.
+PASS view = new Int32Array(new ArrayBuffer(100), 1, 1) threw exception RangeError: byteOffset modulo TypedArray.BYTES_PER_ELEMENT must be 0.
 
 Test for constructor wrong length exception takes precedence over wrong byteoffset exception
-PASS view = new Int32Array(new ArrayBuffer(100), 1, 101) threw exception RangeError: Length out of range of buffer.
+PASS view = new Int32Array(new ArrayBuffer(100), 1, 101) threw exception RangeError: byteOffset modulo TypedArray.BYTES_PER_ELEMENT must be 0.
 
 Test for get methods that work
 PASS view.getInt8(0) is 0

--- a/Source/JavaScriptCore/runtime/JSGenericTypedArrayViewConstructorInlines.h
+++ b/Source/JavaScriptCore/runtime/JSGenericTypedArrayViewConstructorInlines.h
@@ -281,17 +281,20 @@ ALWAYS_INLINE EncodedJSValue constructGenericTypedArrayViewImpl(JSGlobalObject* 
     size_t offset = 0;
     std::optional<size_t> length;
     if (auto* arrayBuffer = dynamicDowncast<JSArrayBuffer>(firstValue)) {
-        if (argCount > 1) {
-            offset = callFrame->uncheckedArgument(1).toIndex(globalObject, "byteOffset"_s);
-            RETURN_IF_EXCEPTION(scope, { });
-        }
-
         if (arrayBuffer->isResizableOrGrowableShared()) {
             structure = JSC_GET_DERIVED_STRUCTURE(vm, resizableOrGrowableSharedTypedArrayStructureWithTypedArrayType<ViewClass::TypedArrayStorageType>, newTarget, callFrame->jsCallee());
             RETURN_IF_EXCEPTION(scope, { });
         } else {
             structure = JSC_GET_DERIVED_STRUCTURE(vm, typedArrayStructureWithTypedArrayType<ViewClass::TypedArrayStorageType>, newTarget, callFrame->jsCallee());
             RETURN_IF_EXCEPTION(scope, { });
+        }
+
+        if (argCount > 1) {
+            offset = callFrame->uncheckedArgument(1).toIndex(globalObject, "byteOffset"_s);
+            RETURN_IF_EXCEPTION(scope, { });
+
+            if (offset % ViewClass::elementSize) [[unlikely]]
+                return throwVMRangeError(globalObject, scope, "byteOffset modulo TypedArray.BYTES_PER_ELEMENT must be 0"_s);
         }
 
         if (argCount > 2) {


### PR DESCRIPTION
#### 8608a8ac3b201b79a2d5475af207d84309f518ca
<pre>
[JSC] test 262 fail: test/staging/sm/TypedArray/constructor-buffer-sequence.js
<a href="https://bugs.webkit.org/show_bug.cgi?id=313927">https://bugs.webkit.org/show_bug.cgi?id=313927</a>

Reviewed by Yusuke Suzuki.

This change fixes some spec compliant issues to pass the test:

1. The step 7-a `AllocateTypedArray` of <a href="https://tc39.es/ecma262/2026/#sec-typedarray">https://tc39.es/ecma262/2026/#sec-typedarray</a> should be executed:
    1. before the step 2 `ToIndex(byteOffset)` of <a href="https://tc39.es/ecma262/2026/#sec-initializetypedarrayfromarraybuffer">https://tc39.es/ecma262/2026/#sec-initializetypedarrayfromarraybuffer</a>
2. The step 3 of <a href="https://tc39.es/ecma262/2026/#sec-initializetypedarrayfromarraybuffer">https://tc39.es/ecma262/2026/#sec-initializetypedarrayfromarraybuffer</a> should be executed:
    1. before the step 6 `IsDetachedBuffer(buffer)`.
    2. before the step 5-a `ToIndex(length)`.

----

This change just fixes failures shown as these test cases:

- JSTests/stress/typedarray-constructor-bug-313927-allocatetypedarray-before-toindex-byteoffset.js
- JSTests/stress/typedarray-constructor-bug-313927-byteoffset-modulo-elementsize-before-isdetachedbuffer-weird-byteoffset.js
- JSTests/stress/typedarray-constructor-bug-313927-byteoffset-modulo-elementsize-before-isdetachedbuffer.js
- JSTests/stress/typedarray-constructor-bug-313927-byteoffset-modulo-elementsize-before-toindex-length.js

Other added test cases are just a port of the rest of test/staging/sm/TypedArray/constructor-buffer-sequence.js
to improve the test coverage as a regression test.

Tests: JSTests/stress/typedarray-constructor-allocatetypedarray-before-isdetachedbuffer-prototype-getter-detach.js
       JSTests/stress/typedarray-constructor-allocatetypedarray-before-isdetachedbuffer.js
       JSTests/stress/typedarray-constructor-allocatetypedarray-before-toindex-byteoffset.js
       JSTests/stress/typedarray-constructor-allocatetypedarray-before-toindex-length.js
       JSTests/stress/typedarray-constructor-byteoffset-modulo-elementsize-before-isdetachedbuffer-weird-byteoffset.js
       JSTests/stress/typedarray-constructor-byteoffset-modulo-elementsize-before-isdetachedbuffer.js
       JSTests/stress/typedarray-constructor-byteoffset-modulo-elementsize-before-toindex-length.js
       JSTests/stress/typedarray-constructor-isdetachbuffer-before-bufferbytelength-modulo-elementsize-weird-byteoffset-detach.js
       JSTests/stress/typedarray-constructor-isdetachbuffer-before-bufferbytelength-modulo-elementsize.js
       JSTests/stress/typedarray-constructor-isdetachbuffer-before-newbytelength-lt-0-weird-byteoffset.js
       JSTests/stress/typedarray-constructor-isdetachbuffer-before-newbytelength-lt-0.js
       JSTests/stress/typedarray-constructor-isdetachbuffer-before-offset+newbytelength-gt-bufferbytelength-byteoffset-too-large.js
       JSTests/stress/typedarray-constructor-isdetachbuffer-before-offset+newbytelength-gt-bufferbytelength-length-too-large.js
       JSTests/stress/typedarray-constructor-toindex-byteoffset-before-isdetachedbuffer-weird-byteoffset-detach.js
       JSTests/stress/typedarray-constructor-toindex-byteoffset-before-isdetachedbuffer.js
       JSTests/stress/typedarray-constructor-toindex-byteoffset-detach-buffer.js
       JSTests/stress/typedarray-constructor-toindex-length-before-isdetachedbuffer-weird-byteoffset-detach.js
       JSTests/stress/typedarray-constructor-toindex-length-before-isdetachedbuffer-weird-length-detach.js
       JSTests/stress/typedarray-constructor-toindex-length-before-isdetachedbuffer.js
       JSTests/stress/typedarray-constructor-toindex-length-detach-buffer.js

* JSTests/stress/typedarray-constructor-allocatetypedarray-before-isdetachedbuffer-prototype-getter-detach.js: Added.
* JSTests/stress/typedarray-constructor-allocatetypedarray-before-isdetachedbuffer.js: Added.
* JSTests/stress/typedarray-constructor-allocatetypedarray-before-toindex-byteoffset.js: Added.
* JSTests/stress/typedarray-constructor-allocatetypedarray-before-toindex-length.js: Added.
* JSTests/stress/typedarray-constructor-byteoffset-modulo-elementsize-before-isdetachedbuffer-weird-byteoffset.js: Added.
* JSTests/stress/typedarray-constructor-byteoffset-modulo-elementsize-before-isdetachedbuffer.js: Added.
* JSTests/stress/typedarray-constructor-byteoffset-modulo-elementsize-before-toindex-length.js: Added.
* JSTests/stress/typedarray-constructor-isdetachbuffer-before-bufferbytelength-modulo-elementsize-weird-byteoffset-detach.js: Added.
* JSTests/stress/typedarray-constructor-isdetachbuffer-before-bufferbytelength-modulo-elementsize.js: Added.
* JSTests/stress/typedarray-constructor-isdetachbuffer-before-newbytelength-lt-0-weird-byteoffset.js: Added.
* JSTests/stress/typedarray-constructor-isdetachbuffer-before-newbytelength-lt-0.js: Added.
* JSTests/stress/typedarray-constructor-isdetachbuffer-before-offset+newbytelength-gt-bufferbytelength-byteoffset-too-large.js: Added.
* JSTests/stress/typedarray-constructor-isdetachbuffer-before-offset+newbytelength-gt-bufferbytelength-length-too-large.js: Added.
* JSTests/stress/typedarray-constructor-toindex-byteoffset-before-isdetachedbuffer-weird-byteoffset-detach.js: Added.
* JSTests/stress/typedarray-constructor-toindex-byteoffset-before-isdetachedbuffer.js: Added.
* JSTests/stress/typedarray-constructor-toindex-byteoffset-detach-buffer.js: Added.
* JSTests/stress/typedarray-constructor-toindex-length-before-isdetachedbuffer-weird-byteoffset-detach.js: Added.
* JSTests/stress/typedarray-constructor-toindex-length-before-isdetachedbuffer-weird-length-detach.js: Added.
* JSTests/stress/typedarray-constructor-toindex-length-before-isdetachedbuffer.js: Added.
* JSTests/stress/typedarray-constructor-toindex-length-detach-buffer.js: Added.
* LayoutTests/fast/canvas/webgl/data-view-test-expected.txt:
    Thrown error was changed due to add |byteOffset modulo TypedArray.BYTES_PER_ELEMENT| check.
* Source/JavaScriptCore/runtime/JSGenericTypedArrayViewConstructorInlines.h:

Canonical link: <a href="https://commits.webkit.org/313401@main">https://commits.webkit.org/313401@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/121500e315c46ac7f851ba661c04ec2bfe89c9b5

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/161701 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/35175 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/28278 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/170604 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/118072 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/35276 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/35176 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/125452 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/88375 "2 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/164660 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/27763 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/145244 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/106048 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/26812 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/25322 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/18325 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/153758 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/136505 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/22999 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/173092 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/22539 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/20133 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/24640 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/133744 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/34849 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/29414 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/133749 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/34833 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/144794 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/96839 "The change is no longer eligible for processing.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/24793 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/28286 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/21615 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/194100 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/34343 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/101788 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/50013 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/33843 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/34086 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/33992 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->