### PR TITLE
[WebXR Layers] Non projection layers should share more code

### DIFF
--- a/Source/WebCore/Modules/webxr/XRWebGLCylinderLayerBacking.cpp
+++ b/Source/WebCore/Modules/webxr/XRWebGLCylinderLayerBacking.cpp
@@ -29,7 +29,6 @@
 #if ENABLE(WEBXR_LAYERS)
 
 #include "WebXRSession.h"
-#include "WebXRWebGLLayer.h"
 #include "WebXRWebGLSwapchain.h"
 #include "XRCylinderLayerInit.h"
 #include <wtf/TZoneMallocInlines.h>
@@ -40,41 +39,11 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(XRWebGLCylinderLayerBacking);
 
 ExceptionOr<Ref<XRWebGLCylinderLayerBacking>> XRWebGLCylinderLayerBacking::create(WebXRSession& session, WebGLRenderingContextBase& context, const XRCylinderLayerInit& init)
 {
-    auto device = session.device();
-    if (!device)
-        return Exception { ExceptionCode::OperationError, "Cannot create a cylinder layer without a valid device."_s };
-
-    auto computeCylinderLayerData = [](const XRCylinderLayerInit& init) -> std::pair<IntSize, PlatformXR::LayerLayout> {
-        switch (init.layout) {
-        case XRLayerLayout::Mono:
-            return { IntSize { static_cast<int>(init.viewPixelWidth), static_cast<int>(init.viewPixelHeight) }, PlatformXR::LayerLayout::Mono };
-        case XRLayerLayout::Stereo:
-        case XRLayerLayout::StereoLeftRight:
-            return { IntSize { static_cast<int>(init.viewPixelWidth * 2), static_cast<int>(init.viewPixelHeight) }, PlatformXR::LayerLayout::StereoLeftRight };
-        case XRLayerLayout::StereoTopBottom:
-            return { IntSize { static_cast<int>(init.viewPixelWidth), static_cast<int>(init.viewPixelHeight * 2) }, PlatformXR::LayerLayout::StereoTopBottom };
-        default:
-        case XRLayerLayout::Default:
-            ASSERT_NOT_REACHED_WITH_MESSAGE("Default layout is not supported for non-projection Layers");
-            return { IntSize(), PlatformXR::LayerLayout::Mono };
-        };
-    };
-
-    auto [ cylinderLayerSize, cylinderLayerLayout ] = computeCylinderLayerData(init);
-
-    auto layerInfo = device->createCompositionLayer(PlatformXR::CompositionLayerType::Cylinder, cylinderLayerSize, cylinderLayerLayout);
-    if (!layerInfo)
-        return Exception { ExceptionCode::OperationError, "Unable to create a cylinder layer."_s };
-
-    auto colorSwapchain = WebXRWebGLSharedImageSwapchain::create(context, WebXRSwapchain::SwapchainTargetFlags::Color, init.colorFormat, init.clearOnAccess, layerInfo->numImages);
-    if (!colorSwapchain)
-        return Exception { ExceptionCode::OperationError, "Failed to create a WebGL swapchain."_s };
-
-    std::unique_ptr<WebXRWebGLSwapchain> depthStencilSwapchain;
-    if (init.depthFormat && init.depthFormat.value())
-        depthStencilSwapchain = XRWebGLLayerBacking::createDepthSwapchain(context, init.depthFormat.value(), cylinderLayerSize, init.clearOnAccess, layerInfo->numImages);
-
-    return adoptRef(*new XRWebGLCylinderLayerBacking(layerInfo->handle, WTF::move(colorSwapchain), WTF::move(depthStencilSwapchain), init));
+    auto swapchains = XRWebGLLayerBacking::createCompositionLayerSwapchains(session, context, PlatformXR::CompositionLayerType::Cylinder, init);
+    if (swapchains.hasException())
+        return swapchains.releaseException();
+    auto [handle, colorSwapchain, depthSwapchain] = swapchains.releaseReturnValue();
+    return adoptRef(*new XRWebGLCylinderLayerBacking(handle, WTF::move(colorSwapchain), WTF::move(depthSwapchain), init));
 }
 
 XRWebGLCylinderLayerBacking::XRWebGLCylinderLayerBacking(PlatformXR::LayerHandle handle, std::unique_ptr<WebXRWebGLSwapchain>&& colorSwapchain, std::unique_ptr<WebXRWebGLSwapchain>&& depthSwapchain, const XRCylinderLayerInit& init)

