### PR TITLE
[claude] Add test harness

### DIFF
--- a/.claude/plugins/git-webkit/skills/classify/tests/basic.yaml
+++ b/.claude/plugins/git-webkit/skills/classify/tests/basic.yaml
@@ -1,0 +1,5 @@
+name: basic-classify
+test:
+  prompt: "What type of commit is 312302@main"
+validation:
+  prompt: "312302@main is a Gardening commit"

--- a/.claude/plugins/git-webkit/skills/find/tests/basic.yaml
+++ b/.claude/plugins/git-webkit/skills/find/tests/basic.yaml
@@ -1,0 +1,5 @@
+name: basic-find
+test:
+  prompt: "Who authored 234567@main"
+validation:
+  prompt: "Jonathan Bedard authored 234567@main"

--- a/Tools/Scripts/libraries/webkitcorepy/run-llm-tests
+++ b/Tools/Scripts/libraries/webkitcorepy/run-llm-tests
@@ -1,4 +1,6 @@
-# Copyright (C) 2023 Apple Inc. All rights reserved.
+#!/usr/bin/env python3
+
+# Copyright (C) 2026 Apple Inc. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -20,7 +22,42 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+import logging
+import os
+import platform
+import sys
+
+from webkitcorepy import AutoInstall, log
 from webkitcorepy.testing.llm_test_runner import LLMTestRunner
-from webkitcorepy.testing.path_test_case import PathTestCase, TestCase
-from webkitcorepy.testing.python_test_runner import PythonTestRunner
-from webkitcorepy.testing.test_runner import TestRunner
+
+
+libraries = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+AutoInstall.set_directory(os.path.join(libraries, 'autoinstalled', 'python-{}-{}'.format(sys.version_info[0], platform.machine())))
+
+
+def find_claude_dir():
+    directory = os.path.abspath(os.getcwd())
+    while True:
+        candidate = os.path.join(directory, '.claude')
+        if os.path.isdir(candidate):
+            return candidate
+        parent = os.path.dirname(directory)
+        if parent == directory:
+            break
+        directory = parent
+    return None
+
+
+if __name__ == '__main__':
+    logging.basicConfig(level=logging.WARNING)
+
+    claude_dir = find_claude_dir()
+    if claude_dir is None:
+        sys.stderr.write('No .claude directory found in current directory or any parent\n')
+        sys.exit(1)
+
+    sys.exit(LLMTestRunner(
+        description='Run structural validation for Claude Code skills.',
+        claude_dir=claude_dir,
+        loggers=[logging.getLogger(), log],
+    ).main(*sys.argv[1:]))

