### PR TITLE
CSS `field-sizing: content` clips the placeholder value on a number input

### DIFF
--- a/LayoutTests/fast/forms/number/number-field-sizing-content-placeholder-expected.html
+++ b/LayoutTests/fast/forms/number/number-field-sizing-content-placeholder-expected.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<style>
+input {
+  field-sizing: content;
+  padding: 0px;
+  border: none;
+  font: 20px Ahem;
+  color: green;
+}
+</style>
+<input type="number" value="1">
+<input type="number" value="1234">

--- a/LayoutTests/fast/forms/number/number-field-sizing-content-placeholder.html
+++ b/LayoutTests/fast/forms/number/number-field-sizing-content-placeholder.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<title>field-sizing: content should size number inputs so the placeholder is not clipped by the spin button</title>
+<link rel="help" href="https://drafts.csswg.org/css-ui-4/#field-sizing">
+<link rel="match" href="number-field-sizing-content-placeholder-expected.html">
+<style>
+input {
+  field-sizing: content;
+  padding: 0px;
+  border: none;
+  font: 20px Ahem;
+}
+::placeholder {
+  color: green;
+  opacity: 1;
+}
+</style>
+<input type="number" placeholder="1">
+<input type="number" placeholder="1234">

--- a/LayoutTests/imported/w3c/web-platform-tests/html/rendering/widgets/field-sizing-input-text-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/rendering/widgets/field-sizing-input-text-expected.txt
@@ -15,7 +15,7 @@ PASS search: Auto width and auto height with a long text
 PASS search: Explicit width and heigth
 PASS search: Explicit width and auto height
 PASS search: Explicit height and auto width
-FAIL search: Text caret is taller than the placeholder assert_less_than: expected a number less than 114 but got 114
+PASS search: Text caret is taller than the placeholder
 PASS search: Text caret is shorter than the placeholder
 PASS search: Update field-sizing property dynamically
 PASS tel: Empty value

--- a/Source/WebCore/rendering/RenderTextControl.cpp
+++ b/Source/WebCore/rendering/RenderTextControl.cpp
@@ -23,6 +23,7 @@
 #include "RenderTextControl.h"
 
 #include "ContainerNodeInlines.h"
+#include "HTMLInputElement.h"
 #include "HTMLTextFormControlElement.h"
 #include "HitTestResult.h"
 #include "PlatformRenderTheme.h"
@@ -173,8 +174,17 @@ float RenderTextControl::scaleEmToUnits(int x) const
 
 void RenderTextControl::computeIntrinsicLogicalWidths(LayoutUnit& minLogicalWidth, LayoutUnit& maxLogicalWidth) const
 {
-    if (style().fieldSizing() == FieldSizing::Content)
-        return RenderBlockFlow::computeIntrinsicLogicalWidths(minLogicalWidth, maxLogicalWidth);
+    if (style().fieldSizing() == FieldSizing::Content) {
+        RenderBlockFlow::computeIntrinsicLogicalWidths(minLogicalWidth, maxLogicalWidth);
+        RefPtr placeholder = textFormControlElement().placeholderElement();
+        CheckedPtr placeholderBox = placeholder ? placeholder->renderBox() : nullptr;
+        if (RefPtr input = placeholderBox ? dynamicDowncast<HTMLInputElement>(textFormControlElement()) : nullptr) {
+            auto decoration = LayoutUnit::fromFloatCeil(input->decorationWidth(maxLogicalWidth));
+            minLogicalWidth = std::max(minLogicalWidth, placeholderBox->minPreferredLogicalWidth() + decoration);
+            maxLogicalWidth = std::max(maxLogicalWidth, placeholderBox->maxPreferredLogicalWidth() + decoration);
+        }
+        return;
+    }
 
     if (shouldApplySizeOrInlineSizeContainment()) {
         if (auto width = explicitIntrinsicInnerLogicalWidth()) {


### PR DESCRIPTION
#### dc59d6076359c9f99233d4a9d3a9b63aafd75c7d
<pre>
CSS `field-sizing: content` clips the placeholder value on a number input
<a href="https://bugs.webkit.org/show_bug.cgi?id=314214">https://bugs.webkit.org/show_bug.cgi?id=314214</a>
<a href="https://rdar.apple.com/175883299">rdar://175883299</a>

Reviewed by Alan Baradlay.

The placeholder and the decoration-bearing container (inner-text + spin
button) are siblings in the UA shadow tree. Block-flow intrinsic width
takes the max across siblings, so when the placeholder is wider than the
empty inner-text, the control sizes to the placeholder alone — leaving
no room for the spin button. The spinner then paints over the
placeholder text, clipping it.

After the block-flow computation, grow the intrinsic width to fit
placeholder + decorationWidth so both can coexist.

Test: fast/forms/number/number-field-sizing-content-placeholder.html

* LayoutTests/fast/forms/number/number-field-sizing-content-placeholder-expected.html: Added.
* LayoutTests/fast/forms/number/number-field-sizing-content-placeholder.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/rendering/widgets/field-sizing-input-text-expected.txt:
* Source/WebCore/rendering/RenderTextControl.cpp:
(WebCore::RenderTextControl::computeIntrinsicLogicalWidths const):

Canonical link: <a href="https://commits.webkit.org/312936@main">https://commits.webkit.org/312936@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fc751086abaf63e3bbd443e4b7017dc45ee4a6f2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/161415 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/34889 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/27989 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/170318 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/117786 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/21f69631-bf6e-4cc9-8953-2ef0d9d75db7) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/163284 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/34990 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/34890 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/125224 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/88214 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/6c1d2fd6-247a-4663-a463-008b6f338826) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/164374 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/27514 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/144997 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/105820 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/b569cc83-008e-403e-a248-27ef6f7b45c2) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/26563 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/25071 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/18039 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/136256 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/22755 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/172804 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/19835 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/24396 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/133510 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/34563 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/29164 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/133517 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36102 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/34547 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/144550 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/96445 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/28051 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/21369 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/34057 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/101498 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/33557 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/33800 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/33706 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->