### PR TITLE
Animated models unexpectedly loop back automatically

### DIFF
--- a/LayoutTests/model-element/model-element-animations-loop-expected.txt
+++ b/LayoutTests/model-element/model-element-animations-loop-expected.txt
@@ -3,4 +3,6 @@ PASS <model> with loop=false should stop after reaching its duration
 PASS <model> with negative playbackRate and loop=false should stop after seeking near the beginning
 PASS <model> with loop=true should loop and continue playing after reaching its duration
 PASS <model> with negative playbackRate and loop=true should loop and continue playing after reaching the beginning
+PASS <model> with loop=false should have currentTime equal to duration after animation completes
+PASS <model> with loop=false should be replayable after animation completes
 

--- a/LayoutTests/model-element/model-element-animations-loop.html
+++ b/LayoutTests/model-element/model-element-animations-loop.html
@@ -53,5 +53,31 @@ promise_test(async t => {
     assert_false(model.paused, "Model animation should keep playing after reaching beginning with negative rate and looping");
 }, `<model> with negative playbackRate and loop=true should loop and continue playing after reaching the beginning`);
 
+promise_test(async t => {
+    const [model, source] = createModelAndSource(t, "resources/stopwatch-60s.usdz");
+    await model.ready;
+
+    await model.play();
+    model.currentTime = model.duration - 0.01;
+    await sleepForSeconds(0.2);
+    assert_true(model.paused, "Model animation should be paused after completion");
+    assert_approx_equals(model.currentTime, model.duration, 0.1, "currentTime should hold at duration after non-looping animation completes");
+}, `<model> with loop=false should have currentTime equal to duration after animation completes`);
+
+promise_test(async t => {
+    const [model, source] = createModelAndSource(t, "resources/stopwatch-60s.usdz");
+    await model.ready;
+
+    await model.play();
+    model.currentTime = model.duration - 0.01;
+    await sleepForSeconds(0.2);
+    assert_true(model.paused, "Model animation should be paused after completion");
+
+    model.currentTime = 0;
+    assert_approx_equals(model.currentTime, 0, 0.1, "currentTime should be 0 after seeking");
+    await model.play();
+    assert_false(model.paused, "Model animation should be playing after replay");
+}, `<model> with loop=false should be replayable after animation completes`);
+
 </script>
 </body>

--- a/Source/WebKit/WebKitSwift/RealityKit/WKRKEntity.swift
+++ b/Source/WebKit/WebKitSwift/RealityKit/WKRKEntity.swift
@@ -50,6 +50,10 @@ extension WKRKEntity {
     private var backingDuration: TimeInterval? = nil
     @nonobjc
     private var backingPlaybackRate: Float = 1.0
+    @nonobjc
+    private var backingAnimation: AnimationResource? = nil
+    @nonobjc
+    private var backingCurrentTime: TimeInterval = 0
 
     private static var defaultEnvironmentResource: EnvironmentResource?
 
@@ -185,6 +189,17 @@ extension WKRKEntity {
             animationPlaybackController?.isPaused ?? true
         }
         set {
+            if animationPlaybackController == nil {
+                guard !newValue, let animation = backingAnimation else {
+                    return
+                }
+                let controller = entity.playAnimation(animation, startsPaused: false)
+                controller.speed = backingPlaybackRate
+                animationPlaybackController = controller
+                animationPlaybackStateDidUpdate()
+                return
+            }
+
             guard let animationPlaybackController, animationPlaybackController.isPaused != newValue else {
                 return
             }
@@ -200,11 +215,21 @@ extension WKRKEntity {
 
     var currentTime: TimeInterval {
         get {
-            animationPlaybackController?.time ?? 0
+            animationPlaybackController?.time ?? backingCurrentTime
         }
 
         set {
-            guard let animationPlaybackController, let duration = backingDuration else {
+            guard let duration = backingDuration else {
+                return
+            }
+
+            if animationPlaybackController == nil, let animation = backingAnimation {
+                let controller = entity.playAnimation(animation, startsPaused: true)
+                controller.speed = backingPlaybackRate
+                animationPlaybackController = controller
+            }
+
+            guard let animationPlaybackController else {
                 return
             }
 
@@ -222,6 +247,7 @@ extension WKRKEntity {
             return
         }
 
+        backingAnimation = animation
         animationPlaybackController = entity.playAnimation(animation, startsPaused: !autoplay)
         guard let animationPlaybackController else {
             Logger.realityKitEntity.error("Cannot play entity animation")
@@ -246,8 +272,14 @@ extension WKRKEntity {
                 return
             }
 
-            let startsPaused = !self.loop
-            let animationController = self.entity.playAnimation(animation, startsPaused: startsPaused)
+            guard self.loop else {
+                self.backingCurrentTime = self.backingDuration ?? 0
+                self.animationPlaybackController = nil
+                self.animationPlaybackStateDidUpdate()
+                return
+            }
+
+            let animationController = self.entity.playAnimation(animation, startsPaused: false)
             animationController.speed = self.backingPlaybackRate
             self.animationPlaybackController = animationController
             self.animationPlaybackStateDidUpdate()


### PR DESCRIPTION
#### 571830838b6c0b1c551b9af44ca71d3454031c6c
<pre>
Animated models unexpectedly loop back automatically
<a href="https://bugs.webkit.org/show_bug.cgi?id=314059">https://bugs.webkit.org/show_bug.cgi?id=314059</a>
<a href="https://rdar.apple.com/176190998">rdar://176190998</a>

Reviewed by Etienne Segonzac.

Previously, when a non-looping animation completed, a new paused animation
controller was created at frame 0, causing the entity to visually snap back
to its initial pose. Now the controller is released on completion so the
entity holds its final frame. The animation resource is retained so that
setting currentTime or paused after completion lazily recreates the
controller, preserving the ability to replay.

* LayoutTests/model-element/model-element-animations-loop-expected.txt:
* LayoutTests/model-element/model-element-animations-loop.html:

* Source/WebKit/WebKitSwift/RealityKit/WKRKEntity.swift:
(WKRKEntity.backingAnimation):
(WKRKEntity.backingCurrentTime):
(WKRKEntity.paused):
(WKRKEntity.currentTime):
(WKRKEntity.setUpAnimationWithAutoPlay(_:)):

Canonical link: <a href="https://commits.webkit.org/312777@main">https://commits.webkit.org/312777@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0cffef9380cfe248d79f266ca752f8c545ecdcf7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/160562 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/34035 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/27136 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/169465 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/115628 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/34136 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/34035 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/124513 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/87935 "2 flakes 2 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/163521 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/26757 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/144232 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/105113 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/25809 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/24310 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/17185 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/135503 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/21995 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/171944 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/18755 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/23635 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/132780 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/33709 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/28403 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/132795 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35974 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/33693 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/143790 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/95489 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/27385 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/20604 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/33204 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/100359 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/32703 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/32947 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/32851 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->