### PR TITLE
Make run-api-tests default to --child-processes=1 when only specific tests are named

### DIFF
--- a/Tools/Scripts/webkitpy/api_tests/manager.py
+++ b/Tools/Scripts/webkitpy/api_tests/manager.py
@@ -183,20 +183,31 @@ class Manager(object):
                 return self._port.path_to_api_test_binaries().keys()
         return binaries or self._port.path_to_api_test_binaries().keys()
 
-    def _update_worker_count(self):
+    _SPECIFIC_TEST_ARG_RE = re.compile(r'\S+\..+')
+
+    @classmethod
+    def _args_specify_individual_tests(cls, args):
+        return bool(args) and all(cls._SPECIFIC_TEST_ARG_RE.match(arg) for arg in args)
+
+    def _update_worker_count(self, args):
         child_processes_option_value = int(self._options.child_processes or 0)
-        specified_child_processes = (
+        if not child_processes_option_value and self._args_specify_individual_tests(args):
+            # When the user names specific tests (e.g. Foo.Bar), avoid booting
+            # one simulator per CPU just to run a handful of tests.
+            _log.info('All arguments name specific tests; defaulting to --child-processes=1')
+            self._options.child_processes = 1
+            return
+        self._options.child_processes = (
             child_processes_option_value
             or self._port.default_child_processes()
         )
-        self._options.child_processes = specified_child_processes
 
-    def _set_up_run(self, device_type=None):
+    def _set_up_run(self, args, device_type=None):
         self._stream.write_update("Starting helper ...")
         if not self._port.start_helper():
             return False
 
-        self._update_worker_count()
+        self._update_worker_count(args)
         self._port.reset_preferences()
 
         # Set up devices for the test run
@@ -245,7 +256,7 @@ class Manager(object):
             _log.error('Build check failed')
             return Manager.FAILED_BUILD_CHECK
 
-        if not self._set_up_run():
+        if not self._set_up_run(args):
             return Manager.FAILED_BUILD_CHECK
 
         configuration_for_upload = self._port.configuration_for_upload(self._port.target_host(0))

--- a/Tools/Scripts/webkitpy/api_tests/manager_unittest.py
+++ b/Tools/Scripts/webkitpy/api_tests/manager_unittest.py
@@ -117,3 +117,14 @@ TestWebKitAPI.WKWebViewSwiftOverlayTests/evaluateJavaScriptYieldsExpectedRespons
     def test_find_test_subset_no_match(self):
         superset = ["TestWebKitAPI.WebKit.SomeTest"]
         self.assertEqual([], Manager._find_test_subset(superset, ["NonExistent"]))
+
+    def test_args_specify_individual_tests(self):
+        self.assertTrue(Manager._args_specify_individual_tests(["WebKit.SomeTest"]))
+        self.assertTrue(Manager._args_specify_individual_tests(["TestWebKitAPI.WebKit.SomeTest"]))
+        self.assertTrue(Manager._args_specify_individual_tests([
+            "TestWebKitAPI.WebKit.SomeTest",
+            "TestWebKitAPI.WKWebViewSwiftOverlayTests/evaluateJavaScriptWithNilResponse()",
+        ]))
+        self.assertFalse(Manager._args_specify_individual_tests([]))
+        self.assertFalse(Manager._args_specify_individual_tests(["WebKit"]))
+        self.assertFalse(Manager._args_specify_individual_tests(["WebKit.SomeTest", "WebKit"]))


### PR DESCRIPTION
#### 722055b887045655ae912d09fcda5cdade4cc905
<pre>
Make run-api-tests default to --child-processes=1 when only specific tests are named
<a href="https://bugs.webkit.org/show_bug.cgi?id=314178">https://bugs.webkit.org/show_bug.cgi?id=314178</a>
<a href="https://rdar.apple.com/176339262">rdar://176339262</a>

Reviewed by Jonathan Bedard.

Running `run-api-tests --ios-simulator Foo.Bar` currently boots one simulator
per CPU, which is extremely slow and frequently times out before the test
runs. The standard workaround is `--child-processes=1`, but it&apos;s easy to
forget.

When every positional argument matches `\S+\..+` (i.e., the user named
specific tests, not a whole binary or suite), default --child-processes to 1.
Users can still override with an explicit --child-processes=N.

* Tools/Scripts/webkitpy/api_tests/manager.py:
(Manager):
(Manager._args_specify_individual_tests):
(Manager._update_worker_count):
(Manager._set_up_run):
(Manager.run):
* Tools/Scripts/webkitpy/api_tests/manager_unittest.py:
(test_find_test_subset_no_match):
(test_args_specify_individual_tests):

Canonical link: <a href="https://commits.webkit.org/312716@main">https://commits.webkit.org/312716@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/24e37df15bce60cb6e9c88b318910e6e52731a0c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/160791 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/34264 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/27365 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/169694 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/115857 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/162660 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/34365 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/34264 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/124709 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/88053 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/163750 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/26961 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/144431 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/105306 "Passed tests") | | ⏳ 🛠 vision-apple 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/160111 "Passed tests") | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/26013 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/24513 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/17414 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/135707 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/22194 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/172176 "Built successfully") | | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/23835 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/132977 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/33938 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/28605 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/132988 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35931 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/33922 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/143989 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/95735 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/27579 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/20804 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/33433 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/32932 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/33176 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/33080 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->