### PR TITLE
Fix flaky WebVTT WPT

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -612,6 +612,9 @@ webkit.org/b/290522 imported/w3c/web-platform-tests/html/canvas/offscreen/manual
 imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video [ ImageOnlyFailure ]
 
 # These are the WebVTT rendering WPT we are already passing.
+imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/2_tracks.html [ Pass ]
+imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/3_tracks.html [ Pass ]
+imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/audio_has_no_subtitles.html [ Pass ]
 imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/bidi/u06E9_no_strong_dir.html [ Pass ]
 imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/dom_override_remove_cue_while_paused.html [ Pass ]
 imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/embedded_style_cascade_priority.html [ Pass ]
@@ -624,6 +627,7 @@ imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-mode
 imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/embedded_style_urls.html [ Pass ]
 imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/evil/media_404_omit_subtitles.html [ Pass ]
 imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/evil/media_height_19.html [ Pass ]
+imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/evil/non-standard-pseudo-elements.html [ Pass ]
 imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/2_cues_overlapping_completely_move_up.html [ Pass ]
 imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/decode_escaped_entities.html [ Pass ]
 imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/dom_override_cue_align_position_line_size_while_paused.html [ Pass ]
@@ -638,17 +642,9 @@ imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-mode
 imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/color_hex.html [ Pass ]
 imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/color_hsla.html [ Pass ]
 imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/id_color.html [ Pass ]
-
-# These WebVTT rendering WPT are flaky.
-imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/evil/non-standard-pseudo-elements.html [ ImageOnlyFailure Pass Failure ]
-imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/audio_has_no_subtitles.html [ ImageOnlyFailure Pass Failure ]
-imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/class_object/class_white-space_pre-line_wrapped.html [ Crash ImageOnlyFailure ]
-imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/white-space_normal_wrapped.html [ ImageOnlyFailure Pass Failure ]
-imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/white-space_nowrap_wrapped.html [ ImageOnlyFailure Pass Failure ]
-
-# These WebVTT rendering WPT occasionally time out.
-imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/2_tracks.html [ Skip ]
-imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/3_tracks.html [ Skip ]
+imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/white-space_normal_wrapped.html [ Pass ]
+imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/white-space_nowrap_wrapped.html [ Pass ]
+imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue/white-space_pre.html [ Pass ]
 
 ## -- Enhanced <select> tests -- ##
 # No calc-size() in default style.

--- a/LayoutTests/imported/w3c/web-platform-tests/common/reftest-wait.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/common/reftest-wait.js
@@ -23,6 +23,7 @@ function takeScreenshotDelayed(timeout) {
  * Ensure that a precondition is met before waiting for a screenshot.
  * @param {bool} condition - Fail the test if this evaluates to false
  * @param {string} msg - Error message to write to the screenshot
+ * @returns {bool} True if the condition passed, false if it failed
  */
 function failIfNot(condition, msg) {
   const fail = () => {
@@ -35,5 +36,46 @@ function failIfNot(condition, msg) {
     } else {
       document.addEventListener("DOMContentLoaded", fail, false);
     }
+    return false;
   }
+  return true;
 }
+
+/**
+ * Once a text track cue becomes active, pause the video, wait
+ * for layout to update, then call takeScreenshot().
+ */
+function waitForActiveCueAndTakeScreenshot() {
+    var videoElement = document.querySelector("video");
+    var trackElement = document.querySelector("track");
+
+    if (!failIfNot(videoElement, "Video element not found"))
+        return;
+
+    if (!failIfNot(trackElement, "Track element not found"))
+        return;
+
+    var textTrack = trackElement.track;
+
+    function pauseVideoAndTakeScreenshot() {
+        if (videoElement.paused)
+            requestAnimationFrame(() => takeScreenshot());
+        else {
+            videoElement.addEventListener("pause", function() {
+                requestAnimationFrame(() => takeScreenshot());
+            });
+            videoElement.pause();
+        }
+    }
+
+    textTrack.oncuechange = function() {
+        if (textTrack.activeCues && textTrack.activeCues.length) {
+            textTrack.oncuechange = null;
+            pauseVideoAndTakeScreenshot();
+        }
+    };
+
+    if (textTrack.activeCues && textTrack.activeCues.length)
+        pauseVideoAndTakeScreenshot();
+}
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/media-elements/track/track-element/track-cue-rendering-line-doesnt-fit-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/media-elements/track/track-element/track-cue-rendering-line-doesnt-fit-expected.html
@@ -24,7 +24,7 @@
 }
 </style>
 <div class="container">
-  <video autoplay onplaying="this.onplaying = null; this.pause(); takeScreenshot();">
+  <video autoplay onplaying="this.onplaying = null; waitForActiveCueAndTakeScreenshot();">
     <source src="/media/white.webm" type="video/webm">
     <source src="/media/white.mp4" type="video/mp4">
   </video>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/media-elements/track/track-element/track-cue-rendering-line-doesnt-fit-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/media-elements/track/track-element/track-cue-rendering-line-doesnt-fit-ref.html
@@ -24,7 +24,7 @@
 }
 </style>
 <div class="container">
-  <video autoplay onplaying="this.onplaying = null; this.pause(); takeScreenshot();">
+  <video autoplay onplaying="this.onplaying = null; waitForActiveCueAndTakeScreenshot();">
     <source src="/media/white.webm" type="video/webm">
     <source src="/media/white.mp4" type="video/mp4">
   </video>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/media-elements/track/track-element/track-cue-rendering-line-doesnt-fit.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/media-elements/track/track-element/track-cue-rendering-line-doesnt-fit.html
@@ -17,7 +17,7 @@ video::cue {
   background-color: green;
 }
 </style>
-<video autoplay onplaying="this.onplaying = null; this.pause(); takeScreenshot();">
+<video autoplay onplaying="this.onplaying = null; waitForActiveCueAndTakeScreenshot();">
   <source src="/media/white.webm" type="video/webm">
   <source src="/media/white.mp4" type="video/mp4">
   <script>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/media-elements/track/track-element/track-cue-rendering-transformed-video-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/media-elements/track/track-element/track-cue-rendering-transformed-video-expected.html
@@ -26,7 +26,7 @@
 }
 </style>
 <div class="container">
-  <video autoplay onplaying="this.onplaying = null; this.pause(); takeScreenshot();">
+  <video autoplay onplaying="this.onplaying = null; waitForActiveCueAndTakeScreenshot();">
     <source src="/media/white.webm" type="video/webm">
     <source src="/media/white.mp4" type="video/mp4">
   </video>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/media-elements/track/track-element/track-cue-rendering-transformed-video-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/media-elements/track/track-element/track-cue-rendering-transformed-video-ref.html
@@ -26,7 +26,7 @@
 }
 </style>
 <div class="container">
-  <video autoplay onplaying="this.onplaying = null; this.pause(); takeScreenshot();">
+  <video autoplay onplaying="this.onplaying = null; waitForActiveCueAndTakeScreenshot();">
     <source src="/media/white.webm" type="video/webm">
     <source src="/media/white.mp4" type="video/mp4">
   </video>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/media-elements/track/track-element/track-cue-rendering-transformed-video.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/media-elements/track/track-element/track-cue-rendering-transformed-video.html
@@ -12,7 +12,7 @@ video::cue {
   background-color: green;
 }
 </style>
-<video autoplay onplaying="this.onplaying = null; this.pause(); takeScreenshot();">
+<video autoplay onplaying="this.onplaying = null; waitForActiveCueAndTakeScreenshot();">
   <source src="/media/white.webm" type="video/webm">
   <source src="/media/white.mp4" type="video/mp4">
   <script>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/media-elements/track/track-element/track-webvtt-non-snap-to-lines-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/media-elements/track/track-element/track-webvtt-non-snap-to-lines-expected.html
@@ -19,7 +19,7 @@
 }
 </style>
 <div class="container">
-  <video autoplay onplaying="this.onplaying = null; this.pause(); takeScreenshot();">
+  <video autoplay onplaying="this.onplaying = null; waitForActiveCueAndTakeScreenshot();">
     <script>
     document.currentScript.parentNode.src = getVideoURI("/media/test");
     </script>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/media-elements/track/track-element/track-webvtt-non-snap-to-lines-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/media-elements/track/track-element/track-webvtt-non-snap-to-lines-ref.html
@@ -19,7 +19,7 @@
 }
 </style>
 <div class="container">
-  <video autoplay onplaying="this.onplaying = null; this.pause(); takeScreenshot();">
+  <video autoplay onplaying="this.onplaying = null; waitForActiveCueAndTakeScreenshot();">
     <script>
     document.currentScript.parentNode.src = getVideoURI("/media/test");
     </script>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/media-elements/track/track-element/track-webvtt-non-snap-to-lines.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/media-elements/track/track-element/track-webvtt-non-snap-to-lines.html
@@ -9,7 +9,7 @@
   background: green;
 }
 </style>
-<video autoplay onplaying="this.onplaying = null; this.pause(); takeScreenshot();"></video>
+<video autoplay onplaying="this.onplaying = null; waitForActiveCueAndTakeScreenshot();"></video>
 <script>
 var video = document.querySelector("video");
 var track = video.addTextTrack("captions");

--- a/LayoutTests/imported/w3c/web-platform-tests/tools/third_party/html5lib/benchmarks/data/wpt/random/background_shorthand_css_relative_url.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/tools/third_party/html5lib/benchmarks/data/wpt/random/background_shorthand_css_relative_url.html
@@ -13,7 +13,7 @@ body { margin:0 }
 }
 </style>
 <script src="/common/reftest-wait.js"></script>
-<video width="320" height="180" autoplay onplaying="this.onplaying = null; this.pause(); takeScreenshot();">
+<video width="320" height="180" autoplay onplaying="this.onplaying = null; waitForActiveCueAndTakeScreenshot();">
     <source src="/media/white.webm" type="video/webm">
     <source src="/media/white.mp4" type="video/mp4">
     <track src="../../support/test.vtt">

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/2_tracks.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/2_tracks.html
@@ -11,7 +11,7 @@ body { margin:0 }
 }
 </style>
 <script src="/common/reftest-wait.js"></script>
-<video width="320" height="180" autoplay onplaying="this.onplaying = null; this.pause(); takeScreenshot();">
+<video width="320" height="180" autoplay>
     <source src="/media/white.webm" type="video/webm">
     <source src="/media/white.mp4" type="video/mp4">
     <track src="support/test.vtt">
@@ -20,5 +20,6 @@ body { margin:0 }
 <script>
 document.getElementsByTagName('track')[0].track.mode = 'showing';
 document.getElementsByTagName('track')[1].track.mode = 'showing';
+waitForActiveCueAndTakeScreenshot();
 </script>
 </html>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/3_tracks.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/3_tracks.html
@@ -11,7 +11,7 @@ body { margin:0 }
 }
 </style>
 <script src="/common/reftest-wait.js"></script>
-<video width="320" height="180" autoplay onplaying="this.onplaying = null; this.pause(); takeScreenshot();">
+<video width="320" height="180" autoplay>
     <source src="/media/white.webm" type="video/webm">
     <source src="/media/white.mp4" type="video/mp4">
     <track src="support/test.vtt">
@@ -21,6 +21,7 @@ body { margin:0 }
     document.getElementsByTagName('track')[0].track.mode = 'showing';
     document.getElementsByTagName('track')[1].track.mode = 'showing';
     document.getElementsByTagName('track')[2].track.mode = 'showing';
+    waitForActiveCueAndTakeScreenshot();
     </script>
 </video>
 </html>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/align_center.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/align_center.html
@@ -12,12 +12,13 @@ body { margin:0 }
 }
 </style>
 <script src="/common/reftest-wait.js"></script>
-<video width="320" height="180" autoplay onplaying="this.onplaying = null; this.pause(); takeScreenshot();">
+<video width="320" height="180" autoplay>
     <source src="/media/white.webm" type="video/webm">
     <source src="/media/white.mp4" type="video/mp4">
     <track src="support/align_center.vtt">
     <script>
     document.getElementsByTagName('track')[0].track.mode = 'showing';
+    waitForActiveCueAndTakeScreenshot();
     </script>
 </video>
 </html>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/align_center_position_50.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/align_center_position_50.html
@@ -12,12 +12,13 @@ body { margin:0 }
 }
 </style>
 <script src="/common/reftest-wait.js"></script>
-<video width="320" height="180" autoplay onplaying="this.onplaying = null; this.pause(); takeScreenshot();">
+<video width="320" height="180" autoplay>
     <source src="/media/white.webm" type="video/webm">
     <source src="/media/white.mp4" type="video/mp4">
     <track src="support/align_center_position_50.vtt">
     <script>
     document.getElementsByTagName('track')[0].track.mode = 'showing';
+    waitForActiveCueAndTakeScreenshot();
     </script>
 </video>
 </html>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/align_center_position_gt_50.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/align_center_position_gt_50.html
@@ -12,12 +12,13 @@ body { margin:0 }
 }
 </style>
 <script src="/common/reftest-wait.js"></script>
-<video width="320" height="180" autoplay onplaying="this.onplaying = null; this.pause(); takeScreenshot();">
+<video width="320" height="180" autoplay>
     <source src="/media/white.webm" type="video/webm">
     <source src="/media/white.mp4" type="video/mp4">
     <track src="support/align_center_position_gt_50.vtt">
     <script>
     document.getElementsByTagName('track')[0].track.mode = 'showing';
+    waitForActiveCueAndTakeScreenshot();
     </script>
 </video>
 </html>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/align_center_position_gt_50_size_gt_maximum_size.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/align_center_position_gt_50_size_gt_maximum_size.html
@@ -12,12 +12,13 @@ body { margin:0 }
 }
 </style>
 <script src="/common/reftest-wait.js"></script>
-<video width="320" height="180" autoplay onplaying="this.onplaying = null; this.pause(); takeScreenshot();">
+<video width="320" height="180" autoplay>
     <source src="/media/white.webm" type="video/webm">
     <source src="/media/white.mp4" type="video/mp4">
     <track src="support/align_center_position_gt_50_size_gt_maximum_size.vtt">
 </video>
 <script>
 document.getElementsByTagName('track')[0].track.mode = 'showing';
+waitForActiveCueAndTakeScreenshot();
 </script>
 </html>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/align_center_position_lt_50.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/align_center_position_lt_50.html
@@ -12,12 +12,13 @@ body { margin:0 }
 }
 </style>
 <script src="/common/reftest-wait.js"></script>
-<video width="320" height="180" autoplay onplaying="this.onplaying = null; this.pause(); takeScreenshot();">
+<video width="320" height="180" autoplay>
     <source src="/media/white.webm" type="video/webm">
     <source src="/media/white.mp4" type="video/mp4">
     <track src="support/align_center_position_lt_50.vtt">
     <script>
     document.getElementsByTagName('track')[0].track.mode = 'showing';
+    waitForActiveCueAndTakeScreenshot();
     </script>
 </video>
 </html>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/align_center_position_lt_50_size_gt_maximum_size.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/align_center_position_lt_50_size_gt_maximum_size.html
@@ -12,12 +12,13 @@ body { margin:0 }
 }
 </style>
 <script src="/common/reftest-wait.js"></script>
-<video width="320" height="180" autoplay onplaying="this.onplaying = null; this.pause(); takeScreenshot();">
+<video width="320" height="180" autoplay>
     <source src="/media/white.webm" type="video/webm">
     <source src="/media/white.mp4" type="video/mp4">
     <track src="support/align_center_position_lt_50_size_gt_maximum_size.vtt">
 </video>
 <script>
 document.getElementsByTagName('track')[0].track.mode = 'showing';
+waitForActiveCueAndTakeScreenshot();
 </script>
 </html>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/align_center_wrapped.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/align_center_wrapped.html
@@ -12,12 +12,13 @@ body { margin:0 }
 }
 </style>
 <script src="/common/reftest-wait.js"></script>
-<video width="320" height="180" autoplay onplaying="this.onplaying = null; this.pause(); takeScreenshot();">
+<video width="320" height="180" autoplay>
     <source src="/media/white.webm" type="video/webm">
     <source src="/media/white.mp4" type="video/mp4">
     <track src="support/align_center_long.vtt">
     <script>
     document.getElementsByTagName('track')[0].track.mode = 'showing';
+    waitForActiveCueAndTakeScreenshot();
     </script>
 </video>
 </html>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/align_end.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/align_end.html
@@ -12,12 +12,13 @@ body { margin:0 }
 }
 </style>
 <script src="/common/reftest-wait.js"></script>
-<video width="320" height="180" autoplay onplaying="this.onplaying = null; this.pause(); takeScreenshot();">
+<video width="320" height="180" autoplay>
     <source src="/media/white.webm" type="video/webm">
     <source src="/media/white.mp4" type="video/mp4">
     <track src="support/align_end.vtt">
     <script>
     document.getElementsByTagName('track')[0].track.mode = 'showing';
+    waitForActiveCueAndTakeScreenshot();
     </script>
 </video>
 </html>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/align_end_wrapped.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/align_end_wrapped.html
@@ -12,12 +12,13 @@ body { margin:0 }
 }
 </style>
 <script src="/common/reftest-wait.js"></script>
-<video width="320" height="180" autoplay onplaying="this.onplaying = null; this.pause(); takeScreenshot();">
+<video width="320" height="180" autoplay>
     <source src="/media/white.webm" type="video/webm">
     <source src="/media/white.mp4" type="video/mp4">
     <track src="support/align_end_long.vtt">
     <script>
     document.getElementsByTagName('track')[0].track.mode = 'showing';
+    waitForActiveCueAndTakeScreenshot();
     </script>
 </video>
 </html>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/align_start.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/align_start.html
@@ -12,12 +12,13 @@ body { margin:0 }
 }
 </style>
 <script src="/common/reftest-wait.js"></script>
-<video width="320" height="180" autoplay onplaying="this.onplaying = null; this.pause(); takeScreenshot();">
+<video width="320" height="180" autoplay>
     <source src="/media/white.webm" type="video/webm">
     <source src="/media/white.mp4" type="video/mp4">
     <track src="support/align_start.vtt">
     <script>
     document.getElementsByTagName('track')[0].track.mode = 'showing';
+    waitForActiveCueAndTakeScreenshot();
     </script>
 </video>
 </html>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/align_start_wrapped.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/align_start_wrapped.html
@@ -12,12 +12,13 @@ body { margin:0 }
 }
 </style>
 <script src="/common/reftest-wait.js"></script>
-<video width="320" height="180" autoplay onplaying="this.onplaying = null; this.pause(); takeScreenshot();">
+<video width="320" height="180" autoplay>
     <source src="/media/white.webm" type="video/webm">
     <source src="/media/white.mp4" type="video/mp4">
     <track src="support/align_start_long.vtt">
     <script>
     document.getElementsByTagName('track')[0].track.mode = 'showing';
+    waitForActiveCueAndTakeScreenshot();
     </script>
 </video>
 </html>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/basic.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/basic.html
@@ -12,12 +12,13 @@ body { margin:0 }
 }
 </style>
 <script src="/common/reftest-wait.js"></script>
-<video width="320" height="180" autoplay onplaying="this.onplaying = null; this.pause(); takeScreenshot();">
+<video width="320" height="180" autoplay>
     <source src="/media/white.webm" type="video/webm">
     <source src="/media/white.mp4" type="video/mp4">
     <track src="support/test.vtt">
     <script>
     document.getElementsByTagName('track')[0].track.mode = 'showing';
+    waitForActiveCueAndTakeScreenshot();
     </script>
 </video>
 </html>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/bidi/bidi_ruby.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/bidi/bidi_ruby.html
@@ -7,12 +7,13 @@ html { overflow:hidden }
 body { margin:0 }
 </style>
 <script src="/common/reftest-wait.js"></script>
-<video width="320" height="180" autoplay onplaying="this.onplaying = null; this.pause(); takeScreenshot();">
+<video width="320" height="180" autoplay>
     <source src="/media/white.webm" type="video/webm">
     <source src="/media/white.mp4" type="video/mp4">
     <track src="../support/bidi_ruby.vtt">
     <script>
     document.getElementsByTagName('track')[0].track.mode = 'showing';
+    waitForActiveCueAndTakeScreenshot();
     </script>
 </video>
 </html>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/bidi/start_alignment.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/bidi/start_alignment.html
@@ -11,9 +11,13 @@ body { margin:0 }
 }
 </style>
 <script src="/common/reftest-wait.js"></script>
-<video width="320" height="180" autoplay onplaying="this.onplaying = null; this.pause(); takeScreenshot();">
+<video width="320" height="180" autoplay>
     <source src="/media/white.webm" type="video/webm">
     <source src="/media/white.mp4" type="video/mp4">
     <track src="../support/start_alignment.vtt" default>
 </video>
