### PR TITLE
REGRESSION(310941@main): Null deref in AlternativeTextController::respondToChangedSelection when endOfWord() returns null

### DIFF
--- a/LayoutTests/editing/mac/spelling/respond-to-changed-selection-null-end-of-word-crash-expected.txt
+++ b/LayoutTests/editing/mac/spelling/respond-to-changed-selection-null-end-of-word-crash-expected.txt
@@ -1,0 +1,1 @@
+This test passes if it does not crash.

--- a/LayoutTests/editing/mac/spelling/respond-to-changed-selection-null-end-of-word-crash.html
+++ b/LayoutTests/editing/mac/spelling/respond-to-changed-selection-null-end-of-word-crash.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html>
+<body>
+<p>This test passes if it does not crash.</p>
+<script>
+if (window.testRunner) {
+    testRunner.dumpAsText();
+    testRunner.waitUntilDone();
+}
+
+(async () => {
+    if (window.internals)
+        internals.withUserGesture(() => {});
+    const output = document.createElement("output");
+    document.documentElement.appendChild(output);
+    const picture = document.createElement("picture");
+    output.appendChild(picture);
+    await output.requestFullscreen();
+    picture.outerText = "x";
+    document.execCommand("SelectAll");
+    document.designMode = "on";
+    document.execCommand("InsertText", false, "y");
+    document.designMode = "off";
+    await document.exitFullscreen();
+    output.remove();
+    if (window.testRunner)
+        testRunner.notifyDone();
+})();
+</script>
+</body>
+</html>

--- a/Source/WebCore/editing/AlternativeTextController.cpp
+++ b/Source/WebCore/editing/AlternativeTextController.cpp
@@ -434,6 +434,9 @@ void AlternativeTextController::respondToChangedSelection(const VisibleSelection
     
     VisiblePosition startPositionOfWord = startOfWord(selectionPosition, WordSide::RightWordIfOnBoundary);
     VisiblePosition endPositionOfWord = endOfWord(selectionPosition, WordSide::LeftWordIfOnBoundary);
+    if (endPositionOfWord.isNull())
+        return;
+
     if (!oldSelectionPosition.isNull()) {
         VisiblePosition oldStartPositionOfWord = startOfWord(oldSelectionPosition, WordSide::RightWordIfOnBoundary);
         VisiblePosition oldEndPositionOfWord = endOfWord(oldSelectionPosition, WordSide::LeftWordIfOnBoundary);
@@ -446,11 +449,11 @@ void AlternativeTextController::respondToChangedSelection(const VisibleSelection
         return;
 
     RefPtr node = position.containerNode();
+    ASSERT(node);
     CheckedPtr markers = node->document().markersIfExists();
     if (!markers)
         return;
 
-    ASSERT(node);
     bool handled = false;
     for (auto& marker : markers->markersFor(*node)) {
         ASSERT(marker);


### PR DESCRIPTION
#### b444717fbb43dfc8a567db476ace60e8ff3efe02
<pre>
REGRESSION(310941@main): Null deref in AlternativeTextController::respondToChangedSelection when endOfWord() returns null
<a href="https://bugs.webkit.org/show_bug.cgi?id=314157">https://bugs.webkit.org/show_bug.cgi?id=314157</a>
<a href="https://rdar.apple.com/176140938">rdar://176140938</a>

Reviewed by Megan Gardner and Ryosuke Niwa.

310941@main removed the `if (selectionPosition != endPositionOfWord) return;`
guard, which had incidentally guaranteed that `endPositionOfWord` was non-null
(since `selectionPosition` is null-checked just above). `endOfWord()` can
legitimately return a null VisiblePosition when canonicalPosition refuses to
produce a position that crosses an editable-root boundary -- for example, when
a fullscreen element creates an editable island whose parent is inert. A
default-constructed Position has anchorType() == PositionIsOffsetInAnchor, so
the existing anchorType() check does not reject the null case, and we crash
dereferencing the null result of `position.containerNode()`.

Add an explicit null check on `endPositionOfWord`, matching the established
pattern in Editor::updateMarkersForWordsAffectedByEditing. Also move the
`ASSERT(node)` to immediately after `containerNode()` -- it previously sat
after `node-&gt;document()`, where it was unreachable.

* LayoutTests/editing/mac/spelling/respond-to-changed-selection-null-end-of-word-crash-expected.txt: Added.
* LayoutTests/editing/mac/spelling/respond-to-changed-selection-null-end-of-word-crash.html: Added.
* Source/WebCore/editing/AlternativeTextController.cpp:
(WebCore::AlternativeTextController::respondToChangedSelection):

Canonical link: <a href="https://commits.webkit.org/312857@main">https://commits.webkit.org/312857@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/55a15783e2d806882e374dce0a0cec7849fda296

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/160959 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/34432 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/27533 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/169862 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/117219 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/42980780-e4c6-4dbe-85cd-745c43c8372f) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/162828 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/34533 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/34432 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/124854 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/88099 "1 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/7ac595c2-f1de-4611-869d-de8108ee1a27) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/163918 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/27122 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/144590 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/105451 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/9ce7499b-8ae8-4e93-8361-886b03b397ef) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/26173 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/24669 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/17582 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/135867 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/22352 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/172345 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/19366 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/23993 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/133130 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/34106 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/28762 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/133140 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36026 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/34090 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/144147 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/95929 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/27707 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/20964 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/33601 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/101026 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/33100 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/33344 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/33249 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->