### PR TITLE
[:has() perf] Build better scope selector for nested :is()

### DIFF
--- a/LayoutTests/fast/selectors/has-invalidation-traversal-size-expected.txt
+++ b/LayoutTests/fast/selectors/has-invalidation-traversal-size-expected.txt
@@ -34,4 +34,10 @@
   Traversal count: 17
 (Ancestor, SiblingDescendant) .c18:has(~ .other18 .trigger18) .target
   Traversal count: 17
+:is(.other:has(.trigger)) with merged scope .c19.other
+  Traversal count: 7
+:is(div:has(.trigger)) with type in inner compound - scope stays .c20
+  Traversal count: 7
+.c21 div:is(.other:has(.trigger)) with type in outer compound
+  Traversal count: 7
 

--- a/LayoutTests/fast/selectors/has-invalidation-traversal-size.html
+++ b/LayoutTests/fast/selectors/has-invalidation-traversal-size.html
@@ -38,6 +38,12 @@
 .c17:has(~ .other17 > .trigger17) .target { color: green; }
 /* Non-subject (Ancestor, SiblingDescendant): subject is descendant of bearer */
 .c18:has(~ .other18 .trigger18) .target { color: green; }
+/* :has() inside :is() with compound peers at both levels - scope merges to .c19.other */
+.c19:is(.other:has(.trigger)) .target { color: green; }
+/* :has() inside :is() with type selector in inner compound - inner skipped, scope stays .c20 */
+.c20:is(div:has(.trigger)) .target { color: green; }
+/* :has() inside :is() with type selector in outer compound and class peer in inner */
+.c21 div:is(.other:has(.trigger)) .target { color: green; }
 </style>
 <script>
 if (window.testRunner)
@@ -220,6 +226,24 @@ runTest("(Ancestor, SiblingDescendant) .c18:has(~ .other18 .trigger18) .target",
     trigger.className = "trigger18";
     other.firstElementChild.appendChild(trigger);
 }, true, { setup: setupFollowingOther("other18") });
+
+runTest(":is(.other:has(.trigger)) with merged scope .c19.other", "c19 other", function(container) {
+    var trigger = document.createElement("div");
+    trigger.className = "trigger";
+    container.appendChild(trigger);
+}, true, { wrapperClass: "c19" });
+
+runTest(":is(div:has(.trigger)) with type in inner compound - scope stays .c20", "c20", function(container) {
+    var trigger = document.createElement("div");
+    trigger.className = "trigger";
+    container.appendChild(trigger);
+}, true);
+
+runTest(".c21 div:is(.other:has(.trigger)) with type in outer compound", "other", function(container) {
+    var trigger = document.createElement("div");
+    trigger.className = "trigger";
+    container.appendChild(trigger);
+}, true, { wrapperClass: "c21" });
 </script>
 </script>
 </body>

--- a/Source/WebCore/css/parser/CSSSelectorParser.cpp
+++ b/Source/WebCore/css/parser/CSSSelectorParser.cpp
@@ -1593,19 +1593,47 @@ static CSSSelectorList buildScopeSelector(const HasCompoundContext& context)
     return CSSSelectorList { WTF::move(result) };
 }
 
-// Returns a selector for the :has() scope element. Encodes three cases:
+// Returns a selector for the :has() scope element. Encodes two cases:
 //   - Specific selectors: strong scope (e.g. `.c1` for `.c1:has(> .trigger)`).