+<script>
+document.getElementsByTagName('track')[0].track.mode = 'showing';
+waitForActiveCueAndTakeScreenshot();
+</script>
 </html>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/bidi/u002E_LF_u05D0.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/bidi/u002E_LF_u05D0.html
@@ -7,12 +7,13 @@ html { overflow:hidden }
 body { margin:0 }
 </style>
 <script src="/common/reftest-wait.js"></script>
-<video width="320" height="180" autoplay onplaying="this.onplaying = null; this.pause(); takeScreenshot();">
+<video width="320" height="180" autoplay>
     <source src="/media/white.webm" type="video/webm">
     <source src="/media/white.mp4" type="video/mp4">
     <track src="../support/u002E_LF_u05D0.vtt">
     <script>
     document.getElementsByTagName('track')[0].track.mode = 'showing';
+    waitForActiveCueAndTakeScreenshot();
     </script>
 </video>
 </html>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/bidi/u002E_u2028_u05D0.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/bidi/u002E_u2028_u05D0.html
@@ -7,12 +7,13 @@ html { overflow:hidden }
 body { margin:0 }
 </style>
 <script src="/common/reftest-wait.js"></script>
-<video width="320" height="180" autoplay onplaying="this.onplaying = null; this.pause(); takeScreenshot();">
+<video width="320" height="180" autoplay>
     <source src="/media/white.webm" type="video/webm">
     <source src="/media/white.mp4" type="video/mp4">
     <track src="../support/u002E_u2028_u05D0.vtt">
     <script>
     document.getElementsByTagName('track')[0].track.mode = 'showing';
+    waitForActiveCueAndTakeScreenshot();
     </script>
 </video>
 </html>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/bidi/u002E_u2029_u05D0.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/bidi/u002E_u2029_u05D0.html
@@ -7,12 +7,13 @@ html { overflow:hidden }
 body { margin:0 }
 </style>
 <script src="/common/reftest-wait.js"></script>
-<video width="320" height="180" autoplay onplaying="this.onplaying = null; this.pause(); takeScreenshot();">
+<video width="320" height="180" autoplay>
     <source src="/media/white.webm" type="video/webm">
     <source src="/media/white.mp4" type="video/mp4">
     <track src="../support/u002E_u2029_u05D0.vtt">
     <script>
     document.getElementsByTagName('track')[0].track.mode = 'showing';
+    waitForActiveCueAndTakeScreenshot();
     </script>
 </video>
 </html>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/bidi/u0041_first.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/bidi/u0041_first.html
@@ -11,12 +11,13 @@ html { overflow:hidden }
 body { margin:0 }
 </style>
 <script src="/common/reftest-wait.js"></script>
-<video width="320" height="180" autoplay onplaying="this.onplaying = null; this.pause(); takeScreenshot();">
+<video width="320" height="180" autoplay>
     <source src="/media/white.webm" type="video/webm">
     <source src="/media/white.mp4" type="video/mp4">
     <track src="../support/u0041_first.vtt">
     <script>
     document.getElementsByTagName('track')[0].track.mode = 'showing';
+    waitForActiveCueAndTakeScreenshot();
     </script>
 </video>
 </html>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/bidi/u05D0_first.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/bidi/u05D0_first.html
@@ -11,12 +11,13 @@ html { overflow:hidden }
 body { margin:0 }
 </style>
 <script src="/common/reftest-wait.js"></script>
-<video width="320" height="180" autoplay onplaying="this.onplaying = null; this.pause(); takeScreenshot();">
+<video width="320" height="180" autoplay>
     <source src="/media/white.webm" type="video/webm">
     <source src="/media/white.mp4" type="video/mp4">
     <track src="../support/u05D0_first.vtt">
     <script>
     document.getElementsByTagName('track')[0].track.mode = 'showing';
+    waitForActiveCueAndTakeScreenshot();
     </script>
 </video>
 </html>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/bidi/u0628_first.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/bidi/u0628_first.html
@@ -11,12 +11,13 @@ html { overflow:hidden }
 body { margin:0 }
 </style>
 <script src="/common/reftest-wait.js"></script>
-<video width="320" height="180" autoplay onplaying="this.onplaying = null; this.pause(); takeScreenshot();">
+<video width="320" height="180" autoplay>
     <source src="/media/white.webm" type="video/webm">
     <source src="/media/white.mp4" type="video/mp4">
     <track src="../support/u0628_first.vtt">
     <script>
     document.getElementsByTagName('track')[0].track.mode = 'showing';
+    waitForActiveCueAndTakeScreenshot();
     </script>
 </video>
 </html>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/bidi/u06E9_no_strong_dir.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/bidi/u06E9_no_strong_dir.html
@@ -11,12 +11,13 @@ html { overflow:hidden }
 body { margin:0 }
 </style>
 <script src="/common/reftest-wait.js"></script>
-<video width="320" height="180" autoplay onplaying="this.onplaying = null; this.pause(); takeScreenshot();">
+<video width="320" height="180" autoplay>
     <source src="/media/white.webm" type="video/webm">
     <source src="/media/white.mp4" type="video/mp4">
     <track src="../support/u06E9_no_strong_dir.vtt">
     <script>
     document.getElementsByTagName('track')[0].track.mode = 'showing';
+    waitForActiveCueAndTakeScreenshot();
     </script>
 </video>
 </html>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/bidi/vertical_lr.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/bidi/vertical_lr.html
@@ -7,12 +7,13 @@ html { overflow:hidden }
 body { margin:0 }
 </style>
 <script src="/common/reftest-wait.js"></script>
-<video width="320" height="180" autoplay onplaying="this.onplaying = null; this.pause(); takeScreenshot();">
+<video width="320" height="180" autoplay>
     <source src="/media/white.webm" type="video/webm">
     <source src="/media/white.mp4" type="video/mp4">
     <track src="../support/bidi_vertical_lr.vtt">
     <script>
     document.getElementsByTagName('track')[0].track.mode = 'showing';
+    waitForActiveCueAndTakeScreenshot();
     </script>
 </video>
 </html>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/bidi/vertical_rl.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/bidi/vertical_rl.html
@@ -7,12 +7,13 @@ html { overflow:hidden }
 body { margin:0 }
 </style>
 <script src="/common/reftest-wait.js"></script>
-<video width="320" height="180" autoplay onplaying="this.onplaying = null; this.pause(); takeScreenshot();">
+<video width="320" height="180" autoplay>
     <source src="/media/white.webm" type="video/webm">
     <source src="/media/white.mp4" type="video/mp4">
     <track src="../support/bidi_vertical_rl.vtt">
     <script>
     document.getElementsByTagName('track')[0].track.mode = 'showing';
+    waitForActiveCueAndTakeScreenshot();
     </script>
 </video>
 </html>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/cue_too_long.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/cue_too_long.html
@@ -12,12 +12,13 @@ body { margin:0 }
 }
 </style>
 <script src="/common/reftest-wait.js"></script>
-<video width="320" height="180" autoplay onplaying="this.onplaying = null; this.pause(); takeScreenshot();">
+<video width="320" height="180" autoplay>
     <source src="/media/white.webm" type="video/webm">
     <source src="/media/white.mp4" type="video/mp4">
     <track src="support/very_long_cue.vtt">
     <script>
     document.getElementsByTagName('track')[0].track.mode = 'showing';
+    waitForActiveCueAndTakeScreenshot();
     </script>
 </video>
 </html>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/decode_escaped_entities.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/decode_escaped_entities.html
@@ -12,12 +12,13 @@ body { margin:0 }
 }
 </style>
 <script src="/common/reftest-wait.js"></script>
-<video width="320" height="180" autoplay onplaying="this.onplaying = null; this.pause(); takeScreenshot();">
+<video width="320" height="180" autoplay>
     <source src="/media/white.webm" type="video/webm">
     <source src="/media/white.mp4" type="video/mp4">
     <track src="support/decode_escaped_entities.vtt">
     <script>
     document.getElementsByTagName('track')[0].track.mode = 'showing';
+    waitForActiveCueAndTakeScreenshot();
     </script>
 </video>
 </html>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/embedded_style_multiple_tracks-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/embedded_style_multiple_tracks-expected.html
@@ -7,13 +7,13 @@
 }
 </style>
 <script src="/common/reftest-wait.js"></script>
-<video width="320" height="180" autoplay onplaying="this.onplaying = null; this.pause(); takeScreenshot();">
+<video width="320" height="180" autoplay>
     <source src="/media/white.webm" type="video/webm">
     <source src="/media/white.mp4" type="video/mp4">
     <track src="support/embedded_style_without_style.vtt">
     <script>
     document.getElementsByTagName('track')[0].track.mode = 'showing';
-    document.getElementsByTagName('track')[1].track.mode = 'showing';
+    waitForActiveCueAndTakeScreenshot();
     </script>
 </video>
 </html>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/embedded_style_multiple_tracks-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/embedded_style_multiple_tracks-ref.html
@@ -7,13 +7,14 @@
 }
 </style>
 <script src="/common/reftest-wait.js"></script>
-<video width="320" height="180" autoplay onplaying="this.onplaying = null; this.pause(); takeScreenshot();">
+<video width="320" height="180" autoplay>
     <source src="/media/white.webm" type="video/webm">
     <source src="/media/white.mp4" type="video/mp4">
     <track src="support/embedded_style_without_style.vtt">
     <script>
     document.getElementsByTagName('track')[0].track.mode = 'showing';
     document.getElementsByTagName('track')[1].track.mode = 'showing';
+    waitForActiveCueAndTakeScreenshot();
     </script>
 </video>
 </html>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/embedded_style_multiple_tracks.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/embedded_style_multiple_tracks.html
@@ -4,7 +4,7 @@
 <link rel="match" href="embedded_style_multiple_tracks-ref.html">
 <link rel="help" href="https://w3c.github.io/webvtt/#obtaining-css-boxes">
 <script src="/common/reftest-wait.js"></script>
-<video width="320" height="180" autoplay onplaying="this.onplaying = null; this.pause(); takeScreenshot();">
+<video width="320" height="180" autoplay>
     <source src="/media/white.webm" type="video/webm">
     <source src="/media/white.mp4" type="video/mp4">
     <track src="support/embedded_style_multiple_tracks1.vtt">
@@ -12,6 +12,7 @@
     <script>
     document.getElementsByTagName('track')[0].track.mode = 'showing';
     document.getElementsByTagName('track')[1].track.mode = 'showing';
+    waitForActiveCueAndTakeScreenshot();
     </script>
 </video>
 </html>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/evil/media_height_19.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/evil/media_height_19.html
@@ -12,12 +12,13 @@ body { margin:0 }
 }
 </style>
 <script src="/common/reftest-wait.js"></script>
-<video width="320" height="19" autoplay onplaying="this.onplaying = null; this.pause(); takeScreenshot();">
+<video width="320" height="19" autoplay>
     <source src="/media/white.webm" type="video/webm">
     <source src="/media/white.mp4" type="video/mp4">
     <track src="support/test.vtt">
     <script>
     document.getElementsByTagName('track')[0].track.mode = 'showing';
+    waitForActiveCueAndTakeScreenshot();
     </script>
 </video>
 </html>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/evil/single_quote.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/evil/single_quote.html
@@ -12,12 +12,13 @@ body { margin:0 }
 }
 </style>
 <script src="/common/reftest-wait.js"></script>
-<video width="320" height="180" autoplay onplaying="this.onplaying = null; this.pause(); takeScreenshot();">
+<video width="320" height="180" autoplay>
     <source src="/media/white.webm" type="video/webm">
     <source src="/media/white.mp4" type="video/mp4">
     <track src="support/single_quote.vtt">
     <script>
     document.getElementsByTagName('track')[0].track.mode = 'showing';
+    waitForActiveCueAndTakeScreenshot();
     </script>
 </video>
 </html>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/evil/size_90.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/evil/size_90.html
@@ -12,12 +12,13 @@ body { margin:0 }
 }
 </style>
 <script src="/common/reftest-wait.js"></script>
-<video width="320" height="180" autoplay onplaying="this.onplaying = null; this.pause(); takeScreenshot();">
+<video width="320" height="180" autoplay>
     <source src="/media/white.webm" type="video/webm">
     <source src="/media/white.mp4" type="video/mp4">
     <track src="support/size_90.vtt">
     <script>
     document.getElementsByTagName('track')[0].track.mode = 'showing';
+    waitForActiveCueAndTakeScreenshot();
     </script>
 </video>
 </html>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/evil/size_99.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/evil/size_99.html
@@ -12,12 +12,13 @@ body { margin:0 }
 }
 </style>
 <script src="/common/reftest-wait.js"></script>
-<video width="320" height="180" autoplay onplaying="this.onplaying = null; this.pause(); takeScreenshot();">
+<video width="320" height="180" autoplay>
     <source src="/media/white.webm" type="video/webm">
     <source src="/media/white.mp4" type="video/mp4">
     <track src="support/size_99.vtt">
     <script>
     document.getElementsByTagName('track')[0].track.mode = 'showing';
+    waitForActiveCueAndTakeScreenshot();
     </script>
 </video>
 </html>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/line_-2_wrapped_cue_grow_upwards.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/line_-2_wrapped_cue_grow_upwards.html
@@ -12,12 +12,13 @@ body { margin:0 }
 }
 </style>
 <script src="/common/reftest-wait.js"></script>
-<video width="320" height="180" autoplay onplaying="this.onplaying = null; this.pause(); takeScreenshot();">
+<video width="320" height="180" autoplay>
     <source src="/media/white.webm" type="video/webm">
     <source src="/media/white.mp4" type="video/mp4">
     <track src="support/line_-2_long.vtt">
     <script>
     document.getElementsByTagName('track')[0].track.mode = 'showing';
+    waitForActiveCueAndTakeScreenshot();
     </script>
 </video>
 </html>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/line_0_is_top.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/line_0_is_top.html
@@ -12,12 +12,13 @@ body { margin:0 }
 }
 </style>
 <script src="/common/reftest-wait.js"></script>
-<video width="320" height="180" autoplay onplaying="this.onplaying = null; this.pause(); takeScreenshot();">
+<video width="320" height="180" autoplay>
     <source src="/media/white.webm" type="video/webm">
     <source src="/media/white.mp4" type="video/mp4">
     <track src="support/line_0.vtt">
     <script>
     document.getElementsByTagName('track')[0].track.mode = 'showing';
+    waitForActiveCueAndTakeScreenshot();
     </script>
 </video>
 </html>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/line_1_wrapped_cue_grow_downwards.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/line_1_wrapped_cue_grow_downwards.html
@@ -12,12 +12,13 @@ body { margin:0 }
 }
 </style>
 <script src="/common/reftest-wait.js"></script>
-<video width="320" height="180" autoplay onplaying="this.onplaying = null; this.pause(); takeScreenshot();">
+<video width="320" height="180" autoplay>
     <source src="/media/white.webm" type="video/webm">
     <source src="/media/white.mp4" type="video/mp4">
     <track src="support/line_1_long.vtt">
     <script>
     document.getElementsByTagName('track')[0].track.mode = 'showing';
+    waitForActiveCueAndTakeScreenshot();
     </script>
 </video>
 </html>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/line_50_percent.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/line_50_percent.html
@@ -12,12 +12,13 @@ body { margin:0 }
 }
 </style>
 <script src="/common/reftest-wait.js"></script>
-<video width="320" height="180" autoplay onplaying="this.onplaying = null; this.pause(); takeScreenshot();">
+<video width="320" height="180" autoplay>
     <source src="/media/white.webm" type="video/webm">
     <source src="/media/white.mp4" type="video/mp4">
     <track src="support/line_50_percent.vtt">
     <script>
     document.getElementsByTagName('track')[0].track.mode = 'showing';
+    waitForActiveCueAndTakeScreenshot();
     </script>
 </video>
 </html>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/line_integer_and_percent_mixed_overlap.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/line_integer_and_percent_mixed_overlap.html
@@ -12,12 +12,13 @@ body { margin:0 }
 }
 </style>
 <script src="/common/reftest-wait.js"></script>
-<video width="320" height="180" autoplay onplaying="this.onplaying = null; this.pause(); takeScreenshot();">
+<video width="320" height="180" autoplay>
     <source src="/media/white.webm" type="video/webm">
     <source src="/media/white.mp4" type="video/mp4">
     <track src="support/line_integer_and_percent_overlap.vtt">
     <script>
     document.getElementsByTagName('track')[0].track.mode = 'showing';
+    waitForActiveCueAndTakeScreenshot();
     </script>
 </video>
 </html>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/line_integer_and_percent_mixed_overlap_move_up.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/line_integer_and_percent_mixed_overlap_move_up.html
@@ -12,12 +12,13 @@ body { margin:0 }
 }
 </style>
 <script src="/common/reftest-wait.js"></script>
-<video width="320" height="180" autoplay onplaying="this.onplaying = null; this.pause(); takeScreenshot();">
+<video width="320" height="180" autoplay>
     <source src="/media/white.webm" type="video/webm">
     <source src="/media/white.mp4" type="video/mp4">
     <track src="support/line_integer_and_percent_overlap_move_up.vtt">
     <script>
     document.getElementsByTagName('track')[0].track.mode = 'showing';
+    waitForActiveCueAndTakeScreenshot();
     </script>
 </video>
 </html>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/line_percent_and_integer_mixed_overlap.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/line_percent_and_integer_mixed_overlap.html
@@ -12,12 +12,13 @@ body { margin:0 }
 }
 </style>
 <script src="/common/reftest-wait.js"></script>
-<video width="320" height="180" autoplay onplaying="this.onplaying = null; this.pause(); takeScreenshot();">
+<video width="320" height="180" autoplay>
     <source src="/media/white.webm" type="video/webm">
     <source src="/media/white.mp4" type="video/mp4">
     <track src="support/line_percent_and_integer_overlap.vtt">
     <script>
     document.getElementsByTagName('track')[0].track.mode = 'showing';
+    waitForActiveCueAndTakeScreenshot();
     </script>
 </video>
 </html>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/line_percent_and_integer_mixed_overlap_move_up.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/line_percent_and_integer_mixed_overlap_move_up.html
@@ -12,12 +12,13 @@ body { margin:0 }
 }
 </style>
 <script src="/common/reftest-wait.js"></script>
-<video width="320" height="180" autoplay onplaying="this.onplaying = null; this.pause(); takeScreenshot();">
+<video width="320" height="180" autoplay>
     <source src="/media/white.webm" type="video/webm">
     <source src="/media/white.mp4" type="video/mp4">
     <track src="support/line_percent_and_integer_overlap_move_up.vtt">
     <script>
     document.getElementsByTagName('track')[0].track.mode = 'showing';
+    waitForActiveCueAndTakeScreenshot();
     </script>
 </video>
 </html>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/one_line_cue_plus_wrapped_cue.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/one_line_cue_plus_wrapped_cue.html
@@ -12,12 +12,13 @@ body { margin:0 }
 }
 </style>
 <script src="/common/reftest-wait.js"></script>
-<video width="320" height="180" autoplay onplaying="this.onplaying = null; this.pause(); takeScreenshot();">
+<video width="320" height="180" autoplay>
     <source src="/media/white.webm" type="video/webm">
     <source src="/media/white.mp4" type="video/mp4">
     <track src="support/one_line_cue_plus_wrapped_cue.vtt">
     <script>
     document.getElementsByTagName('track')[0].track.mode = 'showing';
+    waitForActiveCueAndTakeScreenshot();
     </script>
 </video>
 </html>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/portrait.tentative.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/portrait.tentative.html
@@ -12,12 +12,13 @@ body { margin:0 }
 }
 </style>
 <script src="/common/reftest-wait.js"></script>
-<video width="180" height="320" autoplay onplaying="this.onplaying = null; this.pause(); takeScreenshot();">
+<video width="180" height="320" autoplay>
     <source src="/media/white.webm" type="video/webm">
     <source src="/media/white.mp4" type="video/mp4">
     <track src="support/test.vtt">
     <script>
     document.getElementsByTagName('track')[0].track.mode = 'showing';
+    waitForActiveCueAndTakeScreenshot();
     </script>
 </video>
 </html>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/regions/basic.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/regions/basic.html
@@ -12,12 +12,13 @@ body { margin:0 }
 }
 </style>
 <script src="/common/reftest-wait.js"></script>
-<video width="320" height="180" autoplay onplaying="this.onplaying = null; this.pause(); takeScreenshot();">
+<video width="320" height="180" autoplay>
     <source src="/media/white.webm" type="video/webm">
     <source src="/media/white.mp4" type="video/mp4">
     <track src="support/basic.vtt">
     <script>
     document.getElementsByTagName('track')[0].track.mode = 'showing';
