### PR TITLE
Sync `the-location-interface` from WPT Upstream

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -768,6 +768,7 @@ imported/w3c/web-platform-tests/html/semantics/embedded-content/media-elements/a
 imported/w3c/web-platform-tests/html/semantics/embedded-content/media-elements/autoplay-allowed-by-permissions-policy.https.sub.html [ Skip ] # timeout and passes a subtest
 imported/w3c/web-platform-tests/html/semantics/embedded-content/media-elements/autoplay-default-permissions-policy.https.sub.html [ Skip ] # timeout and passes a subtest
 imported/w3c/web-platform-tests/html/browsers/history/the-location-interface/location-origin-idna.sub.window.html [ Skip ]
+imported/w3c/web-platform-tests/html/browsers/history/the-location-interface/location_replace_session_history.html [ Skip ] # timeout on all browsers
 imported/w3c/web-platform-tests/html/browsers/history/the-location-interface/location_assign.html [ Skip ]
 imported/w3c/web-platform-tests/html/browsers/history/the-location-interface/per-global.window.html [ Skip ]
 # bfcache is not enabled in WebKitTestRunner.

--- a/LayoutTests/imported/w3c/web-platform-tests/html/browsers/history/the-location-interface/WEB_FEATURES.yml
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/browsers/history/the-location-interface/WEB_FEATURES.yml
@@ -1,0 +1,17 @@
+features:
+- name: location
+  files:
+  - assign-*
+  - document_location.html
+  - location-*
+  - location_*
+  - "!location_hashchange_infinite_loop.html"
+  - no-browsing-context.window.js
+  - reload_*
+  - replace-with-nested-iframe.html
+  - same-hash.html
+  - scripted_*
+- name: hashchange
+  files:
+  - location_hashchange_infinite_loop.html
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/browsers/history/the-location-interface/assign_after_load-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/browsers/history/the-location-interface/assign_after_load-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL Assignment to location after document is completely loaded assert_equals: expected 4 but got 3
+PASS Assignment to location after document is completely loaded
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/browsers/history/the-location-interface/assign_after_load.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/browsers/history/the-location-interface/assign_after_load.html
@@ -16,7 +16,7 @@ onload = t.step_func(function() {
 });
 
 do_test = t.step_func(function() {
-    assert_equals(history.length, history_length + 2);
+    assert_equals(history.length, history_length + 1);
     t.done();
 });
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/browsers/history/the-location-interface/assign_before_load-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/browsers/history/the-location-interface/assign_before_load-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL Assignment to location before document is completely loaded assert_equals: expected 3 but got 2
+PASS Assignment to location before document is completely loaded
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/browsers/history/the-location-interface/assign_before_load.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/browsers/history/the-location-interface/assign_before_load.html
@@ -16,7 +16,7 @@ onload = t.step_func(function() {
 });
 
 do_test = t.step_func(function() {
-    assert_equals(history.length, history_length + 1);
+    assert_equals(history.length, history_length);
     t.done();
 });
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/browsers/history/the-location-interface/create-script-set-location-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/browsers/history/the-location-interface/create-script-set-location-expected.txt
@@ -1,0 +1,4 @@
+button
+
+PASS Setting href in appended script still creates history entry
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/browsers/history/the-location-interface/create-script-set-location.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/browsers/history/the-location-interface/create-script-set-location.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<title>Setting href in appended script still creates history entry</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+<button id="button">button</button>
+<script>
+  let navigationType = 'none';
+  navigation.addEventListener('navigate', (e) => {
+    e.intercept();
+    navigationType = e.navigationType;
+  });
+  button.addEventListener('click', () => {
+    let s = document.createElement('script');
+    s.textContent = 'location.href="?foo"';
+    document.body.append(s);
+  });
+  promise_test(async() => {
+    await test_driver.click(button);
+    assert_equals(navigationType, 'push', 'Setting href in script appended on button click should cause push navigation');
+  });
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/browsers/history/the-location-interface/cross-origin-location-stringify-crash.sub.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/browsers/history/the-location-interface/cross-origin-location-stringify-crash.sub.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html class="test-wait">
+<meta charset="utf-8">
+<title>Stringifying cross-origin location should not crash</title>
+<meta name="assert" content="console.log of a cross-origin location object should not crash.">
+<script src="/common/get-host-info.sub.js"></script>
+<body>
+<script>
+  var iframe = document.createElement("iframe");
+  iframe.src = get_host_info().HTTP_REMOTE_ORIGIN + "/common/blank.html";
+  iframe.onload = function() {
+    console.log(iframe.contentWindow.location);
+    document.documentElement.classList.remove("test-wait");
+  };
+  document.body.appendChild(iframe);
+</script>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/browsers/history/the-location-interface/location-ancestor-origins-referrerpolicy-snapshot-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/browsers/history/the-location-interface/location-ancestor-origins-referrerpolicy-snapshot-expected.txt
@@ -1,0 +1,5 @@
+
+
+FAIL location.ancestorOrigins snapshot timing of referrerpolicy assert_array_equals: expected property 0 to be "null" but got "http://web-platform.test:8800" (expected array ["null"] got ["http://web-platform.test:8800"])
+FAIL location.ancestorOrigins snapshot timing of referrerpolicy 1 assert_array_equals: expected property 0 to be "null" but got "http://web-platform.test:8800" (expected array ["null"] got ["http://web-platform.test:8800"])
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/browsers/history/the-location-interface/location-ancestor-origins-referrerpolicy-snapshot.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/browsers/history/the-location-interface/location-ancestor-origins-referrerpolicy-snapshot.html
@@ -1,0 +1,42 @@
+<!doctype html>
+<title>location.ancestorOrigins snapshot timing of referrerpolicy</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<body>
+<script>
+promise_test(async () => {
+  assert_implements(location.ancestorOrigins);
+  const iframe = document.createElement('iframe');
+  iframe.src = '/common/blank.html?pipe=trickle(d1)';
+  iframe.referrerPolicy = 'no-referrer';
+  const loaded = new Promise(resolve => iframe.onload = resolve);
+  document.body.append(iframe);
+  // initial about:blank should see 'no-referrer' results
+  assert_array_equals(Array.from(iframe.contentWindow.location.ancestorOrigins), ['null']);
+  iframe.referrerPolicy = '';
+  await loaded;
+  // The referrerpolicy attribute get snapshotted at step 16 of "beginning navigation"
+  // https://html.spec.whatwg.org/#beginning-navigation and result should therefore,
+  // still be ["null"], here.
+  assert_array_equals(Array.from(iframe.contentWindow.location.ancestorOrigins), ["null"]);
+});
+
+promise_test(async () => {
+  assert_implements(location.ancestorOrigins);
+  const iframe = document.createElement('iframe');
+
+  iframe.referrerPolicy = 'no-referrer';
+  const loaded = new Promise(resolve => iframe.onload = resolve);
+  document.body.append(iframe);
+  // initial about:blank should see 'no-referrer' results
+  assert_array_equals(Array.from(iframe.contentWindow.location.ancestorOrigins), ['null']);
+  iframe.referrerPolicy = '';
+  await loaded;
+
+  await new Promise(resolve => {
+    iframe.onload = resolve;
+    iframe.src = '/common/blank.html?pipe=trickle(d1)';
+  });
+  assert_array_equals(Array.from(iframe.contentWindow.location.ancestorOrigins), [window.origin]);
+});
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/browsers/history/the-location-interface/location-ancestor-origins.sub-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/browsers/history/the-location-interface/location-ancestor-origins.sub-expected.txt
@@ -1,0 +1,18 @@
+
+PASS test A1 -> B1 (no-referrer in response header) -> C1 -> B2
+PASS test A1 -> A2 (no-referrer in response header) -> B1 -> C1
+FAIL test no-referrer attribute on iframe for iframe containing B1 assert_array_equals: expected property 0 to be "null" but got "http://web-platform.test:8800" (expected array ["null"] got ["http://web-platform.test:8800"])
+PASS test default referrer policy, A1 -> B1 -> A2
+FAIL test toggle of masked A1 -> B1 iframe for A2 sets no-referrer -> A2 assert_array_equals: expected property 0 to be "null" but got "http://not-web-platform.test:8800" (expected array ["null", "http://web-platform.test:8800"] got ["http://not-web-platform.test:8800", "http://web-platform.test:8800"])
+FAIL test of toggle of masked at first origin != parentDocOrigin, A1 -> B1 -> B2 -> A2 assert_array_equals: expected property 0 to be "null" but got "http://not-web-platform.test:8800" (expected array ["null", "null", "http://web-platform.test:8800"] got ["http://not-web-platform.test:8800", "http://not-web-platform.test:8800", "http://web-platform.test:8800"])
+PASS test sandboxed iframe in A1, A1 iframe attribute sandbox -> C1 -> B1 -> C2
+FAIL Test same-origin referrer policy, A1 -> B1 -> A2 iframe attribute same-origin -> B2 assert_array_equals: expected property 0 to be "null" but got "http://web-platform.test:8800" (expected array ["null", "http://not-web-platform.test:8800", "http://web-platform.test:8800"] got ["http://web-platform.test:8800", "http://not-web-platform.test:8800", "http://web-platform.test:8800"])
+FAIL Test that mutating the iframe referrerpolicy attribute of B1 before creation of B2 does not impact the hiding/non-hiding when creating a grandchild browsing context (keep null) assert_array_equals: expected property 0 to be "null" but got "http://not-web-platform.test:8800" (expected array ["null", "http://web-platform.test:8800"] got ["http://not-web-platform.test:8800", "http://web-platform.test:8800"])
+PASS Test that mutating the iframe referrerpolicy attribute does not impact the hiding/non-hiding when creating a grandchild browsing context (keep origins)
+PASS Test that tightening policy using meta, does not affect list
+PASS Test that loosening policy in policy container has no effect.
+PASS about:blank's location.ancestorOrigin policy=null
+FAIL about:blank's location.ancestorOrigin policy=no-referrer assert_array_equals: expected property 0 to be "null" but got "http://web-platform.test:8800" (expected array ["null"] got ["http://web-platform.test:8800"])
+PASS A -> about:blank -> B1 -> B2
+FAIL A -> about:blank, that set iframe referrer policy=no-referrer -> B1 -> B2 assert_array_equals: expected property 1 to be "null" but got "http://web-platform.test:8800" (expected array ["http://not-web-platform.test:8800", "null", "null"] got ["http://not-web-platform.test:8800", "http://web-platform.test:8800", "http://web-platform.test:8800"])
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/browsers/history/the-location-interface/location-ancestor-origins.sub.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/browsers/history/the-location-interface/location-ancestor-origins.sub.html
@@ -1,0 +1,328 @@
+<!DOCTYPE html>
+<title>
+  Location#ancestorOrigins test
+</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+<script src="./resources/location-ancestor-origins-create-iframe.js"></script>
+
+<body>
+  <script>
+    function waitFor(action, frameName) {
+      return new Promise((resolve) => {
+        window.addEventListener("message", function listener(e) {
+          if (e.data.event === action && e.data.name === frameName) {
+            window.removeEventListener("message", listener);
+            resolve(event.data);
+          }
+        });
+      });
+    }
+
+    const frameCreatorPath = "html/browsers/history/the-location-interface/resources/location-ancestor-origins-recursive-iframe.html"
+
+    const createOrigin = (src) => {
+      const url = new URL(src);
+      return {
+        src: src,
+        origin: url.origin,
+        // change referrer policy value in header
+        withHeaders: (policyValue) => {
+          if (!policyValue)
+            return src;
+          return `${src}&pipe=header(Referrer-Policy,${policyValue})`;
+        }
+      }
+    }
+
+    // iframeSources[0] origins shares origin with top level
+    let iframeSources = [
+      createOrigin(`http://{{hosts[][]}}:{{ports[http][0]}}/${frameCreatorPath}?a`),
+      createOrigin(`http://{{hosts[alt][]}}:{{ports[http][0]}}/${frameCreatorPath}?b`),
+      createOrigin(`http://{{hosts[][www]}}:{{ports[http][0]}}/${frameCreatorPath}?c`)
+    ];
+
+    const A = iframeSources[0]
+    const B = iframeSources[1];
+    const C = iframeSources[2];
+
+    const policy = {
+      Default: "",
+      NoRef: "no-referrer",
+      SameOrigin: "same-origin"
+    }
+
+    // options takes optional values for iframe attribute, or a pre-configure
+    // step before creating the iframe that a call to `config` configures,
+    // like changing iframe referrer policy of a frame in a specific target.
+    // options is created by calling mutatePolicyOf, insertMetaForWithPolicyOf
+    // or an object containing { sandbox: boolean }
+    // The options argument can specify something that should happen before
+    // the creation of the frame this configures.
+
+    // for example: config("B2", B.src, policy.Default, mutatePolicyOf("B1", "")) means
+    // create a frame named B2 in the inner-most frame, with src=B.src, referrerPolicy = the default
+    // but before the frame is bound to the tree,
+    // perform an action in "B1" that mutates B1's referrer policy attribute (in this case to the default, i.e. the empty string)
+    const config = (name, src, iframeRefPolicyAttr, options = null) => ({ name: name, src, referrerPolicy: iframeRefPolicyAttr, options })
+
+    const mutatePolicyOf = (target, value) => {
+      return { target, action: Actions.changeReferrerPolicy, value }
+    }
+
+    const insertMetaForWithPolicyOf = (target, value) => {
+      return { target, action: Actions.insertMetaElement, value }
+    }
+
+    // Top-level === A1
+    // Only referrerpolicy on the element (e.g. iframe) should affect the ancestorOrigins list.
+    // Some of these tests may seem counterintuitive/not useful, but they are to make sure that nothing but
+    // that attribute, has effect.
+    const testCases = [
+      {
+        description: "test A1 -> B1 (no-referrer in response header) -> C1 -> B2",
+        frames: [
+          config("B1", B.withHeaders(policy.NoRef), policy.Default),
+          config("C1", C.src, policy.Default),
+          config("B2", B.src, policy.Default),
+        ],
+        expected: [
+          [A.origin],
+          [B.origin, A.origin],
+          [C.origin, B.origin, A.origin],
+        ]
+      },
+      {
+        description: "test A1 -> A2 (no-referrer in response header) -> B1 -> C1",
+        frames: [
+          config("A2", A.withHeaders(policy.NoRef), policy.Default),
+          config("B1", B.src, policy.Default),
+          config("C1", C.src, policy.Default),
+        ],
+        expected: [
+          [A.origin],
+          [A.origin, A.origin],
+          [B.origin, A.origin, A.origin],
+        ]
+      },
+      {
+        description: "test no-referrer attribute on iframe for iframe containing B1",
+        frames: [
+          config("B1", B.src, policy.NoRef)
+        ],
+        expected: [
+          ["null"]
+        ]
+      },
+      {
+        description: "test default referrer policy, A1 -> B1 -> A2",
+        frames: [
+          config("B1", B.src, policy.Default),
+          config("A2", A.src, policy.Default)
+        ],
+        expected: [
+          [A.origin],
+          [B.origin, A.origin]
+        ]
+      },
+      {
+        description: "test toggle of masked A1 -> B1 iframe for A2 sets no-referrer -> A2",
+        frames: [
+          config("B1", B.src, policy.Default),
+          config("A2", A.src, policy.NoRef)
+        ],
+        expected: [
+          [A.origin],
+          ["null", A.origin]
+        ]
+      },
+      {
+        description: "test of toggle of masked at first origin != parentDocOrigin, A1 -> B1 -> B2 -> A2",
+        frames: [
+          config("B1", B.src, policy.Default),
+          config("B2", B.src, policy.Default),
+          config("A2", A.src, policy.NoRef)
+        ],
+        expected: [
+          [A.origin],
+          [B.origin, A.origin],
+          ["null", "null", A.origin]
+        ]
+      },
+      {
+        description: "test sandboxed iframe in A1, A1 iframe attribute sandbox -> C1 -> B1 -> C2",
+        frames: [
+          config("C1", C.src, policy.Default, { sandbox: true }),
+          config("B1", B.src, policy.Default),
+          config("C2", C.src, policy.Default),
+        ],
+        expected: [
+          [A.origin],
+          ["null", A.origin],
+          ["null", "null", A.origin],
+        ]
+      },
+      {
+        description: "Test same-origin referrer policy, A1 -> B1 -> A2 iframe attribute same-origin -> B2",
+        frames: [
+          config("B1", B.src, policy.Default),
+          config("A2", A.src, policy.Default),
+          config("B2", B.src, policy.SameOrigin)
+        ],
+        expected: [
+          [A.origin],
+          [B.origin, A.origin],
+          ["null", B.origin, A.origin]
+        ]
+      },
+      {
+        description: "Test that mutating the iframe referrerpolicy attribute of B1 before creation of B2 does not impact the hiding/non-hiding when creating a grandchild browsing context (keep null)",
+        frames: [
+          config("B1", B.src, policy.Default),
+          config("C1", C.src, policy.NoRef),
+          // change <iframe src=C1> in B1, referrer policy to default, before creating this context
+          config("B2", B.src, policy.Default, mutatePolicyOf("B1", "")),
+        ],
+        expected: [
+          [A.origin],
+          ["null", A.origin],
+          [C.origin, "null", A.origin]
+        ],
+      },
+      {
+        description: "Test that mutating the iframe referrerpolicy attribute does not impact the hiding/non-hiding when creating a grandchild browsing context (keep origins)",
+        frames: [
+          config("B1", B.src, policy.Default),
+          config("C1", C.src, policy.Default),
+          // change <iframe src=C1> in B1, referrer policy to no-referrer, before creating this context
+          config("B2", B.src, policy.Default, mutatePolicyOf("B1", "no-referrer")),
+        ],
+        expected: [
+          [A.origin],
+          [B.origin, A.origin],
+          [C.origin, B.origin, A.origin]
+        ],
+      },
+      {
+        description: "Test that tightening policy using meta, does not affect list",
+        frames: [
+          config("B1", B.src, policy.Default),
+          config("C1", C.src, policy.Default, insertMetaForWithPolicyOf("B1", "no-referrer")),
+        ],
+        expected: [
+          [A.origin],
+          [B.origin, A.origin],
+        ],
+      },
+      {
+        description: "Test that loosening policy in policy container has no effect.",
+        frames: [
+          config("B1", B.withHeaders("no-referrer"), policy.Default),
+          config("C1", C.src, policy.Default, insertMetaForWithPolicyOf("B1", "strict-origin-when-cross-origin")),
+        ],
+        expected: [
+          [A.origin],
+          [B.origin, A.origin],
+        ],
+      },
+    ]
+
+    testCases.forEach((cfg, index) => {
+      promise_test(async (t) => {
+        assert_implements(location.ancestorOrigins, "location.ancestorOrigins not implemented");
+        const iframeDetails = cfg.frames[0];
+
+        const topFrameAncestorOrigins = waitFor("sentOrigins", iframeDetails.name);
+        const iframe = document.createElement("iframe");
+        await configAndNavigateIFrame(iframe, iframeDetails);
+        const res = await topFrameAncestorOrigins;
+
+        t.add_cleanup(() => {
+          iframe.remove();
+        });
+
+        let results = [res];
+
+        for (let i = 1; i < cfg.frames.length; ++i) {
+          // name of frame, that shall create a new frame
+          const parentName = cfg.frames[i - 1].name;
+          const { target, action, value } = cfg.frames[i].options ?? {};
+          if (target) {
+            iframe.contentWindow.postMessage({ action: action, request: { value: value }, name: target }, "*");
+          }
+          iframe.contentWindow.postMessage({ action: Actions.addFrame, request: cfg.frames[i], name: parentName }, "*");
+          const res = await waitFor("sentOrigins", cfg.frames[i].name);
+          results.push(res);
+        }
+
+        let i = 0;
+        for (const { event, name, origins } of results) {
+          assert_equals(origins.length, cfg.expected[i].length, `[test configuration ${index}, frame ${name}]`);
+          assert_array_equals(origins, cfg.expected[i]);
+          i += 1;
+        }
+      }, cfg.description);
+    });
+
+    [{ policy: null, expected: [A.origin] }, { policy: "no-referrer", expected: ["null"] }].forEach(test => {
+      promise_test(async t => {
+        assert_implements(location.ancestorOrigins, "location.ancestorOrigins not implemented");
+        const iframe = document.createElement("iframe");
+        t.add_cleanup(() => {
+          iframe.remove();
+        })
+        iframe.referrerPolicy = test.policy;
+        document.body.appendChild(iframe);
+        assert_array_equals(Array.from(iframe.contentWindow.location.ancestorOrigins), test.expected);
+      }, `about:blank's location.ancestorOrigin policy=${test.policy}`)
+    })
+
+    // Tests bottom-most frame's results only.
+    const expectedAboutBlankResults = [
+      {
+        description: "A -> about:blank -> B1 -> B2",
+        expected: [B.origin, A.origin, A.origin],
+        setNoreferrer: false
+      },
+      {
+        description: "A -> about:blank, that set iframe referrer policy=no-referrer -> B1 -> B2",
+        expected: [B.origin, "null", "null"],
+        setNoreferrer: true
+      }
+    ].forEach(test => {
+      promise_test(async (t) => {
+        assert_implements(location.ancestorOrigins, "location.ancestorOrigins not implemented");
+
+        const iframe1 = document.createElement("iframe");
+        // top level document's origin = A1.
+        iframe1.name = "A2";
+        t.add_cleanup(() => {
+          iframe1.remove();
+        });
+        document.body.appendChild(iframe1);
+
+        let iframe2 = document.createElement("iframe");
+        iframe2.name = "B1";
+
+        if (test.setNoreferrer) {
+          iframe2.referrerPolicy = "no-referrer";
+        }
+
+        let p = new Promise((resolve) => {
+          iframe2.addEventListener("load", resolve, { once: true });
+          iframe2.src = B.src;
+        });
+        iframe1.contentDocument.body.appendChild(iframe2);
+        await p;
+
+        let resPromise = waitFor("sentOrigins", "B2");
+        iframe2.contentWindow.postMessage({ action: Actions.addFrame, request: config("B2", B.src, policy.Default), name: "B1" }, "*")
+        let res = await resPromise;
+
+        assert_array_equals(Array.from(res.origins), test.expected);
+      }, test.description);
+    })
+  </script>
+</body>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/browsers/history/the-location-interface/location_replace_session_history.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/browsers/history/the-location-interface/location_replace_session_history.html
@@ -1,0 +1,19 @@
+<!DOCTYPE HTML>
+<html>
+  <head>
+    <title>location.replace replaces the active session history entry</title>
+    <script src="/resources/testharness.js"></script>
+    <script src="/resources/testharnessreport.js"></script>
+  </head>
+  <body>
+    <div id="log"></div>
+    <script>
+      var t = async_test();
+      t.step(() => {
+          let i = document.createElement('iframe');
+          i.src = "resources/iframe_location_replace.html";
+          document.body.appendChild(i);
+      });
+    </script>
+  </body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/browsers/history/the-location-interface/location_search-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/browsers/history/the-location-interface/location_search-expected.txt
@@ -1,3 +1,4 @@
 
 PASS location search
