### PR TITLE
[WGSL] shader,validation,expression,call,builtin,clamp:* is failing

### DIFF
--- a/LayoutTests/http/tests/webgpu/webgpu/shader/validation/expression/call/builtin/clamp-expected.txt
+++ b/LayoutTests/http/tests/webgpu/webgpu/shader/validation/expression/call/builtin/clamp-expected.txt
@@ -64,721 +64,145 @@ PASS :mismatched:e="vec2%3Cu32%3E"
 PASS :mismatched:e="vec3%3Cu32%3E"
 PASS :mismatched:e="vec4%3Cu32%3E"
 PASS :low_high:type="f32";lowStage="constant";highStage="constant"
-FAIL :low_high:type="f32";lowStage="constant";highStage="override" assert_unreached:
-  - (in subcase: low=0;high=1;in_shader=false) INFO: subcase ran
-  - (in subcase: low=0;high=1;in_shader=true) INFO: subcase ran
-  - (in subcase: low=1;high=1;in_shader=false) INFO: subcase ran
-  - (in subcase: low=1;high=1;in_shader=true) INFO: subcase ran
-  - (in subcase: low=1;high=0;in_shader=false) INFO: subcase ran
-  - (in subcase: low=1;high=0;in_shader=true) EXPECTATION FAILED: Expected validation error
-    eventualAsyncExpectation@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:258:33
-    expectGPUError@http://127.0.0.1:8000/webgpu/webgpu/gpu_test.js:1143:34
-    expectPipelineResult@http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:209:24
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/expression/call/builtin/clamp.spec.js:171:27
-  - (in subcase: low=1;high=0;in_shader=true) INFO: subcase ran
- Reached unreachable code
+PASS :low_high:type="f32";lowStage="constant";highStage="override"
 PASS :low_high:type="f32";lowStage="constant";highStage="runtime"
-FAIL :low_high:type="f32";lowStage="override";highStage="constant" assert_unreached:
-  - (in subcase: low=0;high=1;in_shader=false) INFO: subcase ran
-  - (in subcase: low=0;high=1;in_shader=true) INFO: subcase ran
-  - (in subcase: low=1;high=1;in_shader=false) INFO: subcase ran
-  - (in subcase: low=1;high=1;in_shader=true) INFO: subcase ran
-  - (in subcase: low=1;high=0;in_shader=false) INFO: subcase ran
-  - (in subcase: low=1;high=0;in_shader=true) EXPECTATION FAILED: Expected validation error
-    eventualAsyncExpectation@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:258:33
-    expectGPUError@http://127.0.0.1:8000/webgpu/webgpu/gpu_test.js:1143:34
-    expectPipelineResult@http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:209:24
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/expression/call/builtin/clamp.spec.js:171:27
-  - (in subcase: low=1;high=0;in_shader=true) INFO: subcase ran
- Reached unreachable code
-FAIL :low_high:type="f32";lowStage="override";highStage="override" assert_unreached:
-  - (in subcase: low=0;high=1;in_shader=false) INFO: subcase ran
-  - (in subcase: low=0;high=1;in_shader=true) INFO: subcase ran
-  - (in subcase: low=1;high=1;in_shader=false) INFO: subcase ran
-  - (in subcase: low=1;high=1;in_shader=true) INFO: subcase ran
-  - (in subcase: low=1;high=0;in_shader=false) INFO: subcase ran
-  - (in subcase: low=1;high=0;in_shader=true) EXPECTATION FAILED: Expected validation error
-    eventualAsyncExpectation@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:258:33
-    expectGPUError@http://127.0.0.1:8000/webgpu/webgpu/gpu_test.js:1143:34
-    expectPipelineResult@http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:209:24
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/expression/call/builtin/clamp.spec.js:171:27
-  - (in subcase: low=1;high=0;in_shader=true) INFO: subcase ran
- Reached unreachable code
+PASS :low_high:type="f32";lowStage="override";highStage="constant"
+PASS :low_high:type="f32";lowStage="override";highStage="override"
 PASS :low_high:type="f32";lowStage="override";highStage="runtime"
 PASS :low_high:type="f32";lowStage="runtime";highStage="constant"
 PASS :low_high:type="f32";lowStage="runtime";highStage="override"
 PASS :low_high:type="f32";lowStage="runtime";highStage="runtime"
 PASS :low_high:type="f16";lowStage="constant";highStage="constant"
-FAIL :low_high:type="f16";lowStage="constant";highStage="override" assert_unreached:
-  - (in subcase: low=0;high=1;in_shader=false) INFO: subcase ran
-  - (in subcase: low=0;high=1;in_shader=true) INFO: subcase ran
-  - (in subcase: low=1;high=1;in_shader=false) INFO: subcase ran
-  - (in subcase: low=1;high=1;in_shader=true) INFO: subcase ran
-  - (in subcase: low=1;high=0;in_shader=false) INFO: subcase ran
-  - (in subcase: low=1;high=0;in_shader=true) EXPECTATION FAILED: Expected validation error
-    eventualAsyncExpectation@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:258:33
-    expectGPUError@http://127.0.0.1:8000/webgpu/webgpu/gpu_test.js:1143:34
-    expectPipelineResult@http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:209:24
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/expression/call/builtin/clamp.spec.js:171:27
-  - (in subcase: low=1;high=0;in_shader=true) INFO: subcase ran
- Reached unreachable code
+PASS :low_high:type="f16";lowStage="constant";highStage="override"
 PASS :low_high:type="f16";lowStage="constant";highStage="runtime"
-FAIL :low_high:type="f16";lowStage="override";highStage="constant" assert_unreached:
-  - (in subcase: low=0;high=1;in_shader=false) INFO: subcase ran
-  - (in subcase: low=0;high=1;in_shader=true) INFO: subcase ran
-  - (in subcase: low=1;high=1;in_shader=false) INFO: subcase ran
-  - (in subcase: low=1;high=1;in_shader=true) INFO: subcase ran
-  - (in subcase: low=1;high=0;in_shader=false) INFO: subcase ran
-  - (in subcase: low=1;high=0;in_shader=true) EXPECTATION FAILED: Expected validation error
-    eventualAsyncExpectation@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:258:33
-    expectGPUError@http://127.0.0.1:8000/webgpu/webgpu/gpu_test.js:1143:34
-    expectPipelineResult@http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:209:24
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/expression/call/builtin/clamp.spec.js:171:27
-  - (in subcase: low=1;high=0;in_shader=true) INFO: subcase ran
- Reached unreachable code
-FAIL :low_high:type="f16";lowStage="override";highStage="override" assert_unreached:
-  - (in subcase: low=0;high=1;in_shader=false) INFO: subcase ran
-  - (in subcase: low=0;high=1;in_shader=true) INFO: subcase ran
-  - (in subcase: low=1;high=1;in_shader=false) INFO: subcase ran
-  - (in subcase: low=1;high=1;in_shader=true) INFO: subcase ran
-  - (in subcase: low=1;high=0;in_shader=false) INFO: subcase ran
-  - (in subcase: low=1;high=0;in_shader=true) EXPECTATION FAILED: Expected validation error
-    eventualAsyncExpectation@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:258:33
-    expectGPUError@http://127.0.0.1:8000/webgpu/webgpu/gpu_test.js:1143:34
-    expectPipelineResult@http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:209:24
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/expression/call/builtin/clamp.spec.js:171:27
-  - (in subcase: low=1;high=0;in_shader=true) INFO: subcase ran
- Reached unreachable code
+PASS :low_high:type="f16";lowStage="override";highStage="constant"
+PASS :low_high:type="f16";lowStage="override";highStage="override"
 PASS :low_high:type="f16";lowStage="override";highStage="runtime"
 PASS :low_high:type="f16";lowStage="runtime";highStage="constant"
 PASS :low_high:type="f16";lowStage="runtime";highStage="override"
 PASS :low_high:type="f16";lowStage="runtime";highStage="runtime"
 PASS :low_high:type="vec2%3Cf32%3E";lowStage="constant";highStage="constant"
-FAIL :low_high:type="vec2%3Cf32%3E";lowStage="constant";highStage="override" assert_unreached:
-  - (in subcase: low=0;high=1;in_shader=false) INFO: subcase ran
-  - (in subcase: low=0;high=1;in_shader=true) INFO: subcase ran
-  - (in subcase: low=1;high=1;in_shader=false) INFO: subcase ran
-  - (in subcase: low=1;high=1;in_shader=true) INFO: subcase ran
-  - (in subcase: low=1;high=0;in_shader=false) INFO: subcase ran
-  - (in subcase: low=1;high=0;in_shader=true) EXPECTATION FAILED: Expected validation error
-    eventualAsyncExpectation@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:258:33
-    expectGPUError@http://127.0.0.1:8000/webgpu/webgpu/gpu_test.js:1143:34
-    expectPipelineResult@http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:209:24
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/expression/call/builtin/clamp.spec.js:171:27
-  - (in subcase: low=1;high=0;in_shader=true) INFO: subcase ran
- Reached unreachable code
+PASS :low_high:type="vec2%3Cf32%3E";lowStage="constant";highStage="override"
 PASS :low_high:type="vec2%3Cf32%3E";lowStage="constant";highStage="runtime"