+    waitForActiveCueAndTakeScreenshot();
     </script>
 </video>
 </html>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/regions/regionanchor_x_50_percent.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/regions/regionanchor_x_50_percent.html
@@ -12,12 +12,13 @@ body { margin:0 }
 }
 </style>
 <script src="/common/reftest-wait.js"></script>
-<video width="320" height="180" autoplay onplaying="this.onplaying = null; this.pause(); takeScreenshot();">
+<video width="320" height="180" autoplay>
     <source src="/media/white.webm" type="video/webm">
     <source src="/media/white.mp4" type="video/mp4">
     <track src="support/regionanchor_x_50_percent.vtt">
     <script>
     document.getElementsByTagName('track')[0].track.mode = 'showing';
+    waitForActiveCueAndTakeScreenshot();
     </script>
 </video>
 </html>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/regions/regionanchor_y_50_percent.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/regions/regionanchor_y_50_percent.html
@@ -12,12 +12,13 @@ body { margin:0 }
 }
 </style>
 <script src="/common/reftest-wait.js"></script>
-<video width="320" height="180" autoplay onplaying="this.onplaying = null; this.pause(); takeScreenshot();">
+<video width="320" height="180" autoplay>
     <source src="/media/white.webm" type="video/webm">
     <source src="/media/white.mp4" type="video/mp4">
     <track src="support/regionanchor_y_50_percent.vtt">
     <script>
     document.getElementsByTagName('track')[0].track.mode = 'showing';
+    waitForActiveCueAndTakeScreenshot();
     </script>
 </video>
 </html>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/regions/single_line_top_left.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/regions/single_line_top_left.html
@@ -12,12 +12,13 @@ body { margin:0 }
 }
 </style>
 <script src="/common/reftest-wait.js"></script>
-<video width="320" height="180" autoplay onplaying="this.onplaying = null; this.pause(); takeScreenshot();">
+<video width="320" height="180" autoplay>
     <source src="/media/white.webm" type="video/webm">
     <source src="/media/white.mp4" type="video/mp4">
     <track src="support/single_line_top_left.vtt">
     <script>
     document.getElementsByTagName('track')[0].track.mode = 'showing';
+    waitForActiveCueAndTakeScreenshot();
     </script>
 </video>
 </html>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/regions/viewportanchor_x_50_percent.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/regions/viewportanchor_x_50_percent.html
@@ -12,12 +12,13 @@ body { margin:0 }
 }
 </style>
 <script src="/common/reftest-wait.js"></script>
-<video width="320" height="180" autoplay onplaying="this.onplaying = null; this.pause(); takeScreenshot();">
+<video width="320" height="180" autoplay>
     <source src="/media/white.webm" type="video/webm">
     <source src="/media/white.mp4" type="video/mp4">
     <track src="support/viewportanchor_x_50_percent.vtt">
     <script>
     document.getElementsByTagName('track')[0].track.mode = 'showing';
+    waitForActiveCueAndTakeScreenshot();
     </script>
 </video>
 </html>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/regions/viewportanchor_y_50_percent.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/regions/viewportanchor_y_50_percent.html
@@ -12,12 +12,13 @@ body { margin:0 }
 }
 </style>
 <script src="/common/reftest-wait.js"></script>
-<video width="320" height="180" autoplay onplaying="this.onplaying = null; this.pause(); takeScreenshot();">
+<video width="320" height="180" autoplay>
     <source src="/media/white.webm" type="video/webm">
     <source src="/media/white.mp4" type="video/mp4">
     <track src="support/viewportanchor_y_50_percent.vtt">
     <script>
     document.getElementsByTagName('track')[0].track.mode = 'showing';
+    waitForActiveCueAndTakeScreenshot();
     </script>
 </video>
 </html>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/regions/width_50_percent.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/regions/width_50_percent.html
@@ -12,12 +12,13 @@ body { margin:0 }
 }
 </style>
 <script src="/common/reftest-wait.js"></script>
-<video width="320" height="180" autoplay onplaying="this.onplaying = null; this.pause(); takeScreenshot();">
+<video width="320" height="180" autoplay>
     <source src="/media/white.webm" type="video/webm">
     <source src="/media/white.mp4" type="video/mp4">
     <track src="support/width_50_percent.vtt">
     <script>
     document.getElementsByTagName('track')[0].track.mode = 'showing';
+    waitForActiveCueAndTakeScreenshot();
     </script>
 </video>
 </html>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue-region/font_properties.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue-region/font_properties.html
@@ -20,12 +20,13 @@ body { margin:0 }
 }
 </style>
 <script src="/common/reftest-wait.js"></script>
-<video width="320" height="180" autoplay onplaying="this.onplaying = null; this.pause(); takeScreenshot();">
+<video width="320" height="180" autoplay>
     <source src="/media/white.webm" type="video/webm">
     <source src="/media/white.mp4" type="video/mp4">
     <track src="support/test.vtt">
     <script>
     document.getElementsByTagName('track')[0].track.mode = 'showing';
+    waitForActiveCueAndTakeScreenshot();
     </script>
 </video>
 </html>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue-region_function/font_properties.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue-region_function/font_properties.html
@@ -20,12 +20,13 @@ body { margin:0 }
 }
 </style>
 <script src="/common/reftest-wait.js"></script>
-<video width="320" height="180" autoplay onplaying="this.onplaying = null; this.pause(); takeScreenshot();">
+<video width="320" height="180" autoplay>
     <source src="/media/white.webm" type="video/webm">
     <source src="/media/white.mp4" type="video/mp4">
     <track src="support/test.vtt">
     <script>
     document.getElementsByTagName('track')[0].track.mode = 'showing';
+    waitForActiveCueAndTakeScreenshot();
     </script>
 </video>
 </html>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue/background_properties.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue/background_properties.html
@@ -16,12 +16,13 @@ body { margin:0 }
 }
 </style>
 <script src="/common/reftest-wait.js"></script>
-<video width="320" height="180" autoplay onplaying="this.onplaying = null; this.pause(); takeScreenshot();">
+<video width="320" height="180" autoplay>
     <source src="/media/white.webm" type="video/webm">
     <source src="/media/white.mp4" type="video/mp4">
     <track src="../../support/test.vtt">
     <script>
     document.getElementsByTagName('track')[0].track.mode = 'showing';
+    waitForActiveCueAndTakeScreenshot();
     </script>
 </video>
 </html>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue/background_shorthand.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue/background_shorthand.html
@@ -13,12 +13,13 @@ body { margin:0 }
 }
 </style>
 <script src="/common/reftest-wait.js"></script>
-<video width="320" height="180" autoplay onplaying="this.onplaying = null; this.pause(); takeScreenshot();">
+<video width="320" height="180" autoplay>
     <source src="/media/white.webm" type="video/webm">
     <source src="/media/white.mp4" type="video/mp4">
     <track src="../../support/test.vtt">
     <script>
     document.getElementsByTagName('track')[0].track.mode = 'showing';
+    waitForActiveCueAndTakeScreenshot();
     </script>
 </video>
 </html>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue/color_hex.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue/color_hex.html
@@ -12,12 +12,13 @@ body { margin:0 }
 }
 </style>
 <script src="/common/reftest-wait.js"></script>
-<video width="320" height="180" autoplay onplaying="this.onplaying = null; this.pause(); takeScreenshot();">
+<video width="320" height="180" autoplay>
     <source src="/media/white.webm" type="video/webm">
     <source src="/media/white.mp4" type="video/mp4">
     <track src="../../support/test.vtt">
     <script>
     document.getElementsByTagName('track')[0].track.mode = 'showing';
+    waitForActiveCueAndTakeScreenshot();
     </script>
 </video>
 </html>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue/color_hsla.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue/color_hsla.html
@@ -12,12 +12,13 @@ body { margin:0 }
 }
 </style>
 <script src="/common/reftest-wait.js"></script>
-<video width="320" height="180" autoplay onplaying="this.onplaying = null; this.pause(); takeScreenshot();">
+<video width="320" height="180" autoplay>
     <source src="/media/white.webm" type="video/webm">
     <source src="/media/white.mp4" type="video/mp4">
     <track src="../../support/test.vtt">
     <script>
     document.getElementsByTagName('track')[0].track.mode = 'showing';
+    waitForActiveCueAndTakeScreenshot();
     </script>
 </video>
 </html>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue/color_rgba.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue/color_rgba.html
@@ -12,12 +12,13 @@ body { margin:0 }
 }
 </style>
 <script src="/common/reftest-wait.js"></script>
-<video width="320" height="180" autoplay onplaying="this.onplaying = null; this.pause(); takeScreenshot();">
+<video width="320" height="180" autoplay>
     <source src="/media/white.webm" type="video/webm">
     <source src="/media/white.mp4" type="video/mp4">
     <track src="../../support/test.vtt">
     <script>
     document.getElementsByTagName('track')[0].track.mode = 'showing';
+    waitForActiveCueAndTakeScreenshot();
     </script>
 </video>
 </html>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue/cue_selector_single_colon.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue/cue_selector_single_colon.html
@@ -11,12 +11,13 @@ body { margin:0 }
 }
 </style>
 <script src="/common/reftest-wait.js"></script>
-<video width="320" height="180" autoplay onplaying="this.onplaying = null; this.pause(); takeScreenshot();">
+<video width="320" height="180" autoplay>
     <source src="/media/white.webm" type="video/webm">
     <source src="/media/white.mp4" type="video/mp4">
     <track src="../../support/test.vtt">
     <script>
     document.getElementsByTagName('track')[0].track.mode = 'showing';
+    waitForActiveCueAndTakeScreenshot();
     </script>
 </video>
 </html>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue/font_properties.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue/font_properties.html
@@ -15,12 +15,13 @@ body { margin:0 }
 }
 </style>
 <script src="/common/reftest-wait.js"></script>
-<video width="320" height="180" autoplay onplaying="this.onplaying = null; this.pause(); takeScreenshot();">
+<video width="320" height="180" autoplay>
     <source src="/media/white.webm" type="video/webm">
     <source src="/media/white.mp4" type="video/mp4">
     <track src="../../support/test_long.vtt">
     <script>
     document.getElementsByTagName('track')[0].track.mode = 'showing';
+    waitForActiveCueAndTakeScreenshot();
     </script>
 </video>
 </html>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue/font_shorthand.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue/font_shorthand.html
@@ -10,12 +10,13 @@ body { margin:0 }
 }
 </style>
 <script src="/common/reftest-wait.js"></script>
-<video width="320" height="180" autoplay onplaying="this.onplaying = null; this.pause(); takeScreenshot();">
+<video width="320" height="180" autoplay>
     <source src="/media/white.webm" type="video/webm">
     <source src="/media/white.mp4" type="video/mp4">
     <track src="../../support/test_long.vtt">
     <script>
     document.getElementsByTagName('track')[0].track.mode = 'showing';
+    waitForActiveCueAndTakeScreenshot();
     </script>
 </video>
 </html>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue/inherit_values_from_media_element.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue/inherit_values_from_media_element.html
@@ -23,12 +23,13 @@ video {
 }
 </style>
 <script src="/common/reftest-wait.js"></script>
-<video width="320" height="180" autoplay onplaying="this.onplaying = null; this.pause(); takeScreenshot();">
+<video width="320" height="180" autoplay>
     <source src="/media/white.webm" type="video/webm">
     <source src="/media/white.mp4" type="video/mp4">
     <track src="../../support/white-spaces_long.vtt">
     <script>
     document.getElementsByTagName('track')[0].track.mode = 'showing';
+    waitForActiveCueAndTakeScreenshot();
     </script>
 </video>
 </html>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue/outline_properties.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue/outline_properties.html
@@ -15,12 +15,13 @@ body { margin:0 }
 }
 </style>
 <script src="/common/reftest-wait.js"></script>
-<video width="320" height="180" autoplay onplaying="this.onplaying = null; this.pause(); takeScreenshot();">
+<video width="320" height="180" autoplay>
     <source src="/media/white.webm" type="video/webm">
     <source src="/media/white.mp4" type="video/mp4">
     <track src="../../support/test.vtt">
     <script>
     document.getElementsByTagName('track')[0].track.mode = 'showing';
+    waitForActiveCueAndTakeScreenshot();
     </script>
 </video>
 </html>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue/outline_shorthand.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue/outline_shorthand.html
@@ -13,12 +13,13 @@ body { margin:0 }
 }
 </style>
 <script src="/common/reftest-wait.js"></script>
-<video width="320" height="180" autoplay onplaying="this.onplaying = null; this.pause(); takeScreenshot();">
+<video width="320" height="180" autoplay>
     <source src="/media/white.webm" type="video/webm">
     <source src="/media/white.mp4" type="video/mp4">
     <track src="../../support/test.vtt">
     <script>
     document.getElementsByTagName('track')[0].track.mode = 'showing';
+    waitForActiveCueAndTakeScreenshot();
     </script>
 </video>
 </html>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue/text-decoration_line-through.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue/text-decoration_line-through.html
@@ -11,12 +11,13 @@ body { margin:0 }
 }
 </style>
 <script src="/common/reftest-wait.js"></script>
-<video width="320" height="180" autoplay onplaying="this.onplaying = null; this.pause(); takeScreenshot();">
+<video width="320" height="180" autoplay>
     <source src="/media/white.webm" type="video/webm">
     <source src="/media/white.mp4" type="video/mp4">
     <track src="../../support/test.vtt">
     <script>
     document.getElementsByTagName('track')[0].track.mode = 'showing';
+    waitForActiveCueAndTakeScreenshot();
     </script>
 </video>
 </html>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue/text-decoration_overline.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue/text-decoration_overline.html
@@ -11,12 +11,13 @@ body { margin:0 }
 }
 </style>
 <script src="/common/reftest-wait.js"></script>
-<video width="320" height="180" autoplay onplaying="this.onplaying = null; this.pause(); takeScreenshot();">
+<video width="320" height="180" autoplay>
     <source src="/media/white.webm" type="video/webm">
     <source src="/media/white.mp4" type="video/mp4">
     <track src="../../support/test.vtt">
     <script>
     document.getElementsByTagName('track')[0].track.mode = 'showing';
+    waitForActiveCueAndTakeScreenshot();
     </script>
 </video>
 </html>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue/text-decoration_overline_underline_line-through.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue/text-decoration_overline_underline_line-through.html
@@ -11,12 +11,13 @@ body { margin:0 }
 }
 </style>
 <script src="/common/reftest-wait.js"></script>
-<video width="320" height="180" autoplay onplaying="this.onplaying = null; this.pause(); takeScreenshot();">
+<video width="320" height="180" autoplay>
     <source src="/media/white.webm" type="video/webm">
     <source src="/media/white.mp4" type="video/mp4">
     <track src="../../support/test.vtt">
     <script>
     document.getElementsByTagName('track')[0].track.mode = 'showing';
+    waitForActiveCueAndTakeScreenshot();
     </script>
 </video>
 </html>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue/text-decoration_underline.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue/text-decoration_underline.html
@@ -11,12 +11,13 @@ body { margin:0 }
 }
 </style>
 <script src="/common/reftest-wait.js"></script>
-<video width="320" height="180" autoplay onplaying="this.onplaying = null; this.pause(); takeScreenshot();">
+<video width="320" height="180" autoplay>
     <source src="/media/white.webm" type="video/webm">
     <source src="/media/white.mp4" type="video/mp4">
     <track src="../../support/test.vtt">
     <script>
     document.getElementsByTagName('track')[0].track.mode = 'showing';
+    waitForActiveCueAndTakeScreenshot();
     </script>
 </video>
 </html>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue/text-shadow.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue/text-shadow.html
@@ -11,12 +11,13 @@ body { margin:0 }
 }
 </style>
 <script src="/common/reftest-wait.js"></script>
-<video width="320" height="180" autoplay onplaying="this.onplaying = null; this.pause(); takeScreenshot();">
+<video width="320" height="180" autoplay>
     <source src="/media/white.webm" type="video/webm">
     <source src="/media/white.mp4" type="video/mp4">
     <track src="../../support/test.vtt">
     <script>
     document.getElementsByTagName('track')[0].track.mode = 'showing';
+    waitForActiveCueAndTakeScreenshot();
     </script>
 </video>
 </html>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue/vertical_text-combine-upright.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue/vertical_text-combine-upright.html
@@ -14,12 +14,13 @@ body { margin:0 }
 }
 </style>
 <script src="/common/reftest-wait.js"></script>
-<video width="320" height="180" autoplay onplaying="this.onplaying = null; this.pause(); takeScreenshot();">
+<video width="320" height="180" autoplay>
     <source src="/media/white.webm" type="video/webm">
     <source src="/media/white.mp4" type="video/mp4">
     <track src="../../support/bidi_text-combine-upright.vtt">
     <script>
     document.getElementsByTagName('track')[0].track.mode = 'showing';
+    waitForActiveCueAndTakeScreenshot();
     </script>
 </video>
 </html>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue/white-space_normal_wrapped.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue/white-space_normal_wrapped.html
@@ -10,12 +10,13 @@ body { margin:0 }
 }
 </style>
 <script src="/common/reftest-wait.js"></script>
-<video width="320" height="180" autoplay onplaying="this.onplaying = null; this.pause(); takeScreenshot();">
+<video width="320" height="180" autoplay>
     <source src="/media/white.webm" type="video/webm">
     <source src="/media/white.mp4" type="video/mp4">
     <track src="../../support/foo_space_space_bar_LF_baz.vtt">
     <script>
     document.getElementsByTagName('track')[0].track.mode = 'showing';
+    waitForActiveCueAndTakeScreenshot();
     </script>
 </video>
 </html>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue/white-space_nowrap_wrapped.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue/white-space_nowrap_wrapped.html
@@ -10,12 +10,13 @@ body { margin:0 }
 }
 </style>
 <script src="/common/reftest-wait.js"></script>
-<video width="320" height="180" autoplay onplaying="this.onplaying = null; this.pause(); takeScreenshot();">
+<video width="320" height="180" autoplay>
     <source src="/media/white.webm" type="video/webm">
     <source src="/media/white.mp4" type="video/mp4">
     <track src="../../support/white-spaces_long_size_20.vtt">
     <script>
     document.getElementsByTagName('track')[0].track.mode = 'showing';
+    waitForActiveCueAndTakeScreenshot();
     </script>
 </video>
 </html>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue/white-space_pre-line_wrapped.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue/white-space_pre-line_wrapped.html
@@ -10,12 +10,13 @@ body { margin:0 }
 }
 </style>
 <script src="/common/reftest-wait.js"></script>
-<video width="320" height="180" autoplay onplaying="this.onplaying = null; this.pause(); takeScreenshot();">
+<video width="320" height="180" autoplay>
     <source src="/media/white.webm" type="video/webm">
     <source src="/media/white.mp4" type="video/mp4">
     <track src="../../support/white-spaces_long_size_20.vtt">
     <script>
     document.getElementsByTagName('track')[0].track.mode = 'showing';
+    waitForActiveCueAndTakeScreenshot();
     </script>
 </video>
 </html>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue/white-space_pre-wrap_wrapped.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue/white-space_pre-wrap_wrapped.html
@@ -10,12 +10,13 @@ body { margin:0 }
 }
 </style>
 <script src="/common/reftest-wait.js"></script>
-<video width="320" height="180" autoplay onplaying="this.onplaying = null; this.pause(); takeScreenshot();">
+<video width="320" height="180" autoplay>
     <source src="/media/white.webm" type="video/webm">
     <source src="/media/white.mp4" type="video/mp4">
     <track src="../../support/white-spaces_long.vtt">
     <script>
     document.getElementsByTagName('track')[0].track.mode = 'showing';
+    waitForActiveCueAndTakeScreenshot();
     </script>
 </video>
 </html>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue/white-space_pre.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue/white-space_pre.html
@@ -10,12 +10,13 @@ body { margin:0 }
 }
 </style>
 <script src="/common/reftest-wait.js"></script>
-<video width="320" height="180" autoplay onplaying="this.onplaying = null; this.pause(); takeScreenshot();">
+<video width="320" height="180" autoplay>
     <source src="/media/white.webm" type="video/webm">
     <source src="/media/white.mp4" type="video/mp4">
     <track src="../../support/white-spaces.vtt">
     <script>
     document.getElementsByTagName('track')[0].track.mode = 'showing';
+    waitForActiveCueAndTakeScreenshot();
     </script>
 </video>
 </html>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue/white-space_pre_wrapped.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue/white-space_pre_wrapped.html