+PASS location.search on about:blank
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/browsers/history/the-location-interface/location_search.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/browsers/history/the-location-interface/location_search.html
@@ -15,6 +15,17 @@
       assert_equals(search, "?x=1", "search");
 
     }, "location search");
+
+    promise_test(async function() {
+      var iframe = document.createElement("iframe");
+      iframe.src = "about:blank?foo";
+      document.body.appendChild(iframe);
+      assert_equals(iframe.contentWindow.location.search, "?foo");
+
+      iframe.contentWindow.location.search = "?bar";
+      await new Promise(res => iframe.addEventListener("load", res));
+      assert_equals(iframe.contentWindow.location.search, "?bar");
+    }, "location.search on about:blank");
     </script>
   </body>
 </html>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/browsers/history/the-location-interface/non-automated/WEB_FEATURES.yml
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/browsers/history/the-location-interface/non-automated/WEB_FEATURES.yml
@@ -1,0 +1,4 @@
+features:
+- name: location
+  files:
+  - manual_*

--- a/LayoutTests/imported/w3c/web-platform-tests/html/browsers/history/the-location-interface/non-automated/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/browsers/history/the-location-interface/non-automated/w3c-import.log
@@ -14,6 +14,7 @@ Property values requiring vendor prefixes:
 None
 ------------------------------------------------------------------------
 List of files:
