### PR TITLE
[Smart Lists] Going into list format while composing mail does not keep style

### DIFF
--- a/Source/WebCore/editing/InsertTextCommand.cpp
+++ b/Source/WebCore/editing/InsertTextCommand.cpp
@@ -208,6 +208,7 @@ bool InsertTextCommand::applySmartListsIfNeeded()
     if (!areCompatibleListMarkers(*currentSmartList, *previousSmartList))
         return false;
 
+    Ref styleToPreserve = EditingStyle::create(endingSelection().start(), EditingStyle::PropertiesToInclude::EditingPropertiesInEffect);
     Ref document = this->document();
 
     // Insert a list for the previous line
@@ -245,6 +246,10 @@ bool InsertTextCommand::applySmartListsIfNeeded()
     // And delete the marker from the current line.
 
     deleteSelection();
+
+    styleToPreserve->prepareToApplyAt(endingSelection().end());
+    if (!styleToPreserve->isEmpty())
+        m_styleToPreserveForSmartList = WTF::move(styleToPreserve);
 
     return true;
 }

--- a/Source/WebCore/editing/InsertTextCommand.h
+++ b/Source/WebCore/editing/InsertTextCommand.h
@@ -84,6 +84,7 @@ private:
     bool m_selectInsertedText;
     RebalanceType m_rebalanceType;
     RefPtr<TextInsertionMarkerSupplier> m_markerSupplier;
+    RefPtr<EditingStyle> m_styleToPreserveForSmartList;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/editing/TypingCommand.cpp
+++ b/Source/WebCore/editing/TypingCommand.cpp
@@ -558,9 +558,13 @@ void TypingCommand::insertTextRunWithoutNewlines(const String& text, bool select
     auto allowPasswordEcho = triggeringEventIsUntrusted() ? AllowPasswordEcho::No : AllowPasswordEcho::Yes;
     auto rebalanceWhitespaces = m_compositionType == TextCompositionType::None ? InsertTextCommand::RebalanceLeadingAndTrailingWhitespaces : InsertTextCommand::RebalanceAllWhitespaces;
     auto command = InsertTextCommand::create(document(), text, allowPasswordEcho, selectInsertedText, rebalanceWhitespaces, EditAction::TypingInsertText);
+    Ref insertTextCommand = command.get();
 
     applyCommandToComposite(WTF::move(command), endingSelection());
     typingAddedToOpenCommand(Type::InsertText);
+
+    if (insertTextCommand->m_styleToPreserveForSmartList)
+        document().selection().setTypingStyle(WTF::move(insertTextCommand->m_styleToPreserveForSmartList));
 }
 
 void TypingCommand::insertLineBreak()

