### PR TITLE
[MSE][Cocoa] Silence spurious UpcomingPTSExpectation warnings from

### DIFF
--- a/Source/WebCore/platform/graphics/TrackBuffer.cpp
+++ b/Source/WebCore/platform/graphics/TrackBuffer.cpp
@@ -110,6 +110,18 @@ void TrackBuffer::addSample(MediaSample& sample)
             if (sample.presentationTime() < previousSample->presentationTime())
                 m_hasOutOfOrderFrames = true;
         }
+
+        // Track reorder depth in decode order. We can't publish a trustworthy
+        // minimum upcoming PTS until we've seen at least m_maxObservedReorderDepth
+        // + 1 samples past the head — a B-frame with lower PTS may still be on
+        // its way.
+        if (m_maxPresentationTimeSeenInDecodeOrder.isInvalid() || sample.presentationTime() > m_maxPresentationTimeSeenInDecodeOrder) {
+            m_maxPresentationTimeSeenInDecodeOrder = sample.presentationTime();
+            m_samplesSinceMaxPresentationTime = 0;
+        } else {
+            ++m_samplesSinceMaxPresentationTime;
+            m_maxObservedReorderDepth = std::max(m_maxObservedReorderDepth, m_samplesSinceMaxPresentationTime);
+        }
     }
 
     // NOTE: the spec considers the need to check the last frame duration but doesn't specify if that last frame
@@ -183,6 +195,17 @@ void TrackBuffer::updateMinimumUpcomingPresentationTime()
         m_minimumEnqueuedPresentationTime = MediaTime::invalidTime();
         return;
     }
+
+    // For streams with B-frames we can't trust the sliding-window minimum until
+    // we've seen enough samples past the head to cover the observed reorder
+    // depth — a later-arriving B-frame could have a lower PTS than what's
+    // currently in the queue, and publishing the too-high minimum to the
+    // renderer triggers UpcomingPTSExpectation warnings for every B-frame.
+    if (m_hasOutOfOrderFrames && m_decodeQueue.size() < m_maxObservedReorderDepth + 1) {
+        m_minimumEnqueuedPresentationTime = MediaTime::invalidTime();
+        return;
+    }
+
     size_t forwardIndex = 0;
     m_minimumEnqueuedPresentationTime = MediaTime::positiveInfiniteTime();
     for (auto it = m_decodeQueue.begin(); it != m_decodeQueue.end() && forwardIndex < MaximumSlidingWindowLength; ++forwardIndex, ++it) {
@@ -529,6 +552,11 @@ void TrackBuffer::clearDecodeQueue()
     m_minimumEnqueuedPresentationTime = MediaTime::invalidTime();
     m_highestEnqueuedPresentationTime = MediaTime::invalidTime();
     m_lastEnqueuedDecodeKey = { MediaTime::invalidTime(), MediaTime::invalidTime() };
+    // Reset the running reorder observation but keep m_maxObservedReorderDepth —
+    // the codec-declared / previously-seen reorder depth remains valid across a
+    // decode-queue flush (same stream, same codec config).
+    m_maxPresentationTimeSeenInDecodeOrder = MediaTime::invalidTime();
+    m_samplesSinceMaxPresentationTime = 0;
 }
 
 void TrackBuffer::setRoundedTimestampOffset(const MediaTime& time, uint32_t timeScale, const MediaTime& roundingMargin)

--- a/Source/WebCore/platform/graphics/TrackBuffer.h
+++ b/Source/WebCore/platform/graphics/TrackBuffer.h
@@ -81,6 +81,11 @@ public:
     void setHighestEnqueuedPresentationTime(MediaTime timestamp) { m_highestEnqueuedPresentationTime = WTF::move(timestamp); }
     const MediaTime& minimumEnqueuedPresentationTime() const LIFETIME_BOUND { return m_minimumEnqueuedPresentationTime; }
 
