### PR TITLE
Cherry-pick 311862@main (ebcf88c1bc30). https://bugs.webkit.org/show_bug.cgi?id=312236

### DIFF
--- a/LayoutTests/accessibility/aria-hidden-deep-dom-no-crash-expected.txt
+++ b/LayoutTests/accessibility/aria-hidden-deep-dom-no-crash-expected.txt
@@ -1,0 +1,9 @@
+This test ensures toggling aria-hidden on a deep DOM does not crash due to unbounded recursion in enumerateDescendantsIncludingIgnored.
+
+PASS: webArea.childrenCount === 0
+PASS: webArea.childrenCount > 0 === true
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+Deep content

--- a/LayoutTests/accessibility/aria-hidden-deep-dom-no-crash.html
+++ b/LayoutTests/accessibility/aria-hidden-deep-dom-no-crash.html
@@ -1,0 +1,42 @@
+<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
+<html>
+<head>
+<script src="../resources/accessibility-helper.js"></script>
+<script src="../resources/js-test.js"></script>
+</head>
+<body>
+
+<div id="container"></div>
+
+<script>
+var output = "This test ensures toggling aria-hidden on a deep DOM does not crash due to unbounded recursion in enumerateDescendantsIncludingIgnored.\n\n";
+
+let container = document.getElementById("container");
+let deepest = container;
+for (let i = 0; i < 509; i++) {
+    const div = document.createElement("div");
+    deepest.appendChild(div);
+    deepest = div;
+}
+deepest.innerText = "Deep content";
+
+if (window.accessibilityController) {
+    window.jsTestIsAsync = true;
+
+    var webArea = accessibilityController.rootElement.childAtIndex(0);
+    setTimeout(async function() {
+        // Toggle aria-hidden to trigger recomputeIsIgnoredForDescendants, which
+        // calls enumerateDescendantsIncludingIgnored on the entire subtree.
+        container.setAttribute("aria-hidden", "true");
+        output += await expectAsync("webArea.childrenCount", "0");
+
+        container.setAttribute("aria-hidden", "false");
+        output += await expectAsync("webArea.childrenCount > 0", "true");
+
+        debug(output);
+        finishJSTest();
+    }, 0);
+}
+</script>
+</body>
+</html>