-//   - Universal `*`: weak scope. Bearer has no compound peer (e.g. `:has(+ .trigger)`).
-//   - Empty list: scope-breaking. A nested :is()/:not() combinator reaches outside the scope.
-CSSSelectorList CSSSelectorParser::makeHasScopeSelector(const CSSSelector& hasPseudoClass)
+//   - Universal `*`: weak scope. No compound peer at any level.
+// Scope-breaking is signalled by the caller passing an empty list.
+// `compoundSelectors` lists the compounds contributing to the scope, from outermost
+// (an enclosing :is()/:not()) to innermost (the :has() itself). For `.foo:is(.bar:has(.x))`
+// the outermost contributes `.foo` and the innermost contributes `.bar`, giving scope `.foo.bar`.
+// Only the outermost's left context (combinator + ancestor chain) is relevant; inner compounds
+// live inside :is()/:not() arguments. Inner compounds containing a type selector are skipped
+// to avoid synthesizing an invalid two-type compound.
+CSSSelectorList CSSSelectorParser::makeHasScopeSelector(const Vector<const CSSSelector*>& compoundSelectors)
 {
-    auto context = collectHasCompoundContext(hasPseudoClass);
-    if (!context) {
+    ASSERT(!compoundSelectors.isEmpty());
+
+    auto* outermost = compoundSelectors.first()->firstInCompound();
+
+    Vector<const CSSSelector*> mergedPeers;
+    for (size_t i = 0; i < compoundSelectors.size(); ++i) {
+        auto context = collectHasCompoundContext(*compoundSelectors[i]);
+        if (!context)
+            continue;
+
+        if (i > 0) {
+            auto containsTypeSelector = std::ranges::any_of(context->compoundPeers, [](auto* peer) {
+                return peer->match() == CSSSelector::Match::Tag;
+            });
+            if (containsTypeSelector)
+                continue;
+        }
+
+        mergedPeers.appendVector(context->compoundPeers);
+    }
+
+    if (mergedPeers.isEmpty()) {
         MutableCSSSelectorList result;
         result.append(makeUnique<MutableCSSSelector>(anyQName()));
         return CSSSelectorList { WTF::move(result) };
     }
-    return buildScopeSelector(*context);
+
+    HasCompoundContext merged { WTF::move(mergedPeers), outermost->relation(), outermost->precedingInComplexSelector() };
+    return buildScopeSelector(merged);
 }
 
 CSSSelectorList CSSSelectorParser::makeHasArgumentWithScope(const CSSSelector& hasArgument, const CSSSelector& scopeSelector)

--- a/Source/WebCore/css/parser/CSSSelectorParser.h
+++ b/Source/WebCore/css/parser/CSSSelectorParser.h
@@ -59,7 +59,7 @@ public:
 
     static bool supportsComplexSelector(CSSParserTokenRange, const CSSSelectorParserContext&);
     static CSSSelectorList resolveNestingParent(const CSSSelectorList& nestedSelectorList, const CSSSelectorList* parentResolvedSelectorList, bool parentRuleIsScope = false);
-    static CSSSelectorList makeHasScopeSelector(const CSSSelector& hasPseudoClass);
+    static CSSSelectorList makeHasScopeSelector(const Vector<const CSSSelector*>& compoundSelectors);
     static CSSSelectorList makeHasArgumentWithScope(const CSSSelector& hasArgument, const CSSSelector& scopeSelector);
     static std::optional<Style::PseudoElementIdentifier> parsePseudoElement(const String&, const CSSSelectorParserContext&);
 

--- a/Source/WebCore/style/RuleFeature.cpp
+++ b/Source/WebCore/style/RuleFeature.cpp
@@ -248,7 +248,7 @@ static bool isHasScopeBreakingCombinator(CSSSelector::Relation relation, MatchEl
 struct RuleFeatureSet::RecursiveCollectionContext {
     MatchElement matchElement { MatchElement::Relation::Subject, { } };
     IsNegation isNegation { IsNegation::No };
-    const CSSSelector* outerCompoundSelector { nullptr };
+    Vector<const CSSSelector*> outerCompoundSelectors { };
     const CSSSelector* hasPseudoClass { nullptr };
     bool isNestedInLogicalCombination { false };
     bool crossedScopeBreakingCombinator { false };
@@ -292,12 +292,14 @@ void RuleFeatureSet::recursivelyCollectFeaturesFromSelector(SelectorFeatures& se
         // we crossed a combinator that reaches outside (e.g. descendant inside :is, or sibling
         // inside :is when :has() itself is in sibling/subject position). Otherwise the matched
         // element is always within the scope subtree and the scope selector can bound traversal.
-        auto scopeSource = [&] -> const CSSSelector* {
+        auto scopeSources = [&] -> Vector<const CSSSelector*> {
             if (context.isNestedInLogicalCombination && crossedScopeBreakingCombinator)
-                return nullptr;
-            return context.outerCompoundSelector ? context.outerCompoundSelector : context.hasPseudoClass;
+                return { };
+            auto result = context.outerCompoundSelectors;
+            result.append(context.hasPseudoClass);
+            return result;
         }();
-        selectorFeatures.hasPseudoClasses.append({ selector, matchElement, context.isNegation, scopeSource });
+        selectorFeatures.hasPseudoClasses.append({ selector, matchElement, context.isNegation, WTF::move(scopeSources) });
     };
 
     while (true) {
@@ -332,14 +334,13 @@ void RuleFeatureSet::recursivelyCollectFeaturesFromSelector(SelectorFeatures& se
             for (auto& subSelector : *selectorList) {
                 auto subResult = computeSubSelectorMatchElement(matchElement, *selector, subSelector);
 
-                RecursiveCollectionContext subContext { subResult, subSelectorIsNegation, context.outerCompoundSelector, context.hasPseudoClass, context.isNestedInLogicalCombination, crossedScopeBreakingCombinator };
+                RecursiveCollectionContext subContext { subResult, subSelectorIsNegation, context.outerCompoundSelectors, context.hasPseudoClass, context.isNestedInLogicalCombination, crossedScopeBreakingCombinator };
 
                 // When entering a logical combination (not :has() itself), record the outer compound
                 // so nested :has() can use it for scope selector extraction.
                 // Mark as nested so only sibling boundary entries are emitted, not rightmost.
                 if (selector->match() == CSSSelector::Match::PseudoClass && isLogicalCombinationPseudoClass(selector->pseudoClass()) && selector->pseudoClass() != CSSSelector::PseudoClass::Has) {
-                    if (!subContext.outerCompoundSelector)
-                        subContext.outerCompoundSelector = selector;
+                    subContext.outerCompoundSelectors.append(selector);
                     if (subContext.hasPseudoClass)
                         subContext.isNestedInLogicalCombination = true;
                 }
@@ -515,7 +516,7 @@ void RuleFeatureSet::collectFeatures(CollectionContext& collectionContext, const
     }
 
     for (auto& entry : selectorFeatures.hasPseudoClasses) {
-        auto& [selector, matchElement, isNegation, hasPseudoClass] = entry;
+        auto& [selector, matchElement, isNegation, scopeSources] = entry;
         // The selector argument points to a selector inside :has() selector list instead of :has() itself.
         auto& featureVector = *hasPseudoClassRules.ensure(makePseudoClassInvalidationKey(CSSSelector::PseudoClass::Has, *selector), [] {
             return makeUnique<Vector<RuleFeatureWithInvalidationSelector>>();
@@ -526,7 +527,7 @@ void RuleFeatureSet::collectFeatures(CollectionContext& collectionContext, const
             matchElement,
             isNegation,
             CSSSelectorList::makeCopyingComplexSelector(*selector),
-            hasPseudoClass ? CSSSelectorParser::makeHasScopeSelector(*hasPseudoClass) : CSSSelectorList { }
+            scopeSources.isEmpty() ? CSSSelectorList { } : CSSSelectorParser::makeHasScopeSelector(scopeSources)
         });
 
         setUsesRelation(matchElement.relation);

--- a/Source/WebCore/style/RuleFeature.h
+++ b/Source/WebCore/style/RuleFeature.h
@@ -164,7 +164,7 @@ struct RuleFeatureSet {
 private:
     struct SelectorFeatures {
         using InvalidationFeature = std::tuple<const CSSSelector*, MatchElement, IsNegation>;
-        using HasInvalidationFeature = std::tuple<const CSSSelector*, MatchElement, IsNegation, const CSSSelector*>;
+        using HasInvalidationFeature = std::tuple<const CSSSelector*, MatchElement, IsNegation, Vector<const CSSSelector*>>;
 
         Vector<InvalidationFeature> ids;
         Vector<InvalidationFeature> classes;


### PR DESCRIPTION
#### 72bd1bab23f7b55d21cba762339f3bfbe81d8ba9
<pre>
[:has() perf] Build better scope selector for nested :is()
<a href="https://bugs.webkit.org/show_bug.cgi?id=314192">https://bugs.webkit.org/show_bug.cgi?id=314192</a>
<a href="https://rdar.apple.com/176354723">rdar://176354723</a>

Reviewed by Alan Baradlay.

In cases like

.foo:is(.bar:has(.changed)) .baz

the scope selector could be .foo.bar but is currently just .bar. Merge
compound peers across enclosing logical pseudo-classes so all levels
contribute. Inner compounds containing a type selector are skipped to
avoid synthesizing an invalid two-type compound (e.g. div.span).

* LayoutTests/fast/selectors/has-invalidation-traversal-size-expected.txt:
* LayoutTests/fast/selectors/has-invalidation-traversal-size.html:

Add cases covering merge across levels, inner-type skip, and
outer-type with inner-class merge.

* Source/WebCore/css/parser/CSSSelectorParser.cpp:
(WebCore::CSSSelectorParser::makeHasScopeSelector):
* Source/WebCore/css/parser/CSSSelectorParser.h:

Take a vector of compound selectors (outermost to :has()) and union
their compound peers. The outermost contributes the compound relation
and ancestor chain.

* Source/WebCore/style/RuleFeature.cpp:
(WebCore::Style::RuleFeatureSet::recursivelyCollectFeaturesFromSelector):
(WebCore::Style::RuleFeatureSet::collectFeatures):
* Source/WebCore/style/RuleFeature.h:

Track the full stack of enclosing logical compounds rather than only the
outermost.

Canonical link: <a href="https://commits.webkit.org/312715@main">https://commits.webkit.org/312715@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/acf17bef4cfb0ecd7dcd597e5b77c4244e54a295

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/160853 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/34326 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/27427 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/169756 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/115919 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/b5507a3a-08b2-459a-87a9-0047d091921f) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/162722 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/34427 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/34326 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/124761 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/115919 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/2a01cd00-cc29-4d44-8c9a-3702b8d66844) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/163812 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/27016 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/144493 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/105358 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/d2e05cb1-101c-4440-9794-2549314250d1) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/26068 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/24568 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/17476 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/135762 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/22256 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/172239 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/19260 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/23897 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/133030 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/34000 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/28661 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/133041 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35929 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/33984 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/144051 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/95822 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/27635 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/20866 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/33495 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/100920 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/32994 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/33238 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/33142 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->