### PR TITLE
[JSC] Split DataView construction step into a separated code path from other TypedArrays

### DIFF
--- a/JSTests/stress/create-subclass-structure-might-throw.js
+++ b/JSTests/stress/create-subclass-structure-might-throw.js
@@ -3,8 +3,14 @@ function assert(b) {
         throw new Error("bad assertion.");
 }
 
+function sameValue(a, b, testname) {
+    if (a !== b)
+        throw new Error(`${testname}: Expected ${b} but got ${a}`);
+}
+
 let targets = [Function, String, Array, Set, Map, WeakSet, WeakMap, RegExp, Number, Promise, Date, Boolean, Error, TypeError, SyntaxError, ArrayBuffer, Int32Array, Int8Array, Uint8Array, Uint8ClampedArray, Int16Array, Uint16Array, Uint32Array, Float32Array, Float64Array, DataView];
 for (let target of targets) {
+    const testname = target.name;
     let error = null;
     let called = false;
     let handler = {
@@ -23,15 +29,17 @@ for (let target of targets) {
         try {
             if (target === Promise)
                 new proxy(function() {});
+            if (target === DataView)
+                new proxy(new ArrayBuffer(64));
             else
                 new proxy;
         } catch(e) {
             threw = true;
-            assert(e === error);
+            sameValue(e, error, testname);
             error = null;
         }
-        assert(threw);
-        assert(called);
+        sameValue(threw, true, testname);
+        sameValue(called, true, testname);
         called = false;
     }
 }

--- a/JSTests/stress/dataview-constructor-toindex-byteoffset-before-ordinarycreatefromctor.js
+++ b/JSTests/stress/dataview-constructor-toindex-byteoffset-before-ordinarycreatefromctor.js
@@ -1,0 +1,41 @@
+// The original is https://github.com/tc39/test262/blob/d0c1b4555b03dd404873fd6422a4b5da00136500/test/built-ins/DataView/byteOffset-validated-against-initial-buffer-length.js
+
+function shouldThrow(caseName, fn, expectedErrorCtor, expectedErrorMessage) {
+    if (!caseName)
+        throw new Error(`must specify test case name`);
+
+    const expected = `${expectedErrorCtor.name}(${expectedErrorMessage})`;
+    try {
+        fn();
+        throw new Error(`${caseName}: Expected to throw ${expected}, but succeeded`);
+    } catch (e) {
+        const actual = `${e.name}(${e.message})`;
+        if (!(e instanceof expectedErrorCtor) || e.message !== expectedErrorMessage)
+            throw new Error(`${caseName}: Expected ${expected} but got ${actual}`);
+    }
+}
+
+const newTarget = Object.defineProperty(function(){}.bind(), "prototype", {
+  get() {
+    throw new Error("GetPrototypeFromConstructor not executed");
+  }
+});
+
+const TEST_TARGET = [
+    DataView,
+];
+
+for (const ctor of TEST_TARGET) {
+    const label = ctor.name;
+
+    // Zero length buffer.
+    const ab = new ArrayBuffer(0);
+    // Byte offset is larger than the buffer length, which is zero.
+    const byteOffset = 10;
+    
+    // https://tc39.es/ecma262/2026/#sec-dataview-constructor
+    // The step 3 |ToIndex(byteOffset)| should happens before the step 10 |OrdinaryCreateFromConstructor|.
+    shouldThrow(label, () => {
+        Reflect.construct(ctor, [ab, byteOffset], newTarget);
+    }, RangeError, 'byteOffset exceeds source ArrayBuffer byteLength');
+}

--- a/Source/JavaScriptCore/runtime/JSGenericTypedArrayViewConstructorInlines.h
+++ b/Source/JavaScriptCore/runtime/JSGenericTypedArrayViewConstructorInlines.h
@@ -113,48 +113,55 @@ inline JSObject* constructGenericTypedArrayViewFromIterator(JSGlobalObject* glob
 }
 
 constinit const ASCIILiteral typedArrayErrorMessageBufferIsAlreadyDetached = "Buffer is already detached"_s;
+constinit const ASCIILiteral typedArrayErrorMessageByteOffsetExceedSourceBufferByteLength = "byteOffset exceeds source ArrayBuffer byteLength"_s;
 
 template<typename ViewClass>
-inline JSObject* constructGenericTypedArrayViewWithArguments(JSGlobalObject* globalObject, Structure* structure, JSValue firstValue, size_t offset, std::optional<size_t> lengthOpt)
+inline JSObject* constructGenericTypedArrayViewWithArrayBuffer(JSGlobalObject* globalObject, Structure* structure, JSArrayBuffer* jsBuffer, size_t offset, std::optional<size_t> lengthOpt)
 {
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    // https://tc39.es/proposal-resizablearraybuffer/#sec-initializetypedarrayfromarraybuffer
-    if (JSArrayBuffer* jsBuffer = dynamicDowncast<JSArrayBuffer>(firstValue)) {
-        RefPtr<ArrayBuffer> buffer = jsBuffer->impl();
-        if (buffer->isDetached()) {
-            throwTypeError(globalObject, scope, typedArrayErrorMessageBufferIsAlreadyDetached);
-            return nullptr;
-        }
-
-        std::optional<size_t> length;
-        if (lengthOpt)
-            length = lengthOpt;
-        else {
-            size_t byteLength = buffer->byteLength();
-            if (buffer->isResizableOrGrowableShared()) {
-                if (offset > byteLength) [[unlikely]] {
-                    throwRangeError(globalObject, scope, "byteOffset exceeds source ArrayBuffer byteLength"_s);
-                    return nullptr;
-                }
-            } else {
-                if ((byteLength - offset) % ViewClass::elementSize) [[unlikely]] {
-                    throwRangeError(globalObject, scope, "ArrayBuffer length minus the byteOffset is not a multiple of the element size"_s);
-                    return nullptr;
-                }
-                length = (byteLength - offset) / ViewClass::elementSize;
-            }
-        }
-
-        RELEASE_AND_RETURN(scope, ViewClass::create(globalObject, structure, WTF::move(buffer), offset, length));
-    }
-    ASSERT(!offset && !lengthOpt);
-
-    if constexpr (ViewClass::TypedArrayStorageType == TypeDataView) {
-        throwTypeError(globalObject, scope, "Expected ArrayBuffer for the first argument."_s);
+    RefPtr<ArrayBuffer> buffer = jsBuffer->impl();
+    if (buffer->isDetached()) {
+        throwTypeError(globalObject, scope, typedArrayErrorMessageBufferIsAlreadyDetached);
         return nullptr;
     }
+
+    std::optional<size_t> length;
+    if (lengthOpt)
+        length = lengthOpt;
+    else {
+        size_t byteLength = buffer->byteLength();
+        if (buffer->isResizableOrGrowableShared()) {
+            if (offset > byteLength) [[unlikely]] {
+                throwRangeError(globalObject, scope, typedArrayErrorMessageByteOffsetExceedSourceBufferByteLength);
+                return nullptr;
+            }
+        } else {
+            if ((byteLength - offset) % ViewClass::elementSize) [[unlikely]] {
+                throwRangeError(globalObject, scope, "ArrayBuffer length minus the byteOffset is not a multiple of the element size"_s);
+                return nullptr;
+            }
+            length = (byteLength - offset) / ViewClass::elementSize;
+        }
+    }
+
+    RELEASE_AND_RETURN(scope, ViewClass::create(globalObject, structure, WTF::move(buffer), offset, length));
+}
+
+template<typename ViewClass>
+inline JSObject* constructGenericTypedArrayViewWithArguments(JSGlobalObject* globalObject, Structure* structure, JSValue firstValue, size_t offset, std::optional<size_t> lengthOpt)
+{
+    static_assert(ViewClass::TypedArrayStorageType != TypeDataView);
+
+    VM& vm = globalObject->vm();
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
+    // https://tc39.es/ecma262/#sec-initializetypedarrayfromarraybuffer
+    if (JSArrayBuffer* jsBuffer = dynamicDowncast<JSArrayBuffer>(firstValue))
+        RELEASE_AND_RETURN(scope, constructGenericTypedArrayViewWithArrayBuffer<ViewClass>(globalObject, structure, jsBuffer, offset, lengthOpt));
+
+    ASSERT(!offset && !lengthOpt);
     
     // For everything but DataView, we allow construction with any of:
     // - Another array. This creates a copy of the of that array.
@@ -247,9 +254,12 @@ inline JSObject* constructGenericTypedArrayViewWithArguments(JSGlobalObject* glo
     RELEASE_AND_RETURN(scope, ViewClass::create(globalObject, structure, length));
 }
 
+// This is equivalent to https://tc39.es/ecma262/#sec-typedarray
 template<typename ViewClass>
 ALWAYS_INLINE EncodedJSValue constructGenericTypedArrayViewImpl(JSGlobalObject* globalObject, CallFrame* callFrame)
 {
+    static_assert(ViewClass::TypedArrayStorageType != TypeDataView);
+
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
@@ -260,9 +270,6 @@ ALWAYS_INLINE EncodedJSValue constructGenericTypedArrayViewImpl(JSGlobalObject* 
     if (!argCount) {
         Structure* structure = JSC_GET_DERIVED_STRUCTURE(vm, typedArrayStructureWithTypedArrayType<ViewClass::TypedArrayStorageType>, newTarget, callFrame->jsCallee());
         RETURN_IF_EXCEPTION(scope, { });
-
-        if constexpr (ViewClass::TypedArrayStorageType == TypeDataView)
-            return throwVMTypeError(globalObject, scope, "DataView constructor requires at least one argument."_s);
 
         RELEASE_AND_RETURN(scope, JSValue::encode(ViewClass::create(globalObject, structure, 0)));
     }
@@ -275,19 +282,6 @@ ALWAYS_INLINE EncodedJSValue constructGenericTypedArrayViewImpl(JSGlobalObject* 
         if (argCount > 1) {
             offset = callFrame->uncheckedArgument(1).toIndex(globalObject, "byteOffset"_s);
             RETURN_IF_EXCEPTION(scope, { });
-
-            if constexpr (ViewClass::TypedArrayStorageType == TypeDataView) {
-                RefPtr<ArrayBuffer> buffer = arrayBuffer->impl();
-                if (buffer->isDetached()) [[unlikely]] {
-                    throwVMTypeError(globalObject, scope, typedArrayErrorMessageBufferIsAlreadyDetached);
-                    RETURN_IF_EXCEPTION(scope, { });
-                }
-
-                if (offset > buffer->byteLength()) [[unlikely]] {
-                    throwRangeError(globalObject, scope, "byteOffset exceeds source ArrayBuffer byteLength"_s);
-                    RETURN_IF_EXCEPTION(scope, { });
-                }
-            }
         }
 
         if (arrayBuffer->isResizableOrGrowableShared()) {
@@ -302,7 +296,7 @@ ALWAYS_INLINE EncodedJSValue constructGenericTypedArrayViewImpl(JSGlobalObject* 
             // If the length value is present but undefined, treat it as missing.
             JSValue lengthValue = callFrame->uncheckedArgument(2);
             if (!lengthValue.isUndefined()) {
-                length = lengthValue.toIndex(globalObject, ViewClass::TypedArrayStorageType == TypeDataView ? "byteLength"_s : "length"_s);
+                length = lengthValue.toIndex(globalObject, "length"_s);
                 RETURN_IF_EXCEPTION(scope, encodedJSValue());
             }
         }
@@ -312,6 +306,78 @@ ALWAYS_INLINE EncodedJSValue constructGenericTypedArrayViewImpl(JSGlobalObject* 
     }
 
     RELEASE_AND_RETURN(scope, JSValue::encode(constructGenericTypedArrayViewWithArguments<ViewClass>(globalObject, structure, firstValue, offset, length)));
+}
+
+static EncodedJSValue constructDataViewImpl(JSGlobalObject* globalObject, CallFrame* callFrame)
+{
+    VM& vm = globalObject->vm();
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
+    // [`DataView`][dataview] and [the other `%TypedArray%` constructors][typedarray] take almost same arguments and behave very similarly
+    // but the spec has a different abstract operation steps.
+    // It makes a difference for an order of checking their arguments and throwing errors in the detail.
+    // And its difference comes with an user observable behavior in a corner case.
+    // We should have a separate code path among them to implement the spec correctly & simply.
+    //
+    // [dataview]: https://tc39.es/ecma262/#sec-dataview-buffer-byteoffset-bytelength
+    // [typedarray]: https://tc39.es/ecma262/#sec-typedarray
+
+    size_t argCount = callFrame->argumentCount();
+    if (!argCount) [[unlikely]]
+        return throwVMTypeError(globalObject, scope, "DataView constructor requires at least one argument."_s);
+
+    ASSERT(argCount > 0);
+
+    JSValue firstValue = callFrame->uncheckedArgument(0);
+    JSArrayBuffer* arrayBuffer = dynamicDowncast<JSArrayBuffer>(firstValue);
+    if (!arrayBuffer) [[unlikely]]
+        return throwVMTypeError(globalObject, scope, "Expected ArrayBuffer for the first argument."_s);
+
+    RefPtr<ArrayBuffer> buffer = arrayBuffer->impl();
+
+    size_t offset = 0;
+    if (argCount > 1) {
+        offset = callFrame->uncheckedArgument(1).toIndex(globalObject, "byteOffset"_s);
+        RETURN_IF_EXCEPTION(scope, { });
+    }
+
+    if (buffer->isDetached()) [[unlikely]]
+        return throwVMTypeError(globalObject, scope, typedArrayErrorMessageBufferIsAlreadyDetached);
+
+    size_t bufferByteLength = buffer->byteLength();
+    if (offset > bufferByteLength) [[unlikely]]
+        return throwVMRangeError(globalObject, scope, typedArrayErrorMessageByteOffsetExceedSourceBufferByteLength);
+
+    std::optional<size_t> length { };
+    if (argCount > 2) {
+        // If the length value is present but undefined, treat it as missing.
+        if (JSValue lengthValue = callFrame->uncheckedArgument(2); !lengthValue.isUndefined()) [[likely]] {
+            length = lengthValue.toIndex(globalObject, "byteLength"_s);
+            RETURN_IF_EXCEPTION(scope, { });
+        }
+    }
+
+    JSObject* newTarget = asObject(callFrame->newTarget());
+    Structure* structure = nullptr;
+    if (arrayBuffer->isResizableOrGrowableShared()) {
+        structure = JSC_GET_DERIVED_STRUCTURE(vm, resizableOrGrowableSharedTypedArrayStructureWithTypedArrayType<JSDataView::TypedArrayStorageType>, newTarget, callFrame->jsCallee());
+        RETURN_IF_EXCEPTION(scope, { });
+    } else {
+        structure = JSC_GET_DERIVED_STRUCTURE(vm, typedArrayStructureWithTypedArrayType<JSDataView::TypedArrayStorageType>, newTarget, callFrame->jsCallee());
+        RETURN_IF_EXCEPTION(scope, { });
+    }
+
+    RELEASE_AND_RETURN(scope, JSValue::encode(constructGenericTypedArrayViewWithArrayBuffer<JSDataView>(globalObject, structure, arrayBuffer, offset, length)));
+}
+
+// This is equivalent to https://tc39.es/ecma262/#sec-dataview-buffer-byteoffset-bytelength
+template<>
+ALWAYS_INLINE EncodedJSValue constructGenericTypedArrayViewImpl<JSDataView>(JSGlobalObject* globalObject, CallFrame* callFrame)
+{
+    VM& vm = globalObject->vm();
+    auto scope = DECLARE_THROW_SCOPE(vm);
+    EncodedJSValue dataview = constructDataViewImpl(globalObject, callFrame);
+    RELEASE_AND_RETURN(scope, dataview);
 }
 
 template<typename ViewClass>


### PR DESCRIPTION
#### 1a8dfc920f4cc261c77b2a663392f6a4412adf1a
<pre>
[JSC] Split DataView construction step into a separated code path from other TypedArrays
<a href="https://bugs.webkit.org/show_bug.cgi?id=313416">https://bugs.webkit.org/show_bug.cgi?id=313416</a>

Reviewed by Yusuke Suzuki.

This reland <a href="https://commits.webkit.org/312483@main">https://commits.webkit.org/312483@main</a>
with fixing a regression.

---

`DataView` and %TypedArray%` constructors take almost same arguments and behave very similarly
but the spec has a different abstract operation steps.
It makes a difference for an order of checking their arguments and throwing errors in the detail.
And its difference comes with an user observable behavior.

- <a href="https://tc39.es/ecma262/#sec-dataview-buffer-byteoffset-bytelength">https://tc39.es/ecma262/#sec-dataview-buffer-byteoffset-bytelength</a>
- <a href="https://tc39.es/ecma262/#sec-typedarray">https://tc39.es/ecma262/#sec-typedarray</a>

Our previous implementation shares the infrastructure for both of them via C++ template and if constexpr.
But `if constexpr` branch makes a thing complex.

To prepare to resolve <a href="https://bugs.webkit.org/show_bug.cgi?id=313230">https://bugs.webkit.org/show_bug.cgi?id=313230</a>,
let&apos;s split into separate paths.

Test: JSTests/stress/dataview-constructor-toindex-byteoffset-before-ordinarycreatefromctor.js

* JSTests/stress/create-subclass-structure-might-throw.js:
    By this change, `new DataView` would throw error _earlier_ if the argument count is 0 just like as `Promise`.
    This fix add the case of `DataView`.
* JSTests/stress/dataview-constructor-toindex-byteoffset-before-ordinarycreatefromctor.js: Added.
    This is a regression test that failed in <a href="https://commits.webkit.org/312483@main.">https://commits.webkit.org/312483@main.</a>
* Source/JavaScriptCore/runtime/JSGenericTypedArrayViewConstructorInlines.h:
(JSC::constructGenericTypedArrayViewWithArrayBuffer):
    Share the part of the construction with JSArrayBuffer.
(JSC::constructGenericTypedArrayViewWithArguments):
    This removes JSDataView branches.
(JSC::constructGenericTypedArrayViewImpl):
    This removes JSDataView branches.
(JSC::constructDataViewImpl):
    To clarify the purpose, this change adds this function.
(JSC::constructGenericTypedArrayViewImpl&lt;JSDataView&gt;):
    This is a C++ template specialization to call the actual new separated implementation.
    This is useful to not change the exist code base on caller side.

Canonical link: <a href="https://commits.webkit.org/312778@main">https://commits.webkit.org/312778@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/452712c347945695c0ebd9ce66aaeaed3d95ca3b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/160762 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/34235 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/27336 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/169665 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/115828 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/34336 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/34235 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/124682 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/88031 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/163721 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/26932 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/144404 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/105279 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/25984 "Passed tests") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/24485 "Found 1 new API test failure: TestWebKitAPI.WebKit.InterruptionBetweenSameProcessPages (failure)") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/17385 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/152818 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/135678 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/22167 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/172147 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/21600 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/19130 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/23808 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/132950 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/33909 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/28577 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/132961 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/33893 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/143962 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/95703 "The change is no longer eligible for processing.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/24492 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/27560 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/20777 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/193161 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/33404 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/100780 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/49744 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/32903 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/33147 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/33051 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->