-FAIL :low_high:type="vec2%3Cf32%3E";lowStage="override";highStage="constant" assert_unreached:
-  - (in subcase: low=0;high=1;in_shader=false) INFO: subcase ran
-  - (in subcase: low=0;high=1;in_shader=true) INFO: subcase ran
-  - (in subcase: low=1;high=1;in_shader=false) INFO: subcase ran
-  - (in subcase: low=1;high=1;in_shader=true) INFO: subcase ran
-  - (in subcase: low=1;high=0;in_shader=false) INFO: subcase ran
-  - (in subcase: low=1;high=0;in_shader=true) EXPECTATION FAILED: Expected validation error
-    eventualAsyncExpectation@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:258:33
-    expectGPUError@http://127.0.0.1:8000/webgpu/webgpu/gpu_test.js:1143:34
-    expectPipelineResult@http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:209:24
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/expression/call/builtin/clamp.spec.js:171:27
-  - (in subcase: low=1;high=0;in_shader=true) INFO: subcase ran
- Reached unreachable code
-FAIL :low_high:type="vec2%3Cf32%3E";lowStage="override";highStage="override" assert_unreached:
-  - (in subcase: low=0;high=1;in_shader=false) INFO: subcase ran
-  - (in subcase: low=0;high=1;in_shader=true) INFO: subcase ran
-  - (in subcase: low=1;high=1;in_shader=false) INFO: subcase ran
-  - (in subcase: low=1;high=1;in_shader=true) INFO: subcase ran
-  - (in subcase: low=1;high=0;in_shader=false) INFO: subcase ran
-  - (in subcase: low=1;high=0;in_shader=true) EXPECTATION FAILED: Expected validation error
-    eventualAsyncExpectation@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:258:33
-    expectGPUError@http://127.0.0.1:8000/webgpu/webgpu/gpu_test.js:1143:34
-    expectPipelineResult@http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:209:24
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/expression/call/builtin/clamp.spec.js:171:27
-  - (in subcase: low=1;high=0;in_shader=true) INFO: subcase ran
- Reached unreachable code
+PASS :low_high:type="vec2%3Cf32%3E";lowStage="override";highStage="constant"
+PASS :low_high:type="vec2%3Cf32%3E";lowStage="override";highStage="override"
 PASS :low_high:type="vec2%3Cf32%3E";lowStage="override";highStage="runtime"
 PASS :low_high:type="vec2%3Cf32%3E";lowStage="runtime";highStage="constant"
 PASS :low_high:type="vec2%3Cf32%3E";lowStage="runtime";highStage="override"
 PASS :low_high:type="vec2%3Cf32%3E";lowStage="runtime";highStage="runtime"
 PASS :low_high:type="vec2%3Cf16%3E";lowStage="constant";highStage="constant"
-FAIL :low_high:type="vec2%3Cf16%3E";lowStage="constant";highStage="override" assert_unreached:
-  - (in subcase: low=0;high=1;in_shader=false) INFO: subcase ran
-  - (in subcase: low=0;high=1;in_shader=true) INFO: subcase ran
-  - (in subcase: low=1;high=1;in_shader=false) INFO: subcase ran
-  - (in subcase: low=1;high=1;in_shader=true) INFO: subcase ran
-  - (in subcase: low=1;high=0;in_shader=false) INFO: subcase ran
-  - (in subcase: low=1;high=0;in_shader=true) EXPECTATION FAILED: Expected validation error
-    eventualAsyncExpectation@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:258:33
-    expectGPUError@http://127.0.0.1:8000/webgpu/webgpu/gpu_test.js:1143:34
-    expectPipelineResult@http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:209:24
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/expression/call/builtin/clamp.spec.js:171:27
-  - (in subcase: low=1;high=0;in_shader=true) INFO: subcase ran
- Reached unreachable code
+PASS :low_high:type="vec2%3Cf16%3E";lowStage="constant";highStage="override"
 PASS :low_high:type="vec2%3Cf16%3E";lowStage="constant";highStage="runtime"
-FAIL :low_high:type="vec2%3Cf16%3E";lowStage="override";highStage="constant" assert_unreached:
-  - (in subcase: low=0;high=1;in_shader=false) INFO: subcase ran
-  - (in subcase: low=0;high=1;in_shader=true) INFO: subcase ran
-  - (in subcase: low=1;high=1;in_shader=false) INFO: subcase ran
-  - (in subcase: low=1;high=1;in_shader=true) INFO: subcase ran
-  - (in subcase: low=1;high=0;in_shader=false) INFO: subcase ran
-  - (in subcase: low=1;high=0;in_shader=true) EXPECTATION FAILED: Expected validation error
-    eventualAsyncExpectation@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:258:33
-    expectGPUError@http://127.0.0.1:8000/webgpu/webgpu/gpu_test.js:1143:34
-    expectPipelineResult@http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:209:24
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/expression/call/builtin/clamp.spec.js:171:27
-  - (in subcase: low=1;high=0;in_shader=true) INFO: subcase ran
- Reached unreachable code
-FAIL :low_high:type="vec2%3Cf16%3E";lowStage="override";highStage="override" assert_unreached:
-  - (in subcase: low=0;high=1;in_shader=false) INFO: subcase ran
-  - (in subcase: low=0;high=1;in_shader=true) INFO: subcase ran
-  - (in subcase: low=1;high=1;in_shader=false) INFO: subcase ran
-  - (in subcase: low=1;high=1;in_shader=true) INFO: subcase ran
-  - (in subcase: low=1;high=0;in_shader=false) INFO: subcase ran
-  - (in subcase: low=1;high=0;in_shader=true) EXPECTATION FAILED: Expected validation error
-    eventualAsyncExpectation@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:258:33
-    expectGPUError@http://127.0.0.1:8000/webgpu/webgpu/gpu_test.js:1143:34
-    expectPipelineResult@http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:209:24
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/expression/call/builtin/clamp.spec.js:171:27
-  - (in subcase: low=1;high=0;in_shader=true) INFO: subcase ran
- Reached unreachable code
+PASS :low_high:type="vec2%3Cf16%3E";lowStage="override";highStage="constant"
+PASS :low_high:type="vec2%3Cf16%3E";lowStage="override";highStage="override"
 PASS :low_high:type="vec2%3Cf16%3E";lowStage="override";highStage="runtime"
 PASS :low_high:type="vec2%3Cf16%3E";lowStage="runtime";highStage="constant"
 PASS :low_high:type="vec2%3Cf16%3E";lowStage="runtime";highStage="override"
 PASS :low_high:type="vec2%3Cf16%3E";lowStage="runtime";highStage="runtime"
 PASS :low_high:type="vec3%3Cf32%3E";lowStage="constant";highStage="constant"
-FAIL :low_high:type="vec3%3Cf32%3E";lowStage="constant";highStage="override" assert_unreached:
-  - (in subcase: low=0;high=1;in_shader=false) INFO: subcase ran
-  - (in subcase: low=0;high=1;in_shader=true) INFO: subcase ran
-  - (in subcase: low=1;high=1;in_shader=false) INFO: subcase ran
-  - (in subcase: low=1;high=1;in_shader=true) INFO: subcase ran
-  - (in subcase: low=1;high=0;in_shader=false) INFO: subcase ran
-  - (in subcase: low=1;high=0;in_shader=true) EXPECTATION FAILED: Expected validation error
-    eventualAsyncExpectation@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:258:33
-    expectGPUError@http://127.0.0.1:8000/webgpu/webgpu/gpu_test.js:1143:34
-    expectPipelineResult@http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:209:24
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/expression/call/builtin/clamp.spec.js:171:27
-  - (in subcase: low=1;high=0;in_shader=true) INFO: subcase ran
- Reached unreachable code
+PASS :low_high:type="vec3%3Cf32%3E";lowStage="constant";highStage="override"
 PASS :low_high:type="vec3%3Cf32%3E";lowStage="constant";highStage="runtime"