--- a/Source/WebCore/Modules/webxr/XRWebGLEquirectLayerBacking.cpp
+++ b/Source/WebCore/Modules/webxr/XRWebGLEquirectLayerBacking.cpp
@@ -29,7 +29,6 @@
 #if ENABLE(WEBXR_LAYERS)
 
 #include "WebXRSession.h"
-#include "WebXRWebGLLayer.h"
 #include "WebXRWebGLSwapchain.h"
 #include "XREquirectLayerInit.h"
 #include <wtf/TZoneMallocInlines.h>
@@ -40,37 +39,11 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(XRWebGLEquirectLayerBacking);
 
 ExceptionOr<Ref<XRWebGLEquirectLayerBacking>> XRWebGLEquirectLayerBacking::create(WebXRSession& session, WebGLRenderingContextBase& context, const XREquirectLayerInit& init)
 {
-    auto device = session.device();
-    if (!device)
-        return Exception { ExceptionCode::OperationError, "Cannot create an equirect layer without a valid device."_s };
-
-    auto computeEquirectLayerData = [](XREquirectLayerInit init) -> std::pair<IntSize, PlatformXR::LayerLayout> {
-        switch (init.layout) {
-        case XRLayerLayout::Mono:
-            return { IntSize { static_cast<int>(init.viewPixelWidth), static_cast<int>(init.viewPixelHeight) }, PlatformXR::LayerLayout::Mono };
-        case XRLayerLayout::Stereo:
-        case XRLayerLayout::StereoLeftRight:
-            return { IntSize { static_cast<int>(init.viewPixelWidth * 2), static_cast<int>(init.viewPixelHeight) }, PlatformXR::LayerLayout::StereoLeftRight };
-        case XRLayerLayout::StereoTopBottom:
-            return { IntSize { static_cast<int>(init.viewPixelWidth), static_cast<int>(init.viewPixelHeight * 2) }, PlatformXR::LayerLayout::StereoTopBottom };
-        default:
-        case XRLayerLayout::Default:
-            ASSERT_NOT_REACHED_WITH_MESSAGE("Default layout is not supported for non-projection Layers");
-            return { IntSize(), PlatformXR::LayerLayout::Mono };
-        };
-    };
-
-    auto [ equirectLayerSize, equirectLayerLayout ] = computeEquirectLayerData(init);
-
-    auto layerInfo = device->createCompositionLayer(PlatformXR::CompositionLayerType::Equirect, equirectLayerSize, equirectLayerLayout);
-    if (!layerInfo)
-        return Exception { ExceptionCode::OperationError, "Unable to create an equirect layer."_s };
-
-    auto colorSwapchain = WebXRWebGLSharedImageSwapchain::create(context, WebXRSwapchain::SwapchainTargetFlags::Color, init.colorFormat, init.clearOnAccess, layerInfo->numImages);
-    if (!colorSwapchain)
-        return Exception { ExceptionCode::OperationError, "Failed to create a WebGL swapchain."_s };
-
-    return adoptRef(*new XRWebGLEquirectLayerBacking(layerInfo->handle, WTF::move(colorSwapchain), nullptr, init));
+    auto swapchains = XRWebGLLayerBacking::createCompositionLayerSwapchains(session, context, PlatformXR::CompositionLayerType::Equirect, init);
+    if (swapchains.hasException())
+        return swapchains.releaseException();
+    auto [handle, colorSwapchain, depthSwapchain] = swapchains.releaseReturnValue();
+    return adoptRef(*new XRWebGLEquirectLayerBacking(handle, WTF::move(colorSwapchain), WTF::move(depthSwapchain), init));
 }
 
 XRWebGLEquirectLayerBacking::XRWebGLEquirectLayerBacking(PlatformXR::LayerHandle handle, std::unique_ptr<WebXRWebGLSwapchain>&& colorSwapchain, std::unique_ptr<WebXRWebGLSwapchain>&& depthSwapchain, const XREquirectLayerInit& init)

--- a/Source/WebCore/Modules/webxr/XRWebGLLayerBacking.cpp
+++ b/Source/WebCore/Modules/webxr/XRWebGLLayerBacking.cpp
@@ -28,11 +28,15 @@
 
 #if ENABLE(WEBXR_LAYERS)
 
+#include "FloatSize.h"
 #include "GraphicsContextGL.h"
+#include "PlatformXR.h"
 #include "WebGLOpaqueTexture.h"
 #include "WebGLRenderingContextBase.h"
 #include "WebXROpaqueFramebuffer.h"
