### PR TITLE
[TextureMapper] Round-clip shader needs highp on PowerVR B-Series

### DIFF
--- a/LayoutTests/compositing/clipping/border-radius-async-overflow-stacking.html
+++ b/LayoutTests/compositing/clipping/border-radius-async-overflow-stacking.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html> <!-- webkit-test-runner [ AsyncOverflowScrollingEnabled=true ] -->
 <html>
 <head>
-    <meta name="fuzzy" content="maxDifference=0-42; totalPixels=0-48" />
+    <meta name="fuzzy" content="maxDifference=0-42; totalPixels=0-400" />
     <style>
         .scroller {
             margin: 10px;

--- a/LayoutTests/svg/compositing/svg-poster-circle.html
+++ b/LayoutTests/svg/compositing/svg-poster-circle.html
@@ -2,7 +2,7 @@
 <html>
   <head>
     <!-- FIXME: SVG content slightly clipped (up to 1px) due to off-device-pixel-alignment issue, remove when fixed. -->
-    <meta name="fuzzy" content="maxDifference=0-92; totalPixels=0-11546" />
+    <meta name="fuzzy" content="maxDifference=0-110; totalPixels=0-12500" />
 
     <style>
       html, body {

--- a/Source/WebCore/platform/graphics/texmap/TextureMapperShaderProgram.cpp
+++ b/Source/WebCore/platform/graphics/texmap/TextureMapperShaderProgram.cpp
@@ -87,7 +87,7 @@ static const char* vertexTemplateLT320Vars =
         varying vec2 v_texCoord;
         varying vec2 v_transformedTexCoord;
         varying float v_antialias;
-        varying vec4 v_nonProjectedPosition;
+        varying highp vec4 v_nonProjectedPosition;
     );
 // clang-format off
 static const char* vertexTemplateCommon =
@@ -237,7 +237,7 @@ static const char* fragmentTemplateLT320Vars =
         varying float v_antialias;
         varying vec2 v_texCoord;
         varying vec2 v_transformedTexCoord;
-        varying vec4 v_nonProjectedPosition;
+        varying highp vec4 v_nonProjectedPosition;
     );
 
 static const char* fragmentTemplateYUVToRGB =
@@ -350,8 +350,8 @@ static const char* fragmentTemplateCommon =
         uniform int u_gaussianKernelHalfSize;
         uniform vec2 u_blurDirection;
         uniform int u_roundedRectNumber;
-        uniform vec4 u_roundedRect[ROUNDED_RECT_ARRAY_SIZE];
-        uniform mat4 u_roundedRectInverseTransformMatrix[ROUNDED_RECT_INVERSE_TRANSFORM_ARRAY_SIZE];
+        uniform highp vec4 u_roundedRect[ROUNDED_RECT_ARRAY_SIZE];
+        uniform highp mat4 u_roundedRectInverseTransformMatrix[ROUNDED_RECT_INVERSE_TRANSFORM_ARRAY_SIZE];
 
         void noop(inout vec4 dummyParameter) { }
         void noop(inout vec4 dummyParameter, vec2 texCoord) { }
@@ -558,32 +558,32 @@ static const char* fragmentTemplateCommon =
 
         void applySolidColor(inout vec4 color) { color *= u_color; }
 
-        float ellipsisDist(vec2 p, vec2 radius)
+        float ellipsisDist(highp vec2 p, highp vec2 radius)
         {
             if (radius == vec2(0, 0))
                 return 0.0;
 
-            vec2 p0 = p / radius;
-            vec2 p1 = 2.0 * p0 / radius;
+            highp vec2 p0 = p / radius;
+            highp vec2 p1 = 2.0 * p0 / radius;
 
             return (dot(p0, p0) - 1.0) / length (p1);
         }
 
-        float ellipsisCoverage(vec2 point, vec2 center, vec2 radius)
+        float ellipsisCoverage(highp vec2 point, highp vec2 center, highp vec2 radius)
         {
-            float d = ellipsisDist(point - center, radius);
+            highp float d = ellipsisDist(point - center, radius);
             return clamp(0.5 - d, 0.0, 1.0);
         }
 