-FAIL :low_high:type="vec3%3Cf32%3E";lowStage="override";highStage="constant" assert_unreached:
-  - (in subcase: low=0;high=1;in_shader=false) INFO: subcase ran
-  - (in subcase: low=0;high=1;in_shader=true) INFO: subcase ran
-  - (in subcase: low=1;high=1;in_shader=false) INFO: subcase ran
-  - (in subcase: low=1;high=1;in_shader=true) INFO: subcase ran
-  - (in subcase: low=1;high=0;in_shader=false) INFO: subcase ran
-  - (in subcase: low=1;high=0;in_shader=true) EXPECTATION FAILED: Expected validation error
-    eventualAsyncExpectation@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:258:33
-    expectGPUError@http://127.0.0.1:8000/webgpu/webgpu/gpu_test.js:1143:34
-    expectPipelineResult@http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:209:24
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/expression/call/builtin/clamp.spec.js:171:27
-  - (in subcase: low=1;high=0;in_shader=true) INFO: subcase ran
- Reached unreachable code
-FAIL :low_high:type="vec3%3Cf32%3E";lowStage="override";highStage="override" assert_unreached:
-  - (in subcase: low=0;high=1;in_shader=false) INFO: subcase ran
-  - (in subcase: low=0;high=1;in_shader=true) INFO: subcase ran
-  - (in subcase: low=1;high=1;in_shader=false) INFO: subcase ran
-  - (in subcase: low=1;high=1;in_shader=true) INFO: subcase ran
-  - (in subcase: low=1;high=0;in_shader=false) INFO: subcase ran
-  - (in subcase: low=1;high=0;in_shader=true) EXPECTATION FAILED: Expected validation error
-    eventualAsyncExpectation@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:258:33
-    expectGPUError@http://127.0.0.1:8000/webgpu/webgpu/gpu_test.js:1143:34
-    expectPipelineResult@http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:209:24
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/expression/call/builtin/clamp.spec.js:171:27
-  - (in subcase: low=1;high=0;in_shader=true) INFO: subcase ran
- Reached unreachable code
+PASS :low_high:type="vec3%3Cf32%3E";lowStage="override";highStage="constant"
+PASS :low_high:type="vec3%3Cf32%3E";lowStage="override";highStage="override"
 PASS :low_high:type="vec3%3Cf32%3E";lowStage="override";highStage="runtime"
 PASS :low_high:type="vec3%3Cf32%3E";lowStage="runtime";highStage="constant"
 PASS :low_high:type="vec3%3Cf32%3E";lowStage="runtime";highStage="override"
 PASS :low_high:type="vec3%3Cf32%3E";lowStage="runtime";highStage="runtime"
 PASS :low_high:type="vec3%3Cf16%3E";lowStage="constant";highStage="constant"
-FAIL :low_high:type="vec3%3Cf16%3E";lowStage="constant";highStage="override" assert_unreached:
-  - (in subcase: low=0;high=1;in_shader=false) INFO: subcase ran
-  - (in subcase: low=0;high=1;in_shader=true) INFO: subcase ran
-  - (in subcase: low=1;high=1;in_shader=false) INFO: subcase ran
-  - (in subcase: low=1;high=1;in_shader=true) INFO: subcase ran
-  - (in subcase: low=1;high=0;in_shader=false) INFO: subcase ran
-  - (in subcase: low=1;high=0;in_shader=true) EXPECTATION FAILED: Expected validation error
-    eventualAsyncExpectation@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:258:33
-    expectGPUError@http://127.0.0.1:8000/webgpu/webgpu/gpu_test.js:1143:34
-    expectPipelineResult@http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:209:24
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/expression/call/builtin/clamp.spec.js:171:27
-  - (in subcase: low=1;high=0;in_shader=true) INFO: subcase ran
- Reached unreachable code
+PASS :low_high:type="vec3%3Cf16%3E";lowStage="constant";highStage="override"
 PASS :low_high:type="vec3%3Cf16%3E";lowStage="constant";highStage="runtime"
-FAIL :low_high:type="vec3%3Cf16%3E";lowStage="override";highStage="constant" assert_unreached:
-  - (in subcase: low=0;high=1;in_shader=false) INFO: subcase ran
-  - (in subcase: low=0;high=1;in_shader=true) INFO: subcase ran
-  - (in subcase: low=1;high=1;in_shader=false) INFO: subcase ran
-  - (in subcase: low=1;high=1;in_shader=true) INFO: subcase ran
-  - (in subcase: low=1;high=0;in_shader=false) INFO: subcase ran
-  - (in subcase: low=1;high=0;in_shader=true) EXPECTATION FAILED: Expected validation error
-    eventualAsyncExpectation@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:258:33
-    expectGPUError@http://127.0.0.1:8000/webgpu/webgpu/gpu_test.js:1143:34
-    expectPipelineResult@http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:209:24
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/expression/call/builtin/clamp.spec.js:171:27
-  - (in subcase: low=1;high=0;in_shader=true) INFO: subcase ran
- Reached unreachable code
-FAIL :low_high:type="vec3%3Cf16%3E";lowStage="override";highStage="override" assert_unreached:
-  - (in subcase: low=0;high=1;in_shader=false) INFO: subcase ran
-  - (in subcase: low=0;high=1;in_shader=true) INFO: subcase ran
-  - (in subcase: low=1;high=1;in_shader=false) INFO: subcase ran
-  - (in subcase: low=1;high=1;in_shader=true) INFO: subcase ran
-  - (in subcase: low=1;high=0;in_shader=false) INFO: subcase ran
-  - (in subcase: low=1;high=0;in_shader=true) EXPECTATION FAILED: Expected validation error
-    eventualAsyncExpectation@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:258:33
-    expectGPUError@http://127.0.0.1:8000/webgpu/webgpu/gpu_test.js:1143:34
-    expectPipelineResult@http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:209:24
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/expression/call/builtin/clamp.spec.js:171:27
-  - (in subcase: low=1;high=0;in_shader=true) INFO: subcase ran
- Reached unreachable code
+PASS :low_high:type="vec3%3Cf16%3E";lowStage="override";highStage="constant"
+PASS :low_high:type="vec3%3Cf16%3E";lowStage="override";highStage="override"
 PASS :low_high:type="vec3%3Cf16%3E";lowStage="override";highStage="runtime"
 PASS :low_high:type="vec3%3Cf16%3E";lowStage="runtime";highStage="constant"
 PASS :low_high:type="vec3%3Cf16%3E";lowStage="runtime";highStage="override"
 PASS :low_high:type="vec3%3Cf16%3E";lowStage="runtime";highStage="runtime"
 PASS :low_high:type="vec4%3Cf32%3E";lowStage="constant";highStage="constant"
-FAIL :low_high:type="vec4%3Cf32%3E";lowStage="constant";highStage="override" assert_unreached:
-  - (in subcase: low=0;high=1;in_shader=false) INFO: subcase ran
-  - (in subcase: low=0;high=1;in_shader=true) INFO: subcase ran
-  - (in subcase: low=1;high=1;in_shader=false) INFO: subcase ran
-  - (in subcase: low=1;high=1;in_shader=true) INFO: subcase ran
-  - (in subcase: low=1;high=0;in_shader=false) INFO: subcase ran
-  - (in subcase: low=1;high=0;in_shader=true) EXPECTATION FAILED: Expected validation error
-    eventualAsyncExpectation@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:258:33
-    expectGPUError@http://127.0.0.1:8000/webgpu/webgpu/gpu_test.js:1143:34
-    expectPipelineResult@http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:209:24
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/expression/call/builtin/clamp.spec.js:171:27
-  - (in subcase: low=1;high=0;in_shader=true) INFO: subcase ran
- Reached unreachable code
+PASS :low_high:type="vec4%3Cf32%3E";lowStage="constant";highStage="override"
 PASS :low_high:type="vec4%3Cf32%3E";lowStage="constant";highStage="runtime"
