### PR TITLE
[macOS Debug] TestWebKitAPI.WKWebsiteDataStore.FetchPersistentCredentials is flaky

### DIFF
--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -8516,8 +8516,6 @@ webkit.org/b/304995 [ Release ] imported/w3c/web-platform-tests/largest-contentf
 
 webkit.org/b/305404 imported/w3c/web-platform-tests/css/css-text-decor/text-emphasis-position-auto-001.html [ Pass ImageOnlyFailure ]
 
-webkit.org/b/305508 http/tests/resourceLoadStatistics/log-cross-site-load-with-link-decoration.html [ Pass Failure ]
-
 webkit.org/b/309370 fast/css/vertical-text-overflow-ellipsis-text-align-center.html [ Failure Pass ]
 
 webkit.org/b/305605 media/volume-sleep-disable.html [ Failure ]

--- a/LayoutTests/platform/mac-wk2/TestExpectations
+++ b/LayoutTests/platform/mac-wk2/TestExpectations
@@ -2164,8 +2164,6 @@ webkit.org/b/312919 http/wpt/webauthn/public-key-credential-create-success-local
 webkit.org/b/312919 http/wpt/webauthn/public-key-credential-get-success-local.https.html [ Crash Failure ]
 webkit.org/b/312919 http/wpt/webauthn/public-key-credential-get-failure-local.https.html [ Crash Failure ]
 
-webkit.org/b/305508 http/tests/resourceLoadStatistics/log-cross-site-load-with-link-decoration.html [ Pass Failure ]
-
 webkit.org/b/305581 http/tests/workers/service/shownotification-allowed.html [ Pass Failure ]
 
 webkit.org/b/310052 [ Tahoe Debug arm64 ] inspector/unit-tests/array-utilities.html [ Slow ]

--- a/Source/WebKit/NetworkProcess/Classifier/WebResourceLoadStatisticsStore.cpp
+++ b/Source/WebKit/NetworkProcess/Classifier/WebResourceLoadStatisticsStore.cpp
@@ -327,6 +327,11 @@ void WebResourceLoadStatisticsStore::resourceLoadStatisticsUpdated(Vector<Resour
             return;
         }
 
+        if (statistics.isEmpty()) {
+            postTaskReply(WTF::move(completionHandler));
+            return;
+        }
+
         statisticsStore->mergeStatistics(WTF::move(statistics));
         postTaskReply(WTF::move(completionHandler));
         // We can cancel any pending request to process statistics since we're doing it synchronously below.

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKWebsiteDatastore.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKWebsiteDatastore.mm
@@ -50,15 +50,17 @@ static bool usePersistentCredentialStorage = false;
 
 @implementation NavigationTestDelegate {
     bool _hasFinishedNavigation;
+    bool _isFirstChallenge;
 }
 
 - (instancetype)init
 {
     if (!(self = [super init]))
         return nil;
-    
+
     _hasFinishedNavigation = false;
-    
+    _isFirstChallenge = true;
+
     return self;
 }
 
@@ -74,9 +76,8 @@ static bool usePersistentCredentialStorage = false;
 
 - (void)webView:(WKWebView *)webView didReceiveAuthenticationChallenge:(NSURLAuthenticationChallenge *)challenge completionHandler:(void (^)(NSURLSessionAuthChallengeDisposition, NSURLCredential *))completionHandler
 {
-    static bool firstChallenge = true;
-    if (firstChallenge) {
-        firstChallenge = false;
+    if (_isFirstChallenge) {
+        _isFirstChallenge = false;
         persistentCredential = adoptNS([[NSURLCredential alloc] initWithUser:@"username" password:@"password" persistence:(usePersistentCredentialStorage ? NSURLCredentialPersistencePermanent: NSURLCredentialPersistenceForSession)]);
         return completionHandler(NSURLSessionAuthChallengeUseCredential, persistentCredential.get());
     }
@@ -281,12 +282,7 @@ TEST(WKWebsiteDataStore, FetchNonPersistentCredentials)
     TestWebKitAPI::Util::run(&done);
 }
 
-// FIXME when webkit.org/b/309374 is resolved.
-#if PLATFORM(MAC) && !defined(NDEBUG)
-TEST(WKWebsiteDataStore, DISABLED_FetchPersistentCredentials)
-#else
 TEST(WKWebsiteDataStore, FetchPersistentCredentials)
-#endif
 {
     HTTPServer server(HTTPServer::respondWithChallengeThenOK);
 
@@ -302,6 +298,11 @@ TEST(WKWebsiteDataStore, FetchPersistentCredentials)
 
     [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:[NSString stringWithFormat:@"http://127.0.0.1:%d/", server.port()]]]];
     [navigationDelegate waitForDidFinishNavigation];
