### PR TITLE
dataTransfer.types includes "Files" but dataTransfer.files is empty when dragging images from Mail.app

### DIFF
--- a/Source/WebKit/UIProcess/mac/WebViewImpl.mm
+++ b/Source/WebKit/UIProcess/mac/WebViewImpl.mm
@@ -4589,7 +4589,11 @@ bool WebViewImpl::performDragOperation(id<NSDraggingInfo> draggingInfo)
     SandboxExtension::Handle sandboxExtensionHandle;
     Vector<SandboxExtension::Handle> sandboxExtensionForUpload;
 
-    if (![types containsObject:PasteboardTypes::WebArchivePboardType] && [types containsObject:WebCore::legacyFilesPromisePasteboardTypeSingleton()])
+    // https://bugs.webkit.org/show_bug.cgi?id=307601
+    bool hasWebArchive = [types containsObject:PasteboardTypes::WebArchivePboardType];
+    bool hasFilePromises = [types containsObject:WebCore::legacyFilesPromisePasteboardTypeSingleton()];
+    bool isDragFromSelf = dragData->flags().contains(WebCore::DragApplicationFlags::IsSource);
+    if (hasFilePromises && !(hasWebArchive && isDragFromSelf))
         return handleLegacyFilesPromisePasteboard(draggingInfo, WTF::move(dragData), page(), m_view.get());
 
     if ([types containsObject:WebCore::legacyFilenamesPasteboardTypeSingleton()])

--- a/Tools/TestWebKitAPI/Helpers/cocoa/DragAndDropSimulator.h
+++ b/Tools/TestWebKitAPI/Helpers/cocoa/DragAndDropSimulator.h
@@ -148,6 +148,7 @@ typedef NSDictionary<NSNumber *, NSValue *> *ProgressToCGPointValueMap;
 @property (nonatomic, copy) dispatch_block_t willEndDraggingHandler;
 
 - (void)writePromisedFiles:(NSArray<NSURL *> *)fileURLs;
+- (void)writePromisedFilesWithWebArchive:(NSArray<NSURL *> *)fileURLs;
 - (void)writeFiles:(NSArray<NSURL *> *)fileURLs;
 - (NSArray<NSURL *> *)receivePromisedFiles;
 

--- a/Tools/TestWebKitAPI/Helpers/mac/DragAndDropSimulatorMac.mm
+++ b/Tools/TestWebKitAPI/Helpers/mac/DragAndDropSimulatorMac.mm
@@ -452,6 +452,20 @@ static BOOL getFilePathsAndTypeIdentifiers(NSArray<NSURL *> *fileURLs, NSArray<N
     [_externalDragPasteboard setPropertyList:names forType:NSFilenamesPboardType];
 }
 
+- (void)writePromisedFilesWithWebArchive:(NSArray<NSURL *> *)fileURLs
+{
+    NSArray *paths = nil;
+    NSArray *types = nil;
+    if (!getFilePathsAndTypeIdentifiers(fileURLs, &paths, &types))
+        return;
+
+    _externalPromisedFiles = fileURLs;
+    _externalDragPasteboard = [NSPasteboard pasteboardWithUniqueName];
+    [_externalDragPasteboard declareTypes:@[NSFilesPromisePboardType, @"Apple Web Archive pasteboard type"] owner:nil];
+    [_externalDragPasteboard setPropertyList:types forType:NSFilesPromisePboardType];
+    [_externalDragPasteboard setData:[NSData data] forType:@"Apple Web Archive pasteboard type"];
+}
+
 - (void)writeFiles:(NSArray<NSURL *> *)fileURLs
 {
     NSArray *paths = nil;

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/mac/DragAndDropTestsMac.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/mac/DragAndDropTestsMac.mm
@@ -266,6 +266,23 @@ TEST(DragAndDropTests, DragPromisedImageFileIntoFileUpload)
     EXPECT_WK_STREQ(UTTypeGIF.identifier, filePromiseReceiver.fileTypes.firstObject);
 }
 
