### PR TITLE
Browser back/forward button skipping some pages on github

### DIFF
--- a/Source/WebCore/loader/HistoryController.cpp
+++ b/Source/WebCore/loader/HistoryController.cpp
@@ -573,8 +573,10 @@ void HistoryController::updateForStandardLoad(HistoryUpdateType updateType)
 
 #if PLATFORM(COCOA)
             if (linkedOnOrAfterSDKWithBehavior(SDKAlignedBehavior::AllBackForwardItemsWithoutUserGestureInvisibleToUI)) {
-                if (m_currentItem && m_frame->isMainFrame() && !documentLoader->triggeringAction().processingUserGesture() && !documentLoader->isRequestFromClientOrUserInput())
-                    m_currentItem->setWasCreatedByJSWithoutUserInteraction(true);
+                if (m_currentItem && m_frame->isMainFrame() && !documentLoader->triggeringAction().processingUserGesture() && !documentLoader->isRequestFromClientOrUserInput()) {
+                    if (RefPtr document = m_frame->document(); document && !document->hasRecentUserInteractionForNavigationFromJS())
+                        m_currentItem->setWasCreatedByJSWithoutUserInteraction(true);
+                }
             }
 #endif
 

--- a/Source/WebKit/Shared/WebBackForwardListFrameItem.cpp
+++ b/Source/WebKit/Shared/WebBackForwardListFrameItem.cpp
@@ -200,6 +200,8 @@ String WebBackForwardListFrameItem::loggingStringAtIndent(size_t indent)
         if (m_frameState->wasCreatedByJSWithoutUserInteraction)
             builder.append(" (no user gesture)"_s);
         builder.append('\n');
