### PR TITLE
`ASSERTION FAILED: m_wrapper` when visiting pages in Safari in Debug

### DIFF
--- a/Source/WebCore/bindings/js/DOMWrapperWorld.cpp
+++ b/Source/WebCore/bindings/js/DOMWrapperWorld.cpp
@@ -22,6 +22,8 @@
 #include "DOMWrapperWorld.h"
 
 #include "CommonVM.h"
+#include "JSEventListener.h"
+#include "Logging.h"
 #include "WebCoreJSClientData.h"
 #include "WindowProxy.h"
 #include <JavaScriptCore/HeapCellInlines.h>
@@ -55,11 +57,28 @@ DOMWrapperWorld::~DOMWrapperWorld()
 
 void DOMWrapperWorld::clearWrappers()
 {
+    if (!m_eventListeners.isEmptyIgnoringNullReferences()) {
+        RELEASE_LOG_ERROR(Bindings, "DOMWrapperWorld::clearWrappers() called when there were still registered event listeners");
+        auto eventListeners = std::exchange(m_eventListeners, { });
+        for (Ref eventListener : eventListeners)
+            eventListener->invalidate();
+    }
+
     m_wrappers.clear();
 
     // These items are created lazily.
     while (!m_jsWindowProxies.isEmpty())
         (*m_jsWindowProxies.begin())->destroyJSWindowProxy(*this);
+}
+
+void DOMWrapperWorld::addEventListener(JSEventListener& listener)
+{
+    m_eventListeners.add(listener);
+}
+
+void DOMWrapperWorld::removeEventListener(JSEventListener& listener)
+{
+    m_eventListeners.remove(listener);
 }
 
 DOMWrapperWorld& normalWorld(JSC::VM& vm)

--- a/Source/WebCore/bindings/js/DOMWrapperWorld.h
+++ b/Source/WebCore/bindings/js/DOMWrapperWorld.h
@@ -24,10 +24,12 @@
 #include <WebCore/JSDOMGlobalObject.h>
 #include <wtf/Compiler.h>
 #include <wtf/Forward.h>
