### PR TITLE
REGRESSION(312533@main): export-w3c-test-changes failing constructing linter

### DIFF
--- a/Tools/Scripts/webkitpy/w3c/test_exporter.py
+++ b/Tools/Scripts/webkitpy/w3c/test_exporter.py
@@ -223,7 +223,7 @@ class WebPlatformTestExporter(object):
         self._remote = self._init_wpt_remote()
         if not self._remote:
             return 1
-        self._linter = self._linter(repository_directory, self._host.filesystem)
+        self._linter = self._linter(repository_directory)
         return True
 
     def clean(self):

--- a/Tools/Scripts/webkitpy/w3c/test_exporter_unittest.py
+++ b/Tools/Scripts/webkitpy/w3c/test_exporter_unittest.py
@@ -32,8 +32,6 @@ from webkitbugspy import mocks as bmocks, Tracker, bugzilla
 from webkitcorepy import mocks as wkmocks, testing, OutputCapture
 from webkitscmpy import mocks as mocks
 
-mock_linter = None
-
 
 class TestExporterTest(testing.PathTestCase):
     maxDiff = None
@@ -78,20 +76,6 @@ class TestExporterTest(testing.PathTestCase):
         def scm(self):
             return self._mockSCM
 
-    class MockWPTLinter(object):
-        def __init__(self, repository_directory, filesystem):
-            self.calls = [repository_directory]
-            # workaround to appease the style checker which thinks
-            # exporter._linter is an instance of WPTLinter and
-            # complains if we try to access the calls property which
-            # only exists on MockWPTLinter
-            global mock_linter
-            mock_linter = self
-
-        def lint(self):
-            self.calls.append('lint')
-            return iter([])
-
     def test_export(self):
         with OutputCapture(level=logging.INFO) as captured, bmocks.Bugzilla(self.BUGZILLA_URL.split('://')[1], issues=bmocks.ISSUES, environment=wkmocks.Environment(
             BUGS_EXAMPLE_COM_USERNAME='tcontributor@example.com',
@@ -101,7 +85,9 @@ class TestExporterTest(testing.PathTestCase):
         }) as wpt_remote, mocks.local.Git(
             self.path,
             remote='https://{}'.format(wpt_remote.remote)
-        ), patch('webkitbugspy.Tracker._trackers', [bugzilla.Tracker(self.BUGZILLA_URL)]):
+        ), patch('webkitbugspy.Tracker._trackers', [bugzilla.Tracker(self.BUGZILLA_URL)]), patch(
+            'webkitpy.w3c.test_exporter.WPTLinter', autospec=True, spec_set=True,
+        ) as mock_linter_class:
             host = TestExporterTest.MyMockHost()
             host.filesystem.maybe_make_directory(self.path)
             host.filesystem.write_binary_file(f'{self.path}/resources/testharness.js', '')
@@ -109,14 +95,15 @@ class TestExporterTest(testing.PathTestCase):
 
             host.web.responses.append({'status_code': 200, 'body': '{"login": "USER"}'})
             options = parse_args(['test_exporter.py', '-g', '1@main', '-b', '1', '-c', '-n', 'USER', '-t', 'TOKEN', '-d', self.path])
-            exporter = WebPlatformTestExporter(host, options, TestExporterTest.MockBugzilla, TestExporterTest.MockWPTLinter, 1)
+            exporter = WebPlatformTestExporter(host, options, TestExporterTest.MockBugzilla, mock_linter_class, 1)
             exporter.do_export()
 
             issue = Tracker.from_string('{}/show_bug.cgi?id=1'.format(self.BUGZILLA_URL))
             self.assertEqual(issue.comments[-1].content, 'Submitted web-platform-tests pull request: https://github.com/web-platform-tests/wpt/pull/1')
             self.assertEqual(issue.related_links, ['https://github.com/web-platform-tests/wpt/pull/1'])
 
-        self.assertEqual(mock_linter.calls, [self.path, 'lint'])
+        mock_linter_class.assert_called_once_with(self.path)
+        mock_linter_class.return_value.lint.assert_called_once_with()
 
         self.assertEqual(
             captured.stdout.getvalue(),
@@ -147,20 +134,23 @@ class TestExporterTest(testing.PathTestCase):
         }) as wpt_remote, mocks.local.Git(
             self.path,
             remote='https://{}'.format(wpt_remote.remote)
-        ), patch('webkitbugspy.Tracker._trackers', [bugzilla.Tracker(self.BUGZILLA_URL)]):
+        ), patch('webkitbugspy.Tracker._trackers', [bugzilla.Tracker(self.BUGZILLA_URL)]), patch(
+            'webkitpy.w3c.test_exporter.WPTLinter', autospec=True, spec_set=True,
+        ) as mock_linter_class:
             host = TestExporterTest.MyMockHost()
             host.filesystem.maybe_make_directory(self.path)
             host.filesystem.write_binary_file(f'{self.path}/resources/testharness.js', '')
             host.filesystem.write_binary_file(f'{self.path}/wpt', '')
             host.web.responses.append({'status_code': 200, 'body': '{"login": "USER"}'})
             options = parse_args(['test_exporter.py', '-g', 'HEAD', '-b', '1', '-c', '-n', 'USER', '-t', 'TOKEN', '-bn', 'wpt-export-branch', '-d', self.path])
