### PR TITLE
[cocoa] AVStreamDataParser accepts media segments not preceded by an init segment

### DIFF
--- a/LayoutTests/media/media-source/media-source-append-media-before-init-expected.txt
+++ b/LayoutTests/media/media-source/media-source-append-media-before-init-expected.txt
@@ -1,0 +1,45 @@
+
+
+Test 1: Append media segment before any init segment - should error
+EVENT(sourceopen)
+EXPECTED (gotError == 'true') OK
+InvalidStateError: The object is in an invalid state.
+PASS
+
+Test 2: Non-segment boxes before init should be silently dropped
+EVENT(sourceopen)
+EVENT(updateend)
+EXPECTED (sourceBuffer.buffered.length == '0') OK
+PASS
+
+Test 3: Init segment after dropped boxes should succeed
+EVENT(updateend)
+EVENT(updateend)
+EXPECTED (sourceBuffer.buffered.length == '1') OK
+PASS
+
+Test 4: Init segment preceded by free box in same append
+EVENT(sourceopen)
+EVENT(updateend)
+EVENT(updateend)
+EXPECTED (sourceBuffer.buffered.length == '1') OK
+PASS
+
+Test 5: After changeType, media segment without init should error
+EVENT(sourceopen)
+EVENT(updateend)
+EVENT(updateend)
+EXPECTED (sourceBuffer.buffered.length == '1') OK
+EXPECTED (gotError == 'true') OK
+PASS
+
+Test 6: After changeType, appending init then media should succeed
+EVENT(sourceopen)
+EVENT(updateend)
+EVENT(updateend)
+EVENT(updateend)
+EVENT(updateend)
+EXPECTED (sourceBuffer.buffered.length == '1') OK
+PASS
+END OF TEST
+

