### PR TITLE
REGRESSION (297241@main): Overflow siblings at parser's max DOM tree depth get fully rendered, causing slow layout

### DIFF
--- a/PerformanceTests/Layout/deep-nesting-overflow-siblings.html
+++ b/PerformanceTests/Layout/deep-nesting-overflow-siblings.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html>
+<body>
+<script src="../resources/runner.js"></script>
+<script>
+// Deep markup that exceeds the parser's max DOM tree depth (default 512), so the
+// parser produces a long flat run of overflow siblings at the depth boundary.
+// 100000 spans ~= 999500 overflow siblings, matching the regression magnitude observed
+// in the original Mail thread (~15s render time pre-fix).
+const depth = 100000;
+let markup = "<!DOCTYPE html><body>";
+for (let i = 0; i < depth; ++i)
+    markup += "<span>";
+
+let iframe;
+
+function setup() {
+    if (iframe)
+        document.body.removeChild(iframe);
+    iframe = document.createElement("iframe");
+    iframe.sandbox = "allow-same-origin";
+    document.body.appendChild(iframe);
+    iframe.contentDocument.open();
+    iframe.contentDocument.write(markup);
+    iframe.contentDocument.close();
+}
+
+PerfTestRunner.measureTime({
+    description: "Render time for deeply-nested HTML that exceeds the parser's max DOM tree depth and produces a long run of overflow siblings.",
+    setup: setup,
+    run: function () {
+        iframe.contentDocument.body.offsetHeight;
+    }
+});
+</script>
+</body>
+</html>

--- a/Source/WebCore/style/StyleTreeResolver.cpp
+++ b/Source/WebCore/style/StyleTreeResolver.cpp
@@ -1306,7 +1306,12 @@ void TreeResolver::resolveComposedTree()
 
         Ref element = Ref { downcast<Element>(node.get()) };
 
-        if (it.depth() > maximumRenderTreeDepth()) {
+        // At the maximum render tree depth, only the first child per parent gets a renderer.
+        // The HTML parser caps DOM depth by attaching overflow elements as siblings at this
+        // boundary (see HTMLConstructionSite::attachLater); skipping later siblings here keeps
+        // those overflow elements from being styled and laid out.
+        if (auto depth = it.depth(); depth > maximumRenderTreeDepth()
+            || (depth == maximumRenderTreeDepth() && element->previousElementSibling())) {
             resetStyleForNonRenderedDescendants(element.get());
             it.traverseNextSkippingChildren();
             continue;


### PR DESCRIPTION
#### 69a399de80ab627e8f02ee00abd0e78904eec10c
<pre>
REGRESSION (297241@main): Overflow siblings at parser&apos;s max DOM tree depth get fully rendered, causing slow layout
<a href="https://bugs.webkit.org/show_bug.cgi?id=314139">https://bugs.webkit.org/show_bug.cgi?id=314139</a>
<a href="https://rdar.apple.com/172219636">rdar://172219636</a>

Reviewed by Sammy Gill and Alan Baradlay.

When the parser&apos;s DOM depth cap is reached, HTMLConstructionSite::attachLater
attaches further elements as siblings at the boundary depth (see 297241@main).
The render tree&apos;s depth check skipped elements above the cap but not at it,
so the overflow run was fully styled and laid out — causing ~15s render times
on content with thousands of overflow siblings (e.g. mail with embedded crash
logs containing unmatched &lt;unavailable&gt; tags).

At the maximum render tree depth, skip elements that have a previous element
sibling. The single legitimate deepest element keeps its renderer; the
overflow siblings get none.

* PerformanceTests/Layout/deep-nesting-overflow-siblings.html: Added.
* Source/WebCore/style/StyleTreeResolver.cpp:
(WebCore::Style::TreeResolver::resolveComposedTree):

Canonical link: <a href="https://commits.webkit.org/312751@main">https://commits.webkit.org/312751@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d0c4f04923e7a86d448919c6b4338b8bc76fa692

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/160943 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/159/builds/34416 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/27517 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/169846 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/117203 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/abea9513-5b7a-4777-902e-2b8ee8d3a44f) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/162812 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/34517 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/34416 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/124840 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/117203 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/dc1b2da3-4df9-452c-850f-2dd0eb7a7353) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/163902 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/27108 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/144575 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/105437 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/cc2d75ba-8480-4873-98e9-ddaad90f4952) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/26159 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/24655 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/17566 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/135853 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/22337 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/172329 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/19350 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/23978 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/133112 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/34090 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/28748 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/133122 "Found 1 new API test failure: TestWebKit:WebKit.InjectedBundleFrameHitTest (failure)") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35955 "Built successfully and passed tests") | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/34074 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/144132 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/95913 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/160/builds/34074 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/20948 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/33585 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/101010 "Built successfully") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/33084 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/33328 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/33233 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->