@@ -10,12 +10,13 @@ body { margin:0 }
 }
 </style>
 <script src="/common/reftest-wait.js"></script>
-<video width="320" height="180" autoplay onplaying="this.onplaying = null; this.pause(); takeScreenshot();">
+<video width="320" height="180" autoplay>
     <source src="/media/white.webm" type="video/webm">
     <source src="/media/white.mp4" type="video/mp4">
     <track src="../../support/white-spaces_long.vtt">
     <script>
     document.getElementsByTagName('track')[0].track.mode = 'showing';
+    waitForActiveCueAndTakeScreenshot();
     </script>
 </video>
 </html>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/background_box.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/background_box.html
@@ -11,12 +11,13 @@ body { margin:0 }
 }
 </style>
 <script src="/common/reftest-wait.js"></script>
-<video width="320" height="180" autoplay onplaying="this.onplaying = null; this.pause(); takeScreenshot();">
+<video width="320" height="180" autoplay>
     <source src="/media/white.webm" type="video/webm">
     <source src="/media/white.mp4" type="video/mp4">
     <track src="../../support/test.vtt">
     <script>
     document.getElementsByTagName('track')[0].track.mode = 'showing';
+    waitForActiveCueAndTakeScreenshot();
     </script>
 </video>
 </html>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/background_properties.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/background_properties.html
@@ -16,12 +16,13 @@ body { margin:0 }
 }
 </style>
 <script src="/common/reftest-wait.js"></script>
-<video width="320" height="180" autoplay onplaying="this.onplaying = null; this.pause(); takeScreenshot();">
+<video width="320" height="180" autoplay>
     <source src="/media/white.webm" type="video/webm">
     <source src="/media/white.mp4" type="video/mp4">
     <track src="../../support/test.vtt">
     <script>
     document.getElementsByTagName('track')[0].track.mode = 'showing';
+    waitForActiveCueAndTakeScreenshot();
     </script>
 </video>
 </html>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/background_shorthand.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/background_shorthand.html
@@ -13,12 +13,13 @@ body { margin:0 }
 }
 </style>
 <script src="/common/reftest-wait.js"></script>
-<video width="320" height="180" autoplay onplaying="this.onplaying = null; this.pause(); takeScreenshot();">
+<video width="320" height="180" autoplay>
     <source src="/media/white.webm" type="video/webm">
     <source src="/media/white.mp4" type="video/mp4">
     <track src="../../support/test.vtt">
     <script>
     document.getElementsByTagName('track')[0].track.mode = 'showing';
+    waitForActiveCueAndTakeScreenshot();
     </script>
 </video>
 </html>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/background_shorthand_css_relative_url.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/background_shorthand_css_relative_url.html
@@ -13,12 +13,13 @@ body { margin:0 }
 }
 </style>
 <script src="/common/reftest-wait.js"></script>
-<video width="320" height="180" autoplay onplaying="this.onplaying = null; this.pause(); takeScreenshot();">
+<video width="320" height="180" autoplay>
     <source src="/media/white.webm" type="video/webm">
     <source src="/media/white.mp4" type="video/mp4">
     <track src="../../support/test.vtt">
     <script>
     document.getElementsByTagName('track')[0].track.mode = 'showing';
+    waitForActiveCueAndTakeScreenshot();
     </script>
 </video>
 </html>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/bold_object/bold_background_properties.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/bold_object/bold_background_properties.html
@@ -15,12 +15,13 @@ body { margin:0 }
 }
 </style>
 <script src="/common/reftest-wait.js"></script>
-<video width="320" height="180" autoplay onplaying="this.onplaying = null; this.pause(); takeScreenshot();">
+<video width="320" height="180" autoplay>
     <source src="/media/white.webm" type="video/webm">
     <source src="/media/white.mp4" type="video/mp4">
     <track src="../../../support/test_bold.vtt">
     <script>
     document.getElementsByTagName('track')[0].track.mode = 'showing';
+    waitForActiveCueAndTakeScreenshot();
     </script>
 </video>
 </html>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/bold_object/bold_background_shorthand.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/bold_object/bold_background_shorthand.html
@@ -12,12 +12,13 @@ body { margin:0 }
 }
 </style>
 <script src="/common/reftest-wait.js"></script>
-<video width="320" height="180" autoplay onplaying="this.onplaying = null; this.pause(); takeScreenshot();">
+<video width="320" height="180" autoplay>
     <source src="/media/white.webm" type="video/webm">
     <source src="/media/white.mp4" type="video/mp4">
     <track src="../../../support/test_bold.vtt">
     <script>
     document.getElementsByTagName('track')[0].track.mode = 'showing';
+    waitForActiveCueAndTakeScreenshot();
     </script>
 </video>
 </html>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/bold_object/bold_color.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/bold_object/bold_color.html
@@ -11,12 +11,13 @@ body { margin:0 }
 }
 </style>
 <script src="/common/reftest-wait.js"></script>
-<video width="320" height="180" autoplay onplaying="this.onplaying = null; this.pause(); takeScreenshot();">
+<video width="320" height="180" autoplay>
     <source src="/media/white.webm" type="video/webm">
     <source src="/media/white.mp4" type="video/mp4">
     <track src="../../../support/test_bold.vtt">
     <script>
     document.getElementsByTagName('track')[0].track.mode = 'showing';
+    waitForActiveCueAndTakeScreenshot();
     </script>
 </video>
 </html>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/bold_object/bold_font_properties.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/bold_object/bold_font_properties.html
@@ -15,12 +15,13 @@ body { margin:0 }
 }
 </style>
 <script src="/common/reftest-wait.js"></script>
-<video width="320" height="180" autoplay onplaying="this.onplaying = null; this.pause(); takeScreenshot();">
+<video width="320" height="180" autoplay>
     <source src="/media/white.webm" type="video/webm">
     <source src="/media/white.mp4" type="video/mp4">
     <track src="../../../support/test_bold.vtt">
     <script>
     document.getElementsByTagName('track')[0].track.mode = 'showing';
+    waitForActiveCueAndTakeScreenshot();
     </script>
 </video>
 </html>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/bold_object/bold_font_shorthand.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/bold_object/bold_font_shorthand.html
@@ -10,12 +10,13 @@ body { margin:0 }
 }
 </style>
 <script src="/common/reftest-wait.js"></script>
-<video width="320" height="180" autoplay onplaying="this.onplaying = null; this.pause(); takeScreenshot();">
+<video width="320" height="180" autoplay>
     <source src="/media/white.webm" type="video/webm">
     <source src="/media/white.mp4" type="video/mp4">
     <track src="../../../support/test_bold.vtt">
     <script>
     document.getElementsByTagName('track')[0].track.mode = 'showing';
+    waitForActiveCueAndTakeScreenshot();
     </script>
 </video>
 </html>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/bold_object/bold_namespace.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/bold_object/bold_namespace.html
@@ -16,12 +16,13 @@ body { margin:0 }
 }
 </style>
 <script src="/common/reftest-wait.js"></script>
-<video width="320" height="180" autoplay onplaying="this.onplaying = null; this.pause(); takeScreenshot();">
+<video width="320" height="180" autoplay>
     <source src="/media/white.webm" type="video/webm">
     <source src="/media/white.mp4" type="video/mp4">
     <track src="../../../support/test_bold.vtt">
     <script>
     document.getElementsByTagName('track')[0].track.mode = 'showing';
+    waitForActiveCueAndTakeScreenshot();
     </script>
 </video>
 </html>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/bold_object/bold_outline_properties.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/bold_object/bold_outline_properties.html
@@ -13,12 +13,13 @@ body { margin:0 }
 }
 </style>
 <script src="/common/reftest-wait.js"></script>
-<video width="320" height="180" autoplay onplaying="this.onplaying = null; this.pause(); takeScreenshot();">
+<video width="320" height="180" autoplay>
     <source src="/media/white.webm" type="video/webm">
     <source src="/media/white.mp4" type="video/mp4">
     <track src="../../../support/test_bold.vtt">
     <script>
     document.getElementsByTagName('track')[0].track.mode = 'showing';
+    waitForActiveCueAndTakeScreenshot();
     </script>
 </video>
 </html>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/bold_object/bold_outline_shorthand.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/bold_object/bold_outline_shorthand.html
@@ -11,12 +11,13 @@ body { margin:0 }
 }
 </style>
 <script src="/common/reftest-wait.js"></script>
-<video width="320" height="180" autoplay onplaying="this.onplaying = null; this.pause(); takeScreenshot();">
+<video width="320" height="180" autoplay>
     <source src="/media/white.webm" type="video/webm">
     <source src="/media/white.mp4" type="video/mp4">
     <track src="../../../support/test_bold.vtt">
     <script>
     document.getElementsByTagName('track')[0].track.mode = 'showing';
+    waitForActiveCueAndTakeScreenshot();
     </script>
 </video>
 </html>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/bold_object/bold_text-decoration_line-through.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/bold_object/bold_text-decoration_line-through.html
@@ -11,12 +11,13 @@ body { margin:0 }
 }
 </style>
 <script src="/common/reftest-wait.js"></script>
-<video width="320" height="180" autoplay onplaying="this.onplaying = null; this.pause(); takeScreenshot();">
+<video width="320" height="180" autoplay>
     <source src="/media/white.webm" type="video/webm">
     <source src="/media/white.mp4" type="video/mp4">
     <track src="../../../support/test_bold.vtt">
     <script>
     document.getElementsByTagName('track')[0].track.mode = 'showing';
+    waitForActiveCueAndTakeScreenshot();
     </script>
 </video>
 </html>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/bold_object/bold_text-shadow.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/bold_object/bold_text-shadow.html
@@ -11,12 +11,13 @@ body { margin:0 }
 }
 </style>
 <script src="/common/reftest-wait.js"></script>
-<video width="320" height="180" autoplay onplaying="this.onplaying = null; this.pause(); takeScreenshot();">
+<video width="320" height="180" autoplay>
     <source src="/media/white.webm" type="video/webm">
     <source src="/media/white.mp4" type="video/mp4">
     <track src="../../../support/test_bold.vtt">
     <script>
     document.getElementsByTagName('track')[0].track.mode = 'showing';
+    waitForActiveCueAndTakeScreenshot();
     </script>
 </video>
 </html>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/bold_object/bold_white-space_normal_wrapped.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/bold_object/bold_white-space_normal_wrapped.html
@@ -10,12 +10,13 @@ body { margin:0 }
 }
 </style>
 <script src="/common/reftest-wait.js"></script>
-<video width="320" height="180" autoplay onplaying="this.onplaying = null; this.pause(); takeScreenshot();">
+<video width="320" height="180" autoplay>
     <source src="/media/white.webm" type="video/webm">
     <source src="/media/white.mp4" type="video/mp4">
     <track src="../../../support/bold_long.vtt">
     <script>
     document.getElementsByTagName('track')[0].track.mode = 'showing';
+    waitForActiveCueAndTakeScreenshot();
     </script>
 </video>
 </html>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/bold_object/bold_white-space_nowrap.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/bold_object/bold_white-space_nowrap.html
@@ -10,12 +10,13 @@ body { margin:0 }
 }
 </style>
 <script src="/common/reftest-wait.js"></script>
-<video width="320" height="180" autoplay onplaying="this.onplaying = null; this.pause(); takeScreenshot();">
+<video width="320" height="180" autoplay>
     <source src="/media/white.webm" type="video/webm">
     <source src="/media/white.mp4" type="video/mp4">
     <track src="../../../support/bold_long.vtt">
     <script>
     document.getElementsByTagName('track')[0].track.mode = 'showing';
+    waitForActiveCueAndTakeScreenshot();
     </script>
 </video>
 </html>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/bold_object/bold_white-space_pre-line_wrapped.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/bold_object/bold_white-space_pre-line_wrapped.html
@@ -10,12 +10,13 @@ body { margin:0 }
 }
 </style>
 <script src="/common/reftest-wait.js"></script>
-<video width="320" height="180" autoplay onplaying="this.onplaying = null; this.pause(); takeScreenshot();">
+<video width="320" height="180" autoplay>
     <source src="/media/white.webm" type="video/webm">
     <source src="/media/white.mp4" type="video/mp4">
     <track src="../../../support/bold_long.vtt">
     <script>
     document.getElementsByTagName('track')[0].track.mode = 'showing';
+    waitForActiveCueAndTakeScreenshot();
     </script>
 </video>
 </html>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/bold_object/bold_white-space_pre-wrap_wrapped.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/bold_object/bold_white-space_pre-wrap_wrapped.html
@@ -10,12 +10,13 @@ body { margin:0 }
 }
 </style>
 <script src="/common/reftest-wait.js"></script>
-<video width="320" height="180" autoplay onplaying="this.onplaying = null; this.pause(); takeScreenshot();">
+<video width="320" height="180" autoplay>
     <source src="/media/white.webm" type="video/webm">
     <source src="/media/white.mp4" type="video/mp4">
     <track src="../../../support/bold_long.vtt">
     <script>
     document.getElementsByTagName('track')[0].track.mode = 'showing';
+    waitForActiveCueAndTakeScreenshot();
     </script>
 </video>
 </html>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/bold_object/bold_white-space_pre_wrapped.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/bold_object/bold_white-space_pre_wrapped.html
@@ -10,12 +10,13 @@ body { margin:0 }
 }
 </style>
 <script src="/common/reftest-wait.js"></script>
-<video width="320" height="180" autoplay onplaying="this.onplaying = null; this.pause(); takeScreenshot();">
+<video width="320" height="180" autoplay>
     <source src="/media/white.webm" type="video/webm">
     <source src="/media/white.mp4" type="video/mp4">
     <track src="../../../support/bold_long.vtt">
     <script>
     document.getElementsByTagName('track')[0].track.mode = 'showing';
+    waitForActiveCueAndTakeScreenshot();
     </script>
 </video>
 </html>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/bold_object/bold_with_class.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/bold_object/bold_with_class.html
@@ -11,12 +11,13 @@ body { margin:0 }
 }
 </style>
 <script src="/common/reftest-wait.js"></script>
-<video width="320" height="180" autoplay onplaying="this.onplaying = null; this.pause(); takeScreenshot();">
+<video width="320" height="180" autoplay>
     <source src="/media/white.webm" type="video/webm">
     <source src="/media/white.mp4" type="video/mp4">
     <track src="../../../support/test_bold_with_class.vtt">
     <script>
     document.getElementsByTagName('track')[0].track.mode = 'showing';
+    waitForActiveCueAndTakeScreenshot();
     </script>
 </video>
 </html>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/bold_object/bold_with_class_object_specific_selector.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/bold_object/bold_with_class_object_specific_selector.html
@@ -11,12 +11,13 @@ body { margin:0 }
 }
 </style>
 <script src="/common/reftest-wait.js"></script>
-<video width="320" height="180" autoplay onplaying="this.onplaying = null; this.pause(); takeScreenshot();">
+<video width="320" height="180" autoplay>
     <source src="/media/white.webm" type="video/webm">
     <source src="/media/white.mp4" type="video/mp4">
     <track src="../../../support/test_bold_with_class.vtt">
     <script>
     document.getElementsByTagName('track')[0].track.mode = 'showing';
+    waitForActiveCueAndTakeScreenshot();
     </script>
 </video>
 </html>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/class_object/class_background_properties.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/class_object/class_background_properties.html
@@ -15,12 +15,13 @@ body { margin:0 }
 }
 </style>
 <script src="/common/reftest-wait.js"></script>
-<video width="320" height="180" autoplay onplaying="this.onplaying = null; this.pause(); takeScreenshot();">
+<video width="320" height="180" autoplay>
     <source src="/media/white.webm" type="video/webm">
     <source src="/media/white.mp4" type="video/mp4">
     <track src="../../../support/test_class.vtt">
     <script>
     document.getElementsByTagName('track')[0].track.mode = 'showing';
+    waitForActiveCueAndTakeScreenshot();
     </script>
 </video>
 </html>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/class_object/class_background_shorthand.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/class_object/class_background_shorthand.html
@@ -12,12 +12,13 @@ body { margin:0 }
 }
 </style>
 <script src="/common/reftest-wait.js"></script>
-<video width="320" height="180" autoplay onplaying="this.onplaying = null; this.pause(); takeScreenshot();">
+<video width="320" height="180" autoplay>
     <source src="/media/white.webm" type="video/webm">
     <source src="/media/white.mp4" type="video/mp4">
     <track src="../../../support/test_class.vtt">
     <script>
     document.getElementsByTagName('track')[0].track.mode = 'showing';
+    waitForActiveCueAndTakeScreenshot();
     </script>
 </video>
 </html>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/class_object/class_color.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/class_object/class_color.html
@@ -11,12 +11,13 @@ body { margin:0 }
 }
 </style>
 <script src="/common/reftest-wait.js"></script>
-<video width="320" height="180" autoplay onplaying="this.onplaying = null; this.pause(); takeScreenshot();">
+<video width="320" height="180" autoplay>
     <source src="/media/white.webm" type="video/webm">
     <source src="/media/white.mp4" type="video/mp4">
     <track src="../../../support/test_class.vtt">
     <script>
     document.getElementsByTagName('track')[0].track.mode = 'showing';
+    waitForActiveCueAndTakeScreenshot();
     </script>
 </video>
 </html>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/class_object/class_font_properties.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/class_object/class_font_properties.html
@@ -15,12 +15,13 @@ body { margin:0 }
 }
 </style>
 <script src="/common/reftest-wait.js"></script>
-<video width="320" height="180" autoplay onplaying="this.onplaying = null; this.pause(); takeScreenshot();">
+<video width="320" height="180" autoplay>
     <source src="/media/white.webm" type="video/webm">
     <source src="/media/white.mp4" type="video/mp4">
     <track src="../../../support/test_class.vtt">
     <script>
     document.getElementsByTagName('track')[0].track.mode = 'showing';
+    waitForActiveCueAndTakeScreenshot();
     </script>
 </video>
 </html>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/class_object/class_font_shorthand.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/class_object/class_font_shorthand.html
@@ -10,12 +10,13 @@ body { margin:0 }
 }
 </style>
 <script src="/common/reftest-wait.js"></script>
-<video width="320" height="180" autoplay onplaying="this.onplaying = null; this.pause(); takeScreenshot();">
+<video width="320" height="180" autoplay>
     <source src="/media/white.webm" type="video/webm">
     <source src="/media/white.mp4" type="video/mp4">
     <track src="../../../support/test_class.vtt">
     <script>
     document.getElementsByTagName('track')[0].track.mode = 'showing';
+    waitForActiveCueAndTakeScreenshot();
     </script>
 </video>
 </html>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/class_object/class_namespace.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/class_object/class_namespace.html
@@ -18,12 +18,13 @@ body { margin:0 }
 }
 </style>
 <script src="/common/reftest-wait.js"></script>
-<video width="320" height="180" autoplay onplaying="this.onplaying = null; this.pause(); takeScreenshot();">
+<video width="320" height="180" autoplay>
     <source src="/media/white.webm" type="video/webm">
     <source src="/media/white.mp4" type="video/mp4">
     <track src="../../../support/test_class.vtt">
     <script>
     document.getElementsByTagName('track')[0].track.mode = 'showing';
+    waitForActiveCueAndTakeScreenshot();
     </script>
 </video>
 </html>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/class_object/class_outline_properties.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/class_object/class_outline_properties.html
@@ -13,12 +13,13 @@ body { margin:0 }
 }
 </style>
 <script src="/common/reftest-wait.js"></script>
-<video width="320" height="180" autoplay onplaying="this.onplaying = null; this.pause(); takeScreenshot();">
+<video width="320" height="180" autoplay>
     <source src="/media/white.webm" type="video/webm">
     <source src="/media/white.mp4" type="video/mp4">
     <track src="../../../support/test_class.vtt">
     <script>
     document.getElementsByTagName('track')[0].track.mode = 'showing';
+    waitForActiveCueAndTakeScreenshot();
     </script>
 </video>
 </html>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/class_object/class_outline_shorthand.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/class_object/class_outline_shorthand.html
@@ -11,12 +11,13 @@ body { margin:0 }
 }
 </style>
 <script src="/common/reftest-wait.js"></script>
-<video width="320" height="180" autoplay onplaying="this.onplaying = null; this.pause(); takeScreenshot();">
+<video width="320" height="180" autoplay>
     <source src="/media/white.webm" type="video/webm">
     <source src="/media/white.mp4" type="video/mp4">
     <track src="../../../support/test_class.vtt">
     <script>
     document.getElementsByTagName('track')[0].track.mode = 'showing';
+    waitForActiveCueAndTakeScreenshot();
     </script>
 </video>
 </html>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/class_object/class_text-decoration_line-through.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/class_object/class_text-decoration_line-through.html