-            exporter = WebPlatformTestExporter(host, options, TestExporterTest.MockBugzilla, TestExporterTest.MockWPTLinter, 1)
+            exporter = WebPlatformTestExporter(host, options, TestExporterTest.MockBugzilla, mock_linter_class, 1)
             exporter.do_export()
             issue = Tracker.from_string('{}/show_bug.cgi?id=1'.format(self.BUGZILLA_URL))
             self.assertEqual(issue.comments[-1].content, 'Submitted web-platform-tests pull request: https://github.com/web-platform-tests/wpt/pull/1')
             self.assertEqual(issue.related_links, ['https://github.com/web-platform-tests/wpt/pull/1'])
 
-        self.assertEqual(mock_linter.calls, [self.path, 'lint'])
+        mock_linter_class.assert_called_once_with(self.path)
+        mock_linter_class.return_value.lint.assert_called_once_with()
 
         self.assertEqual(
             captured.stdout.getvalue(),
@@ -191,20 +181,23 @@ class TestExporterTest(testing.PathTestCase):
         }) as wpt_remote, mocks.local.Git(
             self.path,
             remote='https://{}'.format(wpt_remote.remote)
-        ), patch('webkitbugspy.Tracker._trackers', [bugzilla.Tracker(self.BUGZILLA_URL)]):
+        ), patch('webkitbugspy.Tracker._trackers', [bugzilla.Tracker(self.BUGZILLA_URL)]), patch(
+            'webkitpy.w3c.test_exporter.WPTLinter', autospec=True, spec_set=True,
+        ) as mock_linter_class:
             host = TestExporterTest.MyMockHost()
             host.filesystem.maybe_make_directory(self.path)
             host.filesystem.write_binary_file(f'{self.path}/resources/testharness.js', '')
             host.filesystem.write_binary_file(f'{self.path}/wpt', '')
             host.web.responses.append({'status_code': 200, 'body': '{"login": "USER"}'})
             options = parse_args(['test_exporter.py', '-g', 'HEAD', '-b', '1', '-c', '-n', 'USER', '-t', 'TOKEN', '--no-clean', '-d', self.path])
-            exporter = WebPlatformTestExporter(host, options, TestExporterTest.MockBugzilla, TestExporterTest.MockWPTLinter, 1)
+            exporter = WebPlatformTestExporter(host, options, TestExporterTest.MockBugzilla, mock_linter_class, 1)
             exporter.do_export()
             issue = Tracker.from_string('{}/show_bug.cgi?id=1'.format(self.BUGZILLA_URL))
             self.assertEqual(issue.comments[-1].content, 'Submitted web-platform-tests pull request: https://github.com/web-platform-tests/wpt/pull/1')
             self.assertEqual(issue.related_links, ['https://github.com/web-platform-tests/wpt/pull/1'])
 
-        self.assertEqual(mock_linter.calls, [self.path, 'lint'])
+        mock_linter_class.assert_called_once_with(self.path)
+        mock_linter_class.return_value.lint.assert_called_once_with()
 
         self.assertEqual(
             captured.stdout.getvalue(),
@@ -235,12 +228,14 @@ class TestExporterTest(testing.PathTestCase):
         }) as wpt_remote, mocks.local.Git(
             self.path,
             remote='https://{}'.format(wpt_remote.remote)
-        ), patch('webkitbugspy.Tracker._trackers', [bugzilla.Tracker(self.BUGZILLA_URL)]):
+        ), patch('webkitbugspy.Tracker._trackers', [bugzilla.Tracker(self.BUGZILLA_URL)]), patch(
+            'webkitpy.w3c.test_exporter.WPTLinter', autospec=True, spec_set=True,
+        ) as mock_linter_class:
             host = TestExporterTest.MyMockHost()
             host.filesystem.maybe_make_directory(self.path)
             host.web.responses.append({'status_code': 200, 'body': '{"login": "USER"}'})
             options = parse_args(['test_exporter.py', '-g', 'HEAD', '-b', '1', '-c', '-n', 'USER', '-t', 'TOKEN', '--interactive', '-d', self.path])
