### PR TITLE
AX: Override aria-hidden on a modal when the page would otherwise be completely empty due to inertness

### DIFF
--- a/LayoutTests/accessibility/aria-hidden-modal-override-when-page-empty-expected.txt
+++ b/LayoutTests/accessibility/aria-hidden-modal-override-when-page-empty-expected.txt
@@ -1,0 +1,12 @@
+This tests that when all page content is inert and an aria-modal dialog is inside an aria-hidden container, the dialog content is still accessible.
+
+PASS: accessibilityController.accessibleElementById('article') === null
+PASS: heading && !heading.isIgnored === true
+PASS: button && !button.isIgnored === true
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+Terms and Conditions
+
+Agree

--- a/LayoutTests/accessibility/aria-hidden-modal-override-when-page-empty.html
+++ b/LayoutTests/accessibility/aria-hidden-modal-override-when-page-empty.html
@@ -1,0 +1,48 @@
+<!DOCTYPE HTML>
+<html>
+<head>
+<script src="../resources/accessibility-helper.js"></script>
+<script src="../resources/js-test.js"></script>
+</head>
+<body>
+
+<div id="main-content" inert>
+    <p id="article">Main article content</p>
+</div>
+
+<div aria-hidden="true">
+    <div role="dialog" aria-modal="true">
+        <h2 id="dialog-heading">Terms and Conditions</h2>
+        <button id="agree-button">Agree</button>
+    </div>
+</div>
+
+<script>
+var output = "This tests that when all page content is inert and an aria-modal dialog is inside an aria-hidden container, the dialog content is still accessible.\n\n";
+var heading, button;
+
+if (window.accessibilityController) {
+    window.jsTestIsAsync = true;
+
+    // The main content is inert, so it should not be accessible.
+    output += expect("accessibilityController.accessibleElementById('article')", "null");
+
+    (async function() {
+        // The dialog content should be accessible despite the ancestor aria-hidden,
+        // because without the override the page would be completely empty.
+        await waitFor(() => {
+            heading = accessibilityController.accessibleElementById("dialog-heading");
+            return heading && !heading.isIgnored;
+        });
+        output += expect("heading && !heading.isIgnored", "true");
+        button = accessibilityController.accessibleElementById("agree-button");
+        output += expect("button && !button.isIgnored", "true");
+
+        document.getElementById("main-content").style.display = "none";
+        debug(output);
+        finishJSTest();
+    })();
+}
+</script>
+</body>
+</html>

--- a/Source/WebCore/accessibility/AXObjectCache.cpp
+++ b/Source/WebCore/accessibility/AXObjectCache.cpp
@@ -538,6 +538,11 @@ void AXObjectCache::findModalNodes()
             m_modalElements.append(element.get());
     }
 
+    // Arm the aria-hidden override check in case a modal is blocked by
+    // ancestor aria-hidden with an otherwise empty page.
+    if (!m_modalElements.isEmpty())
+        m_needsAriaHiddenModalOverrideCheck = true;
+
     m_modalNodesInitialized = true;
 }
 
@@ -692,6 +697,47 @@ Node* AXObjectCache::modalNode()
 
     // Recompute the valid aria modal node when m_currentModalElement is null or hidden.
     updateCurrentModalNode();
+
+    if (m_needsAriaHiddenModalOverrideCheck && !m_currentModalElement) {
+        m_needsAriaHiddenModalOverrideCheck = false;
+
+        // This block is designed to fix a web developer mistake where an aria-modal
+        // is added to the page, all content outside the modal is inert, and the author
+        // mistakenly leaves the modal as aria-hidden. This is an extremely specific
+        // scenario, but one we found on a real, very popular webpage, and it's an
+        // understandable mistake. Only do this if literally nothing on the page is
+        // accessible (!m_unignoredContentObjectCount).
+        if (!m_unignoredContentObjectCount) {
+            for (auto& modal : m_modalElements) {
+                if (!modal || !isModalElement(*modal))
+                    continue;
+
+                RefPtr<Element> ariaHiddenAncestor;
+                bool isVisible = modal->renderer() && modal->renderer()->style().display() != Style::DisplayType::None;
+                for (RefPtr current = modal.get(); current && isVisible; current = current->parentElementInComposedTree()) {
+                    if (auto* renderer = current->renderer()) {
+                        if (renderer->style().opacity().isTransparent()) {
+                            isVisible = false;
+                            break;
+                        }
+                    }
+
+                    if (!ariaHiddenAncestor && equalLettersIgnoringASCIICase(current->attributeWithDefaultARIA(aria_hiddenAttr), "true"_s))
+                        ariaHiddenAncestor = current;
+                }
+
+                if (!isVisible || !ariaHiddenAncestor)
+                    continue;
+
+                if (RefPtr axObject = getOrCreate(*ariaHiddenAncestor)) {
+                    axObject->setShouldIgnoreARIAHidden(true);
+                    handleAriaHiddenChange(*ariaHiddenAncestor);
+                }
+                break;
+            }
+        }
+    }
+
     return m_currentModalElement;
 }
 
