### PR TITLE
[Style] Unify numeric type resolution functions (part 1)

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/CSS2/normal-flow/margin-collapse-through-for-various-height-values.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/CSS2/normal-flow/margin-collapse-through-for-various-height-values.tentative-expected.txt
@@ -9,8 +9,8 @@ PASS {"height":"1%","parentHeight":"auto"}
 FAIL {"height":"1%","parentHeight":"0px"} assert_equals: margins should collapse through expected 50 but got 100
 PASS {"height":"1%","parentHeight":"100px"}
 PASS {"height":"calc(0px + 0%)","parentHeight":"auto"}
-FAIL {"height":"calc(0px + 0%)","parentHeight":"0px"} assert_equals: margins should collapse through expected 50 but got 100
-FAIL {"height":"calc(0px + 0%)","parentHeight":"100px"} assert_equals: margins should collapse through expected 50 but got 100
+PASS {"height":"calc(0px + 0%)","parentHeight":"0px"}
+PASS {"height":"calc(0px + 0%)","parentHeight":"100px"}
 PASS {"height":"calc(0px + 1%)","parentHeight":"auto"}
 FAIL {"height":"calc(0px + 1%)","parentHeight":"0px"} assert_equals: margins should collapse through expected 50 but got 100
 PASS {"height":"calc(0px + 1%)","parentHeight":"100px"}
@@ -32,9 +32,9 @@ PASS {"minHeight":"0%","parentHeight":"100px"}
 FAIL {"minHeight":"1%","parentHeight":"auto"} assert_equals: margins should collapse through expected 50 but got 100
 FAIL {"minHeight":"1%","parentHeight":"0px"} assert_equals: margins should collapse through expected 50 but got 100
 PASS {"minHeight":"1%","parentHeight":"100px"}
-FAIL {"minHeight":"calc(0px + 0%)","parentHeight":"auto"} assert_equals: margins should collapse through expected 50 but got 100
-FAIL {"minHeight":"calc(0px + 0%)","parentHeight":"0px"} assert_equals: margins should collapse through expected 50 but got 100
-FAIL {"minHeight":"calc(0px + 0%)","parentHeight":"100px"} assert_equals: margins should collapse through expected 50 but got 100
+PASS {"minHeight":"calc(0px + 0%)","parentHeight":"auto"}
+PASS {"minHeight":"calc(0px + 0%)","parentHeight":"0px"}
+PASS {"minHeight":"calc(0px + 0%)","parentHeight":"100px"}
 FAIL {"minHeight":"calc(0px + 1%)","parentHeight":"auto"} assert_equals: margins should collapse through expected 50 but got 100
 FAIL {"minHeight":"calc(0px + 1%)","parentHeight":"0px"} assert_equals: margins should collapse through expected 50 but got 100
 PASS {"minHeight":"calc(0px + 1%)","parentHeight":"100px"}

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-values/animations/calc-interpolation-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-values/animations/calc-interpolation-expected.txt
@@ -5,28 +5,28 @@ PASS CSS Transitions: property <left> from [0px] to [calc(infinity * 1px)] at (0
 PASS CSS Transitions: property <left> from [0px] to [calc(infinity * 1px)] at (0.5) should be [16777214px]
 PASS CSS Transitions: property <left> from [0px] to [calc(infinity * 1px)] at (0.75) should be [25165821px]
 PASS CSS Transitions: property <left> from [0px] to [calc(infinity * 1px)] at (1) should be [33554428px]
-FAIL CSS Transitions: property <left> from [0px] to [calc(infinity * 1px)] at (1.25) should be [41943035px] assert_equals: expected "33554428px " but got "41943036px "
+PASS CSS Transitions: property <left> from [0px] to [calc(infinity * 1px)] at (1.25) should be [41943035px]
 PASS CSS Transitions with transition: all: property <left> from [0px] to [calc(infinity * 1px)] at (-0.25) should be [-8388607px]
 PASS CSS Transitions with transition: all: property <left> from [0px] to [calc(infinity * 1px)] at (0) should be [0px]
 PASS CSS Transitions with transition: all: property <left> from [0px] to [calc(infinity * 1px)] at (0.25) should be [8388607px]
 PASS CSS Transitions with transition: all: property <left> from [0px] to [calc(infinity * 1px)] at (0.5) should be [16777214px]
 PASS CSS Transitions with transition: all: property <left> from [0px] to [calc(infinity * 1px)] at (0.75) should be [25165821px]
 PASS CSS Transitions with transition: all: property <left> from [0px] to [calc(infinity * 1px)] at (1) should be [33554428px]
-FAIL CSS Transitions with transition: all: property <left> from [0px] to [calc(infinity * 1px)] at (1.25) should be [41943035px] assert_equals: expected "33554428px " but got "41943036px "
+PASS CSS Transitions with transition: all: property <left> from [0px] to [calc(infinity * 1px)] at (1.25) should be [41943035px]
 FAIL CSS Animations: property <left> from [0px] to [calc(infinity * 1px)] at (-0.25) should be [-33554428px] assert_equals: expected "- 33554428px " but got "- 8388607px "
 PASS CSS Animations: property <left> from [0px] to [calc(infinity * 1px)] at (0) should be [0px]
 FAIL CSS Animations: property <left> from [0px] to [calc(infinity * 1px)] at (0.25) should be [33554428px] assert_equals: expected "33554428px " but got "8388607px "
 FAIL CSS Animations: property <left> from [0px] to [calc(infinity * 1px)] at (0.5) should be [33554428px] assert_equals: expected "33554428px " but got "16777214px "
 FAIL CSS Animations: property <left> from [0px] to [calc(infinity * 1px)] at (0.75) should be [33554428px] assert_equals: expected "33554428px " but got "25165820px "
 PASS CSS Animations: property <left> from [0px] to [calc(infinity * 1px)] at (1) should be [33554428px]
-FAIL CSS Animations: property <left> from [0px] to [calc(infinity * 1px)] at (1.25) should be [33554428px] assert_equals: expected "33554428px " but got "41943036px "
+PASS CSS Animations: property <left> from [0px] to [calc(infinity * 1px)] at (1.25) should be [33554428px]
 FAIL Web Animations: property <left> from [0px] to [calc(infinity * 1px)] at (-0.25) should be [-33554428px] assert_equals: expected "- 33554428px " but got "- 8388607px "
 PASS Web Animations: property <left> from [0px] to [calc(infinity * 1px)] at (0) should be [0px]
 FAIL Web Animations: property <left> from [0px] to [calc(infinity * 1px)] at (0.25) should be [33554428px] assert_equals: expected "33554428px " but got "8388607px "
 FAIL Web Animations: property <left> from [0px] to [calc(infinity * 1px)] at (0.5) should be [33554428px] assert_equals: expected "33554428px " but got "16777214px "
 FAIL Web Animations: property <left> from [0px] to [calc(infinity * 1px)] at (0.75) should be [33554428px] assert_equals: expected "33554428px " but got "25165820px "
 PASS Web Animations: property <left> from [0px] to [calc(infinity * 1px)] at (1) should be [33554428px]
-FAIL Web Animations: property <left> from [0px] to [calc(infinity * 1px)] at (1.25) should be [33554428px] assert_equals: expected "33554428px " but got "41943036px "
+PASS Web Animations: property <left> from [0px] to [calc(infinity * 1px)] at (1.25) should be [33554428px]
 PASS CSS Transitions: property <left> from [calc(50% - 25px)] to [calc(100% - 10px)] at (-0.25) should be [-10px]
 PASS CSS Transitions: property <left> from [calc(50% - 25px)] to [calc(100% - 10px)] at (0) should be [0px]
 PASS CSS Transitions: property <left> from [calc(50% - 25px)] to [calc(100% - 10px)] at (0.25) should be [10px]

--- a/Source/WebCore/css/CSSPrimitiveValue.h
+++ b/Source/WebCore/css/CSSPrimitiveValue.h
@@ -40,44 +40,22 @@ class RenderView;
 
 template<typename> class ExceptionOr;
 
-// Max/min values for CSS, needs to slightly smaller/larger than the true max/min values to allow for rounding without overflowing.
-// Subtract two (rather than one) to allow for values to be converted to float and back without exceeding the LayoutUnit::max.
-constexpr float maxValueForCssLength = static_cast<float>(intMaxForLayoutUnit - 2);
-constexpr float minValueForCssLength = static_cast<float>(intMinForLayoutUnit + 2);
-
 class CSSPrimitiveValue final : public CSSValue {
 public:
-    static constexpr bool isLength(CSSUnitType);
-
-    template<CSS::AngleUnit, typename T = double> static T computeAngle(CSSUnitType, T angle);
-    template<CSS::TimeUnit, typename T = double> static T computeTime(CSSUnitType, T time);
-    template<CSS::FrequencyUnit, typename T = double> static T computeFrequency(CSSUnitType, T frequency);
-    template<CSS::ResolutionUnit, typename T = double> static T computeResolution(CSSUnitType, T resolution);
-
     // FIXME: Some of these use primitiveUnitType() and some use NODELETE primitiveType(). Many that use primitiveUnitType() are likely broken with calc().
     bool isAngle() const { return unitCategory(primitiveType()) == CSSUnitCategory::Angle; }
     bool isFontIndependentLength() const { return isFontIndependentLength(primitiveUnitType()); }
     bool isFontRelativeLength() const { return isFontRelativeLength(primitiveUnitType()); }
     bool isParentFontRelativeLength() const { return isPercentage() || (isFontRelativeLength() && !isRootFontRelativeLength()); }
     bool isRootFontRelativeLength() const { return isRootFontRelativeLength(primitiveUnitType()); }
-    bool isQuirkyEms() const { return primitiveType() == CSSUnitType::CSS_QUIRKY_EM; }
     bool isLength() const { return isLength(static_cast<CSSUnitType>(primitiveType())); }
     bool isNumber() const { return primitiveType() == CSSUnitType::CSS_NUMBER; }
     bool isInteger() const { return primitiveType() == CSSUnitType::CSS_INTEGER; }
     bool isNumberOrInteger() const { return isNumber() || isInteger(); }
     bool isPercentage() const { return primitiveType() == CSSUnitType::CSS_PERCENTAGE; }
     bool isPx() const { return primitiveType() == CSSUnitType::CSS_PX; }
-    bool isTime() const { return unitCategory(primitiveType()) == CSSUnitCategory::Time; }
-    bool isFrequency() const { return unitCategory(primitiveType()) == CSSUnitCategory::Frequency; }
     bool isCalculated() const { return primitiveUnitType() == CSSUnitType::CSS_CALC; }
     bool isCalculatedPercentageWithLength() const { return primitiveType() == CSSUnitType::CSS_CALC_PERCENTAGE_WITH_LENGTH; }
-    bool isDotsPerInch() const { return primitiveType() == CSSUnitType::CSS_DPI; }
-    bool isDotsPerPixel() const { return primitiveType() == CSSUnitType::CSS_DPPX; }
-    bool isDotsPerCentimeter() const { return primitiveType() == CSSUnitType::CSS_DPCM; }
-    bool isX() const { return primitiveType() == CSSUnitType::CSS_X; }
-    bool isResolution() const { return unitCategory(primitiveType()) == CSSUnitCategory::Resolution; }
-    bool isViewportPercentageLength() const { return isViewportPercentageLength(primitiveUnitType()); }
-    bool isContainerPercentageLength() const { return isContainerPercentageLength(primitiveUnitType()); }
     bool isFlex() const { return primitiveType() == CSSUnitType::CSS_FR; }
 
     bool NODELETE conversionToCanonicalUnitRequiresConversionData() const;
@@ -112,24 +90,6 @@ public:
     template<typename T = double> T resolveAsPercentageDeprecated() const;
     template<typename T = double> std::optional<T> resolveAsPercentageIfNotCalculated() const;
 
-    // MARK: Angle (requires `isAngle() == true`)
-    template<typename T = double, CSS::AngleUnit = CSS::UnitTraits<CSS::AngleUnit>::canonical> T resolveAsAngle(const CSSToLengthConversionData&) const;
-    template<typename T = double, CSS::AngleUnit = CSS::UnitTraits<CSS::AngleUnit>::canonical> T resolveAsAngleNoConversionDataRequired() const;
-    template<typename T = double, CSS::AngleUnit = CSS::UnitTraits<CSS::AngleUnit>::canonical> T resolveAsAngleDeprecated() const;
-
-    // MARK: Time (requires `isTime() == true`)
-    template<typename T = double, CSS::TimeUnit = CSS::UnitTraits<CSS::TimeUnit>::canonical> T resolveAsTime(const CSSToLengthConversionData&) const;
-    template<typename T = double, CSS::TimeUnit = CSS::UnitTraits<CSS::TimeUnit>::canonical> T resolveAsTimeNoConversionDataRequired() const;
-
-    // MARK: Resolution (requires `isResolution() == true`)
-    template<typename T = double, CSS::ResolutionUnit = CSS::UnitTraits<CSS::ResolutionUnit>::canonical> T resolveAsResolution(const CSSToLengthConversionData&) const;
-    template<typename T = double, CSS::ResolutionUnit = CSS::UnitTraits<CSS::ResolutionUnit>::canonical> T resolveAsResolutionNoConversionDataRequired() const;
-    template<typename T = double, CSS::ResolutionUnit = CSS::UnitTraits<CSS::ResolutionUnit>::canonical> T resolveAsResolutionDeprecated() const;
-
-    // MARK: Flex (requires `isFlex() == true`)
-    template<typename T = double> T resolveAsFlex(const CSSToLengthConversionData&) const;
-    template<typename T = double> T resolveAsFlexNoConversionDataRequired() const;
-
     // MARK: Length (requires `isLength() == true`)
     template<typename T = double> T resolveAsLength(const CSSToLengthConversionData&) const;
     template<typename T = double> T resolveAsLengthNoConversionDataRequired() const;
@@ -139,6 +99,19 @@ public:
     template<typename T = double> T value(const CSSToLengthConversionData& conversionData) const { return clampTo<T>(doubleValue(conversionData)); }
     template<typename T = double> T valueNoConversionDataRequired() const { return clampTo<T>(doubleValueNoConversionDataRequired()); }
     template<typename T = double> std::optional<T> valueIfNotCalculated() const;
+
+    using Calc = CSSCalc::Value;
+    struct Raw {
+        CSSUnitType unit;
+        double value;
+    };
+    template<typename... F> decltype(auto) switchOn(F&&... f) const
+    {
+        auto visitor = WTF::makeVisitor(std::forward<F>(f)...);
+        if (isCalculated())
+            return visitor(protect(*m_value.calc));
+        return visitor(Raw { primitiveUnitType(), m_value.number });
+    }
 
     // MARK: Divides value by 100 if percentage.
     template<typename T = double> T valueDividingBy100IfPercentage(const CSSToLengthConversionData& conversionData) const { return clampTo<T>(doubleValueDividingBy100IfPercentage(conversionData)); }
@@ -212,6 +185,8 @@ private:
     ALWAYS_INLINE String serializeInternal(const CSS::SerializationContext&) const;
     NEVER_INLINE String formatNumberValue(ASCIILiteral suffix) const;
     NEVER_INLINE String formatIntegerValue(ASCIILiteral suffix) const;
+
+    static constexpr bool isLength(CSSUnitType);
     static constexpr bool isFontIndependentLength(CSSUnitType);
     static constexpr bool isFontRelativeLength(CSSUnitType);
     static constexpr bool isRootFontRelativeLength(CSSUnitType);
@@ -371,248 +346,6 @@ template<typename T> std::optional<T> CSSPrimitiveValue::resolveAsPercentageIfNo
 {
     ASSERT(isPercentage());
     return valueIfNotCalculated<T>();
-}
-
-// MARK: Angle
-
-template<CSS::AngleUnit angleUnit, typename T> T CSSPrimitiveValue::computeAngle(CSSUnitType type, T angle)
-{
-    if constexpr (angleUnit == CSS::AngleUnit::Deg) {
-        switch (type) {
-        case CSSUnitType::CSS_DEG:
-            return angle;
-        case CSSUnitType::CSS_RAD:
-            return rad2deg(angle);
-        case CSSUnitType::CSS_GRAD:
-            return grad2deg(angle);
-        case CSSUnitType::CSS_TURN:
-            return turn2deg(angle);
-        default:
-            ASSERT_NOT_REACHED();
-            return 0;
-        }
-    } else if constexpr (angleUnit == CSS::AngleUnit::Rad) {
-        switch (type) {
-        case CSSUnitType::CSS_DEG:
-            return deg2rad(angle);
-        case CSSUnitType::CSS_RAD:
-            return angle;
-        case CSSUnitType::CSS_GRAD:
-            return grad2rad(angle);
-        case CSSUnitType::CSS_TURN:
-            return turn2rad(angle);
-        default:
-            ASSERT_NOT_REACHED();
-            return 0;
-        }
-    } else if constexpr (angleUnit == CSS::AngleUnit::Grad) {
-        switch (type) {
-        case CSSUnitType::CSS_DEG:
-            return deg2grad(angle);
-        case CSSUnitType::CSS_RAD:
-            return rad2grad(angle);
-        case CSSUnitType::CSS_GRAD:
-            return angle;
-        case CSSUnitType::CSS_TURN:
-            return turn2grad(angle);
-        default:
-            ASSERT_NOT_REACHED();
-            return 0;
-        }
-    } else if constexpr (angleUnit == CSS::AngleUnit::Turn) {
-        switch (type) {
-        case CSSUnitType::CSS_DEG:
-            return deg2turn(angle);
-        case CSSUnitType::CSS_RAD:
-            return rad2Turn(angle);
-        case CSSUnitType::CSS_GRAD:
-            return grad2turn(angle);
-        case CSSUnitType::CSS_TURN:
-            return angle;
-        default:
-            ASSERT_NOT_REACHED();
-            return 0;
-        }
-    }
-}
-
-template<typename T, CSS::AngleUnit angleUnit> T CSSPrimitiveValue::resolveAsAngle(const CSSToLengthConversionData& conversionData) const
-{
-    ASSERT(isAngle());
-    return clampTo<T>(computeAngle<angleUnit>(primitiveType(), value<double>(conversionData)));
-}
-
-template<typename T, CSS::AngleUnit angleUnit> T CSSPrimitiveValue::resolveAsAngleNoConversionDataRequired() const
-{
-    ASSERT(isAngle());
-    return clampTo<T>(computeAngle<angleUnit>(primitiveType(), valueNoConversionDataRequired<double>()));
-}
-
-template<typename T, CSS::AngleUnit angleUnit> T CSSPrimitiveValue::resolveAsAngleDeprecated() const
-{
-    ASSERT(isAngle());
-    return clampTo<T>(computeAngle<angleUnit>(primitiveType(), valueDeprecated<double>()));
-}
-
-// MARK: Time
-
-template<CSS::TimeUnit timeUnit, typename T> inline T CSSPrimitiveValue::computeTime(CSSUnitType type, T value)
-{
-    if constexpr (timeUnit == CSS::TimeUnit::S) {
-        switch (type) {
-        case CSSUnitType::CSS_S:
-            return value;
-        case CSSUnitType::CSS_MS:
-            return value * CSS::secondsPerMillisecond;
-        default:
-            ASSERT_NOT_REACHED();
-            return 0;
-        }
-    } else if constexpr (timeUnit == CSS::TimeUnit::Ms) {
-        switch (type) {
-        case CSSUnitType::CSS_S:
-            return value / CSS::secondsPerMillisecond;
-        case CSSUnitType::CSS_MS:
-            return value;
-        default:
-            ASSERT_NOT_REACHED();
-            return 0;
-        }
-    }
-}
-
-template<typename T, CSS::TimeUnit timeUnit> T CSSPrimitiveValue::resolveAsTime(const CSSToLengthConversionData& conversionData) const
-{
-    ASSERT(isTime());
-    return clampTo<T>(computeTime<timeUnit>(primitiveType(), value<double>(conversionData)));
-}
-
-template<typename T, CSS::TimeUnit timeUnit> T CSSPrimitiveValue::resolveAsTimeNoConversionDataRequired() const
-{
-    ASSERT(isTime());
-    return clampTo<T>(computeTime<timeUnit>(primitiveType(), valueNoConversionDataRequired<double>()));
-}
-
-// MARK: Frequency
-
-template<CSS::FrequencyUnit frequencyUnit, typename T> inline T CSSPrimitiveValue::computeFrequency(CSSUnitType type, T value)
-{
-    if constexpr (frequencyUnit == CSS::FrequencyUnit::Hz) {
-        switch (type) {
-        case CSSUnitType::CSS_HZ:
-            return value;
-        case CSSUnitType::CSS_KHZ:
-            return value * CSS::hertzPerKilohertz;
-        default:
-            ASSERT_NOT_REACHED();
-            return 0;
-        }
-    } else if constexpr (frequencyUnit == CSS::FrequencyUnit::Khz) {
-        switch (type) {
-        case CSSUnitType::CSS_HZ:
-            return value / CSS::hertzPerKilohertz;
-        case CSSUnitType::CSS_KHZ:
-            return value;
-        default:
-            ASSERT_NOT_REACHED();
-            return 0;
-        }
-    }
-}
-
-// MARK: Resolution
-
-template<CSS::ResolutionUnit resolutionUnit, typename T> inline T CSSPrimitiveValue::computeResolution(CSSUnitType type, T resolution)
-{
-    if constexpr (resolutionUnit == CSS::ResolutionUnit::Dppx) {
-        switch (type) {
-        case CSSUnitType::CSS_DPPX:
-            return resolution;
-        case CSSUnitType::CSS_X:
-            return resolution * CSS::dppxPerX;
-        case CSSUnitType::CSS_DPI:
-            return resolution * CSS::dppxPerDpi;
-        case CSSUnitType::CSS_DPCM:
-            return resolution * CSS::dppxPerDpcm;
-        default:
-            ASSERT_NOT_REACHED();
-            return 0;
-        }
-    } else if constexpr (resolutionUnit == CSS::ResolutionUnit::X) {
-        switch (type) {
-        case CSSUnitType::CSS_DPPX:
-            return resolution / CSS::dppxPerX;
-        case CSSUnitType::CSS_X:
-            return resolution;
-        case CSSUnitType::CSS_DPI:
-            return resolution * CSS::dppxPerDpi / CSS::dppxPerX;
-        case CSSUnitType::CSS_DPCM:
-            return resolution * CSS::dppxPerDpcm / CSS::dppxPerX;
-        default:
-            ASSERT_NOT_REACHED();
-            return 0;
-        }
-    } else if constexpr (resolutionUnit == CSS::ResolutionUnit::Dpi) {
-        switch (type) {
-        case CSSUnitType::CSS_DPPX:
-            return resolution / CSS::dppxPerDpi;
-        case CSSUnitType::CSS_X:
-            return resolution * CSS::dppxPerX / CSS::dppxPerDpi;
-        case CSSUnitType::CSS_DPI:
-            return resolution;
-        case CSSUnitType::CSS_DPCM:
-            return resolution * CSS::dppxPerDpcm / CSS::dppxPerDpi;
-        default:
-            ASSERT_NOT_REACHED();
-            return 0;
-        }
-    } else if constexpr (resolutionUnit == CSS::ResolutionUnit::Dpcm) {
-        switch (type) {
-        case CSSUnitType::CSS_DPPX:
-            return resolution / CSS::dppxPerDpcm;
-        case CSSUnitType::CSS_X:
-            return resolution * CSS::dppxPerX / CSS::dppxPerDpcm;
-        case CSSUnitType::CSS_DPI:
-            return resolution * CSS::dppxPerDpi / CSS::dppxPerDpcm;
-        case CSSUnitType::CSS_DPCM:
-            return resolution;
-        default:
-            ASSERT_NOT_REACHED();
-            return 0;
-        }
-    }
-}
-
-template<typename T, CSS::ResolutionUnit resolutionUnit> T CSSPrimitiveValue::resolveAsResolution(const CSSToLengthConversionData& conversionData) const
-{
-    ASSERT(isResolution());
-    return clampTo<T>(computeResolution<resolutionUnit>(primitiveType(), value<double>(conversionData)));
-}
-
-template<typename T, CSS::ResolutionUnit resolutionUnit> T CSSPrimitiveValue::resolveAsResolutionNoConversionDataRequired() const
-{
-    ASSERT(isResolution());
-    return clampTo<T>(computeResolution<resolutionUnit>(primitiveType(), valueNoConversionDataRequired<double>()));
-}
-
-template<typename T, CSS::ResolutionUnit resolutionUnit> T CSSPrimitiveValue::resolveAsResolutionDeprecated() const
-{
-    ASSERT(isResolution());
-    return clampTo<T>(computeResolution<resolutionUnit>(primitiveType(), valueDeprecated<double>()));
-}
-
-// MARK: Flex
-
-template<typename T> T CSSPrimitiveValue::resolveAsFlex(const CSSToLengthConversionData& conversionData) const
-{
-    ASSERT(isFlex());
-    return value<T>(conversionData);
-}
-
-template<typename T> T CSSPrimitiveValue::resolveAsFlexNoConversionDataRequired() const
-{
-    ASSERT(isFlex());
-    return valueNoConversionDataRequired<T>();
 }
 
 // MARK: Length

--- a/Source/WebCore/css/calc/CSSCalcValue.cpp
+++ b/Source/WebCore/css/calc/CSSCalcValue.cpp
@@ -225,7 +225,7 @@ inline double Value::clampToPermittedRange(double value) const
     if (m_category == CSS::Category::Integer)
         value = std::floor(value + 0.5);
 
-    return std::clamp(value, m_range.min, m_range.max);
+    return CSS::clampToRange<double>(value, m_range);
 }
 
 double Value::doubleValue(const CSSToLengthConversionData& conversionData) const

--- a/Source/WebCore/css/parser/CSSPropertyParserConsumer+Image.cpp
+++ b/Source/WebCore/css/parser/CSSPropertyParserConsumer+Image.cpp
@@ -314,7 +314,7 @@ template<SupportsColorHints supportsColorHints, typename Stop, typename Consumer
 template<SupportsColorHints supportsColorHints> static std::optional<CSS::GradientLinearColorStopList> consumeLinearColorStopList(CSSParserTokenRange& range, CSS::PropertyParserState& state)
 {
     return consumeColorStopList<supportsColorHints, CSS::GradientLinearColorStop>(range, state, [&](auto& range) {
-        return MetaConsumer<CSS::LengthPercentage<CSS::AllUnzoomed>>::consume(range, state);
+        return MetaConsumer<CSS::LengthPercentage<CSS::AllLayoutUnitClampedUnzoomed>>::consume(range, state);
     });
 }
 

--- a/Source/WebCore/css/parser/CSSPropertyParserConsumer+IntegerDefinitions.h
+++ b/Source/WebCore/css/parser/CSSPropertyParserConsumer+IntegerDefinitions.h
@@ -51,11 +51,7 @@ template<typename Primitive, typename Validator> struct NumberConsumerForInteger
         if (range.peek().numericValueType() != IntegerValueType)
             return std::nullopt;
 
-        auto rawValue = typename Primitive::Raw { CSS::IntegerUnit::Integer, range.peek().numericValue() };
-
-        if constexpr (rawValue.range.clampOptions != CSS::RangeClampOptions::Default)
-            rawValue = performParseTimeClamp(rawValue);
-
+        auto rawValue = performOptionalParseTimeClamp(typename Primitive::Raw { CSS::IntegerUnit::Integer, range.peek().numericValue() });
         if (!Validator::isValid(rawValue, options))
             return std::nullopt;
 

--- a/Source/WebCore/css/parser/CSSPropertyParserConsumer+MetaConsumerDefinitions.h
+++ b/Source/WebCore/css/parser/CSSPropertyParserConsumer+MetaConsumerDefinitions.h
@@ -80,27 +80,33 @@ template<typename Raw, typename F> bool isValidDimensionValue(Raw raw, F&& funct
     if (std::isinf(raw.value))
         return false;
 
-    if constexpr (raw.range.min == -CSS::Range::infinity && raw.range.max == CSS::Range::infinity)
+    static constexpr auto effectiveMin = (raw.range.minParseTimeBehavior == CSS::RangeParseTimeBehavior::Ignore) ? -CSS::Range::infinity : raw.range.min;
+    static constexpr auto effectiveMax = (raw.range.maxParseTimeBehavior == CSS::RangeParseTimeBehavior::Ignore) ? CSS::Range::infinity : raw.range.max;
+
+    if constexpr (effectiveMin == -CSS::Range::infinity && effectiveMax == CSS::Range::infinity)
         return true;
-    else if constexpr (raw.range.min == 0 && raw.range.max == CSS::Range::infinity)
+    else if constexpr (effectiveMin == 0 && effectiveMax == CSS::Range::infinity)
         return raw.value >= 0;
-    else if constexpr (raw.range.min == -CSS::Range::infinity && raw.range.max == 0)
+    else if constexpr (effectiveMin == -CSS::Range::infinity && effectiveMax == 0)
         return raw.value <= 0;
     else
         return functor();
 }
 
-// Shared validator for types that only support 0 and +/-∞ as valid range constraints.
+// Shared validator for types that only support 0, +/-∞ as valid range constraints.
 template<typename Raw> bool isValidNonCanonicalizableDimensionValue(Raw raw)
 {
     if (std::isinf(raw.value))
         return false;
 
-    if constexpr (raw.range.min == -CSS::Range::infinity && raw.range.max == CSS::Range::infinity)
+    static constexpr auto effectiveMin = (raw.range.minParseTimeBehavior == CSS::RangeParseTimeBehavior::Ignore) ? -CSS::Range::infinity : raw.range.min;
+    static constexpr auto effectiveMax = (raw.range.maxParseTimeBehavior == CSS::RangeParseTimeBehavior::Ignore) ? CSS::Range::infinity : raw.range.max;
+
+    if constexpr (effectiveMin == -CSS::Range::infinity && effectiveMax == CSS::Range::infinity)
         return true;
-    else if constexpr (raw.range.min == 0 && raw.range.max == CSS::Range::infinity)
+    else if constexpr (effectiveMin == 0 && effectiveMax == CSS::Range::infinity)
         return raw.value >= 0;
-    else if constexpr (raw.range.min == -CSS::Range::infinity && raw.range.max == 0)
+    else if constexpr (effectiveMin == -CSS::Range::infinity && effectiveMax == 0)
         return raw.value <= 0;
 }
 
@@ -110,27 +116,30 @@ template<typename Raw> bool isValidCanonicalValue(Raw raw)
     if (std::isinf(raw.value))
         return false;
 
-    if constexpr (raw.range.min == -CSS::Range::infinity && raw.range.max == CSS::Range::infinity)
+    static constexpr auto effectiveMin = (raw.range.minParseTimeBehavior == CSS::RangeParseTimeBehavior::Ignore) ? -CSS::Range::infinity : raw.range.min;
+    static constexpr auto effectiveMax = (raw.range.maxParseTimeBehavior == CSS::RangeParseTimeBehavior::Ignore) ? CSS::Range::infinity : raw.range.max;
+
+    if constexpr (effectiveMin == -CSS::Range::infinity && effectiveMax == CSS::Range::infinity)
         return true;
-    else if constexpr (raw.range.max == CSS::Range::infinity)
-        return raw.value >= raw.range.min;
-    else if constexpr (raw.range.min == -CSS::Range::infinity)
-        return raw.value <= raw.range.max;
+    else if constexpr (effectiveMax == CSS::Range::infinity)
+        return raw.value >= effectiveMin;
+    else if constexpr (effectiveMin == -CSS::Range::infinity)
+        return raw.value <= effectiveMax;
     else
-        return raw.value >= raw.range.min && raw.value <= raw.range.max;
+        return raw.value >= effectiveMin && raw.value <= effectiveMax;
 }
 
 // Shared clamping utility.
