### PR TITLE
[HDR] Some HDR images on gregbenzphotography.com page flicker to SDR when hovered

### DIFF
--- a/LayoutTests/compositing/hdr/hdr-in-shared-backing-expected.txt
+++ b/LayoutTests/compositing/hdr/hdr-in-shared-backing-expected.txt
@@ -1,0 +1,25 @@
+
+(GraphicsLayer
+  (anchor 0.00 0.00)
+  (bounds 800.00 600.00)
+  (children 1
+    (GraphicsLayer
+      (bounds 800.00 600.00)
+      (contentsOpaque 1)
+      (children 2
+        (GraphicsLayer
+          (position 8.00 8.00)
+          (bounds 50.00 50.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 30.00 30.00)
+          (bounds 302.00 302.00)
+          (drawsContent 1)
+          (drawsHDRContent 1)
+        )
+      )
+    )
+  )
+)
+

--- a/LayoutTests/compositing/hdr/hdr-in-shared-backing.html
+++ b/LayoutTests/compositing/hdr/hdr-in-shared-backing.html
@@ -1,0 +1,67 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <style>
+        .clipping {
+            position: absolute;
+            top: 20px;
+            left: 20px;
+            overflow: hidden;
+            height: 300px;
+            width: 300px;
+            margin: 10px;
+            border: 1px solid black;
+        }
+        
+        .sharing {
+            position: relative;
+            top: 50px;
+            left: 50px;
+            width: 180px;
+            height: 180px;
+            background-color: green;
+        }
+
+        .trigger {
+            transform: translateZ(0);
+            width: 50px;
+            height: 50px;
+            background-color: silver;
+        }
+    </style>
+</head>
+<body>
+    <div class="trigger"></div>
+    <div class="clipping">
+        <img class="sharing" width="150" height="150">
+    </div>
+    <pre id="layers">Layer tree goes here</pre>
+
+    <script>
+        if (window.internals && window.testRunner) {
+            internals.clearMemoryCache();
+            internals.setScreenContentsFormatsForTesting(["RGBA8", "RGBA16F"]);
+            testRunner.dumpAsText();
+            testRunner.waitUntilDone();
+        }
+
+        let image = new Image;
+        image.onload = (() => {
+            if (window.internals)
+                internals.setHasHDRContentForTesting(image);
+
+            const elements = document.querySelectorAll("img");
+
+            elements.forEach((element) => {
+                element.src = image.src;
+            });
+
+            if (window.testRunner) {
+                document.getElementById("layers").textContent = internals.layerTreeAsText(document);
+                testRunner.notifyDone();
+            }
+        });
+        image.src = "../../fast/images/resources/green-400x400.png";
+    </script>
+</body>
+</html>