--- a/Tools/TestWebKitAPI/Helpers/cocoa/SmartListsSupport.swift
+++ b/Tools/TestWebKitAPI/Helpers/cocoa/SmartListsSupport.swift
@@ -104,9 +104,16 @@ extension SmartListsSupport {
         try await page.callJavaScript("document.body.focus()")
 
         for character in configuration.input {
-            if character == "⌫" {
+            switch character {
+            case "⌫":
                 await page.executeEditCommand(.deleteBackward)
-            } else {
+            case "𝐁":
+                await page.executeEditCommand(.toggleBold)
+            case "𝐼":
+                await page.executeEditCommand(.toggleItalic)
+            case "𝐔":
+                await page.executeEditCommand(.toggleUnderline)
+            default:
                 await page.insertText("\(character)")
             }
         }

--- a/Tools/TestWebKitAPI/Helpers/cocoa/WebPage+Extras.swift
+++ b/Tools/TestWebKitAPI/Helpers/cocoa/WebPage+Extras.swift
@@ -39,6 +39,9 @@ extension WebPage {
     /// An edit command that can be used to interact with the web page.
     public enum EditCommand: String {
         case deleteBackward = "DeleteBackward"
+        case toggleBold = "ToggleBold"
+        case toggleItalic = "ToggleItalic"
+        case toggleUnderline = "ToggleUnderline"
     }
 
     /// Suspends execution of the current context until the next presentation update has occurred for this page.

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/SmartLists.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/SmartLists.mm
@@ -412,6 +412,19 @@ TEST(SmartLists, InsertingSpaceAfterLargeNumberDoesNotGenerateOrderedList)
     runTest(input, expectedHTML.createNSString().get(), @"//body/text()", input.length);
 }
 
+TEST(SmartLists, ListPreservesTypingStyle)
+{
+    static constexpr auto expectedHTML = R"""(
+    <body contenteditable="">
+        <ol start="1" style="list-style-type: decimal;" class="Apple-decimal-list">
+            <li><b><i><u>this is styled text</u></i></b></li>
+            <li><b><i><u>this is styled text</u></i></b></li>
+            <li><b><i><u>this is styled text</u></i></b></li>
+        </ol>
+    </body>)"""_s;
+    runTest(@"𝐁𝐼𝐔1. this is styled text\n2. this is styled text\nthis is styled text", expectedHTML.createNSString().get(), @"//body/ol/li[3]/b/i/u/text()", @"this is styled text".length);
+}
+
 TEST(SmartLists, InsertingDifferentListStylesDoesNotMergeLists)
 {
     auto dashMarker = WTF::makeString(WTF::Unicode::hyphenMinus, WTF::Unicode::noBreakSpace, WTF::Unicode::noBreakSpace);


### PR DESCRIPTION
#### ff708abf6cdbca9586609ec7984ac3a997f7a20c
<pre>
[Smart Lists] Going into list format while composing mail does not keep style
<a href="https://bugs.webkit.org/show_bug.cgi?id=314170">https://bugs.webkit.org/show_bug.cgi?id=314170</a>
<a href="https://rdar.apple.com/175551917">rdar://175551917</a>

Reviewed by Richard Robinson and Abrar Rahman Protyasha.

Smart Lists does not have logic to preserve the styling of the
text before creating the list. This means if the original text
is styled (such as &lt;b&gt;1. &lt;/b&gt;), triggering smart list will remove
this from the DOM and an empty &lt;li&gt; is created without the styling.

So, in InsertTextCommand::applySmartListsIfNeeded() before any
alterations, get the editing style from the DOM node before it gets
deleted.

Then when the list item is created and the original marker is deleted,
call prepareToApplyAt to get the remaining styles that are not part of
the new &lt;li&gt;. Set the preserved style so the next time a character is
typed, it reads from document().selection().typingStyle() and gets the
style from before.

Note that this has to be set after typingAddedToOpenCommand, which calls
appliedEditing, because appliedEditing clears typing style.

Also, add testing support for recognizing bold, italics, and underline
in the SmartLists API tests. Write an API test for this change and
verify the styling is preserved.

* Source/WebCore/editing/InsertTextCommand.cpp:
(WebCore::InsertTextCommand::applySmartListsIfNeeded):
* Source/WebCore/editing/InsertTextCommand.h:
* Source/WebCore/editing/TypingCommand.cpp:
(WebCore::TypingCommand::insertTextRunWithoutNewlines):
* Tools/TestWebKitAPI/Helpers/cocoa/SmartListsSupport.swift:
(SmartListsSupport.processConfiguration(_:)):
* Tools/TestWebKitAPI/Helpers/cocoa/WebPage+Extras.swift:
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/SmartLists.mm:
((SmartLists, ListPreservesTypingStyle)):

Canonical link: <a href="https://commits.webkit.org/312887@main">https://commits.webkit.org/312887@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f93dd4903fc9c6de41683000e9a663da9d124cf9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/160940 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/34413 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/27514 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/169843 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/117200 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/12f1ea82-125d-4e97-9bd9-ffedba051e74) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/162809 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/34514 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/34413 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/124835 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/88094 "1 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/4a322486-331a-4b9f-9de2-47bf048f2c60) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/163899 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/27096 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/144566 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/105432 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/aa77e281-6a5d-4f61-a3ec-5f054636ffcd) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/26148 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/24650 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/17563 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/135842 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/22328 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/172326 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/19347 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/23969 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/133111 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/34087 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/28742 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/133121 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/34071 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/144123 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/95910 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/24531 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/27699 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/20939 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/33582 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/101007 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/33081 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/33325 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/33230 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->