### PR TITLE
Scrollbar changes in subtree are not properly handled for various shrink to fit type of content.

### DIFF
--- a/LayoutTests/fast/overflow/intrinsic-width-container-with-scrollable-descendant-expected.html
+++ b/LayoutTests/fast/overflow/intrinsic-width-container-with-scrollable-descendant-expected.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+.container {
+  background-color: green;
+  width: intrinsic;
+}
+.parent {
+  height: 79px;
+  overflow-y: scroll;
+}
+.content {
+  width: 10px;
+  height: 80px;
+}
+</style>
+</head>
+<body>
+<div class=container>
+  <div class=parent>
+    <div class=content></div>
+  </div>
+</div>
+</body>
+</html>

--- a/LayoutTests/fast/overflow/intrinsic-width-container-with-scrollable-descendant.html
+++ b/LayoutTests/fast/overflow/intrinsic-width-container-with-scrollable-descendant.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+.container {
+  background-color: green;
+  width: intrinsic;
+}
+.parent {
+  height: 79px;
+  overflow: auto;
+}
+.content {
+  width: 10px;
+  height: 80px;
+}
+</style>
+</head>
+<body>
+<div class=container>
+  <div class=parent>
+    <div class=content></div>
+  </div>
+</div>
+</body>
+</html>

--- a/LayoutTests/fast/overflow/min-intrinsic-width-container-with-scrollable-descendant-expected.html
+++ b/LayoutTests/fast/overflow/min-intrinsic-width-container-with-scrollable-descendant-expected.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+.container {
+  background-color: green;
+  width: min-intrinsic;
+}
+.parent {
+  height: 79px;
+  overflow-y: scroll;
+}
+.content {
+  width: 10px;
+  height: 80px;
+}
+</style>
+</head>
+<body>
+<div class=container>
+  <div class=parent>
+    <div class=content></div>
+  </div>
+</div>
+</body>
+</html>

--- a/LayoutTests/fast/overflow/min-intrinsic-width-container-with-scrollable-descendant.html
+++ b/LayoutTests/fast/overflow/min-intrinsic-width-container-with-scrollable-descendant.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+.container {
+  background-color: green;
+  width: min-intrinsic;
+}
+.parent {
+  height: 79px;
+  overflow: auto;
+}
+.content {
+  width: 10px;
+  height: 80px;
+}
+</style>
+</head>
+<body>
+<div class=container>
+  <div class=parent>
+    <div class=content></div>
+  </div>
+</div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/flexbox-min-height-auto-003-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/flexbox-min-height-auto-003-expected.txt
@@ -2,5 +2,5 @@
 PASS overflow-y:visible: min-height:auto holds; width has no scrollbar gutter
 PASS overflow-y:hidden: min-height:auto resolves to 0; no scrollbar gutter
 PASS overflow-y:scroll: min-height:auto resolves to 0; width includes scrollbar gutter
-FAIL overflow-y:auto: min-height:auto resolves to 0; width includes scrollbar gutter assert_equals: offsetWidth expected 59 but got 44
+PASS overflow-y:auto: min-height:auto resolves to 0; width includes scrollbar gutter
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/flexbox-min-height-auto-004-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/flexbox-min-height-auto-004-expected.txt
@@ -1,6 +1,6 @@
 
 PASS overflow-x:visible: overflow-y stays visible; min-height:auto holds; no scrollbar gutter