--- a/Source/WebCore/accessibility/AXCoreObject.h
+++ b/Source/WebCore/accessibility/AXCoreObject.h
@@ -1509,6 +1509,8 @@ inline bool AXCoreObject::emitsNewline() const
 
 namespace Accessibility {
 
+constexpr unsigned maxDescendantTraversalIterations = 100000;
+
 template<typename T, typename MatchFunctionT, typename StopFunctionT>
 T* crossFrameFindAncestor(const T& object, bool includeSelf, const MatchFunctionT& matches, const StopFunctionT& shouldStop)
 {
@@ -1596,11 +1598,36 @@ AXCoreObject* findUnignoredDescendant(T& object, bool includeSelf, const F& matc
     if (includeSelf && matches(object) && !object.isIgnored())
         return &object;
 
-    for (Ref child : object.childrenIncludingIgnored()) {
-        if (RefPtr descendant = findUnignoredDescendant(child.get(), /* includeSelf */ true, matches))
-            return descendant.unsafeGet();
+    Vector<Ref<AXCoreObject>> stack;
+    for (const auto& child : object.childrenIncludingIgnored())
+        stack.append(child);
+
+    unsigned iterationCount = 0;
+#if AX_ASSERTS_ENABLED
+    HashSet<Ref<AXCoreObject>> visited;
+#endif
+
+    RefPtr<AXCoreObject> result = nullptr;
+    while (!stack.isEmpty()) {
+        if (++iterationCount > maxDescendantTraversalIterations)
+            break;
+
+        Ref current = stack.takeLast();
+#if AX_ASSERTS_ENABLED
+        bool foundCycle = !visited.add(current.copyRef()).isNewEntry;
+        AX_ASSERT(!foundCycle);
+        if (foundCycle)
+            break;
+#endif
+        if (matches(current.get()) && !current->isIgnored()) {
+            result = current.ptr();
+            break;
+        }
+
+        for (const auto& child : current->childrenIncludingIgnored())
+            stack.append(child);
     }
-    return nullptr;
+    return result.unsafeGet();
 }
 
 template<typename T, typename F>
@@ -1629,8 +1656,30 @@ void enumerateDescendantsIncludingIgnored(T& object, bool includeSelf, const F& 
     if (includeSelf)
         lambda(object);
 
-    for (const auto& child : object.childrenIncludingIgnored())
-        enumerateDescendantsIncludingIgnored(child.get(), true, lambda);
+    unsigned iterationCount = 0;
+#if AX_ASSERTS_ENABLED
+    HashSet<Ref<AXCoreObject>> visited;
+#endif
+
+    Vector<Ref<AXCoreObject>> stack;
+    for (auto& child : object.childrenIncludingIgnored())
+        stack.append(child);
+
+    while (!stack.isEmpty()) {
+        if (++iterationCount > maxDescendantTraversalIterations)
+            break;
+
+        Ref current = stack.takeLast();
+#if AX_ASSERTS_ENABLED
+        bool foundCycle = !visited.add(current.copyRef()).isNewEntry;
+        AX_ASSERT(!foundCycle);
+        if (foundCycle)
+            break;
+#endif
+        lambda(current.get());
+        for (auto& child : current->childrenIncludingIgnored())
+            stack.append(child);
+    }
 }
 
 template<typename T, typename F>
@@ -1639,11 +1688,30 @@ void enumerateUnignoredDescendants(T& object, bool includeSelf, const F& lambda)
     if (includeSelf)
         lambda(object);
 
-    // We have a reference to unignored children here, so it's possible that it will change when enumerating the unignored
-    // descendants, so copying here ensures they don't change.
-    auto children = object.unignoredChildren();
-    for (const auto& child : children)
-        enumerateUnignoredDescendants(child.get(), true, lambda);
+    Vector<Ref<AXCoreObject>> stack;
+    for (const auto& child : object.unignoredChildren())
+        stack.append(child);
+
+    unsigned iterationCount = 0;
+#if AX_ASSERTS_ENABLED
+    HashSet<Ref<AXCoreObject>> visited;
+#endif
+
+    while (!stack.isEmpty()) {
+        if (++iterationCount > maxDescendantTraversalIterations)
+            break;
+
+        Ref current = stack.takeLast();
+#if AX_ASSERTS_ENABLED
+        bool foundCycle = !visited.add(current.copyRef()).isNewEntry;
+        AX_ASSERT(!foundCycle);
+        if (foundCycle)
+            break;
+#endif
+        lambda(current.get());
+        for (const auto& child : current->unignoredChildren())
+            stack.append(child);
+    }
 }
 
 template<typename U> inline void performFunctionOnMainThreadAndWait(U&& lambda)

--- a/Source/WebCore/contentextensions/ImmutableNFA.h
+++ b/Source/WebCore/contentextensions/ImmutableNFA.h
@@ -36,6 +36,8 @@ namespace ContentExtensions {
 
 template <typename CharacterType>
 struct ImmutableRange {
+    ImmutableRange() { zeroBytes(*this); }
+
     uint32_t targetStart;
     uint32_t targetEnd;
     CharacterType first;

--- a/Source/WebCore/contentextensions/ImmutableNFANodeBuilder.h
+++ b/Source/WebCore/contentextensions/ImmutableNFANodeBuilder.h
@@ -195,7 +195,12 @@ private:
                 m_immutableNFA->targets.append(target);
             unsigned targetsEnd = m_immutableNFA->targets.size();
 
-            m_immutableNFA->transitions.append(ImmutableRange<CharacterType> { targetsStart, targetsEnd, range.first, range.last });
+            ImmutableRange<CharacterType> transition;
+            transition.targetStart = targetsStart;
+            transition.targetEnd = targetsEnd;
+            transition.first = range.first;
+            transition.last = range.last;
+            m_immutableNFA->transitions.append(WTF::move(transition));
         }
         unsigned transitionsEnd = m_immutableNFA->transitions.size();
 

--- a/Source/WebCore/inspector/agents/InspectorLayerTreeAgent.cpp
+++ b/Source/WebCore/inspector/agents/InspectorLayerTreeAgent.cpp
@@ -360,7 +360,7 @@ Inspector::CommandResult<String> InspectorLayerTreeAgent::requestContent(const I
 
     FloatSize layerSize = graphicsLayer->size();
     if (layerSize.isEmpty())
-        return makeUnexpected("Layer has zero size"_s);
+        return emptyString();
 
     constexpr float scaleFactor = 2.0;
     IntSize integralSize = IntSize(layerSize);

--- a/Source/WebCore/platform/glib/UserAgentQuirks.cpp
+++ b/Source/WebCore/platform/glib/UserAgentQuirks.cpp
@@ -92,6 +92,9 @@ static bool urlRequiresFirefoxBrowser(const String& domain)
 #if ENABLE(THUNDER)
     if (domain == "www.netflix.com"_s)
         return true;
+
+    if (domain == "www.disneyplus.com"_s)
+        return true;
 #endif
 
     return false;

--- a/Source/WebCore/style/MatchedDeclarationsCache.cpp
+++ b/Source/WebCore/style/MatchedDeclarationsCache.cpp
@@ -181,6 +181,11 @@ void MatchedDeclarationsCache::add(const RenderStyle& style, const RenderStyle& 
     });
     if (addResult.iterator->value.size() < maxEntriesPerHash)
         addResult.iterator->value.append(Entry { &matchResult, RenderStyle::clonePtr(style), RenderStyle::clonePtr(parentStyle) });
+
+    // Protect against unlimited growth.
+    constexpr size_t maximumSize = 16 * 1024;
+    if (m_entries.size() > maximumSize)
+        m_entries.remove(m_entries.random());
 }
 
 void MatchedDeclarationsCache::remove(unsigned hash)

--- a/Source/WebInspectorUI/UserInterface/Controllers/LayerTreeManager.js
+++ b/Source/WebInspectorUI/UserInterface/Controllers/LayerTreeManager.js
@@ -211,7 +211,7 @@ WI.LayerTreeManager = class LayerTreeManager extends WI.Object
                 callback(null);
                 return;
             }
-            callback(content);
+            callback(content || null);
         });
     }
 

