### PR TITLE
AX: Fix isolated tree mode test failures for sync actions, element-by-ID lookup, and async tree updates

### DIFF
--- a/LayoutTests/accessibility-isolated-tree/TestExpectations
+++ b/LayoutTests/accessibility-isolated-tree/TestExpectations
@@ -4,8 +4,6 @@ accessibility/isolated-tree [ Pass ]
 #
 # Potentially caused by: https://github.com/WebKit/WebKit/commit/2517a540e6f5a2037c6843102f3a9cb753f2f9f0
 accessibility/content-editable-set-inner-text-generates-axvalue-notification.html [ Failure Pass ]
-accessibility/keyevents-for-actions-mimic-real-key-events.html [ Failure ]
-accessibility/keyevents-posted-for-increment-actions.html [ Failure ]
 accessibility/mac/focus-setting-selection-syncronizing-not-clearing.html [ Crash ]
 # Fails because of (1) stale focus ID for the iFrame and (2) iFrame #2 being ignored.
 accessibility/mac/frame-with-title.html [ Failure ]
@@ -28,6 +26,14 @@ accessibility/mac/style-range.html [ Pass ]
 
 # Flaky: https://bugs.webkit.org/show_bug.cgi?id=290946
 accessibility/datetime/input-date-field-labels-and-value-changes.html [ Pass Failure ]
+
+# With ENABLE(ACCESSIBILITY_LOCAL_FRAME), child frames have their own AXObjectCache.
+# The child frame's isolated tree is created lazily, but the parent frame's tree
+# isn't reliably notified to re-fetch cross-frame children after the child loads.
+# This causes the iframe's accessibility subtree to sometimes be absent from the
+# parent's isolated tree. Fixing requires ensuring the parent's isolated tree is
+# updated when a child frame's AXObjectCache is created and content becomes available.
+accessibility/loading-iframe-sends-notification.html [ Pass Failure ]
 
 # Fails in ITM since introduced.
 accessibility/text-marker/text-marker-bidi-element-arabic.html [ Failure ]

--- a/LayoutTests/accessibility/aria-owns-deep-chain-no-timeout.html
+++ b/LayoutTests/accessibility/aria-owns-deep-chain-no-timeout.html
@@ -13,6 +13,7 @@
 
 <script>
 var output = "This test ensures deeply chained aria-owns relations don't cause a timeout due to quadratic cycle detection.\n\n";
