### PR TITLE
Web Inspector: Give style events unique color

### DIFF
--- a/Source/WebInspectorUI/UserInterface/Images/TypeIcons.svg
+++ b/Source/WebInspectorUI/UserInterface/Images/TypeIcons.svg
@@ -330,8 +330,8 @@
     <g id="Exception-light" class="light blue"><use href="#box"/><use href="#Ex"/></g>
     <g id="Function-dark" class="dark green"><use href="#box"/><use href="#f"/></g>
     <g id="Function-light" class="light green"><use href="#box"/><use href="#f"/></g>
-    <g id="HeapSnapshot-dark" class="dark beige"><use href="#box"/><use href="#S"/></g>
-    <g id="HeapSnapshot-light" class="light beige"><use href="#box"/><use href="#S"/></g>
+    <g id="HeapSnapshot-dark" class="dark grey"><use href="#box"/><use href="#S"/></g>
+    <g id="HeapSnapshot-light" class="light grey"><use href="#box"/><use href="#S"/></g>
     <g id="HeapSnapshot-selected" class="selected"><use href="#box"/><use href="#S"/></g>
     <g id="HeapSnapshotDiff-dark" class="dark green"><use href="#box"/><use href="#D"/></g>
     <g id="HeapSnapshotDiff-light" class="light green"><use href="#box"/><use href="#D"/></g>
@@ -405,8 +405,8 @@
     <g id="TimelineRecordCSSTransition-light" class="light green"><use href="#box"/><use href="#T"/></g>
     <g id="TimelineRecordEvent-dark" class="dark purple"><use href="#box"/><use href="#E"/></g>
     <g id="TimelineRecordEvent-light" class="light purple"><use href="#box"/><use href="#E"/></g>
-    <g id="TimelineRecordGarbageCollection-dark" class="dark beige"><use href="#box"/><use href="#C"/></g>
-    <g id="TimelineRecordGarbageCollection-light" class="light beige"><use href="#box"/><use href="#C"/></g>
+    <g id="TimelineRecordGarbageCollection-dark" class="dark grey"><use href="#box"/><use href="#C"/></g>
+    <g id="TimelineRecordGarbageCollection-light" class="light grey"><use href="#box"/><use href="#C"/></g>
     <g id="TimelineRecordLayout-dark" class="dark red"><use href="#box"/><use href="#L"/></g>
     <g id="TimelineRecordLayout-light" class="light red"><use href="#box"/><use href="#L"/></g>
     <g id="TimelineRecordMediaElement-dark" class="dark green"><use href="#box"/><use href="#E"/></g>
@@ -417,8 +417,8 @@
     <g id="TimelineRecordProbeSampled-light" class="light purple"><use href="#box"/><use href="#P"/></g>
     <g id="TimelineRecordScriptEvaluated-dark" class="dark purple"><use href="#box"/><use href="#S"/></g>
     <g id="TimelineRecordScriptEvaluated-light" class="light purple"><use href="#box"/><use href="#S"/></g>
-    <g id="TimelineRecordStyle-dark" class="dark red"><use href="#box"/><use href="#S"/></g>
-    <g id="TimelineRecordStyle-light" class="light red"><use href="#box"/><use href="#S"/></g>
+    <g id="TimelineRecordStyle-dark" class="dark beige"><use href="#box"/><use href="#S"/></g>
+    <g id="TimelineRecordStyle-light" class="light beige"><use href="#box"/><use href="#S"/></g>
     <g id="TimelineRecordTimer-dark" class="dark purple"><use href="#box"/><use href="#T"/></g>
     <g id="TimelineRecordTimer-light" class="light purple"><use href="#box"/><use href="#T"/></g>
     <g id="TypeBigInt-dark" class="dark cyan"><use href="#box"/><use href="#B"/></g>

--- a/Source/WebInspectorUI/UserInterface/Views/TimelineRecordBar.css
+++ b/Source/WebInspectorUI/UserInterface/Views/TimelineRecordBar.css
@@ -132,6 +132,12 @@ body[dir=rtl] .timeline-record-bar > .segment:last-of-type {
     --record-bar-segment-border-color: hsl(0, 54%, 62%);
 }
 
+.timeline-record-bar.timeline-record-type-layout.invalidate-styles > .segment,
+.timeline-record-bar.timeline-record-type-layout.recalculate-styles > .segment {
+    background-color: hsl(23, 69%, 73%);
+    --record-bar-segment-border-color: hsl(11, 54%, 62%);
+}
+
 
 .timeline-record-bar.timeline-record-type-layout.paint > .segment,
 .timeline-record-bar.timeline-record-type-layout.composite > .segment {
@@ -151,8 +157,8 @@ body[dir=rtl] .timeline-record-bar > .segment:last-of-type {
 
 .timeline-record-bar.timeline-record-type-script.garbage-collected > .segment,
 .timeline-record-bar.timeline-record-type-heap-allocations > .segment {
-    background-color: hsl(23, 69%, 73%);
-    --record-bar-segment-border-color: hsl(11, 54%, 62%);
+    background-color: hsl(0, 0%, 70%);
+    --record-bar-segment-border-color: hsl(0, 0%, 55%);
 }
 
 .timeline-record-bar.timeline-record-type-media > .segment {


### PR DESCRIPTION
#### 86929c4ad2d511dab9545af2674218a2c982eba7
<pre>
Web Inspector: Give style events unique color
<a href="https://bugs.webkit.org/show_bug.cgi?id=314193">https://bugs.webkit.org/show_bug.cgi?id=314193</a>

Reviewed by Devin Rousso.

Style events such as &quot;Style Invalidated&quot; and &quot;Style Recalculated&quot; use
the same color as layout events, making it hard to recognize them at
glance in Timeline view.

Use `beige` color for style events icon and segments to match the color
used in the CPU timeline.

Also, change the color of &quot;Garbage Collected&quot; events to `grey` to make
them more distinguishable from style events in the overview.

* Source/WebInspectorUI/UserInterface/Images/TypeIcons.svg:
* Source/WebInspectorUI/UserInterface/Views/TimelineRecordBar.css:
(.timeline-record-bar.timeline-record-type-layout.invalidate-styles &gt; .segment,):
(.timeline-record-bar.timeline-record-type-script.garbage-collected &gt; .segment,):

Canonical link: <a href="https://commits.webkit.org/312995@main">https://commits.webkit.org/312995@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5ddad4b20a250e48d762e995f055bba33959e7c4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/161354 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/34827 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/27928 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/170257 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/117725 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/34928 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/34828 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/125166 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/88196 "1 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/164313 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/27454 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/144931 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/105763 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/26502 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/25013 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/17977 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/136196 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/22690 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/172740 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/19774 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/24331 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/133449 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/34514 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/29105 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/133457 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36139 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/34486 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/144485 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/96359 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/27994 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/21304 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/33996 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/101437 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/33495 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/33739 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/33644 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->