+/LayoutTests/imported/w3c/web-platform-tests/html/browsers/history/the-location-interface/non-automated/WEB_FEATURES.yml
 /LayoutTests/imported/w3c/web-platform-tests/html/browsers/history/the-location-interface/non-automated/manual_click_assign_during_load-1.html
 /LayoutTests/imported/w3c/web-platform-tests/html/browsers/history/the-location-interface/non-automated/manual_click_assign_during_load-2.html
 /LayoutTests/imported/w3c/web-platform-tests/html/browsers/history/the-location-interface/non-automated/manual_click_location_replace_during_load-1.html

--- a/LayoutTests/imported/w3c/web-platform-tests/html/browsers/history/the-location-interface/resources/iframe_location_replace.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/browsers/history/the-location-interface/resources/iframe_location_replace.html
@@ -1,0 +1,13 @@
+<!DOCTYPE HTML>replace.html
+<script>
+  let pageshowCount = 0;
+  onpageshow = parent.t.step_func(() => {
+      pageshowCount += 1;
+      if (pageshowCount == 2) {
+          location.replace("resources/iframe_location_replace3.html");
+      }
+  });
+  onload = parent.t.step_func(() => {
+      location.href = "resources/iframe_location_replace2.html";
+  });
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/browsers/history/the-location-interface/resources/iframe_location_replace2.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/browsers/history/the-location-interface/resources/iframe_location_replace2.html
@@ -1,0 +1,13 @@
+<!DOCTYPE HTML>replace2.html
+<script>
+  let pageshowCount = 0;
+  onpageshow = parent.t.step_func(() => {
+      pageshowCount += 1;
+      if (pageshowCount == 2) {
+          parent.t.done();
+      }
+  });
+  onload = parent.t.step_func(() => {
+      history.back();
+  });
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/browsers/history/the-location-interface/resources/iframe_location_replace3.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/browsers/history/the-location-interface/resources/iframe_location_replace3.html
@@ -1,0 +1,6 @@
+<!DOCTYPE HTML>replace3.html
+<script>
+  onload = parent.t.step_func(() => {
+      history.forward();
+  });
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/browsers/history/the-location-interface/resources/location-ancestor-origins-create-iframe.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/browsers/history/the-location-interface/resources/location-ancestor-origins-create-iframe.js
@@ -1,0 +1,20 @@
+// The different actions that we send to a cross-origin document via postMessage (since they may be/are site isolated)
+const Actions = {
+  addFrame: "addFrame",
+  changeReferrerPolicy: "changeReferrerPolicy",
+  insertMetaElement: "insertMetaElement",
+}
+
+async function configAndNavigateIFrame(iframe, { src, name, referrerPolicy, options }) {
+  iframe.name = name;
+  iframe.referrerPolicy = referrerPolicy;
+  if (options?.sandbox) {
+    // postMessage needs to work
+    iframe.setAttribute("sandbox", "allow-scripts");
+  }
+  document.body.appendChild(iframe);
+  await new Promise((resolve) => {
+    iframe.addEventListener("load", resolve, { once: true });
+    iframe.src = src;
+  });
+}

