### PR TITLE
Promote SVG layer children sandwiched between composited siblings to composited

### DIFF
--- a/LayoutTests/platform/ios/svg/compositing/de-promotion-after-anchor-removed-layer-tree-expected.txt
+++ b/LayoutTests/platform/ios/svg/compositing/de-promotion-after-anchor-removed-layer-tree-expected.txt
@@ -1,0 +1,90 @@
+ === Initial: middle <rect> is sandwich-promoted ===
+(GraphicsLayer
+  (anchor 0.00 0.00)
+  (bounds 800.00 600.00)
+  (children 1
+    (GraphicsLayer
+      (bounds 800.00 600.00)
+      (contentsOpaque 1)
+      (children 1
+        (GraphicsLayer
+          (bounds 200.00 200.00)
+          (drawsContent 1)
+          (children 1
+            (GraphicsLayer
+              (bounds 200.00 200.00)
+              (children 1
+                (GraphicsLayer
+                  (offsetFromRenderer width=10 height=10)
+                  (position 10.00 10.00)
+                  (anchor -0.06 -0.06)
+                  (bounds 180.00 180.00)
+                  (contentsVisible 0)
+                  (children 3
+                    (GraphicsLayer
+                      (anchor -0.08 -0.08)
+                      (bounds 120.00 120.00)
+                      (drawsContent 1)
+                    )
+                    (GraphicsLayer
+                      (position 30.00 30.00)
+                      (bounds 120.00 120.00)
+                      (drawsContent 1)
+                    )
+                    (GraphicsLayer
+                      (position 60.00 60.00)
+                      (anchor -0.58 -0.58)
+                      (bounds 120.00 120.00)
+                      (drawsContent 1)
+                    )
+                  )
+                )
+              )
+            )
+          )
+        )
+      )
+    )
+  )
+)
+
+=== After mutation: middle <rect> should be de-promoted ===
+(GraphicsLayer
+  (anchor 0.00 0.00)
+  (bounds 800.00 931.00)
+  (children 1
+    (GraphicsLayer
+      (bounds 800.00 931.00)
+      (contentsOpaque 1)
+      (children 1
+        (GraphicsLayer
+          (bounds 200.00 200.00)
+          (drawsContent 1)
+          (children 1
+            (GraphicsLayer
+              (bounds 200.00 200.00)
+              (children 1
+                (GraphicsLayer
+                  (offsetFromRenderer width=10 height=10)
+                  (position 10.00 10.00)
+                  (anchor -0.06 -0.06)
+                  (bounds 180.00 180.00)
+                  (children 1
+                    (GraphicsLayer
+                      (position 60.00 60.00)
+                      (anchor -0.58 -0.58)
+                      (bounds 120.00 120.00)
+                      (drawsContent 1)
+                    )
+                  )
+                )
+              )
+            )
+          )
+        )
+      )
+    )
+  )
+)
+
+

--- a/LayoutTests/platform/mac-wk2/TestExpectations
+++ b/LayoutTests/platform/mac-wk2/TestExpectations
@@ -2436,3 +2436,5 @@ webkit.org/b/316036 [ Debug ] inspector/timeline/timeline-event-TimerFire.html [
 webkit.org/b/315982 [ Sequoia Release x86_64 ] webgl/pending/conformance/glsl/misc/swizzle-as-lvalue.html [ Pass Timeout ]
 
 webkit.org/b/316089 [ Sequoia Release ] inspector/css/setLayoutContextTypeChangedMode.html [ Pass Failure ]
+
+webkit.org/b/313785 svg/compositing/de-promotion-after-derived-anchor-decomposited-layer-tree.html [ Failure ]

--- a/LayoutTests/platform/mac/svg/compositing/de-promotion-after-derived-anchor-decomposited-layer-tree-expected.txt
+++ b/LayoutTests/platform/mac/svg/compositing/de-promotion-after-derived-anchor-decomposited-layer-tree-expected.txt
@@ -1,0 +1,46 @@
+ === Anchors composited ===
+(GraphicsLayer
+  (anchor 0.00 0.00)
+  (bounds 800.00 600.00)
+  (children 1
+    (GraphicsLayer
+      (bounds 800.00 600.00)
+      (contentsOpaque 1)
+      (children 1
+        (GraphicsLayer
+          (bounds 200.00 200.00)
+          (drawsContent 1)
+          (children 1
+            (GraphicsLayer
+              (bounds 200.00 200.00)
+              (children 2
+                (GraphicsLayer
+                  (position 10.00 10.00)
+                  (anchor -0.08 -0.08)
+                  (bounds 120.00 120.00)
+                  (drawsContent 1)
+                )
+                (GraphicsLayer
+                  (position 70.00 70.00)
+                  (bounds 120.00 120.00)
+                  (drawsContent 1)
+                  (children 1
+                    (GraphicsLayer
+                      (anchor -0.58 -0.58)
+                      (bounds 120.00 120.00)
+                      (drawsContent 1)
+                    )
+                  )
+                )
+              )
+            )
+          )
+        )
+      )
+    )
+  )
+)
+
+=== Anchors de-composited: no composited SVG children must remain ===
+
+

--- a/LayoutTests/svg/compositing/de-promotion-after-anchor-element-removed-layer-tree-expected.txt
+++ b/LayoutTests/svg/compositing/de-promotion-after-anchor-element-removed-layer-tree-expected.txt
@@ -1,0 +1,38 @@
+ (GraphicsLayer
+  (anchor 0.00 0.00)
+  (bounds 800.00 600.00)
+  (children 1
+    (GraphicsLayer
+      (bounds 800.00 600.00)
+      (contentsOpaque 1)
+      (children 1
+        (GraphicsLayer
+          (bounds 200.00 200.00)
+          (drawsContent 1)
+          (children 1
+            (GraphicsLayer
+              (bounds 200.00 200.00)
+              (children 1
+                (GraphicsLayer
+                  (offsetFromRenderer width=40 height=40)
+                  (position 40.00 40.00)
+                  (anchor -0.27 -0.27)
+                  (bounds 150.00 150.00)
+                  (children 1
+                    (GraphicsLayer
+                      (position 30.00 30.00)
+                      (anchor -0.58 -0.58)
+                      (bounds 120.00 120.00)
+                      (drawsContent 1)
+                    )
+                  )
+                )
+              )
+            )
+          )
+        )
+      )
+    )
+  )
+)
+

--- a/LayoutTests/svg/compositing/de-promotion-after-anchor-element-removed-layer-tree.html
+++ b/LayoutTests/svg/compositing/de-promotion-after-anchor-element-removed-layer-tree.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ LayerBasedSVGEngineEnabled=true ] -->
+<html>
+<head>
+<style>
+    html, body { margin: 0; padding: 0; }
+    svg { width: 200px; height: 200px; }
+    .anchor { transform: translateZ(0); }
+</style>
+<script>
+    if (window.testRunner) {
+        testRunner.dumpAsText();
+        testRunner.waitUntilDone();
+    }
+    window.addEventListener('load', () => {
+        requestAnimationFrame(() => {
+            document.body.offsetTop;
+            // Remove the first anchor entirely. After the removal, the middle
+            // <rect> no longer has an intrinsically-layered preceding sibling,
+            // so it must de-promote: only g#last-anchor should remain composited.
+            document.getElementById('first-anchor').remove();
+            requestAnimationFrame(() => {
+                if (window.internals)
+                    document.getElementById('layers').textContent = internals.layerTreeAsText(document);
+                if (window.testRunner)
+                    testRunner.notifyDone();
+            });
+        });
+    });
+</script>
+</head>
+<body>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200">
+    <g id="first-anchor" class="anchor"><rect x="10" y="10" width="120" height="120" fill="red"/></g>
+    <rect x="40" y="40" width="120" height="120" fill="green"/>
+    <g id="last-anchor" class="anchor"><rect x="70" y="70" width="120" height="120" fill="blue"/></g>
+</svg>
+<pre id="layers"></pre>
+</body>
+</html>

--- a/LayoutTests/svg/compositing/de-promotion-after-anchor-removed-expected.html
+++ b/LayoutTests/svg/compositing/de-promotion-after-anchor-removed-expected.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+    html, body { margin: 0; padding: 0; }
+    svg { width: 200px; height: 200px; }
+</style>
+</head>
+<body>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200">
+    <rect x="10" y="10" width="120" height="120" fill="red"/>
+    <rect x="40" y="40" width="120" height="120" fill="green"/>
+    <rect x="70" y="70" width="120" height="120" fill="blue"/>
+</svg>
+</body>
+</html>

--- a/LayoutTests/svg/compositing/de-promotion-after-anchor-removed-layer-tree-expected.txt
+++ b/LayoutTests/svg/compositing/de-promotion-after-anchor-removed-layer-tree-expected.txt
@@ -1,0 +1,90 @@
+ === Initial: middle <rect> is sandwich-promoted ===
+(GraphicsLayer
+  (anchor 0.00 0.00)
+  (bounds 800.00 600.00)
+  (children 1
+    (GraphicsLayer
+      (bounds 800.00 600.00)
+      (contentsOpaque 1)
+      (children 1
+        (GraphicsLayer
+          (bounds 200.00 200.00)
+          (drawsContent 1)
+          (children 1
+            (GraphicsLayer
+              (bounds 200.00 200.00)
+              (children 1
+                (GraphicsLayer
+                  (offsetFromRenderer width=10 height=10)
+                  (position 10.00 10.00)
+                  (anchor -0.06 -0.06)
+                  (bounds 180.00 180.00)
+                  (contentsVisible 0)
+                  (children 3
+                    (GraphicsLayer
+                      (anchor -0.08 -0.08)
+                      (bounds 120.00 120.00)
+                      (drawsContent 1)
+                    )
+                    (GraphicsLayer
+                      (position 30.00 30.00)
+                      (bounds 120.00 120.00)
+                      (drawsContent 1)
+                    )
+                    (GraphicsLayer
+                      (position 60.00 60.00)
+                      (anchor -0.58 -0.58)
+                      (bounds 120.00 120.00)
+                      (drawsContent 1)
+                    )
+                  )
+                )
+              )
+            )
+          )
+        )
+      )
+    )
+  )
+)
+
+=== After mutation: middle <rect> should be de-promoted ===
+(GraphicsLayer
+  (anchor 0.00 0.00)
+  (bounds 785.00 980.00)
+  (children 1
+    (GraphicsLayer
+      (bounds 785.00 980.00)
+      (contentsOpaque 1)
+      (children 1
+        (GraphicsLayer
+          (bounds 200.00 200.00)
+          (drawsContent 1)
+          (children 1
+            (GraphicsLayer
+              (bounds 200.00 200.00)
+              (children 1
+                (GraphicsLayer
+                  (offsetFromRenderer width=10 height=10)
+                  (position 10.00 10.00)
+                  (anchor -0.06 -0.06)
+                  (bounds 180.00 180.00)
+                  (children 1
+                    (GraphicsLayer
+                      (position 60.00 60.00)
+                      (anchor -0.58 -0.58)
+                      (bounds 120.00 120.00)
+                      (drawsContent 1)
+                    )
+                  )
+                )
+              )
+            )
+          )
+        )
+      )
+    )
+  )
+)
+
+

--- a/LayoutTests/svg/compositing/de-promotion-after-anchor-removed-layer-tree.html
+++ b/LayoutTests/svg/compositing/de-promotion-after-anchor-removed-layer-tree.html
@@ -1,0 +1,50 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ LayerBasedSVGEngineEnabled=true ] -->
+<html>
+<head>
+<style>
+    html, body { margin: 0; padding: 0; }
+    svg { width: 200px; height: 200px; }
+    .anchor { transform: translateZ(0); }
+</style>
+<script>
+    if (window.testRunner) {
+        testRunner.dumpAsText();
+        testRunner.waitUntilDone();
+    }
+
+    function dumpLayers(out, label) {
+        if (!window.internals)
+            return;
+        out.textContent += '=== ' + label + ' ===\n' + internals.layerTreeAsText(document) + '\n';
+    }
+
+    window.addEventListener('load', () => {
+        requestAnimationFrame(() => {
+            document.body.offsetTop;
+            // Phase 1: both anchors active -> middle <rect> sandwich-promoted.
+            document.getElementById('first-anchor').setAttribute('class', 'anchor');
+            document.getElementById('last-anchor').setAttribute('class', 'anchor');
+            const out = document.getElementById('layers');
+            out.textContent = '';
+            dumpLayers(out, 'Initial: middle <rect> is sandwich-promoted');
+
+            // Phase 2: drop the first anchor -> window collapses, middle de-promotes.
+            document.getElementById('first-anchor').removeAttribute('class');
+            requestAnimationFrame(() => {
+                dumpLayers(out, 'After mutation: middle <rect> should be de-promoted');
+                if (window.testRunner)
+                    testRunner.notifyDone();
+            });
+        });
+    });
+</script>
+</head>
+<body>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200">
+    <g id="first-anchor"><rect x="10" y="10" width="120" height="120" fill="red"/></g>
+    <rect x="40" y="40" width="120" height="120" fill="green"/>
+    <g id="last-anchor"><rect x="70" y="70" width="120" height="120" fill="blue"/></g>
+</svg>
+<pre id="layers"></pre>
+</body>
+</html>

--- a/LayoutTests/svg/compositing/de-promotion-after-anchor-removed.html
+++ b/LayoutTests/svg/compositing/de-promotion-after-anchor-removed.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ LayerBasedSVGEngineEnabled=true ] -->
+<html class="reftest-wait">
+<head>
+<style>
+    html, body { margin: 0; padding: 0; }
+    svg { width: 200px; height: 200px; }
+</style>
+<script>
+    if (window.testRunner) {
+        testRunner.waitUntilDone();
+        testRunner.dumpAsPixels = true;
+    }
+
+    // Initial state: red <g filter> and blue <g will-change> are anchors, the green
+    // <rect> is sandwich-promoted. Removing the filter from the first anchor collapses
+    // the sandwich window — the green <rect> must de-promote so post-mutation rendering
+    // still reflects DOM order with two non-composited children and one composited one.
+    window.addEventListener('load', () => {
+        requestAnimationFrame(() => requestAnimationFrame(() => {
+            document.getElementById('first-anchor').removeAttribute('filter');
+            requestAnimationFrame(() => requestAnimationFrame(() => {
+                document.documentElement.classList.remove('reftest-wait');
+                if (window.testRunner)
+                    testRunner.notifyDone();
+            }));
+        }));
+    });
+</script>
+</head>
+<body>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200">
+    <g id="first-anchor" filter="url(#f)">
+        <rect x="10" y="10" width="120" height="120" fill="red"/>
+    </g>
+    <rect x="40" y="40" width="120" height="120" fill="green"/>
+    <g style="will-change: transform">
+        <rect x="70" y="70" width="120" height="120" fill="blue"/>
+    </g>
+    <defs>
+        <filter id="f" x="-10%" y="-10%" width="120%" height="120%">
+            <feOffset dx="0" dy="0"/>
+        </filter>
+    </defs>
+</svg>
+</body>
+</html>

--- a/LayoutTests/svg/compositing/de-promotion-after-derived-anchor-decomposited-layer-tree-expected.txt
+++ b/LayoutTests/svg/compositing/de-promotion-after-derived-anchor-decomposited-layer-tree-expected.txt
@@ -1,0 +1,58 @@
+ === Anchors composited ===
+(GraphicsLayer
+  (anchor 0.00 0.00)
+  (bounds 800.00 600.00)
+  (children 1
+    (GraphicsLayer
+      (bounds 800.00 600.00)
+      (contentsOpaque 1)
+      (children 1
+        (GraphicsLayer
+          (bounds 200.00 200.00)
+          (drawsContent 1)
+          (children 1
+            (GraphicsLayer
+              (bounds 200.00 200.00)
+              (children 1
+                (GraphicsLayer
+                  (offsetFromRenderer width=10 height=10)
+                  (position 10.00 10.00)
+                  (anchor -0.06 -0.06)
+                  (bounds 180.00 180.00)
+                  (children 3
+                    (GraphicsLayer
+                      (anchor -0.08 -0.08)
+                      (bounds 120.00 120.00)
+                      (drawsContent 1)
+                    )
+                    (GraphicsLayer
+                      (position 30.00 30.00)
+                      (bounds 120.00 120.00)
+                      (drawsContent 1)
+                    )
+                    (GraphicsLayer
+                      (position 60.00 60.00)
+                      (bounds 120.00 120.00)
+                      (drawsContent 1)
+                      (children 1
+                        (GraphicsLayer
+                          (anchor -0.58 -0.58)
+                          (bounds 120.00 120.00)
+                          (drawsContent 1)
+                        )
+                      )
+                    )
+                  )
+                )
+              )
+            )
+          )
+        )
+      )
+    )
+  )
+)
+
+=== Anchors de-composited: no composited SVG children must remain ===
+
+