@@ -11,12 +11,13 @@ body { margin:0 }
 }
 </style>
 <script src="/common/reftest-wait.js"></script>
-<video width="320" height="180" autoplay onplaying="this.onplaying = null; this.pause(); takeScreenshot();">
+<video width="320" height="180" autoplay>
     <source src="/media/white.webm" type="video/webm">
     <source src="/media/white.mp4" type="video/mp4">
     <track src="../../../support/test_class.vtt">
     <script>
     document.getElementsByTagName('track')[0].track.mode = 'showing';
+    waitForActiveCueAndTakeScreenshot();
     </script>
 </video>
 </html>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/class_object/class_text-shadow.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/class_object/class_text-shadow.html
@@ -11,12 +11,13 @@ body { margin:0 }
 }
 </style>
 <script src="/common/reftest-wait.js"></script>
-<video width="320" height="180" autoplay onplaying="this.onplaying = null; this.pause(); takeScreenshot();">
+<video width="320" height="180" autoplay>
     <source src="/media/white.webm" type="video/webm">
     <source src="/media/white.mp4" type="video/mp4">
     <track src="../../../support/test_class.vtt">
     <script>
     document.getElementsByTagName('track')[0].track.mode = 'showing';
+    waitForActiveCueAndTakeScreenshot();
     </script>
 </video>
 </html>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/class_object/class_vertical_text-combine-upright.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/class_object/class_vertical_text-combine-upright.html
@@ -14,12 +14,13 @@ body { margin:0 }
 }
 </style>
 <script src="/common/reftest-wait.js"></script>
-<video width="320" height="180" autoplay onplaying="this.onplaying = null; this.pause(); takeScreenshot();">
+<video width="320" height="180" autoplay>
     <source src="/media/white.webm" type="video/webm">
     <source src="/media/white.mp4" type="video/mp4">
     <track src="../../../support/class_text-combine-upright.vtt">
     <script>
     document.getElementsByTagName('track')[0].track.mode = 'showing';
+    waitForActiveCueAndTakeScreenshot();
     </script>
 </video>
 </html>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/class_object/class_white-space_normal_wrapped.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/class_object/class_white-space_normal_wrapped.html
@@ -10,12 +10,13 @@ body { margin:0 }
 }
 </style>
 <script src="/common/reftest-wait.js"></script>
-<video width="320" height="180" autoplay onplaying="this.onplaying = null; this.pause(); takeScreenshot();">
+<video width="320" height="180" autoplay>
     <source src="/media/white.webm" type="video/webm">
     <source src="/media/white.mp4" type="video/mp4">
     <track src="../../../support/class_long.vtt">
     <script>
     document.getElementsByTagName('track')[0].track.mode = 'showing';
+    waitForActiveCueAndTakeScreenshot();
     </script>
 </video>
 </html>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/class_object/class_white-space_nowrap.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/class_object/class_white-space_nowrap.html
@@ -10,12 +10,13 @@ body { margin:0 }
 }
 </style>
 <script src="/common/reftest-wait.js"></script>
-<video width="320" height="180" autoplay onplaying="this.onplaying = null; this.pause(); takeScreenshot();">
+<video width="320" height="180" autoplay>
     <source src="/media/white.webm" type="video/webm">
     <source src="/media/white.mp4" type="video/mp4">
     <track src="../../../support/class_long.vtt">
     <script>
     document.getElementsByTagName('track')[0].track.mode = 'showing';
+    waitForActiveCueAndTakeScreenshot();
     </script>
 </video>
 </html>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/class_object/class_white-space_pre-line_wrapped.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/class_object/class_white-space_pre-line_wrapped.html
@@ -10,12 +10,13 @@ body { margin:0 }
 }
 </style>
 <script src="/common/reftest-wait.js"></script>
-<video width="320" height="180" autoplay onplaying="this.onplaying = null; this.pause(); takeScreenshot();">
+<video width="320" height="180" autoplay>
     <source src="/media/white.webm" type="video/webm">
     <source src="/media/white.mp4" type="video/mp4">
     <track src="../../../support/class_long.vtt">
     <script>
     document.getElementsByTagName('track')[0].track.mode = 'showing';
+    waitForActiveCueAndTakeScreenshot();
     </script>
 </video>
 </html>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/class_object/class_white-space_pre-wrap_wrapped.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/class_object/class_white-space_pre-wrap_wrapped.html
@@ -10,12 +10,13 @@ body { margin:0 }
 }
 </style>
 <script src="/common/reftest-wait.js"></script>
-<video width="320" height="180" autoplay onplaying="this.onplaying = null; this.pause(); takeScreenshot();">
+<video width="320" height="180" autoplay>
     <source src="/media/white.webm" type="video/webm">
     <source src="/media/white.mp4" type="video/mp4">
     <track src="../../../support/class_long.vtt">
     <script>
     document.getElementsByTagName('track')[0].track.mode = 'showing';
+    waitForActiveCueAndTakeScreenshot();
     </script>
 </video>
 </html>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/class_object/class_white-space_pre_wrapped.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/class_object/class_white-space_pre_wrapped.html
@@ -10,12 +10,13 @@ body { margin:0 }
 }
 </style>
 <script src="/common/reftest-wait.js"></script>
-<video width="320" height="180" autoplay onplaying="this.onplaying = null; this.pause(); takeScreenshot();">
+<video width="320" height="180" autoplay>
     <source src="/media/white.webm" type="video/webm">
     <source src="/media/white.mp4" type="video/mp4">
     <track src="../../../support/class_long.vtt">
     <script>
     document.getElementsByTagName('track')[0].track.mode = 'showing';
+    waitForActiveCueAndTakeScreenshot();
     </script>
 </video>
 </html>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/class_object/class_with_class.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/class_object/class_with_class.html
@@ -11,12 +11,13 @@ body { margin:0 }
 }
 </style>
 <script src="/common/reftest-wait.js"></script>
-<video width="320" height="180" autoplay onplaying="this.onplaying = null; this.pause(); takeScreenshot();">
+<video width="320" height="180" autoplay>
     <source src="/media/white.webm" type="video/webm">
     <source src="/media/white.mp4" type="video/mp4">
     <track src="../../../support/test_class_with_class.vtt">
     <script>
     document.getElementsByTagName('track')[0].track.mode = 'showing';
+    waitForActiveCueAndTakeScreenshot();
     </script>
 </video>
 </html>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/class_object/class_with_class_object_specific_selector.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/class_object/class_with_class_object_specific_selector.html
@@ -11,12 +11,13 @@ body { margin:0 }
 }
 </style>
 <script src="/common/reftest-wait.js"></script>
-<video width="320" height="180" autoplay onplaying="this.onplaying = null; this.pause(); takeScreenshot();">
+<video width="320" height="180" autoplay>
     <source src="/media/white.webm" type="video/webm">
     <source src="/media/white.mp4" type="video/mp4">
     <track src="../../../support/test_class_with_class.vtt">
     <script>
     document.getElementsByTagName('track')[0].track.mode = 'showing';
+    waitForActiveCueAndTakeScreenshot();
     </script>
 </video>
 </html>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/color_hex.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/color_hex.html
@@ -12,12 +12,13 @@ body { margin:0 }
 }
 </style>
 <script src="/common/reftest-wait.js"></script>
-<video width="320" height="180" autoplay onplaying="this.onplaying = null; this.pause(); takeScreenshot();">
+<video width="320" height="180" autoplay>
     <source src="/media/white.webm" type="video/webm">
     <source src="/media/white.mp4" type="video/mp4">
     <track src="../../support/test.vtt">
     <script>
     document.getElementsByTagName('track')[0].track.mode = 'showing';
+    waitForActiveCueAndTakeScreenshot();
     </script>
 </video>
 </html>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/color_hsla.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/color_hsla.html
@@ -12,12 +12,13 @@ body { margin:0 }
 }
 </style>
 <script src="/common/reftest-wait.js"></script>
-<video width="320" height="180" autoplay onplaying="this.onplaying = null; this.pause(); takeScreenshot();">
+<video width="320" height="180" autoplay>
     <source src="/media/white.webm" type="video/webm">
     <source src="/media/white.mp4" type="video/mp4">
     <track src="../../support/test.vtt">
     <script>
     document.getElementsByTagName('track')[0].track.mode = 'showing';
+    waitForActiveCueAndTakeScreenshot();
     </script>
 </video>
 </html>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/color_rgba.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/color_rgba.html
@@ -12,12 +12,13 @@ body { margin:0 }
 }
 </style>
 <script src="/common/reftest-wait.js"></script>
-<video width="320" height="180" autoplay onplaying="this.onplaying = null; this.pause(); takeScreenshot();">
+<video width="320" height="180" autoplay>
     <source src="/media/white.webm" type="video/webm">
     <source src="/media/white.mp4" type="video/mp4">
     <track src="../../support/test.vtt">
     <script>
     document.getElementsByTagName('track')[0].track.mode = 'showing';
+    waitForActiveCueAndTakeScreenshot();
     </script>
 </video>
 </html>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/cue_func_selector_single_colon.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/cue_func_selector_single_colon.html
@@ -11,12 +11,13 @@ body { margin:0 }
 }
 </style>
 <script src="/common/reftest-wait.js"></script>
-<video width="320" height="180" autoplay onplaying="this.onplaying = null; this.pause(); takeScreenshot();">
+<video width="320" height="180" autoplay>
     <source src="/media/white.webm" type="video/webm">
     <source src="/media/white.mp4" type="video/mp4">
     <track src="../../support/test.vtt">
     <script>
     document.getElementsByTagName('track')[0].track.mode = 'showing';
+    waitForActiveCueAndTakeScreenshot();
     </script>
 </video>
 </html>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/font_properties.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/font_properties.html
@@ -15,12 +15,13 @@ body { margin:0 }
 }
 </style>
 <script src="/common/reftest-wait.js"></script>
-<video width="320" height="180" autoplay onplaying="this.onplaying = null; this.pause(); takeScreenshot();">
+<video width="320" height="180" autoplay>
     <source src="/media/white.webm" type="video/webm">
     <source src="/media/white.mp4" type="video/mp4">
     <track src="../../support/test_long.vtt">
     <script>
     document.getElementsByTagName('track')[0].track.mode = 'showing';
+    waitForActiveCueAndTakeScreenshot();
     </script>
 </video>
 </html>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/font_shorthand.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/font_shorthand.html
@@ -10,12 +10,13 @@ body { margin:0 }
 }
 </style>
 <script src="/common/reftest-wait.js"></script>
-<video width="320" height="180" autoplay onplaying="this.onplaying = null; this.pause(); takeScreenshot();">
+<video width="320" height="180" autoplay>
     <source src="/media/white.webm" type="video/webm">
     <source src="/media/white.mp4" type="video/mp4">
     <track src="../../support/test_long.vtt">
     <script>
     document.getElementsByTagName('track')[0].track.mode = 'showing';
+    waitForActiveCueAndTakeScreenshot();
     </script>
 </video>
 </html>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/id_color.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/id_color.html
@@ -12,12 +12,13 @@ body { margin:0 }
 }
 </style>
 <script src="/common/reftest-wait.js"></script>
-<video width="320" height="180" autoplay onplaying="this.onplaying = null; this.pause(); takeScreenshot();">
+<video width="320" height="180" autoplay>
     <source src="/media/white.webm" type="video/webm">
     <source src="/media/white.mp4" type="video/mp4">
     <track src="../../support/cue_with_id.vtt">
     <script>
     document.getElementsByTagName('track')[0].track.mode = 'showing';
+    waitForActiveCueAndTakeScreenshot();
     </script>
 </video>
 </html>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/inherit_values_from_media_element.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/inherit_values_from_media_element.html
@@ -23,12 +23,13 @@ video {
 }
 </style>
 <script src="/common/reftest-wait.js"></script>
-<video width="320" height="180" autoplay onplaying="this.onplaying = null; this.pause(); takeScreenshot();">
+<video width="320" height="180" autoplay>
     <source src="/media/white.webm" type="video/webm">
     <source src="/media/white.mp4" type="video/mp4">
     <track src="../../support/white-spaces_long.vtt">
     <script>
     document.getElementsByTagName('track')[0].track.mode = 'showing';
+    waitForActiveCueAndTakeScreenshot();
     </script>
 </video>
 </html>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/italic_object/italic_background_properties.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/italic_object/italic_background_properties.html
@@ -15,12 +15,13 @@ body { margin:0 }
 }
 </style>
 <script src="/common/reftest-wait.js"></script>
-<video width="320" height="180" autoplay onplaying="this.onplaying = null; this.pause(); takeScreenshot();">
+<video width="320" height="180" autoplay>
     <source src="/media/white.webm" type="video/webm">
     <source src="/media/white.mp4" type="video/mp4">
     <track src="../../../support/test_italic.vtt">
 </video>
 <script>
 document.getElementsByTagName('track')[0].track.mode = 'showing';
+waitForActiveCueAndTakeScreenshot();
 </script>
 </html>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/italic_object/italic_background_shorthand.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/italic_object/italic_background_shorthand.html
@@ -12,12 +12,13 @@ body { margin:0 }
 }
 </style>
 <script src="/common/reftest-wait.js"></script>
-<video width="320" height="180" autoplay onplaying="this.onplaying = null; this.pause(); takeScreenshot();">
+<video width="320" height="180" autoplay>
     <source src="/media/white.webm" type="video/webm">
     <source src="/media/white.mp4" type="video/mp4">
     <track src="../../../support/test_italic.vtt">
     <script>
     document.getElementsByTagName('track')[0].track.mode = 'showing';
+    waitForActiveCueAndTakeScreenshot();
     </script>
 </video>
 </html>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/italic_object/italic_color.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/italic_object/italic_color.html
@@ -11,12 +11,13 @@ body { margin:0 }
 }
 </style>
 <script src="/common/reftest-wait.js"></script>
-<video width="320" height="180" autoplay onplaying="this.onplaying = null; this.pause(); takeScreenshot();">
+<video width="320" height="180" autoplay>
     <source src="/media/white.webm" type="video/webm">
     <source src="/media/white.mp4" type="video/mp4">
     <track src="../../../support/test_italic.vtt">
     <script>
     document.getElementsByTagName('track')[0].track.mode = 'showing';
+    waitForActiveCueAndTakeScreenshot();
     </script>
 </video>
 </html>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/italic_object/italic_font_properties.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/italic_object/italic_font_properties.html
@@ -15,12 +15,13 @@ body { margin:0 }
 }
 </style>
 <script src="/common/reftest-wait.js"></script>
-<video width="320" height="180" autoplay onplaying="this.onplaying = null; this.pause(); takeScreenshot();">
+<video width="320" height="180" autoplay>
     <source src="/media/white.webm" type="video/webm">
     <source src="/media/white.mp4" type="video/mp4">
     <track src="../../../support/test_italic.vtt">
     <script>
     document.getElementsByTagName('track')[0].track.mode = 'showing';
+    waitForActiveCueAndTakeScreenshot();
     </script>
 </video>
 </html>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/italic_object/italic_font_shorthand.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/italic_object/italic_font_shorthand.html
@@ -10,12 +10,13 @@ body { margin:0 }
 }
 </style>
 <script src="/common/reftest-wait.js"></script>
-<video width="320" height="180" autoplay onplaying="this.onplaying = null; this.pause(); takeScreenshot();">
+<video width="320" height="180" autoplay>
     <source src="/media/white.webm" type="video/webm">
     <source src="/media/white.mp4" type="video/mp4">
     <track src="../../../support/test_italic.vtt">
     <script>
     document.getElementsByTagName('track')[0].track.mode = 'showing';
+    waitForActiveCueAndTakeScreenshot();
     </script>
 </video>
 </html>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/italic_object/italic_namespace.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/italic_object/italic_namespace.html
@@ -16,12 +16,13 @@ body { margin:0 }
 }
 </style>
 <script src="/common/reftest-wait.js"></script>
-<video width="320" height="180" autoplay onplaying="this.onplaying = null; this.pause(); takeScreenshot();">
+<video width="320" height="180" autoplay>
     <source src="/media/white.webm" type="video/webm">
     <source src="/media/white.mp4" type="video/mp4">
     <track src="../../../support/test_italic.vtt">
     <script>
     document.getElementsByTagName('track')[0].track.mode = 'showing';
+    waitForActiveCueAndTakeScreenshot();
     </script>
 </video>
 </html>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/italic_object/italic_outline_properties.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/italic_object/italic_outline_properties.html
@@ -13,12 +13,13 @@ body { margin:0 }
 }
 </style>
 <script src="/common/reftest-wait.js"></script>
-<video width="320" height="180" autoplay onplaying="this.onplaying = null; this.pause(); takeScreenshot();">
+<video width="320" height="180" autoplay>
     <source src="/media/white.webm" type="video/webm">
     <source src="/media/white.mp4" type="video/mp4">
     <track src="../../../support/test_italic.vtt">
     <script>
     document.getElementsByTagName('track')[0].track.mode = 'showing';
+    waitForActiveCueAndTakeScreenshot();
     </script>
 </video>
 </html>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/italic_object/italic_outline_shorthand.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/italic_object/italic_outline_shorthand.html
@@ -11,12 +11,13 @@ body { margin:0 }
 }
 </style>
 <script src="/common/reftest-wait.js"></script>
-<video width="320" height="180" autoplay onplaying="this.onplaying = null; this.pause(); takeScreenshot();">
+<video width="320" height="180" autoplay>
     <source src="/media/white.webm" type="video/webm">
     <source src="/media/white.mp4" type="video/mp4">
     <track src="../../../support/test_italic.vtt">
     <script>
     document.getElementsByTagName('track')[0].track.mode = 'showing';
+    waitForActiveCueAndTakeScreenshot();
     </script>
 </video>
 </html>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/italic_object/italic_text-decoration_line-through.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/italic_object/italic_text-decoration_line-through.html
@@ -11,12 +11,13 @@ body { margin:0 }
 }
 </style>
 <script src="/common/reftest-wait.js"></script>
-<video width="320" height="180" autoplay onplaying="this.onplaying = null; this.pause(); takeScreenshot();">
+<video width="320" height="180" autoplay>
     <source src="/media/white.webm" type="video/webm">
     <source src="/media/white.mp4" type="video/mp4">
     <track src="../../../support/test_italic.vtt">
     <script>
     document.getElementsByTagName('track')[0].track.mode = 'showing';
+    waitForActiveCueAndTakeScreenshot();
     </script>
 </video>
 </html>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/italic_object/italic_text-shadow.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/italic_object/italic_text-shadow.html
@@ -11,12 +11,13 @@ body { margin:0 }
 }
 </style>
 <script src="/common/reftest-wait.js"></script>
-<video width="320" height="180" autoplay onplaying="this.onplaying = null; this.pause(); takeScreenshot();">
+<video width="320" height="180" autoplay>
     <source src="/media/white.webm" type="video/webm">
     <source src="/media/white.mp4" type="video/mp4">
     <track src="../../../support/test_italic.vtt">
     <script>
     document.getElementsByTagName('track')[0].track.mode = 'showing';
+    waitForActiveCueAndTakeScreenshot();
     </script>
 </video>
 </html>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/italic_object/italic_white-space_normal_wrapped.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/italic_object/italic_white-space_normal_wrapped.html
@@ -10,12 +10,13 @@ body { margin:0 }
 }
 </style>
 <script src="/common/reftest-wait.js"></script>
-<video width="320" height="180" autoplay onplaying="this.onplaying = null; this.pause(); takeScreenshot();">
+<video width="320" height="180" autoplay>
     <source src="/media/white.webm" type="video/webm">
     <source src="/media/white.mp4" type="video/mp4">
     <track src="../../../support/italic_long.vtt">
     <script>
     document.getElementsByTagName('track')[0].track.mode = 'showing';
+    waitForActiveCueAndTakeScreenshot();
     </script>
 </video>
 </html>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/italic_object/italic_white-space_nowrap.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/italic_object/italic_white-space_nowrap.html
@@ -10,12 +10,13 @@ body { margin:0 }
 }
 </style>
 <script src="/common/reftest-wait.js"></script>
-<video width="320" height="180" autoplay onplaying="this.onplaying = null; this.pause(); takeScreenshot();">
+<video width="320" height="180" autoplay>
     <source src="/media/white.webm" type="video/webm">
     <source src="/media/white.mp4" type="video/mp4">
     <track src="../../../support/italic_long.vtt">
     <script>
     document.getElementsByTagName('track')[0].track.mode = 'showing';
+    waitForActiveCueAndTakeScreenshot();
     </script>
 </video>
 </html>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/italic_object/italic_white-space_pre-line_wrapped.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/italic_object/italic_white-space_pre-line_wrapped.html
