### PR TITLE
Resync `html/semantics/embedded-content` from WPT Upstream

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/media-elements/event_volumechange-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/media-elements/event_volumechange-expected.txt
@@ -4,9 +4,15 @@ PASS setting audio.muted fires volumechange
 PASS setting audio.volume/muted to the same value does not fire volumechange
 PASS setting audio.volume/muted repeatedly fires volumechange repeatedly
 PASS setting audio.volume/muted before load will not fire volumechange
+PASS adding/removing audio muted content attribute will not fire volumechange
+PASS setting audio.muted to false when false by default will not fire volumechange
+FAIL setting audio.muted to true when true by default will not fire volumechange assert_unreached: Reached unreachable code
 PASS setting video.volume fires volumechange
 PASS setting video.muted fires volumechange
 PASS setting video.volume/muted to the same value does not fire volumechange
 PASS setting video.volume/muted repeatedly fires volumechange repeatedly
 PASS setting video.volume/muted before load will not fire volumechange
+PASS adding/removing video muted content attribute will not fire volumechange
+PASS setting video.muted to false when false by default will not fire volumechange
+FAIL setting video.muted to true when true by default will not fire volumechange assert_unreached: Reached unreachable code
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/media-elements/event_volumechange.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/media-elements/event_volumechange.html
@@ -76,6 +76,47 @@ function volumechange_test(tagName) {
       t.done();
     }, 1000);
   }, "setting " + tagName + ".volume/muted before load will not fire volumechange");
+
+  async_test(function(t) {
+    var e = document.createElement(tagName);
+    e.onvolumechange = t.unreached_func();
+    assert_false(e.muted);
+    e.setAttribute('muted', '');
+    assert_true(e.muted);
+    e.removeAttribute('muted');
+    assert_false(e.muted);
+    // Despite e.muted changing (twice), no volumechange event.
+    t.step_timeout(() => {
+      t.done();
+    }, 1000);
+  }, "adding/removing " + tagName + " muted content attribute will not fire volumechange");
+
+  async_test(function(t) {
+    var e = document.createElement(tagName);
+    e.onvolumechange = t.unreached_func();
+    // This changes the internal muted state from default to false, but the IDL
+    // attribute value doesn't change, so no volumechange event.
+    assert_false(e.muted);
+    e.muted = false;
+    assert_false(e.muted);
+    t.step_timeout(() => {
+      t.done();
+    }, 1000);
+  }, "setting " + tagName + ".muted to false when false by default will not fire volumechange");
+
+  async_test(function(t) {
+    var e = document.createElement(tagName);
+    e.onvolumechange = t.unreached_func();
+    e.setAttribute('muted', '');
+    // This changes the internal muted state from default to true, but the IDL
+    // attribute value doesn't change, so no volumechange event.
+    assert_true(e.muted);
+    e.muted = true;
+    assert_true(e.muted);
+    t.step_timeout(() => {
+      t.done();
+    }, 1000);
+  }, "setting " + tagName + ".muted to true when true by default will not fire volumechange");
 }
 
 volumechange_test("audio");

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/media-elements/track/track-element/track-cue-rendering-line-doesnt-fit-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/media-elements/track/track-element/track-cue-rendering-line-doesnt-fit-expected.html
@@ -24,7 +24,7 @@
 }
 </style>
 <div class="container">
-  <video autoplay onplaying="this.onplaying = null; waitForActiveCueAndTakeScreenshot();">
+  <video autoplay onplaying="this.onplaying = null; this.pause(); takeScreenshot();">
     <source src="/media/white.webm" type="video/webm">
     <source src="/media/white.mp4" type="video/mp4">
   </video>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/media-elements/track/track-element/track-cue-rendering-line-doesnt-fit-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/media-elements/track/track-element/track-cue-rendering-line-doesnt-fit-ref.html
@@ -24,7 +24,7 @@
 }
 </style>
 <div class="container">
-  <video autoplay onplaying="this.onplaying = null; waitForActiveCueAndTakeScreenshot();">
+  <video autoplay onplaying="this.onplaying = null; this.pause(); takeScreenshot();">
     <source src="/media/white.webm" type="video/webm">
     <source src="/media/white.mp4" type="video/mp4">
   </video>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/media-elements/track/track-element/track-cue-rendering-line-doesnt-fit.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/media-elements/track/track-element/track-cue-rendering-line-doesnt-fit.html