--- a/LayoutTests/imported/w3c/web-platform-tests/html/browsers/history/the-location-interface/resources/location-ancestor-origins-recursive-iframe.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/browsers/history/the-location-interface/resources/location-ancestor-origins-recursive-iframe.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<meta charset="utf-8" />
+<title>Recursive iframe document used for Location.ancestorOrigins tests</title>
+<!--- This file is used for the creation of the hosted pages inside the iframes. --->
+
+<body>
+  <script src="/resources/testdriver.js"></script>
+  <script src="/resources/testdriver-vendor.js"></script>
+  <script src="./location-ancestor-origins-create-iframe.js"></script>
+  <script>
+    let iframe = null;
+
+    window.addEventListener("message", async (e) => {
+      // Message is not for us, try to pass it on...
+      if (e.data.name !== window.name) {
+        iframe?.contentWindow.postMessage(e.data, "*");
+        return;
+      }
+      switch (e.data.action) {
+        case Actions.addFrame: {
+          iframe = document.createElement("iframe");
+          await configAndNavigateIFrame(iframe, e.data.request);
+          break;
+        }
+        case Actions.changeReferrerPolicy: {
+          iframe.referrerPolicy = e.data.request.value;
+          break;
+        }
+        case Actions.insertMetaElement: {
+          const meta = document.createElement("meta");
+          meta.name = "referrer";
+          meta.content = e.data.request.value;
+          document.head.appendChild(meta);
+          break;
+        }
+        default:
+          window.top.postMessage(e.data, "*");
+      }
+    });
+
+    window.top.postMessage({ event: "sentOrigins", name: window.name, origins: Array.from(location.ancestorOrigins) }, "*");
+  </script>
+</body>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/browsers/history/the-location-interface/resources/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/browsers/history/the-location-interface/resources/w3c-import.log
@@ -17,6 +17,11 @@ List of files:
 /LayoutTests/imported/w3c/web-platform-tests/html/browsers/history/the-location-interface/resources/iframe-contents.sub.html
 /LayoutTests/imported/w3c/web-platform-tests/html/browsers/history/the-location-interface/resources/iframe-postmessage-to-parent-parent.sub.html
 /LayoutTests/imported/w3c/web-platform-tests/html/browsers/history/the-location-interface/resources/iframe-with-iframe.html