--- a/LayoutTests/media/media-source/media-source-append-media-before-init.html
+++ b/LayoutTests/media/media-source/media-source-append-media-before-init.html
@@ -1,0 +1,137 @@
+<!DOCTYPE html><!-- webkit-test-runner [ SourceBufferChangeTypeEnabled=true ] -->
+ <html>
+<head>
+    <title>media-source-append-media-before-init</title>
+    <script src="media-source-loader.js"></script>
+    <script src="../video-test.js"></script>
+    <script>
+    var loader;
+    var source;
+    var sourceBuffer;
+    var freeBox;
+    var initWithPrefix;
+    var gotError;
+    var video;
+
+    function makeFreeBox(size) {
+        var buffer = new ArrayBuffer(size);
+        var view = new DataView(buffer);
+        view.setUint32(0, size);
+        view.setUint32(4, 0x66726565); // 'free'
+        return buffer;
+    }
+
+    function prependData(prefix, buffer) {
+        var combined = new Uint8Array(prefix.byteLength + buffer.byteLength);
+        combined.set(new Uint8Array(prefix), 0);
+        combined.set(new Uint8Array(buffer), prefix.byteLength);
+        return combined.buffer;
+    }
+
+    async function createSourceBuffer() {
+        source = new MediaSource();
+        video.src = URL.createObjectURL(source);
+        await waitFor(source, 'sourceopen');
+        sourceBuffer = source.addSourceBuffer(loader.type());
+        return sourceBuffer;
+    }
+
+    function waitForErrorAndUpdateEnd(target) {
+        return new Promise((resolve) => {
+            var gotError = false;
+            target.addEventListener('error', () => { gotError = true; }, { once: true });
+            target.addEventListener('updateend', () => { resolve(gotError); }, { once: true });
+        });
+    }
+
+    window.addEventListener('load', async event => {
+        try {
+            video = document.querySelector('video');
+            loader = new MediaSourceLoader('content/test-fragmented-video-manifest.json');
+            await loaderPromise(loader);
+
+            consoleWrite('');
+            consoleWrite('Test 1: Append media segment before any init segment - should error');
+            await createSourceBuffer();
+            sourceBuffer.appendBuffer(loader.mediaSegment(0));
+            gotError = await waitForErrorAndUpdateEnd(sourceBuffer);
+            testExpected('gotError', true);
+            testExpected('sourceBuffer.buffered.length', 0);
+            consoleWrite('PASS');
+
+            consoleWrite('');
+            consoleWrite('Test 2: Non-segment boxes before init should be silently dropped');
+            await createSourceBuffer();
+            freeBox = makeFreeBox(64);
+            sourceBuffer.appendBuffer(freeBox);
+            await waitFor(sourceBuffer, 'updateend');
+            testExpected('sourceBuffer.buffered.length', 0);
+            consoleWrite('PASS');
+
+            consoleWrite('');
+            consoleWrite('Test 3: Init segment after dropped boxes should succeed');
+            sourceBuffer.appendBuffer(loader.initSegment());
+            await waitFor(sourceBuffer, 'updateend');
+            sourceBuffer.appendBuffer(loader.mediaSegment(0));
+            await waitFor(sourceBuffer, 'updateend');
+            testExpected('sourceBuffer.buffered.length', 1);
+            consoleWrite('PASS');
+
+            consoleWrite('');
+            consoleWrite('Test 4: Init segment preceded by free box in same append');
+            await createSourceBuffer();
+            initWithPrefix = prependData(makeFreeBox(32), loader.initSegment());
+            sourceBuffer.appendBuffer(initWithPrefix);
+            await waitFor(sourceBuffer, 'updateend');
+            sourceBuffer.appendBuffer(loader.mediaSegment(0));
+            await waitFor(sourceBuffer, 'updateend');
+            testExpected('sourceBuffer.buffered.length', 1);
+            consoleWrite('PASS');
+
+            consoleWrite('');
+            consoleWrite('Test 5: After changeType, media segment without init should error');
+            await createSourceBuffer();
+            sourceBuffer.appendBuffer(loader.initSegment());
+            await waitFor(sourceBuffer, 'updateend');
+            sourceBuffer.appendBuffer(loader.mediaSegment(0));
+            await waitFor(sourceBuffer, 'updateend');
+            testExpected('sourceBuffer.buffered.length', 1);
+            sourceBuffer.changeType(loader.type());
+            sourceBuffer.appendBuffer(loader.mediaSegment(1));
+            gotError = await waitForErrorAndUpdateEnd(sourceBuffer);
+            testExpected('gotError', true);
+            consoleWrite('PASS');
+
+            consoleWrite('');
+            consoleWrite('Test 6: After changeType, appending init then media should succeed');
+            await createSourceBuffer();
+            sourceBuffer.appendBuffer(loader.initSegment());
+            await waitFor(sourceBuffer, 'updateend');
+            sourceBuffer.appendBuffer(loader.mediaSegment(0));
+            await waitFor(sourceBuffer, 'updateend');
+            sourceBuffer.changeType(loader.type());
+            sourceBuffer.appendBuffer(loader.initSegment());
+            await waitFor(sourceBuffer, 'updateend');
+            sourceBuffer.appendBuffer(loader.mediaSegment(0));
+            await waitFor(sourceBuffer, 'updateend');
+            testExpected('sourceBuffer.buffered.length', 1);
+            consoleWrite('PASS');
+
+            endTest();
+        } catch (e) {
+            failTest(`Caught exception: "${e}"`);
+        }
+    });
+
+    function loaderPromise(loader) {
+        return new Promise((resolve, reject) => {
+            loader.onload = resolve;
+            loader.onerror = reject;
+        });
+    }
+    </script>
+</head>
+<body>
+    <video></video>
+</body>
+</html>

--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -5461,6 +5461,8 @@ webkit.org/b/313511 media/media-source/media-source-real-duration-after-append.h
 webkit.org/b/313511 media/media-source/media-source-real-fastseek.html [ Failure ]
 webkit.org/b/313511 media/media-source/media-source-real-overlapping-dts.html [ Failure ]
 
+webkit.org/b/314089 media/media-source/media-source-append-media-before-init.html [ Failure ]
+
 [ Debug ] imported/w3c/web-platform-tests/dom/events/Event-dispatch-single-activation-behavior.html [ Pass Failure ]
 
 webkit.org/b/305531 webgl/webgl2-provoking-vertex-primitive-restart-uint16-nocrash.html [ Skip ]