--- a/Tools/Scripts/libraries/webkitcorepy/setup.py
+++ b/Tools/Scripts/libraries/webkitcorepy/setup.py
@@ -51,9 +51,11 @@ setup(
     packages=[
         'webkitcorepy',
         'webkitcorepy.mocks',
+        'webkitcorepy.skill_testing',
         'webkitcorepy.testing',
         'webkitcorepy.tests',
         'webkitcorepy.tests.mocks',
+        'webkitcorepy.tests.skill_testing',
     ],
     install_requires=[
         'requests',

--- a/Tools/Scripts/libraries/webkitcorepy/webkitcorepy/skill_testing/__init__.py
+++ b/Tools/Scripts/libraries/webkitcorepy/webkitcorepy/skill_testing/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2023 Apple Inc. All rights reserved.
+# Copyright (C) 2026 Apple Inc. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -20,7 +20,6 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-from webkitcorepy.testing.llm_test_runner import LLMTestRunner
-from webkitcorepy.testing.path_test_case import PathTestCase, TestCase
-from webkitcorepy.testing.python_test_runner import PythonTestRunner
-from webkitcorepy.testing.test_runner import TestRunner
+from webkitcorepy.skill_testing.skill_file import SkillFile
+from webkitcorepy.skill_testing.skill_test import SkillTest
+from webkitcorepy.skill_testing.validators import DirectoryValidator, SkillValidator, ValidationResult

--- a/Tools/Scripts/libraries/webkitcorepy/webkitcorepy/skill_testing/skill_file.py
+++ b/Tools/Scripts/libraries/webkitcorepy/webkitcorepy/skill_testing/skill_file.py
@@ -1,0 +1,109 @@
+# Copyright (C) 2026 Apple Inc. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1.  Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+# 2.  Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS'' AND ANY
+# EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR ANY
+# DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+# ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+import os
+import re
+
+from webkitcorepy import AutoInstall
+
+
+class SkillFile(object):
+    FRONTMATTER_DELIMITER = '---'
+
+    @classmethod
+    def discover(cls, claude_dir):
+        results = []
+        for dirpath, dirnames, filenames in os.walk(claude_dir, followlinks=True):
+            dirnames[:] = [d for d in dirnames if d != '__pycache__']
+            if 'SKILL.md' in filenames:
+                results.append(cls(os.path.join(dirpath, 'SKILL.md')))
+        return sorted(results, key=lambda s: s.path)
+
+    def __init__(self, path):
+        self.path = os.path.abspath(path)
+        self.skill_dir = os.path.dirname(self.path)
+
+        frontmatter = None
+        body = None
+
+        with open(self.path, 'r') as f:
+            content = f.read()
+
+        lines = content.split('\n')
+        if not lines or lines[0].strip() != self.FRONTMATTER_DELIMITER:
+            body = content
+        else:
+            end = None
+            for i in range(1, len(lines)):
+                if lines[i].strip() == self.FRONTMATTER_DELIMITER:
+                    end = i
+                    break
+
+            if end is None:
+                body = content
+            else:
+                AutoInstall.install('pyyaml')
+                import yaml
+                try:
+                    frontmatter = yaml.safe_load('\n'.join(lines[1:end])) or {}
+                except yaml.YAMLError:
+                    frontmatter = None
+                    body = content
+
+                if frontmatter is not None:
+                    body = '\n'.join(lines[end + 1:])
+
+        self.frontmatter = frontmatter
+        self.body = body
+
+        if frontmatter:
+            self.name = frontmatter.get('name')
+            self.description = frontmatter.get('description')
+            self.user_invocable = frontmatter.get('user-invocable')
+            self.model = frontmatter.get('model')
+            self.effort = frontmatter.get('effort')
+
+            value = frontmatter.get('allowed-tools') or frontmatter.get('allowedTools')
+            if value is None:
+                self.allowed_tools = []
+            elif isinstance(value, list):
+                self.allowed_tools = [str(t).strip() for t in value if str(t).strip()]
+            else:
+                self.allowed_tools = [t.strip() for t in str(value).split(',') if t.strip()]
+        else:
+            self.name = None
+            self.description = None
+            self.user_invocable = None
+            self.model = None
+            self.effort = None
+            self.allowed_tools = []
+
+        if body:
+            self.sections = re.findall(r'^#{1,6}\s+(.+)$', body, re.MULTILINE)
+            link_refs = re.findall(r'\[.*?\]\(([^)]+)\)', body)
+            self.references = [ref for ref in link_refs if not ref.startswith(('http://', 'https://', '#'))]
+        else:
+            self.sections = []
+            self.references = []
+
+    def __repr__(self):
+        return 'SkillFile({!r})'.format(self.path)

--- a/Tools/Scripts/libraries/webkitcorepy/webkitcorepy/skill_testing/skill_test.py
+++ b/Tools/Scripts/libraries/webkitcorepy/webkitcorepy/skill_testing/skill_test.py
@@ -1,0 +1,146 @@
+# Copyright (C) 2026 Apple Inc. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1.  Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+# 2.  Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS'' AND ANY
+# EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR ANY
+# DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+# ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+import json
+import logging
+import os
+import subprocess
+
+from webkitcorepy import AutoInstall
+
+log = logging.getLogger('skill_testing')
+
+
+class SkillTest(object):
+    @classmethod
+    def discover(cls, skill):
+        tests_dir = os.path.join(skill.skill_dir, 'tests')
+        if not os.path.isdir(tests_dir):
+            return []
+        results = []
+        for filename in sorted(os.listdir(tests_dir)):
+            if filename.endswith(('.yaml', '.yml')):
+                results.append(cls(os.path.join(tests_dir, filename)))
+        return results
+
+    def __init__(self, path):
+        self.path = os.path.abspath(path)
+
+        AutoInstall.install('pyyaml')
+        import yaml
+
+        with open(self.path, 'r') as f:
+            data = yaml.safe_load(f)
+
+        self.name = data.get('name')
+
+        test_section = data.get('test', {})
+        self.test_prompt = test_section.get('prompt')
+        self.test_args = test_section.get('args', [])
+
+        validation_section = data.get('validation', {})
+        self.validation_prompt = validation_section.get('prompt')
+        self.validation_args = validation_section.get('args', [])
+        self.validation_command = validation_section.get('command')
+        self.validation_expectation = validation_section.get('expectation')
+
+        self.files = data.get('files', [])
+
+    def _invoke_claude(self, prompt, args, cwd):
+        cmd = ['claude'] + args + ['-p', prompt]
+        log.debug('\nRunning: %s', ' '.join(cmd))
+        return subprocess.run(cmd, cwd=cwd, capture_output=True, text=True)
+
+    def _cleanup_files(self, cwd):
+        for filename in self.files:
+            filepath = os.path.join(cwd, filename)
+            try:
+                if os.path.isfile(filepath):
+                    os.remove(filepath)
+                elif os.path.isdir(filepath):
+                    import shutil
+                    shutil.rmtree(filepath)
+            except OSError:
+                pass
+
+    def _validate_with_command(self, cwd):
+        log.debug('\nRunning: %s', ' '.join(self.validation_command))
+        result = subprocess.run(self.validation_command, cwd=cwd, capture_output=True, text=True)
+        if result.returncode != 0:
+            return False, 'Command {} exited with code {}: {}'.format(
+                self.validation_command, result.returncode, result.stderr.strip())
+        if self.validation_expectation is not None:
+            stdout = result.stdout.strip()
+            if self.validation_expectation not in stdout:
+                return False, 'Expected \'{}\' in output, got: {}'.format(self.validation_expectation, stdout)
+        return True, 'Command succeeded'
+
+    def _validate_with_claude(self, cwd, dump_path):
+        assess_prompt = (
+            "You are assessing the output of a skill. "
+            "Look at '{}'. "
+            "Does this match the expectation '{}'. "
+            "Answer json in the form of "
+            "{{\"status\": \"passed\", \"reason\": <rationale>}} or "
+            "{{\"status\": \"failed\", \"reason\": <rationale>}}"
+        ).format(dump_path, self.validation_prompt)
+
+        assess_result = self._invoke_claude(assess_prompt, self.validation_args, cwd)
+
+        response = assess_result.stdout.strip()
+        start = response.find('{')
+        end = response.rfind('}')
+        if start == -1 or end == -1:
+            return False, 'Assessment response is not valid JSON: {}'.format(response)
+
+        try:
+            verdict = json.loads(response[start:end + 1])
+        except (json.JSONDecodeError, ValueError) as e:
+            return False, 'Failed to parse assessment JSON: {}'.format(e)
+
+        status = verdict.get('status', '').lower()
+        reason = verdict.get('reason', '')
+
+        if status == 'passed':
+            return True, reason
+        return False, reason
+
+    def run(self, cwd):
+        dump_path = os.path.join(cwd, '.llm_test_dump.txt')
+        try:
+            test_result = self._invoke_claude(self.test_prompt, self.test_args, cwd)
+
+            with open(dump_path, 'w') as f:
+                f.write(test_result.stdout)
+
+            if self.validation_command:
+                return self._validate_with_command(cwd)
+            return self._validate_with_claude(cwd, dump_path)
+        finally:
+            try:
+                os.remove(dump_path)
+            except OSError:
+                pass
+            self._cleanup_files(cwd)
+
+    def __repr__(self):
+        return 'SkillTest({!r})'.format(self.path)

--- a/Tools/Scripts/libraries/webkitcorepy/webkitcorepy/skill_testing/validators.py
+++ b/Tools/Scripts/libraries/webkitcorepy/webkitcorepy/skill_testing/validators.py
@@ -1,0 +1,227 @@
+# Copyright (C) 2026 Apple Inc. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1.  Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+# 2.  Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS'' AND ANY
+# EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR ANY
+# DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+# ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+import json
+import os
+import re
+
+
+class ValidationResult(object):
+    def __init__(self, passed, rule, message, severity='error'):
+        self.passed = passed
+        self.rule = rule
+        self.message = message
+        self.severity = severity
+
+    def __repr__(self):
+        status = 'PASS' if self.passed else self.severity.upper()
+        return '{}: [{}] {}'.format(status, self.rule, self.message)
+
+    def __bool__(self):
+        return self.passed
+
+
+class SkillValidator(object):
+    VALID_MODELS = {'opus', 'sonnet', 'haiku'}
+    VALID_EFFORTS = {'max', 'high', 'medium', 'low'}
+    KNOWN_FRONTMATTER_KEYS = {
+        'name', 'description', 'allowed-tools', 'allowedTools',
+        'user-invocable', 'model', 'effort',
+        'disable-model-invocation', 'argument-hint',
+    }
+    TOOL_PATTERN = re.compile(
+        r'^[A-Za-z_][A-Za-z0-9_]*'
+        r'(?:__[A-Za-z0-9_*-]+)*'
+        r'(?:\(.*\))?$'
+    )
+
+    @staticmethod
+    def validate_frontmatter_presence(skill):
+        if skill.frontmatter is not None:
+            return [ValidationResult(True, 'frontmatter.presence', 'Frontmatter present')]
+        return [ValidationResult(False, 'frontmatter.presence', 'No YAML frontmatter found')]
+
+    @staticmethod
+    def validate_required_fields(skill):
+        results = []
+        fm = skill.frontmatter
+        if fm is None:
+            results.append(ValidationResult(False, 'frontmatter.required.name', 'No frontmatter, cannot check required fields'))
+            return results
+
+        for field in ('name', 'description'):
+            value = fm.get(field)
+            if value:
+                results.append(ValidationResult(True, 'frontmatter.required.{}'.format(field), '{} is present'.format(field)))
+            else:
+                results.append(ValidationResult(False, 'frontmatter.required.{}'.format(field), 'Required field \'{}\' is missing'.format(field)))
+        return results
+
+    @classmethod
+    def validate_field_values(cls, skill):
+        results = []
+        fm = skill.frontmatter
+        if fm is None:
+            return results
+
+        model = fm.get('model')
+        if model is not None:
+            if model in cls.VALID_MODELS:
+                results.append(ValidationResult(True, 'frontmatter.values.model', 'model \'{}\' is valid'.format(model)))
+            else:
+                results.append(ValidationResult(
+                    False, 'frontmatter.values.model',
+                    'model \'{}\' is not valid, expected one of: {}'.format(model, ', '.join(sorted(cls.VALID_MODELS))),
+                ))
+
+        effort = fm.get('effort')
+        if effort is not None:
+            if effort in cls.VALID_EFFORTS:
+                results.append(ValidationResult(True, 'frontmatter.values.effort', 'effort \'{}\' is valid'.format(effort)))
+            else:
+                results.append(ValidationResult(
+                    False, 'frontmatter.values.effort',
+                    'effort \'{}\' is not valid, expected one of: {}'.format(effort, ', '.join(sorted(cls.VALID_EFFORTS))),
+                ))
+
+        for field in ('user-invocable', 'disable-model-invocation'):
+            value = fm.get(field)
+            if value is not None and not isinstance(value, bool):
+                results.append(ValidationResult(
+                    False, 'frontmatter.values.{}'.format(field),
+                    '\'{}\' should be a boolean, got {}'.format(field, type(value).__name__),
+                ))
+            elif value is not None:
+                results.append(ValidationResult(True, 'frontmatter.values.{}'.format(field), '\'{}\' is a valid boolean'.format(field)))
+
+        return results
+
+    @classmethod
+    def validate_unknown_keys(cls, skill):
+        results = []
+        fm = skill.frontmatter
+        if fm is None:
+            return results
+
+        unknown = set(fm.keys()) - cls.KNOWN_FRONTMATTER_KEYS
+        if unknown:
+            for key in sorted(unknown):
+                results.append(ValidationResult(
+                    False, 'frontmatter.unknown_key',
+                    'Unknown frontmatter key: \'{}\''.format(key),
+                    severity='warning',
+                ))
+        else:
+            results.append(ValidationResult(True, 'frontmatter.unknown_key', 'No unknown frontmatter keys'))
+        return results
+
+    @classmethod
+    def validate_allowed_tools_format(cls, skill):
+        results = []
+        tools = skill.allowed_tools
+        if not tools:
+            return results
+
+        for tool in tools:
+            if cls.TOOL_PATTERN.match(tool):
+                results.append(ValidationResult(True, 'frontmatter.allowed_tools.format', '\'{}\' is valid'.format(tool)))
+            else:
+                results.append(ValidationResult(
+                    False, 'frontmatter.allowed_tools.format',
+                    '\'{}\' does not match expected format ToolName or ToolName(pattern)'.format(tool),
+                ))
+        return results
+
+    @staticmethod
+    def validate_name_matches_directory(skill):
+        fm = skill.frontmatter
+        if fm is None or not fm.get('name'):
+            return []
+        dirname = os.path.basename(skill.skill_dir)
+        name = fm['name']
+        if name == dirname:
+            return [ValidationResult(True, 'frontmatter.name_matches_dir', 'name \'{}\' matches directory'.format(name))]
+        return [ValidationResult(
+            False, 'frontmatter.name_matches_dir',
+            'name \'{}\' does not match directory \'{}\''.format(name, dirname),
+            severity='warning',
+        )]
+
+    @staticmethod
+    def validate_references_exist(skill):
+        results = []
+        refs = skill.references
+        if not refs:
+            return results
+
+        for ref in refs:
+            full_path = os.path.normpath(os.path.join(skill.skill_dir, ref))
+            if os.path.exists(full_path):
+                results.append(ValidationResult(True, 'references.exist', '\'{}\' exists'.format(ref)))
+            else:
+                results.append(ValidationResult(
+                    False, 'references.exist',
+                    'Referenced file \'{}\' does not exist (resolved to {})'.format(ref, full_path),
+                    severity='warning',
+                ))
+        return results
+
+    @classmethod
+    def validate_all(cls, skill):
+        results = []
+        results.extend(cls.validate_frontmatter_presence(skill))
+        results.extend(cls.validate_required_fields(skill))
+        results.extend(cls.validate_field_values(skill))
+        results.extend(cls.validate_unknown_keys(skill))
+        results.extend(cls.validate_allowed_tools_format(skill))
+        results.extend(cls.validate_name_matches_directory(skill))
+        results.extend(cls.validate_references_exist(skill))
+        return results
+
+
+class DirectoryValidator(object):
+    @staticmethod
+    def validate_settings_json(claude_dir):
+        path = os.path.join(claude_dir, 'settings.json')
+        if not os.path.exists(path):
+            return [ValidationResult(True, 'settings.json', 'settings.json not present (optional)')]
+        try:
+            with open(path, 'r') as f:
+                json.load(f)
+        except (json.JSONDecodeError, ValueError) as e:
+            return [ValidationResult(False, 'settings.json', 'settings.json is not valid JSON: {}'.format(e))]
+        return [ValidationResult(True, 'settings.json', 'settings.json is valid JSON')]
+
+    @staticmethod
+    def validate_marketplace_json(claude_dir):
+        plugins_dir = os.path.join(claude_dir, 'plugins')
+        if not os.path.isdir(plugins_dir):
+            return []
+        path = os.path.join(plugins_dir, '.claude-plugin', 'marketplace.json')
+        if not os.path.exists(path):
+            return [ValidationResult(False, 'marketplace.json', 'plugins directory exists but marketplace.json is missing')]
+        try:
+            with open(path, 'r') as f:
+                json.load(f)
+        except (json.JSONDecodeError, ValueError) as e:
+            return [ValidationResult(False, 'marketplace.json', 'marketplace.json is not valid JSON: {}'.format(e))]
+        return [ValidationResult(True, 'marketplace.json', 'marketplace.json is valid JSON')]

--- a/Tools/Scripts/libraries/webkitcorepy/webkitcorepy/testing/llm_test_runner.py
+++ b/Tools/Scripts/libraries/webkitcorepy/webkitcorepy/testing/llm_test_runner.py
@@ -1,0 +1,228 @@
+# Copyright (C) 2026 Apple Inc. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1.  Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+# 2.  Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS'' AND ANY
+# EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR ANY
+# DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+# ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+import json
+import logging
+import os
+import shutil
+import unittest
+
+from webkitcorepy.skill_testing import SkillFile, SkillTest, SkillValidator, DirectoryValidator
+from webkitcorepy.skill_testing.skill_test import log as skill_test_log
+from webkitcorepy.testing.test_runner import TestRunner
+
+
+class LLMTestRunner(TestRunner):
+    VALIDATORS = [
+        ('validate_frontmatter_presence', SkillValidator.validate_frontmatter_presence),
+        ('validate_required_fields', SkillValidator.validate_required_fields),
+        ('validate_field_values', SkillValidator.validate_field_values),
+        ('validate_unknown_keys', SkillValidator.validate_unknown_keys),
+        ('validate_allowed_tools_format', SkillValidator.validate_allowed_tools_format),
+        ('validate_name_matches_directory', SkillValidator.validate_name_matches_directory),
+        ('validate_references_exist', SkillValidator.validate_references_exist),
+    ]
+
+    DIRECTORY_VALIDATORS = [
+        ('validate_settings_json', DirectoryValidator.validate_settings_json),
+        ('validate_marketplace_json', DirectoryValidator.validate_marketplace_json),
+    ]
+
+    def __init__(self, description, claude_dir=None, name=None, directories=None, loggers=None):
+        loggers = list(loggers or [logging.getLogger()])
+        if skill_test_log not in loggers:
+            loggers.append(skill_test_log)
+        super(LLMTestRunner, self).__init__(description, loggers=loggers)
+
+        self.parser.add_argument(
+            '-f', '--fast',
+            help='Skip functional tests that invoke claude',
+            action='store_true',
+            default=False,
+        )
+
+        if directories:
+            self._directories = directories
+        else:
+            self._directories = [(name, claude_dir)]
+        self._tests = {}
+        self._functional_tests = set()
+        self._discover()
+
+    @staticmethod
+    def _skill_relative_name(skill, claude_dir):
+        rel = os.path.relpath(skill.skill_dir, claude_dir)
+        parts = rel.split(os.sep)
+        if skill.name:
+            parts[-1] = skill.name
+        return '.'.join(parts)
+
+    @staticmethod
+    def _make_validator_method(validator_func, skill):
+        def test_method(self):
+            results = validator_func(skill)
+            errors = [r for r in results if not r.passed and r.severity == 'error']
+            warnings = [r for r in results if not r.passed and r.severity == 'warning']
+            for w in warnings:
+                self.warnings.append(str(w))
+            if errors:
+                self.fail('\n'.join(str(e) for e in errors))
+        return test_method
+
+    @classmethod
+    def _make_skill_test_cases(cls, skills, claude_dir, name=None):
+        prefix = '{}.llm_testing'.format(name) if name else 'llm_testing'
+        test_cases = {}
+        for skill in skills:
+            rel_name = cls._skill_relative_name(skill, claude_dir)
+            safe_name = rel_name.replace('-', '_')
+
+            attrs = {'skill': skill, 'warnings': [], '__module__': prefix}
+            for validator_name, validator_func in cls.VALIDATORS:
+                attrs['test_{}'.format(validator_name)] = cls._make_validator_method(validator_func, skill)
+
+            test_cases[safe_name] = type(safe_name, (unittest.TestCase,), attrs)
+
+        return test_cases
+
+    @classmethod
+    def _make_directory_test_case(cls, claude_dir, name=None):
+        prefix = '{}.llm_testing'.format(name) if name else 'llm_testing'
+
+        attrs = {'warnings': [], '__module__': prefix}
+        for validator_name, validator_func in cls.DIRECTORY_VALIDATORS:
+            attrs['test_{}'.format(validator_name)] = cls._make_validator_method(validator_func, claude_dir)
+
+        return type('directory', (unittest.TestCase,), attrs)
+
+    @staticmethod
+    def _get_installed_plugins(project_path):
+        installed_path = os.path.join(os.path.expanduser('~'), '.claude', 'plugins', 'installed_plugins.json')
+        if not os.path.exists(installed_path):
+            return set()
+        try:
+            with open(installed_path, 'r') as f:
+                data = json.load(f)
+        except (json.JSONDecodeError, ValueError):
+            return set()
+
+        installed = set()
+        for key, entries in data.get('plugins', {}).items():
+            plugin_name = key.split('@')[0]
+            for entry in entries:
+                if entry.get('projectPath') == project_path:
+                    installed.add(plugin_name)
+        return installed
+
+    @staticmethod
+    def _plugin_name_for_skill(skill, claude_dir):
+        rel = os.path.relpath(skill.skill_dir, claude_dir)
+        parts = rel.split(os.sep)
+        if len(parts) >= 2 and parts[0] == 'plugins':
+            return parts[1]
+        return None
+
+    @classmethod
+    def _make_functional_test_cases(cls, skills, claude_dir, name=None):
+        prefix = '{}.llm_testing'.format(name) if name else 'llm_testing'
+        cwd = os.path.dirname(claude_dir)
+        installed_plugins = cls._get_installed_plugins(cwd)
+        test_cases = {}
+
+        for skill in skills:
+            plugin = cls._plugin_name_for_skill(skill, claude_dir)
+            if plugin and plugin not in installed_plugins:
+                continue
+
+            skill_tests = SkillTest.discover(skill)
+            if not skill_tests:
+                continue
+
+            rel_name = cls._skill_relative_name(skill, claude_dir)
+            safe_skill = rel_name.replace('-', '_')
+
+            for skill_test in skill_tests:
+                safe_test = skill_test.name.replace('-', '_') if skill_test.name else os.path.splitext(os.path.basename(skill_test.path))[0]
+
+                def _make_functional_method(st, working_dir):
+                    def test_method(self):
+                        passed, reason = st.run(working_dir)
+                        if not passed:
+                            self.fail(reason)
+                    return test_method
+
+                attrs = {
+                    'warnings': [],
+                    '__module__': prefix,
+                    'test_{}'.format(safe_test): _make_functional_method(skill_test, cwd),
+                }
+                test_cases['{}.{}'.format(safe_skill, safe_test)] = type(safe_skill, (unittest.TestCase,), attrs)
+
+        return test_cases
+
+    def _discover(self):
+        for name, claude_dir in self._directories:
+            skills = SkillFile.discover(claude_dir)
+
+            for cls_name, cls in self._make_skill_test_cases(skills, claude_dir, name=name).items():
+                for test in unittest.TestLoader().loadTestsFromTestCase(cls):
+                    self._tests[test.id()] = test
+
+            for test in unittest.TestLoader().loadTestsFromTestCase(self._make_directory_test_case(claude_dir, name=name)):
+                self._tests[test.id()] = test
+
+            for cls_name, cls in self._make_functional_test_cases(skills, claude_dir, name=name).items():
+                for test in unittest.TestLoader().loadTestsFromTestCase(cls):
+                    self._tests[test.id()] = test
+                    self._functional_tests.add(test.id())
+
+    def _skip_functional(self, args):
+        if args and getattr(args, 'fast', False):
+            return True
+        if not shutil.which('claude'):
+            return True
+        return False
+
+    def tests(self, args=None):
+        filters = [] if not args or not args.tests else args.tests
+        skip_functional = self._skip_functional(args)
+        matched_filters = {pattern.pattern: 0 for pattern in filters}
+        for name in sorted(self._tests.keys()):
+            if skip_functional and name in self._functional_tests:
+                continue
+            if not filters:
+                yield name
+                continue
+            for pattern in filters:
+                if pattern.match(name):
+                    yield name
+                    matched_filters[pattern.pattern] += 1
+                    break
+
+    def run_test(self, test):
+        result = unittest.TestResult()
+        try:
+            to_run = self._tests[test]
+            to_run.run(result=result)
+        except KeyError:
+            result.errors.append((test, "No test named '{}'\n".format(test)))
+        return result

--- a/Tools/Scripts/libraries/webkitcorepy/webkitcorepy/tests/skill_testing/__init__.py
+++ b/Tools/Scripts/libraries/webkitcorepy/webkitcorepy/tests/skill_testing/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2023 Apple Inc. All rights reserved.
+# Copyright (C) 2026 Apple Inc. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -19,8 +19,3 @@
 # ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
-from webkitcorepy.testing.llm_test_runner import LLMTestRunner
-from webkitcorepy.testing.path_test_case import PathTestCase, TestCase
-from webkitcorepy.testing.python_test_runner import PythonTestRunner
-from webkitcorepy.testing.test_runner import TestRunner

--- a/Tools/Scripts/libraries/webkitcorepy/webkitcorepy/tests/skill_testing/skill_file_unittest.py
+++ b/Tools/Scripts/libraries/webkitcorepy/webkitcorepy/tests/skill_testing/skill_file_unittest.py
@@ -1,0 +1,228 @@
+# Copyright (C) 2026 Apple Inc. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1.  Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+# 2.  Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS'' AND ANY
+# EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR ANY
+# DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+# ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+import os
+import unittest
+
+from webkitcorepy import testing
+from webkitcorepy.skill_testing import SkillFile
+
+
+class SkillFileParseTest(testing.PathTestCase):
+    basepath = 'mock/skills'
+
+    def _write_skill(self, content, name='SKILL.md'):
+        path = os.path.join(self.path, name)
+        with open(path, 'w') as f:
+            f.write(content)
+        return path
+
+    def test_basic_frontmatter(self):
+        path = self._write_skill(
+            '---\n'
+            'name: test-skill\n'
+            'description: A test skill\n'
+            '---\n'
+            '\n'
+            '# Body\n'
+            'Some content\n'
+        )
+        skill = SkillFile(path)
+        self.assertEqual(skill.name, 'test-skill')
+        self.assertEqual(skill.description, 'A test skill')
+        self.assertIn('# Body', skill.body)
+
+    def test_no_frontmatter(self):
+        path = self._write_skill('# Just markdown\n\nNo frontmatter here.\n')
+        skill = SkillFile(path)
+        self.assertIsNone(skill.frontmatter)
+        self.assertIsNone(skill.name)
+        self.assertIn('Just markdown', skill.body)
+
+    def test_allowed_tools_string(self):
+        path = self._write_skill(
+            '---\n'
+            'name: tools-test\n'
+            'description: test\n'
+            'allowed-tools: Bash(git log:*), Read, Grep(src/**)\n'
+            '---\n'
+        )
+        skill = SkillFile(path)
+        self.assertEqual(skill.allowed_tools, ['Bash(git log:*)', 'Read', 'Grep(src/**)'])
+
+    def test_allowed_tools_list(self):
+        path = self._write_skill(
+            '---\n'
+            'name: tools-test\n'
+            'description: test\n'
+            'allowedTools:\n'
+            '  - Bash(make *)\n'
+            '  - Read\n'
+            '---\n'
+        )
+        skill = SkillFile(path)
+        self.assertEqual(skill.allowed_tools, ['Bash(make *)', 'Read'])
+
+    def test_no_allowed_tools(self):
+        path = self._write_skill(
+            '---\n'
+            'name: no-tools\n'
+            'description: test\n'
+            '---\n'
+        )
+        skill = SkillFile(path)
+        self.assertEqual(skill.allowed_tools, [])
+
+    def test_boolean_fields(self):
+        path = self._write_skill(
+            '---\n'
+            'name: bool-test\n'
+            'description: test\n'
+            'user-invocable: true\n'
+            'disable-model-invocation: false\n'
+            '---\n'
+        )
+        skill = SkillFile(path)
+        self.assertTrue(skill.user_invocable)
+
+    def test_model_and_effort(self):
+        path = self._write_skill(
+            '---\n'
+            'name: model-test\n'
+            'description: test\n'
+            'model: opus\n'
+            'effort: max\n'
+            '---\n'
+        )
+        skill = SkillFile(path)
+        self.assertEqual(skill.model, 'opus')
+        self.assertEqual(skill.effort, 'max')
+
+    def test_sections(self):
+        path = self._write_skill(
+            '---\n'
+            'name: sections-test\n'
+            'description: test\n'
+            '---\n'
+            '\n'
+            '# Top heading\n'
+            '\n'
+            '## Section One\n'
+            '\n'
+            'Content\n'
+            '\n'
+            '## Section Two\n'
+            '\n'
+            '### Subsection\n'
+        )
+        skill = SkillFile(path)
+        self.assertEqual(skill.sections, ['Top heading', 'Section One', 'Section Two', 'Subsection'])
+
+    def test_references(self):
+        path = self._write_skill(
+            '---\n'
+            'name: refs-test\n'
+            'description: test\n'
+            '---\n'
+            '\n'
+            'See [config](../config.json) and [docs](https://example.com).\n'
+            'Also [anchor](#section).\n'
+        )
+        skill = SkillFile(path)
+        self.assertEqual(skill.references, ['../config.json'])
+
+    def test_skill_dir(self):
+        path = self._write_skill(
+            '---\n'
+            'name: dir-test\n'
+            'description: test\n'
+            '---\n'
+        )
+        skill = SkillFile(path)
+        self.assertEqual(skill.skill_dir, self.path)
+
+    def test_unclosed_frontmatter(self):
+        path = self._write_skill(
+            '---\n'
+            'name: unclosed\n'
+            'description: test\n'
+            '\n'
+            '# Body starts here\n'
+        )
+        skill = SkillFile(path)
+        self.assertIsNone(skill.frontmatter)
+        self.assertIn('---', skill.body)
+
+    def test_repr(self):
+        path = self._write_skill(
+            '---\n'
+            'name: repr-test\n'
+            'description: test\n'
+            '---\n'
+        )
+        skill = SkillFile(path)
+        self.assertIn('SKILL.md', repr(skill))
+
+
+class SkillFileDiscoverTest(testing.PathTestCase):
+    basepath = 'mock/repo'
+
+    def test_discover_finds_skills(self):
+        claude_dir = os.path.join(self.path, '.claude')
+        skill_dir = os.path.join(claude_dir, 'skills', 'my-skill')
+        os.makedirs(skill_dir)
+        with open(os.path.join(skill_dir, 'SKILL.md'), 'w') as f:
+            f.write('---\nname: my-skill\ndescription: test\n---\n')
+
+        skills = SkillFile.discover(claude_dir)
+        self.assertEqual(len(skills), 1)
+        self.assertEqual(skills[0].name, 'my-skill')
+
+    def test_discover_finds_plugin_skills(self):
+        claude_dir = os.path.join(self.path, '.claude')
+        skill_dir = os.path.join(claude_dir, 'plugins', 'my-plugin', 'skills', 'my-skill')
+        os.makedirs(skill_dir)
+        with open(os.path.join(skill_dir, 'SKILL.md'), 'w') as f:
+            f.write('---\nname: my-skill\ndescription: test\n---\n')
+
+        skills = SkillFile.discover(claude_dir)
+        self.assertEqual(len(skills), 1)
+        self.assertEqual(skills[0].name, 'my-skill')
+
+    def test_discover_empty_repo(self):
+        claude_dir = os.path.join(self.path, '.claude')
+        os.makedirs(claude_dir)
+        skills = SkillFile.discover(claude_dir)
+        self.assertEqual(len(skills), 0)
+
+    def test_discover_multiple_skills(self):
+        claude_dir = os.path.join(self.path, '.claude')
+        for name in ('alpha', 'beta'):
+            skill_dir = os.path.join(claude_dir, 'skills', name)
+            os.makedirs(skill_dir)
+            with open(os.path.join(skill_dir, 'SKILL.md'), 'w') as f:
+                f.write('---\nname: {}\ndescription: test\n---\n'.format(name))
+
+        skills = SkillFile.discover(claude_dir)
+        self.assertEqual(len(skills), 2)
+        self.assertEqual(skills[0].name, 'alpha')
+        self.assertEqual(skills[1].name, 'beta')

--- a/Tools/Scripts/libraries/webkitcorepy/webkitcorepy/tests/skill_testing/skill_test_unittest.py
+++ b/Tools/Scripts/libraries/webkitcorepy/webkitcorepy/tests/skill_testing/skill_test_unittest.py
@@ -1,0 +1,185 @@
+# Copyright (C) 2026 Apple Inc. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1.  Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+# 2.  Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS'' AND ANY
+# EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR ANY
+# DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+# ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+import os
+import unittest
+
+from webkitcorepy import testing
+from webkitcorepy.skill_testing import SkillFile, SkillTest
+
+
+class SkillTestParseTest(testing.PathTestCase):
+    basepath = 'mock/skills/my-skill/tests'
+
+    def _write_test(self, content, name='basic.yaml'):
+        path = os.path.join(self.path, name)
+        with open(path, 'w') as f:
+            f.write(content)
+        return path
+
+    def test_basic_parse(self):
+        path = self._write_test(
+            'name: basic-test\n'
+            'test:\n'
+            '  prompt: "Tell me about something"\n'
+            'validation:\n'
+            '  prompt: "Should mention something"\n'
+        )
+        st = SkillTest(path)
+        self.assertEqual(st.name, 'basic-test')
+        self.assertEqual(st.test_prompt, 'Tell me about something')
+        self.assertEqual(st.validation_prompt, 'Should mention something')
+        self.assertIsNone(st.validation_command)
+        self.assertIsNone(st.validation_expectation)
+        self.assertEqual(st.test_args, [])
+        self.assertEqual(st.validation_args, [])
+        self.assertEqual(st.files, [])
+
+    def test_with_args(self):
+        path = self._write_test(
+            'name: args-test\n'
+            'test:\n'
+            '  prompt: "Write a script"\n'
+            '  args: ["--allowedTools", "Edit,Write"]\n'
+            'validation:\n'
+            '  prompt: "Run the script"\n'
+            '  args: ["--allowedTools", "python3 script.py"]\n'
+        )
+        st = SkillTest(path)
+        self.assertEqual(st.test_args, ['--allowedTools', 'Edit,Write'])
+        self.assertEqual(st.validation_args, ['--allowedTools', 'python3 script.py'])
+
+    def test_with_files(self):
+        path = self._write_test(
+            'name: files-test\n'
+            'test:\n'
+            '  prompt: "Create output.txt"\n'
+            'validation:\n'
+            '  prompt: "Check output.txt"\n'
+            'files: ["output.txt", "temp_dir"]\n'
+        )
+        st = SkillTest(path)
+        self.assertEqual(st.files, ['output.txt', 'temp_dir'])
+
+    def test_command_validation(self):
+        path = self._write_test(
+            'name: cmd-test\n'
+            'test:\n'
+            '  prompt: "Write a script"\n'
+            '  args: ["--allowedTools", "Edit,Write"]\n'
+            'validation:\n'
+            '  command: ["python3", "script.py"]\n'
+            '  expectation: "hello"\n'
+            'files: ["script.py"]\n'
+        )
+        st = SkillTest(path)
+        self.assertEqual(st.validation_command, ['python3', 'script.py'])
+        self.assertEqual(st.validation_expectation, 'hello')
+        self.assertIsNone(st.validation_prompt)
+
+    def test_command_validation_no_expectation(self):
+        path = self._write_test(
+            'name: cmd-no-expect\n'
+            'test:\n'
+            '  prompt: "Do something"\n'
+            'validation:\n'
+            '  command: ["true"]\n'
+        )
+        st = SkillTest(path)
+        self.assertEqual(st.validation_command, ['true'])
+        self.assertIsNone(st.validation_expectation)
+
+    def test_no_args_defaults(self):
+        path = self._write_test(
+            'name: defaults-test\n'
+            'test:\n'
+            '  prompt: "Do something"\n'
+            'validation:\n'
+            '  prompt: "Check result"\n'
+        )
+        st = SkillTest(path)
+        self.assertEqual(st.test_args, [])
+        self.assertEqual(st.validation_args, [])
+        self.assertEqual(st.files, [])
+
+    def test_repr(self):
+        path = self._write_test(
+            'name: repr-test\n'
+            'test:\n'
+            '  prompt: "test"\n'
+            'validation:\n'
+            '  prompt: "check"\n'
+        )
+        st = SkillTest(path)
+        self.assertIn('basic.yaml', repr(st))
+
+
+class SkillTestDiscoverTest(testing.PathTestCase):
+    basepath = 'mock/skills'
+
+    BASIC_YAML = (
+        'name: basic\n'
+        'test:\n'
+        '  prompt: "test"\n'
+        'validation:\n'
+        '  prompt: "result"\n'
+    )
+
+    def _make_skill_with_tests(self, skill_name, test_files):
+        skill_dir = os.path.join(self.path, skill_name)
+        os.makedirs(skill_dir)
+        with open(os.path.join(skill_dir, 'SKILL.md'), 'w') as f:
+            f.write('---\nname: {}\ndescription: test\n---\n'.format(skill_name))
+        tests_dir = os.path.join(skill_dir, 'tests')
+        os.makedirs(tests_dir)
+        for filename, content in test_files.items():
+            with open(os.path.join(tests_dir, filename), 'w') as f:
+                f.write(content)
+        return SkillFile(os.path.join(skill_dir, 'SKILL.md'))
+
+    def test_discover_yaml_tests(self):
+        advanced_yaml = self.BASIC_YAML.replace('basic', 'advanced')
+        skill = self._make_skill_with_tests('my-skill', {
+            'basic.yaml': self.BASIC_YAML,
+            'advanced.yml': advanced_yaml,
+        })
+        tests = SkillTest.discover(skill)
+        self.assertEqual(len(tests), 2)
+        self.assertEqual(tests[0].name, 'advanced')
+        self.assertEqual(tests[1].name, 'basic')
+
+    def test_discover_ignores_non_yaml(self):
+        skill = self._make_skill_with_tests('my-skill', {
+            'basic.yaml': self.BASIC_YAML,
+            'notes.txt': 'not a test\n',
+        })
+        tests = SkillTest.discover(skill)
+        self.assertEqual(len(tests), 1)
+
+    def test_discover_no_tests_dir(self):
+        skill_dir = os.path.join(self.path, 'no-tests')
+        os.makedirs(skill_dir)
+        with open(os.path.join(skill_dir, 'SKILL.md'), 'w') as f:
+            f.write('---\nname: no-tests\ndescription: test\n---\n')
+        skill = SkillFile(os.path.join(skill_dir, 'SKILL.md'))
+        tests = SkillTest.discover(skill)
+        self.assertEqual(len(tests), 0)

--- a/Tools/Scripts/libraries/webkitcorepy/webkitcorepy/tests/skill_testing/validators_unittest.py
+++ b/Tools/Scripts/libraries/webkitcorepy/webkitcorepy/tests/skill_testing/validators_unittest.py
@@ -1,0 +1,340 @@
+# Copyright (C) 2026 Apple Inc. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1.  Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+# 2.  Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS'' AND ANY
+# EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR ANY
+# DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+# ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+import os
+import unittest
+
+from webkitcorepy import testing
+from webkitcorepy.skill_testing import SkillFile, SkillValidator, DirectoryValidator, ValidationResult
+
+
+class ValidationResultTest(unittest.TestCase):
+    def test_pass_is_truthy(self):
+        r = ValidationResult(True, 'test.rule', 'passed')
+        self.assertTrue(r)
+
+    def test_fail_is_falsy(self):
+        r = ValidationResult(False, 'test.rule', 'failed')
+        self.assertFalse(r)
+
+    def test_repr_pass(self):
+        r = ValidationResult(True, 'test.rule', 'all good')
+        self.assertIn('PASS', repr(r))
+
+    def test_repr_fail_error(self):
+        r = ValidationResult(False, 'test.rule', 'bad', severity='error')
+        self.assertIn('ERROR', repr(r))
+
+    def test_repr_fail_warning(self):
+        r = ValidationResult(False, 'test.rule', 'meh', severity='warning')
+        self.assertIn('WARNING', repr(r))
+
+
+class ValidateFrontmatterPresenceTest(testing.PathTestCase):
+    basepath = 'mock/skills'
+
+    def _make_skill(self, content):
+        path = os.path.join(self.path, 'SKILL.md')
+        with open(path, 'w') as f:
+            f.write(content)
+        return SkillFile(path)
+
+    def test_with_frontmatter(self):
+        skill = self._make_skill('---\nname: x\ndescription: y\n---\n')
+        results = SkillValidator.validate_frontmatter_presence(skill)
+        self.assertTrue(all(r.passed for r in results))
+
+    def test_without_frontmatter(self):
+        skill = self._make_skill('# Just markdown\n')
+        results = SkillValidator.validate_frontmatter_presence(skill)
+        self.assertTrue(any(not r.passed for r in results))
+
+
+class ValidateRequiredFieldsTest(testing.PathTestCase):
+    basepath = 'mock/skills'
+
+    def _make_skill(self, content):
+        path = os.path.join(self.path, 'SKILL.md')
+        with open(path, 'w') as f:
+            f.write(content)
+        return SkillFile(path)
+
+    def test_all_present(self):
+        skill = self._make_skill('---\nname: test\ndescription: A test\n---\n')
+        results = SkillValidator.validate_required_fields(skill)
+        self.assertTrue(all(r.passed for r in results))
+
+    def test_missing_name(self):
+        skill = self._make_skill('---\ndescription: A test\n---\n')
+        results = SkillValidator.validate_required_fields(skill)
+        failed = [r for r in results if not r.passed]
+        self.assertEqual(len(failed), 1)
+        self.assertIn('name', failed[0].message)
+
+    def test_missing_description(self):
+        skill = self._make_skill('---\nname: test\n---\n')
+        results = SkillValidator.validate_required_fields(skill)
+        failed = [r for r in results if not r.passed]
+        self.assertEqual(len(failed), 1)
+        self.assertIn('description', failed[0].message)
+
+    def test_no_frontmatter(self):
+        skill = self._make_skill('# Just markdown\n')
+        results = SkillValidator.validate_required_fields(skill)
+        self.assertTrue(any(not r.passed for r in results))
+
+
+class ValidateFieldValuesTest(testing.PathTestCase):
+    basepath = 'mock/skills'
+
+    def _make_skill(self, content):
+        path = os.path.join(self.path, 'SKILL.md')
+        with open(path, 'w') as f:
+            f.write(content)
+        return SkillFile(path)
+
+    def test_valid_model(self):
+        skill = self._make_skill('---\nname: x\ndescription: y\nmodel: opus\n---\n')
+        results = SkillValidator.validate_field_values(skill)
+        self.assertTrue(all(r.passed for r in results))
+
+    def test_invalid_model(self):
+        skill = self._make_skill('---\nname: x\ndescription: y\nmodel: gpt4\n---\n')
+        results = SkillValidator.validate_field_values(skill)
+        failed = [r for r in results if not r.passed]
+        self.assertEqual(len(failed), 1)
+        self.assertIn('gpt4', failed[0].message)
+
+    def test_valid_effort(self):
+        skill = self._make_skill('---\nname: x\ndescription: y\neffort: max\n---\n')
+        results = SkillValidator.validate_field_values(skill)
+        self.assertTrue(all(r.passed for r in results))
+
+    def test_invalid_effort(self):
+        skill = self._make_skill('---\nname: x\ndescription: y\neffort: turbo\n---\n')
+        results = SkillValidator.validate_field_values(skill)
+        failed = [r for r in results if not r.passed]
+        self.assertEqual(len(failed), 1)
+        self.assertIn('turbo', failed[0].message)
+
+    def test_boolean_field_valid(self):
+        skill = self._make_skill('---\nname: x\ndescription: y\nuser-invocable: true\n---\n')
+        results = SkillValidator.validate_field_values(skill)
+        self.assertTrue(all(r.passed for r in results))
+
+    def test_boolean_field_invalid(self):
+        skill = self._make_skill('---\nname: x\ndescription: y\nuser-invocable: "yes"\n---\n')
+        results = SkillValidator.validate_field_values(skill)
+        failed = [r for r in results if not r.passed]
+        self.assertEqual(len(failed), 1)
+        self.assertIn('boolean', failed[0].message)
+
+    def test_no_optional_fields(self):
+        skill = self._make_skill('---\nname: x\ndescription: y\n---\n')
+        results = SkillValidator.validate_field_values(skill)
+        self.assertEqual(len(results), 0)
+
+
+class ValidateUnknownKeysTest(testing.PathTestCase):
+    basepath = 'mock/skills'
+
+    def _make_skill(self, content):
+        path = os.path.join(self.path, 'SKILL.md')
+        with open(path, 'w') as f:
+            f.write(content)
+        return SkillFile(path)
+
+    def test_known_keys_only(self):
+        skill = self._make_skill('---\nname: x\ndescription: y\nmodel: opus\n---\n')
+        results = SkillValidator.validate_unknown_keys(skill)
+        self.assertTrue(all(r.passed for r in results))
+
+    def test_unknown_key(self):
+        skill = self._make_skill('---\nname: x\ndescription: y\ntypo-field: bad\n---\n')
+        results = SkillValidator.validate_unknown_keys(skill)
+        failed = [r for r in results if not r.passed]
+        self.assertEqual(len(failed), 1)
+        self.assertIn('typo-field', failed[0].message)
+        self.assertEqual(failed[0].severity, 'warning')
+
+
+class ValidateAllowedToolsFormatTest(testing.PathTestCase):
+    basepath = 'mock/skills'
+
+    def _make_skill(self, content):
+        path = os.path.join(self.path, 'SKILL.md')
+        with open(path, 'w') as f:
+            f.write(content)
+        return SkillFile(path)
+
+    def test_valid_tools(self):
+        skill = self._make_skill('---\nname: x\ndescription: y\nallowed-tools: Bash(git log:*), Read, Grep(src/**)\n---\n')
+        results = SkillValidator.validate_allowed_tools_format(skill)
+        self.assertTrue(all(r.passed for r in results))
+
+    def test_tool_name_only(self):
+        skill = self._make_skill('---\nname: x\ndescription: y\nallowed-tools: Read\n---\n')
+        results = SkillValidator.validate_allowed_tools_format(skill)
+        self.assertTrue(all(r.passed for r in results))
+
+    def test_no_tools(self):
+        skill = self._make_skill('---\nname: x\ndescription: y\n---\n')
+        results = SkillValidator.validate_allowed_tools_format(skill)
+        self.assertEqual(len(results), 0)
+
+
+class ValidateNameMatchesDirectoryTest(testing.PathTestCase):
+    basepath = 'mock/skills/my-skill'
+
+    def _make_skill(self, content):
+        path = os.path.join(self.path, 'SKILL.md')
+        with open(path, 'w') as f:
+            f.write(content)
+        return SkillFile(path)
+
+    def test_name_matches(self):
+        skill = self._make_skill('---\nname: my-skill\ndescription: test\n---\n')
+        results = SkillValidator.validate_name_matches_directory(skill)
+        self.assertTrue(all(r.passed for r in results))
+
+    def test_name_mismatch(self):
+        skill = self._make_skill('---\nname: other-name\ndescription: test\n---\n')
+        results = SkillValidator.validate_name_matches_directory(skill)
+        failed = [r for r in results if not r.passed]
+        self.assertEqual(len(failed), 1)
+        self.assertEqual(failed[0].severity, 'warning')
+
+
+class ValidateReferencesExistTest(testing.PathTestCase):
+    basepath = 'mock/skills/ref-skill'
+
+    def _make_skill(self, content):
+        path = os.path.join(self.path, 'SKILL.md')
+        with open(path, 'w') as f:
+            f.write(content)
+        return SkillFile(path)
+
+    def test_existing_reference(self):
+        with open(os.path.join(self.path, 'config.json'), 'w') as f:
+            f.write('{}')
+        skill = self._make_skill('---\nname: x\ndescription: y\n---\n\nSee [cfg](config.json).\n')
+        results = SkillValidator.validate_references_exist(skill)
+        self.assertTrue(all(r.passed for r in results))
+
+    def test_missing_reference(self):
+        skill = self._make_skill('---\nname: x\ndescription: y\n---\n\nSee [cfg](missing.json).\n')
+        results = SkillValidator.validate_references_exist(skill)
+        failed = [r for r in results if not r.passed]
+        self.assertEqual(len(failed), 1)
+        self.assertIn('missing.json', failed[0].message)
+
+    def test_no_references(self):
+        skill = self._make_skill('---\nname: x\ndescription: y\n---\n\nNo links here.\n')
+        results = SkillValidator.validate_references_exist(skill)
+        self.assertEqual(len(results), 0)
+
+
+class ValidateAllTest(testing.PathTestCase):
+    basepath = 'mock/skills/all-test'
+
+    def _make_skill(self, content):
+        path = os.path.join(self.path, 'SKILL.md')
+        with open(path, 'w') as f:
+            f.write(content)
+        return SkillFile(path)
+
+    def test_valid_skill(self):
+        skill = self._make_skill(
+            '---\n'
+            'name: all-test\n'
+            'description: A fully valid skill\n'
+            'model: opus\n'
+            'effort: max\n'
+            'user-invocable: true\n'
+            '---\n'
+            '\n'
+            '# Instructions\n'
+        )
+        results = SkillValidator.validate_all(skill)
+        errors = [r for r in results if not r.passed and r.severity == 'error']
+        self.assertEqual(len(errors), 0)
+
+    def test_invalid_skill(self):
+        skill = self._make_skill('# No frontmatter at all\n')
+        results = SkillValidator.validate_all(skill)
+        errors = [r for r in results if not r.passed and r.severity == 'error']
+        self.assertGreater(len(errors), 0)
+
+
+class ValidateSettingsJsonTest(testing.PathTestCase):
+    basepath = 'mock/claude'
+
+    def test_valid_settings(self):
+        with open(os.path.join(self.path, 'settings.json'), 'w') as f:
+            f.write('{"permissions": {"allow": ["Read"]}}')
+        results = DirectoryValidator.validate_settings_json(self.path)
+        self.assertTrue(all(r.passed for r in results))
+
+    def test_invalid_settings(self):
+        with open(os.path.join(self.path, 'settings.json'), 'w') as f:
+            f.write('{bad json}')
+        results = DirectoryValidator.validate_settings_json(self.path)
+        failed = [r for r in results if not r.passed]
+        self.assertEqual(len(failed), 1)
+        self.assertIn('not valid JSON', failed[0].message)
+
+    def test_no_settings(self):
+        results = DirectoryValidator.validate_settings_json(self.path)
+        self.assertTrue(all(r.passed for r in results))
+
+
+class ValidateMarketplaceJsonTest(testing.PathTestCase):
+    basepath = 'mock/claude'
+
+    def test_valid_marketplace(self):
+        plugin_dir = os.path.join(self.path, 'plugins', '.claude-plugin')
+        os.makedirs(plugin_dir)
+        with open(os.path.join(plugin_dir, 'marketplace.json'), 'w') as f:
+            f.write('{"name": "test", "plugins": []}')
+        results = DirectoryValidator.validate_marketplace_json(self.path)
+        self.assertTrue(all(r.passed for r in results))
+
+    def test_invalid_marketplace(self):
+        plugin_dir = os.path.join(self.path, 'plugins', '.claude-plugin')
+        os.makedirs(plugin_dir)
+        with open(os.path.join(plugin_dir, 'marketplace.json'), 'w') as f:
+            f.write('{not valid}')
+        results = DirectoryValidator.validate_marketplace_json(self.path)
+        failed = [r for r in results if not r.passed]
+        self.assertEqual(len(failed), 1)
+        self.assertIn('not valid JSON', failed[0].message)
+
+    def test_missing_marketplace(self):
+        os.makedirs(os.path.join(self.path, 'plugins'))
+        results = DirectoryValidator.validate_marketplace_json(self.path)
+        failed = [r for r in results if not r.passed]
+        self.assertEqual(len(failed), 1)
+        self.assertIn('missing', failed[0].message)
+
+    def test_no_plugins_dir(self):
+        results = DirectoryValidator.validate_marketplace_json(self.path)
+        self.assertEqual(len(results), 0)

--- a/Tools/Scripts/run-llm-tests
+++ b/Tools/Scripts/run-llm-tests
@@ -1,4 +1,6 @@
-# Copyright (C) 2023 Apple Inc. All rights reserved.
+#!/usr/bin/env python3
+
+# Copyright (C) 2026 Apple Inc. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -20,7 +22,32 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+import logging
+import os
+import sys
+
+scripts_dir = os.path.dirname(os.path.abspath(__file__))
+libraries_dir = os.path.join(scripts_dir, 'libraries')
+sys.path.insert(0, os.path.join(libraries_dir, 'webkitcorepy'))
+
+import webkitpy
+
+from webkitcorepy import log
 from webkitcorepy.testing.llm_test_runner import LLMTestRunner
-from webkitcorepy.testing.path_test_case import PathTestCase, TestCase
-from webkitcorepy.testing.python_test_runner import PythonTestRunner
-from webkitcorepy.testing.test_runner import TestRunner
+
+if __name__ == '__main__':
+    logging.basicConfig(level=logging.WARNING)
+
+    opensource_dir = os.path.dirname(os.path.dirname(scripts_dir))
+    claude_dir = os.path.join(opensource_dir, '.claude')
+
+    if not os.path.isdir(claude_dir):
+        sys.stderr.write('Expected .claude directory at {}\n'.format(claude_dir))
+        sys.exit(1)
+
+    sys.exit(LLMTestRunner(
+        description='Run structural validation for Claude Code skills in WebKit.',
+        claude_dir=claude_dir,
+        name='webkit',
+        loggers=[logging.getLogger(), log],
+    ).main(*sys.argv[1:]))


### PR DESCRIPTION
#### b96e73ea307e8a07ea7dd850da351453baae23d9
<pre>
[claude] Add test harness
<a href="https://bugs.webkit.org/show_bug.cgi?id=314017">https://bugs.webkit.org/show_bug.cgi?id=314017</a>
<a href="https://rdar.apple.com/176211978">rdar://176211978</a>

Reviewed by David Kilzer.

Add a new script, run-llm-tests, which lints and validates Claude skills within a repository.

* .claude/plugins/git-webkit/skills/classify/tests/basic.yaml: Added new testcase.
* .claude/plugins/git-webkit/skills/find/tests/basic.yaml: Added new testcase.
* Tools/Scripts/libraries/webkitcorepy/run-llm-tests: Generic test runner which tests the first .claude directory it encounters.
* Tools/Scripts/libraries/webkitcorepy/setup.py: Add skill_testing.
* Tools/Scripts/libraries/webkitcorepy/webkitcorepy/skill_testing/__init__.py: Added.
* Tools/Scripts/libraries/webkitcorepy/webkitcorepy/skill_testing/skill_file.py:
(SkillFile): Parsed representation of a Skill file.
* Tools/Scripts/libraries/webkitcorepy/webkitcorepy/skill_testing/skill_test.py: Added.
(SkillTest): Integration test for a single Skill.
* Tools/Scripts/libraries/webkitcorepy/webkitcorepy/skill_testing/validators.py: Added.
(ValidationResult):
(SkillValidator): Specific skill-linting rules.
(DirectoryValidator): Specific .claude directory linting rules.
* Tools/Scripts/libraries/webkitcorepy/webkitcorepy/testing/__init__.py:
* Tools/Scripts/libraries/webkitcorepy/webkitcorepy/testing/llm_test_runner.py:
(LLMTestRunner): Test runner invoked by run-llm-tests scripts.
* Tools/Scripts/libraries/webkitcorepy/webkitcorepy/tests/skill_testing/__init__.py: Added..
* Tools/Scripts/libraries/webkitcorepy/webkitcorepy/tests/skill_testing/skill_file_unittest.py: Added.
(SkillFileParseTest):
* Tools/Scripts/libraries/webkitcorepy/webkitcorepy/tests/skill_testing/skill_test_unittest.py: Added.
(SkillTestParseTest):
(SkillTestDiscoverTest):
* Tools/Scripts/libraries/webkitcorepy/webkitcorepy/tests/skill_testing/validators_unittest.py: Added.
(ValidationResultTest):
(ValidateFrontmatterPresenceTest):
(ValidateRequiredFieldsTest):
(ValidateFieldValuesTest):
(ValidateUnknownKeysTest):
(ValidateAllowedToolsFormatTest):
(ValidateNameMatchesDirectoryTest):
(ValidateReferencesExistTest):
(ValidateAllTest):
(ValidateSettingsJsonTest):
(ValidateMarketplaceJsonTest):
* Tools/Scripts/run-llm-tests: Run LLM tests for the WebKit project, specifically.

Canonical link: <a href="https://commits.webkit.org/312718@main">https://commits.webkit.org/312718@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/73cbd907dd6d3d3774b5cae933dc5adcf243770b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/160873 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/159/builds/34346 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/27447 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/169776 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/116382 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/162742 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/34447 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/156/builds/34346 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/169776 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/116382 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/163832 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/34447 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/144508 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/169776 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | ⏳ 🛠 vision-apple 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/160193 "Passed tests") | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/34447 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/156/builds/34346 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk3-libwebrtc~~](https://ews-build.webkit.org/#/builders/173/builds/17496 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/34447 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/167/builds/22271 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/172259 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/23912 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/172259 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/160270 "Passed tests") | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/34020 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/156/builds/34346 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/172259 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/34004 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/144066 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/95843 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/24473 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/160/builds/34004 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/20881 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/33515 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/33014 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/33258 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/33162 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->