### PR TITLE
REGRESSION(312301@main): [macOS] TestWebKitAPI.WKInspectorExtension.EvaluateScriptInExtensionTabCanReturnPromises is a flaky timeout

### DIFF
--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKInspectorExtension.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKInspectorExtension.mm
@@ -299,12 +299,7 @@ TEST(WKInspectorExtension, ExtensionTabIsPersistent)
     TestWebKitAPI::Util::run(&pendingCallbackWasCalled);
 }
 
-// FIXME when webkit.org/b/313860 is resolved.
-#if PLATFORM(MAC)
-TEST(WKInspectorExtension, DISABLED_EvaluateScriptInExtensionTabCanReturnPromises)
-#else
 TEST(WKInspectorExtension, EvaluateScriptInExtensionTabCanReturnPromises)
-#endif
 {
     resetGlobalState();
 


### PR DESCRIPTION
#### a4e2d0ff9bf2716cbb2766a1c062aec9b5d17055
<pre>
REGRESSION(312301@main): [macOS] TestWebKitAPI.WKInspectorExtension.EvaluateScriptInExtensionTabCanReturnPromises is a flaky timeout
<a href="https://bugs.webkit.org/show_bug.cgi?id=313860">https://bugs.webkit.org/show_bug.cgi?id=313860</a>
<a href="https://rdar.apple.com/176058970">rdar://176058970</a>

Reviewed by Ryan Reno.

Local testing confirms that this now runs reliably after the changes in 312630@main.

* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKInspectorExtension.mm:
(TEST(WKInspectorExtension, EvaluateScriptInExtensionTabCanReturnPromises)):

Canonical link: <a href="https://commits.webkit.org/312719@main">https://commits.webkit.org/312719@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/71abc0f40aeeb6841ba47ea92f4eced0113a23c5

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/160701 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/34174 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/27275 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/169604 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/115767 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/162570 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/34275 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/34174 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/124626 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/87995 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/163660 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/26874 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/144342 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/105223 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/25926 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/24426 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/17324 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/135620 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/22105 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/172084 "Built successfully") | | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/23745 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/132891 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/33848 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/28518 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/132904 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35932 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/33832 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/143900 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/95641 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/27498 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/20715 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/33343 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/32842 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/33086 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/32990 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->