### PR TITLE
[HDR] Retrieve the frame gain-map from the CGImageSource when it is avaliable

### DIFF
--- a/Source/WebCore/Configurations/AllowedSPI.toml
+++ b/Source/WebCore/Configurations/AllowedSPI.toml
@@ -100,6 +100,10 @@ request = "rdar://175714562"
 cleanup = "rdar://175714562"
 symbols = [
     "CGImageApplyHDRGainMap",
+    "CGImageSourceCopyAuxiliaryDataInfoAtIndexWithOptions",
+    "kCGImageAuxiliaryDataInfoPixelBuffer",
+    "kCGImageAuxiliaryDataRepresentation",
+    "kCGImageAuxiliaryDataRepresentationPixelBuffer",
 ]
 
 [[not-web-essential]]

--- a/Source/WebCore/PAL/pal/spi/cg/ImageIOSPI.h
+++ b/Source/WebCore/PAL/pal/spi/cg/ImageIOSPI.h
@@ -45,6 +45,9 @@ typedef struct CF_BRIDGED_TYPE(id) __CVBuffer* CVPixelBufferRef;
 IMAGEIO_EXTERN const CFStringRef kCGImageAuxiliaryDataInfoColorSpace;
 IMAGEIO_EXTERN const CFStringRef kCGImageAuxiliaryDataInfoMetadata;
 IMAGEIO_EXTERN const CFStringRef kCGImageAuxiliaryDataTypeISOGainMap;
+IMAGEIO_EXTERN const CFStringRef kCGImageAuxiliaryDataInfoPixelBuffer;
+IMAGEIO_EXTERN const CFStringRef kCGImageAuxiliaryDataRepresentation;
+IMAGEIO_EXTERN const CFStringRef kCGImageAuxiliaryDataRepresentationPixelBuffer;
 IMAGEIO_EXTERN const CFStringRef kCGImageSourceShouldCacheImmediately;
 IMAGEIO_EXTERN const CFStringRef kCGImageSourceShouldPreferRGB32;
 IMAGEIO_EXTERN const CFStringRef kCGImageSourceSkipMetadata;
@@ -52,6 +55,7 @@ IMAGEIO_EXTERN const CFStringRef kCGImageSourceSubsampleFactor;
 IMAGEIO_EXTERN const CFStringRef kCGImageSourceUseHardwareAcceleration;
 
 WTF_EXTERN_C_BEGIN
+
 CFStringRef CGImageSourceGetTypeWithData(CFDataRef, CFStringRef, bool*);
 OSStatus CGImageSourceSetAllowableTypes(CFArrayRef allowableTypes);
 
@@ -59,6 +63,8 @@ IMAGEIO_EXTERN OSStatus CGImageSourceDisableHardwareDecoding();
 IMAGEIO_EXTERN OSStatus CGImageSourceEnableRestrictedDecoding();
 
 IMAGEIO_EXTERN uint16_t CGImageGetContentAverageLightLevelNits(CGImageRef);
+
+IMAGEIO_EXTERN CFDictionaryRef CGImageSourceCopyAuxiliaryDataInfoAtIndexWithOptions(CGImageSourceRef, size_t index, CFStringRef auxiliaryDataType, CFDictionaryRef options);
 
 IMAGEIO_EXTERN OSStatus CGImageApplyHDRGainMap(CVPixelBufferRef inputImage, CVPixelBufferRef inputGainmap, CVPixelBufferRef outputImage, CFDictionaryRef options);
 

--- a/Source/WebCore/platform/cocoa/CoreVideoSoftLink.h
+++ b/Source/WebCore/platform/cocoa/CoreVideoSoftLink.h
@@ -34,7 +34,6 @@
 
 typedef struct __IOSurface* IOSurfaceRef;
 
-WTF_DECLARE_CF_TYPE_TRAIT(CVPixelBuffer);
 WTF_DECLARE_CF_TYPE_TRAIT(CVPixelBufferPool);
 
 SOFT_LINK_FRAMEWORK_FOR_HEADER(WebCore, CoreVideo)