-FAIL overflow-x:hidden: forces overflow-y to auto; min-height:auto resolves to 0; width includes scrollbar gutter assert_equals: offsetWidth expected 59 but got 44
-FAIL overflow-x:scroll: forces overflow-y to auto; min-height:auto resolves to 0; width includes scrollbar gutter assert_equals: offsetWidth expected 59 but got 44
-FAIL overflow-x:auto: forces overflow-y to auto; min-height:auto resolves to 0; width includes scrollbar gutter assert_equals: offsetWidth expected 59 but got 44
+PASS overflow-x:hidden: forces overflow-y to auto; min-height:auto resolves to 0; width includes scrollbar gutter
+PASS overflow-x:scroll: forces overflow-y to auto; min-height:auto resolves to 0; width includes scrollbar gutter
+PASS overflow-x:auto: forces overflow-y to auto; min-height:auto resolves to 0; width includes scrollbar gutter
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-overflow/abspos-shrink-to-fit-with-scrollable-descendant-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-overflow/abspos-shrink-to-fit-with-scrollable-descendant-expected.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+.positioned {
+  position: relative;
+  height: 200px;
+}
+.container {
+  position: absolute;
+  background-color: green;
+}
+.parent {
+  height: 79px;
+  overflow-y: scroll;
+}
+.content {
+  width: 10px;
+  height: 80px;
+}
+</style>
+</head>
+<body>
+<div class=positioned>
+  <div class=container>
+    <div class=parent>
+      <div class=content></div>
+    </div>
+  </div>
+</div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-overflow/abspos-shrink-to-fit-with-scrollable-descendant-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-overflow/abspos-shrink-to-fit-with-scrollable-descendant-ref.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+.positioned {
+  position: relative;
+  height: 200px;
+}
+.container {
+  position: absolute;
+  background-color: green;
+}
+.parent {
+  height: 79px;
+  overflow-y: scroll;
+}
+.content {
+  width: 10px;
+  height: 80px;
+}
+</style>
+</head>
+<body>
+<div class=positioned>
+  <div class=container>
+    <div class=parent>
+      <div class=content></div>
+    </div>
+  </div>
+</div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-overflow/abspos-shrink-to-fit-with-scrollable-descendant.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-overflow/abspos-shrink-to-fit-with-scrollable-descendant.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="match" href="abspos-shrink-to-fit-with-scrollable-descendant-ref.html">
+<link rel="help" href="https://drafts.csswg.org/css-overflow-3/#scrollbar-sizing">
+<style>
+.positioned {
+  position: relative;
+  height: 200px;
+}
+.container {
+  position: absolute;
+  background-color: green;
+}
+.parent {
+  height: 79px;
+  overflow: auto;
+}
+.content {
+  width: 10px;
+  height: 80px;
+}
+</style>
+</head>
+<body>
+<div class=positioned>
+  <div class=container id="container">
+    <div class=parent id="parent">
+      <div class=content></div>
+    </div>
+  </div>
+</div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-overflow/button-with-scrollable-descendant-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-overflow/button-with-scrollable-descendant-expected.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+button {
+  background-color: green;
+  border: none;
+  padding: 0;
+}
+.parent {
+  height: 79px;
+  overflow-y: scroll;
+}
+.content {
+  width: 10px;
+  height: 80px;
+}
+</style>
+</head>
+<body>
+<button>
+  <div class=parent>
+    <div class=content></div>
+  </div>
+</button>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-overflow/button-with-scrollable-descendant-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-overflow/button-with-scrollable-descendant-ref.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+button {
+  background-color: green;
+  border: none;
+  padding: 0;
+}
+.parent {
+  height: 79px;
+  overflow-y: scroll;
+}
+.content {
+  width: 10px;
+  height: 80px;
+}
+</style>
+</head>
+<body>
+<button>
+  <div class=parent>
+    <div class=content></div>
+  </div>
+</button>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-overflow/button-with-scrollable-descendant.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-overflow/button-with-scrollable-descendant.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="match" href="button-with-scrollable-descendant-ref.html">
+<link rel="help" href="https://drafts.csswg.org/css-overflow-3/#scrollbar-sizing">
+<style>
+button {
+  background-color: green;
+  border: none;
+  padding: 0;
+}
+.parent {
+  height: 79px;
+  overflow: auto;
+}
+.content {
+  width: 10px;
+  height: 80px;
+}
+</style>
+</head>
+<body>
+<button>
+  <div class=parent>
+    <div class=content></div>
+  </div>
+</button>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-overflow/float-with-scrollable-descendant-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-overflow/float-with-scrollable-descendant-expected.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+.container {
+  float: left;
+  background-color: green;
+}
+.parent {
+  height: 79px;
+  overflow-y: scroll;
+}
+.content {
+  width: 10px;
+  height: 80px;
+}
+</style>
+</head>
+<body>
+<div class=container>
+  <div class=parent>
+    <div class=content></div>
+  </div>
+</div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-overflow/float-with-scrollable-descendant-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-overflow/float-with-scrollable-descendant-ref.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+.container {
+  float: left;
+  background-color: green;
+}
+.parent {
+  height: 79px;
+  overflow-y: scroll;
+}
+.content {
+  width: 10px;
+  height: 80px;
+}
+</style>
+</head>
+<body>
+<div class=container>
+  <div class=parent>
+    <div class=content></div>
+  </div>
+</div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-overflow/float-with-scrollable-descendant.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-overflow/float-with-scrollable-descendant.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="match" href="float-with-scrollable-descendant-ref.html">
+<link rel="help" href="https://drafts.csswg.org/css-overflow-3/#scrollbar-sizing">
+<style>
+.container {
+  float: left;
+  background-color: green;
+}
+.parent {
+  height: 79px;
+  overflow: auto;
+}
+.content {
+  width: 10px;
+  height: 80px;
+}
+</style>
+</head>
+<body>
+<div class=container>
+  <div class=parent>
+    <div class=content></div>
+  </div>
+</div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-overflow/inline-block-with-scrollable-descendant-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-overflow/inline-block-with-scrollable-descendant-expected.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+.container {
+  display: inline-block;
+  background-color: green;
+}
+.parent {
+  height: 79px;
+  overflow-y: scroll;
+}
+.content {
+  width: 10px;
+  height: 80px;
+}
+</style>
+</head>
+<body>
+<div class=container>
+  <div class=parent>
+    <div class=content></div>
+  </div>
+</div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-overflow/inline-block-with-scrollable-descendant-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-overflow/inline-block-with-scrollable-descendant-ref.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+.container {
+  display: inline-block;
+  background-color: green;
+}
+.parent {
+  height: 79px;
+  overflow-y: scroll;
+}
+.content {
+  width: 10px;
+  height: 80px;
+}
+</style>
+</head>
+<body>
+<div class=container>
+  <div class=parent>
+    <div class=content></div>
+  </div>
+</div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-overflow/inline-block-with-scrollable-descendant.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-overflow/inline-block-with-scrollable-descendant.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="match" href="inline-block-with-scrollable-descendant-ref.html">
+<link rel="help" href="https://drafts.csswg.org/css-overflow-3/#scrollbar-sizing">
+<style>
+.container {
+  display: inline-block;
+  background-color: green;
+}
+.parent {
+  height: 79px;
+  overflow: auto;
+}
+.content {
+  width: 10px;
+  height: 80px;
+}
+</style>
+</head>
+<body>
+<div class=container>
+  <div class=parent>
+    <div class=content></div>
+  </div>
+</div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-overflow/max-content-with-float-scrollable-descendant-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-overflow/max-content-with-float-scrollable-descendant-expected.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+.container {
+  width: max-content;
+  background-color: green;
+}
+.float {
+  float: left;
+}
+.parent {
+  height: 79px;
+  overflow-y: scroll;
+}
+.content {
+  width: 10px;
+  height: 80px;
+}
+</style>
+</head>
+<body>
+<div class=container>
+  <div class=float>
+    <div class=parent>
+      <div class=content></div>
+    </div>
+  </div>
+</div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-overflow/max-content-with-float-scrollable-descendant-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-overflow/max-content-with-float-scrollable-descendant-ref.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+.container {
+  width: max-content;
+  background-color: green;
+}
+.float {
+  float: left;
+}
+.parent {
+  height: 79px;
+  overflow-y: scroll;
+}
+.content {
+  width: 10px;
+  height: 80px;
+}
+</style>
+</head>
+<body>
+<div class=container>
+  <div class=float>
+    <div class=parent>
+      <div class=content></div>
+    </div>
+  </div>
+</div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-overflow/max-content-with-float-scrollable-descendant.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-overflow/max-content-with-float-scrollable-descendant.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="match" href="max-content-with-float-scrollable-descendant-ref.html">
+<link rel="help" href="https://drafts.csswg.org/css-overflow-3/#scrollbar-sizing">
+<style>
+.container {
+  width: max-content;
+  background-color: green;
+}
+.float {
+  float: left;
+}
+.parent {
+  height: 79px;
+  overflow: auto;
+}
+.content {
+  width: 10px;
+  height: 80px;
+}
+</style>
+</head>
+<body>
+<div class=container>
+  <div class=float>
+    <div class=parent>
+      <div class=content></div>
+    </div>
+  </div>
+</div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-overflow/max-content-with-multiple-scrollable-descendants-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-overflow/max-content-with-multiple-scrollable-descendants-expected.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+.container {
+  width: max-content;
+  background-color: green;
+}
+.parent {
+  height: 79px;
+  overflow-y: scroll;
+}
+.content-narrow {
+  width: 10px;
+  height: 80px;
+}
+.content-wide {
+  width: 30px;
+  height: 80px;
+}
+</style>
+</head>
+<body>
+<div class=container>
+  <div class=parent>
+    <div class=content-narrow></div>
+  </div>
+  <div class=parent>
+    <div class=content-wide></div>
+  </div>
+</div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-overflow/max-content-with-multiple-scrollable-descendants-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-overflow/max-content-with-multiple-scrollable-descendants-ref.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+.container {
+  width: max-content;
+  background-color: green;
+}
+.parent {
+  height: 79px;
+  overflow-y: scroll;
+}
+.content-narrow {
+  width: 10px;
+  height: 80px;
+}
+.content-wide {
+  width: 30px;
+  height: 80px;
+}
+</style>
+</head>
+<body>
+<div class=container>
+  <div class=parent>
+    <div class=content-narrow></div>
+  </div>
+  <div class=parent>
+    <div class=content-wide></div>
+  </div>
+</div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-overflow/max-content-with-multiple-scrollable-descendants.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-overflow/max-content-with-multiple-scrollable-descendants.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="match" href="max-content-with-multiple-scrollable-descendants-ref.html">
+<link rel="help" href="https://drafts.csswg.org/css-overflow-3/#scrollbar-sizing">
+<style>
+.container {
+  width: max-content;
+  background-color: green;
+}
+.parent {
+  height: 79px;
+  overflow: auto;
+}
+.content-narrow {
+  width: 10px;
+  height: 80px;
+}
+.content-wide {
+  width: 30px;
+  height: 80px;
+}
+</style>
+</head>
+<body>
+<div class=container>
+  <div class=parent>
+    <div class=content-narrow></div>
+  </div>
+  <div class=parent>
+    <div class=content-wide></div>
+  </div>
+</div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-overflow/orthogonal-writing-mode-with-scrollable-descendant-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-overflow/orthogonal-writing-mode-with-scrollable-descendant-expected.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+.container {
+  float: left;
+  background-color: green;
+}
+.parent {
+  height: 79px;
+  overflow-y: scroll;
+}
+.content {
+  width: 10px;
+  height: 80px;
+}
+</style>
+</head>
+<body>
+<div class=container>
+  <div class=parent>
+    <div class=content></div>
+  </div>
+</div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-overflow/orthogonal-writing-mode-with-scrollable-descendant-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-overflow/orthogonal-writing-mode-with-scrollable-descendant-ref.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+.container {
+  float: left;
+  background-color: green;
+}
+.parent {
+  height: 79px;
+  overflow-y: scroll;
+}
+.content {
+  width: 10px;
+  height: 80px;
+}
+</style>
+</head>
+<body>
+<div class=container>
+  <div class=parent>
+    <div class=content></div>
+  </div>
+</div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-overflow/orthogonal-writing-mode-with-scrollable-descendant.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-overflow/orthogonal-writing-mode-with-scrollable-descendant.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="match" href="orthogonal-writing-mode-with-scrollable-descendant-ref.html">
+<link rel="help" href="https://drafts.csswg.org/css-overflow-3/#scrollbar-sizing">
+<style>
+.outer {
+  writing-mode: vertical-lr;
+}
+.orthogonal {
+  writing-mode: horizontal-tb;
+  background-color: green;
+}
+.parent {
+  height: 79px;
+  overflow: auto;
+}
+.content {
+  width: 10px;
+  height: 80px;
+}
+</style>
+</head>
+<body>
+<div class=outer>
+  <div class=orthogonal>
+    <div class=parent>
+      <div class=content></div>
+    </div>
+  </div>
+</div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-overflow/table-max-content-with-scrollable-descendant-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-overflow/table-max-content-with-scrollable-descendant-expected.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+.container {
+  width: max-content;
+  background-color: green;
+}
+table {
+  border-spacing: 0;
+}
+td {
+  padding: 0;
+}
+.parent {
+  height: 79px;
+  overflow-y: scroll;
+}
+.content {
+  width: 10px;
+  height: 80px;
+}
+</style>
+</head>
+<body>
+<div class=container>
+  <table><tr><td>
+    <div class=parent>
+      <div class=content></div>
+    </div>
+  </td></tr></table>
+</div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-overflow/table-max-content-with-scrollable-descendant-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-overflow/table-max-content-with-scrollable-descendant-ref.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+.container {
+  width: max-content;
+  background-color: green;
+}
+table {
+  border-spacing: 0;
+}
+td {
+  padding: 0;
+}
+.parent {
+  height: 79px;
+  overflow-y: scroll;
+}
+.content {
+  width: 10px;
+  height: 80px;
+}
+</style>
+</head>
+<body>
+<div class=container>
+  <table><tr><td>
+    <div class=parent>
+      <div class=content></div>
+    </div>
+  </td></tr></table>
+</div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-overflow/table-max-content-with-scrollable-descendant.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-overflow/table-max-content-with-scrollable-descendant.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="match" href="table-max-content-with-scrollable-descendant-ref.html">
+<link rel="help" href="https://drafts.csswg.org/css-overflow-3/#scrollbar-sizing">
+<style>
+.container {
+  width: max-content;
+  background-color: green;
+}
+table {
+  border-spacing: 0;
+}
+td {
+  padding: 0;
+}
+.parent {
+  height: 79px;
+  overflow: auto;
+}
+.content {
+  width: 10px;
+  height: 80px;
+}
+</style>
+</head>
+<body>
+<div class=container>
+  <table><tr><td>
+    <div class=parent>
+      <div class=content></div>
+    </div>
+  </td></tr></table>
+</div>
+</body>
+</html>