+var axContainer;
 
 if (window.accessibilityController) {
     const container = document.getElementById("container");
@@ -32,7 +33,7 @@ if (window.accessibilityController) {
     }
 
     // Accessing the AX tree triggers relation processing, including cycle detection.
-    var axContainer = accessibilityController.accessibleElementById("container");
+    axContainer = accessibilityController.accessibleElementById("container");
     output += expect("axContainer.childrenCount > 0", "true");
 
     output += "PASS: Did not timeout.\n";

--- a/LayoutTests/accessibility/element-reflection-ariaactivedescendant.html
+++ b/LayoutTests/accessibility/element-reflection-ariaactivedescendant.html
@@ -54,8 +54,8 @@
 
         target3.ariaActiveDescendantElement = descendant3;
         descendant3.id = "descendant3-new";
+        axDescendant3 = await waitForElementById("descendant3-new");
         axTarget3 = accessibilityController.accessibleElementById("target3");
-        axDescendant3 = accessibilityController.accessibleElementById("descendant3-new");
         await waitFor(() => {
             selectedChild = axTarget3.selectedChildAtIndex(0);
             return selectedChild && selectedChild.isEqual(axDescendant3);

--- a/LayoutTests/accessibility/element-reflection-ariacontrols.html
+++ b/LayoutTests/accessibility/element-reflection-ariacontrols.html
@@ -79,7 +79,7 @@ if (window.accessibilityController) {
 
         tab4.ariaControlsElements = [panel4];
         panel4.id = "panel4-new";
-        axPanel4 = accessibilityController.accessibleElementById("panel4-new");
+        axPanel4 = await waitForElementById("panel4-new");
         axTab4 = accessibilityController.accessibleElementById("tab4");
         await waitFor(() => axTab4.ariaControlsElementAtIndex(0) != null);
         output += expect("axTab4.ariaControlsElementAtIndex(0).isEqual(axPanel4)", "true");

--- a/LayoutTests/accessibility/element-reflection-ariadetails.html
+++ b/LayoutTests/accessibility/element-reflection-ariadetails.html
@@ -80,7 +80,7 @@ if (window.accessibilityController) {
 
         target4.ariaDetailsElements = [detail4];
         detail4.id = "detail4-new";
-        axDetail4 = accessibilityController.accessibleElementById("detail4-new");
+        axDetail4 = await waitForElementById("detail4-new");
         axTarget4 = accessibilityController.accessibleElementById("target4");
         await waitFor(() => axTarget4.ariaDetailsElementAtIndex(0));
         output += expect("axTarget4.ariaDetailsElementAtIndex(0).isEqual(axDetail4)", "true");

--- a/LayoutTests/accessibility/element-reflection-ariaerrormessage.html
+++ b/LayoutTests/accessibility/element-reflection-ariaerrormessage.html
@@ -85,7 +85,7 @@ if (window.accessibilityController) {
         target4.ariaInvalid = true;
         target4.ariaErrorMessageElements = [error4];
         error4.id = "error4-new";
-        axErrorMessage4 = accessibilityController.accessibleElementById("error4-new");
+        axErrorMessage4 = await waitForElementById("error4-new");
         axTarget4 = accessibilityController.accessibleElementById("target4");
         await waitFor(() => axTarget4.ariaErrorMessageElementAtIndex(0));
         output += expect("axTarget4.ariaErrorMessageElementAtIndex(0).isEqual(axErrorMessage4)", "true");

--- a/LayoutTests/accessibility/element-reflection-ariaflowto.html
+++ b/LayoutTests/accessibility/element-reflection-ariaflowto.html
@@ -80,7 +80,7 @@ if (window.accessibilityController) {
 
         target4.ariaFlowToElements = [flow4];
         flow4.id = "flow4-new";
-        axFlow4 = accessibilityController.accessibleElementById("flow4-new");
+        axFlow4 = await waitForElementById("flow4-new");
         axTarget4 = accessibilityController.accessibleElementById("target4");
         await waitFor(() => axTarget4.ariaFlowToElementAtIndex(0));
         output += expect("axTarget4.ariaFlowToElementAtIndex(0).isEqual(axFlow4)", "true");

--- a/LayoutTests/accessibility/element-reflection-ariaowns.html
+++ b/LayoutTests/accessibility/element-reflection-ariaowns.html
@@ -90,7 +90,7 @@ if (window.accessibilityController) {
 
         target4.ariaOwnsElements = [own4];
         own4.id = "own4-new";
-        axOwn4 = accessibilityController.accessibleElementById("own4-new");
+        axOwn4 = await waitForElementById("own4-new");
         axTarget4 = accessibilityController.accessibleElementById("target4");
         await waitFor(() => axTarget4.ariaOwnsElementAtIndex(0));
         output += expect("axTarget4.ariaOwnsElementAtIndex(0).isEqual(axOwn4)", "true");

--- a/LayoutTests/accessibility/heading-level.html
+++ b/LayoutTests/accessibility/heading-level.html
@@ -7,36 +7,36 @@
 <body>
 
 <!-- implicit level of tag -->
-<h1 class="ex" data-expected="1">X</h1>
-<h2 class="ex" data-expected="2">X</h2>
-<h3 class="ex" data-expected="3">X</h3>
-<h4 class="ex" data-expected="4">X</h4>
-<h5 class="ex" data-expected="5">X</h5>
-<h6 class="ex" data-expected="6">X</h6>
+<h1 id="ex0" class="ex" data-expected="1">X</h1>
+<h2 id="ex1" class="ex" data-expected="2">X</h2>
+<h3 id="ex2" class="ex" data-expected="3">X</h3>
+<h4 id="ex3" class="ex" data-expected="4">X</h4>
+<h5 id="ex4" class="ex" data-expected="5">X</h5>
+<h6 id="ex5" class="ex" data-expected="6">X</h6>
 
 <!-- explicit aria-level overrides on h1-h6 (withOUT explicit heading role declaration) -->
-<h6 class="ex" data-expected="1" aria-level="1">X</h6>
-<h5 class="ex" data-expected="2" aria-level="2">X</h5>
-<h4 class="ex" data-expected="3" aria-level="3">X</h4>
-<h3 class="ex" data-expected="4" aria-level="4">X</h3>
-<h2 class="ex" data-expected="5" aria-level="5">X</h2>
-<h1 class="ex" data-expected="6" aria-level="6">X</h1>
+<h6 id="ex6" class="ex" data-expected="1" aria-level="1">X</h6>
+<h5 id="ex7" class="ex" data-expected="2" aria-level="2">X</h5>
+<h4 id="ex8" class="ex" data-expected="3" aria-level="3">X</h4>
+<h3 id="ex9" class="ex" data-expected="4" aria-level="4">X</h3>
+<h2 id="ex10" class="ex" data-expected="5" aria-level="5">X</h2>
+<h1 id="ex11" class="ex" data-expected="6" aria-level="6">X</h1>
 
 <!-- explicit aria-level overrides on h1-h6 (with explicit heading role declaration) -->
-<h6 class="ex" role="heading" data-expected="1" aria-level="1">X</h6>
-<h5 class="ex" role="heading" data-expected="2" aria-level="2">X</h5>
-<h4 class="ex" role="heading" data-expected="3" aria-level="3">X</h4>
-<h3 class="ex" role="heading" data-expected="4" aria-level="4">X</h3>
-<h2 class="ex" role="heading" data-expected="5" aria-level="5">X</h2>
-<h1 class="ex" role="heading" data-expected="6" aria-level="6">X</h1>
+<h6 id="ex12" class="ex" role="heading" data-expected="1" aria-level="1">X</h6>
+<h5 id="ex13" class="ex" role="heading" data-expected="2" aria-level="2">X</h5>
+<h4 id="ex14" class="ex" role="heading" data-expected="3" aria-level="3">X</h4>
+<h3 id="ex15" class="ex" role="heading" data-expected="4" aria-level="4">X</h3>
+<h2 id="ex16" class="ex" role="heading" data-expected="5" aria-level="5">X</h2>
+<h1 id="ex17" class="ex" role="heading" data-expected="6" aria-level="6">X</h1>
 
 <!-- explicit aria-level set on div with explicit heading role declaration -->
-<div class="ex" role="heading" data-expected="1" aria-level="1">X</div>
-<div class="ex" role="heading" data-expected="2" aria-level="2">X</div>
-<div class="ex" role="heading" data-expected="3" aria-level="3">X</div>
-<div class="ex" role="heading" data-expected="4" aria-level="4">X</div>
-<div class="ex" role="heading" data-expected="5" aria-level="5">X</div>
-<div class="ex" role="heading" data-expected="6" aria-level="6">X</div>
+<div id="ex18" class="ex" role="heading" data-expected="1" aria-level="1">X</div>
+<div id="ex19" class="ex" role="heading" data-expected="2" aria-level="2">X</div>
+<div id="ex20" class="ex" role="heading" data-expected="3" aria-level="3">X</div>
+<div id="ex21" class="ex" role="heading" data-expected="4" aria-level="4">X</div>
+<div id="ex22" class="ex" role="heading" data-expected="5" aria-level="5">X</div>
+<div id="ex23" class="ex" role="heading" data-expected="6" aria-level="6">X</div>
 
 <div id="dynamic-aria-heading" role="heading" aria-level="1">X</div>
 
@@ -53,7 +53,6 @@
             const examples = document.querySelectorAll('.ex');
             for (let i = 0; i < examples.length; ++i) {
                 el = examples[i];
-                el.id = `ex${i}`;
 
                 axElement = await waitForElementById(el.id);
 

--- a/LayoutTests/accessibility/image-load-on-delay.html
+++ b/LayoutTests/accessibility/image-load-on-delay.html
@@ -2,6 +2,7 @@
 <html>
 <head>
 <script src="../resources/js-test-pre.js"></script>
+<script src="../resources/accessibility-helper.js"></script>
 </head>
 <body id="body">
 
@@ -23,16 +24,17 @@
           var content = accessibilityController.accessibleElementById("content");
           debug("BEFORE: Group count: " + content.childrenCount);
 
-          document.getElementById("image").onload = function() {
+          document.getElementById("image").onload = async function() {
               document.body.offsetHeight;
-              setTimeout(function() {
-                  debug("AFTER: Group count: " + content.childrenCount);
-                  finishJSTest();
-              }, 0);
+              await waitFor(() => {
+                  return content.childrenCount === 3;
+              });
+              debug("AFTER: Group count: " + content.childrenCount);
+              finishJSTest();
           };
 
-          setTimeout(function() { 
-              document.getElementById("image").src = "resources/cake.png"; 
+          setTimeout(function() {
+              document.getElementById("image").src = "resources/cake.png";
           }, 100);
     }
 

--- a/LayoutTests/accessibility/insert-text-into-password-field-expected.txt
+++ b/LayoutTests/accessibility/insert-text-into-password-field-expected.txt
@@ -1,7 +1,8 @@
 This test ensures that inserting text into a password field works.
 
 Focusing #password-input, and then inserting text 'foo' into it.
-#password-input AXValue: •••
+PASS: passwordInput.stringValue === 'AXValue: \u2022\u2022\u2022'
+
 PASS successfullyParsed is true
 
 TEST COMPLETE

--- a/LayoutTests/accessibility/insert-text-into-password-field.html
+++ b/LayoutTests/accessibility/insert-text-into-password-field.html
@@ -10,16 +10,22 @@
 
 <script>
     var testOutput = "This test ensures that inserting text into a password field works.\n\n";
+    var passwordInput;
 
     if (window.accessibilityController) {
+        window.jsTestIsAsync = true;
+
         testOutput += "Focusing #password-input, and then inserting text 'foo' into it.\n";
         // Put focus into the password input so `insertText` has a target.
         document.getElementById("password-input").focus();
-        var passwordInput = accessibilityController.accessibleElementById("password-input");
+        passwordInput = accessibilityController.accessibleElementById("password-input");
         passwordInput.insertText("foo");
 
-        testOutput += `#password-input ${passwordInput.stringValue}`;
-        debug(testOutput);
+        setTimeout(async function() {
+            testOutput += await expectAsync("passwordInput.stringValue", "'AXValue: \\u2022\\u2022\\u2022'");
+            debug(testOutput);
+            finishJSTest();
+        }, 0);
     }
 </script>
 </body>

--- a/LayoutTests/accessibility/mac/async-increment-decrement-action-expected.txt
+++ b/LayoutTests/accessibility/mac/async-increment-decrement-action-expected.txt
@@ -8,7 +8,10 @@ PASS obj.intValue is 25
 PASS obj.intValue is 50
 PASS obj.intValue is 25
 PASS obj.intValue is 25
-PASS obj.intValue is 25
+PASS: obj.intValue === 50
+
+PASS: obj.intValue === 25
+
 PASS successfullyParsed is true
 
 TEST COMPLETE

--- a/LayoutTests/accessibility/mac/async-increment-decrement-action.html
+++ b/LayoutTests/accessibility/mac/async-increment-decrement-action.html
@@ -2,6 +2,7 @@
 <html>
 <head>
 <script src="../../resources/js-test-pre.js"></script>
+<script src="../../resources/accessibility-helper.js"></script>
 </head>
 <body id="body">
 
@@ -15,9 +16,10 @@
     description("This tests that increment and decrement actions are async.");
 
     if (window.accessibilityController) {
+        window.jsTestIsAsync = true;
 
         var obj = accessibilityController.accessibleElementById("range1");
-        
+
         shouldBe("obj.intValue", "25");
 
         // sync version
@@ -27,12 +29,19 @@
         shouldBe("obj.intValue", "25");
 
         // async version
-        // The increment/decrement actions are now async so that they won't 
+        // The increment/decrement actions are now async so that they won't
         // block the test run loop by changing the value.
         obj.asyncIncrement();
         shouldBe("obj.intValue", "25");
-        obj.asyncDecrement();
-        shouldBe("obj.intValue", "25");
+
+        setTimeout(async function() {
+            // Wait for the async increment to be reflected before issuing the async
+            // decrement, so we can verify both async operations take effect.
+            debug(await expectAsync("obj.intValue", "50"));
+            obj.asyncDecrement();
+            debug(await expectAsync("obj.intValue", "25"));
+            finishJSTest();
+        }, 0);
     }
 
 </script>

--- a/LayoutTests/accessibility/roles-computedRoleString.html
+++ b/LayoutTests/accessibility/roles-computedRoleString.html
@@ -8,278 +8,278 @@
 <!-- This only tests elements that have an exact 1:1 ARIA role mapping, and computed role overrides. -->
 <!-- ==================================================================================================== -->
 <div id="content">
-<a data-role="link" href="#" data-note="[href]" data-platform="atspi,mac" class="ex">X</a>
-<article data-role="article" data-platform="atspi,mac" class="ex">X</article>
-<aside data-role="complementary" data-platform="atspi,mac" class="ex">X</aside>
-<button data-role="button" data-platform="atspi,mac" class="ex">X</button>
-<code data-role="code" data-platform="atspi,mac" class="ex">X</code>
-<del data-role="deletion" data-platform="atspi,mac" class="ex">X</ins>
-<dfn data-role="term" data-platform="atspi,mac" class="ex">X</dfn>
-<dl data-role="" data-platform="atspi,mac" class="ex">
+<a data-role="link" href="#" data-note="[href]" data-platform="atspi,mac" id="ex0" class="ex">X</a>
+<article data-role="article" data-platform="atspi,mac" id="ex1" class="ex">X</article>
+<aside data-role="complementary" data-platform="atspi,mac" id="ex2" class="ex">X</aside>
+<button data-role="button" data-platform="atspi,mac" id="ex3" class="ex">X</button>
+<code data-role="code" data-platform="atspi,mac" id="ex4" class="ex">X</code>
+<del data-role="deletion" data-platform="atspi,mac" id="ex5" class="ex">X</ins>
+<dfn data-role="term" data-platform="atspi,mac" id="ex6" class="ex">X</dfn>
+<dl data-role="" data-platform="atspi,mac" id="ex7" class="ex">
     <dt>X</dt>
     <dd>X</dd>
 </dl>
-<footer data-role="contentinfo" data-platform="atspi,mac" class="ex">X</footer>
-<form data-role="form" data-platform="atspi,mac" class="ex">X</form>
-<header data-role="banner" data-platform="atspi,mac" class="ex">X</header>
-<h1 data-role="heading" data-platform="atspi,mac" class="ex">X</h1>
-<h2 data-role="heading" data-platform="atspi,mac" class="ex">X</h2>
-<h3 data-role="heading" data-platform="atspi,mac" class="ex">X</h3>
-<h4 data-role="heading" data-platform="atspi,mac" class="ex">X</h4>
-<h5 data-role="heading" data-platform="atspi,mac" class="ex">X</h5>
-<h5 data-role="heading" data-platform="atspi,mac" class="ex">X</h6>
-<hr data-role="separator" data-platform="atspi,mac" class="ex">
-<img data-role="image" data-platform="atspi,mac" class="ex" data-note=":not([src]):not([alt])">
-<img data-role="" data-platform="atspi,mac" class="ex" alt="" data-note="[alt='']">
-<img data-role="image" data-platform="atspi,mac" class="ex" src="foo.png" data-note="[src]:not([alt])">
-<img data-role="image" data-platform="atspi,mac" class="ex" alt="X" data-note="[alt='X']">
-<input type="button" value="X" data-role="button" data-platform="atspi,mac" class="ex" data-note="[type='button']">
-<input type="checkbox" data-role="checkbox" data-platform="atspi,mac" class="ex" data-note="[type='checkbox']">
-<input type="date" data-role="textbox" data-platform="atspi,mac" class="ex" data-note="[type='date']">
-<input type="datetime" value="X" data-role="textbox" data-platform="atspi,mac" class="ex" data-note="[type='datetime']">
-<input type="datetime-local" value="X" data-role="textbox" data-platform="atspi,mac" class="ex" data-note="[type='datetime-local']">
-<input type="email" value="X" data-role="textbox" data-platform="atspi,mac" class="ex" data-note="[type='email']">
-<input type="file" data-role="button" data-platform="atspi,mac" class="ex" data-note="[type='file']">
-<input type="hidden" data-role="" data-platform="atspi,mac" class="ex" data-note="[type='hidden']">
-<input type="image" data-role="button" data-platform="atspi,mac" class="ex" data-note="[type='image']">
-<input type="month" value="X" data-role="textbox" data-platform="atspi,mac" class="ex" data-note="[type='month']">
-<input type="number" value="X" data-role="textbox" data-platform="atspi,mac" class="ex" data-note="[type='number']">
-<input type="password" value="X" data-role="textbox" data-platform="atspi,mac" class="ex" data-note="[type='password']">
-<input type="radio" data-role="radio" data-platform="atspi,mac" class="ex" data-note="[type='radio']">
-<input type="range" data-role="slider" data-platform="atspi,mac" class="ex" data-note="[type='range']">
-<input type="reset" data-role="button" data-platform="atspi,mac" class="ex" data-note="[type='reset']">
-<input type="search" value="X" data-role="searchbox" data-platform="atspi,mac" class="ex" data-note="[type='search']">
-<input type="submit" data-role="button" data-platform="atspi,mac" class="ex" data-note="[type='submit']">
-<input type="tel" value="X" data-role="textbox" data-platform="atspi,mac" class="ex" data-note="[type='tel']">
-<input type="text" value="X" data-role="textbox" data-platform="atspi,mac" class="ex" data-note="[type='text']">
-<input type="time" value="X" data-role="textbox" data-platform="atspi,mac" class="ex" data-note="[type='time']">
-<input type="url" value="X" data-role="textbox" data-platform="atspi,mac" class="ex" data-note="[type='url']">
-<input type="week" value="X" data-role="textbox" data-platform="atspi,mac" class="ex" data-note="[type='week']">
-<ins data-role="insertion" data-platform="atspi,mac" class="ex">X</ins>
-<mark data-role="mark" data-platform="atspi,mac" class="ex">X</mark>
-<math data-role="math" data-platform="atspi,mac" class="ex">X</math>
+<footer data-role="contentinfo" data-platform="atspi,mac" id="ex8" class="ex">X</footer>
+<form data-role="form" data-platform="atspi,mac" id="ex9" class="ex">X</form>
+<header data-role="banner" data-platform="atspi,mac" id="ex10" class="ex">X</header>
+<h1 data-role="heading" data-platform="atspi,mac" id="ex11" class="ex">X</h1>
+<h2 data-role="heading" data-platform="atspi,mac" id="ex12" class="ex">X</h2>
+<h3 data-role="heading" data-platform="atspi,mac" id="ex13" class="ex">X</h3>
+<h4 data-role="heading" data-platform="atspi,mac" id="ex14" class="ex">X</h4>
+<h5 data-role="heading" data-platform="atspi,mac" id="ex15" class="ex">X</h5>
+<h5 data-role="heading" data-platform="atspi,mac" id="ex16" class="ex">X</h6>
+<hr data-role="separator" data-platform="atspi,mac" id="ex17" class="ex">
+<img data-role="image" data-platform="atspi,mac" id="ex18" class="ex" data-note=":not([src]):not([alt])">
+<img data-role="" data-platform="atspi,mac" id="ex19" class="ex" alt="" data-note="[alt='']">
+<img data-role="image" data-platform="atspi,mac" id="ex20" class="ex" src="foo.png" data-note="[src]:not([alt])">
+<img data-role="image" data-platform="atspi,mac" id="ex21" class="ex" alt="X" data-note="[alt='X']">
+<input type="button" value="X" data-role="button" data-platform="atspi,mac" id="ex22" class="ex" data-note="[type='button']">
+<input type="checkbox" data-role="checkbox" data-platform="atspi,mac" id="ex23" class="ex" data-note="[type='checkbox']">
+<input type="date" data-role="textbox" data-platform="atspi,mac" id="ex24" class="ex" data-note="[type='date']">
+<input type="datetime" value="X" data-role="textbox" data-platform="atspi,mac" id="ex25" class="ex" data-note="[type='datetime']">
+<input type="datetime-local" value="X" data-role="textbox" data-platform="atspi,mac" id="ex26" class="ex" data-note="[type='datetime-local']">
+<input type="email" value="X" data-role="textbox" data-platform="atspi,mac" id="ex27" class="ex" data-note="[type='email']">
+<input type="file" data-role="button" data-platform="atspi,mac" id="ex28" class="ex" data-note="[type='file']">
+<input type="hidden" data-role="" data-platform="atspi,mac" id="ex29" class="ex" data-note="[type='hidden']">
+<input type="image" data-role="button" data-platform="atspi,mac" id="ex30" class="ex" data-note="[type='image']">
+<input type="month" value="X" data-role="textbox" data-platform="atspi,mac" id="ex31" class="ex" data-note="[type='month']">
+<input type="number" value="X" data-role="textbox" data-platform="atspi,mac" id="ex32" class="ex" data-note="[type='number']">
+<input type="password" value="X" data-role="textbox" data-platform="atspi,mac" id="ex33" class="ex" data-note="[type='password']">
+<input type="radio" data-role="radio" data-platform="atspi,mac" id="ex34" class="ex" data-note="[type='radio']">
+<input type="range" data-role="slider" data-platform="atspi,mac" id="ex35" class="ex" data-note="[type='range']">
+<input type="reset" data-role="button" data-platform="atspi,mac" id="ex36" class="ex" data-note="[type='reset']">
+<input type="search" value="X" data-role="searchbox" data-platform="atspi,mac" id="ex37" class="ex" data-note="[type='search']">
+<input type="submit" data-role="button" data-platform="atspi,mac" id="ex38" class="ex" data-note="[type='submit']">
+<input type="tel" value="X" data-role="textbox" data-platform="atspi,mac" id="ex39" class="ex" data-note="[type='tel']">
+<input type="text" value="X" data-role="textbox" data-platform="atspi,mac" id="ex40" class="ex" data-note="[type='text']">
+<input type="time" value="X" data-role="textbox" data-platform="atspi,mac" id="ex41" class="ex" data-note="[type='time']">
+<input type="url" value="X" data-role="textbox" data-platform="atspi,mac" id="ex42" class="ex" data-note="[type='url']">
+<input type="week" value="X" data-role="textbox" data-platform="atspi,mac" id="ex43" class="ex" data-note="[type='week']">
+<ins data-role="insertion" data-platform="atspi,mac" id="ex44" class="ex">X</ins>
+<mark data-role="mark" data-platform="atspi,mac" id="ex45" class="ex">X</mark>
+<math data-role="math" data-platform="atspi,mac" id="ex46" class="ex">X</math>
 <!-- skipped <menu> -->
 <!-- skipped <meta> -->
-<!-- renable for atspi after http://webkit.org/b/163383 fixed --><meter data-role="meter" data-platform="mac" class="ex" value="0.75">X</meter>
-<nav data-role="navigation" data-platform="atspi,mac" class="ex">X</nav>
+<!-- renable for atspi after http://webkit.org/b/163383 fixed --><meter data-role="meter" data-platform="mac" id="ex47" class="ex" value="0.75">X</meter>
+<nav data-role="navigation" data-platform="atspi,mac" id="ex48" class="ex">X</nav>
 <!-- skipped <noscript> -->
 <!-- skipped <object> -->
-<ol data-role="list" data-platform="atspi,mac" class="ex">
-    <li data-role="listitem" data-platform="atspi,mac" class="ex">X</li>
+<ol data-role="list" data-platform="atspi,mac" id="ex49" class="ex">
+    <li data-role="listitem" data-platform="atspi,mac" id="ex50" class="ex">X</li>
 </ol>
 <!-- skipped <optgroup> -->
 <!-- skipped <option> -->
 <!-- skipped <output> -->
-<p data-role="paragraph" data-platform="atspi,mac" class="ex">X</p>
+<p data-role="paragraph" data-platform="atspi,mac" id="ex51" class="ex">X</p>
 <!-- skipped <param> -->
-<pre data-role="" data-platform="atspi,mac" class="ex">X</pre>
-<progress data-role="progressbar" data-platform="atspi,mac" class="ex" value="0.75">X</progress>
-<q data-role="" data-platform="atspi,mac" class="ex">X</q>
+<pre data-role="" data-platform="atspi,mac" id="ex52" class="ex">X</pre>
+<progress data-role="progressbar" data-platform="atspi,mac" id="ex53" class="ex" value="0.75">X</progress>
+<q data-role="" data-platform="atspi,mac" id="ex54" class="ex">X</q>
 <!-- skipped <ruby/rp/rt> -->
-<s data-role="" data-platform="atspi,mac" class="ex">X</s>
-<samp data-role="" data-platform="atspi,mac" class="ex">X</samp>
+<s data-role="" data-platform="atspi,mac" id="ex55" class="ex">X</s>
+<samp data-role="" data-platform="atspi,mac" id="ex56" class="ex">X</samp>
 <!-- skipped <script> -->
-<section data-role="" data-platform="atspi,mac" class="ex" data-note=":not([aria-label]:not([aria-labelledby])">X</section>
-<section data-role="region" data-platform="atspi,mac" class="ex" aria-label="x" data-note="[aria-label]">X</section>
-<section data-role="region" data-platform="atspi,mac" class="ex" aria-labelledby="section-label" data-note="[aria-labelledby]">
+<section data-role="" data-platform="atspi,mac" id="ex57" class="ex" data-note=":not([aria-label]:not([aria-labelledby])">X</section>
+<section data-role="region" data-platform="atspi,mac" id="ex58" class="ex" aria-label="x" data-note="[aria-label]">X</section>
+<section data-role="region" data-platform="atspi,mac" id="ex59" class="ex" aria-labelledby="section-label" data-note="[aria-labelledby]">
     <h2 id="section-label">X</h2>
 </section>
-<select data-role="button" data-platform="atspi,mac" class="ex" data-note=":not([multiple])">
-    <option data-role="" data-platform="atspi,mac" class="ex">X</option>
-    <optgroup data-role="" data-platform="atspi,mac" class="ex" label="more">
-        <option data-role="" data-platform="atspi,mac" class="ex">X</option>
+<select data-role="button" data-platform="atspi,mac" id="ex60" class="ex" data-note=":not([multiple])">
+    <option data-role="" data-platform="atspi,mac" id="ex61" class="ex">X</option>
+    <optgroup data-role="" data-platform="atspi,mac" id="ex62" class="ex" label="more">
+        <option data-role="" data-platform="atspi,mac" id="ex63" class="ex">X</option>
     </optgroup>
 </select>
-<select data-role="listbox" data-platform="atspi,mac" class="ex" multiple data-note="[multiple]">
-    <option data-role="option" data-platform="atspi,mac" class="ex">X</option>
-    <optgroup data-role="option" data-platform="atspi,mac" class="ex" label="more">
-        <option data-role="option" data-platform="atspi,mac" class="ex">Y</option>
-        <option data-role="option" data-platform="atspi,mac" class="ex">Z</option>
+<select data-role="listbox" data-platform="atspi,mac" id="ex64" class="ex" multiple data-note="[multiple]">
+    <option data-role="option" data-platform="atspi,mac" id="ex65" class="ex">X</option>
+    <optgroup data-role="option" data-platform="atspi,mac" id="ex66" class="ex" label="more">
+        <option data-role="option" data-platform="atspi,mac" id="ex67" class="ex">Y</option>
+        <option data-role="option" data-platform="atspi,mac" id="ex68" class="ex">Z</option>
     </optgroup>
 </select>
-<small data-role="" data-platform="atspi,mac" class="ex">X</small>
-<span data-role="" data-platform="atspi,mac" class="ex">X</span>
-<strong data-role="" data-platform="atspi,mac" class="ex">X</strong>
-<sub data-role="subscript" data-platform="atspi,mac" class="ex">X</sub>
-<sup data-role="superscript" data-platform="atspi,mac" class="ex">X</sup>
-<svg data-role="" data-platform="atspi,mac" class="ex">X</svg>
+<small data-role="" data-platform="atspi,mac" id="ex69" class="ex">X</small>
+<span data-role="" data-platform="atspi,mac" id="ex70" class="ex">X</span>
+<strong data-role="" data-platform="atspi,mac" id="ex71" class="ex">X</strong>
+<sub data-role="subscript" data-platform="atspi,mac" id="ex72" class="ex">X</sub>
+<sup data-role="superscript" data-platform="atspi,mac" id="ex73" class="ex">X</sup>
+<svg data-role="" data-platform="atspi,mac" id="ex74" class="ex">X</svg>
 
-<table data-role="table" data-platform="atspi,mac" class="ex">
-    <caption data-role="caption" data-platform="atspi,mac" class="ex">X</caption>
-    <thead data-role="rowgroup" data-platform="atspi,mac" class="ex">
-        <tr data-role="row" data-platform="atspi,mac" class="ex">
-            <th data-role="columnheader" data-platform="atspi,mac" class="ex">X</th>
+<table data-role="table" data-platform="atspi,mac" id="ex75" class="ex">
+    <caption data-role="caption" data-platform="atspi,mac" id="ex76" class="ex">X</caption>
+    <thead data-role="rowgroup" data-platform="atspi,mac" id="ex77" class="ex">
+        <tr data-role="row" data-platform="atspi,mac" id="ex78" class="ex">
+            <th data-role="columnheader" data-platform="atspi,mac" id="ex79" class="ex">X</th>
         </tr>
     </thead>
-    <tbody data-role="rowgroup" data-platform="atspi,mac" class="ex">
-        <tr data-role="row" data-platform="atspi,mac" class="ex">
-            <td data-role="cell" data-platform="atspi,mac" class="ex">X</td>
+    <tbody data-role="rowgroup" data-platform="atspi,mac" id="ex80" class="ex">
+        <tr data-role="row" data-platform="atspi,mac" id="ex81" class="ex">
+            <td data-role="cell" data-platform="atspi,mac" id="ex82" class="ex">X</td>
         </tr>
     </tbody>
-    <tfoot data-role="rowgroup" data-platform="atspi,mac" class="ex">
-        <tr data-role="row" data-platform="atspi,mac" class="ex">
-            <td data-role="cell" data-platform="atspi,mac" class="ex">X</td>
+    <tfoot data-role="rowgroup" data-platform="atspi,mac" id="ex83" class="ex">
+        <tr data-role="row" data-platform="atspi,mac" id="ex84" class="ex">
+            <td data-role="cell" data-platform="atspi,mac" id="ex85" class="ex">X</td>
         </tr>
     </tfoot>
 </table>
 
-<table role="grid" data-role="grid" data-platform="atspi,mac" class="ex">
-    <caption data-role="caption" data-platform="atspi,mac" class="ex">X</caption>
-    <thead data-role="rowgroup" data-platform="atspi,mac" class="ex">
-        <tr data-role="row" data-platform="atspi,mac" class="ex">
-            <th data-role="columnheader" data-platform="atspi,mac" class="ex">X</th>
+<table role="grid" data-role="grid" data-platform="atspi,mac" id="ex86" class="ex">
+    <caption data-role="caption" data-platform="atspi,mac" id="ex87" class="ex">X</caption>
+    <thead data-role="rowgroup" data-platform="atspi,mac" id="ex88" class="ex">
+        <tr data-role="row" data-platform="atspi,mac" id="ex89" class="ex">
+            <th data-role="columnheader" data-platform="atspi,mac" id="ex90" class="ex">X</th>
         </tr>
     </thead>
-    <tbody data-role="rowgroup" data-platform="atspi,mac" class="ex">
-        <tr data-role="row" data-platform="atspi,mac" class="ex">
-            <td role="gridcell" data-role="gridcell" data-platform="atspi,mac" class="ex">X</td>
+    <tbody data-role="rowgroup" data-platform="atspi,mac" id="ex91" class="ex">
+        <tr data-role="row" data-platform="atspi,mac" id="ex92" class="ex">
+            <td role="gridcell" data-role="gridcell" data-platform="atspi,mac" id="ex93" class="ex">X</td>
         </tr>
     </tbody>
-    <tfoot data-role="rowgroup" data-platform="atspi,mac" class="ex">
-        <tr data-role="row" data-platform="atspi,mac" class="ex">
-            <td role="gridcell" data-role="gridcell" data-platform="atspi,mac" class="ex">X</td>
+    <tfoot data-role="rowgroup" data-platform="atspi,mac" id="ex94" class="ex">
+        <tr data-role="row" data-platform="atspi,mac" id="ex95" class="ex">
+            <td role="gridcell" data-role="gridcell" data-platform="atspi,mac" id="ex96" class="ex">X</td>
         </tr>
     </tfoot>
 </table>
 
-<textarea data-role="textbox" data-platform="atspi,mac" class="ex">X</textarea>
-<time data-role="time" data-platform="atspi,mac" class="ex">X</time>
-<ul data-role="list" data-platform="atspi,mac" class="ex">
-    <li data-role="listitem" data-platform="atspi,mac" class="ex">X</li>
+<textarea data-role="textbox" data-platform="atspi,mac" id="ex97" class="ex">X</textarea>
+<time data-role="time" data-platform="atspi,mac" id="ex98" class="ex">X</time>
+<ul data-role="list" data-platform="atspi,mac" id="ex99" class="ex">
+    <li data-role="listitem" data-platform="atspi,mac" id="ex100" class="ex">X</li>
 </ul>
-<var data-role="" data-platform="atspi,mac" class="ex">X</var>
-<wbr data-role="" data-platform="atspi,mac" class="ex">X</wbr>
+<var data-role="" data-platform="atspi,mac" id="ex101" class="ex">X</var>
+<wbr data-role="" data-platform="atspi,mac" id="ex102" class="ex">X</wbr>
 
 <!-- ==================================================================================================== -->
 <!-- Abstract ARIA roles in alphabetical order; only generic role should be exposed on abstract roles -->
 <!-- ==================================================================================================== -->
-<div role="command"     data-role="generic" data-platform="atspi,mac" class="ex">X</div>
-<div role="composite"   data-role="generic" data-platform="atspi,mac" class="ex">X</div>
-<div role="input"       data-role="generic" data-platform="atspi,mac" class="ex">X</div>
-<div role="landmark"    data-role="generic" data-platform="atspi,mac" class="ex">X</div>
-<div role="range"       data-role="generic" data-platform="atspi,mac" class="ex">X</div>
-<div role="roletype"    data-role="generic" data-platform="atspi,mac" class="ex">X</div>
-<div role="section"     data-role="generic" data-platform="atspi,mac" class="ex">X</div>
-<div role="sectionhead" data-role="generic" data-platform="atspi,mac" class="ex">X</div>
-<div role="select"      data-role="generic" data-platform="atspi,mac" class="ex">X</div>
-<div role="structure"   data-role="generic" data-platform="atspi,mac" class="ex">X</div>
-<div role="widget"      data-role="generic" data-platform="atspi,mac" class="ex">X</div>
-<div role="window"      data-role="generic" data-platform="atspi,mac" class="ex">X</div>
+<div role="command"     data-role="generic" data-platform="atspi,mac" id="ex103" class="ex">X</div>
+<div role="composite"   data-role="generic" data-platform="atspi,mac" id="ex104" class="ex">X</div>
+<div role="input"       data-role="generic" data-platform="atspi,mac" id="ex105" class="ex">X</div>
+<div role="landmark"    data-role="generic" data-platform="atspi,mac" id="ex106" class="ex">X</div>
+<div role="range"       data-role="generic" data-platform="atspi,mac" id="ex107" class="ex">X</div>
+<div role="roletype"    data-role="generic" data-platform="atspi,mac" id="ex108" class="ex">X</div>
+<div role="section"     data-role="generic" data-platform="atspi,mac" id="ex109" class="ex">X</div>
+<div role="sectionhead" data-role="generic" data-platform="atspi,mac" id="ex110" class="ex">X</div>
+<div role="select"      data-role="generic" data-platform="atspi,mac" id="ex111" class="ex">X</div>
+<div role="structure"   data-role="generic" data-platform="atspi,mac" id="ex112" class="ex">X</div>
+<div role="widget"      data-role="generic" data-platform="atspi,mac" id="ex113" class="ex">X</div>
+<div role="window"      data-role="generic" data-platform="atspi,mac" id="ex114" class="ex">X</div>
 
 
 <!-- ==================================================================================================== -->
 <!-- Non-abstract ARIA roles in alphabetical order, excepting the need for nesting (e.g. row is with its grid parent) -->
 <!-- ==================================================================================================== -->
-<div role="alert"                    data-role="alert" data-platform="atspi,mac" class="ex">X</div>
-<div role="alertdialog"              data-role="alertdialog" data-platform="atspi,mac" class="ex">X</div>
-<div role="application"              data-role="application" data-platform="atspi,mac" class="ex">X</div>
-<div role="article"                  data-role="article" data-platform="atspi,mac" class="ex">X</div>
-<div role="banner"                   data-role="banner" data-platform="atspi,mac" class="ex">X</div>
-<div role="blockquote"               data-role="blockquote" data-platform="atspi,mac" class="ex">X</div>
-<div role="button"                   data-role="button" data-platform="atspi,mac" class="ex">X</div>
-<div role="caption"                  data-role="caption" data-platform="atspi,mac" class="ex">X</div>
-<div role="checkbox"                 data-role="checkbox" data-platform="atspi,mac" class="ex">X</div>
-<div role="code"                     data-role="code" data-platform="atspi,mac" class="ex">X</div>
-<div role="combobox"                 data-role="combobox" data-platform="atspi,mac" class="ex">X</div>
-<div role="complementary"            data-role="complementary" data-platform="atspi,mac" class="ex">X</div>
-<div role="contentinfo"              data-role="contentinfo" data-platform="atspi,mac" class="ex">X</div>
-<div role="definition"               data-role="definition" data-platform="atspi,mac" class="ex">X</div>
-<div role="deletion"                 data-role="deletion" data-platform="atspi,mac" class="ex">X</div>
-<div role="dialog"                   data-role="dialog" data-platform="atspi,mac" class="ex">X</div>
-<div role="directory"                data-role="list" data-platform="atspi,mac" class="ex">X</div><!-- FIXME: should be directory -->
-<div role="document"                 data-role="document" data-platform="atspi,mac" class="ex">X</div>
-<div role="figure"                   data-role="figure" data-platform="atspi,mac" class="ex">X</div>
-<div role="form"                     data-role="generic" data-platform="atspi,mac" class="ex" data-note=":not([aria-label]:not([aria-labelledby])">X</div>
-<div role="form"                     data-role="form" data-platform="atspi,mac" class="ex" aria-label="x" data-note="[aria-label]">X</div>
-<div role="form"                     data-role="form" data-platform="atspi,mac" class="ex" aria-labelledby="form-label" data-note="[aria-labelledby]">
+<div role="alert"                    data-role="alert" data-platform="atspi,mac" id="ex115" class="ex">X</div>
+<div role="alertdialog"              data-role="alertdialog" data-platform="atspi,mac" id="ex116" class="ex">X</div>
+<div role="application"              data-role="application" data-platform="atspi,mac" id="ex117" class="ex">X</div>
+<div role="article"                  data-role="article" data-platform="atspi,mac" id="ex118" class="ex">X</div>
+<div role="banner"                   data-role="banner" data-platform="atspi,mac" id="ex119" class="ex">X</div>
+<div role="blockquote"               data-role="blockquote" data-platform="atspi,mac" id="ex120" class="ex">X</div>
+<div role="button"                   data-role="button" data-platform="atspi,mac" id="ex121" class="ex">X</div>
+<div role="caption"                  data-role="caption" data-platform="atspi,mac" id="ex122" class="ex">X</div>
+<div role="checkbox"                 data-role="checkbox" data-platform="atspi,mac" id="ex123" class="ex">X</div>
+<div role="code"                     data-role="code" data-platform="atspi,mac" id="ex124" class="ex">X</div>
+<div role="combobox"                 data-role="combobox" data-platform="atspi,mac" id="ex125" class="ex">X</div>
+<div role="complementary"            data-role="complementary" data-platform="atspi,mac" id="ex126" class="ex">X</div>
+<div role="contentinfo"              data-role="contentinfo" data-platform="atspi,mac" id="ex127" class="ex">X</div>
+<div role="definition"               data-role="definition" data-platform="atspi,mac" id="ex128" class="ex">X</div>
+<div role="deletion"                 data-role="deletion" data-platform="atspi,mac" id="ex129" class="ex">X</div>
+<div role="dialog"                   data-role="dialog" data-platform="atspi,mac" id="ex130" class="ex">X</div>
+<div role="directory"                data-role="list" data-platform="atspi,mac" id="ex131" class="ex">X</div><!-- FIXME: should be directory -->
+<div role="document"                 data-role="document" data-platform="atspi,mac" id="ex132" class="ex">X</div>
+<div role="figure"                   data-role="figure" data-platform="atspi,mac" id="ex133" class="ex">X</div>
+<div role="form"                     data-role="generic" data-platform="atspi,mac" id="ex134" class="ex" data-note=":not([aria-label]:not([aria-labelledby])">X</div>
+<div role="form"                     data-role="form" data-platform="atspi,mac" id="ex135" class="ex" aria-label="x" data-note="[aria-label]">X</div>
+<div role="form"                     data-role="form" data-platform="atspi,mac" id="ex136" class="ex" aria-labelledby="form-label" data-note="[aria-labelledby]">
     <h2 id="form-label">X</h2>
 </div>
-<div role="grid"                     data-role="grid" data-platform="atspi,mac" class="ex">
-    <div role="rowgroup"             data-role="rowgroup" data-platform="atspi,mac" class="ex">
-        <div role="row"              data-role="row" data-platform="atspi,mac" class="ex">
-            <div role="rowheader"    data-role="rowheader" data-platform="atspi,mac" class="ex">X</div>
-            <div role="columnheader" data-role="columnheader" data-platform="atspi,mac" class="ex">X</div>
-            <div role="gridcell"     data-role="gridcell" data-platform="atspi,mac" class="ex">X</div>
+<div role="grid"                     data-role="grid" data-platform="atspi,mac" id="ex137" class="ex">
+    <div role="rowgroup"             data-role="rowgroup" data-platform="atspi,mac" id="ex138" class="ex">
+        <div role="row"              data-role="row" data-platform="atspi,mac" id="ex139" class="ex">
+            <div role="rowheader"    data-role="rowheader" data-platform="atspi,mac" id="ex140" class="ex">X</div>
+            <div role="columnheader" data-role="columnheader" data-platform="atspi,mac" id="ex141" class="ex">X</div>
+            <div role="gridcell"     data-role="gridcell" data-platform="atspi,mac" id="ex142" class="ex">X</div>
         </div>
     </div>
 </div>
-<div role="feed"                     data-role="feed" data-platform="atspi,mac" class="ex">X</div>
-<div role="group"                    data-role="group" data-platform="atspi,mac" class="ex">X</div>
-<div role="heading"                  data-role="heading" data-platform="atspi,mac" class="ex">X</div>
-<div role="img"                      data-role="image" data-platform="atspi,mac" class="ex">X</div>
-<div role="insertion"                data-role="insertion" data-platform="atspi,mac" class="ex">X</div>
-<div role="link"                     data-role="link" data-platform="atspi,mac" class="ex">X</div>
-<div role="list"                     data-role="list" data-platform="atspi,mac" class="ex">
-    <div role="listitem"             data-role="listitem" data-platform="atspi,mac" class="ex">X</div>
+<div role="feed"                     data-role="feed" data-platform="atspi,mac" id="ex143" class="ex">X</div>
+<div role="group"                    data-role="group" data-platform="atspi,mac" id="ex144" class="ex">X</div>
+<div role="heading"                  data-role="heading" data-platform="atspi,mac" id="ex145" class="ex">X</div>
+<div role="img"                      data-role="image" data-platform="atspi,mac" id="ex146" class="ex">X</div>
+<div role="insertion"                data-role="insertion" data-platform="atspi,mac" id="ex147" class="ex">X</div>
+<div role="link"                     data-role="link" data-platform="atspi,mac" id="ex148" class="ex">X</div>
+<div role="list"                     data-role="list" data-platform="atspi,mac" id="ex149" class="ex">
+    <div role="listitem"             data-role="listitem" data-platform="atspi,mac" id="ex150" class="ex">X</div>
 </div>
-<div role="listbox" data-role="listbox" data-platform="atspi,mac" class="ex">
-    <div role="option"               data-role="option" data-platform="atspi,mac" class="ex">X</div>
+<div role="listbox" data-role="listbox" data-platform="atspi,mac" id="ex151" class="ex">
+    <div role="option"               data-role="option" data-platform="atspi,mac" id="ex152" class="ex">X</div>
 </div>
-<div role="log"                      data-role="log" data-platform="atspi,mac" class="ex">X</div>
-<div role="main"                     data-role="main" data-platform="atspi,mac" class="ex">X</div>
-<div role="marquee"                  data-role="marquee" data-platform="atspi,mac" class="ex">X</div>
-<div role="math"                     data-role="math" data-platform="atspi,mac" class="ex">X</div>
-<div role="menu"                     data-role="menu" data-platform="atspi,mac" class="ex">
-    <div role="menuitem"             data-role="menuitem" data-platform="atspi,mac" class="ex">X</div>
-    <div role="menuitemcheckbox"     data-role="menuitemcheckbox" data-platform="atspi,mac" class="ex">X</div>
-    <div role="menuitemradio"        data-role="menuitemradio" data-platform="atspi,mac" class="ex">X</div>
-    <div role="group"                data-role="group" data-platform="atspi,mac" class="ex">
-        <div role="menuitem"         data-role="menuitem" data-platform="atspi,mac" class="ex">x</div>
+<div role="log"                      data-role="log" data-platform="atspi,mac" id="ex153" class="ex">X</div>
+<div role="main"                     data-role="main" data-platform="atspi,mac" id="ex154" class="ex">X</div>
+<div role="marquee"                  data-role="marquee" data-platform="atspi,mac" id="ex155" class="ex">X</div>
+<div role="math"                     data-role="math" data-platform="atspi,mac" id="ex156" class="ex">X</div>
+<div role="menu"                     data-role="menu" data-platform="atspi,mac" id="ex157" class="ex">
+    <div role="menuitem"             data-role="menuitem" data-platform="atspi,mac" id="ex158" class="ex">X</div>
+    <div role="menuitemcheckbox"     data-role="menuitemcheckbox" data-platform="atspi,mac" id="ex159" class="ex">X</div>
+    <div role="menuitemradio"        data-role="menuitemradio" data-platform="atspi,mac" id="ex160" class="ex">X</div>
+    <div role="group"                data-role="group" data-platform="atspi,mac" id="ex161" class="ex">
+        <div role="menuitem"         data-role="menuitem" data-platform="atspi,mac" id="ex162" class="ex">x</div>
     </div>
 </div>
-<div role="menubar"                  data-role="menubar" data-platform="atspi,mac" class="ex">
-    <div role="menuitem"             data-role="menuitem" data-platform="atspi,mac" class="ex">X</div>
-    <div role="menuitemcheckbox"     data-role="menuitemcheckbox" data-platform="atspi,mac" class="ex">X</div>
-    <div role="menuitemradio"        data-role="menuitemradio" data-platform="atspi,mac" class="ex">X</div>
-    <div role="group"                data-role="group" data-platform="atspi,mac" class="ex">
-        <div role="menuitem"         data-role="menuitem" data-platform="atspi,mac" class="ex">x</div>
+<div role="menubar"                  data-role="menubar" data-platform="atspi,mac" id="ex163" class="ex">
+    <div role="menuitem"             data-role="menuitem" data-platform="atspi,mac" id="ex164" class="ex">X</div>
+    <div role="menuitemcheckbox"     data-role="menuitemcheckbox" data-platform="atspi,mac" id="ex165" class="ex">X</div>
+    <div role="menuitemradio"        data-role="menuitemradio" data-platform="atspi,mac" id="ex166" class="ex">X</div>
+    <div role="group"                data-role="group" data-platform="atspi,mac" id="ex167" class="ex">
+        <div role="menuitem"         data-role="menuitem" data-platform="atspi,mac" id="ex168" class="ex">x</div>
     </div>
 </div>
-<div role="meter"                    data-role="meter" data-platform="atspi,mac" class="ex">X</div>
-<div role="navigation"               data-role="navigation" data-platform="atspi,mac" class="ex">X</div>
-<div role="note"                     data-role="note" data-platform="atspi,mac" class="ex">X</div>
-<div role="paragraph"                data-role="paragraph" data-platform="atspi,mac" class="ex">X</div>
-<div role="presentation"             data-role="" data-platform="atspi,mac" class="ex">X</div>
-<div role="progressbar"              data-role="progressbar" data-platform="atspi,mac" class="ex">X</div>
-<div role="radiogroup"               data-role="radiogroup" data-platform="atspi,mac" class="ex">
-    <div role="radio"                data-role="radio" data-platform="atspi,mac" class="ex">X</div>
+<div role="meter"                    data-role="meter" data-platform="atspi,mac" id="ex169" class="ex">X</div>
+<div role="navigation"               data-role="navigation" data-platform="atspi,mac" id="ex170" class="ex">X</div>
+<div role="note"                     data-role="note" data-platform="atspi,mac" id="ex171" class="ex">X</div>
+<div role="paragraph"                data-role="paragraph" data-platform="atspi,mac" id="ex172" class="ex">X</div>
+<div role="presentation"             data-role="" data-platform="atspi,mac" id="ex173" class="ex">X</div>
+<div role="progressbar"              data-role="progressbar" data-platform="atspi,mac" id="ex174" class="ex">X</div>
+<div role="radiogroup"               data-role="radiogroup" data-platform="atspi,mac" id="ex175" class="ex">
+    <div role="radio"                data-role="radio" data-platform="atspi,mac" id="ex176" class="ex">X</div>
 </div>
-<div role="region"                   data-platform="atspi,mac" class="ex" data-role="generic" data-note=":not([aria-label]:not([aria-labelledby])">X</div>
-<div role="region"                   data-platform="atspi,mac" class="ex" data-role="region" aria-label="x" data-note="[aria-label]">X</div>
-<div role="region"                   data-platform="atspi,mac" class="ex" data-role="region" aria-labelledby="region-label" data-note="[aria-labelledby]">
+<div role="region"                   data-platform="atspi,mac" id="ex177" class="ex" data-role="generic" data-note=":not([aria-label]:not([aria-labelledby])">X</div>
+<div role="region"                   data-platform="atspi,mac" id="ex178" class="ex" data-role="region" aria-label="x" data-note="[aria-label]">X</div>
+<div role="region"                   data-platform="atspi,mac" id="ex179" class="ex" data-role="region" aria-labelledby="region-label" data-note="[aria-labelledby]">
     <h2 id="region-label">X</h2>
 </div>
 
-<div role="scrollbar"                data-role="scrollbar" data-platform="atspi,mac" class="ex">X</div>
-<div role="search"                   data-role="search" data-platform="atspi,mac" class="ex">X</div>
-<div role="separator"                data-role="separator" data-platform="atspi,mac" class="ex">X</div>
-<div role="slider"                   data-role="slider" data-platform="atspi,mac" class="ex">X</div>
-<div role="spinbutton"               data-role="spinbutton" data-platform="atspi,mac" class="ex">X</div>
-<div role="status"                   data-role="status" data-platform="atspi,mac" class="ex">X</div>
-<div role="subscript"                data-role="subscript" data-platform="atspi,mac" class="ex">X</div>
-<div role="superscript"              data-role="superscript" data-platform="atspi,mac" class="ex">X</div>
-<div role="tablist"                  data-role="tablist" data-platform="atspi,mac" class="ex">
-    <div role="tab"                  data-role="tab" data-platform="atspi,mac" class="ex">X</div>
+<div role="scrollbar"                data-role="scrollbar" data-platform="atspi,mac" id="ex180" class="ex">X</div>
+<div role="search"                   data-role="search" data-platform="atspi,mac" id="ex181" class="ex">X</div>
+<div role="separator"                data-role="separator" data-platform="atspi,mac" id="ex182" class="ex">X</div>
+<div role="slider"                   data-role="slider" data-platform="atspi,mac" id="ex183" class="ex">X</div>
+<div role="spinbutton"               data-role="spinbutton" data-platform="atspi,mac" id="ex184" class="ex">X</div>
+<div role="status"                   data-role="status" data-platform="atspi,mac" id="ex185" class="ex">X</div>
+<div role="subscript"                data-role="subscript" data-platform="atspi,mac" id="ex186" class="ex">X</div>
+<div role="superscript"              data-role="superscript" data-platform="atspi,mac" id="ex187" class="ex">X</div>
+<div role="tablist"                  data-role="tablist" data-platform="atspi,mac" id="ex188" class="ex">
+    <div role="tab"                  data-role="tab" data-platform="atspi,mac" id="ex189" class="ex">X</div>
 </div>
-<div role="tabpanel"                 data-role="tabpanel" data-platform="atspi,mac" class="ex">X</div>
-<div role="textbox"                  data-role="textbox" data-platform="atspi,mac" class="ex">X</div>
-<div role="term"                     data-role="term" data-platform="atspi,mac" class="ex">X</div>
-<div role="time"                     data-role="time" data-platform="atspi,mac" class="ex">X</div>
-<div role="timer"                    data-role="timer" data-platform="atspi,mac" class="ex">X</div>
-<div role="toolbar"                  data-role="toolbar" data-platform="atspi,mac" class="ex">X</div>
-<div role="tooltip"                  data-role="tooltip" data-platform="atspi,mac" class="ex">X</div>
-<div role="tree"                     data-role="tree" data-platform="atspi,mac" class="ex">
-    <div role="treeitem"             data-role="treeitem" data-platform="atspi,mac" class="ex">X</div>
-    <div role="group"                data-role="group" data-platform="atspi,mac" class="ex">
-        <div role="treeitem"         data-role="treeitem" data-platform="atspi,mac" class="ex">X</div>
+<div role="tabpanel"                 data-role="tabpanel" data-platform="atspi,mac" id="ex190" class="ex">X</div>
+<div role="textbox"                  data-role="textbox" data-platform="atspi,mac" id="ex191" class="ex">X</div>
+<div role="term"                     data-role="term" data-platform="atspi,mac" id="ex192" class="ex">X</div>
+<div role="time"                     data-role="time" data-platform="atspi,mac" id="ex193" class="ex">X</div>
+<div role="timer"                    data-role="timer" data-platform="atspi,mac" id="ex194" class="ex">X</div>
+<div role="toolbar"                  data-role="toolbar" data-platform="atspi,mac" id="ex195" class="ex">X</div>
+<div role="tooltip"                  data-role="tooltip" data-platform="atspi,mac" id="ex196" class="ex">X</div>
+<div role="tree"                     data-role="tree" data-platform="atspi,mac" id="ex197" class="ex">
+    <div role="treeitem"             data-role="treeitem" data-platform="atspi,mac" id="ex198" class="ex">X</div>
+    <div role="group"                data-role="group" data-platform="atspi,mac" id="ex199" class="ex">
+        <div role="treeitem"         data-role="treeitem" data-platform="atspi,mac" id="ex200" class="ex">X</div>
     </div>
 </div>
-<div role="treegrid"                 data-role="treegrid" data-platform="atspi,mac" class="ex">
-    <div role="rowgroup"             data-role="rowgroup" data-platform="atspi,mac" class="ex">
-        <div role="row"              data-role="row" data-platform="atspi,mac" class="ex">
-            <div role="rowheader"    data-role="rowheader" data-platform="atspi,mac" class="ex">X</div>
-            <div role="columnheader" data-role="columnheader" data-platform="atspi,mac" class="ex">X</div>
-            <div role="gridcell"     data-role="gridcell" data-platform="atspi,mac" class="ex">X</div>
+<div role="treegrid"                 data-role="treegrid" data-platform="atspi,mac" id="ex201" class="ex">
+    <div role="rowgroup"             data-role="rowgroup" data-platform="atspi,mac" id="ex202" class="ex">
+        <div role="row"              data-role="row" data-platform="atspi,mac" id="ex203" class="ex">
+            <div role="rowheader"    data-role="rowheader" data-platform="atspi,mac" id="ex204" class="ex">X</div>
+            <div role="columnheader" data-role="columnheader" data-platform="atspi,mac" id="ex205" class="ex">X</div>
+            <div role="gridcell"     data-role="gridcell" data-platform="atspi,mac" id="ex206" class="ex">X</div>
         </div>
     </div>
 </div>
@@ -288,31 +288,31 @@
 <!-- ==================================================================================================== -->
 <!-- generic role attribute parsing tests -->
 <!-- ==================================================================================================== -->
-<div role="generic"                  data-role="generic" data-platform="atspi,mac" class="ex">X</div>
-<div role="button foo"               data-role="button" data-platform="atspi,mac" class="ex">X</div>
-<div role="foo button bar"           data-role="button" data-platform="atspi,mac" class="ex">X</div>
-<div role="foo  button  bar"         data-role="button" data-platform="atspi,mac" class="ex">X</div><!-- [sic] Two spaces in role string -->
+<div role="generic"                  data-role="generic" data-platform="atspi,mac" id="ex207" class="ex">X</div>
+<div role="button foo"               data-role="button" data-platform="atspi,mac" id="ex208" class="ex">X</div>
+<div role="foo button bar"           data-role="button" data-platform="atspi,mac" id="ex209" class="ex">X</div>
+<div role="foo  button  bar"         data-role="button" data-platform="atspi,mac" id="ex210" class="ex">X</div><!-- [sic] Two spaces in role string -->
 
-<div role="foo	button	bar"         data-role="button" data-platform="atspi,mac" class="ex">X</div><!-- [sic] Tab chars in role string -->
+<div role="foo	button	bar"         data-role="button" data-platform="atspi,mac" id="ex211" class="ex">X</div><!-- [sic] Tab chars in role string -->
 <div role="foo
 button
-bar"                                 data-role="button" data-platform="atspi,mac" class="ex">X</div><!-- [sic] Newlines in role string -->
+bar"                                 data-role="button" data-platform="atspi,mac" id="ex212" class="ex">X</div><!-- [sic] Newlines in role string -->
 
 
 <!-- ==================================================================================================== -->
 <!-- implicit role parsing tests -->
 <!-- ==================================================================================================== -->
-<img role="foo" src="foo.png"        data-role="image" alt="X" data-platform="atspi,mac" class="ex">
-<img role="foo bar" src="foo.png"    data-role="image" alt="X" data-platform="atspi,mac" class="ex">
-<img role="foo  bar" src="foo.png"    data-role="image" alt="X" data-platform="atspi,mac" class="ex"><!-- [sic] Two spaces in role string -->
-<img role="foo	bar" src="foo.png"   data-role="image" alt="X" data-platform="atspi,mac" class="ex"><!-- [sic] Newline in role string -->
+<img role="foo" src="foo.png"        data-role="image" alt="X" data-platform="atspi,mac" id="ex213" class="ex">
+<img role="foo bar" src="foo.png"    data-role="image" alt="X" data-platform="atspi,mac" id="ex214" class="ex">
+<img role="foo  bar" src="foo.png"    data-role="image" alt="X" data-platform="atspi,mac" id="ex215" class="ex"><!-- [sic] Two spaces in role string -->
+<img role="foo	bar" src="foo.png"   data-role="image" alt="X" data-platform="atspi,mac" id="ex216" class="ex"><!-- [sic] Newline in role string -->
 <img role="foo	
-bar" src="foo.png"                   data-role="image" alt="X" data-platform="atspi,mac" class="ex"><!-- [sic] Tab char in role string -->
-<img role="text" src="foo.png"       data-role="text" alt="X" data-platform="atspi,mac" class="ex">
-<img role="text img" src="foo.png"   data-role="text" alt="X" data-platform="atspi,mac" class="ex">
-<img role="img text" src="foo.png"   data-role="image" alt="X" data-platform="atspi,mac" class="ex">
-<img role="presentation"             data-role="image" data-note="[aria-label]" alt="X" src="foo.png" aria-label="X" data-platform="atspi,mac" class="ex"><!-- presentation with global attr should fallback to implicit role -->
-<a href="#" role="foo bar"           data-role="link" data-platform="atspi,mac" class="ex">X</a>
+bar" src="foo.png"                   data-role="image" alt="X" data-platform="atspi,mac" id="ex217" class="ex"><!-- [sic] Tab char in role string -->
+<img role="text" src="foo.png"       data-role="text" alt="X" data-platform="atspi,mac" id="ex218" class="ex">
+<img role="text img" src="foo.png"   data-role="text" alt="X" data-platform="atspi,mac" id="ex219" class="ex">
+<img role="img text" src="foo.png"   data-role="image" alt="X" data-platform="atspi,mac" id="ex220" class="ex">
+<img role="presentation"             data-role="image" data-note="[aria-label]" alt="X" src="foo.png" aria-label="X" data-platform="atspi,mac" id="ex221" class="ex"><!-- presentation with global attr should fallback to implicit role -->
+<a href="#" role="foo bar"           data-role="link" data-platform="atspi,mac" id="ex222" class="ex">X</a>
 </div>
 
 <div id="console"></div>
@@ -325,7 +325,6 @@ if (window.testRunner && window.accessibilityController) {
     let consoleOutput = "";
     for (var i = 0, c = examples.length; i < c; i++) {
         el = examples[i];
-		el.id = "ex" + i
 
         axElement = accessibilityController.accessibleElementById(el.id);
         if (!axElement)

--- a/LayoutTests/accessibility/roles-exposed.html
+++ b/LayoutTests/accessibility/roles-exposed.html
@@ -8,223 +8,223 @@
 <!-- ==================================================================================================== -->
 <!-- HTML elements in alphabetical order, excepting the need for nesting (e.g., <li> is with its <menu>, <ol>, and <ul> parents) -->
 <!-- ==================================================================================================== -->
-<a data-platform="atspi,mac" href="#" data-note="[href]" class="ex">X</a>
-<a data-platform="atspi,mac" data-note=":not([href])" class="ex">X</a>
-<abbr data-platform="atspi,mac" data-note=":not([title])" class="ex">X</abbr>
-<abbr data-platform="atspi,mac" title="Times" data-note="[title]" class="ex">X</abbr>
-<!-- http://webkit.org/b/83989 --><address data-platform="atspi,mac" class="ex">X</address>
+<a data-platform="atspi,mac" href="#" data-note="[href]" id="ex0" class="ex">X</a>
+<a data-platform="atspi,mac" data-note=":not([href])" id="ex1" class="ex">X</a>
+<abbr data-platform="atspi,mac" data-note=":not([title])" id="ex2" class="ex">X</abbr>
+<abbr data-platform="atspi,mac" title="Times" data-note="[title]" id="ex3" class="ex">X</abbr>
+<!-- http://webkit.org/b/83989 --><address data-platform="atspi,mac" id="ex4" class="ex">X</address>
 <!-- skipped <area> -->
-<article data-platform="atspi,mac" class="ex">X</article>
-<aside data-platform="atspi,mac" class="ex">X</aside>
-<audio data-platform="atspi,mac" class="ex">X</audio>
-<b data-platform="atspi,mac" class="ex">X</b>
-<bdo data-platform="atspi,mac" class="ex">X</bdo>
-<blockquote data-platform="atspi,mac" class="ex">X</blockquote>
-<button data-platform="atspi,mac" class="ex">X</button>
-<canvas data-platform="atspi,mac" class="ex">X</canvas>
-<cite data-platform="atspi,mac" class="ex">X</cite>
-<code data-platform="atspi,mac" class="ex">X</code>
+<article data-platform="atspi,mac" id="ex5" class="ex">X</article>
+<aside data-platform="atspi,mac" id="ex6" class="ex">X</aside>
+<audio data-platform="atspi,mac" id="ex7" class="ex">X</audio>
+<b data-platform="atspi,mac" id="ex8" class="ex">X</b>
+<bdo data-platform="atspi,mac" id="ex9" class="ex">X</bdo>
+<blockquote data-platform="atspi,mac" id="ex10" class="ex">X</blockquote>
+<button data-platform="atspi,mac" id="ex11" class="ex">X</button>
+<canvas data-platform="atspi,mac" id="ex12" class="ex">X</canvas>
+<cite data-platform="atspi,mac" id="ex13" class="ex">X</cite>
+<code data-platform="atspi,mac" id="ex14" class="ex">X</code>
 <!-- skipped <command> -->
 <!-- skipped <datalist> -->
-<del data-platform="atspi,mac" data-note=":not([datetime])" class="ex">X</del>
-<del data-platform="atspi,mac" datetime="2014-10-31 00:00" data-note="[datetime]" class="ex">X</del>
+<del data-platform="atspi,mac" data-note=":not([datetime])" id="ex15" class="ex">X</del>
+<del data-platform="atspi,mac" datetime="2014-10-31 00:00" data-note="[datetime]" id="ex16" class="ex">X</del>
 <!-- skipped <details/summary> http://webkit.org/b/108979 -->
-<dfn data-platform="atspi,mac" class="ex">X</dfn>
-<dl data-platform="atspi,mac" class="ex">
-    <dt data-platform="atspi,mac" class="ex">X</dt>
-    <dd data-platform="atspi,mac" class="ex">X</dd>
+<dfn data-platform="atspi,mac" id="ex17" class="ex">X</dfn>
+<dl data-platform="atspi,mac" id="ex18" class="ex">
+    <dt data-platform="atspi,mac" id="ex19" class="ex">X</dt>
+    <dd data-platform="atspi,mac" id="ex20" class="ex">X</dd>
 </dl>
-<div data-platform="atspi,mac" class="ex">X</div>
-<em data-platform="atspi,mac" class="ex">X</em>
+<div data-platform="atspi,mac" id="ex21" class="ex">X</div>
+<em data-platform="atspi,mac" id="ex22" class="ex">X</em>
 <!-- skipped <embed> -->
-<fieldset data-platform="atspi,mac" class="ex">
-    <legend data-platform="atspi,mac" class="ex">X</legend>
+<fieldset data-platform="atspi,mac" id="ex23" class="ex">
+    <legend data-platform="atspi,mac" id="ex24" class="ex">X</legend>
 </fieldset>
-<figure data-platform="atspi,mac" class="ex">X</figure>
-<footer data-platform="atspi,mac" class="ex">X</footer>
-<form data-platform="atspi,mac" class="ex">X</form>
+<figure data-platform="atspi,mac" id="ex25" class="ex">X</figure>
+<footer data-platform="atspi,mac" id="ex26" class="ex">X</footer>
+<form data-platform="atspi,mac" id="ex27" class="ex">X</form>
 <!-- skipped <frame> -->
 <!-- skipped <frameset> -->
 <!-- skipped <head> -->
-<!-- http://webkit.org/b/109013 --><header data-platform="atspi,mac" class="ex">X</header>
-<hgroup data-platform="atspi,mac" class="ex">X</hgroup>
-<h1 data-platform="atspi,mac" class="ex">X</h1>
-<h2 data-platform="atspi,mac" class="ex">X</h2>
-<h3 data-platform="atspi,mac" class="ex">X</h3>
-<h4 data-platform="atspi,mac" class="ex">X</h4>
-<h5 data-platform="atspi,mac" class="ex">X</h5>
-<h6 data-platform="atspi,mac" class="ex">X</h6>
-<hr data-platform="atspi,mac" class="ex">
+<!-- http://webkit.org/b/109013 --><header data-platform="atspi,mac" id="ex28" class="ex">X</header>
+<hgroup data-platform="atspi,mac" id="ex29" class="ex">X</hgroup>
+<h1 data-platform="atspi,mac" id="ex30" class="ex">X</h1>
+<h2 data-platform="atspi,mac" id="ex31" class="ex">X</h2>
+<h3 data-platform="atspi,mac" id="ex32" class="ex">X</h3>
+<h4 data-platform="atspi,mac" id="ex33" class="ex">X</h4>
+<h5 data-platform="atspi,mac" id="ex34" class="ex">X</h5>
+<h6 data-platform="atspi,mac" id="ex35" class="ex">X</h6>
+<hr data-platform="atspi,mac" id="ex36" class="ex">
 <!-- skipped <html> -->
-<i data-platform="atspi,mac" class="ex">X</i>
+<i data-platform="atspi,mac" id="ex37" class="ex">X</i>
 <!-- skipped <iframe> -->
-<img data-platform="atspi,mac" class="ex" data-note=":not([src]):not([alt])">
-<img data-platform="atspi,mac" class="ex" alt="" data-note="[alt='']">
-<img data-platform="atspi,mac" class="ex" src="foo.png" data-note="[src]:not([alt])">
-<img data-platform="atspi,mac" class="ex" alt="X" data-note="[alt='X']">
-<img data-platform="atspi,mac" class="ex" alt="X" usemap="imagemap" data-note="[usemap][alt='X']">
-<img data-platform="atspi,mac" class="ex" usemap="imagemap" data-note="[usemap]:not([alt])">
-<input data-platform="atspi,mac" type="button" value="X" class="ex" data-note="[type='button']">
+<img data-platform="atspi,mac" id="ex38" class="ex" data-note=":not([src]):not([alt])">
+<img data-platform="atspi,mac" id="ex39" class="ex" alt="" data-note="[alt='']">
+<img data-platform="atspi,mac" id="ex40" class="ex" src="foo.png" data-note="[src]:not([alt])">
+<img data-platform="atspi,mac" id="ex41" class="ex" alt="X" data-note="[alt='X']">
+<img data-platform="atspi,mac" id="ex42" class="ex" alt="X" usemap="imagemap" data-note="[usemap][alt='X']">
+<img data-platform="atspi,mac" id="ex43" class="ex" usemap="imagemap" data-note="[usemap]:not([alt])">
+<input data-platform="atspi,mac" type="button" value="X" id="ex44" class="ex" data-note="[type='button']">
 <!-- skipped <menu><input type="button"></menu> -->
-<!-- http://webkit.org/b/109017 --><input data-platform="atspi,mac" type="color" value="X" class="ex" data-note="[type='color']">
-<input data-platform="atspi,mac" type="checkbox" class="ex" data-note="[type='checkbox']">
+<!-- http://webkit.org/b/109017 --><input data-platform="atspi,mac" type="color" value="X" id="ex45" class="ex" data-note="[type='color']">
+<input data-platform="atspi,mac" type="checkbox" id="ex46" class="ex" data-note="[type='checkbox']">
 <!-- skipped <menu><input type="checkbox"></menu> -->
-<!-- http://webkit.org/b/109017 --><input data-platform="atspi,mac" type="date" value="X" class="ex" data-note="[type='date']">
-<!-- http://webkit.org/b/109017 --><input data-platform="atspi,mac" type="datetime" value="X" class="ex" data-note="[type='datetime']">
-<!-- http://webkit.org/b/109017 --><input data-platform="atspi,mac" type="datetime-local" value="X" class="ex" data-note="[type='datetime-local']">
-<!-- http://webkit.org/b/109017 --><input data-platform="atspi,mac" type="email" value="X" class="ex" data-note="[type='email']">
-<input data-platform="atspi,mac" type="file" class="ex" data-note="[type='file']">
-<input data-platform="atspi,mac" type="hidden" class="ex" data-note="[type='hidden']">
-<input data-platform="atspi,mac" type="image" class="ex" data-note="[type='image']">
-<!-- http://webkit.org/b/109017 --><input data-platform="atspi,mac" type="month" value="X" class="ex" data-note="[type='month']">
-<!-- http://webkit.org/b/109017 --><input data-platform="atspi,mac" type="number" value="X" class="ex" data-note="[type='number']">
-<input data-platform="atspi,mac" type="password" value="X" class="ex" data-note="[type='password']">
-<input data-platform="atspi,mac" type="radio" class="ex" data-note="[type='radio']">
+<!-- http://webkit.org/b/109017 --><input data-platform="atspi,mac" type="date" value="X" id="ex47" class="ex" data-note="[type='date']">
+<!-- http://webkit.org/b/109017 --><input data-platform="atspi,mac" type="datetime" value="X" id="ex48" class="ex" data-note="[type='datetime']">
+<!-- http://webkit.org/b/109017 --><input data-platform="atspi,mac" type="datetime-local" value="X" id="ex49" class="ex" data-note="[type='datetime-local']">
+<!-- http://webkit.org/b/109017 --><input data-platform="atspi,mac" type="email" value="X" id="ex50" class="ex" data-note="[type='email']">
+<input data-platform="atspi,mac" type="file" id="ex51" class="ex" data-note="[type='file']">
+<input data-platform="atspi,mac" type="hidden" id="ex52" class="ex" data-note="[type='hidden']">
+<input data-platform="atspi,mac" type="image" id="ex53" class="ex" data-note="[type='image']">
+<!-- http://webkit.org/b/109017 --><input data-platform="atspi,mac" type="month" value="X" id="ex54" class="ex" data-note="[type='month']">
+<!-- http://webkit.org/b/109017 --><input data-platform="atspi,mac" type="number" value="X" id="ex55" class="ex" data-note="[type='number']">
+<input data-platform="atspi,mac" type="password" value="X" id="ex56" class="ex" data-note="[type='password']">
+<input data-platform="atspi,mac" type="radio" id="ex57" class="ex" data-note="[type='radio']">
 <!-- skipped <menu><input type="radio"></menu> -->
-<input data-platform="atspi,mac" type="range" class="ex" data-note="[type='range']">
-<input data-platform="atspi,mac" type="reset" class="ex" data-note="[type='reset']">
-<input data-platform="atspi,mac" type="search" value="X" class="ex" data-note="[type='search']">
-<input data-platform="atspi,mac" type="submit" class="ex" data-note="[type='submit']">
-<!-- http://webkit.org/b/109017 --><input data-platform="atspi,mac" type="tel" value="X" class="ex" data-note="[type='tel']">
-<input data-platform="atspi,mac" type="text" value="X" class="ex" data-note="[type='text']">
+<input data-platform="atspi,mac" type="range" id="ex58" class="ex" data-note="[type='range']">
+<input data-platform="atspi,mac" type="reset" id="ex59" class="ex" data-note="[type='reset']">
+<input data-platform="atspi,mac" type="search" value="X" id="ex60" class="ex" data-note="[type='search']">
+<input data-platform="atspi,mac" type="submit" id="ex61" class="ex" data-note="[type='submit']">
+<!-- http://webkit.org/b/109017 --><input data-platform="atspi,mac" type="tel" value="X" id="ex62" class="ex" data-note="[type='tel']">
+<input data-platform="atspi,mac" type="text" value="X" id="ex63" class="ex" data-note="[type='text']">
 <!-- skipped <input type="text"> with suggestions source element: http://www.w3.org/html/wg/drafts/html/master/forms.html#concept-input-list -->
-<!-- http://webkit.org/b/109017 --><input data-platform="atspi,mac" type="time" value="X" class="ex" data-note="[type='time']">
-<!-- http://webkit.org/b/109017 --><input data-platform="atspi,mac" type="url" value="X" class="ex" data-note="[type='url']">
-<!-- http://webkit.org/b/109017 --><input data-platform="atspi,mac" type="week" value="X" class="ex" data-note="[type='week']">
-<ins data-platform="atspi,mac" data-note=":not([datetime])" class="ex">X</ins>
-<ins data-platform="atspi,mac" datetime="2014-10-31 00:00" data-note="[datetime]" class="ex">X</ins>
+<!-- http://webkit.org/b/109017 --><input data-platform="atspi,mac" type="time" value="X" id="ex64" class="ex" data-note="[type='time']">
+<!-- http://webkit.org/b/109017 --><input data-platform="atspi,mac" type="url" value="X" id="ex65" class="ex" data-note="[type='url']">
+<!-- http://webkit.org/b/109017 --><input data-platform="atspi,mac" type="week" value="X" id="ex66" class="ex" data-note="[type='week']">
+<ins data-platform="atspi,mac" data-note=":not([datetime])" id="ex67" class="ex">X</ins>
+<ins data-platform="atspi,mac" datetime="2014-10-31 00:00" data-note="[datetime]" id="ex68" class="ex">X</ins>
 <!-- skipped <link> -->
-<map data-platform="atspi,mac" class="ex" name="imagemap">
-  <area data-platform="atspi,mac" class="ex" shape="rect" coords="0,0,10,10" href="#" title="x" />
+<map data-platform="atspi,mac" id="ex69" class="ex" name="imagemap">
+  <area data-platform="atspi,mac" id="ex70" class="ex" shape="rect" coords="0,0,10,10" href="#" title="x" />
 </map>
-<main data-platform="atspi,mac" class="ex">X</main>
-<!-- http://webkit.org/b/109018 --><mark data-platform="atspi,mac" class="ex">X</mark>
-<!-- Some MathML elements do not become hidden by display: none, so hide them after the test via a parent element. http://webkit.org/b/139403 --><div class="ex">
-<math data-platform="atspi,mac" class="ex"><mi>X</mi></math>
-<math><merror data-platform="atspi,mac" class="ex"><mtext>Syntax error</mtext></merror></math>
-<math><mfenced data-platform="atspi,mac" class="ex"><mi class="ex">X</mi></mfenced></math>
-<math><mfrac data-platform="atspi,mac" class="ex"><mi class="ex">X</mi><mn class="ex">Y</mn></mfrac></math>
-<math><mi data-platform="atspi,mac" class="ex">X</mi></math>
-<math><mn data-platform="atspi,mac" class="ex">X</mn></math>
-<math><mo data-platform="atspi,mac" class="ex">X</mo></math>
-<math><mroot data-platform="atspi,mac" class="ex"><mi>X</mi></mroot></math>
-<math><msqrt data-platform="atspi,mac" class="ex"><mi>X</mi></msqrt></math>
-<math><mrow data-platform="atspi,mac" class="ex"><mi class="ex">X</mi></mrow></math>
-<math><ms data-platform="atspi,mac" class="ex">X</ms></math>
+<main data-platform="atspi,mac" id="ex71" class="ex">X</main>
+<!-- http://webkit.org/b/109018 --><mark data-platform="atspi,mac" id="ex72" class="ex">X</mark>
+<!-- Some MathML elements do not become hidden by display: none, so hide them after the test via a parent element. http://webkit.org/b/139403 --><div id="ex73" class="ex">
+<math data-platform="atspi,mac" id="ex74" class="ex"><mi>X</mi></math>
+<math><merror data-platform="atspi,mac" id="ex75" class="ex"><mtext>Syntax error</mtext></merror></math>
+<math><mfenced data-platform="atspi,mac" id="ex76" class="ex"><mi id="ex77" class="ex">X</mi></mfenced></math>
+<math><mfrac data-platform="atspi,mac" id="ex78" class="ex"><mi id="ex79" class="ex">X</mi><mn id="ex80" class="ex">Y</mn></mfrac></math>
+<math><mi data-platform="atspi,mac" id="ex81" class="ex">X</mi></math>
+<math><mn data-platform="atspi,mac" id="ex82" class="ex">X</mn></math>
+<math><mo data-platform="atspi,mac" id="ex83" class="ex">X</mo></math>
+<math><mroot data-platform="atspi,mac" id="ex84" class="ex"><mi>X</mi></mroot></math>
+<math><msqrt data-platform="atspi,mac" id="ex85" class="ex"><mi>X</mi></msqrt></math>
+<math><mrow data-platform="atspi,mac" id="ex86" class="ex"><mi id="ex87" class="ex">X</mi></mrow></math>
+<math><ms data-platform="atspi,mac" id="ex88" class="ex">X</ms></math>
 <math>
-  <msub data-platform="atspi,mac" class="ex">
-    <mi data-platform="atspi,mac" class="ex">X</mi>
-    <mi data-platform="atspi,mac" class="ex">X</mi>
+  <msub data-platform="atspi,mac" id="ex89" class="ex">
+    <mi data-platform="atspi,mac" id="ex90" class="ex">X</mi>
+    <mi data-platform="atspi,mac" id="ex91" class="ex">X</mi>
   </msub>
-  <msup data-platform="atspi,mac" class="ex">
-    <mi data-platform="atspi,mac" class="ex">X</mi>
-    <mi data-platform="atspi,mac" class="ex">X</mi>
+  <msup data-platform="atspi,mac" id="ex92" class="ex">
+    <mi data-platform="atspi,mac" id="ex93" class="ex">X</mi>
+    <mi data-platform="atspi,mac" id="ex94" class="ex">X</mi>
   </msup>
-  <msubsup data-platform="atspi,mac" class="ex">
-    <mi data-platform="atspi,mac" class="ex">X</mi>
-    <mi data-platform="atspi,mac" class="ex">X</mi>
-    <mi data-platform="atspi,mac" class="ex">x</mi>
+  <msubsup data-platform="atspi,mac" id="ex95" class="ex">
+    <mi data-platform="atspi,mac" id="ex96" class="ex">X</mi>
+    <mi data-platform="atspi,mac" id="ex97" class="ex">X</mi>
+    <mi data-platform="atspi,mac" id="ex98" class="ex">x</mi>
   </msubsup>
-  <mmultiscripts data-platform="atspi,mac" class="ex">
-    <mi data-platform="atspi,mac" class="ex">X</mi>
-    <mi data-platform="atspi,mac" class="ex">X</mi>
-    <mi data-platform="atspi,mac" class="ex">x</mi>
-    <mprescripts data-platform="atspi,mac" class="ex" />
-    <mi data-platform="atspi,mac" class="ex">X</mi>
-    <mi data-platform="atspi,mac" class="ex">x</mi>
+  <mmultiscripts data-platform="atspi,mac" id="ex99" class="ex">
+    <mi data-platform="atspi,mac" id="ex100" class="ex">X</mi>
+    <mi data-platform="atspi,mac" id="ex101" class="ex">X</mi>
+    <mi data-platform="atspi,mac" id="ex102" class="ex">x</mi>
+    <mprescripts data-platform="atspi,mac" id="ex103" class="ex" />
+    <mi data-platform="atspi,mac" id="ex104" class="ex">X</mi>
+    <mi data-platform="atspi,mac" id="ex105" class="ex">x</mi>
   </mmultiscripts>
 </math>
 </math>
-<math><mtext data-platform="atspi,mac" class="ex">X</mtext></math>
+<math><mtext data-platform="atspi,mac" id="ex106" class="ex">X</mtext></math>
 <math>
-  <mtable data-platform="atspi,mac" class="ex">
-    <mlabeledtr data-platform="atspi,mac" class="ex"><mtd data-platform="atspi,mac" class="ex"><mi>X</mi></mtd></mlabeledtr>
-    <mtr data-platform="atspi,mac" class="ex"><mtd data-platform="atspi,mac" class="ex"><mi>X</mi></mtd></mtr>
+  <mtable data-platform="atspi,mac" id="ex107" class="ex">
+    <mlabeledtr data-platform="atspi,mac" id="ex108" class="ex"><mtd data-platform="atspi,mac" id="ex109" class="ex"><mi>X</mi></mtd></mlabeledtr>
+    <mtr data-platform="atspi,mac" id="ex110" class="ex"><mtd data-platform="atspi,mac" id="ex111" class="ex"><mi>X</mi></mtd></mtr>
   </mtable>
 </math>
 </div>
-<menu data-platform="atspi,mac" class="ex">
-    <li data-platform="atspi,mac" class="ex">X</li>
+<menu data-platform="atspi,mac" id="ex112" class="ex">
+    <li data-platform="atspi,mac" id="ex113" class="ex">X</li>
 </menu>
 <!-- skipped <meta> -->
-<!-- reenable for atspi after http://webkit.org/b/163383 fixed --><meter data-platform="mac" class="ex" value="0.75">X</meter>
-<nav data-platform="atspi,mac" class="ex">X</nav>
+<!-- reenable for atspi after http://webkit.org/b/163383 fixed --><meter data-platform="mac" id="ex114" class="ex" value="0.75">X</meter>
+<nav data-platform="atspi,mac" id="ex115" class="ex">X</nav>
 <!-- skipped <noscript> -->
 <!-- skipped <object> -->
-<ol data-platform="atspi,mac" class="ex">
-    <li data-platform="atspi,mac" class="ex">X</li>
+<ol data-platform="atspi,mac" id="ex116" class="ex">
+    <li data-platform="atspi,mac" id="ex117" class="ex">X</li>
 </ol>
 <!-- skipped <optgroup> -->
 <!-- skipped <option> -->
 <!-- skipped <output> -->
-<p data-platform="atspi,mac" class="ex">X</p>
+<p data-platform="atspi,mac" id="ex118" class="ex">X</p>
 <!-- skipped <param> -->
-<pre data-platform="atspi,mac" class="ex">X</pre>
-<progress data-platform="atspi,mac" class="ex" value="0.75">X</progress>
-<q data-platform="atspi,mac" class="ex">X</q>
+<pre data-platform="atspi,mac" id="ex119" class="ex">X</pre>
+<progress data-platform="atspi,mac" id="ex120" class="ex" value="0.75">X</progress>
+<q data-platform="atspi,mac" id="ex121" class="ex">X</q>
 <!-- skipped <ruby/rp/rt> -->
-<s data-platform="atspi,mac" class="ex">X</s>
-<samp data-platform="atspi,mac" class="ex">X</samp>
+<s data-platform="atspi,mac" id="ex122" class="ex">X</s>
+<samp data-platform="atspi,mac" id="ex123" class="ex">X</samp>
 <!-- skipped <script> -->
-<search data-platform="atspi,mac" class="ex">X</search>
-<!-- http://webkit.org/b/109024 --><section data-platform="atspi,mac" data-note=":not([aria-label]:not([aria-labelledby])" class="ex">X</section>
-<section data-platform="atspi,mac" class="ex" aria-label="x" data-note="[aria-label]">X</section>
-<section data-platform="atspi,mac" class="ex" aria-labelledby="section-label" data-note="[aria-labelledby]">
+<search data-platform="atspi,mac" id="ex124" class="ex">X</search>
+<!-- http://webkit.org/b/109024 --><section data-platform="atspi,mac" data-note=":not([aria-label]:not([aria-labelledby])" id="ex125" class="ex">X</section>
+<section data-platform="atspi,mac" id="ex126" class="ex" aria-label="x" data-note="[aria-label]">X</section>
+<section data-platform="atspi,mac" id="ex127" class="ex" aria-labelledby="section-label" data-note="[aria-labelledby]">
     <h2 id="section-label">X</h2>
 </section>
-<select data-platform="atspi,mac" class="ex" data-note=":not([multiple])">
-    <option data-platform="atspi,mac" class="ex">X</option>
-    <optgroup data-platform="atspi,mac" class="ex" label="more">
+<select data-platform="atspi,mac" id="ex128" class="ex" data-note=":not([multiple])">
+    <option data-platform="atspi,mac" id="ex129" class="ex">X</option>
+    <optgroup data-platform="atspi,mac" id="ex130" class="ex" label="more">
         <option data-platform="atspi,mac">X</option>
     </optgroup>
 </select>
-<select data-platform="atspi,mac" class="ex" multiple data-note="[multiple]">
-    <option data-platform="atspi,mac" class="ex">X</option>
-    <optgroup data-platform="atspi,mac" class="ex" label="more">
+<select data-platform="atspi,mac" id="ex131" class="ex" multiple data-note="[multiple]">
+    <option data-platform="atspi,mac" id="ex132" class="ex">X</option>
+    <optgroup data-platform="atspi,mac" id="ex133" class="ex" label="more">
         <option>Y</option>
         <option>Z</option>
     </optgroup>
 </select>
-<small data-platform="atspi,mac" class="ex">X</small>
+<small data-platform="atspi,mac" id="ex134" class="ex">X</small>
 <!-- skipped <source> -->
-<span data-platform="atspi,mac" data-note=":not([onclick])" class="ex">X</span>
-<span data-platform="atspi,mac" onclick="return;" data-note="[onclick]" class="ex">X</span>
-<strong data-platform="atspi,mac" class="ex">X</strong>
+<span data-platform="atspi,mac" data-note=":not([onclick])" id="ex135" class="ex">X</span>
+<span data-platform="atspi,mac" onclick="return;" data-note="[onclick]" id="ex136" class="ex">X</span>
+<strong data-platform="atspi,mac" id="ex137" class="ex">X</strong>
 <!-- skipped <style> -->
-<sub data-platform="atspi,mac" class="ex">X</sub>
-<sup data-platform="atspi,mac" class="ex">X</sup>
-<svg data-platform="atspi,mac" class="ex">X</svg>
+<sub data-platform="atspi,mac" id="ex138" class="ex">X</sub>
+<sup data-platform="atspi,mac" id="ex139" class="ex">X</sup>
+<svg data-platform="atspi,mac" id="ex140" class="ex">X</svg>
 
-<table data-platform="atspi,mac" class="ex">
-    <caption data-platform="atspi,mac" class="ex">X</caption>
-    <thead data-platform="atspi,mac" class="ex">
-        <!-- [ATSPI] Object not exposed (webkit.org/b/139005) --><tr data-platform="atspi,mac" class="ex">
+<table data-platform="atspi,mac" id="ex141" class="ex">
+    <caption data-platform="atspi,mac" id="ex142" class="ex">X</caption>
+    <thead data-platform="atspi,mac" id="ex143" class="ex">
+        <!-- [ATSPI] Object not exposed (webkit.org/b/139005) --><tr data-platform="atspi,mac" id="ex144" class="ex">
             <!-- Need separate test to verify colheader/rowheader -->
-            <th data-platform="atspi,mac" class="ex">X</th>
+            <th data-platform="atspi,mac" id="ex145" class="ex">X</th>
         </tr>
     </thead>
-    <tbody data-platform="atspi,mac" class="ex">
-        <!-- [ATSPI] Object not exposed (webkit.org/b/139005) --><tr data-platform="atspi,mac" class="ex">
-            <td data-platform="atspi,mac" class="ex">X</td>
+    <tbody data-platform="atspi,mac" id="ex146" class="ex">
+        <!-- [ATSPI] Object not exposed (webkit.org/b/139005) --><tr data-platform="atspi,mac" id="ex147" class="ex">
+            <td data-platform="atspi,mac" id="ex148" class="ex">X</td>
         </tr>
     </tbody>
-    <tfoot data-platform="atspi,mac" class="ex">
-        <!-- [ATSPI] Object not exposed (webkit.org/b/139005) --><tr data-platform="atspi,mac" class="ex">
+    <tfoot data-platform="atspi,mac" id="ex149" class="ex">
+        <!-- [ATSPI] Object not exposed (webkit.org/b/139005) --><tr data-platform="atspi,mac" id="ex150" class="ex">
             <!-- Need separate test to verify colheader/rowheader -->
-            <th data-platform="atspi,mac" class="ex">X</th>
+            <th data-platform="atspi,mac" id="ex151" class="ex">X</th>
         </tr>
     </tfoot>
 </table>
-<textarea data-platform="atspi,mac" class="ex">X</textarea>
-<time data-platform="atspi,mac" data-note=":not([datetime])" class="ex">X</time>
-<time data-platform="atspi,mac" datetime="2014-10-31 00:00" data-note="[datetime]" class="ex">X</time>
+<textarea data-platform="atspi,mac" id="ex152" class="ex">X</textarea>
+<time data-platform="atspi,mac" data-note=":not([datetime])" id="ex153" class="ex">X</time>
+<time data-platform="atspi,mac" datetime="2014-10-31 00:00" data-note="[datetime]" id="ex154" class="ex">X</time>
 <!-- skipped <title> -->
-<ul data-platform="atspi,mac" class="ex">
-    <li data-platform="atspi,mac" class="ex">X</li>
+<ul data-platform="atspi,mac" id="ex155" class="ex">
+    <li data-platform="atspi,mac" id="ex156" class="ex">X</li>
 </ul>
-<var data-platform="atspi,mac" class="ex">X</var>
+<var data-platform="atspi,mac" id="ex157" class="ex">X</var>
 <!-- skipped <video> -->
-<wbr data-platform="atspi,mac" class="ex">X</wbr>
+<wbr data-platform="atspi,mac" id="ex158" class="ex">X</wbr>
 <!-- Todo: I left off adding HTML5 elements here at previous element: https://dvcs.w3.org/hg/html-api-map/raw-file/default/Overview.html -->
 
 
@@ -232,171 +232,171 @@
 <!-- ==================================================================================================== -->
 <!-- Abstract ARIA roles in alphabetical order; only generic AXGroup role should be exposed on abstract roles -->
 <!-- ==================================================================================================== -->
-<div role="command"     data-platform="atspi,mac" class="ex">X</div>
-<div role="composite"   data-platform="atspi,mac" class="ex">X</div>
-<div role="input"       data-platform="atspi,mac" class="ex">X</div>
-<div role="landmark"    data-platform="atspi,mac" class="ex">X</div>
-<div role="range"       data-platform="atspi,mac" class="ex">X</div>
-<div role="roletype"    data-platform="atspi,mac" class="ex">X</div>
-<div role="section"     data-platform="atspi,mac" class="ex">X</div>
-<div role="sectionhead" data-platform="atspi,mac" class="ex">X</div>
-<div role="select"      data-platform="atspi,mac" class="ex">X</div>
-<div role="structure"   data-platform="atspi,mac" class="ex">X</div>
-<div role="widget"      data-platform="atspi,mac" class="ex">X</div>
-<div role="window"      data-platform="atspi,mac" class="ex">X</div>
+<div role="command"     data-platform="atspi,mac" id="ex159" class="ex">X</div>
+<div role="composite"   data-platform="atspi,mac" id="ex160" class="ex">X</div>
+<div role="input"       data-platform="atspi,mac" id="ex161" class="ex">X</div>
+<div role="landmark"    data-platform="atspi,mac" id="ex162" class="ex">X</div>
+<div role="range"       data-platform="atspi,mac" id="ex163" class="ex">X</div>
+<div role="roletype"    data-platform="atspi,mac" id="ex164" class="ex">X</div>
+<div role="section"     data-platform="atspi,mac" id="ex165" class="ex">X</div>
+<div role="sectionhead" data-platform="atspi,mac" id="ex166" class="ex">X</div>
+<div role="select"      data-platform="atspi,mac" id="ex167" class="ex">X</div>
+<div role="structure"   data-platform="atspi,mac" id="ex168" class="ex">X</div>
+<div role="widget"      data-platform="atspi,mac" id="ex169" class="ex">X</div>
+<div role="window"      data-platform="atspi,mac" id="ex170" class="ex">X</div>
 
 
 <!-- ==================================================================================================== -->
 <!-- Non-abstract ARIA roles in alphabetical order, excepting the need for nesting (e.g. row is with its grid parent) -->
 <!-- ==================================================================================================== -->
-<div role="alert"                    data-platform="atspi,mac" class="ex">X</div>
-<div role="alertdialog"              data-platform="atspi,mac" class="ex">X</div>
-<div role="application"              data-platform="atspi,mac" class="ex">X</div>
-<div role="article"                  data-platform="atspi,mac" class="ex">X</div>
-<div role="banner"                   data-platform="atspi,mac" class="ex">X</div>
-<div role="blockquote"               data-platform="atspi,mac" class="ex">X</div>
-<div role="button"                   data-platform="atspi,mac" class="ex">X</div>
-<div role="caption"                  data-platform="atspi,mac" class="ex">X</div>
-<div role="checkbox"                 data-platform="atspi,mac" class="ex">X</div>
-<div role="combobox"                 data-platform="atspi,mac" class="ex">X</div>
-<div role="complementary"            data-platform="atspi,mac" class="ex">X</div>
-<div role="contentinfo"              data-platform="atspi,mac" class="ex">X</div>
-<div role="definition"               data-platform="atspi,mac" class="ex">X</div>
-<div role="deletion"                 data-platform="atspi,mac" class="ex">X</div>
-<div role="dialog"                   data-platform="atspi,mac" class="ex">X</div>
-<div role="directory"                data-platform="atspi,mac" class="ex">X</div>
+<div role="alert"                    data-platform="atspi,mac" id="ex171" class="ex">X</div>
+<div role="alertdialog"              data-platform="atspi,mac" id="ex172" class="ex">X</div>
+<div role="application"              data-platform="atspi,mac" id="ex173" class="ex">X</div>
+<div role="article"                  data-platform="atspi,mac" id="ex174" class="ex">X</div>
+<div role="banner"                   data-platform="atspi,mac" id="ex175" class="ex">X</div>
+<div role="blockquote"               data-platform="atspi,mac" id="ex176" class="ex">X</div>
+<div role="button"                   data-platform="atspi,mac" id="ex177" class="ex">X</div>
+<div role="caption"                  data-platform="atspi,mac" id="ex178" class="ex">X</div>
+<div role="checkbox"                 data-platform="atspi,mac" id="ex179" class="ex">X</div>
+<div role="combobox"                 data-platform="atspi,mac" id="ex180" class="ex">X</div>
+<div role="complementary"            data-platform="atspi,mac" id="ex181" class="ex">X</div>
+<div role="contentinfo"              data-platform="atspi,mac" id="ex182" class="ex">X</div>
+<div role="definition"               data-platform="atspi,mac" id="ex183" class="ex">X</div>
+<div role="deletion"                 data-platform="atspi,mac" id="ex184" class="ex">X</div>
+<div role="dialog"                   data-platform="atspi,mac" id="ex185" class="ex">X</div>
+<div role="directory"                data-platform="atspi,mac" id="ex186" class="ex">X</div>
 <!-- The 'doc-*' roles are defined the ARIA DPUB mobile: https://www.w3.org/TR/dpub-aam-1.0/ -->
 <!-- Editor's draft is currently at https://rawgit.com/w3c/aria/master/dpub-aam/dpub-aam.html -->
-<div role="doc-abstract"             data-platform="atspi,mac" class="ex">X</div>
-<div role="doc-acknowledgments"      data-platform="atspi,mac" class="ex">X</div>
-<div role="doc-afterword"            data-platform="atspi,mac" class="ex">X</div>
-<div role="doc-appendix"             data-platform="atspi,mac" class="ex">X</div>
-<div role="doc-backlink"             data-platform="atspi,mac" class="ex">X</div>
-<div role="doc-biblioentry"          data-platform="atspi,mac" class="ex">X</div>
-<div role="doc-bibliography"         data-platform="atspi,mac" class="ex">X</div>
-<div role="doc-biblioref"            data-platform="atspi,mac" class="ex">X</div>
-<div role="doc-chapter"              data-platform="atspi,mac" class="ex">X</div>
-<div role="doc-colophon"             data-platform="atspi,mac" class="ex">X</div>
-<div role="doc-conclusion"           data-platform="atspi,mac" class="ex">X</div>
-<div role="doc-cover"                data-platform="atspi,mac" class="ex">X</div>
-<div role="doc-credit"               data-platform="atspi,mac" class="ex">X</div>
-<div role="doc-credits"              data-platform="atspi,mac" class="ex">X</div>
-<div role="doc-dedication"           data-platform="atspi,mac" class="ex">X</div>
-<div role="doc-endnote"              data-platform="atspi,mac" class="ex">X</div>
-<div role="doc-endnotes"             data-platform="atspi,mac" class="ex">X</div>
-<div role="doc-epigraph"             data-platform="atspi,mac" class="ex">X</div>
-<div role="doc-epilogue"             data-platform="atspi,mac" class="ex">X</div>
-<div role="doc-errata"               data-platform="atspi,mac" class="ex">X</div>
-<div role="doc-example"              data-platform="atspi,mac" class="ex">X</div>
-<div role="doc-footnote"             data-platform="atspi,mac" class="ex">X</div>
-<div role="doc-foreword"             data-platform="atspi,mac" class="ex">X</div>
-<div role="doc-glossary"             data-platform="atspi,mac" class="ex">X</div>
-<div role="doc-glossref"             data-platform="atspi,mac" class="ex">X</div>
-<div role="doc-index"                data-platform="atspi,mac" class="ex">X</div>
-<div role="doc-introduction"         data-platform="atspi,mac" class="ex">X</div>
-<div role="doc-noteref"              data-platform="atspi,mac" class="ex">X</div>
-<div role="doc-notice"               data-platform="atspi,mac" class="ex">X</div>
-<div role="doc-pagebreak"            data-platform="atspi,mac" class="ex">X</div>
-<div role="doc-pagelist"             data-platform="atspi,mac" class="ex">X</div>
-<div role="doc-part"                 data-platform="atspi,mac" class="ex">X</div>
-<div role="doc-preface"              data-platform="atspi,mac" class="ex">X</div>
-<div role="doc-prologue"             data-platform="atspi,mac" class="ex">X</div>
-<div role="doc-pullquote"            data-platform="atspi,mac" class="ex">X</div>
-<div role="doc-qna"                  data-platform="atspi,mac" class="ex">X</div>
-<div role="doc-subtitle"             data-platform="atspi,mac" class="ex">X</div>
-<div role="doc-tip"                  data-platform="atspi,mac" class="ex">X</div>
-<div role="doc-toc"                  data-platform="atspi,mac" class="ex">X</div>
-<div role="document"                 data-platform="atspi,mac" class="ex">X</div>
-<div role="figure"                   data-platform="atspi,mac" class="ex">X</div>
-<div role="form"                     data-platform="atspi,mac" class="ex">X</div>
-<div role="graphics-document"        data-platform="atspi,mac" class="ex">X</div>
-<div role="graphics-object"          data-platform="atspi,mac" class="ex">X</div>
-<div role="graphics-symbol"          data-platform="atspi,mac" class="ex">X</div>
-<div role="grid"                     data-platform="atspi,mac" class="ex">
-    <div role="rowgroup"             data-platform="atspi,mac" class="ex">
-        <div role="row"              data-platform="atspi,mac" class="ex">
+<div role="doc-abstract"             data-platform="atspi,mac" id="ex187" class="ex">X</div>
+<div role="doc-acknowledgments"      data-platform="atspi,mac" id="ex188" class="ex">X</div>
+<div role="doc-afterword"            data-platform="atspi,mac" id="ex189" class="ex">X</div>
+<div role="doc-appendix"             data-platform="atspi,mac" id="ex190" class="ex">X</div>
+<div role="doc-backlink"             data-platform="atspi,mac" id="ex191" class="ex">X</div>
+<div role="doc-biblioentry"          data-platform="atspi,mac" id="ex192" class="ex">X</div>
+<div role="doc-bibliography"         data-platform="atspi,mac" id="ex193" class="ex">X</div>
+<div role="doc-biblioref"            data-platform="atspi,mac" id="ex194" class="ex">X</div>
+<div role="doc-chapter"              data-platform="atspi,mac" id="ex195" class="ex">X</div>
+<div role="doc-colophon"             data-platform="atspi,mac" id="ex196" class="ex">X</div>
+<div role="doc-conclusion"           data-platform="atspi,mac" id="ex197" class="ex">X</div>
+<div role="doc-cover"                data-platform="atspi,mac" id="ex198" class="ex">X</div>
+<div role="doc-credit"               data-platform="atspi,mac" id="ex199" class="ex">X</div>
+<div role="doc-credits"              data-platform="atspi,mac" id="ex200" class="ex">X</div>
+<div role="doc-dedication"           data-platform="atspi,mac" id="ex201" class="ex">X</div>
+<div role="doc-endnote"              data-platform="atspi,mac" id="ex202" class="ex">X</div>
+<div role="doc-endnotes"             data-platform="atspi,mac" id="ex203" class="ex">X</div>
+<div role="doc-epigraph"             data-platform="atspi,mac" id="ex204" class="ex">X</div>
+<div role="doc-epilogue"             data-platform="atspi,mac" id="ex205" class="ex">X</div>
+<div role="doc-errata"               data-platform="atspi,mac" id="ex206" class="ex">X</div>
+<div role="doc-example"              data-platform="atspi,mac" id="ex207" class="ex">X</div>
+<div role="doc-footnote"             data-platform="atspi,mac" id="ex208" class="ex">X</div>
+<div role="doc-foreword"             data-platform="atspi,mac" id="ex209" class="ex">X</div>
+<div role="doc-glossary"             data-platform="atspi,mac" id="ex210" class="ex">X</div>
+<div role="doc-glossref"             data-platform="atspi,mac" id="ex211" class="ex">X</div>
+<div role="doc-index"                data-platform="atspi,mac" id="ex212" class="ex">X</div>
+<div role="doc-introduction"         data-platform="atspi,mac" id="ex213" class="ex">X</div>
+<div role="doc-noteref"              data-platform="atspi,mac" id="ex214" class="ex">X</div>
+<div role="doc-notice"               data-platform="atspi,mac" id="ex215" class="ex">X</div>
+<div role="doc-pagebreak"            data-platform="atspi,mac" id="ex216" class="ex">X</div>
+<div role="doc-pagelist"             data-platform="atspi,mac" id="ex217" class="ex">X</div>
+<div role="doc-part"                 data-platform="atspi,mac" id="ex218" class="ex">X</div>
+<div role="doc-preface"              data-platform="atspi,mac" id="ex219" class="ex">X</div>
+<div role="doc-prologue"             data-platform="atspi,mac" id="ex220" class="ex">X</div>
+<div role="doc-pullquote"            data-platform="atspi,mac" id="ex221" class="ex">X</div>
+<div role="doc-qna"                  data-platform="atspi,mac" id="ex222" class="ex">X</div>
+<div role="doc-subtitle"             data-platform="atspi,mac" id="ex223" class="ex">X</div>
+<div role="doc-tip"                  data-platform="atspi,mac" id="ex224" class="ex">X</div>
+<div role="doc-toc"                  data-platform="atspi,mac" id="ex225" class="ex">X</div>
+<div role="document"                 data-platform="atspi,mac" id="ex226" class="ex">X</div>
+<div role="figure"                   data-platform="atspi,mac" id="ex227" class="ex">X</div>
+<div role="form"                     data-platform="atspi,mac" id="ex228" class="ex">X</div>
+<div role="graphics-document"        data-platform="atspi,mac" id="ex229" class="ex">X</div>
+<div role="graphics-object"          data-platform="atspi,mac" id="ex230" class="ex">X</div>
+<div role="graphics-symbol"          data-platform="atspi,mac" id="ex231" class="ex">X</div>
+<div role="grid"                     data-platform="atspi,mac" id="ex232" class="ex">
+    <div role="rowgroup"             data-platform="atspi,mac" id="ex233" class="ex">
+        <div role="row"              data-platform="atspi,mac" id="ex234" class="ex">
             <!-- Note: diff between rowheader, columnheader, and gridcell is in cross-reference from grid; need additional non-role verification in another test. -->
-            <div role="rowheader"    data-platform="atspi,mac" class="ex">X</div>
-            <div role="columnheader" data-platform="atspi,mac" class="ex">X</div>
-            <div role="gridcell"     data-platform="atspi,mac" class="ex">X</div>
+            <div role="rowheader"    data-platform="atspi,mac" id="ex235" class="ex">X</div>
+            <div role="columnheader" data-platform="atspi,mac" id="ex236" class="ex">X</div>
+            <div role="gridcell"     data-platform="atspi,mac" id="ex237" class="ex">X</div>
         </div>
     </div>
 </div>
-<div role="feed"                     data-platform="atspi,mac" class="ex">X</div>
-<div role="group"                    data-platform="atspi,mac" class="ex">X</div>
-<div role="heading"                  data-platform="atspi,mac" class="ex">X</div>
-<div role="img"                      data-platform="atspi,mac" class="ex">X</div>
-<div role="insertion"                data-platform="atspi,mac" class="ex">X</div>
-<div role="link"                     data-platform="atspi,mac" class="ex">X</div>
-<div role="list"                     data-platform="atspi,mac" class="ex">
-    <div role="listitem"             data-platform="atspi,mac" class="ex">X</div>
+<div role="feed"                     data-platform="atspi,mac" id="ex238" class="ex">X</div>
+<div role="group"                    data-platform="atspi,mac" id="ex239" class="ex">X</div>
+<div role="heading"                  data-platform="atspi,mac" id="ex240" class="ex">X</div>
+<div role="img"                      data-platform="atspi,mac" id="ex241" class="ex">X</div>
+<div role="insertion"                data-platform="atspi,mac" id="ex242" class="ex">X</div>
+<div role="link"                     data-platform="atspi,mac" id="ex243" class="ex">X</div>
+<div role="list"                     data-platform="atspi,mac" id="ex244" class="ex">
+    <div role="listitem"             data-platform="atspi,mac" id="ex245" class="ex">X</div>
 </div>
-<div role="listbox"                  data-platform="atspi,mac" class="ex">
-    <div role="option"               data-platform="atspi,mac" class="ex">X</div>
+<div role="listbox"                  data-platform="atspi,mac" id="ex246" class="ex">
+    <div role="option"               data-platform="atspi,mac" id="ex247" class="ex">X</div>
 </div>
-<div role="log"                      data-platform="atspi,mac" class="ex">X</div>
-<div role="main"                     data-platform="atspi,mac" class="ex">X</div>
-<div role="marquee"                  data-platform="atspi,mac" class="ex">X</div>
-<div role="math"                     data-platform="atspi,mac" class="ex">X</div>
-<div role="menu"                     data-platform="atspi,mac" class="ex">
+<div role="log"                      data-platform="atspi,mac" id="ex248" class="ex">X</div>
+<div role="main"                     data-platform="atspi,mac" id="ex249" class="ex">X</div>
+<div role="marquee"                  data-platform="atspi,mac" id="ex250" class="ex">X</div>
+<div role="math"                     data-platform="atspi,mac" id="ex251" class="ex">X</div>
+<div role="menu"                     data-platform="atspi,mac" id="ex252" class="ex">
     <!-- Note: diff between menuitem types is an attribute; need additional non-role verification in another test. -->
-    <div role="menuitem"             data-platform="atspi,mac" class="ex">X</div>
-    <div role="menuitemcheckbox"     data-platform="atspi,mac" class="ex">X</div>
-    <div role="menuitemradio"        data-platform="atspi,mac" class="ex">X</div>
+    <div role="menuitem"             data-platform="atspi,mac" id="ex253" class="ex">X</div>
+    <div role="menuitemcheckbox"     data-platform="atspi,mac" id="ex254" class="ex">X</div>
+    <div role="menuitemradio"        data-platform="atspi,mac" id="ex255" class="ex">X</div>
 </div>
-<div role="menubar"                  data-platform="atspi,mac" class="ex">
+<div role="menubar"                  data-platform="atspi,mac" id="ex256" class="ex">
     <!-- Note: diff between menuitem types is an attribute; need additional non-role verification in another test. -->
-    <div role="menuitem"             data-platform="atspi,mac" class="ex">X</div>
-    <div role="menuitemcheckbox"     data-platform="atspi,mac" class="ex">X</div>
-    <div role="menuitemradio"        data-platform="atspi,mac" class="ex">X</div>
+    <div role="menuitem"             data-platform="atspi,mac" id="ex257" class="ex">X</div>
+    <div role="menuitemcheckbox"     data-platform="atspi,mac" id="ex258" class="ex">X</div>
+    <div role="menuitemradio"        data-platform="atspi,mac" id="ex259" class="ex">X</div>
 </div>
-<div role="meter"                    data-platform="atspi,mac" class="ex">X</div>
-<div role="navigation"               data-platform="atspi,mac" class="ex">X</div>
-<div role="note"                     data-platform="atspi,mac" class="ex">X</div>
-<div role="paragraph"                data-platform="atspi,mac" class="ex">X</div>
-<div role="presentation"             data-platform="atspi,mac" class="ex">X</div>
-<div role="progressbar"              data-platform="atspi,mac" class="ex">X</div>
-<div role="radiogroup"               data-platform="atspi,mac" class="ex">
-    <div role="radio"                data-platform="atspi,mac" class="ex">X</div>
+<div role="meter"                    data-platform="atspi,mac" id="ex260" class="ex">X</div>
+<div role="navigation"               data-platform="atspi,mac" id="ex261" class="ex">X</div>
+<div role="note"                     data-platform="atspi,mac" id="ex262" class="ex">X</div>
+<div role="paragraph"                data-platform="atspi,mac" id="ex263" class="ex">X</div>
+<div role="presentation"             data-platform="atspi,mac" id="ex264" class="ex">X</div>
+<div role="progressbar"              data-platform="atspi,mac" id="ex265" class="ex">X</div>
+<div role="radiogroup"               data-platform="atspi,mac" id="ex266" class="ex">
+    <div role="radio"                data-platform="atspi,mac" id="ex267" class="ex">X</div>
 </div>
-<div role="region"                   data-platform="atspi,mac" class="ex" data-note=":not([aria-label]:not([aria-labelledby])">X</div>
-<div role="region"                   data-platform="atspi,mac" class="ex" aria-label="x" data-note="[aria-label]">X</div>
-<div role="region"                   data-platform="atspi,mac" class="ex" aria-labelledby="region-label" data-note="[aria-labelledby]">
+<div role="region"                   data-platform="atspi,mac" id="ex268" class="ex" data-note=":not([aria-label]:not([aria-labelledby])">X</div>
+<div role="region"                   data-platform="atspi,mac" id="ex269" class="ex" aria-label="x" data-note="[aria-label]">X</div>
+<div role="region"                   data-platform="atspi,mac" id="ex270" class="ex" aria-labelledby="region-label" data-note="[aria-labelledby]">
     <h2 id="region-label">X</h2>
 </div>
-<div role="scrollbar"                data-platform="atspi,mac" class="ex">X</div>
-<div role="search"                   data-platform="atspi,mac" class="ex">X</div>
-<div role="searchbox"                data-platform="atspi,mac" class="ex">X</div>
-<div role="separator"                data-platform="atspi,mac" class="ex">X</div>
-<div role="slider"                   data-platform="atspi,mac" class="ex">X</div>
-<div role="spinbutton"               data-platform="atspi,mac" class="ex">X</div>
-<div role="status"                   data-platform="atspi,mac" class="ex">X</div>
-<div role="subscript"                data-platform="atspi,mac" class="ex">X</div>
-<div role="superscript"              data-platform="atspi,mac" class="ex">X</div>
-<div role="switch"                   data-platform="atspi,mac" class="ex">X</div>
-<div role="tablist"                  data-platform="atspi,mac" class="ex">
-    <div role="tab"                  data-platform="atspi,mac" class="ex">X</div>
+<div role="scrollbar"                data-platform="atspi,mac" id="ex271" class="ex">X</div>
+<div role="search"                   data-platform="atspi,mac" id="ex272" class="ex">X</div>
+<div role="searchbox"                data-platform="atspi,mac" id="ex273" class="ex">X</div>
+<div role="separator"                data-platform="atspi,mac" id="ex274" class="ex">X</div>
+<div role="slider"                   data-platform="atspi,mac" id="ex275" class="ex">X</div>
+<div role="spinbutton"               data-platform="atspi,mac" id="ex276" class="ex">X</div>
+<div role="status"                   data-platform="atspi,mac" id="ex277" class="ex">X</div>
+<div role="subscript"                data-platform="atspi,mac" id="ex278" class="ex">X</div>
+<div role="superscript"              data-platform="atspi,mac" id="ex279" class="ex">X</div>
+<div role="switch"                   data-platform="atspi,mac" id="ex280" class="ex">X</div>
+<div role="tablist"                  data-platform="atspi,mac" id="ex281" class="ex">
+    <div role="tab"                  data-platform="atspi,mac" id="ex282" class="ex">X</div>
 </div>
-<div role="tabpanel"                 data-platform="atspi,mac" class="ex">X</div>
-<div role="term"                     data-platform="atspi,mac" class="ex">X</div>
-<div role="textbox"                  data-platform="atspi,mac" class="ex">X</div>
-<div role="time"                     data-platform="atspi,mac" class="ex">X</div>
-<div role="timer"                    data-platform="atspi,mac" class="ex">X</div>
-<div role="toolbar"                  data-platform="atspi,mac" class="ex">X</div>
-<div role="tooltip"                  data-platform="atspi,mac" class="ex">X</div>
-<div role="tree"                     data-platform="atspi,mac" class="ex">
-    <div role="treeitem"             data-platform="atspi,mac" class="ex">X</div>
-    <div role="group"                data-platform="atspi,mac" class="ex">
-        <div role="treeitem"         data-platform="atspi,mac" class="ex">X</div>
+<div role="tabpanel"                 data-platform="atspi,mac" id="ex283" class="ex">X</div>
+<div role="term"                     data-platform="atspi,mac" id="ex284" class="ex">X</div>
+<div role="textbox"                  data-platform="atspi,mac" id="ex285" class="ex">X</div>
+<div role="time"                     data-platform="atspi,mac" id="ex286" class="ex">X</div>
+<div role="timer"                    data-platform="atspi,mac" id="ex287" class="ex">X</div>
+<div role="toolbar"                  data-platform="atspi,mac" id="ex288" class="ex">X</div>
+<div role="tooltip"                  data-platform="atspi,mac" id="ex289" class="ex">X</div>
+<div role="tree"                     data-platform="atspi,mac" id="ex290" class="ex">
+    <div role="treeitem"             data-platform="atspi,mac" id="ex291" class="ex">X</div>
+    <div role="group"                data-platform="atspi,mac" id="ex292" class="ex">
+        <div role="treeitem"         data-platform="atspi,mac" id="ex293" class="ex">X</div>
     </div>
 </div>
-<div role="treegrid"                 data-platform="atspi,mac" class="ex">
-    <div role="rowgroup"             data-platform="atspi,mac" class="ex">
-        <div role="row"              data-platform="atspi,mac" class="ex">
+<div role="treegrid"                 data-platform="atspi,mac" id="ex294" class="ex">
+    <div role="rowgroup"             data-platform="atspi,mac" id="ex295" class="ex">
+        <div role="row"              data-platform="atspi,mac" id="ex296" class="ex">
             <!-- Note: diff between rowheader, columnheader, and gridcell is in cross-reference from grid; need additional non-role verification in another test. -->
-            <div role="rowheader"    data-platform="atspi,mac" class="ex">X</div>
-            <div role="columnheader" data-platform="atspi,mac" class="ex">X</div>
-            <div role="gridcell"     data-platform="atspi,mac" class="ex">X</div>
+            <div role="rowheader"    data-platform="atspi,mac" id="ex297" class="ex">X</div>
+            <div role="columnheader" data-platform="atspi,mac" id="ex298" class="ex">X</div>
+            <div role="gridcell"     data-platform="atspi,mac" id="ex299" class="ex">X</div>
         </div>
     </div>
 </div>
@@ -417,7 +417,6 @@ if (window.testRunner && window.accessibilityController) {
             continue;
 
         let ariaRole = el.getAttribute('role');
-        el.id = `ex${i}`;
         output += el.tagName.toLowerCase() + (ariaRole ? ("[role=" + ariaRole + "]") : '');
         if (el.getAttribute('data-note'))
             output += el.getAttribute('data-note');

--- a/LayoutTests/accessibility/roles-table-and-cell.html
+++ b/LayoutTests/accessibility/roles-table-and-cell.html
@@ -9,16 +9,16 @@
 <!-- This tests ARIA table role and cell role work as intended                                            -->
 <!-- ==================================================================================================== -->
 
-<div role="grid" data-role="grid" class="ex">
-    <div role="gridcell" data-role="gridcell" class="ex">data</div>
-    <div role="cell" data-role="cell" class="ex">data2</div>
-    <div role="cell" data-role="cell" class="ex">data3</div>
+<div role="grid" data-role="grid" id="ex0" class="ex">
+    <div role="gridcell" data-role="gridcell" id="ex1" class="ex">data</div>
+    <div role="cell" data-role="cell" id="ex2" class="ex">data2</div>
+    <div role="cell" data-role="cell" id="ex3" class="ex">data3</div>
 </div>
 
-<table role="table" data-role="table" class="ex">
-    <td role="gridcell" data-role="gridcell" class="ex">data</td>
-    <td data-role="cell" class="ex">data2</td>
-    <td role="cell" data-role="cell" class="ex">data3</td>
+<table role="table" data-role="table" id="ex4" class="ex">
+    <td role="gridcell" data-role="gridcell" id="ex5" class="ex">data</td>
+    <td data-role="cell" id="ex6" class="ex">data2</td>
+    <td role="cell" data-role="cell" id="ex7" class="ex">data3</td>
 </table>
 
 <script>
@@ -28,7 +28,6 @@
         let examples = document.querySelectorAll(".ex");
         for (let i = 0; i < examples.length; i++) {
             let el = examples[i];
-            el.id = "ex" + i;
 
             axElement = accessibilityController.accessibleElementById(el.id);
             if (!axElement)

--- a/Source/WebCore/accessibility/AXCoreObject.h
+++ b/Source/WebCore/accessibility/AXCoreObject.h
@@ -1073,6 +1073,7 @@ public:
     virtual void setSelectedRows(AccessibilityChildrenVector&&) = 0;
 
     virtual bool press() = 0;
+    virtual bool syncPress() = 0;
     bool performDefaultAction() { return press(); }
     virtual bool performDismissAction() { return false; }
     virtual void performDismissActionIgnoringResult() = 0;
@@ -1088,6 +1089,8 @@ public:
 
     virtual void increment() = 0;
     virtual void decrement() = 0;
+    virtual void syncIncrement() = 0;
+    virtual void syncDecrement() = 0;
 
     // When ENABLE(INCLUDE_IGNORED_IN_CORE_AX_TREE) is true, this returns ignored children.
     // When it is not, it returns unignored children. After ENABLE(INCLUDE_IGNORED_IN_CORE_AX_TREE)

--- a/Source/WebCore/accessibility/AXObjectCache.cpp
+++ b/Source/WebCore/accessibility/AXObjectCache.cpp
@@ -3551,8 +3551,9 @@ void AXObjectCache::handleAttributeChange(Element* element, const QualifiedName&
             }
         }
 
-#if ENABLE(ACCESSIBILITY_ISOLATED_TREE) && !LOG_DISABLED
-        updateIsolatedTree(get(*element), AXNotification::IdAttributeChanged);
+#if ENABLE(ACCESSIBILITY_ISOLATED_TREE)
+        if (AXIsolatedTree::shouldCacheIdentifierAttribute())
+            updateIsolatedTree(get(*element), AXNotification::IdAttributeChanged);
 #endif
     }
     else if (attrName == openAttr) {

--- a/Source/WebCore/accessibility/AccessibilityObject.h
+++ b/Source/WebCore/accessibility/AccessibilityObject.h
@@ -575,11 +575,14 @@ public:
 
     void performDismissActionIgnoringResult() final { performDismissAction(); }
     bool press() override;
+    bool syncPress() override { return press(); }
     bool performShowMenuAction();
 
     std::optional<AccessibilityOrientation> explicitOrientation() const override { return std::nullopt; }
     void increment() override { }
     void decrement() override { }
+    void syncIncrement() override { increment(); }
+    void syncDecrement() override { decrement(); }
     virtual bool toggleDetailsAncestor() { return false; }
     // Reveals details elements and hidden="until-found" elements.
     virtual void revealAncestors() { }

--- a/Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.cpp
+++ b/Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.cpp
@@ -1707,6 +1707,15 @@ bool AXIsolatedObject::press()
     return false;
 }
 
+bool AXIsolatedObject::syncPress()
+{
+    return Accessibility::retrieveValueFromMainThreadWithTimeoutAndDefault([context = mainThreadContext()] () -> bool {
+        if (RefPtr axObject = context.axObjectOnMainThread())
+            return axObject->press();
+        return false;
+    }, Accessibility::InteractiveTimeout, false);
+}
+
 void AXIsolatedObject::increment()
 {
     performFunctionOnMainThread([] (auto* axObject) {
@@ -1719,6 +1728,22 @@ void AXIsolatedObject::decrement()
     performFunctionOnMainThread([] (auto* axObject) {
         axObject->decrement();
     });
+}
+
+void AXIsolatedObject::syncIncrement()
+{
+    Accessibility::performFunctionOnMainThreadAndWaitWithTimeout([context = mainThreadContext()] {
+        if (RefPtr axObject = context.axObjectOnMainThread())
+            axObject->increment();
+    }, Accessibility::InteractiveTimeout);
+}
+
+void AXIsolatedObject::syncDecrement()
+{
+    Accessibility::performFunctionOnMainThreadAndWaitWithTimeout([context = mainThreadContext()] {
+        if (RefPtr axObject = context.axObjectOnMainThread())
+            axObject->decrement();
+    }, Accessibility::InteractiveTimeout);
 }
 
 bool AXIsolatedObject::isAccessibilityNodeObject() const
@@ -1762,15 +1787,14 @@ int AXIsolatedObject::insertionPointLineNumber() const
 
 String AXIsolatedObject::identifierAttribute() const
 {
-#if !LOG_DISABLED
-    return stringAttributeValue(AXProperty::IdentifierAttribute);
-#else
+    if (AXIsolatedTree::shouldCacheIdentifierAttribute())
+        return stringAttributeValue(AXProperty::IdentifierAttribute);
+
     return Accessibility::retrieveValueFromMainThreadWithTimeoutAndDefault([context = mainThreadContext()] () -> String {
         if (RefPtr object = context.axObjectOnMainThread())
             return object->identifierAttribute().isolatedCopy();
         return { };
     }, Accessibility::GeneralPropertyTimeout, emptyString());
-#endif
 }
 
 CharacterRange AXIsolatedObject::doAXRangeForLine(unsigned lineIndex) const

--- a/Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.h
+++ b/Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.h
@@ -498,6 +498,8 @@ private:
     FloatRect convertFrameToSpace(const FloatRect&, AccessibilityConversionSpace) const final;
     void increment() final;
     void decrement() final;
+    void syncIncrement() final;
+    void syncDecrement() final;
     bool performDismissAction() final;
     void performDismissActionIgnoringResult() final;
     void scrollToMakeVisible() const final;
@@ -506,6 +508,7 @@ private:
     bool replaceTextInRange(const String&, const CharacterRange&) final;
     bool insertText(const String&) final;
     bool press() final;
+    bool syncPress() final;
 
     bool isAccessibilityObject() const final { return false; }
 

--- a/Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.cpp
+++ b/Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.cpp
@@ -2110,6 +2110,10 @@ IsolatedObjectData createIsolatedObjectData(const Ref<AccessibilityObject>& axOb
             setProperty(AXProperty::IsBlockFlow, true);
             setProperty(AXProperty::StitchGroups, object.stitchGroups());
         }
+
+        if (AXIsolatedTree::shouldCacheIdentifierAttribute())
+            setProperty(AXProperty::IdentifierAttribute, object.identifierAttribute().isolatedCopy());
+
         appendBasePlatformProperties(properties, propertyFlags, axObject);
 
 #if ENABLE_ACCESSIBILITY_LOCAL_FRAME
@@ -2167,11 +2171,6 @@ IsolatedObjectData createIsolatedObjectData(const Ref<AccessibilityObject>& axOb
         setProperty(AXProperty::ExplicitInvalidStatus, object.explicitInvalidStatus().isolatedCopy());
         setProperty(AXProperty::SupportsExpanded, object.supportsExpanded());
         setProperty(AXProperty::SortDirection, static_cast<int>(object.sortDirection()));
-#if !LOG_DISABLED
-        // Eagerly cache ID when logging is enabled so that we can log isolated objects without constant deadlocks.
-        // Don't cache ID when logging is disabled because we don't expect non-test AX clients to actually request it.
-        setProperty(AXProperty::IdentifierAttribute, object.identifierAttribute().isolatedCopy());
-#endif
         // FIXME: We never update AXProperty::SupportsDropping.
         setProperty(AXProperty::SupportsDropping, object.supportsDropping());
         setProperty(AXProperty::SupportsDragging, object.supportsDragging());

--- a/Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.h
+++ b/Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.h
@@ -545,6 +545,17 @@ public:
     static bool anyTreeNeedsTearDown() { return s_anyTreeNeedsTearDown.load(std::memory_order_relaxed); }
     static void clearAnyTreeNeedsTearDown() { s_anyTreeNeedsTearDown.store(false, std::memory_order_relaxed); }
 
+    static bool shouldCacheIdentifierAttribute()
+    {
+#if !LOG_DISABLED
+        // Always cache the ID when logging is enabled to avoid
+        // main-thread hits when logging objects.
+        return true;
+#else
+        return AXObjectCache::clientIsInTestMode();
+#endif
+    }
+
     constexpr AXTreeID treeID() const { return m_id; }
     constexpr ProcessID processID() const { return m_processID; }
     void setPageActivityState(OptionSet<ActivityState>);

--- a/Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperMac.mm
+++ b/Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperMac.mm
@@ -3094,13 +3094,12 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_BEGIN
 
     if ([action isEqualToString:NSAccessibilityPressAction])
         [self accessibilityPerformPressAction];
-    else if ([action isEqualToString:NSAccessibilitySyncPressAction]) {
-        // Used in layout tests, so that we don't have to wait for the async press action.
-        [self _accessibilityPerformPressAction];
-    } else if ([action isEqualToString:NSAccessibilitySyncIncrementAction])
-        [self _accessibilityPerformIncrementAction];
+    else if ([action isEqualToString:NSAccessibilitySyncPressAction])
+        backingObject->syncPress();
+    else if ([action isEqualToString:NSAccessibilitySyncIncrementAction])
+        backingObject->syncIncrement();
     else if ([action isEqualToString:NSAccessibilitySyncDecrementAction])
-        [self _accessibilityPerformDecrementAction];
+        backingObject->syncDecrement();
     else if ([action isEqualToString:NSAccessibilityShowMenuAction])
         [self accessibilityPerformShowMenuAction];
     else if ([action isEqualToString:NSAccessibilityIncrementAction])

--- a/Tools/WebKitTestRunner/InjectedBundle/mac/AccessibilityUIElementMac.mm
+++ b/Tools/WebKitTestRunner/InjectedBundle/mac/AccessibilityUIElementMac.mm
@@ -3230,9 +3230,19 @@ JSRetainPtr<JSStringRef> AccessibilityUIElementMac::supportedActions() const
 bool AccessibilityUIElementMac::performAction(NSString *actionName) const
 {
     BEGIN_AX_OBJC_EXCEPTIONS
-    s_controller->executeOnAXThread([actionName, this] {
-        [m_element accessibilityPerformAction:actionName];
-    });
+    if ([actionName hasPrefix:@"AXSync"]) {
+        // Sync actions (e.g. AXSyncIncrementAction) use AXIsolatedObject::syncIncrement(),
+        // which waits for the main thread to complete the action. We must also wait here
+        // for the AX thread to finish, otherwise the calling JS would read stale values
+        // because the AX thread hasn't even begun executing the action yet.
+        s_controller->executeOnAXThreadAndWait([actionName, this] {
+            [m_element accessibilityPerformAction:actionName];
+        });
+    } else {
+        s_controller->executeOnAXThread([actionName, this] {
+            [m_element accessibilityPerformAction:actionName];
+        });
+    }
     END_AX_OBJC_EXCEPTIONS
 
     // macOS actions don't return a value.


### PR DESCRIPTION
#### 10cf146df71dda384d82998189b436a8af1d04ed
<pre>
AX: Fix isolated tree mode test failures for sync actions, element-by-ID lookup, and async tree updates
<a href="https://bugs.webkit.org/show_bug.cgi?id=314200">https://bugs.webkit.org/show_bug.cgi?id=314200</a>
<a href="https://rdar.apple.com/176364545">rdar://176364545</a>

Reviewed by Dominic Mazzoni.

C++ Source changes:

  - Add syncIncrement(), syncDecrement(), syncPress() to AXIsolatedObject that use
    performFunctionOnMainThreadAndWaitWithTimeout with InteractiveTimeout. The regular
    increment()/decrement() remain async (fire-and-forget) for real client use.

  - WebAccessibilityObjectWrapperMac&apos;s accessibilityPerformAction: now calls
    syncIncrement()/syncDecrement()/syncPress() directly for AXSync* action variants
    instead of going through the _accessibilityPerform*Action helpers.

  - In test mode, AXProperty::IdentifierAttribute is now eagerly cached during isolated tree
    construction (for all objects, including ignored ones) and kept up-to-date via IdAttributeChanged notifications.
    This allows accessibleElementById to find elements by DOM ID without a main-thread round-trip, avoiding the 25ms
    timeout that failed when the main thread was busy (e.g. processing large deferred cache updates as part of
    deep-aria-owns-chain.html and most critically: client tests).

    Tests that dynamically assigned IDs solely for lookup purposes (roles-exposed, roles-computedRoleString,
    roles-table-and-cell, heading-level) were updated to use static IDs instead, since they weren&apos;t intending
    to test dynamic ID behavior. Tests that intentionally test dynamic ID changes (element-reflection-aria*)
    use await waitForElementById to wait for the change to propagate.

  - AXIsolatedObject::identifierAttribute(), in test mode only, now uses callOnMainThreadAndWait
    (no timeout) instead of the 25ms-timeout dispatch, which failed us in tests that
    caused the main-thread to do a lot of work (e.g. aria-owns-deep-chain-no-timeout.html).

Test runner changes:

  - AccessibilityUIElementMac::performAction uses executeOnAXThreadAndWait for sync
    actions (AXSync* prefix) so JS waits for the AX thread to complete the action.

Test changes:

  - insert-text-into-password-field: made async, uses expectAsync to wait for value.

  - image-load-on-delay: uses waitFor(() =&gt; childrenCount === 3) to explicitly wait for
    the condition we expect rather than hoping we get lucky with timing on a setTimeout(0).

  - async-increment-decrement-action: sync actions are now actually sync per above. async actions
    now use expectAsync to wait for values to propagate between operations.

  - loading-iframe-sends-notification: marked [ Pass Failure ] in ITM TestExpectations
    due to a pre-existing cross-frame isolated tree bug (child frame&apos;s AXObjectCache
    doesn&apos;t reliably notify parent to re-fetch cross-frame children after load).

  - keyevents-for-actions-mimic-real-key-events and
    keyevents-posted-for-increment-actions: removed [ Failure ] expectation since the
    performAction sync fix makes them pass.

Overall, this fixes the following tests when run with ITM:
  1. accessibility/aria-owns-deep-chain-no-timeout.html
  2. accessibility/insert-text-into-password-field.html
  3. accessibility/image-load-on-delay.html
  4. accessibility/mac/async-increment-decrement-action.html
  5. accessibility/keyevents-for-actions-mimic-real-key-events.html
  6. accessibility/keyevents-posted-for-increment-actions.html

* LayoutTests/accessibility-isolated-tree/TestExpectations:
* LayoutTests/accessibility/aria-owns-deep-chain-no-timeout.html:
* LayoutTests/accessibility/image-load-on-delay.html:
* LayoutTests/accessibility/insert-text-into-password-field-expected.txt:
* LayoutTests/accessibility/insert-text-into-password-field.html:
* LayoutTests/accessibility/mac/async-increment-decrement-action-expected.txt:
* LayoutTests/accessibility/mac/async-increment-decrement-action.html:
* Source/WebCore/accessibility/AXCoreObject.h:
* Source/WebCore/accessibility/AccessibilityObject.h:
* Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.cpp:
(WebCore::AXIsolatedObject::syncPress):
(WebCore::AXIsolatedObject::syncIncrement):
(WebCore::AXIsolatedObject::syncDecrement):
(WebCore::AXIsolatedObject::identifierAttribute const):
* Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.h:
* Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperMac.mm:
(-[WebAccessibilityObjectWrapper accessibilityPerformAction:]):
* Tools/WebKitTestRunner/InjectedBundle/mac/AccessibilityUIElementMac.mm:
(WTR::AccessibilityUIElementMac::performAction const):

Canonical link: <a href="https://commits.webkit.org/312848@main">https://commits.webkit.org/312848@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/954a47d32eab7714abe062aca9682cc58f8cb812

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/161032 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/34505 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/27606 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/169935 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/117292 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/9dfe24a3-8f5f-4f88-b9f0-159ef6194fa9) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/162901 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/34606 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/34505 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/124905 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/117292 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/163991 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/27173 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/144645 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/105502 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/13bea83d-9591-4683-bda8-e5b95fe6dd1f) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/26222 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/24722 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/17655 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/135916 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/22407 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/172418 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/19439 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/24048 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/133185 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/34179 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/28815 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/133195 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36020 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/34163 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/144202 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/96002 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/27754 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/21020 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/33674 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/101099 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/33173 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/33417 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/33322 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->