### PR TITLE
Make sure the JS context is locked before calling methods on it to avoid debug assertions

### DIFF
--- a/Source/WebKit/WebProcess/Inspector/WebInspectorUIExtensionController.cpp
+++ b/Source/WebKit/WebProcess/Inspector/WebInspectorUIExtensionController.cpp
@@ -434,6 +434,8 @@ void WebInspectorUIExtensionController::evaluateScriptInExtensionTab(const Inspe
             return;
         }
 
+        JSC::JSLockHolder lock(frontendGlobalObject);
+
         if (auto parsedError = weakThis->parseExtensionErrorFromEvaluationResult(result)) {
             if (!result.value().has_value()) {
                 auto exceptionDetails = result.value().error();

--- a/Source/WebKit/WebProcess/UserContent/WebUserContentController.cpp
+++ b/Source/WebKit/WebProcess/UserContent/WebUserContentController.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014-2025 Apple Inc. All rights reserved.
+ * Copyright (C) 2014-2026 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -44,6 +44,7 @@
 #include <JavaScriptCore/APICast.h>
 #include <JavaScriptCore/JSCJSValueInlines.h>
 #include <JavaScriptCore/JSContextRef.h>
+#include <JavaScriptCore/JSLock.h>
 #include <JavaScriptCore/JSRetainPtr.h>
 #include <WebCore/DOMWrapperWorld.h>
 #include <WebCore/FrameDestructionObserverInlines.h>
@@ -329,6 +330,7 @@ private:
             return;
 
         protect(WebProcess::singleton().parentProcessConnection())->sendWithAsyncReply(Messages::WebProcessProxy::DidPostMessage(webPage->webPageProxyIdentifier(), m_controller->identifier(), webFrame->info(), m_identifier, *message), [completionHandler = WTF::move(completionHandler), context](Expected<WebKit::JavaScriptEvaluationResult, String>&& result) {
+            JSC::JSLockHolder lock(toJS(context.get()));
             if (!result)
                 return completionHandler(JSC::jsUndefined(), result.error());
             completionHandler(toJS(toJS(context.get()), result->toJS(context.get()).get()), { });
@@ -358,6 +360,7 @@ private:
         auto [result] = sendResult.takeReplyOr(makeUnexpected(String()));
         if (!result)
             return JSC::jsUndefined();
+        JSC::JSLockHolder lock(toJS(context.get()));
         return toJS(toJS(context.get()), result->toJS(context.get()).get());
     }
 

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/UserContentController.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/UserContentController.mm
@@ -37,6 +37,7 @@
 #import <WebKit/WKContentWorld.h>
 #import <WebKit/WKContentWorldConfiguration.h>
 #import <WebKit/WKContentWorldPrivate.h>
+#import <WebKit/WKJSSerializedNode.h>
 #import <WebKit/WKProcessPoolPrivate.h>
 #import <WebKit/WKScriptMessage.h>
 #import <WebKit/WKScriptMessageHandlerWithReply.h>
@@ -2006,4 +2007,46 @@ TEST(WKUserContentController, EvaluateLargeJavaScriptStringInAutoFillWorld)
     // Check that script still works after caching.
     result = [webView objectByEvaluatingJavaScript:largeScript inFrame:nil inContentWorld:autofillWorld.get()];
     EXPECT_EQ([result intValue], 2);
+}
+
+@interface SerializedNodeReplyHandler : NSObject <WKScriptMessageHandlerWithReply>
+@property (nonatomic, strong) WKContentWorld *world;
+@end
+
+@implementation SerializedNodeReplyHandler
+
+- (void)userContentController:(WKUserContentController *)userContentController didReceiveScriptMessage:(WKScriptMessage *)message replyHandler:(void (^)(id, NSString *errorMessage))replyHandler
+{
+    WKWebView *webView = message.webView;
+    [webView evaluateJavaScript:@"window.webkit.serializeNode(document.createElement('div'))" inFrame:nil inContentWorld:self.world completionHandler:^(id result, NSError *error) {
+        EXPECT_NULL(error);
+        EXPECT_TRUE([result isKindOfClass:WKJSSerializedNode.class]);
+        replyHandler(result, nil);
+    }];
+}
+
+@end
+
+TEST(WKUserContentController, MessageHandlerReplyWithSerializedNode)
+{
+    RetainPtr worldConfiguration = adoptNS([WKContentWorldConfiguration new]);
+    worldConfiguration.get().nodeSerializationEnabled = YES;
+    RetainPtr world = [WKContentWorld worldWithConfiguration:worldConfiguration.get()];
+
+    RetainPtr handler = adoptNS([SerializedNodeReplyHandler new]);
+    handler.get().world = world.get();
+
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    [[configuration userContentController] addScriptMessageHandlerWithReply:handler.get() contentWorld:world.get() name:@"testHandler"];
+
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+    [webView synchronouslyLoadHTMLString:@"<body>test</body>"];
+
+    __block bool done = false;
+    [webView callAsyncJavaScript:@"let node = await window.webkit.messageHandlers.testHandler.postMessage('serialize'); return node.nodeName" arguments:nil inFrame:nil inContentWorld:world.get() completionHandler:^(id result, NSError *error) {
+        EXPECT_NULL(error);
+        EXPECT_WK_STREQ(result, "DIV");
+        done = true;
+    }];
+    TestWebKitAPI::Util::run(&done);
 }


### PR DESCRIPTION
#### dda1770b178be44f1b8cfb9c1e4caed3aa516ce2
<pre>
Make sure the JS context is locked before calling methods on it to avoid debug assertions
<a href="https://bugs.webkit.org/show_bug.cgi?id=314032">https://bugs.webkit.org/show_bug.cgi?id=314032</a>
&lt;<a href="https://rdar.apple.com/problem/173871861">rdar://problem/173871861</a>&gt;

Reviewed by Chris Dumez.

The JSC team identified that some IPC completion handlers in the WebProcess touch JSC
objects without holding the JSLock. This causes assertion failures in Debug builds when
the JSC heap allocator checks vm.currentThreadIsHoldingAPILock().

The changes are related to a new off-by-default API (WKJSSerializedNode).

I noticed this mistake was made in the WebInspector adoption of the new API, and corrected
that call site as well.

Test: Tools/TestWebKitAPI/Tests/WebKit/WKWebView/UserContentController.mm

* Source/WebKit/WebProcess/Inspector/WebInspectorUIExtensionController.cpp:
(WebKit::WebInspectorUIExtensionController::evaluateScriptInExtensionTab): Add missing JSLock.
* Source/WebKit/WebProcess/UserContent/WebUserContentController.cpp:
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/UserContentController.mm:
(-[SerializedNodeReplyHandler userContentController:didReceiveScriptMessage:replyHandler:]):
(TEST(WKUserContentController, MessageHandlerReplyWithSerializedNode)): Added.

Canonical link: <a href="https://commits.webkit.org/312630@main">https://commits.webkit.org/312630@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a3a4b53857523ecf859f0b99804d23c6855ead2f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/160595 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/34068 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/27169 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/169498 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/115661 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/aeb4cd43-a774-4a15-9e50-df914c60d42d) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/162464 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/34169 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/34068 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/124538 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/115661 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/ff4a80d9-519f-4fdc-9ad8-6d60290a8767) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/163554 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/26785 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/144255 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/105138 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/40f0a5a8-bc75-40c5-a196-8aac11c35a27) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/25837 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/24342 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/17218 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/135531 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/22018 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/171977 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/18845 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/23658 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/132806 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/33742 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/28435 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/132821 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35888 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/33726 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/143813 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/95530 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/27415 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/20627 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/33237 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/100448 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/32736 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/32980 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/32884 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->