+    // Raises the tracked reorder depth. Call once per init segment with the
+    // codec-declared max_num_reorder_frames / sps_max_num_reorder_pics when
+    // available. The running observation in addSample() can only grow it further.
+    void setInitialReorderDepth(size_t depth) { m_maxObservedReorderDepth = std::max(m_maxObservedReorderDepth, depth); }
+
     const DecodeOrderSampleMap::KeyType& lastEnqueuedDecodeKey() const LIFETIME_BOUND { return m_lastEnqueuedDecodeKey; }
     void setLastEnqueuedDecodeKey(DecodeOrderSampleMap::KeyType key) { m_lastEnqueuedDecodeKey = WTF::move(key); }
 
@@ -137,6 +142,14 @@ private:
 
     MediaTime m_highestEnqueuedPresentationTime { MediaTime::invalidTime() };
     MediaTime m_minimumEnqueuedPresentationTime { MediaTime::invalidTime() };
+
+    // Running observation of decode-order reorder depth. Seeded by
+    // setInitialReorderDepth; grown when a deeper reorder is seen. Gates
+    // publication of m_minimumEnqueuedPresentationTime so a yet-to-arrive
+    // B-frame can't invalidate the value handed to the renderer.
+    MediaTime m_maxPresentationTimeSeenInDecodeOrder { MediaTime::invalidTime() };
+    size_t m_samplesSinceMaxPresentationTime { 0 };
+    size_t m_maxObservedReorderDepth { 3 };
 
     DecodeOrderSampleMap::KeyType m_lastEnqueuedDecodeKey { MediaTime::invalidTime(), MediaTime::invalidTime() };
 