+// https://bugs.webkit.org/show_bug.cgi?id=307601
+TEST(DragAndDropTests, DragPromisedImageFileWithWebArchiveIntoFileUpload)
+{
+    RetainPtr simulator = adoptNS([[DragAndDropSimulator alloc] initWithWebViewFrame:NSMakeRect(0, 0, 400, 400)]);
+    TestWKWebView *webView = [simulator webView];
+    [webView synchronouslyLoadTestPageNamed:@"image-and-file-upload"];
+
+    NSURL *imageURL = [NSBundle.test_resourcesBundle URLForResource:@"apple" withExtension:@"gif"];
+    [simulator writePromisedFilesWithWebArchive:@[ imageURL ]];
+    [simulator runFrom:NSMakePoint(100, 100) to:NSMakePoint(100, 300)];
+
+    TestWebKitAPI::Util::waitForConditionWithLogging([&] () -> bool {
+        return [webView stringByEvaluatingJavaScript:@"imageload.textContent"].boolValue;
+    }, 2, @"Expected image to finish loading.");
+    EXPECT_EQ(1, [webView stringByEvaluatingJavaScript:@"filecount.textContent"].integerValue);
+}
+
 TEST(DragAndDropTests, ReadURLWhenDroppingPromisedWebLoc)
 {
     RetainPtr simulator = adoptNS([[DragAndDropSimulator alloc] initWithWebViewFrame:NSMakeRect(0, 0, 400, 400)]);


### PR DESCRIPTION
#### 9a5dd61958c8778b9d3c24c43a680628cd015826
<pre>
dataTransfer.types includes &quot;Files&quot; but dataTransfer.files is empty when dragging images from Mail.app
<a href="https://bugs.webkit.org/show_bug.cgi?id=307601">https://bugs.webkit.org/show_bug.cgi?id=307601</a>
<a href="https://rdar.apple.com/170672606">rdar://170672606</a>

Reviewed by Ryosuke Niwa.

The problem: dataTransfer.files is empty when dragging an inline image
from the Mail app to a web page even though dataTransfer.types contains
the &quot;Files&quot; type. Mail puts both WebArchivePboardType and
NSFilesPromisePboardType on the pasteboard. The image data is only available
through the file promise, but WebKit skips file promise resolution whenever
WebArchive is present on the pasteboard.

The fix: The old code skipped file promise resolution whenever WebArchive
was on the pasteboard. Now it only skips when the drag came from the same
WebView (checked via DragApplicationFlags::IsSource). Mail.app is not the
same view, so its file promises get resolved.
Safari-to-Safari drags still use the WebArchive path since IsSource is true.

Tests: Tools/TestWebKitAPI/Helpers/cocoa/DragAndDropSimulator.h
       Tools/TestWebKitAPI/Helpers/mac/DragAndDropSimulatorMac.mm
       Tools/TestWebKitAPI/Tests/WebKit/WKWebView/mac/DragAndDropTestsMac.mm

* Source/WebKit/UIProcess/mac/WebViewImpl.mm:
(WebKit::WebViewImpl::performDragOperation):
* Tools/TestWebKitAPI/Helpers/cocoa/DragAndDropSimulator.h:
* Tools/TestWebKitAPI/Helpers/mac/DragAndDropSimulatorMac.mm:
(-[DragAndDropSimulator writePromisedFilesWithWebArchive:]):
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/mac/DragAndDropTestsMac.mm:
(TEST(DragAndDropTests, DragPromisedImageFileWithWebArchiveIntoFileUpload)):

Canonical link: <a href="https://commits.webkit.org/312711@main">https://commits.webkit.org/312711@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d319d02d5f6584f14b8d2a11792e35896d13be25

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/160695 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/34168 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/27269 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/169598 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/115761 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/2c9b3fbe-c2dc-4e41-b213-82099688e5bf) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/162564 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/34269 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/34168 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/124621 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/87991 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/e5109fe7-c79d-4209-8396-e42e163369b7) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/163654 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/26866 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/144339 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/105218 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/72a6affc-7684-4a8c-94cc-4af837a66902) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/25918 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/24420 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/17318 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/135612 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/22102 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/172078 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/18999 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/23742 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/132884 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/33842 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/28512 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/132897 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35926 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/33826 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/143897 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/95635 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/27496 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/20712 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/33337 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/100611 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/32836 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/33080 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/32984 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->