@@ -2280,6 +2326,13 @@ void AXObjectCache::onFrameSelectionFocusedOrActiveStateChanged(Document& docume
 
 void AXObjectCache::onInertOrVisibilityChange(RenderElement& renderer)
 {
+    if (renderer.style().effectiveInert() || renderer.style().usedVisibility() != Visibility::Visible) {
+        // An element becoming inert can cause all page content to become ignored,
+        // which may require overriding aria-hidden on a blocked modal to prevent
+        // an empty page. Arm the check for the next modalNode() query.
+        m_needsAriaHiddenModalOverrideCheck = true;
+    }
+
 #if ENABLE(INCLUDE_IGNORED_IN_CORE_AX_TREE)
     RefPtr axObject = get(renderer);
     if (!axObject)
@@ -3643,6 +3696,12 @@ void AXObjectCache::handleAttributeChange(Element* element, const QualifiedName&
         if (!equalLettersIgnoringASCIICase(element->attributeWithDefaultARIA(aria_hiddenAttr), "true"_s)) {
             if (RefPtr axObject = getOrCreate(*element))
                 axObject->setShouldIgnoreARIAHidden(false);
+        } else {
+            // Setting aria-hidden="true" can cause all page content to become
+            // ignored, which may require overriding this aria-hidden on a blocked
+            // modal to prevent an empty page. Arm the check for the next
+            // modalNode() query.
+            m_needsAriaHiddenModalOverrideCheck = true;
         }
         handleAriaHiddenChange(*element);
 

--- a/Source/WebCore/accessibility/AXObjectCache.h
+++ b/Source/WebCore/accessibility/AXObjectCache.h
@@ -768,6 +768,39 @@ public:
 
     void objectBecameIgnored(const AccessibilityObject&);
     void objectBecameUnignored(const AccessibilityObject&);
+    static bool isMockObjectOrWebAreaRole(AccessibilityRole role)
+    {
+        switch (role) {
+        case AccessibilityRole::WebArea:
+        case AccessibilityRole::ScrollArea:
+        case AccessibilityRole::ScrollBar:
+        case AccessibilityRole::LocalFrame:
+        case AccessibilityRole::FrameHost:
+        case AccessibilityRole::RemoteFrame:
+        case AccessibilityRole::SliderThumb:
+        case AccessibilityRole::SpinButton:
+        case AccessibilityRole::SpinButtonPart:
+        case AccessibilityRole::MenuListPopup:
+        case AccessibilityRole::Column:
+        case AccessibilityRole::TableHeaderContainer:
+            return true;
+        default:
+            return false;
+        }
+    }
+    void incrementUnignoredContentObjectCount(AccessibilityRole role)
+    {
+        if (!isMockObjectOrWebAreaRole(role))
+            ++m_unignoredContentObjectCount;
+    }
+    void decrementUnignoredContentObjectCount(AccessibilityRole role)
+    {
+        if (isMockObjectOrWebAreaRole(role))
+            return;
+        AX_ASSERT(m_unignoredContentObjectCount);
+        if (m_unignoredContentObjectCount)
+            --m_unignoredContentObjectCount;
+    }
 
 #if PLATFORM(COCOA)
     static void NODELETE setShouldRepostNotificationsForTests(bool);
@@ -1083,12 +1116,17 @@ private:
     Vector<WeakPtr<Element, WeakPtrImplWithEventTargetData>> m_modalElements;
     bool m_modalNodesInitialized { false };
     bool m_isRetrievingCurrentModalNode { false };
+    bool m_needsAriaHiddenModalOverrideCheck { false };
 
 #if PLATFORM(COCOA)
     bool m_liveRegionManagerInitialized { false };
 
     static std::atomic<bool> gShouldRepostNotificationsForTests;
 #endif
+    // "Unignored content object count" and not "unignored object count"
+    // because we exclude certain roles from this count (e.g. web-areas, mock objects)
+    // on the basis of them not being meaningful content.
+    unsigned m_unignoredContentObjectCount { 0 };
 
     Timer m_performCacheUpdateTimer;
 

--- a/Source/WebCore/accessibility/AccessibilityObject.cpp
+++ b/Source/WebCore/accessibility/AccessibilityObject.cpp
@@ -146,6 +146,11 @@ AccessibilityObject::AccessibilityObject(AXID axID, AXObjectCache& cache)
 AccessibilityObject::~AccessibilityObject()
 {
     AX_ASSERT(isDetached());
+
+    if (!cachedIsIgnored()) {
+        if (auto* cache = m_axObjectCache.get())
+            cache->decrementUnignoredContentObjectCount(role());
+    }
 }
 
 String AccessibilityObject::debugDescriptionInternal(bool verbose, std::optional<OptionSet<AXDebugStringOption>> debugOptions) const
@@ -4263,6 +4268,12 @@ bool AccessibilityObject::isIgnoredWithoutCache(AXObjectCache* cache) const
     const_cast<AccessibilityObject*>(this)->setLastKnownIsIgnoredValue(ignored);
 
     if (cache) {
+        bool wasCountedAsUnignored = previousLastKnownIsIgnoredValue == AccessibilityObjectInclusion::IncludeObject;
+        if (!wasCountedAsUnignored && !ignored)
+            cache->incrementUnignoredContentObjectCount(role());
+        else if (wasCountedAsUnignored && ignored)
+            cache->decrementUnignoredContentObjectCount(role());
+
         bool becameUnignored = previousLastKnownIsIgnoredValue == AccessibilityObjectInclusion::IgnoreObject && !ignored;
         bool becameIgnored = !becameUnignored && previousLastKnownIsIgnoredValue == AccessibilityObjectInclusion::IncludeObject && ignored;
 


### PR DESCRIPTION
#### 4170dc9cf75853ff467290575972ddd2ab8dff6a
<pre>
AX: Override aria-hidden on a modal when the page would otherwise be completely empty due to inertness
<a href="https://bugs.webkit.org/show_bug.cgi?id=314165">https://bugs.webkit.org/show_bug.cgi?id=314165</a>
<a href="https://rdar.apple.com/176326010">rdar://176326010</a>

Reviewed by Dominic Mazzoni.

On a very popular webpage, the web developer added an aria-modal to the
page, and used JavaScript to make all other content outside the modal
inert. This is reasonable, but unfortunately they forget to remove
aria-hidden=&quot;true&quot; from the modal&apos;s container element, meaning the page
remains empty forever.

To fix this, we start detecting this scenario during modalNode() queries. When
the page has zero unignored content objects and a modal element exists
that is blocked by an ancestor aria-hidden, we override aria-hidden on
that ancestor using the existing shouldIgnoreARIAHidden mechanism.

To make the &quot;is the page empty&quot; check O(1), we maintain an unignored
content object counter that is incremented/decremented during
ignored-state transitions in isIgnoredWithoutCache and decremented in
the AccessibilityObject destructor. Structural roles (web areas, mock
objects, scroll bars, etc.) are excluded from the count since they
don&apos;t represent meaningful content, and the lifetime model for mock
objects is broken (we leak all of them), so including them in the count
would make it difficult to maintain.

The override check is armed lazily: only when aria-hidden is set to
true, when an element becomes inert/invisible, or when modal elements
are found. There is no cost on pages that don&apos;t hit this pattern.

* LayoutTests/accessibility/aria-hidden-modal-override-when-page-empty-expected.txt: Added.
* LayoutTests/accessibility/aria-hidden-modal-override-when-page-empty.html: Added.
* Source/WebCore/accessibility/AXObjectCache.cpp:
(WebCore::AXObjectCache::findModalNodes):
(WebCore::AXObjectCache::modalNode):
(WebCore::AXObjectCache::onInertOrVisibilityChange):
(WebCore::AXObjectCache::handleAttributeChange):
* Source/WebCore/accessibility/AXObjectCache.h:
* Source/WebCore/accessibility/AccessibilityObject.cpp:
(WebCore::AccessibilityObject::~AccessibilityObject):
(WebCore::AccessibilityObject::isIgnoredWithoutCache const):

Canonical link: <a href="https://commits.webkit.org/312744@main">https://commits.webkit.org/312744@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b4467d44ae28a25d7f859c86a19beba312da0310

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/160755 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/34228 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/27329 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/169658 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/115821 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/162624 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/34329 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/34228 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/124674 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/88028 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/163714 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/26927 "Passed tests") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/144399 "Found 1 new API test failure: TestWebKitAPI.WKWebExtensionAPIAction.ClearTabSpecificActionPropertiesOnNavigation (failure)") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/105271 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/25979 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/24479 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/17378 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/135673 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/22162 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/172140 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/19115 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/23803 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/132941 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/33902 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/28571 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/132953 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35951 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/33886 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/143957 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/95695 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/27545 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/20772 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/33397 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/100727 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/32896 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/33140 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/33044 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->