--- a/LayoutTests/svg/compositing/de-promotion-after-derived-anchor-decomposited-layer-tree.html
+++ b/LayoutTests/svg/compositing/de-promotion-after-derived-anchor-decomposited-layer-tree.html
@@ -1,0 +1,62 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ LayerBasedSVGEngineEnabled=true ] -->
+<html>
+<head>
+<style>
+    html, body { margin: 0; padding: 0; }
+    svg { width: 200px; height: 200px; }
+    .anchor { transform: translateZ(0); }
+</style>
+<script>
+    if (window.testRunner) {
+        testRunner.dumpAsText();
+        testRunner.waitUntilDone();
+    }
+
+    function dumpLayers(out, label) {
+        if (!window.internals)
+            return;
+        out.textContent += '=== ' + label + ' ===\n' + internals.layerTreeAsText(document) + '\n';
+    }
+
+    window.addEventListener('load', () => {
+        requestAnimationFrame(() => {
+            document.body.offsetTop;
+            const out = document.getElementById('layers');
+            out.textContent = '';
+
+            // Phase 1: give the <rect> in each wrapping <g> a composited reason (translateZ). Each wrapping
+            // <g style="isolation: isolate"> then composites for a *derived* reason (GraphicalEffect:
+            // createsGroup via isolation + a composited descendant). A derived anchor only settles
+            // during the compositing recursion, so any sandwiched child it promotes goes through the
+            // after-recursion pass and carries IndirectCompositingReason::SVGSiblingOrderingForLBSE
+            // (which - unlike a before-pass mark - is never rewritten to Stacking).
+            document.getElementById('ar').setAttribute('class', 'anchor');
+            document.getElementById('cr').setAttribute('class', 'anchor');
+            dumpLayers(out, 'Anchors composited');
+
+            // Phase 2: drop both composited descendants so neither wrapping <g> composites any more.
+            // With no anchor left, every sandwich-promoted child must de-promote and the SVG content
+            // must end up with no composited children at all. Regression guard for the before-recursion
+            // pass: it must clear stale SVGSiblingOrderingForLBSE marks even when it finds no anchor
+            // (the buggy version returned early on "no anchor", leaving after-pass-promoted children
+            // composited forever).
+            document.getElementById('ar').removeAttribute('class');
+            document.getElementById('cr').removeAttribute('class');
+            requestAnimationFrame(() => {
+                dumpLayers(out, 'Anchors de-composited: no composited SVG children must remain');
+                if (window.testRunner)
+                    testRunner.notifyDone();
+            });
+        });
+    });
+</script>
+</head>
+<body>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200">
+    <g style="isolation: isolate"><rect id="ar" x="10" y="10" width="120" height="120" fill="red"/></g>
+    <rect x="40" y="40" width="120" height="120" fill="green"/>
+    <g style="isolation: isolate"><rect id="cr" x="70" y="70" width="120" height="120" fill="blue"/></g>
+</svg>
+<pre id="layers"></pre>
+</body>
+</html>

--- a/LayoutTests/svg/compositing/de-promotion-after-reparenting-layer-tree-expected.txt
+++ b/LayoutTests/svg/compositing/de-promotion-after-reparenting-layer-tree-expected.txt
@@ -1,0 +1,43 @@
+ (GraphicsLayer
+  (anchor 0.00 0.00)
+  (bounds 800.00 600.00)
+  (children 1
+    (GraphicsLayer
+      (bounds 800.00 600.00)
+      (contentsOpaque 1)
+      (children 1
+        (GraphicsLayer
+          (bounds 200.00 200.00)
+          (drawsContent 1)
+          (children 1
+            (GraphicsLayer
+              (bounds 200.00 200.00)
+              (children 1
+                (GraphicsLayer
+                  (offsetFromRenderer width=10 height=10)
+                  (position 10.00 10.00)
+                  (anchor -0.08 -0.05)
+                  (bounds 120.00 190.00)
+                  (children 2
+                    (GraphicsLayer
+                      (anchor -0.17 -0.17)
+                      (bounds 60.00 60.00)
+                      (drawsContent 1)
+                    )
+                    (GraphicsLayer
+                      (position 60.00 60.00)
+                      (anchor -1.17 -1.17)
+                      (bounds 60.00 60.00)
+                      (drawsContent 1)
+                    )
+                  )
+                )
+              )
+            )
+          )
+        )
+      )
+    )
+  )
+)
+

--- a/LayoutTests/svg/compositing/de-promotion-after-reparenting-layer-tree.html
+++ b/LayoutTests/svg/compositing/de-promotion-after-reparenting-layer-tree.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ LayerBasedSVGEngineEnabled=true ] -->
+<html>
+<head>
+<style>
+    html, body { margin: 0; padding: 0; }
+    svg { width: 200px; height: 200px; }
+    .anchor { transform: translateZ(0); }
+</style>
+<script>
+    if (window.testRunner) {
+        testRunner.dumpAsText();
+        testRunner.waitUntilDone();
+    }
+    window.addEventListener('load', () => {
+        requestAnimationFrame(() => {
+            document.body.offsetTop;
+            // Initially: <rect id="middle"> is sandwich-promoted inside g#source
+            // (between two anchors). Move it into g#empty-dest, which has no
+            // anchored siblings. middle must de-promote: no preceding
+            // intrinsically-layered sibling in its new parent.
+            const middle = document.getElementById('middle');
+            document.getElementById('empty-dest').appendChild(middle);
+            requestAnimationFrame(() => {
+                if (window.internals)
+                    document.getElementById('layers').textContent = internals.layerTreeAsText(document);
+                if (window.testRunner)
+                    testRunner.notifyDone();
+            });
+        });
+    });
+</script>
+</head>
+<body>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200">
+    <g id="source">
+        <g class="anchor"><rect x="10" y="10" width="60" height="60" fill="red"/></g>
+        <rect id="middle" x="40" y="40" width="60" height="60" fill="green"/>
+        <g class="anchor"><rect x="70" y="70" width="60" height="60" fill="blue"/></g>
+    </g>
+    <g id="empty-dest" transform="translate(0 100)"></g>
+</svg>
+<pre id="layers"></pre>
+</body>
+</html>

--- a/LayoutTests/svg/compositing/multiple-sandwiched-children-between-composited-siblings-expected.html
+++ b/LayoutTests/svg/compositing/multiple-sandwiched-children-between-composited-siblings-expected.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+    html, body { margin: 0; padding: 0; }
+    svg { width: 240px; height: 240px; }
+</style>
+</head>
+<body>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 240 240">
+    <rect x="10" y="10" width="100" height="100" fill="red"/>
+    <rect x="40" y="40" width="100" height="100" fill="orange"/>
+    <rect x="70" y="70" width="100" height="100" fill="green"/>
+    <rect x="100" y="100" width="100" height="100" fill="purple"/>
+    <rect x="130" y="130" width="100" height="100" fill="blue"/>
+</svg>
+</body>
+</html>

--- a/LayoutTests/svg/compositing/multiple-sandwiched-children-between-composited-siblings-layer-tree-expected.txt
+++ b/LayoutTests/svg/compositing/multiple-sandwiched-children-between-composited-siblings-layer-tree-expected.txt
@@ -1,0 +1,60 @@
+ (GraphicsLayer
+  (anchor 0.00 0.00)
+  (bounds 800.00 600.00)
+  (children 1
+    (GraphicsLayer
+      (bounds 800.00 600.00)
+      (contentsOpaque 1)
+      (children 1
+        (GraphicsLayer
+          (bounds 240.00 240.00)
+          (drawsContent 1)
+          (children 1
+            (GraphicsLayer
+              (bounds 240.00 240.00)
+              (children 1
+                (GraphicsLayer
+                  (offsetFromRenderer width=10 height=10)
+                  (position 10.00 10.00)
+                  (anchor -0.05 -0.05)
+                  (bounds 220.00 220.00)
+                  (contentsVisible 0)
+                  (children 5
+                    (GraphicsLayer
+                      (anchor -0.10 -0.10)
+                      (bounds 100.00 100.00)
+                      (drawsContent 1)
+                    )
+                    (GraphicsLayer
+                      (position 30.00 30.00)
+                      (bounds 100.00 100.00)
+                      (drawsContent 1)
+                    )
+                    (GraphicsLayer
+                      (position 60.00 60.00)
+                      (anchor -0.70 -0.70)
+                      (bounds 100.00 100.00)
+                      (drawsContent 1)
+                    )
+                    (GraphicsLayer
+                      (position 90.00 90.00)
+                      (bounds 100.00 100.00)
+                      (drawsContent 1)
+                    )
+                    (GraphicsLayer
+                      (position 120.00 120.00)
+                      (anchor -1.30 -1.30)
+                      (bounds 100.00 100.00)
+                      (drawsContent 1)
+                    )
+                  )
+                )
+              )
+            )
+          )
+        )
+      )
+    )
+  )
+)
+

--- a/LayoutTests/svg/compositing/multiple-sandwiched-children-between-composited-siblings-layer-tree.html
+++ b/LayoutTests/svg/compositing/multiple-sandwiched-children-between-composited-siblings-layer-tree.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ LayerBasedSVGEngineEnabled=true ] -->
+<html>
+<head>
+<style>
+    html, body { margin: 0; padding: 0; }
+    svg { width: 240px; height: 240px; }
+    .anchor { transform: translateZ(0); }
+</style>
+<script>
+    if (window.testRunner) {
+        testRunner.dumpAsText();
+        testRunner.waitUntilDone();
+    }
+    window.addEventListener('load', () => {
+        requestAnimationFrame(() => {
+            document.body.offsetTop;
+            for (const id of ['a', 'b', 'c'])
+                document.getElementById(id).setAttribute('class', 'anchor');
+            if (window.internals)
+                document.getElementById('layers').textContent = internals.layerTreeAsText(document);
+            if (window.testRunner)
+                testRunner.notifyDone();
+        });
+    });
+</script>
+</head>
+<body>
+<!-- Layer-tree dump: three composited anchors with two plain <rect>s between
+     consecutive pairs. Both orange and purple must appear as composited layers with
+     reason "SVG sibling ordering". -->
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 240 240">
+    <g id="a"><rect x="10" y="10" width="100" height="100" fill="red"/></g>
+    <rect x="40" y="40" width="100" height="100" fill="orange"/>
+    <g id="b"><rect x="70" y="70" width="100" height="100" fill="green"/></g>
+    <rect x="100" y="100" width="100" height="100" fill="purple"/>
+    <g id="c"><rect x="130" y="130" width="100" height="100" fill="blue"/></g>
+</svg>
+<pre id="layers"></pre>
+</body>
+</html>

--- a/LayoutTests/svg/compositing/multiple-sandwiched-children-between-composited-siblings.html
+++ b/LayoutTests/svg/compositing/multiple-sandwiched-children-between-composited-siblings.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ LayerBasedSVGEngineEnabled=true ] -->
+<html>
+<head>
+<style>
+    html, body { margin: 0; padding: 0; }
+    svg { width: 240px; height: 240px; }
+</style>
+</head>
+<body>
+<!-- Three composited <g> siblings (filter, will-change:transform, filter) with two
+     plain <rect> siblings between them. The "sandwhich promotion" causes both plain rects
+     to be composited so DOM order is preserved across all five overlapping shapes. -->
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 240 240">
+    <g filter="url(#f)">
+        <rect x="10" y="10" width="100" height="100" fill="red"/>
+    </g>
+    <rect x="40" y="40" width="100" height="100" fill="orange"/>
+    <g style="will-change: transform">
+        <rect x="70" y="70" width="100" height="100" fill="green"/>
+    </g>
+    <rect x="100" y="100" width="100" height="100" fill="purple"/>
+    <g filter="url(#f)">
+        <rect x="130" y="130" width="100" height="100" fill="blue"/>
+    </g>
+    <defs>
+        <filter id="f" x="-10%" y="-10%" width="120%" height="120%">
+            <feOffset dx="0" dy="0"/>
+        </filter>
+    </defs>
+</svg>
+</body>
+</html>

--- a/LayoutTests/svg/compositing/multiple-sandwiched-with-mixed-anchor-types-expected.html
+++ b/LayoutTests/svg/compositing/multiple-sandwiched-with-mixed-anchor-types-expected.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+    html, body { margin: 0; padding: 0; }
+    svg { width: 240px; height: 240px; }
+</style>
+</head>
+<body>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 240 240">
+    <rect x="10" y="10" width="100" height="100" fill="red"/>
+    <rect x="40" y="40" width="100" height="100" fill="orange"/>
+    <rect x="70" y="70" width="100" height="100" fill="green"/>
+    <rect x="100" y="100" width="100" height="100" fill="purple"/>
+    <rect x="130" y="130" width="100" height="100" fill="blue"/>
+</svg>
+</body>
+</html>

--- a/LayoutTests/svg/compositing/multiple-sandwiched-with-mixed-anchor-types-layer-tree-expected.txt
+++ b/LayoutTests/svg/compositing/multiple-sandwiched-with-mixed-anchor-types-layer-tree-expected.txt
@@ -1,0 +1,60 @@
+ (GraphicsLayer
+  (anchor 0.00 0.00)
+  (bounds 800.00 600.00)
+  (children 1
+    (GraphicsLayer
+      (bounds 800.00 600.00)
+      (contentsOpaque 1)
+      (children 1
+        (GraphicsLayer
+          (bounds 240.00 240.00)
+          (drawsContent 1)
+          (children 1
+            (GraphicsLayer
+              (bounds 240.00 240.00)
+              (children 1
+                (GraphicsLayer
+                  (offsetFromRenderer width=10 height=10)
+                  (position 10.00 10.00)
+                  (anchor -0.05 -0.05)
+                  (bounds 220.00 220.00)
+                  (contentsVisible 0)
+                  (children 5
+                    (GraphicsLayer
+                      (anchor -0.10 -0.10)
+                      (bounds 100.00 100.00)
+                      (drawsContent 1)
+                    )
+                    (GraphicsLayer
+                      (position 30.00 30.00)
+                      (bounds 100.00 100.00)
+                      (drawsContent 1)
+                    )
+                    (GraphicsLayer
+                      (position 60.00 60.00)
+                      (anchor -0.70 -0.70)
+                      (bounds 100.00 100.00)
+                      (drawsContent 1)
+                    )
+                    (GraphicsLayer
+                      (position 90.00 90.00)
+                      (bounds 100.00 100.00)
+                      (drawsContent 1)
+                    )
+                    (GraphicsLayer
+                      (position 120.00 120.00)
+                      (anchor -1.30 -1.30)
+                      (bounds 100.00 100.00)
+                      (drawsContent 1)
+                    )
+                  )
+                )
+              )
+            )
+          )
+        )
+      )
+    )
+  )
+)
+

--- a/LayoutTests/svg/compositing/multiple-sandwiched-with-mixed-anchor-types-layer-tree.html
+++ b/LayoutTests/svg/compositing/multiple-sandwiched-with-mixed-anchor-types-layer-tree.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ LayerBasedSVGEngineEnabled=true ] -->
+<html>
+<head>
+<style>
+    html, body { margin: 0; padding: 0; }
+    svg { width: 240px; height: 240px; }
+    .anchor { transform: translateZ(0); }
+</style>
+<script>
+    if (window.testRunner) {
+        testRunner.dumpAsText();
+        testRunner.waitUntilDone();
+    }
+    window.addEventListener('load', () => {
+        requestAnimationFrame(() => {
+            document.body.offsetTop;
+            for (const id of ['a', 'b', 'c'])
+                document.getElementById(id).setAttribute('class', 'anchor');
+            if (window.internals)
+                document.getElementById('layers').textContent = internals.layerTreeAsText(document);
+            if (window.testRunner)
+                testRunner.notifyDone();
+        });
+    });
+</script>
+</head>
+<body>
+<!-- Layer-tree dump: three anchors with two plain <rect>s between consecutive pairs.
+     Both orange and purple must appear with reason "SVG sibling ordering". (The visual
+     ref test next to this exercises mixed compositing reasons; here we use translateZ
+     uniformly for reliable layer-tree dumping.) -->
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 240 240">
+    <g id="a"><rect x="10" y="10" width="100" height="100" fill="red"/></g>
+    <rect x="40" y="40" width="100" height="100" fill="orange"/>
+    <g id="b"><rect x="70" y="70" width="100" height="100" fill="green"/></g>
+    <rect x="100" y="100" width="100" height="100" fill="purple"/>
+    <g id="c"><rect x="130" y="130" width="100" height="100" fill="blue"/></g>
+</svg>
+<pre id="layers"></pre>
+</body>
+</html>

