### PR TITLE
[Win] Improvements to run loop timer resolution & Make MiniBrowser use WTF::RunLoop

### DIFF
--- a/Source/WTF/wtf/RunLoop.h
+++ b/Source/WTF/wtf/RunLoop.h
@@ -146,6 +146,8 @@ public:
 #endif
 
 #if USE(WINDOWS_EVENT_LOOP)
+    using WindowsMessageHandler = Function<bool(MSG&)>;
+    WTF_EXPORT_PRIVATE static void setWindowsMessageHandler(WindowsMessageHandler&&);
     static void registerRunLoopMessageWindowClass();
 #endif
 
@@ -319,10 +321,14 @@ private:
 #if USE(WINDOWS_EVENT_LOOP)
     static LRESULT CALLBACK RunLoopWndProc(HWND, UINT, WPARAM, LPARAM);
     LRESULT wndProc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam);
+    void dispatchMessage(MSG&);
+    DWORD msTillNextTimer();
+    void fireTimers();
     HWND m_runLoopMessageWindow;
-    UncheckedKeyHashSet<UINT_PTR> m_liveTimers;
+    Deque<TimerBase*> m_timers;
 
     Lock m_loopLock;
+    WindowsMessageHandler m_windowsMessageHandler;
 #elif USE(COCOA_EVENT_LOOP)
     static void performWork(void*);
     const RetainPtr<CFRunLoopRef> m_runLoop;

--- a/Source/WTF/wtf/win/RunLoopWin.cpp
+++ b/Source/WTF/wtf/win/RunLoopWin.cpp
@@ -32,7 +32,7 @@ namespace WTF {
 
 static const UINT PerformWorkMessage = WM_USER + 1;
 static const UINT SetTimerMessage = WM_USER + 2;
-static const UINT KillTimerMessage = WM_USER + 3;
+static const UINT FireTimerMessage = WM_USER + 3;
 static const LPCWSTR kRunLoopMessageWindowClassName = L"RunLoopMessageWindow";
 
 LRESULT CALLBACK RunLoop::RunLoopWndProc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam)
@@ -58,18 +58,10 @@ LRESULT RunLoop::wndProc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam)
         performWork();
         return 0;
     case SetTimerMessage:
-        ::SetTimer(hWnd, wParam, lParam, nullptr);
         return 0;
-    case KillTimerMessage:
-        ::KillTimer(hWnd, wParam);
-        return 0;
-    case WM_TIMER:
+    case FireTimerMessage:
         RunLoop::TimerBase* timer = nullptr;
-        {
-            Locker locker { m_loopLock };
-            if (m_liveTimers.contains(wParam))
-                timer = std::bit_cast<RunLoop::TimerBase*>(wParam);
-        }
+        timer = std::bit_cast<RunLoop::TimerBase*>(wParam);
         if (timer != nullptr)
             timer->timerFired();
         return 0;
