### PR TITLE
[JSC] Use simple merge for TypedArray.prototype.sort

### DIFF
--- a/Source/JavaScriptCore/runtime/ArrayPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/ArrayPrototype.cpp
@@ -923,18 +923,18 @@ static ALWAYS_INLINE std::span<EncodedJSValue> sortStableSort(JSGlobalObject* gl
     if (callData.type == CallData::Type::JS) [[likely]] {
         CachedCall cachedCall(globalObject, uncheckedDowncast<JSFunction>(comparator), 2);
         RETURN_IF_EXCEPTION(scope, compacted);
-        RELEASE_AND_RETURN(scope, arrayStableSort(vm, compacted, workingSet, [&](auto left, auto right) ALWAYS_INLINE_LAMBDA {
+        RELEASE_AND_RETURN(scope, (arrayStableSort<MergeStrategy::Galloping>(vm, compacted, workingSet, [&](auto left, auto right) ALWAYS_INLINE_LAMBDA {
             auto scope = DECLARE_THROW_SCOPE(vm);
 
             JSValue jsResult = cachedCall.callWithArguments(globalObject, jsUndefined(), JSValue::decode(left), JSValue::decode(right));
             RETURN_IF_EXCEPTION_WITH_TRAPS_DEFERRED(scope, false);
 
             RELEASE_AND_RETURN(scope, coerceComparatorResultToBoolean(globalObject, jsResult));
-        }));
+        })));
     }
 
     MarkedArgumentBuffer args;
-    RELEASE_AND_RETURN(scope, arrayStableSort(vm, compacted, workingSet, [&](auto left, auto right) ALWAYS_INLINE_LAMBDA {
+    RELEASE_AND_RETURN(scope, (arrayStableSort<MergeStrategy::Galloping>(vm, compacted, workingSet, [&](auto left, auto right) ALWAYS_INLINE_LAMBDA {
         auto scope = DECLARE_THROW_SCOPE(vm);
 
         args.clear();
@@ -950,7 +950,7 @@ static ALWAYS_INLINE std::span<EncodedJSValue> sortStableSort(JSGlobalObject* gl
         RETURN_IF_EXCEPTION(scope, false);
 
         RELEASE_AND_RETURN(scope, coerceComparatorResultToBoolean(globalObject, jsResult));
-    }));
+    })));
 }
 
 static ALWAYS_INLINE void sortCommit(JSGlobalObject* globalObject, JSObject* thisObject, uint64_t length, IndexingType indexingType, std::span<const EncodedJSValue> sorted, uint64_t undefinedCount)

--- a/Source/JavaScriptCore/runtime/JSGenericTypedArrayViewPrototypeFunctions.h
+++ b/Source/JavaScriptCore/runtime/JSGenericTypedArrayViewPrototypeFunctions.h
@@ -1757,7 +1757,7 @@ static ALWAYS_INLINE EncodedJSValue genericTypedArrayViewProtoFuncSortImpl(VM& v
     if (callData.type == CallData::Type::JS) [[likely]] {
         CachedCall cachedCall(globalObject, uncheckedDowncast<JSFunction>(comparatorValue), 2);
         RETURN_IF_EXCEPTION(scope, { });
-        result = arrayStableSort(vm, src, workingSet, [&](auto left, auto right) ALWAYS_INLINE_LAMBDA {
+        result = arrayStableSort<MergeStrategy::Simple>(vm, src, workingSet, [&](auto left, auto right) ALWAYS_INLINE_LAMBDA {
             auto scope = DECLARE_THROW_SCOPE(vm);
 
             JSValue leftValue = ViewClass::Adaptor::toJSValue(globalObject, left);
@@ -1773,7 +1773,7 @@ static ALWAYS_INLINE EncodedJSValue genericTypedArrayViewProtoFuncSortImpl(VM& v
         RETURN_IF_EXCEPTION(scope, { });
     } else {
         MarkedArgumentBuffer args;
-        result = arrayStableSort(vm, src, workingSet, [&](auto left, auto right) ALWAYS_INLINE_LAMBDA {
+        result = arrayStableSort<MergeStrategy::Simple>(vm, src, workingSet, [&](auto left, auto right) ALWAYS_INLINE_LAMBDA {
             auto scope = DECLARE_THROW_SCOPE(vm);
 
             args.clear();

--- a/Source/JavaScriptCore/runtime/StableSort.h
+++ b/Source/JavaScriptCore/runtime/StableSort.h
@@ -261,6 +261,43 @@ static ALWAYS_INLINE size_t gallopRight(VM& vm, const ElementType& key, const El
     return offset;
 }
 
+// Gallop and Simple are code size-time tradeoffs. Gallop is faster and is more code, while Simple is
+// slower and is less code. Currently galloping is used for Array sorting, while Simple is used for
+// TypedArray sorting. Array sorting is expected to be fast, while TypedArray sorting is relatively
+// rare and would incur a significant number of template instantiations across all the TypedArray
+// kinds.
+enum class MergeStrategy { Galloping, Simple };
+
+template<typename ElementType, typename Functor>
+static ALWAYS_INLINE void mergeRunsSimple(VM& vm, std::span<ElementType> dst, std::span<const ElementType> src, size_t srcIndex1, size_t srcEnd1, size_t srcIndex2, size_t srcEnd2, const Functor& comparator)
+{
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
+    size_t left = srcIndex1;
+    size_t leftEnd = srcEnd1;
+    size_t right = srcIndex2;
+    size_t rightEnd = srcEnd2;
+
+    ASSERT(leftEnd <= right);
+    ASSERT(rightEnd <= src.size());
+
+    for (size_t dstIndex = left; dstIndex < rightEnd; ++dstIndex) {
+        if (right < rightEnd) {
+            if (left >= leftEnd) {
+                dst[dstIndex] = src[right++];
+                continue;
+            }
+            bool result = comparator(src[right], src[left]);
+            RETURN_IF_EXCEPTION_WITH_TRAPS_DEFERRED(scope, void());
+            if (result) {
+                dst[dstIndex] = src[right++];
+                continue;
+            }
+        }
+        dst[dstIndex] = src[left++];
+    }
+}
+
 // webkit.org/b/313694 : Workaround GCC 13 slowness building this.
 #if COMPILER(GCC) && GCC_VERSION < 140000
 #define MAYBE_ALWAYS_INLINE inline
@@ -430,7 +467,7 @@ struct SortedRun {
     size_t m_end;
 };
 
-template<typename ElementType, typename Functor, size_t forceRunLength = 64>
+template<MergeStrategy mergeStrategy, typename ElementType, typename Functor, size_t forceRunLength = 64>
 static ALWAYS_INLINE std::span<ElementType> arrayStableSort(VM& vm, std::span<ElementType> src, std::span<ElementType> workingSet, const Functor& comparator)
 {
     constexpr size_t extendRunCutoff = 8;
@@ -476,7 +513,7 @@ static ALWAYS_INLINE std::span<ElementType> arrayStableSort(VM& vm, std::span<El
     // floor(lg(n)) + 1
     powerstack.reserveCapacity(8 * sizeof(numElements) - WTF::clz(numElements));
 
-    size_t minGallop = minGallopThreshold;
+    [[maybe_unused]] size_t minGallop = minGallopThreshold;
 
     SortedRun run1 { 0, 0 };
 
@@ -530,7 +567,10 @@ static ALWAYS_INLINE std::span<ElementType> arrayStableSort(VM& vm, std::span<El
             auto rangeToMerge = powerstack.takeLast().run;
             ASSERT(rangeToMerge.m_end == run1.m_begin - 1);
 
-            mergePowersortRuns(vm, workingSet, spanConstCast<const ElementType>(src), rangeToMerge.m_begin, rangeToMerge.m_end + 1, run1.m_begin, run1.m_end + 1, comparator, minGallop);
+            if constexpr (mergeStrategy == MergeStrategy::Galloping)
+                mergePowersortRuns(vm, workingSet, spanConstCast<const ElementType>(src), rangeToMerge.m_begin, rangeToMerge.m_end + 1, run1.m_begin, run1.m_end + 1, comparator, minGallop);
+            else
+                mergeRunsSimple(vm, workingSet, spanConstCast<const ElementType>(src), rangeToMerge.m_begin, rangeToMerge.m_end + 1, run1.m_begin, run1.m_end + 1, comparator);
             RETURN_IF_EXCEPTION_WITH_TRAPS_DEFERRED(scope, src);
             WTF::copyElements(src.subspan(rangeToMerge.m_begin, run1.m_end + 1 - rangeToMerge.m_begin), spanConstCast<const ElementType>(workingSet).subspan(rangeToMerge.m_begin, run1.m_end + 1 - rangeToMerge.m_begin));
             run1.m_begin = rangeToMerge.m_begin;
@@ -544,7 +584,10 @@ static ALWAYS_INLINE std::span<ElementType> arrayStableSort(VM& vm, std::span<El
         auto rangeToMerge = powerstack.takeLast().run;
         ASSERT(rangeToMerge.m_end == run1.m_begin - 1);
 
-        mergePowersortRuns(vm, workingSet, spanConstCast<const ElementType>(src), rangeToMerge.m_begin, rangeToMerge.m_end + 1, run1.m_begin, run1.m_end + 1, comparator, minGallop);
+        if constexpr (mergeStrategy == MergeStrategy::Galloping)
+            mergePowersortRuns(vm, workingSet, spanConstCast<const ElementType>(src), rangeToMerge.m_begin, rangeToMerge.m_end + 1, run1.m_begin, run1.m_end + 1, comparator, minGallop);
+        else
+            mergeRunsSimple(vm, workingSet, spanConstCast<const ElementType>(src), rangeToMerge.m_begin, rangeToMerge.m_end + 1, run1.m_begin, run1.m_end + 1, comparator);
         RETURN_IF_EXCEPTION_WITH_TRAPS_DEFERRED(scope, src);
         WTF::copyElements(src.subspan(rangeToMerge.m_begin, run1.m_end + 1 - rangeToMerge.m_begin), spanConstCast<const ElementType>(workingSet).subspan(rangeToMerge.m_begin, run1.m_end + 1 - rangeToMerge.m_begin));
         run1.m_begin = rangeToMerge.m_begin;


### PR DESCRIPTION
#### 10ba9a046aec686fc5f8484c3fb875e22506d443
<pre>
[JSC] Use simple merge for TypedArray.prototype.sort
<a href="https://bugs.webkit.org/show_bug.cgi?id=314223">https://bugs.webkit.org/show_bug.cgi?id=314223</a>
<a href="https://rdar.apple.com/176291674">rdar://176291674</a>

Reviewed by Keith Miller and Yusuke Suzuki.

Galloping merge trades code size for sorting performance. Absolute performance
isn&apos;t necessary for TypedArray sorting, so recoup some binary size by using a
simple merge for TypedArrays.

On a Release arm64 build, this PR reduces binary size by 955KB.

This is covered by existing sort tests.

* Source/JavaScriptCore/runtime/ArrayPrototype.cpp:
(JSC::sortStableSort):
* Source/JavaScriptCore/runtime/JSGenericTypedArrayViewPrototypeFunctions.h:
(JSC::genericTypedArrayViewProtoFuncSortImpl):
* Source/JavaScriptCore/runtime/StableSort.h:
(JSC::mergeRunsSimple):
(JSC::arrayStableSort):

Canonical link: <a href="https://commits.webkit.org/312803@main">https://commits.webkit.org/312803@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fcb300e85a24a6df1e0172072ffbf8e9eb91bd68

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/160931 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/34404 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/27505 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/169834 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/117191 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/e8fd7e6c-9db9-4ed8-b8fc-dafa0b838461) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/34505 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/34404 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/124828 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/117191 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/a91a5bec-8235-492b-9514-40957270aec9) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/163890 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/27087 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/144556 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/105425 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/f82fb04c-74eb-45b7-848c-cb14418571f5) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/26139 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/24640 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/17554 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/152987 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/135833 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/22318 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/172317 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/21769 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/19338 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/23959 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/133103 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/34078 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/28732 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/133113 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35993 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/34062 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/144113 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/95901 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/27690 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/20929 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/193330 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/33573 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/100998 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/49780 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/33072 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/33316 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/33221 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->