--- a/Source/WebCore/platform/graphics/avfoundation/AudioVideoRendererAVFObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/AudioVideoRendererAVFObjC.mm
@@ -259,7 +259,7 @@ void AudioVideoRendererAVFObjC::enqueueSample(TrackIdentifier trackId, Ref<Media
         }
         m_keyframeNeeded = false;
         if (RefPtr videoRenderer = m_videoRenderer; videoRenderer && isEnabledVideoTrackId(trackId)) {
-            videoRenderer->enqueueSample(sample, minimumUpcomingTime.value_or(sample->presentationTime()));
+            videoRenderer->enqueueSample(sample, minimumUpcomingTime);
             if (!m_hasEverSubmittedVideoSample) {
                 m_hasEverSubmittedVideoSample = true;
                 m_previousRendererConfiguration.isRenderingCompressedVideo = !isUsingDecompressionSession();

--- a/Source/WebCore/platform/graphics/cocoa/VideoMediaSampleRenderer.h
+++ b/Source/WebCore/platform/graphics/cocoa/VideoMediaSampleRenderer.h
@@ -82,7 +82,7 @@ public:
 
     bool isReadyForMoreMediaData() const;
     void requestMediaDataWhenReady(Function<void()>&&);
-    void enqueueSample(const MediaSample&, const MediaTime&);
+    void enqueueSample(const MediaSample&, std::optional<MediaTime> minimumUpcomingTime);
     void stopRequestingMediaData();
 
     void notifyFirstFrameAvailable(Function<void(const MediaTime&, double)>&&);
@@ -209,7 +209,7 @@ private:
     TimebaseAndTimerSource m_timebaseAndTimerSource WTF_GUARDED_BY_LOCK(m_lock);
     RefPtr<EffectiveRateChangedListener> m_effectiveRateChangedListener;
     std::atomic<FlushId> m_flushId { 0 };
-    Deque<std::tuple<Ref<const MediaSample>, MediaTime, FlushId, bool>> m_compressedSampleQueue WTF_GUARDED_BY_CAPABILITY(dispatcher().get());
+    Deque<std::tuple<Ref<const MediaSample>, std::optional<MediaTime>, FlushId, bool>> m_compressedSampleQueue WTF_GUARDED_BY_CAPABILITY(dispatcher().get());
     std::atomic<uint32_t> m_compressedSamplesCount { 0 };
     std::atomic<uint32_t> m_pendingSamplesCount { 0 };
     MediaSampleReorderQueue m_decodedSampleQueue WTF_GUARDED_BY_CAPABILITY(dispatcher().get());

--- a/Source/WebCore/platform/graphics/cocoa/VideoMediaSampleRenderer.mm
+++ b/Source/WebCore/platform/graphics/cocoa/VideoMediaSampleRenderer.mm
@@ -417,10 +417,10 @@ MediaTime VideoMediaSampleRenderer::currentTime() const
     return MediaTime::invalidTime();
 }
 
-void VideoMediaSampleRenderer::enqueueSample(const MediaSample& sample, const MediaTime& minimumUpcomingTime)
+void VideoMediaSampleRenderer::enqueueSample(const MediaSample& sample, std::optional<MediaTime> minimumUpcomingTime)
 {
     assertIsMainThread();
-    DEBUG_LOG(LOGIDENTIFIER, "sample: ", sample, " minimumUpcomingTime: ", minimumUpcomingTime);
+    DEBUG_LOG(LOGIDENTIFIER, "sample: ", sample, " minimumUpcomingTime: ", minimumUpcomingTime.value_or(MediaTime::invalidTime()));
 
     ASSERT(sample.type() == MediaSample::Type::CMSampleBuffer);
     if (sample.type() != MediaSample::Type::CMSampleBuffer)
@@ -501,19 +501,23 @@ void VideoMediaSampleRenderer::decodeNextSampleIfNeeded()
         if (currentTime.isValid() && !m_wasProtected && !m_decompressionSessionWasBlocked) {
             auto endTime = lastDecodedSampleTime();
             if (endTime.isValid() && endTime > highWaterMarkTime) {
-                auto [sample, upcomingMinimum, flushId, blocked] = m_compressedSampleQueue.first();
-                upcomingMinimum = std::min(sample->presentationTime(), upcomingMinimum.isValid() ? upcomingMinimum : MediaTime::positiveInfiniteTime());
-
-                if (endTime < upcomingMinimum) {
-                    if (m_lastMinimumUpcomingPresentationTime.isInvalid() || upcomingMinimum != m_lastMinimumUpcomingPresentationTime) {
-                        ASSERT(m_lastMinimumUpcomingPresentationTime.isInvalid() || m_lastMinimumUpcomingPresentationTime < upcomingMinimum);
-                        m_lastMinimumUpcomingPresentationTime = upcomingMinimum;
-                        LogPerformance("VideoMediaSampleRenderer::decodeNextSampleIfNeeded currentTime:%0.2f expectMinimumUpcomingSampleBufferPresentationTime:%0.2f decoded queued:%zu upcoming:%zu high watermark reached", currentTime.toDouble(), m_lastMinimumUpcomingPresentationTime.toDouble(), decodedSamplesCount(), compressedSamplesCount());
-                        [rendererOrDisplayLayer() expectMinimumUpcomingSampleBufferPresentationTime:PAL::toCMTime(m_lastMinimumUpcomingPresentationTime)];
+                const auto& [sample, upcomingMinimumOpt, flushId, blocked] = m_compressedSampleQueue.first();
+                if (upcomingMinimumOpt) {
+                    auto upcomingMinimum = std::min(sample->presentationTime(), *upcomingMinimumOpt);
+                    if (endTime < upcomingMinimum) {
+                        if (m_lastMinimumUpcomingPresentationTime.isInvalid() || upcomingMinimum != m_lastMinimumUpcomingPresentationTime) {
+                            ASSERT(m_lastMinimumUpcomingPresentationTime.isInvalid() || m_lastMinimumUpcomingPresentationTime < upcomingMinimum);
+                            m_lastMinimumUpcomingPresentationTime = upcomingMinimum;
+                            LogPerformance("VideoMediaSampleRenderer::decodeNextSampleIfNeeded currentTime:%0.2f expectMinimumUpcomingSampleBufferPresentationTime:%0.2f decoded queued:%zu upcoming:%zu high watermark reached", currentTime.toDouble(), m_lastMinimumUpcomingPresentationTime.toDouble(), decodedSamplesCount(), compressedSamplesCount());
+                            [rendererOrDisplayLayer() expectMinimumUpcomingSampleBufferPresentationTime:PAL::toCMTime(m_lastMinimumUpcomingPresentationTime)];
+                        }
+                        return;
                     }
-                    return;
+                    DEBUG_LOG(LOGIDENTIFIER, "Out of order frames detected, forcing extra decode");
                 }
-                DEBUG_LOG(LOGIDENTIFIER, "Out of order frames detected, forcing extra decode");
+                // Without a caller lookahead we can't safely publish a floor — a
+                // later-arriving B-frame could have a lower PTS and would be
+                // rejected by the renderer. Fall through and keep decoding.
             }
             if (endTime.isValid() && endTime >= lowWaterMarkTime && playbackRate > 0.9 && playbackRate < 1.1) {
                 LogPerformance("VideoMediaSampleRenderer::decodeNextSampleIfNeeded expectMinimumUpcomingSampleBufferPresentationTime:%0.2f decoded queued:%zu upcoming:%zu currentTime:%0.2f endTime:%0.2f low:%0.2f high:%0.2f low watermark reached", m_lastMinimumUpcomingPresentationTime.toDouble(), decodedSamplesCount(), compressedSamplesCount(), currentTime.toDouble(), endTime.toDouble(), lowWaterMarkTime.toDouble(), highWaterMarkTime.toDouble());
@@ -521,7 +525,7 @@ void VideoMediaSampleRenderer::decodeNextSampleIfNeeded()
             }
         }
 
-        auto [sample, upcomingMinimum, flushId, blocked] = m_compressedSampleQueue.takeFirst();
+        auto [sample, upcomingMinimumOpt, flushId, blocked] = m_compressedSampleQueue.takeFirst();
         m_compressedSamplesCount = m_compressedSampleQueue.size();
         maybeBecomeReadyForMoreMediaData();
 


### PR DESCRIPTION
#### 62987e20ab97418bd379d1fddeab9a181c064e3c
<pre>
[MSE][Cocoa] Silence spurious UpcomingPTSExpectation warnings from
AVSampleBufferVideoRenderer on B-frame content
<a href="https://bugs.webkit.org/show_bug.cgi?id=314077">https://bugs.webkit.org/show_bug.cgi?id=314077</a>
<a href="https://rdar.apple.com/176260662">rdar://176260662</a>

Reviewed by Jer Noble.

AVSampleBufferVideoRenderer&apos;s _enqueueSingleSampleBuffer: compares each
incoming sample&apos;s PTS against a floor that WebKit publishes via
-[AVSampleBufferDisplayLayer expectMinimumUpcomingSampleBufferPresentationTime:]
and logs &quot;UpcomingPTSExpectation is enabled, but enqueuePTS:X is smaller
than expectedMinimumUpcomingPTS:Y&quot; whenever a later sample arrives with
a lower PTS. The log is informational only — samples are still accepted
— but on B-frame streams the message fires every frame pair: a 5-minute
Twitch capture produced 6197 lines, burying other signal during stall
investigations.

The floor came from TrackBuffer::minimumEnqueuedPresentationTime(),
recomputed by TrackBuffer::updateMinimumUpcomingPresentationTime() as a
sliding-window minimum over m_decodeQueue. When the parser feeds samples
one at a time (typical Twitch behaviour, and the common case during
post-changeType recovery) the decode queue is near-empty after each pop
and the scan can only see the current sample&apos;s own PTS. In decode order
that&apos;s a P-frame at the top of a GOP triplet, with two B-frames at lower
PTS arriving next — and the floor we publish is therefore always too
high by the B-frame reorder distance.

Two coordinated changes:

1. TrackBuffer now tracks the max observed reorder depth. On every
    addSample() we count samples in decode order since the most recent
    new-max PTS; the running maximum is stored in
    m_maxObservedReorderDepth, seeded to a conservative default of 3 to
    cover typical IPBB/IPBBB patterns and growing on deeper reorder.
    updateMinimumUpcomingPresentationTime() refuses to publish a value
    until the queue contains at least m_maxObservedReorderDepth + 1
    samples past the head when m_hasOutOfOrderFrames is set — that&apos;s the
    point at which the sliding-window scan has actually seen every
    B-frame that could come before the head&apos;s PTS. A new
    setInitialReorderDepth(size_t) hook is exposed so a future change
    can seed the depth from the codec config (H.264 max_num_reorder_frames
    / H.265 sps_max_num_reorder_pics); today it is unused and the
    mechanism is purely empirical.

2. Propagate the &quot;no lookahead available&quot; state cleanly down to the
    renderer instead of masking it. AudioVideoRendererAVFObjC::enqueueSample()
    no longer falls back to sample-&gt;presentationTime() when the caller
    passes std::nullopt; VideoMediaSampleRenderer::enqueueSample() now
    takes std::optional&lt;MediaTime&gt; and stores the optional in
    m_compressedSampleQueue. decodeNextSampleIfNeeded() only calls
    -expectMinimumUpcomingSampleBufferPresentationTime: when the stored
    optional holds a value. Without a lookahead it falls through and
    keeps decoding, which was the previous unintended behaviour anyway
    (the floor we were publishing was wrong).

Net effect: zero warnings in steady-state Twitch playback, and none
during ad/content transitions once the first handful of samples have
established the reorder depth.

No tests added; manual verification via
log stream --predicate=&apos;(process=&quot;Safari&quot; or process=&quot;com.apple.WebKit.GPU.Development&quot;)&apos;
with a Twitch session shows the &quot;UpcomingPTSExpectation is enabled&quot;
message count drop from ~6000 / 5 min to near zero.

* Source/WebCore/platform/graphics/TrackBuffer.h:
(WebCore::TrackBuffer::setInitialReorderDepth):
Add setInitialReorderDepth() and the three new members backing the
reorder-depth observation.
* Source/WebCore/platform/graphics/TrackBuffer.cpp:
(WebCore::TrackBuffer::addSample):
Track the running reorder depth alongside m_hasOutOfOrderFrames.
(WebCore::TrackBuffer::updateMinimumUpcomingPresentationTime):
Gate publication on having at least m_maxObservedReorderDepth + 1
samples in the queue when m_hasOutOfOrderFrames is set.
(WebCore::TrackBuffer::clearDecodeQueue):
Reset the observation counters but keep the learned depth.
* Source/WebCore/platform/graphics/avfoundation/AudioVideoRendererAVFObjC.mm:
(WebCore::AudioVideoRendererAVFObjC::enqueueSample):
Pass the std::optional&lt;MediaTime&gt; through instead of substituting the
sample&apos;s own PTS.
* Source/WebCore/platform/graphics/cocoa/VideoMediaSampleRenderer.h:
Change enqueueSample() signature and m_compressedSampleQueue element
type to carry std::optional&lt;MediaTime&gt;.
* Source/WebCore/platform/graphics/cocoa/VideoMediaSampleRenderer.mm:
(WebCore::VideoMediaSampleRenderer::enqueueSample):
Accept std::optional&lt;MediaTime&gt;.
(WebCore::VideoMediaSampleRenderer::decodeNextSampleIfNeeded):
Only publish a floor when the stored optional is present; fall through
and decode otherwise.

Canonical link: <a href="https://commits.webkit.org/312763@main">https://commits.webkit.org/312763@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/11fa89fbd19d4418db622b5ea5fdb36cee631510

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/160558 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/34031 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/27132 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/169461 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/115624 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/6722acae-8187-4f16-bd3b-0c452f425ecc) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/162427 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/34132 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/34031 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/124508 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/87932 "1 flakes 2 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/b25ec38d-4c63-478a-bbfd-aec1ede73931) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/163517 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/26749 "Passed tests") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/144225 "Found 1 new API test failure: TestWebKitAPI.WKWebExtensionAPIScripting.ExecuteScriptWithUserGesture (failure)") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/105108 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/1639a2d3-30e8-4f6e-afb2-7b9c5b7bea5d) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/25801 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/24304 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/17181 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/135495 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/21988 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/171940 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/18749 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/23628 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/132773 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/33705 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/28397 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/132788 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35962 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/33689 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/143783 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/95485 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/27379 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/20597 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/33200 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/100349 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/32699 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/32943 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/32847 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->