### PR TITLE
[Swift GTK] Guard Apple-specific WTF headers

### DIFF
--- a/Source/WTF/wtf/BlockPtr.h
+++ b/Source/WTF/wtf/BlockPtr.h
@@ -25,6 +25,10 @@
 
 #pragma once
 
+#include <wtf/Platform.h>
+
+#if PLATFORM(COCOA)
+
 #include <Block.h>
 #include <utility>
 #include <wtf/Assertions.h>
@@ -243,3 +247,5 @@ inline auto makeBlockPtr(F&& function)
 
 using WTF::BlockPtr;
 using WTF::makeBlockPtr;
+
+#endif // PLATFORM(COCOA)

--- a/Source/WTF/wtf/MachSendRightAnnotated.h
+++ b/Source/WTF/wtf/MachSendRightAnnotated.h
@@ -25,6 +25,10 @@
 
 #pragma once
 
+#import <wtf/Platform.h>
+
+#if PLATFORM(COCOA)
+
 #import <wtf/FixedVector.h>
 #import <wtf/MachSendRight.h>
 
@@ -36,3 +40,5 @@ struct MachSendRightAnnotated {
 };
 
 }
+
+#endif // PLATFORM(COCOA)

--- a/Source/WTF/wtf/SchedulePair.h
+++ b/Source/WTF/wtf/SchedulePair.h
@@ -28,6 +28,10 @@
 
 #pragma once
 
+#include <wtf/Platform.h>
+
+#if USE(CF)
+
 #include <wtf/HashSet.h>
 #include <wtf/Hasher.h>
 #include <wtf/Ref.h>
@@ -104,3 +108,5 @@ using SchedulePairHashSet = HashSet<Ref<SchedulePair>, SchedulePairHash>;
 
 using WTF::SchedulePair;
 using WTF::SchedulePairHashSet;
+
+#endif // USE(CF)

--- a/Source/WTF/wtf/SoftLinking.h
+++ b/Source/WTF/wtf/SoftLinking.h
@@ -30,6 +30,4 @@
 #include <wtf/cocoa/SoftLinking.h>
 #elif OS(WINDOWS)
 #include <wtf/win/SoftLinking.h>
-#else
-#error "SoftLinking not defined for platform"
 #endif

--- a/Source/WTF/wtf/WeakObjCPtr.h
+++ b/Source/WTF/wtf/WeakObjCPtr.h
@@ -25,6 +25,10 @@
 
 #pragma once
 
+#include <wtf/Platform.h>
+
+#if PLATFORM(COCOA)
+
 #include <objc/runtime.h>
 #include <type_traits>
 #include <wtf/RetainPtr.h>
@@ -131,3 +135,5 @@ inline RetainPtr<typename WeakObjCPtr<T>::ValueType> protect(const WeakObjCPtr<T
 
 using WTF::protect;
 using WTF::WeakObjCPtr;
+
+#endif // PLATFORM(COCOA)


### PR DESCRIPTION
#### 4a7474b8b00ab6bfde206d275376e37cb31d14ca
<pre>
[Swift GTK] Guard Apple-specific WTF headers
<a href="https://bugs.webkit.org/show_bug.cgi?id=314072">https://bugs.webkit.org/show_bug.cgi?id=314072</a>
<a href="https://rdar.apple.com/176259431">rdar://176259431</a>

Reviewed by Richard Robinson.

Once we ask Swift on non-Apple platforms to respect WebKit headers, it will
need to start to use the WTF modulemap. That causes it to interpret all headers
listed therein, including those relating to features that only occur on the
Apple platform. Add header guards so that they don&apos;t cause compilation problems
on non-Apple platforms.

Alternatives considered:
- Different modulemaps per platform. Obviously more complex.
- Add directives to the modulemap to state that some headers are
  platform-specific. I&apos;m led to believe that the approach in this PR is
  preferred.

Canonical link: <a href="https://commits.webkit.org/312898@main">https://commits.webkit.org/312898@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/df955d5d95c2663064bfdd0e16f97f9325afb45b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/161265 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/34738 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/27839 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/170168 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/117636 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/34839 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/34739 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/125089 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/117636 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/a4f3dfd3-4198-447e-8b6c-4389cb50e10e) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/164224 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/27379 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/144857 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/105686 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/f8069bdc-5040-4987-837c-49903f2e966c) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/26427 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/24932 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/17888 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/153322 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/136121 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/22617 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/172651 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/22103 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/19672 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/24258 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/133367 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/34412 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/29025 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/133376 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36063 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/34397 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/144412 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/96262 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/27929 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/21230 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/193664 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/33907 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/101332 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/49891 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/33406 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/33650 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/33555 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->