+        builder.append(indentString);
+        builder.append("("_s, m_frameState->title, ")\n"_s);
     }
 
     for (size_t i = 0; i < m_children.size(); ++i) {

--- a/Source/WebKit/UIProcess/API/Cocoa/WKBackForwardListInternal.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKBackForwardListInternal.h
@@ -23,7 +23,7 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#import "WKBackForwardList.h"
+#import "WKBackForwardListPrivate.h"
 
 #import "WKObject.h"
 #import "WebBackForwardList.h"

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKBackForwardListTests.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKBackForwardListTests.mm
@@ -566,7 +566,7 @@ static void runBackForwardNavigationSkipsItemsWithoutUserGestureTest(Function<vo
 
     [webView loadRequest:[NSURLRequest requestWithURL:url3.get()]];
     [navigationDelegate waitForDidFinishNavigationOrDidSameDocumentNavigation];
-    EXPECT_FALSE(webView.get().backForwardList.currentItem._wasCreatedByJSWithoutUserInteraction);
+    EXPECT_FALSE([webView backForwardList].currentItem._wasCreatedByJSWithoutUserInteraction);
 
     // url1 -> url2 -> url2#a (no user gesture) -> url2#b (no user gesture) -> url2#c (no user gesture) -> url3 **
     EXPECT_EQ([webView backForwardList].backList.count, 2U);
@@ -1661,6 +1661,44 @@ TEST(WKBackForwardList, BackForwardNavigationSkipsPromiseRedirectWithoutUserInte
     // Attempting to goBack now should simply fail.
     auto *navigation = [popupWebView goBack];
     EXPECT_NULL(navigation);
+}
+
+TEST(WKBackForwardList, CrossDocumentNavigationWithRecentUserGestureNotFlagged)
+{
+    TestWebKitAPI::HTTPServer server({
+        { "/source"_s, { "Source page"_s } },
+        { "/destination"_s, { "Destination page"_s } },
+    }, TestWebKitAPI::HTTPServer::Protocol::Http);
+
+    RetainPtr webView = adoptNS([[WKWebView alloc] init]);
+    [webView _setDontResetTransientActivationAfterRunJavaScript:YES];
+    RetainPtr navigationDelegate = adoptNS([WKBackForwardNavigationDelegate new]);
+    webView.get().navigationDelegate = navigationDelegate.get();
+
+    [webView loadRequest:server.request("/source"_s)];
+    [navigationDelegate waitForDidFinishNavigation];
+
+    // A pattern that's been seen is:
+    // - JS intercepts link click with preventDefault()
+    // - In an async callback, navigates via location.href = <...>
+    // There is a 1-second user gesture forwarding window for such timers.
+    // So sometimes when the load commits and the standard load history update takes place,
+    // it's within the user gesture window, and the resulting back/forward list item is "normal"
+    // Other times it takes longer than a second, and the resulting item is flagged as
+    // "created by JS without user gesture"
+    //
+    // But in other places where we set that flag on a back/forward item we consider the
+    // `lastActivationTimestamp` recency - Which gives 10 seconds of leniency.
+    //
+    // The code change to fix this issue was to allow for the same 10 seconds.
+    // The test has to wait "longer than 1 second" to make sure it exercises the code change.
+    NSString *destinationURL = server.request("/destination"_s).URL.absoluteString;
+    [webView evaluateJavaScript:[NSString stringWithFormat:@"setTimeout(() => { location.href = '%@'; }, 1100);", destinationURL] completionHandler:nil];
+    [navigationDelegate waitForDidFinishNavigation];
+
+    EXPECT_STREQ([webView URL].absoluteString.UTF8String, destinationURL.UTF8String);
+    EXPECT_FALSE([webView backForwardList].currentItem._wasCreatedByJSWithoutUserInteraction);
+    EXPECT_EQ([webView backForwardList].backList.count, 1U);
 }
 
 TEST(WKBackForwardList, BackButtonWorksAfterUserClickFromJSCreatedPage)


### PR DESCRIPTION
#### c39b0f0fee87fbf2d7cc1581fcbabfdbb244a8cb
<pre>
Browser back/forward button skipping some pages on github
<a href="https://rdar.apple.com/176231638">rdar://176231638</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=314156">https://bugs.webkit.org/show_bug.cgi?id=314156</a>

Reviewed by Abrar Rahman Protyasha.

Github does the following when clicking certain types of links on some pages:
1 - Prevent&apos;s default on the link click
2 - Performs a `fetch` for the resource instead
3 - In the fetch callback, sometimes replaces the content inline and changes URL with `pushState`
4 - Other times in the fetch callback, navigates by setting `location.href`

In the (4) case, the fact that the navigation is logically the direct result of a user click is lost.
This means that when the back/forward item for that navigation is created, it is incorrectly
flagged as &quot;created by JS without user gesture&quot;.

As of 311615@main we started hiding some of these items from clients at the WebKit API level,
leading to a confusing back/forward button experience at github.

This patch extends the 10-second &quot;last transient activation&quot; mechanism to the history update,
allowing items created within this span to be considered user created.

Also committing some drive by fixes I noticed while I was debugging the issue

Claude helped come up with this test.

Test: Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKBackForwardListTests.mm

* Source/WebCore/loader/HistoryController.cpp:
(WebCore::HistoryController::updateForStandardLoad):

* Source/WebKit/Shared/WebBackForwardListFrameItem.cpp:
(WebKit::WebBackForwardListFrameItem::loggingStringAtIndent):
* Source/WebKit/UIProcess/API/Cocoa/WKBackForwardListInternal.h:

* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKBackForwardListTests.mm:
(TEST(WKBackForwardList, CrossDocumentNavigationWithRecentUserGestureNotFlagged)):

Canonical link: <a href="https://commits.webkit.org/312709@main">https://commits.webkit.org/312709@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d697af5c17cc7c02067c7d4d868853eaa778f48f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/160860 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/34333 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/27434 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/169763 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/115928 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/66cf9b45-27cb-4281-a24d-9ef55d4ed703) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/162729 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/34434 "Build is in progress. Recent messages:OS: Tahoe (26.2), Xcode: 26.2; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (warnings)") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/34333 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/124769 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/115928 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/9d79768e-b983-4272-8a94-963e158a7271) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/163819 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/27028 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/144496 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/105366 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/98d3fcc3-4130-4475-ab10-d92766cacf6e) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/26080 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/24576 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/17483 "Built successfully") | | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/152916 "Build is in progress. Recent messages:") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/135774 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/167/builds/22259 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/172246 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/19267 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/23900 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/133037 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/34007 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/28669 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/133048 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35924 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/33991 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/144054 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/95830 "Built successfully") | | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/164/builds/27644 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/20869 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/33502 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/100927 "Built successfully") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/33001 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/33245 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/33149 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->