--- a/LayoutTests/svg/compositing/multiple-sandwiched-with-mixed-anchor-types.html
+++ b/LayoutTests/svg/compositing/multiple-sandwiched-with-mixed-anchor-types.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ LayerBasedSVGEngineEnabled=true ] -->
+<html>
+<head>
+<style>
+    html, body { margin: 0; padding: 0; }
+    svg { width: 240px; height: 240px; }
+</style>
+</head>
+<body>
+<!-- Three anchors of different types: filter (intrinsic), will-change (intrinsic),
+     and isolation+composited-descendant (derived). Two plain <rect> siblings sit
+     between consecutive anchors — both must be promoted across the mixed types. -->
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 240 240">
+    <g filter="url(#f)">
+        <rect x="10" y="10" width="100" height="100" fill="red"/>
+    </g>
+    <rect x="40" y="40" width="100" height="100" fill="orange"/>
+    <g style="will-change: transform">
+        <rect x="70" y="70" width="100" height="100" fill="green"/>
+    </g>
+    <rect x="100" y="100" width="100" height="100" fill="purple"/>
+    <g style="isolation: isolate">
+        <rect style="will-change: transform" x="130" y="130" width="100" height="100" fill="blue"/>
+    </g>
+    <defs>
+        <filter id="f" x="-10%" y="-10%" width="120%" height="120%">
+            <feOffset dx="0" dy="0"/>
+        </filter>
+    </defs>
+</svg>
+</body>
+</html>

--- a/LayoutTests/svg/compositing/nested-sandwich-at-multiple-depths-expected.html
+++ b/LayoutTests/svg/compositing/nested-sandwich-at-multiple-depths-expected.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+    html, body { margin: 0; padding: 0; }
+    svg { width: 240px; height: 240px; }
+</style>
+</head>
+<body>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 240 240">
+    <rect x="10" y="10" width="100" height="100" fill="red"/>
+    <rect x="30" y="30" width="40" height="40" fill="green"/>
+    <rect x="50" y="50" width="40" height="40" fill="purple"/>
+    <rect x="70" y="70" width="40" height="40" fill="cyan"/>
+    <rect x="90" y="90" width="40" height="40" fill="orange"/>
+    <rect x="130" y="130" width="100" height="100" fill="blue"/>
+</svg>
+</body>
+</html>

--- a/LayoutTests/svg/compositing/nested-sandwich-at-multiple-depths-layer-tree-expected.txt
+++ b/LayoutTests/svg/compositing/nested-sandwich-at-multiple-depths-layer-tree-expected.txt
@@ -1,0 +1,71 @@
+ (GraphicsLayer
+  (anchor 0.00 0.00)
+  (bounds 800.00 600.00)
+  (children 1
+    (GraphicsLayer
+      (bounds 800.00 600.00)
+      (contentsOpaque 1)
+      (children 1
+        (GraphicsLayer
+          (bounds 240.00 240.00)
+          (drawsContent 1)
+          (children 1
+            (GraphicsLayer
+              (bounds 240.00 240.00)
+              (children 1
+                (GraphicsLayer
+                  (offsetFromRenderer width=10 height=10)
+                  (position 10.00 10.00)
+                  (anchor -0.05 -0.05)
+                  (bounds 220.00 220.00)
+                  (contentsVisible 0)
+                  (children 7
+                    (GraphicsLayer
+                      (anchor -0.10 -0.10)
+                      (bounds 100.00 100.00)
+                      (drawsContent 1)
+                    )
+                    (GraphicsLayer
+                      (position 20.00 20.00)
+                      (bounds 100.00 100.00)
+                      (drawsContent 1)
+                    )
+                    (GraphicsLayer
+                      (position 20.00 20.00)
+                      (anchor -0.75 -0.75)
+                      (bounds 40.00 40.00)
+                      (drawsContent 1)
+                    )
+                    (GraphicsLayer
+                      (position 40.00 40.00)
+                      (bounds 40.00 40.00)
+                      (drawsContent 1)
+                    )
+                    (GraphicsLayer
+                      (position 60.00 60.00)
+                      (anchor -1.75 -1.75)
+                      (bounds 40.00 40.00)
+                      (drawsContent 1)
+                    )
+                    (GraphicsLayer
+                      (position 80.00 80.00)
+                      (bounds 40.00 40.00)
+                      (drawsContent 1)
+                    )
+                    (GraphicsLayer
+                      (position 120.00 120.00)
+                      (anchor -1.30 -1.30)
+                      (bounds 100.00 100.00)
+                      (drawsContent 1)
+                    )
+                  )
+                )
+              )
+            )
+          )
+        )
+      )
+    )
+  )
+)
+

--- a/LayoutTests/svg/compositing/nested-sandwich-at-multiple-depths-layer-tree.html
+++ b/LayoutTests/svg/compositing/nested-sandwich-at-multiple-depths-layer-tree.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ LayerBasedSVGEngineEnabled=true ] -->
+<html>
+<head>
+<style>
+    html, body { margin: 0; padding: 0; }
+    svg { width: 240px; height: 240px; }
+    .anchor { transform: translateZ(0); }
+</style>
+<script>
+    if (window.testRunner) {
+        testRunner.dumpAsText();
+        testRunner.waitUntilDone();
+    }
+    window.addEventListener('load', () => {
+        requestAnimationFrame(() => {
+            document.body.offsetTop;
+            // Outer anchors a, c plus inner anchors alpha, gamma.
+            for (const id of ['a', 'c', 'alpha', 'gamma'])
+                document.getElementById(id).setAttribute('class', 'anchor');
+            if (window.internals)
+                document.getElementById('layers').textContent = internals.layerTreeAsText(document);
+            if (window.testRunner)
+                testRunner.notifyDone();
+        });
+    });
+</script>
+</head>
+<body>
+<!-- Layer-tree dump: the outer middle <g> is sandwich-promoted; inside it, the inner
+     middle <rect> (between alpha and gamma anchors) and the trailing plain <rect>
+     (after gamma) must both appear with reason "SVG sibling ordering" — three
+     "SVG sibling ordering" layers in total. -->
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 240 240">
+    <g id="a"><rect x="10" y="10" width="100" height="100" fill="red"/></g>
+    <g>
+        <g id="alpha"><rect x="30" y="30" width="40" height="40" fill="green"/></g>
+        <rect x="50" y="50" width="40" height="40" fill="purple"/>
+        <g id="gamma"><rect x="70" y="70" width="40" height="40" fill="cyan"/></g>
+        <rect x="90" y="90" width="40" height="40" fill="orange"/>
+    </g>
+    <g id="c"><rect x="130" y="130" width="100" height="100" fill="blue"/></g>
+</svg>
+<pre id="layers"></pre>
+</body>
+</html>

--- a/LayoutTests/svg/compositing/nested-sandwich-at-multiple-depths.html
+++ b/LayoutTests/svg/compositing/nested-sandwich-at-multiple-depths.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ LayerBasedSVGEngineEnabled=true ] -->
+<html>
+<head>
+<style>
+    html, body { margin: 0; padding: 0; }
+    svg { width: 240px; height: 240px; }
+</style>
+</head>
+<body>
+<!-- The middle <g> at the outer level is itself sandwiched between filter and will-change
+     anchors. Inside that middle <g>, a nested sandwich (alpha filter / beta plain /
+     gamma will-change) is followed by a non-composited "after-last" child (delta). All
+     three inner promotions plus the outer promotion must apply so DOM order is preserved
+     at both depths. -->
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 240 240">
+    <g filter="url(#f)">
+        <rect x="10" y="10" width="100" height="100" fill="red"/>
+    </g>
+    <g>
+        <g filter="url(#f)">
+            <rect x="30" y="30" width="40" height="40" fill="green"/>
+        </g>
+        <rect x="50" y="50" width="40" height="40" fill="purple"/>
+        <g style="will-change: transform">
+            <rect x="70" y="70" width="40" height="40" fill="cyan"/>
+        </g>
+        <rect x="90" y="90" width="40" height="40" fill="orange"/>
+    </g>
+    <g style="will-change: transform">
+        <rect x="130" y="130" width="100" height="100" fill="blue"/>
+    </g>
+    <defs>
+        <filter id="f" x="-10%" y="-10%" width="120%" height="120%">
+            <feOffset dx="0" dy="0"/>
+        </filter>
+    </defs>
+</svg>
+</body>
+</html>

--- a/LayoutTests/svg/compositing/non-composited-child-after-last-composited-sibling-expected.html
+++ b/LayoutTests/svg/compositing/non-composited-child-after-last-composited-sibling-expected.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+    html, body { margin: 0; padding: 0; }
+    svg { width: 200px; height: 200px; }
+</style>
+</head>
+<body>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200">
+    <rect x="10" y="10" width="120" height="120" fill="red"/>
+    <rect x="40" y="40" width="120" height="120" fill="green"/>
+    <rect x="70" y="70" width="120" height="120" fill="blue"/>
+</svg>
+</body>
+</html>

--- a/LayoutTests/svg/compositing/non-composited-child-after-last-composited-sibling-layer-tree-expected.txt
+++ b/LayoutTests/svg/compositing/non-composited-child-after-last-composited-sibling-layer-tree-expected.txt
@@ -1,0 +1,49 @@
+ (GraphicsLayer
+  (anchor 0.00 0.00)
+  (bounds 800.00 600.00)
+  (children 1
+    (GraphicsLayer
+      (bounds 800.00 600.00)
+      (contentsOpaque 1)
+      (children 1
+        (GraphicsLayer
+          (bounds 200.00 200.00)
+          (drawsContent 1)
+          (children 1
+            (GraphicsLayer
+              (bounds 200.00 200.00)
+              (children 1
+                (GraphicsLayer
+                  (offsetFromRenderer width=10 height=10)
+                  (position 10.00 10.00)
+                  (anchor -0.06 -0.06)
+                  (bounds 180.00 180.00)
+                  (contentsVisible 0)
+                  (children 3
+                    (GraphicsLayer
+                      (anchor -0.08 -0.08)
+                      (bounds 120.00 120.00)
+                      (drawsContent 1)
+                    )
+                    (GraphicsLayer
+                      (position 30.00 30.00)
+                      (anchor -0.33 -0.33)
+                      (bounds 120.00 120.00)
+                      (drawsContent 1)
+                    )
+                    (GraphicsLayer
+                      (position 60.00 60.00)
+                      (bounds 120.00 120.00)
+                      (drawsContent 1)
+                    )
+                  )
+                )
+              )
+            )
+          )
+        )
+      )
+    )
+  )
+)
+

--- a/LayoutTests/svg/compositing/non-composited-child-after-last-composited-sibling-layer-tree.html
+++ b/LayoutTests/svg/compositing/non-composited-child-after-last-composited-sibling-layer-tree.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ LayerBasedSVGEngineEnabled=true ] -->
+<html>
+<head>
+<style>
+    html, body { margin: 0; padding: 0; }
+    svg { width: 200px; height: 200px; }
+    .anchor { transform: translateZ(0); }
+</style>
+<script>
+    if (window.testRunner) {
+        testRunner.dumpAsText();
+        testRunner.waitUntilDone();
+    }
+    window.addEventListener('load', () => {
+        requestAnimationFrame(() => {
+            document.body.offsetTop;
+            document.getElementById('a').setAttribute('class', 'anchor');
+            document.getElementById('b').setAttribute('class', 'anchor');
+            if (window.internals)
+                document.getElementById('layers').textContent = internals.layerTreeAsText(document);
+            if (window.testRunner)
+                testRunner.notifyDone();
+        });
+    });
+</script>
+</head>
+<body>
+<!-- Layer-tree dump: the trailing plain <rect> (DOM-after the last anchor) must
+     appear with reason "SVG sibling ordering" — the generalized algorithm promotes
+     any non-composited child past the first composited one. -->
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200">
+    <g id="a"><rect x="10" y="10" width="120" height="120" fill="red"/></g>
+    <g id="b"><rect x="40" y="40" width="120" height="120" fill="green"/></g>
+    <rect x="70" y="70" width="120" height="120" fill="blue"/>
+</svg>
+<pre id="layers"></pre>
+</body>
+</html>

--- a/LayoutTests/svg/compositing/non-composited-child-after-last-composited-sibling.html
+++ b/LayoutTests/svg/compositing/non-composited-child-after-last-composited-sibling.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ LayerBasedSVGEngineEnabled=true ] -->
+<html>
+<head>
+<style>
+    html, body { margin: 0; padding: 0; }
+    svg { width: 200px; height: 200px; }
+</style>
+</head>
+<body>
+<!-- A non-composited <rect> sits AFTER the last composited sibling. Without promotion
+     it would render in the parent's contents (below all composited sublayers), losing
+     DOM order. The generalized promotion must promote any non-composited child past the
+     first composited sibling, not just children strictly between two composited ones. -->
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200">
+    <g filter="url(#f)">
+        <rect x="10" y="10" width="120" height="120" fill="red"/>
+    </g>
+    <g style="will-change: transform">
+        <rect x="40" y="40" width="120" height="120" fill="green"/>
+    </g>
+    <rect x="70" y="70" width="120" height="120" fill="blue"/>
+    <defs>
+        <filter id="f" x="-10%" y="-10%" width="120%" height="120%">
+            <feOffset dx="0" dy="0"/>
+        </filter>
+    </defs>
+</svg>
+</body>
+</html>

--- a/LayoutTests/svg/compositing/promotion-after-anchor-element-inserted-layer-tree-expected.txt
+++ b/LayoutTests/svg/compositing/promotion-after-anchor-element-inserted-layer-tree-expected.txt
@@ -1,0 +1,49 @@
+ (GraphicsLayer
+  (anchor 0.00 0.00)
+  (bounds 800.00 600.00)
+  (children 1
+    (GraphicsLayer
+      (bounds 800.00 600.00)
+      (contentsOpaque 1)
+      (children 1
+        (GraphicsLayer
+          (bounds 200.00 200.00)
+          (drawsContent 1)
+          (children 1
+            (GraphicsLayer
+              (bounds 200.00 200.00)
+              (children 1
+                (GraphicsLayer
+                  (offsetFromRenderer width=10 height=10)
+                  (position 10.00 10.00)
+                  (anchor -0.06 -0.06)
+                  (bounds 180.00 180.00)
+                  (contentsVisible 0)
+                  (children 3
+                    (GraphicsLayer
+                      (anchor -0.08 -0.08)
+                      (bounds 120.00 120.00)
+                      (drawsContent 1)
+                    )
+                    (GraphicsLayer
+                      (position 30.00 30.00)
+                      (bounds 120.00 120.00)
+                      (drawsContent 1)
+                    )
+                    (GraphicsLayer
+                      (position 60.00 60.00)
+                      (anchor -0.58 -0.58)
+                      (bounds 120.00 120.00)
+                      (drawsContent 1)
+                    )
+                  )
+                )
+              )
+            )
+          )
+        )
+      )
+    )
+  )
+)
+

--- a/LayoutTests/svg/compositing/promotion-after-anchor-element-inserted-layer-tree.html
+++ b/LayoutTests/svg/compositing/promotion-after-anchor-element-inserted-layer-tree.html
@@ -1,0 +1,51 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ LayerBasedSVGEngineEnabled=true ] -->
+<html>
+<head>
+<style>
+    html, body { margin: 0; padding: 0; }
+    svg { width: 200px; height: 200px; }
+    .anchor { transform: translateZ(0); }
+</style>
+<script>
+    if (window.testRunner) {
+        testRunner.dumpAsText();
+        testRunner.waitUntilDone();
+    }
+    window.addEventListener('load', () => {
+        requestAnimationFrame(() => {
+            document.body.offsetTop;
+            // Initially: <rect id="middle"> has no preceding intrinsically-layered
+            // sibling (g#last-anchor is after it), so it has no layer.
+            // Insert a new anchored <g> before middle. middle now has an
+            // intrinsically-layered preceding sibling and must sandwich-promote.
+            const svg = document.querySelector('svg');
+            const middle = document.getElementById('middle');
+            const newAnchor = document.createElementNS('http://www.w3.org/2000/svg', 'g');
+            newAnchor.setAttribute('id', 'first-anchor');
+            newAnchor.setAttribute('class', 'anchor');
+            const rect = document.createElementNS('http://www.w3.org/2000/svg', 'rect');
+            rect.setAttribute('x', '10');
+            rect.setAttribute('y', '10');
+            rect.setAttribute('width', '120');
+            rect.setAttribute('height', '120');
+            rect.setAttribute('fill', 'red');
+            newAnchor.appendChild(rect);
+            svg.insertBefore(newAnchor, middle);
+            requestAnimationFrame(() => {
+                if (window.internals)
+                    document.getElementById('layers').textContent = internals.layerTreeAsText(document);
+                if (window.testRunner)
+                    testRunner.notifyDone();
+            });
+        });
+    });
+</script>
+</head>
+<body>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200">
+    <rect id="middle" x="40" y="40" width="120" height="120" fill="green"/>
+    <g id="last-anchor" class="anchor"><rect x="70" y="70" width="120" height="120" fill="blue"/></g>
+</svg>
+<pre id="layers"></pre>
+</body>
+</html>

