### PR TITLE
[view-transitions] Fix crash in copyElementBaseProperties with content-visibility:auto ancestor

### DIFF
--- a/LayoutTests/fast/css/view-transition-capture-with-content-visibility-crash-expected.txt
+++ b/LayoutTests/fast/css/view-transition-capture-with-content-visibility-crash-expected.txt
@@ -1,0 +1,3 @@
+CONSOLE MESSAGE: ok
+CONSOLE MESSAGE: ok
+PASS if no crash.

--- a/LayoutTests/fast/css/view-transition-capture-with-content-visibility-crash.html
+++ b/LayoutTests/fast/css/view-transition-capture-with-content-visibility-crash.html
@@ -1,0 +1,27 @@
+<style>
+#htmlvar00004, .class3 { padding: 1 1px; voice-balance: 0; -webkit-text-emphasis-position: over; -webkit-column-gap: 0px; transform-origin: right top -1px; -webkit-justify-content: center; stroke-width: 0; border-top: 5em  solid; spatial-navigation-function: grid; border-inline-style: dotted inset; border-image-width: 59 8 1 0; border-block-start-width: medium; border-block: 0px currentcolor; border-block-end-radius: 12 -1em / 75px; font-optical-sizing: none; overscroll-behavior-inline: auto; contain-intrinsic-size: none; -webkit-animation-iteration-count: 92; -webkit-tap-highlight-color: transparent; overflow-block: clip }
+:not(feColorMatrix) { -webkit-transform: ""; -webkit-margin-before: 0px; pause-before: x-strong; text-autospace: auto; container-type: inline-size; flow-from: a1; margin-inline-start: 63px; padding-right: auto; scroll-timeline-axis: vertical, vertical; border-inline-color: <element()>; scroll-timeline-axis: block, block; break-after: left; font-family: 'Lucida Grande'; -webkit-transition-duration: 1s; -webkit-user-select: none; text-decoration-style: dashed; -webkit-line-clamp: none; border-limit: sides 29; font-variant: lining-nums stacked-fractions ordinal; content-visibility: auto }
+embed { cx: 0em; line-snap: baseline; border-bottom-style: groove; glyph-orientation-vertical: 90; place-items: safe flex-start right; overflow-clip-margin-left: content-box 1px; -webkit-mask-box-image-width: 0px; -webkit-border-before-style: dashed; -webkit-mask-origin: border-box; -ms-text-combine-horizontal: all; perspective-origin: 10% 0px; view-transition-name: a0; font-weight: normal; border-inline: thin; -webkit-logical-height: 0px; block-step-size: none; -webkit-mask-box-image-outset: ""; -webkit-background-clip: padding-box; pause-before: x-weak; mask-mode: match-source, luminance }
+</style>
+<script>
+if (window.testRunner) {
+    testRunner.dumpAsText();
+    testRunner.waitUntilDone();
+}
+function eventhandler5()
+{
+    document.startViewTransition(function() { console.log("ok"); });
+}
+setTimeout(function() {
+    if (location.hash) {
+        document.body.textContent = "PASS if no crash.";
+        if (window.testRunner)
+            testRunner.notifyDone();
+    } else {
+        location.hash = "#reloaded";
+        location.reload();
+    }
+}, 200);
+</script>
+<embed id="htmlvar00004" width="0" hidden="hidden" type="date" height="0" quality="high" method="HR&amp;W,:!" checked="checked" z="0.8931198919751014" backgroundColor="B!g9" clientWidth="0">
+<style id="htmlvar00006" onload="eventhandler5()" nonce="nonce" dir="auto" translate="yes">Vq</style>

--- a/Source/WebCore/dom/ViewTransition.cpp
+++ b/Source/WebCore/dom/ViewTransition.cpp
@@ -923,7 +923,11 @@ void ViewTransition::copyElementBaseProperties(RenderLayerModelObject& renderer,
     });
 
     output.overflowRect = captureOverflowRect(renderer);
-    output.properties = styleExtractor.copyProperties(transitionProperties);
+
+    // Layout is already up to date (callers invoke updateLayoutIgnorePendingStylesheets()
+    // before iterating renderers). Forcing layout here for layout-dependent properties such
+    // as backdrop-filter can rebuild the render tree and destroy `renderer`.
+    output.properties = styleExtractor.copyProperties(transitionProperties, Style::Extractor::UpdateLayout::No);
 
     CheckedRef frameView = renderer.view().frameView();
 

