### PR TITLE
Pack some animation classes more tightly

### DIFF
--- a/Source/WebCore/animation/BlendingKeyframes.h
+++ b/Source/WebCore/animation/BlendingKeyframes.h
@@ -183,16 +183,16 @@ private:
     HashSet<AnimatableCSSProperty> m_explicitFromProperties; // The properties with an explicit value for the 0% keyframe.
     HashSet<AnimatableCSSProperty> m_propertiesSetToInherit;
     HashSet<AnimatableCSSProperty> m_propertiesSetToCurrentColor;
-    bool m_usesRelativeFontWeight { false };
-    bool m_containsSubstitutionFunctions { false };
-    bool m_usesAnchorFunctions { false };
-    bool m_hasWidthDependentTransform { false };
-    bool m_hasHeightDependentTransform { false };
-    bool m_hasDiscreteTransformInterval { false };
-    bool m_hasExplicitlyInheritedKeyframeProperty { false };
-    bool m_hasKeyframeNotUsingRangeOffset { false };
-    bool m_hasPropertiesWithRevertRuleOrLayer { false };
-    bool m_animatesOffsetDistanceToPercentOrCalculated { false };
+    bool m_usesRelativeFontWeight : 1 { false };
+    bool m_containsSubstitutionFunctions : 1 { false };
+    bool m_usesAnchorFunctions : 1 { false };
+    bool m_hasWidthDependentTransform : 1 { false };
+    bool m_hasHeightDependentTransform : 1 { false };
+    bool m_hasDiscreteTransformInterval : 1 { false };
+    bool m_hasExplicitlyInheritedKeyframeProperty : 1 { false };
+    bool m_hasKeyframeNotUsingRangeOffset : 1 { false };
+    bool m_hasPropertiesWithRevertRuleOrLayer : 1 { false };
+    bool m_animatesOffsetDistanceToPercentOrCalculated : 1 { false };
 };
 
 } // namespace WebCore

--- a/Source/WebCore/animation/KeyframeEffect.h
+++ b/Source/WebCore/animation/KeyframeEffect.h
@@ -314,6 +314,8 @@ private:
     WeakPtr<AcceleratedEffect> m_acceleratedRepresentation;
 #endif
 
+    size_t m_transformFunctionListsMatchPrefix { 0 };
+
     AcceleratedAction m_lastRecordedAcceleratedAction { AcceleratedAction::Stop };
     WebAnimationType m_animationType { WebAnimationType::WebAnimation };
     IterationCompositeOperation m_iterationCompositeOperation { IterationCompositeOperation::Replace };
@@ -321,19 +323,18 @@ private:
     AcceleratedProperties m_acceleratedPropertiesState { AcceleratedProperties::None };
     AnimationEffectPhase m_phaseAtLastApplication { AnimationEffectPhase::Idle };
     RunningAccelerated m_runningAccelerated { RunningAccelerated::NotStarted };
-    bool m_needsForcedLayout { false };
-    bool m_triggersStackingContext { false };
-    size_t m_transformFunctionListsMatchPrefix { 0 };
-    bool m_inTargetEffectStack { false };
-    bool m_someKeyframesUseLinearTimingFunctionWithPoints { false };
-    bool m_someKeyframesUseStepsTimingFunction { false };
-    bool m_hasImplicitKeyframeForAcceleratedProperty { false };
-    bool m_hasKeyframeComposingAcceleratedProperty { false };
-    bool m_hasAcceleratedPropertyOverriddenByCascadeProperty { false };
-    bool m_hasReferenceFilter { false };
-    bool m_animatesSizeAndSizeDependentTransform { false };
-    bool m_isAssociatedWithProgressBasedTimeline { false };
-    bool m_needsComputedKeyframeOffsetsUpdate { false };
+    bool m_needsForcedLayout : 1 { false };
+    bool m_triggersStackingContext : 1 { false };
+    bool m_inTargetEffectStack : 1 { false };
+    bool m_someKeyframesUseLinearTimingFunctionWithPoints : 1 { false };
+    bool m_someKeyframesUseStepsTimingFunction : 1 { false };
+    bool m_hasImplicitKeyframeForAcceleratedProperty : 1 { false };
+    bool m_hasKeyframeComposingAcceleratedProperty : 1 { false };
+    bool m_hasAcceleratedPropertyOverriddenByCascadeProperty : 1 { false };
+    bool m_hasReferenceFilter : 1 { false };
+    bool m_animatesSizeAndSizeDependentTransform : 1 { false };
+    bool m_isAssociatedWithProgressBasedTimeline : 1 { false };
+    bool m_needsComputedKeyframeOffsetsUpdate : 1 { false };
 };
 
 } // namespace WebCore


### PR DESCRIPTION
#### 1cbd47871e33b755d1b591df464e9c0ed5a49d8e
<pre>
Pack some animation classes more tightly
<a href="https://rdar.apple.com/176219365">rdar://176219365</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=314028">https://bugs.webkit.org/show_bug.cgi?id=314028</a>

Reviewed by Simon Fraser.

KeyframeEffect: 456 bytes (99 padding) -&gt; 432 (93 padding)
BlendingKeyframes: 96 bytes (13 padding) -&gt; 88 (13 padding)

Refactoring, no behavioral changes.

* Source/WebCore/animation/BlendingKeyframes.h:
* Source/WebCore/animation/KeyframeEffect.h:

Canonical link: <a href="https://commits.webkit.org/312600@main">https://commits.webkit.org/312600@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8d6975d44aeb46c02e03187aaf7fc8540a445289

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/160439 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/33912 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/27013 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/169342 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/115505 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/162308 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/34013 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/33912 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/124397 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/87865 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/163397 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/26642 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/144110 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/104996 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/25694 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/24196 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/17061 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/135388 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/21873 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/171820 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/18209 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/23513 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/132658 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/33586 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/28290 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/132679 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35869 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/33570 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/143668 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/95352 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/27276 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/20482 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/33080 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/99872 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/32580 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/32824 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/32728 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->