### PR TITLE
Use grammar UUID to deduplicate text effects instead of ranges.

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -1547,6 +1547,8 @@ webkit.org/b/116473 editing/selection/user-drag-element-and-user-select-none.htm
 webkit.org/b/139862 editing/spelling/editing-multiple-words-with-markers.html [ Timeout Pass ]
 webkit.org/b/139903 editing/spelling/grammar-paste.html [ Timeout Pass ]
 
+editing/spelling/grammar-text-effect-not-reapplied.html [ Skip ]
+
 # This test will run slowly in debug mode, but is plenty fast in release.
 [ Debug ] js/slow-stress/emscripten-memops.html [ Skip ]
 

--- a/LayoutTests/editing/spelling/grammar-text-effect-not-reapplied-expected.txt
+++ b/LayoutTests/editing/spelling/grammar-text-effect-not-reapplied-expected.txt
@@ -1,0 +1,13 @@
+This test verifies that grammar text effects are not reapplied when grammar checking re-fires on the same text with the same UUID. This test requires WebKitTestRunner to run.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS internals.hasGrammarMarker(4, 4) became true
+PASS effectCountAfterFirstCheck is >= 1
+PASS internals.hasGrammarMarker(4, 4) became true
+PASS effectCountAfterSecondCheck is effectCountAfterFirstCheck
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/editing/spelling/grammar-text-effect-not-reapplied.html
+++ b/LayoutTests/editing/spelling/grammar-text-effect-not-reapplied.html
@@ -1,0 +1,90 @@
+<!DOCTYPE html><!-- webkit-test-runner [ spellCheckingDots=true TextEffectsEnabled=true ] -->
+<html lang="en">
+<meta charset="UTF-8">
+<style>
+div[contenteditable] {
+    font-family: monospace;
+    font-size: 32px;
+    width: 100%;
+}
+</style>
+<script src="../../resources/ui-helper.js"></script>
+<script src="../../resources/js-test.js"></script>
+
+<script>
+jsTestIsAsync = true;
+
+description(`This test verifies that grammar text effects are not reapplied when
+    grammar checking re-fires on the same text with the same UUID.
+    This test requires WebKitTestRunner to run.`);
+
+if (window.internals)
+    internals.setContinuousSpellCheckingEnabled(true);
+
+async function runTest()
+{
+    const editor = document.getElementById("editor");
+    const grammarText = "She have a dog";
+
+    await UIHelper.activateElementAndWaitForInputSession(editor);
+
+    document.execCommand("insertText", false, grammarText);
+    document.execCommand("insertParagraph");
+    await UIHelper.ensurePresentationUpdate();
+
+    const selection = window.getSelection();
+    selection.collapse(editor.firstChild, 0);
+
+    await shouldBecomeEqual('internals.hasGrammarMarker(4, 4)', 'true');
+
+    effectCountAfterFirstCheck = internals.appliedGrammarTextEffectCount();
+    shouldBeGreaterThanOrEqual('effectCountAfterFirstCheck', '1');
+
+    // Move to the end of "She have a dog", delete the paragraph break,
+    // then re-insert it to trigger grammar re-checking on the same text.
+    selection.collapse(editor.firstChild, grammarText.length);
+    await UIHelper.ensurePresentationUpdate();
+
+    document.execCommand("forwardDelete");
+    await UIHelper.ensurePresentationUpdate();
+
+    document.execCommand("insertParagraph");
+    await UIHelper.ensurePresentationUpdate();
+
+    selection.collapse(editor.firstChild, 0);
+    await shouldBecomeEqual('internals.hasGrammarMarker(4, 4)', 'true');
+
+    effectCountAfterSecondCheck = internals.appliedGrammarTextEffectCount();
+    shouldBe('effectCountAfterSecondCheck', 'effectCountAfterFirstCheck');
+
+    editor.textContent = "";
+    editor.blur();
+    finishJSTest();
+}
+</script>
+<body>
+<div contenteditable="true" id="editor"></div>
+<script>
+UIHelper.setSpellCheckerResults({
+    "She have a dog" : [
+        {
+            type: "grammar",
+            from: 4,
+            to: 8,
+            details: [{ from: 0, to: 4, corrections: ["has"], uuid: "96878B1F-76DC-15F6-CD95-651E9447A4DF" }]
+        }
+    ],
+    "She have a dog\n" : [
+        {
+            type: "grammar",
+            from: 4,
+            to: 8,
+            details: [{ from: 0, to: 4, corrections: ["has"], uuid: "96878B1F-76DC-15F6-CD95-651E9447A4DF" }]
+        }
+    ]
+}).then(runTest);
+</script>
+<pre id="description"></pre>
+<pre id="console"></pre>
+</body>
+</html>

