### PR TITLE
revert-layer doesn't compute correctly if there is a leading empty/space substitution

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-variables/variable-css-wide-keywords-after-substitution-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-variables/variable-css-wide-keywords-after-substitution-expected.txt
@@ -1,0 +1,19 @@
+direct initial
+substituted initial
+direct inherit
+substituted inherit
+direct unset
+substituted unset
+direct revert
+substituted revert
+direct revert-layer
+substituted revert-layer
+use-as-sibling
+
+PASS CSS-wide keyword `initial` after var() substitution
+PASS CSS-wide keyword `inherit` after var() substitution
+PASS CSS-wide keyword `unset` after var() substitution
+PASS CSS-wide keyword `revert` after var() substitution
+PASS CSS-wide keyword `revert-layer` after var() substitution
+PASS revert-layer after var() substitution takes effect on the cascade
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-variables/variable-css-wide-keywords-after-substitution.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-variables/variable-css-wide-keywords-after-substitution.html
@@ -1,0 +1,88 @@
+<!DOCTYPE html>
+<title>CSS Custom Properties: CSS-wide keyword detected after var() substitution</title>
+<link rel="help" href="https://drafts.csswg.org/css-variables-2/#defining-variables">
+<link rel="help" href="https://drafts.csswg.org/css-values-5/#substitute-arbitrary-substitution-function">
+<meta name="assert" content="A CSS-wide keyword as the sole non-whitespace token of a custom property's value after arbitrary substitution is treated as that keyword, equivalent to specifying the keyword directly.">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<style>
+  #parent > .direct,
+  #parent > .substituted,
+  #parent > .use-as-sibling {
+    --empty: ;
+  }
+
+  /* initial */
+  #parent > .direct.initial     { --x: initial; }
+  #parent > .substituted.initial { --x: var(--empty) initial; }
+
+  /* inherit */
+  #parent > .direct.inherit     { --x: inherit; }
+  #parent > .substituted.inherit { --x: var(--empty) inherit; }
+
+  /* unset */
+  #parent > .direct.unset       { --x: unset; }
+  #parent > .substituted.unset   { --x: var(--empty) unset; }
+
+  /* revert */
+  #parent > .direct.revert      { --x: revert; }
+  #parent > .substituted.revert  { --x: var(--empty) revert; }
+
+  /* revert-layer (layered) */
+  #parent > .direct.revert-layer {
+    @layer a { --x: layer-a-value; }
+    @layer b { & { --x: revert-layer; } }
+  }
+  #parent > .substituted.revert-layer {
+    @layer a { --x: layer-a-value; }
+    @layer b { & { --x: var(--empty) revert-layer; } }
+  }
+
+  /* Use --x as a sibling of a literal (exercises the bug's failure mode too). */
+  #parent > .use-as-sibling {
+    @layer a { --x: ; }
+    @layer b { & { --x: var(--empty) revert-layer; } }
+    background: var(--x) green;
+  }
+</style>
+
+<div id="parent">
+  <div class="direct initial">direct initial</div>
+  <div class="substituted initial">substituted initial</div>
+
+  <div class="direct inherit">direct inherit</div>
+  <div class="substituted inherit">substituted inherit</div>
+
+  <div class="direct unset">direct unset</div>
+  <div class="substituted unset">substituted unset</div>
+
+  <div class="direct revert">direct revert</div>
+  <div class="substituted revert">substituted revert</div>
+
+  <div class="direct revert-layer">direct revert-layer</div>
+  <div class="substituted revert-layer">substituted revert-layer</div>
+
+  <div class="use-as-sibling">use-as-sibling</div>
+</div>
+
+<script>
+  const keywords = ['initial', 'inherit', 'unset', 'revert', 'revert-layer'];
+  for (const keyword of keywords) {
+    test(() => {
+      const direct = document.querySelector('#parent > .direct.' + CSS.escape(keyword));
+      const substituted = document.querySelector('#parent > .substituted.' + CSS.escape(keyword));
+      const directValue = getComputedStyle(direct).getPropertyValue('--x');
+      const substitutedValue = getComputedStyle(substituted).getPropertyValue('--x');
+      assert_equals(substitutedValue, directValue,
+        '`var(--empty) ' + keyword + '` must resolve identically to `' + keyword + '`');
+    }, 'CSS-wide keyword `' + keyword + '` after var() substitution');
+  }
+
+  test(() => {
+    // `--x: var(--empty) revert-layer;` in layer b must revert to layer a's empty value,
+    // so `background: var(--x) green` resolves to `background: green`.
+    const el = document.querySelector('#parent > .use-as-sibling');
+    assert_equals(getComputedStyle(el).backgroundColor, 'rgb(0, 128, 0)');
+  }, 'revert-layer after var() substitution takes effect on the cascade');
+</script>