+/LayoutTests/imported/w3c/web-platform-tests/html/browsers/history/the-location-interface/resources/iframe_location_replace.html
+/LayoutTests/imported/w3c/web-platform-tests/html/browsers/history/the-location-interface/resources/iframe_location_replace2.html
+/LayoutTests/imported/w3c/web-platform-tests/html/browsers/history/the-location-interface/resources/iframe_location_replace3.html
+/LayoutTests/imported/w3c/web-platform-tests/html/browsers/history/the-location-interface/resources/location-ancestor-origins-create-iframe.js
+/LayoutTests/imported/w3c/web-platform-tests/html/browsers/history/the-location-interface/resources/location-ancestor-origins-recursive-iframe.html
 /LayoutTests/imported/w3c/web-platform-tests/html/browsers/history/the-location-interface/resources/post-your-origin.html
 /LayoutTests/imported/w3c/web-platform-tests/html/browsers/history/the-location-interface/resources/post-your-protocol.html
 /LayoutTests/imported/w3c/web-platform-tests/html/browsers/history/the-location-interface/resources/reload_post_1-1.py

--- a/LayoutTests/imported/w3c/web-platform-tests/html/browsers/history/the-location-interface/scripted_form_submit_assign_during_load-1.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/browsers/history/the-location-interface/scripted_form_submit_assign_during_load-1.html
@@ -1,6 +1,6 @@
 <!doctype html>
 <script>