--- a/Source/WebCore/dom/DocumentMarker.h
+++ b/Source/WebCore/dom/DocumentMarker.h
@@ -149,6 +149,11 @@ public:
         float opacity { 0 };
     };
 
+    struct GrammarData {
+        String description;
+        String uuid;
+    };
+
     using Data = Variant<
         String
         , DictationData // DictationAlternatives
@@ -165,6 +170,7 @@ public:
 #endif
         , TransparentContentData // TransparentContent
         , DictationStreamingOpacityData // DictationStreamingOpacity
+        , GrammarData // Grammar
     >;
 
     DocumentMarker(DocumentMarkerType, OffsetRange, Data&& = { });
@@ -241,6 +247,9 @@ inline String DocumentMarker::description() const
 {
     if (auto* description = std::get_if<String>(&m_data))
         return *description;
+
+    if (auto* data = std::get_if<DocumentMarker::GrammarData>(&m_data))
+        return data->description;
 
 #if ENABLE(WRITING_TOOLS)
     if (auto* data = std::get_if<DocumentMarker::WritingToolsTextSuggestionData>(&m_data))

--- a/Source/WebCore/dom/DocumentMarkerController.cpp
+++ b/Source/WebCore/dom/DocumentMarkerController.cpp
@@ -80,7 +80,7 @@ void DocumentMarkerController::detach()
     m_fadeAnimationTimer.stop();
     m_writingToolsTextSuggestionAnimationTimer.stop();
 #if ENABLE(WRITING_TOOLS_TEXT_EFFECTS)
-    m_appliedGrammarTextEffectRanges.clear();
+    m_appliedGrammarTextEffectUUIDs.clear();
 #endif
 }
 
