### PR TITLE
WebGL: WebGLTimerQueryEXT creation is not infallible

### DIFF
--- a/LayoutTests/webgl/query-context-lost-restore-expected.txt
+++ b/LayoutTests/webgl/query-context-lost-restore-expected.txt
@@ -1,35 +1,66 @@
-Tests that active query state is properly reset after context loss: queries can be begun after restore and active query objects are collectible.
+Tests that query context loss and restore behavior
 
 On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
 
-TEST COMPLETE: 25 PASS, 0 FAIL
+TEST COMPLETE: 54 PASS, 0 FAIL
 
 Running test: contextType: webgl, queryTarget: TIME_ELAPSED_EXT
-PASS getError was expected value: NO_ERROR : beginQueryEXT should succeed
+PASS query is non-null.
+PASS getError was expected value: NO_ERROR : beginQueryEXT(TIME_ELAPSED_EXT) should succeed
 PASS gl.isContextLost() is true
+PASS lostQuery is non-null.
 PASS Active query was collected after context loss
 PASS gl.isContextLost() is false
-PASS getError was expected value: NO_ERROR : beginQueryEXT with new query should succeed after restore
-PASS getError was expected value: NO_ERROR : endQueryEXT should succeed
+PASS newQuery is non-null.
+PASS getError was expected value: NO_ERROR : beginQueryEXT(TIME_ELAPSED_EXT) with new query should succeed after restore
+PASS getError was expected value: NO_ERROR : endQueryEXT(TIME_ELAPSED_EXT) should succeed
+Running test: contextType: webgl, queryTarget: TIMESTAMP_EXT
+PASS query is non-null.
+PASS getError was expected value: NO_ERROR : queryCounterEXT(TIMESTAMP_EXT) should succeed
+PASS gl.isContextLost() is true
+PASS lostQuery is non-null.
+PASS Active query was collected after context loss
+PASS gl.isContextLost() is false
+PASS newQuery is non-null.
+PASS getError was expected value: NO_ERROR : queryCounterEXT(TIMESTAMP_EXT) with new query should succeed after restore
 Running test: contextType: webgl2, queryTarget: ANY_SAMPLES_PASSED
+PASS query is non-null.
 PASS getError was expected value: NO_ERROR : beginQuery(ANY_SAMPLES_PASSED) should succeed
 PASS gl.isContextLost() is true
+PASS lostQuery is non-null.
 PASS Active ANY_SAMPLES_PASSED query was collected after context loss
 PASS gl.isContextLost() is false
+PASS newQuery is non-null.
 PASS getError was expected value: NO_ERROR : beginQuery(ANY_SAMPLES_PASSED) with new query should succeed after restore
 PASS getError was expected value: NO_ERROR : endQuery(ANY_SAMPLES_PASSED) should succeed
+Running test: contextType: webgl2, queryTarget: ANY_SAMPLES_PASSED_CONSERVATIVE
+PASS query is non-null.
+PASS getError was expected value: NO_ERROR : beginQuery(ANY_SAMPLES_PASSED_CONSERVATIVE) should succeed
+PASS gl.isContextLost() is true
+PASS lostQuery is non-null.
+PASS Active ANY_SAMPLES_PASSED_CONSERVATIVE query was collected after context loss
+PASS gl.isContextLost() is false
+PASS newQuery is non-null.
+PASS getError was expected value: NO_ERROR : beginQuery(ANY_SAMPLES_PASSED_CONSERVATIVE) with new query should succeed after restore
+PASS getError was expected value: NO_ERROR : endQuery(ANY_SAMPLES_PASSED_CONSERVATIVE) should succeed
 Running test: contextType: webgl2, queryTarget: TRANSFORM_FEEDBACK_PRIMITIVES_WRITTEN
+PASS query is non-null.
 PASS getError was expected value: NO_ERROR : beginQuery(TRANSFORM_FEEDBACK_PRIMITIVES_WRITTEN) should succeed
 PASS gl.isContextLost() is true
+PASS lostQuery is non-null.
 PASS Active TRANSFORM_FEEDBACK_PRIMITIVES_WRITTEN query was collected after context loss
 PASS gl.isContextLost() is false
+PASS newQuery is non-null.
 PASS getError was expected value: NO_ERROR : beginQuery(TRANSFORM_FEEDBACK_PRIMITIVES_WRITTEN) with new query should succeed after restore
 PASS getError was expected value: NO_ERROR : endQuery(TRANSFORM_FEEDBACK_PRIMITIVES_WRITTEN) should succeed
 Running test: contextType: webgl2, queryTarget: TIME_ELAPSED_EXT
+PASS query is non-null.
 PASS getError was expected value: NO_ERROR : beginQuery(TIME_ELAPSED_EXT) should succeed
 PASS gl.isContextLost() is true