--- a/Tools/TestWebKitAPI/Tests/WebCore/UserAgentQuirks.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/UserAgentQuirks.cpp
@@ -103,6 +103,7 @@ TEST(UserAgentTest, Quirks)
 
 #if ENABLE(THUNDER)
     assertUserAgentForURLHasFirefoxBrowserQuirk("http://www.netflix.com/");
+    assertUserAgentForURLHasFirefoxBrowserQuirk("http://www.disneyplus.com/");
 #endif
 
     assertUserAgentForURLHasMacPlatformQuirk("http://www.yahoo.com/");


### PR DESCRIPTION
#### bd4109270ef111055a019a637ad96311017b0449
<pre>
Cherry-pick 311862@main (ebcf88c1bc30). <a href="https://bugs.webkit.org/show_bug.cgi?id=312236">https://bugs.webkit.org/show_bug.cgi?id=312236</a>

    Page memory grows unboundedly when animating @property-registered custom properties consumed by calc() across many elements
    <a href="https://bugs.webkit.org/show_bug.cgi?id=312236">https://bugs.webkit.org/show_bug.cgi?id=312236</a>
    <a href="https://rdar.apple.com/171659746">rdar://171659746</a>

    Reviewed by Simon Fraser.

    Some scenarios like animated custom properties may lead to unlimited cache growth. While these should be fixed
    with a better cache design it is also good idea to protect against this with a hard maximum size.

    * Source/WebCore/style/MatchedDeclarationsCache.cpp:
    (WebCore::Style::MatchedDeclarationsCache::add):

    Limit MDC size to 16k entries.

    Canonical link: <a href="https://commits.webkit.org/311862@main">https://commits.webkit.org/311862@main</a>