-template<typename Raw> Raw performParseTimeClamp(Raw raw)
+template<typename Raw> Raw performOptionalParseTimeClamp(Raw raw)
 {
-    static_assert(raw.range.clampOptions != CSS::RangeClampOptions::Default);
-
-    if constexpr (raw.range.clampOptions == CSS::RangeClampOptions::ClampLower)
-        return { std::max<typename Raw::ResolvedValueType>(raw.value, raw.range.min) };
-    else if constexpr (raw.range.clampOptions == CSS::RangeClampOptions::ClampUpper)
-        return { std::min<typename Raw::ResolvedValueType>(raw.value, raw.range.max) };
-    else if constexpr (raw.range.clampOptions == CSS::RangeClampOptions::ClampBoth)
-        return { std::clamp<typename Raw::ResolvedValueType>(raw.value, raw.range.min, raw.range.max) };
+    if constexpr (raw.range.minParseTimeBehavior == CSS::RangeParseTimeBehavior::Clamp && raw.range.maxParseTimeBehavior == CSS::RangeParseTimeBehavior::Clamp)
+        return { raw.unit, std::clamp<typename Raw::ResolvedValueType>(raw.value, raw.range.min, raw.range.max) };
+    if constexpr (raw.range.minParseTimeBehavior == CSS::RangeParseTimeBehavior::Clamp)
+        return { raw.unit, std::max<typename Raw::ResolvedValueType>(raw.value, raw.range.min) };
+    else if constexpr (raw.range.maxParseTimeBehavior == CSS::RangeParseTimeBehavior::Clamp)
+        return { raw.unit, std::min<typename Raw::ResolvedValueType>(raw.value, raw.range.max) };
+    else
+        return raw;
 }
 
 // Shared consumer for `Dimension` tokens.
