### PR TITLE
Use protect() instead of RefPtr { } in editing code

### DIFF
--- a/Source/WebCore/editing/ApplyStyleCommand.cpp
+++ b/Source/WebCore/editing/ApplyStyleCommand.cpp
@@ -474,7 +474,7 @@ RefPtr<HTMLElement> ApplyStyleCommand::splitAncestorsWithUnicodeBidi(Node* node,
     RefPtr<Node> highestAncestorWithUnicodeBidi;
     RefPtr<Node> nextHighestAncestorWithUnicodeBidi;
     int highestAncestorUnicodeBidi = 0;
-    for (auto ancestor = RefPtr { node->parentNode() }; ancestor != block; ancestor = ancestor->parentNode()) {
+    for (RefPtr ancestor { node->parentNode() }; ancestor != block; ancestor = ancestor->parentNode()) {
         int unicodeBidi = valueID(Style::Extractor(ancestor.get()).propertyValue(CSSPropertyUnicodeBidi).get());
         if (unicodeBidi && unicodeBidi != CSSValueNormal) {
             highestAncestorUnicodeBidi = unicodeBidi;

--- a/Source/WebCore/editing/EditingStyle.cpp
+++ b/Source/WebCore/editing/EditingStyle.cpp
@@ -1603,7 +1603,7 @@ void EditingStyle::removeEquivalentProperties(T& style)
         auto id = property.id();
         if (alreadyHandled.contains(id))
             continue;
-        if (!style.propertyMatches(property.id(), RefPtr { property.value() }.get()))
+        if (!style.propertyMatches(property.id(), protect(property.value())))
             continue;
 
         // Only the text-decoration longhands support serializing with the shorthand in all editing properties.
@@ -1755,7 +1755,7 @@ RefPtr<EditingStyle> EditingStyle::styleAtSelectionStart(const VisibleSelection&
     // and find the background color of the common ancestor.
     if (shouldUseBackgroundColorInEffect && (selection.isRange() || hasTransparentBackgroundColor(protect(style->style()).get()))) {
         if (auto range = selection.toNormalizedRange()) {
-            if (RefPtr value = backgroundColorInEffect(RefPtr { commonInclusiveAncestor<ComposedTree>(*range) }.get()))
+            if (RefPtr value = backgroundColorInEffect(protect(commonInclusiveAncestor<ComposedTree>(*range))))
                 style->setProperty(CSSPropertyBackgroundColor, value->cssText(CSS::defaultSerializationContext()));
         }
     }

--- a/Source/WebCore/editing/FormatBlockCommand.cpp
+++ b/Source/WebCore/editing/FormatBlockCommand.cpp
@@ -70,7 +70,7 @@ void FormatBlockCommand::formatRange(const Position& start, const Position& end,
 {
     RefPtr nodeToSplitTo = enclosingBlockToSplitTreeTo(start.deprecatedNode());
     ASSERT(nodeToSplitTo);
-    RefPtr<Node> outerBlock = (start.deprecatedNode() == nodeToSplitTo) ? RefPtr { start.deprecatedNode() } : splitTreeToNode(*start.deprecatedNode(), *nodeToSplitTo);
+    RefPtr<Node> outerBlock = (start.deprecatedNode() == nodeToSplitTo) ? protect(start.deprecatedNode()) : splitTreeToNode(*start.deprecatedNode(), *nodeToSplitTo);
     if (!outerBlock)
         return;
 

--- a/Source/WebCore/editing/IndentOutdentCommand.cpp
+++ b/Source/WebCore/editing/IndentOutdentCommand.cpp
@@ -107,7 +107,7 @@ void IndentOutdentCommand::indentIntoBlockquote(const Position& start, const Pos
     if (!nodeToSplitTo)
         return;
 
-    RefPtr<Node> outerBlock = (start.containerNode() == nodeToSplitTo) ? RefPtr { start.containerNode() } : splitTreeToNode(*start.containerNode(), *nodeToSplitTo);
+    RefPtr<Node> outerBlock = (start.containerNode() == nodeToSplitTo) ? protect(start.containerNode()) : splitTreeToNode(*start.containerNode(), *nodeToSplitTo);
     if (!outerBlock)
         return;
 

--- a/Source/WebCore/editing/TextInsertionBaseCommand.cpp
+++ b/Source/WebCore/editing/TextInsertionBaseCommand.cpp
@@ -64,7 +64,7 @@ String dispatchBeforeTextInsertedEvent(const String& text, const VisibleSelectio
         if (startNode->rootEditableElement()) {
             // Send BeforeTextInsertedEvent. The event handler will update text if necessary.
             Ref event = BeforeTextInsertedEvent::create(text);
-            RefPtr { startNode->rootEditableElement() }->dispatchEvent(event);
+            protect(startNode->rootEditableElement())->dispatchEvent(event);
             newText = event->text();
         }
     }

--- a/Source/WebCore/editing/markup.cpp
+++ b/Source/WebCore/editing/markup.cpp
@@ -1112,7 +1112,7 @@ static RefPtr<Node> highestAncestorToWrapMarkup(const Position& start, const Pos
             specialCommonAncestor = WTF::move(highestMailBlockquote);
     }
 
-    RefPtr checkAncestor = specialCommonAncestor ? specialCommonAncestor : RefPtr { &commonAncestor };
+    RefPtr checkAncestor = specialCommonAncestor ? specialCommonAncestor : protect(commonAncestor);
     if (checkAncestor->renderer() && checkAncestor->renderer()->containingBlock()) {
         RefPtr newSpecialCommonAncestor = highestEnclosingNodeOfType(firstPositionInNode(*checkAncestor), &isElementPresentational, CanCrossEditingBoundary, protect(checkAncestor->renderer()->containingBlock()->element()).get());
         if (newSpecialCommonAncestor)


### PR DESCRIPTION
#### 353c0103c9ab7f41cbd0ff0c30d1205b6f72e7b9
<pre>
Use protect() instead of RefPtr { } in editing code
<a href="https://bugs.webkit.org/show_bug.cgi?id=314007">https://bugs.webkit.org/show_bug.cgi?id=314007</a>
<a href="https://rdar.apple.com/176206072">rdar://176206072</a>

Reviewed by Ryosuke Niwa.

Mechanical migration from RefPtr { expr } to protect(expr) in editing code,
aligning with the codebase-wide transition away from brace-initialized smart
pointer temporaries.

No new tests needed (no behavioral change, style-only refactor).

* Source/WebCore/editing/ApplyStyleCommand.cpp:
(WebCore::highestEmbeddingAncestor):
* Source/WebCore/editing/EditingStyle.cpp:
(WebCore::EditingStyle::propertiesMatchingProperty):
(WebCore::EditingStyle::mergeStyle):
* Source/WebCore/editing/FormatBlockCommand.cpp:
(WebCore::FormatBlockCommand::formatRange):
* Source/WebCore/editing/IndentOutdentCommand.cpp:
(WebCore::IndentOutdentCommand::formatSelection):
* Source/WebCore/editing/TextInsertionBaseCommand.cpp:
(WebCore::dispatchBeforeTextInsertedEvent):
* Source/WebCore/editing/markup.cpp:
(WebCore::serializePreservingVisualAppearanceInternal):

Canonical link: <a href="https://commits.webkit.org/312587@main">https://commits.webkit.org/312587@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2d3ac0fa7321595525b682ff962c6d14ac79a23e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/160378 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/33851 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/26952 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/169281 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/115444 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/a2289c6b-0cc8-4391-8374-5d9772544abc) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/162247 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/33952 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/33851 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/124345 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/87843 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/5a1fa711-7e2f-4a18-b9f8-289b230e12f5) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/163336 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/26595 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/144056 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/104944 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/8e4fad70-5e12-41e9-a674-4a214eb0cc79) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/25647 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/24143 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/17000 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/135340 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/21819 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/171758 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/18116 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/23459 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/132602 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/33524 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/28237 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/132623 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35856 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/33509 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/143614 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/95291 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/27227 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/20428 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/33018 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/99779 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/32519 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/32763 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/32667 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->