### PR TITLE
WebGL: Subobjects should be detached from context on context loss

### DIFF
--- a/LayoutTests/webgl/query-context-lost-restore-expected.txt
+++ b/LayoutTests/webgl/query-context-lost-restore-expected.txt
@@ -2,29 +2,33 @@ Tests that active query state is properly reset after context loss: queries can 
 
 On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
 
-TEST COMPLETE: 21 PASS, 0 FAIL
+TEST COMPLETE: 25 PASS, 0 FAIL
 
 Running test: contextType: webgl, queryTarget: TIME_ELAPSED_EXT
 PASS getError was expected value: NO_ERROR : beginQueryEXT should succeed
 PASS gl.isContextLost() is true
+PASS Active query was collected after context loss
 PASS gl.isContextLost() is false
 PASS getError was expected value: NO_ERROR : beginQueryEXT with new query should succeed after restore
 PASS getError was expected value: NO_ERROR : endQueryEXT should succeed
 Running test: contextType: webgl2, queryTarget: ANY_SAMPLES_PASSED
 PASS getError was expected value: NO_ERROR : beginQuery(ANY_SAMPLES_PASSED) should succeed
 PASS gl.isContextLost() is true
+PASS Active ANY_SAMPLES_PASSED query was collected after context loss
 PASS gl.isContextLost() is false
 PASS getError was expected value: NO_ERROR : beginQuery(ANY_SAMPLES_PASSED) with new query should succeed after restore
 PASS getError was expected value: NO_ERROR : endQuery(ANY_SAMPLES_PASSED) should succeed
 Running test: contextType: webgl2, queryTarget: TRANSFORM_FEEDBACK_PRIMITIVES_WRITTEN
 PASS getError was expected value: NO_ERROR : beginQuery(TRANSFORM_FEEDBACK_PRIMITIVES_WRITTEN) should succeed
 PASS gl.isContextLost() is true
+PASS Active TRANSFORM_FEEDBACK_PRIMITIVES_WRITTEN query was collected after context loss
 PASS gl.isContextLost() is false
 PASS getError was expected value: NO_ERROR : beginQuery(TRANSFORM_FEEDBACK_PRIMITIVES_WRITTEN) with new query should succeed after restore
 PASS getError was expected value: NO_ERROR : endQuery(TRANSFORM_FEEDBACK_PRIMITIVES_WRITTEN) should succeed
 Running test: contextType: webgl2, queryTarget: TIME_ELAPSED_EXT
 PASS getError was expected value: NO_ERROR : beginQuery(TIME_ELAPSED_EXT) should succeed
 PASS gl.isContextLost() is true
+PASS Active TIME_ELAPSED_EXT query was collected after context loss
 PASS gl.isContextLost() is false
 PASS getError was expected value: NO_ERROR : beginQuery(TIME_ELAPSED_EXT) with new query should succeed after restore
 PASS getError was expected value: NO_ERROR : endQuery(TIME_ELAPSED_EXT) should succeed