@@ -147,11 +156,7 @@ template<typename Primitive, typename Validator> struct DimensionConsumer {
         if (!validatedUnit)
             return std::nullopt;
 
-        auto rawValue = typename Primitive::Raw { *validatedUnit, token.numericValue() };
-
-        if constexpr (rawValue.range.clampOptions != CSS::RangeClampOptions::Default)
-            rawValue = performParseTimeClamp(rawValue);
-
+        auto rawValue = performOptionalParseTimeClamp(typename Primitive::Raw { *validatedUnit, token.numericValue() });
         if (!Validator::isValid(rawValue, options))
             return std::nullopt;
 
@@ -168,11 +173,7 @@ template<typename Primitive, typename Validator> struct PercentageConsumer {
     {
         ASSERT(range.peek().type() == PercentageToken);
 
-        auto rawValue = typename Primitive::Raw { CSS::PercentageUnit::Percentage, range.peek().numericValue() };
-
-        if constexpr (rawValue.range.clampOptions != CSS::RangeClampOptions::Default)
-            rawValue = performParseTimeClamp(rawValue);
-
+        auto rawValue = performOptionalParseTimeClamp(typename Primitive::Raw { CSS::PercentageUnit::Percentage, range.peek().numericValue() });
         if (!Validator::isValid(rawValue, options))
             return std::nullopt;
 
@@ -189,11 +190,7 @@ template<typename Primitive, typename Validator> struct NumberConsumer {
     {
         ASSERT(range.peek().type() == NumberToken);
 
-        auto rawValue = typename Primitive::Raw { CSS::NumberUnit::Number, range.peek().numericValue() };
-
-        if constexpr (rawValue.range.clampOptions != CSS::RangeClampOptions::Default)
-            rawValue = performParseTimeClamp(rawValue);
-
+        auto rawValue = performOptionalParseTimeClamp(typename Primitive::Raw { CSS::NumberUnit::Number, range.peek().numericValue() });
         if (!Validator::isValid(rawValue, options))
             return std::nullopt;
 
@@ -214,11 +211,7 @@ template<typename Primitive, typename Validator, auto unit> struct NumberConsume
         if (!Validator::shouldAcceptUnitlessValue(numericValue, state, options))
             return std::nullopt;
 
-        auto rawValue = typename Primitive::Raw { unit, numericValue };
-
-        if constexpr (rawValue.range.clampOptions != CSS::RangeClampOptions::Default)
-            rawValue = performParseTimeClamp(rawValue);
-
+        auto rawValue = performOptionalParseTimeClamp(typename Primitive::Raw { unit, numericValue });
         if (!Validator::isValid(rawValue, options))
             return std::nullopt;
 

--- a/Source/WebCore/css/values/CSSNoConversionDataRequiredToken.h
+++ b/Source/WebCore/css/values/CSSNoConversionDataRequiredToken.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 Samuel Weinig <sam@webkit.org>
+ * Copyright (C) 2024-2026 Samuel Weinig <sam@webkit.org>
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -27,6 +27,6 @@
 namespace WebCore {
 
 // Token passed around to indicate that the caller has checked that no conversion data is required.
-struct NoConversionDataRequiredToken { };
+struct NoConversionDataRequiredToken { constexpr explicit NoConversionDataRequiredToken() { } };
 
 } // namespace WebCore

--- a/Source/WebCore/css/values/color/CSSColorConversion+Normalize.h
+++ b/Source/WebCore/css/values/color/CSSColorConversion+Normalize.h
@@ -37,14 +37,29 @@ namespace WebCore {
 
 // MARK: - normalizeAndClampNumericComponents
 
+inline bool shouldTreatAngleComponentValueAsInfinite(double value)
+{
+    // FIXME: Though not directly specified, https://drafts.csswg.org/css-color-4/#example-hue-normalization
+    // indicates that calc(infinity) and calc(-infinity) should resolve to 0 for <hue>
+    // components. This is at odds with the specified behavior of calc(), which is to
+    // resolve calc(infinity) to std::numeric_limits<double>::max() and calc(-infinity)
+    // to -std::numeric_limits<double>::max(), so we are checking for those specific
+    // values here. A cleaner way of handling this would be to pipe a flag through for
+    // these types (perhaps as a new bit on CSS::Range) that either preserves the
+    // infinities or directly resolves them to 0.
+    return value == std::numeric_limits<double>::max() || value == -std::numeric_limits<double>::max();
+}
+
 template<typename Descriptor, unsigned Index>
 CSS::Number<> normalizeAndClampNumericComponents(CSS::NumberRaw<> number)
 {
     constexpr auto info = std::get<Index>(Descriptor::components);
 
-    if constexpr (info.type == ColorComponentType::Angle)
+    if constexpr (info.type == ColorComponentType::Angle) {
+        if (shouldTreatAngleComponentValueAsInfinite(number.value))
+            return { 0 };
         return { normalizeHue(number.value) };
-    else if constexpr (info.min == -std::numeric_limits<double>::infinity() && info.max == std::numeric_limits<double>::infinity())
+    } else if constexpr (info.min == -std::numeric_limits<double>::infinity() && info.max == std::numeric_limits<double>::infinity())
         return { number.value };
     else if constexpr (info.min == -std::numeric_limits<double>::infinity())
         return { std::min(number.value, info.max) };
@@ -116,9 +131,11 @@ CSS::Number<> normalizeNumericComponents(CSS::NumberRaw<> number)
 {
     constexpr auto info = std::get<Index>(Descriptor::components);
 
-    if constexpr (info.type == ColorComponentType::Angle)
+    if constexpr (info.type == ColorComponentType::Angle) {
+        if (shouldTreatAngleComponentValueAsInfinite(number.value))
+            return { 0 };
         return { normalizeHue(number.value) };
-    else
+    } else
         return { number.value };
 }
 

--- a/Source/WebCore/css/values/color/CSSColorConversion+ToTypedColor.h
+++ b/Source/WebCore/css/values/color/CSSColorConversion+ToTypedColor.h
@@ -41,9 +41,11 @@ template<typename Descriptor, unsigned Index> float convertToTypeColorComponent(
     constexpr auto min = info.min * info.numberMultiplier;
     constexpr auto max = info.max * info.numberMultiplier;
 
-    if constexpr (info.type == ColorComponentType::Angle)
+    if constexpr (info.type == ColorComponentType::Angle) {
+        if (shouldTreatAngleComponentValueAsInfinite(number.value))
+            return 0;
         return normalizeHue(number.value);
-    else if constexpr (info.min == -std::numeric_limits<double>::infinity() && info.max == std::numeric_limits<double>::infinity())
+    } else if constexpr (info.min == -std::numeric_limits<double>::infinity() && info.max == std::numeric_limits<double>::infinity())
         return number.value * multiplier;
     else if constexpr (info.min == -std::numeric_limits<double>::infinity())
         return std::min(number.value * multiplier, max);

--- a/Source/WebCore/css/values/images/CSSGradient.h
+++ b/Source/WebCore/css/values/images/CSSGradient.h
@@ -84,7 +84,8 @@ using GradientAngularColorStop = GradientColorStop<GradientAngularColorStopColor
 using GradientAngularColorStopList = GradientColorStopList<GradientAngularColorStop>;
 
 using GradientLinearColorStopColor = Markable<Color>;
-using GradientLinearColorStopPosition = std::optional<LengthPercentage<CSS::AllUnzoomed>>;
+// FIXME: `GradientLinearColorStopPosition` should use a range of `AllUnzoomed`, but doing so was causing imported/w3c/web-platform-tests/css/css-images/gradient/gradient-infinity-001.html to fail for the GTK/WPE graphics backends.
+using GradientLinearColorStopPosition = std::optional<LengthPercentage<AllLayoutUnitClampedUnzoomed>>;
 using GradientLinearColorStop = GradientColorStop<GradientLinearColorStopColor, GradientLinearColorStopPosition>;
 using GradientLinearColorStopList = GradientColorStopList<GradientLinearColorStop>;
 

--- a/Source/WebCore/css/values/primitives/CSSPrimitiveNumeric.h
+++ b/Source/WebCore/css/values/primitives/CSSPrimitiveNumeric.h
@@ -223,11 +223,17 @@ template<Range R = All, typename V = float> struct AnglePercentage : PrimitiveNu
     using Base = PrimitiveNumeric<AnglePercentageRaw<R, V>>;
     using Base::Base;
     using MarkableTraits = PrimitiveDataMarkableTraits<AnglePercentage<R, V>>;
+
+    using Dimension = CSS::Angle<R, V>;
+    using Percentage = CSS::Percentage<R, V>;
 };
 template<Range R = All, typename V = float> struct LengthPercentage : PrimitiveNumeric<LengthPercentageRaw<R, V>> {
     using Base = PrimitiveNumeric<LengthPercentageRaw<R, V>>;
     using Base::Base;
     using MarkableTraits = PrimitiveDataMarkableTraits<LengthPercentage<R, V>>;
+
+    using Dimension = CSS::Length<R, V>;
+    using Percentage = CSS::Percentage<R, V>;
 };
 
 

--- a/Source/WebCore/css/values/primitives/CSSPrimitiveNumericRange.h
+++ b/Source/WebCore/css/values/primitives/CSSPrimitiveNumericRange.h
@@ -31,26 +31,19 @@
 namespace WebCore {
 namespace CSS {
 
-// Options to indicate how the range should be interpreted.
-enum class RangeClampOptions {
+// Used to indicate how one of the bounds (upper or lower) of range should be interpreted
+// at parse time.
+enum class RangeParseTimeBehavior {
     // `Default` indicates that at parse time, out of range values invalidate the parse.
-    // Out of range values at style building always clamp.
     Default,
 
-    // `ClampLower` indicates that parse time, an out of range lower value should clamp
-    // instead of invalidating the parse. An out of range upper value will still invalidate
-    // the parse. Out of range values at style building always clamp.
-    ClampLower,
+    // `Clamp` indicates that parse time, out of range values should clamp instead
+    // of invalidating the parse.
+    Clamp,
 
-    // `ClampUpper` indicates that parse time, an out of range upper value should clamp
-    // instead of invalidating the parse. An out of range lower value will still invalidate
-    // the parse. Out of range values at style building always clamp.
-    ClampUpper,
-
-    // `ClampBoth` indicates that parse time, an out of range lower or upper value should
-    // clamp instead of invalidating the parse. Out of range values at style building
-    // always clamp.
-    ClampBoth
+    // `Ignore` indicates that parse time, out of range values should be ignored,
+    // allowing them as if they were in range.
+    Ignore,
 };
 
 // Options to indicate how the primitive should consider its value with regards to zoom.
@@ -72,13 +65,15 @@ struct Range {
 
     double min { -infinity };
     double max {  infinity };
-    RangeClampOptions clampOptions { RangeClampOptions::Default };
+    RangeParseTimeBehavior minParseTimeBehavior { RangeParseTimeBehavior::Default };
+    RangeParseTimeBehavior maxParseTimeBehavior { RangeParseTimeBehavior::Default };
     RangeZoomOptions zoomOptions { RangeZoomOptions::Default };
 
-    constexpr Range(double min, double max, RangeClampOptions clampOptions = RangeClampOptions::Default, RangeZoomOptions zoomOptions = RangeZoomOptions::Default)
+    constexpr Range(double min, double max, RangeParseTimeBehavior minParseTimeBehavior = RangeParseTimeBehavior::Default, RangeParseTimeBehavior maxParseTimeBehavior = RangeParseTimeBehavior::Default, RangeZoomOptions zoomOptions = RangeZoomOptions::Default)
         : min { min }
         , max { max }
-        , clampOptions { clampOptions }
+        , minParseTimeBehavior { minParseTimeBehavior }
+        , maxParseTimeBehavior { maxParseTimeBehavior }
         , zoomOptions { zoomOptions }
     {
     }
@@ -88,45 +83,60 @@ struct Range {
 
 // Constant value for `[−∞,∞]`.
 inline constexpr auto All = Range { -Range::infinity, Range::infinity };
-inline constexpr auto AllUnzoomed = Range { -Range::infinity, Range::infinity, RangeClampOptions::Default, RangeZoomOptions::Unzoomed };
+inline constexpr auto AllUnzoomed = Range { -Range::infinity, Range::infinity, RangeParseTimeBehavior::Default, RangeParseTimeBehavior::Default, RangeZoomOptions::Unzoomed };
 
 // Constant value for `[0,∞]`.
 inline constexpr auto Nonnegative = Range { 0, Range::infinity };
-inline constexpr auto NonnegativeUnzoomed = Range { 0, Range::infinity, RangeClampOptions::Default, RangeZoomOptions::Unzoomed };
+inline constexpr auto NonnegativeUnzoomed = Range { 0, Range::infinity, RangeParseTimeBehavior::Default, RangeParseTimeBehavior::Default, RangeZoomOptions::Unzoomed };
 
 // Constant value for `[1,∞]`.
 inline constexpr auto Positive = Range { 1, Range::infinity };
-inline constexpr auto PositiveUnzoomed = Range { 1, Range::infinity, RangeClampOptions::Default, RangeZoomOptions::Unzoomed };
+inline constexpr auto PositiveUnzoomed = Range { 1, Range::infinity, RangeParseTimeBehavior::Default, RangeParseTimeBehavior::Default, RangeZoomOptions::Unzoomed };
 
 // Constant value for `[-∞,-1]`.
 inline constexpr auto Negative = Range { -Range::infinity, -1 };
-inline constexpr auto NegativeUnzoomed = Range { -Range::infinity, -1, RangeClampOptions::Default, RangeZoomOptions::Unzoomed };
+inline constexpr auto NegativeUnzoomed = Range { -Range::infinity, -1, RangeParseTimeBehavior::Default, RangeParseTimeBehavior::Default, RangeZoomOptions::Unzoomed };
 
 // Constant value for `[0,1]`.
 inline constexpr auto ClosedUnitRange = Range { 0, 1 };
-inline constexpr auto ClosedUnitRangeUnzoomed = Range { 0, 1, RangeClampOptions::Default, RangeZoomOptions::Unzoomed };
+inline constexpr auto ClosedUnitRangeUnzoomed = Range { 0, 1, RangeParseTimeBehavior::Default, RangeParseTimeBehavior::Default, RangeZoomOptions::Unzoomed };
 
 // Constant value for `[0,1(clamp upper)]`.
-inline constexpr auto ClosedUnitRangeClampUpper = Range { 0, 1, RangeClampOptions::ClampUpper };
-inline constexpr auto ClosedUnitRangeClampUpperUnzoomed = Range { 0, 1, RangeClampOptions::ClampUpper, RangeZoomOptions::Unzoomed };
+inline constexpr auto ClosedUnitRangeClampUpper = Range { 0, 1, RangeParseTimeBehavior::Default, RangeParseTimeBehavior::Clamp };
+inline constexpr auto ClosedUnitRangeClampUpperUnzoomed = Range { 0, 1, RangeParseTimeBehavior::Default, RangeParseTimeBehavior::Clamp, RangeZoomOptions::Unzoomed };
 
 // Constant value for `[0,1(clamp both)]`.
-inline constexpr auto ClosedUnitRangeClampBoth = Range { 0, 1, RangeClampOptions::ClampBoth };
-inline constexpr auto ClosedUnitRangeClampBothUnzoomed = Range { 0, 1, RangeClampOptions::ClampBoth, RangeZoomOptions::Unzoomed };
+inline constexpr auto ClosedUnitRangeClampBoth = Range { 0, 1, RangeParseTimeBehavior::Clamp, RangeParseTimeBehavior::Clamp };
+inline constexpr auto ClosedUnitRangeClampBothUnzoomed = Range { 0, 1, RangeParseTimeBehavior::Clamp, RangeParseTimeBehavior::Clamp, RangeZoomOptions::Unzoomed };
 
 // Constant value for `[0,100]`.
 inline constexpr auto ClosedPercentageRange = Range { 0, 100 };
-inline constexpr auto ClosedPercentageRangeUnzoomed = Range { 0, 100, RangeClampOptions::Default, RangeZoomOptions::Unzoomed };
+inline constexpr auto ClosedPercentageRangeUnzoomed = Range { 0, 100, RangeParseTimeBehavior::Default, RangeParseTimeBehavior::Default, RangeZoomOptions::Unzoomed };
 
 // Constant value for `[0,100(clamp upper)]`.
-inline constexpr auto ClosedPercentageRangeClampUpper = Range { 0, 100, RangeClampOptions::ClampUpper };
-inline constexpr auto ClosedPercentageRangeClampUpperUnzoomed = Range { 0, 100, RangeClampOptions::ClampUpper, RangeZoomOptions::Unzoomed };
+inline constexpr auto ClosedPercentageRangeClampUpper = Range { 0, 100, RangeParseTimeBehavior::Default, RangeParseTimeBehavior::Clamp };
+inline constexpr auto ClosedPercentageRangeClampUpperUnzoomed = Range { 0, 100, RangeParseTimeBehavior::Default, RangeParseTimeBehavior::Clamp, RangeZoomOptions::Unzoomed };
 
 // Constant value for `[0,100(clamp both)]`.
-inline constexpr auto ClosedPercentageRangeClampBoth = Range { 0, 100, RangeClampOptions::ClampBoth };
-inline constexpr auto ClosedPercentageRangeClampBothUnzoomed = Range { 0, 100, RangeClampOptions::ClampBoth, RangeZoomOptions::Unzoomed };
+inline constexpr auto ClosedPercentageRangeClampBoth = Range { 0, 100, RangeParseTimeBehavior::Clamp, RangeParseTimeBehavior::Clamp };
+inline constexpr auto ClosedPercentageRangeClampBothUnzoomed = Range { 0, 100, RangeParseTimeBehavior::Clamp, RangeParseTimeBehavior::Clamp, RangeZoomOptions::Unzoomed };
 
-// Clamps a floating point value to within `range`.
+// Special Range constants that restrict down to what LayoutUnit supports.
+
+// Max/min values for CSS, needs to be slightly smaller/larger than the true max/min values
+// supported by LayoutUnit to allow for rounding without overflowing.
+constexpr double minValueForCssLength = static_cast<double>((INT_MIN / (1 << 6)) + 2);
+constexpr double maxValueForCssLength = static_cast<double>((INT_MAX / (1 << 6)) - 2);
+
+// Constant value for `[0,∞]` limited to LayoutUnit restrictions.
+inline constexpr auto AllLayoutUnitClamped = Range { minValueForCssLength, maxValueForCssLength, RangeParseTimeBehavior::Ignore, RangeParseTimeBehavior::Ignore };
+inline constexpr auto AllLayoutUnitClampedUnzoomed = Range { minValueForCssLength, maxValueForCssLength, RangeParseTimeBehavior::Ignore, RangeParseTimeBehavior::Ignore, RangeZoomOptions::Unzoomed };
+
+// Constant value for `[0,∞]` limited to LayoutUnit restrictions.
+inline constexpr auto NonnegativeLayoutUnitClamped = Range { 0, maxValueForCssLength, RangeParseTimeBehavior::Default, RangeParseTimeBehavior::Ignore };
+inline constexpr auto NonnegativeLayoutUnitClampedUnzoomed = Range { 0, maxValueForCssLength, RangeParseTimeBehavior::Default, RangeParseTimeBehavior::Ignore, RangeZoomOptions::Unzoomed };
+
+// Clamps a floating point value to within static `range`.
 template<Range range, std::floating_point T, typename U> constexpr T clampToRange(U value)
 {
     return clampTo<T>(
@@ -136,13 +146,13 @@ template<Range range, std::floating_point T, typename U> constexpr T clampToRang
     );
 }
 
-// Clamps a floating point value to within `range` and within additional provided range.
-template<Range range, std::floating_point T, typename U> constexpr T clampToRange(U value, T additionalMinimum, T additionalMaximum)
+// Clamps a floating point value to within dynamic `range`.
+template<std::floating_point T, typename U> constexpr T clampToRange(U value, Range range)
 {
     return clampTo<T>(
         value,
-        std::max<T>(std::max<T>(range.min, -std::numeric_limits<T>::max()), additionalMinimum),
-        std::min<T>(std::min<T>(range.max,  std::numeric_limits<T>::max()), additionalMaximum)
+        std::max<T>(range.min, -std::numeric_limits<T>::max()),
+        std::min<T>(range.max,  std::numeric_limits<T>::max())
     );
 }
 

--- a/Source/WebCore/css/values/primitives/CSSPrimitiveNumericRaw.h
+++ b/Source/WebCore/css/values/primitives/CSSPrimitiveNumericRaw.h
@@ -222,10 +222,16 @@ template<Range R = All, typename V = double> struct FlexRaw : PrimitiveNumericRa
 template<Range R = All, typename V = float> struct AnglePercentageRaw : PrimitiveNumericRaw<R, AnglePercentageUnit, V> {
     using Base = PrimitiveNumericRaw<R, AnglePercentageUnit, V>;
     using Base::Base;
+
+    using Dimension = CSS::AngleRaw<R, V>;
+    using Percentage = CSS::PercentageRaw<R, V>;
 };
 template<Range R = All, typename V = float> struct LengthPercentageRaw : PrimitiveNumericRaw<R, LengthPercentageUnit, V> {
     using Base = PrimitiveNumericRaw<R, LengthPercentageUnit, V>;
     using Base::Base;
+
+    using Dimension = CSS::LengthRaw<R, V>;
+    using Percentage = CSS::PercentageRaw<R, V>;
 };
 
 } // namespace CSS

--- a/Source/WebCore/css/values/primitives/CSSPrimitiveNumericTypes+Canonicalization.h
+++ b/Source/WebCore/css/values/primitives/CSSPrimitiveNumericTypes+Canonicalization.h
@@ -32,6 +32,33 @@ struct NoConversionDataRequiredToken;
 
 namespace CSS {
 
+// MARK: Integer
+
+// There are no integer units, so canonicalization is trivially just return the underlying value.
+
+template<auto R, typename V> double canonicalize(IntegerRaw<R, V> raw)
+{
+    return raw.value;
+}
+
+// MARK: Number
+
+// There are no number units, so canonicalization is trivially just return the underlying value.
+
+template<auto R, typename V> double canonicalize(NumberRaw<R, V> raw)
+{
+    return raw.value;
+}
+
+// MARK: Percentage
+
+// There are no percentage units, so canonicalization is trivially just return the underlying value.
+
+template<auto R, typename V> double canonicalize(PercentageRaw<R, V> raw)
+{
+    return raw.value;
+}
+
 // MARK: Angle
 
 double canonicalizeAngle(double value, AngleUnit);
@@ -66,6 +93,15 @@ double canonicalizeResolution(double, ResolutionUnit);
 template<auto R, typename V> double canonicalize(ResolutionRaw<R, V> raw)
 {
     return canonicalizeResolution(raw.value, raw.unit);
+}
+
+// MARK: Flex
+
+// There is only one flex unit, `fr`, so canonicalization is trivially just return the underlying value.
+
+template<auto R, typename V> double canonicalize(FlexRaw<R, V> raw)
+{
+    return raw.value;
 }
 
 } // namespace CSS

--- a/Source/WebCore/page/IntersectionObserver.cpp
+++ b/Source/WebCore/page/IntersectionObserver.cpp
@@ -31,8 +31,8 @@
 #include "ContextDestructionObserverInlines.h"
 #include "CSSParserTokenRange.h"
 #include "CSSPropertyParserConsumer+Background.h"
-#include "CSSPropertyParserConsumer+CSSPrimitiveValueResolver.h"
 #include "CSSPropertyParserConsumer+LengthPercentageDefinitions.h"
+#include "CSSPropertyParserConsumer+MetaConsumer.h"
 #include "CSSTokenizer.h"
 #include "DocumentQuirks.h"
 #include "DocumentSecurityOrigin.h"
@@ -54,6 +54,7 @@
 #include "RenderObjectInlines.h"
 #include "RenderView.h"
 #include "StyleKeyword+Logging.h"
+#include "StylePrimitiveNumericTypes+Conversions.h"
 #include "StylePrimitiveNumericTypes+Evaluation.h"
 #include "StylePrimitiveNumericTypes+Logging.h"
 #include "VisibleRectContext.h"
@@ -82,21 +83,30 @@ static ExceptionOr<IntersectionObserverMarginBox> parseMargin(String& margin, co
         return IntersectionObserverMarginBox { IntersectionObserverMarginEdge::Fixed { 0 } };
 
     auto consumeEdge = [&] -> ExceptionOr<IntersectionObserverMarginEdge> {
-        auto parsedValue = CSSPrimitiveValueResolver<CSS::LengthPercentage<>>::consumeAndResolve(tokenRange, parserState);
+        auto parsedValue = MetaConsumer<CSS::LengthPercentage<CSS::All, float>>::consume(tokenRange, parserState);
 
-        if (!parsedValue || parsedValue->isCalculated())
+        if (!parsedValue || parsedValue->isCalc())
             return Exception { ExceptionCode::SyntaxError, makeString("Failed to construct 'IntersectionObserver': "_s, marginName, " must be specified in pixels or percent."_s) };
 
-        if (parsedValue->isPercentage())
-            return { IntersectionObserverMarginEdge::Percentage { parsedValue->resolveAsPercentageNoConversionDataRequired<float>() } };
-
-        // FIXME: This should support all absolute length units, not just px.
-        // Spec states: "Similar to the CSS margin property, this is a string of 1-4 components, each either an *absolute length* or a percentage."
-        // https://w3c.github.io/IntersectionObserver/#dom-intersectionobserverinit-rootmargin
-        if (parsedValue->isPx())
-            return { IntersectionObserverMarginEdge::Fixed { parsedValue->resolveAsLengthNoConversionDataRequired<float>() } };
-
-        return Exception { ExceptionCode::SyntaxError, makeString("Failed to construct 'IntersectionObserver': "_s, marginName, " must be specified in pixels or percent."_s) };
+        auto raw = parsedValue->raw();
+        return CSS::switchOnUnitType(raw->unit,
+            [&](CSS::PercentageUnit) -> ExceptionOr<IntersectionObserverMarginEdge> {
+                return { IntersectionObserverMarginEdge::Percentage {
+                    Style::toStyle(CSS::PercentageRaw<CSS::All, float> { raw->value }, NoConversionDataRequiredToken { }).value
+                } };
+            },
+            [&](CSS::LengthUnit lengthUnit) -> ExceptionOr<IntersectionObserverMarginEdge> {
+                // FIXME: This should support all absolute length units, not just px.
+                // Spec states: "Similar to the CSS margin property, this is a string of 1-4 components, each either an *absolute length* or a percentage."
+                // https://w3c.github.io/IntersectionObserver/#dom-intersectionobserverinit-rootmargin
+                if (lengthUnit == CSS::LengthUnit::Px) {
+                    return { IntersectionObserverMarginEdge::Fixed {
+                        Style::toStyle(CSS::LengthRaw<CSS::All, float> { lengthUnit, raw->value }, NoConversionDataRequiredToken { }).unresolvedValue()
+                    } };
+                }
+                return Exception { ExceptionCode::SyntaxError, makeString("Failed to construct 'IntersectionObserver': "_s, marginName, " must be specified in pixels or percent."_s) };
+            }
+        );
     };
 
     auto edge1 = consumeEdge();

--- a/Source/WebCore/rendering/RenderBox.cpp
+++ b/Source/WebCore/rendering/RenderBox.cpp
@@ -1553,17 +1553,7 @@ bool RenderBox::hasTrimmedMargin(std::optional<Style::MarginTrimSide> marginTrim
     return marginTrimType ? rareData().trimmedMargins.contains(*marginTrimType) : !rareData().trimmedMargins.isEmpty();
 }
 
-LayoutUnit RenderBox::adjustBorderBoxLogicalWidthForBoxSizing(const Style::Length<CSS::Nonnegative, float>& logicalWidth) const
-{
-    auto width = LayoutUnit { logicalWidth.resolveZoom(Style::ZoomNeeded { }) };
-    auto bordersPlusPadding = borderAndPaddingLogicalWidth();
-    if (style().boxSizing() == BoxSizing::ContentBox)
-        return width + bordersPlusPadding;
-    return std::max(width, bordersPlusPadding);
-}
-
-
-LayoutUnit RenderBox::adjustBorderBoxLogicalWidthForBoxSizing(const Style::Length<CSS::NonnegativeUnzoomed, float>& logicalWidth) const
+LayoutUnit RenderBox::adjustBorderBoxLogicalWidthForBoxSizing(const Style::Length<CSS::NonnegativeLayoutUnitClampedUnzoomed, float>& logicalWidth) const
 {
     auto width = LayoutUnit { logicalWidth.resolveZoom(style().usedZoomForLength()) };
     auto bordersPlusPadding = borderAndPaddingLogicalWidth();
@@ -1588,15 +1578,7 @@ LayoutUnit RenderBox::adjustBorderBoxLogicalHeightForBoxSizing(LayoutUnit height
     return std::max(height, bordersPlusPadding);
 }
 
-LayoutUnit RenderBox::adjustContentBoxLogicalWidthForBoxSizing(const Style::Length<CSS::Nonnegative, float>& logicalWidth) const
-{
-    auto width = LayoutUnit { logicalWidth.resolveZoom(Style::ZoomNeeded { }) };
-    if (style().boxSizing() == BoxSizing::ContentBox)
-        return std::max(0_lu, width);
-    return std::max(0_lu, width - borderAndPaddingLogicalWidth());
-}
-
-LayoutUnit RenderBox::adjustContentBoxLogicalWidthForBoxSizing(const Style::Length<CSS::NonnegativeUnzoomed, float>& logicalWidth) const
+LayoutUnit RenderBox::adjustContentBoxLogicalWidthForBoxSizing(const Style::Length<CSS::NonnegativeLayoutUnitClampedUnzoomed, float>& logicalWidth) const
 {
     auto width = LayoutUnit { logicalWidth.resolveZoom(style().usedZoomForLength()) };
     if (style().boxSizing() == BoxSizing::ContentBox)
@@ -4014,12 +3996,12 @@ std::optional<LayoutUnit> RenderBox::computePercentageLogicalHeight(const Style:
     return computePercentageLogicalHeightGeneric(logicalHeight, updateDescendants);
 }
 
-std::optional<LayoutUnit> RenderBox::computePercentageLogicalHeight(const Style::Percentage<CSS::Nonnegative, float>& logicalHeight, UpdatePercentageHeightDescendants updateDescendants) const
+std::optional<LayoutUnit> RenderBox::computePercentageLogicalHeight(const Style::Percentage<CSS::NonnegativeLayoutUnitClampedUnzoomed, float>& logicalHeight, UpdatePercentageHeightDescendants updateDescendants) const
 {
     return computePercentageLogicalHeightGeneric(logicalHeight, updateDescendants);
 }
 
-std::optional<LayoutUnit> RenderBox::computePercentageLogicalHeight(const Style::UnevaluatedCalculation<CSS::LengthPercentage<CSS::NonnegativeUnzoomed, float>>& logicalHeight, UpdatePercentageHeightDescendants updateDescendants) const
+std::optional<LayoutUnit> RenderBox::computePercentageLogicalHeight(const Style::UnevaluatedCalculation<CSS::LengthPercentage<CSS::NonnegativeLayoutUnitClampedUnzoomed, float>>& logicalHeight, UpdatePercentageHeightDescendants updateDescendants) const
 {
     return computePercentageLogicalHeightGeneric(logicalHeight, updateDescendants);
 }

--- a/Source/WebCore/rendering/RenderBox.h
+++ b/Source/WebCore/rendering/RenderBox.h
@@ -325,11 +325,9 @@ public:
 
     LayoutSize offsetFromContainer(const RenderElement&, const LayoutPoint&, bool* offsetDependsOnPoint = nullptr) const override;
     
-    LayoutUnit adjustBorderBoxLogicalWidthForBoxSizing(const Style::Length<CSS::Nonnegative, float>& logicalWidth) const;
-    LayoutUnit adjustBorderBoxLogicalWidthForBoxSizing(const Style::Length<CSS::NonnegativeUnzoomed, float>& logicalWidth) const;
+    LayoutUnit adjustBorderBoxLogicalWidthForBoxSizing(const Style::Length<CSS::NonnegativeLayoutUnitClampedUnzoomed, float>& logicalWidth) const;
     LayoutUnit adjustBorderBoxLogicalWidthForBoxSizing(LayoutUnit computedLogicalWidth) const;
-    LayoutUnit adjustContentBoxLogicalWidthForBoxSizing(const Style::Length<CSS::Nonnegative, float>& logicalWidth) const;
-    LayoutUnit adjustContentBoxLogicalWidthForBoxSizing(const Style::Length<CSS::NonnegativeUnzoomed, float>& logicalWidth) const;
+    LayoutUnit adjustContentBoxLogicalWidthForBoxSizing(const Style::Length<CSS::NonnegativeLayoutUnitClampedUnzoomed, float>& logicalWidth) const;
     LayoutUnit adjustContentBoxLogicalWidthForBoxSizing(LayoutUnit computedLogicalWidth) const;
 
     // Overridden by fieldsets to subtract out the intrinsic border.
@@ -426,8 +424,8 @@ public:
     std::optional<LayoutUnit> computePercentageLogicalHeight(const Style::MinimumSize& logicalHeight, UpdatePercentageHeightDescendants = UpdatePercentageHeightDescendants::Yes) const;
     std::optional<LayoutUnit> computePercentageLogicalHeight(const Style::MaximumSize& logicalHeight, UpdatePercentageHeightDescendants = UpdatePercentageHeightDescendants::Yes) const;
     std::optional<LayoutUnit> computePercentageLogicalHeight(const Style::FlexBasis& logicalHeight, UpdatePercentageHeightDescendants = UpdatePercentageHeightDescendants::Yes) const;
-    std::optional<LayoutUnit> computePercentageLogicalHeight(const Style::Percentage<CSS::Nonnegative, float>& logicalHeight, UpdatePercentageHeightDescendants = UpdatePercentageHeightDescendants::Yes) const;
-    std::optional<LayoutUnit> computePercentageLogicalHeight(const Style::UnevaluatedCalculation<CSS::LengthPercentage<CSS::NonnegativeUnzoomed, float>>& logicalHeight, UpdatePercentageHeightDescendants = UpdatePercentageHeightDescendants::Yes) const;
+    std::optional<LayoutUnit> computePercentageLogicalHeight(const Style::Percentage<CSS::NonnegativeLayoutUnitClampedUnzoomed, float>& logicalHeight, UpdatePercentageHeightDescendants = UpdatePercentageHeightDescendants::Yes) const;
+    std::optional<LayoutUnit> computePercentageLogicalHeight(const Style::UnevaluatedCalculation<CSS::LengthPercentage<CSS::NonnegativeLayoutUnitClampedUnzoomed, float>>& logicalHeight, UpdatePercentageHeightDescendants = UpdatePercentageHeightDescendants::Yes) const;
     bool hasAutoHeightOrContainingBlockWithAutoHeight(UpdatePercentageHeightDescendants = UpdatePercentageHeightDescendants::Yes) const;
 
     virtual LayoutUnit availableLogicalHeight(AvailableLogicalHeightType) const;

--- a/Source/WebCore/style/StyleResolveForFont.cpp
+++ b/Source/WebCore/style/StyleResolveForFont.cpp
@@ -131,11 +131,6 @@ FontSelectionValue fontStretchFromCSSValueDeprecated(const CSSValue& value)
 
 // MARK: - 'font-style'
 
-FontSelectionValue fontStyleAngleFromCSSValueDeprecated(const CSSValue& value)
-{
-    return normalizedFontItalicValue(downcast<CSSPrimitiveValue>(value).resolveAsAngleDeprecated<float>());
-}
-
 std::optional<FontSelectionValue> fontStyleAngleFromCSSFontStyleWithAngleValueDeprecated(const CSSFontStyleWithAngleValue& value)
 {
     if (requiresConversionData(value.obliqueAngle()))

--- a/Source/WebCore/style/StyleResolveForFont.h
+++ b/Source/WebCore/style/StyleResolveForFont.h
@@ -50,7 +50,6 @@ FontSelectionValue fontWeightFromCSSValueDeprecated(const CSSValue&);
 
 FontSelectionValue fontStretchFromCSSValueDeprecated(const CSSValue&);
 
-FontSelectionValue fontStyleAngleFromCSSValueDeprecated(const CSSValue&);
 std::optional<FontSelectionValue> fontStyleAngleFromCSSFontStyleWithAngleValueDeprecated(const CSSFontStyleWithAngleValue&);
 std::optional<FontSelectionValue> fontStyleFromCSSValueDeprecated(const CSSValue&);
 

--- a/Source/WebCore/style/values/fill-stroke/StyleStrokeWidth.cpp
+++ b/Source/WebCore/style/values/fill-stroke/StyleStrokeWidth.cpp
@@ -38,6 +38,8 @@ namespace Style {
 
 auto CSSValueConversion<StrokeWidth>::operator()(BuilderState& state, const CSSValue& value) -> StrokeWidth
 {
+    using namespace CSS::Literals;
+
     RefPtr primitiveValue = requiredDowncast<CSSPrimitiveValue>(state, value);
     if (!primitiveValue)
         return 0_css_px;

--- a/Source/WebCore/style/values/flexbox/StyleFlexBasis.h
+++ b/Source/WebCore/style/values/flexbox/StyleFlexBasis.h
@@ -33,7 +33,7 @@ struct PreferredSize;
 
 // <'flex-basis'> = content | <‘width’>
 // https://drafts.csswg.org/css-flexbox/#propdef-flex-basis
-struct FlexBasis : LengthWrapperBase<LengthPercentage<CSS::NonnegativeUnzoomed>, CSS::Keyword::Content, CSS::Keyword::Auto, CSS::Keyword::MinContent, CSS::Keyword::MaxContent, CSS::Keyword::FitContent, CSS::Keyword::Stretch, CSS::Keyword::Intrinsic, CSS::Keyword::MinIntrinsic> {
+struct FlexBasis : LengthWrapperBase<LengthPercentage<CSS::NonnegativeLayoutUnitClampedUnzoomed>, CSS::Keyword::Content, CSS::Keyword::Auto, CSS::Keyword::MinContent, CSS::Keyword::MaxContent, CSS::Keyword::FitContent, CSS::Keyword::Stretch, CSS::Keyword::Intrinsic, CSS::Keyword::MinIntrinsic> {
     using Base::Base;
 
     // `FlexBasis` is a superset of `PreferredSize` and therefore this conversion can fail when type is `content`.

--- a/Source/WebCore/style/values/images/StyleGradient.cpp
+++ b/Source/WebCore/style/values/images/StyleGradient.cpp
@@ -128,15 +128,15 @@ static std::optional<float> resolveColorStopPosition(const GradientLinearColorSt
         return std::nullopt;
 
     return WTF::switchOn(*position,
-        [&](const LengthPercentage<CSS::AllUnzoomed>::Dimension& length) -> std::optional<float> {
+        [&](const LengthPercentage<CSS::AllLayoutUnitClampedUnzoomed>::Dimension& length) -> std::optional<float> {
             if (gradientLength <= 0)
                 return 0;
             return evaluate<float>(length, zoom) / gradientLength;
         },
-        [&](const LengthPercentage<CSS::AllUnzoomed>::Percentage& percentage) -> std::optional<float> {
+        [&](const LengthPercentage<CSS::AllLayoutUnitClampedUnzoomed>::Percentage& percentage) -> std::optional<float> {
             return percentage.value / 100.0;
         },
-        [&](const LengthPercentage<CSS::AllUnzoomed>::Calc& calc) -> std::optional<float> {
+        [&](const LengthPercentage<CSS::AllLayoutUnitClampedUnzoomed>::Calc& calc) -> std::optional<float> {
             if (gradientLength <= 0)
                 return 0;
             return evaluate<float>(calc, gradientLength, zoom) / gradientLength;

--- a/Source/WebCore/style/values/images/StyleGradient.h
+++ b/Source/WebCore/style/values/images/StyleGradient.h
@@ -84,7 +84,8 @@ using GradientAngularColorStop = GradientColorStop<GradientAngularColorStopColor
 using GradientAngularColorStopList = GradientColorStopList<GradientAngularColorStop>;
 
 using GradientLinearColorStopColor = Markable<Color>;
-using GradientLinearColorStopPosition = std::optional<LengthPercentage<CSS::AllUnzoomed>>;
+// FIXME: `GradientLinearColorStopPosition` should use a range of `AllUnzoomed`, but doing so was causing imported/w3c/web-platform-tests/css/css-images/gradient/gradient-infinity-001.html to fail for the GTK/WPE graphics backends.
+using GradientLinearColorStopPosition = std::optional<LengthPercentage<CSS::AllLayoutUnitClampedUnzoomed>>;
 using GradientLinearColorStop = GradientColorStop<GradientLinearColorStopColor, GradientLinearColorStopPosition>;
 using GradientLinearColorStopList = GradientColorStopList<GradientLinearColorStop>;
 

--- a/Source/WebCore/style/values/inline/StyleLineHeight.cpp
+++ b/Source/WebCore/style/values/inline/StyleLineHeight.cpp
@@ -70,43 +70,81 @@ auto CSSValueConversion<LineHeight>::operator()(BuilderState& state, const CSSVa
         return Style::ZoomFactor { conversionData.zoom() };
     };
 
-    if (primitiveValue->isLength() || primitiveValue->isCalculatedPercentageWithLength()) {
-        double fixedValue = 0;
-        if (primitiveValue->isLength())
-            fixedValue = primitiveValue->resolveAsLength(conversionData);
-        else
-            fixedValue = protect(primitiveValue->cssCalcValue())->createCalculationValue(conversionData, CSSCalcSymbolTable { })->evaluate(state.style().fontDescription().computedSizeForRangeZoomOption(conversionData.rangeZoomOption()), zoomFactor());
+    auto percentageBasis = [&] {
+        return state.style().fontDescription().computedSizeForRangeZoomOption(conversionData.rangeZoomOption());
+    };
 
-        if (multiplier != 1.0f)
-            fixedValue *= multiplier;
+    using StyleSpecified = typename LineHeight::Specified;
+    using CSSRaw = typename StyleSpecified::CSS::Raw;
+    using CSSDimensionRaw = typename CSSRaw::Dimension;
+    using CSSPercentageRaw = typename CSSRaw::Percentage;
 
-        return LineHeight::Fixed {
-            CSS::clampToRange<LineHeight::Fixed::range, float>(fixedValue, minValueForCssLength, maxValueForCssLength)
-        };
-    }
+    using StyleNumber = Number<CSS::Nonnegative>;
+    using CSSNumberRaw = typename StyleNumber::CSS::Raw;;
 
-    // Line-height percentages need to inherit as if they were Fixed pixel values. In the example:
-    // <div style="font-size: 10px; line-height: 150%;"><div style="font-size: 100px;"></div></div>
-    // the inner element should have line-height of 15px. However, in this example:
-    // <div style="font-size: 10px; line-height: 1.5;"><div style="font-size: 100px;"></div></div>
-    // the inner element should have a line-height of 150px. Therefore, we map percentages to Fixed
-    // values and raw numbers to percentages.
-    if (primitiveValue->isPercentage()) {
+    auto handleFixed = [&](const StyleSpecified::Dimension& fixed) {
+        return LineHeight::Fixed { CSS::clampToRangeOf<LineHeight::Fixed>(fixed.unresolvedValue() * multiplier) };
+    };
+
+    auto handlePercentage = [&](const StyleSpecified::Percentage& percentage) {
+        // Line-height percentages need to inherit as if they were pixel values. In the example:
+        // <div style="font-size: 10px; line-height: 150%;"><div style="font-size: 100px;"></div></div>
+        // the inner element should have line-height of 15px. However, in this example:
+        // <div style="font-size: 10px; line-height: 1.5;"><div style="font-size: 100px;"></div></div>
+        // the inner element should have a line-height of 150px. Therefore, we map percentages to Fixed
+        // values and raw numbers to percentages.
+
         // FIXME: percentage should not be restricted to an integer here.
-        auto textZoom = evaluationTimeZoomEnabled(state) ? conversionData.zoom() : 1.0f;
-        return LineHeight::Fixed {
-            CSS::clampToRange<LineHeight::Fixed::range, float>((state.style().fontDescription().computedSizeForRangeZoomOption(conversionData.rangeZoomOption()) * primitiveValue->resolveAsPercentage<int>(conversionData) * textZoom) / 100.0, minValueForCssLength, maxValueForCssLength)
-        };
-    }
+        auto percentageValue = static_cast<int>(percentage.value);
 
-    if (primitiveValue->isNumber()) {
-        return LineHeight::Percentage {
-            CSS::clampToRange<LineHeight::Percentage::range, float>(primitiveValue->resolveAsNumber(conversionData) * 100.0)
-        };
-    }
+        return LineHeight::Fixed { CSS::clampToRangeOf<LineHeight::Fixed>((percentageValue * percentageBasis() * zoomFactor().value) / 100.0) };
+    };
 
-    state.setCurrentPropertyInvalidAtComputedValueTime();
-    return CSS::Keyword::Normal { };
+    auto handleCalc = [&](const StyleSpecified::Calc& calc) {
+        return LineHeight::Fixed { CSS::clampToRangeOf<LineHeight::Fixed>(protect(calc.calculation())->evaluate(percentageBasis(), zoomFactor()) * multiplier) };
+    };
+
+    auto handleNumber = [&](const StyleNumber& number) {
+        return LineHeight::Percentage { CSS::clampToRangeOf<LineHeight::Percentage>(number.value * 100.0) };
+    };
+
+    return WTF::switchOn(*primitiveValue,
+        [&](const CSSPrimitiveValue::Calc& calc) -> LineHeight {
+            if (calc.category() == CSS::Category::Number || calc.category() == CSS::Category::Integer)
+                return handleNumber(toStyle(CSS::UnevaluatedCalc<CSSNumberRaw>( const_cast<CSSPrimitiveValue::Calc&>(calc)), conversionData));
+
+            ASSERT(calc.category() == CSS::Category::Length || calc.category() == CSS::Category::Percentage || calc.category() == CSS::Category::LengthPercentage);
+
+            // <length-percentage> calc() can become a raw <length> or <percentage>, or can stay a calc() when converting,
+            // so we have to handle all those cases here.
+
+            auto convertedCalc = toStyle(CSS::UnevaluatedCalc<CSSRaw>(const_cast<CSSPrimitiveValue::Calc&>(calc)), conversionData);
+            return WTF::switchOn(convertedCalc,
+                [&](const StyleSpecified::Dimension& fixed) {
+                    return handleFixed(fixed);
+                },
+                [&](const StyleSpecified::Percentage& percentage) {
+                    return handlePercentage(percentage);
+                },
+                [&](const StyleSpecified::Calc& calc) {
+                    return handleCalc(calc);
+                }
+            );
+        },
+        [&](const CSSPrimitiveValue::Raw& raw) -> LineHeight {
+            if (auto unit = CSSNumberRaw::UnitTraits::validate(raw.unit))
+                return handleNumber(toStyle(CSSNumberRaw(*unit, raw.value), conversionData));
+
+            if (auto unit = CSSPercentageRaw::UnitTraits::validate(raw.unit))
+                return handlePercentage(toStyle(CSSPercentageRaw(*unit, raw.value), conversionData));
+
+            if (auto unit = CSSDimensionRaw::UnitTraits::validate(raw.unit))
+                return handleFixed(toStyle(CSSDimensionRaw(*unit, raw.value), conversionData));
+
+            state.setCurrentPropertyInvalidAtComputedValueTime();
+            return CSS::Keyword::Normal { };
+        }
+    );
 }
 
 // MARK: - Blending

--- a/Source/WebCore/style/values/non-standard/StyleWebKitTextStrokeWidth.cpp
+++ b/Source/WebCore/style/values/non-standard/StyleWebKitTextStrokeWidth.cpp
@@ -38,6 +38,8 @@ namespace Style {
 
 auto CSSValueConversion<WebkitTextStrokeWidth>::operator()(BuilderState& state, const CSSValue& value) -> WebkitTextStrokeWidth
 {
+    using namespace CSS::Literals;
+
     if (RefPtr keywordValue = dynamicDowncast<CSSKeywordValue>(value)) {
         auto convertFromEms = [&](auto ems) -> WebkitTextStrokeWidth::Length {
             return emToPx<float>(ems, state.renderStyle());

--- a/Source/WebCore/style/values/position/StyleInset.h
+++ b/Source/WebCore/style/values/position/StyleInset.h
@@ -31,7 +31,7 @@ namespace Style {
 
 // <'top'>/<'right'>/<'bottom'>/<'left'> = auto | <length-percentage>
 // https://drafts.csswg.org/css-position/#insets
-struct InsetEdge : LengthWrapperBase<LengthPercentage<CSS::AllUnzoomed>, CSS::Keyword::Auto> {
+struct InsetEdge : LengthWrapperBase<LengthPercentage<CSS::AllLayoutUnitClampedUnzoomed>, CSS::Keyword::Auto> {
     using Base::Base;
 
     ALWAYS_INLINE bool isAuto() const { return holdsAlternative<CSS::Keyword::Auto>(); }

--- a/Source/WebCore/style/values/primitives/StyleLengthWrapper+CSSValueConversion.h
+++ b/Source/WebCore/style/values/primitives/StyleLengthWrapper+CSSValueConversion.h
@@ -34,133 +34,230 @@ namespace Style {
 
 // MARK: - Conversion
 
-template<LengthWrapperBaseDerived T> struct CSSValueConversion<T> {
-    template<typename K>
-    static auto processKeyword(const K& keyword, CSSValueID valueID, std::optional<T>& result) -> bool
-    {
-        if (valueID == keyword.value) {
-            result = T { keyword };
+// Generic implementation of conversion of keywords and numeric values for length wrapper types.
+
+// MARK: Keyword conversion
+
+template<LengthWrapperBaseDerived StyleType, typename K>
+static auto processKeywordForCSSValueConversion(const K& keyword, CSSValueID valueID, std::optional<StyleType>& result) -> bool
+{
+    if (valueID == keyword.value) {
+        result = StyleType { keyword };
+        return true;
+    }
+
+    // A few keywords have alternative spellings.
+    // FIXME: Find a generic solution to this problem.
+    if constexpr (std::same_as<K, CSS::Keyword::MinContent>) {
+        if (valueID == CSSValueWebkitMinContent) {
+            result = StyleType { keyword };
             return true;
         }
-
-        // A few keywords have alternative spellings.
-        // FIXME: Find a generic solution to this problem.
-        if constexpr (std::same_as<K, CSS::Keyword::MinContent>) {
-            if (valueID == CSSValueWebkitMinContent) {
-                result = T { keyword };
-                return true;
-            }
-        } else if constexpr (std::same_as<K, CSS::Keyword::MaxContent>) {
-            if (valueID == CSSValueWebkitMaxContent) {
-                result = T { keyword };
-                return true;
-            }
-        } else if constexpr (std::same_as<K, CSS::Keyword::FitContent>) {
-            if (valueID == CSSValueWebkitFitContent) {
-                result = T { keyword };
-                return true;
-            }
-        } else if constexpr (std::same_as<K, CSS::Keyword::Stretch>) {
-            if (valueID == CSSValueWebkitFillAvailable) {
-                result = T { keyword };
-                return true;
-            }
+    } else if constexpr (std::same_as<K, CSS::Keyword::MaxContent>) {
+        if (valueID == CSSValueWebkitMaxContent) {
+            result = StyleType { keyword };
+            return true;
         }
-
-        return false;
-    }
-
-    static auto selectConversionData(BuilderState& builderState) -> CSSToLengthConversionData
-    {
-        if constexpr (T::Fixed::range.zoomOptions == CSS::RangeZoomOptions::Default) {
-            return builderState.useSVGZoomRulesForLength()
-                ? builderState.cssToLengthConversionData().copyWithAdjustedZoom(1.0f)
-                : builderState.cssToLengthConversionData();
-        } else if constexpr (T::Fixed::range.zoomOptions == CSS::RangeZoomOptions::Unzoomed) {
-            if (evaluationTimeZoomEnabled(builderState))
-                return builderState.cssToLengthConversionData().copyWithAdjustedZoom(1.0f, T::Fixed::range.zoomOptions);
-
-            return builderState.useSVGZoomRulesForLength()
-                ? builderState.cssToLengthConversionData().copyWithAdjustedZoom(1.0f)
-                : builderState.cssToLengthConversionData();
+    } else if constexpr (std::same_as<K, CSS::Keyword::FitContent>) {
+        if (valueID == CSSValueWebkitFitContent) {
+            result = StyleType { keyword };
+            return true;
+        }
+    } else if constexpr (std::same_as<K, CSS::Keyword::Stretch>) {
+        if (valueID == CSSValueWebkitFillAvailable) {
+            result = StyleType { keyword };
+            return true;
         }
     }
 
-    auto operator()(BuilderState& state, const CSSPrimitiveValue& primitiveValue) -> T
-    {
-        using namespace CSS::Literals;
+    return false;
+}
 
-        auto conversionData = selectConversionData(state);
+template<LengthWrapperBaseDerived StyleType, typename... Rest>
+auto convertLengthWrapperFromCSSValue(const CSSKeywordValue& value, Rest&&...) -> std::optional<StyleType>
+{
+    auto valueID = value.valueID();
 
-        if (primitiveValue.isLength()) {
-            return T {
-                typename T::Fixed {
-                    CSS::clampToRange<T::Fixed::range, float>(primitiveValue.resolveAsLength(conversionData), minValueForCssLength, maxValueForCssLength),
-                },
-                primitiveValue.primitiveType() == CSSUnitType::CSS_QUIRKY_EM
-            };
+    constexpr auto keywordsTuple = StyleType::Keywords::tuple;
+
+    return std::apply([&](const auto& ...keyword) {
+        std::optional<StyleType> result;
+        (processKeywordForCSSValueConversion<StyleType>(keyword, valueID, result) || ...);
+        return result;
+    }, keywordsTuple);
+}
+
+template<LengthWrapperBaseDerived StyleType, typename... Rest>
+auto convertLengthWrapperFromCSSValue(const CSSToLengthConversionData&, const CSSKeywordValue& value, Rest&&... rest) -> std::optional<StyleType>
+{
+    return convertLengthWrapperFromCSSValue<StyleType>(value, std::forward<Rest>(rest)...);
+}
+
+template<LengthWrapperBaseDerived StyleType, typename... Rest>
+auto convertLengthWrapperFromCSSValue(BuilderState& state, const CSSKeywordValue& value, Rest&&... rest) -> StyleType
+{
+    using namespace CSS::Literals;
+
+    auto result = convertLengthWrapperFromCSSValue<StyleType>(value, std::forward<Rest>(rest)...);
+    if (result)
+        return *result;
+
+    state.setCurrentPropertyInvalidAtComputedValueTime();
+    return 0_css_px;
+}
+
+// MARK: <length-percentage> conversion
+
+template<LengthWrapperBaseDerived StyleType, typename... Rest>
+auto convertLengthWrapperFromCSSValue(const CSSPrimitiveValue& value, Rest&&... rest) -> std::optional<StyleType>
+{
+    using CSSSpecified = typename StyleType::Specified::CSS;
+    using CSSRaw = typename CSSSpecified::Raw;
+    using CSSDimensionRaw = typename CSSRaw::Dimension;
+    using CSSPercentageRaw = typename CSSRaw::Percentage;
+
+    return WTF::switchOn(value,
+        [&](const CSSPrimitiveValue::Calc&) -> std::optional<StyleType> {
+            return std::nullopt;
+        },
+        [&](const CSSPrimitiveValue::Raw& raw) -> std::optional<StyleType> {
+            if (auto unit = CSSPercentageRaw::UnitTraits::validate(raw.unit))
+                return StyleType { toStyle(CSSPercentageRaw(*unit, raw.value), NoConversionDataRequiredToken { }, std::forward<Rest>(rest)...) };
+            if (raw.unit == CSSUnitType::CSS_PX)
+                return StyleType { toStyle(CSSDimensionRaw(CSS::LengthUnit::Px, raw.value), NoConversionDataRequiredToken { }, std::forward<Rest>(rest)...) };
+
+            return std::nullopt;
         }
+    );
+}
 
-        if (primitiveValue.isPercentage()) {
-            return T {
-                typename T::Percentage {
-                    CSS::clampToRange<T::Percentage::range, float>(primitiveValue.resolveAsPercentage(conversionData)),
-                }
-            };
+template<LengthWrapperBaseDerived StyleType, typename... Rest>
+auto convertLengthWrapperFromCSSValue(const CSSToLengthConversionData& conversionData, const CSSPrimitiveValue& value, Rest&&... rest) -> std::optional<StyleType>
+{
+    using CSSSpecified = typename StyleType::Specified::CSS;
+    using CSSRaw = typename CSSSpecified::Raw;
+    using CSSDimensionRaw = typename CSSRaw::Dimension;
+    using CSSPercentageRaw = typename CSSRaw::Percentage;
+
+    return WTF::switchOn(value,
+        [&](const CSSPrimitiveValue::Calc& calc) -> std::optional<StyleType> {
+            return StyleType { toStyle(CSS::UnevaluatedCalc<CSSRaw>(const_cast<CSSPrimitiveValue::Calc&>(calc)), conversionData, std::forward<Rest>(rest)...) };
+        },
+        [&](const CSSPrimitiveValue::Raw& raw) -> std::optional<StyleType> {
+            if (auto unit = CSSPercentageRaw::UnitTraits::validate(raw.unit))
+                return StyleType { toStyle(CSSPercentageRaw(*unit, raw.value), conversionData, std::forward<Rest>(rest)...) };
+            if (auto unit = CSSDimensionRaw::UnitTraits::validate(raw.unit))
+                return StyleType { toStyle(CSSDimensionRaw(*unit, raw.value), conversionData, std::forward<Rest>(rest)...), *unit == CSS::LengthUnit::QuirkyEm };
+
+            return std::nullopt;
         }
+    );
+}
 
-        if (primitiveValue.isCalculatedPercentageWithLength()) {
-            return T {
-                typename T::Calc {
-                    protect(primitiveValue.cssCalcValue())->createCalculationValue(conversionData, CSSCalcSymbolTable { })
-                }
-            };
+template<LengthWrapperBaseDerived StyleType, typename... Rest>
+auto convertLengthWrapperFromCSSValue(BuilderState& state, const CSSPrimitiveValue& value, Rest&&... rest) -> StyleType
+{
+    using CSSSpecified = typename StyleType::Specified::CSS;
+    using CSSRaw = typename CSSSpecified::Raw;
+    using CSSDimensionRaw = typename CSSRaw::Dimension;
+    using CSSPercentageRaw = typename CSSRaw::Percentage;
+
+    using namespace CSS::Literals;
+
+    return WTF::switchOn(value,
+        [&](const CSSPrimitiveValue::Calc& calc) -> StyleType {
+            return StyleType { toStyle(CSS::UnevaluatedCalc<CSSRaw>(const_cast<CSSPrimitiveValue::Calc&>(calc)), state, std::forward<Rest>(rest)...) };
+        },
+        [&](const CSSPrimitiveValue::Raw& raw) -> StyleType {
+            if (auto unit = CSSPercentageRaw::UnitTraits::validate(raw.unit))
+                return StyleType { toStyle(CSSPercentageRaw(*unit, raw.value), state, std::forward<Rest>(rest)...) };
+            if (auto unit = CSSDimensionRaw::UnitTraits::validate(raw.unit))
+                return StyleType { toStyle(CSSDimensionRaw(*unit, raw.value), state, std::forward<Rest>(rest)...), *unit == CSS::LengthUnit::QuirkyEm };
+
+            ASSERT_NOT_REACHED();
+            state.setCurrentPropertyInvalidAtComputedValueTime();
+            return 0_css_px;
         }
+    );
+}
 
-        ASSERT_NOT_REACHED();
-        state.setCurrentPropertyInvalidAtComputedValueTime();
-        return 0_css_px;
+// MARK: <length-percentage> + keyword conversion
+
+template<LengthWrapperBaseDerived StyleType, typename... Rest>
+auto convertLengthWrapperFromCSSValue(const CSSValue& value, Rest&&... rest) -> std::optional<StyleType>
+{
+    using namespace CSS::Literals;
+
+    if constexpr (!StyleType::Keywords::count) {
+        RefPtr primitiveValue = dynamicDowncast<CSSPrimitiveValue>(value);
+        if (!primitiveValue)
+            return std::nullopt;
+        return convertLengthWrapperFromCSSValue<StyleType>(*primitiveValue, std::forward<Rest>(rest)...);
+    } else {
+        if (RefPtr primitiveValue = dynamicDowncast<CSSPrimitiveValue>(value))
+            return convertLengthWrapperFromCSSValue<StyleType>(*primitiveValue, std::forward<Rest>(rest)...);
+
+        RefPtr keywordValue = dynamicDowncast<CSSKeywordValue>(value);
+        if (!keywordValue)
+            return std::nullopt;
+        return convertLengthWrapperFromCSSValue<StyleType>(*keywordValue, std::forward<Rest>(rest)...);
     }
+}
 
-    auto operator()(BuilderState& state, const CSSKeywordValue& keywordValue) -> T
-    {
-        using namespace CSS::Literals;
+template<LengthWrapperBaseDerived StyleType, typename... Rest>
+auto convertLengthWrapperFromCSSValue(const CSSToLengthConversionData& conversionData, const CSSValue& value, Rest&&... rest) -> std::optional<StyleType>
+{
+    using namespace CSS::Literals;
 
-        auto valueID = keywordValue.valueID();
+    if constexpr (!StyleType::Keywords::count) {
+        RefPtr primitiveValue = dynamicDowncast<CSSPrimitiveValue>(value);
+        if (!primitiveValue)
+            return std::nullopt;
+        return convertLengthWrapperFromCSSValue<StyleType>(conversionData, *primitiveValue, std::forward<Rest>(rest)...);
+    } else {
+        if (RefPtr primitiveValue = dynamicDowncast<CSSPrimitiveValue>(value))
+            return convertLengthWrapperFromCSSValue<StyleType>(conversionData, *primitiveValue, std::forward<Rest>(rest)...);
 
-        constexpr auto keywordsTuple = T::Keywords::tuple;
-
-        auto result = std::apply([&](const auto& ...keyword) {
-            std::optional<T> result;
-            (processKeyword(keyword, valueID, result) || ...);
-            return result;
-        }, keywordsTuple);
-
-        if (result)
-            return *result;
-
-        state.setCurrentPropertyInvalidAtComputedValueTime();
-        return 0_css_px;
+        RefPtr keywordValue = dynamicDowncast<CSSKeywordValue>(value);
+        if (!keywordValue)
+            return std::nullopt;
+        return convertLengthWrapperFromCSSValue<StyleType>(conversionData, *keywordValue, std::forward<Rest>(rest)...);
     }
+}
 
-    auto operator()(BuilderState& state, const CSSValue& value) -> T
+template<LengthWrapperBaseDerived StyleType, typename... Rest>
+auto convertLengthWrapperFromCSSValue(BuilderState& state, const CSSValue& value, Rest&&... rest) -> StyleType
+{
+    using namespace CSS::Literals;
+
+    if constexpr (!StyleType::Keywords::count) {
+        RefPtr primitiveValue = requiredDowncast<CSSPrimitiveValue>(state, value);
+        if (!primitiveValue)
+            return 0_css_px;
+        return convertLengthWrapperFromCSSValue<StyleType>(state, *primitiveValue, std::forward<Rest>(rest)...);
+    } else {
+        if (RefPtr primitiveValue = dynamicDowncast<CSSPrimitiveValue>(value))
+            return convertLengthWrapperFromCSSValue<StyleType>(state, *primitiveValue, std::forward<Rest>(rest)...);
+
+        RefPtr keywordValue = requiredDowncast<CSSKeywordValue>(state, value);
+        if (!keywordValue)
+            return 0_css_px;
+        return convertLengthWrapperFromCSSValue<StyleType>(state, *keywordValue, std::forward<Rest>(rest)...);
+    }
+}
+
+template<LengthWrapperBaseDerived StyleType> struct CSSValueConversion<StyleType> {
+    template<typename... Rest> auto operator()(BuilderState& state, const CSSPrimitiveValue& value, Rest&&... rest) -> StyleType
     {
-        using namespace CSS::Literals;
-
-        if constexpr (!T::Keywords::count) {
-            RefPtr primitiveValue = requiredDowncast<CSSPrimitiveValue>(state, value);
-            if (!primitiveValue)
-                return 0_css_px;
-            return this->operator()(state, *primitiveValue);
-        } else {
-            if (RefPtr primitiveValue = dynamicDowncast<CSSPrimitiveValue>(value))
-                return this->operator()(state, *primitiveValue);
-
-            RefPtr keywordValue = requiredDowncast<CSSKeywordValue>(state, value);
-            if (!keywordValue)
-                return 0_css_px;
-            return this->operator()(state, *keywordValue);
-        }
+        return convertLengthWrapperFromCSSValue<StyleType>(state, value, std::forward<Rest>(rest)...);
+    }
+    template<typename... Rest> auto operator()(BuilderState& state, const CSSKeywordValue& value, Rest&&... rest) -> StyleType
+    {
+        return convertLengthWrapperFromCSSValue<StyleType>(state, value, std::forward<Rest>(rest)...);
+    }
+    template<typename... Rest> auto operator()(BuilderState& state, const CSSValue& value, Rest&&... rest) -> StyleType
+    {
+        return convertLengthWrapperFromCSSValue<StyleType>(state, value, std::forward<Rest>(rest)...);
     }
 };
 

--- a/Source/WebCore/style/values/primitives/StyleLengthWrapper+DeprecatedCSSValueConversion.h
+++ b/Source/WebCore/style/values/primitives/StyleLengthWrapper+DeprecatedCSSValueConversion.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2025 Samuel Weinig <sam@webkit.org>
+ * Copyright (C) 2025-2026 Samuel Weinig <sam@webkit.org>
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -34,97 +34,24 @@ namespace Style {
 
 std::optional<CSSToLengthConversionData> deprecatedLengthConversionCreateCSSToLengthConversionData(RefPtr<Element>);
 
-template<LengthWrapperBaseDerived T> struct DeprecatedCSSValueConversion<T> {
-    auto operator()(const RefPtr<Element>& element, const CSSPrimitiveValue& primitiveValue) -> std::optional<T>
+template<LengthWrapperBaseDerived StyleType> struct DeprecatedCSSValueConversion<StyleType> {
+    auto operator()(const RefPtr<Element>& element, const CSSPrimitiveValue& value) -> std::optional<StyleType>
     {
-        using namespace CSS::Literals;
-
-        auto conversionData = deprecatedLengthConversionCreateCSSToLengthConversionData(element);
-        if (!conversionData) {
-            if (primitiveValue.isCalculated())
-                return std::nullopt;
-
-            if (primitiveValue.isPx()) {
-                return T {
-                    typename T::Fixed {
-                        CSS::clampToRange<T::Fixed::range, float>(primitiveValue.resolveAsLengthNoConversionDataRequired(), minValueForCssLength, maxValueForCssLength),
-                    },
-                    primitiveValue.primitiveType() == CSSUnitType::CSS_QUIRKY_EM
-                };
-            }
-
-            if (primitiveValue.isPercentage()) {
-                return T {
-                    typename T::Percentage {
-                        CSS::clampToRange<T::Percentage::range, float>(primitiveValue.resolveAsPercentageNoConversionDataRequired()),
-                    }
-                };
-            }
-
-            return std::nullopt;
-        }
-
-        if (primitiveValue.isLength()) {
-            return T {
-                typename T::Fixed {
-                    CSS::clampToRange<T::Fixed::range, float>(primitiveValue.resolveAsLength(*conversionData), minValueForCssLength, maxValueForCssLength),
-                },
-                primitiveValue.primitiveType() == CSSUnitType::CSS_QUIRKY_EM
-            };
-        }
-
-        if (primitiveValue.isPercentage()) {
-            return T {
-                typename T::Percentage {
-                    CSS::clampToRange<T::Percentage::range, float>(primitiveValue.resolveAsPercentage(*conversionData)),
-                }
-            };
-        }
-
-        if (primitiveValue.isCalculatedPercentageWithLength()) {
-            return T {
-                typename T::Calc {
-                    protect(primitiveValue.cssCalcValue())->createCalculationValue(*conversionData, CSSCalcSymbolTable { })
-                }
-            };
-        }
-
-        return std::nullopt;
+        if (auto conversionData = deprecatedLengthConversionCreateCSSToLengthConversionData(element))
+            return convertLengthWrapperFromCSSValue<StyleType>(*conversionData, value);
+        return convertLengthWrapperFromCSSValue<StyleType>(value);
     }
 
-    auto operator()(const RefPtr<Element>&, const CSSKeywordValue& keywordValue) -> std::optional<T>
+    auto operator()(const RefPtr<Element>&, const CSSKeywordValue& value) -> std::optional<StyleType>
     {
-        auto valueID = keywordValue.valueID();
-
-        constexpr auto keywordsTuple = T::Keywords::tuple;
-
-        auto result = std::apply([&](const auto& ...keyword) {
-            std::optional<T> result;
-            (CSSValueConversion<T>::processKeyword(keyword, valueID, result) || ...);
-            return result;
-        }, keywordsTuple);
-
-        return result;
+        return convertLengthWrapperFromCSSValue<StyleType>(value);
     }
 
-    auto operator()(const RefPtr<Element>& element, const CSSValue& value) -> std::optional<T>
+    auto operator()(const RefPtr<Element>& element, const CSSValue& value) -> std::optional<StyleType>
     {
-        using namespace CSS::Literals;
-
-        if constexpr (!T::Keywords::count) {
-            RefPtr primitiveValue = dynamicDowncast<CSSPrimitiveValue>(value);
-            if (!primitiveValue)
-                return std::nullopt;
-            return this->operator()(element, *primitiveValue);
-        } else {
-            if (RefPtr primitiveValue = dynamicDowncast<CSSPrimitiveValue>(value))
-                return this->operator()(element, *primitiveValue);
-
-            RefPtr keywordValue = dynamicDowncast<CSSKeywordValue>(value);
-            if (!keywordValue)
-                return std::nullopt;
-            return this->operator()(element, *keywordValue);
-        }
+        if (auto conversionData = deprecatedLengthConversionCreateCSSToLengthConversionData(element))
+            return convertLengthWrapperFromCSSValue<StyleType>(*conversionData, value);
+        return convertLengthWrapperFromCSSValue<StyleType>(value);
     }
 };
 

--- a/Source/WebCore/style/values/primitives/StylePrimitiveNumericTypes+CSSValueConversion.h
+++ b/Source/WebCore/style/values/primitives/StylePrimitiveNumericTypes+CSSValueConversion.h
@@ -34,240 +34,240 @@
 namespace WebCore {
 namespace Style {
 
-using namespace CSS::Literals;
+// Generic implementation of conversion for numeric types.
+
+template<Numeric StyleType, typename... Rest>
+auto convertNumericFromCSSValue(const CSSToLengthConversionData& conversionData, const CSSPrimitiveValue& value, Rest&&... rest) -> std::optional<StyleType>
+{
+    using CSSRaw = typename StyleType::CSS::Raw;
+
+    return WTF::switchOn(value,
+        [&](const CSSPrimitiveValue::Calc& calc) -> std::optional<StyleType> {
+            return toStyle(CSS::UnevaluatedCalc<CSSRaw>(const_cast<CSSPrimitiveValue::Calc&>(calc)), conversionData, std::forward<Rest>(rest)...);
+        },
+        [&](const CSSPrimitiveValue::Raw& raw) -> std::optional<StyleType> {
+            if constexpr (DimensionPercentageNumeric<StyleType>) {
+                using CSSDimensionRaw = typename StyleType::Dimension::CSS::Raw;
+                using CSSPercentageRaw = typename StyleType::Percentage::CSS::Raw;
+
+                if (auto unit = CSSDimensionRaw::UnitTraits::validate(raw.unit))
+                    return toStyle(CSSDimensionRaw(*unit, raw.value), conversionData, std::forward<Rest>(rest)...);
+                if (auto unit = CSSPercentageRaw::UnitTraits::validate(raw.unit))
+                    return toStyle(CSSPercentageRaw(*unit, raw.value), conversionData, std::forward<Rest>(rest)...);
+            } else if constexpr (StyleType::category == CSS::Category::Integer || StyleType::category == CSS::Category::Number) {
+                if (raw.unit == CSSUnitType::CSS_NUMBER || raw.unit == CSSUnitType::CSS_INTEGER)
+                    return toStyle(CSSRaw(raw.value), conversionData, std::forward<Rest>(rest)...);
+            } else {
+                if (auto unit = CSSRaw::UnitTraits::validate(raw.unit))
+                    return toStyle(CSSRaw(*unit, raw.value), conversionData, std::forward<Rest>(rest)...);
+            }
+
+            ASSERT_NOT_REACHED();
+            return std::nullopt;
+        }
+    );
+}
+
+template<Numeric StyleType, typename... Rest>
+auto convertNumericFromCSSValue(BuilderState& state, const CSSPrimitiveValue& value, Rest&&... rest) -> StyleType
+{
+    using CSSRaw = typename StyleType::CSS::Raw;
+
+    return WTF::switchOn(value,
+        [&](const CSSPrimitiveValue::Calc& calc) -> StyleType {
+            return toStyle(CSS::UnevaluatedCalc<CSSRaw>(const_cast<CSSPrimitiveValue::Calc&>(calc)), state, std::forward<Rest>(rest)...);
+        },
+        [&](const CSSPrimitiveValue::Raw& raw) -> StyleType {
+            if constexpr (DimensionPercentageNumeric<StyleType>) {
+                using CSSDimensionRaw = typename StyleType::Dimension::CSS::Raw;
+                using CSSPercentageRaw = typename StyleType::Percentage::CSS::Raw;
+
+                if (auto unit = CSSDimensionRaw::UnitTraits::validate(raw.unit))
+                    return toStyle(CSSDimensionRaw(*unit, raw.value), state, std::forward<Rest>(rest)...);
+                if (auto unit = CSSPercentageRaw::UnitTraits::validate(raw.unit))
+                    return toStyle(CSSPercentageRaw(*unit, raw.value), state, std::forward<Rest>(rest)...);
+            } else if constexpr (StyleType::category == CSS::Category::Integer || StyleType::category == CSS::Category::Number) {
+                if (raw.unit == CSSUnitType::CSS_NUMBER || raw.unit == CSSUnitType::CSS_INTEGER)
+                    return toStyle(CSSRaw(raw.value), state, std::forward<Rest>(rest)...);
+            } else {
+                if (auto unit = CSSRaw::UnitTraits::validate(raw.unit))
+                    return toStyle(CSSRaw(*unit, raw.value), state, std::forward<Rest>(rest)...);
+            }
+
+            ASSERT_NOT_REACHED();
+            state.setCurrentPropertyInvalidAtComputedValueTime();
+
+            if constexpr (DimensionPercentageNumeric<StyleType>) {
+                return StyleType { typename StyleType::Dimension { 0 } };
+            } else {
+                return StyleType { 0 };
+            }
+        }
+    );
+}
+
+// NOTE: This overload that takes a `CSSValue` does not constrain `StyleType` to `Numeric` as it
+// is useful for `NumberOrPercentage` and `NumberOrPercentageResolvedToNumber` which do not conform
+// to the `Numeric` concept. It is useful because all it does is forward to a `CSSValueConversion`
+// for the `StyleType` if the value is a `CSSPrimitiveValue`.
+template<typename StyleType, typename... Rest>
+auto convertNumericFromCSSValue(BuilderState& state, const CSSValue& value, Rest&&... rest) -> StyleType
+{
+    RefPtr protectedValue = requiredDowncast<CSSPrimitiveValue>(state, value);
+    if (!protectedValue)
+        return StyleType { 0 };
+    return toStyleFromCSSValue<StyleType>(state, *protectedValue, std::forward<Rest>(rest)...);
+}
 
 template<auto R, typename V> struct CSSValueConversion<Integer<R, V>> {
-    auto operator()(BuilderState& builderState, const CSSPrimitiveValue& value) -> Integer<R, V>
+    using StyleType = Integer<R, V>;
+
+    template<typename... Rest> auto operator()(BuilderState& state, const CSSPrimitiveValue& value, Rest&&... rest) -> StyleType
     {
-        Ref protectedValue = value;
-        return { CSS::clampToRange<R, V>(protectedValue->resolveAsNumber<V>(builderState.cssToLengthConversionData())) };
+        return convertNumericFromCSSValue<StyleType>(state, value, std::forward<Rest>(rest)...);
     }
-    auto operator()(BuilderState& builderState, const CSSValue& value) -> Integer<R, V>
+    template<typename... Rest> auto operator()(BuilderState& state, const CSSValue& value, Rest&&... rest) -> StyleType
     {
-        RefPtr protectedValue = requiredDowncast<CSSPrimitiveValue>(builderState, value);
-        if (!protectedValue)
-            return 0_css_integer;
-        return { CSS::clampToRange<R, V>(protectedValue->resolveAsNumber<V>(builderState.cssToLengthConversionData())) };
+        return convertNumericFromCSSValue<StyleType>(state, value, std::forward<Rest>(rest)...);
     }
 };
 
 template<auto R, typename V> struct CSSValueConversion<Number<R, V>> {
-    auto operator()(BuilderState& builderState, const CSSPrimitiveValue& value) -> Number<R, V>
+    using StyleType = Number<R, V>;
+
+    template<typename... Rest> auto operator()(BuilderState& state, const CSSPrimitiveValue& value, Rest&&... rest) -> Number<R, V>
     {
-        Ref protectedValue = value;
-        return { CSS::clampToRange<R, V>(protectedValue->resolveAsNumber<V>(builderState.cssToLengthConversionData())) };
+        return convertNumericFromCSSValue<StyleType>(state, value, std::forward<Rest>(rest)...);
     }
-    auto operator()(BuilderState& builderState, const CSSValue& value) -> Number<R, V>
+    template<typename... Rest> auto operator()(BuilderState& state, const CSSValue& value, Rest&&... rest) -> Number<R, V>
     {
-        RefPtr protectedValue = requiredDowncast<CSSPrimitiveValue>(builderState, value);
-        if (!protectedValue)
-            return 0_css_number;
-        return { CSS::clampToRange<R, V>(protectedValue->resolveAsNumber<V>(builderState.cssToLengthConversionData())) };
+        return convertNumericFromCSSValue<StyleType>(state, value, std::forward<Rest>(rest)...);
     }
 };
 
 template<auto R, typename V> struct CSSValueConversion<Percentage<R, V>> {
-    auto operator()(BuilderState& builderState, const CSSPrimitiveValue& value) -> Percentage<R, V>
+    using StyleType = Percentage<R, V>;
+
+    template<typename... Rest> auto operator()(BuilderState& state, const CSSPrimitiveValue& value, Rest&&... rest) -> StyleType
     {
-        Ref protectedValue = value;
-        return { CSS::clampToRange<R, V>(protectedValue->resolveAsPercentage<V>(builderState.cssToLengthConversionData())) };
+        return convertNumericFromCSSValue<StyleType>(state, value, std::forward<Rest>(rest)...);
     }
-    auto operator()(BuilderState& builderState, const CSSValue& value) -> Percentage<R, V>
+    template<typename... Rest> auto operator()(BuilderState& state, const CSSValue& value, Rest&&... rest) -> StyleType
     {
-        RefPtr protectedValue = requiredDowncast<CSSPrimitiveValue>(builderState, value);
-        if (!protectedValue)
-            return 0_css_percentage;
-        return { CSS::clampToRange<R, V>(protectedValue->resolveAsPercentage<V>(builderState.cssToLengthConversionData())) };
+        return convertNumericFromCSSValue<StyleType>(state, value, std::forward<Rest>(rest)...);
     }
 };
 
 template<auto R, typename V> struct CSSValueConversion<Angle<R, V>> {
-    auto operator()(BuilderState& builderState, const CSSPrimitiveValue& value) -> Angle<R, V>
+    using StyleType = Angle<R, V>;
+
+    template<typename... Rest> auto operator()(BuilderState& state, const CSSPrimitiveValue& value, Rest&&... rest) -> StyleType
     {
-        Ref protectedValue = value;
-        return { CSS::clampToRange<R, V>(protectedValue->resolveAsAngle<V>(builderState.cssToLengthConversionData())) };
+        return convertNumericFromCSSValue<StyleType>(state, value, std::forward<Rest>(rest)...);
     }
-    auto operator()(BuilderState& builderState, const CSSValue& value) -> Angle<R, V>
+    template<typename... Rest> auto operator()(BuilderState& state, const CSSValue& value, Rest&&... rest) -> StyleType
     {
-        RefPtr protectedValue = requiredDowncast<CSSPrimitiveValue>(builderState, value);
-        if (!protectedValue)
-            return 0_css_deg;
-        return { CSS::clampToRange<R, V>(protectedValue->resolveAsAngle<V>(builderState.cssToLengthConversionData())) };
+        return convertNumericFromCSSValue<StyleType>(state, value, std::forward<Rest>(rest)...);
     }
 };
 
 template<auto R, typename V> struct CSSValueConversion<Length<R, V>> {
-    static auto selectConversionData(BuilderState& builderState) -> CSSToLengthConversionData
-    {
-        if constexpr (R.zoomOptions == CSS::RangeZoomOptions::Default) {
-            return builderState.useSVGZoomRulesForLength()
-                ? builderState.cssToLengthConversionData().copyWithAdjustedZoom(1.0f)
-                : builderState.cssToLengthConversionData();
-        } else if constexpr (R.zoomOptions == CSS::RangeZoomOptions::Unzoomed) {
-            if (evaluationTimeZoomEnabled(builderState))
-                return builderState.cssToLengthConversionData().copyWithAdjustedZoom(1.0f, R.zoomOptions);
+    using StyleType = Length<R, V>;
 
-            return builderState.useSVGZoomRulesForLength()
-                ? builderState.cssToLengthConversionData().copyWithAdjustedZoom(1.0f, R.zoomOptions)
-                : builderState.cssToLengthConversionData();
-        }
-    }
-    auto operator()(BuilderState& builderState, const CSSPrimitiveValue& value) -> Length<R, V>
+    template<typename... Rest> auto operator()(const CSSToLengthConversionData& conversionData, const CSSPrimitiveValue& value, Rest&&... rest) -> Length<R, V>
     {
-        Ref protectedValue = value;
-        auto conversionData = selectConversionData(builderState);
-        return { CSS::clampToRange<R, V>(protectedValue->resolveAsLength<V>(conversionData)) };
+        return convertNumericFromCSSValue<StyleType>(conversionData, value, std::forward<Rest>(rest)...).value_or(StyleType { 0 });
     }
-    auto operator()(BuilderState& builderState, const CSSValue& value) -> Length<R, V>
-    {
-        RefPtr protectedValue = requiredDowncast<CSSPrimitiveValue>(builderState, value);
-        if (!protectedValue)
-            return 0_css_px;
 
-        auto conversionData = selectConversionData(builderState);
-        return { CSS::clampToRange<R, V>(protectedValue->resolveAsLength<V>(conversionData)) };
-    }
-    auto operator()(const CSSToLengthConversionData& conversionData, const CSSPrimitiveValue& value) -> Length<R, V>
+    template<typename... Rest> auto operator()(BuilderState& state, const CSSPrimitiveValue& value, Rest&&... rest) -> StyleType
     {
-        Ref protectedValue = value;
-        return { CSS::clampToRange<R, V>(protectedValue->resolveAsLength<V>(conversionData)) };
+        return convertNumericFromCSSValue<StyleType>(state, value, std::forward<Rest>(rest)...);
+    }
+    template<typename... Rest> auto operator()(BuilderState& state, const CSSValue& value, Rest&&... rest) -> StyleType
+    {
+        return convertNumericFromCSSValue<StyleType>(state, value, std::forward<Rest>(rest)...);
     }
 };
 
 template<auto R, typename V> struct CSSValueConversion<Time<R, V>> {
-    auto operator()(BuilderState& builderState, const CSSPrimitiveValue& value) -> Time<R, V>
+    using StyleType = Time<R, V>;
+
+    template<typename... Rest> auto operator()(BuilderState& state, const CSSPrimitiveValue& value, Rest&&... rest) -> StyleType
     {
-        Ref protectedValue = value;
-        return { CSS::clampToRange<R, V>(protectedValue->resolveAsTime<V>(builderState.cssToLengthConversionData())) };
+        return convertNumericFromCSSValue<StyleType>(state, value, std::forward<Rest>(rest)...);
     }
-    auto operator()(BuilderState& builderState, const CSSValue& value) -> Time<R, V>
+    template<typename... Rest> auto operator()(BuilderState& state, const CSSValue& value, Rest&&... rest) -> StyleType
     {
-        RefPtr protectedValue = requiredDowncast<CSSPrimitiveValue>(builderState, value);
-        if (!protectedValue)
-            return 0_css_s;
-        return { CSS::clampToRange<R, V>(protectedValue->resolveAsTime<V>(builderState.cssToLengthConversionData())) };
+        return convertNumericFromCSSValue<StyleType>(state, value, std::forward<Rest>(rest)...);
     }
 };
 
 template<auto R, typename V> struct CSSValueConversion<Resolution<R, V>> {
-    auto operator()(BuilderState& builderState, const CSSPrimitiveValue& value) -> Resolution<R, V>
+    using StyleType = Resolution<R, V>;
+
+    template<typename... Rest> auto operator()(BuilderState& state, const CSSPrimitiveValue& value, Rest&&... rest) -> StyleType
     {
-        Ref protectedValue = value;
-        return { CSS::clampToRange<R, V>(protectedValue->resolveAsResolution<V>(builderState.cssToLengthConversionData())) };
+        return convertNumericFromCSSValue<StyleType>(state, value, std::forward<Rest>(rest)...);
     }
-    auto operator()(BuilderState& builderState, const CSSValue& value) -> Resolution<R, V>
+    template<typename... Rest> auto operator()(BuilderState& state, const CSSValue& value, Rest&&... rest) -> StyleType
     {
-        RefPtr protectedValue = requiredDowncast<CSSPrimitiveValue>(builderState, value);
-        if (!protectedValue)
-            return 0_css_dppx;
-        return { CSS::clampToRange<R, V>(protectedValue->resolveAsResolution<V>(builderState.cssToLengthConversionData())) };
+        return convertNumericFromCSSValue<StyleType>(state, value, std::forward<Rest>(rest)...);
     }
 };
 
 template<auto R, typename V> struct CSSValueConversion<Flex<R, V>> {
-    auto operator()(BuilderState& builderState, const CSSPrimitiveValue& value) -> Flex<R, V>
+    using StyleType = Flex<R, V>;
+
+    template<typename... Rest> auto operator()(BuilderState& state, const CSSPrimitiveValue& value, Rest&&... rest) -> StyleType
     {
-        Ref protectedValue = value;
-        return { CSS::clampToRange<R, V>(protectedValue->resolveAsFlex<V>(builderState.cssToLengthConversionData())) };
+        return convertNumericFromCSSValue<StyleType>(state, value, std::forward<Rest>(rest)...);
     }
-    auto operator()(BuilderState& builderState, const CSSValue& value) -> Flex<R, V>
+    template<typename... Rest> auto operator()(BuilderState& state, const CSSValue& value, Rest&&... rest) -> StyleType
     {
-        RefPtr protectedValue = requiredDowncast<CSSPrimitiveValue>(builderState, value);
-        if (!protectedValue)
-            return 0_css_fr;
-        return { CSS::clampToRange<R, V>(protectedValue->resolveAsFlex<V>(builderState.cssToLengthConversionData())) };
+        return convertNumericFromCSSValue<StyleType>(state, value, std::forward<Rest>(rest)...);
     }
 };
 
 template<auto R, typename V> struct CSSValueConversion<LengthPercentage<R, V>> {
     using StyleType = LengthPercentage<R, V>;
 
-    static auto selectConversionData(BuilderState& builderState) -> CSSToLengthConversionData
+    template<typename... Rest> auto operator()(BuilderState& state, const CSSPrimitiveValue& value, Rest&&... rest) -> StyleType
     {
-        if constexpr (StyleType::Dimension::range.zoomOptions == CSS::RangeZoomOptions::Default) {
-            return builderState.useSVGZoomRulesForLength()
-                ? builderState.cssToLengthConversionData().copyWithAdjustedZoom(1.0f)
-                : builderState.cssToLengthConversionData();
-        } else if constexpr (LengthPercentage<R, V>::Dimension::range.zoomOptions == CSS::RangeZoomOptions::Unzoomed) {
-            if (evaluationTimeZoomEnabled(builderState))
-                return builderState.cssToLengthConversionData().copyWithAdjustedZoom(1.0f);
-
-            return builderState.useSVGZoomRulesForLength()
-                ? builderState.cssToLengthConversionData().copyWithAdjustedZoom(1.0f)
-                : builderState.cssToLengthConversionData();
-        }
+        return convertNumericFromCSSValue<StyleType>(state, value, std::forward<Rest>(rest)...);
     }
-    auto operator()(BuilderState& builderState, const CSSPrimitiveValue& value) -> StyleType
+    template<typename... Rest> auto operator()(BuilderState& state, const CSSValue& value, Rest&&... rest) -> StyleType
     {
-        Ref protectedValue = value;
-        auto conversionData = selectConversionData(builderState);
-        if (protectedValue->isPercentage())
-            return typename StyleType::Percentage { CSS::clampToRange<R, V>(protectedValue->resolveAsPercentage<V>(conversionData)) };
-        if (protectedValue->isCalculatedPercentageWithLength())
-            return typename StyleType::Calc { protect(protectedValue->cssCalcValue())->createCalculationValue(conversionData, CSSCalcSymbolTable { }) };
-        return typename StyleType::Dimension { CSS::clampToRange<R, V>(protectedValue->resolveAsLength<V>(conversionData)) };
-    }
-    auto operator()(BuilderState& builderState, const CSSValue& value) -> StyleType
-    {
-        RefPtr protectedValue = requiredDowncast<CSSPrimitiveValue>(builderState, value);
-        if (!protectedValue)
-            return 0_css_px;
-        auto conversionData = selectConversionData(builderState);
-        if (protectedValue->isPercentage())
-            return typename StyleType::Percentage { CSS::clampToRange<R, V>(protectedValue->resolveAsPercentage<V>(conversionData)) };
-        if (protectedValue->isCalculatedPercentageWithLength())
-            return typename StyleType::Calc { protect(protectedValue->cssCalcValue())->createCalculationValue(conversionData, CSSCalcSymbolTable { }) };
-        return typename StyleType::Dimension { CSS::clampToRange<R, V>(protectedValue->resolveAsLength<V>(conversionData)) };
+        return convertNumericFromCSSValue<StyleType>(state, value, std::forward<Rest>(rest)...);
     }
 };
 
 template<auto nR, auto pR, typename V> struct CSSValueConversion<NumberOrPercentage<nR, pR, V>> {
     using StyleType = NumberOrPercentage<nR, pR, V>;
 
-    auto operator()(BuilderState& builderState, const CSSPrimitiveValue& value) -> StyleType
+    template<typename... Rest> auto operator()(BuilderState& state, const CSSPrimitiveValue& value, Rest&&... rest) -> StyleType
     {
-        Ref protectedValue = value;
-
-        auto& conversionData = builderState.cssToLengthConversionData();
-        if (protectedValue->isPercentage())
-            return typename StyleType::Percentage { CSS::clampToRange<pR, V>(protectedValue->resolveAsPercentage<V>(conversionData)) };
-        return typename StyleType::Number { CSS::clampToRange<nR, V>(protectedValue->resolveAsNumber<V>(conversionData)) };
+        if (value.isPercentage())
+            return toStyleFromCSSValue<typename StyleType::Percentage>(state, value, std::forward<Rest>(rest)...);
+        return toStyleFromCSSValue<typename StyleType::Number>(state, value, std::forward<Rest>(rest)...);
     }
-    auto operator()(BuilderState& builderState, const CSSValue& value) -> StyleType
+    template<typename... Rest> auto operator()(BuilderState& state, const CSSValue& value, Rest&&... rest) -> StyleType
     {
-        RefPtr protectedValue = requiredDowncast<CSSPrimitiveValue>(builderState, value);
-        if (!protectedValue)
-            return 0_css_number;
-
-        auto& conversionData = builderState.cssToLengthConversionData();
-        if (protectedValue->isPercentage())
-            return typename StyleType::Percentage { CSS::clampToRange<pR, V>(protectedValue->resolveAsPercentage<V>(conversionData)) };
-        return typename StyleType::Number { CSS::clampToRange<nR, V>(protectedValue->resolveAsNumber<V>(conversionData)) };
+        return convertNumericFromCSSValue<StyleType>(state, value, std::forward<Rest>(rest)...);
     }
 };
 
 template<auto nR, auto pR, typename V> struct CSSValueConversion<NumberOrPercentageResolvedToNumber<nR, pR, V>> {
     using StyleType = NumberOrPercentageResolvedToNumber<nR, pR, V>;
 
-    auto operator()(BuilderState& builderState, const CSSPrimitiveValue& value) -> StyleType
+    template<typename... Rest> auto operator()(BuilderState& state, const CSSPrimitiveValue& value, Rest&&... rest) -> StyleType
     {
-        Ref protectedValue = value;
-
-        auto& conversionData = builderState.cssToLengthConversionData();
-        if (protectedValue->isPercentage())
-            return typename StyleType::Percentage { CSS::clampToRange<pR, V>(protectedValue->resolveAsPercentage<V>(conversionData)) };
-        return typename StyleType::Number { CSS::clampToRange<nR, V>(protectedValue->resolveAsNumber<V>(conversionData)) };
+        if (value.isPercentage())
+            return toStyleFromCSSValue<typename StyleType::Percentage>(state, value, std::forward<Rest>(rest)...);
+        return toStyleFromCSSValue<typename StyleType::Number>(state, value, std::forward<Rest>(rest)...);
     }
-    auto operator()(BuilderState& builderState, const CSSValue& value) -> StyleType
+    template<typename... Rest> auto operator()(BuilderState& state, const CSSValue& value, Rest&&... rest) -> StyleType
     {
-        RefPtr protectedValue = requiredDowncast<CSSPrimitiveValue>(builderState, value);
-        if (!protectedValue)
-            return 0_css_number;
-
-        auto& conversionData = builderState.cssToLengthConversionData();
-        if (protectedValue->isPercentage())
-            return typename StyleType::Percentage { CSS::clampToRange<pR, V>(protectedValue->resolveAsPercentage<V>(conversionData)) };
-        return typename StyleType::Number { CSS::clampToRange<nR, V>(protectedValue->resolveAsNumber<V>(conversionData)) };
+        return convertNumericFromCSSValue<StyleType>(state, value, std::forward<Rest>(rest)...);
     }
 };
 

--- a/Source/WebCore/style/values/primitives/StylePrimitiveNumericTypes+Conversions.cpp
+++ b/Source/WebCore/style/values/primitives/StylePrimitiveNumericTypes+Conversions.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 Samuel Weinig <sam@webkit.org>
+ * Copyright (C) 2024-2026 Samuel Weinig <sam@webkit.org>
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -43,21 +43,6 @@ double canonicalizeLength(double value, CSS::LengthUnit unit, NoConversionDataRe
 double canonicalizeLength(double value, CSS::LengthUnit unit, const CSSToLengthConversionData& conversionData)
 {
     return computeNonCalcLengthDouble(value, unit, conversionData);
-}
-
-float clampLengthToAllowedLimits(double value)
-{
-    return clampTo<float>(narrowPrecisionToFloat(value), minValueForCssLength, maxValueForCssLength);
-}
-
-float canonicalizeAndClampLength(double value, CSS::LengthUnit unit, NoConversionDataRequiredToken token)
-{
-    return clampLengthToAllowedLimits(canonicalizeLength(value, unit, token));
-}
-
-float canonicalizeAndClampLength(double value, CSS::LengthUnit unit, const CSSToLengthConversionData& conversionData)
-{
-    return clampLengthToAllowedLimits(canonicalizeLength(value, unit, conversionData));
 }
 
 // MARK: ToCSS utilities

--- a/Source/WebCore/style/values/primitives/StylePrimitiveNumericTypes+Conversions.h
+++ b/Source/WebCore/style/values/primitives/StylePrimitiveNumericTypes+Conversions.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 Samuel Weinig <sam@webkit.org>
+ * Copyright (C) 2024-2026 Samuel Weinig <sam@webkit.org>
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -38,7 +38,9 @@
 namespace WebCore {
 namespace Style {
 
-// Out of line to avoid inclusion of RenderStyle+GettersInlines.h
+// Out of line to avoid additional includes.
+double canonicalizeLength(double, CSS::LengthUnit, NoConversionDataRequiredToken);
+double canonicalizeLength(double, CSS::LengthUnit, const CSSToLengthConversionData&);
 float NODELETE adjustForZoom(float, const RenderStyle&);
 bool NODELETE evaluationTimeZoomEnabled(const RenderStyle&);
 bool NODELETE evaluationTimeZoomEnabled(const BuilderState&);
@@ -52,7 +54,7 @@ template<typename T> struct ConversionDataSpecializer {
     }
 };
 
-template<auto R, typename V> struct ConversionDataSpecializer<CSS::LengthRaw<R, V>> {
+template<auto R, typename V> struct ConversionDataSpecializer<Style::Length<R, V>> {
     CSSToLengthConversionData operator()(const BuilderState& state)
     {
         if constexpr (R.zoomOptions == CSS::RangeZoomOptions::Default) {
@@ -70,7 +72,7 @@ template<auto R, typename V> struct ConversionDataSpecializer<CSS::LengthRaw<R, 
     }
 };
 
-template<auto R, typename V> struct ConversionDataSpecializer<CSS::LengthPercentageRaw<R, V>> {
+template<auto R, typename V> struct ConversionDataSpecializer<Style::LengthPercentage<R, V>> {
     CSSToLengthConversionData operator()(const BuilderState& state)
     {
         if constexpr (R.zoomOptions == CSS::RangeZoomOptions::Default) {
@@ -118,147 +120,71 @@ template<CSS::Numeric T> struct CSSToRawMapping {
 
 // MARK: - Raw canonicalization
 
-// MARK: Length
-
-double canonicalizeLength(double, CSS::LengthUnit, NoConversionDataRequiredToken);
-double canonicalizeLength(double, CSS::LengthUnit, const CSSToLengthConversionData&);
-float NODELETE clampLengthToAllowedLimits(double);
-float canonicalizeAndClampLength(double, CSS::LengthUnit, NoConversionDataRequiredToken);
-float canonicalizeAndClampLength(double, CSS::LengthUnit, const CSSToLengthConversionData&);
-
-template<auto R, typename V, typename... Rest> constexpr Integer<R, V> canonicalize(const CSS::IntegerRaw<R, V>& raw, NoConversionDataRequiredToken, Rest&&...)
+template<auto R, typename V, typename... Rest> constexpr Integer<R, V> canonicalize(const CSS::IntegerRaw<R, V>& raw, Rest&&...)
 {
-    return { clampTo<V>(raw.value) };
+    return { CSS::clampToRangeOf<Integer<R, V>>(CSS::canonicalize(raw)) };
 }
 
-template<auto R, typename V, typename... Rest> constexpr Integer<R, V> canonicalize(const CSS::IntegerRaw<R, V>& raw, const CSSToLengthConversionData&, Rest&&... rest)
+template<auto R, typename V, typename... Rest> constexpr Number<R, V> canonicalize(const CSS::NumberRaw<R, V>& raw, Rest&&...)
 {
-    return canonicalize(raw, NoConversionDataRequiredToken { }, std::forward<Rest>(rest)...);
+    return { CSS::clampToRangeOf<Number<R, V>>(CSS::canonicalize(raw)) };
 }
 
-template<auto R, typename V, typename... Rest> constexpr Number<R, V> canonicalize(const CSS::NumberRaw<R, V>& raw, NoConversionDataRequiredToken, Rest&&...)
+template<auto R, typename V, typename... Rest> constexpr Percentage<R, V> canonicalize(const CSS::PercentageRaw<R, V>& raw, Rest&&...)
 {
-    return { raw.value };
+    return { CSS::clampToRangeOf<Percentage<R, V>>(CSS::canonicalize(raw)) };
 }
 
-template<auto R, typename V, typename... Rest> constexpr Number<R, V> canonicalize(const CSS::NumberRaw<R, V>& raw, const CSSToLengthConversionData&, Rest&&... rest)
+template<auto R, typename V, typename... Rest> Angle<R, V> canonicalize(const CSS::AngleRaw<R, V>& raw, Rest&&...)
 {
-    return canonicalize(raw, NoConversionDataRequiredToken { }, std::forward<Rest>(rest)...);
+    return { CSS::clampToRangeOf<Angle<R, V>>(CSS::canonicalize(raw)) };
 }
 
-template<auto R, typename V, typename... Rest> constexpr Percentage<R, V> canonicalize(const CSS::PercentageRaw<R, V>& raw, NoConversionDataRequiredToken, Rest&&...)
+template<auto R, typename V, typename... Rest> Time<R, V> canonicalize(const CSS::TimeRaw<R, V>& raw, Rest&&...)
 {
-    return { static_cast<V>(raw.value) };
+    return { CSS::clampToRangeOf<Time<R, V>>(CSS::canonicalize(raw)) };
 }
 
-template<auto R, typename V, typename... Rest> constexpr Percentage<R, V> canonicalize(const CSS::PercentageRaw<R, V>& raw, const CSSToLengthConversionData&, Rest&&... rest)
+template<auto R, typename V, typename... Rest> Frequency<R, V> canonicalize(const CSS::FrequencyRaw<R, V>& raw, Rest&&...)
 {
-    return canonicalize(raw, NoConversionDataRequiredToken { }, std::forward<Rest>(rest)...);
+    return { CSS::clampToRangeOf<Frequency<R, V>>(CSS::canonicalize(raw)) };
 }
 
-template<auto R, typename V, typename... Rest> Angle<R, V> canonicalize(const CSS::AngleRaw<R, V>& raw, NoConversionDataRequiredToken, Rest&&...)
+template<auto R, typename V, typename... Rest> Resolution<R, V> canonicalize(const CSS::ResolutionRaw<R, V>& raw, Rest&&...)
 {
-    return { static_cast<V>(CSS::canonicalize(raw)) };
+    return { CSS::clampToRangeOf<Resolution<R, V>>(CSS::canonicalize(raw)) };
 }
 
-template<auto R, typename V, typename... Rest> Angle<R, V> canonicalize(const CSS::AngleRaw<R, V>& raw, const CSSToLengthConversionData&, Rest&&... rest)
+template<auto R, typename V, typename... Rest> constexpr Flex<R, V> canonicalize(const CSS::FlexRaw<R, V>& raw, Rest&&...)
 {
-    return canonicalize(raw, NoConversionDataRequiredToken { }, std::forward<Rest>(rest)...);
+    return { CSS::clampToRangeOf<Flex<R, V>>(CSS::canonicalize(raw)) };
 }
 
-template<auto R, typename V, typename... Rest> Length<R, V> canonicalize(const CSS::LengthRaw<R, V>& raw, NoConversionDataRequiredToken token, Rest&&... rest)
+template<auto R, typename V, typename... Rest> Length<R, V> canonicalize(const CSS::LengthRaw<R, V>& raw, Rest&&... rest)
 {
-    ASSERT(!requiresConversionData(raw));
-
-    return { canonicalizeAndClampLength(raw.value, raw.unit, token, std::forward<Rest>(rest)...) };
+    return { CSS::clampToRangeOf<Length<R, V>>(canonicalizeLength(raw.value, raw.unit, std::forward<Rest>(rest)...)) };
 }
 
-template<auto R, typename V, typename... Rest> Length<R, V> canonicalize(const CSS::LengthRaw<R, V>& raw, const CSSToLengthConversionData& conversionData, Rest&&...)
-{
-    ASSERT(CSS::collectComputedStyleDependencies(raw).canResolveDependenciesWithConversionData(conversionData));
-
-    return { canonicalizeAndClampLength(raw.value, raw.unit, conversionData) };
-}
-
-template<auto R, typename V, typename... Rest> Time<R, V> canonicalize(const CSS::TimeRaw<R, V>& raw, NoConversionDataRequiredToken, Rest&&...)
-{
-    return { static_cast<V>(CSS::canonicalize(raw)) };
-}
-
-template<auto R, typename V, typename... Rest> Time<R, V> canonicalize(const CSS::TimeRaw<R, V>& raw, const CSSToLengthConversionData&, Rest&&... rest)
-{
-    return canonicalize(raw, NoConversionDataRequiredToken { }, std::forward<Rest>(rest)...);
-}
-
-template<auto R, typename V, typename... Rest> Frequency<R, V> canonicalize(const CSS::FrequencyRaw<R, V>& raw, NoConversionDataRequiredToken, Rest&&...)
-{
-    return { static_cast<V>(CSS::canonicalize(raw)) };
-}
-
-template<auto R, typename V, typename... Rest> Frequency<R, V> canonicalize(const CSS::FrequencyRaw<R, V>& raw, const CSSToLengthConversionData&, Rest&&... rest)
-{
-    return canonicalize(raw, NoConversionDataRequiredToken { }, std::forward<Rest>(rest)...);
-}
-
-template<auto R, typename V, typename... Rest> Resolution<R, V> canonicalize(const CSS::ResolutionRaw<R, V>& raw, NoConversionDataRequiredToken, Rest&&...)
-{
-    return { static_cast<V>(CSS::canonicalize(raw)) };
-}
-
-template<auto R, typename V, typename... Rest> Resolution<R, V> canonicalize(const CSS::ResolutionRaw<R, V>& raw, const CSSToLengthConversionData&, Rest&&... rest)
-{
-    return canonicalize(raw, NoConversionDataRequiredToken { }, std::forward<Rest>(rest)...);
-}
-
-template<auto R, typename V, typename... Rest> constexpr Flex<R, V> canonicalize(const CSS::FlexRaw<R, V>& raw, NoConversionDataRequiredToken, Rest&&...)
-{
-    return { static_cast<V>(raw.value) };
-}
-
-template<auto R, typename V, typename... Rest> constexpr Flex<R, V> canonicalize(const CSS::FlexRaw<R, V>& raw, const CSSToLengthConversionData&, Rest&&... rest)
-{
-    return canonicalize(raw, NoConversionDataRequiredToken { }, std::forward<Rest>(rest)...);
-}
-
-template<auto R, typename V, typename... Rest> AnglePercentage<R, V> canonicalize(const CSS::AnglePercentageRaw<R, V>& raw, NoConversionDataRequiredToken token, Rest&&... rest)
+template<auto R, typename V, typename... Rest> AnglePercentage<R, V> canonicalize(const CSS::AnglePercentageRaw<R, V>& raw, Rest&&... rest)
 {
     return CSS::switchOnUnitType(raw.unit,
         [&](CSS::PercentageUnit) -> AnglePercentage<R, V> {
-            return { canonicalize(CSS::PercentageRaw<R, V> { raw.value }, token, std::forward<Rest>(rest)...) };
+            return { canonicalize(CSS::PercentageRaw<R, V> { raw.value }, std::forward<Rest>(rest)...) };
         },
         [&](CSS::AngleUnit angleUnit) -> AnglePercentage<R, V> {
-            return { canonicalize(CSS::AngleRaw<R, V> { angleUnit, raw.value }, token, std::forward<Rest>(rest)...) };
+            return { canonicalize(CSS::AngleRaw<R, V> { angleUnit, raw.value }, std::forward<Rest>(rest)...) };
         }
     );
 }
 
-template<auto R, typename V, typename... Rest> AnglePercentage<R, V> canonicalize(const CSS::AnglePercentageRaw<R, V>& raw, const CSSToLengthConversionData&, Rest&&... rest)
-{
-    return canonicalize(raw, NoConversionDataRequiredToken { }, std::forward<Rest>(rest)...);
-}
-
-template<auto R, typename V, typename... Rest> LengthPercentage<R, V> canonicalize(const CSS::LengthPercentageRaw<R, V>& raw, NoConversionDataRequiredToken token, Rest&&... rest)
+template<auto R, typename V, typename... Rest> LengthPercentage<R, V> canonicalize(const CSS::LengthPercentageRaw<R, V>& raw, Rest&&... rest)
 {
     return CSS::switchOnUnitType(raw.unit,
         [&](CSS::PercentageUnit) -> LengthPercentage<R, V> {
-            return canonicalize(CSS::PercentageRaw<R, V> { raw.value }, token, std::forward<Rest>(rest)...);
+            return canonicalize(CSS::PercentageRaw<R, V> { raw.value }, std::forward<Rest>(rest)...);
         },
         [&](CSS::LengthUnit lengthUnit) -> LengthPercentage<R, V> {
-            return canonicalize(CSS::LengthRaw<R, V> { lengthUnit, raw.value }, token, std::forward<Rest>(rest)...);
-        }
-    );
-}
-
-template<auto R, typename V, typename... Rest> LengthPercentage<R, V> canonicalize(const CSS::LengthPercentageRaw<R, V>& raw, const CSSToLengthConversionData& conversionData, Rest&&... rest)
-{
-    // ASSERT(CSS::collectComputedStyleDependencies(raw).canResolveDependenciesWithConversionData(conversionData));
-
-    return CSS::switchOnUnitType(raw.unit,
-        [&](CSS::PercentageUnit) -> LengthPercentage<R, V> {
-            return canonicalize(CSS::PercentageRaw<R, V> { raw.value }, conversionData, std::forward<Rest>(rest)...);
-        },
-        [&](CSS::LengthUnit lengthUnit) -> LengthPercentage<R, V> {
-            return canonicalize(CSS::LengthRaw<R, V> { lengthUnit, raw.value }, conversionData, std::forward<Rest>(rest)...);
+            return canonicalize(CSS::LengthRaw<R, V> { lengthUnit, raw.value }, std::forward<Rest>(rest)...);
         }
     );
 }
@@ -351,6 +277,42 @@ template<auto nR, auto pR, typename V> struct ToCSS<NumberOrPercentageResolvedTo
 
 // MARK: - Conversion from CSS -> Style
 
+// Integer and Number require specialized implementations to allow for either <integer> or <number> category values.
+
+template<auto R, typename V> struct ToStyle<CSS::UnevaluatedCalc<CSS::IntegerRaw<R, V>>> {
+    using From = CSS::UnevaluatedCalc<CSS::IntegerRaw<R, V>>;
+    using To = Integer<R, V>;
+
+    template<typename... Rest> auto operator()(const From& value, Rest&&... rest) -> To
+    {
+        ASSERT(value.calcValue().category() == CSS::Category::Number || value.calcValue().category() == CSS::Category::Integer);
+        return { canonicalize(CSS::IntegerRaw<R, V> { To::unit, value.evaluate(value.calcValue().category(), rest...) }, rest...) };
+    }
+
+    // Implement `BuilderState` overload to explicitly forward to the `CSSToLengthConversionData` overload.
+    template<typename... Rest> auto operator()(const From& value, const BuilderState& state, Rest&&... rest) -> To
+    {
+        return toStyle(value, conversionData<To>(state), std::forward<Rest>(rest)...);
+    }
+};
+
+template<auto R, typename V> struct ToStyle<CSS::UnevaluatedCalc<CSS::NumberRaw<R, V>>> {
+    using From = CSS::UnevaluatedCalc<CSS::NumberRaw<R, V>>;
+    using To = Number<R, V>;
+
+    template<typename... Rest> auto operator()(const From& value, Rest&&... rest) -> To
+    {
+        ASSERT(value.calcValue().category() == CSS::Category::Number || value.calcValue().category() == CSS::Category::Integer);
+        return { canonicalize(CSS::NumberRaw<R, V> { To::unit, value.evaluate(value.calcValue().category(), rest...) }, rest...) };
+    }
+
+    // Implement `BuilderState` overload to explicitly forward to the `CSSToLengthConversionData` overload.
+    template<typename... Rest> auto operator()(const From& value, const BuilderState& state, Rest&&... rest) -> To
+    {
+        return toStyle(value, conversionData<To>(state), std::forward<Rest>(rest)...);
+    }
+};
+
 // AnglePercentage and LengthPercentage require specialized implementations for their calc canonicalization.
 
 template<auto R, typename V> struct ToStyle<CSS::UnevaluatedCalc<CSS::AnglePercentageRaw<R, V>>> {
@@ -392,6 +354,12 @@ template<auto R, typename V> struct ToStyle<CSS::UnevaluatedCalc<CSS::AnglePerce
             return canonicalize(CSS::PercentageRaw<R, V> { doubleValue }, std::forward<Rest>(rest)...);
         }
         return typename To::Calc { simplifiedCalc->createCalculationValue(std::forward<Rest>(rest)...) };
+    }
+
+    // Implement `BuilderState` overload to explicitly forward to the `CSSToLengthConversionData` overload.
+    template<typename... Rest> auto operator()(const From& value, const BuilderState& state, Rest&&... rest) -> To
+    {
+        return toStyle(value, conversionData<To>(state), std::forward<Rest>(rest)...);
     }
 };
 
@@ -435,6 +403,12 @@ template<auto R, typename V> struct ToStyle<CSS::UnevaluatedCalc<CSS::LengthPerc
         }
         return typename To::Calc { simplifiedCalc->createCalculationValue(std::forward<Rest>(rest)...) };
     }
+
+    // Implement `BuilderState` overload to explicitly forward to the `CSSToLengthConversionData` overload.
+    template<typename... Rest> auto operator()(const From& value, const BuilderState& state, Rest&&... rest) -> To
+    {
+        return toStyle(value, conversionData<To>(state), std::forward<Rest>(rest)...);
+    }
 };
 
 // Partial specialization for remaining numeric types.
@@ -447,6 +421,12 @@ template<CSS::NumericRaw RawType> struct ToStyle<RawType> {
     {
         return { canonicalize(value, std::forward<Rest>(rest)...) };
     }
+
+    // Implement `BuilderState` overload to explicitly forward to the `CSSToLengthConversionData` overload.
+    template<typename... Rest> auto operator()(const From& value, const BuilderState& state, Rest&&... rest) -> To
+    {
+        return toStyle(value, conversionData<To>(state), std::forward<Rest>(rest)...);
+    }
 };
 
 template<CSS::NumericRaw RawType> struct ToStyle<CSS::UnevaluatedCalc<RawType>> {
@@ -456,6 +436,12 @@ template<CSS::NumericRaw RawType> struct ToStyle<CSS::UnevaluatedCalc<RawType>> 
     template<typename... Rest> auto operator()(const From& value, Rest&&... rest) -> To
     {
         return { canonicalize(RawType { To::unit, value.evaluate(From::category, rest...) }, rest...) };
+    }
+
+    // Implement `BuilderState` overload to explicitly forward to the `CSSToLengthConversionData` overload.
+    template<typename... Rest> auto operator()(const From& value, const BuilderState& state, Rest&&... rest) -> To
+    {
+        return toStyle(value, conversionData<To>(state), std::forward<Rest>(rest)...);
     }
 };
 
@@ -467,12 +453,6 @@ template<CSS::Numeric NumericType> struct ToStyle<NumericType> {
     {
         return WTF::switchOn(value, [&](const auto& value) -> To { return toStyle(value, std::forward<Rest>(rest)...); });
     }
-
-    // Implement `BuilderState` overload to explicitly forward to the `CSSToLengthConversionData` overload.
-    template<typename... Rest> auto operator()(const From& value, const BuilderState& state, Rest&&... rest) -> To
-    {
-        return toStyle(value, conversionData<typename From::Raw>(state), std::forward<Rest>(rest)...);
-    }
 };
 
 // NumberOrPercentageResolvedToNumber, as the name implies, resolves its percentage to a number.
@@ -482,11 +462,7 @@ template<auto nR, auto pR, typename V> struct ToStyle<CSS::NumberOrPercentageRes
 
     template<typename... Rest> auto operator()(const From& value, Rest&&... rest) -> To
     {
-        return WTF::switchOn(value,
-            [&](const auto& numberOrPercentage) -> To {
-                return { toStyle(numberOrPercentage, std::forward<Rest>(rest)...) };
-            }
-        );
+        return WTF::switchOn(value, [&](const auto& value) -> To { return toStyle(value, std::forward<Rest>(rest)...); });
     }
 };
 

--- a/Source/WebCore/style/values/primitives/StylePrimitiveNumericTypes+Evaluation.h
+++ b/Source/WebCore/style/values/primitives/StylePrimitiveNumericTypes+Evaluation.h
@@ -444,7 +444,7 @@ template<auto R, typename V> auto reflect(const LengthPercentage<R, V>& value) -
 // Merges the two ranges, `aR` and `bR`, creating a union of their ranges.
 consteval CSS::Range mergeRanges(CSS::Range aR, CSS::Range bR)
 {
-    return CSS::Range { std::min(aR.min, bR.min), std::max(aR.max, bR.max), aR.clampOptions, aR.zoomOptions };
+    return CSS::Range { std::min(aR.min, bR.min), std::max(aR.max, bR.max), aR.minParseTimeBehavior, aR.maxParseTimeBehavior, aR.zoomOptions };
 }
 
 // Convert to `calc(100% - (a + b))`.
@@ -452,7 +452,8 @@ consteval CSS::Range mergeRanges(CSS::Range aR, CSS::Range bR)
 // Returns a LengthPercentage with range, `resultR`, equal to union of the two input ranges `aR` and `bR`.
 template<auto aR, auto bR, typename V> auto reflectSum(const LengthPercentage<aR, V>& a, const LengthPercentage<bR, V>& b) -> LengthPercentage<mergeRanges(aR, bR), V>
 {
-    static_assert(aR.clampOptions == bR.clampOptions);
+    static_assert(aR.minParseTimeBehavior == bR.minParseTimeBehavior);
+    static_assert(aR.maxParseTimeBehavior == bR.maxParseTimeBehavior);
     static_assert(aR.zoomOptions == bR.zoomOptions);
 
     constexpr auto resultR = mergeRanges(aR, bR);

--- a/Source/WebCore/style/values/sizing/StyleContainIntrinsicSize.cpp
+++ b/Source/WebCore/style/values/sizing/StyleContainIntrinsicSize.cpp
@@ -29,6 +29,7 @@
 #include "CSSPrimitiveValue.h"
 #include "StyleBuilderChecking.h"
 #include "StylePrimitiveNumericTypes+Blending.h"
+#include "StylePrimitiveNumericTypes+CSSValueConversion.h"
 
 namespace WebCore {
 namespace Style {
@@ -45,11 +46,8 @@ auto CSSValueConversion<ContainIntrinsicSize>::operator()(BuilderState& state, c
         }
     }
 
-    if (auto* primitiveValue = dynamicDowncast<CSSPrimitiveValue>(value)) {
-        return ContainIntrinsicSize::Length {
-            primitiveValue->resolveAsLength<float>(state.cssToLengthConversionData().copyWithAdjustedZoom(1.0f))
-        };
-    }
+    if (auto* primitiveValue = dynamicDowncast<CSSPrimitiveValue>(value))
+        return toStyleFromCSSValue<ContainIntrinsicSize::Length>(state.cssToLengthConversionData().copyWithAdjustedZoom(1.0f), *primitiveValue);
 
     auto pair = requiredPairDowncast<CSSKeywordValue, CSSValue>(state, value);
     if (!pair)
@@ -73,9 +71,7 @@ auto CSSValueConversion<ContainIntrinsicSize>::operator()(BuilderState& state, c
     if (RefPtr primitiveSecondValue = dynamicDowncast<CSSPrimitiveValue>(pair->second)) {
         return {
             CSS::Keyword::Auto { },
-            ContainIntrinsicSize::Length {
-                primitiveSecondValue->resolveAsLength<float>(state.cssToLengthConversionData().copyWithAdjustedZoom(1.0f))
-            }
+            toStyleFromCSSValue<ContainIntrinsicSize::Length>(state.cssToLengthConversionData().copyWithAdjustedZoom(1.0f), *primitiveSecondValue),
         };
     }
 

--- a/Source/WebCore/style/values/sizing/StyleMaximumSize.h
+++ b/Source/WebCore/style/values/sizing/StyleMaximumSize.h
@@ -46,7 +46,7 @@ namespace Style {
 //
 // https://drafts.csswg.org/css-sizing-3/#max-size-properties
 // https://drafts.csswg.org/css-sizing-4/#sizing-values (additional values added)
-struct MaximumSize : LengthWrapperBase<LengthPercentage<CSS::NonnegativeUnzoomed>, CSS::Keyword::None, CSS::Keyword::MinContent, CSS::Keyword::MaxContent, CSS::Keyword::FitContent, CSS::Keyword::Stretch, CSS::Keyword::Intrinsic, CSS::Keyword::MinIntrinsic> {
+struct MaximumSize : LengthWrapperBase<LengthPercentage<CSS::NonnegativeLayoutUnitClampedUnzoomed>, CSS::Keyword::None, CSS::Keyword::MinContent, CSS::Keyword::MaxContent, CSS::Keyword::FitContent, CSS::Keyword::Stretch, CSS::Keyword::Intrinsic, CSS::Keyword::MinIntrinsic> {
     using Base::Base;
 
     ALWAYS_INLINE bool isNone() const { return holdsAlternative<CSS::Keyword::None>(); }

--- a/Source/WebCore/style/values/sizing/StyleMinimumSize.h
+++ b/Source/WebCore/style/values/sizing/StyleMinimumSize.h
@@ -48,7 +48,7 @@ struct PreferredSize;
 //
 // https://drafts.csswg.org/css-sizing-3/#min-size-properties
 // https://drafts.csswg.org/css-sizing-4/#sizing-values (additional values added)
-struct MinimumSize : LengthWrapperBase<LengthPercentage<CSS::NonnegativeUnzoomed>, CSS::Keyword::Auto, CSS::Keyword::MinContent, CSS::Keyword::MaxContent, CSS::Keyword::FitContent, CSS::Keyword::Stretch, CSS::Keyword::Intrinsic, CSS::Keyword::MinIntrinsic> {
+struct MinimumSize : LengthWrapperBase<LengthPercentage<CSS::NonnegativeLayoutUnitClampedUnzoomed>, CSS::Keyword::Auto, CSS::Keyword::MinContent, CSS::Keyword::MaxContent, CSS::Keyword::FitContent, CSS::Keyword::Stretch, CSS::Keyword::Intrinsic, CSS::Keyword::MinIntrinsic> {
     using Base::Base;
 
     ALWAYS_INLINE bool isAuto() const { return holdsAlternative<CSS::Keyword::Auto>(); }

--- a/Source/WebCore/style/values/sizing/StylePreferredSize.h
+++ b/Source/WebCore/style/values/sizing/StylePreferredSize.h
@@ -49,7 +49,7 @@ struct MinimumSize;
 //
 // https://drafts.csswg.org/css-sizing-3/#preferred-size-properties
 // https://drafts.csswg.org/css-sizing-4/#sizing-values (additional values added)
-struct PreferredSize : LengthWrapperBase<LengthPercentage<CSS::NonnegativeUnzoomed>, CSS::Keyword::Auto, CSS::Keyword::MinContent, CSS::Keyword::MaxContent, CSS::Keyword::FitContent, CSS::Keyword::Stretch, CSS::Keyword::Intrinsic, CSS::Keyword::MinIntrinsic> {
+struct PreferredSize : LengthWrapperBase<LengthPercentage<CSS::NonnegativeLayoutUnitClampedUnzoomed>, CSS::Keyword::Auto, CSS::Keyword::MinContent, CSS::Keyword::MaxContent, CSS::Keyword::FitContent, CSS::Keyword::Stretch, CSS::Keyword::Intrinsic, CSS::Keyword::MinIntrinsic> {
     using Base::Base;
 
     // `PreferredSize` is a structural twin to `MinimumSize` and therefore can be losslessly converted.

--- a/Source/WebCore/style/values/text/StyleLetterSpacing.cpp
+++ b/Source/WebCore/style/values/text/StyleLetterSpacing.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2025 Samuel Weinig <sam@webkit.org>
+ * Copyright (C) 2025-2026 Samuel Weinig <sam@webkit.org>
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -25,10 +25,6 @@
 #include "config.h"
 #include "StyleLetterSpacing.h"
 
-#include "CSSKeywordValue.h"
-#include "FrameDestructionObserverInlines.h"
-#include "RenderStyle+GettersInlines.h"
-#include "StyleBuilderChecking.h"
 #include "StyleLengthWrapper+CSSValueConversion.h"
 
 namespace WebCore {
@@ -36,13 +32,6 @@ namespace Style {
 
 auto CSSValueConversion<LetterSpacing>::operator()(BuilderState& state, const CSSValue& value) -> LetterSpacing
 {
-    auto cssToLengthConversionDataWithTextZoomFactor = [](BuilderState& state) -> CSSToLengthConversionData {
-        auto zoom = state.zoomWithTextZoomFactor();
-        if (zoom == state.cssToLengthConversionData().zoom())
-            return state.cssToLengthConversionData();
-        return state.cssToLengthConversionData().copyWithAdjustedZoom(zoom, LetterSpacing::Fixed::range.zoomOptions);
-    };
-
     if (auto* keywordValue = dynamicDowncast<CSSKeywordValue>(value)) {
         switch (keywordValue->valueID()) {
         case CSSValueNormal:
@@ -57,34 +46,17 @@ auto CSSValueConversion<LetterSpacing>::operator()(BuilderState& state, const CS
     if (!primitiveValue)
         return CSS::Keyword::Normal { };
 
-    auto conversionData = state.useSVGZoomRulesForLength()
-        ? state.cssToLengthConversionData().copyWithAdjustedZoom(1.0f)
-        : cssToLengthConversionDataWithTextZoomFactor(state);
+    auto conversionData = [](BuilderState& state) -> CSSToLengthConversionData {
+        if (state.useSVGZoomRulesForLength())
+            return state.cssToLengthConversionData().copyWithAdjustedZoom(1.0f);
+        auto zoom = state.zoomWithTextZoomFactor();
+        if (zoom == state.cssToLengthConversionData().zoom())
+            return state.cssToLengthConversionData();
+        return state.cssToLengthConversionData().copyWithAdjustedZoom(zoom, LetterSpacing::Fixed::range.zoomOptions);
+    };
 
-    if (primitiveValue->isLength()) {
-        return LetterSpacing {
-            typename LetterSpacing::Fixed {
-                CSS::clampToRange<LetterSpacing::Fixed::range, float>(primitiveValue->resolveAsLength(conversionData), minValueForCssLength, maxValueForCssLength),
-            },
-            primitiveValue->primitiveType() == CSSUnitType::CSS_QUIRKY_EM
-        };
-    }
-
-    if (primitiveValue->isPercentage()) {
-        return LetterSpacing {
-            typename LetterSpacing::Percentage {
-                CSS::clampToRange<LetterSpacing::Percentage::range, float>(primitiveValue->resolveAsPercentage(conversionData)),
-            }
-        };
-    }
-
-    if (primitiveValue->isCalculatedPercentageWithLength()) {
-        return LetterSpacing {
-            typename LetterSpacing::Calc {
-                protect(primitiveValue->cssCalcValue())->createCalculationValue(conversionData, CSSCalcSymbolTable { })
-            }
-        };
-    }
+    if (auto result = convertLengthWrapperFromCSSValue<LetterSpacing>(conversionData(state), *primitiveValue))
+        return *result;
 
     state.setCurrentPropertyInvalidAtComputedValueTime();
     return CSS::Keyword::Normal { };

--- a/Source/WebCore/style/values/text/StyleLetterSpacing.h
+++ b/Source/WebCore/style/values/text/StyleLetterSpacing.h
@@ -33,7 +33,7 @@ namespace Style {
 // <'letter-spacing'> = normal | <length-percentage>
 // NOTE: Computed value resolves `normal` to 0px.
 // https://drafts.csswg.org/css-text-4/#propdef-letter-spacing
-struct LetterSpacing : LengthWrapperBase<LengthPercentage<CSS::AllUnzoomed>> {
+struct LetterSpacing : LengthWrapperBase<LengthPercentage<CSS::AllLayoutUnitClampedUnzoomed>> {
     using Base::Base;
 
     LetterSpacing(CSS::Keyword::Normal)

--- a/Source/WebCore/style/values/text/StyleTextIndent.h
+++ b/Source/WebCore/style/values/text/StyleTextIndent.h
@@ -30,7 +30,7 @@
 namespace WebCore {
 namespace Style {
 
-struct TextIndentLength : LengthWrapperBase<LengthPercentage<CSS::AllUnzoomed>> {
+struct TextIndentLength : LengthWrapperBase<LengthPercentage<CSS::AllLayoutUnitClampedUnzoomed>> {
     using Base::Base;
 };
 

--- a/Source/WebCore/style/values/text/StyleWordSpacing.cpp
+++ b/Source/WebCore/style/values/text/StyleWordSpacing.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2025 Samuel Weinig <sam@webkit.org>
+ * Copyright (C) 2025-2026 Samuel Weinig <sam@webkit.org>
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -25,10 +25,6 @@
 #include "config.h"
 #include "StyleWordSpacing.h"
 
-#include "CSSKeywordValue.h"
-#include "FrameDestructionObserverInlines.h"
-#include "RenderStyle+GettersInlines.h"
-#include "StyleBuilderChecking.h"
 #include "StyleLengthWrapper+CSSValueConversion.h"
 
 namespace WebCore {
@@ -36,13 +32,6 @@ namespace Style {
 
 auto CSSValueConversion<WordSpacing>::operator()(BuilderState& state, const CSSValue& value) -> WordSpacing
 {
-    auto cssToLengthConversionDataWithTextZoomFactor = [](BuilderState& state) -> CSSToLengthConversionData {
-        auto zoom = state.zoomWithTextZoomFactor();
-        if (zoom == state.cssToLengthConversionData().zoom())
-            return state.cssToLengthConversionData();
-        return state.cssToLengthConversionData().copyWithAdjustedZoom(zoom, WordSpacing::Fixed::range.zoomOptions);
-    };
-
     if (auto* keywordValue = dynamicDowncast<CSSKeywordValue>(value)) {
         switch (keywordValue->valueID()) {
         case CSSValueNormal:
@@ -57,34 +46,17 @@ auto CSSValueConversion<WordSpacing>::operator()(BuilderState& state, const CSSV
     if (!primitiveValue)
         return CSS::Keyword::Normal { };
 
-    auto conversionData = state.useSVGZoomRulesForLength()
-        ? state.cssToLengthConversionData().copyWithAdjustedZoom(1.0f)
-        : cssToLengthConversionDataWithTextZoomFactor(state);
+    auto conversionData = [](BuilderState& state) -> CSSToLengthConversionData {
+        if (state.useSVGZoomRulesForLength())
+            return state.cssToLengthConversionData().copyWithAdjustedZoom(1.0f);
+        auto zoom = state.zoomWithTextZoomFactor();
+        if (zoom == state.cssToLengthConversionData().zoom())
+            return state.cssToLengthConversionData();
+        return state.cssToLengthConversionData().copyWithAdjustedZoom(zoom, WordSpacing::Fixed::range.zoomOptions);
+    };
 
-    if (primitiveValue->isLength()) {
-        return WordSpacing {
-            typename WordSpacing::Fixed {
-                CSS::clampToRange<WordSpacing::Fixed::range, float>(primitiveValue->resolveAsLength(conversionData), minValueForCssLength, maxValueForCssLength),
-            },
-            primitiveValue->primitiveType() == CSSUnitType::CSS_QUIRKY_EM
-        };
-    }
-
-    if (primitiveValue->isPercentage()) {
-        return WordSpacing {
-            typename WordSpacing::Percentage {
-                CSS::clampToRange<WordSpacing::Percentage::range, float>(primitiveValue->resolveAsPercentage(conversionData)),
-            }
-        };
-    }
-
-    if (primitiveValue->isCalculatedPercentageWithLength()) {
-        return WordSpacing {
-            typename WordSpacing::Calc {
-                protect(primitiveValue->cssCalcValue())->createCalculationValue(conversionData, CSSCalcSymbolTable { })
-            }
-        };
-    }
+    if (auto result = convertLengthWrapperFromCSSValue<WordSpacing>(conversionData(state), *primitiveValue))
+        return *result;
 
     state.setCurrentPropertyInvalidAtComputedValueTime();
     return CSS::Keyword::Normal { };

--- a/Source/WebCore/style/values/text/StyleWordSpacing.h
+++ b/Source/WebCore/style/values/text/StyleWordSpacing.h
@@ -33,7 +33,7 @@ namespace Style {
 // <'word-spacing'> = normal | <length-percentage>
 // NOTE: Computed value resolves `normal` to 0px.
 // https://drafts.csswg.org/css-text-4/#propdef-word-spacing
-struct WordSpacing : LengthWrapperBase<LengthPercentage<CSS::AllUnzoomed>> {
+struct WordSpacing : LengthWrapperBase<LengthPercentage<CSS::AllLayoutUnitClampedUnzoomed>> {
     using Base::Base;
 
     WordSpacing(CSS::Keyword::Normal)

--- a/Source/WebCore/style/values/transforms/StylePerspective.cpp
+++ b/Source/WebCore/style/values/transforms/StylePerspective.cpp
@@ -27,6 +27,7 @@
 
 #include "CSSKeywordValue.h"
 #include "StyleBuilderChecking.h"
+#include "StylePrimitiveNumericTypes+CSSValueConversion.h"
 
 namespace WebCore::Style {
 
@@ -48,24 +49,17 @@ auto CSSValueConversion<Perspective>::operator()(BuilderState& state, const CSSV
     if (!primitiveValue)
         return CSS::Keyword::None { };
 
-    auto& conversionData = state.cssToLengthConversionData();
-
-    // NOTE: The isNumber() case below is only possible due to the `-webkit-perspective` legacy shorthand
+    // NOTE: The <number> cases below are only possible due to the `-webkit-perspective` legacy shorthand
     // which extends the grammar to `<'perspective'> | <number [0,inf]>`.
 
-    float perspective = -1;
     if (primitiveValue->isLength())
-        perspective = primitiveValue->resolveAsLength<float>(conversionData);
-    else if (primitiveValue->isNumber())
-        perspective = primitiveValue->resolveAsNumber<float>(conversionData) * conversionData.zoom();
-    else
-        ASSERT_NOT_REACHED();
+        return toStyleFromCSSValue<Perspective::Length>(state, *primitiveValue);
 
-    // FIXME: This should probably clamp to 0, like other numeric values would, rather than return CSS::Keyword::None.
-    if (perspective < 0)
-        return CSS::Keyword::None { };
+    if (primitiveValue->isNumber())
+        return Perspective::Length { toStyleFromCSSValue<Number<CSS::Nonnegative, float>>(state, *primitiveValue).value * state.cssToLengthConversionData().zoom() };
 
-    return Style::Perspective::Length { perspective };
+    state.setCurrentPropertyInvalidAtComputedValueTime();
+    return CSS::Keyword::None { };
 }
 
 } // namespace WebCore::Style

--- a/Source/WebCore/style/values/transforms/StyleTransformFunction.cpp
+++ b/Source/WebCore/style/values/transforms/StyleTransformFunction.cpp
@@ -44,6 +44,7 @@
 #include "StyleInterpolationContext.h"
 #include "StyleKeyword+CSSValueConversion.h"
 #include "StyleLengthWrapper+Blending.h"
+#include "StyleLengthWrapper+CSSValueConversion.h"
 #include "StyleMatrix3DTransformFunction.h"
 #include "StyleMatrixTransformFunction.h"
 #include "StylePerspectiveTransformFunction.h"
@@ -58,34 +59,6 @@
 
 namespace WebCore {
 namespace Style {
-
-static TranslateTransformFunction::LengthPercentage resolveAsTranslateLengthPercentage(const CSSPrimitiveValue& primitiveValue, BuilderState& state)
-{
-    // FIXME: This should use `toStyleFromCSSValue<TranslateTransformFunction::LengthPercentage>`, but doing so breaks transforms/hittest-translated-content-off-to-infinity-and-back.html, due to it clamping between minValueForCssLength/maxValueForCssLength.
-
-    auto& conversionData = state.cssToLengthConversionData();
-    if (primitiveValue.isLength())
-        return TranslateTransformFunction::LengthPercentage::Fixed { static_cast<float>(primitiveValue.resolveAsLength<double>(conversionData)) };
-    if (primitiveValue.isPercentage())
-        return TranslateTransformFunction::LengthPercentage::Percentage { static_cast<float>(primitiveValue.resolveAsPercentage<double>(conversionData)) };
-    if (primitiveValue.isCalculated())
-        return TranslateTransformFunction::LengthPercentage::Calc { protect(primitiveValue.cssCalcValue())->createCalculationValue(conversionData, CSSCalcSymbolTable { }) };
-
-    state.setCurrentPropertyInvalidAtComputedValueTime();
-    return 0_css_px;
-}
-
-static TranslateTransformFunction::Length resolveAsTranslateLength(const CSSPrimitiveValue& primitiveValue, BuilderState& state)
-{
-    // FIXME: This should use `toStyleFromCSSValue<TranslateTransformFunction::Length>`, but doing so breaks transforms/hittest-translated-content-off-to-infinity-and-back.html, due to it clamping between minValueForCssLength/maxValueForCssLength.
-
-    auto& conversionData = state.cssToLengthConversionData();
-    if (primitiveValue.isLength())
-        return TranslateTransformFunction::Length { static_cast<float>(primitiveValue.resolveAsLength<double>(conversionData)) };
-
-    state.setCurrentPropertyInvalidAtComputedValueTime();
-    return 0_css_px;
-}
 
 // MARK: Matrix
 
@@ -370,8 +343,8 @@ static RefPtr<const TransformFunctionBase> createTranslateTransformFunction(cons
     if (!function)
         return { };
 
-    auto tx = resolveAsTranslateLengthPercentage(function->item(0), state);
-    auto ty = function->size() > 1 ? resolveAsTranslateLengthPercentage(function->item(1), state) : TranslateTransformFunction::LengthPercentage { 0_css_px };
+    auto tx = toStyleFromCSSValue<TranslateTransformFunction::LengthPercentage>(state, function->item(0));
+    auto ty = function->size() > 1 ? toStyleFromCSSValue<TranslateTransformFunction::LengthPercentage>(state, function->item(1)) : TranslateTransformFunction::LengthPercentage { 0_css_px };
     auto tz = 0_css_px;
 
     return TranslateTransformFunction::create(WTF::move(tx), WTF::move(ty), WTF::move(tz), TransformFunctionType::Translate);
@@ -386,9 +359,9 @@ static RefPtr<const TransformFunctionBase> createTranslate3dTransformFunction(co
     if (!function)
         return { };
 
-    auto tx = resolveAsTranslateLengthPercentage(function->item(0), state);
-    auto ty = resolveAsTranslateLengthPercentage(function->item(1), state);
-    auto tz = resolveAsTranslateLength(function->item(2), state);
+    auto tx = toStyleFromCSSValue<TranslateTransformFunction::LengthPercentage>(state, function->item(0));
+    auto ty = toStyleFromCSSValue<TranslateTransformFunction::LengthPercentage>(state, function->item(1));
+    auto tz = toStyleFromCSSValue<TranslateTransformFunction::Length>(state, function->item(2));
 
     return TranslateTransformFunction::create(WTF::move(tx), WTF::move(ty), WTF::move(tz), TransformFunctionType::Translate3D);
 }
@@ -402,7 +375,7 @@ static RefPtr<const TransformFunctionBase> createTranslateXTransformFunction(con
     if (!function)
         return { };
 
-    auto tx = resolveAsTranslateLengthPercentage(function->item(0), state);
+    auto tx = toStyleFromCSSValue<TranslateTransformFunction::LengthPercentage>(state, function->item(0));
     auto ty = 0_css_px;
     auto tz = 0_css_px;
 
@@ -419,7 +392,7 @@ static RefPtr<const TransformFunctionBase> createTranslateYTransformFunction(con
         return { };
 
     auto tx = 0_css_px;
-    auto ty = resolveAsTranslateLengthPercentage(function->item(0), state);
+    auto ty = toStyleFromCSSValue<TranslateTransformFunction::LengthPercentage>(state, function->item(0));
     auto tz = 0_css_px;
 
     return TranslateTransformFunction::create(WTF::move(tx), WTF::move(ty), WTF::move(tz), TransformFunctionType::TranslateY);
@@ -436,7 +409,7 @@ static RefPtr<const TransformFunctionBase> createTranslateZTransformFunction(con
 
     auto tx = 0_css_px;
     auto ty = 0_css_px;
-    auto tz = resolveAsTranslateLength(function->item(0), state);
+    auto tz = toStyleFromCSSValue<TranslateTransformFunction::Length>(state, function->item(0));
 
     return TranslateTransformFunction::create(WTF::move(tx), WTF::move(ty), WTF::move(tz), TransformFunctionType::TranslateZ);
 }


### PR DESCRIPTION
#### 282da0f6ab84554f8e611949397ba3ec5cd65ee1
<pre>
[Style] Unify numeric type resolution functions (part 1)
<a href="https://bugs.webkit.org/show_bug.cgi?id=314110">https://bugs.webkit.org/show_bug.cgi?id=314110</a>

Reviewed by Darin Adler.

The goal of this refactoring series is to unify the way `CSSPrimitiveValue`
values get resolved.

This first change focuses on unifying the StyleLengthWrapper+CSSValueConversion.h,
StyleLengthWrapper+DeprecatedCSSValueConversion.h and StylePrimitiveNumericTypes+CSSValueConversion.h
to utilize the converters in StylePrimitiveNumericTypes+Conversion.h and providing
utilities for non-standard &lt;length-percentage&gt;/&lt;length&gt; conversions to reuse parts
of the general conversion infrastructure rather than reimplementing.

* LayoutTests/imported/w3c/web-platform-tests/css/CSS2/normal-flow/margin-collapse-through-for-various-height-values.tentative-expected.txt:
    - This test is now passing more subtests due to now correctly simplifying all &lt;length-percentage&gt;
      calc() values in all cases, not just when a strong CSS value has be parsed.

* LayoutTests/imported/w3c/web-platform-tests/css/css-values/animations/calc-interpolation-expected.txt:
    - This test is now passing more subtests due to uniformly applying clamping in more places.

* Source/WebCore/css/CSSPrimitiveValue.h:
    - Remove unused resolveAs() functions and predicates.

* Source/WebCore/css/calc/CSSCalcValue.cpp:
    - Switch to using CSS::clampToRange.

* Source/WebCore/css/values/CSSNoConversionDataRequiredToken.h:
    - Made default constructor explicit so that callers must use the `NoConversionDataRequiredToken { }`
      form and just use `{ }`. This makes it more clear at call sites what is being requested.

* Source/WebCore/css/values/primitives/CSSPrimitiveNumeric.h:
    - Add type aliases on AnglePercentage and LengthPercentage that expose the Dimension/Percentage
      types. This matches StylePrimitiveNumeric and is useful during generic conversion.

* Source/WebCore/css/values/primitives/CSSPrimitiveNumericRange.h:
    - Adds version of `clampToRangeOf` that forwards to the `clampToRange` function that takes
      additional range arguments.

* Source/WebCore/css/values/primitives/CSSPrimitiveNumericRaw.h:
    - Add constructors that force eager clamping the value to the specified range.
    - Also adds type aliases on AnglePercentage and LengthPercentage that expose the
      Dimension/Percentage like was done in CSSPrimitiveNumeric.h

* Source/WebCore/css/values/primitives/CSSPrimitiveNumericTypes+Canonicalization.h:
    - Add trivial canonicalization for Flex to allow the conversion code to generalize.

* Source/WebCore/page/IntersectionObserver.cpp:
    - Avoid a CSSPrimitiveValue entirely by using MetaConsumer with strong CSS types and
      using Style::toStyle() for conversions.

* Source/WebCore/style/StyleResolveForFont.cpp:
* Source/WebCore/style/StyleResolveForFont.h:
    - Remove unused function `fontStyleAngleFromCSSValueDeprecated` and the last
      caller of `CSSPrimitiveValue::resolveAsAngleDeprecated`.

* Source/WebCore/style/values/fill-stroke/StyleStrokeWidth.cpp:
    - Add missing `using namespace CSS::Literals`. It was getting this previously due
      to StylePrimitiveNumericTypes+CSSValueConversions.h doing it globally.

* Source/WebCore/style/values/inline/StyleLineHeight.cpp:
    - Refactor to remove use of `CSSPrimitiveValue::resolveAs{type}` functions and instead
      use new `CSSPrimitiveValue::switchOn` + `toStyle()`.

* Source/WebCore/style/values/non-standard/StyleWebKitTextStrokeWidth.cpp:
    - Add missing `using namespace CSS::Literals`. It was getting this previously due
      to StylePrimitiveNumericTypes+CSSValueConversions.h doing it globally.

* Source/WebCore/style/values/primitives/StyleLengthWrapper+CSSValueConversion.h:
* Source/WebCore/style/values/primitives/StyleLengthWrapper+DeprecatedCSSValueConversion.h:
    - Extracts numeric conversions from both files into `convertLengthWrapperFromCSSValue`
      overloads that use `CSSPrimitiveValue::switchOn` + `Style::toStyle` for conversion.
      The `convertLengthWrapperFromCSSValue` functions allow LetterSpacing/WordSpacing
      to remove much of their duplicate logic.
    - Removes duplication of CSSToLengthConversionData selection, using the shared one
      in StylePrimitiveNumericTypes+Conversions.h.
    - Removes duplication of canonicalization, relying on `Style::toStyle` to do it.

* Source/WebCore/style/values/primitives/StylePrimitiveNumericTypes+CSSValueConversion.h:
    - Extracts numeric conversions into `convertNumericFromCSSValue` overloads that use
      `CSSPrimitiveValue::switchOn` + `Style::toStyle` for conversion.
    - Adds overloads that take `CSSToLengthConversionData`, matching strong type conversion.

* Source/WebCore/style/values/primitives/StylePrimitiveNumericTypes+Conversions.h:
    - Switches ConversionDataSpecializer to specialize based on Style type instead of
      CSS type, useful for cases where a CSS type converts to multiple Style types.
    - Makes passing rest parameters consistent through canonicalization.
    - Adds overloads that convert from `BuilderState` to `CSSToLengthConversionData`
      consistently for all numeric types.
    - Removes special clamping to LayoutUnit range. Types that want that opt-in via
      new CSS::Range values.

* Source/WebCore/style/values/sizing/StyleContainIntrinsicSize.cpp:
    - Replace use of `CSSPrimitiveValue::resolveAsLength` with `toStyleFromCSSValue`.

* Source/WebCore/style/values/text/StyleLetterSpacing.cpp:
* Source/WebCore/style/values/text/StyleWordSpacing.cpp:
    - Use `convertLengthWrapperFromCSSValue` with custom `CSSToLengthConversionData`
      rather than duplicating conversion logic.

* Source/WebCore/style/values/transforms/StylePerspective.cpp:
    - Replace use of `CSSPrimitiveValue::resolve{type}` with `toStyleFromCSSValue`.

* Source/WebCore/style/values/transforms/StyleTransformFunction.cpp:
    - Replace use of `CSSPrimitiveValue::resolve{type}` with `toStyleFromCSSValue`.
      Now that the LayoutUnit range clamping is declared via CSS::Range, the
      normal path can work here.

Canonical link: <a href="https://commits.webkit.org/312965@main">https://commits.webkit.org/312965@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/897d0d9c0e06ff434e342daec81ae66dad3ac50a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/161667 "13 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/35141 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/28244 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/170570 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/118038 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/163536 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/35242 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/35142 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/125423 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/88345 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/164626 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/27730 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/145210 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/106019 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/26779 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/25288 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/18291 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/136472 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/22966 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/173058 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/20099 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/24607 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/133713 "Found 1 new test failure: imported/w3c/web-platform-tests/svg/geometry/reftests/circle-004.svg (failure)") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/34815 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/29381 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/133718 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36122 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/34799 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/144761 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/96780 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/28252 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/21581 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/34309 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/101754 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/33809 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/34052 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/33958 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->