@@ -80,18 +72,66 @@ LRESULT RunLoop::wndProc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam)
 
 void RunLoop::run()
 {
-    MSG message;
-    while (BOOL result = ::GetMessage(&message, nullptr, 0, 0)) {
-        if (result == -1)
-            break;
-        ::TranslateMessage(&message);
-        ::DispatchMessage(&message);
+    auto& runLoop = RunLoop::currentSingleton();
+    while (true) {
+        runLoop.fireTimers();
+        MSG message;
+        while (BOOL result = ::PeekMessage(&message, nullptr, 0, 0, PM_REMOVE)) {
+            if (result == -1)
+                break;
+            if (message.message == WM_QUIT)
+                return;
+            runLoop.dispatchMessage(message);
+        }
+
+        DWORD timeout = runLoop.msTillNextTimer();
+        if (timeout > 0)
+            ::MsgWaitForMultipleObjectsEx(0, nullptr, timeout, QS_ALLINPUT, MWMO_INPUTAVAILABLE);
+    }
+}
+
+DWORD RunLoop::msTillNextTimer()
+{
+    Locker locker { m_loopLock };
+    Seconds timeout = Seconds(3600);
+
+    if (!m_timers.isEmpty()) {
+        auto now = MonotonicTime::now();
+        auto firstTimer = m_timers.last();
+
+        timeout = std::max<Seconds>(firstTimer->m_nextFireDate - now, 0_s);
+    }
+    return timeout.milliseconds();
+}
+
+void RunLoop::fireTimers()
+{
+    Locker locker { m_loopLock };
+
+    // Can bail here if there's no timers before we check the time
+    if (m_timers.isEmpty())
+        return;
+
+    // Fire any timers ready from the front of the queue
+    auto now = MonotonicTime::now();
+
+    while (!m_timers.isEmpty()) {
+        auto timer = m_timers.last();
+        if (timer->m_nextFireDate > now)
+            return;
+        ::PostMessage(m_runLoopMessageWindow, FireTimerMessage, std::bit_cast<uintptr_t>(timer), 0LL);
+        m_timers.removeLast();
     }
 }
 
 void RunLoop::setWakeUpCallback(WTF::Function<void()>&& function)
 {
     RunLoop::currentSingleton().m_wakeUpCallback = WTF::move(function);
+}
+
+void RunLoop::setWindowsMessageHandler(WindowsMessageHandler&& handler)
+{
+    RunLoop::currentSingleton().m_windowsMessageHandler = WTF::move(handler);
 }
 
 void RunLoop::stop()
@@ -137,15 +177,25 @@ void RunLoop::wakeUp()
 
 RunLoop::CycleResult RunLoop::cycle(RunLoopMode)
 {
+    auto& runLoop = RunLoop::currentSingleton();
+    runLoop.fireTimers();
     MSG message;
     while (::PeekMessage(&message, nullptr, 0, 0, PM_REMOVE)) {
         if (message.message == WM_QUIT)
             return CycleResult::Stop;
 
-        ::TranslateMessage(&message);
-        ::DispatchMessage(&message);
+        runLoop.dispatchMessage(message);
     }
     return CycleResult::Continue;
+}
+
+void RunLoop::dispatchMessage(MSG& message)
+{
+    if (m_windowsMessageHandler && m_windowsMessageHandler(message))
+        return;
+
+    ::TranslateMessage(&message);
+    ::DispatchMessage(&message);
 }
 
 // RunLoop::Timer
@@ -160,9 +210,13 @@ void RunLoop::TimerBase::timerFired()
 
         if (!m_isRepeating) {
             m_isActive = false;
-            ::KillTimer(m_runLoop->m_runLoopMessageWindow, std::bit_cast<uintptr_t>(this));
-        } else
+            m_nextFireDate = MonotonicTime::infinity();
+        } else {
             m_nextFireDate = MonotonicTime::timePointFromNow(m_interval);
+            m_runLoop->m_timers.appendAndBubble(this, [&] (TimerBase* otherTimer) -> bool {
+                return m_nextFireDate > otherTimer->m_nextFireDate;
+            });
+        }
     }
 
     fired();
@@ -182,12 +236,23 @@ RunLoop::TimerBase::~TimerBase()
 void RunLoop::TimerBase::start(Seconds interval, bool repeat)
 {
     Locker locker { m_runLoop->m_loopLock };
+    if (isActiveWithLock()) {
+        // Rescheduling timer that's already started
+        m_runLoop->m_timers.removeFirstMatching([&] (TimerBase* t) -> bool {
+            return this == t;
+        });
+    }
+
     m_isRepeating = repeat;
     m_isActive = true;
     m_interval = interval;
     m_nextFireDate = MonotonicTime::timePointFromNow(m_interval);
-    m_runLoop->m_liveTimers.add(std::bit_cast<uintptr_t>(this));
-    ::PostMessage(m_runLoop->m_runLoopMessageWindow, SetTimerMessage, std::bit_cast<uintptr_t>(this), interval.millisecondsAs<UINT>());
+    m_runLoop->m_timers.appendAndBubble(this, [&] (TimerBase* otherTimer) -> bool {
+        return m_nextFireDate > otherTimer->m_nextFireDate;
+    });
+    // If this is the first timer now, we need to cycle the run loop so we don't sleep through it
+    if (m_runLoop->m_timers.last() == this)
+        ::PostMessage(m_runLoop->m_runLoopMessageWindow, SetTimerMessage, std::bit_cast<uintptr_t>(this), interval.millisecondsAs<UINT>());
 }
 
 void RunLoop::TimerBase::stop()
@@ -197,8 +262,11 @@ void RunLoop::TimerBase::stop()
         return;
 
     m_isActive = false;