--- a/LayoutTests/webgl/query-context-lost-restore.html
+++ b/LayoutTests/webgl/query-context-lost-restore.html
@@ -56,10 +56,30 @@ async function testWebGL1TimerQuery() {
     ext.beginQueryEXT(ext.TIME_ELAPSED_EXT, query);
     wtu.glErrorShouldBe(gl, gl.NO_ERROR, "beginQueryEXT should succeed");
 
+    const weakQuery = new WeakRef(query);
+    query = null;
+
     const contextLostPromise = waitForEvent(canvas, "webglcontextlost", (e) => e.preventDefault());
     WEBGL_lose_context.loseContext();
     await contextLostPromise;
     shouldBeTrue("gl.isContextLost()");
+
+    ext = null;
+    if (window.GCController)
+        GCController.collect();
+    else if (window.gc)
+        gc();
+    await new Promise(resolve => setTimeout(resolve, 0));
+    if (window.GCController)
+        GCController.collect();
+    else if (window.gc)
+        gc();
+    await new Promise(resolve => setTimeout(resolve, 0));
+
+    if (weakQuery.deref() === undefined)
+        testPassed("Active query was collected after context loss");
+    else
+        testFailed("Active query should have been collected after context loss but is still alive");
 
     const contextRestoredPromise = waitForEvent(canvas, "webglcontextrestored");
     await new Promise(resolve => setTimeout(resolve, 0));
@@ -111,10 +131,29 @@ async function testWebGL2Query(queryTarget, queryTargetName, requiresExtension) 
     gl.beginQuery(queryTarget, query);
     wtu.glErrorShouldBe(gl, gl.NO_ERROR, `beginQuery(${queryTargetName}) should succeed`);
 
+    const weakQuery = new WeakRef(query);
+    query = null;
+
     const contextLostPromise = waitForEvent(canvas, "webglcontextlost", (e) => e.preventDefault());
     WEBGL_lose_context.loseContext();
     await contextLostPromise;
     shouldBeTrue("gl.isContextLost()");
+
+    if (window.GCController)
+        GCController.collect();
+    else if (window.gc)
+        gc();
+    await new Promise(resolve => setTimeout(resolve, 0));
+    if (window.GCController)
+        GCController.collect();
+    else if (window.gc)
+        gc();
+    await new Promise(resolve => setTimeout(resolve, 0));
+
+    if (weakQuery.deref() === undefined)
+        testPassed(`Active ${queryTargetName} query was collected after context loss`);
+    else
+        testFailed(`Active ${queryTargetName} query should have been collected after context loss but is still alive`);
 
     const contextRestoredPromise = waitForEvent(canvas, "webglcontextrestored");
     await new Promise(resolve => setTimeout(resolve, 0));

--- a/Source/WebCore/html/canvas/WebGL2RenderingContext.cpp
+++ b/Source/WebCore/html/canvas/WebGL2RenderingContext.cpp
@@ -122,31 +122,14 @@ std::unique_ptr<WebGL2RenderingContext> WebGL2RenderingContext::create(CanvasBas
 
 WebGL2RenderingContext::~WebGL2RenderingContext()
 {
-    // Remove all references to WebGLObjects so if they are the last reference
-    // they will be freed before the last context is removed from the context group.
-    m_readFramebufferBinding = nullptr;
-    m_boundTransformFeedback = nullptr;
-    m_boundTransformFeedbackBuffer = nullptr;
-    m_boundUniformBuffer = nullptr;
-    m_boundIndexedUniformBuffers.clear();
-    for (auto& activeQuery : m_activeQueries)
-        activeQuery = nullptr;
+    // The object -> context WeakPtr might be used with upcasting. This is not
+    // safe, so mark the context lost.
+    m_contextObjectWeakPtrFactory.revokeAll();
 }
 
 void WebGL2RenderingContext::initializeContextState()
 {
     WebGLRenderingContextBase::initializeContextState();
-
-    m_readFramebufferBinding = nullptr;
-
-    m_boundCopyReadBuffer = nullptr;
-    m_boundCopyWriteBuffer = nullptr;
-    m_boundPixelPackBuffer = nullptr;
-    m_boundPixelUnpackBuffer = nullptr;
-    m_boundTransformFeedbackBuffer = nullptr;
-    m_boundUniformBuffer = nullptr;
-
-    // NEEDS_PORT: boolean occlusion query, transform feedback primitives written query, elapsed query
 
     RefPtr context = m_context;
     m_maxTransformFeedbackSeparateAttribs = context->getInteger(GraphicsContextGL::MAX_TRANSFORM_FEEDBACK_SEPARATE_ATTRIBS);
@@ -163,11 +146,7 @@ void WebGL2RenderingContext::initializeContextState()
     m_max3DTextureLevel = WebGLTexture::computeLevelCount(m_max3DTextureSize, m_max3DTextureSize);
     m_maxArrayTextureLayers = context->getInteger(GraphicsContextGL::MAX_ARRAY_TEXTURE_LAYERS);
 
-    for (auto& activeQuery : m_activeQueries)
-        activeQuery = nullptr;
-
-    m_boundSamplers.clear();
-    m_boundSamplers.grow(m_textureUnits.size());
+    m_boundSamplers.resize(m_textureUnits.size());
 }
 
 long long WebGL2RenderingContext::getInt64Parameter(GCGLenum pname)
@@ -180,10 +159,26 @@ void WebGL2RenderingContext::initializeDefaultObjects()
     WebGLRenderingContextBase::initializeDefaultObjects();
     m_defaultVertexArrayObject = WebGLVertexArrayObject::create(*this, WebGLVertexArrayObject::Type::Default);
     m_boundVertexArrayObject = m_defaultVertexArrayObject;
-    if (!m_defaultVertexArrayObject)
-        return;
-    // The default VAO was removed in OpenGL 3.3 but not from WebGL 2; bind the default for WebGL to use.
-    graphicsContextGL()->bindVertexArray(m_defaultVertexArrayObject->object());
+    if (m_defaultVertexArrayObject)
+        graphicsContextGL()->bindVertexArray(m_defaultVertexArrayObject->object());
+}
+
+void WebGL2RenderingContext::detachAndRemoveAllObjects()
+{
+    WebGLRenderingContextBase::detachAndRemoveAllObjects();
+    m_readFramebufferBinding = nullptr;
+    m_boundTransformFeedback = nullptr;
+    m_defaultTransformFeedback = nullptr;
+    m_boundCopyReadBuffer = nullptr;
+    m_boundCopyWriteBuffer = nullptr;
+    m_boundPixelPackBuffer = nullptr;
+    m_boundPixelUnpackBuffer = nullptr;
+    m_boundTransformFeedbackBuffer = nullptr;
+    m_boundUniformBuffer = nullptr;
+    m_boundIndexedUniformBuffers.clear();
+    for (auto& activeQuery : m_activeQueries)
+        activeQuery = nullptr;
+    m_boundSamplers.clear();
 }
 
 bool WebGL2RenderingContext::validateBufferTarget(ASCIILiteral functionName, GCGLenum target)
@@ -1510,7 +1505,7 @@ void WebGL2RenderingContext::vertexAttribI4uiv(GCGLuint index, Uint32List&& list
         synthesizeGLError(GraphicsContextGL::INVALID_VALUE, "vertexAttribI4uiv"_s, "no array"_s);
         return;
     }
-    
+
     int size = list.length();
     if (size < 4) {
         synthesizeGLError(GraphicsContextGL::INVALID_VALUE, "vertexAttribI4uiv"_s, "array too small"_s);
@@ -1939,7 +1934,7 @@ void WebGL2RenderingContext::bindSampler(GCGLuint unit, WebGLSampler* sampler)
     Locker locker { objectGraphLock() };
     if (!validateNullableWebGLObject("bindSampler"_s, sampler))
         return;
-    
+
     if (unit >= m_boundSamplers.size()) {
         synthesizeGLError(GraphicsContextGL::INVALID_VALUE, "bindSampler"_s, "invalid texture unit"_s);
         return;
@@ -2045,7 +2040,7 @@ GCGLenum WebGL2RenderingContext::clientWaitSync(WebGLSync& sync, GCGLbitfield fl
         synthesizeGLError(GraphicsContextGL::INVALID_OPERATION, "clientWaitSync"_s, "timeout > MAX_CLIENT_WAIT_TIMEOUT_WEBGL"_s);
         return GraphicsContextGL::WAIT_FAILED_WEBGL;
     }
-    
+
     if (flags && flags != GraphicsContextGL::SYNC_FLUSH_COMMANDS_BIT) {
         synthesizeGLError(GraphicsContextGL::INVALID_VALUE, "clientWaitSync"_s, "invalid flags"_s);
         return GraphicsContextGL::WAIT_FAILED_WEBGL;
@@ -2181,7 +2176,7 @@ void WebGL2RenderingContext::beginTransformFeedback(GCGLenum primitiveMode)
 {
     if (isContextLost())
         return;
-    
+
     if (!ValidateTransformFeedbackPrimitiveMode(primitiveMode)) {
         synthesizeGLError(GraphicsContextGL::INVALID_ENUM, "beginTransformFeedback"_s, "invalid transform feedback primitive mode"_s);
         return;
@@ -2223,7 +2218,7 @@ void WebGL2RenderingContext::endTransformFeedback()
         synthesizeGLError(GraphicsContextGL::INVALID_OPERATION, "endTransformFeedback"_s, "transform feedback is not active"_s);
         return;
     }
-    
+
     graphicsContextGL()->endTransformFeedback();
 
     m_boundTransformFeedback->setPaused(false);
@@ -2236,7 +2231,7 @@ void WebGL2RenderingContext::transformFeedbackVaryings(WebGLProgram& program, co
         return;
     if (!validateWebGLObject("transformFeedbackVaryings"_s, program))
         return;
-    
+
     switch (bufferMode) {
     case GraphicsContextGL::SEPARATE_ATTRIBS:
         if (varyings.size() > m_maxTransformFeedbackSeparateAttribs) {

--- a/Source/WebCore/html/canvas/WebGL2RenderingContext.h
+++ b/Source/WebCore/html/canvas/WebGL2RenderingContext.h
@@ -270,6 +270,7 @@ private:
     Vector<bool> getIndexedBooleanArrayParameter(GCGLenum pname, GCGLuint index);
 
     void initializeDefaultObjects() final;
+    void detachAndRemoveAllObjects() WTF_REQUIRES_LOCK(objectGraphLock()) final;
     bool validateBufferTarget(ASCIILiteral functionName, GCGLenum target) final;
     bool validateBufferTargetCompatibility(ASCIILiteral, GCGLenum, WebGLBuffer*);
     RefPtr<WebGLBuffer> validateBufferDataParameters(ASCIILiteral functionName, GCGLenum target, GCGLenum usage) final;

--- a/Source/WebCore/html/canvas/WebGLRenderingContext.cpp
+++ b/Source/WebCore/html/canvas/WebGLRenderingContext.cpp
@@ -121,13 +121,9 @@ std::unique_ptr<WebGLRenderingContext> WebGLRenderingContext::create(CanvasBase&
 
 WebGLRenderingContext::~WebGLRenderingContext()
 {
-    m_activeQuery = nullptr;
-}
-
-void WebGLRenderingContext::initializeContextState()
-{
-    WebGLRenderingContextBase::initializeContextState();
-    m_activeQuery = nullptr;
+    // The object -> context WeakPtr might be used with upcasting. This is not
+    // safe, so mark the context lost.
+    m_contextObjectWeakPtrFactory.revokeAll();
 }
 
 void WebGLRenderingContext::initializeDefaultObjects()
@@ -135,6 +131,12 @@ void WebGLRenderingContext::initializeDefaultObjects()
     WebGLRenderingContextBase::initializeDefaultObjects();
     m_defaultVertexArrayObject = WebGLVertexArrayObjectOES::createDefault(*this);
     m_boundVertexArrayObject = m_defaultVertexArrayObject;
+}
+
+void WebGLRenderingContext::detachAndRemoveAllObjects()
+{
+    WebGLRenderingContextBase::detachAndRemoveAllObjects();
+    m_activeQuery = nullptr;
 }
 
 std::optional<WebGLExtensionAny> WebGLRenderingContext::getExtension(const String& name)
@@ -361,7 +363,7 @@ void WebGLRenderingContext::addMembersToOpaqueRoots(JSC::AbstractSlotVisitor& vi
     WebGLRenderingContextBase::addMembersToOpaqueRoots(visitor);
 
     Locker locker { objectGraphLock() };
-    addWebCoreOpaqueRoot(visitor, protect(m_activeQuery.get()).get());
+    SUPPRESS_UNCHECKED_LOCAL addWebCoreOpaqueRoot(visitor, m_activeQuery.get());
 }
 
 WebCoreOpaqueRoot root(const WebGLExtension<WebGLRenderingContext>* extension)

--- a/Source/WebCore/html/canvas/WebGLRenderingContext.h
+++ b/Source/WebCore/html/canvas/WebGLRenderingContext.h
@@ -50,7 +50,6 @@ public:
 
     GCGLint maxDrawBuffers() final;
     GCGLint maxColorAttachments() final;
-    void initializeDefaultObjects() final;
 
     void addMembersToOpaqueRoots(JSC::AbstractSlotVisitor&) final;
 
@@ -61,7 +60,8 @@ protected:
 
 private:
     using WebGLRenderingContextBase::WebGLRenderingContextBase;
-    void initializeContextState() final;
+    void initializeDefaultObjects() final;
+    void detachAndRemoveAllObjects() WTF_REQUIRES_LOCK(objectGraphLock()) final;
 };
 
 WebCoreOpaqueRoot NODELETE root(const WebGLExtension<WebGLRenderingContext>*);

--- a/Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp
+++ b/Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp
@@ -622,30 +622,36 @@ void WebGLRenderingContextBase::initializeDefaultObjects()
     m_defaultFramebuffer = WebGLDefaultFramebuffer::create(*this, clampedCanvasSize());
 }
 
-void WebGLRenderingContextBase::addCompressedTextureFormat(GCGLenum format)
+void WebGLRenderingContextBase::detachAndRemoveAllObjects()
 {
-    if (!m_compressedTextureFormats.contains(format))
-        m_compressedTextureFormats.append(format);
-}
-
-
-WebGLRenderingContextBase::~WebGLRenderingContextBase()
-{
-    // Remove all references to WebGLObjects so if they are the last reference
-    // they will be freed before the last context is removed from the context group.
+    m_contextObjectWeakPtrFactory.revokeAll();
     m_boundArrayBuffer = nullptr;
     m_defaultVertexArrayObject = nullptr;
     m_boundVertexArrayObject = nullptr;
     m_currentProgram = nullptr;
     m_framebufferBinding = nullptr;
     m_renderbufferBinding = nullptr;
-
     for (auto& textureUnit : m_textureUnits) {
         textureUnit.texture2DBinding = nullptr;
         textureUnit.textureCubeMapBinding = nullptr;
+        textureUnit.texture3DBinding = nullptr;
+        textureUnit.texture2DArrayBinding = nullptr;
     }
+}
 
-    detachAndRemoveAllObjects();
+void WebGLRenderingContextBase::addCompressedTextureFormat(GCGLenum format)
+{
+    if (!m_compressedTextureFormats.contains(format))
+        m_compressedTextureFormats.append(format);
+}
+
+WebGLRenderingContextBase::~WebGLRenderingContextBase()
+{
+    // Subclasses should reset the weak ptr factory so that webgl objects that point to
+    // context do not upcast to already deleted subclass.
+    ASSERT(!m_contextObjectWeakPtrFactory.isInitialized());
+
+    // Currently the extensions are not part of the weak ptr object graph. Lose them explicitly.
     loseExtensions(LostContextMode::RealLostContext);
     destroyGraphicsContextGL();
 
@@ -4677,7 +4683,10 @@ void WebGLRenderingContextBase::forceLostContext(WebGLRenderingContextBase::Lost
     m_contextLostState = ContextLostState { mode };
     m_contextLostState->errors.add(GCGLErrorCode::ContextLost);
 
-    detachAndRemoveAllObjects();
+    {
+        Locker locker { objectGraphLock() };
+        detachAndRemoveAllObjects();
+    }
     loseExtensions(mode);
 
     graphicsContextGL()->getErrors();
@@ -4717,12 +4726,6 @@ RefPtr<GraphicsLayerContentsDisplayDelegate> WebGLRenderingContextBase::layerCon
 WeakPtr<WebGLRenderingContextBase> WebGLRenderingContextBase::createRefForContextObject()
 {
     return m_contextObjectWeakPtrFactory.createWeakPtr(*this);
-}
-
-void WebGLRenderingContextBase::detachAndRemoveAllObjects()
-{
-    Locker locker { objectGraphLock() };
-    m_contextObjectWeakPtrFactory.revokeAll();
 }
 
 void WebGLRenderingContextBase::stop()
@@ -5302,7 +5305,10 @@ void WebGLRenderingContextBase::maybeRestoreContext()
             return;
         }
         // Remove the possible objects added during the initialization.
-        detachAndRemoveAllObjects();
+        {
+            Locker locker { objectGraphLock() };
+            detachAndRemoveAllObjects();
+        }
     }
 
     // Either we failed to create context or the context was lost during initialization.

--- a/Source/WebCore/html/canvas/WebGLRenderingContextBase.h
+++ b/Source/WebCore/html/canvas/WebGLRenderingContextBase.h
@@ -539,13 +539,12 @@ protected:
     void initializeNewContext(Ref<GraphicsContextGL>);
     virtual void initializeContextState();
     virtual void initializeDefaultObjects();
+    virtual void detachAndRemoveAllObjects() WTF_REQUIRES_LOCK(objectGraphLock());
 
     // ActiveDOMObject
     void stop() override;
     void suspend(ReasonForSuspension) override;
     void resume() override;
-
-    void detachAndRemoveAllObjects();
 
     void destroyGraphicsContextGL();
 
@@ -785,6 +784,7 @@ protected:
     HashSet<GCGLenum> m_supportedTexImageSourceInternalFormats;
     HashSet<GCGLenum> m_supportedTexImageSourceFormats;
     HashSet<GCGLenum> m_supportedTexImageSourceTypes;
+    WeakPtrFactory<WebGLRenderingContextBase> m_contextObjectWeakPtrFactory;
 
     // Helpers for getParameter and other similar functions.
     bool getBooleanParameter(GCGLenum);
@@ -1054,12 +1054,11 @@ private:
 #if ENABLE(WEB_CODECS)
     ExceptionOr<void> texImageSource(TexImageFunctionID, GCGLenum target, GCGLint level, GCGLint internalformat, GCGLint border, GCGLenum format, GCGLenum type, GCGLint xoffset, GCGLint yoffset, GCGLint zoffset, const IntRect& inputSourceImageRect, GCGLsizei depth, GCGLint unpackImageHeight, WebCodecsVideoFrame& source);
 #endif
+    // The ordinal number of when the context was last active (drew, read pixels).
+    uint64_t m_activeOrdinal { 0 };
 
     bool m_isSuspended { false };
     bool m_packReverseRowOrderSupported { false };
-    // The ordinal number of when the context was last active (drew, read pixels).
-    uint64_t m_activeOrdinal { 0 };
-    WeakPtrFactory<WebGLRenderingContextBase> m_contextObjectWeakPtrFactory;
 };
 
 template<typename T>


### PR DESCRIPTION
#### b388badda30401104caccaac01c12c59efb119d5
<pre>
WebGL: Subobjects should be detached from context on context loss
<a href="https://bugs.webkit.org/show_bug.cgi?id=314068">https://bugs.webkit.org/show_bug.cgi?id=314068</a>
<a href="https://rdar.apple.com/176257432">rdar://176257432</a>

Reviewed by Dan Glastonbury.

The context should detach all the objects it points to
when context loss happens. This fixes bugs related to
initializeContextState not initializing these objects
and makes it testable to test the behavior.

Fixes a thread-safety crash where WebGL disjoint timer query
ref would be taken in GC thread.

* LayoutTests/webgl/query-context-lost-restore-expected.txt:
* LayoutTests/webgl/query-context-lost-restore.html:
* Source/WebCore/html/canvas/WebGL2RenderingContext.cpp:
(WebCore::WebGL2RenderingContext::~WebGL2RenderingContext):
(WebCore::WebGL2RenderingContext::initializeContextState):
(WebCore::WebGL2RenderingContext::initializeDefaultObjects):
(WebCore::WebGL2RenderingContext::detachAndRemoveAllObjects):
* Source/WebCore/html/canvas/WebGL2RenderingContext.h:
* Source/WebCore/html/canvas/WebGLRenderingContext.cpp:
(WebCore::WebGLRenderingContext::~WebGLRenderingContext):
(WebCore::WebGLRenderingContext::detachAndRemoveAllObjects):
(WebCore::WebGLRenderingContext::addMembersToOpaqueRoots):
(WebCore::WebGLRenderingContext::initializeContextState): Deleted.
* Source/WebCore/html/canvas/WebGLRenderingContext.h:
* Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp:
(WebCore::WebGLRenderingContextBase::~WebGLRenderingContextBase):
(WebCore::WebGLRenderingContextBase::forceLostContext):
(WebCore::WebGLRenderingContextBase::maybeRestoreContext):
(WebCore::WebGLRenderingContextBase::detachAndRemoveAllObjects):
(WebCore::WebGLRenderingContextBase::loseExtensions): Deleted.
* Source/WebCore/html/canvas/WebGLRenderingContextBase.h:

Canonical link: <a href="https://commits.webkit.org/312678@main">https://commits.webkit.org/312678@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/420a7136b6720be7ad9bb7639259f3608a6b223e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/160795 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/34268 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/27369 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/169698 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/115861 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/162664 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/34369 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/34268 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/124714 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/115861 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/163754 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/26965 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/144439 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/105311 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/26017 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/24517 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/17418 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/135711 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/22202 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/172180 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/19202 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/23843 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/132980 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/33942 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/28609 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/132991 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35910 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/33926 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/143997 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/95742 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/27583 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/20812 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/33437 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/100862 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/32936 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/33180 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/33084 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->