### PR TITLE
REGRESSION: WebAssembly SIMD produces incorrect result on x86_64 Linux (argon2id hash mismatch)

### DIFF
--- a/JSTests/wasm/stress/simd-shuffle-compose-rightimm.js
+++ b/JSTests/wasm/stress/simd-shuffle-compose-rightimm.js
@@ -1,0 +1,72 @@
+//@ skip if !$isSIMDPlatform
+import { instantiate } from "../wabt-wrapper.js"
+import * as assert from "../assert.js"
+
+// Regression test for argon2id wasm SIMD miscompilation on x64.
+//
+// Before the fix, OMGIRGenerator::addSIMDShuffle on x64 split a wasm binary
+// i8x16.shuffle into two unary VectorSwizzles (one per source) plus a
+// VectorOr, but it kept the original wasm bytes 16..31 in the rightImm
+// pattern and relied on PSHUFB's index masking. B3ReduceStrength's
+// SwizzleSwizzle composition (composeUnaryShuffle) treats indices ≥ 16 as
+// out-of-bounds (ARM64 TBL semantics), so when the rightImm-side unary
+// swizzle's input was itself a VectorSwizzle the composed pattern was all
+// 0xFF and the resulting PSHUFB returned all zeros. The fix canonicalizes
+// rightImm to use 0..15 indices.
+//
+// The argon2 BLAKE2b inner loop produced this pattern via:
+//   i8x16.shuffle <select-from-arg2> arg1 (i8x16.shuffle <rotr16> b b)
+// which after the buggy split-and-compose miscomputed the multiplier input
+// as zero, propagating wrong bytes through the rest of the BLAKE2b round.
+//
+// This test reproduces the smallest pattern shape under OMG and asserts
+// against the expected byte result.
+
+async function test() {
+    // Two wasm i8x16.shuffles. The outer takes (anything, inner_result) and
+    // selects only bytes from arg2 (indices 16..31). The inner is a unary
+    // shuffle over `b`. Without the canonicalization fix, the outer's split
+    // rightImm has bytes 16..31 in the B3 IR; SwizzleSwizzle composition
+    // (since the rightImm-side's child(0) is the inner VectorSwizzle on x64)
+    // produces composed = all 0xFF and PSHUFB returns all zeros.
+    let wat = `(module
+      (memory (export "mem") 1)
+
+      (func (export "compose_test") (param $aPtr i32) (param $bPtr i32) (param $outPtr i32)
+        (local.set $aPtr (local.get $aPtr))
+        (v128.store (local.get $outPtr)
+          ;; outer: take bytes 16..31 of (a, inner_result) → identity-of-arg2.
+          (i8x16.shuffle 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31
+            (v128.load (local.get $aPtr))
+            ;; inner: rotr16 of b within each i64x2 lane.
+            (i8x16.shuffle 2 3 4 5 6 7 0 1 10 11 12 13 14 15 8 9
+              (v128.load (local.get $bPtr))
+              (v128.load (local.get $bPtr))))))
+    )`
+
+    const instance = await instantiate(wat, { }, { simd: true })
+    const memory = new Uint8Array(instance.exports.mem.buffer)
+
+    // Set 'a' to a distinguishable pattern (will be discarded by outer shuffle).
+    for (let i = 0; i < 16; ++i)
+        memory[i] = 0xA0 + i
+    // Set 'b' to 0x10..0x1F so the rotr16 result is easy to verify.
+    for (let i = 0; i < 16; ++i)
+        memory[16 + i] = 0x10 + i
+
+    const expected = new Uint8Array(16)
+    // rotr16 byte pattern: {2,3,4,5,6,7,0,1, 10,11,12,13,14,15,8,9}
+    const rotr16 = [2,3,4,5,6,7,0,1, 10,11,12,13,14,15,8,9]
+    for (let i = 0; i < 16; ++i)
+        expected[i] = 0x10 + rotr16[i]
+
+    // Trigger OMG by running many times.
+    const loopCount = (typeof wasmTestLoopCount === 'number') ? wasmTestLoopCount : 1000
+    for (let iter = 0; iter < loopCount; ++iter) {
+        instance.exports.compose_test(0, 16, 32)
+        for (let i = 0; i < 16; ++i)
+            assert.eq(memory[32 + i], expected[i], `byte ${i} at iteration ${iter}`)
+    }
+}
+
+await assert.asyncTest(test())

--- a/Source/JavaScriptCore/b3/B3ReduceStrength.cpp
+++ b/Source/JavaScriptCore/b3/B3ReduceStrength.cpp
@@ -3747,19 +3747,24 @@ private:
                     break;
                 }
 