@@ -10,12 +10,13 @@ body { margin:0 }
 }
 </style>
 <script src="/common/reftest-wait.js"></script>
-<video width="320" height="180" autoplay onplaying="this.onplaying = null; this.pause(); takeScreenshot();">
+<video width="320" height="180" autoplay>
     <source src="/media/white.webm" type="video/webm">
     <source src="/media/white.mp4" type="video/mp4">
     <track src="../../../support/italic_long.vtt">
     <script>
     document.getElementsByTagName('track')[0].track.mode = 'showing';
+    waitForActiveCueAndTakeScreenshot();
     </script>
 </video>
 </html>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/italic_object/italic_white-space_pre-wrap_wrapped.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/italic_object/italic_white-space_pre-wrap_wrapped.html
@@ -10,12 +10,13 @@ body { margin:0 }
 }
 </style>
 <script src="/common/reftest-wait.js"></script>
-<video width="320" height="180" autoplay onplaying="this.onplaying = null; this.pause(); takeScreenshot();">
+<video width="320" height="180" autoplay>
     <source src="/media/white.webm" type="video/webm">
     <source src="/media/white.mp4" type="video/mp4">
     <track src="../../../support/italic_long.vtt">
     <script>
     document.getElementsByTagName('track')[0].track.mode = 'showing';
+    waitForActiveCueAndTakeScreenshot();
     </script>
 </video>
 </html>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/italic_object/italic_white-space_pre_wrapped.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/italic_object/italic_white-space_pre_wrapped.html
@@ -10,12 +10,13 @@ body { margin:0 }
 }
 </style>
 <script src="/common/reftest-wait.js"></script>
-<video width="320" height="180" autoplay onplaying="this.onplaying = null; this.pause(); takeScreenshot();">
+<video width="320" height="180" autoplay>
     <source src="/media/white.webm" type="video/webm">
     <source src="/media/white.mp4" type="video/mp4">
     <track src="../../../support/italic_long.vtt">
     <script>
     document.getElementsByTagName('track')[0].track.mode = 'showing';
+    waitForActiveCueAndTakeScreenshot();
     </script>
 </video>
 </html>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/italic_object/italic_with_class.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/italic_object/italic_with_class.html
@@ -11,12 +11,13 @@ body { margin:0 }
 }
 </style>
 <script src="/common/reftest-wait.js"></script>
-<video width="320" height="180" autoplay onplaying="this.onplaying = null; this.pause(); takeScreenshot();">
+<video width="320" height="180" autoplay>
     <source src="/media/white.webm" type="video/webm">
     <source src="/media/white.mp4" type="video/mp4">
     <track src="../../../support/test_italic_with_class.vtt">
     <script>
     document.getElementsByTagName('track')[0].track.mode = 'showing';
+    waitForActiveCueAndTakeScreenshot();
     </script>
 </video>
 </html>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/italic_object/italic_with_class_object_specific_selector.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/italic_object/italic_with_class_object_specific_selector.html
@@ -11,12 +11,13 @@ body { margin:0 }
 }
 </style>
 <script src="/common/reftest-wait.js"></script>
-<video width="320" height="180" autoplay onplaying="this.onplaying = null; this.pause(); takeScreenshot();">
+<video width="320" height="180" autoplay>
     <source src="/media/white.webm" type="video/webm">
     <source src="/media/white.mp4" type="video/mp4">
     <track src="../../../support/test_italic_with_class.vtt">
     <script>
     document.getElementsByTagName('track')[0].track.mode = 'showing';
+    waitForActiveCueAndTakeScreenshot();
     </script>
 </video>
 </html>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/lang_object/lang_attribute.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/lang_object/lang_attribute.html
@@ -15,12 +15,13 @@ body { margin:0 }
 }
 </style>
 <script src="/common/reftest-wait.js"></script>
-<video width="320" height="180" autoplay onplaying="this.onplaying = null; this.pause(); takeScreenshot();">
+<video width="320" height="180" autoplay>
     <source src="/media/white.webm" type="video/webm">
     <source src="/media/white.mp4" type="video/mp4">
     <track src="../../../support/test_lang_object.vtt" srclang="de" default>
     <script>
     document.getElementsByTagName('track')[0].track.mode = 'showing';
+    waitForActiveCueAndTakeScreenshot();
     </script>
 </video>
 </html>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/lang_object/lang_color.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/lang_object/lang_color.html
@@ -11,12 +11,13 @@ body { margin:0 }
 }
 </style>
 <script src="/common/reftest-wait.js"></script>
-<video width="320" height="180" autoplay onplaying="this.onplaying = null; this.pause(); takeScreenshot();">
+<video width="320" height="180" autoplay>
     <source src="/media/white.webm" type="video/webm">
     <source src="/media/white.mp4" type="video/mp4">
     <track src="../../../support/test_lang_object.vtt">
     <script>
     document.getElementsByTagName('track')[0].track.mode = 'showing';
+    waitForActiveCueAndTakeScreenshot();
     </script>
 </video>
 </html>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/not_allowed_properties.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/not_allowed_properties.html
@@ -36,12 +36,13 @@ body { margin:0 }
 }
 </style>
 <script src="/common/reftest-wait.js"></script>
-<video width="320" height="180" autoplay onplaying="this.onplaying = null; this.pause(); takeScreenshot();">
+<video width="320" height="180" autoplay>
     <source src="/media/white.webm" type="video/webm">
     <source src="/media/white.mp4" type="video/mp4">
     <track src="../../support/test.vtt">
     <script>
     document.getElementsByTagName('track')[0].track.mode = 'showing';
+    waitForActiveCueAndTakeScreenshot();
     </script>
 </video>
 </html>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/not_root_selector.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/not_root_selector.html
@@ -11,12 +11,13 @@ body { margin:0 }
 }
 </style>
 <script src="/common/reftest-wait.js"></script>
-<video width="320" height="180" autoplay onplaying="this.onplaying = null; this.pause(); takeScreenshot();">
+<video width="320" height="180" autoplay>
     <source src="/media/white.webm" type="video/webm">
     <source src="/media/white.mp4" type="video/mp4">
     <track src="../../support/foo_c_bar.vtt">
     <script>
     document.getElementsByTagName('track')[0].track.mode = 'showing';
+    waitForActiveCueAndTakeScreenshot();
     </script>
 </video>
 </html>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/outline_properties.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/outline_properties.html
@@ -15,12 +15,13 @@ body { margin:0 }
 }
 </style>
 <script src="/common/reftest-wait.js"></script>
-<video width="320" height="180" autoplay onplaying="this.onplaying = null; this.pause(); takeScreenshot();">
+<video width="320" height="180" autoplay>
     <source src="/media/white.webm" type="video/webm">
     <source src="/media/white.mp4" type="video/mp4">
     <track src="../../support/test.vtt">
     <script>
     document.getElementsByTagName('track')[0].track.mode = 'showing';
+    waitForActiveCueAndTakeScreenshot();
     </script>
 </video>
 </html>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/outline_shorthand.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/outline_shorthand.html
@@ -13,12 +13,13 @@ body { margin:0 }
 }
 </style>
 <script src="/common/reftest-wait.js"></script>
-<video width="320" height="180" autoplay onplaying="this.onplaying = null; this.pause(); takeScreenshot();">
+<video width="320" height="180" autoplay>
     <source src="/media/white.webm" type="video/webm">
     <source src="/media/white.mp4" type="video/mp4">
     <track src="../../support/test.vtt">
     <script>
     document.getElementsByTagName('track')[0].track.mode = 'showing';
+    waitForActiveCueAndTakeScreenshot();
     </script>
 </video>
 </html>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/root_namespace.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/root_namespace.html
@@ -17,12 +17,13 @@ body { margin:0 }
 }
 </style>
 <script src="/common/reftest-wait.js"></script>
-<video width="320" height="180" autoplay onplaying="this.onplaying = null; this.pause(); takeScreenshot();">
+<video width="320" height="180" autoplay>
     <source src="/media/white.webm" type="video/webm">
     <source src="/media/white.mp4" type="video/mp4">
     <track src="../../support/test.vtt">
     <script>
     document.getElementsByTagName('track')[0].track.mode = 'showing';
+    waitForActiveCueAndTakeScreenshot();
     </script>
 </video>
 </html>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/root_selector.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/root_selector.html
@@ -10,12 +10,13 @@ body { margin:0 }
 }
 </style>
 <script src="/common/reftest-wait.js"></script>
-<video width="320" height="180" autoplay onplaying="this.onplaying = null; this.pause(); takeScreenshot();">
+<video width="320" height="180" autoplay>
     <source src="/media/white.webm" type="video/webm">
     <source src="/media/white.mp4" type="video/mp4">
     <track src="../../support/test.vtt">
     <script>
     document.getElementsByTagName('track')[0].track.mode = 'showing';
+    waitForActiveCueAndTakeScreenshot();
     </script>
 </video>
 </html>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/text-decoration_line-through.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/text-decoration_line-through.html
@@ -11,12 +11,13 @@ body { margin:0 }
 }
 </style>
 <script src="/common/reftest-wait.js"></script>
-<video width="320" height="180" autoplay onplaying="this.onplaying = null; this.pause(); takeScreenshot();">
+<video width="320" height="180" autoplay>
     <source src="/media/white.webm" type="video/webm">
     <source src="/media/white.mp4" type="video/mp4">
     <track src="../../support/test.vtt">
     <script>
     document.getElementsByTagName('track')[0].track.mode = 'showing';
+    waitForActiveCueAndTakeScreenshot();
     </script>
 </video>
 </html>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/text-decoration_overline.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/text-decoration_overline.html
@@ -11,12 +11,13 @@ body { margin:0 }
 }
 </style>
 <script src="/common/reftest-wait.js"></script>
-<video width="320" height="180" autoplay onplaying="this.onplaying = null; this.pause(); takeScreenshot();">
+<video width="320" height="180" autoplay>
     <source src="/media/white.webm" type="video/webm">
     <source src="/media/white.mp4" type="video/mp4">
     <track src="../../support/test.vtt">
     <script>
     document.getElementsByTagName('track')[0].track.mode = 'showing';
+    waitForActiveCueAndTakeScreenshot();
     </script>
 </video>
 </html>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/text-decoration_overline_underline_line-through.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/text-decoration_overline_underline_line-through.html
@@ -11,12 +11,13 @@ body { margin:0 }
 }
 </style>
 <script src="/common/reftest-wait.js"></script>
-<video width="320" height="180" autoplay onplaying="this.onplaying = null; this.pause(); takeScreenshot();">
+<video width="320" height="180" autoplay>
     <source src="/media/white.webm" type="video/webm">
     <source src="/media/white.mp4" type="video/mp4">
     <track src="../../support/test.vtt">
     <script>
     document.getElementsByTagName('track')[0].track.mode = 'showing';
+    waitForActiveCueAndTakeScreenshot();
     </script>
 </video>
 </html>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/text-decoration_underline.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/text-decoration_underline.html
@@ -11,12 +11,13 @@ body { margin:0 }
 }
 </style>
 <script src="/common/reftest-wait.js"></script>
-<video width="320" height="180" autoplay onplaying="this.onplaying = null; this.pause(); takeScreenshot();">
+<video width="320" height="180" autoplay>
     <source src="/media/white.webm" type="video/webm">
     <source src="/media/white.mp4" type="video/mp4">
     <track src="../../support/test.vtt">
     <script>
     document.getElementsByTagName('track')[0].track.mode = 'showing';
+    waitForActiveCueAndTakeScreenshot();
     </script>
 </video>
 </html>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/text-shadow.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/text-shadow.html
@@ -11,12 +11,13 @@ body { margin:0 }
 }
 </style>
 <script src="/common/reftest-wait.js"></script>
-<video width="320" height="180" autoplay onplaying="this.onplaying = null; this.pause(); takeScreenshot();">
+<video width="320" height="180" autoplay>
     <source src="/media/white.webm" type="video/webm">
     <source src="/media/white.mp4" type="video/mp4">
     <track src="../../support/test.vtt">
     <script>
     document.getElementsByTagName('track')[0].track.mode = 'showing';
+    waitForActiveCueAndTakeScreenshot();
     </script>
 </video>
 </html>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/type_selector_root.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/type_selector_root.html
@@ -11,12 +11,13 @@ body { margin:0 }
 }
 </style>
 <script src="/common/reftest-wait.js"></script>
-<video width="320" height="180" autoplay onplaying="this.onplaying = null; this.pause(); takeScreenshot();">
+<video width="320" height="180" autoplay>
     <source src="/media/white.webm" type="video/webm">
     <source src="/media/white.mp4" type="video/mp4">
     <track src="../../support/test.vtt">
     <script>
     document.getElementsByTagName('track')[0].track.mode = 'showing';
+    waitForActiveCueAndTakeScreenshot();
     </script>
 </video>
 </html>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/underline_object/underline_background_properties.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/underline_object/underline_background_properties.html
@@ -15,12 +15,13 @@ body { margin:0 }
 }
 </style>
 <script src="/common/reftest-wait.js"></script>
-<video width="320" height="180" autoplay onplaying="this.onplaying = null; this.pause(); takeScreenshot();">
+<video width="320" height="180" autoplay>
     <source src="/media/white.webm" type="video/webm">
     <source src="/media/white.mp4" type="video/mp4">
     <track src="../../../support/test_underline.vtt">
     <script>
     document.getElementsByTagName('track')[0].track.mode = 'showing';
+    waitForActiveCueAndTakeScreenshot();
     </script>
 </video>
 </html>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/underline_object/underline_background_shorthand.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/underline_object/underline_background_shorthand.html
@@ -12,12 +12,13 @@ body { margin:0 }
 }
 </style>
 <script src="/common/reftest-wait.js"></script>
-<video width="320" height="180" autoplay onplaying="this.onplaying = null; this.pause(); takeScreenshot();">
+<video width="320" height="180" autoplay>
     <source src="/media/white.webm" type="video/webm">
     <source src="/media/white.mp4" type="video/mp4">
     <track src="../../../support/test_underline.vtt">
     <script>
     document.getElementsByTagName('track')[0].track.mode = 'showing';
+    waitForActiveCueAndTakeScreenshot();
     </script>
 </video>
 </html>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/underline_object/underline_color.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/underline_object/underline_color.html
@@ -11,12 +11,13 @@ body { margin:0 }
 }
 </style>
 <script src="/common/reftest-wait.js"></script>
-<video width="320" height="180" autoplay onplaying="this.onplaying = null; this.pause(); takeScreenshot();">
+<video width="320" height="180" autoplay>
     <source src="/media/white.webm" type="video/webm">
     <source src="/media/white.mp4" type="video/mp4">
     <track src="../../../support/test_underline.vtt">
     <script>
     document.getElementsByTagName('track')[0].track.mode = 'showing';
+    waitForActiveCueAndTakeScreenshot();
     </script>
 </video>
 </html>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/underline_object/underline_font_properties.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/underline_object/underline_font_properties.html
@@ -15,12 +15,13 @@ body { margin:0 }
 }
 </style>
 <script src="/common/reftest-wait.js"></script>
-<video width="320" height="180" autoplay onplaying="this.onplaying = null; this.pause(); takeScreenshot();">
+<video width="320" height="180" autoplay>
     <source src="/media/white.webm" type="video/webm">
     <source src="/media/white.mp4" type="video/mp4">
     <track src="../../../support/test_underline.vtt">
     <script>
     document.getElementsByTagName('track')[0].track.mode = 'showing';
+    waitForActiveCueAndTakeScreenshot();
     </script>
 </video>
 </html>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/underline_object/underline_font_shorthand.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/underline_object/underline_font_shorthand.html
@@ -10,12 +10,13 @@ body { margin:0 }
 }
 </style>
 <script src="/common/reftest-wait.js"></script>
-<video width="320" height="180" autoplay onplaying="this.onplaying = null; this.pause(); takeScreenshot();">
+<video width="320" height="180" autoplay>
     <source src="/media/white.webm" type="video/webm">
     <source src="/media/white.mp4" type="video/mp4">
     <track src="../../../support/test_underline.vtt">
     <script>
     document.getElementsByTagName('track')[0].track.mode = 'showing';
+    waitForActiveCueAndTakeScreenshot();
     </script>
 </video>
 </html>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/underline_object/underline_namespace.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/underline_object/underline_namespace.html
@@ -16,12 +16,13 @@ body { margin:0 }
 }
 </style>
 <script src="/common/reftest-wait.js"></script>
-<video width="320" height="180" autoplay onplaying="this.onplaying = null; this.pause(); takeScreenshot();">
+<video width="320" height="180" autoplay>
     <source src="/media/white.webm" type="video/webm">
     <source src="/media/white.mp4" type="video/mp4">
     <track src="../../../support/test_underline.vtt">
     <script>
     document.getElementsByTagName('track')[0].track.mode = 'showing';
+    waitForActiveCueAndTakeScreenshot();
     </script>
 </video>
 </html>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/underline_object/underline_outline_properties.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/underline_object/underline_outline_properties.html
@@ -13,12 +13,13 @@ body { margin:0 }
 }
 </style>
 <script src="/common/reftest-wait.js"></script>
-<video width="320" height="180" autoplay onplaying="this.onplaying = null; this.pause(); takeScreenshot();">
+<video width="320" height="180" autoplay>
     <source src="/media/white.webm" type="video/webm">
     <source src="/media/white.mp4" type="video/mp4">
     <track src="../../../support/test_underline.vtt">
     <script>
     document.getElementsByTagName('track')[0].track.mode = 'showing';
+    waitForActiveCueAndTakeScreenshot();
     </script>
 </video>
 </html>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/underline_object/underline_outline_shorthand.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/underline_object/underline_outline_shorthand.html
@@ -11,12 +11,13 @@ body { margin:0 }
 }
 </style>
 <script src="/common/reftest-wait.js"></script>
-<video width="320" height="180" autoplay onplaying="this.onplaying = null; this.pause(); takeScreenshot();">
+<video width="320" height="180" autoplay>
     <source src="/media/white.webm" type="video/webm">
     <source src="/media/white.mp4" type="video/mp4">
     <track src="../../../support/test_underline.vtt">
     <script>
     document.getElementsByTagName('track')[0].track.mode = 'showing';
+    waitForActiveCueAndTakeScreenshot();
     </script>
 </video>
 </html>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/underline_object/underline_text-decoration_line-through.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/underline_object/underline_text-decoration_line-through.html
@@ -11,12 +11,13 @@ body { margin:0 }
 }
 </style>
 <script src="/common/reftest-wait.js"></script>
-<video width="320" height="180" autoplay onplaying="this.onplaying = null; this.pause(); takeScreenshot();">
+<video width="320" height="180" autoplay>
     <source src="/media/white.webm" type="video/webm">
     <source src="/media/white.mp4" type="video/mp4">
     <track src="../../../support/test_underline.vtt">
     <script>
     document.getElementsByTagName('track')[0].track.mode = 'showing';
+    waitForActiveCueAndTakeScreenshot();
     </script>
 </video>
 </html>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/underline_object/underline_text-shadow.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/underline_object/underline_text-shadow.html
@@ -11,12 +11,13 @@ body { margin:0 }
 }
 </style>
 <script src="/common/reftest-wait.js"></script>
-<video width="320" height="180" autoplay onplaying="this.onplaying = null; this.pause(); takeScreenshot();">
+<video width="320" height="180" autoplay>
     <source src="/media/white.webm" type="video/webm">
     <source src="/media/white.mp4" type="video/mp4">
     <track src="../../../support/test_underline.vtt">
 </video>
 <script>
 document.getElementsByTagName('track')[0].track.mode = 'showing';
+waitForActiveCueAndTakeScreenshot();
 </script>
 </html>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/underline_object/underline_white-space_normal_wrapped.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/underline_object/underline_white-space_normal_wrapped.html
@@ -10,12 +10,13 @@ body { margin:0 }
 }
 </style>
 <script src="/common/reftest-wait.js"></script>
-<video width="320" height="180" autoplay onplaying="this.onplaying = null; this.pause(); takeScreenshot();">
+<video width="320" height="180" autoplay>
     <source src="/media/white.webm" type="video/webm">
     <source src="/media/white.mp4" type="video/mp4">
     <track src="../../../support/underline_long.vtt">
     <script>
     document.getElementsByTagName('track')[0].track.mode = 'showing';
+    waitForActiveCueAndTakeScreenshot();
     </script>
 </video>
 </html>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/underline_object/underline_white-space_nowrap.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/underline_object/underline_white-space_nowrap.html
@@ -10,12 +10,13 @@ body { margin:0 }
 }
 </style>
 <script src="/common/reftest-wait.js"></script>