-FAIL :low_high:type="vec4%3Cf32%3E";lowStage="override";highStage="constant" assert_unreached:
-  - (in subcase: low=0;high=1;in_shader=false) INFO: subcase ran
-  - (in subcase: low=0;high=1;in_shader=true) INFO: subcase ran
-  - (in subcase: low=1;high=1;in_shader=false) INFO: subcase ran
-  - (in subcase: low=1;high=1;in_shader=true) INFO: subcase ran
-  - (in subcase: low=1;high=0;in_shader=false) INFO: subcase ran
-  - (in subcase: low=1;high=0;in_shader=true) EXPECTATION FAILED: Expected validation error
-    eventualAsyncExpectation@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:258:33
-    expectGPUError@http://127.0.0.1:8000/webgpu/webgpu/gpu_test.js:1143:34
-    expectPipelineResult@http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:209:24
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/expression/call/builtin/clamp.spec.js:171:27
-  - (in subcase: low=1;high=0;in_shader=true) INFO: subcase ran
- Reached unreachable code
-FAIL :low_high:type="vec4%3Cf32%3E";lowStage="override";highStage="override" assert_unreached:
-  - (in subcase: low=0;high=1;in_shader=false) INFO: subcase ran
-  - (in subcase: low=0;high=1;in_shader=true) INFO: subcase ran
-  - (in subcase: low=1;high=1;in_shader=false) INFO: subcase ran
-  - (in subcase: low=1;high=1;in_shader=true) INFO: subcase ran
-  - (in subcase: low=1;high=0;in_shader=false) INFO: subcase ran
-  - (in subcase: low=1;high=0;in_shader=true) EXPECTATION FAILED: Expected validation error
-    eventualAsyncExpectation@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:258:33
-    expectGPUError@http://127.0.0.1:8000/webgpu/webgpu/gpu_test.js:1143:34
-    expectPipelineResult@http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:209:24
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/expression/call/builtin/clamp.spec.js:171:27
-  - (in subcase: low=1;high=0;in_shader=true) INFO: subcase ran
- Reached unreachable code
+PASS :low_high:type="vec4%3Cf32%3E";lowStage="override";highStage="constant"
+PASS :low_high:type="vec4%3Cf32%3E";lowStage="override";highStage="override"
 PASS :low_high:type="vec4%3Cf32%3E";lowStage="override";highStage="runtime"
 PASS :low_high:type="vec4%3Cf32%3E";lowStage="runtime";highStage="constant"
 PASS :low_high:type="vec4%3Cf32%3E";lowStage="runtime";highStage="override"
 PASS :low_high:type="vec4%3Cf32%3E";lowStage="runtime";highStage="runtime"
 PASS :low_high:type="vec4%3Cf16%3E";lowStage="constant";highStage="constant"
-FAIL :low_high:type="vec4%3Cf16%3E";lowStage="constant";highStage="override" assert_unreached:
-  - (in subcase: low=0;high=1;in_shader=false) INFO: subcase ran
-  - (in subcase: low=0;high=1;in_shader=true) INFO: subcase ran
-  - (in subcase: low=1;high=1;in_shader=false) INFO: subcase ran
-  - (in subcase: low=1;high=1;in_shader=true) INFO: subcase ran
-  - (in subcase: low=1;high=0;in_shader=false) INFO: subcase ran
-  - (in subcase: low=1;high=0;in_shader=true) EXPECTATION FAILED: Expected validation error
-    eventualAsyncExpectation@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:258:33
-    expectGPUError@http://127.0.0.1:8000/webgpu/webgpu/gpu_test.js:1143:34
-    expectPipelineResult@http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:209:24
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/expression/call/builtin/clamp.spec.js:171:27
-  - (in subcase: low=1;high=0;in_shader=true) INFO: subcase ran
- Reached unreachable code
+PASS :low_high:type="vec4%3Cf16%3E";lowStage="constant";highStage="override"
 PASS :low_high:type="vec4%3Cf16%3E";lowStage="constant";highStage="runtime"
-FAIL :low_high:type="vec4%3Cf16%3E";lowStage="override";highStage="constant" assert_unreached:
-  - (in subcase: low=0;high=1;in_shader=false) INFO: subcase ran
-  - (in subcase: low=0;high=1;in_shader=true) INFO: subcase ran
-  - (in subcase: low=1;high=1;in_shader=false) INFO: subcase ran
-  - (in subcase: low=1;high=1;in_shader=true) INFO: subcase ran
-  - (in subcase: low=1;high=0;in_shader=false) INFO: subcase ran
-  - (in subcase: low=1;high=0;in_shader=true) EXPECTATION FAILED: Expected validation error
-    eventualAsyncExpectation@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:258:33
-    expectGPUError@http://127.0.0.1:8000/webgpu/webgpu/gpu_test.js:1143:34
-    expectPipelineResult@http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:209:24
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/expression/call/builtin/clamp.spec.js:171:27
-  - (in subcase: low=1;high=0;in_shader=true) INFO: subcase ran
- Reached unreachable code
-FAIL :low_high:type="vec4%3Cf16%3E";lowStage="override";highStage="override" assert_unreached:
-  - (in subcase: low=0;high=1;in_shader=false) INFO: subcase ran
-  - (in subcase: low=0;high=1;in_shader=true) INFO: subcase ran
-  - (in subcase: low=1;high=1;in_shader=false) INFO: subcase ran
-  - (in subcase: low=1;high=1;in_shader=true) INFO: subcase ran
-  - (in subcase: low=1;high=0;in_shader=false) INFO: subcase ran
-  - (in subcase: low=1;high=0;in_shader=true) EXPECTATION FAILED: Expected validation error
-    eventualAsyncExpectation@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:258:33
-    expectGPUError@http://127.0.0.1:8000/webgpu/webgpu/gpu_test.js:1143:34
-    expectPipelineResult@http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:209:24
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/expression/call/builtin/clamp.spec.js:171:27
-  - (in subcase: low=1;high=0;in_shader=true) INFO: subcase ran
- Reached unreachable code
+PASS :low_high:type="vec4%3Cf16%3E";lowStage="override";highStage="constant"
+PASS :low_high:type="vec4%3Cf16%3E";lowStage="override";highStage="override"
 PASS :low_high:type="vec4%3Cf16%3E";lowStage="override";highStage="runtime"
 PASS :low_high:type="vec4%3Cf16%3E";lowStage="runtime";highStage="constant"
 PASS :low_high:type="vec4%3Cf16%3E";lowStage="runtime";highStage="override"
 PASS :low_high:type="vec4%3Cf16%3E";lowStage="runtime";highStage="runtime"
 PASS :low_high:type="i32";lowStage="constant";highStage="constant"
-FAIL :low_high:type="i32";lowStage="constant";highStage="override" assert_unreached:
-  - (in subcase: low=0;high=1;in_shader=false) INFO: subcase ran
-  - (in subcase: low=0;high=1;in_shader=true) INFO: subcase ran
-  - (in subcase: low=1;high=1;in_shader=false) INFO: subcase ran
-  - (in subcase: low=1;high=1;in_shader=true) INFO: subcase ran
-  - (in subcase: low=1;high=0;in_shader=false) INFO: subcase ran
-  - (in subcase: low=1;high=0;in_shader=true) EXPECTATION FAILED: Expected validation error
-    eventualAsyncExpectation@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:258:33
-    expectGPUError@http://127.0.0.1:8000/webgpu/webgpu/gpu_test.js:1143:34
-    expectPipelineResult@http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:209:24
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/expression/call/builtin/clamp.spec.js:171:27
-  - (in subcase: low=1;high=0;in_shader=true) INFO: subcase ran
- Reached unreachable code
+PASS :low_high:type="i32";lowStage="constant";highStage="override"
 PASS :low_high:type="i32";lowStage="constant";highStage="runtime"
-FAIL :low_high:type="i32";lowStage="override";highStage="constant" assert_unreached:
-  - (in subcase: low=0;high=1;in_shader=false) INFO: subcase ran
-  - (in subcase: low=0;high=1;in_shader=true) INFO: subcase ran
-  - (in subcase: low=1;high=1;in_shader=false) INFO: subcase ran
-  - (in subcase: low=1;high=1;in_shader=true) INFO: subcase ran
-  - (in subcase: low=1;high=0;in_shader=false) INFO: subcase ran
-  - (in subcase: low=1;high=0;in_shader=true) EXPECTATION FAILED: Expected validation error
-    eventualAsyncExpectation@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:258:33
-    expectGPUError@http://127.0.0.1:8000/webgpu/webgpu/gpu_test.js:1143:34
-    expectPipelineResult@http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:209:24
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/expression/call/builtin/clamp.spec.js:171:27
-  - (in subcase: low=1;high=0;in_shader=true) INFO: subcase ran
- Reached unreachable code
-FAIL :low_high:type="i32";lowStage="override";highStage="override" assert_unreached:
-  - (in subcase: low=0;high=1;in_shader=false) INFO: subcase ran
-  - (in subcase: low=0;high=1;in_shader=true) INFO: subcase ran
-  - (in subcase: low=1;high=1;in_shader=false) INFO: subcase ran
-  - (in subcase: low=1;high=1;in_shader=true) INFO: subcase ran
-  - (in subcase: low=1;high=0;in_shader=false) INFO: subcase ran
-  - (in subcase: low=1;high=0;in_shader=true) EXPECTATION FAILED: Expected validation error
-    eventualAsyncExpectation@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:258:33
-    expectGPUError@http://127.0.0.1:8000/webgpu/webgpu/gpu_test.js:1143:34
-    expectPipelineResult@http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:209:24
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/expression/call/builtin/clamp.spec.js:171:27
-  - (in subcase: low=1;high=0;in_shader=true) INFO: subcase ran
- Reached unreachable code
+PASS :low_high:type="i32";lowStage="override";highStage="constant"
+PASS :low_high:type="i32";lowStage="override";highStage="override"
 PASS :low_high:type="i32";lowStage="override";highStage="runtime"
 PASS :low_high:type="i32";lowStage="runtime";highStage="constant"
 PASS :low_high:type="i32";lowStage="runtime";highStage="override"
 PASS :low_high:type="i32";lowStage="runtime";highStage="runtime"
 PASS :low_high:type="vec2%3Ci32%3E";lowStage="constant";highStage="constant"