-            exporter = WebPlatformTestExporter(host, options, TestExporterTest.MockBugzilla, TestExporterTest.MockWPTLinter, 1)
+            exporter = WebPlatformTestExporter(host, options, TestExporterTest.MockBugzilla, mock_linter_class, 1)
             exporter.do_export()
 
     def test_export_invalid_token(self):
@@ -253,8 +248,10 @@ class TestExporterTest(testing.PathTestCase):
         }) as wpt_remote, mocks.local.Git(
             self.path,
             remote='https://{}'.format(wpt_remote.remote)
-        ), self.assertRaises(Exception) as context:
-            exporter = WebPlatformTestExporter(host, options, TestExporterTest.MockBugzilla, TestExporterTest.MockWPTLinter, 1)
+        ), self.assertRaises(Exception) as context, patch('webkitpy.w3c.test_exporter.WPTLinter',
+            autospec=True, spec_set=True,
+        ) as mock_linter_class:
+            exporter = WebPlatformTestExporter(host, options, TestExporterTest.MockBugzilla, mock_linter_class, 1)
             exporter.do_export()
             self.assertIn('OAuth token is not valid', str(context.exception))
 
@@ -268,8 +265,10 @@ class TestExporterTest(testing.PathTestCase):
         }) as wpt_remote, mocks.local.Git(
             self.path,
             remote='https://{}'.format(wpt_remote.remote)
-        ), self.assertRaises(Exception) as context:
-            exporter = WebPlatformTestExporter(host, options, TestExporterTest.MockBugzilla, TestExporterTest.MockWPTLinter, 1)
+        ), self.assertRaises(Exception) as context, patch('webkitpy.w3c.test_exporter.WPTLinter',
+            autospec=True, spec_set=True,
+        ) as mock_linter_class:
+            exporter = WebPlatformTestExporter(host, options, TestExporterTest.MockBugzilla, mock_linter_class, 1)
             exporter.do_export()
             self.assertIn('OAuth token does not match the provided username', str(context.exception))
 
@@ -277,8 +276,10 @@ class TestExporterTest(testing.PathTestCase):
         host = TestExporterTest.MyMockHost()
         host.filesystem.maybe_make_directory(self.path)
         options = parse_args(['test_exporter.py', '-g', 'HEAD', '-b', '1', '-c', '-n', 'USER', '-t', 'TOKEN', '-d', self.path])
-        with mocks.local.Git(self.path) as repo:
-            exporter = WebPlatformTestExporter(host, options, TestExporterTest.MockBugzilla, TestExporterTest.MockWPTLinter, 1)
+        with mocks.local.Git(self.path), patch('webkitpy.w3c.test_exporter.WPTLinter',
+            autospec=True, spec_set=True,
+        ) as mock_linter_class:
+            exporter = WebPlatformTestExporter(host, options, TestExporterTest.MockBugzilla, mock_linter_class, 1)
             self.assertTrue(exporter.has_wpt_changes())
 
     def test_has_no_wpt_changes_for_no_diff(self):
@@ -291,8 +292,10 @@ class TestExporterTest(testing.PathTestCase):
         }) as wpt_remote, mocks.local.Git(
             self.path,
             remote='https://{}'.format(wpt_remote.remote)
-        ):
-            exporter = WebPlatformTestExporter(host, options, TestExporterTest.MockBugzilla, TestExporterTest.MockWPTLinter, 1)
+        ), patch('webkitpy.w3c.test_exporter.WPTLinter',
+            autospec=True, spec_set=True,
+        ) as mock_linter_class:
+            exporter = WebPlatformTestExporter(host, options, TestExporterTest.MockBugzilla, mock_linter_class, 1)
             self.assertFalse(exporter.has_wpt_changes())
 
     def test_ignore_changes_to_expected_file(self):
@@ -317,8 +320,10 @@ diff --git a/LayoutTests/imported/w3c/web-platform-tests/fetch/api/headers/heade
 +change to any.sharedworker
 """
         options = parse_args(['test_exporter.py', '-g', 'HEAD', '-b', '1', '-c', '-n', 'USER', '-t', 'TOKEN', '-d', self.path])
-        with mocks.local.Git(self.path) as repo:
-            exporter = WebPlatformTestExporter(host, options, TestExporterTest.MockBugzilla, TestExporterTest.MockWPTLinter, 1)
+        with mocks.local.Git(self.path), patch('webkitpy.w3c.test_exporter.WPTLinter',
+            autospec=True, spec_set=True,
+        ) as mock_linter_class:
+            exporter = WebPlatformTestExporter(host, options, TestExporterTest.MockBugzilla, mock_linter_class, 1)
         self.assertFalse(exporter.has_wpt_changes())
 
     def test_ignore_changes_to_expected_mismatch_file(self):
@@ -331,8 +336,10 @@ diff --git a/LayoutTests/imported/w3c/web-platform-tests/css/css-counter-styles/
 +change to expected-mismatch
 """
         options = parse_args(['test_exporter.py', '-g', 'HEAD', '-b', '1', '-c', '-n', 'USER', '-t', 'TOKEN', '-d', self.path])