Canonical link: <a href="https://commits.webkit.org/305877.473@webkitglib/2.52">https://commits.webkit.org/305877.473@webkitglib/2.52</a>
</pre>
----------------------------------------------------------------------
#### e4da6546450a23e93bc733749efa9af7c7dc5b01
<pre>
Cherry-pick 312425@main (07918cccab88). <a href="https://bugs.webkit.org/show_bug.cgi?id=312298">https://bugs.webkit.org/show_bug.cgi?id=312298</a>

    Uninitialized memory write in WebCore::ContentExtensions::SerializedNFA::serialize
    <a href="https://bugs.webkit.org/show_bug.cgi?id=312298">https://bugs.webkit.org/show_bug.cgi?id=312298</a>
    <a href="https://rdar.apple.com/175273937">rdar://175273937</a>

    Reviewed by Michael Catanzaro.

    ImmutableRange&lt;char&gt; has 2 bytes of struct padding after its char fields.
    When SerializedNFA serializes the transitions vector as raw bytes, valgrind
    flags those uninitialized padding bytes passed to the write() syscall.

    Add a default constructor that calls zeroBytes() to ensure padding is
    always zeroed.

    * Source/WebCore/contentextensions/ImmutableNFA.h:
    (WebCore::ContentExtensions::ImmutableRange::ImmutableRange):
    * Source/WebCore/contentextensions/ImmutableNFANodeBuilder.h:
    (WebCore::ContentExtensions::ImmutableNFANodeBuilder::sinkTransitions):

    Canonical link: <a href="https://commits.webkit.org/312425@main">https://commits.webkit.org/312425@main</a>

Canonical link: <a href="https://commits.webkit.org/305877.472@webkitglib/2.52">https://commits.webkit.org/305877.472@webkitglib/2.52</a>
</pre>
----------------------------------------------------------------------
#### 306ced7208c5521d1157324f3538fd61210544b9
<pre>
Cherry-pick 311611@main (e22f4427f1ee). <a href="https://bugs.webkit.org/show_bug.cgi?id=312780">https://bugs.webkit.org/show_bug.cgi?id=312780</a>

    AX: Convert recursive descendant traversal functions to iterative to prevent stack overflow
    <a href="https://bugs.webkit.org/show_bug.cgi?id=312780">https://bugs.webkit.org/show_bug.cgi?id=312780</a>
    <a href="https://rdar.apple.com/172861598">rdar://172861598</a>

    Reviewed by Joshua Hoffman.

    enumerateDescendantsIncludingIgnored, findUnignoredDescendant, and
    enumerateUnignoredDescendants used unbounded recursion to traverse the
    accessibility tree. This could cause stack overflow in two scenarios:

      1. JavaScript constructs a deeply nested DOM (e.g. via appendChild) and
         toggles aria-hidden, recomputeIsIgnoredForDescendants calls enumerateDescendantsIncludingIgnored,
         which recurses through every descendant with no depth limit.

      2. The tree has a cycle, and we recurse infinitely following the cycle
         until we crash.

    This commit converts all three functions from recursion to iterative DFS
    using an explicit Vector stack, preventing the possibility of stack overflow.
    An iteration limit is added to avoid looping forever, and asserts are
    added to detect cyles so we can try to debug and fix them (if that is
    indeed what was causing this).

    * LayoutTests/accessibility/aria-hidden-deep-dom-no-crash-expected.txt: Added.
    * LayoutTests/accessibility/aria-hidden-deep-dom-no-crash.html: Added.
    * Source/WebCore/accessibility/AXCoreObject.h:
    (WebCore::Accessibility::findUnignoredDescendant):
    (WebCore::Accessibility::enumerateDescendantsIncludingIgnored):
    (WebCore::Accessibility::enumerateUnignoredDescendants):

    Canonical link: <a href="https://commits.webkit.org/311611@main">https://commits.webkit.org/311611@main</a>

