### PR TITLE
https://bugs.webkit.org/show_bug.cgi?id=314035

### DIFF
--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaSampleAVFObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaSampleAVFObjC.mm
@@ -126,19 +126,6 @@ static bool doesCMSampleBufferHaveSyncInfo(CMSampleBufferRef sample)
     return PAL::CMSampleBufferGetSampleAttachmentsArray(sample, false);
 }
 
-static bool isCMSampleBufferRandomAccess(CMSampleBufferRef sample)
-{
-    RetainPtr attachments = PAL::CMSampleBufferGetSampleAttachmentsArray(sample, false);
-    if (!attachments)
-        return true;
-
-    if (CFArrayGetCount(attachments.get()) < 1)
-        return true;
-
-    RetainPtr firstAttachment = checked_cf_cast<CFDictionaryRef>(CFArrayGetValueAtIndex(attachments.get(), 0));
-    return isCMSampleBufferAttachmentRandomAccess(firstAttachment.get());
-}
-
 static bool isCMSampleBufferAttachmentNonDisplaying(CFDictionaryRef attachmentDict)
 {
     return CFDictionaryContainsKey(attachmentDict, PAL::kCMSampleAttachmentKey_DoNotDisplay);

--- a/Source/WebCore/platform/graphics/cocoa/CMUtilities.h
+++ b/Source/WebCore/platform/graphics/cocoa/CMUtilities.h
@@ -108,6 +108,8 @@ Vector<AudioStreamPacketDescription> getPacketDescriptions(CMSampleBufferRef);
 
 RetainPtr<CMSampleBufferRef> sampleBufferFromVideoData(std::span<const uint8_t>, CMVideoFormatDescriptionRef);
 
+WEBCORE_EXPORT bool isCMSampleBufferRandomAccess(CMSampleBufferRef);
+
 }
 
 #endif

--- a/Source/WebCore/platform/graphics/cocoa/CMUtilities.mm
+++ b/Source/WebCore/platform/graphics/cocoa/CMUtilities.mm
@@ -1014,6 +1014,15 @@ RetainPtr<CMSampleBufferRef> sampleBufferFromVideoData(std::span<const uint8_t> 
     return adoptCF(sampleBuffer);
 }
 
+bool isCMSampleBufferRandomAccess(CMSampleBufferRef sample)
+{
+    RetainPtr attachments = PAL::CMSampleBufferGetSampleAttachmentsArray(sample, false);
+    if (!attachments || CFArrayGetCount(attachments.get()) < 1)
+        return true;
+    RetainPtr firstAttachment = checked_cf_cast<CFDictionaryRef>(CFArrayGetValueAtIndex(attachments.get(), 0));
+    return !CFDictionaryContainsKey(firstAttachment.get(), PAL::kCMSampleAttachmentKey_NotSync);
+}
+
 } // namespace WebCore
 
 #endif // PLATFORM(COCOA)

--- a/Source/WebCore/platform/graphics/cocoa/WebCoreDecompressionSession.h
+++ b/Source/WebCore/platform/graphics/cocoa/WebCoreDecompressionSession.h
@@ -74,7 +74,7 @@ public:
     using DecodingFlags = OptionSet<DecodingFlag>;
 
     WEBCORE_EXPORT Ref<DecodingPromise> decodeSample(CMSampleBufferRef, DecodingFlags);
-    WEBCORE_EXPORT void NODELETE flush();
+    WEBCORE_EXPORT void flush();
 
     void setResourceOwner(const ProcessIdentity& resourceOwner) { m_resourceOwner = resourceOwner; }
     bool isHardwareAccelerated() const;
@@ -109,6 +109,12 @@ private:
     Vector<RetainPtr<CMSampleBufferRef>> m_lastDecodedSamples WTF_GUARDED_BY_CAPABILITY(m_dispatcher.get());
     RetainPtr<CMFormatDescriptionRef> m_lastFormatDescription WTF_GUARDED_BY_LOCK(m_lock);
     OSStatus m_lastDecodingError WTF_GUARDED_BY_CAPABILITY(m_dispatcher.get()) { noErr };
