### PR TITLE
Re-enable WebsiteDataStoreCustomPaths API tests

### DIFF
--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WebsiteDataStoreCustomPaths.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WebsiteDataStoreCustomPaths.mm
@@ -89,6 +89,7 @@ static void runWebsiteDataStoreCustomPaths(ShouldEnableProcessPrewarming shouldE
     RetainPtr localStoragePath = [NSURL fileURLWithPath:[@"~/Library/WebKit/com.apple.WebKit.TestWebKitAPI/CustomWebsiteData/LocalStorage/" stringByExpandingTildeInPath] isDirectory:YES];
     RetainPtr cookieStorageFile = [NSURL fileURLWithPath:[@"~/Library/WebKit/com.apple.WebKit.TestWebKitAPI/CustomWebsiteData/CookieStorage/Cookie.File" stringByExpandingTildeInPath] isDirectory:NO];
     RetainPtr resourceLoadStatisticsPath = [NSURL fileURLWithPath:[@"~/Library/WebKit/com.apple.WebKit.TestWebKitAPI/CustomWebsiteData/ResourceLoadStatistics/" stringByExpandingTildeInPath] isDirectory:YES];
+    RetainPtr generalStoragePath = [NSURL fileURLWithPath:[@"~/Library/WebKit/com.apple.WebKit.TestWebKitAPI/CustomWebsiteData/Storage/" stringByExpandingTildeInPath] isDirectory:YES];
     RetainPtr defaultIDBPath = [NSURL fileURLWithPath:[@"~/Library/WebKit/com.apple.WebKit.TestWebKitAPI/WebsiteData/IndexedDB/" stringByExpandingTildeInPath] isDirectory:YES];
     RetainPtr defaultLocalStoragePath = [NSURL fileURLWithPath:[@"~/Library/WebKit/com.apple.WebKit.TestWebKitAPI/WebsiteData/LocalStorage/" stringByExpandingTildeInPath] isDirectory:YES];
     RetainPtr defaultResourceLoadStatisticsPath = [NSURL fileURLWithPath:[@"~/Library/WebKit/com.apple.WebKit.TestWebKitAPI/WebsiteData/ResourceLoadStatistics/" stringByExpandingTildeInPath] isDirectory:YES];
@@ -97,6 +98,7 @@ static void runWebsiteDataStoreCustomPaths(ShouldEnableProcessPrewarming shouldE
     [[NSFileManager defaultManager] removeItemAtURL:localStoragePath.get() error:nil];
     [[NSFileManager defaultManager] removeItemAtURL:cookieStorageFile.get() error:nil];
     [[NSFileManager defaultManager] removeItemAtURL:resourceLoadStatisticsPath.get() error:nil];
+    [[NSFileManager defaultManager] removeItemAtURL:generalStoragePath.get() error:nil];
     [[NSFileManager defaultManager] removeItemAtURL:defaultIDBPath.get() error:nil];
     [[NSFileManager defaultManager] removeItemAtURL:defaultLocalStoragePath.get() error:nil];
     [[NSFileManager defaultManager] removeItemAtURL:defaultResourceLoadStatisticsPath.get() error:nil];
@@ -105,6 +107,7 @@ static void runWebsiteDataStoreCustomPaths(ShouldEnableProcessPrewarming shouldE
     EXPECT_FALSE([[NSFileManager defaultManager] fileExistsAtPath:localStoragePath.get().path]);
     EXPECT_FALSE([[NSFileManager defaultManager] fileExistsAtPath:cookieStorageFile.get().path]);
     EXPECT_FALSE([[NSFileManager defaultManager] fileExistsAtPath:resourceLoadStatisticsPath.get().path]);
+    EXPECT_FALSE([[NSFileManager defaultManager] fileExistsAtPath:generalStoragePath.get().path]);
     EXPECT_FALSE([[NSFileManager defaultManager] fileExistsAtPath:defaultIDBPath.get().path]);
     EXPECT_FALSE([[NSFileManager defaultManager] fileExistsAtPath:defaultLocalStoragePath.get().path]);
     EXPECT_FALSE([[NSFileManager defaultManager] fileExistsAtPath:defaultResourceLoadStatisticsPath.get().path]);
@@ -115,6 +118,7 @@ static void runWebsiteDataStoreCustomPaths(ShouldEnableProcessPrewarming shouldE
     websiteDataStoreConfiguration.get()._webStorageDirectory = localStoragePath.get();
     websiteDataStoreConfiguration.get()._cookieStorageFile = cookieStorageFile.get();
     websiteDataStoreConfiguration.get()._resourceLoadStatisticsDirectory = resourceLoadStatisticsPath.get();
+    websiteDataStoreConfiguration.get().generalStorageDirectory = generalStoragePath.get();
 
     configuration.get().websiteDataStore = adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:websiteDataStoreConfiguration.get()]).get();
     configuration.get().processPool = processPool.get();
@@ -270,22 +274,12 @@ static void runWebsiteDataStoreCustomPaths(ShouldEnableProcessPrewarming shouldE
     EXPECT_FALSE([WKWebsiteDataStore _defaultDataStoreExists]);
 }
 
-// FIXME when webkit.org/b/313786 is resolved.
-#if PLATFORM(MAC) && !defined(NDEBUG)
-TEST(WebKit, DISABLED_WebsiteDataStoreCustomPathsWithoutPrewarming)
-#else
 TEST(WebKit, WebsiteDataStoreCustomPathsWithoutPrewarming)
-#endif
 {
     runWebsiteDataStoreCustomPaths(ShouldEnableProcessPrewarming::No);
 }
 
-// FIXME when webkit.org/b/313786 is resolved.
-#if PLATFORM(MAC) && !defined(NDEBUG)
-TEST(WebKit, DISABLED_WebsiteDataStoreCustomPathsWithPrewarming)
-#else
 TEST(WebKit, WebsiteDataStoreCustomPathsWithPrewarming)
-#endif
 {
     runWebsiteDataStoreCustomPaths(ShouldEnableProcessPrewarming::Yes);
 }


### PR DESCRIPTION
#### 6e84ca1cf0099237672d4d2e51ff7965a20e0c5a
<pre>
Re-enable WebsiteDataStoreCustomPaths API tests
<a href="https://bugs.webkit.org/show_bug.cgi?id=314006">https://bugs.webkit.org/show_bug.cgi?id=314006</a>
<a href="https://rdar.apple.com/176205715">rdar://176205715</a>

Reviewed by Chris Dumez.

Use a custom general storage directory for the tests so they do not share the default directory with other API tests.
When the default directory is shared, origins written by other tests are picked up by getAllOrigins(). Some of those
origins use custom schemes (e.g. sw-ext://) that were registered as scheme handlers in the original test but are not
registered in the WebsiteDataStoreCustomPaths test process. When such an origin is reconstructed from on-disk data,
SecurityOriginData::shouldTreatAsOpaqueOrigin() treats it as opaque, so optionalDatabaseIdentifier() returns an empty
string. This makes LocalStorageManager::localStorageFilePath() return an empty path even though the custom local storage
directory is set, which triggers the assertion in OriginStorageManager that the custom path and root path must both be
empty or both be non-empty.

* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WebsiteDataStoreCustomPaths.mm:
(runWebsiteDataStoreCustomPaths):
(TEST(WebKit, WebsiteDataStoreCustomPathsWithoutPrewarming)):
(TEST(WebKit, WebsiteDataStoreCustomPathsWithPrewarming)):

Canonical link: <a href="https://commits.webkit.org/312584@main">https://commits.webkit.org/312584@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/534b9f3c3e7ae1a2e57633cd46d267fb12648f61

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/160371 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/33844 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/26945 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/169274 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/115437 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/d5011c08-f288-460a-8328-432823f136e1) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/162240 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/33945 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/33844 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/124340 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/87838 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/978de496-0a9c-4e2e-a7b5-48f413095cc9) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/163329 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/26579 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/144048 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/104939 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/8c5117cc-9358-4acc-8650-a0732829fcd8) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/25631 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/24137 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/16993 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/135324 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/21811 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/171751 "Built successfully") | | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/23451 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/132597 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/33517 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/28231 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/132618 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35854 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/33502 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/143606 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/95284 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/27231 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/20420 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/33011 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/32512 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/32756 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/32660 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->