### PR TITLE
[Site Isolation] Allow a page to be detached from and re-attached to the same BrowsingContextGroup

### DIFF
--- a/Source/WebKit/UIProcess/BrowsingContextGroup.cpp
+++ b/Source/WebKit/UIProcess/BrowsingContextGroup.cpp
@@ -123,7 +123,7 @@ RefPtr<FrameProcess> BrowsingContextGroup::processForSite(const Site& site)
 void BrowsingContextGroup::processDidTerminate(WebPageProxy& page, WebProcessProxy& process)
 {
     if (&page.siteIsolatedProcess() == &process)
-        m_pages.remove(page);
+        detachPage(page);
 }
 
 void BrowsingContextGroup::addFrameProcess(FrameProcess& process)
@@ -222,6 +222,16 @@ void BrowsingContextGroup::addPage(WebPageProxy& page)
 
         if (process->process().coreProcessIdentifier() == page.legacyMainFrameProcess().coreProcessIdentifier())
             return false;
+
+        // During BFCache restoration, the target BCG is the suspended page's original BCG,
+        // whose m_remotePages[page] entries were preserved by detachPage(). The existing
+        // RemotePageProxies already cover these (process, site) pairs — do not duplicate.
+        bool alreadyExists = std::ranges::any_of(set, [&](auto& existing) {
+            return existing->process().coreProcessIdentifier() == process->process().coreProcessIdentifier() && existing->site() == site;
+        });
+        if (alreadyExists)
+            return false;
+
         Ref processProxy = process->process();
         Ref newRemotePage = RemotePageProxy::create(page, processProxy, site);
         newRemotePage->injectPageIntoNewProcess();
@@ -245,8 +255,13 @@ void BrowsingContextGroup::addRemotePage(WebPageProxy& page, Ref<RemotePageProxy
 
 void BrowsingContextGroup::removePage(WebPageProxy& page)
 {
-    m_pages.remove(page);
+    detachPage(page);
     closeRemotePagesForPage(page);
+}
+
+void BrowsingContextGroup::detachPage(WebPageProxy& page)
+{
+    m_pages.remove(page);
 }
 
 void BrowsingContextGroup::closeRemotePagesForPage(WebPageProxy& page)

--- a/Source/WebKit/UIProcess/BrowsingContextGroup.h
+++ b/Source/WebKit/UIProcess/BrowsingContextGroup.h
@@ -74,6 +74,7 @@ public:
     void addPage(WebPageProxy&);
     void addRemotePage(WebPageProxy&, Ref<RemotePageProxy>&&);
     void removePage(WebPageProxy&);
+    void detachPage(WebPageProxy&);
     void closeRemotePagesForPage(WebPageProxy&);
     bool hasMultiplePages() const;
     void forEachRemotePage(const WebPageProxy&, Function<void(RemotePageProxy&)>&&);

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -1492,6 +1492,7 @@ bool WebPageProxy::suspendCurrentPageIfPossible(API::Navigation& navigation, Ref
     WEBPAGEPROXY_RELEASE_LOG(ProcessSwapping, "suspendCurrentPageIfPossible: Suspending current page for process pid %i", m_legacyMainFrameProcess->processID());
     mainFrame->frameLoadState().didSuspend();
 
+    protect(m_browsingContextGroup)->detachPage(*this);
     Ref suspendedPage = SuspendedPageProxy::create(*this, protect(legacyMainFrameProcess()), mainFrame.releaseNonNull(), std::exchange(m_browsingContextGroup, BrowsingContextGroup::create()), shouldDelayClosingUntilFirstLayerFlush);
     std::optional<BackForwardFrameItemIdentifier> mainFrameItemID;
     if (fromItem && protect(preferences())->multiProcessBackForwardCacheEnabled())


### PR DESCRIPTION
#### 71a7e8523d6ebe16b50c6139114fee6a24639218
<pre>
[Site Isolation] Allow a page to be detached from and re-attached to the same BrowsingContextGroup
<a href="https://bugs.webkit.org/show_bug.cgi?id=314127">https://bugs.webkit.org/show_bug.cgi?id=314127</a>
<a href="https://rdar.apple.com/176304864">rdar://176304864</a>

Reviewed by NOBODY (OOPS!).

When a page is suspended into BFCache under Site Isolation, the
BrowsingContextGroup (BCG) needs to survive the suspension so it can be
reused on restore. Today, suspending a page leaves it registered in the
old BCG&apos;s m_pages while simultaneously std::exchange&apos;ing the page&apos;s
m_browsingContextGroup to a fresh one -- inconsistent accounting. When
the page is later restored into its preserved BCG, addPage() cannot
distinguish that m_remotePages[page] already holds RemotePageProxies
from before suspension, and creates duplicates.

Introduce BrowsingContextGroup::detachPage(), which removes the page
from m_pages but preserves its m_remotePages entries. Call it from
WebPageProxy::suspendCurrentPageIfPossible so the BCG reflects the
detach. Make addPage() idempotent: when iterating m_processMap, skip
creating a RemotePageProxy for a (process, site) pair that
m_remotePages[page] already covers.

Without this fix, the debug ASSERT in BrowsingContextGroup::addPage
fires on BFCache restore with cross-site iframes, and release silently
leaks duplicate RemotePageProxies.

* Source/WebKit/UIProcess/BrowsingContextGroup.cpp:
(WebKit::BrowsingContextGroup::processDidTerminate):
(WebKit::BrowsingContextGroup::addPage):
(WebKit::BrowsingContextGroup::removePage):
(WebKit::BrowsingContextGroup::detachPage):
* Source/WebKit/UIProcess/BrowsingContextGroup.h:
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::suspendCurrentPageIfPossible):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/71a7e8523d6ebe16b50c6139114fee6a24639218

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/160877 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/34350 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/27451 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/169780 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/117028 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/175a5a9e-87ff-49f1-979c-2721236939b6) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/34451 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/34350 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/124779 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/117028 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/9729c7cc-0eb5-40d6-af9e-a03c4f9fbf54) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/163836 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/27049 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/144515 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/105376 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/3abd465c-3d4f-4296-8a4f-ba6f7b9bac3f) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/26101 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/24589 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/17500 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/135795 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/172263 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/19284 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/23918 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/133052 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/34024 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/28682 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/133062 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/34008 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/144072 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/95847 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/27656 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/20887 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/33519 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/100944 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/33018 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/33262 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/33167 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->