### PR TITLE
[JSC] normalizeWidths() should return a RegisterSet

### DIFF
--- a/JSTests/wasm/stress/simd-v128-arg-clobbered-by-call-polymorphic-callee-thunk.js
+++ b/JSTests/wasm/stress/simd-v128-arg-clobbered-by-call-polymorphic-callee-thunk.js
@@ -1,0 +1,63 @@
+//@ skip if !$isSIMDPlatform
+import { instantiate } from "../wabt-wrapper.js"
+import * as assert from "../assert.js"
+
+/*
+Regression test for an ARM64 wasm thunk bug where callPolymorphicCalleeGenerator
+(the call_indirect IC-miss slow path) saves/restores v0-v7 at Width64 instead
+of Width128. Because the thunk tail-calls the resolved callee via brab, the
+upper 64 bits of any v128 argument passed in v0-v7 are clobbered by the C
+helper.
+
+We trigger the slow path by rotating through more callees than the 4-way IC
+holds. Each callee is `(param v128) (result v128)` and returns its argument
+unchanged. The driver passes a v128 whose high lane is a known nonzero
+pattern, then reads lane 1 back; if the bug strikes, the high lane comes back
+as 0 (or garbage).
+*/
+
+let wat = `
+(module
+    (type $sig (func (param v128) (result v128)))
+
+    (table 6 6 funcref)
+
+    (func $f0 (type $sig) (local.get 0))
+    (func $f1 (type $sig) (local.get 0))
+    (func $f2 (type $sig) (local.get 0))
+    (func $f3 (type $sig) (local.get 0))
+    (func $f4 (type $sig) (local.get 0))
+    (func $f5 (type $sig) (local.get 0))
+
+    (elem (i32.const 0) $f0 $f1 $f2 $f3 $f4 $f5)
+
+    ;; Takes an index, does call_indirect with a v128 whose high lane is
+    ;; 0xDEADBEEFDEADBEEF, and returns the high lane of the result.
+    (func $driver (export "driver") (param $idx i32) (result i64)
+        (i64x2.extract_lane 1
+            (call_indirect (type $sig)
+                (v128.const i64x2 0xCAFEBABE00000000 0xDEADBEEFDEADBEEF)
+                (local.get $idx))))
+)
+`
+
+async function test() {
+    const instance = await instantiate(wat, {}, { simd: true })
+    const { driver } = instance.exports
+
+    // i64x2.extract_lane returns a signed i64 BigInt; mask to unsigned for bit-pattern compare.
+    const expected = 0xDEADBEEFDEADBEEFn
+
+    for (let i = 0; i < wasmTestLoopCount; ++i) {
+        const idx = i % 6
+        const got = BigInt.asUintN(64, driver(idx))
+        if (got !== expected) {
+            print("FAIL at iteration " + i + " idx=" + idx +
+                  " expected=0x" + expected.toString(16) +
+                  " got=0x" + got.toString(16))
+            throw new Error("v128 high lane clobbered by call_indirect thunk")
+        }
+    }
+}
+
+await assert.asyncTest(test())

--- a/Source/JavaScriptCore/jit/RegisterSet.h
+++ b/Source/JavaScriptCore/jit/RegisterSet.h
@@ -129,7 +129,7 @@ public:
     }
 
     [[nodiscard]] inline constexpr ScalarRegisterSet toScalarRegisterSet() const;
-    [[nodiscard]] inline constexpr ScalarRegisterSet normalizeWidths() const;
+    [[nodiscard]] inline constexpr RegisterSet normalizeWidths() const;
 
     inline constexpr void forEach(const Invocable<void(Reg)> auto& func) const
     {
@@ -455,11 +455,11 @@ constexpr ScalarRegisterSet RegisterSet::toScalarRegisterSet() const
     return ScalarRegisterSet(*this);
 }
 
-constexpr ScalarRegisterSet RegisterSet::normalizeWidths() const
+constexpr RegisterSet RegisterSet::normalizeWidths() const
 {
-    auto bits = m_bits;
-    bits.merge(m_upperBits);
-    return ScalarRegisterSet { bits };
+    RegisterSet result = *this;
+    result.m_bits.merge(result.m_upperBits);
+    return result;
 }
 
 struct ScalarRegisterSetHash {


### PR DESCRIPTION
#### e1cc09104fdd8f98c6985e30a5027785dff163ff
<pre>
[JSC] normalizeWidths() should return a RegisterSet
<a href="https://bugs.webkit.org/show_bug.cgi?id=314029">https://bugs.webkit.org/show_bug.cgi?id=314029</a>
<a href="https://rdar.apple.com/176035764">rdar://176035764</a>

Reviewed by Yusuke Suzuki.

RegisterSet::normalizeWidths() returned a ScalarRegisterSet, which only
tracks m_bits and has no m_upperBits field. Callers that assigned the
result back into a RegisterSet via the implicit conversion silently lost
all vector-width information: registers that were originally Width128
appeared as Width64 in the normalized set.

This manifested as v128 argument corruption in the wasm thunks that use
normalizeWidths() to size their register-save areas:
materializeBaselineDataGenerator, callPolymorphicCalleeGenerator, and
triggerOMGEntryTierUpThunkGenerator. Because callPolymorphicCallee
tail-calls the resolved target and materializeBaselineData returns
directly into BBQ code with v0-v7 still live as caller arg/return
registers, any v128 value in v0-v7 at the point of the thunk call would
have its high 64 bits reset to zero.

Test: JSTests/wasm/stress/simd-v128-arg-clobbered-by-call-polymorphic-callee-thunk.js
Canonical link: <a href="https://commits.webkit.org/312610@main">https://commits.webkit.org/312610@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1755b927a8b29f0ef066db81e06b69286e522049

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/160538 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/34011 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/27112 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/169441 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/115604 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/34112 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/34011 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/124491 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/115604 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/163496 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/34112 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/144205 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/105091 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/34112 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/24288 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/17160 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/152594 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/34112 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/167/builds/21968 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/171920 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [  ~~🛠 🧪 jsc-debug-arm64~~](https://ews-build.webkit.org/#/builders/171/builds/21375 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/18590 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/23608 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/171920 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/33685 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/28381 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/171920 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/33669 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/143763 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/95458 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/24422 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/160/builds/33669 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/20577 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/192937 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/33179 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/100192 "Built successfully") | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/49680 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/32679 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/32923 "Built successfully") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/32827 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->