### PR TITLE
[MotionMark 1.3] IOSurfacePool should not evict in-use surfaces based on byte limits

### DIFF
--- a/Source/WebCore/platform/graphics/cg/IOSurfacePool.cpp
+++ b/Source/WebCore/platform/graphics/cg/IOSurfacePool.cpp
@@ -98,19 +98,23 @@ void IOSurfacePool::willAddSurface(IOSurface& surface, bool inUse)
 
     size_t surfaceBytes = surface.totalBytes();
 
-    evict(surfaceBytes);
-
-    m_bytesCached += surfaceBytes;
-    if (inUse)
+    if (inUse) {
         m_inUseBytesCached += surfaceBytes;
+        while (m_inUseSurfaces.size() >= maximumInUseSurfaceCount)
+            tryEvictInUseSurface();
+    } else {
+        evict(surfaceBytes);
+        m_bytesCached += surfaceBytes;
+    }
 }
 
 void IOSurfacePool::didRemoveSurface(IOSurface& surface, bool inUse)
 {
     size_t surfaceBytes = surface.totalBytes();
-    m_bytesCached -= surfaceBytes;
     if (inUse)
         m_inUseBytesCached -= surfaceBytes;
+    else
+        m_bytesCached -= surfaceBytes;
 
     m_surfaceDetails.remove(&surface);
 }
@@ -193,6 +197,8 @@ void IOSurfacePool::addSurface(std::unique_ptr<IOSurface>&& surface)
     if (!shouldCacheSurface(*surface))
         return;
 
+    collectInUseSurfaces();
+
     bool surfaceIsInUse = surface->isInUse();
 
     willAddSurface(*surface, surfaceIsInUse);
@@ -268,19 +274,8 @@ void IOSurfacePool::evict(size_t additionalSize)
     // FIXME: Perhaps purgeable surfaces should count less against the cap?
     // We don't want to end up with a ton of empty (purged) surfaces, though, as that would defeat the purpose of the pool.
     size_t targetSize = m_maximumBytesCached - additionalSize;
-
-    // Interleave eviction of old cached surfaces and more recent in-use surfaces.
-    // In-use surfaces are more recently used, but less useful in the pool, as they aren't
-    // immediately available when requested.
-    while (m_bytesCached > targetSize) {
+    while (m_bytesCached > targetSize)
         tryEvictOldestCachedSurface();
-
-        if (m_inUseBytesCached > maximumInUseBytes || m_bytesCached > targetSize)
-            tryEvictInUseSurface();
-    }
-
-    while (m_inUseBytesCached > maximumInUseBytes || m_bytesCached > targetSize)
-        tryEvictInUseSurface();
 
     DUMP_POOL_STATISTICS(stream << "IOSurfacePool::evict [" << m_poolIdentifier << "] - after evict\n" << poolStatistics());
 }
@@ -297,7 +292,10 @@ void IOSurfacePool::collectInUseSurfaces()
         if (auto it = m_surfaceDetails.find(surface); it != m_surfaceDetails.end())
             it->value.inCurrentlyUsedSurfaceCache = false;
 
-        m_inUseBytesCached -= surface->totalBytes();
+        size_t surfaceBytes = surface->totalBytes();
+        m_inUseBytesCached -= surfaceBytes;
+        evict(surfaceBytes);
+        m_bytesCached += surfaceBytes;
         insertSurfaceIntoPool(WTF::move(*surfaceIter));
     }
 
@@ -407,7 +405,8 @@ String IOSurfacePool::poolStatistics() const
     stream << "   IN USE: " << m_inUseSurfaces.size() << " surfaces for " << inUseSize / (1024.0 * 1024.0) << " MB";
 
     // FIXME: Should move consistency checks elsewhere, and always perform them in debug builds.