Canonical link: <a href="https://commits.webkit.org/305877.471@webkitglib/2.52">https://commits.webkit.org/305877.471@webkitglib/2.52</a>
</pre>
----------------------------------------------------------------------
#### 23c92463651b8d38d616e449d97205a52e515c2b
<pre>
Cherry-pick 312435@main (95810670932e). <a href="https://bugs.webkit.org/show_bug.cgi?id=307431">https://bugs.webkit.org/show_bug.cgi?id=307431</a>

    Navigating with the Layers inspector tab open breaks the visualization
    <a href="https://bugs.webkit.org/show_bug.cgi?id=307431">https://bugs.webkit.org/show_bug.cgi?id=307431</a>
    <a href="https://rdar.apple.com/170836910">rdar://170836910</a>

    Reviewed by Devin Rousso and Qianlang Chen.

    There&apos;s a race condition that occurs between backend and frontend during page reload/navigation
    while the Layers tab is open resulting in requesting layer snapshots for layers that have been
    resized to zero during the transition.

    Page navigation triggers a `WI.LayerTreeManager.Event.LayerTreeDidChange` event which
    `WI.Layers3DContentView.prototype._layerTreeDidChange` handles by causing layout of the Layers tab.

    Layout fetches layers via `WI.Layers3DContentView.prototype.layersForNode()`. At this point,
    layers exist and have valid sizes. Then for each layer, the frontend calls:
    `_populateLayerGroup()` → `_loadLayerTexture()` → `snapshotForLayer()`.

    The request for snapshot sends `LayerTreeAgent.requestContent` to the backend. But, during the
    navigation, the render tree has changed: layers may have been destroyed, lost their compositing backing,
    lost their graphics layer, or resized to zero during the transition.
    All states throw errors in `InspectorLayerTreeAgent::requestContent`.

    The zero-size case is common because, during navigation, the new page&apos;s render tree initially creates
    layers with zero dimensions before layout runs.

    The error returned by the backend is handled by calling the callback to `snapshotForLayer()` with `null`
    which is a case handled further down the call chain in `WI.Layers3DContentView.prototype._loadLayerTexture()`.

    This is only an issue in Engineering / Debug builds of Web Inspector where
    `WI.reportInternalError(error)` surfaces the exception. In release builds, the `null` case is silently handled.
    This patch changes the backend to return an empty string instead of throwing an error for zero-size layers
    given how common the case is during page navigation and that zero-sized layers aren&apos;t really an error state.

    The issue itself is transient because during reload/navigation, more layer tree change events are dispatched.

    The compositing update that resized layers to zero isn&apos;t the last one. When the new page finishes loading and layout,
    `RenderLayerCompositor::updateCompositingLayers` runs again, firing another event.

    The failed snapshot from the transitional state just results in `callback(null)` in
    `WI.Layers3DContentView.prototype._loadLayerTexture`, which means no texture is applied to that layer group.
    Then, the next successful cycle replaces it with the correct textured mesh.

    The zero-size layer error only hits during the intermediate state. The final stable state always produces a clean pass.

    * Source/WebCore/inspector/agents/InspectorLayerTreeAgent.cpp:
    (WebCore::InspectorLayerTreeAgent::requestContent):
    * Source/WebInspectorUI/UserInterface/Controllers/LayerTreeManager.js:
    (WI.LayerTreeManager.prototype.snapshotForLayer):

    Canonical link: <a href="https://commits.webkit.org/312435@main">https://commits.webkit.org/312435@main</a>