-FAIL :low_high:type="vec2%3Ci32%3E";lowStage="constant";highStage="override" assert_unreached:
-  - (in subcase: low=0;high=1;in_shader=false) INFO: subcase ran
-  - (in subcase: low=0;high=1;in_shader=true) INFO: subcase ran
-  - (in subcase: low=1;high=1;in_shader=false) INFO: subcase ran
-  - (in subcase: low=1;high=1;in_shader=true) INFO: subcase ran
-  - (in subcase: low=1;high=0;in_shader=false) INFO: subcase ran
-  - (in subcase: low=1;high=0;in_shader=true) EXPECTATION FAILED: Expected validation error
-    eventualAsyncExpectation@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:258:33
-    expectGPUError@http://127.0.0.1:8000/webgpu/webgpu/gpu_test.js:1143:34
-    expectPipelineResult@http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:209:24
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/expression/call/builtin/clamp.spec.js:171:27
-  - (in subcase: low=1;high=0;in_shader=true) INFO: subcase ran
- Reached unreachable code
+PASS :low_high:type="vec2%3Ci32%3E";lowStage="constant";highStage="override"
 PASS :low_high:type="vec2%3Ci32%3E";lowStage="constant";highStage="runtime"
-FAIL :low_high:type="vec2%3Ci32%3E";lowStage="override";highStage="constant" assert_unreached:
-  - (in subcase: low=0;high=1;in_shader=false) INFO: subcase ran
-  - (in subcase: low=0;high=1;in_shader=true) INFO: subcase ran
-  - (in subcase: low=1;high=1;in_shader=false) INFO: subcase ran
-  - (in subcase: low=1;high=1;in_shader=true) INFO: subcase ran
-  - (in subcase: low=1;high=0;in_shader=false) INFO: subcase ran
-  - (in subcase: low=1;high=0;in_shader=true) EXPECTATION FAILED: Expected validation error
-    eventualAsyncExpectation@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:258:33
-    expectGPUError@http://127.0.0.1:8000/webgpu/webgpu/gpu_test.js:1143:34
-    expectPipelineResult@http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:209:24
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/expression/call/builtin/clamp.spec.js:171:27
-  - (in subcase: low=1;high=0;in_shader=true) INFO: subcase ran
- Reached unreachable code
-FAIL :low_high:type="vec2%3Ci32%3E";lowStage="override";highStage="override" assert_unreached:
-  - (in subcase: low=0;high=1;in_shader=false) INFO: subcase ran
-  - (in subcase: low=0;high=1;in_shader=true) INFO: subcase ran
-  - (in subcase: low=1;high=1;in_shader=false) INFO: subcase ran
-  - (in subcase: low=1;high=1;in_shader=true) INFO: subcase ran
-  - (in subcase: low=1;high=0;in_shader=false) INFO: subcase ran
-  - (in subcase: low=1;high=0;in_shader=true) EXPECTATION FAILED: Expected validation error
-    eventualAsyncExpectation@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:258:33
-    expectGPUError@http://127.0.0.1:8000/webgpu/webgpu/gpu_test.js:1143:34
-    expectPipelineResult@http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:209:24
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/expression/call/builtin/clamp.spec.js:171:27
-  - (in subcase: low=1;high=0;in_shader=true) INFO: subcase ran
- Reached unreachable code
+PASS :low_high:type="vec2%3Ci32%3E";lowStage="override";highStage="constant"
+PASS :low_high:type="vec2%3Ci32%3E";lowStage="override";highStage="override"
 PASS :low_high:type="vec2%3Ci32%3E";lowStage="override";highStage="runtime"
 PASS :low_high:type="vec2%3Ci32%3E";lowStage="runtime";highStage="constant"
 PASS :low_high:type="vec2%3Ci32%3E";lowStage="runtime";highStage="override"
 PASS :low_high:type="vec2%3Ci32%3E";lowStage="runtime";highStage="runtime"
 PASS :low_high:type="vec3%3Ci32%3E";lowStage="constant";highStage="constant"
-FAIL :low_high:type="vec3%3Ci32%3E";lowStage="constant";highStage="override" assert_unreached:
-  - (in subcase: low=0;high=1;in_shader=false) INFO: subcase ran
-  - (in subcase: low=0;high=1;in_shader=true) INFO: subcase ran
-  - (in subcase: low=1;high=1;in_shader=false) INFO: subcase ran
-  - (in subcase: low=1;high=1;in_shader=true) INFO: subcase ran
-  - (in subcase: low=1;high=0;in_shader=false) INFO: subcase ran
-  - (in subcase: low=1;high=0;in_shader=true) EXPECTATION FAILED: Expected validation error
-    eventualAsyncExpectation@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:258:33
-    expectGPUError@http://127.0.0.1:8000/webgpu/webgpu/gpu_test.js:1143:34
-    expectPipelineResult@http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:209:24
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/expression/call/builtin/clamp.spec.js:171:27
-  - (in subcase: low=1;high=0;in_shader=true) INFO: subcase ran
- Reached unreachable code
+PASS :low_high:type="vec3%3Ci32%3E";lowStage="constant";highStage="override"
 PASS :low_high:type="vec3%3Ci32%3E";lowStage="constant";highStage="runtime"
-FAIL :low_high:type="vec3%3Ci32%3E";lowStage="override";highStage="constant" assert_unreached:
-  - (in subcase: low=0;high=1;in_shader=false) INFO: subcase ran
-  - (in subcase: low=0;high=1;in_shader=true) INFO: subcase ran
-  - (in subcase: low=1;high=1;in_shader=false) INFO: subcase ran
-  - (in subcase: low=1;high=1;in_shader=true) INFO: subcase ran
-  - (in subcase: low=1;high=0;in_shader=false) INFO: subcase ran
-  - (in subcase: low=1;high=0;in_shader=true) EXPECTATION FAILED: Expected validation error
-    eventualAsyncExpectation@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:258:33
-    expectGPUError@http://127.0.0.1:8000/webgpu/webgpu/gpu_test.js:1143:34
-    expectPipelineResult@http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:209:24
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/expression/call/builtin/clamp.spec.js:171:27
-  - (in subcase: low=1;high=0;in_shader=true) INFO: subcase ran
- Reached unreachable code
-FAIL :low_high:type="vec3%3Ci32%3E";lowStage="override";highStage="override" assert_unreached:
-  - (in subcase: low=0;high=1;in_shader=false) INFO: subcase ran
-  - (in subcase: low=0;high=1;in_shader=true) INFO: subcase ran
-  - (in subcase: low=1;high=1;in_shader=false) INFO: subcase ran
-  - (in subcase: low=1;high=1;in_shader=true) INFO: subcase ran
-  - (in subcase: low=1;high=0;in_shader=false) INFO: subcase ran
-  - (in subcase: low=1;high=0;in_shader=true) EXPECTATION FAILED: Expected validation error
-    eventualAsyncExpectation@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:258:33
-    expectGPUError@http://127.0.0.1:8000/webgpu/webgpu/gpu_test.js:1143:34
-    expectPipelineResult@http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:209:24
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/expression/call/builtin/clamp.spec.js:171:27
-  - (in subcase: low=1;high=0;in_shader=true) INFO: subcase ran
- Reached unreachable code
+PASS :low_high:type="vec3%3Ci32%3E";lowStage="override";highStage="constant"
+PASS :low_high:type="vec3%3Ci32%3E";lowStage="override";highStage="override"
 PASS :low_high:type="vec3%3Ci32%3E";lowStage="override";highStage="runtime"
 PASS :low_high:type="vec3%3Ci32%3E";lowStage="runtime";highStage="constant"
 PASS :low_high:type="vec3%3Ci32%3E";lowStage="runtime";highStage="override"
 PASS :low_high:type="vec3%3Ci32%3E";lowStage="runtime";highStage="runtime"
 PASS :low_high:type="vec4%3Ci32%3E";lowStage="constant";highStage="constant"
