### PR TITLE
Style checker should ignore libpas header guards

### DIFF
--- a/Tools/Scripts/webkitpy/style/checkers/cpp.py
+++ b/Tools/Scripts/webkitpy/style/checkers/cpp.py
@@ -163,6 +163,8 @@ _NO_CONFIG_H_PATH_PATTERNS = [
     '^Source/WebKitLegacy/',
 ]
 
+_LIBPAS_PATH_PATTERN = '(^|/)Source/bmalloc/libpas/'
+
 _EXPORT_MACRO_SPEC = {
     'BEXPORT': '(Source/bmalloc|Source/JavaScriptCore/API/ExtraSymbolsForTAPI.h)',
     'JS_EXPORT': 'Source/JavaScriptCore/API',
@@ -1010,21 +1012,32 @@ def check_for_header_guard(file_path, lines, error):
     if filename == 'config.h' or filename.endswith('Prefix.h'):
         return
 
+    in_libpas = is_libpas_path(file_path)
+
     first_blank_line_number = 0
     has_import_statement = False
     has_objc_check = False
     has_objc_keywords = False
+    pragma_once_line_number = None
     for line_number, line in enumerate(lines):
         if line == '' and first_blank_line_number == 0:
             first_blank_line_number = line_number
         if line.startswith('#pragma once'):
-            return
+            if in_libpas:
+                pragma_once_line_number = line_number
+            else:
+                return
         if line.startswith('#import '):
             has_import_statement = True
         if '__OBJC__' in line:
             has_objc_check = True
         if functools.reduce(lambda x, y: x or y, map(lambda x: x in line, ['@class', '@interface', '@protocol'])):
             has_objc_keywords = True
+
+    if in_libpas and pragma_once_line_number is not None:
+        error(pragma_once_line_number, 'build/header_guard', 5,
+              'Do not use #pragma once in libpas; use #ifndef/#define header guards instead.')
+        return
 
     if (has_import_statement or has_objc_keywords) and not has_objc_check:
         return  # Objective-C-only headers don't need guards.
@@ -1039,13 +1052,19 @@ def check_for_header_guard(file_path, lines, error):
             if len(previous_line_split) >= 2 and len(line_split) >= 2:
                 if previous_line_split[0] == '#ifndef' and line_split[0] == '#define' \
                         and previous_line_split[1] == line_split[1]:
+                    if in_libpas:
+                        return  # libpas uses #ifndef/#define guards.
                     error(line_number, 'build/header_guard', 5,
                           'Use #pragma once instead of #ifndef for header guard.')
                     return
         previous_line = line
 
-    error(first_blank_line_number + 1, 'build/header_guard_missing', 5,
-          'Missing #pragma once for header guard.')
+    if in_libpas:
+        error(first_blank_line_number + 1, 'build/header_guard_missing', 5,
+              'Missing #ifndef/#define header guard.')
+    else:
+        error(first_blank_line_number + 1, 'build/header_guard_missing', 5,
+              'Missing #pragma once for header guard.')
 
 
 def check_for_unicode_replacement_characters(lines, error):
@@ -4851,6 +4870,11 @@ def check_has_config_header(file_path):
         if re.match(pattern, file_path):
             return False
     return True
+
+
+def is_libpas_path(file_path):
+    """Check if the file is inside libpas, which uses #ifndef/#define header guards rather than #pragma once."""
+    return re.search(_LIBPAS_PATH_PATTERN, _unix_path(file_path)) is not None
 
 
 def files_belong_to_same_module(filename_cpp, filename_h):

--- a/Tools/Scripts/webkitpy/style/checkers/cpp_unittest.py
+++ b/Tools/Scripts/webkitpy/style/checkers/cpp_unittest.py
@@ -3046,6 +3046,31 @@ class CppStyleTest(CppStyleTestBase):
             'Missing #pragma once for header guard.'
             '  [build/header_guard_missing] [5]')
 
+        # libpas headers must use #ifndef/#define guards, not #pragma once.
+        libpas_header = 'Source/bmalloc/libpas/src/libpas/pas_foo.h'
+
+        # No warning for libpas header with #ifndef/#define guard.
+        self.assert_header_guard(
+            '#ifndef PAS_FOO_H\n'
+            '#define PAS_FOO_H\n'
+            '#endif /* PAS_FOO_H */\n',
+            '',
+            libpas_header)
+
+        # Warning if a libpas header uses #pragma once.
+        self.assert_header_guard(
+            '#pragma once\n',
+            'Do not use #pragma once in libpas; use #ifndef/#define header guards instead.'
+            '  [build/header_guard] [5]',
+            libpas_header)
+
+        # Warning for libpas header with no guard at all.
+        self.assert_header_guard(
+            '',
+            'Missing #ifndef/#define header guard.'
+            '  [build/header_guard_missing] [5]',
+            libpas_header)
+
     def test_build_printf_format(self):
         self.assert_lint(
             r'SAFE_PRINTF("\%%d", value);',


### PR DESCRIPTION
#### b903bdd2907cb8f8e4a2506f753b4f8ed99e8567
<pre>
Style checker should ignore libpas header guards
<a href="https://bugs.webkit.org/show_bug.cgi?id=314195">https://bugs.webkit.org/show_bug.cgi?id=314195</a>

Reviewed by Yusuke Suzuki.

This is important for portability, let&apos;s get rid of these extra style
errors in libpas.

* Tools/Scripts/webkitpy/style/checkers/cpp.py:
(check_for_header_guard):
(is_libpas_path):
* Tools/Scripts/webkitpy/style/checkers/cpp_unittest.py:
(CppStyleTest):

Canonical link: <a href="https://commits.webkit.org/312872@main">https://commits.webkit.org/312872@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/46ec7accbcdadf6d566d92423a52ed177830a25a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/160833 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/34306 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/27407 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/169736 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/115899 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/162702 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/34407 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/34306 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/124744 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/88066 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/163792 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/27000 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/144471 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/105341 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/160153 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/26052 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/24551 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/17456 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/135746 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/22234 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/172218 "Built successfully") | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/23875 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/133013 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/33980 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/28643 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/133024 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36040 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/33964 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/144029 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/95795 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/27618 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/20844 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/33475 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/32974 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/33218 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/33122 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->