@@ -104,19 +104,9 @@ bool DocumentMarkerController::addMarker(const SimpleRange& range, DocumentMarke
     const auto textEffectsEnabled = page && page->settings().textEffectsEnabled();
     auto needsTextEffect = false;
     if (isGrammar && textEffectsEnabled) {
-        needsTextEffect = true;
-        auto textRanges = collectTextRanges(range);
-        for (auto& textPiece : textRanges) {
-            SimpleRange pieceRange { BoundaryPoint { textPiece.node.copyRef(), textPiece.range.start }, BoundaryPoint { textPiece.node.copyRef(), textPiece.range.end } };
-            for (auto& applied : m_appliedGrammarTextEffectRanges) {
-                if (applied == pieceRange) {
-                    needsTextEffect = false;
-                    break;
-                }
-            }
-            if (!needsTextEffect)
-                break;
-        }
+        auto& grammarUUID = std::get<DocumentMarker::GrammarData>(data).uuid;
+        if (grammarUUID.isEmpty() || !m_appliedGrammarTextEffectUUIDs.contains(grammarUUID))
+            needsTextEffect = true;
     }
     RefPtr<TextIndicator> textIndicator;
     if (needsTextEffect)
@@ -132,8 +122,9 @@ bool DocumentMarkerController::addMarker(const SimpleRange& range, DocumentMarke
     if (needsTextEffect) {
         RefPtr decorationIndicator = page->textEffectController().createTextIndicatorForRange(range, IncludeDocumentMarkers::Yes);
         page->textEffectController().addTextEffect(range, WTF::move(textIndicator), WTF::move(decorationIndicator));
-        for (auto& textPiece : collectTextRanges(range))
-            m_appliedGrammarTextEffectRanges.append(SimpleRange { BoundaryPoint { textPiece.node.copyRef(), textPiece.range.start }, BoundaryPoint { textPiece.node.copyRef(), textPiece.range.end } });
+        auto& grammarUUID = std::get<DocumentMarker::GrammarData>(data).uuid;
+        if (!grammarUUID.isEmpty())
+            m_appliedGrammarTextEffectUUIDs.add(grammarUUID);
     }
 #endif
     return added;
@@ -969,6 +960,15 @@ std::tuple<float, float> DocumentMarkerController::markerYPositionAndHeightForFo
     auto height = 0.13247 * fontSize;
 
     return { y, height };
+}
+
+size_t DocumentMarkerController::appliedGrammarTextEffectCount() const
+{
+#if ENABLE(WRITING_TOOLS_TEXT_EFFECTS)
+    return m_appliedGrammarTextEffectUUIDs.size();
+#else
+    return 0;
+#endif
 }
 
 void addMarker(const SimpleRange& range, DocumentMarkerType type, const DocumentMarker::Data& data)

--- a/Source/WebCore/dom/DocumentMarkerController.h
+++ b/Source/WebCore/dom/DocumentMarkerController.h
@@ -30,6 +30,7 @@
 #include <WebCore/Timer.h>
 #include <memory>
 #include <wtf/HashMap.h>
+#include <wtf/HashSet.h>
 #include <wtf/TZoneMalloc.h>
 #include <wtf/Vector.h>
 #include <wtf/WeakRef.h>
@@ -70,6 +71,8 @@ public:
     WEBCORE_EXPORT void addTransparentContentMarker(const SimpleRange&, WTF::UUID);
     WEBCORE_EXPORT void addDictationStreamingOpacityMarker(const SimpleRange&, float opacity);
     WEBCORE_EXPORT void removeAllDictationStreamingOpacityMarkers();
+
+    WEBCORE_EXPORT size_t appliedGrammarTextEffectCount() const;
 
     void copyMarkers(Node& source, OffsetRange, Node& destination);
     bool hasMarkers() const;
@@ -142,7 +145,7 @@ private:
     Timer m_writingToolsTextSuggestionAnimationTimer;
 
 #if ENABLE(WRITING_TOOLS_TEXT_EFFECTS)
-    Vector<SimpleRange> m_appliedGrammarTextEffectRanges;
+    HashSet<String> m_appliedGrammarTextEffectUUIDs;
 #endif
 };
 

--- a/Source/WebCore/editing/Editor.cpp
+++ b/Source/WebCore/editing/Editor.cpp
@@ -2867,7 +2867,7 @@ void Editor::advanceToNextMisspelling(bool startBeforeSelection)
         document->selection().revealSelection();
         
         client()->updateSpellingUIWithGrammarString(ungrammaticalPhrase.phrase, ungrammaticalPhrase.detail);
