### PR TITLE
[WebXR Layers] Crashes in OpenXRLayer's endFrame() for various layer types

### DIFF
--- a/Source/WebCore/Modules/webxr/WebXRSession.cpp
+++ b/Source/WebCore/Modules/webxr/WebXRSession.cpp
@@ -710,10 +710,8 @@ void WebXRSession::onFrame(PlatformXR::FrameData&& frameData)
         // 5. If the active flag of any view in the list of views has changed since the last XR animation frame, update the viewports.
         // FIXME: implement.
 
-        // FIXME: I moved step 7 before 6 because of https://github.com/immersive-web/webxr/issues/1164
-        // 7.If session’s pending render state is not null, apply the pending render state.
-        if (session.m_pendingRenderState)
-            session.applyPendingRenderState();
+        if (session.m_inputInitialized)
+            session.m_inputSources->update(now, session.m_frameData.inputSources);
 
 #if ENABLE(WEBXR_HIT_TEST)
         // Cancel hit test sources that are not referenced by the application.
@@ -740,11 +738,6 @@ void WebXRSession::onFrame(PlatformXR::FrameData&& frameData)
 
             // 6.3.Set frame’s active boolean to true.
             frame->setActive(true);
-
-            // 6.4.Apply frame updates for frame.
-            if (session.m_inputInitialized)
-                session.m_inputSources->update(now, session.m_frameData.inputSources);
-
             tracePoint(WebXRSessionFrameCallbacksStart);
             session.minimalUpdateRendering();
             // 6.5.For each entry in session’s list of currently running animation frame callbacks, in order:
@@ -786,6 +779,9 @@ void WebXRSession::onFrame(PlatformXR::FrameData&& frameData)
             if (RefPtr device = session.m_device.get())
                 device->submitFrame(WTF::move(frameLayers));
         }
+
+        if (session.m_pendingRenderState)
+            session.applyPendingRenderState();
 
         session.requestFrameIfNeeded();
     });

--- a/Source/WebKit/UIProcess/XR/openxr/OpenXRLayer.cpp
+++ b/Source/WebKit/UIProcess/XR/openxr/OpenXRLayer.cpp
@@ -765,10 +765,7 @@ std::optional<PlatformXR::FrameData::LayerData> OpenXRCylinderLayer::startFrame(
 
 Vector<XrCompositionLayerBaseHeader*> OpenXRCylinderLayer::endFrame(const PlatformXR::DeviceLayer& layer, XrSpace space, const Vector<XrView>& frameViews)
 {
-    if (!m_swapchain->acquiredTexture()) {
-        LOG_ERROR("OpenXRCylinderLayer::endFrame called without a valid acquired texture");
-        return { };
-    }
+    ASSERT(m_swapchain->acquiredTexture());
 
 #if OS(ANDROID) || USE(GBM)
     if (needsBlitTexture()) {

--- a/Source/WebKit/UIProcess/XR/openxr/PlatformXROpenXR.cpp
+++ b/Source/WebKit/UIProcess/XR/openxr/PlatformXROpenXR.cpp
@@ -66,7 +66,7 @@ struct OpenXRCoordinator::RenderState {
     XrFrameState frameState;
     bool passthroughFullyObscured { false };
     Vector<PlatformXR::LayerHandle> activeLayerHandles;
-    Vector<PlatformXR::LayerHandle> currentFrameLayerHandles;
+    Vector<PlatformXR::LayerHandle> frameActiveLayerHandles;
 #if ENABLE(WEBXR_HIT_TEST)
     HashMap<PlatformXR::HitTestSource, UniqueRef<PlatformXR::HitTestOptions>> hitTestSources;
     HashMap<PlatformXR::TransientInputHitTestSource, UniqueRef<PlatformXR::TransientInputHitTestOptions>> transientInputHitTestSources;
@@ -364,7 +364,7 @@ void OpenXRCoordinator::startSession(WebPageProxy& page, WeakPtr<PlatformXRCoord
                     cleanupAllResources();
                     return;
                 }
-                renderLoop(renderState);
+                waitForSessionReady(renderState, [] { });
             });
         },
         [&](Active&) {
@@ -396,10 +396,15 @@ void OpenXRCoordinator::endSessionIfExists(WebPageProxy& page)
                     cleanupAllResources();
                     return;
                 }
+                // If xrBeginFrame() was called but submitFrame() cannot be dispatched (the main thread is blocked in dispatchSync),
+                // close the open frame before requesting exit, as OpenXR requires xrEndFrame() to be paired with every xrBeginFrame().
+                if (renderState->pendingFrame)
+                    endFrame(renderState, { });
+
                 // OpenXR will transition the session to STOPPING state and then we will call xrEndSession().
                 CHECK_XRCMD(xrRequestExitSession(m_session));
                 while (m_session != XR_NULL_HANDLE)
-                    renderLoop(renderState);
+                    pollEvents();
             });
             active.renderQueue = nullptr;
 
