### PR TITLE
REGRESSION (297757@main): [ Tahoe wk2 debug arm64 ] Multiple http/tests/iframe-monitor tests are consistent timeouts

### DIFF
--- a/LayoutTests/platform/mac-wk2/TestExpectations
+++ b/LayoutTests/platform/mac-wk2/TestExpectations
@@ -108,19 +108,6 @@ compositing/repaint/sticky-repaint-on-scroll.html [ Pass ]
 
 # Cocoa-only tests
 http/tests/iframe-monitor/ [ Pass ]
-webkit.org/b/307300 [ Debug arm64 ] http/tests/iframe-monitor/blob-resource.html [ Pass Timeout ]
-webkit.org/b/307300 [ Debug arm64 ] http/tests/iframe-monitor/cached-resource.html [ Pass Timeout ]
-webkit.org/b/307300 [ Debug arm64 ] http/tests/iframe-monitor/compressed-resource.html [ Pass Timeout ]
-webkit.org/b/307300 [ Debug arm64 ] http/tests/iframe-monitor/dark-mode.html [ Pass Timeout ]
-webkit.org/b/307300 [ Debug arm64 ] http/tests/iframe-monitor/data-url-resource.html [ Pass Timeout ]
-webkit.org/b/307300 [ Debug arm64 ] http/tests/iframe-monitor/eligibility.html [ Pass Timeout ]
-webkit.org/b/307300 [ Debug arm64 ] http/tests/iframe-monitor/iframe-unload.html [ Pass Timeout ]
-webkit.org/b/307300 [ Debug arm64 ] http/tests/iframe-monitor/just-use-eligible-subresource.html [ Pass Timeout ]
-webkit.org/b/307300 [ Debug arm64 ] http/tests/iframe-monitor/throttler.html [ Pass Timeout ]
-webkit.org/b/307300 [ Debug arm64 ] http/tests/iframe-monitor/workers/service-worker-not-count-twice.html [ Pass Timeout ]
-webkit.org/b/307300 [ Debug arm64 ] http/tests/iframe-monitor/workers/service-worker.html [ Pass Timeout ]
-webkit.org/b/307300 [ Debug arm64 ] http/tests/iframe-monitor/workers/shared-worker.html [ Pass Timeout ]
-webkit.org/b/307300 [ Debug arm64 ] http/tests/inspector/network/copy-as-curl.html [ Pass Timeout ]
 
 webkit.org/b/308178 [ Tahoe+ Debug arm64 ] http/tests/site-isolation/mouse-events/context-menu-event-twice.html [ Pass Timeout ]
 

--- a/Source/WebKit/Platform/cocoa/WebPrivacyHelpers.h
+++ b/Source/WebKit/Platform/cocoa/WebPrivacyHelpers.h
@@ -197,6 +197,7 @@ public:
     void getSource(CompletionHandler<void(String&&)>&&);
 
     void setContentRuleListStore(API::ContentRuleListStore&);
+    API::ContentRuleListStore* contentRuleListStore() const { return m_contentRuleListStore; }
 
 private:
     friend class NeverDestroyed<ResourceMonitorURLsController, MainRunLoopAccessTraits>;

--- a/Source/WebKit/UIProcess/API/APIContentRuleListStore.cpp
+++ b/Source/WebKit/UIProcess/API/APIContentRuleListStore.cpp
@@ -46,6 +46,7 @@
 #include <wtf/CrossThreadCopier.h>
 #include <wtf/FileHandle.h>
 #include <wtf/FileSystem.h>
+#include <wtf/HashMap.h>
 #include <wtf/NeverDestroyed.h>
 #include <wtf/RunLoop.h>
 #include <wtf/StdLibExtras.h>
