### PR TITLE
[AppKit Gestures] Double clicking text in Safari does not highlight text (selection flickers)

### DIFF
--- a/Source/WebKit/UIProcess/mac/WKAppKitGestureController.h
+++ b/Source/WebKit/UIProcess/mac/WKAppKitGestureController.h
@@ -56,6 +56,7 @@ OBJC_CLASS NSPanGestureRecognizer;
 
 - (instancetype)initWithPage:(std::reference_wrapper<WebKit::WebPageProxy>)page viewImpl:(std::reference_wrapper<WebKit::WebViewImpl>)viewImpl;
 - (void)enableGesturesIfNeeded;
+- (void)cancelClick;
 - (NSGestureRecognizer *)activeDragGestureRecognizer;
 - (void)setGestureDraggingSession:(NSDraggingSession *)session;
 - (void)clearGestureDragState;

--- a/Source/WebKit/UIProcess/mac/WKAppKitGestureController.mm
+++ b/Source/WebKit/UIProcess/mac/WKAppKitGestureController.mm
@@ -296,6 +296,14 @@ static WebCore::FloatSize toRawPlatformDelta(WebCore::FloatSize delta)
     [gesture setEnabled:gestureEnabled];
 }
 
+- (void)cancelClick
+{
+    [self _handleClickCancelled];
+
+    if (RefPtr page = _page.get())
+        page->cancelPotentialClick();
+}
+
 #pragma mark - Gesture Recognition
 
 - (void)panGestureRecognized:(NSGestureRecognizer *)gesture

