### PR TITLE
[Site Isolation] http/tests/contentextensions/block-everything-unless-domain.html is flaky on macOS post-commit bots

### DIFF
--- a/LayoutTests/http/tests/contentextensions/block-everything-unless-domain.html
+++ b/LayoutTests/http/tests/contentextensions/block-everything-unless-domain.html
@@ -4,23 +4,21 @@ if (window.testRunner) {
     testRunner.dumpAsText();
 }
 
-var maxEventLoopRuns = 50;
-function helperLoaded () {
-    if (!maxEventLoopRuns) {
+function waitForProvisionalNavigationFailure() {
+    if (testRunner.lastProvisionalNavigationFailureURL.includes("resources/should-not-load.html")) {
         if (helper.location == "http://127.0.0.1:8000/contentextensions/resources/block-everything-unless-domain-helper.html")
             console.log("PASS - blocked the load");
         else
             console.log("FAIL - loaded blocked URL");
         testRunner.notifyDone();
     } else {
-        setTimeout(helperLoaded, 1);
-        maxEventLoopRuns--;
+        setTimeout(waitForProvisionalNavigationFailure, 10);
     }
 }
 
 var helper = window.open("resources/block-everything-unless-domain-helper.html");
 if (helper)
-    helper.addEventListener('load', helperLoaded);
+    helper.addEventListener('load', waitForProvisionalNavigationFailure);
 else {
     console.log("opening window failed");
     testRunner.notifyDone();


### PR DESCRIPTION
#### 95ea1fff522f22d45276eb6513749d75dff930ca
<pre>
[Site Isolation] http/tests/contentextensions/block-everything-unless-domain.html is flaky on macOS post-commit bots
<a href="https://bugs.webkit.org/show_bug.cgi?id=314025">https://bugs.webkit.org/show_bug.cgi?id=314025</a>
<a href="https://rdar.apple.com/176216963">rdar://176216963</a>

Reviewed by Sihui Liu.

<a href="https://commits.webkit.org/311882@main">https://commits.webkit.org/311882@main</a> fixed http/tests/contentextensions/block-everything-unless-domain.html
with site isolation enabled.

The test is not constantly failing, but is now flaky on macOS release site-isolation post-commit bots
with the following diff:

```
--- /Volumes/Data/worker/Apple-Tahoe-Release-WK2-Site-Isolation-Tree-Tests/build/layout-test-results/http/tests/contentextensions/block-everything-unless-domain-expected.txt
+++ /Volumes/Data/worker/Apple-Tahoe-Release-WK2-Site-Isolation-Tree-Tests/build/layout-test-results/http/tests/contentextensions/block-everything-unless-domain-actual.txt
@@ -1,4 +1,3 @@
 CONSOLE MESSAGE: helper loaded
-CONSOLE MESSAGE: Content blocker prevented frame displaying <a href="http://localhost">http://localhost</a>:8000/contentextensions/resources/should-not-load.html from loading a resource from <a href="http://localhost">http://localhost</a>:8000/contentextensions/resources/should-not-load.html
 CONSOLE MESSAGE: PASS - blocked the load
 ```

With site isolation enabled, the process swap for the popup window&apos;s navigation from
127.0.0.1 to localhost can take longer than the test&apos;s 50ms polling window. When this
happens, the test calls notifyDone() before the UIProcess has finished processing the
provisional navigation failure, so the content blocker console message hasn&apos;t arrived yet.

Fixed by replacing the polling loop with
testRunner.lastProvisionalNavigationFailureURL, which synchronously
queries the UIProcess for whether the navigation failure has been processed.

This test attempts to fix
http/tests/contentextensions/block-everything-unless-domain.html
with site isolation enabled

* LayoutTests/http/tests/contentextensions/block-everything-unless-domain.html:

Canonical link: <a href="https://commits.webkit.org/312807@main">https://commits.webkit.org/312807@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f02573c1d06b772717174584ad4f999d8d7fba09

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/160954 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/34427 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/27528 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/169857 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/117214 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/08ac81ec-d014-4123-af15-83bb1da17592) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/34528 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/34427 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/124850 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/117214 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/8c5436f6-8a4c-40c7-94f6-ee7fe0fe4849) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/163913 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/27114 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/144586 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/105447 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/dee3e83c-4ee0-4092-97da-f43c36d26874) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/26165 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/24663 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/17577 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/135859 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/22348 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/172340 "Built successfully") | | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/23989 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/133125 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/34101 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/28756 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/133135 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/34085 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/144143 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/95924 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/24502 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/27704 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/20960 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/33596 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/33095 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/33339 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/33244 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->