-FAIL :low_high:type="vec4%3Ci32%3E";lowStage="constant";highStage="override" assert_unreached:
-  - (in subcase: low=0;high=1;in_shader=false) INFO: subcase ran
-  - (in subcase: low=0;high=1;in_shader=true) INFO: subcase ran
-  - (in subcase: low=1;high=1;in_shader=false) INFO: subcase ran
-  - (in subcase: low=1;high=1;in_shader=true) INFO: subcase ran
-  - (in subcase: low=1;high=0;in_shader=false) INFO: subcase ran
-  - (in subcase: low=1;high=0;in_shader=true) EXPECTATION FAILED: Expected validation error
-    eventualAsyncExpectation@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:258:33
-    expectGPUError@http://127.0.0.1:8000/webgpu/webgpu/gpu_test.js:1143:34
-    expectPipelineResult@http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:209:24
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/expression/call/builtin/clamp.spec.js:171:27
-  - (in subcase: low=1;high=0;in_shader=true) INFO: subcase ran
- Reached unreachable code
+PASS :low_high:type="vec4%3Ci32%3E";lowStage="constant";highStage="override"
 PASS :low_high:type="vec4%3Ci32%3E";lowStage="constant";highStage="runtime"
-FAIL :low_high:type="vec4%3Ci32%3E";lowStage="override";highStage="constant" assert_unreached:
-  - (in subcase: low=0;high=1;in_shader=false) INFO: subcase ran
-  - (in subcase: low=0;high=1;in_shader=true) INFO: subcase ran
-  - (in subcase: low=1;high=1;in_shader=false) INFO: subcase ran
-  - (in subcase: low=1;high=1;in_shader=true) INFO: subcase ran
-  - (in subcase: low=1;high=0;in_shader=false) INFO: subcase ran
-  - (in subcase: low=1;high=0;in_shader=true) EXPECTATION FAILED: Expected validation error
-    eventualAsyncExpectation@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:258:33
-    expectGPUError@http://127.0.0.1:8000/webgpu/webgpu/gpu_test.js:1143:34
-    expectPipelineResult@http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:209:24
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/expression/call/builtin/clamp.spec.js:171:27
-  - (in subcase: low=1;high=0;in_shader=true) INFO: subcase ran
- Reached unreachable code
-FAIL :low_high:type="vec4%3Ci32%3E";lowStage="override";highStage="override" assert_unreached:
-  - (in subcase: low=0;high=1;in_shader=false) INFO: subcase ran
-  - (in subcase: low=0;high=1;in_shader=true) INFO: subcase ran
-  - (in subcase: low=1;high=1;in_shader=false) INFO: subcase ran
-  - (in subcase: low=1;high=1;in_shader=true) INFO: subcase ran
-  - (in subcase: low=1;high=0;in_shader=false) INFO: subcase ran
-  - (in subcase: low=1;high=0;in_shader=true) EXPECTATION FAILED: Expected validation error
-    eventualAsyncExpectation@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:258:33
-    expectGPUError@http://127.0.0.1:8000/webgpu/webgpu/gpu_test.js:1143:34
-    expectPipelineResult@http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:209:24
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/expression/call/builtin/clamp.spec.js:171:27
-  - (in subcase: low=1;high=0;in_shader=true) INFO: subcase ran
- Reached unreachable code
+PASS :low_high:type="vec4%3Ci32%3E";lowStage="override";highStage="constant"
+PASS :low_high:type="vec4%3Ci32%3E";lowStage="override";highStage="override"
 PASS :low_high:type="vec4%3Ci32%3E";lowStage="override";highStage="runtime"
 PASS :low_high:type="vec4%3Ci32%3E";lowStage="runtime";highStage="constant"
 PASS :low_high:type="vec4%3Ci32%3E";lowStage="runtime";highStage="override"
 PASS :low_high:type="vec4%3Ci32%3E";lowStage="runtime";highStage="runtime"
 PASS :low_high:type="u32";lowStage="constant";highStage="constant"
-FAIL :low_high:type="u32";lowStage="constant";highStage="override" assert_unreached:
-  - (in subcase: low=0;high=1;in_shader=false) INFO: subcase ran
-  - (in subcase: low=0;high=1;in_shader=true) INFO: subcase ran
-  - (in subcase: low=1;high=1;in_shader=false) INFO: subcase ran
-  - (in subcase: low=1;high=1;in_shader=true) INFO: subcase ran
-  - (in subcase: low=1;high=0;in_shader=false) INFO: subcase ran
-  - (in subcase: low=1;high=0;in_shader=true) EXPECTATION FAILED: Expected validation error
-    eventualAsyncExpectation@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:258:33
-    expectGPUError@http://127.0.0.1:8000/webgpu/webgpu/gpu_test.js:1143:34
-    expectPipelineResult@http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:209:24
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/expression/call/builtin/clamp.spec.js:171:27
-  - (in subcase: low=1;high=0;in_shader=true) INFO: subcase ran
- Reached unreachable code
+PASS :low_high:type="u32";lowStage="constant";highStage="override"
 PASS :low_high:type="u32";lowStage="constant";highStage="runtime"
-FAIL :low_high:type="u32";lowStage="override";highStage="constant" assert_unreached:
-  - (in subcase: low=0;high=1;in_shader=false) INFO: subcase ran
-  - (in subcase: low=0;high=1;in_shader=true) INFO: subcase ran
-  - (in subcase: low=1;high=1;in_shader=false) INFO: subcase ran
-  - (in subcase: low=1;high=1;in_shader=true) INFO: subcase ran
-  - (in subcase: low=1;high=0;in_shader=false) INFO: subcase ran
-  - (in subcase: low=1;high=0;in_shader=true) EXPECTATION FAILED: Expected validation error
-    eventualAsyncExpectation@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:258:33
-    expectGPUError@http://127.0.0.1:8000/webgpu/webgpu/gpu_test.js:1143:34
-    expectPipelineResult@http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:209:24
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/expression/call/builtin/clamp.spec.js:171:27
-  - (in subcase: low=1;high=0;in_shader=true) INFO: subcase ran
- Reached unreachable code
-FAIL :low_high:type="u32";lowStage="override";highStage="override" assert_unreached:
-  - (in subcase: low=0;high=1;in_shader=false) INFO: subcase ran
-  - (in subcase: low=0;high=1;in_shader=true) INFO: subcase ran
-  - (in subcase: low=1;high=1;in_shader=false) INFO: subcase ran
-  - (in subcase: low=1;high=1;in_shader=true) INFO: subcase ran
-  - (in subcase: low=1;high=0;in_shader=false) INFO: subcase ran
-  - (in subcase: low=1;high=0;in_shader=true) EXPECTATION FAILED: Expected validation error
-    eventualAsyncExpectation@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:258:33
-    expectGPUError@http://127.0.0.1:8000/webgpu/webgpu/gpu_test.js:1143:34
-    expectPipelineResult@http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:209:24
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/expression/call/builtin/clamp.spec.js:171:27
-  - (in subcase: low=1;high=0;in_shader=true) INFO: subcase ran
- Reached unreachable code
+PASS :low_high:type="u32";lowStage="override";highStage="constant"
+PASS :low_high:type="u32";lowStage="override";highStage="override"
 PASS :low_high:type="u32";lowStage="override";highStage="runtime"
 PASS :low_high:type="u32";lowStage="runtime";highStage="constant"
 PASS :low_high:type="u32";lowStage="runtime";highStage="override"
 PASS :low_high:type="u32";lowStage="runtime";highStage="runtime"
 PASS :low_high:type="vec2%3Cu32%3E";lowStage="constant";highStage="constant"
-FAIL :low_high:type="vec2%3Cu32%3E";lowStage="constant";highStage="override" assert_unreached:
-  - (in subcase: low=0;high=1;in_shader=false) INFO: subcase ran
-  - (in subcase: low=0;high=1;in_shader=true) INFO: subcase ran
-  - (in subcase: low=1;high=1;in_shader=false) INFO: subcase ran
-  - (in subcase: low=1;high=1;in_shader=true) INFO: subcase ran
-  - (in subcase: low=1;high=0;in_shader=false) INFO: subcase ran
-  - (in subcase: low=1;high=0;in_shader=true) EXPECTATION FAILED: Expected validation error
-    eventualAsyncExpectation@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:258:33
-    expectGPUError@http://127.0.0.1:8000/webgpu/webgpu/gpu_test.js:1143:34
-    expectPipelineResult@http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:209:24
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/expression/call/builtin/clamp.spec.js:171:27
-  - (in subcase: low=1;high=0;in_shader=true) INFO: subcase ran
- Reached unreachable code
+PASS :low_high:type="vec2%3Cu32%3E";lowStage="constant";highStage="override"
 PASS :low_high:type="vec2%3Cu32%3E";lowStage="constant";highStage="runtime"
