### PR TITLE
[GStreamer][MSE] Enable changeType support

### DIFF
--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -5117,7 +5117,6 @@ webkit.org/b/302326 fast/dom/rtl-scroll-to-leftmost-and-resize.html [ Failure Ti
 
 webkit.org/b/298463 accessibility/crash-deleting-dynamically-updated-text-input.html [ Skip ]
 
-webkit.org/b/303124 media/media-source/media-source-changetype-vp8-vp9.html [ Failure ]
 webkit.org/b/303130 media/media-source/media-source-ended.html [ Failure ]
 
 webkit.org/b/303208 imported/blink/fast/pagination/viewport-y-horizontal-bt-rtl.html [ Pass ImageOnlyFailure ]

--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/media-source/mediasource-changetype-play-without-codecs-parameter-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/media-source/mediasource-changetype-play-without-codecs-parameter-expected.txt
@@ -1,21 +1,21 @@
 
 PASS Check if browser supports enough test media types
-FAIL Test audio-only changeType for audio/webm; codecs="vorbis" <-> audio/webm; codecs="vorbis" (using types without codecs parameters) sourceBuffer.changeType is not a function. (In 'sourceBuffer.changeType(typeB)', 'sourceBuffer.changeType' is undefined)
-FAIL Test audio-only changeType for audio/webm; codecs="vorbis" <-> audio/mp4; codecs="mp4a.40.2" (using types without codecs parameters) sourceBuffer.changeType is not a function. (In 'sourceBuffer.changeType(typeB)', 'sourceBuffer.changeType' is undefined)
-FAIL Test audio-only changeType for audio/webm; codecs="vorbis" <-> audio/mpeg (using types without codecs parameters) sourceBuffer.changeType is not a function. (In 'sourceBuffer.changeType(typeB)', 'sourceBuffer.changeType' is undefined)
-FAIL Test audio-only changeType for audio/mp4; codecs="mp4a.40.2" <-> audio/webm; codecs="vorbis" (using types without codecs parameters) sourceBuffer.changeType is not a function. (In 'sourceBuffer.changeType(typeB)', 'sourceBuffer.changeType' is undefined)
-FAIL Test audio-only changeType for audio/mp4; codecs="mp4a.40.2" <-> audio/mp4; codecs="mp4a.40.2" (using types without codecs parameters) sourceBuffer.changeType is not a function. (In 'sourceBuffer.changeType(typeB)', 'sourceBuffer.changeType' is undefined)
-FAIL Test audio-only changeType for audio/mp4; codecs="mp4a.40.2" <-> audio/mpeg (using types without codecs parameters) sourceBuffer.changeType is not a function. (In 'sourceBuffer.changeType(typeB)', 'sourceBuffer.changeType' is undefined)
-FAIL Test audio-only changeType for audio/mpeg <-> audio/webm; codecs="vorbis" (using types without codecs parameters) sourceBuffer.changeType is not a function. (In 'sourceBuffer.changeType(typeB)', 'sourceBuffer.changeType' is undefined)
-FAIL Test audio-only changeType for audio/mpeg <-> audio/mp4; codecs="mp4a.40.2" (using types without codecs parameters) sourceBuffer.changeType is not a function. (In 'sourceBuffer.changeType(typeB)', 'sourceBuffer.changeType' is undefined)
-FAIL Test audio-only changeType for audio/mpeg <-> audio/mpeg (using types without codecs parameters) sourceBuffer.changeType is not a function. (In 'sourceBuffer.changeType(typeB)', 'sourceBuffer.changeType' is undefined)
-FAIL Test video-only changeType for video/webm; codecs="vp8" <-> video/webm; codecs="vp8" (using types without codecs parameters) sourceBuffer.changeType is not a function. (In 'sourceBuffer.changeType(typeB)', 'sourceBuffer.changeType' is undefined)
-FAIL Test video-only changeType for video/webm; codecs="vp8" <-> video/webm; codecs="vp9" (using types without codecs parameters) sourceBuffer.changeType is not a function. (In 'sourceBuffer.changeType(typeB)', 'sourceBuffer.changeType' is undefined)
-FAIL Test video-only changeType for video/webm; codecs="vp8" <-> video/mp4; codecs="avc1.4D4001" (using types without codecs parameters) sourceBuffer.changeType is not a function. (In 'sourceBuffer.changeType(typeB)', 'sourceBuffer.changeType' is undefined)
-FAIL Test video-only changeType for video/webm; codecs="vp9" <-> video/webm; codecs="vp8" (using types without codecs parameters) sourceBuffer.changeType is not a function. (In 'sourceBuffer.changeType(typeB)', 'sourceBuffer.changeType' is undefined)
-FAIL Test video-only changeType for video/webm; codecs="vp9" <-> video/webm; codecs="vp9" (using types without codecs parameters) sourceBuffer.changeType is not a function. (In 'sourceBuffer.changeType(typeB)', 'sourceBuffer.changeType' is undefined)
-FAIL Test video-only changeType for video/webm; codecs="vp9" <-> video/mp4; codecs="avc1.4D4001" (using types without codecs parameters) sourceBuffer.changeType is not a function. (In 'sourceBuffer.changeType(typeB)', 'sourceBuffer.changeType' is undefined)
-FAIL Test video-only changeType for video/mp4; codecs="avc1.4D4001" <-> video/webm; codecs="vp8" (using types without codecs parameters) sourceBuffer.changeType is not a function. (In 'sourceBuffer.changeType(typeB)', 'sourceBuffer.changeType' is undefined)
-FAIL Test video-only changeType for video/mp4; codecs="avc1.4D4001" <-> video/webm; codecs="vp9" (using types without codecs parameters) sourceBuffer.changeType is not a function. (In 'sourceBuffer.changeType(typeB)', 'sourceBuffer.changeType' is undefined)
-FAIL Test video-only changeType for video/mp4; codecs="avc1.4D4001" <-> video/mp4; codecs="avc1.4D4001" (using types without codecs parameters) sourceBuffer.changeType is not a function. (In 'sourceBuffer.changeType(typeB)', 'sourceBuffer.changeType' is undefined)
+PASS Test audio-only changeType for audio/webm; codecs="vorbis" <-> audio/webm; codecs="vorbis" (using types without codecs parameters)
+PASS Test audio-only changeType for audio/webm; codecs="vorbis" <-> audio/mp4; codecs="mp4a.40.2" (using types without codecs parameters)
+PASS Test audio-only changeType for audio/webm; codecs="vorbis" <-> audio/mpeg (using types without codecs parameters)
+FAIL Test audio-only changeType for audio/mp4; codecs="mp4a.40.2" <-> audio/webm; codecs="vorbis" (using types without codecs parameters) assert_unreached: Unexpected event 'error' Reached unreachable code
+PASS Test audio-only changeType for audio/mp4; codecs="mp4a.40.2" <-> audio/mp4; codecs="mp4a.40.2" (using types without codecs parameters)
+FAIL Test audio-only changeType for audio/mp4; codecs="mp4a.40.2" <-> audio/mpeg (using types without codecs parameters) assert_unreached: Unexpected event 'error' Reached unreachable code
+PASS Test audio-only changeType for audio/mpeg <-> audio/webm; codecs="vorbis" (using types without codecs parameters)
+FAIL Test audio-only changeType for audio/mpeg <-> audio/mp4; codecs="mp4a.40.2" (using types without codecs parameters) assert_unreached: Unexpected event 'error' Reached unreachable code
+PASS Test audio-only changeType for audio/mpeg <-> audio/mpeg (using types without codecs parameters)
+PASS Test video-only changeType for video/webm; codecs="vp8" <-> video/webm; codecs="vp8" (using types without codecs parameters)
+PASS Test video-only changeType for video/webm; codecs="vp8" <-> video/webm; codecs="vp9" (using types without codecs parameters)
+PASS Test video-only changeType for video/webm; codecs="vp8" <-> video/mp4; codecs="avc1.4D4001" (using types without codecs parameters)
+PASS Test video-only changeType for video/webm; codecs="vp9" <-> video/webm; codecs="vp8" (using types without codecs parameters)
+PASS Test video-only changeType for video/webm; codecs="vp9" <-> video/webm; codecs="vp9" (using types without codecs parameters)
+FAIL Test video-only changeType for video/webm; codecs="vp9" <-> video/mp4; codecs="avc1.4D4001" (using types without codecs parameters) assert_unreached: Unexpected event 'error' Reached unreachable code
+FAIL Test video-only changeType for video/mp4; codecs="avc1.4D4001" <-> video/webm; codecs="vp8" (using types without codecs parameters) assert_unreached: Unexpected event 'error' Reached unreachable code
+FAIL Test video-only changeType for video/mp4; codecs="avc1.4D4001" <-> video/webm; codecs="vp9" (using types without codecs parameters) assert_unreached: Unexpected event 'error' Reached unreachable code
+PASS Test video-only changeType for video/mp4; codecs="avc1.4D4001" <-> video/mp4; codecs="avc1.4D4001" (using types without codecs parameters)
 

--- a/LayoutTests/platform/glib/media/media-source/media-source-changetype-second-init-expected.txt
+++ b/LayoutTests/platform/glib/media/media-source/media-source-changetype-second-init-expected.txt
@@ -1,7 +1,0 @@
-
-EXPECTED (source.readyState == 'closed') OK
-EVENT(sourceopen)
-RUN(sourceBuffer = source.addSourceBuffer("video/mock; codecs=mock"))
-SourceBuffer.changeType is undefined
-END OF TEST
-

--- a/LayoutTests/platform/glib/media/media-source/media-source-changetype-support-expected.txt
+++ b/LayoutTests/platform/glib/media/media-source/media-source-changetype-support-expected.txt
@@ -1,7 +1,0 @@
-
-EXPECTED (source.readyState == 'closed') OK
-EVENT(sourceopen)
-RUN(sourceBuffer = source.addSourceBuffer("video/mock; codecs=mock"))
-EXPECTED (sourceBuffer.changeType != 'undefined'), OBSERVED 'undefined' FAIL
-END OF TEST
-

--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -7772,10 +7772,8 @@ SourceBufferChangeTypeEnabled:
     WebKitLegacy:
       default: true
     WebKit:
-      "USE(GSTREAMER)": false
       default: true
     WebCore:
-      "USE(GSTREAMER)": false
       default: true
 
 SpatialImageControlsEnabled:


### PR DESCRIPTION
#### 8c1d4e3b50c72aadb8cbc9b1c0c90e16fd9b09e8
<pre>
[GStreamer][MSE] Enable changeType support
<a href="https://bugs.webkit.org/show_bug.cgi?id=314117">https://bugs.webkit.org/show_bug.cgi?id=314117</a>

Reviewed by NOBODY (OOPS!).

As of <a href="https://commits.webkit.org/306852@main">306852@main</a> changeType should be supported, so mark it as such in WebPreferences.

* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8c1d4e3b50c72aadb8cbc9b1c0c90e16fd9b09e8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/160809 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/34282 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/27383 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/169712 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/115875 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/34383 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/34282 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/124725 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/88059 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/163768 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/26977 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/144449 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/105322 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/26029 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/24531 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/17432 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/152865 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/135723 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/22212 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/172194 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/21647 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/19216 "Built successfully") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/23853 "Found 1 new test failure: imported/w3c/web-platform-tests/css/selectors/invalidation/media-pseudo-classes-in-has.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/132991 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/33956 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/28623 "Found 8 new test failures: http/tests/site-isolation/inspector/console/message-from-iframe.html http/tests/site-isolation/inspector/console/message-from-worker.html http/tests/site-isolation/inspector/dom/getDocument-frame-target.html http/tests/site-isolation/inspector/page/override-user-agent-cross-origin-iframe.html http/tests/site-isolation/inspector/target/target-cross-origin-page-navigation.html http/tests/site-isolation/inspector/target/target.html http/tests/site-isolation/inspector/unit-tests/target-manager.html http/tests/site-isolation/inspector/worker/worker-in-cross-origin-iframe.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/133002 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/33940 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/144007 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/95761 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/27594 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/20822 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/193208 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/33451 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/100876 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/49756 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/32950 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/33194 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/33098 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->