### PR TITLE
[JSC][Temporal] Change Duration storage from double array to int64_t/Int128 fields

### DIFF
--- a/Source/JavaScriptCore/runtime/ISO8601.cpp
+++ b/Source/JavaScriptCore/runtime/ISO8601.cpp
@@ -31,6 +31,7 @@
 #include "IntlObject.h"
 #include "ParseInt.h"
 #include "TemporalObject.h"
+#include <bit>
 #include <limits>
 #include <wtf/CheckedArithmetic.h>
 #include <wtf/DateMath.h>
@@ -147,23 +148,23 @@ static std::optional<Duration> parseDuration(StringParsingBuffer<CharacterType>&
         case 'Y':
             if (datePartIndex)
                 return std::nullopt;
-            result.setYears(integer);
+            result.setField(TemporalUnit::Year, integer);
             datePartIndex = 1;
             break;
         case 'M':
             if (datePartIndex >= 2)
                 return std::nullopt;
-            result.setMonths(integer);
+            result.setField(TemporalUnit::Month, integer);
             datePartIndex = 2;
             break;
         case 'W':
             if (datePartIndex >= 3)
                 return std::nullopt;
-            result.setWeeks(integer);
+            result.setField(TemporalUnit::Week, integer);
             datePartIndex = 3;
             break;
         case 'D':
-            result.setDays(integer);
+            result.setField(TemporalUnit::Day, integer);
             datePartIndex = 4;
             break;
         default:
@@ -207,7 +208,7 @@ static std::optional<Duration> parseDuration(StringParsingBuffer<CharacterType>&
         case 'H':
             if (timePartIndex)
                 return std::nullopt;
-            result.setHours(integer);
+            result.setField(TemporalUnit::Hour, integer);
             if (fractionalPart) {
                 handleFraction(result, factor, fractionalPart, TemporalUnit::Hour);
                 timePartIndex = 3;
@@ -217,7 +218,7 @@ static std::optional<Duration> parseDuration(StringParsingBuffer<CharacterType>&
         case 'M':
             if (timePartIndex >= 2)
                 return std::nullopt;
-            result.setMinutes(integer);
+            result.setField(TemporalUnit::Minute, integer);
             if (fractionalPart) {
                 handleFraction(result, factor, fractionalPart, TemporalUnit::Minute);
                 timePartIndex = 3;
@@ -225,7 +226,7 @@ static std::optional<Duration> parseDuration(StringParsingBuffer<CharacterType>&
                 timePartIndex = 2;
             break;
         case 'S':
-            result.setSeconds(integer);
+            result.setField(TemporalUnit::Second, integer);
             if (fractionalPart)
                 handleFraction(result, factor, fractionalPart, TemporalUnit::Second);
             timePartIndex = 3;
@@ -1624,7 +1625,7 @@ CheckedInt128 checkedCastDoubleToInt128(double n)
     static constexpr uint64_t absMask = signMask - uint64_t { 1 };
 
     // Break n into sign, exponent, significand parts.
-    const uint64_t bits = *reinterpret_cast<uint64_t*>(&n);
+    const uint64_t bits = std::bit_cast<uint64_t>(n);
     const uint64_t nAbs = bits & absMask;
     const int sign = bits & signMask ? -1 : 1;
     const int exponent = (nAbs >> significandBits) - exponentBias;
@@ -1651,6 +1652,59 @@ CheckedInt128 checkedCastDoubleToInt128(double n)
 
 namespace ISO8601 {
 
+// IsValidDuration step 8 bound: abs(normalizedNanoseconds) < 2^53 × 10^9 nanoseconds.
+static constexpr Int128 durationNanosecondsLimit = (Int128(1) << 53) * 1000000000LL;
+
+// Sentinel for Duration::setField — stored when checkedCastDoubleToInt128 overflows
+// (input double >= 2^127). Any value >= durationNanosecondsLimit causes
+// isValidDuration() to return false via the totalNanoseconds overflow check.
+static constexpr Int128 subsecondOutOfRangeSentinel = durationNanosecondsLimit;
+
+// Converts a JS Number (double) to the Duration's typed storage.
+// int64_t fields (years–milliseconds): doubleToInt64Saturating avoids UB for out-of-range values.
+// Int128 fields (microseconds, nanoseconds): checkedCastDoubleToInt128 handles values >= 2^127
+// by returning a sentinel >= durationNanosecondsLimit so isValidDuration rejects the Duration.
+void Duration::setField(TemporalUnit u, double v)
+{
+    switch (u) {
+    case TemporalUnit::Year:
+        m_years = doubleToInt64Saturating(v);
+        return;
+    case TemporalUnit::Month:
+        m_months = doubleToInt64Saturating(v);
+        return;
+    case TemporalUnit::Week:
+        m_weeks = doubleToInt64Saturating(v);
+        return;
+    case TemporalUnit::Day:
+        m_days = doubleToInt64Saturating(v);
+        return;
+    case TemporalUnit::Hour:
+        m_hours = doubleToInt64Saturating(v);
+        return;
+    case TemporalUnit::Minute:
+        m_minutes = doubleToInt64Saturating(v);
+        return;
+    case TemporalUnit::Second:
+        m_seconds = doubleToInt64Saturating(v);
+        return;
+    case TemporalUnit::Millisecond:
+        m_milliseconds = doubleToInt64Saturating(v);
+        return;
+    case TemporalUnit::Microsecond: {
+        auto safe = checkedCastDoubleToInt128(v);
+        m_microseconds = safe.hasOverflowed() ? subsecondOutOfRangeSentinel : static_cast<Int128>(safe);
+        return;
+    }
+    case TemporalUnit::Nanosecond: {
+        auto safe = checkedCastDoubleToInt128(v);
+        m_nanoseconds = safe.hasOverflowed() ? subsecondOutOfRangeSentinel : static_cast<Int128>(safe);
+        return;
+    }
+    }
+    ASSERT_NOT_REACHED();
+}
+
 template<TemporalUnit unit>
 std::optional<Int128> Duration::totalNanoseconds() const
 {
@@ -1658,32 +1712,20 @@ std::optional<Int128> Duration::totalNanoseconds() const
 
     CheckedInt128 resultNs { 0 };
 
-    if constexpr (unit <= TemporalUnit::Day) {
-        CheckedInt128 days = checkedCastDoubleToInt128(this->days());
-        resultNs += days * ExactTime::nsPerDay;
-    }
-    if constexpr (unit <= TemporalUnit::Hour) {
-        CheckedInt128 hours = checkedCastDoubleToInt128(this->hours());
-        resultNs += hours * ExactTime::nsPerHour;
-    }
-    if constexpr (unit <= TemporalUnit::Minute) {
-        CheckedInt128 minutes = checkedCastDoubleToInt128(this->minutes());
-        resultNs += minutes * ExactTime::nsPerMinute;
-    }
-    if constexpr (unit <= TemporalUnit::Second) {
-        CheckedInt128 seconds = checkedCastDoubleToInt128(this->seconds());
-        resultNs += seconds * ExactTime::nsPerSecond;
-    }
-    if constexpr (unit <= TemporalUnit::Millisecond) {
-        CheckedInt128 milliseconds = checkedCastDoubleToInt128(this->milliseconds());
-        resultNs += milliseconds * ExactTime::nsPerMillisecond;
-    }
-    if constexpr (unit <= TemporalUnit::Microsecond) {
-        CheckedInt128 microseconds = checkedCastDoubleToInt128(this->microseconds());
-        resultNs += microseconds * ExactTime::nsPerMicrosecond;
-    }
+    if constexpr (unit <= TemporalUnit::Day)
+        resultNs += CheckedInt128(this->days()) * ExactTime::nsPerDay;
+    if constexpr (unit <= TemporalUnit::Hour)
+        resultNs += CheckedInt128(this->hours()) * ExactTime::nsPerHour;
+    if constexpr (unit <= TemporalUnit::Minute)
+        resultNs += CheckedInt128(this->minutes()) * ExactTime::nsPerMinute;
+    if constexpr (unit <= TemporalUnit::Second)
+        resultNs += CheckedInt128(this->seconds()) * ExactTime::nsPerSecond;
+    if constexpr (unit <= TemporalUnit::Millisecond)
+        resultNs += CheckedInt128(this->milliseconds()) * ExactTime::nsPerMillisecond;
+    if constexpr (unit <= TemporalUnit::Microsecond)
+        resultNs += CheckedInt128(this->microseconds()) * ExactTime::nsPerMicrosecond;
     if constexpr (unit <= TemporalUnit::Nanosecond)
-        resultNs += checkedCastDoubleToInt128(this->nanoseconds());
+        resultNs += CheckedInt128(this->nanoseconds());
 
     if (resultNs.hasOverflowed())
         return std::nullopt;
@@ -1699,27 +1741,45 @@ template std::optional<Int128> Duration::totalNanoseconds<TemporalUnit::Microsec
 // https://tc39.es/proposal-temporal/#sec-temporal-isvalidduration
 bool isValidDuration(const Duration& duration)
 {
+    // Check sign consistency: all non-zero fields must have the same sign.
     int sign = 0;
-    for (auto value : duration) {
-        if (!std::isfinite(value) || (value < 0 && sign > 0) || (value > 0 && sign < 0))
-            return false;
-
-        if (!sign && value)
-            sign = value > 0 ? 1 : -1;
-    }
+#define JSC_CHECK_DURATION_FIELD(field) \
+    do { \
+        auto v = duration.field(); \
+        if (v < 0 && sign > 0) \
+            return false; \
+        if (v > 0 && sign < 0) \
+            return false; \
+        if (!sign && v) \
+            sign = v > 0 ? 1 : -1; \
+    } while (false);
+    JSC_CHECK_DURATION_FIELD(years)
+    JSC_CHECK_DURATION_FIELD(months)
+    JSC_CHECK_DURATION_FIELD(weeks)
+    JSC_CHECK_DURATION_FIELD(days)
+    JSC_CHECK_DURATION_FIELD(hours)
+    JSC_CHECK_DURATION_FIELD(minutes)
+    JSC_CHECK_DURATION_FIELD(seconds)
+    JSC_CHECK_DURATION_FIELD(milliseconds)
+    JSC_CHECK_DURATION_FIELD(microseconds)
+    JSC_CHECK_DURATION_FIELD(nanoseconds)
+#undef JSC_CHECK_DURATION_FIELD
 
     // 3. If abs(years) ≥ 2^32, return false.
     // 4. If abs(months) ≥ 2^32, return false.
     // 5. If abs(weeks) ≥ 2^32, return false.
-    constexpr double limit = 1ULL << 32;
-    if (std::abs(duration[TemporalUnit::Year]) >= limit || std::abs(duration[TemporalUnit::Month]) >= limit || std::abs(duration[TemporalUnit::Week]) >= limit)
+    // Use range comparisons to avoid UB from std::abs(INT64_MIN).
+    constexpr int64_t limit = static_cast<int64_t>(1) << 32;
+    if (duration.years() >= limit || duration.years() <= -limit
+        || duration.months() >= limit || duration.months() <= -limit
+        || duration.weeks() >= limit || duration.weeks() <= -limit)
         return false;
 
     // 6. Let normalizedSeconds be days × 86,400 + hours × 3600 + minutes × 60 + seconds + ℝ(𝔽(milliseconds)) × 10^-3 + ℝ(𝔽(microseconds)) × 10^-6 + ℝ(𝔽(nanoseconds)) × 10^-9.
     auto normalizedNanoseconds = duration.totalNanoseconds<TemporalUnit::Day>();
     // 8. If abs(normalizedSeconds) ≥ 2^53, return false.
-    constexpr Int128 nanosecondsLimit = (Int128(1) << 53) * 1000000000;
-    if (!normalizedNanoseconds || absInt128(normalizedNanoseconds.value()) >= nanosecondsLimit)
+    // nullopt from totalNanoseconds means Int128 overflow — far beyond the 2^53 limit.
+    if (!normalizedNanoseconds || normalizedNanoseconds.value() >= durationNanosecondsLimit || normalizedNanoseconds.value() <= -durationNanosecondsLimit)
         return false;
 
     return true;
@@ -1739,17 +1799,17 @@ std::optional<ExactTime> ExactTime::add(Duration duration) const
     // time span for exact time, so if we already know that the duration exceeds
     // that, then we can bail out.
 
-    CheckedInt128 hours = checkedCastDoubleToInt128(duration.hours());
+    CheckedInt128 hours = CheckedInt128(duration.hours());
     resultNs += hours * ExactTime::nsPerHour;
-    CheckedInt128 minutes = checkedCastDoubleToInt128(duration.minutes());
+    CheckedInt128 minutes = CheckedInt128(duration.minutes());
     resultNs += minutes * ExactTime::nsPerMinute;
-    CheckedInt128 seconds = checkedCastDoubleToInt128(duration.seconds());
+    CheckedInt128 seconds = CheckedInt128(duration.seconds());
     resultNs += seconds * ExactTime::nsPerSecond;
-    CheckedInt128 milliseconds = checkedCastDoubleToInt128(duration.milliseconds());
+    CheckedInt128 milliseconds = CheckedInt128(duration.milliseconds());
     resultNs += milliseconds * ExactTime::nsPerMillisecond;
-    CheckedInt128 microseconds = checkedCastDoubleToInt128(duration.microseconds());
+    CheckedInt128 microseconds = CheckedInt128(duration.microseconds());
     resultNs += microseconds * ExactTime::nsPerMicrosecond;
-    resultNs += checkedCastDoubleToInt128(duration.nanoseconds());
+    resultNs += CheckedInt128(duration.nanoseconds());
     if (resultNs.hasOverflowed())
         return std::nullopt;
 

--- a/Source/JavaScriptCore/runtime/ISO8601.h
+++ b/Source/JavaScriptCore/runtime/ISO8601.h
@@ -42,53 +42,127 @@ static constexpr int32_t outOfRangeYear = minYear - 1;
 class Duration {
     WTF_MAKE_TZONE_ALLOCATED(Duration);
 public:
-    using const_iterator = std::array<double, numberOfTemporalUnits>::const_iterator;
-
     Duration() = default;
-    Duration(double years, double months, double weeks, double days, double hours, double minutes, double seconds, double milliseconds, double microseconds, double nanoseconds)
-        : m_data {
-            years,
-            months,
-            weeks,
-            days,
-            hours,
-            minutes,
-            seconds,
-            milliseconds,
-            microseconds,
-            nanoseconds,
+
+    // Converts double to int64_t without C++ UB. Values outside int64_t range
+    // saturate to INT64_MIN/MAX — those sentinel values always fail isValidDuration
+    // (INT64_MAX >> 2^32 limit for date fields; saturated time fields overflow
+    // totalNanoseconds). For in-range inputs the conversion is exact.
+    static int64_t doubleToInt64Saturating(double v)
+    {
+        // INT64_MIN (-2^63) is exactly representable as double; INT64_MAX (2^63-1) is not —
+        // it rounds up to 2^63 = -(double)INT64_MIN. So both bounds derive from INT64_MIN.
+        static constexpr double int64AsDoubleMin = static_cast<double>(std::numeric_limits<int64_t>::min()); // -2^63, exact
+        static constexpr double int64AsDoubleMax = -static_cast<double>(std::numeric_limits<int64_t>::min()); // +2^63, > INT64_MAX
+        if (!(v < int64AsDoubleMax))
+            return std::numeric_limits<int64_t>::max();
+        if (!(v > int64AsDoubleMin))
+            return std::numeric_limits<int64_t>::min();
+        return truncateDoubleToInt64(v);
+    }
+
+    Duration(int64_t years, int64_t months, int64_t weeks, int64_t days, int64_t hours, int64_t minutes, int64_t seconds, int64_t milliseconds, Int128 microseconds, Int128 nanoseconds)
+        : m_years(years)
+        , m_months(months)
+        , m_weeks(weeks)
+        , m_days(days)
+        , m_hours(hours)
+        , m_minutes(minutes)
+        , m_seconds(seconds)
+        , m_milliseconds(milliseconds)
+        , m_microseconds(microseconds)
+        , m_nanoseconds(nanoseconds)
+    {
+    }
+
+    int64_t years() const { return m_years; }
+    int64_t months() const { return m_months; }
+    int64_t weeks() const { return m_weeks; }
+    int64_t days() const { return m_days; }
+    int64_t hours() const { return m_hours; }
+    int64_t minutes() const { return m_minutes; }
+    int64_t seconds() const { return m_seconds; }
+    int64_t milliseconds() const { return m_milliseconds; }
+    Int128 microseconds() const { return m_microseconds; }
+    Int128 nanoseconds() const { return m_nanoseconds; }
+
+    // Typed setters for internal arithmetic with already-validated integer values.
+    // double overloads are deleted: use setField(TemporalUnit, double) for JS inputs,
+    // which routes through doubleToInt64Saturating to avoid UB on ARM32.
+    void setYears(int64_t v) { m_years = v; }
+    void setYears(double) = delete;
+    void setMonths(int64_t v) { m_months = v; }
+    void setMonths(double) = delete;
+    void setWeeks(int64_t v) { m_weeks = v; }
+    void setWeeks(double) = delete;
+    void setDays(int64_t v) { m_days = v; }
+    void setDays(double) = delete;
+    void setHours(int64_t v) { m_hours = v; }
+    void setHours(double) = delete;
+    void setMinutes(int64_t v) { m_minutes = v; }
+    void setMinutes(double) = delete;
+    void setSeconds(int64_t v) { m_seconds = v; }
+    void setSeconds(double) = delete;
+    void setMilliseconds(int64_t v) { m_milliseconds = v; }
+    void setMilliseconds(double) = delete;
+    void setMicroseconds(Int128 v) { m_microseconds = v; }
+    void setNanoseconds(Int128 v) { m_nanoseconds = v; }
+
+    // Read-only field access by index or TemporalUnit — returns double for JS-layer compatibility.
+    double operator[](size_t i) const { return (*this)[static_cast<TemporalUnit>(i)]; }
+    double operator[](TemporalUnit u) const {
+        switch (u) {
+        case TemporalUnit::Year:
+            return static_cast<double>(m_years);
+        case TemporalUnit::Month:
+            return static_cast<double>(m_months);
+        case TemporalUnit::Week:
+            return static_cast<double>(m_weeks);
+        case TemporalUnit::Day:
+            return static_cast<double>(m_days);
+        case TemporalUnit::Hour:
+            return static_cast<double>(m_hours);
+        case TemporalUnit::Minute:
+            return static_cast<double>(m_minutes);
+        case TemporalUnit::Second:
+            return static_cast<double>(m_seconds);
+        case TemporalUnit::Millisecond:
+            return static_cast<double>(m_milliseconds);
+        case TemporalUnit::Microsecond:
+            return static_cast<double>(m_microseconds);
+        case TemporalUnit::Nanosecond:
+            return static_cast<double>(m_nanoseconds);
         }
-    { }
+        ASSERT_NOT_REACHED();
+        return 0;
+    }
 
-#define JSC_DEFINE_ISO8601_DURATION_FIELD(name, capitalizedName) \
-    double name##s() const { return m_data[static_cast<uint8_t>(TemporalUnit::capitalizedName)]; } \
-    void set##capitalizedName##s(double value) { m_data[static_cast<uint8_t>(TemporalUnit::capitalizedName)] = !value ? 0 : value; }
-    JSC_TEMPORAL_UNITS(JSC_DEFINE_ISO8601_DURATION_FIELD);
-#undef JSC_DEFINE_ISO8601_DURATION_FIELD
+    void setField(size_t i, double v) { setField(static_cast<TemporalUnit>(i), v); }
+    void setField(TemporalUnit, double);
 
-    double& operator[](size_t i) { return m_data[i]; }
-    const double& operator[](size_t i) const { return m_data[i]; }
-    double& operator[](TemporalUnit u) { return m_data[static_cast<uint8_t>(u)]; }
-    const double& operator[](TemporalUnit u) const { return m_data[static_cast<uint8_t>(u)]; }
-    const_iterator begin() const { return m_data.begin(); }
-    const_iterator end() const { return m_data.end(); }
-    void clear() { m_data.fill(0); }
+    void clear() { *this = Duration(); }
 
     template<TemporalUnit unit>
     std::optional<Int128> NODELETE totalNanoseconds() const;
 
     Duration operator-() const
     {
-        Duration result(*this);
-        for (auto& value : result.m_data) {
-            if (value)
-                value = -value;
-        }
-        return result;
+        return Duration(-m_years, -m_months, -m_weeks, -m_days,
+            -m_hours, -m_minutes, -m_seconds, -m_milliseconds,
+            -m_microseconds, -m_nanoseconds);
     }
 
 private:
-    std::array<double, numberOfTemporalUnits> m_data { };
+    int64_t m_years { 0 };
+    int64_t m_months { 0 };
+    int64_t m_weeks { 0 };
+    int64_t m_days { 0 };
+    int64_t m_hours { 0 };
+    int64_t m_minutes { 0 };
+    int64_t m_seconds { 0 };
+    int64_t m_milliseconds { 0 };
+    Int128 m_microseconds { 0 };
+    Int128 m_nanoseconds { 0 };
 };
 
 class InternalDuration;

--- a/Source/JavaScriptCore/runtime/IntlDurationFormat.cpp
+++ b/Source/JavaScriptCore/runtime/IntlDurationFormat.cpp
@@ -328,7 +328,8 @@ enum class DurationSignType : uint8_t {
 // https://tc39.es/proposal-intl-duration-format/#sec-durationsign
 static DurationSignType NODELETE getDurationSign(ISO8601::Duration duration)
 {
-    for (auto value : duration) {
+    for (size_t i = 0; i < numberOfTemporalUnits; ++i) {
+        auto value = duration[i];
         if (value < 0)
             return DurationSignType::Negative;
         if (value > 0)

--- a/Source/JavaScriptCore/runtime/TemporalCalendar.cpp
+++ b/Source/JavaScriptCore/runtime/TemporalCalendar.cpp
@@ -438,7 +438,7 @@ ISO8601::PlainDate TemporalCalendar::isoDateAdd(JSGlobalObject* globalObject, co
 
 static ISO8601::Duration NODELETE dateDuration(double y, double m, double w, double d)
 {
-    return ISO8601::Duration { y, m, w, d, 0, 0, 0, 0, 0, 0 };
+    return ISO8601::Duration { static_cast<int64_t>(y), static_cast<int64_t>(m), static_cast<int64_t>(w), static_cast<int64_t>(d), 0, 0, 0, 0, 0, 0 };
 }
 
 static bool NODELETE isoDateSurpasses(int32_t sign, double y1, double m1, double d1, const ISO8601::PlainDate& isoDate2)

--- a/Source/JavaScriptCore/runtime/TemporalDuration.cpp
+++ b/Source/JavaScriptCore/runtime/TemporalDuration.cpp
@@ -93,13 +93,14 @@ ISO8601::Duration TemporalDuration::fromDurationLike(JSGlobalObject* globalObjec
             continue;
 
         hasRelevantProperty = true;
-        result[unit] = value.toNumber(globalObject) + 0.0;
+        double v = value.toNumber(globalObject) + 0.0;
         RETURN_IF_EXCEPTION(scope, { });
 
-        if (!isInteger(result[unit])) {
+        if (!isInteger(v) || !std::isfinite(v)) {
             throwRangeError(globalObject, scope, "Temporal.Duration properties must be integers"_s);
             return { };
         }
+        result.setField(unit, v);
     }
 
     if (!hasRelevantProperty) {
@@ -212,7 +213,7 @@ static double NODELETE totalSubseconds(ISO8601::Duration& duration)
 {
     auto milliseconds = duration.milliseconds();
     auto microseconds = 1000 * milliseconds + duration.microseconds();
-    return 1000 * microseconds + duration.nanoseconds();
+    return static_cast<double>(1000 * microseconds + duration.nanoseconds());
 }
 
 // https://tc39.es/proposal-temporal/#sec-temporal-add24hourdaystonormalizedtimeduration
@@ -263,7 +264,8 @@ JSValue TemporalDuration::compare(JSGlobalObject* globalObject, JSValue valueOne
 
 int TemporalDuration::sign(const ISO8601::Duration& duration)
 {
-    for (auto value : duration) {
+    for (size_t i = 0; i < numberOfTemporalUnits; ++i) {
+        auto value = duration[i];
         if (value < 0)
             return -1;
 
@@ -286,18 +288,19 @@ ISO8601::Duration TemporalDuration::with(JSGlobalObject* globalObject, JSObject*
         RETURN_IF_EXCEPTION(scope, { });
 
         if (value.isUndefined()) {
-            result[unit] = m_duration[unit];
+            result.setField(unit, m_duration[unit]);
             continue;
         }
 
         hasRelevantProperty = true;
-        result[unit] = value.toNumber(globalObject);
+        double v = value.toNumber(globalObject);
         RETURN_IF_EXCEPTION(scope, { });
 
-        if (!isInteger(result[unit])) {
+        if (!isInteger(v) || !std::isfinite(v)) {
             throwRangeError(globalObject, scope, "Temporal.Duration properties must be integers"_s);
             return { };
         }
+        result.setField(unit, v);
     }
 
     if (!hasRelevantProperty) {
@@ -316,8 +319,10 @@ ISO8601::Duration TemporalDuration::negated() const
 ISO8601::Duration TemporalDuration::abs() const
 {
     ISO8601::Duration result;
-    for (size_t i = 0; i < numberOfTemporalUnits; i++)
-        result[i] = std::abs(m_duration[i]);
+    for (size_t i = 0; i < numberOfTemporalUnits; i++) {
+        double v = m_duration[i];
+        result.setField(i, v < 0 ? -v : v);
+    }
     return result;
 }
 
@@ -355,11 +360,11 @@ ISO8601::InternalDuration TemporalDuration::toInternalDurationRecordWith24HourDa
     auto scope = DECLARE_THROW_SCOPE(vm);
 
     Int128 timeDuration = timeDurationFromComponents(d.hours(), d.minutes(), d.seconds(),
-        d.milliseconds(), d.microseconds(), d.nanoseconds());
+        d.milliseconds(), static_cast<double>(d.microseconds()), static_cast<double>(d.nanoseconds()));
     timeDuration = add24HourDaysToTimeDuration(globalObject, timeDuration, d.days());
     RETURN_IF_EXCEPTION(scope, { });
     ISO8601::Duration dateDuration = ISO8601::Duration { d.years(), d.months(), d.weeks(),
-        0, 0, 0, 0, 0, 0, 0 };
+        0LL, 0, 0, 0, 0, 0, 0 };
     return ISO8601::InternalDuration::combineDateAndTimeDuration(dateDuration,
         timeDuration);
 }
@@ -392,7 +397,7 @@ ISO8601::Duration TemporalDuration::toDateDurationRecordWithoutTime(JSGlobalObje
     auto internalDuration = toInternalDurationRecordWith24HourDays(globalObject, duration);
     RETURN_IF_EXCEPTION(scope, { });
     auto days = internalDuration.time() / ISO8601::ExactTime::nsPerDay;
-    return ISO8601::Duration { internalDuration.dateDuration().years(), internalDuration.dateDuration().months(), internalDuration.dateDuration().weeks(), static_cast<double>(days), 0, 0, 0, 0, 0, 0 };
+    return ISO8601::Duration { internalDuration.dateDuration().years(), internalDuration.dateDuration().months(), internalDuration.dateDuration().weeks(), static_cast<int64_t>(days), 0, 0, 0, 0, 0, 0 };
 }
 
 // BalanceDuration ( days, hours, minutes, seconds, milliseconds, microseconds, nanoseconds, largestUnit [ , relativeTo ] )
@@ -408,7 +413,7 @@ std::optional<double> TemporalDuration::balance(ISO8601::Duration& duration, Tem
     duration.clear();
 
     if (largestUnit <= TemporalUnit::Day) {
-        duration.setDays(std::trunc(seconds / secondsPerDay));
+        duration.setField(TemporalUnit::Day, std::trunc(seconds / secondsPerDay));
         seconds = std::fmod(seconds, secondsPerDay);
     }
 
@@ -416,35 +421,35 @@ std::optional<double> TemporalDuration::balance(ISO8601::Duration& duration, Tem
     double milliseconds = std::trunc(microseconds / 1000);
     double minutes = std::trunc(seconds / 60);
     if (largestUnit <= TemporalUnit::Hour) {
-        duration.setNanoseconds(std::fmod(nanoseconds, 1000));
-        duration.setMicroseconds(std::fmod(microseconds, 1000));
-        duration.setMilliseconds(std::fmod(milliseconds, 1000));
-        duration.setSeconds(std::fmod(seconds, 60));
-        duration.setMinutes(std::fmod(minutes, 60));
-        duration.setHours(std::trunc(minutes / 60));
+        duration.setField(TemporalUnit::Nanosecond, std::fmod(nanoseconds, 1000));
+        duration.setField(TemporalUnit::Microsecond, std::fmod(microseconds, 1000));
+        duration.setField(TemporalUnit::Millisecond, std::fmod(milliseconds, 1000));
+        duration.setField(TemporalUnit::Second, std::fmod(seconds, 60));
+        duration.setField(TemporalUnit::Minute, std::fmod(minutes, 60));
+        duration.setField(TemporalUnit::Hour, std::trunc(minutes / 60));
     } else if (largestUnit == TemporalUnit::Minute) {
-        duration.setNanoseconds(std::fmod(nanoseconds, 1000));
-        duration.setMicroseconds(std::fmod(microseconds, 1000));
-        duration.setMilliseconds(std::fmod(milliseconds, 1000));
-        duration.setSeconds(std::fmod(seconds, 60));
-        duration.setMinutes(minutes);
+        duration.setField(TemporalUnit::Nanosecond, std::fmod(nanoseconds, 1000));
+        duration.setField(TemporalUnit::Microsecond, std::fmod(microseconds, 1000));
+        duration.setField(TemporalUnit::Millisecond, std::fmod(milliseconds, 1000));
+        duration.setField(TemporalUnit::Second, std::fmod(seconds, 60));
+        duration.setField(TemporalUnit::Minute, minutes);
     } else if (largestUnit == TemporalUnit::Second) {
-        duration.setNanoseconds(std::fmod(nanoseconds, 1000));
-        duration.setMicroseconds(std::fmod(microseconds, 1000));
-        duration.setMilliseconds(std::fmod(milliseconds, 1000));
-        duration.setSeconds(seconds);
+        duration.setField(TemporalUnit::Nanosecond, std::fmod(nanoseconds, 1000));
+        duration.setField(TemporalUnit::Microsecond, std::fmod(microseconds, 1000));
+        duration.setField(TemporalUnit::Millisecond, std::fmod(milliseconds, 1000));
+        duration.setField(TemporalUnit::Second, seconds);
     } else if (largestUnit == TemporalUnit::Millisecond) {
-        duration.setNanoseconds(std::fmod(nanoseconds, 1000));
-        duration.setMicroseconds(std::fmod(microseconds, 1000));
+        duration.setField(TemporalUnit::Nanosecond, std::fmod(nanoseconds, 1000));
+        duration.setField(TemporalUnit::Microsecond, std::fmod(microseconds, 1000));
         milliseconds += seconds * 1000;
-        duration.setMilliseconds(milliseconds);
+        duration.setField(TemporalUnit::Millisecond, milliseconds);
     } else if (largestUnit == TemporalUnit::Microsecond) {
-        duration.setNanoseconds(std::fmod(nanoseconds, 1000));
+        duration.setField(TemporalUnit::Nanosecond, std::fmod(nanoseconds, 1000));
         microseconds += seconds * 1000 * 1000;
-        duration.setMicroseconds(microseconds);
+        duration.setField(TemporalUnit::Microsecond, microseconds);
     } else {
         nanoseconds += seconds * 1000 * 1000 * 1000;
-        duration.setNanoseconds(nanoseconds);
+        duration.setField(TemporalUnit::Nanosecond, nanoseconds);
     }
 
     return std::nullopt;
@@ -495,7 +500,7 @@ ISO8601::Duration TemporalDuration::add(JSGlobalObject* globalObject, JSValue ot
 
 ISO8601::InternalDuration TemporalDuration::toInternalDuration(ISO8601::Duration d)
 {
-    auto timeDuration = timeDurationFromComponents(d.hours(), d.minutes(), d.seconds(), d.milliseconds(), d.microseconds(), d.nanoseconds());
+    auto timeDuration = timeDurationFromComponents(d.hours(), d.minutes(), d.seconds(), d.milliseconds(), static_cast<double>(d.microseconds()), static_cast<double>(d.nanoseconds()));
     return ISO8601::InternalDuration::combineDateAndTimeDuration(d, timeDuration);
 }
 
@@ -577,11 +582,14 @@ ISO8601::Duration TemporalDuration::temporalDurationFromInternal(ISO8601::Intern
         microseconds *= sign;
     if (nanoseconds)
         nanoseconds *= sign;
+    // ℝ(𝔽(x)): round sub-millisecond fields through float64 per spec CreateTemporalDuration.
+    // Large Int128 values not exactly float64-representable round past nanosecondsLimit,
+    // which isValidDuration then rejects as required.
     return ISO8601::Duration { internalDuration.dateDuration().years(),
         internalDuration.dateDuration().months(), internalDuration.dateDuration().weeks(),
-        internalDuration.dateDuration().days() + days * sign, hours, minutes,
-        static_cast<double>(seconds), static_cast<double>(milliseconds),
-        static_cast<double>(microseconds), static_cast<double>(nanoseconds) };
+        static_cast<int64_t>(internalDuration.dateDuration().days() + days * sign), static_cast<int64_t>(hours), static_cast<int64_t>(minutes),
+        static_cast<int64_t>(seconds), ISO8601::Duration::doubleToInt64Saturating(static_cast<double>(milliseconds)),
+        Int128(static_cast<double>(microseconds)), Int128(static_cast<double>(nanoseconds)) };
 }
 
 ISO8601::Duration TemporalDuration::subtract(JSGlobalObject* globalObject, JSValue otherValue) const
@@ -616,7 +624,7 @@ static ISO8601::Duration adjustDateDurationRecord(JSGlobalObject* globalObject, 
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    auto result = ISO8601::Duration { dateDuration.years(), months ? months.value() : dateDuration.months(), weeks ? weeks.value() : dateDuration.weeks(), days, 0, 0, 0, 0, 0, 0 };
+    auto result = ISO8601::Duration { dateDuration.years(), months ? static_cast<int64_t>(months.value()) : dateDuration.months(), weeks ? static_cast<int64_t>(weeks.value()) : dateDuration.weeks(), static_cast<int64_t>(days), 0, 0, 0, 0, 0, 0 };
     if (!ISO8601::isValidDuration(result)) {
         throwRangeError(globalObject, scope, "Temporal.Duration properties must be valid and of consistent sign"_s);
         return { };
@@ -666,8 +674,8 @@ Nudged TemporalDuration::nudgeToCalendarUnit(JSGlobalObject* globalObject, int32
             (Int128) increment, RoundingMode::Trunc);
         r1 = (double) years;
         r2 = (double) years + increment * sign;
-        startDuration = ISO8601::Duration { r1, 0, 0, 0, 0, 0, 0, 0, 0, 0 };
-        endDuration = ISO8601::Duration { r2, 0, 0, 0, 0, 0, 0, 0, 0, 0 };
+        startDuration = ISO8601::Duration { static_cast<int64_t>(r1), 0, 0, 0, 0, 0, 0, 0, 0, 0 };
+        endDuration = ISO8601::Duration { static_cast<int64_t>(r2), 0, 0, 0, 0, 0, 0, 0, 0, 0 };
         break;
     }
     case TemporalUnit::Month: {
@@ -929,7 +937,7 @@ ISO8601::InternalDuration TemporalDuration::round(JSGlobalObject* globalObject, 
         double fractionalDays = totalTimeDuration(internalDuration.time(), TemporalUnit::Day);
         double days = roundNumberToIncrementDouble(fractionalDays, increment, mode);
         return ISO8601::InternalDuration::combineDateAndTimeDuration(
-            ISO8601::Duration { 0, 0, 0, (double) days, 0, 0, 0, 0, 0, 0 },
+            ISO8601::Duration { 0, 0, 0, static_cast<int64_t>(days), 0, 0, 0, 0, 0, 0 },
             0);
     } else  {
         std::optional<Int128> timeDuration =
@@ -1203,7 +1211,7 @@ String TemporalDuration::toString(JSGlobalObject* globalObject, const ISO8601::D
         builder.append('D');
     }
 
-    auto secondsDuration = timeDurationFromComponents(0, 0, duration.seconds(), duration.milliseconds(), duration.microseconds(), duration.nanoseconds());
+    auto secondsDuration = timeDurationFromComponents(0, 0, duration.seconds(), duration.milliseconds(), static_cast<double>(duration.microseconds()), static_cast<double>(duration.nanoseconds()));
 
     if (!duration.hours() && !duration.minutes() && !secondsDuration && sign && std::get<0>(precision) == Precision::Auto)
         return builder.toString();

--- a/Source/JavaScriptCore/runtime/TemporalDuration.h
+++ b/Source/JavaScriptCore/runtime/TemporalDuration.h
@@ -53,6 +53,8 @@ class TemporalDuration final : public JSNonFinalObject {
 public:
     using Base = JSNonFinalObject;
 
+    static constexpr uint8_t numberOfLowerTierPreciseCells = 0;
+
     template<typename CellType, SubspaceAccess mode>
     static GCClient::IsoSubspace* subspaceFor(VM& vm)
     {
@@ -71,8 +73,8 @@ public:
     static JSValue compare(JSGlobalObject*, JSValue, JSValue);
 
 #define JSC_DEFINE_TEMPORAL_DURATION_FIELD(name, capitalizedName) \
-    double name##s() const { return m_duration.name##s(); } \
-    void set##capitalizedName##s(double value) { m_duration.set##capitalizedName##s(value); }
+    double name##s() const { return static_cast<double>(m_duration.name##s()); } \
+    void set##capitalizedName##s(double value) { m_duration.setField(TemporalUnit::capitalizedName, value); }
     JSC_TEMPORAL_UNITS(JSC_DEFINE_TEMPORAL_DURATION_FIELD);
 #undef JSC_DEFINE_TEMPORAL_DURATION_FIELD
 
@@ -80,7 +82,7 @@ public:
 
     ISO8601::Duration with(JSGlobalObject*, JSObject* durationLike) const;
     ISO8601::Duration NODELETE negated() const;
-    ISO8601::Duration NODELETE abs() const;
+    ISO8601::Duration abs() const;
     ISO8601::Duration add(JSGlobalObject*, JSValue) const;
     ISO8601::Duration subtract(JSGlobalObject*, JSValue) const;
     ISO8601::Duration round(JSGlobalObject*, JSValue options) const;

--- a/Source/JavaScriptCore/runtime/TemporalDurationConstructor.cpp
+++ b/Source/JavaScriptCore/runtime/TemporalDurationConstructor.cpp
@@ -96,11 +96,12 @@ JSC_DEFINE_HOST_FUNCTION(constructTemporalDuration, (JSGlobalObject* globalObjec
         if (value.isUndefined())
             continue;
 
-        result[i] = value.toNumber(globalObject) + 0.0;
+        double v = value.toNumber(globalObject) + 0.0;
         RETURN_IF_EXCEPTION(scope, { });
 
-        if (!isInteger(result[i]))
+        if (!isInteger(v))
             return throwVMRangeError(globalObject, scope, "Temporal.Duration properties must be integers"_s);
+        result.setField(i, v);
     }
 
     RELEASE_AND_RETURN(scope, JSValue::encode(TemporalDuration::tryCreateIfValid(globalObject, WTF::move(result), structure)));

--- a/Source/JavaScriptCore/runtime/TemporalPlainDateConstructor.cpp
+++ b/Source/JavaScriptCore/runtime/TemporalPlainDateConstructor.cpp
@@ -96,7 +96,7 @@ JSC_DEFINE_HOST_FUNCTION(constructTemporalPlainDate, (JSGlobalObject* globalObje
         auto value = callFrame->uncheckedArgument(0).toIntegerWithTruncation(globalObject);
         if (!std::isfinite(value))
             return throwVMRangeError(globalObject, scope, "Temporal.PlainDate year property must be finite"_s);
-        duration.setYears(value);
+        duration.setField(TemporalUnit::Year, value);
         RETURN_IF_EXCEPTION(scope, { });
     }
 
@@ -104,7 +104,7 @@ JSC_DEFINE_HOST_FUNCTION(constructTemporalPlainDate, (JSGlobalObject* globalObje
         auto value = callFrame->uncheckedArgument(1).toIntegerWithTruncation(globalObject);
         if (!std::isfinite(value))
             return throwVMRangeError(globalObject, scope, "Temporal.PlainDate month property must be finite"_s);
-        duration.setMonths(value);
+        duration.setField(TemporalUnit::Month, value);
         RETURN_IF_EXCEPTION(scope, { });
     }
 
@@ -112,7 +112,7 @@ JSC_DEFINE_HOST_FUNCTION(constructTemporalPlainDate, (JSGlobalObject* globalObje
         auto value = callFrame->uncheckedArgument(2).toIntegerWithTruncation(globalObject);
         if (!std::isfinite(value))
             return throwVMRangeError(globalObject, scope, "Temporal.PlainDate day property must be finite"_s);
-        duration.setDays(value);
+        duration.setField(TemporalUnit::Day, value);
         RETURN_IF_EXCEPTION(scope, { });
     }
 

--- a/Source/JavaScriptCore/runtime/TemporalPlainDateTime.cpp
+++ b/Source/JavaScriptCore/runtime/TemporalPlainDateTime.cpp
@@ -191,18 +191,18 @@ static void incrementDay(ISO8601::Duration& duration)
 
     double daysInMonth = ISO8601::daysInMonth(year, month);
     if (day < daysInMonth) {
-        duration.setDays(day + 1);
+        duration.setField(TemporalUnit::Day, day + 1);
         return;
     }
 
-    duration.setDays(1);
+    duration.setField(TemporalUnit::Day, 1);
     if (month < 12) {
-        duration.setMonths(month + 1);
+        duration.setField(TemporalUnit::Month, month + 1);
         return;
     }
 
-    duration.setMonths(1);
-    duration.setYears(year + 1);
+    duration.setField(TemporalUnit::Month, 1);
+    duration.setField(TemporalUnit::Year, year + 1);
 }
 
 String TemporalPlainDateTime::toString(JSGlobalObject* globalObject, JSValue optionsValue) const
@@ -231,9 +231,9 @@ String TemporalPlainDateTime::toString(JSGlobalObject* globalObject, JSValue opt
     RETURN_IF_EXCEPTION(scope, { });
 
     double extraDays = duration.days();
-    duration.setYears(year());
-    duration.setMonths(month());
-    duration.setDays(day());
+    duration.setYears(static_cast<int64_t>(year()));
+    duration.setMonths(static_cast<int64_t>(month()));
+    duration.setDays(static_cast<int64_t>(day()));
     if (extraDays) {
         ASSERT(extraDays == 1);
         incrementDay(duration);
@@ -289,12 +289,12 @@ TemporalPlainDateTime* TemporalPlainDateTime::with(JSGlobalObject* globalObject,
     RETURN_IF_EXCEPTION(scope, { });
 
     ISO8601::Duration duration { };
-    duration.setHours(optionalHour.value_or(hour()));
-    duration.setMinutes(optionalMinute.value_or(minute()));
-    duration.setSeconds(optionalSecond.value_or(second()));
-    duration.setMilliseconds(optionalMillisecond.value_or(millisecond()));
-    duration.setMicroseconds(optionalMicrosecond.value_or(microsecond()));
-    duration.setNanoseconds(optionalNanosecond.value_or(nanosecond()));
+    duration.setField(TemporalUnit::Hour, optionalHour.value_or(hour()));
+    duration.setField(TemporalUnit::Minute, optionalMinute.value_or(minute()));
+    duration.setField(TemporalUnit::Second, optionalSecond.value_or(second()));
+    duration.setField(TemporalUnit::Millisecond, optionalMillisecond.value_or(millisecond()));
+    duration.setField(TemporalUnit::Microsecond, optionalMicrosecond.value_or(microsecond()));
+    duration.setField(TemporalUnit::Nanosecond, optionalNanosecond.value_or(nanosecond()));
     auto plainTime = TemporalPlainTime::regulateTime(globalObject, WTF::move(duration), overflow);
     RETURN_IF_EXCEPTION(scope, { });
 
@@ -365,9 +365,9 @@ TemporalPlainDateTime* TemporalPlainDateTime::round(JSGlobalObject* globalObject
     RETURN_IF_EXCEPTION(scope, { });
 
     double extraDays = duration.days();
-    duration.setYears(year());
-    duration.setMonths(month());
-    duration.setDays(day());
+    duration.setYears(static_cast<int64_t>(year()));
+    duration.setMonths(static_cast<int64_t>(month()));
+    duration.setDays(static_cast<int64_t>(day()));
     if (extraDays) {
         ASSERT(extraDays == 1);
         incrementDay(duration);

--- a/Source/JavaScriptCore/runtime/TemporalPlainDateTimeConstructor.cpp
+++ b/Source/JavaScriptCore/runtime/TemporalPlainDateTimeConstructor.cpp
@@ -93,10 +93,11 @@ JSC_DEFINE_HOST_FUNCTION(constructTemporalPlainDateTime, (JSGlobalObject* global
     auto count = std::min<size_t>(callFrame->argumentCount(), numberOfTemporalPlainDateUnits + numberOfTemporalPlainTimeUnits);
     for (unsigned i = 0; i < count; i++) {
         unsigned durationIndex = i >= static_cast<unsigned>(TemporalUnit::Week) ? i + 1 : i;
-        duration[durationIndex] = callFrame->uncheckedArgument(i).toIntegerOrInfinity(globalObject);
+        double v = callFrame->uncheckedArgument(i).toIntegerOrInfinity(globalObject);
         RETURN_IF_EXCEPTION(scope, { });
-        if (!std::isfinite(duration[durationIndex]))
+        if (!std::isfinite(v))
             return throwVMRangeError(globalObject, scope, "Temporal.PlainDateTime properties must be finite"_s);
+        duration.setField(durationIndex, v);
     }
 
     RELEASE_AND_RETURN(scope, JSValue::encode(TemporalPlainDateTime::tryCreateIfValid(globalObject, structure, WTF::move(duration))));

--- a/Source/JavaScriptCore/runtime/TemporalPlainTime.cpp
+++ b/Source/JavaScriptCore/runtime/TemporalPlainTime.cpp
@@ -94,8 +94,8 @@ ISO8601::PlainTime TemporalPlainTime::toPlainTime(JSGlobalObject* globalObject, 
     double minute = duration.minutes();
     double second = duration.seconds();
     double millisecond = duration.milliseconds();
-    double microsecond = duration.microseconds();
-    double nanosecond = duration.nanoseconds();
+    double microsecond = static_cast<double>(duration.microseconds());
+    double nanosecond = static_cast<double>(duration.nanoseconds());
     if (!(hour >= 0 && hour <= 23)) {
         throwRangeError(globalObject, scope, "hour is out of range"_s);
         return { };
@@ -190,7 +190,7 @@ static ISO8601::Duration NODELETE balanceTime(Int128 hour, Int128 minute, Int128
         hour += 24;
     }
 
-    return ISO8601::Duration(0, 0, 0, static_cast<double>(days), static_cast<double>(hour), static_cast<double>(minute), static_cast<double>(second), static_cast<double>(millisecond), static_cast<double>(microsecond), static_cast<double>(nanosecond));
+    return ISO8601::Duration(0, 0, 0, static_cast<int64_t>(days), static_cast<int64_t>(hour), static_cast<int64_t>(minute), static_cast<int64_t>(second), static_cast<int64_t>(millisecond), microsecond, nanosecond);
 }
 
 // https://tc39.es/proposal-temporal/#sec-temporal-roundtime
@@ -356,7 +356,7 @@ ISO8601::Duration TemporalPlainTime::toTemporalTimeRecord(JSGlobalObject* global
             throwRangeError(globalObject, scope, "Temporal time properties must be finite"_s);
             return { };
         }
-        duration[unit] = integer;
+        duration.setField(unit, integer);
     }
 
     if (!hasRelevantProperty && !skipRelevantPropertyCheck) {
@@ -411,8 +411,8 @@ static ISO8601::PlainTime constrainTime(ISO8601::Duration&& duration)
         constrainToRange(duration.minutes(), 0, 59),
         constrainToRange(duration.seconds(), 0, 59),
         constrainToRange(duration.milliseconds(), 0, 999),
-        constrainToRange(duration.microseconds(), 0, 999),
-        constrainToRange(duration.nanoseconds(), 0, 999));
+        constrainToRange(static_cast<double>(duration.microseconds()), 0, 999),
+        constrainToRange(static_cast<double>(duration.nanoseconds()), 0, 999));
 }
 
 ISO8601::PlainTime TemporalPlainTime::regulateTime(JSGlobalObject* globalObject, ISO8601::Duration&& duration, TemporalOverflow overflow)
@@ -560,12 +560,12 @@ ISO8601::PlainTime TemporalPlainTime::with(JSGlobalObject* globalObject, JSObjec
     RETURN_IF_EXCEPTION(scope, { });
 
     ISO8601::Duration duration { };
-    duration.setHours(hourOptional.value_or(hour()));
-    duration.setMinutes(minuteOptional.value_or(minute()));
-    duration.setSeconds(secondOptional.value_or(second()));
-    duration.setMilliseconds(millisecondOptional.value_or(millisecond()));
-    duration.setMicroseconds(microsecondOptional.value_or(microsecond()));
-    duration.setNanoseconds(nanosecondOptional.value_or(nanosecond()));
+    duration.setField(TemporalUnit::Hour, hourOptional.value_or(hour()));
+    duration.setField(TemporalUnit::Minute, minuteOptional.value_or(minute()));
+    duration.setField(TemporalUnit::Second, secondOptional.value_or(second()));
+    duration.setField(TemporalUnit::Millisecond, millisecondOptional.value_or(millisecond()));
+    duration.setField(TemporalUnit::Microsecond, microsecondOptional.value_or(microsecond()));
+    duration.setField(TemporalUnit::Nanosecond, nanosecondOptional.value_or(nanosecond()));
 
     RELEASE_AND_RETURN(scope, regulateTime(globalObject, WTF::move(duration), overflow));
 }

--- a/Source/JavaScriptCore/runtime/TemporalPlainTimeConstructor.cpp
+++ b/Source/JavaScriptCore/runtime/TemporalPlainTimeConstructor.cpp
@@ -93,10 +93,11 @@ JSC_DEFINE_HOST_FUNCTION(constructTemporalPlainTime, (JSGlobalObject* globalObje
     auto count = std::min<size_t>(callFrame->argumentCount(), numberOfTemporalPlainTimeUnits);
     for (unsigned i = 0; i < count; i++) {
         unsigned durationIndex = i + static_cast<unsigned>(TemporalUnit::Hour);
-        duration[durationIndex] = callFrame->uncheckedArgument(i).toIntegerOrInfinity(globalObject);
+        double v = callFrame->uncheckedArgument(i).toIntegerOrInfinity(globalObject);
         RETURN_IF_EXCEPTION(scope, { });
-        if (!std::isfinite(duration[durationIndex]))
+        if (!std::isfinite(v))
             return throwVMRangeError(globalObject, scope, "Temporal.PlainTime properties must be finite"_s);
+        duration.setField(durationIndex, v);
     }
     RELEASE_AND_RETURN(scope, JSValue::encode(TemporalPlainTime::tryCreateIfValid(globalObject, structure, WTF::move(duration))));
 }

--- a/Source/WTF/wtf/Int128.h
+++ b/Source/WTF/wtf/Int128.h
@@ -98,7 +98,7 @@ class PrintStream;
 //     uint64_t i = v;                         // Error
 //     uint64_t i = static_cast<uint64_t>(v);  // OK
 //
-class alignas(16) UInt128Impl {
+class UInt128Impl {
  public:
   UInt128Impl() = default;
 
@@ -196,9 +196,7 @@ class alignas(16) UInt128Impl {
   constexpr UInt128Impl(uint64_t high, uint64_t low);
 
   // TODO(strel) Update implementation to use __int128 once all users of
-  // UInt128Impl are fixed to not depend on alignof(UInt128Impl) == 8. Also add
-  // alignas(16) to class definition to keep alignment consistent across
-  // platforms.
+  // UInt128Impl are fixed to not depend on alignof(UInt128Impl) == 8.
 #if CPU(LITTLE_ENDIAN)
   uint64_t lo_;
   uint64_t hi_;
@@ -294,7 +292,7 @@ namespace WTF {
 //     int64_t i = v;                        // Error
 //     int64_t i = static_cast<int64_t>(v);  // OK
 //
-class alignas(16) Int128Impl {
+class Int128Impl {
  public:
   Int128Impl() = default;
 


### PR DESCRIPTION
#### 6d4d99796fa15551cfb7793eb0c0eec22736d3d0
<pre>
[JSC][Temporal] Change Duration storage from double array to int64_t/Int128 fields
<a href="https://bugs.webkit.org/show_bug.cgi?id=314163">https://bugs.webkit.org/show_bug.cgi?id=314163</a>
<a href="https://rdar.apple.com/176325659">rdar://176325659</a>

Reviewed by Yusuke Suzuki.

ISO8601::Duration previously stored all ten temporal fields as
std::array&lt;double, 10&gt;. This loses precision for large-but-valid
integer values: IEEE 754 double has only 53 bits of mantissa, so
integers above 2^53 cannot round-trip. Valid Duration nanoseconds
can reach 2^53 * 10^9 ≈ 9*10^24, well beyond that threshold.

Change storage to int64_t for years–milliseconds and Int128 for
microseconds/nanoseconds, matching temporal_rs (i64/i128 fields).

Key design points:
- Primary constructor takes exact typed storage to eliminate
  useless double round-trips in internal arithmetic.
- setField(TemporalUnit, double) is the JS-entry point; it uses
  doubleToInt64Saturating (avoids UB for out-of-range doubles by
  saturating to INT64_MIN/MAX) and checkedCastDoubleToInt128 (avoids
  UB for values &gt;= 2^127 by storing a sentinel above
  kDurationNanosecondsLimit so isValidDuration rejects them).
- isValidDuration is updated to use typed Int128 comparisons against
  named constants (kDurationNanosecondsLimit) instead of double
  arithmetic, matching the security-branch implementation.
- checkedCastDoubleToInt128 is updated to use std::bit_cast&lt;uint64_t&gt;
  instead of reinterpret_cast, fixing a strict-aliasing UB.
- The TemporalDuration JS-wrapper macro setter now uses setField
  instead of static_cast&lt;int64_t&gt;, which was UB for microsecond
  values above INT64_MAX.

All callers updated; no behavior change for any valid Duration input.

This patch is a prerequisite for the Temporal Stage 4 implementation
follow-up that adds ZonedDateTime, non-ISO calendar support, and the
temporal/core arithmetic layer.

Canonical link: <a href="https://commits.webkit.org/312812@main">https://commits.webkit.org/312812@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a3128ba919e13ee31a9917bdba6d02f6ec8faebd

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/160995 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/34468 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/27569 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/169898 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/117255 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/69e2e54a-0256-4c49-b48e-06a150f72e7f) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/34569 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/34468 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/124888 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/117255 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/8fb9aca8-bf56-47d7-87d9-600d6fa642ba) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/163954 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/27151 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/144623 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/105485 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/81f7a4ca-31de-40c9-9bd0-1e4b98e604ea) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/26200 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/24699 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/17618 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/153051 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/135894 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/22385 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/172381 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/21833 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/19402 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/24026 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/133169 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/34142 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/28792 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/133179 "Passed tests") | | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/34126 "Build is in progress. Recent messages:OS: Tahoe (26.2), Xcode: 26.2; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (warnings)") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/144180 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/95965 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/24505 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/27737 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/20998 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/193394 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/33637 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/101062 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/49802 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/33136 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/33380 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/33285 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->