### PR TITLE
[Site Isolation] Popup's inherited origin lost during didCommitLoad

### DIFF
--- a/LayoutTests/http/tests/site-isolation/resources/navigate-parent-to-blob.html
+++ b/LayoutTests/http/tests/site-isolation/resources/navigate-parent-to-blob.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html>
+<body>
+<script>
+    var blob = new Blob([`
+        <!DOCTYPE html>
+        <script>
+            opener.postMessage("blob loaded", "*");
+        <\/script>
+    `], { type: 'text/html' });
+    parent.location = URL.createObjectURL(blob);
+</script>
+</body>
+</html>

--- a/LayoutTests/http/tests/site-isolation/sandbox-allow-top-navigation-cross-origin-iframe-expected.txt
+++ b/LayoutTests/http/tests/site-isolation/sandbox-allow-top-navigation-cross-origin-iframe-expected.txt
@@ -1,0 +1,10 @@
+Verifies a sandboxed cross-origin iframe with allow-top-navigation can navigate its parent popup to a blob URL.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS event.data is "blob loaded"
+PASS successfullyParsed is true
+
+TEST COMPLETE
+click to run test manually in a browser

--- a/LayoutTests/http/tests/site-isolation/sandbox-allow-top-navigation-cross-origin-iframe.html
+++ b/LayoutTests/http/tests/site-isolation/sandbox-allow-top-navigation-cross-origin-iframe.html
@@ -1,0 +1,29 @@
+<!-- webkit-test-runner [ SiteIsolationEnabled=true ] -->
+<script src="/js-test-resources/js-test.js"></script>
+<script>
+
+description("Verifies a sandboxed cross-origin iframe with allow-top-navigation can navigate its parent popup to a blob URL.");
+jsTestIsAsync = true;
+
+function runTest() {
+    let popup = window.open();
+    let iframe = popup.document.createElement('iframe');
+    iframe.sandbox = "allow-scripts allow-same-origin allow-top-navigation";
+    iframe.src = "http://localhost:8000/site-isolation/resources/navigate-parent-to-blob.html";
+
+    window.addEventListener("message", (event) => {
+        if (event.source !== popup)
+            return;
+        shouldBeEqualToString("event.data", "blob loaded");
+        popup.close();
+        finishJSTest();
+    });
+
+    popup.document.body.appendChild(iframe);
+}
+
+function runTestIfInTestRunner() { if (window.testRunner) { runTest() } }
+</script>
+<body onload="runTestIfInTestRunner()">
+<button onclick="runTest()">click to run test manually in a browser</button>
+</body>

--- a/Source/WebKit/UIProcess/WebFrameProxy.cpp
+++ b/Source/WebKit/UIProcess/WebFrameProxy.cpp
@@ -147,7 +147,7 @@ WebFrameProxy::WebFrameProxy(WebPageProxy& page, FrameProcess& process, FrameIde
     if (previousURL)
         frameLoadState().setURL(WTF::move(*previousURL));
 
-    updateDocumentSecurityOrigin(parent ? parent : opener);
+    updateDocumentSecurityOrigin(parent ? parent : opener, ForInitialization::Yes);
 }
 
 WebFrameProxy::~WebFrameProxy()
@@ -567,7 +567,7 @@ void WebFrameProxy::prepareForProvisionalLoadInProcess(WebProcessProxy& process,
     RefPtr page = m_page.get();
     // FIXME: Main resource (of main or subframe) request redirects should go straight from the network to UI process so we don't need to make the processes for each domain in a redirect chain. <rdar://116202119>
     Site mainFrameSite(page->mainFrame()->url());
-    auto mainFrameDomain = mainFrameSite.domain();
+    auto mainFrameDomain = WebCore::RegistrableDomain { protect(page->mainFrame())->securityOrigin()->data() };
 
     // If we have an effectiveOrigin, it means we are loading about:blank which doesn't have any resources
     // to load can commit it's provisional frame immediately
@@ -1067,7 +1067,7 @@ ProvisionalFrameCreationParameters WebFrameProxy::provisionalFrameCreationParame
     };
 }
 