+#include <wtf/WeakHashSet.h>
 #include <wtf/WeakPtr.h>
 
 namespace WebCore {
 
+class JSEventListener;
 class WindowProxy;
 
 typedef HashMap<void*, JSC::Weak<JSC::JSObject>> DOMObjectWrapperMap;
@@ -91,6 +93,9 @@ public:
 
     JSC::VM& vm() const { return m_vm; }
 
+    void addEventListener(JSEventListener&);
+    void removeEventListener(JSEventListener&);
+
 protected:
     DOMWrapperWorld(JSC::VM&, Type, const String& name);
 
@@ -98,6 +103,8 @@ private:
     JSC::VM& m_vm;
     HashSet<WindowProxy*> m_jsWindowProxies;
     DOMObjectWrapperMap m_wrappers;
+
+    WeakHashSet<JSEventListener> m_eventListeners;
 
     String m_name;
     Type m_type { Type::Internal };

--- a/Source/WebCore/bindings/js/JSEventListener.cpp
+++ b/Source/WebCore/bindings/js/JSEventListener.cpp
@@ -51,21 +51,24 @@
 namespace WebCore {
 using namespace JSC;
 
-JSEventListener::JSEventListener(JSObject* function, JSObject* wrapper, bool isAttribute, CreatedFromMarkup createdFromMarkup, DOMWrapperWorld& isolatedWorld)
+JSEventListener::JSEventListener(JSObject* function, JSObject* wrapper, bool isAttribute, CreatedFromMarkup createdFromMarkup, DOMWrapperWorld& world)
     : EventListener(JSEventListenerType)
     , m_isAttribute(isAttribute)
     , m_wasCreatedFromMarkup(createdFromMarkup == CreatedFromMarkup::Yes)
     , m_isInitialized(false)
     , m_wrapper(wrapper)
-    , m_isolatedWorld(&isolatedWorld)
+    , m_world(&world)
 {
     if (function) {
         ASSERT(wrapper);
         m_jsFunction = JSC::Weak<JSC::JSObject>(function);
         m_isInitialized = true;
     }
-    if (&isolatedWorld.vm() != commonVMOrNull())
-        downcast<JSVMClientData>(isolatedWorld.vm().clientData)->addClient(*this);
+    if (&world.vm() != commonVMOrNull())
+        downcast<JSVMClientData>(world.vm().clientData)->addClient(*this);
+
+    if (!world.isNormal())
+        world.addEventListener(*this);
 }
 
 JSEventListener::~JSEventListener() = default;
@@ -96,9 +99,9 @@ void JSEventListener::replaceJSFunctionForAttributeListener(JSObject* function, 
     }
 }
 
-JSValue eventHandlerAttribute(EventTarget& eventTarget, const AtomString& eventType, DOMWrapperWorld& isolatedWorld)
+JSValue eventHandlerAttribute(EventTarget& eventTarget, const AtomString& eventType, DOMWrapperWorld& world)
 {
-    if (RefPtr jsListener = eventTarget.attributeEventListener(eventType, isolatedWorld)) {
+    if (RefPtr jsListener = eventTarget.attributeEventListener(eventType, world)) {
         if (RefPtr context = eventTarget.scriptExecutionContext()) {
             if (auto* jsFunction = jsListener->ensureJSFunction(*context))
                 return jsFunction;
@@ -148,10 +151,10 @@ void JSEventListener::handleEvent(ScriptExecutionContext& scriptExecutionContext
     if (!jsFunction)
         return;
 
-    if (!m_isolatedWorld) [[unlikely]]
+    if (!m_world) [[unlikely]]
         return;
 
-    SUPPRESS_UNCOUNTED_ARG auto* globalObject = toJSDOMGlobalObject(scriptExecutionContext, *m_isolatedWorld);
+    SUPPRESS_UNCOUNTED_ARG auto* globalObject = toJSDOMGlobalObject(scriptExecutionContext, *m_world);
     if (!globalObject)
         return;
 
@@ -294,7 +297,7 @@ String JSEventListener::functionName() const
     if (!m_wrapper || !m_jsFunction)
         return { };
 
-    auto& vm = m_isolatedWorld->vm();
+    auto& vm = m_world->vm();
     JSC::JSLockHolder lock(vm);
 
     auto* handlerFunction = dynamicDowncast<JSC::JSFunction>(m_jsFunction.get());
@@ -304,12 +307,17 @@ String JSEventListener::functionName() const
     return handlerFunction->name(vm);
 }
 
-void JSEventListener::willDestroyVM()
+void JSEventListener::invalidate()
 {
     m_jsFunction.clear();
     m_wrapper.clear();
     m_isInitialized = false;
-    m_isolatedWorld = nullptr;
+    m_world = nullptr;
+}
+
+void JSEventListener::willDestroyVM()
+{
+    invalidate();
 }
 
 } // namespace WebCore

--- a/Source/WebCore/bindings/js/JSEventListener.h
+++ b/Source/WebCore/bindings/js/JSEventListener.h
@@ -41,6 +41,8 @@ public:
 
     virtual ~JSEventListener();
 
+    USING_CAN_MAKE_WEAKPTR(EventListener);
+
     void ref() const final { EventListener::ref(); }
     void deref() const final { EventListener::deref(); }
 
@@ -52,7 +54,7 @@ public:
     bool wasCreatedFromMarkup() const { return m_wasCreatedFromMarkup; }
 
     JSC::JSObject* ensureJSFunction(ScriptExecutionContext&) const;
-    DOMWrapperWorld* isolatedWorld() const { return m_isolatedWorld.get(); }
+    DOMWrapperWorld* isolatedWorld() const { return m_world; }
 
     JSC::JSObject* jsFunction() const final { return m_jsFunction.get(); }
     JSC::JSObject* wrapper() const final { return m_wrapper.get(); }
@@ -68,6 +70,8 @@ public:
         auto* jsEventListener = dynamicDowncast<JSEventListener>(listener);
         return jsEventListener && jsEventListener->wasCreatedFromMarkup();
     }
+
+    void invalidate();
 
 private:
     virtual JSC::JSObject* initializeJSFunction(ScriptExecutionContext&) const;
@@ -95,7 +99,7 @@ private:
     mutable JSC::Weak<JSC::JSObject> m_jsFunction;
     mutable JSC::Weak<JSC::JSObject> m_wrapper;
 
-    RefPtr<DOMWrapperWorld> m_isolatedWorld;
+    RefPtr<DOMWrapperWorld> m_world;
 };
 
 // For "onxxx" attributes that automatically set up JavaScript event listeners.
@@ -137,10 +141,10 @@ inline JSC::JSObject* JSEventListener::ensureJSFunction(ScriptExecutionContext& 
 {
     // initializeJSFunction can trigger code that deletes this event listener
     // before we're done. It should always return null in this case.
-    if (!m_isolatedWorld) [[unlikely]]
+    if (!m_world) [[unlikely]]
         return nullptr;
 
-    JSC::VM& vm = m_isolatedWorld->vm();
+    JSC::VM& vm = m_world->vm();
     Ref protect = const_cast<JSEventListener&>(*this);
     JSC::EnsureStillAliveScope protectedWrapper(m_wrapper.get());
 

--- a/Source/WebCore/platform/Logging.h
+++ b/Source/WebCore/platform/Logging.h
@@ -83,6 +83,7 @@ namespace WebCore {
     M(ApplePay) \
     M(Archives) \
     M(BackForwardCache) \
+    M(Bindings) \
     M(Calc) \
     M(ClipRects) \
     M(Compositing) \

--- a/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
+++ b/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
@@ -1400,6 +1400,7 @@
 				WebKit/WKWebView/BundleRangeHandlePlugIn.mm,
 				WebKit/WKWebView/BundleRetainPagePlugIn.mm,
 				WebKit/WKWebView/CancelFontSubresourcePlugIn.mm,
+				WebKit/WKWebView/ClearWrappersNavigatePlugIn.mm,
 				WebKit/WKWebView/ClickAutoFillButton.mm,
 				WebKit/WKWebView/ContentFilteringPlugIn.mm,
 				WebKit/WKWebView/ContentWorldPlugIn.mm,

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ClearWrappersNavigatePlugIn.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ClearWrappersNavigatePlugIn.mm
@@ -1,0 +1,63 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import "config.h"
+
+#import <JavaScriptCore/JavaScriptCore.h>
+#import <WebKit/WKWebProcessPlugIn.h>
+#import <WebKit/WKWebProcessPlugInBrowserContextController.h>
+#import <WebKit/WKWebProcessPlugInFrame.h>
+#import <WebKit/WKWebProcessPlugInLoadDelegate.h>
+#import <WebKit/WKWebProcessPlugInScriptWorld.h>
+
+@interface ClearWrappersNavigatePlugIn : NSObject <WKWebProcessPlugIn, WKWebProcessPlugInLoadDelegate>
+@end
+
+@implementation ClearWrappersNavigatePlugIn {
+    RetainPtr<WKWebProcessPlugInScriptWorld> _isolatedWorld;
+    bool _didSetup;
+}
+
+- (void)webProcessPlugIn:(WKWebProcessPlugInController *)plugInController didCreateBrowserContextController:(WKWebProcessPlugInBrowserContextController *)browserContextController
+{
+    _isolatedWorld = [WKWebProcessPlugInScriptWorld world];
+    browserContextController.loadDelegate = self;
+}
+
+- (void)webProcessPlugInBrowserContextController:(WKWebProcessPlugInBrowserContextController *)controller didFinishLoadForFrame:(WKWebProcessPlugInFrame *)frame
+{
+    if (_didSetup)
+        return;
+    _didSetup = true;
+
+    JSContext *context = [frame jsContextForWorld:_isolatedWorld.get()];
+    [context evaluateScript:@"window.navigation.addEventListener('navigate', (event) => { })"];
+    [_isolatedWorld clearWrappers];
+
+    JSContext *normalContext = [frame jsContextForWorld:[WKWebProcessPlugInScriptWorld normalWorld]];
+    [normalContext evaluateScript:@"window._clearWrappersPlugInDidRun = true"];
+}
+
+@end

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/NavigationAPI.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/NavigationAPI.mm
@@ -25,10 +25,13 @@
 
 #import "config.h"
 
+#import "Helpers/PlatformUtilities.h"
 #import "Helpers/cocoa/HTTPServer.h"
 #import "Helpers/cocoa/TestNavigationDelegate.h"
 #import "Helpers/cocoa/TestWKWebView.h"
 #import <WebKit/WKPreferencesPrivate.h>
+#import <WebKit/WKProcessPoolPrivate.h>
+#import <WebKit/_WKProcessPoolConfiguration.h>
 #import <wtf/RetainPtr.h>
 
 namespace TestWebKitAPI {
@@ -189,6 +192,35 @@ TEST(NavigationAPI, InterceptFailsForDifferentUsernameAndPassword)
     EXPECT_NULL(error);
     EXPECT_TRUE([result isKindOfClass:[NSString class]]);
     EXPECT_TRUE([result hasPrefix:@"intercept failed"]);
+}
+
+TEST(NavigationAPI, ClearWrappersWithNavigateEventListener)
+{
+    HTTPServer server({
+        { "/page1"_s, { "page1"_s } },
+    }, HTTPServer::Protocol::HttpsProxy);
+
+    RetainPtr configuration = server.httpsProxyConfiguration();
+
+    RetainPtr processPoolConfiguration = adoptNS([[_WKProcessPoolConfiguration alloc] init]);
+    [processPoolConfiguration setInjectedBundleURL:[[NSBundle mainBundle] URLForResource:@"TestWebKitAPI" withExtension:@"wkbundle"]];
+    RetainPtr processPool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration.get()]);
+    [processPool _setObject:@"ClearWrappersNavigatePlugIn" forBundleParameter:TestWebKitAPI::Util::TestPlugInClassNameParameter];
+    [configuration setProcessPool:processPool.get()];
+
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 300, 300) configuration:configuration.get()]);
+
+    RetainPtr navigationDelegate = adoptNS([TestNavigationDelegate new]);
+    [navigationDelegate allowAnyTLSCertificate];
+    [webView setNavigationDelegate:navigationDelegate.get()];
+
+    [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://example.com/page1"]]];
+    [navigationDelegate waitForDidFinishNavigation];
+
+    [processPool _garbageCollectJavaScriptObjectsForTesting];
+
+    // history.pushState synchronously fires the navigate event.
+    [webView stringByEvaluatingJavaScript:@"history.pushState({}, '', '/foo')"];
 }
 
 } // namespace TestWebKitAPI