@@ -59,10 +60,35 @@ namespace API {
 using namespace WebKit::NetworkCache;
 using namespace FileSystem;
 
-static WorkQueue& fileSystemQueueSingleton()
+static HashMap<WTF::String, std::pair<Ref<WorkQueue>, unsigned>>& workQueueMap()
 {
-    static MainRunLoopNeverDestroyed<Ref<WorkQueue>> fileSystemQueue = WorkQueue::create("ContentRuleListStore FileSystem Queue"_s);
-    return fileSystemQueue.get().get();
+    static MainRunLoopNeverDestroyed<HashMap<WTF::String, std::pair<Ref<WorkQueue>, unsigned>>> map;
+    return map.get();
+}
+
+static WorkQueue& retainWorkQueueForPath(const WTF::String& path)
+{
+    auto& map = workQueueMap();
+    auto result = map.ensure(path, [] {
+        return std::pair { WorkQueue::create("ContentRuleListStore Queue"_s), 0u };
+    });
+    ++result.iterator->value.second;
+    return result.iterator->value.first.get();
+}
+
+static void releaseWorkQueueForPath(const WTF::String& path)
+{
+    auto& map = workQueueMap();
+    auto it = map.find(path);
+    RELEASE_ASSERT(it != map.end());
+    if (!--it->value.second)
+        map.remove(it);
+}
+
+static WTF::String resolvedStorePath(const WTF::String& storePath)
+{
+    makeAllDirectories(storePath);
+    return realPath(storePath);
 }
 
 ContentRuleListStore& ContentRuleListStore::defaultStoreSingleton()
@@ -82,12 +108,15 @@ ContentRuleListStore::ContentRuleListStore()
 }
 
 ContentRuleListStore::ContentRuleListStore(const WTF::String& storePath)
-    : m_storePath(storePath)
+    : m_storePath(resolvedStorePath(storePath))
+    , m_workQueue(retainWorkQueueForPath(m_storePath))
 {
-    makeAllDirectories(storePath);
 }
 
-ContentRuleListStore::~ContentRuleListStore() = default;
+ContentRuleListStore::~ContentRuleListStore()
+{
+    releaseWorkQueueForPath(m_storePath);
+}
 
 static constexpr auto constructedPathPrefix { "ContentRuleList-"_s };
 