-opener.history_length = history.length;
+opener.test_initial_history_length(history.length);
 </script>
 <form onsubmit="location = 'scripted_form_submit_assign_during_load-2.html'; return false;">
 <input type=submit value="Click Me">

--- a/LayoutTests/imported/w3c/web-platform-tests/html/browsers/history/the-location-interface/scripted_form_submit_assign_during_load-2.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/browsers/history/the-location-interface/scripted_form_submit_assign_during_load-2.html
@@ -2,6 +2,6 @@
 <p>This window should close itself and the test result appear in the original window
 <script>
 onload = function() {
-  setTimeout(function() {opener.do_test(history.length); window.close();}, 100);
+  setTimeout(function() {opener.test_assign_during_load(history.length); window.close();}, 100);
 }
 </script>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/browsers/history/the-location-interface/scripted_form_submit_assign_during_load.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/browsers/history/the-location-interface/scripted_form_submit_assign_during_load.html
@@ -10,8 +10,12 @@ var t = async_test();
 var win = window.open("scripted_form_submit_assign_during_load-1.html");
 
 var history_length;
-do_test = t.step_func(function(new_length) {
-  assert_equals(new_length, history_length);
+test_initial_history_length = t.step_func(function(new_length) {
+  history_length = new_length;
+  assert_equals(history_length, 1, "Should have inital history");
+});
+test_assign_during_load = t.step_func(function(new_length) {
+  assert_equals(new_length, history_length, "Assigning to Location during load should replace");
   t.done();
 });
 </script>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/browsers/history/the-location-interface/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/browsers/history/the-location-interface/w3c-import.log
@@ -14,6 +14,7 @@ Property values requiring vendor prefixes:
 None
 ------------------------------------------------------------------------
 List of files:
+/LayoutTests/imported/w3c/web-platform-tests/html/browsers/history/the-location-interface/WEB_FEATURES.yml
 /LayoutTests/imported/w3c/web-platform-tests/html/browsers/history/the-location-interface/allow_prototype_cycle_through_location.sub.html
 /LayoutTests/imported/w3c/web-platform-tests/html/browsers/history/the-location-interface/assign-replace-from-iframe.html
 /LayoutTests/imported/w3c/web-platform-tests/html/browsers/history/the-location-interface/assign-replace-from-top-to-nested-iframe.html
@@ -24,8 +25,14 @@ List of files:
 /LayoutTests/imported/w3c/web-platform-tests/html/browsers/history/the-location-interface/assign_before_load-1.html
 /LayoutTests/imported/w3c/web-platform-tests/html/browsers/history/the-location-interface/assign_before_load-2.html
 /LayoutTests/imported/w3c/web-platform-tests/html/browsers/history/the-location-interface/assign_before_load.html
+/LayoutTests/imported/w3c/web-platform-tests/html/browsers/history/the-location-interface/create-script-set-location.html
+/LayoutTests/imported/w3c/web-platform-tests/html/browsers/history/the-location-interface/cross-origin-location-stringify-crash.sub.html
 /LayoutTests/imported/w3c/web-platform-tests/html/browsers/history/the-location-interface/cross_origin_joined_frame.sub.html
 /LayoutTests/imported/w3c/web-platform-tests/html/browsers/history/the-location-interface/document_location.html
+/LayoutTests/imported/w3c/web-platform-tests/html/browsers/history/the-location-interface/location-ancestor-origins-inactive-document.sub.html
+/LayoutTests/imported/w3c/web-platform-tests/html/browsers/history/the-location-interface/location-ancestor-origins-new-object.html
+/LayoutTests/imported/w3c/web-platform-tests/html/browsers/history/the-location-interface/location-ancestor-origins-referrerpolicy-snapshot.html
+/LayoutTests/imported/w3c/web-platform-tests/html/browsers/history/the-location-interface/location-ancestor-origins.sub.html
 /LayoutTests/imported/w3c/web-platform-tests/html/browsers/history/the-location-interface/location-non-configurable-toString-valueOf.html
 /LayoutTests/imported/w3c/web-platform-tests/html/browsers/history/the-location-interface/location-origin-idna.sub.window.js
 /LayoutTests/imported/w3c/web-platform-tests/html/browsers/history/the-location-interface/location-pathname-setter-question-mark.html
@@ -62,6 +69,7 @@ List of files:
 /LayoutTests/imported/w3c/web-platform-tests/html/browsers/history/the-location-interface/location_reload.html
 /LayoutTests/imported/w3c/web-platform-tests/html/browsers/history/the-location-interface/location_reload_javascript_url.html
 /LayoutTests/imported/w3c/web-platform-tests/html/browsers/history/the-location-interface/location_replace.html
+/LayoutTests/imported/w3c/web-platform-tests/html/browsers/history/the-location-interface/location_replace_session_history.html
 /LayoutTests/imported/w3c/web-platform-tests/html/browsers/history/the-location-interface/location_search.html
 /LayoutTests/imported/w3c/web-platform-tests/html/browsers/history/the-location-interface/no-browsing-context.window.js
 /LayoutTests/imported/w3c/web-platform-tests/html/browsers/history/the-location-interface/per-global.window.js

--- a/LayoutTests/platform/mac-site-isolation/TestExpectations
+++ b/LayoutTests/platform/mac-site-isolation/TestExpectations
@@ -259,6 +259,7 @@ imported/w3c/web-platform-tests/FileAPI/url/url-in-tags-revoke.window.html [ Fai
 imported/w3c/web-platform-tests/fullscreen/rendering/fullscreen-root-block-scroll.html [ Failure ]
 imported/w3c/web-platform-tests/html/browsers/browsing-the-web/history-traversal/pageswap/pageswap-replace-with-cross-origin-redirect.sub.html [ Failure ]
 imported/w3c/web-platform-tests/html/infrastructure/safe-passing-of-structured-data/shared-array-buffers/window-failure.https.html [ Skip ]
+imported/w3c/web-platform-tests/html/browsers/history/the-location-interface/location-ancestor-origins.sub.html [ Failure ]
 imported/w3c/web-platform-tests/html/infrastructure/safe-passing-of-structured-data/shared-array-buffers/window-iframe-messagechannel.https.html [ Failure ]
 imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/image-loading-lazy-in-cross-origin-iframe-001.sub.html [ Failure ]
 imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/image-loading-lazy-in-cross-origin-iframe-002.sub.html [ Failure ]


### PR DESCRIPTION
#### 3289f29403838b83104715afd8b7608080542b5b
<pre>
Sync `the-location-interface` from WPT Upstream
<a href="https://bugs.webkit.org/show_bug.cgi?id=314162">https://bugs.webkit.org/show_bug.cgi?id=314162</a>

Reviewed by Brandon Stewart.

Upstream commit: <a href="https://github.com/web-platform-tests/wpt/commit/ebcf4f0ea1576e23139f133b94127299aa505494">https://github.com/web-platform-tests/wpt/commit/ebcf4f0ea1576e23139f133b94127299aa505494</a>

* LayoutTests/TestExpectations:
* LayoutTests/platform/mac-site-isolation/TestExpectations:
* LayoutTests/imported/w3c/web-platform-tests/html/browsers/history/the-location-interface/WEB_FEATURES.yml: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/browsers/history/the-location-interface/assign_after_load-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/browsers/history/the-location-interface/assign_after_load.html:
* LayoutTests/imported/w3c/web-platform-tests/html/browsers/history/the-location-interface/assign_before_load-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/browsers/history/the-location-interface/assign_before_load.html:
* LayoutTests/imported/w3c/web-platform-tests/html/browsers/history/the-location-interface/create-script-set-location-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/browsers/history/the-location-interface/create-script-set-location.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/browsers/history/the-location-interface/cross-origin-location-stringify-crash.sub.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/browsers/history/the-location-interface/location-ancestor-origins-referrerpolicy-snapshot-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/browsers/history/the-location-interface/location-ancestor-origins-referrerpolicy-snapshot.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/browsers/history/the-location-interface/location-ancestor-origins.sub-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/browsers/history/the-location-interface/location-ancestor-origins.sub.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/browsers/history/the-location-interface/location_replace_session_history.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/browsers/history/the-location-interface/location_search-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/browsers/history/the-location-interface/location_search.html:
* LayoutTests/imported/w3c/web-platform-tests/html/browsers/history/the-location-interface/non-automated/WEB_FEATURES.yml: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/browsers/history/the-location-interface/non-automated/w3c-import.log:
* LayoutTests/imported/w3c/web-platform-tests/html/browsers/history/the-location-interface/resources/iframe_location_replace.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/browsers/history/the-location-interface/resources/iframe_location_replace2.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/browsers/history/the-location-interface/resources/iframe_location_replace3.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/browsers/history/the-location-interface/resources/location-ancestor-origins-create-iframe.js: Added.
(async configAndNavigateIFrame):
* LayoutTests/imported/w3c/web-platform-tests/html/browsers/history/the-location-interface/resources/location-ancestor-origins-recursive-iframe.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/browsers/history/the-location-interface/resources/w3c-import.log:
* LayoutTests/imported/w3c/web-platform-tests/html/browsers/history/the-location-interface/scripted_form_submit_assign_during_load-1.html:
* LayoutTests/imported/w3c/web-platform-tests/html/browsers/history/the-location-interface/scripted_form_submit_assign_during_load-2.html:
* LayoutTests/imported/w3c/web-platform-tests/html/browsers/history/the-location-interface/scripted_form_submit_assign_during_load.html:
* LayoutTests/imported/w3c/web-platform-tests/html/browsers/history/the-location-interface/w3c-import.log:

Canonical link: <a href="https://commits.webkit.org/312943@main">https://commits.webkit.org/312943@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e53fa2749a763d769c8aa88b1785d6aa118092d5

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/161555 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/35029 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/28132 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/170458 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/117926 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/35130 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/35030 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/125338 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/117926 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/164514 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/27636 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/145119 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/105934 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/26685 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/25196 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/18179 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/136379 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/22876 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/172946 "Built successfully") | | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/24517 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/133627 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/34703 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/29291 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/133633 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36107 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/34687 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/144671 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/96595 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/28161 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/21490 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/34197 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/33697 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/33940 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/33846 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->