--- a/Source/WebCore/rendering/RenderBlock.cpp
+++ b/Source/WebCore/rendering/RenderBlock.cpp
@@ -531,8 +531,34 @@ void RenderBlock::relayoutRenderBlockForScrollbarChange(RenderBlock& block)
 
 static bool needsToTrackDescendantScrollbarChanges(const RenderBlock& renderBlock, const LocalFrameViewLayoutContext& layoutContext)
 {
-    auto computedLogicalWidth = renderBlock.style().logicalWidth();
-    return computedLogicalWidth.isIntrinsic() && !layoutContext.subtreeScrollbarChangesState();
+    if (renderBlock.isRenderView())
+        return false;
+
+    // FIXME: This list contains content that should be supported
+    // but need additional invesigation to get working correctly.
+    auto isSupportedForDescendantTracking = [&] {
+        if (renderBlock.writingMode().computedTextDirection() == TextDirection::RTL)
+            return false;
+        return true;
+    };
+    if (!isSupportedForDescendantTracking())
+        return false;
+
+    if (layoutContext.subtreeScrollbarChangesState())
+        return false;
+
+    auto& style = renderBlock.style();
+    auto& computedLogicalWidth = style.logicalWidth();
+    if (computedLogicalWidth.isFixed())
+        return false;
+
+    if (computedLogicalWidth.isIntrinsic() || computedLogicalWidth.isMinIntrinsic())
+        return true;
+
+    if (renderBlock.sizesPreferredLogicalWidthToFitContent())
+        return true;
+
+    return false;
 }
 
 static bool canContainDescendantScrollbarChanges(const RenderBlock& renderBlock, const LocalFrameViewLayoutContext& layoutContext)