+PASS lostQuery is non-null.
 PASS Active TIME_ELAPSED_EXT query was collected after context loss
 PASS gl.isContextLost() is false
+PASS newQuery is non-null.
 PASS getError was expected value: NO_ERROR : beginQuery(TIME_ELAPSED_EXT) with new query should succeed after restore
 PASS getError was expected value: NO_ERROR : endQuery(TIME_ELAPSED_EXT) should succeed
 PASS successfullyParsed is true

--- a/LayoutTests/webgl/query-context-lost-restore.html
+++ b/LayoutTests/webgl/query-context-lost-restore.html
@@ -11,11 +11,14 @@
 <div id="console"></div>
 <script>
 "use strict";
-description("Tests that active query state is properly reset after context loss: queries can be begun after restore and active query objects are collectible.");
+description("Tests that query context loss and restore behavior");
 
 const wtu = WebGLTestUtils;
 
 var gl;
+var query;
+var lostQuery;
+var newQuery;
 
 function waitForEvent(target, eventName, handler) {
     return new Promise((resolve, reject) => {
@@ -28,8 +31,8 @@ function waitForEvent(target, eventName, handler) {
     });
 }
 
-async function testWebGL1TimerQuery() {
-    debug("Running test: contextType: webgl, queryTarget: TIME_ELAPSED_EXT");
+async function testWebGL1TimerQuery(queryTarget, queryTargetName) {
+    debug(`Running test: contextType: webgl, queryTarget: ${queryTargetName}`);
 
     const canvas = document.createElement("canvas");
     canvas.width = 1;
@@ -52,9 +55,15 @@ async function testWebGL1TimerQuery() {
         return;
     }
 
-    let query = ext.createQueryEXT();
-    ext.beginQueryEXT(ext.TIME_ELAPSED_EXT, query);
-    wtu.glErrorShouldBe(gl, gl.NO_ERROR, "beginQueryEXT should succeed");
+    query = ext.createQueryEXT();
+    shouldBeNonNull("query");
+    if (queryTarget == ext.TIME_ELAPSED_EXT) {
+        ext.beginQueryEXT(queryTarget, query);
+        wtu.glErrorShouldBe(gl, gl.NO_ERROR, `beginQueryEXT(${queryTargetName}) should succeed`);
+    } else {
+        ext.queryCounterEXT(query, queryTarget);
+        wtu.glErrorShouldBe(gl, gl.NO_ERROR, `queryCounterEXT(${queryTargetName}) should succeed`);
+    }
 
     const weakQuery = new WeakRef(query);
     query = null;
@@ -63,6 +72,9 @@ async function testWebGL1TimerQuery() {
     WEBGL_lose_context.loseContext();
     await contextLostPromise;
     shouldBeTrue("gl.isContextLost()");
+
+    lostQuery = ext.createQueryEXT();
+    shouldBeNonNull("lostQuery");
 
     ext = null;
     if (window.GCController)
@@ -93,12 +105,17 @@ async function testWebGL1TimerQuery() {
         return;
     }
 
-    const newQuery = ext.createQueryEXT();
-    ext.beginQueryEXT(ext.TIME_ELAPSED_EXT, newQuery);
-    wtu.glErrorShouldBe(gl, gl.NO_ERROR, "beginQueryEXT with new query should succeed after restore");
-
-    ext.endQueryEXT(ext.TIME_ELAPSED_EXT);
-    wtu.glErrorShouldBe(gl, gl.NO_ERROR, "endQueryEXT should succeed");
+    newQuery = ext.createQueryEXT();
+    shouldBeNonNull("newQuery");
+    if (queryTarget == ext.TIME_ELAPSED_EXT) {
+        ext.beginQueryEXT(queryTarget, newQuery);
+        wtu.glErrorShouldBe(gl, gl.NO_ERROR, `beginQueryEXT(${queryTargetName}) with new query should succeed after restore`);
+        ext.endQueryEXT(queryTarget);
+        wtu.glErrorShouldBe(gl, gl.NO_ERROR, `endQueryEXT(${queryTargetName}) should succeed`);
+    } else {
+        ext.queryCounterEXT(newQuery, queryTarget);
+        wtu.glErrorShouldBe(gl, gl.NO_ERROR, `queryCounterEXT(${queryTargetName}) with new query should succeed after restore`);
+    }
 }
 
 async function testWebGL2Query(queryTarget, queryTargetName, requiresExtension) {
@@ -127,7 +144,8 @@ async function testWebGL2Query(queryTarget, queryTargetName, requiresExtension) 
         }
     }
 
-    let query = gl.createQuery();
+    query = gl.createQuery();
+    shouldBeNonNull("query");
     gl.beginQuery(queryTarget, query);
     wtu.glErrorShouldBe(gl, gl.NO_ERROR, `beginQuery(${queryTargetName}) should succeed`);
 
@@ -138,6 +156,9 @@ async function testWebGL2Query(queryTarget, queryTargetName, requiresExtension) 
     WEBGL_lose_context.loseContext();
     await contextLostPromise;
     shouldBeTrue("gl.isContextLost()");
+
+    lostQuery = gl.createQuery();
+    shouldBeNonNull("lostQuery");
 
     if (window.GCController)
         GCController.collect();
@@ -169,7 +190,8 @@ async function testWebGL2Query(queryTarget, queryTargetName, requiresExtension) 
         }
     }
 
