### PR TITLE
Adapt for procfs differences between NetBSD and other operating systems.

### DIFF
--- a/Source/WTF/wtf/glib/FileSystemGlib.cpp
+++ b/Source/WTF/wtf/glib/FileSystemGlib.cpp
@@ -65,7 +65,7 @@ CString currentExecutablePath()
 {
     static std::array<char, PATH_MAX> readLinkBuffer;
     ssize_t result = readlink("/proc/self/exe", readLinkBuffer.data(), readLinkBuffer.size());
-    if (result == -1)
+    if (result <= 0)
         return { };
     return CString(unsafeMakeSpan(readLinkBuffer.data(), static_cast<size_t>(result)));
 }
@@ -83,16 +83,21 @@ CString currentExecutablePath()
     int selfFd = open("/proc/self/exefile", O_RDONLY);
     ssize_t result = read(selfFd, readBuffer, sizeof(readBuffer));
     close(selfFd);
-    if (result == -1)
+    if (result <= 0)
         return { };
     return CString(unsafeMakeSpan(readBuffer, static_cast<size_t>(result)));
 }
 #elif OS(UNIX)
+#if OS(NETBSD)
+#define _PROC_CURPROC_PATH "/proc/curproc/exe"
+#else
+#define _PROC_CURPROC_PATH "/proc/curproc/file"
+#endif
 CString currentExecutablePath()
 {
     static char readLinkBuffer[PATH_MAX];
-    ssize_t result = readlink("/proc/curproc/file", readLinkBuffer, PATH_MAX);
-    if (result == -1)
+    ssize_t result = readlink(_PROC_CURPROC_PATH, readLinkBuffer, PATH_MAX);
+    if (result <= 0)
         return { };
     return CString(unsafeMakeSpan(readLinkBuffer, static_cast<size_t>(result)));
 }


### PR DESCRIPTION
#### 4bbc7d631326fb735ab043506881a8f0bc9713b4
<pre>
Adapt for procfs differences between NetBSD and other operating systems.
<a href="https://bugs.webkit.org/show_bug.cgi?id=313992">https://bugs.webkit.org/show_bug.cgi?id=313992</a>

Reviewed by Claudio Saavedra.

NetBSD does support procfs, but there are some differences.  One is
that the link to the executable is not `/proc/curproc/file` but
`/proc/curproc/exe`.  This causes an error message on the console.

This error also showed an off-by-one - glib2 doesn&apos;t like creating
file names from strings of length zero - fixed as well.

* Source/WTF/wtf/glib/FileSystemGlib.cpp:
(WTF::FileSystemImpl::currentExecutablePath):

Canonical link: <a href="https://commits.webkit.org/312615@main">https://commits.webkit.org/312615@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3afe24eb9d053e829e6b6fac4595f797fb0de04d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/160496 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/33969 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/27070 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/169399 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/115562 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/34070 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/33969 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/124451 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/87900 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/163454 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/26697 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/144172 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/105051 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/25749 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/24252 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/17118 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/152552 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/135443 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/21935 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/171877 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/21333 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/18371 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/23575 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/132713 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/33643 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/28345 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/132730 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/33627 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/143730 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/95410 "The change is no longer eligible for processing.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/24425 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/27326 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/20544 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/192895 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/33137 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/99999 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/49672 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/32637 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/32881 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/32785 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->