### PR TITLE
Main frame scroll stretching may get stuck when gesture is initiated above subscroller and held

### DIFF
--- a/LayoutTests/fast/scrolling/latching/mainframe-stretch-snaps-back-after-hold-over-subscroller-expected.txt
+++ b/LayoutTests/fast/scrolling/latching/mainframe-stretch-snaps-back-after-hold-over-subscroller-expected.txt
@@ -1,0 +1,12 @@
+Tests that when a gesture rubber-bands the main frame with the cursor over a subscroller, and the user holds at max stretch for longer than the latching-relevance timeout before releasing, the frame still snaps back on release.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS sawMainFrameStretch is true
+PASS document.scrollingElement.scrollTop is 0
+PASS subscroller.scrollTop is 0
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/scrolling/latching/mainframe-stretch-snaps-back-after-hold-over-subscroller.html
+++ b/LayoutTests/fast/scrolling/latching/mainframe-stretch-snaps-back-after-hold-over-subscroller.html
@@ -1,0 +1,74 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ AsyncOverflowScrollingEnabled=true ] -->
+<html>
+<head>
+    <style>
+        body {
+            height: 2200px;
+            margin: 0;
+        }
+        #subscroller {
+            width: 430px;
+            height: 300px;
+            overflow: auto;
+            margin: 20px;
+            border: 1px solid black;
+        }
+        #subscroller > .content {
+            height: 2000px;
+        }
+    </style>
+    <script src="../../../resources/js-test.js"></script>
+    <script src="../../../resources/ui-helper.js"></script>
+    <script>
+        jsTestIsAsync = true;
+
+        var subscroller;
+        var sawMainFrameStretch = false;
+
+        async function scrollTest()
+        {
+            if (!window.eventSender)
+                return;
+
+            description('Tests that when a gesture rubber-bands the main frame with the cursor over a subscroller, and the user holds at max stretch for longer than the latching-relevance timeout before releasing, the frame still snaps back on release.');
+
+            subscroller = document.getElementById('subscroller');
+
+            window.addEventListener('scroll', () => {
+                if (document.scrollingElement.scrollTop < 0)
+                    sawMainFrameStretch = true;
+            });
+
+            eventSender.mouseMoveTo(100, 100);
+
+            await UIHelper.startMonitoringWheelEvents();
+
+            // Start the upward scroll gesture.
+            await eventSender.mouseScrollByWithWheelAndMomentumPhases(0, 2, 'began', 'none');
+            await eventSender.mouseScrollByWithWheelAndMomentumPhases(0, 10, 'changed', 'none');
+            await eventSender.mouseScrollByWithWheelAndMomentumPhases(0, 10, 'changed', 'none');
+            await eventSender.mouseScrollByWithWheelAndMomentumPhases(0, 10, 'changed', 'none');
+
+            // Hold at max stretch for longer than the 100ms latching timeout in ScrollingTreeLatchingController.
+            await UIHelper.delayFor(150);
+
+            // Release.
+            await eventSender.mouseScrollByWithWheelAndMomentumPhases(0, 0, 'ended', 'none');
+            await UIHelper.waitForScrollCompletion();
+
+
+            shouldBeTrue('sawMainFrameStretch');
+            shouldBe('document.scrollingElement.scrollTop', '0');
+            shouldBe('subscroller.scrollTop', '0');
+
+            finishJSTest();
+        }
+
+        window.addEventListener('load', scrollTest);
+    </script>
+</head>
+<body>
+    <div id="subscroller"><div class="content"></div></div>
+    <div id="console"></div>
+</body>
+</html>