--- a/LayoutTests/svg/compositing/sandwiched-between-derived-composited-anchors-expected.html
+++ b/LayoutTests/svg/compositing/sandwiched-between-derived-composited-anchors-expected.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+    html, body { margin: 0; padding: 0; }
+    svg { width: 200px; height: 200px; }
+</style>
+</head>
+<body>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200">
+    <rect x="10" y="10" width="120" height="120" fill="red"/>
+    <rect x="40" y="40" width="120" height="120" fill="green"/>
+    <rect x="70" y="70" width="120" height="120" fill="blue"/>
+</svg>
+</body>
+</html>

--- a/LayoutTests/svg/compositing/sandwiched-between-derived-composited-anchors-layer-tree-expected.txt
+++ b/LayoutTests/svg/compositing/sandwiched-between-derived-composited-anchors-layer-tree-expected.txt
@@ -1,0 +1,54 @@
+ (GraphicsLayer
+  (anchor 0.00 0.00)
+  (bounds 800.00 600.00)
+  (children 1
+    (GraphicsLayer
+      (bounds 800.00 600.00)
+      (contentsOpaque 1)
+      (children 1
+        (GraphicsLayer
+          (bounds 200.00 200.00)
+          (drawsContent 1)
+          (children 1
+            (GraphicsLayer
+              (bounds 200.00 200.00)
+              (children 1
+                (GraphicsLayer
+                  (offsetFromRenderer width=10 height=10)
+                  (position 10.00 10.00)
+                  (anchor -0.06 -0.06)
+                  (bounds 180.00 180.00)
+                  (children 3
+                    (GraphicsLayer
+                      (anchor -0.08 -0.08)
+                      (bounds 120.00 120.00)
+                      (drawsContent 1)
+                    )
+                    (GraphicsLayer
+                      (position 30.00 30.00)
+                      (bounds 120.00 120.00)
+                      (drawsContent 1)
+                    )
+                    (GraphicsLayer
+                      (position 60.00 60.00)
+                      (bounds 120.00 120.00)
+                      (drawsContent 1)
+                      (children 1
+                        (GraphicsLayer
+                          (anchor -0.58 -0.58)
+                          (bounds 120.00 120.00)
+                          (drawsContent 1)
+                        )
+                      )
+                    )
+                  )
+                )
+              )
+            )
+          )
+        )
+      )
+    )
+  )
+)
+

--- a/LayoutTests/svg/compositing/sandwiched-between-derived-composited-anchors-layer-tree.html
+++ b/LayoutTests/svg/compositing/sandwiched-between-derived-composited-anchors-layer-tree.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ LayerBasedSVGEngineEnabled=true ] -->
+<html>
+<head>
+<style>
+    html, body { margin: 0; padding: 0; }
+    svg { width: 200px; height: 200px; }
+    .anchor { transform: translateZ(0); }
+</style>
+<script>
+    if (window.testRunner) {
+        testRunner.dumpAsText();
+        testRunner.waitUntilDone();
+    }
+    window.addEventListener('load', () => {
+        requestAnimationFrame(() => {
+            document.body.offsetTop;
+            // The outer <g style="isolation: isolate"> has no intrinsic compositing
+            // reason; making the inner <rect> composite (via translateZ) gives the
+            // outer <g> a composited descendant + createsGroup -> GraphicalEffect.
+            document.getElementById('ar').setAttribute('class', 'anchor');
+            document.getElementById('cr').setAttribute('class', 'anchor');
+            if (window.internals)
+                document.getElementById('layers').textContent = internals.layerTreeAsText(document);
+            if (window.testRunner)
+                testRunner.notifyDone();
+        });
+    });
+</script>
+</head>
+<body>
+<!-- Layer-tree dump: the anchor <g>s composite for a derived reason (GraphicalEffect
+     via isolation + composited descendant). The middle <rect> must still appear
+     with reason "SVG sibling ordering". -->
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200">
+    <g style="isolation: isolate">
+        <rect id="ar" x="10" y="10" width="120" height="120" fill="red"/>
+    </g>
+    <rect x="40" y="40" width="120" height="120" fill="green"/>
+    <g style="isolation: isolate">
+        <rect id="cr" x="70" y="70" width="120" height="120" fill="blue"/>
+    </g>
+</svg>
+<pre id="layers"></pre>
+</body>
+</html>

--- a/LayoutTests/svg/compositing/sandwiched-between-derived-composited-anchors.html
+++ b/LayoutTests/svg/compositing/sandwiched-between-derived-composited-anchors.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ LayerBasedSVGEngineEnabled=true ] -->
+<html>
+<head>
+<style>
+    html, body { margin: 0; padding: 0; }
+    svg { width: 200px; height: 200px; }
+</style>
+</head>
+<body>
+<!-- Anchors are <g> elements that have no intrinsic compositing reason; each
+     composites for a derived reason (GraphicalEffect: createsGroup via isolation +
+     a composited descendant). The plain middle <rect> must still be promoted so
+     DOM order is preserved across the derived-composited siblings. -->
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200">
+    <g style="isolation: isolate">
+        <rect style="will-change: transform" x="10" y="10" width="120" height="120" fill="red"/>
+    </g>
+    <rect x="40" y="40" width="120" height="120" fill="green"/>
+    <g style="isolation: isolate">
+        <rect style="will-change: transform" x="70" y="70" width="120" height="120" fill="blue"/>
+    </g>
+</svg>
+</body>
+</html>

--- a/LayoutTests/svg/compositing/sandwiched-g-container-between-composited-siblings-expected.html
+++ b/LayoutTests/svg/compositing/sandwiched-g-container-between-composited-siblings-expected.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+    html, body { margin: 0; padding: 0; }
+    svg { width: 200px; height: 200px; }
+</style>
+</head>
+<body>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200">
+    <rect x="10" y="10" width="120" height="120" fill="red"/>
+    <rect x="40" y="40" width="120" height="120" fill="green"/>
+    <rect x="70" y="70" width="120" height="120" fill="blue"/>
+</svg>
+</body>
+</html>

--- a/LayoutTests/svg/compositing/sandwiched-g-container-between-composited-siblings-layer-tree-expected.txt
+++ b/LayoutTests/svg/compositing/sandwiched-g-container-between-composited-siblings-layer-tree-expected.txt
@@ -1,0 +1,54 @@
+ (GraphicsLayer
+  (anchor 0.00 0.00)
+  (bounds 800.00 600.00)
+  (children 1
+    (GraphicsLayer
+      (bounds 800.00 600.00)
+      (contentsOpaque 1)
+      (children 1
+        (GraphicsLayer
+          (bounds 200.00 200.00)
+          (drawsContent 1)
+          (children 1
+            (GraphicsLayer
+              (bounds 200.00 200.00)
+              (children 1
+                (GraphicsLayer
+                  (offsetFromRenderer width=10 height=10)
+                  (position 10.00 10.00)
+                  (anchor -0.06 -0.06)
+                  (bounds 180.00 180.00)
+                  (contentsVisible 0)
+                  (children 4
+                    (GraphicsLayer
+                      (anchor -0.08 -0.08)
+                      (bounds 120.00 120.00)
+                      (drawsContent 1)
+                    )
+                    (GraphicsLayer
+                      (position 30.00 30.00)
+                      (bounds 120.00 120.00)
+                      (drawsContent 1)
+                    )
+                    (GraphicsLayer
+                      (position 30.00 30.00)
+                      (bounds 120.00 120.00)
+                      (drawsContent 1)
+                    )
+                    (GraphicsLayer
+                      (position 60.00 60.00)
+                      (anchor -0.58 -0.58)
+                      (bounds 120.00 120.00)
+                      (drawsContent 1)
+                    )
+                  )
+                )
+              )
+            )
+          )
+        )
+      )
+    )
+  )
+)
+

--- a/LayoutTests/svg/compositing/sandwiched-g-container-between-composited-siblings-layer-tree.html
+++ b/LayoutTests/svg/compositing/sandwiched-g-container-between-composited-siblings-layer-tree.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ LayerBasedSVGEngineEnabled=true ] -->
+<html>
+<head>
+<style>
+    html, body { margin: 0; padding: 0; }
+    svg { width: 200px; height: 200px; }
+    .anchor { transform: translateZ(0); }
+</style>
+<script>
+    if (window.testRunner) {
+        testRunner.dumpAsText();
+        testRunner.waitUntilDone();
+    }
+    window.addEventListener('load', () => {
+        requestAnimationFrame(() => {
+            document.body.offsetTop;
+            document.getElementById('a').setAttribute('class', 'anchor');
+            document.getElementById('c').setAttribute('class', 'anchor');
+            if (window.internals)
+                document.getElementById('layers').textContent = internals.layerTreeAsText(document);
+            if (window.testRunner)
+                testRunner.notifyDone();
+        });
+    });
+</script>
+</head>
+<body>
+<!-- Layer-tree dump: the middle <g> container must appear as a composited layer with
+     reason "SVG sibling ordering"; its inner <rect> renders inside that layer. -->
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200">
+    <g id="a"><rect x="10" y="10" width="120" height="120" fill="red"/></g>
+    <g><rect x="40" y="40" width="120" height="120" fill="green"/></g>
+    <g id="c"><rect x="70" y="70" width="120" height="120" fill="blue"/></g>
+</svg>
+<pre id="layers"></pre>
+</body>
+</html>

--- a/LayoutTests/svg/compositing/sandwiched-g-container-between-composited-siblings.html
+++ b/LayoutTests/svg/compositing/sandwiched-g-container-between-composited-siblings.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ LayerBasedSVGEngineEnabled=true ] -->
+<html>
+<head>
+<style>
+    html, body { margin: 0; padding: 0; }
+    svg { width: 200px; height: 200px; }
+</style>
+</head>
+<body>
+<!-- Sandwich child is a <g> container, not a plain <rect>. The middle <g> must be
+     promoted so its descendants paint between the filter and will-change anchors. -->
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200">
+    <g filter="url(#f)">
+        <rect x="10" y="10" width="120" height="120" fill="red"/>
+    </g>
+    <g>
+        <rect x="40" y="40" width="120" height="120" fill="green"/>
+    </g>
+    <g style="will-change: transform">
+        <rect x="70" y="70" width="120" height="120" fill="blue"/>
+    </g>
+    <defs>
+        <filter id="f" x="-10%" y="-10%" width="120%" height="120%">
+            <feOffset dx="0" dy="0"/>
+        </filter>
+    </defs>
+</svg>
+</body>
+</html>

--- a/LayoutTests/svg/compositing/sandwiched-g-with-multiple-children-between-composited-siblings-expected.html
+++ b/LayoutTests/svg/compositing/sandwiched-g-with-multiple-children-between-composited-siblings-expected.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+    html, body { margin: 0; padding: 0; }
+    svg { width: 240px; height: 240px; }
+</style>
+</head>
+<body>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 240 240">
+    <rect x="10" y="10" width="120" height="120" fill="red"/>
+    <rect x="40" y="40" width="80" height="80" fill="green"/>
+    <rect x="70" y="70" width="80" height="80" fill="cyan"/>
+    <rect x="100" y="100" width="120" height="120" fill="blue"/>
+</svg>
+</body>
+</html>

--- a/LayoutTests/svg/compositing/sandwiched-g-with-multiple-children-between-composited-siblings-layer-tree-expected.txt
+++ b/LayoutTests/svg/compositing/sandwiched-g-with-multiple-children-between-composited-siblings-layer-tree-expected.txt
@@ -1,0 +1,59 @@
+ (GraphicsLayer
+  (anchor 0.00 0.00)
+  (bounds 800.00 600.00)
+  (children 1
+    (GraphicsLayer
+      (bounds 800.00 600.00)
+      (contentsOpaque 1)
+      (children 1
+        (GraphicsLayer
+          (bounds 240.00 240.00)
+          (drawsContent 1)
+          (children 1
+            (GraphicsLayer
+              (bounds 240.00 240.00)
+              (children 1
+                (GraphicsLayer
+                  (offsetFromRenderer width=10 height=10)
+                  (position 10.00 10.00)
+                  (anchor -0.05 -0.05)
+                  (bounds 210.00 210.00)
+                  (contentsVisible 0)
+                  (children 5
+                    (GraphicsLayer
+                      (anchor -0.08 -0.08)
+                      (bounds 120.00 120.00)
+                      (drawsContent 1)
+                    )
+                    (GraphicsLayer
+                      (position 30.00 30.00)
+                      (bounds 110.00 110.00)
+                      (drawsContent 1)
+                    )
+                    (GraphicsLayer
+                      (position 30.00 30.00)
+                      (bounds 80.00 80.00)
+                      (drawsContent 1)
+                    )
+                    (GraphicsLayer
+                      (position 60.00 60.00)
+                      (bounds 80.00 80.00)
+                      (drawsContent 1)
+                    )
+                    (GraphicsLayer
+                      (position 90.00 90.00)
+                      (anchor -0.83 -0.83)
+                      (bounds 120.00 120.00)
+                      (drawsContent 1)
+                    )
+                  )
+                )
+              )
+            )
+          )
+        )
+      )
+    )
+  )
+)
+

--- a/LayoutTests/svg/compositing/sandwiched-g-with-multiple-children-between-composited-siblings-layer-tree.html
+++ b/LayoutTests/svg/compositing/sandwiched-g-with-multiple-children-between-composited-siblings-layer-tree.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ LayerBasedSVGEngineEnabled=true ] -->
+<html>
+<head>
+<style>
+    html, body { margin: 0; padding: 0; }
+    svg { width: 240px; height: 240px; }
+    .anchor { transform: translateZ(0); }
+</style>
+<script>
+    if (window.testRunner) {
+        testRunner.dumpAsText();
+        testRunner.waitUntilDone();
+    }
+    window.addEventListener('load', () => {
+        requestAnimationFrame(() => {
+            document.body.offsetTop;
+            document.getElementById('a').setAttribute('class', 'anchor');
+            document.getElementById('c').setAttribute('class', 'anchor');
+            if (window.internals)
+                document.getElementById('layers').textContent = internals.layerTreeAsText(document);
+            if (window.testRunner)
+                testRunner.notifyDone();
+        });
+    });
+</script>
+</head>
+<body>
+<!-- Layer-tree dump: the sandwich <g> with multiple <rect> children must appear as a
+     single composited layer with reason "SVG sibling ordering"; its descendants paint
+     into that layer (no per-rect layers). -->
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 240 240">
+    <g id="a"><rect x="10" y="10" width="120" height="120" fill="red"/></g>
+    <g>
+        <rect x="40" y="40" width="80" height="80" fill="green"/>
+        <rect x="70" y="70" width="80" height="80" fill="cyan"/>
+    </g>
+    <g id="c"><rect x="100" y="100" width="120" height="120" fill="blue"/></g>
+</svg>
+<pre id="layers"></pre>
+</body>
+</html>

--- a/LayoutTests/svg/compositing/sandwiched-g-with-multiple-children-between-composited-siblings.html
+++ b/LayoutTests/svg/compositing/sandwiched-g-with-multiple-children-between-composited-siblings.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ LayerBasedSVGEngineEnabled=true ] -->
+<html>
+<head>
+<style>
+    html, body { margin: 0; padding: 0; }
+    svg { width: 240px; height: 240px; }
+</style>
+</head>
+<body>
+<!-- The sandwich <g> contains multiple <rect> children. After promotion the entire
+     subtree paints between the anchors, with internal DOM order preserved between
+     its children. -->
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 240 240">
+    <g filter="url(#f)">
+        <rect x="10" y="10" width="120" height="120" fill="red"/>
+    </g>
+    <g>
+        <rect x="40" y="40" width="80" height="80" fill="green"/>
+        <rect x="70" y="70" width="80" height="80" fill="cyan"/>
+    </g>
+    <g style="will-change: transform">
+        <rect x="100" y="100" width="120" height="120" fill="blue"/>
+    </g>
+    <defs>
+        <filter id="f" x="-10%" y="-10%" width="120%" height="120%">
+            <feOffset dx="0" dy="0"/>
+        </filter>
+    </defs>
+</svg>
+</body>
+</html>

--- a/LayoutTests/svg/compositing/sandwiched-non-composited-child-between-composited-siblings-expected.html
+++ b/LayoutTests/svg/compositing/sandwiched-non-composited-child-between-composited-siblings-expected.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+    html, body { margin: 0; padding: 0; }
+    svg { width: 200px; height: 200px; }
+</style>
+</head>
+<body>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200">
+    <rect x="10" y="10" width="120" height="120" fill="red"/>
+    <rect x="40" y="40" width="120" height="120" fill="green"/>
+    <rect x="70" y="70" width="120" height="120" fill="blue"/>
+</svg>
+</body>
+</html>