@@ -442,7 +447,7 @@ void OpenXRCoordinator::scheduleAnimationFrame(WebPageProxy& page, std::optional
                     renderState->activeLayerHandles = requestData->activeLayerHandles;
                 }
                 renderState->onFrameUpdate = WTF::move(onFrameUpdateCallback);
-                renderLoop(renderState);
+                maybeBeginFrame(renderState);
             });
         });
 }
@@ -467,7 +472,7 @@ void OpenXRCoordinator::submitFrame(WebPageProxy& page, Vector<PlatformXR::Devic
 
             active.renderQueue->dispatch([this, renderState = active.renderState, layers = WTF::move(layers)]() mutable {
                 endFrame(renderState, WTF::move(layers));
-                renderLoop(renderState);
+                maybeBeginFrame(renderState);
             });
         });
 }
@@ -1119,7 +1124,7 @@ PlatformXR::FrameData OpenXRCoordinator::populateFrameData(Box<RenderState> rend
         frameData.floorTransform = XrIdentityPose();
 
     for (auto& layer : m_layers) {
-        if (!renderState->currentFrameLayerHandles.contains(layer.key))
+        if (!renderState->activeLayerHandles.contains(layer.key))
             continue;
         auto layerData = layer.value->startFrame();
         if (layerData) {
@@ -1232,6 +1237,11 @@ void OpenXRCoordinator::beginFrame(Box<RenderState> renderState)
 {
     ASSERT(!RunLoop::isMain());
 
+    if (pollEvents() == PollResult::Stop)
+        return;
+
+    renderState->frameActiveLayerHandles = renderState->activeLayerHandles;
+
     XrFrameWaitInfo frameWaitInfo = createOpenXRStruct<XrFrameWaitInfo, XR_TYPE_FRAME_WAIT_INFO>();
     XrFrameState frameState = createOpenXRStruct<XrFrameState, XR_TYPE_FRAME_STATE>();
     CHECK_XRCMD(xrWaitFrame(m_session, &frameWaitInfo, &frameState));
@@ -1241,7 +1251,6 @@ void OpenXRCoordinator::beginFrame(Box<RenderState> renderState)
 
     // We should not directly use renderState->frameState in the xrWaitFrame() in order not to override the previous (ongoing) value.
     renderState->frameState = frameState;
-    renderState->currentFrameLayerHandles = renderState->activeLayerHandles;
 
     createReferenceSpacesIfNeeded(renderState);
     PlatformXR::FrameData frameData = populateFrameData(renderState);
@@ -1265,11 +1274,18 @@ void OpenXRCoordinator::endFrame(Box<RenderState> renderState, Vector<PlatformXR
 
     Vector<XrCompositionLayerBaseHeader*> frameEndLayers;
     for (auto& layer : layers) {
-        ASSERT(renderState->currentFrameLayerHandles.contains(layer.handle));
-
         auto it = m_layers.find(layer.handle);
         if (it == m_layers.end()) {
-            LOG(XR, "Didn't find a OpenXRLayer with %d handle", layer.handle);
+            // This should not happen as handlers are created here and never changed in the WebProcess. However it could be the case that a layer
+            // is removed but still submitted for rendering due to some unfortunate timing of IPC messages and/or asynchronous methods.
+            RELEASE_LOG(XR, "OpenXRCoordinator::endFrame: skipping unknown layer handle %d", layer.handle);
+            continue;
+        }
+
+        if (!renderState->frameActiveLayerHandles.contains(layer.handle)) {
+            // endFrame should only process layers that beginFrame started. If IPC delivers a layer handle that was not in frameActiveLayerHandles
+            // (i.e. due to a call to updateRenderState with a different list of layers), skip it to avoid asserting on an unacquired swapchain.
+            RELEASE_LOG(XR, "OpenXRCoordinator::endFrame: skipping layer not started in beginFrame");
             continue;
         }
 
@@ -1292,21 +1308,26 @@ void OpenXRCoordinator::endFrame(Box<RenderState> renderState, Vector<PlatformXR
     renderState->pendingFrame = false;
 }
 
-void OpenXRCoordinator::renderLoop(Box<RenderState> renderState)
+void OpenXRCoordinator::maybeBeginFrame(Box<RenderState> renderState)
 {
-    while (pollEvents() != PollResult::Stop) {
-        if (!m_isSessionRunning && m_sessionState < XR_SESSION_STATE_READY) {
-            RunLoop::currentSingleton().dispatchAfter(250_ms, [this, renderState] {
-                renderLoop(renderState);
-            });
-            return;
-        }
+    ASSERT(!RunLoop::isMain());
+    if (renderState->pendingFrame || !renderState->onFrameUpdate || renderState->terminateRequested)
+        return;
+    beginFrame(renderState);
+}
 
-        if (!renderState->onFrameUpdate || renderState->pendingFrame)
-            return;
-
-        beginFrame(renderState);
+void OpenXRCoordinator::waitForSessionReady(Box<RenderState> renderState, Function<void()>&& onReady)
+{
+    ASSERT(!RunLoop::isMain());
+    if (pollEvents() == PollResult::Stop)
+        return;
+    if (!m_isSessionRunning && m_sessionState < XR_SESSION_STATE_READY) {
+        RunLoop::currentSingleton().dispatchAfter(250_ms, [this, renderState, onReady = WTF::move(onReady)]() mutable {
+            waitForSessionReady(WTF::move(renderState), WTF::move(onReady));
+        });
+        return;
     }
+    onReady();
 }
 
 

--- a/Source/WebKit/UIProcess/XR/openxr/PlatformXROpenXR.h
+++ b/Source/WebKit/UIProcess/XR/openxr/PlatformXROpenXR.h
@@ -110,7 +110,8 @@ private:
     PlatformXR::FrameData populateFrameData(Box<RenderState>);
     void beginFrame(Box<RenderState>);
     void endFrame(Box<RenderState>, Vector<PlatformXR::DeviceLayer>&&);
-    void renderLoop(Box<RenderState>);
+    void maybeBeginFrame(Box<RenderState>);
+    void waitForSessionReady(Box<RenderState>, Function<void()>&&);
     XrEnvironmentBlendMode blendModeForSessionMode(Box<RenderState>) const;
 
     XRDeviceIdentifier m_deviceIdentifier { XRDeviceIdentifier::generate() };


### PR DESCRIPTION
#### b0baaeaf0cd873d4019bc487495cb80e46859404
<pre>
[WebXR Layers] Crashes in OpenXRLayer&apos;s endFrame() for various layer types
<a href="https://bugs.webkit.org/show_bug.cgi?id=314069">https://bugs.webkit.org/show_bug.cgi?id=314069</a>

Reviewed by Dan Glastonbury.

Soon after receiving a scheduleAnimationFrame() call, the UIProcess calls
beginFrame, which acquires a swapchain image for every active layer
(active layers are notified via requestData coming from WebProcess).
Then WebProcess renders into those textures and eventually calls
submitFrame() with the set of active layers (specified by WebXR when
calling updateRenderState) causing the UIProcess to release all those
acquired images. It&apos;s critical to perfectly pair each acquireImage call with
their correspondent releaseImage call, otherwise calling any of those
twice in a row would cause an exception.

The problem arises because JavaScript can call updateRenderState() at
any point — including between a frame callback and the corresponding
submitFrame() — to install a different set of active layers. Per the WebXR
spec, the new layer list takes effect at the start of the next frame. However,
due to the asynchronous nature of most of those calls, the OpenXR
render queue can receive the next scheduleAnimationFrame() message
(carrying the updated layer list, which overwrites activeLayerHandles)
before it receives the submitFrame() message for the current frame.

Should endFrame() check activeLayerHandles at that point, it would be
looking at the new frame&apos;s list, not the one that beginFrame() actually
used when acquiring swapchain images. This produces two failure
scenarios, both of which violate invariants that the OpenXR runtime enforces:

- A layer acquired in beginFrame() but absent from the updated list would
  never be released, leading to two consecutive acquireImage calls.
- A layer present in submitFrame()&apos;s payload but not acquired in the matching
  beginFrame() would be released without a prior acquire.

To ensure consistency, we do snapshot the list of layers available at
beginFrame() and filter out those layers received in submitFrame() that
are not present in the snapshot. This way, we avoid the two problems
mentioned above. The worst case scenario is a layer (or various layers)
not rendered for a single frame.

Apart from revamping the OpenXR pipeline we are also adding a general
purpose fix. As per specs[1] applyind the pending render state should be
done at the very end of the XR animation frame. We used to do it
before calling each one of the currently running animation frame
callbacks, which was wrong. This reduces the amount of potentially
problematic cases in which there is a mismatch between the active
layers at the beginning and end of a frame, but does not remove them all.

We&apos;re also unconditionally updating the input sources independently of
the frame shouldRender status. With the above reorganization, the first
frame could not get rendered (as the active render state is not applied
yet), so the input sources were not updated, and some tests started to fail.

[1] <a href="https://www.w3.org/TR/webxr/#ref-for-apply-the-pending-render-state">https://www.w3.org/TR/webxr/#ref-for-apply-the-pending-render-state</a>

No new tests, as this requires an actual OpenXR runtime running on a
device to reproduce the crashes. The fake XR device we use for testing
does not obviously use OpenXR. The changes in WebXRSession are covered
by existing tests.

* Source/WebCore/Modules/webxr/WebXRSession.cpp:
(WebCore::WebXRSession::onFrame):
* Source/WebKit/UIProcess/XR/openxr/OpenXRLayer.cpp:
* Source/WebKit/UIProcess/XR/openxr/PlatformXROpenXR.cpp:
(WebKit::OpenXRCoordinator::startSession):
(WebKit::OpenXRCoordinator::endSessionIfExists):
(WebKit::OpenXRCoordinator::scheduleAnimationFrame):
(WebKit::OpenXRCoordinator::submitFrame):
(WebKit::OpenXRCoordinator::populateFrameData):
(WebKit::OpenXRCoordinator::beginFrame):
(WebKit::OpenXRCoordinator::endFrame):
(WebKit::OpenXRCoordinator::maybeBeginFrame):
(WebKit::OpenXRCoordinator::waitForSessionReady):
(WebKit::OpenXRCoordinator::renderLoop): Deleted.
* Source/WebKit/UIProcess/XR/openxr/PlatformXROpenXR.h:

Canonical link: <a href="https://commits.webkit.org/312788@main">https://commits.webkit.org/312788@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2163077a3b92df3c8e2e6aca4f91bc290afb440d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/161109 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/34582 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/27683 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/170012 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/117369 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/162978 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/34683 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/34583 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/124966 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/117369 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/164068 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/27242 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/144714 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/105563 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/26291 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/24793 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/17732 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/135985 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/22475 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/172495 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/19516 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/24116 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/133245 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/34256 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/28885 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/133255 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35982 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/34240 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/144270 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/96079 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/27798 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/21088 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/33751 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/101176 "Built successfully") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/33250 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/33494 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/33399 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->