-    const newQuery = gl.createQuery();
+    newQuery = gl.createQuery();
+    shouldBeNonNull("newQuery");
     gl.beginQuery(queryTarget, newQuery);
     wtu.glErrorShouldBe(gl, gl.NO_ERROR, `beginQuery(${queryTargetName}) with new query should succeed after restore`);
 
@@ -177,15 +199,23 @@ async function testWebGL2Query(queryTarget, queryTargetName, requiresExtension) 
     wtu.glErrorShouldBe(gl, gl.NO_ERROR, `endQuery(${queryTargetName}) should succeed`);
 }
 
+var WebGL1QueryTargets = {
+    TIME_ELAPSED_EXT    : 0x88BF,
+    TIMESTAMP_EXT       : 0x8E28,
+};
+
 var WebGL2QueryTargets = {
     ANY_SAMPLES_PASSED                      : 0x8C2F,
+    ANY_SAMPLES_PASSED_CONSERVATIVE         : 0x8D6A,
     TRANSFORM_FEEDBACK_PRIMITIVES_WRITTEN   : 0x8C88,
     TIME_ELAPSED_EXT                        : 0x88BF,
 };
 
 async function runTest() {
-    await testWebGL1TimerQuery();
+    await testWebGL1TimerQuery(WebGL1QueryTargets.TIME_ELAPSED_EXT, "TIME_ELAPSED_EXT");
+    await testWebGL1TimerQuery(WebGL1QueryTargets.TIMESTAMP_EXT, "TIMESTAMP_EXT");
     await testWebGL2Query(WebGL2QueryTargets.ANY_SAMPLES_PASSED, "ANY_SAMPLES_PASSED", null);
+    await testWebGL2Query(WebGL2QueryTargets.ANY_SAMPLES_PASSED_CONSERVATIVE, "ANY_SAMPLES_PASSED_CONSERVATIVE", null);
     await testWebGL2Query(WebGL2QueryTargets.TRANSFORM_FEEDBACK_PRIMITIVES_WRITTEN, "TRANSFORM_FEEDBACK_PRIMITIVES_WRITTEN", null);
     await testWebGL2Query(WebGL2QueryTargets.TIME_ELAPSED_EXT, "TIME_ELAPSED_EXT", "EXT_disjoint_timer_query_webgl2");
     finishTest();

--- a/Source/WebCore/html/canvas/EXTDisjointTimerQuery.cpp
+++ b/Source/WebCore/html/canvas/EXTDisjointTimerQuery.cpp
@@ -56,10 +56,10 @@ bool EXTDisjointTimerQuery::supported(GraphicsContextGL& context)
     return context.supportsExtension(GCGLExtension::EXT_disjoint_timer_query);
 }
 
-RefPtr<WebGLTimerQueryEXT> EXTDisjointTimerQuery::createQueryEXT()
+Ref<WebGLTimerQueryEXT> EXTDisjointTimerQuery::createQueryEXT()
 {
     if (isContextLost())
-        return nullptr;
+        return WebGLTimerQueryEXT::createLost();
     return WebGLTimerQueryEXT::create(context().get());
 }
 

--- a/Source/WebCore/html/canvas/EXTDisjointTimerQuery.h
+++ b/Source/WebCore/html/canvas/EXTDisjointTimerQuery.h
@@ -43,7 +43,7 @@ public:
 
     static bool supported(GraphicsContextGL&);
 
-    RefPtr<WebGLTimerQueryEXT> createQueryEXT();
+    Ref<WebGLTimerQueryEXT> createQueryEXT();
     void deleteQueryEXT(WebGLTimerQueryEXT*);
     GCGLboolean isQueryEXT(WebGLTimerQueryEXT*);
     void beginQueryEXT(GCGLenum target, WebGLTimerQueryEXT&);

--- a/Source/WebCore/html/canvas/EXTDisjointTimerQuery.idl
+++ b/Source/WebCore/html/canvas/EXTDisjointTimerQuery.idl
@@ -36,7 +36,7 @@
   const unsigned long TIMESTAMP_EXT               = 0x8E28;
   const unsigned long GPU_DISJOINT_EXT            = 0x8FBB;
 