### PR DESCRIPTION
#### 8ee6856c51be9aa6874fac8bee521ae6c9c891dc
<pre>
`ASSERTION FAILED: m_wrapper` when visiting pages in Safari in Debug
<a href="https://bugs.webkit.org/show_bug.cgi?id=314051">https://bugs.webkit.org/show_bug.cgi?id=314051</a>
<a href="https://rdar.apple.com/173442940">rdar://173442940</a>

Reviewed by Ben Nham.

When a JSEventListener is created in an isolated world and that world&apos;s
wrappers are subsequently cleared via WKBundleScriptWorldClearWrappers(),
the listener&apos;s weak wrapper reference becomes stale after GC. If an event
then fires, ensureJSFunction() hits ASSERT(m_wrapper) because
m_isInitialized is true but the wrapper has been collected.

Fix this by introducing a DOMWrapperWorldClient interface that allows
objects to be notified before a world&apos;s wrappers are cleared.
JSEventListener now registers as a client and invalidates itself
(clearing its wrapper, function, and world references) in response,
causing ensureJSFunction() to return early via the null m_isolatedWorld
check.

Tests: Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ClearWrappersNavigatePlugIn.mm
       Tools/TestWebKitAPI/Tests/WebKit/WKWebView/NavigationAPI.mm

* Source/WebCore/bindings/js/DOMWrapperWorld.cpp:
(WebCore::DOMWrapperWorld::clearWrappers):
(WebCore::DOMWrapperWorld::addEventListener):
(WebCore::DOMWrapperWorld::removeEventListener):
* Source/WebCore/bindings/js/DOMWrapperWorld.h:
* Source/WebCore/bindings/js/JSEventListener.cpp:
(WebCore::JSEventListener::JSEventListener):
(WebCore::eventHandlerAttribute):
(WebCore::JSEventListener::handleEvent):
(WebCore::JSEventListener::functionName const):
(WebCore::JSEventListener::invalidate):
(WebCore::JSEventListener::willDestroyVM):
* Source/WebCore/bindings/js/JSEventListener.h:
(WebCore::JSEventListener::isolatedWorld const):
(WebCore::JSEventListener::ensureJSFunction const):
* Source/WebCore/platform/Logging.h:
* Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj:
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ClearWrappersNavigatePlugIn.mm: Added.
(-[ClearWrappersNavigatePlugIn webProcessPlugIn:didCreateBrowserContextController:]):
(-[ClearWrappersNavigatePlugIn webProcessPlugInBrowserContextController:didFinishLoadForFrame:]):
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/NavigationAPI.mm:
(TestWebKitAPI::TEST(NavigationAPI, ClearWrappersWithNavigateEventListener)):

Canonical link: <a href="https://commits.webkit.org/312677@main">https://commits.webkit.org/312677@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9c929c846d5e0f8ceaa6f7a447767c8ab6db7f0f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/160718 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/34191 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/27292 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/169621 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/115784 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/346e8e76-1028-4f8e-8801-e847b797e94c) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/162587 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/34292 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/34191 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/124641 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/88004 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/0c988977-5d87-411a-a974-9634d6d35757) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/163677 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/26892 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/144365 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/105238 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/25944 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/24445 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/17341 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/135638 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/22128 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/172103 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/19046 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/23768 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/132912 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/33865 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/28537 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/132924 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35911 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/33849 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/143923 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/95658 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/27512 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/20738 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/33360 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/100653 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/32859 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/33103 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/33007 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->