-FAIL :low_high:type="vec2%3Cu32%3E";lowStage="override";highStage="constant" assert_unreached:
-  - (in subcase: low=0;high=1;in_shader=false) INFO: subcase ran
-  - (in subcase: low=0;high=1;in_shader=true) INFO: subcase ran
-  - (in subcase: low=1;high=1;in_shader=false) INFO: subcase ran
-  - (in subcase: low=1;high=1;in_shader=true) INFO: subcase ran
-  - (in subcase: low=1;high=0;in_shader=false) INFO: subcase ran
-  - (in subcase: low=1;high=0;in_shader=true) EXPECTATION FAILED: Expected validation error
-    eventualAsyncExpectation@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:258:33
-    expectGPUError@http://127.0.0.1:8000/webgpu/webgpu/gpu_test.js:1143:34
-    expectPipelineResult@http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:209:24
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/expression/call/builtin/clamp.spec.js:171:27
-  - (in subcase: low=1;high=0;in_shader=true) INFO: subcase ran
- Reached unreachable code
-FAIL :low_high:type="vec2%3Cu32%3E";lowStage="override";highStage="override" assert_unreached:
-  - (in subcase: low=0;high=1;in_shader=false) INFO: subcase ran
-  - (in subcase: low=0;high=1;in_shader=true) INFO: subcase ran
-  - (in subcase: low=1;high=1;in_shader=false) INFO: subcase ran
-  - (in subcase: low=1;high=1;in_shader=true) INFO: subcase ran
-  - (in subcase: low=1;high=0;in_shader=false) INFO: subcase ran
-  - (in subcase: low=1;high=0;in_shader=true) EXPECTATION FAILED: Expected validation error
-    eventualAsyncExpectation@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:258:33
-    expectGPUError@http://127.0.0.1:8000/webgpu/webgpu/gpu_test.js:1143:34
-    expectPipelineResult@http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:209:24
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/expression/call/builtin/clamp.spec.js:171:27
-  - (in subcase: low=1;high=0;in_shader=true) INFO: subcase ran
- Reached unreachable code
+PASS :low_high:type="vec2%3Cu32%3E";lowStage="override";highStage="constant"
+PASS :low_high:type="vec2%3Cu32%3E";lowStage="override";highStage="override"
 PASS :low_high:type="vec2%3Cu32%3E";lowStage="override";highStage="runtime"
 PASS :low_high:type="vec2%3Cu32%3E";lowStage="runtime";highStage="constant"
 PASS :low_high:type="vec2%3Cu32%3E";lowStage="runtime";highStage="override"
 PASS :low_high:type="vec2%3Cu32%3E";lowStage="runtime";highStage="runtime"
 PASS :low_high:type="vec3%3Cu32%3E";lowStage="constant";highStage="constant"
-FAIL :low_high:type="vec3%3Cu32%3E";lowStage="constant";highStage="override" assert_unreached:
-  - (in subcase: low=0;high=1;in_shader=false) INFO: subcase ran
-  - (in subcase: low=0;high=1;in_shader=true) INFO: subcase ran
-  - (in subcase: low=1;high=1;in_shader=false) INFO: subcase ran
-  - (in subcase: low=1;high=1;in_shader=true) INFO: subcase ran
-  - (in subcase: low=1;high=0;in_shader=false) INFO: subcase ran
-  - (in subcase: low=1;high=0;in_shader=true) EXPECTATION FAILED: Expected validation error
-    eventualAsyncExpectation@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:258:33
-    expectGPUError@http://127.0.0.1:8000/webgpu/webgpu/gpu_test.js:1143:34
-    expectPipelineResult@http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:209:24
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/expression/call/builtin/clamp.spec.js:171:27
-  - (in subcase: low=1;high=0;in_shader=true) INFO: subcase ran
- Reached unreachable code
+PASS :low_high:type="vec3%3Cu32%3E";lowStage="constant";highStage="override"
 PASS :low_high:type="vec3%3Cu32%3E";lowStage="constant";highStage="runtime"
-FAIL :low_high:type="vec3%3Cu32%3E";lowStage="override";highStage="constant" assert_unreached:
-  - (in subcase: low=0;high=1;in_shader=false) INFO: subcase ran
-  - (in subcase: low=0;high=1;in_shader=true) INFO: subcase ran
-  - (in subcase: low=1;high=1;in_shader=false) INFO: subcase ran
-  - (in subcase: low=1;high=1;in_shader=true) INFO: subcase ran
-  - (in subcase: low=1;high=0;in_shader=false) INFO: subcase ran
-  - (in subcase: low=1;high=0;in_shader=true) EXPECTATION FAILED: Expected validation error
-    eventualAsyncExpectation@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:258:33
-    expectGPUError@http://127.0.0.1:8000/webgpu/webgpu/gpu_test.js:1143:34
-    expectPipelineResult@http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:209:24
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/expression/call/builtin/clamp.spec.js:171:27
-  - (in subcase: low=1;high=0;in_shader=true) INFO: subcase ran
- Reached unreachable code
-FAIL :low_high:type="vec3%3Cu32%3E";lowStage="override";highStage="override" assert_unreached:
-  - (in subcase: low=0;high=1;in_shader=false) INFO: subcase ran
-  - (in subcase: low=0;high=1;in_shader=true) INFO: subcase ran
-  - (in subcase: low=1;high=1;in_shader=false) INFO: subcase ran
-  - (in subcase: low=1;high=1;in_shader=true) INFO: subcase ran
-  - (in subcase: low=1;high=0;in_shader=false) INFO: subcase ran
-  - (in subcase: low=1;high=0;in_shader=true) EXPECTATION FAILED: Expected validation error
-    eventualAsyncExpectation@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:258:33
-    expectGPUError@http://127.0.0.1:8000/webgpu/webgpu/gpu_test.js:1143:34
-    expectPipelineResult@http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:209:24
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/expression/call/builtin/clamp.spec.js:171:27
-  - (in subcase: low=1;high=0;in_shader=true) INFO: subcase ran
- Reached unreachable code
+PASS :low_high:type="vec3%3Cu32%3E";lowStage="override";highStage="constant"
+PASS :low_high:type="vec3%3Cu32%3E";lowStage="override";highStage="override"
 PASS :low_high:type="vec3%3Cu32%3E";lowStage="override";highStage="runtime"
 PASS :low_high:type="vec3%3Cu32%3E";lowStage="runtime";highStage="constant"
 PASS :low_high:type="vec3%3Cu32%3E";lowStage="runtime";highStage="override"
 PASS :low_high:type="vec3%3Cu32%3E";lowStage="runtime";highStage="runtime"
 PASS :low_high:type="vec4%3Cu32%3E";lowStage="constant";highStage="constant"
-FAIL :low_high:type="vec4%3Cu32%3E";lowStage="constant";highStage="override" assert_unreached:
-  - (in subcase: low=0;high=1;in_shader=false) INFO: subcase ran
-  - (in subcase: low=0;high=1;in_shader=true) INFO: subcase ran
-  - (in subcase: low=1;high=1;in_shader=false) INFO: subcase ran
-  - (in subcase: low=1;high=1;in_shader=true) INFO: subcase ran
-  - (in subcase: low=1;high=0;in_shader=false) INFO: subcase ran
-  - (in subcase: low=1;high=0;in_shader=true) EXPECTATION FAILED: Expected validation error
-    eventualAsyncExpectation@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:258:33
-    expectGPUError@http://127.0.0.1:8000/webgpu/webgpu/gpu_test.js:1143:34
-    expectPipelineResult@http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:209:24
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/expression/call/builtin/clamp.spec.js:171:27
-  - (in subcase: low=1;high=0;in_shader=true) INFO: subcase ran
- Reached unreachable code
+PASS :low_high:type="vec4%3Cu32%3E";lowStage="constant";highStage="override"
 PASS :low_high:type="vec4%3Cu32%3E";lowStage="constant";highStage="runtime"
