### PR TITLE
[HDR] Replace ShouldDecodeToHDR with DecodingDestination

### DIFF
--- a/Source/WebCore/platform/graphics/BitmapImage.cpp
+++ b/Source/WebCore/platform/graphics/BitmapImage.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2006 Samuel Weinig (sam.weinig@gmail.com)
- * Copyright (C) 2004-2025 Apple Inc. All rights reserved.
+ * Copyright (C) 2004-2026 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -101,9 +101,10 @@ ImageDrawResult BitmapImage::draw(GraphicsContext& context, const FloatRect& des
     auto scaleFactorForDrawing = context.scaleFactorForDrawing(destinationRect, adjustedSourceRect);
     auto sizeForDrawing = expandedIntSize(sourceSize * scaleFactorForDrawing);
     auto subsamplingLevel =  m_source->subsamplingLevelForScaleFactor(context, scaleFactorForDrawing, options.allowImageSubsampling());
-    auto shouldDecodeToHDR = m_source->hasHDRGainMap() && options.drawsHDRContent() == DrawsHDRContent::Yes && options.dynamicRangeLimit() != PlatformDynamicRangeLimit::standard() ? ShouldDecodeToHDR::Yes : ShouldDecodeToHDR::No;
+    auto preferredDecodingDestination = m_source->preferredDecodingDestination(context, options);
 
-    auto nativeImageOrError = m_source->currentNativeImageForDrawing(subsamplingLevel, { options.decodingMode(), shouldDecodeToHDR, sizeForDrawing });
+    auto decodingOptions = DecodingOptions { options.decodingMode(), preferredDecodingDestination, sizeForDrawing };
+    auto nativeImageOrError = m_source->currentNativeImageForDrawing(subsamplingLevel, decodingOptions);
 
     if (!nativeImageOrError) {
         // The decoder has not returned a frame. Fill the image rectangle with a debugging color to show what has happened.
@@ -137,7 +138,7 @@ ImageDrawResult BitmapImage::draw(GraphicsContext& context, const FloatRect& des
             auto headroom = options.headroom();
 
             if (headroom == Headroom::FromImage)
-                headroom = currentFrameHeadroom(shouldDecodeToHDR);
+                headroom = nativeImage->headroom();
 
             context.drawNativeImage(nativeImage, destinationRect, adjustedSourceRect, { options, orientation, headroom });
 #if !HAVE(SUPPORT_HDR_DISPLAY_APIS)

--- a/Source/WebCore/platform/graphics/BitmapImage.h
+++ b/Source/WebCore/platform/graphics/BitmapImage.h
@@ -60,7 +60,6 @@ public:
     unsigned currentFrameIndex() const { return m_source->currentFrameIndex(); }
     bool currentFrameHasAlpha() const { return m_source->currentImageFrame().hasAlpha(); }
     ImageOrientation currentFrameOrientation() const { return m_source->currentImageFrame().orientation(); }
-    Headroom currentFrameHeadroom(ShouldDecodeToHDR shouldDecodeToHDR) const { return m_source->currentImageFrame().headroom(shouldDecodeToHDR); }
     DecodingOptions currentFrameDecodingOptions() const { return m_source->currentImageFrame().decodingOptions(std::nullopt); }
 
     // Primary & current NativeImage

--- a/Source/WebCore/platform/graphics/BitmapImageSource.cpp
+++ b/Source/WebCore/platform/graphics/BitmapImageSource.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024-2025 Apple Inc. All rights reserved.
+ * Copyright (C) 2024-2026 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -201,12 +201,12 @@ void BitmapImageSource::decodedSizeReset(unsigned decodedSize)
     decodedSizeChanged(-static_cast<long long>(decodedSize));
 }
 
-void BitmapImageSource::destroyNativeImageAtIndex(unsigned index, std::optional<ShouldDecodeToHDR> shouldDecodeToHDR)
+void BitmapImageSource::destroyNativeImageAtIndex(unsigned index, std::optional<DecodingDestination> decodingDestination)
 {
     if (index >= m_frames.size())
         return;
 
-    decodedSizeDecreased(m_frames[index].clearImage(shouldDecodeToHDR));
+    decodedSizeDecreased(m_frames[index].clearImage(decodingDestination));
 }
 
 bool BitmapImageSource::canDestroyDecodedData() const
@@ -335,6 +335,14 @@ bool BitmapImageSource::hasEverAnimated() const
     return m_frameAnimator && m_frameAnimator->hasEverAnimated();
 }
 
+DecodingDestination BitmapImageSource::preferredDecodingDestination(GraphicsContext&, ImagePaintingOptions options) const
+{
+    if (options.drawsHDRContent() == DrawsHDRContent::No || options.dynamicRangeLimit() == PlatformDynamicRangeLimit::standard() || !hasHDRGainMap())
+        return DecodingDestination::Base;
+
+    return DecodingDestination::ShouldDecodeToHDR;
+}
+
 bool BitmapImageSource::isLargeForDecoding() const
 {
     auto sizeInBytes = size(ImageOrientation::Orientation::None).unclampedArea() * sizeof(uint32_t);
@@ -380,8 +388,8 @@ void BitmapImageSource::decode(Function<void(DecodingStatus)>&& decodeCallback)
     }
 
     // FIXME: HTMLImageElement.decode() needs a parameter to control whether it should decode SDR or HDR image.
-    auto shouldDecodeToHDR = hasHDRGainMap() ? ShouldDecodeToHDR::Yes : ShouldDecodeToHDR::No;
-    bool isCompatibleNativeImage = isCompatibleWithOptionsAtIndex(index, SubsamplingLevel::Default, { DecodingMode::Asynchronous, shouldDecodeToHDR });
+    auto preferredDecodingDestination = hasHDRContent() ? DecodingDestination::ShouldDecodeToHDR : DecodingDestination::Base;
+    auto isCompatibleNativeImage = isCompatibleWithOptionsAtIndex(index, SubsamplingLevel::Default, { DecodingMode::Asynchronous, preferredDecodingDestination });
 
     RefPtr frameAnimator = this->frameAnimator();
     if (frameAnimator && (frameAnimator->hasEverAnimated() || isCompatibleNativeImage)) {
@@ -395,7 +403,7 @@ void BitmapImageSource::decode(Function<void(DecodingStatus)>&& decodeCallback)
 
     if (!isCompatibleNativeImage) {
         LOG(Images, "BitmapImageSource::%s - %p - url: %s. Decoding for frame at index = %d will be requested.", __FUNCTION__, this, sourceUTF8().data(), index);
-        requestNativeImageAtIndex(index, SubsamplingLevel::Default, ImageAnimatingState::No, { DecodingMode::Asynchronous, shouldDecodeToHDR });
+        requestNativeImageAtIndex(index, SubsamplingLevel::Default, ImageAnimatingState::No, { DecodingMode::Asynchronous, preferredDecodingDestination });
         return;
     }
 
@@ -443,7 +451,7 @@ void BitmapImageSource::imageFrameDecodeAtIndexHasFinished(unsigned index, Subsa
     if (!nativeImage || !m_decoder) {
         LOG(Images, "BitmapImageSource::%s - %p - url: %s. Frame at index = %d has failed.", __FUNCTION__, this, sourceUTF8().data(), index);
 
-        destroyNativeImageAtIndex(index, options.shouldDecodeToHDR());
+        destroyNativeImageAtIndex(index, options.decodingDestination());
         imageFrameDecodeAtIndexHasFinished(index, animatingState, DecodingStatus::Invalid);
     } else {
         LOG(Images, "BitmapImageSource::%s - %p - url: %s. Frame at index = %d has been decoded.", __FUNCTION__, this, sourceUTF8().data(), index);
@@ -488,7 +496,7 @@ void BitmapImageSource::cacheNativeImageAtIndex(unsigned index, SubsamplingLevel
     if (index >= m_frames.size())
         return;
 
-    destroyNativeImageAtIndex(index, options.shouldDecodeToHDR());
+    destroyNativeImageAtIndex(index, options.decodingDestination());
 
     // Do not cache NativeImage if adding its sizeInBytes to MemoryCache will cause numerical overflow.
     auto sizeInBytes = nativeImage->sizeInBytes();
@@ -496,10 +504,10 @@ void BitmapImageSource::cacheNativeImageAtIndex(unsigned index, SubsamplingLevel
         return;
 
     auto& frame = m_frames[index];
-    auto& source = frame.source(options.shouldDecodeToHDR());
-    source.nativeImage = nativeImage.copyRef();
-    source.decodingOptions = options;
-    source.headroom = nativeImage->headroom();
+    auto& destination = frame.destination(options.decodingDestination());
+    destination.nativeImage = nativeImage.copyRef();
+    destination.decodingOptions = options;
+    destination.headroom = nativeImage->headroom();
 
     cacheMetadataAtIndex(index, subsamplingLevel, options);
     decodedSizeIncreased(frame.sizeInBytes());
@@ -585,7 +593,7 @@ Expected<Ref<NativeImage>, DecodingStatus> BitmapImageSource::nativeImageAtIndex
     }
 
     if (!isCompatibleWithOptionsAtIndex(index, subsamplingLevel, options)) {
-        DecodingOptions decodingOptions = { DecodingMode::Synchronous, options.shouldDecodeToHDR() };
+        DecodingOptions decodingOptions = { DecodingMode::Synchronous, options.decodingDestination() };
         PlatformImagePtr platformImage = m_decoder->createFrameImageAtIndex(index, subsamplingLevel, decodingOptions);
 
         RefPtr nativeImage = NativeImage::create(WTF::move(platformImage));
@@ -595,7 +603,7 @@ Expected<Ref<NativeImage>, DecodingStatus> BitmapImageSource::nativeImageAtIndex
         cacheNativeImageAtIndex(index, subsamplingLevel, decodingOptions, nativeImage.releaseNonNull());
     }
 
-    if (RefPtr nativeImage = frameAtIndex(index).nativeImage(options.shouldDecodeToHDR()))
+    if (RefPtr nativeImage = frameAtIndex(index).nativeImage(options.decodingDestination()))
         return nativeImage.releaseNonNull();
 
     return makeUnexpected(DecodingStatus::Invalid);
@@ -612,7 +620,7 @@ Expected<Ref<NativeImage>, DecodingStatus> BitmapImageSource::nativeImageAtIndex
     if (status == DecodingStatus::Invalid || status == DecodingStatus::Decoding)
         return makeUnexpected(status);
 
-    if (RefPtr nativeImage = frameAtIndex(index).nativeImage(options.shouldDecodeToHDR()))
+    if (RefPtr nativeImage = frameAtIndex(index).nativeImage(options.decodingDestination()))
         return nativeImage.releaseNonNull();
 
     return makeUnexpected(DecodingStatus::Invalid);
@@ -636,7 +644,7 @@ Expected<Ref<NativeImage>, DecodingStatus> BitmapImageSource::currentNativeImage
     // If frame0 is displayed for the first time, startAnimation() has to request decoding frame1
     // asynchronously. A flicker will occur if we request decoding frame0 also asynchronously.
     if (options.decodingMode() == DecodingMode::Asynchronous && isAnimated() && !hasEverAnimated())
-        effectiveOptions = { DecodingMode::Synchronous, options.shouldDecodeToHDR(), options.sizeForDrawing() };
+        effectiveOptions = { DecodingMode::Synchronous, options.decodingDestination(), options.sizeForDrawing() };
 
     return nativeImageAtIndexForDrawing(currentFrameIndex(), subsamplingLevel, effectiveOptions);
 }

--- a/Source/WebCore/platform/graphics/BitmapImageSource.h
+++ b/Source/WebCore/platform/graphics/BitmapImageSource.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024-2025 Apple Inc. All rights reserved.
+ * Copyright (C) 2024-2026 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -64,7 +64,7 @@ public:
 
     // Decoding & animation
     bool isPendingDecodingAtIndex(unsigned index, SubsamplingLevel, const DecodingOptions&) const;
-    void destroyNativeImageAtIndex(unsigned index, std::optional<ShouldDecodeToHDR> = std::nullopt);
+    void destroyNativeImageAtIndex(unsigned index, std::optional<DecodingDestination> = std::nullopt);
     void imageFrameAtIndexAvailable(unsigned index, ImageAnimatingState, DecodingStatus);
     void imageFrameDecodeAtIndexHasFinished(unsigned index, SubsamplingLevel, ImageAnimatingState, const DecodingOptions&, RefPtr<NativeImage>&&);
 
@@ -123,6 +123,7 @@ private:
     bool hasEverAnimated() const final;
 
     // Decoding
+    DecodingDestination preferredDecodingDestination(GraphicsContext&, ImagePaintingOptions) const final;
     bool isLargeForDecoding() const final;
     bool NODELETE isDecodingWorkQueueIdle() const;
     bool isCompatibleWithOptionsAtIndex(unsigned index, SubsamplingLevel, const DecodingOptions&) const;

--- a/Source/WebCore/platform/graphics/DecodingOptions.h
+++ b/Source/WebCore/platform/graphics/DecodingOptions.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2023 Apple Inc. All rights reserved.
+ * Copyright (C) 2017-2026 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -36,16 +36,17 @@ enum class DecodingMode : uint8_t {
     Asynchronous
 };
 
-enum class ShouldDecodeToHDR : bool {
-    No,
-    Yes
+// FIXME: Add and handle the DecodingDestination::BaseAndGainMap
+enum class DecodingDestination : uint8_t {
+    Base,
+    ShouldDecodeToHDR
 };
 
 class DecodingOptions {
 public:
-    DecodingOptions(DecodingMode decodingMode = DecodingMode::Synchronous, ShouldDecodeToHDR shouldDecodeToHDR = ShouldDecodeToHDR::No, const std::optional<IntSize>& sizeForDrawing = std::nullopt)
+    DecodingOptions(DecodingMode decodingMode = DecodingMode::Synchronous, DecodingDestination decodingDestination = DecodingDestination::Base, const std::optional<IntSize>& sizeForDrawing = std::nullopt)
         : m_decodingMode(decodingMode)
-        , m_shouldDecodeToHDR(shouldDecodeToHDR)
+        , m_decodingDestination(decodingDestination)
         , m_sizeForDrawing(sizeForDrawing)
     {
     }
@@ -57,7 +58,7 @@ public:
     bool isSynchronous() const { return m_decodingMode == DecodingMode::Synchronous; }
     bool isAsynchronous() const { return m_decodingMode == DecodingMode::Asynchronous; }
 
-    ShouldDecodeToHDR shouldDecodeToHDR() const { return m_shouldDecodeToHDR; }
+    DecodingDestination decodingDestination() const { return m_decodingDestination; }
 
     std::optional<IntSize> sizeForDrawing() const { return m_sizeForDrawing; }
     bool hasFullSize() const { return !m_sizeForDrawing; }
@@ -65,7 +66,7 @@ public:
 
     bool isCompatibleWith(const DecodingOptions& other) const
     {
-        if (shouldDecodeToHDR() != other.shouldDecodeToHDR())
+        if (decodingDestination() != other.decodingDestination())
             return false;
 
         if (isAuto() || other.isAuto())
@@ -82,7 +83,7 @@ public:
 
 private:
     DecodingMode m_decodingMode;
-    ShouldDecodeToHDR m_shouldDecodeToHDR;
+    DecodingDestination m_decodingDestination;
     std::optional<IntSize> m_sizeForDrawing;
 };
 

--- a/Source/WebCore/platform/graphics/ImageDecoder.cpp
+++ b/Source/WebCore/platform/graphics/ImageDecoder.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2024 Apple Inc. All rights reserved.
+ * Copyright (C) 2017-2026 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -158,8 +158,8 @@ bool ImageDecoder::supportsMediaType(MediaType type)
 bool ImageDecoder::fetchFrameMetaDataAtIndex(size_t index, SubsamplingLevel subsamplingLevel, const DecodingOptions& options, ImageFrame& frame) const
 {
     if (options.hasSizeForDrawing()) {
-        ASSERT(frame.hasNativeImage(options.shouldDecodeToHDR()));
-        frame.m_size = frame.nativeImage(options.shouldDecodeToHDR())->size();
+        ASSERT(frame.hasNativeImage(options.decodingDestination()));
+        frame.m_size = frame.nativeImage(options.decodingDestination())->size();
     } else
         frame.m_size = frameSizeAtIndex(index, subsamplingLevel);
 

--- a/Source/WebCore/platform/graphics/ImageFrame.cpp
+++ b/Source/WebCore/platform/graphics/ImageFrame.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2025 Apple Inc. All rights reserved.
+ * Copyright (C) 2016-2026 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -37,8 +37,8 @@ ImageFrame::ImageFrame(Ref<NativeImage>&& nativeImage)
     m_size = nativeImage->size();
     m_hasAlpha = nativeImage->hasAlpha();
 
-    m_source.headroom = nativeImage->headroom();
-    m_source.nativeImage = WTF::move(nativeImage);
+    m_destinations[DecodingDestination::Base].headroom = nativeImage->headroom();
+    m_destinations[DecodingDestination::Base].nativeImage = WTF::move(nativeImage);
 }
 
 ImageFrame::~ImageFrame()
@@ -69,29 +69,25 @@ DecodingStatus ImageFrame::decodingStatus() const
 
 size_t ImageFrame::sizeInBytes() const
 {
-    return CheckedSize(m_source.sizeInBytes()) + m_hdrSource.sizeInBytes();
+    CheckedSize sizeInBytes = 0;
+
+    for (auto& destination : m_destinations)
+        sizeInBytes += destination.sizeInBytes();
+
+    return sizeInBytes;
 }
 
-size_t ImageFrame::clearSourceImage(ShouldDecodeToHDR shouldDecodeToHDR)
+size_t ImageFrame::clearImage(std::optional<DecodingDestination> decodingDestination)
 {
-    auto& source = this->source(shouldDecodeToHDR);
-    if (!source.hasNativeImage())
-        return 0;
+    CheckedSize sizeInBytes = 0;
 
-    source.clear();
-    return sizeInBytes();
-}
+    if (!decodingDestination || *decodingDestination == DecodingDestination::Base)
+        sizeInBytes += destination(DecodingDestination::Base).clear();
 
-size_t ImageFrame::clearImage(std::optional<ShouldDecodeToHDR> shouldDecodeToHDR)
-{
-    CheckedSize frameBytes = 0;
-    if (!shouldDecodeToHDR || *shouldDecodeToHDR == ShouldDecodeToHDR::No)
-        frameBytes += clearSourceImage(ShouldDecodeToHDR::No);
+    if (!decodingDestination || *decodingDestination == DecodingDestination::ShouldDecodeToHDR)
+        sizeInBytes += destination(DecodingDestination::ShouldDecodeToHDR).clear();
 
-    if (!shouldDecodeToHDR || *shouldDecodeToHDR == ShouldDecodeToHDR::Yes)
-        frameBytes += clearSourceImage(ShouldDecodeToHDR::Yes);
-
-    return frameBytes;
+    return sizeInBytes;
 }
 
 size_t ImageFrame::clear()
@@ -101,19 +97,19 @@ size_t ImageFrame::clear()
     return sizeInBytes;
 }
 
-bool ImageFrame::hasNativeImage(ShouldDecodeToHDR shouldDecodeToHDR, SubsamplingLevel subsamplingLevel) const
+bool ImageFrame::hasNativeImage(DecodingDestination decodingDestination, SubsamplingLevel subsamplingLevel) const
 {
-    return source(shouldDecodeToHDR).hasNativeImage() && subsamplingLevel >= m_subsamplingLevel;
+    return destination(decodingDestination).hasNativeImage() && subsamplingLevel >= m_subsamplingLevel;
 }
 
-bool ImageFrame::hasFullSizeNativeImage(ShouldDecodeToHDR shouldDecodeToHDR, SubsamplingLevel subsamplingLevel) const
+bool ImageFrame::hasFullSizeNativeImage(DecodingDestination decodingDestination, SubsamplingLevel subsamplingLevel) const
 {
-    return source(shouldDecodeToHDR).hasFullSizeNativeImage() && subsamplingLevel >= m_subsamplingLevel;
+    return destination(decodingDestination).hasFullSizeNativeImage() && subsamplingLevel >= m_subsamplingLevel;
 }
 
 bool ImageFrame::hasDecodedNativeImageCompatibleWithOptions(const DecodingOptions& decodingOptions, SubsamplingLevel subsamplingLevel) const
 {
-    return isComplete() && source(decodingOptions.shouldDecodeToHDR()).hasDecodedNativeImageCompatibleWithOptions(decodingOptions) && subsamplingLevel >= m_subsamplingLevel;
+    return isComplete() && destination(decodingOptions.decodingDestination()).hasDecodedNativeImageCompatibleWithOptions(decodingOptions) && subsamplingLevel >= m_subsamplingLevel;
 }
 
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/ImageFrame.h
+++ b/Source/WebCore/platform/graphics/ImageFrame.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2025 Apple Inc. All rights reserved.
+ * Copyright (C) 2016-2026 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -31,6 +31,7 @@
 #include <WebCore/ImageTypes.h>
 #include <WebCore/IntSize.h>
 #include <WebCore/NativeImage.h>
+#include <wtf/EnumeratedArray.h>
 #include <wtf/Seconds.h>
 
 namespace WebCore {
@@ -52,8 +53,7 @@ public:
 
     ImageFrame& operator=(const ImageFrame&);
 
-    size_t clearSourceImage(ShouldDecodeToHDR);
-    size_t clearImage(std::optional<ShouldDecodeToHDR> = std::nullopt);
+    size_t clearImage(std::optional<DecodingDestination> = std::nullopt);
     size_t clear();
 
     void NODELETE setDecodingStatus(DecodingStatus);
@@ -76,9 +76,9 @@ public:
 
     SubsamplingLevel subsamplingLevel() const { return m_subsamplingLevel; }
 
-    RefPtr<NativeImage> nativeImage(std::optional<ShouldDecodeToHDR> shouldDecodeToHDR) const { return source(shouldDecodeToHDR).nativeImage; }
-    DecodingOptions decodingOptions(std::optional<ShouldDecodeToHDR> shouldDecodeToHDR) const { return source(shouldDecodeToHDR).decodingOptions; }
-    Headroom headroom(std::optional<ShouldDecodeToHDR> shouldDecodeToHDR) const { return source(shouldDecodeToHDR).headroom; }
+    RefPtr<NativeImage> nativeImage(std::optional<DecodingDestination> decodingDestination) const { return destination(decodingDestination).nativeImage; }
+    DecodingOptions decodingOptions(std::optional<DecodingDestination> decodingDestination) const { return destination(decodingDestination).decodingOptions; }
+    Headroom headroom(std::optional<DecodingDestination> decodingDestination) const { return destination(decodingDestination).headroom; }
 
     void setOrientation(ImageOrientation orientation) { m_orientation = orientation; };
     ImageOrientation orientation() const { return m_orientation; }
@@ -89,14 +89,14 @@ public:
     void setHasAlpha(bool hasAlpha) { m_hasAlpha = hasAlpha; }
     bool hasAlpha() const { return !hasMetadata() || m_hasAlpha; }
 
-    bool hasNativeImage(ShouldDecodeToHDR shouldDecodeToHDR) const { return source(shouldDecodeToHDR).hasNativeImage(); }
-    bool NODELETE hasNativeImage(ShouldDecodeToHDR, SubsamplingLevel) const;
-    bool NODELETE hasFullSizeNativeImage(ShouldDecodeToHDR, SubsamplingLevel) const;
+    bool hasNativeImage(DecodingDestination decodingDestination) const { return m_destinations[decodingDestination].hasNativeImage(); }
+    bool NODELETE hasNativeImage(DecodingDestination, SubsamplingLevel) const;
+    bool NODELETE hasFullSizeNativeImage(DecodingDestination, SubsamplingLevel) const;
     bool hasDecodedNativeImageCompatibleWithOptions(const DecodingOptions&, SubsamplingLevel) const;
     bool hasMetadata() const { return !size().isEmpty(); }
 
 private:
-    struct Source {
+    struct Destination {
         RefPtr<NativeImage> nativeImage;
         DecodingOptions decodingOptions { DecodingMode::Auto };
         Headroom headroom { Headroom::None };
@@ -120,35 +120,33 @@ private:
             return 0;
         }
 
-        void clear()
+        size_t clear()
         {
-            if (RefPtr image = std::exchange(nativeImage, nullptr)) {
-                image->clearSubimages();
+            if (RefPtr nativeImage = std::exchange(this->nativeImage, nullptr)) {
+                nativeImage->clearSubimages();
                 decodingOptions = DecodingOptions();
                 headroom = Headroom::None;
+                return nativeImage->sizeInBytes();
             }
+            return 0;
         }
     };
 
-    ShouldDecodeToHDR shouldDecodeToHDRIfExists() const
+    DecodingDestination decodingDestinationIfExists() const
     {
-        return hasNativeImage(ShouldDecodeToHDR::Yes) ? ShouldDecodeToHDR::Yes : ShouldDecodeToHDR::No;
+        if (m_destinations[DecodingDestination::ShouldDecodeToHDR].hasNativeImage())
+            return DecodingDestination::ShouldDecodeToHDR;
+        return DecodingDestination::Base;
     }
 
-    Source& source(std::optional<ShouldDecodeToHDR> shouldDecodeToHDR)
+    Destination& destination(std::optional<DecodingDestination> decodingDestination)
     {
-        if (shouldDecodeToHDR)
-            return *shouldDecodeToHDR == ShouldDecodeToHDR::No ? m_source : m_hdrSource;
-
-        return shouldDecodeToHDRIfExists() == ShouldDecodeToHDR::No ? m_source : m_hdrSource;
+        return m_destinations[decodingDestination.value_or(decodingDestinationIfExists())];
     }
 
-    const Source& source(std::optional<ShouldDecodeToHDR> shouldDecodeToHDR) const
+    const Destination& destination(std::optional<DecodingDestination> decodingDestination) const
     {
-        if (shouldDecodeToHDR)
-            return *shouldDecodeToHDR == ShouldDecodeToHDR::No ? m_source : m_hdrSource;
-
-        return shouldDecodeToHDRIfExists() == ShouldDecodeToHDR::No ? m_source : m_hdrSource;
+        return m_destinations[decodingDestination.value_or(decodingDestinationIfExists())];
     }
 
     DecodingStatus m_decodingStatus { DecodingStatus::Invalid };
@@ -163,8 +161,7 @@ private:
     Seconds m_duration;
     bool m_hasAlpha { true };
 
-    Source m_source;
-    Source m_hdrSource;
+    EnumeratedArray<DecodingDestination, Destination, DecodingDestination::ShouldDecodeToHDR> m_destinations;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/ImageSource.h
+++ b/Source/WebCore/platform/graphics/ImageSource.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2025 Apple Inc. All rights reserved.
+ * Copyright (C) 2016-2026 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -27,6 +27,7 @@
 
 #include <WebCore/ImageFrame.h>
 #include <WebCore/ImageOrientation.h>
+#include <WebCore/ImagePaintingOptions.h>
 #include <WebCore/ImageResolution.h>
 #include <WebCore/ImageTypes.h>
 #include <wtf/ThreadSafeWeakPtr.h>
@@ -59,6 +60,7 @@ public:
     virtual bool hasEverAnimated() const { return false; }
 
     // Decoding
+    virtual DecodingDestination preferredDecodingDestination(GraphicsContext&, ImagePaintingOptions) const { return DecodingDestination::Base; }
     virtual bool isLargeForDecoding() const { return false; }
     virtual void stopDecodingWorkQueue() { RELEASE_ASSERT_NOT_REACHED(); }
     virtual void decode(Function<void(DecodingStatus)>&&)  { RELEASE_ASSERT_NOT_REACHED(); }

--- a/Source/WebCore/platform/graphics/NativeImageSource.h
+++ b/Source/WebCore/platform/graphics/NativeImageSource.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024-2025 Apple Inc. All rights reserved.
+ * Copyright (C) 2024-2026 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -37,13 +37,13 @@ private:
     NativeImageSource(Ref<NativeImage>&&);
 
     IntSize size(ImageOrientation = ImageOrientation::Orientation::FromImage) const final { return m_frame.size(); }
-    DestinationColorSpace colorSpace() const final { return m_frame.nativeImage(ShouldDecodeToHDR::No)->colorSpace(); }
-    std::optional<Color> singlePixelSolidColor() const final { return m_frame.nativeImage(ShouldDecodeToHDR::No)->singlePixelSolidColor(); }
-    bool hasHDRContent() const final { return m_frame.nativeImage(ShouldDecodeToHDR::No)->hasHDRContent(); }
+    DestinationColorSpace colorSpace() const final { return m_frame.nativeImage(DecodingDestination::Base)->colorSpace(); }
+    std::optional<Color> singlePixelSolidColor() const final { return m_frame.nativeImage(DecodingDestination::Base)->singlePixelSolidColor(); }
+    bool hasHDRContent() const final { return m_frame.nativeImage(DecodingDestination::Base)->hasHDRContent(); }
 
     const ImageFrame& primaryImageFrame(const std::optional<SubsamplingLevel>& = std::nullopt) LIFETIME_BOUND final { return m_frame; }
 
-    RefPtr<NativeImage> primaryNativeImage() final { return m_frame.nativeImage(ShouldDecodeToHDR::No); }
+    RefPtr<NativeImage> primaryNativeImage() final { return m_frame.nativeImage(DecodingDestination::Base); }
 
     void dump(TextStream&) const final;
 

--- a/Source/WebCore/platform/graphics/cg/ImageDecoderCG.cpp
+++ b/Source/WebCore/platform/graphics/cg/ImageDecoderCG.cpp
@@ -121,14 +121,14 @@ static void appendImageSourceOption(CFMutableDictionaryRef options, const IntSiz
     CFDictionarySetValue(options, kCGImageSourceThumbnailMaxPixelSize, maxDimensionNumber.get());
 }
 
-static void appendImageSourceOption(CFMutableDictionaryRef options, ShouldDecodeToHDR shouldDecodeToHDR)
+static void appendImageSourceOption(CFMutableDictionaryRef options, DecodingDestination decodingDestination)
 {
 #if HAVE(SUPPORT_HDR_DISPLAY_APIS)
-    if (shouldDecodeToHDR == ShouldDecodeToHDR::Yes)
+    if (decodingDestination == DecodingDestination::ShouldDecodeToHDR)
         CFDictionarySetValue(options, kCGImageSourceDecodeRequest, kCGImageSourceDecodeToHDR);
 #else
     UNUSED_PARAM(options);
-    UNUSED_PARAM(shouldDecodeToHDR);
+    UNUSED_PARAM(decodingDestination);
 #endif
 }
 
@@ -144,19 +144,19 @@ static RetainPtr<CFMutableDictionaryRef> imageSourceMetadataOptions()
     return options;
 }
 
-static RetainPtr<CFDictionaryRef> imageSourceOptions(SubsamplingLevel subsamplingLevel = SubsamplingLevel::Default, ShouldDecodeToHDR shouldDecodeToHDR = ShouldDecodeToHDR::No)
+static RetainPtr<CFDictionaryRef> imageSourceOptions(SubsamplingLevel subsamplingLevel = SubsamplingLevel::Default, DecodingDestination decodingDestination = DecodingDestination::Base)
 {
     static const auto options = createImageSourceOptions().leakRef();
-    if (subsamplingLevel == SubsamplingLevel::Default && shouldDecodeToHDR == ShouldDecodeToHDR::No)
+    if (subsamplingLevel == SubsamplingLevel::Default && decodingDestination == DecodingDestination::Base)
         return options;
 
     auto extendedOptions = adoptCF(CFDictionaryCreateMutableCopy(nullptr, 0, options));
     appendImageSourceOption(extendedOptions.get(), subsamplingLevel);
-    appendImageSourceOption(extendedOptions.get(), shouldDecodeToHDR);
+    appendImageSourceOption(extendedOptions.get(), decodingDestination);
     return extendedOptions;
 }
 
-static RetainPtr<CFDictionaryRef> imageSourceThumbnailOptions(SubsamplingLevel subsamplingLevel, const IntSize& sizeForDrawing, ShouldDecodeToHDR shouldDecodeToHDR = ShouldDecodeToHDR::No)
+static RetainPtr<CFDictionaryRef> imageSourceThumbnailOptions(SubsamplingLevel subsamplingLevel, const IntSize& sizeForDrawing, DecodingDestination decodingDestination = DecodingDestination::Base)
 {
     static CFMutableDictionaryRef options;
     static std::once_flag initializeOptionsOnce;
@@ -167,7 +167,7 @@ static RetainPtr<CFDictionaryRef> imageSourceThumbnailOptions(SubsamplingLevel s
     auto extendedOptions = adoptCF(CFDictionaryCreateMutableCopy(nullptr, 0, options));
     appendImageSourceOption(extendedOptions.get(), subsamplingLevel);
     appendImageSourceOption(extendedOptions.get(), sizeForDrawing);
-    appendImageSourceOption(extendedOptions.get(), shouldDecodeToHDR);
+    appendImageSourceOption(extendedOptions.get(), decodingDestination);
     return extendedOptions;
 }
 
@@ -612,8 +612,8 @@ bool ImageDecoderCG::fetchFrameMetaDataAtIndex(size_t index, SubsamplingLevel su
         return false;
 
     if (options.hasSizeForDrawing()) {
-        ASSERT(frame.hasNativeImage(options.shouldDecodeToHDR()));
-        frame.m_size = frame.nativeImage(options.shouldDecodeToHDR())->size();
+        ASSERT(frame.hasNativeImage(options.decodingDestination()));
+        frame.m_size = frame.nativeImage(options.decodingDestination())->size();
     } else
         frame.m_size = frameSizeFromProperties(properties.get());
 
@@ -676,7 +676,7 @@ PlatformImagePtr ImageDecoderCG::createFrameImageAtIndex(size_t index, Subsampli
 
     if (decodingOptions.decodingMode() == DecodingMode::Synchronous) {
         // Decode an image synchronously for its native size.
-        options = imageSourceOptions(subsamplingLevel, decodingOptions.shouldDecodeToHDR());
+        options = imageSourceOptions(subsamplingLevel, decodingOptions.decodingDestination());
         image = adoptCF(CGImageSourceCreateImageAtIndex(m_nativeDecoder.get(), index, options.get()));
     } else {
         auto size = frameSizeAtIndex(index, SubsamplingLevel::Default);
@@ -688,7 +688,7 @@ PlatformImagePtr ImageDecoderCG::createFrameImageAtIndex(size_t index, Subsampli
                 size = *sizeForDrawing;
         }
 
-        options = imageSourceThumbnailOptions(subsamplingLevel, size, decodingOptions.shouldDecodeToHDR());
+        options = imageSourceThumbnailOptions(subsamplingLevel, size, decodingOptions.decodingDestination());
         image = adoptCF(CGImageSourceCreateThumbnailAtIndex(m_nativeDecoder.get(), index, options.get()));
     }
     


### PR DESCRIPTION
#### 8d2285e7bc8ef4f0ef7a16b14ec73ff89e462b95
<pre>
[HDR] Replace ShouldDecodeToHDR with DecodingDestination
<a href="https://bugs.webkit.org/show_bug.cgi?id=313600">https://bugs.webkit.org/show_bug.cgi?id=313600</a>
<a href="https://rdar.apple.com/175805956">rdar://175805956</a>

Reviewed by Cameron McCormack.

The enum ShouldDecodeToHDR will be replaced with another enum DecodingDestination.
The values of DecodingDestination are { Base, ShouldDecodeToHDR }. In a future PR,
the enum value BaseAndGainMap will be added and handled.

ImageFrame will now have an EnumeratedArray indexed by DecodingDestination. This
array will hold different decoded destinations for the same frame.

DecodingOptions will hold a member of type DecodingDestination. It will be used
for compatibility matching.

* Source/WebCore/platform/graphics/BitmapImage.cpp:
(WebCore::BitmapImage::draw):
* Source/WebCore/platform/graphics/BitmapImage.h:
* Source/WebCore/platform/graphics/BitmapImageSource.cpp:
(WebCore::BitmapImageSource::destroyNativeImageAtIndex):
(WebCore::BitmapImageSource::preferredDecodingDestination const):
(WebCore::BitmapImageSource::decode):
(WebCore::BitmapImageSource::imageFrameDecodeAtIndexHasFinished):
(WebCore::BitmapImageSource::cacheNativeImageAtIndex):
(WebCore::BitmapImageSource::nativeImageAtIndexCacheIfNeeded):
(WebCore::BitmapImageSource::nativeImageAtIndexRequestIfNeeded):
(WebCore::BitmapImageSource::currentNativeImageForDrawing):
* Source/WebCore/platform/graphics/BitmapImageSource.h:
* Source/WebCore/platform/graphics/DecodingOptions.h:
(WebCore::DecodingOptions::DecodingOptions):
(WebCore::DecodingOptions::decodingDestination const):
(WebCore::DecodingOptions::isCompatibleWith const):
(WebCore::DecodingOptions::shouldDecodeToHDR const): Deleted.
* Source/WebCore/platform/graphics/ImageDecoder.cpp:
(WebCore::ImageDecoder::fetchFrameMetaDataAtIndex const):
* Source/WebCore/platform/graphics/ImageFrame.cpp:
(WebCore::ImageFrame::ImageFrame):
(WebCore::ImageFrame::sizeInBytes const):
(WebCore::ImageFrame::clearImage):
(WebCore::ImageFrame::hasNativeImage const):
(WebCore::ImageFrame::hasFullSizeNativeImage const):
(WebCore::ImageFrame::hasDecodedNativeImageCompatibleWithOptions const):
(WebCore::ImageFrame::clearSourceImage): Deleted.
* Source/WebCore/platform/graphics/ImageFrame.h:
(WebCore::ImageFrame::nativeImage const):
(WebCore::ImageFrame::decodingOptions const):
(WebCore::ImageFrame::headroom const):
(WebCore::ImageFrame::hasNativeImage const):
(WebCore::ImageFrame::Destination::clear):
(WebCore::ImageFrame::decodingDestinationIfExists const):
(WebCore::ImageFrame::destination):
(WebCore::ImageFrame::destination const):
(WebCore::ImageFrame::Source::hasNativeImage const): Deleted.
(WebCore::ImageFrame::Source::hasFullSizeNativeImage const): Deleted.
(WebCore::ImageFrame::Source::hasDecodedNativeImageCompatibleWithOptions const): Deleted.
(WebCore::ImageFrame::Source::sizeInBytes const): Deleted.
(WebCore::ImageFrame::Source::clear): Deleted.
(WebCore::ImageFrame::shouldDecodeToHDRIfExists const): Deleted.
(WebCore::ImageFrame::source): Deleted.
(WebCore::ImageFrame::source const): Deleted.
* Source/WebCore/platform/graphics/ImageSource.h:
(WebCore::ImageSource::preferredDecodingDestination const):
* Source/WebCore/platform/graphics/NativeImageSource.h:
* Source/WebCore/platform/graphics/cg/ImageDecoderCG.cpp:
(WebCore::appendImageSourceOption):
(WebCore::imageSourceOptions):
(WebCore::imageSourceThumbnailOptions):
(WebCore::ImageDecoderCG::fetchFrameMetaDataAtIndex const):
(WebCore::ImageDecoderCG::createFrameImageAtIndex):

Canonical link: <a href="https://commits.webkit.org/312893@main">https://commits.webkit.org/312893@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/88f5105d5d3a274e304c0cc7be6b79e8f51f1bb3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/161308 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/34781 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/27882 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/170211 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/117679 "Build is in progress. Recent messages:") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/83426a77-3428-4bcc-a364-2907bf2e7012) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/163177 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/34882 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/34782 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/125125 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/117679 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/9741eddb-5899-4d49-9e94-55ce23c45325) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/164267 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/27415 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/144893 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/105722 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/29cda07c-14cc-4855-a458-64a335a107a5) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/26463 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/24971 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/17931 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/136157 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/22653 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/172694 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/19715 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/24294 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/133407 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/34455 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/29064 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/133415 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36058 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/34440 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/144448 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/96305 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/27951 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/21266 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/33950 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/101375 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/33449 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/33693 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/33598 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->