### PR TITLE
Bug 311644 `tabIndex` values are not set correctly for MathML elements

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/mathml/relations/html5-tree/tabindex-001.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/mathml/relations/html5-tree/tabindex-001.tentative-expected.txt
@@ -1,6 +1,6 @@
 
-FAIL default and invalid values for a without href assert_equals: no attribute expected 0 but got -1
-FAIL default and invalid values for a with href assert_equals: no attribute expected 0 but got -1
+PASS default and invalid values for a without href
+PASS default and invalid values for a with href
 PASS default and invalid values for annotation without href
 PASS default and invalid values for annotation with href
 PASS default and invalid values for annotation-xml without href

--- a/Source/WebCore/mathml/MathMLElement.cpp
+++ b/Source/WebCore/mathml/MathMLElement.cpp
@@ -366,6 +366,11 @@ bool MathMLElement::supportsFocus() const
     return isLink() || StyledElement::supportsFocus();
 }
 
+int MathMLElement::defaultTabIndex() const
+{
+    return localName() == HTMLNames::aTag ? 0 : -1;
+}
+
 }
 
 #endif // ENABLE(MATHML)

--- a/Source/WebCore/mathml/MathMLElement.h
+++ b/Source/WebCore/mathml/MathMLElement.h
@@ -85,6 +85,7 @@ private:
     bool NODELETE isURLAttribute(const Attribute&) const final;
     bool NODELETE allowsHref() const;
     bool supportsFocus() const final;
+    int defaultTabIndex() const final;
 };
 
 inline bool Node::hasTagName(const MathMLQualifiedName& name) const


### PR DESCRIPTION
#### 56070711b886fc6c0996efed62140409e9d97dbb
<pre>
Bug 311644 `tabIndex` values are not set correctly for MathML elements
<a href="https://bugs.webkit.org/show_bug.cgi?id=311644">https://bugs.webkit.org/show_bug.cgi?id=311644</a>

Reviewed by Anne van Kesteren.

See <a href="https://github.com/whatwg/html/pull/12416">https://github.com/whatwg/html/pull/12416</a>

* LayoutTests/imported/w3c/web-platform-tests/mathml/relations/html5-tree/tabindex-001.tentative-expected.txt: Update expectation now that the tests pass.
* Source/WebCore/mathml/MathMLElement.cpp:
(WebCore::MathMLElement::defaultTabIndex const): Make defaultTabIndex default to 0 for a elements and -1 otherwise.
* Source/WebCore/mathml/MathMLElement.h: Override defaultTabIndex.

Canonical link: <a href="https://commits.webkit.org/312681@main">https://commits.webkit.org/312681@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a9ad9bedfdcfe043162fbf7e771fe603e40a0bb7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/160505 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/33978 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/27079 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/169408 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/115571 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/162374 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/34079 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/33978 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/124458 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/87906 "2 flakes 2 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/163463 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/26705 "Passed tests") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/144178 "Found 1 new API test failure: TestWebKitAPI.WKWebExtensionAPIScripting.ExecuteScriptWithUserGesture (failure)") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/105058 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/25757 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/24260 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/17127 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/135451 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/21941 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/171887 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/18423 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/23581 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/132721 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/33652 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/28353 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/132737 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35912 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/33636 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/143736 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/95420 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/27338 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/20550 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/33146 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/100020 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/32646 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/32890 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/32794 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->