--- a/LayoutTests/svg/compositing/sandwiched-non-composited-child-between-composited-siblings-layer-tree-expected.txt
+++ b/LayoutTests/svg/compositing/sandwiched-non-composited-child-between-composited-siblings-layer-tree-expected.txt
@@ -1,0 +1,49 @@
+ (GraphicsLayer
+  (anchor 0.00 0.00)
+  (bounds 800.00 600.00)
+  (children 1
+    (GraphicsLayer
+      (bounds 800.00 600.00)
+      (contentsOpaque 1)
+      (children 1
+        (GraphicsLayer
+          (bounds 200.00 200.00)
+          (drawsContent 1)
+          (children 1
+            (GraphicsLayer
+              (bounds 200.00 200.00)
+              (children 1
+                (GraphicsLayer
+                  (offsetFromRenderer width=10 height=10)
+                  (position 10.00 10.00)
+                  (anchor -0.06 -0.06)
+                  (bounds 180.00 180.00)
+                  (contentsVisible 0)
+                  (children 3
+                    (GraphicsLayer
+                      (anchor -0.08 -0.08)
+                      (bounds 120.00 120.00)
+                      (drawsContent 1)
+                    )
+                    (GraphicsLayer
+                      (position 30.00 30.00)
+                      (bounds 120.00 120.00)
+                      (drawsContent 1)
+                    )
+                    (GraphicsLayer
+                      (position 60.00 60.00)
+                      (anchor -0.58 -0.58)
+                      (bounds 120.00 120.00)
+                      (drawsContent 1)
+                    )
+                  )
+                )
+              )
+            )
+          )
+        )
+      )
+    )
+  )
+)
+

--- a/LayoutTests/svg/compositing/sandwiched-non-composited-child-between-composited-siblings-layer-tree.html
+++ b/LayoutTests/svg/compositing/sandwiched-non-composited-child-between-composited-siblings-layer-tree.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ LayerBasedSVGEngineEnabled=true ] -->
+<html>
+<head>
+<style>
+    html, body { margin: 0; padding: 0; }
+    svg { width: 200px; height: 200px; }
+    .anchor { transform: translateZ(0); }
+</style>
+<script>
+    if (window.testRunner) {
+        testRunner.dumpAsText();
+        testRunner.waitUntilDone();
+    }
+    window.addEventListener('load', () => {
+        requestAnimationFrame(() => {
+            document.body.offsetTop;
+            document.getElementById('a').setAttribute('class', 'anchor');
+            document.getElementById('c').setAttribute('class', 'anchor');
+            if (window.internals)
+                document.getElementById('layers').textContent = internals.layerTreeAsText(document);
+            if (window.testRunner)
+                testRunner.notifyDone();
+        });
+    });
+</script>
+</head>
+<body>
+<!-- Layer-tree dump of the basic sandwich case: after both <g> anchors gain
+     translateZ(0), the middle <rect> must appear as a composited layer with reason
+     "SVG sibling ordering". -->
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200">
+    <g id="a"><rect x="10" y="10" width="120" height="120" fill="red"/></g>
+    <rect x="40" y="40" width="120" height="120" fill="green"/>
+    <g id="c"><rect x="70" y="70" width="120" height="120" fill="blue"/></g>
+</svg>
+<pre id="layers"></pre>
+</body>
+</html>

--- a/LayoutTests/svg/compositing/sandwiched-non-composited-child-between-composited-siblings.html
+++ b/LayoutTests/svg/compositing/sandwiched-non-composited-child-between-composited-siblings.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ LayerBasedSVGEngineEnabled=true ] -->
+<html>
+<head>
+<style>
+    html, body { margin: 0; padding: 0; }
+    svg { width: 200px; height: 200px; }
+</style>
+</head>
+<body>
+<!-- DOM order: composited <g filter>, plain <rect>, composited <g will-change:transform>.
+     The middle <rect> overlaps both composited siblings. With LBSE's conditional layer
+     creation it would be a non-layer renderer, and naive painting would draw it either
+     below or above both composited siblings. The sandwich promotion" forces it
+     to acquire a layer and composite, so the compositor stacks all three in DOM order
+     — the green <rect> ends up between the red and the blue rectangles. -->
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200">
+    <g filter="url(#f)">
+        <rect x="10" y="10" width="120" height="120" fill="red"/>
+    </g>
+    <rect x="40" y="40" width="120" height="120" fill="green"/>
+    <g style="will-change: transform">
+        <rect x="70" y="70" width="120" height="120" fill="blue"/>
+    </g>
+    <defs>
+        <filter id="f" x="-10%" y="-10%" width="120%" height="120%">
+            <feOffset dx="0" dy="0"/>
+        </filter>
+    </defs>
+</svg>
+</body>
+</html>

--- a/LayoutTests/svg/compositing/sandwiched-non-rect-shape-between-composited-siblings-expected.html
+++ b/LayoutTests/svg/compositing/sandwiched-non-rect-shape-between-composited-siblings-expected.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+    html, body { margin: 0; padding: 0; }
+    svg { width: 200px; height: 200px; }
+</style>
+</head>
+<body>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200">
+    <rect x="10" y="10" width="120" height="120" fill="red"/>
+    <circle cx="100" cy="100" r="60" fill="green"/>
+    <rect x="70" y="70" width="120" height="120" fill="blue"/>
+</svg>
+</body>
+</html>

--- a/LayoutTests/svg/compositing/sandwiched-non-rect-shape-between-composited-siblings-layer-tree-expected.txt
+++ b/LayoutTests/svg/compositing/sandwiched-non-rect-shape-between-composited-siblings-layer-tree-expected.txt
@@ -1,0 +1,49 @@
+ (GraphicsLayer
+  (anchor 0.00 0.00)
+  (bounds 800.00 600.00)
+  (children 1
+    (GraphicsLayer
+      (bounds 800.00 600.00)
+      (contentsOpaque 1)
+      (children 1
+        (GraphicsLayer
+          (bounds 200.00 200.00)
+          (drawsContent 1)
+          (children 1
+            (GraphicsLayer
+              (bounds 200.00 200.00)
+              (children 1
+                (GraphicsLayer
+                  (offsetFromRenderer width=10 height=10)
+                  (position 10.00 10.00)
+                  (anchor -0.06 -0.06)
+                  (bounds 180.00 180.00)
+                  (contentsVisible 0)
+                  (children 3
+                    (GraphicsLayer
+                      (anchor -0.08 -0.08)
+                      (bounds 120.00 120.00)
+                      (drawsContent 1)
+                    )
+                    (GraphicsLayer
+                      (position 30.00 30.00)
+                      (bounds 120.00 120.00)
+                      (drawsContent 1)
+                    )
+                    (GraphicsLayer
+                      (position 60.00 60.00)
+                      (anchor -0.58 -0.58)
+                      (bounds 120.00 120.00)
+                      (drawsContent 1)
+                    )
+                  )
+                )
+              )
+            )
+          )
+        )
+      )
+    )
+  )
+)
+

--- a/LayoutTests/svg/compositing/sandwiched-non-rect-shape-between-composited-siblings-layer-tree.html
+++ b/LayoutTests/svg/compositing/sandwiched-non-rect-shape-between-composited-siblings-layer-tree.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ LayerBasedSVGEngineEnabled=true ] -->
+<html>
+<head>
+<style>
+    html, body { margin: 0; padding: 0; }
+    svg { width: 200px; height: 200px; }
+    .anchor { transform: translateZ(0); }
+</style>
+<script>
+    if (window.testRunner) {
+        testRunner.dumpAsText();
+        testRunner.waitUntilDone();
+    }
+    window.addEventListener('load', () => {
+        requestAnimationFrame(() => {
+            document.body.offsetTop;
+            document.getElementById('a').setAttribute('class', 'anchor');
+            document.getElementById('c').setAttribute('class', 'anchor');
+            if (window.internals)
+                document.getElementById('layers').textContent = internals.layerTreeAsText(document);
+            if (window.testRunner)
+                testRunner.notifyDone();
+        });
+    });
+</script>
+</head>
+<body>
+<!-- Layer-tree dump: <circle> (non-<rect> shape) sandwiched between composited
+     anchors; the circle must appear as a composited layer with reason "SVG sibling
+     ordering". -->
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200">
+    <g id="a"><rect x="10" y="10" width="120" height="120" fill="red"/></g>
+    <circle cx="100" cy="100" r="60" fill="green"/>
+    <g id="c"><rect x="70" y="70" width="120" height="120" fill="blue"/></g>
+</svg>
+<pre id="layers"></pre>
+</body>
+</html>

--- a/LayoutTests/svg/compositing/sandwiched-non-rect-shape-between-composited-siblings.html
+++ b/LayoutTests/svg/compositing/sandwiched-non-rect-shape-between-composited-siblings.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ LayerBasedSVGEngineEnabled=true ] -->
+<html>
+<head>
+<style>
+    html, body { margin: 0; padding: 0; }
+    svg { width: 200px; height: 200px; }
+</style>
+</head>
+<body>
+<!-- The sandwich child is a <circle> rather than a <rect>, exercising the promotion
+     path for non-<rect> SVG shape renderers. -->
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200">
+    <g filter="url(#f)">
+        <rect x="10" y="10" width="120" height="120" fill="red"/>
+    </g>
+    <circle cx="100" cy="100" r="60" fill="green"/>
+    <g style="will-change: transform">
+        <rect x="70" y="70" width="120" height="120" fill="blue"/>
+    </g>
+    <defs>
+        <filter id="f" x="-10%" y="-10%" width="120%" height="120%">
+            <feOffset dx="0" dy="0"/>
+        </filter>
+    </defs>
+</svg>
+</body>
+</html>

--- a/LayoutTests/svg/compositing/sandwiched-rect-between-rect-anchors-expected.html
+++ b/LayoutTests/svg/compositing/sandwiched-rect-between-rect-anchors-expected.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+    html, body { margin: 0; padding: 0; }
+    svg { width: 200px; height: 200px; }
+</style>
+</head>
+<body>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200">
+    <rect x="10" y="10" width="120" height="120" fill="red"/>
+    <rect x="40" y="40" width="120" height="120" fill="green"/>
+    <rect x="70" y="70" width="120" height="120" fill="blue"/>
+</svg>
+</body>
+</html>

--- a/LayoutTests/svg/compositing/sandwiched-rect-between-rect-anchors-layer-tree-expected.txt
+++ b/LayoutTests/svg/compositing/sandwiched-rect-between-rect-anchors-layer-tree-expected.txt
@@ -1,0 +1,49 @@
+ (GraphicsLayer
+  (anchor 0.00 0.00)
+  (bounds 800.00 600.00)
+  (children 1
+    (GraphicsLayer
+      (bounds 800.00 600.00)
+      (contentsOpaque 1)
+      (children 1
+        (GraphicsLayer
+          (bounds 200.00 200.00)
+          (drawsContent 1)
+          (children 1
+            (GraphicsLayer
+              (bounds 200.00 200.00)
+              (children 1
+                (GraphicsLayer
+                  (offsetFromRenderer width=10 height=10)
+                  (position 10.00 10.00)
+                  (anchor -0.06 -0.06)
+                  (bounds 180.00 180.00)
+                  (contentsVisible 0)
+                  (children 3
+                    (GraphicsLayer
+                      (anchor -0.08 -0.08)
+                      (bounds 120.00 120.00)
+                      (drawsContent 1)
+                    )
+                    (GraphicsLayer
+                      (position 30.00 30.00)
+                      (bounds 120.00 120.00)
+                      (drawsContent 1)
+                    )
+                    (GraphicsLayer
+                      (position 60.00 60.00)
+                      (anchor -0.58 -0.58)
+                      (bounds 120.00 120.00)
+                      (drawsContent 1)
+                    )
+                  )
+                )
+              )
+            )
+          )
+        )
+      )
+    )
+  )
+)
+

--- a/LayoutTests/svg/compositing/sandwiched-rect-between-rect-anchors-layer-tree.html
+++ b/LayoutTests/svg/compositing/sandwiched-rect-between-rect-anchors-layer-tree.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ LayerBasedSVGEngineEnabled=true ] -->
+<html>
+<head>
+<style>
+    html, body { margin: 0; padding: 0; }
+    svg { width: 200px; height: 200px; }
+    .anchor { transform: translateZ(0); }
+</style>
+<script>
+    if (window.testRunner) {
+        testRunner.dumpAsText();
+        testRunner.waitUntilDone();
+    }
+    window.addEventListener('load', () => {
+        requestAnimationFrame(() => {
+            document.body.offsetTop;
+            document.getElementById('a').setAttribute('class', 'anchor');
+            document.getElementById('c').setAttribute('class', 'anchor');
+            if (window.internals)
+                document.getElementById('layers').textContent = internals.layerTreeAsText(document);
+            if (window.testRunner)
+                testRunner.notifyDone();
+        });
+    });
+</script>
+</head>
+<body>
+<!-- Layer-tree dump with <rect> elements as anchors (no <g> wrappers). The middle
+     plain <rect> must still appear with reason "SVG sibling ordering". -->
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200">
+    <rect id="a" x="10" y="10" width="120" height="120" fill="red"/>
+    <rect x="40" y="40" width="120" height="120" fill="green"/>
+    <rect id="c" x="70" y="70" width="120" height="120" fill="blue"/>
+</svg>
+<pre id="layers"></pre>
+</body>
+</html>

--- a/LayoutTests/svg/compositing/sandwiched-rect-between-rect-anchors.html
+++ b/LayoutTests/svg/compositing/sandwiched-rect-between-rect-anchors.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ LayerBasedSVGEngineEnabled=true ] -->
+<html>
+<head>
+<style>
+    html, body { margin: 0; padding: 0; }
+    svg { width: 200px; height: 200px; }
+</style>
+</head>
+<body>
+<!-- Anchors are <rect> elements with intrinsic compositing reasons (filter and
+     will-change), not <g> wrappers. The plain middle <rect> must still be promoted. -->
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200">
+    <rect filter="url(#f)" x="10" y="10" width="120" height="120" fill="red"/>
+    <rect x="40" y="40" width="120" height="120" fill="green"/>
+    <rect style="will-change: transform" x="70" y="70" width="120" height="120" fill="blue"/>
+    <defs>
+        <filter id="f" x="-10%" y="-10%" width="120%" height="120%">
+            <feOffset dx="0" dy="0"/>
+        </filter>
+    </defs>
+</svg>
+</body>
+</html>

--- a/Source/WebCore/rendering/RenderLayer.cpp
+++ b/Source/WebCore/rendering/RenderLayer.cpp
@@ -6726,6 +6726,7 @@ TextStream& operator<<(TextStream& ts, IndirectCompositingReason reason)
     case IndirectCompositingReason::GraphicalEffect: ts << "graphical effect"_s; break;
     case IndirectCompositingReason::Perspective: ts << "perspective"_s; break;
     case IndirectCompositingReason::Preserve3D: ts << "preserve-3d"_s; break;
+    case IndirectCompositingReason::SVGSiblingOrderingForLBSE: ts << "SVG sibling ordering"_s; break;
     }
 
     return ts;

--- a/Source/WebCore/rendering/RenderLayer.h
+++ b/Source/WebCore/rendering/RenderLayer.h
@@ -144,7 +144,8 @@ enum class IndirectCompositingReason {
     BackgroundLayer,
     GraphicalEffect, // opacity, mask, filter, transform etc.
     Perspective,
-    Preserve3D
+    Preserve3D,
+    SVGSiblingOrderingForLBSE, // Trails a composited SVG sibling, must composite to preserve DOM order.
 };
 
 enum class ShouldAllowCrossOriginScrolling : bool { No, Yes };
@@ -467,6 +468,7 @@ public:
     }
 
     // SVG-specific methods -- defined in RenderLayerSVGAdditionsInlines.h / RenderLayerSVGAdditions.cpp.
+    bool isSVGLayer() const { return !!m_svgData; }
     inline bool isPaintingResourceLayerForSVG() const;
     inline RenderSVGHiddenContainer* enclosingHiddenOrResourceContainerForSVG() const;
     void paintResourceLayerForSVG(GraphicsContext&, const AffineTransform&);
@@ -475,6 +477,8 @@ public:
     bool hasFailedFilterForSVG() const;
     bool shouldSkipHitTestForSVG() const;
     void updateAncestorDependentStateForSVG();
+    static void reconcileSVGSandwichLayersForChildren(RenderElement& parent);
+    static bool requiresLayerForSVGIntrinsicReasons(const RenderLayerModelObject&);
 
     void repaintIncludingDescendants();
 

--- a/Source/WebCore/rendering/RenderLayerCompositor.cpp
+++ b/Source/WebCore/rendering/RenderLayerCompositor.cpp
@@ -1245,6 +1245,123 @@ bool RenderLayerCompositor::allowBackingStoreDetachingForFixedPosition(RenderLay
     return allowDetaching;
 }
 
