### PR TITLE
REGRESSION(310935@main?):[iOS] fast/scrolling/ios/iframe-scroll-into-view.html is a flaky failure with image diff

### DIFF
--- a/LayoutTests/fast/scrolling/ios/iframe-scroll-into-view.html
+++ b/LayoutTests/fast/scrolling/ios/iframe-scroll-into-view.html
@@ -12,23 +12,23 @@ iframe {
     width: 200px;
 }
 </style>
-</head>
-
- <body>
-<div style="height: 2000px;"></div>
-<iframe srcdoc="<body style='margin: 0;'><div>This tests that the iframe should be scroll to the top of the page on iOS.</div></body>" onload="runTest()"></iframe>
-<div style="height: 2000px;"></div>
-</body>
-
+<script src="../../../resources/ui-helper.js"></script>
 <script>
     if (window.testRunner)
         testRunner.waitUntilDone();
 
-    function runTest() {
+    async function runTest() {
         window.scrollTo(0, 200);
         window.frames[0].document.scrollingElement.scrollIntoView();
+        await UIHelper.waitForTargetScrollAnimationToSettle(document.scrollingElement);
         if (window.testRunner)
             testRunner.notifyDone();
     }
-     </script>
+</script>
+</head>
+<body>
+<div style="height: 2000px;"></div>
+<iframe srcdoc="<body style='margin: 0;'><div>This tests that the iframe should be scroll to the top of the page on iOS.</div></body>" onload="runTest()"></iframe>
+<div style="height: 2000px;"></div>
+</body>
 </html>

--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -8393,8 +8393,6 @@ imported/w3c/web-platform-tests/html/semantics/popovers/popover-shadowhost-focus
 # rdar://168334716 (MTLCompilerService crashes when Metal Shader Validation is enabled on iOS Simulator)
 webgl/webgl2-provoking-vertex-primitive-restart-uint16-nocrash.html [ Skip ]
 
-webkit.org/b/314022 [ Release ] fast/scrolling/ios/iframe-scroll-into-view.html [ Pass ImageOnlyFailure ]
-
 webkit.org/b/314216 imported/w3c/web-platform-tests/css/css-position/fixed-z-index-blend.html [ Pass ImageOnlyFailure ]
 
 # iOS UA stylesheet has :checked form-control rules that add self-invalidation, changing


### PR DESCRIPTION
#### b5b1da78a7e86be9812629d7397c2aa7d52a3e77
<pre>
REGRESSION(310935@main?):[iOS] fast/scrolling/ios/iframe-scroll-into-view.html is a flaky failure with image diff
<a href="https://bugs.webkit.org/show_bug.cgi?id=314022">https://bugs.webkit.org/show_bug.cgi?id=314022</a>
<a href="https://rdar.apple.com/176214070">rdar://176214070</a>

Reviewed by Simon Fraser.

The test calls scrollIntoView() and immediately notifies the test runner to take the
screenshot. On iOS, scrollIntoView() can trigger animated scrolling, so the scroll may
not be visually complete when the screenshot is captured.

Switch to UIHelper.waitForTargetScrollAnimationToSettle() to wait until the parent&apos;s
scroll position has stabilized before notifying the test runner. This helper polls scroll
position over rAFs and works for both animated and non-animated scrolls.

* LayoutTests/fast/scrolling/ios/iframe-scroll-into-view.html: Add requestAnimationFrame.
* LayoutTests/platform/ios/TestExpectations: Remove the flaky annotation.

Canonical link: <a href="https://commits.webkit.org/313574@main">https://commits.webkit.org/313574@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5421d3785ea895aa4577114c08bf28328c14f85d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/163413 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/36896 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/30112 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/172353 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/119860 "Built successfully") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/37225 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/36896 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/126905 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/89451 "layout-tests (failure)") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/166372 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/29174 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/146895 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/107463 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/28220 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/26852 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/20055 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/138115 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/24618 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/174857 "Built successfully") | | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/26274 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/135209 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/36566 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/30952 "Found 2 new test failures: http/tests/site-isolation/page-lifecycle/pagehide.html http/tests/site-isolation/page-lifecycle/pageswap.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/135195 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36457 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/37351 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/146413 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/99307 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/30499 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/23258 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/36062 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/35559 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/1283 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/35807 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/35707 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->