### PR TITLE
Sync `html/browsers/browsing-the-web/resources` from WPT Upstream

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/navigating-across-documents/about-srcdoc-navigation-blocked.window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/navigating-across-documents/about-srcdoc-navigation-blocked.window-expected.txt
@@ -1,5 +1,5 @@
 
-FAIL Navigations to about:srcdoc via window.location must be blocked promise_test: Unhandled rejection with value: object "ReferenceError: Can't find variable: addSrcdocIframe"
-FAIL Navigations to about:srcdoc?query via window.location within an about:srcdoc document must be blocked promise_test: Unhandled rejection with value: object "ReferenceError: Can't find variable: addSrcdocIframe"
-FAIL Navigations to about:srcdoc via window.open() must be blocked promise_test: Unhandled rejection with value: object "ReferenceError: Can't find variable: addSrcdocIframe"
+FAIL Navigations to about:srcdoc via window.location must be blocked promise_test: Unhandled rejection with value: object "Error: Received message "srcdoc ready" but expected to receive no message"
+FAIL Navigations to about:srcdoc?query via window.location within an about:srcdoc document must be blocked promise_test: Unhandled rejection with value: object "Error: Received message "srcdoc ready" but expected to receive no message"
+FAIL Navigations to about:srcdoc via window.open() must be blocked promise_test: Unhandled rejection with value: object "Error: Received message "srcdoc ready" but expected to receive no message"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/navigating-across-documents/navigation-unload-cross-origin.sub.window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/navigating-across-documents/navigation-unload-cross-origin.sub.window-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL Cross-origin navigation started from unload handler must be ignored promise_test: Unhandled rejection with value: object "ReferenceError: Can't find variable: waitForIframeLoad"
+PASS Cross-origin navigation started from unload handler must be ignored
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/navigating-across-documents/navigation-unload-same-origin.window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/navigating-across-documents/navigation-unload-same-origin.window-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL Same-origin navigation started from unload handler must be ignored promise_test: Unhandled rejection with value: object "ReferenceError: Can't find variable: waitForIframeLoad"
+PASS Same-origin navigation started from unload handler must be ignored
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/resources/helpers.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/resources/helpers.js
@@ -1,3 +1,12 @@
+// This file contains general helpers for navigation/history tests. The goal is
+// to make tests more imperative and ordered, instead of requiring lots of
+// nested callbacks and jumping back and forth. However,
+// html/browsers/browsing-the-web/remote-context-helper/resources/remote-context-helper.js
+// might be even better at that, so prefer that when you can.
+//
+// TODO(domenic): consider unifying with
+// overlapping-navigations-and-traversals/resources/helpers.mjs.
+
 window.openWindow = (url, t) => {
   const w = window.open(url);
   t?.add_cleanup(() => w.close());
@@ -17,8 +26,24 @@ window.addIframe = (url = "/common/blank.html", doc = document) => {
   });
 };
 
+window.addSrcdocIframe = async () => {
+  const iframe = document.createElement("iframe");
+  iframe.srcdoc = `<script>window.parent.postMessage("srcdoc ready", "*")</scr` + `ipt>`;
+  document.body.append(iframe);
+
+  assert_equals(await waitForMessage(iframe.contentWindow), "srcdoc ready");
+
+  return iframe;
+};
+
 window.waitToAvoidReplace = t => {
   return new Promise(resolve => t.step_timeout(resolve, 0));
+};
+
+window.waitForIframeLoad = iframe => {
+  return new Promise(resolve => {
+    iframe.addEventListener("load", () => resolve(), { once: true });
+  });
 };
 
 window.waitForMessage = expectedSource => {
@@ -46,4 +71,14 @@ window.srcdocThatPostsParentOpener = text => {
       };
     <\/script>
   `;
+};
+
+window.failOnMessage = expectedSource => {
+  return new Promise((_, reject) => {
+    window.addEventListener("message", ({ source, data }) => {
+      if (source === expectedSource) {
+        reject(new Error(`Received message "${data}" but expected to receive no message`));
+      }
+    });
+  });
 };


### PR DESCRIPTION
#### 0a3baab3cc44c140138087427d85ab0b341418ec
<pre>
Sync `html/browsers/browsing-the-web/resources` from WPT Upstream
<a href="https://bugs.webkit.org/show_bug.cgi?id=314056">https://bugs.webkit.org/show_bug.cgi?id=314056</a>
<a href="https://rdar.apple.com/176245733">rdar://176245733</a>

Reviewed by Vitor Roriz and Anne van Kesteren.

Upstream commit: <a href="https://github.com/web-platform-tests/wpt/commit/fd42b630fcfbdf595d2500628c1e95e8c71b5acb">https://github.com/web-platform-tests/wpt/commit/fd42b630fcfbdf595d2500628c1e95e8c71b5acb</a>

* LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/navigating-across-documents/about-srcdoc-navigation-blocked.window-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/navigating-across-documents/navigation-unload-cross-origin.sub.window-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/navigating-across-documents/navigation-unload-same-origin.window-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/resources/helpers.js:
(window.addSrcdocIframe.async const):
(window.addSrcdocIframe):
(window.failOnMessage.expectedSource.return.new.Promise):

Canonical link: <a href="https://commits.webkit.org/312633@main">https://commits.webkit.org/312633@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/60c0e81474b78e883b96c76b2998930ef0301121

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/160506 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/33979 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/27080 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/169409 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/115572 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/f34f7675-811a-45ba-b2ba-5eb4a1f9b2b3) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/34080 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/33979 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/124459 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/87911 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/d317e278-eda3-4161-9127-a2339c0a2b84) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/163464 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/26708 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/144174 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/105059 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/5acf8893-d8a4-490c-a580-d7b4d0cdb485) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/25760 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/24263 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/17128 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/135454 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/21937 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/171888 "Built successfully") | | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/23577 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/132723 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/33653 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/28356 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/132739 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35891 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/33637 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/143732 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/95421 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/27335 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/20546 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/33147 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/32647 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/32891 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/32795 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->