-        addMarker(badGrammarRange, DocumentMarkerType::Grammar, ungrammaticalPhrase.detail.userDescription);
+        addMarker(badGrammarRange, DocumentMarkerType::Grammar, DocumentMarker::GrammarData { ungrammaticalPhrase.detail.userDescription, ungrammaticalPhrase.detail.uuid });
     } else if (!misspelledWord.word.isEmpty()) {
         // We found a misspelling, but not any earlier bad grammar. Select the misspelling, update the spelling panel, and store
         // a marker so we draw the red squiggle later.
@@ -3407,7 +3407,7 @@ void Editor::markAndReplaceFor(const SpellCheckRequest& request, const Vector<Te
                 ASSERT(detail.range.length > 0);
                 if (paragraph.checkingRangeCovers({ resultLocation + detail.range.location, detail.range.length })) {
                     auto badGrammarRange = paragraph.subrange({ resultLocation + detail.range.location, detail.range.length });
-                    addMarker(badGrammarRange, DocumentMarkerType::Grammar, detail.userDescription);
+                    addMarker(badGrammarRange, DocumentMarkerType::Grammar, DocumentMarker::GrammarData { detail.userDescription, detail.uuid });
                     previousGrammarRanges.append(CharacterRange(resultLocation + detail.range.location, detail.range.length));
                 }
             }

--- a/Source/WebCore/editing/TextCheckingHelper.cpp
+++ b/Source/WebCore/editing/TextCheckingHelper.cpp
@@ -434,7 +434,7 @@ int TextCheckingHelper::findUngrammaticalPhrases(Operation operation, const Vect
         
         if (operation == Operation::MarkAll) {
             auto badGrammarRange = resolveCharacterRange(m_range, { badGrammarPhraseLocation - startOffset + detail->range.location, detail->range.length });
-            addMarker(badGrammarRange, DocumentMarkerType::Grammar, detail->userDescription);
+            addMarker(badGrammarRange, DocumentMarkerType::Grammar, DocumentMarker::GrammarData { detail->userDescription, detail->uuid });
         }
         
         // Remember this detail only if it's earlier than our current candidate (the details aren't in a guaranteed order)

--- a/Source/WebCore/platform/text/TextChecking.h
+++ b/Source/WebCore/platform/text/TextChecking.h
@@ -68,12 +68,14 @@ struct GrammarDetail {
     CharacterRange range;
     Vector<String> guesses;
     String userDescription;
+    String uuid;
 
     GrammarDetail isolatedCopy() && {
         return {
             range,
             crossThreadCopy(WTF::move(guesses)),
-            WTF::move(userDescription).isolatedCopy()
+            WTF::move(userDescription).isolatedCopy(),
+            WTF::move(uuid).isolatedCopy()
         };
     }
 };

--- a/Source/WebCore/testing/Internals.cpp
+++ b/Source/WebCore/testing/Internals.cpp
@@ -3080,6 +3080,14 @@ bool Internals::hasGrammarMarker(int from, int length)
     return hasMarkerFor(DocumentMarkerType::Grammar, from, length);
 }
 
+unsigned Internals::appliedGrammarTextEffectCount() const
+{
+    RefPtr document = contextDocument();
+    if (!document)
+        return 0;
+    return document->markers().appliedGrammarTextEffectCount();
+}
+
 bool Internals::isAlternativeTextUIActive() const
 {
     RefPtr document = contextDocument();

--- a/Source/WebCore/testing/Internals.h
+++ b/Source/WebCore/testing/Internals.h
@@ -502,6 +502,7 @@ public:
     }
     bool hasSpellingMarker(int from, int length);
     bool hasGrammarMarker(int from, int length);
+    unsigned appliedGrammarTextEffectCount() const;
     bool isAlternativeTextUIActive() const;
     bool hasAutocorrectedMarker(int from, int length);
     bool hasDictationAlternativesMarker(int from, int length);

--- a/Source/WebCore/testing/Internals.idl
+++ b/Source/WebCore/testing/Internals.idl
@@ -726,6 +726,7 @@ enum ContentsFormat {
     readonly attribute boolean sentenceRetroCorrectionEnabled;
     boolean hasSpellingMarker(long from, long length);
     boolean hasGrammarMarker(long from, long length);
+    unsigned long appliedGrammarTextEffectCount();
     boolean isAlternativeTextUIActive();
     boolean hasAutocorrectedMarker(long from, long length);
     boolean hasDictationAlternativesMarker(long from, long length);

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -2170,6 +2170,7 @@ header: <WebCore/TextChecking.h>
     WebCore::CharacterRange range;
     Vector<String> guesses;
     String userDescription;
+    String uuid;
 };
 
 header: <WebCore/TextChecking.h>

--- a/Source/WebKit/UIProcess/ios/TextCheckerIOS.mm
+++ b/Source/WebKit/UIProcess/ios/TextCheckerIOS.mm
@@ -261,6 +261,7 @@ Vector<TextCheckingResult> TextChecker::checkTextOfParagraph(SpellDocumentTag sp
                     detail.range = detailNSRange;
                     detail.userDescription = [incomingDetail objectForKey:@"NSGrammarUserDescription"];
                     detail.guesses = makeVector<String>([incomingDetail objectForKey:@"NSGrammarCorrections"]);
+                    detail.uuid = [incomingDetail objectForKey:@"NSGrammarUUID"];
                     result.details.append(WTF::move(detail));
                 }
                 results.append(WTF::move(result));
@@ -386,6 +387,7 @@ static Vector<TextCheckingResult> convertExtendedCheckingResults(NSArray<NSTextC
                 detail.userDescription = [incomingDetail objectForKey:@"NSGrammarUserDescription"];
                 RetainPtr<NSArray> guesses = [incomingDetail objectForKey:@"NSGrammarCorrections"];
                 detail.guesses = makeVector<String>(guesses.get());
+                detail.uuid = [incomingDetail objectForKey:@"NSGrammarUUID"];
                 result.details.append(WTF::move(detail));
             }
             results.append(result);

--- a/Source/WebKit/UIProcess/mac/TextCheckerMac.mm
+++ b/Source/WebKit/UIProcess/mac/TextCheckerMac.mm
@@ -414,6 +414,7 @@ Vector<TextCheckingResult> TextChecker::checkTextOfParagraph(SpellDocumentTag sp
                 detail.userDescription = [incomingDetail objectForKey:NSGrammarUserDescription];
                 RetainPtr<NSArray> guesses = [incomingDetail objectForKey:NSGrammarCorrections];
                 detail.guesses = makeVector<String>(guesses.get());
+                detail.uuid = [incomingDetail objectForKey:@"NSGrammarUUID"];
                 result.details.append(WTF::move(detail));
             }
             results.append(result);
@@ -572,6 +573,7 @@ static Vector<TextCheckingResult> convertExtendedCheckingResults(NSArray<NSTextC
                 detail.userDescription = [incomingDetail objectForKey:NSGrammarUserDescription];
                 RetainPtr<NSArray> guesses = [incomingDetail objectForKey:NSGrammarCorrections];
                 detail.guesses = makeVector<String>(guesses.get());
+                detail.uuid = [incomingDetail objectForKey:@"NSGrammarUUID"];
                 result.details.append(WTF::move(detail));
             }
             results.append(result);

--- a/Source/WebKitLegacy/mac/WebCoreSupport/WebEditorClient.mm
+++ b/Source/WebKitLegacy/mac/WebCoreSupport/WebEditorClient.mm
@@ -1023,6 +1023,7 @@ static Vector<TextCheckingResult> core(NSArray *incomingResults, OptionSet<TextC
                 NSArray *guesses = [incomingDetail objectForKey:NSGrammarCorrections];
                 for (NSString *guess in guesses)
                     detail.guesses.append(String(guess));
+                detail.uuid = [incomingDetail objectForKey:@"NSGrammarUUID"];
                 result.details.append(detail);
             }
             results.append(result);

--- a/Tools/TestRunnerShared/cocoa/LayoutTestSpellChecker.mm
+++ b/Tools/TestRunnerShared/cocoa/LayoutTestSpellChecker.mm
@@ -247,7 +247,10 @@ static LayoutTestSpellChecker *swizzledInitializeTextChecker()
                 NSNumber *detailFrom = detail[@"from"];
                 NSNumber *detailTo = detail[@"to"];
                 auto detailRange = NSMakeRange(detailFrom.intValue, detailTo.intValue - detailFrom.intValue);
-                [details addObject:@{ NSGrammarRange: [NSValue valueWithRange:detailRange], NSGrammarCorrections: detail[@"corrections"] ?: @[ ] }];
+                RetainPtr detailDict = adoptNS([[NSMutableDictionary alloc] initWithDictionary:@{ NSGrammarRange: [NSValue valueWithRange:detailRange], NSGrammarCorrections: detail[@"corrections"] ?: @[ ] }]);
+                if (NSString *uuid = detail[@"uuid"])
+                    [detailDict setObject:uuid forKey:@"NSGrammarUUID"];
+                [details addObject:detailDict.get()];
             }
             [resultsForWord addObject:adoptNS([[LayoutTestTextCheckingResult alloc] initWithType:nsTextCheckingType(type) range:NSMakeRange(from, to - from) replacement:replacement details:details.get()]).get()];
         }