-        with mocks.local.Git(self.path) as repo:
-            exporter = WebPlatformTestExporter(host, options, TestExporterTest.MockBugzilla, TestExporterTest.MockWPTLinter, 1)
+        with mocks.local.Git(self.path), patch('webkitpy.w3c.test_exporter.WPTLinter',
+            autospec=True, spec_set=True,
+        ) as mock_linter_class:
+            exporter = WebPlatformTestExporter(host, options, TestExporterTest.MockBugzilla, mock_linter_class, 1)
         self.assertFalse(exporter.has_wpt_changes())
 
     def test_ignore_changes_to_w3c_import_log(self):
@@ -345,6 +352,8 @@ diff --git a/LayoutTests/imported/w3c/web-platform-tests/fetch/api/headers/w3c-i
 +change to w3c import
 """
         options = parse_args(['test_exporter.py', '-g', 'HEAD', '-b', '1', '-c', '-n', 'USER', '-t', 'TOKEN', '-d', self.path])
-        with mocks.local.Git(self.path) as repo:
-            exporter = WebPlatformTestExporter(host, options, TestExporterTest.MockBugzilla, TestExporterTest.MockWPTLinter, 1)
+        with mocks.local.Git(self.path), patch('webkitpy.w3c.test_exporter.WPTLinter',
+            autospec=True, spec_set=True,
+        ) as mock_linter_class:
+            exporter = WebPlatformTestExporter(host, options, TestExporterTest.MockBugzilla, mock_linter_class, 1)
         self.assertFalse(exporter.has_wpt_changes())


### PR DESCRIPTION
#### b55a08cba370735c0859c131f7d45d3eddf9306f
<pre>
REGRESSION(312533@main): export-w3c-test-changes failing constructing linter
<a href="https://bugs.webkit.org/show_bug.cgi?id=314229">https://bugs.webkit.org/show_bug.cgi?id=314229</a>
<a href="https://rdar.apple.com/176392689">rdar://176392689</a>

Reviewed by Simon Fraser.

* Tools/Scripts/webkitpy/w3c/test_exporter.py:
(WebPlatformTestExporter._get_wpt_repository): Remove now removed argument.
* Tools/Scripts/webkitpy/w3c/test_exporter_unittest.py:
(TestExporterTest.MockWPTLinter): Deleted.
(TestExporterTest.MockWPTLinter.__init__): Deleted.
(TestExporterTest.MockWPTLinter.lint): Deleted.
(TestExporterTest.test_export): Use autospec instead of a custom mock.
(TestExporterTest.test_export_with_specific_branch): Use autospec instead of a custom mock.
(TestExporterTest.test_export_no_clean): Use autospec instead of a custom mock.
(TestExporterTest.test_export_interactive_mode): Use autospec instead of a custom mock.
(TestExporterTest.test_export_invalid_token): Use autospec instead of a custom mock.
(TestExporterTest.test_export_wrong_token): Use autospec instead of a custom mock.
(TestExporterTest.test_has_wpt_changes): Use autospec instead of a custom mock.
(TestExporterTest.test_has_no_wpt_changes_for_no_diff): Use autospec instead of a custom mock.

Canonical link: <a href="https://commits.webkit.org/313010@main">https://commits.webkit.org/313010@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2d04992c0f1657029d4bc9191f749651aedd2daf

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/160928 "14 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/34401 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/27502 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/169831 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/117188 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/176c0e94-924e-4e2b-979f-6b047ca03a3a) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/162797 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/34502 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/34401 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/124824 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/88090 "2 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/60170030-a073-4b8e-99b1-ae8f7f243730) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/163887 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/27085 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/144551 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/105421 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/f75bbf94-0225-4d5f-ab67-b083148bab73) 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/160248 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/26137 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/24638 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/17551 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/135831 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/22313 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/172314 "Built successfully") | | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/23954 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/133098 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/34075 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/28730 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/133108 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/34059 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/144108 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/95898 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/24574 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/27686 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/20924 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/33570 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/33069 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/33313 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/33218 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->