### PR TITLE
REGRESSION(312288@main): [macOS] imported/w3c/web-platform-tests/css/selectors/has-specificity.html is a flaky crash

### DIFF
--- a/Source/WebCore/style/StyleScope.cpp
+++ b/Source/WebCore/style/StyleScope.cpp
@@ -56,6 +56,7 @@
 #include "RuleSet.h"
 #include "SVGElementTypeHelpers.h"
 #include "SVGStyleElement.h"
+#include "SelectorChecker.h"
 #include "Settings.h"
 #include "ShadowRoot.h"
 #include "StyleableInlines.h"
@@ -192,6 +193,7 @@ void Scope::clearResolver()
     RELEASE_ASSERT(!m_isUpdatingStyleResolver);
     RELEASE_ASSERT(!m_document->isResolvingTreeStyle());
 
+    SelectorChecker::clearCompiledHasArgumentSelectors();
     m_resolver = nullptr;
     customPropertyRegistry().clearRegisteredFromStylesheets();
     counterStyleRegistry().clearAuthorCounterStyles();


### PR DESCRIPTION
#### 513b0ea7a9025e7c1d2829e4346a265df27eae78
<pre>
REGRESSION(<a href="https://commits.webkit.org/312288@main">312288@main</a>): [macOS] imported/w3c/web-platform-tests/css/selectors/has-specificity.html is a flaky crash
<a href="https://bugs.webkit.org/show_bug.cgi?id=314100">https://bugs.webkit.org/show_bug.cgi?id=314100</a>
&lt;<a href="https://rdar.apple.com/problem/176274161">rdar://problem/176274161</a>&gt;

Reviewed by NOBODY (OOPS!).

The new compiled :has() argument selector cache (compiledHasArgumentSelectorsMap) is
keyed by CSSSelectorList pointer addresses. When a stylesheet is destroyed, the StyleRule
objects and their CSSSelectorList members are freed, but the cache retains entries with
now-stale pointer keys.

This change clears the :has() JIT cache in Style::Scope::clearResolver(), which is called
whenever stylesheets change. This matches the existing pattern of invalidating the matched
declarations cache at the same point. The cache repopulates naturally on the next style
resolution.

* Source/WebCore/style/StyleScope.cpp:
(WebCore::Style::Scope::clearResolver): Added missing clean-up step.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/513b0ea7a9025e7c1d2829e4346a265df27eae78

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/160661 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/34134 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/27235 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/169564 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/115727 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/0998a0b4-e45d-40a9-a05f-6a0504e7e358) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/162530 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/34235 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/34134 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/124594 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/87972 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/a1b85eb4-529b-4a79-bcaa-85976019b1b6) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/163620 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/26846 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/144314 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/105193 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/d9bbcd43-2b27-439b-85fb-add68351d06a) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/25898 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/24396 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/17284 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/135592 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/22077 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/172043 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/18928 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/23717 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/132861 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/33808 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/28488 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/132875 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/33792 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/143872 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/95601 "Built successfully") | | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/27470 "Build is in progress. Recent messages:OS: Tahoe (26.2), Xcode: 26.2; Running apply-patch; Checked out pull request; Running run-layout-tests-in-stress-mode; Passed layout tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/20687 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/33303 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/100547 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/32802 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/33046 "Built successfully") | | | | 
| | [❌ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/32950 "Hash 513b0ea7 for PR 64300 does not build (failure)") | | | | 
<!--EWS-Status-Bubble-End-->