@@ -17,7 +17,7 @@ video::cue {
   background-color: green;
 }
 </style>
-<video autoplay onplaying="this.onplaying = null; waitForActiveCueAndTakeScreenshot();">
+<video autoplay onplaying="this.onplaying = null; this.pause(); takeScreenshot();">
   <source src="/media/white.webm" type="video/webm">
   <source src="/media/white.mp4" type="video/mp4">
   <script>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/media-elements/track/track-element/track-cue-rendering-transformed-video-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/media-elements/track/track-element/track-cue-rendering-transformed-video-expected.html
@@ -26,7 +26,7 @@
 }
 </style>
 <div class="container">
-  <video autoplay onplaying="this.onplaying = null; waitForActiveCueAndTakeScreenshot();">
+  <video autoplay onplaying="this.onplaying = null; this.pause(); takeScreenshot();">
     <source src="/media/white.webm" type="video/webm">
     <source src="/media/white.mp4" type="video/mp4">
   </video>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/media-elements/track/track-element/track-cue-rendering-transformed-video-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/media-elements/track/track-element/track-cue-rendering-transformed-video-ref.html
@@ -26,7 +26,7 @@
 }
 </style>
 <div class="container">
-  <video autoplay onplaying="this.onplaying = null; waitForActiveCueAndTakeScreenshot();">
+  <video autoplay onplaying="this.onplaying = null; this.pause(); takeScreenshot();">
     <source src="/media/white.webm" type="video/webm">
     <source src="/media/white.mp4" type="video/mp4">
   </video>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/media-elements/track/track-element/track-cue-rendering-transformed-video.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/media-elements/track/track-element/track-cue-rendering-transformed-video.html
@@ -12,7 +12,7 @@ video::cue {
   background-color: green;
 }
 </style>
-<video autoplay onplaying="this.onplaying = null; waitForActiveCueAndTakeScreenshot();">
+<video autoplay onplaying="this.onplaying = null; this.pause(); takeScreenshot();">
   <source src="/media/white.webm" type="video/webm">
   <source src="/media/white.mp4" type="video/mp4">
   <script>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/media-elements/track/track-element/track-webvtt-non-snap-to-lines-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/media-elements/track/track-element/track-webvtt-non-snap-to-lines-expected.html
@@ -19,7 +19,7 @@
 }
 </style>
 <div class="container">
-  <video autoplay onplaying="this.onplaying = null; waitForActiveCueAndTakeScreenshot();">
+  <video autoplay onplaying="this.onplaying = null; this.pause(); takeScreenshot();">
     <script>
     document.currentScript.parentNode.src = getVideoURI("/media/test");
     </script>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/media-elements/track/track-element/track-webvtt-non-snap-to-lines-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/media-elements/track/track-element/track-webvtt-non-snap-to-lines-ref.html
@@ -19,7 +19,7 @@
 }
 </style>
 <div class="container">
-  <video autoplay onplaying="this.onplaying = null; waitForActiveCueAndTakeScreenshot();">
+  <video autoplay onplaying="this.onplaying = null; this.pause(); takeScreenshot();">
     <script>
     document.currentScript.parentNode.src = getVideoURI("/media/test");
     </script>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/media-elements/track/track-element/track-webvtt-non-snap-to-lines.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/media-elements/track/track-element/track-webvtt-non-snap-to-lines.html
@@ -9,7 +9,7 @@
   background: green;
 }
 </style>
-<video autoplay onplaying="this.onplaying = null; waitForActiveCueAndTakeScreenshot();"></video>
+<video autoplay onplaying="this.onplaying = null; this.pause(); takeScreenshot();"></video>
 <script>
 var video = document.querySelector("video");
 var track = video.addTextTrack("captions");

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/media-elements/user-interface/muted-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/media-elements/user-interface/muted-expected.txt
@@ -10,18 +10,26 @@ PASS setting video.muted with muted="" (parser-created)
 PASS getting video.muted with muted="" after load (parser-created)
 PASS getting audio.muted (script-created)
 PASS setting audio.muted (script-created)