--- a/Source/WebCore/rendering/RenderLayerBacking.cpp
+++ b/Source/WebCore/rendering/RenderLayerBacking.cpp
@@ -3292,8 +3292,9 @@ bool RenderLayerBacking::isSimpleContainerCompositingLayer(PaintedContentsInfo& 
 
 // Returning true stops the traversal.
 enum class LayerTraversal { Continue, Stop };
+enum class SharedBackingInclusion { ExcludeSharedBacking, IncludeSharedBacking };
 
-static LayerTraversal traverseVisibleNonCompositedDescendantLayers(RenderLayer& parent, NOESCAPE const Function<LayerTraversal(const RenderLayer&)>& layerFunc)
+static LayerTraversal traverseVisibleNonCompositedDescendantLayers(RenderLayer& parent, SharedBackingInclusion sharedBackingInclusion, NOESCAPE const Function<LayerTraversal(const RenderLayer&)>& layerFunc)
 {
     // FIXME: We shouldn't be called with a stale z-order lists. See bug 85512.
     parent.updateLayerListsIfNeeded();
@@ -3303,14 +3304,26 @@ static LayerTraversal traverseVisibleNonCompositedDescendantLayers(RenderLayer& 
 #endif
 
     for (CheckedPtr childLayer : parent.normalFlowLayers()) {
-        if (compositedWithOwnBackingStore(*childLayer))
+        if (compositedWithOwnBackingStore(*childLayer) || childLayer->paintsIntoProvidedBacking())
             continue;
 
         if (layerFunc(*childLayer) == LayerTraversal::Stop)
             return LayerTraversal::Stop;
 
-        if (traverseVisibleNonCompositedDescendantLayers(*childLayer, layerFunc) == LayerTraversal::Stop)
+        if (traverseVisibleNonCompositedDescendantLayers(*childLayer, SharedBackingInclusion::ExcludeSharedBacking, layerFunc) == LayerTraversal::Stop)
             return LayerTraversal::Stop;
+    }
+
+    if (sharedBackingInclusion == SharedBackingInclusion::IncludeSharedBacking) {
+        if (parent.isComposited() && parent.backing()->hasBackingSharingLayers()) {
+            for (CheckedRef sharingLayer : parent.backing()->backingSharingLayers() | dereferenceView) {
+                if (layerFunc(sharingLayer) == LayerTraversal::Stop)
+                    return LayerTraversal::Stop;
+
+                if (traverseVisibleNonCompositedDescendantLayers(sharingLayer, SharedBackingInclusion::ExcludeSharedBacking, layerFunc) == LayerTraversal::Stop)
+                    return LayerTraversal::Stop;
+            }
+        }
     }
 
     if (parent.isStackingContext() && !parent.hasVisibleDescendant())
@@ -3318,24 +3331,24 @@ static LayerTraversal traverseVisibleNonCompositedDescendantLayers(RenderLayer& 
 
     // Use the m_hasCompositingDescendant bit to optimize?
     for (CheckedPtr childLayer : parent.negativeZOrderLayers()) {
-        if (compositedWithOwnBackingStore(*childLayer))
+        if (compositedWithOwnBackingStore(*childLayer) || childLayer->paintsIntoProvidedBacking())
             continue;
 
         if (layerFunc(*childLayer) == LayerTraversal::Stop)
             return LayerTraversal::Stop;
 
-        if (traverseVisibleNonCompositedDescendantLayers(*childLayer, layerFunc) == LayerTraversal::Stop)
+        if (traverseVisibleNonCompositedDescendantLayers(*childLayer, SharedBackingInclusion::ExcludeSharedBacking, layerFunc) == LayerTraversal::Stop)
             return LayerTraversal::Stop;
     }
 
     for (CheckedPtr childLayer : parent.positiveZOrderLayers()) {
-        if (compositedWithOwnBackingStore(*childLayer))
+        if (compositedWithOwnBackingStore(*childLayer) || childLayer->paintsIntoProvidedBacking())
             continue;
 
         if (layerFunc(*childLayer) == LayerTraversal::Stop)
             return LayerTraversal::Stop;
 
-        if (traverseVisibleNonCompositedDescendantLayers(*childLayer, layerFunc) == LayerTraversal::Stop)
+        if (traverseVisibleNonCompositedDescendantLayers(*childLayer, SharedBackingInclusion::ExcludeSharedBacking, layerFunc) == LayerTraversal::Stop)
             return LayerTraversal::Stop;
     }
 
@@ -3356,7 +3369,7 @@ static std::optional<bool> intersectsWithAncestor(const RenderLayer& child, cons
 void RenderLayerBacking::determineNonCompositedLayerDescendantsPaintedContent(RenderLayer::PaintedContentRequest& request) const
 {
     bool hasPaintingDescendant = false;
-    traverseVisibleNonCompositedDescendantLayers(m_owningLayer, [&hasPaintingDescendant, &request, this](const RenderLayer& layer) {
+    traverseVisibleNonCompositedDescendantLayers(m_owningLayer, SharedBackingInclusion::IncludeSharedBacking, [&hasPaintingDescendant, &request, this](const RenderLayer& layer) {
         auto localRequest = RenderLayer::PaintedContentRequest { };
 #if HAVE(SUPPORT_HDR_DISPLAY)
         localRequest.setHDRRequestState(request.hasHDRContent);
@@ -3379,7 +3392,7 @@ void RenderLayerBacking::determineNonCompositedLayerDescendantsPaintedContent(Re
 bool RenderLayerBacking::hasVisibleNonCompositedDescendants() const
 {
     bool hasVisibleDescendant = false;
-    traverseVisibleNonCompositedDescendantLayers(m_owningLayer, [&hasVisibleDescendant](const RenderLayer& layer) {
+    traverseVisibleNonCompositedDescendantLayers(m_owningLayer, SharedBackingInclusion::ExcludeSharedBacking, [&hasVisibleDescendant](const RenderLayer& layer) {
         hasVisibleDescendant |= layer.hasVisibleContent();
         return hasVisibleDescendant ? LayerTraversal::Stop : LayerTraversal::Continue;
     });


### PR DESCRIPTION
#### 66b092fde2ecd56a0106331d83fcc7569cf18d1b
<pre>
[HDR] Some HDR images on gregbenzphotography.com page flicker to SDR when hovered
<a href="https://bugs.webkit.org/show_bug.cgi?id=305407">https://bugs.webkit.org/show_bug.cgi?id=305407</a>
<a href="https://rdar.apple.com/163382580">rdar://163382580</a>

Reviewed by Mike Wyrzykowski.

The content on <a href="https://gregbenzphotography.com/hdr-gain-map-gallery/">https://gregbenzphotography.com/hdr-gain-map-gallery/</a> hit the &quot;shared backing&quot;
compositing logic (sibling compositing layers drawing into the same backing store). The
logic that detects HDR content was broken in this scenario, by failing to traverse the
contents of the sharing layers.

Fix by traversing sharing layers in `traverseVisibleNonCompositedDescendantLayers()`
as in the order of the backing they are drawing into, rather than their normal
z-order list postion. Opt the contents detection logic into this at
`determineNonCompositedLayerDescendantsPaintedContent()`.

Test: compositing/hdr/hdr-in-shared-backing.html

* LayoutTests/compositing/hdr/hdr-in-shared-backing-expected.txt: Added.
* LayoutTests/compositing/hdr/hdr-in-shared-backing.html: Added.
* Source/WebCore/rendering/RenderLayerBacking.cpp:
(WebCore::traverseVisibleNonCompositedDescendantLayers):
(WebCore::RenderLayerBacking::determineNonCompositedLayerDescendantsPaintedContent const):
(WebCore::RenderLayerBacking::hasVisibleNonCompositedDescendants const):

Canonical link: <a href="https://commits.webkit.org/312702@main">https://commits.webkit.org/312702@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/395a78154313ae59ec9e065cb9b862bdf7132d4c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/160744 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/34217 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/27318 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/169647 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/115810 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/162613 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/34318 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/34217 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/124664 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/88020 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/163703 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/26912 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/144383 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/105261 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/7a33930c-798a-4169-8d9c-4e85a2e1198a) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/25964 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/24465 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/17367 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/135658 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/22146 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/172129 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/19094 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/23787 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/132929 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/33891 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/28557 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/132941 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35922 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/33875 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/143941 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/95684 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/27531 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/20756 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/33386 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/100706 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/32885 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/33129 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/33033 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->