--- a/Source/WebCore/css/parser/CSSPropertyParser.cpp
+++ b/Source/WebCore/css/parser/CSSPropertyParser.cpp
@@ -214,21 +214,6 @@ static RefPtr<CSSValue> consumeCSSWideKeywordValue(CSSParserTokenRange& range)
     return CSSKeywordValue::create(valueID);
 }
 
-static std::optional<CSSWideKeyword> consumeCSSWideKeyword(CSSParserTokenRange& range)
-{
-    auto rangeCopy = range;
-    auto valueID = rangeCopy.consumeIncludingWhitespace().id();
-    if (!rangeCopy.atEnd())
-        return { };
-
-    auto keyword = parseCSSWideKeyword(valueID);
-    if (!keyword)
-        return { };
-
-    range = rangeCopy;
-    return keyword;
-}
-
 // MARK: - Parser entry points
 
 using namespace CSSPropertyParserHelpers;
@@ -462,11 +447,6 @@ RefPtr<CSSValue> CSSPropertyParser::parseWithSyntax(const CSSCustomPropertySynta
     if (!value || !range.atEnd())
         return { };
     return value;
-}
-
-std::optional<CSSWideKeyword> CSSPropertyParser::parseCSSWideKeyword(CSSParserTokenRange range)
-{
-    return consumeCSSWideKeyword(range);
 }
 
 std::pair<RefPtr<CSSValue>, CSSCustomPropertySyntax::Type> consumeCustomPropertyValueWithSyntax(CSSParserTokenRange& range, CSS::PropertyParserState& state, const CSSCustomPropertySyntax& syntax)

--- a/Source/WebCore/css/parser/CSSPropertyParser.h
+++ b/Source/WebCore/css/parser/CSSPropertyParser.h
@@ -69,8 +69,6 @@ public:
     static ComputedStyleDependencies collectParsedCustomPropertyValueDependencies(const CSSCustomPropertySyntax&, CSSParserTokenRange, const CSSParserContext&);
     static bool isValidCustomPropertyValueForSyntax(const CSSCustomPropertySyntax&, CSSParserTokenRange, const CSSParserContext&);
     static RefPtr<CSSValue> parseWithSyntax(const CSSCustomPropertySyntax&, CSSParserTokenRange, const CSSParserContext&);
-
-    static std::optional<CSSWideKeyword> parseCSSWideKeyword(CSSParserTokenRange);
 };
 
 // MARK: - CSSPropertyID parsing

--- a/Source/WebCore/css/parser/CSSPropertyParserConsumer+Ident.cpp
+++ b/Source/WebCore/css/parser/CSSPropertyParserConsumer+Ident.cpp
@@ -150,5 +150,23 @@ RefPtr<CSSValue> consumeDashedIdent(CSSParserTokenRange& range, CSS::PropertyPar
     return nullptr;
 }
 
+// MARK: <CSS-wide keyword>
+// https://drafts.csswg.org/css-values/#common-keywords
+
+std::optional<CSSWideKeyword> consumeCSSWideKeyword(CSSParserTokenRange& range)
+{
+    auto rangeCopy = range;
+    auto valueID = rangeCopy.consumeIncludingWhitespace().id();
+    if (!rangeCopy.atEnd())
+        return { };
+
+    auto keyword = parseCSSWideKeyword(valueID);
+    if (!keyword)
+        return { };
+
+    range = rangeCopy;
+    return keyword;
+}
+
 } // namespace CSSPropertyParserHelpers
 } // namespace WebCore

--- a/Source/WebCore/css/parser/CSSPropertyParserConsumer+Ident.h
+++ b/Source/WebCore/css/parser/CSSPropertyParserConsumer+Ident.h
@@ -29,6 +29,7 @@
 #include "CSSParserToken.h"
 #include "CSSParserTokenRange.h"
 #include "CSSValuePool.h"
+#include "CSSWideKeyword.h"
 #include <optional>
 #include <wtf/RefPtr.h>
 
@@ -85,6 +86,11 @@ StringView consumeEagerlyResolvableDashedIdentRaw(CSSParserTokenRange&);
 std::optional<CSS::CustomIdent> consumeUnresolvedDashedIdent(CSSParserTokenRange&, CSS::PropertyParserState&);
 
 RefPtr<CSSValue> consumeDashedIdent(CSSParserTokenRange&, CSS::PropertyParserState&);
