### PR TITLE
[Site Isolation] http/tests/security/block-top-level-navigation-via-redirect-by-third-party-iframes.html is flaky on macOS post-commit bot

### DIFF
--- a/LayoutTests/http/tests/security/block-top-level-navigation-via-redirect-by-third-party-iframes-expected.txt
+++ b/LayoutTests/http/tests/security/block-top-level-navigation-via-redirect-by-third-party-iframes-expected.txt
@@ -4,7 +4,7 @@ Test blocking of suspicious top-level navigations by a third-party iframe (same-
 On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
 
 
-PASS All navigations by subframes have been blocked
+PASS Navigation by subframe has been blocked
 PASS successfullyParsed is true
 
 TEST COMPLETE

--- a/LayoutTests/http/tests/security/block-top-level-navigation-via-redirect-by-third-party-iframes.html
+++ b/LayoutTests/http/tests/security/block-top-level-navigation-via-redirect-by-third-party-iframes.html
@@ -5,13 +5,17 @@
 <script>
 description("Test blocking of suspicious top-level navigations by a third-party iframe (same-site but redirects to a different site)");
 jsTestIsAsync = true;
+
+internals.setConsoleMessageListener(function(message) {
+    if (message.includes("Unsafe JavaScript attempt to initiate navigation")) {
+        testPassed("Navigation by subframe has been blocked");
+        finishJSTest();
+    }
+});
+
 onload = () => {
     setTimeout(() => {
         document.getElementById('testFrame').src = "http://localhost:8000/security/resources/navigate-top-level-frame-to-failure-page-via-redirect.html";
-        setTimeout(() => {
-            testPassed("All navigations by subframes have been blocked");
-            finishJSTest();
-        }, 1000);
     }, 10);
 }
 </script>


### PR DESCRIPTION
#### 61d4d4fb14a1c4eedfc8452544d4262e32b6b080
<pre>
[Site Isolation] http/tests/security/block-top-level-navigation-via-redirect-by-third-party-iframes.html is flaky on macOS post-commit bot
<a href="https://bugs.webkit.org/show_bug.cgi?id=314016">https://bugs.webkit.org/show_bug.cgi?id=314016</a>
<a href="https://rdar.apple.com/176211967">rdar://176211967</a>

Reviewed by Ryosuke Niwa.

http/tests/security/block-top-level-navigation-via-redirect-by-third-party-iframes.html
is failing flakily with the following diff on macOS site-isolation release post-commit bots

  -CONSOLE MESSAGE: Unsafe JavaScript attempt to initiate navigation for frame with URL
  &apos;<a href="http://127.0.0.1">http://127.0.0.1</a>:8000/security/block-top-level-navigation-via-redirect-by-third-party-iframes.html&apos; from frame with URL
  &apos;<a href="http://localhost">http://localhost</a>:8000/security/resources/navigate-top-level-frame-to-failure-page-via-redirect.html&apos;. The frame attempting navigation of the top-level
  window is cross-origin or untrusted and the user has never interacted with the frame.
   Test blocking of suspicious top-level navigations by a third-party iframe (same-site but redirects to a different site)

   On success, you will see a series of &quot;PASS&quot; messages, followed by &quot;TEST COMPLETE&quot;.

See <a href="https://results.webkit.org/?suite=layout-tests&amp">https://results.webkit.org/?suite=layout-tests&amp</a>;test=http%2Ftests%2Fsecurity%2Fblock-top-level-navigation-via-redirect-by-third-party-iframes.html&amp;flavor=site-isolation

<a href="https://commits.webkit.org/311805@main">https://commits.webkit.org/311805@main</a> attempted to fix this test and added a 1000ms timer
among other changes to fix this test.

That commit was successful in fixing the iOS bots,
but macOS bots are still flaky with the above diff sometimes.

This patch fix replaces the timeout with internals.setConsoleMessageListener,
which finishes the test the moment the console message arrives rather than guessing
how long to wait.

I was unable to reproduce the macOS bot failure with a local Release build so this is a
speculative fix.

* LayoutTests/http/tests/security/block-top-level-navigation-via-redirect-by-third-party-iframes-expected.txt:
* LayoutTests/http/tests/security/block-top-level-navigation-via-redirect-by-third-party-iframes.html:

Canonical link: <a href="https://commits.webkit.org/312592@main">https://commits.webkit.org/312592@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3df654b6a0acdc5ff75acd7f48e20acbb2e72c78

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/160399 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/33872 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/26973 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/169302 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/115465 "Built successfully") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/33973 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/33872 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/124361 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/87854 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/163357 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/26604 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/144065 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/104960 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/25656 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/24160 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/17021 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/135349 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/21828 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/171780 "Built successfully") | | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/23468 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/132620 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/33545 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/28254 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/132641 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35860 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/33530 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/143623 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/95312 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/27243 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/20437 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/33040 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/32540 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/32784 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/32688 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->