@@ -536,7 +565,7 @@ void ContentRuleListStore::lookupContentRuleListFile(WTF::String&& filePath, WTF
 {
     ASSERT(RunLoop::isMain());
 
-    fileSystemQueueSingleton().dispatch([protectedThis = Ref { *this }, filePath = WTF::move(filePath).isolatedCopy(), identifier = WTF::move(identifier).isolatedCopy(), completionHandler = WTF::move(completionHandler)]() mutable {
+    m_workQueue->dispatch([protectedThis = Ref { *this }, filePath = WTF::move(filePath).isolatedCopy(), identifier = WTF::move(identifier).isolatedCopy(), completionHandler = WTF::move(completionHandler)]() mutable {
         auto contentRuleList = openAndMapContentRuleList(filePath);
         if (!contentRuleList) {
             RunLoop::mainSingleton().dispatch([protectedThis = WTF::move(protectedThis), completionHandler = WTF::move(completionHandler)] () mutable {
@@ -573,7 +602,7 @@ void ContentRuleListStore::getAvailableContentRuleListIdentifiers(CompletionHand
 {
     ASSERT(RunLoop::isMain());
 
-    fileSystemQueueSingleton().dispatch([protectedThis = Ref { *this }, storePath = m_storePath.isolatedCopy(), completionHandler = WTF::move(completionHandler)]() mutable {
+    m_workQueue->dispatch([protectedThis = Ref { *this }, storePath = m_storePath.isolatedCopy(), completionHandler = WTF::move(completionHandler)]() mutable {
         Vector<WTF::String> identifiers;
         for (auto& fileName : listDirectory(storePath)) {
             if (fileName.startsWith(constructedPathPrefix))
@@ -606,7 +635,7 @@ void ContentRuleListStore::compileContentRuleListFile(WTF::String&& filePath, WT
             return completionHandler(nullptr, parsedRules.error());
     }
 
-    fileSystemQueueSingleton().dispatch([protectedThis = Ref { *this }, filePath = WTF::move(filePath).isolatedCopy(), identifier = WTF::move(identifier).isolatedCopy(), json = WTF::move(json).isolatedCopy(), parsedRules = crossThreadCopy(WTF::move(parsedRules).value()), storePath = m_storePath.isolatedCopy(), completionHandler = WTF::move(completionHandler), cssSelectorsAllowed] () mutable {
+    m_workQueue->dispatch([protectedThis = Ref { *this }, filePath = WTF::move(filePath).isolatedCopy(), identifier = WTF::move(identifier).isolatedCopy(), json = WTF::move(json).isolatedCopy(), parsedRules = crossThreadCopy(WTF::move(parsedRules).value()), storePath = m_storePath.isolatedCopy(), completionHandler = WTF::move(completionHandler), cssSelectorsAllowed] () mutable {
         if (cssSelectorsAllowed == WebCore::ContentExtensions::CSSSelectorsAllowed::No) {
             auto parsedRulesOnBackgroundQueue = WebCore::ContentExtensions::parseRuleList(json, cssSelectorsAllowed);
             if (!parsedRulesOnBackgroundQueue.has_value())
@@ -641,7 +670,7 @@ void ContentRuleListStore::removeContentRuleListFile(WTF::String&& filePath, Com
 {
     ASSERT(RunLoop::isMain());
 
-    fileSystemQueueSingleton().dispatch([protectedThis = Ref { *this }, filePath = WTF::move(filePath).isolatedCopy(), completionHandler = WTF::move(completionHandler)]() mutable {
+    m_workQueue->dispatch([protectedThis = Ref { *this }, filePath = WTF::move(filePath).isolatedCopy(), completionHandler = WTF::move(completionHandler)]() mutable {
         auto complete = [protectedThis = WTF::move(protectedThis), completionHandler = WTF::move(completionHandler)](std::error_code error) mutable {
             RunLoop::mainSingleton().dispatch([protectedThis = WTF::move(protectedThis), completionHandler = WTF::move(completionHandler), error = WTF::move(error)] () mutable {
                 completionHandler(error);
@@ -744,7 +773,7 @@ void ContentRuleListStore::getContentRuleListSource(WTF::String&& identifier, Co
 {
     ASSERT(RunLoop::isMain());
 
-    fileSystemQueueSingleton().dispatch([protectedThis = Ref { *this }, filePath = constructedPath(m_storePath, identifier).isolatedCopy(), completionHandler = WTF::move(completionHandler)]() mutable {
+    m_workQueue->dispatch([protectedThis = Ref { *this }, filePath = constructedPath(m_storePath, identifier).isolatedCopy(), completionHandler = WTF::move(completionHandler)]() mutable {
         auto complete = [protectedThis = WTF::move(protectedThis), completionHandler = WTF::move(completionHandler)](WTF::String&& source) mutable {
             RunLoop::mainSingleton().dispatch([protectedThis = WTF::move(protectedThis), completionHandler = WTF::move(completionHandler), source = WTF::move(source).isolatedCopy()] () mutable {
                 completionHandler(source);

--- a/Source/WebKit/UIProcess/API/APIContentRuleListStore.h
+++ b/Source/WebKit/UIProcess/API/APIContentRuleListStore.h
@@ -29,6 +29,7 @@
 #include <WebCore/ContentExtensionParser.h>
 #include <system_error>
 #include <wtf/Forward.h>
+#include <wtf/WorkQueue.h>
 #include <wtf/text/WTFString.h>
 
 namespace WebCore {
@@ -82,6 +83,7 @@ private:
     WTF::String defaultStorePath();
 
     const WTF::String m_storePath;
+    const Ref<WorkQueue> m_workQueue;
 #endif // ENABLE(CONTENT_EXTENSIONS)
 };
 

--- a/Source/WebKit/UIProcess/Cocoa/WebProcessPoolCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/WebProcessPoolCocoa.mm
@@ -47,7 +47,7 @@
 #import "SandboxUtilities.h"
 #import "TextChecker.h"
 #import "WKContentRuleListInternal.h"
-#import "WKContentRuleListStore.h"
+#import "WKContentRuleListStoreInternal.h"
 #import "WebBackForwardCache.h"
 #import "WebCompiledContentRuleList.h"
 #import "WebMemoryPressureHandler.h"
@@ -1471,7 +1471,13 @@ void WebProcessPool::platformCompileResourceMonitorRuleList(const String& rulesT
 {
     StringView view { rulesText };
     RetainPtr source = view.createNSStringWithoutCopying();
+
+#if ENABLE(ADVANCED_PRIVACY_PROTECTIONS)
+    auto& controller = ResourceMonitorURLsController::singleton();
+    RetainPtr store = controller.contentRuleListStore() ? WebKit::wrapper(*controller.contentRuleListStore()) : [WKContentRuleListStore defaultStore];
+#else
     RetainPtr store = [WKContentRuleListStore defaultStore];
+#endif
 
     [store compileContentRuleListForIdentifier:WebKitResourceMonitorURLsForTestingIdentifier encodedContentRuleList:source.get() completionHandler:makeBlockPtr([completionHandler = WTF::move(completionHandler)](WKContentRuleList *list, NSError *error) mutable {
         if (error || !list)


### PR DESCRIPTION
#### af0162d45a8f33a9a2687c330ac4d167b7ae5fa7
<pre>
REGRESSION (297757@main): [ Tahoe wk2 debug arm64 ] Multiple http/tests/iframe-monitor tests are consistent timeouts
<a href="https://bugs.webkit.org/show_bug.cgi?id=307300">https://bugs.webkit.org/show_bug.cgi?id=307300</a>
<a href="https://rdar.apple.com/169934202">rdar://169934202</a>

Reviewed by Basuke Suzuki.

297757@main fixed parallel compilations for the same identifier racing on the same
file by replacing per-instance work queues with a single static serial WorkQueue
shared across all ContentRuleListStore instances. This was too aggressive: it
serializes all operations (compiles, reads, removes) across all stores globally,
even when they operate on different directories and cannot conflict.

On Tahoe bots running multiple WebKitTestRunner instances, this causes two problems:

1. Cross-process filesystem contention: platformCompileResourceMonitorRuleList()
   was using [WKContentRuleListStore defaultStore] whose directory is shared across
   all WKTR instances. Multiple processes writing the same file concurrently makes
   compilation extremely slow.

2. Within-process queue starvation: the built-in resource monitor rule list
   compilation (triggered by page navigation via ResourceMonitorURLsController::prepare())
   and the test&apos;s rule list compilation both serialize on the same global queue.
   If the built-in list is large, it blocks the test&apos;s compilation past the timeout.

Fix both issues:

- Replace the global static serial queue with a per-directory serial WorkQueue,
  keyed by store path. Stores sharing the same directory serialize on the same
  queue (preventing the race that 297757@main fixed), while stores with different
  directories operate in parallel. The queue map is reference-counted so entries
  are cleaned up when the last store for a given path is destroyed.

- Have platformCompileResourceMonitorRuleList() use the per-pid store configured
  by WKTR (via ResourceMonitorURLsController) instead of the shared default store,
  eliminating cross-process filesystem contention.

* LayoutTests/platform/mac-wk2/TestExpectations:
* Source/WebKit/Platform/cocoa/WebPrivacyHelpers.h:
(WebKit::ResourceMonitorURLsController::contentRuleListStore const):
* Source/WebKit/UIProcess/API/APIContentRuleListStore.cpp:
(API::workQueueMap):
(API::retainWorkQueueForPath):
(API::releaseWorkQueueForPath):
(API::ContentRuleListStore::ContentRuleListStore):
(API::ContentRuleListStore::~ContentRuleListStore):
(API::ContentRuleListStore::lookupContentRuleListFile):
(API::ContentRuleListStore::getAvailableContentRuleListIdentifiers):
(API::ContentRuleListStore::compileContentRuleListFile):
(API::ContentRuleListStore::removeContentRuleListFile):
(API::ContentRuleListStore::getContentRuleListSource):
* Source/WebKit/UIProcess/API/APIContentRuleListStore.h:
* Source/WebKit/UIProcess/Cocoa/WebProcessPoolCocoa.mm:
(WebKit::WebProcessPool::platformCompileResourceMonitorRuleList):

Canonical link: <a href="https://commits.webkit.org/312745@main">https://commits.webkit.org/312745@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b05d833c089340bf398302843e935975c4575484

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/160829 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/34302 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/27403 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/169732 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/115895 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/afad910e-ecb7-4b85-9334-7a4c4f7a3e37) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/34403 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/34302 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/124741 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/88063 "Passed tests") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/f8087192-c8fa-4ee8-9866-76f69b7c7658) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/163788 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/26997 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/144469 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/105338 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/404affe6-a227-45bf-8ece-0cf19cf2e377) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/26049 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/24548 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/17452 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/135743 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/22232 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/172214 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/19236 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/23873 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/133010 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/33976 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/28640 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/133021 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35953 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/33960 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/144027 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/95790 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/27615 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/20842 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/33471 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/100896 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/32970 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/33214 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/33118 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->