### PR TITLE
Add TestRunner.lastProvisionalNavigationFailureURL

### DIFF
--- a/Tools/WebKitTestRunner/InjectedBundle/Bindings/TestRunner.idl
+++ b/Tools/WebKitTestRunner/InjectedBundle/Bindings/TestRunner.idl
@@ -163,6 +163,8 @@ interface TestRunner {
     readonly attribute boolean didReceiveServerRedirectForProvisionalNavigation;
     undefined clearDidReceiveServerRedirectForProvisionalNavigation();
 
+    readonly attribute DOMString lastProvisionalNavigationFailureURL;
+
     // Window/view state
     undefined setWindowIsKey(boolean isKey);
     undefined setViewSize(double width, double height);

--- a/Tools/WebKitTestRunner/InjectedBundle/InjectedBundle.cpp
+++ b/Tools/WebKitTestRunner/InjectedBundle/InjectedBundle.cpp
@@ -682,6 +682,13 @@ WKRetainPtr<WKStringRef> InjectedBundle::lastRemovedBackgroundFetchIdentifier() 
     return adoptWK(static_cast<WKStringRef>(result));
 }
 
+WKRetainPtr<WKStringRef> InjectedBundle::lastProvisionalNavigationFailureURL() const
+{
+    WKTypeRef result = nullptr;
+    WKBundlePagePostSynchronousMessageForTesting(page()->page(), toWK("LastProvisionalNavigationFailureURL").get(), 0, &result);
+    return adoptWK(static_cast<WKStringRef>(result));
+}
+
 WKRetainPtr<WKStringRef> InjectedBundle::lastUpdatedBackgroundFetchIdentifier() const
 {
     WKTypeRef result = nullptr;

--- a/Tools/WebKitTestRunner/InjectedBundle/InjectedBundle.h
+++ b/Tools/WebKitTestRunner/InjectedBundle/InjectedBundle.h
@@ -150,6 +150,7 @@ public:
     WKRetainPtr<WKStringRef> getBackgroundFetchIdentifier();
     WKRetainPtr<WKStringRef> lastAddedBackgroundFetchIdentifier() const;
     WKRetainPtr<WKStringRef> lastRemovedBackgroundFetchIdentifier() const;
+    WKRetainPtr<WKStringRef> lastProvisionalNavigationFailureURL() const;
     WKRetainPtr<WKStringRef> lastUpdatedBackgroundFetchIdentifier() const;
     WKRetainPtr<WKStringRef> backgroundFetchState(WKStringRef);
 

--- a/Tools/WebKitTestRunner/InjectedBundle/TestRunner.cpp
+++ b/Tools/WebKitTestRunner/InjectedBundle/TestRunner.cpp
@@ -535,6 +535,12 @@ void TestRunner::clearDidReceiveServerRedirectForProvisionalNavigation()
     postSynchronousPageMessage("ClearDidReceiveServerRedirectForProvisionalNavigation");
 }
 