-<video width="320" height="180" autoplay onplaying="this.onplaying = null; this.pause(); takeScreenshot();">
+<video width="320" height="180" autoplay>
     <source src="/media/white.webm" type="video/webm">
     <source src="/media/white.mp4" type="video/mp4">
     <track src="../../../support/underline_long.vtt">
     <script>
     document.getElementsByTagName('track')[0].track.mode = 'showing';
+    waitForActiveCueAndTakeScreenshot();
     </script>
 </video>
 </html>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/underline_object/underline_white-space_pre-line_wrapped.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/underline_object/underline_white-space_pre-line_wrapped.html
@@ -10,12 +10,13 @@ body { margin:0 }
 }
 </style>
 <script src="/common/reftest-wait.js"></script>
-<video width="320" height="180" autoplay onplaying="this.onplaying = null; this.pause(); takeScreenshot();">
+<video width="320" height="180" autoplay>
     <source src="/media/white.webm" type="video/webm">
     <source src="/media/white.mp4" type="video/mp4">
     <track src="../../../support/underline_long.vtt">
     <script>
     document.getElementsByTagName('track')[0].track.mode = 'showing';
+    waitForActiveCueAndTakeScreenshot();
     </script>
 </video>
 </html>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/underline_object/underline_white-space_pre-wrap_wrapped.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/underline_object/underline_white-space_pre-wrap_wrapped.html
@@ -10,12 +10,13 @@ body { margin:0 }
 }
 </style>
 <script src="/common/reftest-wait.js"></script>
-<video width="320" height="180" autoplay onplaying="this.onplaying = null; this.pause(); takeScreenshot();">
+<video width="320" height="180" autoplay>
     <source src="/media/white.webm" type="video/webm">
     <source src="/media/white.mp4" type="video/mp4">
     <track src="../../../support/underline_long.vtt">
     <script>
     document.getElementsByTagName('track')[0].track.mode = 'showing';
+    waitForActiveCueAndTakeScreenshot();
     </script>
 </video>
 </html>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/underline_object/underline_white-space_pre_wrapped.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/underline_object/underline_white-space_pre_wrapped.html
@@ -10,12 +10,13 @@ body { margin:0 }
 }
 </style>
 <script src="/common/reftest-wait.js"></script>
-<video width="320" height="180" autoplay onplaying="this.onplaying = null; this.pause(); takeScreenshot();">
+<video width="320" height="180" autoplay>
     <source src="/media/white.webm" type="video/webm">
     <source src="/media/white.mp4" type="video/mp4">
     <track src="../../../support/underline_long.vtt">
     <script>
     document.getElementsByTagName('track')[0].track.mode = 'showing';
+    waitForActiveCueAndTakeScreenshot();
     </script>
 </video>
 </html>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/underline_object/underline_with_class.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/underline_object/underline_with_class.html
@@ -11,12 +11,13 @@ body { margin:0 }
 }
 </style>
 <script src="/common/reftest-wait.js"></script>
-<video width="320" height="180" autoplay onplaying="this.onplaying = null; this.pause(); takeScreenshot();">
+<video width="320" height="180" autoplay>
     <source src="/media/white.webm" type="video/webm">
     <source src="/media/white.mp4" type="video/mp4">
     <track src="../../../support/test_underline_with_class.vtt">
     <script>
     document.getElementsByTagName('track')[0].track.mode = 'showing';
+    waitForActiveCueAndTakeScreenshot();
     </script>
 </video>
 </html>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/underline_object/underline_with_class_object_specific_selector.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/underline_object/underline_with_class_object_specific_selector.html
@@ -11,12 +11,13 @@ body { margin:0 }
 }
 </style>
 <script src="/common/reftest-wait.js"></script>
-<video width="320" height="180" autoplay onplaying="this.onplaying = null; this.pause(); takeScreenshot();">
+<video width="320" height="180" autoplay>
     <source src="/media/white.webm" type="video/webm">
     <source src="/media/white.mp4" type="video/mp4">
     <track src="../../../support/test_underline_with_class.vtt">
     <script>
     document.getElementsByTagName('track')[0].track.mode = 'showing';
+    waitForActiveCueAndTakeScreenshot();
     </script>
 </video>
 </html>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/voice_object/voice_background_properties.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/voice_object/voice_background_properties.html
@@ -15,12 +15,13 @@ body { margin:0 }
 }
 </style>
 <script src="/common/reftest-wait.js"></script>
-<video width="320" height="180" autoplay onplaying="this.onplaying = null; this.pause(); takeScreenshot();">
+<video width="320" height="180" autoplay>
     <source src="/media/white.webm" type="video/webm">
     <source src="/media/white.mp4" type="video/mp4">
     <track src="../../../support/test_voice.vtt">
     <script>
     document.getElementsByTagName('track')[0].track.mode = 'showing';
+    waitForActiveCueAndTakeScreenshot();
     </script>
 </video>
 </html>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/voice_object/voice_background_shorthand.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/voice_object/voice_background_shorthand.html
@@ -12,12 +12,13 @@ body { margin:0 }
 }
 </style>
 <script src="/common/reftest-wait.js"></script>
-<video width="320" height="180" autoplay onplaying="this.onplaying = null; this.pause(); takeScreenshot();">
+<video width="320" height="180" autoplay>
     <source src="/media/white.webm" type="video/webm">
     <source src="/media/white.mp4" type="video/mp4">
     <track src="../../../support/test_voice.vtt">
     <script>
     document.getElementsByTagName('track')[0].track.mode = 'showing';
+    waitForActiveCueAndTakeScreenshot();
     </script>
 </video>
 </html>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/voice_object/voice_color.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/voice_object/voice_color.html
@@ -11,12 +11,13 @@ body { margin:0 }
 }
 </style>
 <script src="/common/reftest-wait.js"></script>
-<video width="320" height="180" autoplay onplaying="this.onplaying = null; this.pause(); takeScreenshot();">
+<video width="320" height="180" autoplay>
     <source src="/media/white.webm" type="video/webm">
     <source src="/media/white.mp4" type="video/mp4">
     <track src="../../../support/test_voice.vtt">
     <script>
     document.getElementsByTagName('track')[0].track.mode = 'showing';
+    waitForActiveCueAndTakeScreenshot();
     </script>
 </video>
 </html>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/voice_object/voice_font_properties.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/voice_object/voice_font_properties.html
@@ -15,12 +15,13 @@ body { margin:0 }
 }
 </style>
 <script src="/common/reftest-wait.js"></script>
-<video width="320" height="180" autoplay onplaying="this.onplaying = null; this.pause(); takeScreenshot();">
+<video width="320" height="180" autoplay>
     <source src="/media/white.webm" type="video/webm">
     <source src="/media/white.mp4" type="video/mp4">
     <track src="../../../support/test_voice.vtt">
     <script>
     document.getElementsByTagName('track')[0].track.mode = 'showing';
+    waitForActiveCueAndTakeScreenshot();
     </script>
 </video>
 </html>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/voice_object/voice_font_shorthand.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/voice_object/voice_font_shorthand.html
@@ -10,12 +10,13 @@ body { margin:0 }
 }
 </style>
 <script src="/common/reftest-wait.js"></script>
-<video width="320" height="180" autoplay onplaying="this.onplaying = null; this.pause(); takeScreenshot();">
+<video width="320" height="180" autoplay>
     <source src="/media/white.webm" type="video/webm">
     <source src="/media/white.mp4" type="video/mp4">
     <track src="../../../support/test_voice.vtt">
     <script>
     document.getElementsByTagName('track')[0].track.mode = 'showing';
+    waitForActiveCueAndTakeScreenshot();
     </script>
 </video>
 </html>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/voice_object/voice_namespace.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/voice_object/voice_namespace.html
@@ -18,12 +18,13 @@ body { margin:0 }
 }
 </style>
 <script src="/common/reftest-wait.js"></script>
-<video width="320" height="180" autoplay onplaying="this.onplaying = null; this.pause(); takeScreenshot();">
+<video width="320" height="180" autoplay>
     <source src="/media/white.webm" type="video/webm">
     <source src="/media/white.mp4" type="video/mp4">
     <track src="../../../support/test_voice.vtt">
     <script>
     document.getElementsByTagName('track')[0].track.mode = 'showing';
+    waitForActiveCueAndTakeScreenshot();
     </script>
 </video>
 </html>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/voice_object/voice_outline_properties.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/voice_object/voice_outline_properties.html
@@ -13,12 +13,13 @@ body { margin:0 }
 }
 </style>
 <script src="/common/reftest-wait.js"></script>
-<video width="320" height="180" autoplay onplaying="this.onplaying = null; this.pause(); takeScreenshot();">
+<video width="320" height="180" autoplay>
     <source src="/media/white.webm" type="video/webm">
     <source src="/media/white.mp4" type="video/mp4">
     <track src="../../../support/test_voice.vtt">
     <script>
     document.getElementsByTagName('track')[0].track.mode = 'showing';
+    waitForActiveCueAndTakeScreenshot();
     </script>
 </video>
 </html>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/voice_object/voice_outline_shorthand.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/voice_object/voice_outline_shorthand.html
@@ -11,12 +11,13 @@ body { margin:0 }
 }
 </style>
 <script src="/common/reftest-wait.js"></script>
-<video width="320" height="180" autoplay onplaying="this.onplaying = null; this.pause(); takeScreenshot();">
+<video width="320" height="180" autoplay>
     <source src="/media/white.webm" type="video/webm">
     <source src="/media/white.mp4" type="video/mp4">
     <track src="../../../support/test_voice.vtt">
     <script>
     document.getElementsByTagName('track')[0].track.mode = 'showing';
+    waitForActiveCueAndTakeScreenshot();
     </script>
 </video>
 </html>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/voice_object/voice_text-decoration_line-through.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/voice_object/voice_text-decoration_line-through.html
@@ -11,12 +11,13 @@ body { margin:0 }
 }
 </style>
 <script src="/common/reftest-wait.js"></script>
-<video width="320" height="180" autoplay onplaying="this.onplaying = null; this.pause(); takeScreenshot();">
+<video width="320" height="180" autoplay>
     <source src="/media/white.webm" type="video/webm">
     <source src="/media/white.mp4" type="video/mp4">
     <track src="../../../support/test_voice.vtt">
     <script>
     document.getElementsByTagName('track')[0].track.mode = 'showing';
+    waitForActiveCueAndTakeScreenshot();
     </script>
 </video>
 </html>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/voice_object/voice_text-shadow.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/voice_object/voice_text-shadow.html
@@ -11,12 +11,13 @@ body { margin:0 }
 }
 </style>
 <script src="/common/reftest-wait.js"></script>
-<video width="320" height="180" autoplay onplaying="this.onplaying = null; this.pause(); takeScreenshot();">
+<video width="320" height="180" autoplay>
     <source src="/media/white.webm" type="video/webm">
     <source src="/media/white.mp4" type="video/mp4">
     <track src="../../../support/test_voice.vtt">
     <script>
     document.getElementsByTagName('track')[0].track.mode = 'showing';
+    waitForActiveCueAndTakeScreenshot();
     </script>
 </video>
 </html>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/voice_object/voice_voice_attribute.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/voice_object/voice_voice_attribute.html
@@ -11,12 +11,13 @@ body { margin:0 }
 }
 </style>
 <script src="/common/reftest-wait.js"></script>
-<video width="320" height="180" autoplay onplaying="this.onplaying = null; this.pause(); takeScreenshot();">
+<video width="320" height="180" autoplay>
     <source src="/media/white.webm" type="video/webm">
     <source src="/media/white.mp4" type="video/mp4">
     <track src="../../../support/test_two_voices.vtt">
     <script>
     document.getElementsByTagName('track')[0].track.mode = 'showing';
+    waitForActiveCueAndTakeScreenshot();
     </script>
 </video>
 </html>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/voice_object/voice_white-space_normal_wrapped.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/voice_object/voice_white-space_normal_wrapped.html
@@ -10,12 +10,13 @@ body { margin:0 }
 }
 </style>
 <script src="/common/reftest-wait.js"></script>
-<video width="320" height="180" autoplay onplaying="this.onplaying = null; this.pause(); takeScreenshot();">
+<video width="320" height="180" autoplay>
     <source src="/media/white.webm" type="video/webm">
     <source src="/media/white.mp4" type="video/mp4">
     <track src="../../../support/voice_long.vtt">
     <script>
     document.getElementsByTagName('track')[0].track.mode = 'showing';
+    waitForActiveCueAndTakeScreenshot();
     </script>
 </video>
 </html>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/voice_object/voice_white-space_nowrap.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/voice_object/voice_white-space_nowrap.html
@@ -10,12 +10,13 @@ body { margin:0 }
 }
 </style>
 <script src="/common/reftest-wait.js"></script>
-<video width="320" height="180" autoplay onplaying="this.onplaying = null; this.pause(); takeScreenshot();">
+<video width="320" height="180" autoplay>
     <source src="/media/white.webm" type="video/webm">
     <source src="/media/white.mp4" type="video/mp4">
     <track src="../../../support/voice_long.vtt">
     <script>
     document.getElementsByTagName('track')[0].track.mode = 'showing';
+    waitForActiveCueAndTakeScreenshot();
     </script>
 </video>
 </html>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/voice_object/voice_white-space_pre-line_wrapped.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/voice_object/voice_white-space_pre-line_wrapped.html
@@ -10,12 +10,13 @@ body { margin:0 }
 }
 </style>
 <script src="/common/reftest-wait.js"></script>
-<video width="320" height="180" autoplay onplaying="this.onplaying = null; this.pause(); takeScreenshot();">
+<video width="320" height="180" autoplay>
     <source src="/media/white.webm" type="video/webm">
     <source src="/media/white.mp4" type="video/mp4">
     <track src="../../../support/voice_long.vtt">
     <script>
     document.getElementsByTagName('track')[0].track.mode = 'showing';
+    waitForActiveCueAndTakeScreenshot();
     </script>
 </video>
 </html>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/voice_object/voice_white-space_pre-wrap_wrapped.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/voice_object/voice_white-space_pre-wrap_wrapped.html
@@ -10,12 +10,13 @@ body { margin:0 }
 }
 </style>
 <script src="/common/reftest-wait.js"></script>
-<video width="320" height="180" autoplay onplaying="this.onplaying = null; this.pause(); takeScreenshot();">
+<video width="320" height="180" autoplay>
     <source src="/media/white.webm" type="video/webm">
     <source src="/media/white.mp4" type="video/mp4">
     <track src="../../../support/voice_long.vtt">
     <script>
     document.getElementsByTagName('track')[0].track.mode = 'showing';
+    waitForActiveCueAndTakeScreenshot();
     </script>
 </video>
 </html>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/voice_object/voice_white-space_pre_wrapped.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/voice_object/voice_white-space_pre_wrapped.html
@@ -10,12 +10,13 @@ body { margin:0 }
 }
 </style>
 <script src="/common/reftest-wait.js"></script>
-<video width="320" height="180" autoplay onplaying="this.onplaying = null; this.pause(); takeScreenshot();">
+<video width="320" height="180" autoplay>
     <source src="/media/white.webm" type="video/webm">
     <source src="/media/white.mp4" type="video/mp4">
     <track src="../../../support/voice_long.vtt">
     <script>
     document.getElementsByTagName('track')[0].track.mode = 'showing';
+    waitForActiveCueAndTakeScreenshot();
     </script>
 </video>
 </html>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/voice_object/voice_with_class.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/voice_object/voice_with_class.html
@@ -11,12 +11,13 @@ body { margin:0 }
 }
 </style>
 <script src="/common/reftest-wait.js"></script>
-<video width="320" height="180" autoplay onplaying="this.onplaying = null; this.pause(); takeScreenshot();">
+<video width="320" height="180" autoplay>
     <source src="/media/white.webm" type="video/webm">
     <source src="/media/white.mp4" type="video/mp4">
     <track src="../../../support/test_voice_with_class.vtt">
     <script>
     document.getElementsByTagName('track')[0].track.mode = 'showing';
+    waitForActiveCueAndTakeScreenshot();
     </script>
 </video>
 </html>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/voice_object/voice_with_class_object_specific_selector.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/voice_object/voice_with_class_object_specific_selector.html
@@ -11,12 +11,13 @@ body { margin:0 }
 }
 </style>
 <script src="/common/reftest-wait.js"></script>
-<video width="320" height="180" autoplay onplaying="this.onplaying = null; this.pause(); takeScreenshot();">
+<video width="320" height="180" autoplay>
     <source src="/media/white.webm" type="video/webm">
     <source src="/media/white.mp4" type="video/mp4">
     <track src="../../../support/test_voice_with_class.vtt">
     <script>
     document.getElementsByTagName('track')[0].track.mode = 'showing';
+    waitForActiveCueAndTakeScreenshot();
     </script>
 </video>
 </html>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/white-space_normal_wrapped.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/white-space_normal_wrapped.html
@@ -10,12 +10,13 @@ body { margin:0 }
 }
 </style>
 <script src="/common/reftest-wait.js"></script>
-<video width="320" height="180" autoplay onplaying="this.onplaying = null; this.pause(); takeScreenshot();">
+<video width="320" height="180" autoplay>
     <source src="/media/white.webm" type="video/webm">
     <source src="/media/white.mp4" type="video/mp4">
     <track src="../../support/foo_space_space_bar_LF_baz.vtt">
     <script>
     document.getElementsByTagName('track')[0].track.mode = 'showing';
+    waitForActiveCueAndTakeScreenshot();
     </script>
 </video>
 </html>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/white-space_nowrap_wrapped.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/white-space_nowrap_wrapped.html
@@ -10,12 +10,13 @@ body { margin:0 }
 }
 </style>
 <script src="/common/reftest-wait.js"></script>
-<video width="320" height="180" autoplay onplaying="this.onplaying = null; this.pause(); takeScreenshot();">
+<video width="320" height="180" autoplay>
     <source src="/media/white.webm" type="video/webm">
     <source src="/media/white.mp4" type="video/mp4">
     <track src="../../support/white-spaces_long_size_20.vtt">
     <script>
     document.getElementsByTagName('track')[0].track.mode = 'showing';
+    waitForActiveCueAndTakeScreenshot();
     </script>
 </video>
 </html>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/white-space_pre-line_wrapped.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/white-space_pre-line_wrapped.html
@@ -10,12 +10,13 @@ body { margin:0 }
 }
 </style>
 <script src="/common/reftest-wait.js"></script>
-<video width="320" height="180" autoplay onplaying="this.onplaying = null; this.pause(); takeScreenshot();">
+<video width="320" height="180" autoplay>
     <source src="/media/white.webm" type="video/webm">
     <source src="/media/white.mp4" type="video/mp4">
     <track src="../../support/white-spaces_long_size_20.vtt">
     <script>
     document.getElementsByTagName('track')[0].track.mode = 'showing';
+    waitForActiveCueAndTakeScreenshot();
     </script>
 </video>
 </html>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/white-space_pre-wrap_wrapped.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/white-space_pre-wrap_wrapped.html
@@ -10,12 +10,13 @@ body { margin:0 }
 }
 </style>
 <script src="/common/reftest-wait.js"></script>
-<video width="320" height="180" autoplay onplaying="this.onplaying = null; this.pause(); takeScreenshot();">
+<video width="320" height="180" autoplay>
     <source src="/media/white.webm" type="video/webm">
     <source src="/media/white.mp4" type="video/mp4">
     <track src="../../support/white-spaces_long.vtt">
     <script>
     document.getElementsByTagName('track')[0].track.mode = 'showing';
+    waitForActiveCueAndTakeScreenshot();
     </script>
 </video>
 </html>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/white-space_pre.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/white-space_pre.html
@@ -10,12 +10,13 @@ body { margin:0 }
 }
 </style>
 <script src="/common/reftest-wait.js"></script>
-<video width="320" height="180" autoplay onplaying="this.onplaying = null; this.pause(); takeScreenshot();">
+<video width="320" height="180" autoplay>
     <source src="/media/white.webm" type="video/webm">
     <source src="/media/white.mp4" type="video/mp4">
     <track src="../../support/white-spaces.vtt">
     <script>
     document.getElementsByTagName('track')[0].track.mode = 'showing';
+    waitForActiveCueAndTakeScreenshot();
     </script>
 </video>
 </html>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/white-space_pre_wrapped.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/white-space_pre_wrapped.html
@@ -10,12 +10,13 @@ body { margin:0 }
 }
 </style>
 <script src="/common/reftest-wait.js"></script>
-<video width="320" height="180" autoplay onplaying="this.onplaying = null; this.pause(); takeScreenshot();">
+<video width="320" height="180" autoplay>
     <source src="/media/white.webm" type="video/webm">
     <source src="/media/white.mp4" type="video/mp4">
     <track src="../../support/white-spaces_long.vtt">
     <script>
     document.getElementsByTagName('track')[0].track.mode = 'showing';