-void WebFrameProxy::updateDocumentSecurityOrigin(WebFrameProxy* creator)
+void WebFrameProxy::updateDocumentSecurityOrigin(WebFrameProxy* creator, ForInitialization forInitialization)
 {
     if (m_effectiveSandboxFlags.contains(SandboxFlag::Origin)) {
         m_documentSecurityOrigin = WebCore::SecurityOrigin::opaqueOrigin();
@@ -1077,7 +1077,7 @@ void WebFrameProxy::updateDocumentSecurityOrigin(WebFrameProxy* creator)
     if (SecurityPolicy::shouldInheritSecurityOriginFromOwner(url())) {
         if (RefPtr creatorFrame = creator)
             m_documentSecurityOrigin = creatorFrame->securityOrigin().ptr();
-        else
+        else if (forInitialization == ForInitialization::Yes)
             m_documentSecurityOrigin = WebCore::SecurityOrigin::opaqueOrigin();
         return;
     }

--- a/Source/WebKit/UIProcess/WebFrameProxy.h
+++ b/Source/WebKit/UIProcess/WebFrameProxy.h
@@ -317,14 +317,18 @@ public:
     void getNodeForSelectorPaths(Vector<HashSet<String>>&&, CompletionHandler<void(std::optional<JSHandleInfo>&&)>&&);
 
     ProvisionalFrameCreationParameters NODELETE provisionalFrameCreationParameters(std::optional<WebCore::FrameIdentifier>, std::optional<WebCore::LayerHostingContextIdentifier>, CommitTiming);
+
+    Ref<WebCore::SecurityOrigin> NODELETE securityOrigin() const;
+
 private:
     WebFrameProxy(WebPageProxy&, FrameProcess&, WebCore::FrameIdentifier, WebCore::SandboxFlags, WebCore::ReferrerPolicy, WebCore::ScrollbarMode, WebFrameProxy*, WebFrameProxy*, IsMainFrame, std::optional<URL>&&);
 
     std::optional<SharedPreferencesForWebProcess> NODELETE sharedPreferencesForWebProcess() const;
 
     std::optional<WebCore::PageIdentifier> NODELETE pageIdentifier() const;
-    Ref<WebCore::SecurityOrigin> NODELETE securityOrigin() const;
-    void updateDocumentSecurityOrigin(WebFrameProxy*);
+
+    enum class ForInitialization : bool { No, Yes };
+    void updateDocumentSecurityOrigin(WebFrameProxy*, ForInitialization = ForInitialization::No);
 
     RefPtr<WebFrameProxy> deepLastChild();
     WebFrameProxy* NODELETE firstChild() const;

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -1028,7 +1028,9 @@ WebPage::WebPage(PageIdentifier pageID, WebPageCreationParameters&& parameters)
         for (auto& childParameters : remotePageParameters->frameTreeParameters.children)
             constructFrameTree(m_mainFrame.get(), childParameters);
 
-        page->setMainFrameURLAndOrigin(remotePageParameters->initialMainDocumentURL, nullptr);
+        // Use the origin from FrameTreeSyncData so Page::mainFrameOrigin() reflects the inherited origin.
+        RefPtr<SecurityOrigin> mainFrameOrigin = dynamicDowncast<RemoteFrame>(page->mainFrame()) ? protect(page->mainFrame())->frameDocumentSecurityOrigin() : nullptr;
+        page->setMainFrameURLAndOrigin(remotePageParameters->initialMainDocumentURL, WTF::move(mainFrameOrigin));
 
         if (auto websitePolicies = remotePageParameters->websitePoliciesData) {
             if (auto* remoteMainFrameClient = m_mainFrame->remoteFrameClient())


### PR DESCRIPTION
#### 14926e2a244710d9f93bad46f6d4bf5aeaacf3a7
<pre>
[Site Isolation] Popup&apos;s inherited origin lost during didCommitLoad
<a href="https://bugs.webkit.org/show_bug.cgi?id=314116">https://bugs.webkit.org/show_bug.cgi?id=314116</a>
<a href="https://rdar.apple.com/176293477">rdar://176293477</a>

Reviewed by Sihui Liu.

A popup opened via window.open() inherits its opener&apos;s origin during frame construction.
When the about:blank document commits, didCommitLoad calls updateDocumentSecurityOrigin(nullptr)
which overwrites the inherited origin with an opaque one because the creator reference is not
retained. The opaque origin propagates to cross-origin processes via FrameTreeSyncData and Page::mainFrameOrigin(),
causing the sandbox exemption in isNavigationBlockedByThirdPartyIFrameRedirectBlocking to fail
because it can&apos;t verify the parent is same-origin with the top frame, so navigations from sandboxed
allow-top-navigation iframes are incorrectly blocked.

Add a ForInitialization parameter to updateDocumentSecurityOrigin so the constructor path can set opaque when no
creator exists, while didCommitLoad leaves the origin unchanged and preserves whatever was correctly set during
construction. Pass the correct origin from FrameTreeSyncData to setMainFrameURLAndOrigin in the web process so
Page::mainFrameOrigin() reflects the inherited origin. Make securityOrigin() public and use it in
prepareForProvisionalLoadInProcess to derive the main frame domain, so addAllowedFirstPartyForCookies registers
the correct inherited domain instead of an empty one for about:blank popups.

Test: http/tests/site-isolation/sandbox-allow-top-navigation-cross-origin-iframe.html

* LayoutTests/http/tests/site-isolation/resources/navigate-parent-to-blob.html: Added.
* LayoutTests/http/tests/site-isolation/sandbox-allow-top-navigation-cross-origin-iframe-expected.txt: Added.
* LayoutTests/http/tests/site-isolation/sandbox-allow-top-navigation-cross-origin-iframe.html: Added.
* Source/WebKit/UIProcess/WebFrameProxy.cpp:
(WebKit::WebFrameProxy::WebFrameProxy):
(WebKit::WebFrameProxy::prepareForProvisionalLoadInProcess):
(WebKit::WebFrameProxy::updateDocumentSecurityOrigin):
* Source/WebKit/UIProcess/WebFrameProxy.h:
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::m_allowsImmersiveEnvironments):

Canonical link: <a href="https://commits.webkit.org/312937@main">https://commits.webkit.org/312937@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7553d9f183982e2e23049453b426ecfb5b4bddc7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/161521 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/34995 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/28098 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/170424 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/117892 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/d94fd8ec-61aa-462d-9ec4-55b44705d11d) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/35096 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/34996 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/125307 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/117892 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/164480 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/27609 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/145079 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/105903 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/26658 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/25165 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/18145 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/136352 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/22836 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/172911 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/19953 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/24477 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/133594 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/34669 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/29261 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/133601 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36103 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/34653 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/144631 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/96558 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/28128 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/21450 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/34163 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/101608 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/33663 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/33906 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/33812 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->