### PR DESCRIPTION
#### 6b1f3f671bb6681539ec15539de2c48c9c373ab5
<pre>
Use grammar UUID to deduplicate text effects instead of ranges.
<a href="https://bugs.webkit.org/show_bug.cgi?id=314018">https://bugs.webkit.org/show_bug.cgi?id=314018</a>
<a href="https://rdar.apple.com/176211949">rdar://176211949</a>

Reviewed by Aditya Keerthi.

The previous approach in 310132@main tracked applied grammar
text effect ranges to avoid reapplying animations. However,
the grammar checking API provides a UUID (NSGrammarUUID) for
each grammar issue that is stable across re-checks of the same
sentence. Using this UUID is simpler and more reliable than
comparing ranges.

If the UUID is not present, we fall back to always applying
the effect, since we have no way to deduplicate without an
identifier.

Test: editing/spelling/grammar-text-effect-not-reapplied.html

* LayoutTests/TestExpectations:
* LayoutTests/editing/spelling/grammar-text-effect-not-reapplied-expected.txt: Added.
* LayoutTests/editing/spelling/grammar-text-effect-not-reapplied.html: Added.
* Source/WebCore/dom/DocumentMarker.h:
(WebCore::DocumentMarker::description const):
* Source/WebCore/dom/DocumentMarkerController.cpp:
(WebCore::DocumentMarkerController::detach):
(WebCore::DocumentMarkerController::addMarker):
(WebCore::DocumentMarkerController::appliedGrammarTextEffectCount const):
* Source/WebCore/dom/DocumentMarkerController.h:
* Source/WebCore/editing/Editor.cpp:
(WebCore::Editor::advanceToNextMisspelling):
(WebCore::Editor::markAndReplaceFor):
* Source/WebCore/editing/TextCheckingHelper.cpp:
(WebCore::TextCheckingHelper::findUngrammaticalPhrases const):
* Source/WebCore/platform/text/TextChecking.h:
(WebCore::GrammarDetail::isolatedCopy):
* Source/WebCore/testing/Internals.cpp:
(WebCore::Internals::appliedGrammarTextEffectCount const):
* Source/WebCore/testing/Internals.h:
* Source/WebCore/testing/Internals.idl:
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:
* Source/WebKit/UIProcess/ios/TextCheckerIOS.mm:
(WebKit::TextChecker::checkTextOfParagraph):
(WebKit::convertExtendedCheckingResults):
* Source/WebKit/UIProcess/mac/TextCheckerMac.mm:
(WebKit::TextChecker::checkTextOfParagraph):
(WebKit::convertExtendedCheckingResults):
* Source/WebKitLegacy/mac/WebCoreSupport/WebEditorClient.mm:
(core):
* Tools/TestRunnerShared/cocoa/LayoutTestSpellChecker.mm:
(-[LayoutTestSpellChecker setResultsFromJSValue:inContext:]):

Canonical link: <a href="https://commits.webkit.org/312774@main">https://commits.webkit.org/312774@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ee9be1adef61e242501a6b6d0cde0b112fbb6a83

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/161049 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/34522 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/27623 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/169952 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/117309 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/162918 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/34623 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/34522 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/124917 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/117309 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/164008 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/27189 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/144660 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/105514 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/26238 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/24739 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/17672 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/135932 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/22422 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/172435 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/19456 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/24063 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/133196 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/34196 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/28832 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/133206 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35972 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/34180 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/144217 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/96019 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/27760 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/21035 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/33691 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/101116 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/33190 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/33434 "Built successfully") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/33339 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->