### PR TITLE
[TestWebKitAPI] macCatalyst build is broken (FontAttributes.mm:64:89: error: 'objectForKey:' is unavailable: not available on macCatalyst)

### DIFF
--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/FontAttributes.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/FontAttributes.mm
@@ -61,7 +61,8 @@
 
 - (void)_webView:(WKWebView *)webView didChangeFontAttributes:(NSDictionary<NSString *, id> *)fontAttributes
 {
-    NSString *fontTextStyle = [[[fontAttributes objectForKey:@"NSFont"] fontDescriptor] objectForKey:(__bridge NSString *)kCTFontDescriptorTextStyleAttribute];
+    RetainPtr fontDescriptor = [checked_objc_cast<WebCore::CocoaFont>([fontAttributes objectForKey:@"NSFont"]) fontDescriptor];
+    RetainPtr fontTextStyle = checked_objc_cast<NSString>([fontDescriptor objectForKey:bridge_cast(kCTFontDescriptorTextStyleAttribute)]);
 
     if (_willSetFont && [fontTextStyle isEqualToString:@"UICTFontTextStyleTitle1"]) {
         _done = YES;


### PR DESCRIPTION
#### 5cb9042cb70d56982c676f76eae794f6ce1f7c66
<pre>
[TestWebKitAPI] macCatalyst build is broken (FontAttributes.mm:64:89: error: &apos;objectForKey:&apos; is unavailable: not available on macCatalyst)
<a href="https://bugs.webkit.org/show_bug.cgi?id=314043">https://bugs.webkit.org/show_bug.cgi?id=314043</a>
<a href="https://rdar.apple.com/176228243">rdar://176228243</a>

Reviewed by Aditya Keerthi.

Cast the font to CocoaFont before calling -fontDescriptor so the compiler
resolves to the platform-appropriate descriptor type rather than picking
the unavailable NSFontDescriptor overload from an untyped receiver.

* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/FontAttributes.mm:
(-[FontTextStyleUIDelegate _webView:didChangeFontAttributes:]):

Canonical link: <a href="https://commits.webkit.org/312657@main">https://commits.webkit.org/312657@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a0839168c28e666e44e5bc2c07b2cfbc1938c2e6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/160470 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/33943 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/27044 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/169373 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/115536 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/77aa1927-9019-47ca-b951-8660eedf49c7) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/162339 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/34044 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/33943 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/124424 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/87885 "2 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/d1e41336-c60f-465d-a7b7-592bb719bafc) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/163428 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/26668 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/144146 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/105023 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/7c63822f-c678-4257-b732-550d907cd076) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/25720 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/24224 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/17092 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/135414 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/21909 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/171851 "Built successfully") | | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/23549 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/132683 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/33617 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/28318 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/132703 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/33601 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/143704 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/95383 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/24446 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/27299 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/20518 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/33111 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/32611 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/32855 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/32759 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->