-    ASSERT(m_bytesCached == totalSize);
+    ASSERT(m_bytesCached == totalSize - inUseSize);
+    ASSERT(m_inUseBytesCached == inUseSize);
     ASSERT(m_bytesCached <= m_maximumBytesCached);
 
     stream << "   TOTAL: " << totalSurfaces << " surfaces for " << totalSize / (1024.0 * 1024.0) << " MB (" << totalPurgeableSize / (1024.0 * 1024.0) << " MB (" << (totalPurgeableSize * 100.0) / totalSize << "%) purgeable)\n";

--- a/Source/WebCore/platform/graphics/cg/IOSurfacePool.h
+++ b/Source/WebCore/platform/graphics/cg/IOSurfacePool.h
@@ -89,10 +89,10 @@ private:
     static constexpr size_t defaultMaximumBytesCached { 64 * MB };
 #endif
 
-    // We'll never allow more than 1/2 of the cache to be filled with in-use surfaces, because
-    // they can't be immediately returned when requested (but will be freed up in the future).
-    static constexpr size_t maximumInUseBytes = defaultMaximumBytesCached / 2;
-    
+    // In-use surfaces are held by the compositor and cannot be freed by eviction.
+    // We cap them by count as a safety valve against unbounded growth.
+    static constexpr unsigned maximumInUseSurfaceCount { 64 };
+
     bool NODELETE shouldCacheSurface(const IOSurface&) const WTF_REQUIRES_LOCK(m_lock);
 
     void willAddSurface(IOSurface&, bool inUse) WTF_REQUIRES_LOCK(m_lock);


### PR DESCRIPTION
#### b76b97e79c31a08c5cf58108f6eaa2ed68d3dbaf
<pre>
[MotionMark 1.3] IOSurfacePool should not evict in-use surfaces based on byte limits
<a href="https://bugs.webkit.org/show_bug.cgi?id=314135">https://bugs.webkit.org/show_bug.cgi?id=314135</a>
<a href="https://rdar.apple.com/176309124">rdar://176309124</a>

Reviewed by NOBODY (OOPS!).

When ImageBufferSet returns a surface to IOSurfacePool during
swapBuffersForDisplay, the surface is typically still in-use by the
compositor. Previously, these surfaces counted against a 32 MB byte
limit (maximumInUseBytes), causing immediate eviction and destruction on every
frame. This is counterproductive: destroying an in-use surface does not free
physical memory (the compositor retains the IOSurface via IOKit), but forces a
fresh allocation with full page fault cost on the next frame.

Change the eviction policy so that in-use surfaces are tracked separately from
the available pool&apos;s byte budget. They are only evicted if the count exceeds a
safety cap (64 surfaces). Additionally, addSurface now opportunistically scans
the in-use list to move any released surfaces to the available pool immediately,
rather than waiting for the 500ms collection timer.

On MotionMark 1.3 Leaves (J815), this eliminates ~24 MB/frame of IOSurface page
demand and improves fixed-complexity score by 6.6%.

* Source/WebCore/platform/graphics/cg/IOSurfacePool.cpp:
(WebCore::IOSurfacePool::willAddSurface):
(WebCore::IOSurfacePool::didRemoveSurface):
(WebCore::IOSurfacePool::addSurface):
(WebCore::IOSurfacePool::evict):
(WebCore::IOSurfacePool::collectInUseSurfaces):
(WebCore::IOSurfacePool::poolStatistics const):
* Source/WebCore/platform/graphics/cg/IOSurfacePool.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b76b97e79c31a08c5cf58108f6eaa2ed68d3dbaf

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/160685 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/34158 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/27259 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/169588 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/115751 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/c22b2b00-fbd7-47a6-bde2-1a31dffb9004) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/162554 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/34259 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/34158 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/124611 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/87983 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/163644 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/26861 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/144340 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/105208 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/25913 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/24412 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/17308 "Built successfully") | | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/152741 "Build is in progress. Recent messages:") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/135607 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/22103 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/172068 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/18974 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/23743 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/132877 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/33832 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/28504 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/132890 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/33816 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/143898 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/95625 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/27486 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/20713 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/33327 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/100589 "Built successfully") | | | 
| | [❌ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/32826 "Hash b76b97e7 for PR 64306 does not build (failure)") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/33070 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/32974 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->