### PR TITLE
[WPE] [Android] Compilation fixes, allow USE_GBM=OFF to use the EGLImage texture path

### DIFF
--- a/Source/WebCore/platform/graphics/DMABufBuffer.cpp
+++ b/Source/WebCore/platform/graphics/DMABufBuffer.cpp
@@ -26,6 +26,7 @@
 #include "config.h"
 #include "DMABufBuffer.h"
 
+#if USE(GBM)
 #include "CoordinatedPlatformLayerBuffer.h"
 #include "GBMVersioning.h"
 #include "GLDisplay.h"
@@ -74,7 +75,6 @@ std::optional<DMABufBuffer::Attributes> DMABufBuffer::takeAttributes()
     return DMABufBuffer::Attributes { WTF::move(m_attributes.size), std::exchange(m_attributes.fourcc, 0), WTF::move(m_attributes.fds), WTF::move(m_attributes.offsets), WTF::move(m_attributes.strides), std::exchange(m_attributes.modifier, 0) };
 }
 
-#if USE(GBM)
 std::optional<DMABufBufferAttributes> DMABufBufferAttributes::fromGBMBufferObject(struct gbm_bo* bo, EnableModifiers enableModifiers)
 {
     if (!bo)
@@ -102,7 +102,6 @@ std::optional<DMABufBufferAttributes> DMABufBufferAttributes::fromGBMBufferObjec
 
     return attributes;
 }
-#endif
 
 EGLImage DMABufBuffer::createEGLImage(GLDisplay& display) const
 {
@@ -179,3 +178,5 @@ std::optional<Vector<EGLint>> DMABufBuffer::buildEGLImageAttributes(const Attrib
 }
 
 } // namespace WebCore
+
+#endif // USE(GBM)

--- a/Source/WebCore/platform/graphics/texmap/BitmapTexture.cpp
+++ b/Source/WebCore/platform/graphics/texmap/BitmapTexture.cpp
@@ -197,7 +197,9 @@ bool BitmapTexture::allocateTextureFromMemoryMappedGPUBuffer()
     LOG_ERROR("Cannot create EGLImage from dma-buf -- rendering will be broken.");
     return false;
 }
+#endif
 
+#if USE(GBM) || OS(ANDROID)
 BitmapTexture::BitmapTexture(EGLImage image, const IntSize& size, OptionSet<Flags> flags)
     : m_flags(flags)
     , m_size(size)

--- a/Source/WebCore/platform/graphics/texmap/BitmapTexture.h
+++ b/Source/WebCore/platform/graphics/texmap/BitmapTexture.h
@@ -80,7 +80,7 @@ public:
         return adoptRef(*new BitmapTexture(size, flags));
     }
 
-#if USE(GBM)
+#if USE(GBM) || OS(ANDROID)
     static Ref<BitmapTexture> create(EGLImage image, const IntSize& size, OptionSet<Flags> flags = { })
     {
         return adoptRef(*new BitmapTexture(image, size, flags));
@@ -129,7 +129,7 @@ public:
 
 private:
     BitmapTexture(const IntSize&, OptionSet<Flags>);
-#if USE(GBM)
+#if USE(GBM) || OS(ANDROID)
     BitmapTexture(EGLImage, const IntSize&, OptionSet<Flags>);
 #endif
 


### PR DESCRIPTION
#### 34804f9afc4d3181b773db802e6489f1c7e133af
<pre>
[WPE] [Android] Compilation fixes, allow USE_GBM=OFF to use the EGLImage texture path
<a href="https://bugs.webkit.org/show_bug.cgi?id=314114">https://bugs.webkit.org/show_bug.cgi?id=314114</a>

Reviewed by Nikolas Zimmermann.

More fixes for WPE port with USE_GBM=OFF for Android.

* Source/WebCore/platform/graphics/DMABufBuffer.cpp:
  312509@main moved this file out of gbm/ and added partial #if
  USE(GBM) coverage, but left the GBMVersioning.h / drm_fourcc.h
  includes and the EGLImage helper bodies (which use
  DRM_FORMAT_MOD_INVALID) outside the guard. Every caller of the
  public API is itself using USE(GBM), so wrap the entire body in
  a single outer #if USE(GBM), matching the gbm/ subdirectory pattern.

* Source/WebCore/platform/graphics/texmap/BitmapTexture.h:
* Source/WebCore/platform/graphics/texmap/BitmapTexture.cpp:
  290475@main introduced BitmapTexture::create(EGLImage, ...) +
  matching private ctor under #if USE(GBM). The body uses only
  plain EGL/GLES functions, available wherever USE(TEXTURE_MAPPER).
  Drop the guard so the EGLImage texture path compiles for any
  TEXTURE_MAPPER usage, including Android with
  AHardwareBuffer-imported EGLImages.

Canonical link: <a href="https://commits.webkit.org/312783@main">https://commits.webkit.org/312783@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e8e2fd2c29869d59890b90cc8e29a3805336ef9c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/160821 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/34294 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/27395 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/169724 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/115887 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/162690 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/34395 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/34294 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/124734 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/88058 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/163780 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/26988 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/144460 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/105331 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/26040 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/24540 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/17444 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/135734 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/22223 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/172206 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/19228 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/23864 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/133003 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/33968 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/28632 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/133014 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35977 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/33952 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/144018 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/95776 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/27606 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/20833 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/33463 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/100888 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/32962 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/33206 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/33110 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->