Canonical link: <a href="https://commits.webkit.org/305877.470@webkitglib/2.52">https://commits.webkit.org/305877.470@webkitglib/2.52</a>
</pre>
----------------------------------------------------------------------
#### 22684bbb9321e60115f0397bdfc77eb8abca61bd
<pre>
Cherry-pick 312508@main (80b3082d0146). <a href="https://bugs.webkit.org/show_bug.cgi?id=313813">https://bugs.webkit.org/show_bug.cgi?id=313813</a>

    [WPE][GTK] Add a user-agent quirk for disney+
    <a href="https://bugs.webkit.org/show_bug.cgi?id=313813">https://bugs.webkit.org/show_bug.cgi?id=313813</a>

    Reviewed by Carlos Garcia Campos.

    Without this quirk only Fairplay DRM is attempted when trying to play DRM content, because we would
    be detected as a Safari UA. By faking a Firefox UA the page might prompt for more DRM systems, such
    as Widevine.

    * Source/WebCore/platform/glib/UserAgentQuirks.cpp:
    (WebCore::urlRequiresFirefoxBrowser):

    Canonical link: <a href="https://commits.webkit.org/312508@main">https://commits.webkit.org/312508@main</a>

Canonical link: <a href="https://commits.webkit.org/305877.469@webkitglib/2.52">https://commits.webkit.org/305877.469@webkitglib/2.52</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6e986305994279c266948e941bfcde7eb2c22e62

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/160530 "1 style error") | [❌ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/34003 "Unable to build WebKit without PR, please check manually (failure)") | [❌ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/27104 "Unable to build WebKit without PR, please check manually (failure)") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/169433 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/115596 "The change is no longer eligible for processing.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/162399 "Passed tests") | [❌ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/34104 "Unable to build WebKit without PR, please check manually (failure)") | [❌ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/34003 "Unable to build WebKit without PR, please check manually (failure)") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/124484 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/115596 "The change is no longer eligible for processing.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/163488 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/155/builds/34104 "Unable to build WebKit without PR, please check manually (failure)") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/168/builds/27104 "Unable to build WebKit without PR, please check manually (failure)") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/105084 "Passed tests") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/155/builds/34104 "Unable to build WebKit without PR, please check manually (failure)") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/156/builds/34003 "Unable to build WebKit without PR, please check manually (failure)") | [❌ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/17152 "Unable to build WebKit without PR, please check manually (failure)") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/155/builds/34104 "Unable to build WebKit without PR, please check manually (failure)") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/168/builds/27104 "Unable to build WebKit without PR, please check manually (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/171912 "Built successfully") | 
| | [❌ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/18716 "Failed to checkout and rebase branch from PR 64254") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/168/builds/27104 "Unable to build WebKit without PR, please check manually (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/132749 "Passed tests") | 
| | [❌ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/33677 "Unable to build WebKit without PR, please check manually (failure)") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/156/builds/34003 "Unable to build WebKit without PR, please check manually (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/132763 "Passed tests") | 
| | [❌ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/33661 "Unable to build WebKit without PR, please check manually (failure)") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/168/builds/27104 "Unable to build WebKit without PR, please check manually (failure)") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/95448 "The change is no longer eligible for processing.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/24424 "Built successfully and passed tests") | [❌ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/160/builds/33661 "Unable to build WebKit without PR, please check manually (failure)") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/168/builds/27104 "Unable to build WebKit without PR, please check manually (failure)") | | 
| | [❌ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/33171 "Unable to build WebKit without PR, please check manually (failure)") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/100319 "Failed to checkout and rebase branch from PR 64254") | | 
| | [❌ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/32671 "Unable to build WebKit without PR, please check manually (failure)") | | | 
| | [❌ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/32915 "Unable to build WebKit without PR, please check manually (failure)") | | | 
| | [❌ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/32819 "Unable to build WebKit without PR, please check manually (failure)") | | | 
<!--EWS-Status-Bubble-End-->