-FAIL :low_high:type="vec4%3Cu32%3E";lowStage="override";highStage="constant" assert_unreached:
-  - (in subcase: low=0;high=1;in_shader=false) INFO: subcase ran
-  - (in subcase: low=0;high=1;in_shader=true) INFO: subcase ran
-  - (in subcase: low=1;high=1;in_shader=false) INFO: subcase ran
-  - (in subcase: low=1;high=1;in_shader=true) INFO: subcase ran
-  - (in subcase: low=1;high=0;in_shader=false) INFO: subcase ran
-  - (in subcase: low=1;high=0;in_shader=true) EXPECTATION FAILED: Expected validation error
-    eventualAsyncExpectation@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:258:33
-    expectGPUError@http://127.0.0.1:8000/webgpu/webgpu/gpu_test.js:1143:34
-    expectPipelineResult@http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:209:24
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/expression/call/builtin/clamp.spec.js:171:27
-  - (in subcase: low=1;high=0;in_shader=true) INFO: subcase ran
- Reached unreachable code
-FAIL :low_high:type="vec4%3Cu32%3E";lowStage="override";highStage="override" assert_unreached:
-  - (in subcase: low=0;high=1;in_shader=false) INFO: subcase ran
-  - (in subcase: low=0;high=1;in_shader=true) INFO: subcase ran
-  - (in subcase: low=1;high=1;in_shader=false) INFO: subcase ran
-  - (in subcase: low=1;high=1;in_shader=true) INFO: subcase ran
-  - (in subcase: low=1;high=0;in_shader=false) INFO: subcase ran
-  - (in subcase: low=1;high=0;in_shader=true) EXPECTATION FAILED: Expected validation error
-    eventualAsyncExpectation@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:258:33
-    expectGPUError@http://127.0.0.1:8000/webgpu/webgpu/gpu_test.js:1143:34
-    expectPipelineResult@http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:209:24
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/expression/call/builtin/clamp.spec.js:171:27
-  - (in subcase: low=1;high=0;in_shader=true) INFO: subcase ran
- Reached unreachable code
+PASS :low_high:type="vec4%3Cu32%3E";lowStage="override";highStage="constant"
+PASS :low_high:type="vec4%3Cu32%3E";lowStage="override";highStage="override"
 PASS :low_high:type="vec4%3Cu32%3E";lowStage="override";highStage="runtime"
 PASS :low_high:type="vec4%3Cu32%3E";lowStage="runtime";highStage="constant"
 PASS :low_high:type="vec4%3Cu32%3E";lowStage="runtime";highStage="override"

--- a/LayoutTests/platform/mac-wk2/TestExpectations
+++ b/LayoutTests/platform/mac-wk2/TestExpectations
@@ -1467,7 +1467,6 @@ http/tests/webgpu/webgpu/shader/execution/expression/call/builtin/textureSampleG
 http/tests/webgpu/webgpu/shader/execution/expression/call/builtin/textureSampleLevel.html [ Skip ]
 http/tests/webgpu/webgpu/shader/execution/robust_access.html [ Skip ]
 http/tests/webgpu/webgpu/shader/execution/zero_init.html [ Skip ]
-http/tests/webgpu/webgpu/shader/validation/expression/call/builtin/clamp.html [ Skip ]
 webkit.org/b/308252 [ Debug arm64 ] http/tests/webgpu/webgpu/shader/validation/expression/call/builtin/atan2.html [ Skip ]
 http/tests/webgpu/webgpu/shader/validation/expression/call/builtin/faceForward.html [ Skip ]
 webkit.org/b/308252 [ Debug arm64 ] http/tests/webgpu/webgpu/shader/validation/expression/call/builtin/length.html [ Skip ]

--- a/Source/WebGPU/WGSL/GlobalVariableRewriter.cpp
+++ b/Source/WebGPU/WGSL/GlobalVariableRewriter.cpp
@@ -597,6 +597,25 @@ Packing RewriteGlobalVariables::getPacking(AST::BinaryExpression& expression)
 {
     pack(Packing::Unpacked, expression.leftExpression());
     pack(Packing::Unpacked, expression.rightExpression());
+
+    auto operation = toASCIILiteral(expression.operation());
+    if (auto* overload = m_shaderModule.lookupOverload(operation)) {
+        if (auto validate = overload->validationFunction) {
+            m_shaderModule.addOverrideValidation([&shaderModule = m_shaderModule, &expression, validate](auto& overrideValues) -> std::optional<Error> {
+                FixedVector<std::optional<ConstantValue>> validationArguments(2);
+                if (auto value = evaluate(shaderModule, expression.leftExpression(), overrideValues))
+                    validationArguments[0] = { *value };
+                if (auto value = evaluate(shaderModule, expression.rightExpression(), overrideValues))
+                    validationArguments[1] = { *value };
+
+                if (auto error = validate(WTF::move(validationArguments)))
+                    return Error(*error, expression.span());
+
+                return std::nullopt;
+            });
+        }
+    }
+
     return Packing::Unpacked;
 }
 
@@ -695,6 +714,23 @@ Packing RewriteGlobalVariables::getPacking(AST::CallExpression& call)
 
     for (auto& argument : call.arguments())
         pack(Packing::Unpacked, argument);
+
+    if (auto validate = call.validationFunction()) {
+        m_shaderModule.addOverrideValidation([&shaderModule = m_shaderModule, &call, validate](auto& overrideValues) -> std::optional<Error> {
+            unsigned argumentCount = call.arguments().size();
+            FixedVector<std::optional<ConstantValue>> validationArguments(argumentCount);
+            for (unsigned i = 0; i < argumentCount; ++i) {
+                if (auto value = evaluate(shaderModule, call.arguments()[i], overrideValues))
+                    validationArguments[i] = { *value };
+            }
+
+            if (auto error = validate(WTF::move(validationArguments)))
+                return Error(*error, call.span());
+
+            return std::nullopt;
+        });
+    }
+
     return Packing::Unpacked;
 }
 

--- a/Source/WebGPU/WGSL/TypeCheck.cpp
+++ b/Source/WebGPU/WGSL/TypeCheck.cpp
@@ -2171,20 +2171,6 @@ Result<const Type*> TypeChecker::chooseOverload(ASCIILiteral kind, const SourceS
         } else if (auto* validate = overload->validationFunction) {
             if (auto error = validate(WTF::move(validationArguments)))
                 TYPE_ERROR(span, *error);
-
-            m_shaderModule.addOverrideValidation([&shaderModule = m_shaderModule, span, callArguments, validate](auto& overrideValues) -> std::optional<Error> {
-                unsigned argumentCount = callArguments.size();
-                FixedVector<std::optional<ConstantValue>> validationArguments(argumentCount);
-                for (unsigned i = 0; i < argumentCount; ++i) {
-                    if (auto value = evaluate(shaderModule, callArguments[i], overrideValues))
-                        validationArguments[i] = { *value };
-                }
-
-                if (auto error = validate(WTF::move(validationArguments)))
-                    return Error(*error, span);
-
-                return std::nullopt;
-            });
         }
 
         return { selectedOverload->result };


### PR DESCRIPTION
#### cc45b685202c5c4fcc8d94a8e19990799f6e20a8
<pre>
[WGSL] shader,validation,expression,call,builtin,clamp:* is failing
<a href="https://bugs.webkit.org/show_bug.cgi?id=314112">https://bugs.webkit.org/show_bug.cgi?id=314112</a>
<a href="https://rdar.apple.com/176284824">rdar://176284824</a>

Reviewed by Mike Wyrzykowski.

The validation for expressions containing override expressions shouldn&apos;t happen
in the type checker, as that runs for every function, even non-reachable ones
for the shader being compiled. Move that to the GlobalVariableRewriter instead
so only used expressions are checked.

* LayoutTests/http/tests/webgpu/webgpu/shader/validation/expression/call/builtin/clamp-expected.txt:
* LayoutTests/platform/mac-wk2/TestExpectations:
* Source/WebGPU/WGSL/GlobalVariableRewriter.cpp:
(WGSL::RewriteGlobalVariables::getPacking):
* Source/WebGPU/WGSL/TypeCheck.cpp:

Canonical link: <a href="https://commits.webkit.org/312670@main">https://commits.webkit.org/312670@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a285c16a848b35337226ff25d05ac1ea17d15462

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/160609 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/34082 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/27183 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/169512 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/115675 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/fe8b325b-12b9-421e-839a-3f2811b45eed) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/34183 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/34082 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/124553 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/87955 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/2e59d38d-0f46-44b0-b806-0042e60e0d38) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/163568 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/26799 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/144273 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/105153 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/87b8eda2-2fd3-4def-a545-3c53da45e746) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/25851 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/24355 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/17232 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/135545 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/22036 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/171991 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/18868 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/23676 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/132820 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/33756 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/28448 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/132835 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35905 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/33740 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/143831 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/95544 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/27429 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/20646 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/33251 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/100481 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/32750 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/32994 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/32898 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->