-FAIL getting audio.muted with muted="" (script-created) assert_false: expected false got true
-FAIL setting audio.muted with muted="" (script-created) assert_equals: expected false but got true
+PASS getting audio.muted with muted="" (script-created)
+PASS setting audio.muted with muted="" (script-created)
+PASS getting audio.muted with muted="" (cloneNode-created)
 PASS getting audio.muted with muted="" (innerHTML-created)
 PASS getting audio.muted with muted="" (document.write-created)
 PASS cloning audio propagates muted (script-created)
 PASS cloning audio propagates muted (innerHTML-created)
+PASS adding/removing muted attribute dynamically affects audio.muted
+PASS adding muted attribute has no effect on audio.muted after setter
+PASS removing muted attribute has no effect on audio.muted after setter
 PASS getting video.muted (script-created)
 PASS setting video.muted (script-created)
-FAIL getting video.muted with muted="" (script-created) assert_false: expected false got true
-FAIL setting video.muted with muted="" (script-created) assert_equals: expected false but got true
+PASS getting video.muted with muted="" (script-created)
+PASS setting video.muted with muted="" (script-created)
+PASS getting video.muted with muted="" (cloneNode-created)
 PASS getting video.muted with muted="" (innerHTML-created)
 PASS getting video.muted with muted="" (document.write-created)
 PASS cloning video propagates muted (script-created)
 PASS cloning video propagates muted (innerHTML-created)
+PASS adding/removing muted attribute dynamically affects video.muted
+PASS adding muted attribute has no effect on video.muted after setter
+PASS removing muted attribute has no effect on video.muted after setter
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/media-elements/user-interface/muted.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/media-elements/user-interface/muted.html
@@ -21,8 +21,8 @@ function test_setting(e, muted, hasAttribute) {
 }
 </script>
 
-<!-- These tests are inside <audio>/<video> so that the steps for updating the
-     muted IDL attribute cannot be delayed until the end tag is parsed. -->
+<!-- These tests are inside <audio>/<video> so that the parser-created
+     elements are available for testing before the closing tag. -->
 
 <audio id=a1>
 <script>