--- a/Source/WebCore/rendering/SubtreeScrollbarChangesState.cpp
+++ b/Source/WebCore/rendering/SubtreeScrollbarChangesState.cpp
@@ -101,7 +101,7 @@ SubtreeScrollbarChangesHandler::~SubtreeScrollbarChangesHandler()
     auto& subtreeRoot = subtreeScrollbarChangesState->subtreeRoot;
     while (!descendantsWithScrollbarChange.isEmpty()) {
         CheckedPtr rendererWithScrollbarChange = descendantsWithScrollbarChange.takeFirst();
-        rendererWithScrollbarChange->setNeedsPreferredWidthsUpdate(MarkingBehavior::MarkContainingBlockChain, subtreeRoot.ptr());
+        rendererWithScrollbarChange->setNeedsPreferredWidthsUpdate(MarkingBehavior::MarkContainingBlockChain, protect(subtreeRoot->containingBlock()));
     }
 
     subtreeRoot->setNeedsLayout(MarkingBehavior::MarkOnlyThis);


### PR DESCRIPTION
#### 83e73fd66b2dbeebf76f2f425d868d15e859184e
<pre>
Scrollbar changes in subtree are not properly handled for various shrink to fit type of content.
<a href="https://bugs.webkit.org/show_bug.cgi?id=290452">https://bugs.webkit.org/show_bug.cgi?id=290452</a>
<a href="https://rdar.apple.com/problem/148428628">rdar://problem/148428628</a>

