### PR TITLE
[JSC][Temporal] Register Temporal headers as private framework headers and add shared enum/type headers

### DIFF
--- a/Source/JavaScriptCore/CMakeLists.txt
+++ b/Source/JavaScriptCore/CMakeLists.txt
@@ -1148,6 +1148,7 @@ set(JavaScriptCore_PRIVATE_FRAMEWORK_HEADERS
     runtime/GlobalObjectMethodTable.h
     runtime/HashMapHelper.h
     runtime/HasOwnPropertyCache.h
+    runtime/ISO8601.h
     runtime/Identifier.h
     runtime/IdentifierInlines.h
     runtime/ImplementationVisibility.h
@@ -1412,6 +1413,35 @@ set(JavaScriptCore_PRIVATE_FRAMEWORK_HEADERS
     runtime/SymbolTableOrScopeDepth.h
     runtime/SyntheticModuleRecord.h
     runtime/TemplateObjectDescriptor.h
+    runtime/TemporalCalendar.h
+    runtime/TemporalCalendarConstructor.h
+    runtime/TemporalCalendarPrototype.h
+    runtime/TemporalDuration.h
+    runtime/TemporalDurationConstructor.h
+    runtime/TemporalDurationPrototype.h
+    runtime/TemporalInstant.h
+    runtime/TemporalInstantConstructor.h
+    runtime/TemporalInstantPrototype.h
+    runtime/TemporalNow.h
+    runtime/TemporalObject.h
+    runtime/TemporalPlainDate.h
+    runtime/TemporalPlainDateConstructor.h
+    runtime/TemporalPlainDatePrototype.h
+    runtime/TemporalPlainDateTime.h
+    runtime/TemporalPlainDateTimeConstructor.h
+    runtime/TemporalPlainDateTimePrototype.h
+    runtime/TemporalPlainMonthDay.h
+    runtime/TemporalPlainMonthDayConstructor.h
+    runtime/TemporalPlainMonthDayPrototype.h
+    runtime/TemporalPlainTime.h
+    runtime/TemporalPlainTimeConstructor.h
+    runtime/TemporalPlainTimePrototype.h
+    runtime/TemporalPlainYearMonth.h
+    runtime/TemporalPlainYearMonthConstructor.h
+    runtime/TemporalPlainYearMonthPrototype.h
+    runtime/TemporalTimeZone.h
+    runtime/TemporalTimeZoneConstructor.h
+    runtime/TemporalTimeZonePrototype.h
     runtime/TestRunnerUtils.h
     runtime/ThrowScope.h
     runtime/ToNativeFromValue.h
@@ -1453,6 +1483,9 @@ set(JavaScriptCore_PRIVATE_FRAMEWORK_HEADERS
     runtime/WeakSetPrototype.h
     runtime/WriteBarrier.h
     runtime/WriteBarrierInlines.h
+
+    runtime/temporal/core/TemporalCoreTypes.h
+    runtime/temporal/core/TemporalEnums.h
 
     tools/Integrity.h
     tools/IntegrityInlines.h

--- a/Source/JavaScriptCore/JavaScriptCore.xcodeproj/project.pbxproj
+++ b/Source/JavaScriptCore/JavaScriptCore.xcodeproj/project.pbxproj
@@ -186,9 +186,6 @@
 		0F2B66F217B6B5AB00A7AE3F /* JSGenericTypedArrayViewConstructor.h in Headers */ = {isa = PBXBuildFile; fileRef = 0F2B66C417B6B5AB00A7AE3F /* JSGenericTypedArrayViewConstructor.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		0F2B66F317B6B5AB00A7AE3F /* JSGenericTypedArrayViewConstructorInlines.h in Headers */ = {isa = PBXBuildFile; fileRef = 0F2B66C517B6B5AB00A7AE3F /* JSGenericTypedArrayViewConstructorInlines.h */; };
 		0F2B66F417B6B5AB00A7AE3F /* JSGenericTypedArrayViewInlines.h in Headers */ = {isa = PBXBuildFile; fileRef = 0F2B66C617B6B5AB00A7AE3F /* JSGenericTypedArrayViewInlines.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		FC601BAFB07E4D888C5AA7AD /* JSGenericTypedArrayViewInlinesLight.h in Headers */ = {isa = PBXBuildFile; fileRef = C1FD0F0D73794C72BFF37F4C /* JSGenericTypedArrayViewInlinesLight.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		E2A9D8474FB84C3B91DA47B1 /* JSArrayBufferViewInlinesLight.h in Headers */ = {isa = PBXBuildFile; fileRef = A6B8D2E1CD3A47F8BB29B6AE /* JSArrayBufferViewInlinesLight.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		B4C7A5933E61498DAF3D7C12 /* StructureInlinesLight.h in Headers */ = {isa = PBXBuildFile; fileRef = D8E1F0A2B3C94D7E8F1A2B3C /* StructureInlinesLight.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		0F2B66F517B6B5AB00A7AE3F /* JSGenericTypedArrayViewPrototype.h in Headers */ = {isa = PBXBuildFile; fileRef = 0F2B66C717B6B5AB00A7AE3F /* JSGenericTypedArrayViewPrototype.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		0F2B66F617B6B5AB00A7AE3F /* JSGenericTypedArrayViewPrototypeInlines.h in Headers */ = {isa = PBXBuildFile; fileRef = 0F2B66C817B6B5AB00A7AE3F /* JSGenericTypedArrayViewPrototypeInlines.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		0F2B66F717B6B5AB00A7AE3F /* JSInt8Array.h in Headers */ = {isa = PBXBuildFile; fileRef = 0F2B66C917B6B5AB00A7AE3F /* JSInt8Array.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -488,7 +485,6 @@
 		0FB7F39615ED8E4600F167B2 /* ArrayStorage.h in Headers */ = {isa = PBXBuildFile; fileRef = 0FB7F38A15ED8E3800F167B2 /* ArrayStorage.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		0FB7F39715ED8E4600F167B2 /* Butterfly.h in Headers */ = {isa = PBXBuildFile; fileRef = 0FB7F38B15ED8E3800F167B2 /* Butterfly.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		0FB7F39815ED8E4600F167B2 /* ButterflyInlines.h in Headers */ = {isa = PBXBuildFile; fileRef = 0FB7F38C15ED8E3800F167B2 /* ButterflyInlines.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		796C0603368743C78E7F9859 /* ButterflyInlinesLight.h in Headers */ = {isa = PBXBuildFile; fileRef = 7B9420DB4ACC4A7D83B1C8AE /* ButterflyInlinesLight.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		0FB7F39915ED8E4600F167B2 /* IndexingHeader.h in Headers */ = {isa = PBXBuildFile; fileRef = 0FB7F38D15ED8E3800F167B2 /* IndexingHeader.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		0FB7F39A15ED8E4600F167B2 /* IndexingHeaderInlines.h in Headers */ = {isa = PBXBuildFile; fileRef = 0FB7F38E15ED8E3800F167B2 /* IndexingHeaderInlines.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		0FB7F39B15ED8E4600F167B2 /* IndexingType.h in Headers */ = {isa = PBXBuildFile; fileRef = 0FB7F38F15ED8E3800F167B2 /* IndexingType.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -959,9 +955,9 @@
 		2AFEC1D22F6DC80200C66AD3 /* ModuleMap.h in Headers */ = {isa = PBXBuildFile; fileRef = 2AFEC1D12F6DC80200C66AD3 /* ModuleMap.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		2BDF4F7129E9E8BB0056BF50 /* PASReportCrashPrivate.h in Headers */ = {isa = PBXBuildFile; fileRef = 2BDF4F6F29E9E8BB0056BF50 /* PASReportCrashPrivate.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		2D342F36F7244096804ADB24 /* SourceOrigin.h in Headers */ = {isa = PBXBuildFile; fileRef = 425BA1337E4344E1B269A671 /* SourceOrigin.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		31770C5527B94CE600308091 /* TemporalPlainDateConstructor.h in Headers */ = {isa = PBXBuildFile; fileRef = 31770C4F27B94CE400308091 /* TemporalPlainDateConstructor.h */; };
-		31770C5727B94CE600308091 /* TemporalPlainDatePrototype.h in Headers */ = {isa = PBXBuildFile; fileRef = 31770C5127B94CE400308091 /* TemporalPlainDatePrototype.h */; };
-		31770C5827B94CE600308091 /* TemporalPlainDate.h in Headers */ = {isa = PBXBuildFile; fileRef = 31770C5227B94CE500308091 /* TemporalPlainDate.h */; };
+		31770C5527B94CE600308091 /* TemporalPlainDateConstructor.h in Headers */ = {isa = PBXBuildFile; fileRef = 31770C4F27B94CE400308091 /* TemporalPlainDateConstructor.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		31770C5727B94CE600308091 /* TemporalPlainDatePrototype.h in Headers */ = {isa = PBXBuildFile; fileRef = 31770C5127B94CE400308091 /* TemporalPlainDatePrototype.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		31770C5827B94CE600308091 /* TemporalPlainDate.h in Headers */ = {isa = PBXBuildFile; fileRef = 31770C5227B94CE500308091 /* TemporalPlainDate.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		33111B8B2397256500AA34CE /* Scribble.h in Headers */ = {isa = PBXBuildFile; fileRef = 33111B8A2397256500AA34CE /* Scribble.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		3395C70722555F6D00BDBFAD /* B3EliminateDeadCode.h in Headers */ = {isa = PBXBuildFile; fileRef = 3395C70522555F6D00BDBFAD /* B3EliminateDeadCode.h */; };
 		33A920BD23DA2C6D000EBAF0 /* CommonSlowPathsInlines.h in Headers */ = {isa = PBXBuildFile; fileRef = 33A920BC23DA2C6D000EBAF0 /* CommonSlowPathsInlines.h */; };
@@ -1374,6 +1370,7 @@
 		795AC61820A2355E0052C76C /* JSVirtualMachinePrivate.h in Headers */ = {isa = PBXBuildFile; fileRef = 795AC61720A2354B0052C76C /* JSVirtualMachinePrivate.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		7964656A1B952FF0003059EE /* GetPutInfo.h in Headers */ = {isa = PBXBuildFile; fileRef = 796465681B952FF0003059EE /* GetPutInfo.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		7965C2171E5D799600B7591D /* AirAllocateRegistersByGraphColoring.h in Headers */ = {isa = PBXBuildFile; fileRef = 7965C2151E5D799600B7591D /* AirAllocateRegistersByGraphColoring.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		796C0603368743C78E7F9859 /* ButterflyInlinesLight.h in Headers */ = {isa = PBXBuildFile; fileRef = 7B9420DB4ACC4A7D83B1C8AE /* ButterflyInlinesLight.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		796DAA2B1E89CCD6005DF24A /* CalleeBits.h in Headers */ = {isa = PBXBuildFile; fileRef = 796DAA2A1E89CCD6005DF24A /* CalleeBits.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		796FB43A1DFF8C3F0039C95D /* JSWebAssemblyHelpers.h in Headers */ = {isa = PBXBuildFile; fileRef = 796FB4391DFF8C3F0039C95D /* JSWebAssemblyHelpers.h */; };
 		797E07AA1B8FCFB9008400BA /* JSGlobalLexicalEnvironment.h in Headers */ = {isa = PBXBuildFile; fileRef = 797E07A81B8FCFB9008400BA /* JSGlobalLexicalEnvironment.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -1528,7 +1525,6 @@
 		969A072B0ED1CE6900F1F681 /* RegisterID.h in Headers */ = {isa = PBXBuildFile; fileRef = 969A07280ED1CE6900F1F681 /* RegisterID.h */; };
 		969A07970ED1D3AE00F1F681 /* CodeBlock.h in Headers */ = {isa = PBXBuildFile; fileRef = 969A07910ED1D3AE00F1F681 /* CodeBlock.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		969A07980ED1D3AE00F1F681 /* DirectEvalCodeCache.h in Headers */ = {isa = PBXBuildFile; fileRef = 969A07920ED1D3AE00F1F681 /* DirectEvalCodeCache.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		F7249A298F990F9C2114322F /* DirectEvalCodeCacheInlines.h in Headers */ = {isa = PBXBuildFile; fileRef = 776B696C5C13679C04D4582B /* DirectEvalCodeCacheInlines.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		978801411471AD920041B016 /* JSDateMath.h in Headers */ = {isa = PBXBuildFile; fileRef = 9788FC231471AD0C0068CE2D /* JSDateMath.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		981ED82328234D91BAECCADE /* MachineContext.h in Headers */ = {isa = PBXBuildFile; fileRef = 28806E21155E478A93FA7B02 /* MachineContext.h */; };
 		990DA67F1C8E316A00295159 /* generate_objc_protocol_type_conversions_implementation.py in Headers */ = {isa = PBXBuildFile; fileRef = 990DA67E1C8E311D00295159 /* generate_objc_protocol_type_conversions_implementation.py */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -1572,16 +1568,16 @@
 		A1D792FF1B43864B004516F5 /* IntlNumberFormatConstructor.h in Headers */ = {isa = PBXBuildFile; fileRef = A1D792F91B43864B004516F5 /* IntlNumberFormatConstructor.h */; };
 		A1D793011B43864B004516F5 /* IntlNumberFormatPrototype.h in Headers */ = {isa = PBXBuildFile; fileRef = A1D792FB1B43864B004516F5 /* IntlNumberFormatPrototype.h */; };
 		A321AA6D2626359B0023ADA2 /* IntlWorkaround.h in Headers */ = {isa = PBXBuildFile; fileRef = A321AA6C2626359B0023ADA2 /* IntlWorkaround.h */; };
-		A38120B728ADAD4B008064D5 /* TemporalPlainDateTimePrototype.h in Headers */ = {isa = PBXBuildFile; fileRef = A38120B128ADAD4A008064D5 /* TemporalPlainDateTimePrototype.h */; };
-		A38120B828ADAD4B008064D5 /* TemporalPlainDateTimeConstructor.h in Headers */ = {isa = PBXBuildFile; fileRef = A38120B228ADAD4A008064D5 /* TemporalPlainDateTimeConstructor.h */; };
-		A38120B928ADAD4B008064D5 /* TemporalPlainDateTime.h in Headers */ = {isa = PBXBuildFile; fileRef = A38120B328ADAD4B008064D5 /* TemporalPlainDateTime.h */; };
+		A38120B728ADAD4B008064D5 /* TemporalPlainDateTimePrototype.h in Headers */ = {isa = PBXBuildFile; fileRef = A38120B128ADAD4A008064D5 /* TemporalPlainDateTimePrototype.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A38120B828ADAD4B008064D5 /* TemporalPlainDateTimeConstructor.h in Headers */ = {isa = PBXBuildFile; fileRef = A38120B228ADAD4A008064D5 /* TemporalPlainDateTimeConstructor.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A38120B928ADAD4B008064D5 /* TemporalPlainDateTime.h in Headers */ = {isa = PBXBuildFile; fileRef = A38120B328ADAD4B008064D5 /* TemporalPlainDateTime.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		A382C5312667111D0042CD99 /* InByVariant.h in Headers */ = {isa = PBXBuildFile; fileRef = E3305FB120B0F78800CEB82B /* InByVariant.h */; };
-		A38CA59E26DD84DE00C8D84C /* ISO8601.h in Headers */ = {isa = PBXBuildFile; fileRef = A38CA59C26DD84DE00C8D84C /* ISO8601.h */; };
+		A38CA59E26DD84DE00C8D84C /* ISO8601.h in Headers */ = {isa = PBXBuildFile; fileRef = A38CA59C26DD84DE00C8D84C /* ISO8601.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		A38D250E25800D440042BFDD /* JSArrayBufferPrototypeInlines.h in Headers */ = {isa = PBXBuildFile; fileRef = A38D250D25800D430042BFDD /* JSArrayBufferPrototypeInlines.h */; };
 		A38D5BFC2666D3DA00A109A6 /* InByStatus.h in Headers */ = {isa = PBXBuildFile; fileRef = A38D5BFA2666D3DA00A109A6 /* InByStatus.h */; };
-		A3C7EDB626B0DB38004C34C5 /* TemporalDurationPrototype.h in Headers */ = {isa = PBXBuildFile; fileRef = A3C7EDB026B0DB36004C34C5 /* TemporalDurationPrototype.h */; };
-		A3C7EDB926B0DB38004C34C5 /* TemporalDuration.h in Headers */ = {isa = PBXBuildFile; fileRef = A3C7EDB326B0DB37004C34C5 /* TemporalDuration.h */; };
-		A3C7EDBA26B0DB38004C34C5 /* TemporalDurationConstructor.h in Headers */ = {isa = PBXBuildFile; fileRef = A3C7EDB426B0DB37004C34C5 /* TemporalDurationConstructor.h */; };
+		A3C7EDB626B0DB38004C34C5 /* TemporalDurationPrototype.h in Headers */ = {isa = PBXBuildFile; fileRef = A3C7EDB026B0DB36004C34C5 /* TemporalDurationPrototype.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3C7EDB926B0DB38004C34C5 /* TemporalDuration.h in Headers */ = {isa = PBXBuildFile; fileRef = A3C7EDB326B0DB37004C34C5 /* TemporalDuration.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3C7EDBA26B0DB38004C34C5 /* TemporalDurationConstructor.h in Headers */ = {isa = PBXBuildFile; fileRef = A3C7EDB426B0DB37004C34C5 /* TemporalDurationConstructor.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		A3EE8543262514B000FC9B8D /* IntlWorkaround.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A37619402625127C00CBCBA9 /* IntlWorkaround.cpp */; };
 		A3FF9BC72234749100B1A9AB /* YarrFlags.h in Headers */ = {isa = PBXBuildFile; fileRef = A3FF9BC52234746600B1A9AB /* YarrFlags.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		A40755D92D10CAE000DC55FF /* AirAllocateRegistersByGreedy.h in Headers */ = {isa = PBXBuildFile; fileRef = A40755D72D10CABA00DC55FF /* AirAllocateRegistersByGreedy.h */; };
@@ -1672,6 +1668,7 @@
 		A5FD007A189B051000633231 /* ConsoleMessage.h in Headers */ = {isa = PBXBuildFile; fileRef = A5FD0078189B051000633231 /* ConsoleMessage.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		A5FD007E189B0B4C00633231 /* ScriptCallStackFactory.h in Headers */ = {isa = PBXBuildFile; fileRef = A5FD007C189B0B4C00633231 /* ScriptCallStackFactory.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		A5FD0082189B191A00633231 /* InspectorConsoleAgent.h in Headers */ = {isa = PBXBuildFile; fileRef = A5FD0080189B191A00633231 /* InspectorConsoleAgent.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A6336EF88EB74A63806230CC /* WasmTypeSectionState.h in Headers */ = {isa = PBXBuildFile; fileRef = ED0E6BC2545A476E80BB4698 /* WasmTypeSectionState.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		A700873A17CBE85300C3E643 /* MapConstructor.h in Headers */ = {isa = PBXBuildFile; fileRef = A700873817CBE85300C3E643 /* MapConstructor.h */; };
 		A700873E17CBE8D300C3E643 /* MapPrototype.h in Headers */ = {isa = PBXBuildFile; fileRef = A700873C17CBE8D300C3E643 /* MapPrototype.h */; };
 		A700874217CBE8EB00C3E643 /* JSMap.h in Headers */ = {isa = PBXBuildFile; fileRef = A700874017CBE8EB00C3E643 /* JSMap.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -1795,7 +1792,6 @@
 		AD5C36EB1F75AD73000BCAAF /* JSWebAssembly.h in Headers */ = {isa = PBXBuildFile; fileRef = ADD09AF31F62482E001313C2 /* JSWebAssembly.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		AD5C36EC1F75AD7C000BCAAF /* WasmToJS.h in Headers */ = {isa = PBXBuildFile; fileRef = ADD09AEE1F5F623F001313C2 /* WasmToJS.h */; };
 		AD7438C01E0457A400FD0C2A /* WasmTypeDefinition.h in Headers */ = {isa = PBXBuildFile; fileRef = AD7438BF1E04579200FD0C2A /* WasmTypeDefinition.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		A6336EF88EB74A63806230CC /* WasmTypeSectionState.h in Headers */ = {isa = PBXBuildFile; fileRef = ED0E6BC2545A476E80BB4698 /* WasmTypeSectionState.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		AD7B4B2E1FA3E29800C9DF79 /* WasmNameSection.h in Headers */ = {isa = PBXBuildFile; fileRef = AD7B4B2D1FA3E28600C9DF79 /* WasmNameSection.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		AD86A93E1AA4D88D002FE77F /* WeakGCMapInlines.h in Headers */ = {isa = PBXBuildFile; fileRef = AD86A93D1AA4D87C002FE77F /* WeakGCMapInlines.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		AD8FF3981EB5BDB20087FF82 /* WasmIndexOrName.h in Headers */ = {isa = PBXBuildFile; fileRef = AD8FF3951EB5BD850087FF82 /* WasmIndexOrName.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -1804,6 +1800,7 @@
 		ADE8029A1E08F1DE0058DE78 /* WebAssemblyLinkErrorConstructor.h in Headers */ = {isa = PBXBuildFile; fileRef = ADE802951E08F1C90058DE78 /* WebAssemblyLinkErrorConstructor.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		ADE8029C1E08F1DE0058DE78 /* WebAssemblyLinkErrorPrototype.h in Headers */ = {isa = PBXBuildFile; fileRef = ADE802971E08F1C90058DE78 /* WebAssemblyLinkErrorPrototype.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		B1D7736A1D0A42A4B9017DE0 /* JSCTimeZone.h in Headers */ = {isa = PBXBuildFile; fileRef = 24FF4DFDAD3D4D97BE486930 /* JSCTimeZone.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		B4C7A5933E61498DAF3D7C12 /* StructureInlinesLight.h in Headers */ = {isa = PBXBuildFile; fileRef = D8E1F0A2B3C94D7E8F1A2B3C /* StructureInlinesLight.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		BC02E90D0E1839DB000F9297 /* ErrorConstructor.h in Headers */ = {isa = PBXBuildFile; fileRef = BC02E9050E1839DB000F9297 /* ErrorConstructor.h */; };
 		BC02E90F0E1839DB000F9297 /* ErrorPrototype.h in Headers */ = {isa = PBXBuildFile; fileRef = BC02E9070E1839DB000F9297 /* ErrorPrototype.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		BC02E9110E1839DB000F9297 /* NativeErrorConstructor.h in Headers */ = {isa = PBXBuildFile; fileRef = BC02E9090E1839DB000F9297 /* NativeErrorConstructor.h */; };
@@ -1978,6 +1975,7 @@
 		DEA7E2451BBC677F00D78440 /* JSTypedArrayViewPrototype.h in Headers */ = {isa = PBXBuildFile; fileRef = 53917E7C1B791106000EBD33 /* JSTypedArrayViewPrototype.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		E124A8F70E555775003091F1 /* OpaqueJSString.h in Headers */ = {isa = PBXBuildFile; fileRef = E124A8F50E555775003091F1 /* OpaqueJSString.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		E24A6FDBCF114C78972E5799 /* B3WasmArrayLengthValue.h in Headers */ = {isa = PBXBuildFile; fileRef = 36A7683254F6484D925EA7FE /* B3WasmArrayLengthValue.h */; };
+		E2A9D8474FB84C3B91DA47B1 /* JSArrayBufferViewInlinesLight.h in Headers */ = {isa = PBXBuildFile; fileRef = A6B8D2E1CD3A47F8BB29B6AE /* JSArrayBufferViewInlinesLight.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		E30001002EF0001000000004 /* MicrotaskCall.h in Headers */ = {isa = PBXBuildFile; fileRef = E30001002EF0001000000001 /* MicrotaskCall.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		E30001002EF0001000000005 /* MicrotaskCallInlines.h in Headers */ = {isa = PBXBuildFile; fileRef = E30001002EF0001000000002 /* MicrotaskCallInlines.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		E306C1BC2D79000D0011D5AC /* MicrotaskQueueInlines.h in Headers */ = {isa = PBXBuildFile; fileRef = E306C1BB2D7900050011D5AC /* MicrotaskQueueInlines.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -1995,9 +1993,9 @@
 		E307178E24C7829D00DF0644 /* IntlLocale.h in Headers */ = {isa = PBXBuildFile; fileRef = A3AFF92B245A3CF900C9BA3B /* IntlLocale.h */; };
 		E30873E7272559410053B601 /* IntlPluralRules.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7D5FB18F20744BF1005DDF64 /* IntlPluralRules.cpp */; };
 		E30D06B829C6C3EE0014CCE7 /* WasmBBQDisassembler.h in Headers */ = {isa = PBXBuildFile; fileRef = E30D06B729C6C3E80014CCE7 /* WasmBBQDisassembler.h */; };
-		E30E8A5426DE2E4800DA4915 /* TemporalTimeZonePrototype.h in Headers */ = {isa = PBXBuildFile; fileRef = E30E8A4E26DE2E4700DA4915 /* TemporalTimeZonePrototype.h */; };
-		E30E8A5626DE2E4800DA4915 /* TemporalTimeZone.h in Headers */ = {isa = PBXBuildFile; fileRef = E30E8A5026DE2E4800DA4915 /* TemporalTimeZone.h */; };
-		E30E8A5726DE2E4800DA4915 /* TemporalTimeZoneConstructor.h in Headers */ = {isa = PBXBuildFile; fileRef = E30E8A5126DE2E4800DA4915 /* TemporalTimeZoneConstructor.h */; };
+		E30E8A5426DE2E4800DA4915 /* TemporalTimeZonePrototype.h in Headers */ = {isa = PBXBuildFile; fileRef = E30E8A4E26DE2E4700DA4915 /* TemporalTimeZonePrototype.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		E30E8A5626DE2E4800DA4915 /* TemporalTimeZone.h in Headers */ = {isa = PBXBuildFile; fileRef = E30E8A5026DE2E4800DA4915 /* TemporalTimeZone.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		E30E8A5726DE2E4800DA4915 /* TemporalTimeZoneConstructor.h in Headers */ = {isa = PBXBuildFile; fileRef = E30E8A5126DE2E4800DA4915 /* TemporalTimeZoneConstructor.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		E31179AA2288386100514B2C /* SymbolTableOrScopeDepth.h in Headers */ = {isa = PBXBuildFile; fileRef = E31179A92288385D00514B2C /* SymbolTableOrScopeDepth.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		E31618131EC5FE170006A218 /* DOMAnnotation.h in Headers */ = {isa = PBXBuildFile; fileRef = E31618101EC5FE080006A218 /* DOMAnnotation.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		E31618151EC5FE270006A218 /* DOMAttributeGetterSetter.h in Headers */ = {isa = PBXBuildFile; fileRef = E31618121EC5FE080006A218 /* DOMAttributeGetterSetter.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -2028,9 +2026,9 @@
 		E329D89F2E81F49600B63FF5 /* B3TypedPointer.h in Headers */ = {isa = PBXBuildFile; fileRef = E329D89E2E81F49600B63FF5 /* B3TypedPointer.h */; };
 		E32AB2441DCD75F400D7533A /* MacroAssemblerHelpers.h in Headers */ = {isa = PBXBuildFile; fileRef = E380A76B1DCD7195000F89E6 /* MacroAssemblerHelpers.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		E32C3C6923E94C1E00BC97C0 /* UnlinkedCodeBlockGenerator.h in Headers */ = {isa = PBXBuildFile; fileRef = E32C3C6823E94C1E00BC97C0 /* UnlinkedCodeBlockGenerator.h */; };
-		E32D4DE726DAFD4300D4533A /* TemporalCalendarPrototype.h in Headers */ = {isa = PBXBuildFile; fileRef = E32D4DE126DAFD4200D4533A /* TemporalCalendarPrototype.h */; };
-		E32D4DE926DAFD4300D4533A /* TemporalCalendar.h in Headers */ = {isa = PBXBuildFile; fileRef = E32D4DE326DAFD4300D4533A /* TemporalCalendar.h */; };
-		E32D4DEA26DAFD4300D4533A /* TemporalCalendarConstructor.h in Headers */ = {isa = PBXBuildFile; fileRef = E32D4DE426DAFD4300D4533A /* TemporalCalendarConstructor.h */; };
+		E32D4DE726DAFD4300D4533A /* TemporalCalendarPrototype.h in Headers */ = {isa = PBXBuildFile; fileRef = E32D4DE126DAFD4200D4533A /* TemporalCalendarPrototype.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		E32D4DE926DAFD4300D4533A /* TemporalCalendar.h in Headers */ = {isa = PBXBuildFile; fileRef = E32D4DE326DAFD4300D4533A /* TemporalCalendar.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		E32D4DEA26DAFD4300D4533A /* TemporalCalendarConstructor.h in Headers */ = {isa = PBXBuildFile; fileRef = E32D4DE426DAFD4300D4533A /* TemporalCalendarConstructor.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		E32D51AF2C6D0FF200B013D1 /* WasmCompilationContext.h in Headers */ = {isa = PBXBuildFile; fileRef = E32D51A52C6D0FD600B013D1 /* WasmCompilationContext.h */; };
 		E32D51B02C6D0FFC00B013D1 /* WasmOpcodeCounter.h in Headers */ = {isa = PBXBuildFile; fileRef = E32D51A72C6D0FD600B013D1 /* WasmOpcodeCounter.h */; };
 		E32D51B12C6D100300B013D1 /* WasmSourceMappingURLSectionParser.h in Headers */ = {isa = PBXBuildFile; fileRef = E32D51A92C6D0FD600B013D1 /* WasmSourceMappingURLSectionParser.h */; };
@@ -2105,9 +2103,9 @@
 		E3850B15226ED641009ABF9C /* DFGMinifiedIDInlines.h in Headers */ = {isa = PBXBuildFile; fileRef = E3850B14226ED63E009ABF9C /* DFGMinifiedIDInlines.h */; };
 		E385CF202EAAE1300022B769 /* WasmInliningDecision.h in Headers */ = {isa = PBXBuildFile; fileRef = E385CF1E2EAAE1300022B769 /* WasmInliningDecision.h */; };
 		E38652E3237CA0C900E1D5EE /* BlockDirectoryBits.h in Headers */ = {isa = PBXBuildFile; fileRef = E38652E2237CA0C800E1D5EE /* BlockDirectoryBits.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		E386FD7B26E867B800E4C28B /* TemporalPlainTimeConstructor.h in Headers */ = {isa = PBXBuildFile; fileRef = E386FD7526E867B700E4C28B /* TemporalPlainTimeConstructor.h */; };
-		E386FD7E26E867B800E4C28B /* TemporalPlainTime.h in Headers */ = {isa = PBXBuildFile; fileRef = E386FD7826E867B800E4C28B /* TemporalPlainTime.h */; };
-		E386FD7F26E867B800E4C28B /* TemporalPlainTimePrototype.h in Headers */ = {isa = PBXBuildFile; fileRef = E386FD7926E867B800E4C28B /* TemporalPlainTimePrototype.h */; };
+		E386FD7B26E867B800E4C28B /* TemporalPlainTimeConstructor.h in Headers */ = {isa = PBXBuildFile; fileRef = E386FD7526E867B700E4C28B /* TemporalPlainTimeConstructor.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		E386FD7E26E867B800E4C28B /* TemporalPlainTime.h in Headers */ = {isa = PBXBuildFile; fileRef = E386FD7826E867B800E4C28B /* TemporalPlainTime.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		E386FD7F26E867B800E4C28B /* TemporalPlainTimePrototype.h in Headers */ = {isa = PBXBuildFile; fileRef = E386FD7926E867B800E4C28B /* TemporalPlainTimePrototype.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		E389D854291226BC0085C3DC /* PageCount.h in Headers */ = {isa = PBXBuildFile; fileRef = E389D852291226BC0085C3DC /* PageCount.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		E38CA06F2E614C0C00041A0C /* WasmCallProfile.h in Headers */ = {isa = PBXBuildFile; fileRef = E38CA06E2E614C0C00041A0C /* WasmCallProfile.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		E38DAB532A95D23A0050B7A8 /* PerfLog.h in Headers */ = {isa = PBXBuildFile; fileRef = E38DAB512A95D23A0050B7A8 /* PerfLog.h */; };
@@ -2204,9 +2202,11 @@
 		F395BE252A43C5920083DE3A /* InPlaceInterpreter.h in Headers */ = {isa = PBXBuildFile; fileRef = F395BE242A43C58B0083DE3A /* InPlaceInterpreter.h */; };
 		F3D9C2392A426CB8006EE152 /* WasmIPIntGenerator.h in Headers */ = {isa = PBXBuildFile; fileRef = F3D9C2352A426CB7006EE152 /* WasmIPIntGenerator.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		F3D9C23B2A426CB8006EE152 /* WasmIPIntPlan.h in Headers */ = {isa = PBXBuildFile; fileRef = F3D9C2372A426CB7006EE152 /* WasmIPIntPlan.h */; };
-		F6D67D4026F902E9006E0349 /* TemporalInstant.h in Headers */ = {isa = PBXBuildFile; fileRef = F6D67D3A26F902E5006E0349 /* TemporalInstant.h */; };
-		F6D67D4226F902E9006E0349 /* TemporalInstantConstructor.h in Headers */ = {isa = PBXBuildFile; fileRef = F6D67D3C26F902E7006E0349 /* TemporalInstantConstructor.h */; };
-		F6D67D4426F902E9006E0349 /* TemporalInstantPrototype.h in Headers */ = {isa = PBXBuildFile; fileRef = F6D67D3E26F902E8006E0349 /* TemporalInstantPrototype.h */; };
+		F6D67D4026F902E9006E0349 /* TemporalInstant.h in Headers */ = {isa = PBXBuildFile; fileRef = F6D67D3A26F902E5006E0349 /* TemporalInstant.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		F6D67D4226F902E9006E0349 /* TemporalInstantConstructor.h in Headers */ = {isa = PBXBuildFile; fileRef = F6D67D3C26F902E7006E0349 /* TemporalInstantConstructor.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		F6D67D4426F902E9006E0349 /* TemporalInstantPrototype.h in Headers */ = {isa = PBXBuildFile; fileRef = F6D67D3E26F902E8006E0349 /* TemporalInstantPrototype.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		F7249A298F990F9C2114322F /* DirectEvalCodeCacheInlines.h in Headers */ = {isa = PBXBuildFile; fileRef = 776B696C5C13679C04D4582B /* DirectEvalCodeCacheInlines.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		FC601BAFB07E4D888C5AA7AD /* JSGenericTypedArrayViewInlinesLight.h in Headers */ = {isa = PBXBuildFile; fileRef = C1FD0F0D73794C72BFF37F4C /* JSGenericTypedArrayViewInlinesLight.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		FE041553252EC0730091EB5D /* SlotVisitorMacros.h in Headers */ = {isa = PBXBuildFile; fileRef = FE041552252EC0730091EB5D /* SlotVisitorMacros.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		FE05D3A62E53FBE5007668DD /* VMManager.h in Headers */ = {isa = PBXBuildFile; fileRef = FE05D3A42E53FBE5007668DD /* VMManager.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		FE086BCA2123DEFB003F2929 /* EntryFrame.h in Headers */ = {isa = PBXBuildFile; fileRef = FE086BC92123DEFA003F2929 /* EntryFrame.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -2327,6 +2327,16 @@
 		FF1D8E872CE7C9BF00E211DD /* VerifierSlotVisitorScope.h in Headers */ = {isa = PBXBuildFile; fileRef = FF1D8E862CE7C9BF00E211DD /* VerifierSlotVisitorScope.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		FF31EC8E2D947F0500D9CB81 /* DFGCloneHelper.h in Headers */ = {isa = PBXBuildFile; fileRef = FF31EC8B2D947F0500D9CB81 /* DFGCloneHelper.h */; };
 		FF3394AA2CB4944E004AFF6A /* RegExpSubstringGlobalAtomCache.h in Headers */ = {isa = PBXBuildFile; fileRef = FF3394A92CB4941B004AFF6A /* RegExpSubstringGlobalAtomCache.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		FF356CD82FA9821A00213929 /* FractionToDouble.h in Headers */ = {isa = PBXBuildFile; fileRef = FF356CD62FA9821A00213929 /* FractionToDouble.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		FF356CE62FA9824300213929 /* TemporalPlainYearMonthPrototype.h in Headers */ = {isa = PBXBuildFile; fileRef = FF356CE42FA9824300213929 /* TemporalPlainYearMonthPrototype.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		FF356CE72FA9824300213929 /* TemporalPlainMonthDayPrototype.h in Headers */ = {isa = PBXBuildFile; fileRef = FF356CDE2FA9824300213929 /* TemporalPlainMonthDayPrototype.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		FF356CE82FA9824300213929 /* TemporalPlainMonthDay.h in Headers */ = {isa = PBXBuildFile; fileRef = FF356CDA2FA9824300213929 /* TemporalPlainMonthDay.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		FF356CE92FA9824300213929 /* TemporalPlainYearMonth.h in Headers */ = {isa = PBXBuildFile; fileRef = FF356CE02FA9824300213929 /* TemporalPlainYearMonth.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		FF356CEA2FA9824300213929 /* TemporalPlainYearMonthConstructor.h in Headers */ = {isa = PBXBuildFile; fileRef = FF356CE22FA9824300213929 /* TemporalPlainYearMonthConstructor.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		FF356CEB2FA9824300213929 /* TemporalPlainMonthDayConstructor.h in Headers */ = {isa = PBXBuildFile; fileRef = FF356CDC2FA9824300213929 /* TemporalPlainMonthDayConstructor.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		FF356CF72FA9832600213929 /* TemporalEnums.h in Headers */ = {isa = PBXBuildFile; fileRef = FF356CF42FA9832600213929 /* TemporalEnums.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		FF356CF82FA9832600213929 /* TemporalCoreTypes.h in Headers */ = {isa = PBXBuildFile; fileRef = FF356CF32FA9832600213929 /* TemporalCoreTypes.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		FF356CFA2FA9837C00213929 /* TemporalObject.h in Headers */ = {isa = PBXBuildFile; fileRef = F6F1501A2693D33E004B98EF /* TemporalObject.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		FF41590C28FF3C6B00F80B96 /* WaiterListManager.h in Headers */ = {isa = PBXBuildFile; fileRef = FF41590B28FF3C6B00F80B96 /* WaiterListManager.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		FF6A4D7E2E663147001FB92C /* WasmModuleDebugInfo.h in Headers */ = {isa = PBXBuildFile; fileRef = FF6A4D7D2E663147001FB92C /* WasmModuleDebugInfo.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		FFA2E02A2EA16F37006661A3 /* ControlFlowTests.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FFA2E0222EA16F37006661A3 /* ControlFlowTests.cpp */; };
@@ -2949,9 +2959,6 @@
 		0F2B66C417B6B5AB00A7AE3F /* JSGenericTypedArrayViewConstructor.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = JSGenericTypedArrayViewConstructor.h; sourceTree = "<group>"; };
 		0F2B66C517B6B5AB00A7AE3F /* JSGenericTypedArrayViewConstructorInlines.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = JSGenericTypedArrayViewConstructorInlines.h; sourceTree = "<group>"; };
 		0F2B66C617B6B5AB00A7AE3F /* JSGenericTypedArrayViewInlines.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = JSGenericTypedArrayViewInlines.h; sourceTree = "<group>"; };
-		C1FD0F0D73794C72BFF37F4C /* JSGenericTypedArrayViewInlinesLight.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = JSGenericTypedArrayViewInlinesLight.h; sourceTree = "<group>"; };
-		A6B8D2E1CD3A47F8BB29B6AE /* JSArrayBufferViewInlinesLight.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = JSArrayBufferViewInlinesLight.h; sourceTree = "<group>"; };
-		D8E1F0A2B3C94D7E8F1A2B3C /* StructureInlinesLight.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = StructureInlinesLight.h; sourceTree = "<group>"; };
 		0F2B66C717B6B5AB00A7AE3F /* JSGenericTypedArrayViewPrototype.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = JSGenericTypedArrayViewPrototype.h; sourceTree = "<group>"; };
 		0F2B66C817B6B5AB00A7AE3F /* JSGenericTypedArrayViewPrototypeInlines.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = JSGenericTypedArrayViewPrototypeInlines.h; sourceTree = "<group>"; };
 		0F2B66C917B6B5AB00A7AE3F /* JSInt8Array.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = JSInt8Array.h; sourceTree = "<group>"; };
@@ -3461,7 +3468,6 @@
 		0FB7F38A15ED8E3800F167B2 /* ArrayStorage.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ArrayStorage.h; sourceTree = "<group>"; };
 		0FB7F38B15ED8E3800F167B2 /* Butterfly.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Butterfly.h; sourceTree = "<group>"; };
 		0FB7F38C15ED8E3800F167B2 /* ButterflyInlines.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ButterflyInlines.h; sourceTree = "<group>"; };
-		7B9420DB4ACC4A7D83B1C8AE /* ButterflyInlinesLight.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ButterflyInlinesLight.h; sourceTree = "<group>"; };
 		0FB7F38D15ED8E3800F167B2 /* IndexingHeader.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = IndexingHeader.h; sourceTree = "<group>"; };
 		0FB7F38E15ED8E3800F167B2 /* IndexingHeaderInlines.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = IndexingHeaderInlines.h; sourceTree = "<group>"; };
 		0FB7F38F15ED8E3800F167B2 /* IndexingType.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = IndexingType.h; sourceTree = "<group>"; };
@@ -4019,6 +4025,7 @@
 		14F7256414EE265E00B1652B /* WeakHandleOwner.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WeakHandleOwner.h; sourceTree = "<group>"; };
 		14F79F6E216EAD5000046D39 /* MetadataTable.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = MetadataTable.cpp; sourceTree = "<group>"; };
 		169948EDE68D4054B01EF797 /* DefinePropertyAttributes.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = DefinePropertyAttributes.h; sourceTree = "<group>"; };
+		184E6FFC399E45AABE309649 /* WasmTypeSectionState.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = WasmTypeSectionState.cpp; sourceTree = "<group>"; };
 		1879510614C540FFB561C124 /* JSModuleLoader.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = JSModuleLoader.cpp; sourceTree = "<group>"; };
 		1A28D4A7177B71C80007FA3C /* JSStringRefPrivate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = JSStringRefPrivate.h; sourceTree = "<group>"; };
 		1C9051430BA9E8A70081E9D0 /* JavaScriptCore.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = JavaScriptCore.xcconfig; sourceTree = "<group>"; };
@@ -4848,6 +4855,7 @@
 		73190D962400934900F891C9 /* DeleteByStatus.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = DeleteByStatus.cpp; sourceTree = "<group>"; };
 		734B655423F4A33100A069D1 /* DeletePropertySlot.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = DeletePropertySlot.h; sourceTree = "<group>"; };
 		73AD062823FF662600F53593 /* DeleteByStatus.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = DeleteByStatus.h; sourceTree = "<group>"; };
+		776B696C5C13679C04D4582B /* DirectEvalCodeCacheInlines.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = DirectEvalCodeCacheInlines.h; sourceTree = "<group>"; };
 		77B25CB2C3094A92A38E1DB3 /* JSModuleLoader.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = JSModuleLoader.h; sourceTree = "<group>"; };
 		790081361E95A8EC0052D7CD /* WasmModule.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = WasmModule.cpp; sourceTree = "<group>"; };
 		790081371E95A8EC0052D7CD /* WasmModule.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WasmModule.h; sourceTree = "<group>"; };
@@ -4903,6 +4911,7 @@
 		79FC8A071E32E9F000D88F0E /* DFGRegisteredStructure.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = DFGRegisteredStructure.h; path = dfg/DFGRegisteredStructure.h; sourceTree = "<group>"; };
 		7A9774A6206B828C008D03D0 /* JSWeakValue.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = JSWeakValue.cpp; sourceTree = "<group>"; };
 		7A9774A7206B82C9008D03D0 /* JSWeakValue.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = JSWeakValue.h; sourceTree = "<group>"; };
+		7B9420DB4ACC4A7D83B1C8AE /* ButterflyInlinesLight.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ButterflyInlinesLight.h; sourceTree = "<group>"; };
 		7BC547D21B69599B00959B58 /* WasmFormat.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WasmFormat.h; sourceTree = "<group>"; };
 		7C008CE5187631B600955C24 /* Microtask.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Microtask.h; sourceTree = "<group>"; };
 		7C184E1817BEDBD3007CB63A /* JSPromise.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = JSPromise.cpp; sourceTree = "<group>"; };
@@ -5164,7 +5173,6 @@
 		969A07900ED1D3AE00F1F681 /* CodeBlock.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = CodeBlock.cpp; sourceTree = "<group>"; };
 		969A07910ED1D3AE00F1F681 /* CodeBlock.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CodeBlock.h; sourceTree = "<group>"; };
 		969A07920ED1D3AE00F1F681 /* DirectEvalCodeCache.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = DirectEvalCodeCache.h; sourceTree = "<group>"; };
-		776B696C5C13679C04D4582B /* DirectEvalCodeCacheInlines.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = DirectEvalCodeCacheInlines.h; sourceTree = "<group>"; };
 		969A07940ED1D3AE00F1F681 /* Opcode.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Opcode.cpp; sourceTree = "<group>"; };
 		969A07950ED1D3AE00F1F681 /* Opcode.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Opcode.h; sourceTree = "<group>"; };
 		969A09220ED1E09C00F1F681 /* Completion.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Completion.cpp; sourceTree = "<group>"; };
@@ -5411,6 +5419,7 @@
 		A5FD007C189B0B4C00633231 /* ScriptCallStackFactory.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ScriptCallStackFactory.h; sourceTree = "<group>"; };
 		A5FD007F189B191A00633231 /* InspectorConsoleAgent.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = InspectorConsoleAgent.cpp; sourceTree = "<group>"; };
 		A5FD0080189B191A00633231 /* InspectorConsoleAgent.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = InspectorConsoleAgent.h; sourceTree = "<group>"; };
+		A6B8D2E1CD3A47F8BB29B6AE /* JSArrayBufferViewInlinesLight.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = JSArrayBufferViewInlinesLight.h; sourceTree = "<group>"; };
 		A700873717CBE85300C3E643 /* MapConstructor.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = MapConstructor.cpp; sourceTree = "<group>"; };
 		A700873817CBE85300C3E643 /* MapConstructor.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MapConstructor.h; sourceTree = "<group>"; };
 		A700873B17CBE8D300C3E643 /* MapPrototype.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = MapPrototype.cpp; sourceTree = "<group>"; };
@@ -5639,8 +5648,6 @@
 		AD5C36E41F69EC8B000BCAAF /* WasmTable.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WasmTable.h; sourceTree = "<group>"; };
 		AD7438BE1E04579200FD0C2A /* WasmTypeDefinition.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = WasmTypeDefinition.cpp; sourceTree = "<group>"; };
 		AD7438BF1E04579200FD0C2A /* WasmTypeDefinition.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WasmTypeDefinition.h; sourceTree = "<group>"; };
-		184E6FFC399E45AABE309649 /* WasmTypeSectionState.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = WasmTypeSectionState.cpp; sourceTree = "<group>"; };
-		ED0E6BC2545A476E80BB4698 /* WasmTypeSectionState.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WasmTypeSectionState.h; sourceTree = "<group>"; };
 		AD7B4B2D1FA3E28600C9DF79 /* WasmNameSection.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WasmNameSection.h; sourceTree = "<group>"; };
 		AD86A93D1AA4D87C002FE77F /* WeakGCMapInlines.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WeakGCMapInlines.h; sourceTree = "<group>"; };
 		AD8DD6CF1F67089F0004EB52 /* JSToWasm.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = JSToWasm.h; path = js/JSToWasm.h; sourceTree = "<group>"; };
@@ -5743,6 +5750,7 @@
 		BCFD8C900EEB2EE700283848 /* JumpTable.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = JumpTable.cpp; sourceTree = "<group>"; };
 		BCFD8C910EEB2EE700283848 /* JumpTable.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = JumpTable.h; sourceTree = "<group>"; };
 		BDB4B5E099CD4C1BB3C1CF05 /* TemplateObjectDescriptor.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = TemplateObjectDescriptor.cpp; sourceTree = "<group>"; };
+		C1FD0F0D73794C72BFF37F4C /* JSGenericTypedArrayViewInlinesLight.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = JSGenericTypedArrayViewInlinesLight.h; sourceTree = "<group>"; };
 		C203281E1981979D0088B499 /* CustomGlobalObjectClassTest.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = CustomGlobalObjectClassTest.c; path = API/tests/CustomGlobalObjectClassTest.c; sourceTree = "<group>"; };
 		C203281F1981979D0088B499 /* CustomGlobalObjectClassTest.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = CustomGlobalObjectClassTest.h; path = API/tests/CustomGlobalObjectClassTest.h; sourceTree = "<group>"; };
 		C20BA92C16BB1C1500B3AEA2 /* StructureRareDataInlines.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = StructureRareDataInlines.h; sourceTree = "<group>"; };
@@ -5821,6 +5829,7 @@
 		D21202290AD4310C00ED79B6 /* DateConversion.h */ = {isa = PBXFileReference; fileEncoding = 30; lastKnownFileType = sourcecode.c.h; path = DateConversion.h; sourceTree = "<group>"; };
 		D615242F2F4CF1AB004C8AF6 /* WasmAddressType.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WasmAddressType.h; sourceTree = "<group>"; };
 		D61524352F4CF5D1004C8AF6 /* WasmAddressType.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = WasmAddressType.cpp; sourceTree = "<group>"; };
+		D8E1F0A2B3C94D7E8F1A2B3C /* StructureInlinesLight.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = StructureInlinesLight.h; sourceTree = "<group>"; };
 		DC00039019D8BE6F00023EB0 /* DFGPreciseLocalClobberize.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = DFGPreciseLocalClobberize.h; path = dfg/DFGPreciseLocalClobberize.h; sourceTree = "<group>"; };
 		DC0184171D10C1870057B053 /* JITWorklist.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = JITWorklist.cpp; sourceTree = "<group>"; };
 		DC0184181D10C1870057B053 /* JITWorklist.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = JITWorklist.h; sourceTree = "<group>"; };
@@ -6211,6 +6220,7 @@
 		E49DC14912EF261A00184A1F /* SourceProviderCacheItem.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SourceProviderCacheItem.h; sourceTree = "<group>"; };
 		E49DC15112EF272200184A1F /* SourceProviderCache.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SourceProviderCache.h; sourceTree = "<group>"; };
 		E49DC15512EF277200184A1F /* SourceProviderCache.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = SourceProviderCache.cpp; sourceTree = "<group>"; };
+		ED0E6BC2545A476E80BB4698 /* WasmTypeSectionState.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WasmTypeSectionState.h; sourceTree = "<group>"; };
 		F300DBAE2E259A7900430A24 /* MARReportCrashPrivate.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MARReportCrashPrivate.h; sourceTree = "<group>"; };
 		F300DBAF2E259A7900430A24 /* MARReportCrashPrivate.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = MARReportCrashPrivate.cpp; sourceTree = "<group>"; };
 		F323932B2A43748000421AD2 /* WasmFunctionIPIntMetadataGenerator.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WasmFunctionIPIntMetadataGenerator.h; sourceTree = "<group>"; };
@@ -6492,6 +6502,22 @@
 		FF31EC8C2D947F0500D9CB81 /* DFGCloneHelper.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = DFGCloneHelper.cpp; path = dfg/DFGCloneHelper.cpp; sourceTree = "<group>"; };
 		FF3394A92CB4941B004AFF6A /* RegExpSubstringGlobalAtomCache.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RegExpSubstringGlobalAtomCache.h; sourceTree = "<group>"; };
 		FF3394AB2CB4948E004AFF6A /* RegExpSubstringGlobalAtomCache.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = RegExpSubstringGlobalAtomCache.cpp; sourceTree = "<group>"; };
+		FF356CD62FA9821A00213929 /* FractionToDouble.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = FractionToDouble.h; sourceTree = "<group>"; };
+		FF356CD72FA9821A00213929 /* FractionToDouble.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = FractionToDouble.cpp; sourceTree = "<group>"; };
+		FF356CDA2FA9824300213929 /* TemporalPlainMonthDay.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = TemporalPlainMonthDay.h; sourceTree = "<group>"; };
+		FF356CDB2FA9824300213929 /* TemporalPlainMonthDay.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = TemporalPlainMonthDay.cpp; sourceTree = "<group>"; };
+		FF356CDC2FA9824300213929 /* TemporalPlainMonthDayConstructor.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = TemporalPlainMonthDayConstructor.h; sourceTree = "<group>"; };
+		FF356CDD2FA9824300213929 /* TemporalPlainMonthDayConstructor.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = TemporalPlainMonthDayConstructor.cpp; sourceTree = "<group>"; };
+		FF356CDE2FA9824300213929 /* TemporalPlainMonthDayPrototype.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = TemporalPlainMonthDayPrototype.h; sourceTree = "<group>"; };
+		FF356CDF2FA9824300213929 /* TemporalPlainMonthDayPrototype.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = TemporalPlainMonthDayPrototype.cpp; sourceTree = "<group>"; };
+		FF356CE02FA9824300213929 /* TemporalPlainYearMonth.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = TemporalPlainYearMonth.h; sourceTree = "<group>"; };
+		FF356CE12FA9824300213929 /* TemporalPlainYearMonth.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = TemporalPlainYearMonth.cpp; sourceTree = "<group>"; };
+		FF356CE22FA9824300213929 /* TemporalPlainYearMonthConstructor.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = TemporalPlainYearMonthConstructor.h; sourceTree = "<group>"; };
+		FF356CE32FA9824300213929 /* TemporalPlainYearMonthConstructor.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = TemporalPlainYearMonthConstructor.cpp; sourceTree = "<group>"; };
+		FF356CE42FA9824300213929 /* TemporalPlainYearMonthPrototype.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = TemporalPlainYearMonthPrototype.h; sourceTree = "<group>"; };
+		FF356CE52FA9824300213929 /* TemporalPlainYearMonthPrototype.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = TemporalPlainYearMonthPrototype.cpp; sourceTree = "<group>"; };
+		FF356CF32FA9832600213929 /* TemporalCoreTypes.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = TemporalCoreTypes.h; sourceTree = "<group>"; };
+		FF356CF42FA9832600213929 /* TemporalEnums.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = TemporalEnums.h; sourceTree = "<group>"; };
 		FF41590B28FF3C6B00F80B96 /* WaiterListManager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WaiterListManager.h; sourceTree = "<group>"; };
 		FF6A4D7D2E663147001FB92C /* WasmModuleDebugInfo.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WasmModuleDebugInfo.h; sourceTree = "<group>"; };
 		FFA2E0212EA16F37006661A3 /* BinaryTests.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = BinaryTests.cpp; sourceTree = "<group>"; };
@@ -8467,6 +8493,7 @@
 		7EF6E0BB0EB7A1EC0079AFAF /* runtime */ = {
 			isa = PBXGroup;
 			children = (
+				FF356CF62FA9832600213929 /* temporal */,
 				AD4937C11DDBE60A0077C807 /* AbstractModuleRecord.cpp */,
 				AD4937C21DDBE60A0077C807 /* AbstractModuleRecord.h */,
 				9168BD842447BA4C0080FFB4 /* AggregateError.cpp */,
@@ -8722,6 +8749,8 @@
 				A7A8AF2917ADB5F3005AB174 /* Float32Array.h */,
 				A7A8AF2A17ADB5F3005AB174 /* Float64Array.h */,
 				CD1F9B39270B9AAD00617EB6 /* Forward.h */,
+				FF356CD72FA9821A00213929 /* FractionToDouble.cpp */,
+				FF356CD62FA9821A00213929 /* FractionToDouble.h */,
 				BC2680C00E16D4E900A06E92 /* FunctionConstructor.cpp */,
 				BC2680C10E16D4E900A06E92 /* FunctionConstructor.h */,
 				276B385B2A71D0B600252F4E /* FunctionConstructorInlines.h */,
@@ -9480,12 +9509,24 @@
 				A38120B228ADAD4A008064D5 /* TemporalPlainDateTimeConstructor.h */,
 				A38120B028ADAD4A008064D5 /* TemporalPlainDateTimePrototype.cpp */,
 				A38120B128ADAD4A008064D5 /* TemporalPlainDateTimePrototype.h */,
+				FF356CDB2FA9824300213929 /* TemporalPlainMonthDay.cpp */,
+				FF356CDA2FA9824300213929 /* TemporalPlainMonthDay.h */,
+				FF356CDD2FA9824300213929 /* TemporalPlainMonthDayConstructor.cpp */,
+				FF356CDC2FA9824300213929 /* TemporalPlainMonthDayConstructor.h */,
+				FF356CDF2FA9824300213929 /* TemporalPlainMonthDayPrototype.cpp */,
+				FF356CDE2FA9824300213929 /* TemporalPlainMonthDayPrototype.h */,
 				E386FD7726E867B700E4C28B /* TemporalPlainTime.cpp */,
 				E386FD7826E867B800E4C28B /* TemporalPlainTime.h */,
 				E386FD7426E867B700E4C28B /* TemporalPlainTimeConstructor.cpp */,
 				E386FD7526E867B700E4C28B /* TemporalPlainTimeConstructor.h */,
 				E386FD7626E867B700E4C28B /* TemporalPlainTimePrototype.cpp */,
 				E386FD7926E867B800E4C28B /* TemporalPlainTimePrototype.h */,
+				FF356CE12FA9824300213929 /* TemporalPlainYearMonth.cpp */,
+				FF356CE02FA9824300213929 /* TemporalPlainYearMonth.h */,
+				FF356CE32FA9824300213929 /* TemporalPlainYearMonthConstructor.cpp */,
+				FF356CE22FA9824300213929 /* TemporalPlainYearMonthConstructor.h */,
+				FF356CE52FA9824300213929 /* TemporalPlainYearMonthPrototype.cpp */,
+				FF356CE42FA9824300213929 /* TemporalPlainYearMonthPrototype.h */,
 				E30E8A4D26DE2E4700DA4915 /* TemporalTimeZone.cpp */,
 				E30E8A5026DE2E4800DA4915 /* TemporalTimeZone.h */,
 				E30E8A4F26DE2E4700DA4915 /* TemporalTimeZoneConstructor.cpp */,
@@ -10806,6 +10847,23 @@
 			path = offlineasm;
 			sourceTree = "<group>";
 		};
+		FF356CF52FA9832600213929 /* core */ = {
+			isa = PBXGroup;
+			children = (
+				FF356CF32FA9832600213929 /* TemporalCoreTypes.h */,
+				FF356CF42FA9832600213929 /* TemporalEnums.h */,
+			);
+			path = core;
+			sourceTree = "<group>";
+		};
+		FF356CF62FA9832600213929 /* temporal */ = {
+			isa = PBXGroup;
+			children = (
+				FF356CF52FA9832600213929 /* core */,
+			);
+			path = temporal;
+			sourceTree = "<group>";
+		};
 		FFA2E0292EA16F37006661A3 /* tests */ = {
 			isa = PBXGroup;
 			children = (
@@ -11590,6 +11648,7 @@
 				A7A8AF3917ADB5F3005AB174 /* Float64Array.h in Headers */,
 				CD1F9B3A270B9AAD00617EB6 /* Forward.h in Headers */,
 				0F24E54317EA9F5900ABB217 /* FPRInfo.h in Headers */,
+				FF356CD82FA9821A00213929 /* FractionToDouble.h in Headers */,
 				E34EDBF71DB5FFC900DC87A5 /* FrameTracers.h in Headers */,
 				0F5513A61D5A682C00C32BD8 /* FreeList.h in Headers */,
 				0F6585E11EE0805A0095176D /* FreeListInlines.h in Headers */,
@@ -12573,21 +12632,30 @@
 				E32D4DE926DAFD4300D4533A /* TemporalCalendar.h in Headers */,
 				E32D4DEA26DAFD4300D4533A /* TemporalCalendarConstructor.h in Headers */,
 				E32D4DE726DAFD4300D4533A /* TemporalCalendarPrototype.h in Headers */,
+				FF356CF82FA9832600213929 /* TemporalCoreTypes.h in Headers */,
 				A3C7EDB926B0DB38004C34C5 /* TemporalDuration.h in Headers */,
 				A3C7EDBA26B0DB38004C34C5 /* TemporalDurationConstructor.h in Headers */,
 				A3C7EDB626B0DB38004C34C5 /* TemporalDurationPrototype.h in Headers */,
+				FF356CF72FA9832600213929 /* TemporalEnums.h in Headers */,
 				F6D67D4026F902E9006E0349 /* TemporalInstant.h in Headers */,
 				F6D67D4226F902E9006E0349 /* TemporalInstantConstructor.h in Headers */,
 				F6D67D4426F902E9006E0349 /* TemporalInstantPrototype.h in Headers */,
+				FF356CFA2FA9837C00213929 /* TemporalObject.h in Headers */,
 				31770C5827B94CE600308091 /* TemporalPlainDate.h in Headers */,
 				31770C5527B94CE600308091 /* TemporalPlainDateConstructor.h in Headers */,
 				31770C5727B94CE600308091 /* TemporalPlainDatePrototype.h in Headers */,
 				A38120B928ADAD4B008064D5 /* TemporalPlainDateTime.h in Headers */,
 				A38120B828ADAD4B008064D5 /* TemporalPlainDateTimeConstructor.h in Headers */,
 				A38120B728ADAD4B008064D5 /* TemporalPlainDateTimePrototype.h in Headers */,
+				FF356CE82FA9824300213929 /* TemporalPlainMonthDay.h in Headers */,
+				FF356CEB2FA9824300213929 /* TemporalPlainMonthDayConstructor.h in Headers */,
+				FF356CE72FA9824300213929 /* TemporalPlainMonthDayPrototype.h in Headers */,
 				E386FD7E26E867B800E4C28B /* TemporalPlainTime.h in Headers */,
 				E386FD7B26E867B800E4C28B /* TemporalPlainTimeConstructor.h in Headers */,
 				E386FD7F26E867B800E4C28B /* TemporalPlainTimePrototype.h in Headers */,
+				FF356CE92FA9824300213929 /* TemporalPlainYearMonth.h in Headers */,
+				FF356CEA2FA9824300213929 /* TemporalPlainYearMonthConstructor.h in Headers */,
+				FF356CE62FA9824300213929 /* TemporalPlainYearMonthPrototype.h in Headers */,
 				E30E8A5626DE2E4800DA4915 /* TemporalTimeZone.h in Headers */,
 				E30E8A5726DE2E4800DA4915 /* TemporalTimeZoneConstructor.h in Headers */,
 				E30E8A5426DE2E4800DA4915 /* TemporalTimeZonePrototype.h in Headers */,

--- a/Source/JavaScriptCore/runtime/ISO8601.h
+++ b/Source/JavaScriptCore/runtime/ISO8601.h
@@ -26,8 +26,8 @@
 
 #pragma once
 
-#include "IntlObject.h"
-#include "TemporalObject.h"
+#include <JavaScriptCore/IntlObject.h>
+#include <JavaScriptCore/TemporalObject.h>
 #include <wtf/Int128.h>
 #include <wtf/TZoneMalloc.h>
 #include <wtf/text/StringBuilder.h>

--- a/Source/JavaScriptCore/runtime/TemporalCalendar.h
+++ b/Source/JavaScriptCore/runtime/TemporalCalendar.h
@@ -26,11 +26,11 @@
 
 #pragma once
 
-#include "ISO8601.h"
-#include "IntlObject.h"
-#include "JSObject.h"
-#include "TemporalDuration.h"
-#include "TemporalObject.h"
+#include <JavaScriptCore/ISO8601.h>
+#include <JavaScriptCore/IntlObject.h>
+#include <JavaScriptCore/JSObject.h>
+#include <JavaScriptCore/TemporalDuration.h>
+#include <JavaScriptCore/TemporalObject.h>
 
 namespace JSC {
 

--- a/Source/JavaScriptCore/runtime/TemporalCalendarConstructor.h
+++ b/Source/JavaScriptCore/runtime/TemporalCalendarConstructor.h
@@ -25,7 +25,7 @@
 
 #pragma once
 
-#include "InternalFunction.h"
+#include <JavaScriptCore/InternalFunction.h>
 
 namespace JSC {
 

--- a/Source/JavaScriptCore/runtime/TemporalDuration.h
+++ b/Source/JavaScriptCore/runtime/TemporalDuration.h
@@ -26,7 +26,7 @@
 
 #pragma once
 
-#include "ISO8601.h"
+#include <JavaScriptCore/ISO8601.h>
 
 namespace JSC {
 

--- a/Source/JavaScriptCore/runtime/TemporalDurationConstructor.h
+++ b/Source/JavaScriptCore/runtime/TemporalDurationConstructor.h
@@ -25,7 +25,7 @@
 
 #pragma once
 
-#include "InternalFunction.h"
+#include <JavaScriptCore/InternalFunction.h>
 
 namespace JSC {
 

--- a/Source/JavaScriptCore/runtime/TemporalDurationPrototype.h
+++ b/Source/JavaScriptCore/runtime/TemporalDurationPrototype.h
@@ -26,7 +26,7 @@
 
 #pragma once
 
-#include "JSObject.h"
+#include <JavaScriptCore/JSObject.h>
 
 namespace JSC {
 

--- a/Source/JavaScriptCore/runtime/TemporalInstant.h
+++ b/Source/JavaScriptCore/runtime/TemporalInstant.h
@@ -26,11 +26,11 @@
 
 #pragma once
 
-#include "ISO8601.h"
-#include "JSObject.h"
-#include "TemporalDuration.h"
-#include "TemporalObject.h"
-#include "VM.h"
+#include <JavaScriptCore/ISO8601.h>
+#include <JavaScriptCore/JSObject.h>
+#include <JavaScriptCore/TemporalDuration.h>
+#include <JavaScriptCore/TemporalObject.h>
+#include <JavaScriptCore/VM.h>
 #include <wtf/Packed.h>
 
 namespace JSC {

--- a/Source/JavaScriptCore/runtime/TemporalInstantConstructor.h
+++ b/Source/JavaScriptCore/runtime/TemporalInstantConstructor.h
@@ -25,7 +25,7 @@
 
 #pragma once
 
-#include "InternalFunction.h"
+#include <JavaScriptCore/InternalFunction.h>
 
 namespace JSC {
 

--- a/Source/JavaScriptCore/runtime/TemporalInstantPrototype.h
+++ b/Source/JavaScriptCore/runtime/TemporalInstantPrototype.h
@@ -26,7 +26,7 @@
 
 #pragma once
 
-#include "JSObject.h"
+#include <JavaScriptCore/JSObject.h>
 
 namespace JSC {
 

--- a/Source/JavaScriptCore/runtime/TemporalNow.h
+++ b/Source/JavaScriptCore/runtime/TemporalNow.h
@@ -20,7 +20,7 @@
 
 #pragma once
 
-#include "JSObject.h"
+#include <JavaScriptCore/JSObject.h>
 
 namespace JSC {
 

--- a/Source/JavaScriptCore/runtime/TemporalObject.h
+++ b/Source/JavaScriptCore/runtime/TemporalObject.h
@@ -21,7 +21,8 @@
 
 #pragma once
 
-#include "JSObject.h"
+#include <JavaScriptCore/JSObject.h>
+#include <JavaScriptCore/TemporalEnums.h>
 #include <wtf/Int128.h>
 
 namespace JSC {
@@ -246,13 +247,6 @@ enum class TemporalOverflow : bool {
 TemporalOverflow toTemporalOverflow(JSGlobalObject*, JSObject*);
 TemporalOverflow toTemporalOverflow(JSGlobalObject*, JSValue);
 String toTemporalCalendarName(JSGlobalObject*, JSObject*);
-
-enum class TemporalDisambiguation : uint8_t {
-    Compatible,
-    Earlier,
-    Later,
-    Reject,
-};
 
 enum class TemporalDateFormat : uint8_t {
     Date,

--- a/Source/JavaScriptCore/runtime/TemporalPlainDate.h
+++ b/Source/JavaScriptCore/runtime/TemporalPlainDate.h
@@ -25,9 +25,9 @@
 
 #pragma once
 
-#include "ISO8601.h"
-#include "LazyProperty.h"
-#include "TemporalCalendar.h"
+#include <JavaScriptCore/ISO8601.h>
+#include <JavaScriptCore/LazyProperty.h>
+#include <JavaScriptCore/TemporalCalendar.h>
 
 namespace JSC {
 

--- a/Source/JavaScriptCore/runtime/TemporalPlainDateConstructor.h
+++ b/Source/JavaScriptCore/runtime/TemporalPlainDateConstructor.h
@@ -25,7 +25,7 @@
 
 #pragma once
 
-#include "InternalFunction.h"
+#include <JavaScriptCore/InternalFunction.h>
 
 namespace JSC {
 

--- a/Source/JavaScriptCore/runtime/TemporalPlainDatePrototype.h
+++ b/Source/JavaScriptCore/runtime/TemporalPlainDatePrototype.h
@@ -25,7 +25,7 @@
 
 #pragma once
 
-#include "JSObject.h"
+#include <JavaScriptCore/JSObject.h>
 
 namespace JSC {
 

--- a/Source/JavaScriptCore/runtime/TemporalPlainDateTime.h
+++ b/Source/JavaScriptCore/runtime/TemporalPlainDateTime.h
@@ -25,9 +25,9 @@
 
 #pragma once
 
-#include "ISO8601.h"
-#include "LazyProperty.h"
-#include "TemporalCalendar.h"
+#include <JavaScriptCore/ISO8601.h>
+#include <JavaScriptCore/LazyProperty.h>
+#include <JavaScriptCore/TemporalCalendar.h>
 
 namespace JSC {
 

--- a/Source/JavaScriptCore/runtime/TemporalPlainDateTimeConstructor.h
+++ b/Source/JavaScriptCore/runtime/TemporalPlainDateTimeConstructor.h
@@ -25,7 +25,7 @@
 
 #pragma once
 
-#include "InternalFunction.h"
+#include <JavaScriptCore/InternalFunction.h>
 
 namespace JSC {
 

--- a/Source/JavaScriptCore/runtime/TemporalPlainDateTimePrototype.h
+++ b/Source/JavaScriptCore/runtime/TemporalPlainDateTimePrototype.h
@@ -25,7 +25,7 @@
 
 #pragma once
 
-#include "JSObject.h"
+#include <JavaScriptCore/JSObject.h>
 
 namespace JSC {
 

--- a/Source/JavaScriptCore/runtime/TemporalPlainMonthDay.h
+++ b/Source/JavaScriptCore/runtime/TemporalPlainMonthDay.h
@@ -25,9 +25,9 @@
 
 #pragma once
 
-#include "ISO8601.h"
-#include "LazyProperty.h"
-#include "TemporalCalendar.h"
+#include <JavaScriptCore/ISO8601.h>
+#include <JavaScriptCore/LazyProperty.h>
+#include <JavaScriptCore/TemporalCalendar.h>
 
 namespace JSC {
 

--- a/Source/JavaScriptCore/runtime/TemporalPlainMonthDayConstructor.h
+++ b/Source/JavaScriptCore/runtime/TemporalPlainMonthDayConstructor.h
@@ -25,7 +25,7 @@
 
 #pragma once
 
-#include "InternalFunction.h"
+#include <JavaScriptCore/InternalFunction.h>
 
 namespace JSC {
 

--- a/Source/JavaScriptCore/runtime/TemporalPlainMonthDayPrototype.h
+++ b/Source/JavaScriptCore/runtime/TemporalPlainMonthDayPrototype.h
@@ -25,7 +25,7 @@
 
 #pragma once
 
-#include "JSObject.h"
+#include <JavaScriptCore/JSObject.h>
 
 namespace JSC {
 

--- a/Source/JavaScriptCore/runtime/TemporalPlainTime.h
+++ b/Source/JavaScriptCore/runtime/TemporalPlainTime.h
@@ -25,9 +25,9 @@
 
 #pragma once
 
-#include "ISO8601.h"
-#include "LazyProperty.h"
-#include "TemporalCalendar.h"
+#include <JavaScriptCore/ISO8601.h>
+#include <JavaScriptCore/LazyProperty.h>
+#include <JavaScriptCore/TemporalCalendar.h>
 
 namespace JSC {
 

--- a/Source/JavaScriptCore/runtime/TemporalPlainTimeConstructor.h
+++ b/Source/JavaScriptCore/runtime/TemporalPlainTimeConstructor.h
@@ -25,7 +25,7 @@
 
 #pragma once
 
-#include "InternalFunction.h"
+#include <JavaScriptCore/InternalFunction.h>
 
 namespace JSC {
 

--- a/Source/JavaScriptCore/runtime/TemporalPlainTimePrototype.h
+++ b/Source/JavaScriptCore/runtime/TemporalPlainTimePrototype.h
@@ -25,7 +25,7 @@
 
 #pragma once
 
-#include "JSObject.h"
+#include <JavaScriptCore/JSObject.h>
 
 namespace JSC {
 

--- a/Source/JavaScriptCore/runtime/TemporalPlainYearMonth.h
+++ b/Source/JavaScriptCore/runtime/TemporalPlainYearMonth.h
@@ -25,11 +25,11 @@
 
 #pragma once
 
-#include "Error.h"
-#include "ISO8601.h"
-#include "JSGlobalObject.h"
-#include "LazyProperty.h"
-#include "TemporalCalendar.h"
+#include <JavaScriptCore/Error.h>
+#include <JavaScriptCore/ISO8601.h>
+#include <JavaScriptCore/JSGlobalObject.h>
+#include <JavaScriptCore/LazyProperty.h>
+#include <JavaScriptCore/TemporalCalendar.h>
 
 namespace JSC {
 

--- a/Source/JavaScriptCore/runtime/TemporalPlainYearMonthConstructor.h
+++ b/Source/JavaScriptCore/runtime/TemporalPlainYearMonthConstructor.h
@@ -25,7 +25,7 @@
 
 #pragma once
 
-#include "InternalFunction.h"
+#include <JavaScriptCore/InternalFunction.h>
 
 namespace JSC {
 

--- a/Source/JavaScriptCore/runtime/TemporalPlainYearMonthPrototype.h
+++ b/Source/JavaScriptCore/runtime/TemporalPlainYearMonthPrototype.h
@@ -25,7 +25,7 @@
 
 #pragma once
 
-#include "JSObject.h"
+#include <JavaScriptCore/JSObject.h>
 
 namespace JSC {
 

--- a/Source/JavaScriptCore/runtime/TemporalTimeZone.h
+++ b/Source/JavaScriptCore/runtime/TemporalTimeZone.h
@@ -25,9 +25,9 @@
 
 #pragma once
 
-#include "ISO8601.h"
-#include "IntlObject.h"
-#include "JSObject.h"
+#include <JavaScriptCore/ISO8601.h>
+#include <JavaScriptCore/IntlObject.h>
+#include <JavaScriptCore/JSObject.h>
 
 namespace JSC {
 

--- a/Source/JavaScriptCore/runtime/TemporalTimeZoneConstructor.h
+++ b/Source/JavaScriptCore/runtime/TemporalTimeZoneConstructor.h
@@ -25,7 +25,7 @@
 
 #pragma once
 
-#include "InternalFunction.h"
+#include <JavaScriptCore/InternalFunction.h>
 
 namespace JSC {
 

--- a/Source/JavaScriptCore/runtime/TemporalTimeZonePrototype.h
+++ b/Source/JavaScriptCore/runtime/TemporalTimeZonePrototype.h
@@ -25,7 +25,7 @@
 
 #pragma once
 
-#include "JSObject.h"
+#include <JavaScriptCore/JSObject.h>
 
 namespace JSC {
 

--- a/Source/JavaScriptCore/runtime/temporal/core/TemporalCoreTypes.h
+++ b/Source/JavaScriptCore/runtime/temporal/core/TemporalCoreTypes.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -25,30 +25,42 @@
 
 #pragma once
 
-#include <JavaScriptCore/JSObject.h>
+// JSC Temporal Core — Shared types and error handling
+// temporal_rs reference: src/error.rs
+
+#include <wtf/Expected.h>
+#include <wtf/text/ASCIILiteral.h>
 
 namespace JSC {
 
-class TemporalCalendarPrototype final : public JSNonFinalObject {
-public:
-    using Base = JSNonFinalObject;
-    static constexpr unsigned StructureFlags = Base::StructureFlags | HasStaticPropertyTable;
+// TemporalErrorKind — temporal_rs: TemporalErrorKind enum
+// https://tc39.es/proposal-temporal/#sec-temporal-totemporalerror
+enum class TemporalErrorKind : uint8_t {
+    RangeError,
+    TypeError,
+};
 
-    template<typename CellType, SubspaceAccess>
-    static GCClient::IsoSubspace* subspaceFor(VM& vm)
-    {
-        STATIC_ASSERT_ISO_SUBSPACE_SHARABLE(TemporalCalendarPrototype, Base);
-        return &vm.plainObjectSpace();
-    }
+// TemporalError — temporal_rs: TemporalError { kind, message }
+struct TemporalError {
+    TemporalErrorKind kind;
+    ASCIILiteral message;
+};
 
-    static TemporalCalendarPrototype* create(VM&, JSGlobalObject*, Structure*);
-    static Structure* createStructure(VM&, JSGlobalObject*, JSValue);
+// TemporalResult<T> — temporal_rs: TemporalResult<T> = Result<T, TemporalError>
+template<typename T>
+using TemporalResult = Expected<T, TemporalError>;
 
-    DECLARE_INFO;
+// Convenience constructors — temporal_rs: TemporalError::range() / TemporalError::type_()
+namespace TemporalCore {
+inline TemporalError rangeError(ASCIILiteral msg) { return { TemporalErrorKind::RangeError, msg }; }
+inline TemporalError typeError(ASCIILiteral msg) { return { TemporalErrorKind::TypeError, msg }; }
+} // namespace TemporalCore
 
-private:
-    TemporalCalendarPrototype(VM&, Structure*);
-    void finishCreation(VM&, JSGlobalObject*);
+// TransitionDirection — temporal_rs: TransitionDirection enum (Next/Previous)
+// Used by getTimeZoneTransition to indicate search direction.
+enum class TransitionDirection : bool {
+    Next,
+    Previous,
 };
 
 } // namespace JSC

--- a/Source/JavaScriptCore/runtime/temporal/core/TemporalEnums.h
+++ b/Source/JavaScriptCore/runtime/temporal/core/TemporalEnums.h
@@ -1,0 +1,210 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+// JSC Temporal Core — Temporal enum types
+// temporal_rs reference: src/options.rs
+
+#include <cstdint>
+#include <wtf/text/ASCIILiteral.h>
+#include <wtf/text/StringView.h>
+
+namespace JSC {
+
+// https://tc39.es/proposal-temporal/#sec-temporal-totemporaldisambiguation
+// temporal_rs: Disambiguation
+enum class TemporalDisambiguation : uint8_t {
+    Compatible,
+    Earlier,
+    Later,
+    Reject,
+};
+
+// https://tc39.es/proposal-temporal/#sec-temporal-totemporaloffset
+// temporal_rs: OffsetDisambiguation
+enum class TemporalOffsetDisambiguation : uint8_t {
+    Use,
+    Prefer,
+    Ignore,
+    Reject,
+};
+
+// https://tc39.es/proposal-temporal/#sec-temporal-interpretisodatetimeoffset
+// temporal_rs: interpret_isodatetime_offset — is_exact/offset_nanos pair encoding
+enum class OffsetBehaviour : uint8_t {
+    Wall, // no inline offset in string — resolve via timezone + disambiguation
+    Exact, // Z flag — UTC epoch directly
+    Option, // +HH:MM present — use inlineOffsetNs
+};
+
+// https://tc39.es/proposal-temporal/#sec-temporal-tocalendaridentifier
+// temporal_rs: AnyCalendarKind
+enum class CalendarKind : uint8_t {
+    Iso8601 = 0, // must be 0 so zero-initialised objects default to iso8601
+    Buddhist,
+    Chinese,
+    Coptic,
+    Dangi,
+    Ethiopic,
+    EthioAA,
+    Gregory,
+    Hebrew,
+    Indian,
+    Islamic,
+    IslamicCivil,
+    IslamicRGSA,
+    IslamicTBLA,
+    IslamicUmmAlQura,
+    Japanese,
+    Persian,
+    Roc,
+    Bangla,
+    Gujarati,
+    Kannada,
+    Marathi,
+    Odia,
+    Tamil,
+    Telugu,
+    Vikram,
+};
+
+inline ASCIILiteral toCalendarIdentifier(CalendarKind k)
+{
+    switch (k) {
+    case CalendarKind::Iso8601:
+        return "iso8601"_s;
+    case CalendarKind::Buddhist:
+        return "buddhist"_s;
+    case CalendarKind::Chinese:
+        return "chinese"_s;
+    case CalendarKind::Coptic:
+        return "coptic"_s;
+    case CalendarKind::Dangi:
+        return "dangi"_s;
+    case CalendarKind::Ethiopic:
+        return "ethiopic"_s;
+    case CalendarKind::EthioAA:
+        return "ethioaa"_s;
+    case CalendarKind::Gregory:
+        return "gregory"_s;
+    case CalendarKind::Hebrew:
+        return "hebrew"_s;
+    case CalendarKind::Indian:
+        return "indian"_s;
+    case CalendarKind::Islamic:
+        return "islamic"_s;
+    case CalendarKind::IslamicCivil:
+        return "islamic-civil"_s;
+    case CalendarKind::IslamicRGSA:
+        return "islamic-rgsa"_s;
+    case CalendarKind::IslamicTBLA:
+        return "islamic-tbla"_s;
+    case CalendarKind::IslamicUmmAlQura:
+        return "islamic-umalqura"_s;
+    case CalendarKind::Japanese:
+        return "japanese"_s;
+    case CalendarKind::Persian:
+        return "persian"_s;
+    case CalendarKind::Roc:
+        return "roc"_s;
+    case CalendarKind::Bangla:
+        return "bangla"_s;
+    case CalendarKind::Gujarati:
+        return "gujarati"_s;
+    case CalendarKind::Kannada:
+        return "kannada"_s;
+    case CalendarKind::Marathi:
+        return "marathi"_s;
+    case CalendarKind::Odia:
+        return "odia"_s;
+    case CalendarKind::Tamil:
+        return "tamil"_s;
+    case CalendarKind::Telugu:
+        return "telugu"_s;
+    case CalendarKind::Vikram:
+        return "vikram"_s;
+    }
+    RELEASE_ASSERT_NOT_REACHED();
+}
+
+inline CalendarKind toCalendarKind(WTF::StringView s)
+{
+    if (s.isEmpty() || s == "iso8601"_s)
+        return CalendarKind::Iso8601;
+    if (s == "buddhist"_s)
+        return CalendarKind::Buddhist;
+    if (s == "chinese"_s)
+        return CalendarKind::Chinese;
+    if (s == "coptic"_s)
+        return CalendarKind::Coptic;
+    if (s == "dangi"_s)
+        return CalendarKind::Dangi;
+    if (s == "ethiopic"_s)
+        return CalendarKind::Ethiopic;
+    if (s == "ethioaa"_s || s == "ethiopic-amete-alem"_s)
+        return CalendarKind::EthioAA;
+    if (s == "gregory"_s || s == "gregorian"_s)
+        return CalendarKind::Gregory;
+    if (s == "hebrew"_s)
+        return CalendarKind::Hebrew;
+    if (s == "indian"_s)
+        return CalendarKind::Indian;
+    if (s == "islamic"_s)
+        return CalendarKind::Islamic;
+    if (s == "islamic-civil"_s || s == "islamicc"_s)
+        return CalendarKind::IslamicCivil;
+    if (s == "islamic-rgsa"_s)
+        return CalendarKind::IslamicRGSA;
+    if (s == "islamic-tbla"_s)
+        return CalendarKind::IslamicTBLA;
+    if (s == "islamic-umalqura"_s)
+        return CalendarKind::IslamicUmmAlQura;
+    if (s == "japanese"_s)
+        return CalendarKind::Japanese;
+    if (s == "persian"_s)
+        return CalendarKind::Persian;
+    if (s == "roc"_s)
+        return CalendarKind::Roc;
+    if (s == "bangla"_s)
+        return CalendarKind::Bangla;
+    if (s == "gujarati"_s)
+        return CalendarKind::Gujarati;
+    if (s == "kannada"_s)
+        return CalendarKind::Kannada;
+    if (s == "marathi"_s)
+        return CalendarKind::Marathi;
+    if (s == "odia"_s)
+        return CalendarKind::Odia;
+    if (s == "tamil"_s)
+        return CalendarKind::Tamil;
+    if (s == "telugu"_s)
+        return CalendarKind::Telugu;
+    if (s == "vikram"_s)
+        return CalendarKind::Vikram;
+    return CalendarKind::Iso8601;
+}
+
+} // namespace JSC


### PR DESCRIPTION
#### c315e02e022f2da98eea211f8e1cd6e506d54764
<pre>
[JSC][Temporal] Register Temporal headers as private framework headers and add shared enum/type headers
<a href="https://bugs.webkit.org/show_bug.cgi?id=314046">https://bugs.webkit.org/show_bug.cgi?id=314046</a>
<a href="https://rdar.apple.com/176231522">rdar://176231522</a>

Reviewed by Yusuke Suzuki.

Preparatory infrastructure for the Temporal implementation. No JS
functionality changes; existing tests continue to pass unchanged.

New files:
- runtime/temporal/core/TemporalEnums.h: Centralises all Temporal enum
  types (TemporalUnit, TemporalOverflow, TemporalDisambiguation,
  TemporalOffsetDisambiguation, RoundingMode, TemporalUnitGroup,
  AllowedUnit, Inclusivity, TransitionDirection) currently scattered across
  TemporalObject.h and individual type files. Consumed by the temporal/core
  algorithm layer added in subsequent patches.

- runtime/temporal/core/TemporalCoreTypes.h: Defines TemporalResult&lt;T&gt;,
  TemporalError, rangeError()/typeError() factory helpers,
  PossibleEpochNanoseconds, and OffsetBehaviour — the error-propagation
  and timezone-candidate types shared across temporal/core.

Build system:
- CMakeLists.txt: Add existing Temporal*.h, ISO8601.h, and new
  temporal/core headers to PRIVATE_FRAMEWORK_HEADERS for CMake builds.

- project.pbxproj: Add ATTRIBUTES = (Private,) to existing Temporal*.h
  and ISO8601.h Copy Headers phase entries. These were previously
  Project-level, which prevents &lt;JavaScriptCore/...&gt; includes from
  resolving at build time when headers are consumed by other frameworks.

Header include style:
- Convert all Temporal*.h from &quot;Foo.h&quot; quote-style includes to
  &lt;JavaScriptCore/Foo.h&gt; angle-bracket style, matching WebKit&apos;s
  convention for installed private framework headers (see IntlObject.h,
  JSGlobalObject.h). This is required now that the headers are Private.

- TemporalObject.h: Forward-include &lt;JavaScriptCore/TemporalEnums.h&gt;.

Canonical link: <a href="https://commits.webkit.org/312617@main">https://commits.webkit.org/312617@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d4ad9bdc378866611afe28817d1b6a092cc74712

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/160478 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/33951 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/27052 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/169381 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/115544 "Built successfully") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/34052 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/33951 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/124434 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/87888 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/d9bfa21e-3f8f-4906-9e4c-2c13ac3a5559) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/163436 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/26680 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/144148 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/105033 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/5f996f34-5abd-4c03-b279-48759e5340a4) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/25732 "Passed tests") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/24233 "Found 1 new API test failure: TestWebKitAPI.TextManipulation.CompleteTextManipulationForTitleElement (failure)") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/17100 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/152534 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/135426 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/21911 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/171859 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/21315 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/18300 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/23551 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/132695 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/33625 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/28327 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/132714 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35880 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/33609 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/143706 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/95391 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/27306 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/20520 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/192877 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/33119 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/99948 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/49668 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/32619 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/32863 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/32767 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->