-  WebGLTimerQueryEXT? createQueryEXT();
+  WebGLTimerQueryEXT createQueryEXT();
   undefined deleteQueryEXT(WebGLTimerQueryEXT? query);
   boolean isQueryEXT(WebGLTimerQueryEXT? query);
   undefined beginQueryEXT(unsigned long target, WebGLTimerQueryEXT query);

--- a/Source/WebCore/html/canvas/WebGLTimerQueryEXT.cpp
+++ b/Source/WebCore/html/canvas/WebGLTimerQueryEXT.cpp
@@ -32,11 +32,16 @@
 
 namespace WebCore {
 
-RefPtr<WebGLTimerQueryEXT> WebGLTimerQueryEXT::create(WebGLRenderingContextBase& context)
+Ref<WebGLTimerQueryEXT> WebGLTimerQueryEXT::createLost()
+{
+    return adoptRef(*new WebGLTimerQueryEXT { });
+}
+
+Ref<WebGLTimerQueryEXT> WebGLTimerQueryEXT::create(WebGLRenderingContextBase& context)
 {
     auto object = protect(context.graphicsContextGL())->createQueryEXT();
     if (!object)
-        return nullptr;
+        return createLost();
     return adoptRef(*new WebGLTimerQueryEXT { context, object });
 }
 
@@ -52,6 +57,8 @@ WebGLTimerQueryEXT::WebGLTimerQueryEXT(WebGLRenderingContextBase& context, Platf
     : WebGLObject(context, object)
 {
 }
+
+WebGLTimerQueryEXT::WebGLTimerQueryEXT() = default;
 
 void WebGLTimerQueryEXT::deleteObjectImpl(const AbstractLocker&, GraphicsContextGL* context3d, PlatformGLObject object)
 {

--- a/Source/WebCore/html/canvas/WebGLTimerQueryEXT.h
+++ b/Source/WebCore/html/canvas/WebGLTimerQueryEXT.h
@@ -37,7 +37,8 @@ namespace WebCore {
 
 class WebGLTimerQueryEXT final : public WebGLObject {
 public:
-    static RefPtr<WebGLTimerQueryEXT> create(WebGLRenderingContextBase&);
+    static Ref<WebGLTimerQueryEXT> createLost();
+    static Ref<WebGLTimerQueryEXT> create(WebGLRenderingContextBase&);
     virtual ~WebGLTimerQueryEXT();
 
     bool isResultAvailable() const { return m_isResultAvailable; }
@@ -51,6 +52,7 @@ public:
 
 private:
     WebGLTimerQueryEXT(WebGLRenderingContextBase&, PlatformGLObject);
+    WebGLTimerQueryEXT();
     void deleteObjectImpl(const AbstractLocker&, GraphicsContextGL*, PlatformGLObject) override;
 
     bool m_isResultAvailable { false };


### PR DESCRIPTION
#### 47504401f98bf9cc8ab87ccc76366504f34ca2ba
<pre>
WebGL: WebGLTimerQueryEXT creation is not infallible
<a href="https://bugs.webkit.org/show_bug.cgi?id=314071">https://bugs.webkit.org/show_bug.cgi?id=314071</a>
<a href="https://rdar.apple.com/176259418">rdar://176259418</a>

Reviewed by Dan Glastonbury.

Similar to other query objects, make WebGLTimerQueryEXT always succeed.

Create a dummy object if the context is lost at the moment of creation.

* LayoutTests/webgl/query-context-lost-restore-expected.txt:
* LayoutTests/webgl/query-context-lost-restore.html:
* Source/WebCore/html/canvas/EXTDisjointTimerQuery.cpp:
(WebCore::EXTDisjointTimerQuery::createQueryEXT):
* Source/WebCore/html/canvas/EXTDisjointTimerQuery.h:
* Source/WebCore/html/canvas/EXTDisjointTimerQuery.idl:
* Source/WebCore/html/canvas/WebGLTimerQueryEXT.cpp:
(WebCore::WebGLTimerQueryEXT::createLost):
(WebCore::WebGLTimerQueryEXT::create):
* Source/WebCore/html/canvas/WebGLTimerQueryEXT.h:

Canonical link: <a href="https://commits.webkit.org/312764@main">https://commits.webkit.org/312764@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d19d0333500c4912672add7f9f04576569d985ac

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/160822 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/34295 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/27396 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/169725 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/115888 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/162691 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/34396 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/34295 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/124735 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/88060 "Passed tests") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/3e7e5bd0-d747-44da-beb3-577c47caa2b8) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/163781 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/26990 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/144461 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/105332 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/26042 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/24541 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/17445 "Built successfully") | | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/152878 "Build is in progress. Recent messages:") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/135736 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/22224 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/172207 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/19229 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/23865 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/133004 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/33969 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/28633 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/133015 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35963 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/33953 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/144019 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/95778 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/27608 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/20834 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/33464 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/100889 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/32963 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/33207 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/33111 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->