+#include "WebXRSession.h"
 #include "WebXRWebGLSwapchain.h"
+#include "XRProjectionLayerInit.h"
 
 #include <wtf/TZoneMallocInlines.h>
 
@@ -121,6 +125,68 @@ RefPtr<WebGLOpaqueTexture> XRWebGLLayerBacking::currentDepthTexture() const
     return nullptr;
 }
 
+static std::pair<IntSize, PlatformXR::LayerLayout> computeNonProjectionLayerSize(uint32_t viewPixelWidth, uint32_t viewPixelHeight, XRLayerLayout layout)
+{
+    switch (layout) {
+    case XRLayerLayout::Mono:
+        return { IntSize { static_cast<int>(viewPixelWidth), static_cast<int>(viewPixelHeight) }, PlatformXR::LayerLayout::Mono };
+    case XRLayerLayout::Stereo:
+    case XRLayerLayout::StereoLeftRight:
+        return { IntSize { static_cast<int>(viewPixelWidth * 2), static_cast<int>(viewPixelHeight) }, PlatformXR::LayerLayout::StereoLeftRight };
+    case XRLayerLayout::StereoTopBottom:
+        return { IntSize { static_cast<int>(viewPixelWidth), static_cast<int>(viewPixelHeight * 2) }, PlatformXR::LayerLayout::StereoTopBottom };
+    default:
+    case XRLayerLayout::Default:
+        ASSERT_NOT_REACHED_WITH_MESSAGE("Default layout is not supported for non-projection Layers");
+        return { IntSize(), PlatformXR::LayerLayout::Mono };
+    };
+}
+
+ExceptionOr<XRWebGLLayerBacking::XRLayerSwapchains> XRWebGLLayerBacking::createCompositionLayerSwapchains(WebXRSession& session, WebGLRenderingContextBase& context, PlatformXR::CompositionLayerType layerType, const XRLayerInit& init)
+{
+    auto device = session.device();
+    if (!device)
+        return Exception { ExceptionCode::OperationError, "Cannot create a composition layer without a valid device."_s };
+
+    auto [layerSize, layerLayout] = computeNonProjectionLayerSize(init.viewPixelWidth, init.viewPixelHeight, init.layout);
+
+    auto layerInfo = device->createCompositionLayer(layerType, layerSize, layerLayout);
+    if (!layerInfo)
+        return Exception { ExceptionCode::OperationError, "Unable to create a composition layer."_s };
+
+    return createColorAndDepthSwapchains(context, layerInfo->handle, init.colorFormat, init.depthFormat, layerSize, init.clearOnAccess, layerInfo->numImages);
+}
+
+ExceptionOr<XRWebGLLayerBacking::XRLayerSwapchains> XRWebGLLayerBacking::createProjectionLayerSwapchains(WebXRSession& session, WebGLRenderingContextBase& context, const XRProjectionLayerInit& init)
+{
+    constexpr double MinTextureScalingFactor = 0.2;
+    auto device = session.device();
+    if (!device)
+        return Exception { ExceptionCode::OperationError, "Cannot create a projection layer without a valid device."_s };
+
+    double clampedScaleFactor = std::clamp(init.scaleFactor, MinTextureScalingFactor, device->maxFramebufferScalingFactor());
+    FloatSize recommendedSize = session.recommendedWebGLFramebufferResolution();
+    IntSize size = expandedIntSize(recommendedSize.scaled(static_cast<float>(clampedScaleFactor)));
+
+    auto layerInfo = device->createLayerProjection(size.width(), size.height(), true);
+    if (!layerInfo)
+        return Exception { ExceptionCode::OperationError, "Unable to create a projection layer."_s };
+
+    return createColorAndDepthSwapchains(context, layerInfo->handle, init.colorFormat, init.depthFormat, size, init.clearOnAccess, layerInfo->numImages);
+}
+
+ExceptionOr<XRWebGLLayerBacking::XRLayerSwapchains> XRWebGLLayerBacking::createColorAndDepthSwapchains(WebGLRenderingContextBase& context, PlatformXR::LayerHandle handle, GCGLenum colorFormat, std::optional<GCGLenum> depthFormat, IntSize size, bool clearOnAccess, size_t numImages)
+{
+    auto colorSwapchain = WebXRWebGLSharedImageSwapchain::create(context, WebXRSwapchain::SwapchainTargetFlags::Color, colorFormat, clearOnAccess, numImages);
+    if (!colorSwapchain)
+        return Exception { ExceptionCode::OperationError, "Failed to create a WebGL swapchain."_s };
+
+    std::unique_ptr<WebXRWebGLSwapchain> depthSwapchain;
+    if (depthFormat && *depthFormat)
+        depthSwapchain = createDepthSwapchain(context, *depthFormat, size, clearOnAccess, numImages);
+
+    return XRLayerSwapchains { handle, WTF::move(colorSwapchain), WTF::move(depthSwapchain) };
+}
 
 // Based on https://source.chromium.org/chromium/chromium/src/+/main:third_party/blink/renderer/modules/xr/xr_webgl_binding.cc
 struct SwapchainFormats {

--- a/Source/WebCore/Modules/webxr/XRWebGLLayerBacking.h
+++ b/Source/WebCore/Modules/webxr/XRWebGLLayerBacking.h
@@ -30,12 +30,14 @@
 #include "GraphicsTypesGL.h"
 #include "IntSize.h"
 #include "XRLayerBacking.h"
+#include <optional>
 #include <wtf/TZoneMalloc.h>
 
 namespace PlatformXR {
 struct FrameData;
 class Device;
 struct Layer;
+enum class CompositionLayerType : uint8_t;
 }
 
 namespace WebCore {
@@ -43,7 +45,10 @@ namespace WebCore {
 class WebGLOpaqueTexture;
 class WebGLRenderingContextBase;
 class WebXROpaqueFramebuffer;
+class WebXRSession;
 class WebXRWebGLSwapchain;
+struct XRLayerInit;
+struct XRProjectionLayerInit;
 
 class XRWebGLLayerBacking : public XRLayerBacking {
     WTF_MAKE_TZONE_ALLOCATED(XRWebGLLayerBacking);
@@ -71,6 +76,17 @@ public:
 protected:
     XRWebGLLayerBacking(PlatformXR::LayerHandle, std::unique_ptr<WebXRWebGLSwapchain>&& colorSwapchain, std::unique_ptr<WebXRWebGLSwapchain>&& depthSwapchain);
 
+    struct XRLayerSwapchains {
+        PlatformXR::LayerHandle handle;
+        std::unique_ptr<WebXRWebGLSwapchain> colorSwapchain;
+        std::unique_ptr<WebXRWebGLSwapchain> depthSwapchain;
+    };
+
+    static ExceptionOr<XRLayerSwapchains> createCompositionLayerSwapchains(WebXRSession&, WebGLRenderingContextBase&, PlatformXR::CompositionLayerType, const XRLayerInit&);
+    static ExceptionOr<XRLayerSwapchains> createProjectionLayerSwapchains(WebXRSession&, WebGLRenderingContextBase&, const XRProjectionLayerInit&);
+
+private:
+    static ExceptionOr<XRLayerSwapchains> createColorAndDepthSwapchains(WebGLRenderingContextBase&, PlatformXR::LayerHandle, GCGLenum colorFormat, std::optional<GCGLenum> depthFormat, IntSize, bool clearOnAccess, size_t numImages);
     static std::unique_ptr<WebXRWebGLSwapchain> createDepthSwapchain(WebGLRenderingContextBase&, GCGLenum depthFormat, IntSize, bool clearOnAccess, size_t imageCount);
 
     std::unique_ptr<WebXRWebGLSwapchain> m_colorSwapchain;

--- a/Source/WebCore/Modules/webxr/XRWebGLProjectionLayerBacking.cpp
+++ b/Source/WebCore/Modules/webxr/XRWebGLProjectionLayerBacking.cpp
@@ -29,7 +29,6 @@
 #if ENABLE(WEBXR_LAYERS)
 
 #include "WebXRSession.h"
-#include "WebXRWebGLLayer.h"
 #include "WebXRWebGLSwapchain.h"
 #include "XRProjectionLayerInit.h"
 #include <wtf/TZoneMallocInlines.h>
@@ -38,32 +37,13 @@ namespace WebCore {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(XRWebGLProjectionLayerBacking);
 
-// Arbitrary value for minimum texture scaling. Below this threshold the resulting texture would be too small to see.
-constexpr double MinTextureScalingFactor = 0.2;
-
 ExceptionOr<Ref<XRWebGLProjectionLayerBacking>> XRWebGLProjectionLayerBacking::create(WebXRSession& session, WebGLRenderingContextBase& context, const XRProjectionLayerInit& init)
 {
-    auto device = session.device();
-    if (!device)
-        return Exception { ExceptionCode::OperationError, "Cannot create a projection layer without a valid device."_s };
-
-    float scaleFactor = std::clamp(init.scaleFactor, MinTextureScalingFactor, device->maxFramebufferScalingFactor());
-    FloatSize recommendedSize = session.recommendedWebGLFramebufferResolution();
-    IntSize size = expandedIntSize(recommendedSize.scaled(scaleFactor));
-
-    auto layerInfo = device->createLayerProjection(size.width(), size.height(), true);
-    if (!layerInfo)
-        return Exception { ExceptionCode::OperationError, "Unable to create a projection layer."_s };
-
-    auto colorSwapchain = WebXRWebGLSharedImageSwapchain::create(context, WebXRSwapchain::SwapchainTargetFlags::Color, init.colorFormat, init.clearOnAccess, layerInfo->numImages);
-    if (!colorSwapchain)
-        return Exception { ExceptionCode::OperationError, "Failed to create a WebGL swapchain."_s };
-
-    std::unique_ptr<WebXRWebGLSwapchain> depthStencilSwapchain;
-    if (init.depthFormat)
-        depthStencilSwapchain = XRWebGLLayerBacking::createDepthSwapchain(context, init.depthFormat, size, init.clearOnAccess, layerInfo->numImages);
-
-    return adoptRef(*new XRWebGLProjectionLayerBacking(layerInfo->handle, WTF::move(colorSwapchain), WTF::move(depthStencilSwapchain)));
+    auto swapchains = XRWebGLLayerBacking::createProjectionLayerSwapchains(session, context, init);
+    if (swapchains.hasException())
+        return swapchains.releaseException();
+    auto [handle, colorSwapchain, depthSwapchain] = swapchains.releaseReturnValue();
+    return adoptRef(*new XRWebGLProjectionLayerBacking(handle, WTF::move(colorSwapchain), WTF::move(depthSwapchain)));
 }
 
 XRWebGLProjectionLayerBacking::XRWebGLProjectionLayerBacking(PlatformXR::LayerHandle handle, std::unique_ptr<WebXRWebGLSwapchain>&& colorSwapchain, std::unique_ptr<WebXRWebGLSwapchain>&& depthSwapchain)

--- a/Source/WebCore/Modules/webxr/XRWebGLQuadLayerBacking.cpp
+++ b/Source/WebCore/Modules/webxr/XRWebGLQuadLayerBacking.cpp
@@ -29,7 +29,6 @@
 #if ENABLE(WEBXR_LAYERS)
 
 #include "WebXRSession.h"
-#include "WebXRWebGLLayer.h"
 #include "WebXRWebGLSwapchain.h"
 #include "XRQuadLayerInit.h"
 #include <wtf/TZoneMallocInlines.h>
@@ -40,42 +39,11 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(XRWebGLQuadLayerBacking);
 
 ExceptionOr<Ref<XRWebGLQuadLayerBacking>> XRWebGLQuadLayerBacking::create(WebXRSession& session, WebGLRenderingContextBase& context, const XRQuadLayerInit& init)
 {
-    auto device = session.device();
-    if (!device)
-        return Exception { ExceptionCode::OperationError, "Cannot create a quad layer without a valid device."_s };
-
-    // viewPixelWidth and viewPixelHeight specify the size of a single view, so we need to compute the total size of the quad layer based on the layout.
-    auto computeQuadLayerData = [](XRQuadLayerInit init) -> std::pair<IntSize, PlatformXR::LayerLayout> {
-        switch (init.layout) {
-        case XRLayerLayout::Mono:
-            return { IntSize { static_cast<int>(init.viewPixelWidth), static_cast<int>(init.viewPixelHeight) }, PlatformXR::LayerLayout::Mono };
-        case XRLayerLayout::Stereo:
-        case XRLayerLayout::StereoLeftRight:
-            return { IntSize { static_cast<int>(init.viewPixelWidth * 2), static_cast<int>(init.viewPixelHeight) }, PlatformXR::LayerLayout::StereoLeftRight };
-        case XRLayerLayout::StereoTopBottom:
-            return { IntSize { static_cast<int>(init.viewPixelWidth), static_cast<int>(init.viewPixelHeight * 2) }, PlatformXR::LayerLayout::StereoTopBottom };
-        default:
-        case XRLayerLayout::Default:
-            ASSERT_NOT_REACHED_WITH_MESSAGE("Default layout is not supported for non-projection Layers");
-            return { IntSize(), PlatformXR::LayerLayout::Mono };
-        };
-    };
-
-    auto [ quadLayerSize, quadLayerLayout ] = computeQuadLayerData(init);
-
-    auto layerInfo = device->createCompositionLayer(PlatformXR::CompositionLayerType::Quad, quadLayerSize, quadLayerLayout);
-    if (!layerInfo)
-        return Exception { ExceptionCode::OperationError, "Unable to create a quad layer."_s };
-
-    auto colorSwapchain = WebXRWebGLSharedImageSwapchain::create(context, WebXRSwapchain::SwapchainTargetFlags::Color, init.colorFormat, init.clearOnAccess, layerInfo->numImages);
-    if (!colorSwapchain)
-        return Exception { ExceptionCode::OperationError, "Failed to create a WebGL swapchain."_s };
-
-    std::unique_ptr<WebXRWebGLSwapchain> depthStencilSwapchain;
-    if (init.depthFormat && init.depthFormat.value())
-        depthStencilSwapchain = XRWebGLLayerBacking::createDepthSwapchain(context, init.depthFormat.value(), quadLayerSize, init.clearOnAccess, layerInfo->numImages);
-
-    return adoptRef(*new XRWebGLQuadLayerBacking(layerInfo->handle, WTF::move(colorSwapchain), WTF::move(depthStencilSwapchain), init));
+    auto swapchains = XRWebGLLayerBacking::createCompositionLayerSwapchains(session, context, PlatformXR::CompositionLayerType::Quad, init);
+    if (swapchains.hasException())
+        return swapchains.releaseException();
+    auto [handle, colorSwapchain, depthSwapchain] = swapchains.releaseReturnValue();
+    return adoptRef(*new XRWebGLQuadLayerBacking(handle, WTF::move(colorSwapchain), WTF::move(depthSwapchain), init));
 }
 
 XRWebGLQuadLayerBacking::XRWebGLQuadLayerBacking(PlatformXR::LayerHandle handle, std::unique_ptr<WebXRWebGLSwapchain>&& colorSwapchain, std::unique_ptr<WebXRWebGLSwapchain>&& depthSwapchain, const XRQuadLayerInit& init)


### PR DESCRIPTION
#### 853e5d9c790dc52cd8f80b7cb1ae5134ed271513
<pre>
[WebXR Layers] Non projection layers should share more code
<a href="https://bugs.webkit.org/show_bug.cgi?id=314119">https://bugs.webkit.org/show_bug.cgi?id=314119</a>

Reviewed by Dan Glastonbury.

The code that creates the WebGL layer backing for non projection layers
is nearly identical. We should be able to refactor it and avoid
duplicating code.

By moving the code to the parent we can save ~1/3 of the original code.

Last but not least, when equirect layer support landed we forgot to add
support for depth textures. We are using this refactoring to get that
support &quot;for free&quot;.

No new tests as this is a refactoring.

* Source/WebCore/Modules/webxr/XRWebGLCylinderLayerBacking.cpp:
(WebCore::XRWebGLCylinderLayerBacking::create):
* Source/WebCore/Modules/webxr/XRWebGLEquirectLayerBacking.cpp:
(WebCore::XRWebGLEquirectLayerBacking::create):
* Source/WebCore/Modules/webxr/XRWebGLLayerBacking.cpp:
(WebCore::computeNonProjectionLayerSize):
(WebCore::XRWebGLLayerBacking::createCompositionLayerSwapchains):
(WebCore::XRWebGLLayerBacking::createProjectionLayerSwapchains):
(WebCore::XRWebGLLayerBacking::createColorAndDepthSwapchains):
* Source/WebCore/Modules/webxr/XRWebGLLayerBacking.h:
* Source/WebCore/Modules/webxr/XRWebGLProjectionLayerBacking.cpp:
(WebCore::XRWebGLProjectionLayerBacking::create):
* Source/WebCore/Modules/webxr/XRWebGLQuadLayerBacking.cpp:
(WebCore::XRWebGLQuadLayerBacking::create):

Canonical link: <a href="https://commits.webkit.org/312673@main">https://commits.webkit.org/312673@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/106fa472ada8715b3445d5837f634a2580cfd84f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/160790 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/34263 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/27364 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/169693 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/115856 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/162659 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/34364 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/34263 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/124708 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/115856 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/163749 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/26960 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/144432 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/105305 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/26012 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/24512 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/17413 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/135706 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/22195 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/172175 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/19191 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/23836 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/132976 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/33937 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/28604 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/132987 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35908 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/33921 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/143990 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/95734 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/27577 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/20805 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/33432 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/100847 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/32931 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/33175 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/33079 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->