Reviewed by Alan Baradlay.

In 311766@main we added some support that allows renderers with certain
types of computed widths to respond to scrollbar changes in its subtree.
For example, if we have a renderer with width: max-content and a
descendant ends up getting a scrollbar, then that width should take into
consideration the scrollbar. The commit message in 311766@main has a
much more detailed explanation.

However, there are other types of content that have similar
characteristics that are still currently broken. Two examples are inline
blocks and absolutely positioned elements with auto insets, both of
which determine their widths as shrink-to-fit. This patch
expands upon our current infrastructure to allow more type of content.
We use the sizesPreferredLogicalWidthToFitContent to help identify these
cases. Two restrictions that we place are flex items and grid items since those
seem like they will need a bit of additional work which will be done in
a follow up. Note that while EWS does not show any immediate issues with
gird items, I am inluding that content in these restrictions just due to
some similarities between those pieces of code. It is possible that the
investigation to fix the issues with flex will reveal that the
underlying issue does not actually exist in grid.

(WebCore::SubtreeScrollbarChangesHandler::~SubtreeScrollbarChangesHandler):
Unlike the width: max-content cases, the width of the absolutely
positioned elements and inline blocks are computed by calling preferred
widths on the renderer itself. As a result, we need to make sure that it
gets invalidated as well since we were previously stopping at it.

Canonical link: <a href="https://commits.webkit.org/313584@main">https://commits.webkit.org/313584@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0ab5caff8a6cedd3d6b27da5c3e9d25728a1868f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/163562 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/37046 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/30265 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/172502 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/120011 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/43efb286-af8f-4cc8-b347-0453248f299e) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/165431 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/37377 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/37045 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/127037 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/120011 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/c23809a1-c2ae-4ca0-8646-822a1dd1ba29) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/166521 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/29308 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/147044 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/107591 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/426ff205-6b97-467e-8bc0-759a11d66be4) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/28357 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/26990 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/20205 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/138255 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/24763 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/175007 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/27938 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/26426 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/135340 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/36716 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/31092 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/135322 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36465 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/37501 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/146558 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/99554 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/30628 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/23410 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/36211 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/109357 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/35709 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/1436 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/35959 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/35856 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->