+
+    // Terminate the network process to clear any session-level credential copies that
+    // NSURLSession may have cached during authentication. The subsequent fetch will start
+    // a fresh network process that only sees the permanent credential in the keychain.
+    [websiteDataStore _terminateNetworkProcess];
 
     __block bool done = false;
     [websiteDataStore fetchDataRecordsOfTypes:[NSSet setWithObject:_WKWebsiteDataTypeCredentials] completionHandler:^(NSArray<WKWebsiteDataRecord *> *dataRecords) {


### PR DESCRIPTION
#### 03b3b94d31e8589e80ab06ca20aa95f63ebf3afa
<pre>
[macOS Debug] TestWebKitAPI.WKWebsiteDataStore.FetchPersistentCredentials is flaky
<a href="https://bugs.webkit.org/show_bug.cgi?id=309374">https://bugs.webkit.org/show_bug.cgi?id=309374</a>
<a href="https://rdar.apple.com/171928551">rdar://171928551</a>

Reviewed by NOBODY (OOPS!).

The test&apos;s NavigationTestDelegate used a `static bool firstChallenge` shared across all
tests. When FetchPersistentCredentials ran after FetchNonPersistentCredentials, the static
was already false so no credential was provided and the test trivially passed. When it ran
first or in isolation, firstChallenge was true, a permanent credential was stored, and
NSURLSession&apos;s session-level copy appeared in fetchDataRecordsOfTypes (count=1 instead of 0).

Fix by making firstChallenge a per-instance variable so each test gets its own fresh state,
and terminating the network process after navigation to clear any session-level credential
copies before the fetch.

* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKWebsiteDatastore.mm:
(-[NavigationTestDelegate init]):
(-[NavigationTestDelegate webView:didReceiveAuthenticationChallenge:completionHandler:]):
(TestWebKitAPI::(WKWebsiteDataStore, FetchPersistentCredentials)):
(TestWebKitAPI::(WKWebsiteDataStore, DISABLED_FetchPersistentCredentials)(WKWebsiteDataStore, FetchPersistentCredentials)): Deleted.
</pre>
----------------------------------------------------------------------
#### 5fec76ee607896732244639dd7b3dcc00c17be4a
<pre>
REGRESSION(<a href="https://commits.webkit.org/304892@main">304892@main</a>?): http/tests/resourceLoadStatistics/log-cross-site-load-with-link-decoration.html is a flakey text failure
<a href="https://bugs.webkit.org/show_bug.cgi?id=305508">https://bugs.webkit.org/show_bug.cgi?id=305508</a>
<a href="https://rdar.apple.com/168172161">rdar://168172161</a>

Reviewed by NOBODY (OOPS!).

<a href="https://commits.webkit.org/304892@main">304892@main</a> defers old web process shutdown during commitProvisionalPage via a
shutdownPreventingScope. This allows the old process to receive the Close message
and flush its (potentially empty) resource load statistics to the network process.
resourceLoadStatisticsUpdated() unconditionally calls processStatisticsAndDataRecords()
even when there is nothing to merge. This processing iterates all domains and resets
DataRemovalFrequency to Never for any domain that was recently flagged for removal,
racing with logCrossSiteLoadWithLinkDecoration() which just set it to Short.

The fix is to early-return when the statistics vector is empty since there is nothing
to merge and no reason to trigger data records processing.

No new tests, unskip existing test.

* LayoutTests/platform/ios/TestExpectations:
* LayoutTests/platform/mac-wk2/TestExpectations:
* Source/WebKit/NetworkProcess/Classifier/WebResourceLoadStatisticsStore.cpp:
(WebKit::WebResourceLoadStatisticsStore::resourceLoadStatisticsUpdated):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/03b3b94d31e8589e80ab06ca20aa95f63ebf3afa

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/160747 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/34220 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/27321 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/169650 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/115813 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/162616 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/34321 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/34220 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/124665 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/88022 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/163706 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/26915 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/144387 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/105262 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/25967 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/24470 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/17370 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/135661 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/22150 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/172132 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/19099 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/23791 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/132933 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/33894 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/28562 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/132945 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/33878 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/143945 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/95687 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/27534 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/20760 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/33389 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/100712 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/32888 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/33132 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/33036 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->