--- a/Source/WebKit/UIProcess/mac/WKTextSelectionController.swift
+++ b/Source/WebKit/UIProcess/mac/WKTextSelectionController.swift
@@ -235,7 +235,7 @@ extension WKTextSelectionController {
 
     @objc(beginRangeSelectionAtPoint:withGranularity:)
     func beginRangeSelection(at point: NSPoint, with granularity: NSTextSelection.Granularity) {
-        guard let page = view._protectedPage().get() else {
+        guard let page = view._protectedPage().get(), let impl = view._impl() else {
             return
         }
 
@@ -244,6 +244,8 @@ extension WKTextSelectionController {
         )
 
         currentRangeSelectionGranularity = granularity
+
+        impl.cancelClick()
 
         Task.immediate {
             await page.selectText(

--- a/Source/WebKit/UIProcess/mac/WebViewImpl.h
+++ b/Source/WebKit/UIProcess/mac/WebViewImpl.h
@@ -880,6 +880,7 @@ public:
 #if HAVE(APPKIT_GESTURES_SUPPORT)
     void addTextSelectionManager();
     bool isTextSelectedAtPoint(NSPoint);
+    void cancelClick();
 #endif
 
 private:

--- a/Source/WebKit/UIProcess/mac/WebViewImpl.mm
+++ b/Source/WebKit/UIProcess/mac/WebViewImpl.mm
@@ -7646,6 +7646,11 @@ bool WebViewImpl::isTextSelectedAtPoint(NSPoint point)
 {
     return [m_textSelectionController isTextSelectedAtPoint:point];
 }
+
+void WebViewImpl::cancelClick()
+{
+    [m_appKitGestureController cancelClick];
+}
 #endif // HAVE(APPKIT_GESTURES_SUPPORT)
 
 } // namespace WebKit

--- a/Tools/TestWebKitAPI/Tests/WebKit/WebPage/AppKitGesturesTests.swift
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WebPage/AppKitGesturesTests.swift
@@ -165,9 +165,9 @@ struct AppKitGesturesTests {
         #expect(newSelection == crazySelection)
     }
 
-    @Test(arguments: [true, false])
-    func doubleClickingInWordSelectsWord(contentEditable: Bool) async throws {
-        try await loadHTML(contentEditable: contentEditable)
+    @Test(arguments: [true, false], [true, false])
+    func doubleClickingInWordSelectsWord(contentEditable: Bool, clickHandler: Bool) async throws {
+        try await loadHTML(contentEditable: contentEditable, clickHandler: clickHandler)
 
         let crazyRange = try #require(Self.text.utf16Range(of: "crazy"))
         let crazySelection = JavaScriptSelection.range(
@@ -312,9 +312,12 @@ private func convertToCoreGraphicsScreenCoordinates(rectInViewportCoordinates: D
 }
 
 extension AppKitGesturesTests {
-    private func loadHTML(contentEditable: Bool) async throws {
+    private func loadHTML(contentEditable: Bool = false, clickHandler: Bool = false) async throws {
+        let contentEditableMarkup = contentEditable ? "contenteditable" : ""
+        let clickHandlerMarkup = clickHandler ? "onclick='void(0)'" : ""
+
         let html = """
-            <div \(contentEditable ? "contenteditable" : "") id="div" style="font-size: 30px;">\(Self.text)</div>
+            <div \(contentEditableMarkup) \(clickHandlerMarkup) id="div" style="font-size: 30px;">\(Self.text)</div>
             """
 
         try await page.load(html: html).wait()


### PR DESCRIPTION
#### 80675181b655ab80779cdf67fbab5e2f4ecbffb9
<pre>
[AppKit Gestures] Double clicking text in Safari does not highlight text (selection flickers)
<a href="https://bugs.webkit.org/show_bug.cgi?id=314048">https://bugs.webkit.org/show_bug.cgi?id=314048</a>
<a href="https://rdar.apple.com/172217561">rdar://172217561</a>

Reviewed by Abrar Rahman Protyasha.

Double-clicking text to select a word sometimes briefly shows the selection highlight and then
clears it on pages where the clicked text has a clickable ancestor (elements with click handlers,
links, etc.). The selection survives on simpler pages where no ancestor passes
`Node::willRespondToMouseClickEvents`, which masks the bug.

The root cause is that when a user double-clicks, two things happen simultaneously via gesture
recognizers that are allowed to recognize together:

1. `WKAppKitGestureController`&apos;s single-click press gesture fires `_handleClickBegan` (sending
`potentialClickAtPosition`) and then `_handleClickEnded` (sending `commitPotentialClick`).

2. The system calls into the `beginRangeSelection` on `WKTextSelectionController`, which sends
`selectTextWithGranularityAtPoint`.

In the web process, `commitPotentialClick` calls `handleSyntheticClick`. This then enters a 32 ms
content-observation window before dispatching the synthetic click via `completeSyntheticClick`.
Meanwhile, `selectTextWithGranularityAtPoint` arrives and creates the word selection. When the
32 ms observation window expires, `completeSyntheticClick` fires a synthetic mouse press event
that clears the just-created selection, producing the flicker.

The timing between the gesture recognizer actions and the text selection manager callbacks is
non-deterministic:

- Order A: single-click Began fires, then `beginRangeSelection`, then single-click Ended. In
this ordering, cancelling the click before Ended prevents the commit entirely.

- Order B: single-click Began and Ended both fire (committing the click) before
`beginRangeSelection`. The commit IPC is already in flight, but the observation timer in the web
process has not yet fired.

Fix by cancelling the click in both the UI process and the web process when `beginRangeSelection`
is called:

- `_handleClickCancelled` handles Order A by setting `_potentialClickInProgress` to false so
`_handleClickEnded` becomes a no-op.

- An unconditional `cancelPotentialClick` IPC handles Order B: even though the commit was already
 sent, the cancel arrives in the web process and invokes
 `ContentChangeObserver::didCancelPotentialClick`, which cancels the pending observation timer and
 prevents `completeSyntheticClick` from ever firing.

Test: Tools/TestWebKitAPI/Tests/WebKit/WebPage/AppKitGesturesTests.swift

* Source/WebKit/UIProcess/mac/WKAppKitGestureController.h:
* Source/WebKit/UIProcess/mac/WKAppKitGestureController.mm:
(-[WKAppKitGestureController cancelClick]):
* Source/WebKit/UIProcess/mac/WKTextSelectionController.swift:
(WKTextSelectionController.beginRangeSelection(at:with:)):
* Source/WebKit/UIProcess/mac/WebViewImpl.h:
* Source/WebKit/UIProcess/mac/WebViewImpl.mm:
(WebKit::WebViewImpl::cancelClick):
* Tools/TestWebKitAPI/Tests/WebKit/WebPage/AppKitGesturesTests.swift:
(AppKitGesturesTests.doubleClickingInWordSelectsWord(_:clickHandler:)):
(AppKitGesturesTests.loadHTML(_:clickHandler:)):
(AppKitGesturesTests.doubleClickingInWordSelectsWord(_:)): Deleted.
(AppKitGesturesTests.loadHTML(_:)): Deleted.

Canonical link: <a href="https://commits.webkit.org/312666@main">https://commits.webkit.org/312666@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d0ed00adc802e23479e31bfb1d838dc4f397316f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/160634 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/34107 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/27208 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/169537 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/115700 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/ece8a1d5-4325-46b8-a8d9-30d0288c4583) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/162503 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/34208 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/34107 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/124571 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/87965 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/163593 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/26824 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/144294 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/105171 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/d2f7f59d-2c1a-45e4-96ed-7d768643506f) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/25876 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/24380 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/17257 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/135570 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/22057 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/172016 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/18893 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/23697 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/132835 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/33781 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/28472 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/132850 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35902 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/33765 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/143852 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/95574 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/27448 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/20667 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/33276 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/100518 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/32775 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/33019 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/32923 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->