@@ -80,8 +80,8 @@ test(function() {
 </script>
 </video>
 
-<!-- Negative test to ensure that the load algorithm does not update the
-     muted IDL attribute to match the content attribute. -->
+<!-- Negative test to ensure that the load algorithm does not reset the
+     muted state. -->
 
 <video id=v3 muted></video>
 <script>
@@ -112,25 +112,22 @@ async_test(function(t) {
   test(function() {
     var m = document.createElement(tagName);
     m.setAttribute('muted', '');
-    assert_false(m.muted);
+    assert_true(m.muted);
   }, 'getting ' + tagName + '.muted with muted="" (script-created)');
 
   test(function() {
     var m = document.createElement(tagName);
     m.setAttribute('muted', '');
-    test_setting(m, false, true);
+    test_setting(m, true, true);
   }, 'setting ' + tagName + '.muted with muted="" (script-created)');
 
-  // Spec bug: https://www.w3.org/Bugs/Public/show_bug.cgi?id=25153
-  /*
   test(function() {
     var m = document.createElement(tagName);
     m.setAttribute('muted', '');
     m = m.cloneNode(false);
     assert_true(m.hasAttribute('muted'));
-    assert_false(m.muted);
+    assert_true(m.muted);
   }, 'getting ' + tagName + '.muted with muted="" (cloneNode-created)');
-  */
 
   test(function() {
     var div = document.createElement('div');
@@ -165,5 +162,29 @@ async_test(function(t) {
     var c = m.cloneNode(true);
     assert_true(c.muted);
   }, 'cloning ' + tagName + ' propagates muted (innerHTML-created)');
+
+  test(function() {
+    var m = document.createElement(tagName);
+    assert_false(m.muted);
+    m.setAttribute('muted', '');
+    assert_true(m.muted);
+    m.removeAttribute('muted');
+    assert_false(m.muted);
+  }, 'adding/removing muted attribute dynamically affects ' + tagName + '.muted');
+
+  test(function() {
+    var m = document.createElement(tagName);
+    m.muted = false;
+    m.setAttribute('muted', '');
+    assert_false(m.muted);
+  }, 'adding muted attribute has no effect on ' + tagName + '.muted after setter');
+
+  test(function() {
+    var m = document.createElement(tagName);
+    m.setAttribute('muted', '');
+    m.muted = true;
+    m.removeAttribute('muted');
+    assert_true(m.muted);
+  }, 'removing muted attribute has no effect on ' + tagName + '.muted after setter');
 });
 </script>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-audio-element/audio-loading-lazy-source-deferred-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-audio-element/audio-loading-lazy-source-deferred-expected.txt
@@ -1,0 +1,4 @@
+
+
+FAIL Audio with loading=lazy and source does not load until visible assert_false: Audio load should not start while offscreen expected false got true
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-audio-element/audio-loading-lazy-source-deferred.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-audio-element/audio-loading-lazy-source-deferred.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<link rel="author" title="Helmut Januschka" href="mailto:helmut@januschka.com">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<style>
+  .below-viewport {
+    margin-top: 1000vh;
+  }
+</style>
+
+<audio class="below-viewport" loading="lazy" controls>
+  <source src="/media/sine440.mp3" type="audio/mpeg">
+</audio>
+
+<script>
+  async_test(t => {
+    const audio = document.querySelector("audio");
+    let loadStarted = false;
+    audio.addEventListener("loadstart", () => {
+      loadStarted = true;
+    });
+
+    t.step_timeout(() => {
+      assert_false(loadStarted, "Audio load should not start while offscreen");
+      assert_equals(audio.readyState, HTMLMediaElement.HAVE_NOTHING);
+
+      audio.addEventListener("loadstart", t.step_func_done(() => {}),
+                             {once: true});
+      audio.scrollIntoView();
+    }, 1000);
+  }, "Audio with loading=lazy and source does not load until visible");
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-audio-element/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-audio-element/w3c-import.log
@@ -23,6 +23,7 @@ List of files:
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-audio-element/audio-loading-lazy-in-scroller.html
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-audio-element/audio-loading-lazy-in-viewport.html
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-audio-element/audio-loading-lazy-not-rendered.html
+/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-audio-element/audio-loading-lazy-source-deferred.html
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-audio-element/audio-loading-lazy-to-eager.html
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-audio-element/audio-loading-lazy-window-onload.html
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-audio-element/audio-loading-load-deferred.html

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/sizes/sizes-auto-resize-observer-removes-auto-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/sizes/sizes-auto-resize-observer-removes-auto-expected.txt
@@ -1,0 +1,4 @@
+
+
+FAIL ResizeObserver causes image to no longer allow lazy loading assert_true: ResizeObserver should have been notified of resize expected true got false
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/sizes/sizes-auto-resize-observer-removes-auto.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/sizes/sizes-auto-resize-observer-removes-auto.html
@@ -1,0 +1,46 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>ResizeObserver causes image to no longer allow lazy loading</title>
+<link rel="help" href="https://html.spec.whatwg.org/multipage/images.html#parse-a-sizes-attribute">
+<link rel="help" href="https://html.spec.whatwg.org/multipage/embedded-content.html#allows-auto-sizes">
+<link rel="help" href="https://bugzilla.mozilla.org/show_bug.cgi?id=2033652">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<img id="img" sizes="1px" style="width:16px;" loading="lazy">
+<script>
+"use strict";
+/*
+A browser might use resize observer to respond to size changes for sizes=auto images.
+If a resize observer from a page is notified before the browser one, and makes the
+image not allow auto-sizes anymore, the browser resize observer would
+still be notified for the now not sizes=auto image.
+*/
+promise_test(async t => {
+  let waitForLoad = new Promise(r => img.addEventListener('load', r, {once: true}));
+  img.srcset = "/images/green-1x1.png 1w, /images/green-16x16.png 16w, /images/green-256x256.png 256w";
+  await waitForLoad;
+  let resizeObserved = false;
+  let observer = new ResizeObserver(() => {
+    if (img.style.width === "1px") {
+      img.sizes = "256px";
+      resizeObserved = true;
+      observer.disconnect();
+    }
+  });
+  observer.observe(img);
+  let currentSrc = () => new URL(img.currentSrc).pathname;
+  assert_equals(currentSrc(), "/images/green-1x1.png",
+                "image's source should be set based on sizes=1px");
+  waitForLoad = new Promise(r => img.addEventListener('load', r, {once: true}));
+  img.sizes = "auto";
+  await waitForLoad;
+  assert_equals(currentSrc(), "/images/green-16x16.png",
+                "image's source should be set based on sizes=auto and content box width of 16px");
+  waitForLoad = new Promise(r => img.addEventListener('load', r, {once: true}));
+  img.style.width = "1px";
+  await waitForLoad;
+  assert_true(resizeObserved, "ResizeObserver should have been notified of resize");
+  assert_equals(currentSrc(), "/images/green-256x256.png",
+                "image's source should be set based on sizes=256px from ResizeObserver");
+});
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/sizes/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/sizes/w3c-import.log
@@ -29,6 +29,7 @@ List of files:
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/sizes/sizes-auto-rendering-dynamic.html
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/sizes/sizes-auto-rendering-expected.html
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/sizes/sizes-auto-rendering.html
+/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/sizes/sizes-auto-resize-observer-removes-auto.html
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/sizes/sizes-auto.html
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/sizes/sizes-dynamic-001-expected.html
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/sizes/sizes-dynamic-001-ref.html

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-video-element/video-loading-lazy-source-poster-deferred-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-video-element/video-loading-lazy-source-poster-deferred-expected.txt
@@ -1,0 +1,4 @@
+
+
+FAIL Video with loading=lazy, poster and source does not load until visible assert_false: Video load should not start while offscreen expected false got true
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-video-element/video-loading-lazy-source-poster-deferred.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-video-element/video-loading-lazy-source-poster-deferred.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<link rel="author" title="Helmut Januschka" href="mailto:helmut@januschka.com">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<style>
+  .below-viewport {
+    margin-top: 1000vh;
+  }
+</style>
+
+<video class="below-viewport" loading="lazy" poster="/media/2048x1360-random.jpg" controls>
+  <source src="/media/A4.webm" type="video/webm">
+</video>
+
+<script>
+  async_test(t => {
+    const video = document.querySelector("video");
+    let loadStarted = false;
+    video.addEventListener("loadstart", () => {
+      loadStarted = true;
+    });
+
+    t.step_timeout(() => {
+      assert_false(loadStarted, "Video load should not start while offscreen");
+      assert_equals(video.readyState, HTMLMediaElement.HAVE_NOTHING);
+
+      video.addEventListener("loadstart", t.step_func_done(() => {}),
+                             {once: true});
+      video.scrollIntoView();
+    }, 1000);
+  }, "Video with loading=lazy, poster and source does not load until visible");
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-video-element/video-poster-clone-template-expected.htm
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-video-element/video-poster-clone-template-expected.htm
@@ -1,0 +1,5 @@
+<!DOCTYPE HTML>
+<meta charset=UTF-8>
+<title>Reference for poster tests</title>
+<link rel="author" title="Microsoft" href="http://www.microsoft.com/">
+<img src="/media/poster.png">

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-video-element/video-poster-clone-template.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-video-element/video-poster-clone-template.html
@@ -1,0 +1,21 @@
+<!doctype html>
+<meta charset="utf-8" />
+<title>Video poster is shown when cloned from template with relative URL</title>
+<link
+  rel="help"
+  href="https://html.spec.whatwg.org/multipage/#dom-video-poster"
+/>
+<link rel="match" href="video_dynamic_poster-ref.htm" />
+<meta
+  name="assert"
+  content="The poster image is shown when cloned from a template with a relative URL."
+/>
+<body>
+  <script>
+    const template = document.createElement("template");
+    template.innerHTML = `<video src="/media/A4.mp4" poster="/media/poster.png" loop muted>`;
+
+    const video = template.content.firstChild.cloneNode(true);
+    document.body.appendChild(video);
+  </script>
+</body>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-video-element/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-video-element/w3c-import.log
@@ -28,12 +28,15 @@ List of files:
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-video-element/video-loading-lazy-load-when-visible.html
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-video-element/video-loading-lazy-not-rendered.html
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-video-element/video-loading-lazy-poster-when-visible.html
+/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-video-element/video-loading-lazy-source-poster-deferred.html
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-video-element/video-loading-lazy-to-eager.html
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-video-element/video-loading-lazy-window-onload.html
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-video-element/video-loading-load-deferred.html
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-video-element/video-loading-load-preload-auto-deferred.html
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-video-element/video-loading-load-preload-metadata-deferred.html
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-video-element/video-loading-poster-deferred.html
+/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-video-element/video-poster-clone-template-expected.htm
+/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-video-element/video-poster-clone-template.html
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-video-element/video-poster-shown-preload-auto-expected.html
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-video-element/video-poster-shown-preload-auto-ref.html
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-video-element/video-poster-shown-preload-auto.html

--- a/LayoutTests/platform/ios/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/sizes/sizes-auto-resize-observer-removes-auto-expected.txt
+++ b/LayoutTests/platform/ios/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/sizes/sizes-auto-resize-observer-removes-auto-expected.txt
@@ -1,0 +1,4 @@
+
+
+FAIL ResizeObserver causes image to no longer allow lazy loading assert_equals: image's source should be set based on sizes=1px expected "/images/green-1x1.png" but got "/images/green-16x16.png"
+


### PR DESCRIPTION
#### aacfac59351a64d949404c19692dd199d5bfe358
<pre>
Resync `html/semantics/embedded-content` from WPT Upstream
<a href="https://bugs.webkit.org/show_bug.cgi?id=314164">https://bugs.webkit.org/show_bug.cgi?id=314164</a>
<a href="https://rdar.apple.com/problem/176944900">rdar://problem/176944900</a>

Reviewed by Vitor Roriz.

Upstream commit: <a href="https://github.com/web-platform-tests/wpt/commit/7ffd388da42d116fdc6c73919f9432497d5c7851">https://github.com/web-platform-tests/wpt/commit/7ffd388da42d116fdc6c73919f9432497d5c7851</a>

* LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/media-elements/event_volumechange-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/media-elements/event_volumechange.html:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/media-elements/track/track-element/track-cue-rendering-line-doesnt-fit-expected.html:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/media-elements/track/track-element/track-cue-rendering-line-doesnt-fit-ref.html:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/media-elements/track/track-element/track-cue-rendering-line-doesnt-fit.html:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/media-elements/track/track-element/track-cue-rendering-transformed-video-expected.html:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/media-elements/track/track-element/track-cue-rendering-transformed-video-ref.html:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/media-elements/track/track-element/track-cue-rendering-transformed-video.html:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/media-elements/track/track-element/track-webvtt-non-snap-to-lines-expected.html:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/media-elements/track/track-element/track-webvtt-non-snap-to-lines-ref.html:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/media-elements/track/track-element/track-webvtt-non-snap-to-lines.html:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/media-elements/user-interface/muted-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/media-elements/user-interface/muted.html:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-audio-element/audio-loading-lazy-source-deferred-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-audio-element/audio-loading-lazy-source-deferred.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-audio-element/w3c-import.log:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/sizes/sizes-auto-resize-observer-removes-auto-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/sizes/sizes-auto-resize-observer-removes-auto.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/sizes/w3c-import.log:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-video-element/video-loading-lazy-source-poster-deferred-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-video-element/video-loading-lazy-source-poster-deferred.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-video-element/video-poster-clone-template-expected.htm: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-video-element/video-poster-clone-template.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-video-element/w3c-import.log:
* LayoutTests/platform/ios/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/sizes/sizes-auto-resize-observer-removes-auto-expected.txt: Added.

Canonical link: <a href="https://commits.webkit.org/314268@main">https://commits.webkit.org/314268@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a20a248397cdf3745f13b6e0ac6f246ea8da4b73

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/165559 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/39049 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/32630 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/174601 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/122814 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/1295525e-db35-4655-8954-2a8c8861e006) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/39385 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/39053 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/128663 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/90591 "1 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/3ac346d0-db97-40ef-902d-ff7d5ad53892) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/168518 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/30987 "Found 3 new test failures: fast/events/touch/ios/touch-event-regions-layer-tree/mousemove-mouseup.html fast/forms/datalist/datalist-textinput-dynamically-add-options-on-keydown.html fast/forms/ios/drag-range-track.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/148742 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/109187 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/ea44c45a-d6d3-4550-8439-275ff29faff1) 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/30024 "Found 2 new test failures: imported/w3c/web-platform-tests/css/css-images/gradients-with-border.html imported/w3c/web-platform-tests/css/css-images/multiple-position-color-stop-linear.html (failure)") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/28656 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/22679 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/139917 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/26440 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/177125 "Built successfully") | | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/28146 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/136989 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/39118 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/32798 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-display/display-contents-svg-elements.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/136923 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36908 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/39806 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/148236 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/102270 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/32198 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/25103 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/38317 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/37713 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/3184 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/37959 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/37857 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->