+
+// MARK: <CSS-wide keyword>
+// https://drafts.csswg.org/css-values/#common-keywords
+
+std::optional<CSSWideKeyword> consumeCSSWideKeyword(CSSParserTokenRange&);
 
 // MARK: -
 

--- a/Source/WebCore/style/StyleBuilder.cpp
+++ b/Source/WebCore/style/StyleBuilder.cpp
@@ -35,6 +35,7 @@
 #include "CSSFontSelector.h"
 #include "CSSPaintImageValue.h"
 #include "CSSPropertyParser.h"
+#include "CSSPropertyParserConsumer+Ident.h"
 #include "CSSRegisteredCustomProperty.h"
 #include "CSSShorthandSubstitutionValue.h"
 #include "CSSValuePair.h"
@@ -700,7 +701,9 @@ std::optional<Variant<Ref<const Style::CustomProperty>, CSSWideKeyword>> Builder
 
     if (!registered) {
         // CSS-wide keywords are allowed in var() fallbacks of unregistered properties.
-        if (auto keyword = CSSPropertyParser::parseCSSWideKeyword(resolvedData->tokens()))
+        auto tokens = resolvedData->tokenRange();
+        tokens.consumeWhitespace();
+        if (auto keyword = CSSPropertyParserHelpers::consumeCSSWideKeyword(tokens))
             return { { *keyword } };
 
         return { { CustomProperty::createForVariableData(name, *resolvedData) } };


### PR DESCRIPTION
#### b62325155ab05faa8542bd54127e95e1de7aa763
<pre>
revert-layer doesn&apos;t compute correctly if there is a leading empty/space substitution
<a href="https://bugs.webkit.org/show_bug.cgi?id=312853">https://bugs.webkit.org/show_bug.cgi?id=312853</a>
<a href="https://rdar.apple.com/175729680">rdar://175729680</a>

Reviewed by NOBODY (OOPS!).

Given `--on: var(--space) revert-layer;` with `--space` empty,
<a href="https://drafts.csswg.org/css-values-5/#substitute-arbitrary-substitution-function">https://drafts.csswg.org/css-values-5/#substitute-arbitrary-substitution-function</a>
produces the token stream `[whitespace, ident(revert-layer)]`. Per
<a href="https://drafts.csswg.org/css-variables-2/#defining-variables">https://drafts.csswg.org/css-variables-2/#defining-variables</a> this should take
effect as `revert-layer`. The post-substitution keyword check in
Builder::resolveCustomPropertyValue did not skip leading whitespace, so the
literal tokens were stored instead. `var(--on)` then expanded to
&quot; revert-layer&quot;, producing an invalid declaration. All six CSS-wide keywords
were affected.

Test: imported/w3c/web-platform-tests/css/css-variables/variable-css-wide-keywords-after-substitution.html
* LayoutTests/imported/w3c/web-platform-tests/css/css-variables/variable-css-wide-keywords-after-substitution-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-variables/variable-css-wide-keywords-after-substitution.html: Added.
* Source/WebCore/css/parser/CSSPropertyParser.cpp:
(WebCore::consumeCSSWideKeyword): Deleted.
(WebCore::CSSPropertyParser::parseCSSWideKeyword): Deleted.

Also move consumeCSSWideKeyword to CSSPropertyParserHelpers and remove static CSSPropertyParser::parseCSSWideKeyword.

* Source/WebCore/css/parser/CSSPropertyParser.h:
* Source/WebCore/css/parser/CSSPropertyParserConsumer+Ident.cpp:
(WebCore::CSSPropertyParserHelpers::consumeCSSWideKeyword):
* Source/WebCore/css/parser/CSSPropertyParserConsumer+Ident.h:
* Source/WebCore/style/StyleBuilder.cpp:
(WebCore::Style::Builder::resolveCustomPropertyValue):

Consume any whitespace before trying to consume CSS-wide keyword. Usually there can&apos;t be any but var()
substitution might have inserted one.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b62325155ab05faa8542bd54127e95e1de7aa763

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/160864 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/34337 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/27438 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/169767 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/115934 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/af7dd04a-85f7-4318-9ab8-55e088f27cfd) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/162733 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/34438 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/34337 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/124774 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/115934 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/74e01f62-5082-4f0e-b0c3-5a6052ab50b6) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/163823 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/27029 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/144501 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/105371 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/974a2f3e-6e59-4b94-b609-9fb0fd063fd6) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/26081 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/24580 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/17487 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/135775 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/22264 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/172250 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/19271 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/23905 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/133042 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/34011 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/28673 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/133053 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35927 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/33995 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/144059 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/95834 "Built successfully") | | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/164/builds/27649 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/20874 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/33506 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/100931 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/33005 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/33249 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/33153 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->