-                if (auto child = SIMDShuffle::isOnlyOneSideMask(pattern)) {
-                    switch (child.value()) {
+                if (auto result = SIMDShuffle::isOnlyOneSideMask(pattern)) {
+                    auto [child, newPattern] = result.value();
+                    switch (child) {
                     case 0: {
-                        replaceWithNew<SIMDValue>(m_value->origin(), VectorSwizzle, B3::V128, SIMDLane::i8x16, SIMDSignMode::None, m_value->child(0), m_value->child(2));
+                        Value* newPatternValue = m_proc.addConstant(m_value->origin(), B3::V128, newPattern);
+                        m_insertionSet.insertValue(m_index, newPatternValue);
+                        replaceWithNew<SIMDValue>(m_value->origin(), VectorSwizzle, B3::V128, SIMDLane::i8x16, SIMDSignMode::None, m_value->child(0), newPatternValue);
                         break;
                     }
                     case 1: {
-                        v128_t newPattern = pattern;
-                        for (unsigned i = 0; i < 16; ++i)
-                            newPattern.u8x16[i] = pattern.u8x16[i] - 16;
                         Value* newPatternValue = m_proc.addConstant(m_value->origin(), B3::V128, newPattern);
                         m_insertionSet.insertValue(m_index, newPatternValue);
                         replaceWithNew<SIMDValue>(m_value->origin(), VectorSwizzle, B3::V128, SIMDLane::i8x16, SIMDSignMode::None, m_value->child(1), newPatternValue);
+                        break;
+                    }
+                    case 2: {
+                        // All OOB.
+                        replaceWithNewValue(m_proc.addConstant(m_value->origin(), B3::V128, vectorAllZeros()));
                         break;
                     }
                     }
@@ -3805,19 +3810,27 @@ private:
                     // If all composed indices reference only one side (0..15 or 16..31),
                     // emit a 2-child unary shuffle instead of a 3-child binary shuffle.
                     // This enables further optimizations like DUP detection in ReduceStrength.
-                    if (auto side = SIMDShuffle::isOnlyOneSideMask(newPattern)) {
-                        Value* src;
-                        v128_t unaryPattern = newPattern;
-                        if (*side == 0)
-                            src = newChild0;
-                        else {
-                            src = newChild1;
-                            for (unsigned i = 0; i < 16; ++i)
-                                unaryPattern.u8x16[i] -= 16;
+                    if (auto result = SIMDShuffle::isOnlyOneSideMask(newPattern)) {
+                        auto [child, unaryPattern] = result.value();
+                        switch (child) {
+                        case 0: {
+                            Value* newPatternValue = m_proc.addConstant(m_value->origin(), B3::V128, unaryPattern);
+                            m_insertionSet.insertValue(m_index, newPatternValue);
+                            replaceWithNew<SIMDValue>(m_value->origin(), VectorSwizzle, B3::V128, SIMDLane::i8x16, SIMDSignMode::None, newChild0, newPatternValue);
+                            break;
                         }
-                        Value* newPat = m_proc.addConstant(m_value->origin(), B3::V128, unaryPattern);
-                        m_insertionSet.insertValue(m_index, newPat);
-                        replaceWithNew<SIMDValue>(m_value->origin(), VectorSwizzle, B3::V128, SIMDLane::i8x16, SIMDSignMode::None, src, newPat);
+                        case 1: {
+                            Value* newPatternValue = m_proc.addConstant(m_value->origin(), B3::V128, unaryPattern);
+                            m_insertionSet.insertValue(m_index, newPatternValue);
+                            replaceWithNew<SIMDValue>(m_value->origin(), VectorSwizzle, B3::V128, SIMDLane::i8x16, SIMDSignMode::None, newChild1, newPatternValue);
+                            break;
+                        }
+                        case 2: {
+                            // All OOB.
+                            replaceWithNewValue(m_proc.addConstant(m_value->origin(), B3::V128, vectorAllZeros()));
+                            break;
+                        }
+                        }
                         return true;
                     }
 

--- a/Source/JavaScriptCore/b3/testb3.h
+++ b/Source/JavaScriptCore/b3/testb3.h
@@ -1575,6 +1575,14 @@ void testVectorSwizzleToDupElement();
 void testVectorSwizzleComposition();
 void testVectorSwizzleUnaryComposition();
 void testVectorSwizzleCompositionMultiUse();
+void testVectorSwizzleCompositionRightImmOuter();
+void testVectorSwizzleBinaryOnlyOneSideSide0();
+void testVectorSwizzleBinaryOnlyOneSideSide1();
+void testVectorSwizzleBinaryOnlyOneSideSide0WithOOB();
+void testVectorSwizzleBinaryOnlyOneSideSide1WithOOB();
+void testVectorSwizzleBinaryOnlyOneSideAllOOB();
+void testVectorSwizzleBinaryOnlyOneSideMixed();
+void testVectorSwizzleBinaryOnlyOneSideSide1Scattered();
 
 void testRotRFromShiftXorChainSHA256Sigma1_32(int32_t);
 void testRotRFromShiftXorChainSHA512Sigma1_64(int64_t);

--- a/Source/JavaScriptCore/b3/testb3_1.cpp
+++ b/Source/JavaScriptCore/b3/testb3_1.cpp
@@ -1437,6 +1437,13 @@ void run(const TestConfig* config)
         RUN(testVectorSwizzleBinaryCanonical());
         RUN(testVectorSwizzleComposition());
         RUN(testVectorSwizzleCompositionMultiUse());
+        RUN(testVectorSwizzleBinaryOnlyOneSideSide0());
+        RUN(testVectorSwizzleBinaryOnlyOneSideSide1());
+        RUN(testVectorSwizzleBinaryOnlyOneSideSide0WithOOB());
+        RUN(testVectorSwizzleBinaryOnlyOneSideSide1WithOOB());
+        RUN(testVectorSwizzleBinaryOnlyOneSideAllOOB());
+        RUN(testVectorSwizzleBinaryOnlyOneSideMixed());
+        RUN(testVectorSwizzleBinaryOnlyOneSideSide1Scattered());
     }
 
     RUN(testReportUsedRegistersLateUseFollowedByEarlyDefDoesNotMarkUseAsDead());
@@ -1492,6 +1499,7 @@ void run(const TestConfig* config)
         RUN(testVectorCanonicalSameInputFolding());
         RUN(testVectorSwizzleToDupElement());
         RUN(testVectorSwizzleUnaryComposition());
+        RUN(testVectorSwizzleCompositionRightImmOuter());
         RUN(testMulHigh32());
         RUN(testMulHigh64());
         RUN(testUMulHigh32());

--- a/Source/JavaScriptCore/b3/testb3_7.cpp
+++ b/Source/JavaScriptCore/b3/testb3_7.cpp
@@ -5435,6 +5435,239 @@ void testVectorSwizzleCompositionMultiUse()
         CHECK(vectors[3].u8x16[i] == 0x80 + i);
 }
 
+// Regression test for argon2id wasm SIMD miscompilation on x64 (rdar://...).
+//
+// OMGIRGenerator::addSIMDShuffle splits a wasm binary i8x16.shuffle on x64
+// into two unary VectorSwizzles (one per source) plus a VectorOr. The split
+// canonicalizes both patterns so that valid indices are in 0..15 and OOB
+// uses 0xFF — without this canonicalization the rightImm-side pattern would
+// keep the original wasm bytes 16..31 (relying on PSHUFB's index masking),
+// which broke B3ReduceStrength's SwizzleSwizzle composition (composeUnaryShuffle
+// treats bytes ≥ 16 as OOB per ARM64 TBL semantics, producing all-0xFF and
+// thus all-zero PSHUFB output instead of the correctly shuffled bytes).
+//
+// This test reproduces the failing pattern shape directly in B3 IR using
+// canonicalized patterns and verifies that composing two unary VectorSwizzles
+// (rotr16 inner ∘ "lower-8-bytes-of-inner-then-OOB" outer) yields the correct
+// PSHUFB result rather than zero.
+void testVectorSwizzleCompositionRightImmOuter()
+{
+    alignas(16) v128_t vectors[2];
+    Procedure proc;
+    BasicBlock* root = proc.addBlock();
+    auto arguments = cCallArgumentValues<void*>(proc, root);
+    Value* address = arguments[0];
+    Value* input = root->appendNew<MemoryValue>(proc, Load, V128, Origin(), address);
+
+    // Inner: rotr16 of i64x2 (the byte pattern argon2 uses for one of its
+    // BLAKE2b rotations). Bytes 0..15.
+    v128_t innerPat = v128_t::fromU8x16(2, 3, 4, 5, 6, 7, 0, 1, 10, 11, 12, 13, 14, 15, 8, 9);
+    Value* innerPatConst = root->appendNew<Const128Value>(proc, Origin(), innerPat);
+    Value* inner = root->appendNew<SIMDValue>(proc, Origin(), VectorSwizzle, B3::V128, SIMDLane::i8x16, SIMDSignMode::None, input, innerPatConst);
+
+    // Outer: take low 8 bytes of inner_result and zero the rest. This is the
+    // canonicalized form of what addSIMDShuffle now emits as the leftImm or
+    // rightImm pattern for a binary shuffle that selects only one half from
+    // a single side. Bytes 0..7 valid, bytes 8..15 OOB (0xFF).
+    v128_t outerPat;
+    for (unsigned i = 0; i < 8; ++i)
+        outerPat.u8x16[i] = static_cast<uint8_t>(i);
+    for (unsigned i = 8; i < 16; ++i)
+        outerPat.u8x16[i] = 0xFF;
+    Value* outerPatConst = root->appendNew<Const128Value>(proc, Origin(), outerPat);
+    Value* outer = root->appendNew<SIMDValue>(proc, Origin(), VectorSwizzle, B3::V128, SIMDLane::i8x16, SIMDSignMode::None, inner, outerPatConst);
+
+    root->appendNew<MemoryValue>(proc, Store, Origin(), outer, address, static_cast<int32_t>(sizeof(v128_t)));
+    root->appendNewControlValue(proc, Return, Origin());
+
+    auto code = compileProc(proc);
+    for (unsigned i = 0; i < 16; ++i)
+        vectors[0].u8x16[i] = static_cast<uint8_t>(0x10 + i);
+    invoke<void>(*code, vectors);
+
+    // Composition collapses to PSHUFB(input, composed) where
+    //   composed[i] = innerPat[outerPat[i]] for outerPat[i] < 16, else 0xFF.
+    // For i in 0..7: composed[i] = innerPat[i] = rotr16's bytes 0..7
+    //                            = {2, 3, 4, 5, 6, 7, 0, 1} (input indices).
+    // For i in 8..15: composed[i] = 0xFF → 0.
+    // So result.bytes[0..7] = input[2..7, 0..1], result.bytes[8..15] = 0.
+    static constexpr uint8_t expectedLowIndices[8] = { 2, 3, 4, 5, 6, 7, 0, 1 };
+    for (unsigned i = 0; i < 8; ++i)
+        CHECK(vectors[1].u8x16[i] == 0x10 + expectedLowIndices[i]);
+    for (unsigned i = 8; i < 16; ++i)
+        CHECK(vectors[1].u8x16[i] == 0);
+}
+
+// Helpers for testVectorSwizzleBinaryOnlyOneSide{Side0,Side1,WithOOB,AllOOB,Mixed}.
+// Each builds a 3-child VectorSwizzle(a, b, pattern) with the given pattern.
+//
+// The 3-child (binary) VectorSwizzle is only lowered to Air on ARM64
+// (VectorSwizzle2 → TBL2). On x86 the binary form would need to be reduced by
+// B3ReduceStrength to a 2-child unary form before lowering, but at O0 the
+// reductions don't run, so directly constructing a 3-child VectorSwizzle on
+// x86 would crash. These tests are therefore registered only under
+// `if (isARM64())` in testb3_1.cpp. The x86 side of isOnlyOneSideMask is
+// exercised end-to-end by JSTests/wasm/stress/simd-shuffle-compose-rightimm.js
+// (and the broader wasm SIMD tests), where OMGIRGenerator::addSIMDShuffle
+// builds the equivalent unary forms and feeds them through the same
+// B3ReduceStrength pipeline.
+//
+// Expected output is computed byte-by-byte using wasm i8x16.shuffle semantics:
+//   result[i] = pattern[i] < 16 ? a[pattern[i]]
+//             : pattern[i] < 32 ? b[pattern[i] - 16]
+//             : 0 (OOB).
+static void runBinarySwizzleAndCheck(v128_t pattern, v128_t aIn, v128_t bIn)
+{
+    alignas(16) v128_t vectors[3];
+    Procedure proc;
+    BasicBlock* root = proc.addBlock();
+    auto arguments = cCallArgumentValues<void*>(proc, root);
+    Value* address = arguments[0];
+    Value* a = root->appendNew<MemoryValue>(proc, Load, V128, Origin(), address);
+    Value* b = root->appendNew<MemoryValue>(proc, Load, V128, Origin(), address, static_cast<int32_t>(sizeof(v128_t)));
+    Value* patternConst = root->appendNew<Const128Value>(proc, Origin(), pattern);
+    Value* result = root->appendNew<SIMDValue>(proc, Origin(), VectorSwizzle, B3::V128, SIMDLane::i8x16, SIMDSignMode::None, a, b, patternConst);
+    root->appendNew<MemoryValue>(proc, Store, Origin(), result, address, static_cast<int32_t>(2 * sizeof(v128_t)));
+    root->appendNewControlValue(proc, Return, Origin());
+
+    auto code = compileProc(proc);
+    vectors[0] = aIn;
+    vectors[1] = bIn;
+    invoke<void>(*code, vectors);
+
+    for (unsigned i = 0; i < 16; ++i) {
+        uint8_t idx = pattern.u8x16[i];
+        uint8_t expected;
+        if (idx < 16)
+            expected = aIn.u8x16[idx];
+        else if (idx < 32)
+            expected = bIn.u8x16[idx - 16];
+        else
+            expected = 0;
+        CHECK(vectors[2].u8x16[i] == expected);
+    }
+}
+
+// Pattern reads only from `a` (no OOB). isOnlyOneSideMask must return
+// {child=0, normalized=pattern} and the binary VectorSwizzle must collapse
+// to a unary VectorSwizzle on `a`. On x64 the lowering is PSHUFB(a, pattern).
+void testVectorSwizzleBinaryOnlyOneSideSide0()
+{
+    // Reverse bytes within 32-bit groups. Reads only from `a`.
+    v128_t pattern;
+    for (unsigned i = 0; i < 16; i += 4) {
+        pattern.u8x16[i + 0] = static_cast<uint8_t>(i + 3);
+        pattern.u8x16[i + 1] = static_cast<uint8_t>(i + 2);
+        pattern.u8x16[i + 2] = static_cast<uint8_t>(i + 1);
+        pattern.u8x16[i + 3] = static_cast<uint8_t>(i + 0);
+    }
+    v128_t a, b;
+    for (unsigned i = 0; i < 16; ++i) a.u8x16[i] = static_cast<uint8_t>(0x10 + i);
+    for (unsigned i = 0; i < 16; ++i) b.u8x16[i] = static_cast<uint8_t>(0x80 + i);
+    runBinarySwizzleAndCheck(pattern, a, b);
+}
+
+// Pattern reads only from `b` (indices 16..31, no OOB). Must collapse to a
+// unary VectorSwizzle on `b` with normalized pattern (idx - 16) and on x64
+// must NOT mistake the high indices as OOB after composition (the bug fixed
+// by canonicalising rightImm in addSIMDShuffle).
+void testVectorSwizzleBinaryOnlyOneSideSide1()
+{
+    // Reverse bytes within 32-bit groups, but reading from `b`.
+    v128_t pattern;
+    for (unsigned i = 0; i < 16; i += 4) {
+        pattern.u8x16[i + 0] = static_cast<uint8_t>(16 + i + 3);
+        pattern.u8x16[i + 1] = static_cast<uint8_t>(16 + i + 2);
+        pattern.u8x16[i + 2] = static_cast<uint8_t>(16 + i + 1);
+        pattern.u8x16[i + 3] = static_cast<uint8_t>(16 + i + 0);
+    }
+    v128_t a, b;
+    for (unsigned i = 0; i < 16; ++i) a.u8x16[i] = static_cast<uint8_t>(0x80 + i);
+    for (unsigned i = 0; i < 16; ++i) b.u8x16[i] = static_cast<uint8_t>(0x10 + i);
+    runBinarySwizzleAndCheck(pattern, a, b);
+}
+
+// Pattern reads from `a` for some bytes and is OOB (≥ 32) for others. Must
+// collapse to a unary VectorSwizzle on `a` whose pattern has 0xFF in the OOB
+// positions, producing zero bytes there.
+void testVectorSwizzleBinaryOnlyOneSideSide0WithOOB()
+{
+    v128_t pattern;
+    for (unsigned i = 0; i < 8; ++i)
+        pattern.u8x16[i] = static_cast<uint8_t>(2 * i); // {0, 2, 4, 6, 8, 10, 12, 14} from `a`
+    for (unsigned i = 8; i < 16; ++i)
+        pattern.u8x16[i] = 0xFF; // OOB (≥ 32)
+    v128_t a, b;
+    for (unsigned i = 0; i < 16; ++i) a.u8x16[i] = static_cast<uint8_t>(0x10 + i);
+    for (unsigned i = 0; i < 16; ++i) b.u8x16[i] = static_cast<uint8_t>(0x80 + i);
+    runBinarySwizzleAndCheck(pattern, a, b);
+}
+
+// Pattern reads from `b` for some bytes and is OOB for others.
+void testVectorSwizzleBinaryOnlyOneSideSide1WithOOB()
+{
+    v128_t pattern;
+    for (unsigned i = 0; i < 8; ++i)
+        pattern.u8x16[i] = 0xFF; // OOB
+    for (unsigned i = 8; i < 16; ++i)
+        pattern.u8x16[i] = static_cast<uint8_t>(16 + 2 * (i - 8)); // {16,18,20,22,24,26,28,30} from `b`
+    v128_t a, b;
+    for (unsigned i = 0; i < 16; ++i) a.u8x16[i] = static_cast<uint8_t>(0x80 + i);
+    for (unsigned i = 0; i < 16; ++i) b.u8x16[i] = static_cast<uint8_t>(0x10 + i);
+    runBinarySwizzleAndCheck(pattern, a, b);
+}
+
+// All bytes are OOB (≥ 32). isOnlyOneSideMask returns {child=2, all-ones}
+// and the swizzle must collapse to a constant all-zero vector.
+void testVectorSwizzleBinaryOnlyOneSideAllOOB()
+{
+    v128_t pattern;
+    for (unsigned i = 0; i < 16; ++i)
+        pattern.u8x16[i] = 0xFF;
+    v128_t a, b;
+    for (unsigned i = 0; i < 16; ++i) a.u8x16[i] = static_cast<uint8_t>(0x80 + i);
+    for (unsigned i = 0; i < 16; ++i) b.u8x16[i] = static_cast<uint8_t>(0x70 + i);
+    runBinarySwizzleAndCheck(pattern, a, b);
+}
+
+// Pattern uses bytes from BOTH sides — isOnlyOneSideMask must return nullopt.
+// On x64 this still must compile correctly (other binary reductions like
+// canonical UZP/ZIP/EXT or the input-equality normalization step kick in).
+// Use S64x2UnzipEven canonical pattern {0..7, 16..23} to ensure a downstream
+// reduction can handle it.
+void testVectorSwizzleBinaryOnlyOneSideMixed()
+{
+    v128_t pattern;
+    for (unsigned i = 0; i < 8; ++i)
+        pattern.u8x16[i] = static_cast<uint8_t>(i); // a[0..7]
+    for (unsigned i = 0; i < 8; ++i)
+        pattern.u8x16[8 + i] = static_cast<uint8_t>(16 + i); // b[0..7]
+    v128_t a, b;
+    for (unsigned i = 0; i < 16; ++i) a.u8x16[i] = static_cast<uint8_t>(0x10 + i);
+    for (unsigned i = 0; i < 16; ++i) b.u8x16[i] = static_cast<uint8_t>(0x80 + i);
+    runBinarySwizzleAndCheck(pattern, a, b);
+}
+
+// Pattern is byte-reverse-of-side-1 with OOB scattered through it. Tests
+// that the normalization in isOnlyOneSideMask correctly subtracts 16 from
+// every valid byte even when the OOB sentinels are interleaved (rather than
+// in a contiguous run).
+void testVectorSwizzleBinaryOnlyOneSideSide1Scattered()
+{
+    v128_t pattern;
+    // Alternating: b[0], OOB, b[2], OOB, ..., b[14], OOB.
+    for (unsigned i = 0; i < 16; ++i) {
+        if (i % 2 == 0)
+            pattern.u8x16[i] = static_cast<uint8_t>(16 + i);
+        else
+            pattern.u8x16[i] = 0xFF;
+    }
+    v128_t a, b;
+    for (unsigned i = 0; i < 16; ++i) a.u8x16[i] = static_cast<uint8_t>(0x80 + i);
+    for (unsigned i = 0; i < 16; ++i) b.u8x16[i] = static_cast<uint8_t>(0x10 + i);
+    runBinarySwizzleAndCheck(pattern, a, b);
+}
+
 // Test VectorShr(VectorZip{Lower,Higher}(x, x), 8) → VectorExtend{Low,High}(x, i16x8, Signed)
 void testVectorShrZipToExtend()
 {

--- a/Source/JavaScriptCore/jit/SIMDShuffle.h
+++ b/Source/JavaScriptCore/jit/SIMDShuffle.h
@@ -72,27 +72,49 @@ enum class CanonicalShuffle : uint8_t {
 
 class SIMDShuffle {
 public:
-    static std::optional<unsigned> isOnlyOneSideMask(v128_t pattern)
+    static std::optional<std::tuple<unsigned, v128_t>> isOnlyOneSideMask(v128_t pattern)
     {
-        unsigned first = pattern.u8x16[0];
-        if (first < 16) {
-            for (unsigned i = 1; i < 16; ++i) {
-                if (pattern.u8x16[i] >= 16)
+        std::optional<unsigned> index;
+        for (unsigned i = 0; i < 16; ++i) {
+            unsigned element = pattern.u8x16[i];
+            if (element < 16) {
+                if (index && index.value() != 0)
                     return std::nullopt;
+                index = 0;
+            } else if (element < 32) {
+                if (index && index.value() != 1)
+                    return std::nullopt;
+                index = 1;
+            } else {
+                // Accept OOB.
             }
-            return 0;
         }
 
-        if (first >= 32)
-            return std::nullopt;
+        if (!index)
+            return std::tuple { 2, vectorAllOnes() };
 
-        for (unsigned i = 1; i < 16; ++i) {
-            if (pattern.u8x16[i] < 16)
-                return std::nullopt;
-            if (pattern.u8x16[i] >= 32)
-                return std::nullopt;
+        if (index.value() == 0) {
+            auto newPattern = pattern;
+            for (unsigned i = 0; i < 16; ++i) {
+                unsigned element = pattern.u8x16[i];
+                if (element < 16)
+                    newPattern.u8x16[i] = element;
+                else
+                    newPattern.u8x16[i] = 0xFF; // OOB
+            }
+            return std::tuple { 0, newPattern };
         }
-        return 1;
+
+        ASSERT(index.value() == 1);
+        auto newPattern = pattern;
+        for (unsigned i = 0; i < 16; ++i) {
+            unsigned element = pattern.u8x16[i];
+            if (element < 32)
+                newPattern.u8x16[i] = element - 16;
+            else
+                newPattern.u8x16[i] = 0xFF; // OOB
+        }
+        return std::tuple { 1, newPattern };
     }
 
     static std::optional<uint8_t> isI8x16SameElement(v128_t pattern)
@@ -362,6 +384,15 @@ public:
             }
         }
         return result;
+    }
+
+    static v128_t toCanonicalUnaryPattern(v128_t pattern)
+    {
+        for (unsigned i = 0; i < 16; ++i) {
+            if (pattern.u8x16[i] > 15)
+                pattern.u8x16[i] = 0xFF; // Force OOB
+        }
+        return pattern;
     }
 
 private:

--- a/Source/JavaScriptCore/wasm/WasmBBQJIT64.cpp
+++ b/Source/JavaScriptCore/wasm/WasmBBQJIT64.cpp
@@ -47,6 +47,7 @@ WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 #include "JSWebAssemblyStruct.h"
 #include "MacroAssembler.h"
 #include "RegisterSet.h"
+#include "SIMDShuffle.h"
 #include "WasmBBQDisassembler.h"
 #include "WasmCallingConvention.h"
 #include "WasmCompilationMode.h"
@@ -3674,15 +3675,17 @@ void NODELETE BBQJIT::notifyFunctionUsesSIMD()
                 leftImm.u8x16[i] = 0xFF; // Force OOB
             if (rightImm.u8x16[i] < 16 || rightImm.u8x16[i] > 31)
                 rightImm.u8x16[i] = 0xFF; // Force OOB
+            else
+                rightImm.u8x16[i] -= 16; // Canonicalize to 0..15
         }
         // Store each byte (w/ index < 16) of `a` to result
         // and zero clear each byte (w/ index > 15) in result.
-        materializeVectorConstant(leftImm, Location::fromFPR(scratches.fpr(0)));
+        materializeVectorConstant(SIMDShuffle::toCanonicalUnaryPattern(leftImm), Location::fromFPR(scratches.fpr(0)));
         m_jit.vectorSwizzle(aLocation.asFPR(), scratches.fpr(0), scratches.fpr(0));
 
         // Store each byte (w/ index - 16 >= 0) of `b` to result2
         // and zero clear each byte (w/ index - 16 < 0) in result2.
-        materializeVectorConstant(rightImm, Location::fromFPR(wasmScratchFPR));
+        materializeVectorConstant(SIMDShuffle::toCanonicalUnaryPattern(rightImm), Location::fromFPR(wasmScratchFPR));
         m_jit.vectorSwizzle(bLocation.asFPR(), wasmScratchFPR, wasmScratchFPR);
         m_jit.vectorOr(SIMDInfo { SIMDLane::v128, SIMDSignMode::None }, scratches.fpr(0), wasmScratchFPR, resultLocation.asFPR());
         return { };

--- a/Source/JavaScriptCore/wasm/WasmOMGIRGenerator.cpp
+++ b/Source/JavaScriptCore/wasm/WasmOMGIRGenerator.cpp
@@ -66,6 +66,7 @@
 #include "JSWebAssemblyStruct.h"
 #include "ProbeContext.h"
 #include "ProfilerSupport.h"
+#include "SIMDShuffle.h"
 #include "ScratchRegisterAllocator.h"
 #include "WasmBaselineData.h"
 #include "WasmBranchHints.h"
@@ -4227,16 +4228,18 @@ auto OMGIRGenerator::addSIMDShuffle(v128_t imm, ExpressionType a, ExpressionType
                 leftImm.u8x16[i] = 0xFF; // Force OOB
             if (rightImm.u8x16[i] < 16 || rightImm.u8x16[i] > 31)
                 rightImm.u8x16[i] = 0xFF; // Force OOB
+            else
+                rightImm.u8x16[i] -= 16; // Canonicalize to 0..15
         }
         // Store each byte (w/ index < 16) of `a` to result
         // and zero clear each byte (w/ index > 15) in result.
-        Value* leftImmConst = m_currentBlock->appendNew<Const128Value>(m_proc, origin(), leftImm);
+        Value* leftImmConst = m_currentBlock->appendNew<Const128Value>(m_proc, origin(), SIMDShuffle::toCanonicalUnaryPattern(leftImm));
         Value* leftResult = m_currentBlock->appendNew<SIMDValue>(m_proc, origin(),
             VectorSwizzle, B3::V128, SIMDLane::i8x16, SIMDSignMode::None, get(a), leftImmConst);
 
-        // Store each byte (w/ index - 16 >= 0) of `b` to result2
-        // and zero clear each byte (w/ index - 16 < 0) in result2.
-        Value* rightImmConst = m_currentBlock->appendNew<Const128Value>(m_proc, origin(), rightImm);
+        // Store each byte (w/ original index in [16, 32)) of `b` to result2
+        // and zero clear each byte that did not refer to `b` in result2.
+        Value* rightImmConst = m_currentBlock->appendNew<Const128Value>(m_proc, origin(), SIMDShuffle::toCanonicalUnaryPattern(rightImm));
         Value* rightResult = m_currentBlock->appendNew<SIMDValue>(m_proc, origin(),
             VectorSwizzle, B3::V128, SIMDLane::i8x16, SIMDSignMode::None, get(b), rightImmConst);
 


### PR DESCRIPTION
#### 4db9b8c8a06d7d6423ca8dd375832139644df2de
<pre>
REGRESSION: WebAssembly SIMD produces incorrect result on x86_64 Linux (argon2id hash mismatch)
<a href="https://bugs.webkit.org/show_bug.cgi?id=314024">https://bugs.webkit.org/show_bug.cgi?id=314024</a>
<a href="https://rdar.apple.com/176218743">rdar://176218743</a>

Reviewed by Marcus Plutowski.

Fix x64 VectorSwizzle emission in OMG. We are using [16, 32) directly as
a shuffle index by using the fact that x64 VectorSwizzle only cares
about bits corresponding to [0, 15]. But this makes handling B3
reduce-strength harder as this convension is different from ARM64 (on
ARM64, any index &gt;= 16 is OOB). We fix this OMG mask generation code.
We also make isOnlyOneSideMask better with careful canonicalization.

Tests: JSTests/wasm/stress/simd-shuffle-compose-rightimm.js
       Source/JavaScriptCore/b3/testb3_1.cpp
       Source/JavaScriptCore/b3/testb3_7.cpp

* JSTests/wasm/stress/simd-shuffle-compose-rightimm.js: Added.
(from.string_appeared_here.import.as.assert.from.string_appeared_here.async test):
* Source/JavaScriptCore/b3/B3ReduceStrength.cpp:
* Source/JavaScriptCore/b3/testb3.h:
* Source/JavaScriptCore/b3/testb3_1.cpp:
(run):
* Source/JavaScriptCore/b3/testb3_7.cpp:
(testVectorSwizzleCompositionRightImmOuter):
(runBinarySwizzleAndCheck):
(testVectorSwizzleBinaryOnlyOneSideSide0):
(testVectorSwizzleBinaryOnlyOneSideSide1):
(testVectorSwizzleBinaryOnlyOneSideSide0WithOOB):
(testVectorSwizzleBinaryOnlyOneSideSide1WithOOB):
(testVectorSwizzleBinaryOnlyOneSideAllOOB):
(testVectorSwizzleBinaryOnlyOneSideMixed):
(testVectorSwizzleBinaryOnlyOneSideSide1Scattered):
* Source/JavaScriptCore/jit/SIMDShuffle.h:
(JSC::SIMDShuffle::isOnlyOneSideMask):
(JSC::SIMDShuffle::toCanonicalUnaryPattern):
* Source/JavaScriptCore/wasm/WasmBBQJIT64.cpp:
(JSC::Wasm::BBQJITImpl::BBQJIT::addSIMDShuffle):
* Source/JavaScriptCore/wasm/WasmOMGIRGenerator.cpp:
(JSC::Wasm::OMGIRGenerator::addSIMDShuffle):

Canonical link: <a href="https://commits.webkit.org/312648@main">https://commits.webkit.org/312648@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e9d23c2553322b2d99f249a2f7c681dfea9f343f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/160631 "33 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/34104 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/27205 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/169534 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/115697 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/17ad037b-d6cd-44af-98e9-9f79a2d41e8f) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/34205 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/34104 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/124568 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/115697 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/1224ab70-4849-4eaa-b3d5-ea2b5ecef1b7) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/163590 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/26819 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/144289 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/105168 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/3a6cc0d5-325f-4e7c-86b1-a29c27faa0ba) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/25871 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/24374 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/17254 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/152687 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/135565 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/22052 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/172013 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/21469 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/18890 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/23692 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/132834 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/33778 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/28466 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/132849 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/33762 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/143847 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/95571 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/24440 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/27445 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/20662 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/193030 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/33273 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/100515 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/49712 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/32772 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/33016 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/32920 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->