+void RenderLayerCompositor::updateRepaintRectsAfterCompositingChange(RenderLayer& layer, bool wasComposited, BackingSharingState& backingSharingState)
+{
+    // Repaint rects (and the repaint container) are cached relative to the repaint container,
+    // so they must be recomputed when compositing status changes. Also called by the SVG sandwich
+    // after-recursion pass, which forces backing outside the normal post-traversal flow.
+
+    // Repaint in the old container before we recompute the repaint container.
+    if (!wasComposited && layer.repaintContainer() && layer.repaintContainer()->isComposited())
+        repaintOnCompositingChange(layer, layer.repaintContainer());
+
+    // Compute the new repaint container and repaint in it, unless newly compositing (a new
+    // compositing layer fully repaints anyway).
+    if (!layer.isComposited()) {
+        // Defer until backing sharing completes - repaint container computation needs all
+        // that state in place.
+        if (layerRepaintTargetsBackingSharingLayer(layer, backingSharingState))
+            backingSharingState.addLayerNeedingRepaint(layer);
+        else {
+            layer.compositingStatusChanged(LayoutUpToDate::Yes);
+            repaintOnCompositingChange(layer, layer.repaintContainer());
+        }
+    } else
+        layer.compositingStatusChanged(LayoutUpToDate::Yes);
+}
+
+void RenderLayerCompositor::promoteSandwichedSVGChildrenBeforeRecursion(RenderLayer& parent)
+{
+    ASSERT(parent.isSVGLayer());
+
+    auto& children = parent.childrenInDOMOrderForSVG();
+    if (children.size() < 2)
+        return;
+
+    // Prefix pass in DOM order. An "anchor" is a child that composites on its own (intrinsic,
+    // or a non-sandwich indirect reason from a prior cycle). Children carrying our own
+    // SVGSiblingOrderingForLBSE mark are excluded so a promoted child can't anchor itself.
+    // After an anchor, every later composable non-anchor child must be promoted so it doesn't
+    // paint below the anchor and lose DOM order. Stale marks before the first anchor (or on
+    // every child when there is no anchor) are cleared - this de-promotion is why we can't
+    // early-return on "no anchor".
+    bool sawAnchor = false;
+    for (auto& child : children) {
+        CheckedPtr layer = child.layer.get();
+        if (!layer)
+            continue;
+
+        bool canComposite = canBeComposited(*layer);
+        bool hasOurMark = layer->indirectCompositingReason() == IndirectCompositingReason::SVGSiblingOrderingForLBSE;
+
+        bool isAnchor = false;
+        if (canComposite) {
+            // The mark survives a self-recompute, so a marked child may also have gained an
+            // independent (direct/intrinsic) reason, making it a genuine anchor. Neutralize
+            // the mark while querying so the answer ignores the sandwich, then restore it so
+            // the marking logic below sees the original state.
+            if (hasOurMark)
+                layer->setIndirectCompositingReason(IndirectCompositingReason::None);
+            RequiresCompositingData queryData;
+            isAnchor = needsToBeComposited(*layer, queryData);
+            if (hasOurMark)
+                layer->setIndirectCompositingReason(IndirectCompositingReason::SVGSiblingOrderingForLBSE);
+        }
+
+        bool shouldBeMarked = sawAnchor && canComposite && !isAnchor;
+        if (shouldBeMarked != hasOurMark) {
+            layer->setIndirectCompositingReason(shouldBeMarked
+                ? IndirectCompositingReason::SVGSiblingOrderingForLBSE
+                : IndirectCompositingReason::None);
+            // Sets HasDescendantNeedingRequirementsTraversal up the ancestor chain, keeping the
+            // parent off the traverseUnchangedSubtree early-return next cycle so this is observed.
+            layer->setNeedsPostLayoutCompositingUpdate();
+        }
+
+        sawAnchor = sawAnchor || isAnchor;
+    }
+}
+
+void RenderLayerCompositor::promoteSandwichedSVGChildrenAfterRecursion(RenderLayer& parent, CompositingState& currentState, BackingSharingState& backingSharingState)
+{
+    ASSERT(parent.isSVGLayer());
+
+    auto& children = parent.childrenInDOMOrderForSVG();
+    if (children.size() < 2)
+        return;
+
+    size_t firstComposited = children.size();
+    for (size_t i = 0; i < children.size(); ++i) {
+        CheckedPtr layer = children[i].layer.get();
+        if (layer && layer->isComposited()) {
+            firstComposited = i;
+            break;
+        }
+    }
+    if (firstComposited == children.size())
+        return;
+
+    for (size_t i = firstComposited + 1; i < children.size(); ++i) {
+        CheckedPtr layer = children[i].layer.get();
+        if (!layer || layer->isComposited() || !canBeComposited(*layer))
+            continue;
+        // The preceding sibling only became composited during recursion (e.g. GraphicalEffect
+        // from a composited descendant), so pre-recursion missed it. We are now past this
+        // child's own requirements visit, so a deferred mark would not take effect until a
+        // future cycle - materialize backing now so pass-2 plumbs it into the GraphicsLayer
+        // hierarchy this update. The overlap map is not touched, SVG siblings composite by DOM
+        // order within the parent's stacking context, not via overlap-driven backing sharing.
+        layer->setIndirectCompositingReason(IndirectCompositingReason::SVGSiblingOrderingForLBSE);
+        RequiresCompositingData queryData;
+        // The loop guard guarantees this child was not composited, so it composites now.
+        // Recompute repaint rects here - computeCompositingRequirements' own post-traversal
+        // path already ran for this child during recursion.
+        if (updateBacking(*layer, queryData, &backingSharingState, BackingRequired::Yes))
+            updateRepaintRectsAfterCompositingChange(*layer, false /* wasComposited */, backingSharingState);
+        currentState.subtreeIsCompositing = true;
+    }
+}
+
 void RenderLayerCompositor::computeCompositingRequirements(RenderLayer* ancestorLayer, RenderLayer& layer, LayerOverlapMap& overlapMap, CompositingState& compositingState, BackingSharingState& backingSharingState)
 {
 #if !LOG_DISABLED
@@ -1278,7 +1395,10 @@ void RenderLayerCompositor::computeCompositingRequirements(RenderLayer* ancestor
     IndirectCompositingReason compositingReason = compositingState.subtreeIsCompositing ? IndirectCompositingReason::Stacking : IndirectCompositingReason::None;
 
     if (layer.needsPostLayoutCompositingUpdate() || compositingState.fullPaintOrderTraversalRequired || compositingState.descendantsRequireCompositingUpdate) {
-        layer.setIndirectCompositingReason(IndirectCompositingReason::None);
+        // SVGSiblingOrderingForLBSE is set by the parent's sandwich-promotion pass, not derived
+        // from this layer's own state, so it must survive a self-recompute.
+        if (layer.indirectCompositingReason() != IndirectCompositingReason::SVGSiblingOrderingForLBSE)
+            layer.setIndirectCompositingReason(IndirectCompositingReason::None);
         willBeComposited = needsToBeComposited(layer, queryData);
     }
 
@@ -1406,6 +1526,9 @@ void RenderLayerCompositor::computeCompositingRequirements(RenderLayer* ancestor
     bool descendantsAddedToOverlap = currentState.hasNonRootCompositedAncestor();
 
     if (!canSkipComputeCompositingRequirementsForSubtree(layer, willBeComposited)) {
+        if (layer.isSVGLayer())
+            promoteSandwichedSVGChildrenBeforeRecursion(layer);
+
         if (layer.hasNegativeZOrderLayers()) {
             // Speculatively push this layer onto the overlap map.
             bool didSpeculativelyPushOverlapContainer = false;
@@ -1442,6 +1565,9 @@ void RenderLayerCompositor::computeCompositingRequirements(RenderLayer* ancestor
 
         for (CheckedPtr childLayer : layer.positiveZOrderLayers())
             computeCompositingRequirements(&layer, *childLayer, overlapMap, currentState, backingSharingState);
+
+        if (layer.isSVGLayer())
+            promoteSandwichedSVGChildrenAfterRecursion(layer, currentState, backingSharingState);
 
         // Set the flag to say that this layer has compositing children.
         layer.setHasCompositingDescendant(currentState.subtreeIsCompositing);
@@ -1527,26 +1653,8 @@ void RenderLayerCompositor::computeCompositingRequirements(RenderLayer* ancestor
 
     // Update the cached repaint rects now that we've finished updating backing
     // sharing state on descendants
-    if (needsCompositingStatusUpdate) {
-        // Repaint in the old container before we recompute the repaint container.
-        if (!wasComposited && layer.repaintContainer() && layer.repaintContainer()->isComposited())
-            repaintOnCompositingChange(layer, layer.repaintContainer());
-
-        // Compute the new repaint container, and repaint our bounds in it (unless
-        // this layer is newly compositing, in which case the layer will fully repaint already).
-        if (!layer.isComposited()) {
-            // If this layer is going to participate in backing sharing, defer until that's
-            // complete, since repaint container computation depends on all the state being
-            // in-place.
-            if (layerRepaintTargetsBackingSharingLayer(layer, backingSharingState))
-                backingSharingState.addLayerNeedingRepaint(layer);
-            else {
-                layer.compositingStatusChanged(LayoutUpToDate::Yes);
-                repaintOnCompositingChange(layer, layer.repaintContainer());
-            }
-        } else
-            layer.compositingStatusChanged(LayoutUpToDate::Yes);
-    }
+    if (needsCompositingStatusUpdate)
+        updateRepaintRectsAfterCompositingChange(layer, wasComposited, backingSharingState);
 
     layer.setBackingProviderLayerAtEndOfCompositingUpdate(providedBackingLayer.get());
 
@@ -3386,7 +3494,8 @@ bool RenderLayerCompositor::requiresOwnBackingStore(const RenderLayer& layer, co
             || reason == IndirectCompositingReason::Stacking
             || reason == IndirectCompositingReason::BackgroundLayer
             || reason == IndirectCompositingReason::GraphicalEffect
-            || reason == IndirectCompositingReason::Preserve3D; // preserve-3d has to create backing store to ensure that 3d-transformed elements intersect.
+            || reason == IndirectCompositingReason::Preserve3D // preserve-3d has to create backing store to ensure that 3d-transformed elements intersect.
+            || reason == IndirectCompositingReason::SVGSiblingOrderingForLBSE;
     }
 
     return false;
@@ -3494,6 +3603,9 @@ OptionSet<CompositingReason> RenderLayerCompositor::reasonsForCompositing(const 
         break;
     case IndirectCompositingReason::Preserve3D:
         reasons.add(CompositingReason::Preserve3D);
+        break;
+    case IndirectCompositingReason::SVGSiblingOrderingForLBSE:
+        reasons.add(CompositingReason::Stacking);
         break;
     }
 

--- a/Source/WebCore/rendering/RenderLayerCompositor.h
+++ b/Source/WebCore/rendering/RenderLayerCompositor.h
@@ -556,6 +556,16 @@ private:
     bool NODELETE requiresCompositingForAnchorPositioning(const RenderLayer&) const;
     IndirectCompositingReason computeIndirectCompositingReason(const RenderLayer&, bool hasCompositedDescendants, bool has3DTransformedDescendants, bool paintsIntoProvidedBacking) const;
 
+    // LBSE: a non-composited SVG layer child trailing a composited sibling in DOM order must
+    // itself composite to preserve DOM-order paint. The pre-recursion pass marks children
+    // behind an anchor that composites for an intrinsic or prior-cycle indirect reason, the
+    // post-recursion pass catches anchors that only became composited via derived reasons
+    // during recursion.
+    void promoteSandwichedSVGChildrenBeforeRecursion(RenderLayer& parent);
+    void promoteSandwichedSVGChildrenAfterRecursion(RenderLayer& parent, CompositingState&, BackingSharingState&);
+
+    void updateRepaintRectsAfterCompositingChange(RenderLayer&, bool wasComposited, BackingSharingState&);
+
     static ScrollPositioningBehavior layerScrollBehahaviorRelativeToCompositedAncestor(const RenderLayer&, const RenderLayer& compositedAncestor);
 
     static bool styleChangeMayAffectIndirectCompositingReasons(const Style::ComputedStyle& oldStyle, const Style::ComputedStyle& newStyle);

--- a/Source/WebCore/rendering/RenderLayerModelObject.cpp
+++ b/Source/WebCore/rendering/RenderLayerModelObject.cpp
@@ -117,6 +117,35 @@ void RenderLayerModelObject::createLayer()
     m_layer->insertOnlyThisLayer();
 }
 
+bool RenderLayerModelObject::createLayerIfAllowed()
+{
+    if (m_layer || !layerCreationAllowedForSubtree())
+        return false;
+    createLayer();
+    if (parent() && !needsLayout())
+        m_layer->setRepaintStatus(RepaintStatus::NeedsFullRepaint);
+    return true;
+}
+
+void RenderLayerModelObject::removeOnlyThisLayerWithRepaint()
+{
+    ASSERT(m_layer && m_layer->parent());
+    // Repaint the about-to-be-destroyed self-painting layer when a repaint is pending.
+    if (m_layer->isSelfPaintingLayer() && m_layer->repaintStatus() == RepaintStatus::NeedsFullRepaint && m_layer->cachedClippedOverflowRect())
+        repaintUsingContainer(containerForRepaint().renderer.get(), *m_layer->cachedClippedOverflowRect());
+    m_layer->removeOnlyThisLayer();
+}
+
+void RenderLayerModelObject::reconcileLayerCreation()
+{
+    if (requiresLayer()) {
+        createLayerIfAllowed();
+        return;
+    }
+    if (m_layer && m_layer->parent())
+        removeOnlyThisLayerWithRepaint();
+}
+
 bool RenderLayerModelObject::hasSelfPaintingLayer() const
 {
     return m_layer && m_layer->isSelfPaintingLayer();
@@ -158,13 +187,10 @@ void RenderLayerModelObject::styleDidChange(Style::Difference diff, const Style:
 
     bool gainedOrLostLayer = false;
     if (requiresLayer()) {
-        if (!layer() && layerCreationAllowedForSubtree()) {
+        if (createLayerIfAllowed()) {
             gainedOrLostLayer = true;
             if (s_wasFloating && isFloating())
                 setChildNeedsLayout();
-            createLayer();
-            if (parent() && !needsLayout())
-                layer()->setRepaintStatus(RepaintStatus::NeedsFullRepaint);
         }
     } else if (layer() && layer()->parent()) {
         gainedOrLostLayer = true;
@@ -174,11 +200,7 @@ void RenderLayerModelObject::styleDidChange(Style::Difference diff, const Style:
         setHasSVGTransform(false); // Same reason as for setHasTransformRelatedProperty().
         setHasReflection(false);
 
-        // Repaint the about to be destroyed self-painting layer when style change also triggers repaint.
-        if (layer()->isSelfPaintingLayer() && layer()->repaintStatus() == RepaintStatus::NeedsFullRepaint && layer()->cachedClippedOverflowRect())
-            repaintUsingContainer(containerForRepaint().renderer.get(), *(layer()->cachedClippedOverflowRect()));
-
-        layer()->removeOnlyThisLayer(); // calls destroyLayer() which clears m_layer
+        removeOnlyThisLayerWithRepaint();
         if (s_wasFloating && isFloating())
             setChildNeedsLayout();
         if (s_wasTransformed)

--- a/Source/WebCore/rendering/RenderLayerModelObject.h
+++ b/Source/WebCore/rendering/RenderLayerModelObject.h
@@ -53,6 +53,11 @@ public:
 
     void destroyLayer();
 
+    // Create or destroy the layer per requiresLayer(), outside the styleDidChange path. Driven by
+    // RenderLayer::reconcileSVGSandwichLayersForChildren when a sibling layer flip changes whether
+    // this SVG renderer is sandwiched.
+    void reconcileLayerCreation();
+
     bool NODELETE hasSelfPaintingLayer() const;
     RenderLayer* layer() const LIFETIME_BOUND { return m_layer.get(); }
 
@@ -161,6 +166,9 @@ protected:
     virtual void updateFromStyle() { }
 
 private:
+    bool createLayerIfAllowed();
+    void removeOnlyThisLayerWithRepaint();
+
     RenderSVGResourceMarker* svgMarkerResourceFromStyle(const Style::SVGMarkerResource&) const;
 
     UniquelyOwnedPtr<RenderLayer> m_layer;

--- a/Source/WebCore/rendering/RenderLayerSVGAdditions.cpp
+++ b/Source/WebCore/rendering/RenderLayerSVGAdditions.cpp
@@ -27,6 +27,7 @@
 #include "RenderBoxInlines.h"
 #include "RenderDescendantIterator.h"
 #include "RenderElementInlines.h"
+#include "RenderIterator.h"
 #include "RenderLayerBacking.h"
 #include "RenderLayerFilters.h"
 #include "RenderLayerInlines.h"
@@ -184,6 +185,60 @@ bool RenderLayer::shouldSkipRepaintAfterLayoutForSVG() const
 
     // The SVG containers themselves never trigger repaints, only their contents are allowed to.
     return is<RenderSVGContainer>(renderer()) && !shouldPaintWithFilters();
+}
+
+bool RenderLayer::requiresLayerForSVGIntrinsicReasons(const RenderLayerModelObject& renderer)
+{
+    // Plain 2D transforms need no layer, paintRendererByApplyingTransformForSVG() handles them.
+    // 3D transforms require compositing, hence a layer, as do grouping effects, z-index, etc.
+    return renderer.createsGroup()
+        || renderer.style().transform().has3DOperation()
+        || renderer.style().translate().is3DOperation()
+        || renderer.style().scale().is3DOperation()
+        || renderer.style().rotate().is3DOperation()
+        || renderer.style().transformStyle3D() == TransformStyle3D::Preserve3D
+        || !renderer.style().perspective().isNone()
+        || renderer.hasHiddenBackface()
+        || renderer.hasReflection()
+        || !renderer.style().specifiedZIndex().isAuto()
+        || renderer.style().isolation() != Isolation::Auto;
+}
+
+void RenderLayer::reconcileSVGSandwichLayersForChildren(RenderElement& parent)
+{
+    // A child trailing a layered sibling must take a layer too, else it paints below composited
+    // siblings and loses DOM order. Boundaries are RenderSVGForeignObject and intrinsically-layered
+    // RenderSVGModelObject / RenderSVGText, queried via requiresLayerForSVGIntrinsicReasons (not
+    // requiresLayer, to avoid recursion).
+    bool sawBoundary = false;
+    auto reconcileChild = [&](auto& renderer) {
+        bool intrinsic = requiresLayerForSVGIntrinsicReasons(renderer);
+        bool wasLayered = renderer.hasLayer();
+        // An intrinsically-layered child already paints in DOM order. Marking it sandwiched
+        // would add a redundant SVGSiblingOrderingForLBSE reason.
+        renderer.setIsSandwichedBetweenLayeredSiblings(sawBoundary && !intrinsic);
+        renderer.reconcileLayerCreation();
+        // Mid-life layer creation skips styleDidChange, so init transform and visible content.
+        if (!wasLayered && renderer.hasLayer()) {
+            if (CheckedPtr ownLayer = renderer.layer()) {
+                ownLayer->updateTransform();
+                ownLayer->setHasVisibleContent();
+            }
+        }
+        if (intrinsic)
+            sawBoundary = true;
+    };
+
+    for (CheckedRef child : childrenOfType<RenderElement>(parent)) {
+        if (is<RenderSVGForeignObject>(child.get())) {
+            sawBoundary = true;
+            continue;
+        }
+        if (CheckedPtr model = dynamicDowncast<RenderSVGModelObject>(child.get()))
+            reconcileChild(*model);
+        else if (CheckedPtr text = dynamicDowncast<RenderSVGText>(child.get()))
+            reconcileChild(*text);
+    }
 }
 
 bool RenderLayer::shouldSkipHitTestForSVG() const

--- a/Source/WebCore/rendering/RenderView.cpp
+++ b/Source/WebCore/rendering/RenderView.cpp
@@ -1203,6 +1203,22 @@ SingleThreadWeakHashSet<RenderCounter> RenderView::takeCountersNeedingUpdate()
     return std::exchange(m_countersNeedingUpdate, { });
 }
 
+void RenderView::scheduleSVGSandwichLayerReconcile(RenderElement& parent)
+{
+    m_svgSandwichReconcileParents.add(parent);
+}
+
+void RenderView::flushSVGSandwichLayerReconciles()
+{
+    // Loop until empty: a parent re-registered mid-reconcile (unlikely, but cheap to handle)
+    // still gets processed before we return to layout.
+    while (!m_svgSandwichReconcileParents.isEmptyIgnoringNullReferences()) {
+        auto parents = std::exchange(m_svgSandwichReconcileParents, { });
+        for (CheckedRef parent : parents)
+            RenderLayer::reconcileSVGSandwichLayersForChildren(parent);
+    }
+}
+
 SingleThreadWeakPtr<RenderBlockFlow> RenderView::viewTransitionContainingBlock() const
 {
     return m_viewTransitionContainingBlock;

--- a/Source/WebCore/rendering/RenderView.h
+++ b/Source/WebCore/rendering/RenderView.h
@@ -172,6 +172,13 @@ public:
     void addCounterNeedingUpdate(RenderCounter&);
     SingleThreadWeakHashSet<RenderCounter> takeCountersNeedingUpdate();
 
+    // LBSE: coalesced reconcile of SVG sandwich layers among a container's direct children.
+    // Mutations register the parent, one O(n) prefix pass per parent is flushed at the end of the
+    // render-tree update (RenderLayer::reconcileSVGSandwichLayersForChildren), keeping bulk
+    // construction O(n) not O(n^2).
+    void scheduleSVGSandwichLayerReconcile(RenderElement& parent);
+    void flushSVGSandwichLayerReconciles();
+
     void incrementRendersWithOutline() { ++m_renderersWithOutlineCount; }
     void decrementRendersWithOutline() { ASSERT(m_renderersWithOutlineCount > 0); --m_renderersWithOutlineCount; }
     bool hasRenderersWithOutline() const { return m_renderersWithOutlineCount; }
@@ -303,6 +310,7 @@ private:
     SingleThreadWeakHashMap<RenderElement, Vector<WeakPtr<CachedImage>>> m_renderersWithPausedImageAnimation;
     WeakHashSet<SVGSVGElement, WeakPtrImplWithEventTargetData> m_SVGSVGElementsWithPausedImageAnimation;
     SingleThreadWeakHashSet<RenderElement> m_visibleInViewportRenderers;
+    SingleThreadWeakHashSet<RenderElement> m_svgSandwichReconcileParents;
 
     SingleThreadWeakHashSet<const RenderBox> m_boxesWithScrollSnapPositions;
     SingleThreadWeakHashSet<const RenderBox> m_containerQueryBoxes;

--- a/Source/WebCore/rendering/svg/RenderSVGForeignObject.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGForeignObject.cpp
@@ -31,6 +31,7 @@
 #include "RenderLayer.h"
 #include "RenderObject.h"
 #include "RenderSVGBlockInlines.h"
+#include "RenderSVGHiddenContainer.h"
 #include "RenderView.h"
 #include "SVGElementTypeHelpers.h"
 #include "SVGForeignObjectElement.h"
@@ -132,6 +133,28 @@ void RenderSVGForeignObject::updateFromStyle()
 void RenderSVGForeignObject::applyTransform(TransformationMatrix& transform, const Style::ComputedStyle& style, const FloatRect& boundingBox, OptionSet<Style::TransformResolverOption> options) const
 {
     applySVGTransform(transform, protect(foreignObjectElement()), style, boundingBox, std::nullopt, std::nullopt, options);
+}
+
+void RenderSVGForeignObject::insertedIntoTree()
+{
+    RenderSVGBlock::insertedIntoTree();
+
+    // Always a sandwich boundary (UA overflow:hidden forces a layer). Defer to the batched reconcile pass.
+    if (CheckedPtr parent = this->parent(); parent && !is<RenderSVGHiddenContainer>(*parent)) {
+        CheckedRef view = this->view();
+        view->scheduleSVGSandwichLayerReconcile(*parent);
+    }
+}
+
+void RenderSVGForeignObject::willBeRemovedFromTree()
+{
+    // Removing us can de-sandwich trailing siblings, reconcile after we detach.
+    if (CheckedPtr parent = this->parent(); parent && !is<RenderSVGHiddenContainer>(*parent)) {
+        CheckedRef view = this->view();
+        view->scheduleSVGSandwichLayerReconcile(*parent);
+    }
+
+    RenderSVGBlock::willBeRemovedFromTree();
 }
 
 }

--- a/Source/WebCore/rendering/svg/RenderSVGForeignObject.h
+++ b/Source/WebCore/rendering/svg/RenderSVGForeignObject.h
@@ -59,6 +59,9 @@ private:
     void updateLogicalWidth() override;
     LogicalExtentComputedValues computeLogicalHeight(LayoutUnit logicalHeight, LayoutUnit logicalTop) const override;
 
+    void insertedIntoTree() final;
+    void willBeRemovedFromTree() final;
+
     LayoutRect overflowClipRect(const LayoutPoint& location, OverlayScrollbarSizeRelevancy = OverlayScrollbarSizeRelevancy::IgnoreOverlayScrollbarSize, PaintPhase = PaintPhase::BlockBackground) const final;
 
     void updateFromStyle() final;

--- a/Source/WebCore/rendering/svg/RenderSVGModelObject.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGModelObject.cpp
@@ -34,10 +34,13 @@
 
 #include "RenderElementInlines.h"
 #include "RenderGeometryMap.h"
+#include "RenderIterator.h"
 #include "RenderLayer.h"
 #include "RenderLayerInlines.h"
 #include "RenderLayerModelObject.h"
 #include "RenderObjectInlines.h"
+#include "RenderSVGForeignObject.h"
+#include "RenderSVGHiddenContainer.h"
 #include "RenderSVGModelObjectInlines.h"
 #include "RenderView.h"
 #include "SVGElementInlines.h"
@@ -46,6 +49,7 @@
 #include "SVGNames.h"
 #include "SVGPathData.h"
 #include "SVGUseElement.h"
+#include "StyleComputedStyle+GettersInlines.h"
 #include "StyleTransformResolver.h"
 #include "TransformState.h"
 #include <wtf/TZoneMallocInlines.h>
@@ -74,6 +78,11 @@ void RenderSVGModelObject::updateFromStyle()
 {
     RenderLayerModelObject::updateFromStyle();
     updateHasSVGTransformFlags();
+}
+
+bool RenderSVGModelObject::requiresLayerForIntrinsicReasons() const
+{
+    return RenderLayer::requiresLayerForSVGIntrinsicReasons(*this);
 }
 
 void RenderSVGModelObject::updateLocalTransform()
@@ -151,9 +160,39 @@ void RenderSVGModelObject::absoluteQuads(Vector<FloatQuad>& quads, bool* wasFixe
     quads.append(localToAbsoluteQuad(FloatRect { { }, m_layoutRect.size() }, MapCoordinatesMode::UseTransforms, wasFixed));
 }
 
+void RenderSVGModelObject::insertedIntoTree()
+{
+    RenderLayerModelObject::insertedIntoTree();
+
+    // Insertion can change our own or trailing siblings' sandwich state. Defer to the batched
+    // reconcile pass. Skip hidden containers (defs, clipPath, ...), they never paint.
+    if (CheckedPtr parent = this->parent(); parent && !is<RenderSVGHiddenContainer>(*parent)) {
+        CheckedRef view = this->view();
+        view->scheduleSVGSandwichLayerReconcile(*parent);
+    }
+}
+
+void RenderSVGModelObject::willBeRemovedFromTree()
+{
+    // Removing us can de-sandwich trailing siblings, reconcile after we detach.
+    if (CheckedPtr parent = this->parent(); parent && !is<RenderSVGHiddenContainer>(*parent)) {
+        CheckedRef view = this->view();
+        view->scheduleSVGSandwichLayerReconcile(*parent);
+    }
+
+    RenderLayerModelObject::willBeRemovedFromTree();
+}
+
 void RenderSVGModelObject::styleDidChange(Style::Difference diff, const Style::ComputedStyle* oldStyle)
 {
     RenderLayerModelObject::styleDidChange(diff, oldStyle);
+
+    // A style change can flip our boundary state (requiresLayerForSVGIntrinsicReasons) or our own
+    // layer, affecting trailing siblings. Defer to the batched reconcile pass.
+    if (CheckedPtr parent = this->parent(); parent && !is<RenderSVGHiddenContainer>(*parent)) {
+        CheckedRef view = this->view();
+        view->scheduleSVGSandwichLayerReconcile(*parent);
+    }
 
     // Invalidate cached visual overflow rect when relevant styles change.
     if (oldStyle && diff >= Style::DifferenceResult::Repaint) {

--- a/Source/WebCore/rendering/svg/RenderSVGModelObject.h
+++ b/Source/WebCore/rendering/svg/RenderSVGModelObject.h
@@ -52,8 +52,13 @@ public:
     virtual ~RenderSVGModelObject();
 
     bool requiresLayer() const override { return true; }
+    bool requiresLayerForIntrinsicReasons() const;
+
+    void setIsSandwichedBetweenLayeredSiblings(bool flag) { m_isSandwichedBetweenLayeredSiblings = flag; }
 
     void styleDidChange(Style::Difference, const Style::ComputedStyle* oldStyle) override;
+    void insertedIntoTree() override;
+    void willBeRemovedFromTree() override;
 
     static bool checkIntersection(RenderElement*, const FloatRect&);
     static bool checkEnclosure(RenderElement*, const FloatRect&);
@@ -130,6 +135,9 @@ private:
 
     LayoutRect m_layoutRect;
     std::optional<AffineTransform> m_localTransform;
+    // FIXME (webkit.org/b/308565): maintained here now, but only read once layer creation becomes
+    // conditional and requiresLayer() returns it. Drop [[maybe_unused]] when that lands.
+    [[maybe_unused]] bool m_isSandwichedBetweenLayeredSiblings { false };
 };
 
 } // namespace WebCore

--- a/Source/WebCore/rendering/svg/RenderSVGText.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGText.cpp
@@ -46,12 +46,15 @@
 #include "RenderBoxInlines.h"
 #include "RenderElementStyleInlines.h"
 #include "RenderIterator.h"
+#include "RenderLayer.h"
 #include "RenderObjectInlines.h"
 #include "RenderSVGBlockInlines.h"
+#include "RenderSVGHiddenContainer.h"
 #include "RenderSVGInline.h"
 #include "RenderSVGInlineText.h"
 #include "RenderSVGRoot.h"
 #include "RenderSVGTextPath.h"
+#include "RenderView.h"
 #include "SVGElementTypeHelpers.h"
 #include "SVGInlineFlowBox.h"
 #include "SVGInlineTextBox.h"
@@ -229,6 +232,33 @@ void RenderSVGText::willBeDestroyed()
     m_layoutAttributesBuilder.clearTextPositioningElements();
 
     RenderSVGBlock::willBeDestroyed();
+}
+
+void RenderSVGText::insertedIntoTree()
+{
+    RenderSVGBlock::insertedIntoTree();
+
+    if (!document().settings().layerBasedSVGEngineEnabled())
+        return;
+
+    // Conditionally layered like RenderSVGModelObject, so defer to the batched reconcile pass.
+    if (CheckedPtr parent = this->parent(); parent && !is<RenderSVGHiddenContainer>(*parent)) {
+        CheckedRef view = this->view();
+        view->scheduleSVGSandwichLayerReconcile(*parent);
+    }
+}
+
+void RenderSVGText::willBeRemovedFromTree()
+{
+    // Removing us can de-sandwich trailing siblings, reconcile after we detach.
+    if (document().settings().layerBasedSVGEngineEnabled()) {
+        if (CheckedPtr parent = this->parent(); parent && !is<RenderSVGHiddenContainer>(*parent)) {
+            CheckedRef view = this->view();
+            view->scheduleSVGSandwichLayerReconcile(*parent);
+        }
+    }
+
+    RenderSVGBlock::willBeRemovedFromTree();
 }
 
 void RenderSVGText::subtreeChildWillBeRemoved(RenderObject* child, Vector<SVGTextLayoutAttributes*, 2>& affectedAttributes)
@@ -1028,6 +1058,14 @@ void RenderSVGText::styleDidChange(Style::Difference diff, const Style::Computed
         setNeedsTransformUpdate();
 
     RenderSVGBlock::styleDidChange(diff, oldStyle);
+
+    // A style change can flip our boundary state or our own layer, affecting trailing siblings.
+    if (document().settings().layerBasedSVGEngineEnabled()) {
+        if (CheckedPtr parent = this->parent(); parent && !is<RenderSVGHiddenContainer>(*parent)) {
+            CheckedRef view = this->view();
+            view->scheduleSVGSandwichLayerReconcile(*parent);
+        }
+    }
 }
 
 SVGRootInlineBox* RenderSVGText::legacyRootBox() const

--- a/Source/WebCore/rendering/svg/RenderSVGText.h
+++ b/Source/WebCore/rendering/svg/RenderSVGText.h
@@ -86,6 +86,8 @@ public:
 
     SVGRootInlineBox* legacyRootBox() const;
 
+    void setIsSandwichedBetweenLayeredSiblings(bool flag) { m_isSandwichedBetweenLayeredSiblings = flag; }
+
 private:
     void graphicsElement() const = delete;
 
@@ -102,6 +104,9 @@ private:
 
     bool requiresLayer() const override;
     void layout() override;
+
+    void insertedIntoTree() final;
+    void willBeRemovedFromTree() final;
 
     void computePerCharacterLayoutInformation();
     void layoutCharactersInTextBoxes(const InlineIterator::InlineBoxIterator&, SVGTextLayoutEngine&);
@@ -121,6 +126,9 @@ private:
 
     bool NODELETE shouldHandleSubtreeMutations() const;
 
+    // FIXME (webkit.org/b/308565): only read once layer creation becomes conditional and
+    // requiresLayer() returns it. Drop [[maybe_unused]] when that lands.
+    [[maybe_unused]] bool m_isSandwichedBetweenLayeredSiblings { false };
     bool m_needsReordering : 1 { false };
     bool m_needsPositioningValuesUpdate : 1 { false };
     bool m_needsTransformUpdate : 1 { true }; // FIXME: [LBSE] Only needed for legacy SVG engine.

--- a/Source/WebCore/rendering/updating/RenderTreeUpdater.cpp
+++ b/Source/WebCore/rendering/updating/RenderTreeUpdater.cpp
@@ -142,6 +142,10 @@ void RenderTreeUpdater::commit(std::unique_ptr<Style::Update> styleUpdate)
 
     m_builder.updateAfterDescendants(renderView());
 
+    // LBSE: flush coalesced SVG sandwich-layer reconciles before layout reads transforms and
+    // compositing reads layer pointers. Layer creation is legal in this phase, not in the layout walk.
+    renderView().flushSVGSandwichLayerReconciles();
+
     m_styleUpdate = nullptr;
 }
 


### PR DESCRIPTION
#### c6f142f9b2210f4ed95ae3f95e38a8e88da7f267
<pre>
Promote SVG layer children sandwiched between composited siblings to composited
<a href="https://bugs.webkit.org/show_bug.cgi?id=313785">https://bugs.webkit.org/show_bug.cgi?id=313785</a>

Reviewed by NOBODY (OOPS!).

Once LBSE makes RenderLayer creation conditional (bug 308565), an SVG container
can hold a mix of composited and non-composited children. Composited descendants
attach to the parent&apos;s GraphicsLayer in stacking-context order, and
negative-z-index ones split the parent into background/foreground layers. A
non-composited child sitting in DOM order between (or after) composited siblings
would then paint either below or above all of them, never in between, losing DOM
paint order.

The fix hinges on DOM order being preserved across two decisions taken at
different times:

  1. Layer creation, at style / render-tree-update time. requiresLayer() must
     already be true here, before any compositing decision exists.

  2. Compositing, in the later compositing-requirements pass, where the
     compositor decides a layer needs its own backing.

The compositor can only promote children that already own a RenderLayer. So
whenever an SVG renderer is intrinsically layered (a &quot;boundary&quot;), every
following sibling is pre-emptively given a layer, well before any of them is
known to be composited. When the boundary later becomes composited, those
siblings already have layers and can be promoted, restoring DOM order.

Decision 1, layer marking (style / render-tree-update time):

  * RenderLayer::requiresLayerForSVGIntrinsicReasons collects the
    sibling-independent conditions: createsGroup(), 3D transform operations,
    preserve-3d, perspective, hidden backface, reflection, explicit z-index,
    isolation. Plain 2D transforms are excluded, LBSE paints them via
    paintRendererByApplyingTransformForSVG() without a layer.

  * RenderLayer::reconcileSVGSandwichLayersForChildren is the marking pass. In
    one O(n) single-pass DOM-order scan over a parent&apos;s children it tracks
    whether a boundary was seen, sets each RenderSVGModelObject / RenderSVGText
    cached &quot;sandwiched&quot; flag, and calls reconcileLayerCreation() so
    requiresLayer() (which reads that flag) takes effect. RenderSVGForeignObject
    is always a boundary: its UA overflow:hidden already forces a layer, and it
    may host composited HTML descendants. It calls
    requiresLayerForSVGIntrinsicReasons, not requiresLayer, to avoid recursing
    into the cached flag.

  * RenderView::scheduleSVGSandwichLayerReconcile records the affected parent on
    any insert, remove or style mutation, and RenderTreeUpdater::commit flushes
    them once via flushSVGSandwichLayerReconciles. requiresLayer() then reads
    the cached flag in O(1), so bulk construction stays O(n) rather than O(n^2).
    The mutation hooks are
    RenderSVG{ModelObject,Text,ForeignObject}::insertedIntoTree and
    willBeRemovedFromTree, and RenderSVG{ModelObject,Text}::styleDidChange.
    Mutations inside a RenderSVGHiddenContainer (defs, ...) are skipped, those
    subtrees never paint.

  * RenderLayerModelObject::reconcileLayerCreation creates or destroys a layer
    outside the styleDidChange path, when the marking pass flips the
    requiresLayer() answer mid-life. Its create/destroy cores are shared with
    styleDidChange() via the createLayerIfAllowed() and
    removeOnlyThisLayerWithRepaint() helpers.

Decision 2, compositing promotion (compositing-requirements pass), two passes
inside computeCompositingRequirements, both gated on RenderLayer::isSVGLayer():

  1. promoteSandwichedSVGChildrenBeforeRecursion runs before descending, as a
     single-pass DOM-order scan over the children. It finds &quot;anchors&quot;, children
     that needsToBeComposited() for an intrinsic reason (or a non-sandwich
     indirect reason from a prior cycle), excluding children already carrying
     our own SVGSiblingOrderingForLBSE mark so a promoted child cannot anchor a
     window around itself. Past the first anchor, every later canBeComposited()
     child gets IndirectCompositingReason::SVGSiblingOrderingForLBSE. Children
     before the first anchor, and all children when there is no anchor, have any
     leftover mark cleared. That clear must run even with no anchor, it is what
     de-promotes a child once its last anchor stops compositing. Each flipped
     layer also gets setNeedsPostLayoutCompositingUpdate().

  2. promoteSandwichedSVGChildrenAfterRecursion runs after recursion, catching a
     sibling that only became composited via a derived reason during recursion
     (e.g. GraphicalEffect from a composited descendant). For each later
     non-composited canBeComposited child it sets SVGSiblingOrderingForLBSE and
     calls updateBacking, sharing the repaint-rect recompute with the normal
     path via updateRepaintRectsAfterCompositingChange().

The mark survives a self-recompute: when computeCompositingRequirements would
otherwise reset indirectCompositingReason to None, it preserves
SVGSiblingOrderingForLBSE, because the tag is set externally by the parent&apos;s
promotion pass and is not derivable from the child&apos;s own state. It feeds
requiresOwnBackingStore() and reasonsForCompositing() (mapped to the existing
CompositingReason::Stacking bucket).

New tests pass in current LBSE and in the conditional-layer variant.
de-promotion-after-derived-anchor-decomposited-layer-tree.html guards the
before-recursion clear: a child promoted by the after-recursion pass for a
derived-reason anchor must de-promote once that anchor stops compositing, which
the early-return-on-no-anchor version got wrong.

* LayoutTests/platform/ios/svg/compositing/de-promotion-after-anchor-removed-layer-tree-expected.txt: Added.
* LayoutTests/platform/mac-wk2/TestExpectations:
* LayoutTests/platform/mac/svg/compositing/de-promotion-after-derived-anchor-decomposited-layer-tree-expected.txt: Added.
* LayoutTests/svg/compositing/de-promotion-after-anchor-element-removed-layer-tree-expected.txt: Added.
* LayoutTests/svg/compositing/de-promotion-after-anchor-element-removed-layer-tree.html: Added.
* LayoutTests/svg/compositing/de-promotion-after-anchor-removed-expected.html: Added.
* LayoutTests/svg/compositing/de-promotion-after-anchor-removed-layer-tree-expected.txt: Added.
* LayoutTests/svg/compositing/de-promotion-after-anchor-removed-layer-tree.html: Added.
* LayoutTests/svg/compositing/de-promotion-after-anchor-removed.html: Added.
* LayoutTests/svg/compositing/de-promotion-after-derived-anchor-decomposited-layer-tree-expected.txt: Added.
* LayoutTests/svg/compositing/de-promotion-after-derived-anchor-decomposited-layer-tree.html: Added.
* LayoutTests/svg/compositing/de-promotion-after-reparenting-layer-tree-expected.txt: Added.
* LayoutTests/svg/compositing/de-promotion-after-reparenting-layer-tree.html: Added.
* LayoutTests/svg/compositing/multiple-sandwiched-children-between-composited-siblings-expected.html: Added.
* LayoutTests/svg/compositing/multiple-sandwiched-children-between-composited-siblings-layer-tree-expected.txt: Added.
* LayoutTests/svg/compositing/multiple-sandwiched-children-between-composited-siblings-layer-tree.html: Added.
* LayoutTests/svg/compositing/multiple-sandwiched-children-between-composited-siblings.html: Added.
* LayoutTests/svg/compositing/multiple-sandwiched-with-mixed-anchor-types-expected.html: Added.
* LayoutTests/svg/compositing/multiple-sandwiched-with-mixed-anchor-types-layer-tree-expected.txt: Added.
* LayoutTests/svg/compositing/multiple-sandwiched-with-mixed-anchor-types-layer-tree.html: Added.
* LayoutTests/svg/compositing/multiple-sandwiched-with-mixed-anchor-types.html: Added.
* LayoutTests/svg/compositing/nested-sandwich-at-multiple-depths-expected.html: Added.
* LayoutTests/svg/compositing/nested-sandwich-at-multiple-depths-layer-tree-expected.txt: Added.
* LayoutTests/svg/compositing/nested-sandwich-at-multiple-depths-layer-tree.html: Added.
* LayoutTests/svg/compositing/nested-sandwich-at-multiple-depths.html: Added.
* LayoutTests/svg/compositing/non-composited-child-after-last-composited-sibling-expected.html: Added.
* LayoutTests/svg/compositing/non-composited-child-after-last-composited-sibling-layer-tree-expected.txt: Added.
* LayoutTests/svg/compositing/non-composited-child-after-last-composited-sibling-layer-tree.html: Added.
* LayoutTests/svg/compositing/non-composited-child-after-last-composited-sibling.html: Added.
* LayoutTests/svg/compositing/promotion-after-anchor-element-inserted-layer-tree-expected.txt: Added.
* LayoutTests/svg/compositing/promotion-after-anchor-element-inserted-layer-tree.html: Added.
* LayoutTests/svg/compositing/sandwiched-between-derived-composited-anchors-expected.html: Added.
* LayoutTests/svg/compositing/sandwiched-between-derived-composited-anchors-layer-tree-expected.txt: Added.
* LayoutTests/svg/compositing/sandwiched-between-derived-composited-anchors-layer-tree.html: Added.
* LayoutTests/svg/compositing/sandwiched-between-derived-composited-anchors.html: Added.
* LayoutTests/svg/compositing/sandwiched-g-container-between-composited-siblings-expected.html: Added.
* LayoutTests/svg/compositing/sandwiched-g-container-between-composited-siblings-layer-tree-expected.txt: Added.
* LayoutTests/svg/compositing/sandwiched-g-container-between-composited-siblings-layer-tree.html: Added.
* LayoutTests/svg/compositing/sandwiched-g-container-between-composited-siblings.html: Added.
* LayoutTests/svg/compositing/sandwiched-g-with-multiple-children-between-composited-siblings-expected.html: Added.
* LayoutTests/svg/compositing/sandwiched-g-with-multiple-children-between-composited-siblings-layer-tree-expected.txt: Added.
* LayoutTests/svg/compositing/sandwiched-g-with-multiple-children-between-composited-siblings-layer-tree.html: Added.
* LayoutTests/svg/compositing/sandwiched-g-with-multiple-children-between-composited-siblings.html: Added.
* LayoutTests/svg/compositing/sandwiched-non-composited-child-between-composited-siblings-expected.html: Added.
* LayoutTests/svg/compositing/sandwiched-non-composited-child-between-composited-siblings-layer-tree-expected.txt: Added.
* LayoutTests/svg/compositing/sandwiched-non-composited-child-between-composited-siblings-layer-tree.html: Added.
* LayoutTests/svg/compositing/sandwiched-non-composited-child-between-composited-siblings.html: Added.
* LayoutTests/svg/compositing/sandwiched-non-rect-shape-between-composited-siblings-expected.html: Added.
* LayoutTests/svg/compositing/sandwiched-non-rect-shape-between-composited-siblings-layer-tree-expected.txt: Added.
* LayoutTests/svg/compositing/sandwiched-non-rect-shape-between-composited-siblings-layer-tree.html: Added.
* LayoutTests/svg/compositing/sandwiched-non-rect-shape-between-composited-siblings.html: Added.
* LayoutTests/svg/compositing/sandwiched-rect-between-rect-anchors-expected.html: Added.
* LayoutTests/svg/compositing/sandwiched-rect-between-rect-anchors-layer-tree-expected.txt: Added.
* LayoutTests/svg/compositing/sandwiched-rect-between-rect-anchors-layer-tree.html: Added.
* LayoutTests/svg/compositing/sandwiched-rect-between-rect-anchors.html: Added.
* Source/WebCore/rendering/RenderLayer.cpp:
(WebCore::RenderLayer::calculateClipRects const):
* Source/WebCore/rendering/RenderLayer.h:
* Source/WebCore/rendering/RenderLayerCompositor.cpp:
(WebCore::RenderLayerCompositor::updateRepaintRectsAfterCompositingChange):
(WebCore::RenderLayerCompositor::promoteSandwichedSVGChildrenBeforeRecursion):
(WebCore::RenderLayerCompositor::promoteSandwichedSVGChildrenAfterRecursion):
(WebCore::RenderLayerCompositor::computeCompositingRequirements):
(WebCore::RenderLayerCompositor::requiresOwnBackingStore const):
(WebCore::RenderLayerCompositor::reasonsForCompositing const):
* Source/WebCore/rendering/RenderLayerCompositor.h:
* Source/WebCore/rendering/RenderLayerModelObject.cpp:
(WebCore::RenderLayerModelObject::createLayerIfAllowed):
(WebCore::RenderLayerModelObject::removeOnlyThisLayerWithRepaint):
(WebCore::RenderLayerModelObject::reconcileLayerCreation):
(WebCore::RenderLayerModelObject::styleDidChange):
* Source/WebCore/rendering/RenderLayerModelObject.h:
* Source/WebCore/rendering/RenderLayerSVGAdditions.cpp:
(WebCore::RenderLayer::requiresLayerForSVGIntrinsicReasons):
(WebCore::RenderLayer::reconcileSVGSandwichLayersForChildren):
* Source/WebCore/rendering/RenderView.cpp:
(WebCore::RenderView::scheduleSVGSandwichLayerReconcile):
(WebCore::RenderView::flushSVGSandwichLayerReconciles):
* Source/WebCore/rendering/RenderView.h:
* Source/WebCore/rendering/svg/RenderSVGForeignObject.cpp:
(WebCore::RenderSVGForeignObject::insertedIntoTree):
(WebCore::RenderSVGForeignObject::willBeRemovedFromTree):
* Source/WebCore/rendering/svg/RenderSVGForeignObject.h:
* Source/WebCore/rendering/svg/RenderSVGModelObject.cpp:
(WebCore::RenderSVGModelObject::requiresLayerForIntrinsicReasons const):
(WebCore::RenderSVGModelObject::insertedIntoTree):
(WebCore::RenderSVGModelObject::willBeRemovedFromTree):
(WebCore::RenderSVGModelObject::styleDidChange):
* Source/WebCore/rendering/svg/RenderSVGModelObject.h:
(WebCore::RenderSVGModelObject::setIsSandwichedBetweenLayeredSiblings):
* Source/WebCore/rendering/svg/RenderSVGText.cpp:
(WebCore::RenderSVGText::insertedIntoTree):
(WebCore::RenderSVGText::willBeRemovedFromTree):
(WebCore::RenderSVGText::styleDidChange):
* Source/WebCore/rendering/svg/RenderSVGText.h:
* Source/WebCore/rendering/updating/RenderTreeUpdater.cpp:
(WebCore::RenderTreeUpdater::commit):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c6f142f9b2210f4ed95ae3f95e38a8e88da7f267

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/167160 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/40655 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/34244 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/176210 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/124841 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/169026 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/41088 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/40666 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/130019 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/91581 "4 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/170119 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/32421 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/150198 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/110536 "Passed tests") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/31509 "Found 1 new test failure: imported/w3c/web-platform-tests/_venv3/lib/python3.9/site-packages/setuptools/command/launcher manifest.xml (failure)") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/30105 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/24947 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/141386 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/27887 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/178749 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/31649 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/29606 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/138400 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/40729 "Built successfully") | [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/34363 "Build is in progress. Recent messages:OS: Tahoe (26.5), Xcode: 26.5; Running apply-patch; Checked out pull request; Passed layout tests; 20 flakes 2 failures 1 missing results; Uploaded test results; 15 flakes 2 failures 1 missing results; Compiled WebKit (warnings); 2 failures; Found 1 new test failure: imported/w3c/web-platform-tests/_venv3/lib/python3.9/site-packages/setuptools/command/launcher manifest.xml (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/138295 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/41417 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/149685 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/104379 "Built successfully") | 
| | [❌ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/33651 "") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/26662 "Found 2 new test failures: imported/w3c/web-platform-tests/_venv3/lib/python3.9/site-packages/setuptools/command/launcher manifest.xml imported/w3c/web-platform-tests/web-locks/acquire.https.any.sharedworker.html (failure)") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/39921 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/113000 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/39318 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/4760 "") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/39568 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/39462 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->