--- a/Source/WebCore/SourcesCocoa.txt
+++ b/Source/WebCore/SourcesCocoa.txt
@@ -467,6 +467,7 @@ platform/graphics/cocoa/HEVCUtilitiesCocoa.mm @nonARC
 platform/graphics/cocoa/IOSurface.mm @nonARC
 platform/graphics/cocoa/IOSurfaceDrawingBuffer.cpp
 platform/graphics/cocoa/IOSurfacePoolCocoa.mm @nonARC
+platform/graphics/cocoa/ISOBMFFPreParser.cpp
 platform/graphics/cocoa/IconCocoa.mm @nonARC
 platform/graphics/cocoa/IntRectCocoa.mm @nonARC
 platform/graphics/cocoa/ImageAdapterCocoa.mm @nonARC

--- a/Source/WebCore/platform/graphics/avfoundation/objc/SourceBufferParserAVFObjC.h
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/SourceBufferParserAVFObjC.h
@@ -46,13 +46,16 @@ typedef struct opaqueCMSampleBuffer *CMSampleBufferRef;
 
 namespace WebCore {
 
+class ContentType;
+class ISOBMFFPreParser;
+
 class SourceBufferParserAVFObjC final
     : public SourceBufferParser
     , private LoggerHelper {
 public:
     static MediaPlayerEnums::SupportsType isContentTypeSupported(const ContentType&);
 
-    SourceBufferParserAVFObjC(const MediaSourceConfiguration&);
+    SourceBufferParserAVFObjC(const ContentType&, const MediaSourceConfiguration&);
     virtual ~SourceBufferParserAVFObjC();
 
     AVStreamDataParser* streamDataParser() const { return m_parser.get(); }
@@ -84,7 +87,8 @@ private:
 
     RetainPtr<AVStreamDataParser> m_parser;
     RetainPtr<WebAVStreamDataParserListener> m_delegate;
-    MediaSourceConfiguration m_configuration;
+    const MediaSourceConfiguration m_configuration;
+    const std::unique_ptr<ISOBMFFPreParser> m_preParser;
     bool m_parserStateWasReset { false };
     std::optional<int> m_lastErrorCode;
 

--- a/Source/WebCore/platform/graphics/avfoundation/objc/SourceBufferParserAVFObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/SourceBufferParserAVFObjC.mm
@@ -32,7 +32,9 @@
 #import "AVAssetTrackUtilities.h"
 #import "AVStreamDataParserMIMETypeCache.h"
 #import "AudioTrackPrivateMediaSourceAVFObjC.h"
+#import "ContentType.h"
 #import "FourCC.h"
+#import "ISOBMFFPreParser.h"
 #import "MediaDescription.h"
 #import "MediaSample.h"
 #import "MediaSampleAVFObjC.h"
@@ -211,9 +213,24 @@ MediaPlayerEnums::SupportsType SourceBufferParserAVFObjC::isContentTypeSupported
     return AVStreamDataParserMIMETypeCache::singleton().canDecodeType(extendedType);
 }
 
-SourceBufferParserAVFObjC::SourceBufferParserAVFObjC(const MediaSourceConfiguration& configuration)
+static std::unique_ptr<ISOBMFFPreParser> makePreParserIfNeeded(const ContentType& contentType, AVStreamDataParser* parser)
+{
+    auto containerType = contentType.containerType();
+    if (!equalLettersIgnoringASCIICase(containerType, "video/mp4"_s) && !equalLettersIgnoringASCIICase(containerType, "audio/mp4"_s))
+        return nullptr;
+    return makeUnique<ISOBMFFPreParser>([parser = RetainPtr { parser }](Ref<const SharedBuffer>&& buffer, SourceBufferParser::AppendFlags flags) {
+        RetainPtr nsData = buffer->createNSData();
+        if (flags == SourceBufferParser::AppendFlags::Discontinuity)
+            [parser appendStreamData:nsData.get() withFlags:AVStreamDataParserStreamDataDiscontinuity];
+        else
+            [parser appendStreamData:nsData.get()];
+    });
+}
+
+SourceBufferParserAVFObjC::SourceBufferParserAVFObjC(const ContentType& contentType, const MediaSourceConfiguration& configuration)
     : m_parser(adoptNS([PAL::allocAVStreamDataParserInstance() init]))
     , m_configuration(configuration)
+    , m_preParser(makePreParserIfNeeded(contentType, m_parser.get()))
 {
     m_delegate = adoptNS([[WebAVStreamDataParserWithKeySpecifierListener alloc] initWithParser:m_parser.get() parent:this]);
 
@@ -230,15 +247,27 @@ SourceBufferParserAVFObjC::~SourceBufferParserAVFObjC()
     [m_delegate invalidate];
 }
 
-Expected<void, PlatformMediaError> SourceBufferParserAVFObjC::appendData(Ref<const SharedBuffer>&& segment, AppendFlags flags)
+Expected<void, PlatformMediaError> SourceBufferParserAVFObjC::appendData(Ref<const SharedBuffer>&& segment, AppendFlags)
 {
     INFO_LOG_IF_POSSIBLE(LOGIDENTIFIER);
-    RetainPtr nsData = segment->createNSData();
-    if (m_parserStateWasReset || flags == AppendFlags::Discontinuity)
-        [m_parser appendStreamData:nsData.get() withFlags:AVStreamDataParserStreamDataDiscontinuity];
-    else
-        [m_parser appendStreamData:nsData.get()];
-    m_parserStateWasReset = false;
+
+    AppendFlags flags = AppendFlags::None;
+    if (m_parserStateWasReset) {
+        flags = AppendFlags::Discontinuity;
+        m_parserStateWasReset = false;
+    }
+
+    if (m_preParser) {
+        auto result = m_preParser->appendData(WTF::move(segment), flags);
+        if (!result)
+            return result;
+    } else {
+        RetainPtr nsData = segment->createNSData();
+        if (flags == AppendFlags::Discontinuity)
+            [m_parser appendStreamData:nsData.get() withFlags:AVStreamDataParserStreamDataDiscontinuity];
+        else
+            [m_parser appendStreamData:nsData.get()];
+    }
 
     if (m_lastErrorCode)
         return makeUnexpected(PlatformMediaError::ParsingError);
@@ -255,6 +284,8 @@ void SourceBufferParserAVFObjC::resetParserState()
 {
     INFO_LOG_IF_POSSIBLE(LOGIDENTIFIER);
     m_parserStateWasReset = true;
+    if (m_preParser)
+        m_preParser->reset();
 }
 
 void SourceBufferParserAVFObjC::invalidate()

--- a/Source/WebCore/platform/graphics/cocoa/ISOBMFFPreParser.cpp
+++ b/Source/WebCore/platform/graphics/cocoa/ISOBMFFPreParser.cpp
@@ -1,0 +1,261 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "ISOBMFFPreParser.h"
+
+#if ENABLE(MEDIA_SOURCE)
+
+#include "BitReader.h"
+#include "SharedBuffer.h"
+
+namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(ISOBMFFPreParser);
+
+static constexpr auto ftypBox = FourCC(std::span { "ftyp" });
+static constexpr auto moovBox = FourCC(std::span { "moov" });
+static constexpr auto stypBox = FourCC(std::span { "styp" });
+static constexpr auto moofBox = FourCC(std::span { "moof" });
+
+ISOBMFFPreParser::ISOBMFFPreParser(ForwardDataCallback&& callback)
+    : m_forwardDataCallback(WTF::move(callback))
+{
+}
+
+std::optional<ISOBMFFPreParser::BoxHeader> ISOBMFFPreParser::parseBoxHeader(std::span<const uint8_t> data)
+{
+    if (data.size() < 8)
+        return std::nullopt;
+
+    BitReader reader(data);
+
+    auto sizeValue = reader.read<uint32_t>();
+    if (!sizeValue)
+        return std::nullopt;
+
+    auto typeValue = reader.read<uint32_t>();
+    if (!typeValue)
+        return std::nullopt;
+
+    BoxHeader header;
+    header.type = FourCC(*typeValue);
+    header.size = *sizeValue;
+    header.headerSize = 8;
+
+    if (*sizeValue == 1) {
+        auto extendedSize = reader.read<uint64_t>();
+        if (!extendedSize)
+            return std::nullopt;
+        header.size = *extendedSize;
+        header.headerSize = 16;
+    } else if (!*sizeValue)
+        return std::nullopt;
+
+    if (header.size < header.headerSize)
+        return std::nullopt;
+
+    return header;
+}
+
+bool ISOBMFFPreParser::isInitSegmentStartBox(FourCC type)
+{
+    return type == ftypBox;
+}
+
+bool ISOBMFFPreParser::isMediaSegmentStartBox(FourCC type)
+{
+    return type == stypBox || type == moofBox;
+}
+
+void ISOBMFFPreParser::reset()
+{
+    m_state = State::WaitingForSegment;
+    m_pendingHeaderBytes.clear();
+    m_remainingBytesInCurrentBox = 0;
+}
+
+void ISOBMFFPreParser::setPendingInitializationSegmentForChangeType()
+{
+    m_pendingInitializationSegmentForChangeType = true;
+    reset();
+}
+
+Expected<void, PlatformMediaError> ISOBMFFPreParser::appendData(
+    Ref<const SharedBuffer>&& segment, AppendFlags callerFlags)
+{
+    if (segment->isEmpty())
+        return { };
+
+    // Take ownership of any leftover pending header bytes from the previous
+    // call. They form a (≤15 byte) prefix of the conceptual data we walk; we
+    // splice across them and the new segment without copying segment's bytes.
+    Vector<uint8_t, 16> pendingBytes = WTF::move(m_pendingHeaderBytes);
+
+    auto inputSpan = segment->span();
+    auto pendingSize = pendingBytes.size();
+    auto totalSize = pendingSize + inputSpan.size();
+
+    auto shouldForward = [&]() {
+        return m_state != State::WaitingForSegment || m_firstInitializationSegmentReceived;
+    };
+
+    // Read up to 16 contiguous bytes from conceptual offset `offset`. When the
+    // request straddles the pending/segment boundary, the bytes are spliced
+    // into the caller-supplied staging buffer.
+    auto readHeaderBytes = [&](size_t offset, size_t len, std::span<uint8_t> staging) -> std::span<const uint8_t> {
+        ASSERT(len <= staging.size());
+        if (offset >= pendingSize)
+            return inputSpan.subspan(offset - pendingSize, len);
+        if (offset + len <= pendingSize)
+            return pendingBytes.subspan(offset, len);
+        auto pendingPart = pendingSize - offset;
+        memcpySpan(staging.first(pendingPart), pendingBytes.subspan(offset, pendingPart));
+        memcpySpan(staging.subspan(pendingPart, len - pendingPart), inputSpan.first(len - pendingPart));
+        return staging.first(len);
+    };
+
+    // Forward the conceptual range [start, end). When it straddles the
+    // pending/segment boundary, send two SharedBuffers — the pending side as
+    // a fresh small buffer (≤15 bytes), the segment side as a zero-copy view.
+    auto forward = [&](size_t start, size_t end, AppendFlags flags) {
+        ASSERT(start < end);
+        if (start >= pendingSize) {
+            m_forwardDataCallback(segment->getContiguousData(start - pendingSize, end - start), flags);
+            return;
+        }
+        if (end <= pendingSize) {
+            m_forwardDataCallback(SharedBuffer::create(pendingBytes.subspan(start, end - start)), flags);
+            return;
+        }
+        auto pendingPart = pendingSize - start;
+        m_forwardDataCallback(SharedBuffer::create(pendingBytes.subspan(start, pendingPart)), flags);
+        m_forwardDataCallback(segment->getContiguousData(0, end - pendingSize), flags);
+    };
+
+    // Stash conceptual bytes [offset, totalSize) as the new pending header bytes.
+    auto stashRemaining = [&](size_t offset) {
+        ASSERT(totalSize - offset < 16);
+        if (offset < pendingSize) {
+            m_pendingHeaderBytes.append(pendingBytes.subspan(offset));
+            m_pendingHeaderBytes.append(inputSpan);
+        } else
+            m_pendingHeaderBytes.append(inputSpan.subspan(offset - pendingSize));
+    };
+
+    AppendFlags nextChunkFlags = callerFlags;
+    size_t offset = 0;
+    size_t forwardStart = 0;
+
+    while (offset < totalSize) {
+        if (m_remainingBytesInCurrentBox > 0) {
+            auto toConsume = std::min<uint64_t>(totalSize - offset, m_remainingBytesInCurrentBox);
+            m_remainingBytesInCurrentBox -= toConsume;
+            offset += static_cast<size_t>(toConsume);
+            continue;
+        }
+
+        auto available = totalSize - offset;
+
+        if (available < 8) {
+            if (shouldForward() && offset > forwardStart)
+                forward(forwardStart, offset, nextChunkFlags);
+            stashRemaining(offset);
+            return { };
+        }
+
+        Vector<uint8_t, 16> staging(16);
+        auto headerBytes = readHeaderBytes(offset, 8, staging.mutableSpan());
+        uint32_t sizeField = (static_cast<uint32_t>(headerBytes[0]) << 24)
+            | (static_cast<uint32_t>(headerBytes[1]) << 16)
+            | (static_cast<uint32_t>(headerBytes[2]) << 8)
+            | static_cast<uint32_t>(headerBytes[3]);
+        if (sizeField == 1 && available < 16) {
+            if (shouldForward() && offset > forwardStart)
+                forward(forwardStart, offset, nextChunkFlags);
+            stashRemaining(offset);
+            return { };
+        }
+        if (sizeField == 1)
+            headerBytes = readHeaderBytes(offset, 16, staging.mutableSpan());
+
+        auto header = parseBoxHeader(headerBytes);
+        if (!header)
+            return makeUnexpected(PlatformMediaError::ParsingError);
+
+        auto boxType = header->type;
+        auto boxBodySize = header->size - header->headerSize;
+
+        switch (m_state) {
+        case State::WaitingForSegment:
+            if (isInitSegmentStartBox(boxType)) {
+                if (m_firstInitializationSegmentReceived) {
+                    if (offset > forwardStart)
+                        forward(forwardStart, offset, nextChunkFlags);
+                    nextChunkFlags = AppendFlags::Discontinuity;
+                }
+                forwardStart = offset;
+                m_state = State::ParsingInitSegment;
+                break;
+            }
+            if (isMediaSegmentStartBox(boxType)) {
+                if (!m_firstInitializationSegmentReceived || m_pendingInitializationSegmentForChangeType)
+                    return makeUnexpected(PlatformMediaError::ParsingError);
+                m_state = State::ParsingMediaSegment;
+            }
+            break;
+
+        case State::ParsingInitSegment:
+            if (boxType == moovBox) {
+                m_firstInitializationSegmentReceived = true;
+                m_pendingInitializationSegmentForChangeType = false;
+                m_state = State::WaitingForSegment;
+                break;
+            }
+            if (isMediaSegmentStartBox(boxType))
+                return makeUnexpected(PlatformMediaError::ParsingError);
+            break;
+
+        case State::ParsingMediaSegment:
+            if (isInitSegmentStartBox(boxType)) {
+                m_state = State::WaitingForSegment;
+                continue;
+            }
+            break;
+        }
+
+        m_remainingBytesInCurrentBox = boxBodySize;
+        offset += header->headerSize;
+    }
+
+    if (shouldForward() && forwardStart < totalSize)
+        forward(forwardStart, totalSize, nextChunkFlags);
+
+    return { };
+}
+
+} // namespace WebCore
+
+#endif // ENABLE(MEDIA_SOURCE)

--- a/Source/WebCore/platform/graphics/cocoa/ISOBMFFPreParser.h
+++ b/Source/WebCore/platform/graphics/cocoa/ISOBMFFPreParser.h
@@ -1,0 +1,97 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if ENABLE(MEDIA_SOURCE)
+
+#include "FourCC.h"
+#include "PlatformMediaError.h"
+#include "SourceBufferParser.h"
+#include <optional>
+#include <span>
+#include <wtf/Expected.h>
+#include <wtf/Function.h>
+#include <wtf/Ref.h>
+#include <wtf/TZoneMalloc.h>
+#include <wtf/Vector.h>
+
+namespace WebCore {
+
+class SharedBuffer;
+
+// Lightweight ISO-BMFF pre-parser implementing the MSE Segment Parser Loop
+// state machine. Walks box headers (via BitReader) to detect initialization
+// and media segment boundaries without parsing box contents.
+//
+// We intentionally do not reuse ISOBox::peekBox here because it requires
+// JSC::DataView, which routes through Gigacage — accessing non-Gigacaged
+// memory (e.g. from SharedBuffer) causes EXC_BAD_ACCESS. See rdar://171573373.
+class ISOBMFFPreParser {
+    WTF_MAKE_TZONE_ALLOCATED(ISOBMFFPreParser);
+    WTF_MAKE_NONCOPYABLE(ISOBMFFPreParser);
+public:
+    using AppendFlags = SourceBufferParser::AppendFlags;
+    using ForwardDataCallback = Function<void(Ref<const SharedBuffer>&&, AppendFlags)>;
+
+    explicit ISOBMFFPreParser(ForwardDataCallback&&);
+
+    Expected<void, PlatformMediaError> appendData(Ref<const SharedBuffer>&&, AppendFlags = AppendFlags::None);
+
+    // Resets the segment parser loop state. Does NOT clear
+    // m_firstInitializationSegmentReceived per the MSE spec
+    // (abort() resets the parser but remembers that init was received).
+    void reset();
+
+    void setPendingInitializationSegmentForChangeType();
+
+private:
+    enum class State : uint8_t {
+        WaitingForSegment,
+        ParsingInitSegment,
+        ParsingMediaSegment,
+    };
+
+    struct BoxHeader {
+        FourCC type;
+        uint64_t size;
+        uint8_t headerSize; // 8 or 16
+    };
+
+    static std::optional<BoxHeader> parseBoxHeader(std::span<const uint8_t>);
+    static bool isInitSegmentStartBox(FourCC);
+    static bool isMediaSegmentStartBox(FourCC);
+
+    ForwardDataCallback m_forwardDataCallback;
+    State m_state { State::WaitingForSegment };
+    bool m_firstInitializationSegmentReceived { false };
+    bool m_pendingInitializationSegmentForChangeType { false };
+    Vector<uint8_t, 16> m_pendingHeaderBytes;
+    uint64_t m_remainingBytesInCurrentBox { 0 };
+};
+
+} // namespace WebCore
+
+#endif // ENABLE(MEDIA_SOURCE)

--- a/Source/WebCore/platform/graphics/cocoa/SourceBufferParser.cpp
+++ b/Source/WebCore/platform/graphics/cocoa/SourceBufferParser.cpp
@@ -54,7 +54,7 @@ RefPtr<SourceBufferParser> SourceBufferParser::create(const ContentType& type, c
         return SourceBufferParserWebM::create();
 
     if (SourceBufferParserAVFObjC::isContentTypeSupported(type) != MediaPlayerEnums::SupportsType::IsNotSupported)
-        return adoptRef(new SourceBufferParserAVFObjC(configuration));
+        return adoptRef(new SourceBufferParserAVFObjC(type, configuration));
 
     return nullptr;
 }


### PR DESCRIPTION
#### 4ed00073e6733fe3ca073eeea651bbebaf8e43c1
<pre>
[cocoa] AVStreamDataParser accepts media segments not preceded by an init segment
<a href="https://bugs.webkit.org/show_bug.cgi?id=314045">https://bugs.webkit.org/show_bug.cgi?id=314045</a>
<a href="https://rdar.apple.com/176242479">rdar://176242479</a>

Reviewed by Jer Noble.

With Twitch, following a transition from an ad back to streaming content,
the player creates a new MediaSource and begins appending content that
does not always start with an initialization segment. This exposed two
issues in AVStreamDataParser&apos;s handling of the MSE Segment Parser Loop:

- It accepts media segments appended before any initialization segment,
producing CMSampleBuffers with no valid CMFormatDescription that later
may fail to decode.
- When a new initialization segment of a different format is appended
without a preceding abort() or changeType(), its internal MoofManifold
reports a &quot;Second ftyp atom&quot; error (-16046) that is CoreMedia-internal
and never surfaces via didFailToParseStreamDataWithError:. The error is
not fatal, but the new init segment was not applied cleanly because the
parser is never told the stream is discontinuous and invalid sample&apos;s pts
were sometimes observed (which caused them to be dropped and lead to a stall).

AVStreamDataParser already exposes AVStreamDataParserStreamDataDiscontinuity
for the second case, but no caller was ever setting it outside of
resetParserState() (abort()/changeType()). The AppendFlags::Discontinuity
plumbing in SourceBufferParser was effectively dead code for the
mid-stream re-initialization path.

Fix: We add an ISO-BMFF pre-parser upstream of AVStreamDataParser. It walks
box headers across appendData() boundaries (without parsing box contents)
and tracks Segment Parser Loop state. It does two things:

- If a media segment arrives before any initialization segment, the
append is rejected with a parsing error. This matches the MSE spec and
aligns WebKit with Firefox and Chrome.
- When a new `ftyp` is detected after an init segment has already been
received, the append is split: anything before the ftyp is forwarded
with the existing flags, and the ftyp-onward portion is forwarded with
AppendFlags::Discontinuity, which SourceBufferParserAVFObjC translates
into AVStreamDataParserStreamDataDiscontinuity.

The pre-parser uses BitReader rather than ISOBox::peekBox because the
latter requires JSC::DataView and routes through Gigacage; accessing
non-Gigacaged memory (e.g. SharedBuffer contents) causes EXC_BAD_ACCESS
(<a href="https://rdar.apple.com/171573373">rdar://171573373</a>).

Box header parsing handles the 32-bit, 64-bit extended (size==1), and
open-ended (size==0) encodings, and carries partial headers across
appendData() calls via m_pendingHeaderBytes so a header spanning two
appends parses correctly.

* LayoutTests/media/media-source/media-source-append-media-before-init-expected.txt: Added.
* LayoutTests/media/media-source/media-source-append-media-before-init.html: Added.
* Source/WebCore/SourcesCocoa.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
(WebCore::ISOBMFFPreParser::ISOBMFFPreParser):
(WebCore::ISOBMFFPreParser::parseBoxHeader):
(WebCore::ISOBMFFPreParser::isInitSegmentStartBox):
(WebCore::ISOBMFFPreParser::isMediaSegmentStartBox):
(WebCore::ISOBMFFPreParser::reset):
(WebCore::ISOBMFFPreParser::setPendingInitializationSegmentForChangeType):
(WebCore::ISOBMFFPreParser::appendData):
* Source/WebCore/platform/graphics/cocoa/ISOBMFFPreParser.cpp: Added.
* Source/WebCore/platform/graphics/cocoa/ISOBMFFPreParser.h: Added.
* Source/WebCore/platform/graphics/avfoundation/objc/SourceBufferParserAVFObjC.h:
* Source/WebCore/platform/graphics/avfoundation/objc/SourceBufferParserAVFObjC.mm:
(WebCore::SourceBufferParserAVFObjC::SourceBufferParserAVFObjC):
(WebCore::SourceBufferParserAVFObjC::appendData):
(WebCore::SourceBufferParserAVFObjC::resetParserState):

Canonical link: <a href="https://commits.webkit.org/312761@main">https://commits.webkit.org/312761@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/16e3b388918a62fa39304be1a0933ed6022df356

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/160783 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/34256 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/27357 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/169686 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/115849 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/162652 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/34357 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/34256 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/124701 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/88043 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/163742 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/26952 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/144425 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/105298 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/26004 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/24505 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/17406 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/135698 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/22188 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/172168 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/19176 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/23829 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/132969 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/33930 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/28597 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/132980 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35960 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/33914 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/143983 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/95726 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/27569 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/20798 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/33425 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/100833 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/32924 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/33168 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/33072 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->