+    waitForActiveCueAndTakeScreenshot();
     </script>
 </video>
 </html>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/default_styles/bold_object_default_font-style.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/default_styles/bold_object_default_font-style.html
@@ -7,12 +7,13 @@ html { overflow:hidden }
 body { margin:0 }
 </style>
 <script src="/common/reftest-wait.js"></script>
-<video width="320" height="180" autoplay onplaying="this.onplaying = null; this.pause(); takeScreenshot();">
+<video width="320" height="180" autoplay>
     <source src="/media/white.webm" type="video/webm">
     <source src="/media/white.mp4" type="video/mp4">
     <track src="../../support/test_bold.vtt">
     <script>
     document.getElementsByTagName('track')[0].track.mode = 'showing';
+    waitForActiveCueAndTakeScreenshot();
     </script>
 </video>
 </html>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/default_styles/italic_object_default_font-style.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/default_styles/italic_object_default_font-style.html
@@ -7,12 +7,13 @@ html { overflow:hidden }
 body { margin:0 }
 </style>
 <script src="/common/reftest-wait.js"></script>
-<video width="320" height="180" autoplay onplaying="this.onplaying = null; this.pause(); takeScreenshot();">
+<video width="320" height="180" autoplay>
     <source src="/media/white.webm" type="video/webm">
     <source src="/media/white.mp4" type="video/mp4">
     <track src="../../support/test_italic.vtt">
     <script>
     document.getElementsByTagName('track')[0].track.mode = 'showing';
+    waitForActiveCueAndTakeScreenshot();
     </script>
 </video>
 </html>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/default_styles/underline_object_default_font-style.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/default_styles/underline_object_default_font-style.html
@@ -7,12 +7,13 @@ html { overflow:hidden }
 body { margin:0 }
 </style>
 <script src="/common/reftest-wait.js"></script>
-<video width="320" height="180" autoplay onplaying="this.onplaying = null; this.pause(); takeScreenshot();">
+<video width="320" height="180" autoplay>
     <source src="/media/white.webm" type="video/webm">
     <source src="/media/white.mp4" type="video/mp4">
     <track src="../../support/test_underline.vtt">
     <script>
     document.getElementsByTagName('track')[0].track.mode = 'showing';
+    waitForActiveCueAndTakeScreenshot();
     </script>
 </video>
 </html>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/size_50.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/size_50.html
@@ -12,12 +12,13 @@ body { margin:0 }
 }
 </style>
 <script src="/common/reftest-wait.js"></script>
-<video width="320" height="180" autoplay onplaying="this.onplaying = null; this.pause(); takeScreenshot();">
+<video width="320" height="180" autoplay>
     <source src="/media/white.webm" type="video/webm">
     <source src="/media/white.mp4" type="video/mp4">
     <track src="support/size_50.vtt">
     <script>
     document.getElementsByTagName('track')[0].track.mode = 'showing';
+    waitForActiveCueAndTakeScreenshot();
     </script>
 </video>
 </html>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/snap-to-line.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/snap-to-line.html
@@ -12,12 +12,13 @@ body { margin:0 }
 }
 </style>
 <script src="/common/reftest-wait.js"></script>
-<video width="320" height="180" autoplay onplaying="this.onplaying = null; this.pause(); takeScreenshot();">
+<video width="320" height="180" autoplay>
     <source src="/media/white.webm" type="video/webm">
     <source src="/media/white.mp4" type="video/mp4">
     <track src="support/snap-to-line.vtt">
     <script>
     document.getElementsByTagName('track')[0].track.mode = 'showing';
+    waitForActiveCueAndTakeScreenshot();
     </script>
 </video>
 </html>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/too_many_cues.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/too_many_cues.html
@@ -12,12 +12,13 @@ body { margin:0 }
 }
 </style>
 <script src="/common/reftest-wait.js"></script>
-<video width="320" height="180" autoplay onplaying="this.onplaying = null; this.pause(); takeScreenshot();">
+<video width="320" height="180" autoplay>
     <source src="/media/white.webm" type="video/webm">
     <source src="/media/white.mp4" type="video/mp4">
     <track src="support/too_many_cues.vtt">
     <script>
     document.getElementsByTagName('track')[0].track.mode = 'showing';
+    waitForActiveCueAndTakeScreenshot();
     </script>
 </video>
 </html>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/too_many_cues_wrapped.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/too_many_cues_wrapped.html
@@ -12,12 +12,13 @@ body { margin:0 }
 }
 </style>
 <script src="/common/reftest-wait.js"></script>
-<video width="320" height="180" autoplay onplaying="this.onplaying = null; this.pause(); takeScreenshot();">
+<video width="320" height="180" autoplay>
     <source src="/media/white.webm" type="video/webm">
     <source src="/media/white.mp4" type="video/mp4">
     <track src="support/too_many_cues_wrapped.vtt">
     <script>
     document.getElementsByTagName('track')[0].track.mode = 'showing';
+    waitForActiveCueAndTakeScreenshot();
     </script>
 </video>
 </html>

--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -8264,9 +8264,29 @@ webkit.org/b/296657 fast/scrolling/ios/scroll-anchoring-when-revealing-focused-e
 
 webkit.org/b/296707 imported/w3c/web-platform-tests/screen-orientation/non-fully-active.html [ Pass Failure ]
 
-webkit.org/b/296709 imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/evil/media_height_19.html [ ImageOnlyFailure ]
+
 imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/line_1_wrapped_cue_grow_downwards.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/navigate_cue_position.html [ Skip ]
+imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/align_center.html [ Pass ]
+imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/align_center_position_50.html [ Pass ]
+imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/align_start.html [ Pass ]
+imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/basic.html [ Pass ]
+imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/bold_object/bold_white-space_nowrap.html [ Pass ]
+imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/bold_object/bold_with_class.html [ Pass ]
+imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/bold_object/bold_with_class_object_specific_selector.html [ Pass ]
+imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/class_object/class_namespace.html [ Pass ]
+imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/class_object/class_with_class.html [ Pass ]
+imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/class_object/class_with_class_object_specific_selector.html [ Pass ]
+imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/italic_object/italic_with_class.html [ Pass ]
+imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/italic_object/italic_with_class_object_specific_selector.html [ Pass ]
+imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/not_root_selector.html [ Pass ]
+imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/underline_object/underline_with_class.html [ Pass ]
+imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/voice_object/voice_namespace.html [ Pass ]
+imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/voice_object/voice_with_class.html [ Pass ]
+imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/voice_object/voice_with_class_object_specific_selector.html [ Pass ]
+imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue/background_shorthand.html [ Pass ]
+imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue/color_hsla.html [ Pass ]
+imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue/white-space_normal_wrapped.html [ Pass ]
 
 webkit.org/b/296816 [ Release ] imported/w3c/web-platform-tests/css/css-shapes/spec-examples/shape-outside-012.html [ Pass Failure ]
 

--- a/LayoutTests/platform/mac/TestExpectations
+++ b/LayoutTests/platform/mac/TestExpectations
@@ -766,7 +766,6 @@ imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-mode
 imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue/color_hsla.html [ Pass ]
 imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue/white-space_normal_wrapped.html [ Pass ]
 imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue/white-space_nowrap_wrapped.html [ Pass ]
-imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue/white-space_pre.html [ Pass ]
 imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/class_object/class_namespace.html [ Pass ]
 imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/not_root_selector.html [ Pass ]
 imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/voice_object/voice_namespace.html [ Pass ]


### PR DESCRIPTION
#### 14b18119c1701bebc814d2e6728cd00eaa12d615
<pre>
Fix flaky WebVTT WPT
<a href="https://bugs.webkit.org/show_bug.cgi?id=314118">https://bugs.webkit.org/show_bug.cgi?id=314118</a>
<a href="https://rdar.apple.com/176294890">rdar://176294890</a>

Reviewed by Jer Noble.

A number of WebVTT WPT fail due to the screenshot being taken before the cue
has appeared on screen.

To fix this, this patch adds a helper function waitForActiveCueAndTakeScreenshot()
to reftest-wait.js. It waits until a cue is active (via cuechange or an immediate
check of activeCues), pauses the video, then calls requestAnimationFrame()
to wait for rendering to complete before calling takeScreenshot().

This patch also changes the helper function failIfNot(condition, msg) to return a
boolean: true if the condition is true and false otherwise.
waitForActiveCueAndTakeScreenshot() is the only caller that utilizes the return value,
so it can return early if a track element is not found.

All of the WebVTT rendering WPT tests, except for the ones that do not expect a cue to
be shown, now call waitForActiveCueAndTakeScreenshot() instead of takeScreenshot().

* LayoutTests/TestExpectations:
* LayoutTests/imported/w3c/web-platform-tests/common/reftest-wait.js:
(failIfNot):
(waitForActiveCueAndTakeScreenshot.pauseVideoAndTakeScreenshot):
(waitForActiveCueAndTakeScreenshot.textTrack.oncuechange):
(waitForActiveCueAndTakeScreenshot):
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/media-elements/track/track-element/track-cue-rendering-line-doesnt-fit-expected.html:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/media-elements/track/track-element/track-cue-rendering-line-doesnt-fit-ref.html:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/media-elements/track/track-element/track-cue-rendering-line-doesnt-fit.html:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/media-elements/track/track-element/track-cue-rendering-transformed-video-expected.html:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/media-elements/track/track-element/track-cue-rendering-transformed-video-ref.html:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/media-elements/track/track-element/track-cue-rendering-transformed-video.html:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/media-elements/track/track-element/track-webvtt-non-snap-to-lines-expected.html:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/media-elements/track/track-element/track-webvtt-non-snap-to-lines-ref.html:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/media-elements/track/track-element/track-webvtt-non-snap-to-lines.html:
* LayoutTests/imported/w3c/web-platform-tests/tools/third_party/html5lib/benchmarks/data/wpt/random/background_shorthand_css_relative_url.html:
* LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/2_tracks.html:
* LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/3_tracks.html:
* LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/align_center.html:
* LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/align_center_position_50.html:
* LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/align_center_position_gt_50.html:
* LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/align_center_position_gt_50_size_gt_maximum_size.html:
* LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/align_center_position_lt_50.html:
* LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/align_center_position_lt_50_size_gt_maximum_size.html:
* LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/align_center_wrapped.html:
* LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/align_end.html:
* LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/align_end_wrapped.html:
* LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/align_start.html:
* LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/align_start_wrapped.html:
* LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/basic.html:
* LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/bidi/bidi_ruby.html:
* LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/bidi/start_alignment.html:
* LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/bidi/u002E_LF_u05D0.html:
* LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/bidi/u002E_u2028_u05D0.html:
* LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/bidi/u002E_u2029_u05D0.html:
* LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/bidi/u0041_first.html:
* LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/bidi/u05D0_first.html:
* LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/bidi/u0628_first.html:
* LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/bidi/u06E9_no_strong_dir.html:
* LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/bidi/vertical_lr.html:
* LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/bidi/vertical_rl.html:
* LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/cue_too_long.html:
* LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/decode_escaped_entities.html:
* LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/embedded_style_multiple_tracks-expected.html:
* LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/embedded_style_multiple_tracks-ref.html:
* LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/embedded_style_multiple_tracks.html:
* LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/evil/media_height_19.html:
* LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/evil/single_quote.html:
* LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/evil/size_90.html:
* LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/evil/size_99.html:
* LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/line_-2_wrapped_cue_grow_upwards.html:
* LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/line_0_is_top.html:
* LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/line_1_wrapped_cue_grow_downwards.html:
* LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/line_50_percent.html:
* LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/line_integer_and_percent_mixed_overlap.html:
* LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/line_integer_and_percent_mixed_overlap_move_up.html:
* LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/line_percent_and_integer_mixed_overlap.html:
* LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/line_percent_and_integer_mixed_overlap_move_up.html:
* LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/one_line_cue_plus_wrapped_cue.html:
* LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/portrait.tentative.html:
* LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/regions/basic.html:
* LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/regions/regionanchor_x_50_percent.html:
* LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/regions/regionanchor_y_50_percent.html:
* LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/regions/single_line_top_left.html:
* LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/regions/viewportanchor_x_50_percent.html:
* LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/regions/viewportanchor_y_50_percent.html:
* LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/regions/width_50_percent.html:
* LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue-region/font_properties.html:
* LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue-region_function/font_properties.html:
* LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue/background_properties.html:
* LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue/background_shorthand.html:
* LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue/color_hex.html:
* LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue/color_hsla.html:
* LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue/color_rgba.html:
* LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue/cue_selector_single_colon.html:
* LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue/font_properties.html:
* LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue/font_shorthand.html:
* LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue/inherit_values_from_media_element.html:
* LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue/outline_properties.html:
* LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue/outline_shorthand.html:
* LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue/text-decoration_line-through.html:
* LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue/text-decoration_overline.html:
* LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue/text-decoration_overline_underline_line-through.html:
* LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue/text-decoration_underline.html:
* LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue/text-shadow.html:
* LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue/vertical_text-combine-upright.html:
* LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue/white-space_normal_wrapped.html:
* LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue/white-space_nowrap_wrapped.html:
* LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue/white-space_pre-line_wrapped.html:
* LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue/white-space_pre-wrap_wrapped.html:
* LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue/white-space_pre.html:
* LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue/white-space_pre_wrapped.html:
* LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/background_box.html:
* LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/background_properties.html:
* LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/background_shorthand.html:
* LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/background_shorthand_css_relative_url.html:
* LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/bold_object/bold_background_properties.html:
* LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/bold_object/bold_background_shorthand.html:
* LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/bold_object/bold_color.html:
* LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/bold_object/bold_font_properties.html:
* LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/bold_object/bold_font_shorthand.html:
* LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/bold_object/bold_namespace.html:
* LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/bold_object/bold_outline_properties.html:
* LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/bold_object/bold_outline_shorthand.html:
* LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/bold_object/bold_text-decoration_line-through.html:
* LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/bold_object/bold_text-shadow.html:
* LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/bold_object/bold_white-space_normal_wrapped.html:
* LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/bold_object/bold_white-space_nowrap.html:
* LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/bold_object/bold_white-space_pre-line_wrapped.html:
* LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/bold_object/bold_white-space_pre-wrap_wrapped.html:
* LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/bold_object/bold_white-space_pre_wrapped.html:
* LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/bold_object/bold_with_class.html:
* LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/bold_object/bold_with_class_object_specific_selector.html:
* LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/class_object/class_background_properties.html:
* LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/class_object/class_background_shorthand.html:
* LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/class_object/class_color.html:
* LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/class_object/class_font_properties.html:
* LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/class_object/class_font_shorthand.html:
* LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/class_object/class_namespace.html:
* LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/class_object/class_outline_properties.html:
* LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/class_object/class_outline_shorthand.html:
* LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/class_object/class_text-decoration_line-through.html:
* LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/class_object/class_text-shadow.html:
* LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/class_object/class_vertical_text-combine-upright.html:
* LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/class_object/class_white-space_normal_wrapped.html:
* LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/class_object/class_white-space_nowrap.html:
* LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/class_object/class_white-space_pre-line_wrapped.html:
* LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/class_object/class_white-space_pre-wrap_wrapped.html:
* LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/class_object/class_white-space_pre_wrapped.html:
* LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/class_object/class_with_class.html:
* LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/class_object/class_with_class_object_specific_selector.html:
* LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/color_hex.html:
* LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/color_hsla.html:
* LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/color_rgba.html:
* LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/cue_func_selector_single_colon.html:
* LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/font_properties.html:
* LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/font_shorthand.html:
* LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/id_color.html:
* LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/inherit_values_from_media_element.html:
* LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/italic_object/italic_background_properties.html:
* LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/italic_object/italic_background_shorthand.html:
* LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/italic_object/italic_color.html:
* LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/italic_object/italic_font_properties.html:
* LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/italic_object/italic_font_shorthand.html:
* LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/italic_object/italic_namespace.html:
* LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/italic_object/italic_outline_properties.html:
* LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/italic_object/italic_outline_shorthand.html:
* LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/italic_object/italic_text-decoration_line-through.html:
* LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/italic_object/italic_text-shadow.html:
* LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/italic_object/italic_white-space_normal_wrapped.html:
* LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/italic_object/italic_white-space_nowrap.html:
* LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/italic_object/italic_white-space_pre-line_wrapped.html:
* LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/italic_object/italic_white-space_pre-wrap_wrapped.html:
* LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/italic_object/italic_white-space_pre_wrapped.html:
* LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/italic_object/italic_with_class.html:
* LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/italic_object/italic_with_class_object_specific_selector.html:
* LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/lang_object/lang_attribute.html:
* LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/lang_object/lang_color.html:
* LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/not_allowed_properties.html:
* LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/not_root_selector.html:
* LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/outline_properties.html:
* LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/outline_shorthand.html:
* LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/root_namespace.html:
* LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/root_selector.html:
* LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/text-decoration_line-through.html:
* LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/text-decoration_overline.html:
* LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/text-decoration_overline_underline_line-through.html:
* LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/text-decoration_underline.html:
* LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/text-shadow.html:
* LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/type_selector_root.html:
* LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/underline_object/underline_background_properties.html:
* LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/underline_object/underline_background_shorthand.html:
* LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/underline_object/underline_color.html:
* LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/underline_object/underline_font_properties.html:
* LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/underline_object/underline_font_shorthand.html:
* LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/underline_object/underline_namespace.html:
* LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/underline_object/underline_outline_properties.html:
* LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/underline_object/underline_outline_shorthand.html:
* LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/underline_object/underline_text-decoration_line-through.html:
* LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/underline_object/underline_text-shadow.html:
* LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/underline_object/underline_white-space_normal_wrapped.html:
* LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/underline_object/underline_white-space_nowrap.html:
* LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/underline_object/underline_white-space_pre-line_wrapped.html:
* LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/underline_object/underline_white-space_pre-wrap_wrapped.html:
* LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/underline_object/underline_white-space_pre_wrapped.html:
* LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/underline_object/underline_with_class.html:
* LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/underline_object/underline_with_class_object_specific_selector.html:
* LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/voice_object/voice_background_properties.html:
* LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/voice_object/voice_background_shorthand.html:
* LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/voice_object/voice_color.html:
* LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/voice_object/voice_font_properties.html:
* LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/voice_object/voice_font_shorthand.html:
* LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/voice_object/voice_namespace.html:
* LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/voice_object/voice_outline_properties.html:
* LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/voice_object/voice_outline_shorthand.html:
* LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/voice_object/voice_text-decoration_line-through.html:
* LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/voice_object/voice_text-shadow.html:
* LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/voice_object/voice_voice_attribute.html:
* LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/voice_object/voice_white-space_normal_wrapped.html:
* LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/voice_object/voice_white-space_nowrap.html:
* LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/voice_object/voice_white-space_pre-line_wrapped.html:
* LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/voice_object/voice_white-space_pre-wrap_wrapped.html:
* LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/voice_object/voice_white-space_pre_wrapped.html:
* LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/voice_object/voice_with_class.html:
* LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/voice_object/voice_with_class_object_specific_selector.html:
* LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/white-space_normal_wrapped.html:
* LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/white-space_nowrap_wrapped.html:
* LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/white-space_pre-line_wrapped.html:
* LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/white-space_pre-wrap_wrapped.html:
* LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/white-space_pre.html:
* LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/white-space_pre_wrapped.html:
* LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/default_styles/bold_object_default_font-style.html:
* LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/default_styles/italic_object_default_font-style.html:
* LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/default_styles/underline_object_default_font-style.html:
* LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/size_50.html:
* LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/snap-to-line.html:
* LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/too_many_cues.html:
* LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/too_many_cues_wrapped.html:
* LayoutTests/platform/ios/TestExpectations:
* LayoutTests/platform/mac/TestExpectations:

Canonical link: <a href="https://commits.webkit.org/313524@main">https://commits.webkit.org/313524@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1ce411e91d3e803d8c05372873868d91a902b6ec

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/163306 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/36789 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/30004 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/172245 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/119753 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/165175 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/37116 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/36789 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/126816 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/89402 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/166265 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/29088 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/146809 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/107383 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/28134 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/26764 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/19947 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/138029 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/24533 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/174749 "Built successfully") | | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/27320 "Build is in progress. Recent messages:") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/26188 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/135119 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/36457 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/30863 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/135111 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/37244 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/146328 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/99192 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/24862 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/30412 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/23173 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/35953 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/108765 "Build is in progress. Recent messages:") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/35452 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/1198 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/35699 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/35600 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->