+    // Only ever accessed from a single thread per instance: either m_dispatcher
+    // (MSE path, where flush() dispatches its write to serialize with
+    // ensureDecoderForSample()), or the caller thread of decodeSampleSync()
+    // (ImageDecoderAVFObjC path, which never calls flush()). Not annotated
+    // with a capability guard because the owning thread differs per instance.
+    bool m_waitingForKeyframe { true };
     RetainPtr<CMFormatDescriptionRef> m_currentImageDescription WTF_GUARDED_BY_CAPABILITY(m_dispatcher.get());
 
     // Stereo playback support

--- a/Source/WebCore/platform/graphics/cocoa/WebCoreDecompressionSession.mm
+++ b/Source/WebCore/platform/graphics/cocoa/WebCoreDecompressionSession.mm
@@ -26,6 +26,7 @@
 #import "config.h"
 #import "WebCoreDecompressionSession.h"
 
+#import "CMUtilities.h"
 #import "FormatDescriptionUtilities.h"
 #import "IOSurface.h"
 #import "Logging.h"
@@ -249,6 +250,13 @@ static RetainPtr<CMTaggedBufferGroupRef> createTaggedBufferGroupWithRequiredVide
 
 Expected<RefPtr<VideoDecoderVTB>, OSStatus> WebCoreDecompressionSession::ensureDecoderForSample(CMSampleBufferRef cmSample)
 {
+    if (m_waitingForKeyframe) {
+        if (!isCMSampleBufferRandomAccess(cmSample))
+            return RefPtr<VideoDecoderVTB> { };
+        RELEASE_LOG_INFO(Media, "VTDecompressionSession received keyframe after format change, creating new VTDecompressionSession");
+        m_waitingForKeyframe = false;
+    }
+
     Locker lock { m_lock };
 
     if (isInvalidated())
@@ -266,15 +274,16 @@ Expected<RefPtr<VideoDecoderVTB>, OSStatus> WebCoreDecompressionSession::ensureD
     RefPtr videoDecoderVTB = m_videoDecoderVTB;
     if (videoFormatDescriptionChanged && videoDecoderVTB && !videoDecoderVTB->canAccept(videoFormatDescription.get())) {
         auto status = videoDecoderVTB->flush();
-        Ref sample = MediaSampleAVFObjC::create(cmSample, 0);
         m_videoDecoderVTB = nullptr;
         m_isHardwareAccelerated.reset();
-        if (!(sample->flags() & MediaSample::IsSync)) {
-            RELEASE_LOG_INFO(Media, "VTDecompressionSession can't accept format description change on non-keyframe status:%d", int(status));
-            return makeUnexpected(status == kVTInvalidSessionErr ? status : kVTVideoDecoderBadDataErr);
+        if (!isCMSampleBufferRandomAccess(cmSample)) {
+            RELEASE_LOG_ERROR(Media, "VTDecompressionSession can't accept format description change on non-keyframe, waiting for keyframe status:%d", int(status));
+            m_waitingForKeyframe = true;
+            return RefPtr<VideoDecoderVTB> { };
         }
         RELEASE_LOG_INFO(Media, "VTDecompressionSession can't accept format description change on keyframe, creating new VTDecompressionSession status:%d", int(status));
     }
+
     m_lastFormatDescription = videoFormatDescription;
 
     if (!m_videoDecoderVTB) {
@@ -417,6 +426,9 @@ Ref<WebCoreDecompressionSession::DecodingPromise> WebCoreDecompressionSession::d
     if (!result)
         return DecodingPromise::createAndReject(result.error());
     RefPtr videoDecoderVTB = WTF::move(*result);
+
+    if (m_waitingForKeyframe)
+        return DecodingPromise::createAndResolve(Vector<RetainPtr<CMSampleBufferRef>> { });
 
     if (!videoDecoderVTB && !m_videoDecoderCreationFailed) {
         RefPtr<MediaPromise> initPromise;
@@ -593,6 +605,9 @@ RetainPtr<CVPixelBufferRef> WebCoreDecompressionSession::decodeSampleSync(CMSamp
 void WebCoreDecompressionSession::flush()
 {
     m_flushId++;
+    m_dispatcher->dispatch([protectedThis = RefPtr { this }] {
+        protectedThis->m_waitingForKeyframe = true;
+    });
 }
 
 Ref<MediaPromise> WebCoreDecompressionSession::initializeVideoDecoder(FourCharCode codec, std::span<const uint8_t> description, const std::optional<PlatformVideoColorSpace>& colorSpace)

--- a/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
+++ b/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
@@ -704,6 +704,7 @@
 				WebCore/CBORWriterTest.cpp,
 				WebCore/cocoa/AudioStreamDescriptionCocoa.mm,
 				WebCore/cocoa/AudioVideoRendererAVFObjCTests.mm,
+				WebCore/cocoa/WebCoreDecompressionSessionTests.mm,
 				WebCore/cocoa/AVFoundationSoftLinkTest.mm,
 				WebCore/cocoa/BifurcatedGraphicsContextTestsCG.cpp,
 				WebCore/cocoa/CaptionPreferencesTests.mm,

--- a/Tools/TestWebKitAPI/Tests/WebCore/cocoa/WebCoreDecompressionSessionTests.mm
+++ b/Tools/TestWebKitAPI/Tests/WebCore/cocoa/WebCoreDecompressionSessionTests.mm
@@ -1,0 +1,235 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+
+#if USE(AVFOUNDATION)
+
+#include "Helpers/PlatformUtilities.h"
+#include <WebCore/CMUtilities.h>
+#include <WebCore/WebCoreDecompressionSession.h>
+#include <wtf/NativePromise.h>
+
+#include <pal/cf/CoreMediaSoftLink.h>
+
+using namespace WebCore;
+
+namespace TestWebKitAPI {
+
+// H.264 SPS/PPS from mp4-generator.js (640x480, Main profile level 3.0)
+static constexpr uint8_t h264SPS[] = {
+    0x67, 0x4D, 0x40, 0x1E, 0xDA, 0x02, 0x80, 0xF6,
+    0xC0, 0x44, 0x00, 0x00, 0x03, 0x00, 0x04, 0x00,
+    0x00, 0x03, 0x00, 0xC0, 0x3C, 0x58, 0xBA, 0x80
+};
+
+static constexpr uint8_t h264PPS[] = { 0x68, 0xEF, 0x0F, 0x2C, 0x80 };
+
+// H.264 IDR frame NAL data from mp4-generator.js — a valid keyframe
+static constexpr uint8_t h264IDR[] = {
+    0x65, 0x88, 0x84, 0x0B,
+    0xFF, 0xFE, 0xF6, 0xAE, 0xFC, 0xCB, 0x2B, 0x74,
+    0x7E, 0x95, 0x2E, 0x1D, 0x59, 0x7B, 0xB3, 0x51,
+    0xF2, 0xE8, 0x49, 0x72, 0xFD, 0x88, 0x30, 0x7D,
+    0x68, 0x00, 0x00, 0x03, 0x00, 0x00, 0x03, 0x00,
+    0x00, 0x08, 0x07, 0xEA, 0x2F, 0x7A, 0xE6, 0x31,
+    0x2D, 0xF2, 0x90, 0x00, 0x00, 0x04, 0xF0, 0x01,
+    0x1C, 0x06, 0x88, 0x3B, 0x42, 0xBA, 0x22, 0xE2,
+    0x10, 0x23, 0x83, 0x3C, 0x4B, 0x08, 0x50, 0xE9,
+    0x19, 0x40, 0x00, 0x00, 0x03, 0x00, 0x00, 0x03,
+    0x00, 0x00, 0x03, 0x00, 0x00, 0x03, 0x00, 0x00,
+    0x03, 0x00, 0x00, 0x03, 0x00, 0x00, 0x03, 0x00,
+    0x00, 0x03, 0x00, 0x00, 0x03, 0x00, 0x12, 0xF1
+};
+
+// Alternate SPS for format change — same resolution, different level_idc (4.0 instead of 3.0)
+static constexpr uint8_t h264SPS2[] = {
+    0x67, 0x4D, 0x40, 0x28, 0xDA, 0x02, 0x80, 0xF6,
+    0xC0, 0x44, 0x00, 0x00, 0x03, 0x00, 0x04, 0x00,
+    0x00, 0x03, 0x00, 0xC0, 0x3C, 0x58, 0xBA, 0x80
+};
+
+static RetainPtr<CMVideoFormatDescriptionRef> createFormatDescription(std::span<const uint8_t> sps, std::span<const uint8_t> pps)
+{
+    const uint8_t* parameterSetPointers[] = { sps.data(), pps.data() };
+    size_t parameterSetSizes[] = { sps.size(), pps.size() };
+
+    CMVideoFormatDescriptionRef rawDescription = nullptr;
+    auto status = PAL::CMVideoFormatDescriptionCreateFromH264ParameterSets(kCFAllocatorDefault, 2, parameterSetPointers, parameterSetSizes, 4, &rawDescription);
+    if (status != noErr)
+        return nullptr;
+    return adoptCF(rawDescription);
+}
+
+static RetainPtr<CMSampleBufferRef> createH264SampleBuffer(CMVideoFormatDescriptionRef formatDescription, CMTime presentationTime, bool isSync)
+{
+    // Build Annex B → length-prefixed NAL
+    uint32_t nalLength = CFSwapInt32HostToBig(sizeof(h264IDR));
+    Vector<uint8_t> frameData;
+    frameData.append(std::span { reinterpret_cast<const uint8_t*>(&nalLength), 4 });
+    frameData.append(std::span { h264IDR });
+
+    CMBlockBufferRef rawBlockBuffer = nullptr;
+    if (PAL::CMBlockBufferCreateWithMemoryBlock(kCFAllocatorDefault, nullptr, frameData.size(), kCFAllocatorDefault, nullptr, 0, frameData.size(), kCMBlockBufferAssureMemoryNowFlag, &rawBlockBuffer))
+        return nullptr;
+    RetainPtr blockBuffer = adoptCF(rawBlockBuffer);
+
+    if (PAL::CMBlockBufferReplaceDataBytes(frameData.span().data(), blockBuffer.get(), 0, frameData.size()))
+        return nullptr;
+
+    CMSampleTimingInfo timing = { PAL::CMTimeMake(1, 30), presentationTime, presentationTime };
+    size_t sampleSize = frameData.size();
+    CMSampleBufferRef rawSampleBuffer = nullptr;
+    if (PAL::CMSampleBufferCreate(kCFAllocatorDefault, blockBuffer.get(), true, nullptr, nullptr, formatDescription, 1, 1, &timing, 1, &sampleSize, &rawSampleBuffer))
+        return nullptr;
+
+    if (!isSync) {
+        RetainPtr attachments = PAL::CMSampleBufferGetSampleAttachmentsArray(rawSampleBuffer, true);
+        if (attachments && CFArrayGetCount(attachments.get()) > 0) {
+            auto dict = checked_cf_cast<CFMutableDictionaryRef>(CFArrayGetValueAtIndex(attachments.get(), 0));
+            CFDictionarySetValue(dict, PAL::kCMSampleAttachmentKey_NotSync, kCFBooleanTrue);
+        }
+    }
+
+    return adoptCF(rawSampleBuffer);
+}
+
+struct DecodeResult {
+    bool resolved { false };
+    size_t sampleCount { 0 };
+    OSStatus error { 0 };
+};
+
+static DecodeResult decodeSampleAndWait(WebCoreDecompressionSession& session, CMSampleBufferRef sample)
+{
+    bool done = false;
+    DecodeResult decodeResult;
+
+    session.decodeSample(sample, { })->whenSettled(RunLoop::mainSingleton(), [&done, &decodeResult](auto&& result) {
+        decodeResult.resolved = !!result;
+        if (result)
+            decodeResult.sampleCount = result->size();
+        else
+            decodeResult.error = result.error();
+        done = true;
+    });
+    Util::run(&done);
+    return decodeResult;
+}
+
+TEST(WebCoreDecompressionSession, FormatChangeOnNonKeyframeDropsUntilKeyframe)
+{
+    auto session = WebCoreDecompressionSession::createRGB(nullptr);
+
+    auto fmt1 = createFormatDescription(h264SPS, h264PPS);
+    ASSERT_TRUE(fmt1);
+
+    // Decode a keyframe to initialize the session.
+    auto keyframe1 = createH264SampleBuffer(fmt1.get(), PAL::CMTimeMake(0, 30), true);
+    ASSERT_TRUE(keyframe1);
+    auto r1 = decodeSampleAndWait(session, keyframe1.get());
+    EXPECT_TRUE(r1.resolved);
+
+    // Decode another keyframe with same format to confirm decoding works.
+    auto keyframe2 = createH264SampleBuffer(fmt1.get(), PAL::CMTimeMake(1, 30), true);
+    ASSERT_TRUE(keyframe2);
+    auto r2 = decodeSampleAndWait(session, keyframe2.get());
+    EXPECT_TRUE(r2.resolved);
+    EXPECT_EQ(r2.sampleCount, 1u);
+
+    // Non-keyframe with a different format description.
+    // All frames use the same IDR NAL data (decodable), but the format description changes.
+    // This triggers format change on a non-keyframe — should drop, not error.
+    auto fmt2 = createFormatDescription(h264SPS2, h264PPS);
+    ASSERT_TRUE(fmt2);
+    auto nonKeyframe = createH264SampleBuffer(fmt2.get(), PAL::CMTimeMake(2, 30), false);
+    ASSERT_TRUE(nonKeyframe);
+    auto r3 = decodeSampleAndWait(session, nonKeyframe.get());
+    EXPECT_TRUE(r3.resolved);
+    EXPECT_EQ(r3.sampleCount, 0u);
+
+    // Another non-keyframe with new format — still waiting, should drop.
+    auto nonKeyframe2 = createH264SampleBuffer(fmt2.get(), PAL::CMTimeMake(3, 30), false);
+    ASSERT_TRUE(nonKeyframe2);
+    auto r4 = decodeSampleAndWait(session, nonKeyframe2.get());
+    EXPECT_TRUE(r4.resolved);
+    EXPECT_EQ(r4.sampleCount, 0u);
+
+    // Keyframe with new format — should create new decoder and succeed.
+    auto keyframe3 = createH264SampleBuffer(fmt2.get(), PAL::CMTimeMake(4, 30), true);
+    ASSERT_TRUE(keyframe3);
+    auto r5 = decodeSampleAndWait(session, keyframe3.get());
+    EXPECT_TRUE(r5.resolved);
+    EXPECT_EQ(r5.sampleCount, 1u);
+}
+
+TEST(WebCoreDecompressionSession, FlushSetsWaitingForKeyframe)
+{
+    auto session = WebCoreDecompressionSession::createRGB(nullptr);
+
+    auto fmt = createFormatDescription(h264SPS, h264PPS);
+    ASSERT_TRUE(fmt);
+
+    // Decode a keyframe to initialize.
+    auto keyframe1 = createH264SampleBuffer(fmt.get(), PAL::CMTimeMake(0, 30), true);
+    ASSERT_TRUE(keyframe1);
+    auto r1 = decodeSampleAndWait(session, keyframe1.get());
+    EXPECT_TRUE(r1.resolved);
+
+    // Flush — should require a keyframe before resuming decode.
+    session->flush();
+
+    // Non-keyframe after flush — should be dropped.
+    auto nonKeyframe = createH264SampleBuffer(fmt.get(), PAL::CMTimeMake(1, 30), false);
+    ASSERT_TRUE(nonKeyframe);
+    auto r2 = decodeSampleAndWait(session, nonKeyframe.get());
+    EXPECT_TRUE(r2.resolved);
+    EXPECT_EQ(r2.sampleCount, 0u);
+
+    // Keyframe after flush — should succeed.
+    auto keyframe2 = createH264SampleBuffer(fmt.get(), PAL::CMTimeMake(2, 30), true);
+    ASSERT_TRUE(keyframe2);
+    auto r3 = decodeSampleAndWait(session, keyframe2.get());
+    EXPECT_TRUE(r3.resolved);
+    EXPECT_EQ(r3.sampleCount, 1u);
+}
+
+TEST(WebCoreDecompressionSession, IsCMSampleBufferRandomAccess)
+{
+    auto fmt = createFormatDescription(h264SPS, h264PPS);
+    ASSERT_TRUE(fmt);
+
+    auto syncSample = createH264SampleBuffer(fmt.get(), PAL::CMTimeMake(0, 30), true);
+    ASSERT_TRUE(syncSample);
+    EXPECT_TRUE(isCMSampleBufferRandomAccess(syncSample.get()));
+
+    auto nonSyncSample = createH264SampleBuffer(fmt.get(), PAL::CMTimeMake(1, 30), false);
+    ASSERT_TRUE(nonSyncSample);
+    EXPECT_FALSE(isCMSampleBufferRandomAccess(nonSyncSample.get()));
+}
+
+} // namespace TestWebKitAPI
+
+#endif // USE(AVFOUNDATION)


### PR DESCRIPTION
#### 96e956dd67b6d6a941f922bcee5e653dd5bb42df
<pre>
<a href="https://bugs.webkit.org/show_bug.cgi?id=314035">https://bugs.webkit.org/show_bug.cgi?id=314035</a>
<a href="https://rdar.apple.com/176222723">rdar://176222723</a>
[MSE] WebCoreDecompressionSession should drop frames until keyframe after format change instead of failing fatally

Reviewed by Youenn Fablet.

When a video format description change is detected on a non-keyframe,
WebCoreDecompressionSession previously returned kVTVideoDecoderBadDataErr,
which propagated as a fatal decode error tearing down the entire MediaSource.
This could occur during adaptive bitrate switches on live streams (e.g. Twitch)
where format changes don&apos;t always align with keyframe boundaries due to an
issue with AVStreamDataParser that will accept media segments before an init segments.
This will be fixed in a follow-up in webkit.org/b/314045

Instead, drop frames until the next keyframe arrives, then create a new
VTDecompressionSession with the updated format. Also require a keyframe
after every flush, matching decoder expectations.

Extract isCMSampleBufferRandomAccess from MediaSampleAVFObjC into
CMUtilities to avoid allocating a MediaSampleAVFObjC just to check
the sync flag.

* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/platform/graphics/avfoundation/objc/MediaSampleAVFObjC.mm:
(WebCore::isCMSampleBufferRandomAccess): Deleted.
* Source/WebCore/platform/graphics/cocoa/CMUtilities.h:
* Source/WebCore/platform/graphics/cocoa/CMUtilities.mm:
(WebCore::isCMSampleBufferRandomAccess):
* Source/WebCore/platform/graphics/cocoa/WebCoreDecompressionSession.h:
(WebCore::WebCoreDecompressionSession::WTF_GUARDED_BY_CAPABILITY):
* Source/WebCore/platform/graphics/cocoa/WebCoreDecompressionSession.mm:
(WebCore::WebCoreDecompressionSession::ensureDecoderForSample):
(WebCore::WebCoreDecompressionSession::decodeSampleInternal):
(WebCore::WebCoreDecompressionSession::flush):
* Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj:

Canonical link: <a href="https://commits.webkit.org/312672@main">https://commits.webkit.org/312672@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a7b3ba5271d79ccd5db78691df99bc9bf9091ffa

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/160546 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/34019 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/27120 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/169449 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/115612 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/840cc12d-a954-4c48-9da5-029055d357ec) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/162415 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/34120 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/34019 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/124499 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/87926 "1 flakes 2 failures") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/faf30de7-c7ef-41d6-89d8-0747832075b3) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/163505 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/26745 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/144212 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/105099 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/b1ff1e7d-3160-42b8-ad47-de6c44f97e57) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/25797 "Passed tests") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/24295 "Found 1 new API test failure: TestWebKitAPI.WebKit.InterruptionBetweenSameProcessPages (failure)") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/17168 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/135491 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/21975 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/171928 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/18676 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/23615 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/132763 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/33693 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/28388 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/132777 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35907 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/33677 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/143770 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/95473 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/27372 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/20584 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/33187 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/100278 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/32687 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/32931 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/32835 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->