@@ -54,6 +53,11 @@ SOFT_LINK_FUNCTION_FOR_HEADER(WebCore, CoreVideo, CVBufferSetAttachment, void, (
 #define CVBufferGetAttachments softLink_CoreVideo_CVBufferGetAttachments
 SOFT_LINK_FUNCTION_FOR_HEADER(WebCore, CoreVideo, CVPixelBufferGetTypeID, CFTypeID, (), ())
 #define CVPixelBufferGetTypeID softLink_CoreVideo_CVPixelBufferGetTypeID
+// Manual equivalent of WTF_DECLARE_CF_TYPE_TRAIT(CVPixelBuffer) because the
+// soft-linked function CVPixelBufferGetTypeID lives in the WebCore namespace.
+template <> struct WTF::CFTypeTrait<CVPixelBufferRef> {
+    static inline CFTypeID typeID() { return WebCore::CVPixelBufferGetTypeID(); }
+};
 SOFT_LINK_FUNCTION_FOR_HEADER(WebCore, CoreVideo, CVPixelBufferGetDataSize, size_t, (CVPixelBufferRef pixelBuffer), (pixelBuffer))
 #define CVPixelBufferGetDataSize softLink_CoreVideo_CVPixelBufferGetDataSize
 SOFT_LINK_FUNCTION_FOR_HEADER(WebCore, CoreVideo, CVPixelBufferGetWidth, size_t, (CVPixelBufferRef pixelBuffer), (pixelBuffer))

--- a/Source/WebCore/platform/graphics/GainMap.h
+++ b/Source/WebCore/platform/graphics/GainMap.h
@@ -39,7 +39,7 @@ struct GainMap {
 #if PLATFORM(COCOA)
     RetainPtr<CGImageMetadataRef> metadata;
     RetainPtr<CVPixelBufferRef> gainMapPixelBuffer;
-    DestinationColorSpace colorSpace;
+    std::optional<DestinationColorSpace> colorSpace;
 #endif
 };
 

--- a/Source/WebCore/platform/graphics/ImageDecoder.h
+++ b/Source/WebCore/platform/graphics/ImageDecoder.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2024 Apple Inc. All rights reserved.
+ * Copyright (C) 2017-2026 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -26,6 +26,7 @@
 #pragma once
 
 #include <WebCore/DecodingOptions.h>
+#include <WebCore/GainMap.h>
 #include <WebCore/ImageOrientation.h>
 #include <WebCore/ImageResolution.h>
 #include <WebCore/ImageTypes.h>
@@ -123,6 +124,7 @@ public:
 
     WEBCORE_EXPORT virtual bool fetchFrameMetaDataAtIndex(size_t, SubsamplingLevel, const DecodingOptions&, ImageFrame&) const;
 
+    virtual std::optional<GainMap> frameGainMapAtIndex(size_t, const DecodingOptions&) { return std::nullopt; }
     virtual PlatformImagePtr createFrameImageAtIndex(size_t, SubsamplingLevel = SubsamplingLevel::Default, const DecodingOptions& = DecodingOptions(DecodingMode::Synchronous)) = 0;
 
     virtual void setExpectedContentSize(long long) { }

--- a/Source/WebCore/platform/graphics/cg/ImageDecoderCG.cpp
+++ b/Source/WebCore/platform/graphics/cg/ImageDecoderCG.cpp
@@ -42,11 +42,14 @@
 #include <wtf/TZoneMallocInlines.h>
 #include <wtf/cf/TypeCastsCF.h>
 
+#include "CoreVideoSoftLink.h"
 #include "MediaAccessibilitySoftLink.h"
 
 #if ENABLE(SPATIAL_IMAGE_DETECTION)
 #include "PhotosFormatSoftLink.h"
 #endif
+
+WTF_DECLARE_CF_TYPE_TRAIT(CGImageMetadata)
 
 namespace WebCore {
 
@@ -630,6 +633,37 @@ bool ImageDecoderCG::fetchFrameMetaDataAtIndex(size_t index, SubsamplingLevel su
     frame.m_orientation = orientationFromProperties(properties.get());
     frame.m_decodingStatus = frameIsComplete ? DecodingStatus::Complete : DecodingStatus::Partial;
     return true;
+}
+
+std::optional<GainMap> ImageDecoderCG::frameGainMapAtIndex(size_t index, const DecodingOptions&)
+{
+#if HAVE(SUPPORT_HDR_DISPLAY_APIS)
+    RetainPtr auxiliaryOptions = adoptCF(CFDictionaryCreateMutable(nullptr, 0, &kCFTypeDictionaryKeyCallBacks, &kCFTypeDictionaryValueCallBacks));
+    CFDictionarySetValue(auxiliaryOptions.get(), kCGImageAuxiliaryDataRepresentation, kCGImageAuxiliaryDataRepresentationPixelBuffer);
+
+    RetainPtr auxiliaryInfo = adoptCF(CGImageSourceCopyAuxiliaryDataInfoAtIndexWithOptions(m_nativeDecoder.get(), index, kCGImageAuxiliaryDataTypeISOGainMap, auxiliaryOptions.get()));
+    if (!auxiliaryInfo)
+        auxiliaryInfo = adoptCF(CGImageSourceCopyAuxiliaryDataInfoAtIndexWithOptions(m_nativeDecoder.get(), index, kCGImageAuxiliaryDataTypeHDRGainMap, auxiliaryOptions.get()));
+
+    if (!auxiliaryInfo)
+        return std::nullopt;
+
+    RetainPtr metadata = dynamic_cf_cast<CGImageMetadataRef>(CFDictionaryGetValue(auxiliaryInfo.get(), kCGImageAuxiliaryDataInfoMetadata));
+    RetainPtr gainMapPixelBuffer = dynamic_cf_cast<CVPixelBufferRef>(CFDictionaryGetValue(auxiliaryInfo.get(), kCGImageAuxiliaryDataInfoPixelBuffer));
+    RetainPtr colorSpace = dynamic_cf_cast<CGColorSpaceRef>(CFDictionaryGetValue(auxiliaryInfo.get(), kCGImageAuxiliaryDataInfoColorSpace));
+
+    if (!metadata || !gainMapPixelBuffer)
+        return std::nullopt;
+
+    return GainMap {
+        WTF::move(metadata),
+        WTF::move(gainMapPixelBuffer),
+        colorSpace ? std::optional<DestinationColorSpace> { DestinationColorSpace(WTF::move(colorSpace)) } : std::nullopt
+    };
+#else
+    UNUSED_PARAM(index);
+    return std::nullopt;
+#endif
 }
 
 PlatformImagePtr ImageDecoderCG::createFrameImageAtIndex(size_t index, SubsamplingLevel subsamplingLevel, const DecodingOptions& decodingOptions)

--- a/Source/WebCore/platform/graphics/cg/ImageDecoderCG.h
+++ b/Source/WebCore/platform/graphics/cg/ImageDecoderCG.h
@@ -72,6 +72,7 @@ public:
 
     bool fetchFrameMetaDataAtIndex(size_t, SubsamplingLevel, const DecodingOptions&, ImageFrame&) const final;
 
+    std::optional<GainMap> frameGainMapAtIndex(size_t, const DecodingOptions&) final;
     PlatformImagePtr createFrameImageAtIndex(size_t, SubsamplingLevel = SubsamplingLevel::Default, const DecodingOptions& = DecodingOptions(DecodingMode::Synchronous)) final;
 
     void setData(const FragmentedSharedBuffer&, bool allDataReceived) final;

--- a/Source/WebCore/platform/graphics/cocoa/ShareableGainMap.cpp
+++ b/Source/WebCore/platform/graphics/cocoa/ShareableGainMap.cpp
@@ -52,7 +52,7 @@ std::optional<ShareableGainMap> ShareableGainMap::create(const std::optional<Gai
     return ShareableGainMap { WTF::move(metadata), gainMapShareablePixelBuffer.releaseNonNull(), gainMap->colorSpace };
 }
 
-std::optional<ShareableGainMap> ShareableGainMap::create(RetainPtr<CFDataRef>&& metadata, Ref<ShareableCVPixelBuffer>&& gainMapShareablePixelBuffer, const DestinationColorSpace& colorSpace)
+std::optional<ShareableGainMap> ShareableGainMap::create(RetainPtr<CFDataRef>&& metadata, Ref<ShareableCVPixelBuffer>&& gainMapShareablePixelBuffer, const std::optional<DestinationColorSpace> colorSpace)
 {
     if (!metadata)
         return std::nullopt;
@@ -60,7 +60,7 @@ std::optional<ShareableGainMap> ShareableGainMap::create(RetainPtr<CFDataRef>&& 
     return ShareableGainMap { WTF::move(metadata), WTF::move(gainMapShareablePixelBuffer), colorSpace };
 }
 
-ShareableGainMap::ShareableGainMap(RetainPtr<CFDataRef>&& metadata, Ref<ShareableCVPixelBuffer>&& gainMapShareablePixelBuffer, const DestinationColorSpace& colorSpace)
+ShareableGainMap::ShareableGainMap(RetainPtr<CFDataRef>&& metadata, Ref<ShareableCVPixelBuffer>&& gainMapShareablePixelBuffer, const std::optional<DestinationColorSpace> colorSpace)
     : m_metadata(WTF::move(metadata))
     , m_gainMapShareablePixelBuffer(WTF::move(gainMapShareablePixelBuffer))
     , m_colorSpace(colorSpace)
@@ -98,7 +98,7 @@ PlatformImagePtr ShareableGainMap::applyGainMapToBaseImage(PlatformImagePtr base
 
     RetainPtr options = adoptCF(CFDictionaryCreateMutable(nullptr, 0, &kCFTypeDictionaryKeyCallBacks, &kCFTypeDictionaryValueCallBacks));
     CFDictionarySetValue(options, kCGImageAuxiliaryDataInfoMetadata, metadata);
-    CFDictionarySetValue(options, kCGImageAuxiliaryDataInfoColorSpace, m_colorSpace.platformColorSpace());
+    CFDictionarySetValue(options, kCGImageAuxiliaryDataInfoColorSpace, m_colorSpace ? m_colorSpace->platformColorSpace() : nullptr);
 
     auto status = CGImageApplyHDRGainMap(baseImagePixelBuffer, gainMapPixelBuffer, outputImagePixelBuffer, options);
     if (status != kCVReturnSuccess) {

--- a/Source/WebCore/platform/graphics/cocoa/ShareableGainMap.h
+++ b/Source/WebCore/platform/graphics/cocoa/ShareableGainMap.h
@@ -36,18 +36,18 @@ namespace WebCore {
 class ShareableGainMap {
 public:
     WEBCORE_EXPORT static std::optional<ShareableGainMap> create(const std::optional<GainMap>&);
-    WEBCORE_EXPORT static std::optional<ShareableGainMap> create(RetainPtr<CFDataRef>&& metadata, Ref<ShareableCVPixelBuffer>&& gainMapShareablePixelBuffer, const DestinationColorSpace&);
+    WEBCORE_EXPORT static std::optional<ShareableGainMap> create(RetainPtr<CFDataRef>&& metadata, Ref<ShareableCVPixelBuffer>&& gainMapShareablePixelBuffer, std::optional<DestinationColorSpace>);
 
     WEBCORE_EXPORT PlatformImagePtr applyGainMapToBaseImage(PlatformImagePtr) const;
 
 private:
     friend struct IPC::ArgumentCoder<ShareableGainMap>;
 
-    ShareableGainMap(RetainPtr<CFDataRef>&& metadata, Ref<ShareableCVPixelBuffer>&& gainMapShareablePixelBuffer, const DestinationColorSpace&);
+    ShareableGainMap(RetainPtr<CFDataRef>&& metadata, Ref<ShareableCVPixelBuffer>&& gainMapShareablePixelBuffer, std::optional<DestinationColorSpace>);
 
     RetainPtr<CFDataRef> m_metadata;
     Ref<ShareableCVPixelBuffer> m_gainMapShareablePixelBuffer;
-    DestinationColorSpace m_colorSpace;
+    std::optional<DestinationColorSpace> m_colorSpace;
 };
 
 } // namespace WebCore

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -8580,7 +8580,7 @@ header: <WebCore/ShareableGainMap.h>
 [CreateUsing=create] class WebCore::ShareableGainMap {
     RetainPtr<CFDataRef> m_metadata;
     Ref<WebCore::ShareableCVPixelBuffer> m_gainMapShareablePixelBuffer;
-    WebCore::DestinationColorSpace m_colorSpace;
+    std::optional<WebCore::DestinationColorSpace> m_colorSpace;
 }
 
 #endif


### PR DESCRIPTION
#### 378eed42de91e6c07c43a646828899f7e817b66d
<pre>
[HDR] Retrieve the frame gain-map from the CGImageSource when it is avaliable
<a href="https://bugs.webkit.org/show_bug.cgi?id=313602">https://bugs.webkit.org/show_bug.cgi?id=313602</a>
<a href="https://rdar.apple.com/175806142">rdar://175806142</a>

Reviewed by Simon Fraser.

Gain-map images come in two flavors: ISOGainMap and HDRGainMap. We are going to
retrieve any of them for the given frame. In addition to the gain-map image, we
are going to get the gain-map metadata and the alternate colorSpace.

This data will enable accelerated applying the gain-map to produce an HDR image
in GPUProcess.

* Source/WebCore/Configurations/AllowedSPI.toml:
* Source/WebCore/PAL/pal/spi/cg/ImageIOSPI.h:
* Source/WebCore/platform/cocoa/CoreVideoSoftLink.h:
(WTF::CFTypeTrait&lt;CVPixelBufferRef&gt;::typeID):
* Source/WebCore/platform/graphics/GainMap.h:
* Source/WebCore/platform/graphics/ImageDecoder.h:
(WebCore::ImageDecoder::frameGainMapAtIndex):
* Source/WebCore/platform/graphics/cg/ImageDecoderCG.cpp:
(WebCore::ImageDecoderCG::frameGainMapAtIndex):
* Source/WebCore/platform/graphics/cg/ImageDecoderCG.h:
* Source/WebCore/platform/graphics/cocoa/ShareableGainMap.cpp:
(WebCore::ShareableGainMap::create):
(WebCore::ShareableGainMap::ShareableGainMap):
(WebCore::ShareableGainMap::applyGainMapToBaseImage const):
* Source/WebCore/platform/graphics/cocoa/ShareableGainMap.h:
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:

Canonical link: <a href="https://commits.webkit.org/312736@main">https://commits.webkit.org/312736@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5d0aab33702d0ca1952dbf990d7a8404cf521a18

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/160921 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/159/builds/34394 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/27495 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/169824 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/117181 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/162790 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/34495 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/34394 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/124821 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/117181 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/4a55b96f-fbaf-41c7-b8f0-baa20c74db97) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/163880 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/27083 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/144558 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/105418 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/d401398a-c55f-4e11-af39-a27037c19b06) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/26135 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/24637 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/17544 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/135829 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/22320 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/172307 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/19328 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/23961 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/133097 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/34068 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/28729 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/133107 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35941 "Built successfully and passed tests") | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/34052 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/144115 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/95891 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/160/builds/34052 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/20931 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/33563 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/100988 "Built successfully") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/33062 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/33306 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/33211 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->