### PR TITLE
[JSC] Gate `Array#concat` fast path on indexing-type merge compatibility

### DIFF
--- a/JSTests/stress/array-concat-intrinsic-contiguous-double-mismatch.js
+++ b/JSTests/stress/array-concat-intrinsic-contiguous-double-mismatch.js
@@ -1,0 +1,71 @@
+function assert(b, ...m) {
+    if (!b)
+        throw new Error("Bad: ", ...m);
+}
+noInline(assert);
+
+function shallowEq(a, b) {
+    assert(a.length === b.length, a, b);
+    for (let i = 0; i < a.length; i++)
+        assert(a[i] === b[i], a, b);
+}
+noInline(shallowEq);
+
+function runConcat(a, b) {
+    return a.concat(b);
+}
+noInline(runConcat);
+
+function makeContiguous() {
+    let a = [1, "x"];
+    return a;
+}
+noInline(makeContiguous);
+
+function makeDouble() {
+    let a = [1.5, 2.5];
+    return a;
+}
+noInline(makeDouble);
+
+function testContiguousPlusDouble() {
+    let a = makeContiguous();
+    let b = makeDouble();
+    let r = runConcat(a, b);
+    shallowEq(r, [1, "x", 1.5, 2.5]);
+}
+
+function testDoublePlusContiguous() {
+    let a = makeDouble();
+    let b = makeContiguous();
+    let r = runConcat(a, b);
+    shallowEq(r, [1.5, 2.5, 1, "x"]);
+}
+
+function testCoWContiguousPlusDouble() {
+    let a = [1, "x"];
+    let b = [1.5, 2.5];
+    let r = runConcat(a, b);
+    shallowEq(r, [1, "x", 1.5, 2.5]);
+}
+
+function testCoWDoublePlusContiguous() {
+    let a = [1.5, 2.5];
+    let b = [1, "x"];
+    let r = runConcat(a, b);
+    shallowEq(r, [1.5, 2.5, 1, "x"]);
+}
+
+function testEmptyContiguousPlusDouble() {
+    let a = [];
+    let b = [1.5, 2.5];
+    shallowEq(runConcat(a, b), [1.5, 2.5]);
+}
+
+for (let i = 0; i < testLoopCount; i++) {
+    testContiguousPlusDouble();
+    testDoublePlusContiguous();
+    testCoWContiguousPlusDouble();
+    testCoWDoublePlusContiguous();
+    testEmptyContiguousPlusDouble();
+}

--- a/Source/JavaScriptCore/dfg/DFGOperations.cpp
+++ b/Source/JavaScriptCore/dfg/DFGOperations.cpp
@@ -1409,6 +1409,8 @@ JSC_DEFINE_JIT_OPERATION(operationArrayConcatArray, JSArray*, (JSGlobalObject* g
     CallFrame* callFrame = DECLARE_CALL_FRAME(vm);
     JITOperationPrologueCallFrameTracer tracer(vm, callFrame);
     auto scope = DECLARE_THROW_SCOPE(vm);
+    if (firstArray->mergeIndexingTypeForCopying(secondArray->indexingType(), /* allowPromotion */ true) == NonArray) [[unlikely]]
+        OPERATION_RETURN(scope, nullptr);
     OPERATION_RETURN(scope, tryConcatAppendArrayFastWithWatchpoints(globalObject, vm, firstArray, secondArray));
 }
 

--- a/Source/JavaScriptCore/runtime/ArrayPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/ArrayPrototype.cpp
@@ -1606,6 +1606,8 @@ JSArray* tryConcatOneArgFast(JSGlobalObject* globalObject, VM& vm, JSArray* firs
     JSArray* secondArray = uncheckedDowncast<JSArray>(argumentObject);
     if (!firstArray->canFastCopy(secondArray)) [[unlikely]]
         return nullptr;
+    if (firstArray->mergeIndexingTypeForCopying(secondArray->indexingType(), /* allowPromotion */ true) == NonArray) [[unlikely]]
+        return nullptr;
     RELEASE_AND_RETURN(scope, tryConcatAppendArrayFastWithWatchpoints(globalObject, vm, firstArray, secondArray));
 }
 


### PR DESCRIPTION
#### 32e7fe840255aad7b355ad2c58187bd0cf958fc0
<pre>
[JSC] Gate `Array#concat` fast path on indexing-type merge compatibility
<a href="https://bugs.webkit.org/show_bug.cgi?id=314015">https://bugs.webkit.org/show_bug.cgi?id=314015</a>

Reviewed by Yusuke Suzuki.

tryConcatAppendArrayFastWithWatchpoints assumes its callers have
verified that mergeIndexingTypeForCopying yields a valid IndexingType,
but ArrayWithContiguous + ArrayWithDouble (and the symmetric case)
returns NonArray. Reachable via tryConcatOneArgFast and
operationArrayConcatArray (e.g. [1, &quot;x&quot;].concat([1.5, 2.5])):
debug fires ASSERT(type != NonArray); release builds a NonArray
structure and memcpys raw double bits into a JSValue butterfly.

Add an explicit merge-compat check at both callsites so the helper&apos;s
precondition holds. The host caller falls back to the generic concat
loop, and DFG/FTL OSR-exit via ExoticObjectMode.

Test: JSTests/stress/array-concat-intrinsic-contiguous-double-mismatch.js

* JSTests/stress/array-concat-intrinsic-contiguous-double-mismatch.js: Added.
(assert):
(shallowEq):
(runConcat):
(makeContiguous):
(makeDouble):
(testContiguousPlusDouble):
(testDoublePlusContiguous):
(testCoWContiguousPlusDouble):
(testCoWDoublePlusContiguous):
(testEmptyContiguousPlusDouble):
* Source/JavaScriptCore/dfg/DFGOperations.cpp:
(JSC::DFG::JSC_DEFINE_JIT_OPERATION):
* Source/JavaScriptCore/runtime/ArrayPrototype.cpp:
(JSC::tryConcatOneArgFast):

Canonical link: <a href="https://commits.webkit.org/312560@main">https://commits.webkit.org/312560@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/65f1f9257958c5e830d906fc2b51fab13efd8163

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/160387 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/33860 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/26961 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/169290 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/115453 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/33961 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/33860 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/124354 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/115453 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/163345 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/26600 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/144063 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/104953 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/25652 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/24150 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/17009 "Built successfully") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/20/builds/152443 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/135345 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/21826 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/171767 "Built successfully") | 
| [  ~~🛠 🧪 jsc-debug-arm64~~](https://ews-build.webkit.org/#/builders/171/builds/21224 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/18125 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/23466 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/132609 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/33533 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/28244 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/132630 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35845 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/33518 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/143621 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/95300 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/27236 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/20435 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/192786 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/33028 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/99788 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/49640 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/32528 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/32772 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/32676 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->