+JSRetainPtr<JSStringRef> TestRunner::lastProvisionalNavigationFailureURL() const
+{
+    auto url = InjectedBundle::singleton().lastProvisionalNavigationFailureURL();
+    return WKStringCopyJSString(url.get());
+}
+
 void TestRunner::setPageVisibility(JSStringRef state)
 {
     InjectedBundle::singleton().setHidden(JSStringIsEqualToUTF8CString(state, "hidden"));

--- a/Tools/WebKitTestRunner/InjectedBundle/TestRunner.h
+++ b/Tools/WebKitTestRunner/InjectedBundle/TestRunner.h
@@ -240,6 +240,8 @@ public:
     bool didReceiveServerRedirectForProvisionalNavigation() const;
     void clearDidReceiveServerRedirectForProvisionalNavigation();
 
+    JSRetainPtr<JSStringRef> lastProvisionalNavigationFailureURL() const;
+
     bool shouldWaitUntilDone() const;
 
     // Downloads

--- a/Tools/WebKitTestRunner/TestController.cpp
+++ b/Tools/WebKitTestRunner/TestController.cpp
@@ -1602,6 +1602,7 @@ bool TestController::resetStateToConsistentValues(const TestOptions& options, Re
     WKPageDispatchActivityStateUpdateForTesting(m_mainWebView->page());
 
     m_didReceiveServerRedirectForProvisionalNavigation = false;
+    m_lastProvisionalNavigationFailureURL = nullptr;
     m_serverTrustEvaluationCallbackCallsCount = 0;
     m_shouldDismissJavaScriptAlertsAsynchronously = false;
 
@@ -3752,10 +3753,12 @@ void TestController::didFinishNavigation(WKPageRef page, WKNavigationRef navigat
 
 void TestController::didFailProvisionalNavigation(WKPageRef page, WKErrorRef error)
 {
+    auto failingURL = adoptWK(WKErrorCopyFailingURL(error));
+    m_lastProvisionalNavigationFailureURL = failingURL;
+
     if (m_usingServerMode)
         return;
 
-    auto failingURL = adoptWK(WKErrorCopyFailingURL(error));
     if (!m_mainResourceURL || !failingURL || !WKURLIsEqual(failingURL.get(), m_mainResourceURL.get()))
         return;
 
@@ -3765,6 +3768,13 @@ void TestController::didFailProvisionalNavigation(WKPageRef page, WKErrorRef err
     int errorCode = WKErrorGetErrorCode(error);
     auto errorMessage = makeString("Failed: "_s, errorDescription, " (errorDomain="_s, errorDomain, ", code="_s, errorCode, ") for URL "_s, failingURLString);
     printf("%s\n", errorMessage.utf8().data());
+}
+
+WKRetainPtr<WKStringRef> TestController::lastProvisionalNavigationFailureURL() const
+{
+    if (!m_lastProvisionalNavigationFailureURL)
+        return adoptWK(WKStringCreateWithUTF8CString(""));
+    return adoptWK(WKURLCopyString(m_lastProvisionalNavigationFailureURL.get()));
 }
 
 void TestController::didReceiveAuthenticationChallenge(WKPageRef page, WKAuthenticationChallengeRef authenticationChallenge)

--- a/Tools/WebKitTestRunner/TestController.h
+++ b/Tools/WebKitTestRunner/TestController.h
@@ -361,6 +361,8 @@ public:
     bool didReceiveServerRedirectForProvisionalNavigation() const { return m_didReceiveServerRedirectForProvisionalNavigation; }
     void clearDidReceiveServerRedirectForProvisionalNavigation() { m_didReceiveServerRedirectForProvisionalNavigation = false; }
 
+    WKRetainPtr<WKStringRef> lastProvisionalNavigationFailureURL() const;
+
     void addMockMediaDevice(WKStringRef persistentID, WKStringRef label, WKStringRef type, WKDictionaryRef properties);
     void clearMockMediaDevices();
     void removeMockMediaDevice(WKStringRef persistentID);
@@ -816,6 +818,7 @@ private:
     bool m_shouldDecideResponsePolicyAfterDelay { false };
 
     bool m_didReceiveServerRedirectForProvisionalNavigation { false };
+    WKRetainPtr<WKURLRef> m_lastProvisionalNavigationFailureURL;
 
     WKRetainPtr<WKArrayRef> m_openPanelFileURLs;
 #if PLATFORM(IOS_FAMILY)

--- a/Tools/WebKitTestRunner/TestInvocation.cpp
+++ b/Tools/WebKitTestRunner/TestInvocation.cpp
@@ -704,6 +704,8 @@ WKRetainPtr<WKTypeRef> TestInvocation::didReceiveSynchronousMessageFromInjectedB
         return TestController::singleton().lastAddedBackgroundFetchIdentifier();
     if (WKStringIsEqualToUTF8CString(messageName, "LastRemovedBackgroundFetchIdentifier"))
         return TestController::singleton().lastRemovedBackgroundFetchIdentifier();
+    if (WKStringIsEqualToUTF8CString(messageName, "LastProvisionalNavigationFailureURL"))
+        return TestController::singleton().lastProvisionalNavigationFailureURL();
     if (WKStringIsEqualToUTF8CString(messageName, "LastUpdatedBackgroundFetchIdentifier"))
         return TestController::singleton().lastUpdatedBackgroundFetchIdentifier();
     if (WKStringIsEqualToUTF8CString(messageName, "BackgroundFetchState"))


### PR DESCRIPTION
#### 71b020becb533f61969b658a716e4e66b98bc742
<pre>
Add TestRunner.lastProvisionalNavigationFailureURL
<a href="https://bugs.webkit.org/show_bug.cgi?id=314047">https://bugs.webkit.org/show_bug.cgi?id=314047</a>
<a href="https://rdar.apple.com/176233398">rdar://176233398</a>

Reviewed by Ryosuke Niwa.

With site isolation enabled, navigations may trigger process swaps. When a provisional navigation fails (e.g. blocked by
content extensions), the old process has no way to know when the failure has been fully processed by the UIProcess. This
makes it difficult for tests to deterministically wait for provisional navigation failures before ending.

Add testRunner.lastProvisionalNavigationFailureURL, a synchronous attribute that returns the URL of the last provisional
navigation failure observed by the UIProcess. Tests can poll this to determine when it is safe to call notifyDone(),
avoiding race conditions between IPC messages on different connections.

* Tools/WebKitTestRunner/InjectedBundle/Bindings/TestRunner.idl:
* Tools/WebKitTestRunner/InjectedBundle/InjectedBundle.cpp:
(WTR::InjectedBundle::lastProvisionalNavigationFailureURL const):
* Tools/WebKitTestRunner/InjectedBundle/InjectedBundle.h:
* Tools/WebKitTestRunner/InjectedBundle/TestRunner.cpp:
(WTR::TestRunner::lastProvisionalNavigationFailureURL const):
* Tools/WebKitTestRunner/InjectedBundle/TestRunner.h:
* Tools/WebKitTestRunner/TestController.cpp:
(WTR::TestController::resetStateToConsistentValues):
* Tools/WebKitTestRunner/TestController.h:
* Tools/WebKitTestRunner/TestInvocation.cpp:
(WTR::TestInvocation::didReceiveSynchronousMessageFromInjectedBundle):

Canonical link: <a href="https://commits.webkit.org/312622@main">https://commits.webkit.org/312622@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/aba53c6d805e01417f5c2c76baadb9e4b79051d5

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/160480 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/33953 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/27054 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/169383 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/115546 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/55689233-c4ea-4a9b-8b05-c4db1d230e15) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/162349 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/34054 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/33953 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/124436 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/87890 "2 failures") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/06befdb5-6d32-4894-9a2a-29e0b5aabcf1) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/163438 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/26681 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/144152 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/105035 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/0ec17841-11c6-4a38-b836-637a6bebb02c) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/25733 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/24235 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/17102 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/135427 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/21915 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/171861 "Built successfully") | | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/23555 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/132697 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/33627 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/28329 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/132716 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35883 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/33611 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/143710 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/95393 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/27311 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/20524 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/33121 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/32621 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/32865 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/32769 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->