-    m_runLoop->m_liveTimers.remove(std::bit_cast<uintptr_t>(this));
-    ::PostMessage(m_runLoop->m_runLoopMessageWindow, KillTimerMessage, std::bit_cast<uintptr_t>(this), 0LL);
+    m_nextFireDate = MonotonicTime::infinity();
+
+    m_runLoop->m_timers.removeFirstMatching([&] (TimerBase* t) -> bool {
+        return this == t;
+    });
 }
 
 bool RunLoop::TimerBase::isActiveWithLock() const

--- a/Tools/MiniBrowser/win/WinMain.cpp
+++ b/Tools/MiniBrowser/win/WinMain.cpp
@@ -32,6 +32,7 @@
 #include "Common.h"
 #include "MiniBrowserLibResource.h"
 #include "WebKitBrowserWindow.h"
+#include <wtf/RunLoop.h>
 
 int WINAPI wWinMain(_In_ HINSTANCE hInstance, _In_opt_ HINSTANCE, _In_ LPWSTR, _In_ int nCmdShow)
 {
@@ -41,7 +42,6 @@ int WINAPI wWinMain(_In_ HINSTANCE hInstance, _In_opt_ HINSTANCE, _In_ LPWSTR, _
     _CrtSetReportMode(_CRT_WARN, _CRTDBG_MODE_FILE);
 #endif
 
-    MSG msg { };
     HACCEL hAccelTable, hPreAccelTable;
 
     INITCOMMONCONTROLSEX InitCtrlEx;
@@ -78,17 +78,15 @@ int WINAPI wWinMain(_In_ HINSTANCE hInstance, _In_opt_ HINSTANCE, _In_ LPWSTR, _
 
     // Main message loop:
     __try {
-        while (GetMessage(&msg, nullptr, 0, 0)) {
+        RunLoop::setWindowsMessageHandler([hAccelTable, hPreAccelTable] (MSG& msg) {
             if (TranslateAccelerator(msg.hwnd, hPreAccelTable, &msg))
-                continue;
+                return true;
             bool processed = false;
             if (MainWindow::isInstance(msg.hwnd))
                 processed = TranslateAccelerator(msg.hwnd, hAccelTable, &msg);
-            if (!processed) {
-                TranslateMessage(&msg);
-                DispatchMessage(&msg);
-            }
-        }
+            return processed;
+        });
+        RunLoop::run();
     } __except(createCrashReport(GetExceptionInformation()), EXCEPTION_EXECUTE_HANDLER) { }
 
 exit:
@@ -99,5 +97,5 @@ exit:
     // Shut down COM.
     OleUninitialize();
 
-    return static_cast<int>(msg.wParam);
+    return 0;
 }


### PR DESCRIPTION
#### 9c0e11595b57609920d4a83dff22f45a56722b4a
<pre>
[Win] Improvements to run loop timer resolution &amp; Make MiniBrowser use WTF::RunLoop
<a href="https://bugs.webkit.org/show_bug.cgi?id=284823">https://bugs.webkit.org/show_bug.cgi?id=284823</a>

Reviewed by Don Olmstead.

WM_TIMER has a 10ms resolution, which means we can&apos;t hit 60fps on
requestAnimationFrame. By using MsgWaitForMultipleObjectsEx and
maintaining our own timer queue we can get better timer resolution.

Make Windows MiniBrowser run the UI thread with WTF::RunLoop::run(),
letting WTF own the main run loop while still giving MiniBrowser a chance
to consume Win32 messages before the default TranslateMessage()/DispatchMessage() path.

Co-authored-by: Ian Grunert &lt;ian.grunert@gmail.com&gt;
Canonical link: <a href="https://commits.webkit.org/312750@main">https://commits.webkit.org/312750@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/eb86bf7e95d52e44a6e0ba30dd90aa1001a2ecf6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/160684 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/34157 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/27258 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/169587 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/115750 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/162553 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/34258 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/34157 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/124617 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/87984 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/163643 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/26872 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/144344 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/105214 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/25924 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/24416 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/17307 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/152740 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/135618 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/22107 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/172067 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/21522 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/18973 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/23747 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/132893 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/33831 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/28508 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/132906 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35952 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/33815 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/143902 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/95624 "The change is no longer eligible for processing.") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/27491 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/20717 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/193083 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/33326 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/100587 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/49729 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/32825 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/33069 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/32973 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->