-        float roundedRectCoverage(vec2 p, vec4 bounds, vec2 topLeftRadii, vec2 topRightRadii, vec2 bottomLeftRadii, vec2 bottomRightRadii)
+        float roundedRectCoverage(highp vec2 p, highp vec4 bounds, highp vec2 topLeftRadii, highp vec2 topRightRadii, highp vec2 bottomLeftRadii, highp vec2 bottomRightRadii)
         {
             if (p.x < bounds.x || p.y < bounds.y || p.x >= bounds.z || p.y >= bounds.w)
                 return 0.0;
 
-            vec2 topLeftCenter = bounds.xy + topLeftRadii;
-            vec2 topRightCenter = bounds.zy + (topRightRadii * vec2(-1, 1));
-            vec2 bottomLeftCenter = bounds.xw + (bottomLeftRadii * vec2(1, -1));
-            vec2 bottomRightCenter = bounds.zw + (bottomRightRadii * vec2(-1, -1));
+            highp vec2 topLeftCenter = bounds.xy + topLeftRadii;
+            highp vec2 topRightCenter = bounds.zy + (topRightRadii * vec2(-1, 1));
+            highp vec2 bottomLeftCenter = bounds.xw + (bottomLeftRadii * vec2(1, -1));
+            highp vec2 bottomRightCenter = bounds.zw + (bottomRightRadii * vec2(-1, -1));
 
             if (p.x < topLeftCenter.x && p.y < topLeftCenter.y)
                 return ellipsisCoverage(p, topLeftCenter, topLeftRadii);
@@ -611,17 +611,24 @@ static const char* fragmentTemplateCommon =
             //
             // This implementation is not optimal, but it's done this way in order to overcome rpi3's
             // proprietary video driver limitations (see https://bugs.webkit.org/show_bug.cgi?id=219739).
+            //
+            // The round-clip data, varying and locals carry highp because some proprietary GLES
+            // drivers mishandle the (dot(p0,p0) - 1.0) / length(p1) form in ellipsisDist() under
+            // mediump (fp16): on PowerVR B-Series (Imagination DDK) ellipsisCoverage returns 0
+            // for fragments deep inside the inscribed ellipse, turning the clipped descendant
+            // layers into solid coverage=0 (silent black). highp on the round-clip path only
+            // restores correct output and preserves mediump elsewhere.
 
             for (int rectIndex = 0; rectIndex < ROUNDED_RECT_MAX_RECTS; rectIndex++) {
                 if (rectIndex >= u_roundedRectNumber)
                     break;
 
-                vec4 fragCoord = u_roundedRectInverseTransformMatrix[rectIndex] * v_nonProjectedPosition;
-                vec4 bounds = vec4(u_roundedRect[rectIndex * 3].xy, u_roundedRect[rectIndex * 3].xy + u_roundedRect[rectIndex * 3].zw);
-                vec2 topLeftRadii = u_roundedRect[(rectIndex * 3) + 1].xy;
-                vec2 topRightRadii = u_roundedRect[(rectIndex * 3) + 1].zw;
-                vec2 bottomLeftRadii = u_roundedRect[(rectIndex * 3) + 2].xy;
-                vec2 bottomRightRadii = u_roundedRect[(rectIndex * 3) + 2].zw;
+                highp vec4 fragCoord = u_roundedRectInverseTransformMatrix[rectIndex] * v_nonProjectedPosition;
+                highp vec4 bounds = vec4(u_roundedRect[rectIndex * 3].xy, u_roundedRect[rectIndex * 3].xy + u_roundedRect[rectIndex * 3].zw);
+                highp vec2 topLeftRadii = u_roundedRect[(rectIndex * 3) + 1].xy;
+                highp vec2 topRightRadii = u_roundedRect[(rectIndex * 3) + 1].zw;
+                highp vec2 bottomLeftRadii = u_roundedRect[(rectIndex * 3) + 2].xy;
+                highp vec2 bottomRightRadii = u_roundedRect[(rectIndex * 3) + 2].zw;
                 float coverage = roundedRectCoverage(fragCoord.xy, bounds, topLeftRadii, topRightRadii, bottomLeftRadii, bottomRightRadii);
 
                 // Pixels outside the rect have coverage 0.0.


### PR DESCRIPTION
#### 74a41b5f4ec4b216ca4ddac4ffa0ba325374924f
<pre>
[TextureMapper] Round-clip shader needs highp on PowerVR B-Series
<a href="https://bugs.webkit.org/show_bug.cgi?id=314201">https://bugs.webkit.org/show_bug.cgi?id=314201</a>

Reviewed by Miguel Gomez.

The GLSL helpers used by applyRoundedRectClip (ellipsisDist,
ellipsisCoverage, roundedRectCoverage) compute corner coverage as
(dot(p0,p0) - 1.0) / length(p1). On some proprietary GLES drivers this
form is miscomputed under mediump (fp16). Reproduced on PowerVR
B-Series (Imagination DDK 24.1@6554834): ellipsisCoverage returns 0
for fragments well inside the inscribed ellipse, so descendants under
a &apos;border-radius + overflow:hidden&apos; ancestor render as solid
coverage=0 (silent black) instead of being correctly clipped.

The fix here is to promote precision on the round-clip path only:

* v_nonProjectedPosition varying (vertex + fragment templates)
* u_roundedRect, u_roundedRectInverseTransformMatrix uniforms
* parameters and locals in ellipsisDist, ellipsisCoverage,
roundedRectCoverage
* locals in applyRoundedRectClip (fragCoord, bounds, *Radii)

This keeps mediump for the rest of the fragment shader (filters,
blur, tone-map) so the cost is confined to the round-clip path.

Tested on device, glitch is gone. The same issue can be reproduced using
WebGL, so a separate bug to Imagination might need to be raised.
Updated layout tests to add a bit more leeway due to the changes in the
shader (no visual difference at plain sight).

* LayoutTests/compositing/clipping/border-radius-async-overflow-stacking.html:
* LayoutTests/svg/compositing/svg-poster-circle.html:
* Source/WebCore/platform/graphics/texmap/TextureMapperShaderProgram.cpp:

Canonical link: <a href="https://commits.webkit.org/312802@main">https://commits.webkit.org/312802@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ccf2e1514fc01873e4ce36d5b1d5882fa27142a8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/161133 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/34606 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/27707 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/170036 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/117393 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/163002 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/34707 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/34607 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/124987 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/117393 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/164092 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/27262 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/144739 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/105584 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/26311 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/24815 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/17756 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/136005 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/22500 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/172519 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/19540 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/24141 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/133266 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/34280 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/28908 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/133276 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35992 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/34264 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/144295 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/96103 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/27823 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/21113 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/33775 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/101200 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/33274 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/33518 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/33423 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->