--- a/Source/WebCore/page/scrolling/ScrollingTreeLatchingController.cpp
+++ b/Source/WebCore/page/scrolling/ScrollingTreeLatchingController.cpp
@@ -47,7 +47,7 @@ void ScrollingTreeLatchingController::receivedWheelEvent(const PlatformWheelEven
         return;
 
     Locker locker { m_latchedNodeLock };
-    if (wheelEvent.isGestureStart() && !latchedNodeIsRelevant()) {
+    if (wheelEvent.isGestureStart() && !latchedNodeHasRecentInteraction()) {
         if (m_latchedNodeAndSteps) {
             LOG_WITH_STREAM(ScrollLatching, stream << "ScrollingTreeLatchingController " << this << " receivedWheelEvent - " << (MonotonicTime::now() - m_lastLatchedNodeInterationTime).milliseconds() << "ms since last event, clearing latched node");
             m_latchedNodeAndSteps.reset();
@@ -63,13 +63,14 @@ std::optional<ScrollingTreeLatchingController::ScrollingNodeAndProcessingSteps> 
 
     Locker locker { m_latchedNodeLock };
 
-    // If we have a latched node, use it.
-    if (wheelEvent.useLatchedEventElement() && m_latchedNodeAndSteps && latchedNodeIsRelevant()) {
-        LOG_WITH_STREAM(ScrollLatching, stream << "ScrollingTreeLatchingController " << this << " latchedNodeForEvent: returning " << m_latchedNodeAndSteps->scrollingNodeID);
-        return m_latchedNodeAndSteps;
-    }
+    if (!wheelEvent.useLatchedEventElement() || !m_latchedNodeAndSteps)
+        return std::nullopt;
 
-    return std::nullopt;
+    if (wheelEvent.isGestureStart() && !latchedNodeHasRecentInteraction())
+        return std::nullopt;
+
+    LOG_WITH_STREAM(ScrollLatching, stream << "ScrollingTreeLatchingController " << this << " latchedNodeForEvent: returning " << m_latchedNodeAndSteps->scrollingNodeID);
+    return m_latchedNodeAndSteps;
 }
 
 std::optional<ScrollingNodeID> ScrollingTreeLatchingController::latchedNodeID() const
@@ -142,7 +143,7 @@ void ScrollingTreeLatchingController::clearLatchedNode()
     m_latchedNodeAndSteps.reset();
 }
 
-bool ScrollingTreeLatchingController::latchedNodeIsRelevant() const
+bool ScrollingTreeLatchingController::latchedNodeHasRecentInteraction() const
 {
     auto secondsSinceLastInteraction = MonotonicTime::now() - m_lastLatchedNodeInterationTime;
     return secondsSinceLastInteraction < resetLatchedStateTimeout;

--- a/Source/WebCore/page/scrolling/ScrollingTreeLatchingController.h
+++ b/Source/WebCore/page/scrolling/ScrollingTreeLatchingController.h
@@ -59,7 +59,7 @@ public:
     void clearLatchedNode();
 
 private:
-    bool latchedNodeIsRelevant() const;
+    bool latchedNodeHasRecentInteraction() const;
 
     mutable Lock m_latchedNodeLock;
     std::optional<ScrollingNodeAndProcessingSteps> m_latchedNodeAndSteps WTF_GUARDED_BY_LOCK(m_latchedNodeLock);


### PR DESCRIPTION
#### efd075461ed0d76cd9e6697e469674fa0577bf79
<pre>
Main frame scroll stretching may get stuck when gesture is initiated above subscroller and held
<a href="https://bugs.webkit.org/show_bug.cgi?id=314055">https://bugs.webkit.org/show_bug.cgi?id=314055</a>
<a href="https://rdar.apple.com/173104821">rdar://173104821</a>

Reviewed by Wenson Hsieh and Abrar Rahman Protyasha.

If the the mainframe and a subscroller are both scrolled to the top of the page,
the user initiates a scroll gesture above the subscroller which causes the main
frame to enter a scroll stretch, and the user then holds the gesture for more
than 100ms, the stretch gets stuck if the cursor is still above the subscroller.

This bug is caused by an issue with scroll latching. If a scroll gesture begins
over a subscroller and neither that subscroller nor any of its parent scrollers
can scroll in the direction of the gesture without going out of bounds, then the
main frame&apos;s root scrolling node becomes the latched node, and the main frame
correctly enters a scroll stretch. However, when the gesture is held longer than
100ms, the latched node (main frame&apos;s root scrolling node in this case)
is no longer considered relevant, so it stops automatically receiving wheel events.
When the gesture is finally released, instead of dispatching the ending event to
the latched node, a hit-test is performed. If the cursor is above the subscroller
still when this happens, the ending wheel event is sent there instead of the main
frame&apos;s root scrolling node. Since the main frame does not receive an ending wheel
event, it does not rubberband back.

To resolve this, we now also consider the latched node relevant if the wheel event
phase is not `Began` so that the latched node remains relevant for the entirety
of a continuous scroll gesture.

Test: fast/scrolling/latching/mainframe-stretch-snaps-back-after-hold-over-subscroller.html

* LayoutTests/fast/scrolling/latching/mainframe-stretch-snaps-back-after-hold-over-subscroller-expected.txt: Added.
* LayoutTests/fast/scrolling/latching/mainframe-stretch-snaps-back-after-hold-over-subscroller.html: Added.
* Source/WebCore/page/scrolling/ScrollingTreeLatchingController.cpp:
(WebCore::ScrollingTreeLatchingController::receivedWheelEvent):
(WebCore::ScrollingTreeLatchingController::latchingDataForEvent const):
(WebCore::ScrollingTreeLatchingController::latchedNodeHasRecentInteraction const):
(WebCore::ScrollingTreeLatchingController::latchedNodeIsRelevant const): Deleted.
* Source/WebCore/page/scrolling/ScrollingTreeLatchingController.h:

Canonical link: <a href="https://commits.webkit.org/312628@main">https://commits.webkit.org/312628@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a1885d1572f1faa3409fd5103701f8ac6dd6f15c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/160607 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/34080 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/27181 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/169510 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/115673 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/f5eb282e-e90b-453c-a7e3-7edf1fc7fa67) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/162476 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/34181 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/34080 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/124550 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/115673 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/e2b60b2f-6146-4679-856f-a61864b6e35c) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/163566 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/26803 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/144268 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/105150 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/d05be91f-fcf9-4e7e-9ba6-d746271a913a) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/25855 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/24352 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/17230 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/135549 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/167/builds/22031 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/171989 "Built successfully") | | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/18866 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/23671 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/132817 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/33754 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/28445 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/132832 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/33738 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/143826 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/95542 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/24428 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/27427 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/20641 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/33249 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/100477 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/32748 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/32992 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/32896 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->