--- a/Source/WebCore/style/StyleExtractor.cpp
+++ b/Source/WebCore/style/StyleExtractor.cpp
@@ -559,10 +559,10 @@ bool Extractor::propertyMatches(CSSPropertyID propertyID, const CSSValue* value)
     return computedValue && value && computedValue->equals(*value);
 }
 
-Ref<MutableStyleProperties> Extractor::copyProperties(std::span<const CSSPropertyID> properties) const
+Ref<MutableStyleProperties> Extractor::copyProperties(std::span<const CSSPropertyID> properties, UpdateLayout updateLayout) const
 {
     auto vector = WTF::compactMap(properties, [&](auto& property) -> std::optional<CSSProperty> {
-        if (auto value = propertyValue(property))
+        if (auto value = propertyValue(property, updateLayout))
             return CSSProperty(property, value.releaseNonNull());
         return std::nullopt;
     });

--- a/Source/WebCore/style/StyleExtractor.h
+++ b/Source/WebCore/style/StyleExtractor.h
@@ -84,7 +84,7 @@ public:
     WTF::String customPropertyValueSerializationInStyle(const RenderStyle&, const AtomString& propertyName, const CSS::SerializationContext&) const;
 
     // Helper methods for HTML editing.
-    Ref<MutableStyleProperties> copyProperties(std::span<const CSSPropertyID>) const;
+    Ref<MutableStyleProperties> copyProperties(std::span<const CSSPropertyID>, UpdateLayout = UpdateLayout::Yes) const;
     Ref<MutableStyleProperties> copyProperties() const;
     RefPtr<CSSValue> getFontSizeCSSValuePreferringKeyword() const;
     bool useFixedFontDefaultSize() const;


### PR DESCRIPTION
#### 34c7eaf0d914296464408365d3d4564a7ad816d9
<pre>
[view-transitions] Fix crash in copyElementBaseProperties with content-visibility:auto ancestor
<a href="https://bugs.webkit.org/show_bug.cgi?id=314154">https://bugs.webkit.org/show_bug.cgi?id=314154</a>
<a href="https://rdar.apple.com/175664956">rdar://175664956</a>

Reviewed by NOBODY (OOPS!).

ViewTransition::copyElementBaseProperties is called from captureOldState and captureNewState while iterating renderers held by
CheckedRef/CheckedPtr. It extracted CSS properties via Style::Extractor::copyProperties(), which calls propertyValue() with the default
UpdateLayout::Yes. Because CSSPropertyBackdropFilter is treated as layout-dependent, this triggered updateLayoutIgnorePendingStylesheets({
TreatContentVisibilityAutoAsVisible }), which can rebuild the render tree when the captured element sits under a content-visibility:auto
container — destroying the very renderer being captured. The subsequent renderer.view() access then read from CheckedPtr zombie memory and
crashed.

Since all callers already call updateLayoutIgnorePendingStylesheets() before iterating, layout is clean at that point. Call styleExtractor.copyProperties
with the new Style::Extractor::UpdateLayout::No. The default value is UpdateLayout = UpdateLayout::Yes to keep current bvehavior in other places.

LayoutTests/fast/css/view-transition-capture-with-content-visibility-crash.html

* LayoutTests/fast/css/view-transition-capture-with-content-visibility-crash-expected.txt: Added.
* LayoutTests/fast/css/view-transition-capture-with-content-visibility-crash.html: Added.
* Source/WebCore/dom/ViewTransition.cpp:
(WebCore::ViewTransition::copyElementBaseProperties):
* Source/WebCore/style/StyleExtractor.cpp:
(WebCore::Style::Extractor::copyProperties const):
* Source/WebCore/style/StyleExtractor.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/34c7eaf0d914296464408365d3d4564a7ad816d9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/160753 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/34226 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/27327 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/169656 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/115819 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/bd1445f3-e26d-46d5-933b-df41d79185ad) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/162622 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/34327 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/34226 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/124672 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/88026 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/163712 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/26923 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/144397 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/105269 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/ce0260c1-0dcb-4e76-8a11-c45005570bf3) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/25975 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/24477 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/17376 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/135669 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/22160 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/172138 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/19110 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/23801 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/132939 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/33900 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/28569 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/132951 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/33884 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/143955 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/95693 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/27542 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/20770 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/33395 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/100723 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/32894 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/33138 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/33042 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->