### PR TITLE
[Site Isolation] When navigating to a new document, LocalFrame::documentURLOrOriginDidChange is called before LocalFrame's Document gets updated

### DIFF
--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -4596,8 +4596,6 @@ void Document::setURL(URL&& url)
     auto topOrigin = isTopDocument() && !SecurityContext::securityOrigin() ? SecurityOrigin::create(newURL)->data() : this->topOrigin().data();
     m_syncData->documentURL = newURL;
     m_url = { WTF::move(newURL), topOrigin };
-    if (m_frame)
-        m_frame->documentURLOrOriginDidChange();
 
     m_documentURI = m_url.url();
     m_adjustedURL = adjustedURL();
@@ -11933,8 +11931,6 @@ void Document::securityOriginDidChange()
 {
     m_syncData->documentSecurityOrigin = SecurityContext::securityOrigin();
     m_permissionsPolicy = nullptr;
-    if (m_frame)
-        m_frame->documentURLOrOriginDidChange();
 }
 
 Element* Document::cachedFirstElementWithAttribute(const QualifiedName& attribute) const

--- a/Source/WebCore/page/LocalFrame.cpp
+++ b/Source/WebCore/page/LocalFrame.cpp
@@ -1294,17 +1294,6 @@ LocalFrame* LocalFrame::contentFrameFromWindowOrFrameElement(JSContextRef contex
     return frameOwner ? dynamicDowncast<LocalFrame>(frameOwner->contentFrame()) : nullptr;
 }
 
-void LocalFrame::documentURLOrOriginDidChange()
-{
-    if (!isMainFrame())
-        return;
-
-    RefPtr page = this->page();
-    RefPtr document = this->document();
-    if (page && document)
-        page->setMainFrameURLAndOrigin(document->url(), protect(document->securityOrigin()));
-}
-
 void LocalFrame::dispatchLoadEventToParent()
 {
     if (is<RemoteFrame>(tree().parent()))

--- a/Source/WebCore/page/LocalFrame.h
+++ b/Source/WebCore/page/LocalFrame.h
@@ -327,7 +327,6 @@ public:
     void NODELETE selfOnlyRef();
     void selfOnlyDeref();
 
-    void documentURLOrOriginDidChange();
     void dispatchLoadEventToParent();
 
     void storageAccessExceptionReceivedForDomain(const RegistrableDomain&);

--- a/Source/WebCore/page/Page.cpp
+++ b/Source/WebCore/page/Page.cpp
@@ -871,27 +871,14 @@ void Page::setMainFrameURLAndOrigin(const URL& url, RefPtr<SecurityOrigin>&& ori
 {
     // This URL and SecurityOrigin is relevant to this Page only if it is not
     // directly hosting the local main frame.
-    RefPtr localFrame = dynamicDowncast<LocalFrame>(m_mainFrame.get());
-    if (!localFrame) {
-        m_topDocumentSyncData->documentURL = url;
-
-        if (!origin)
-            origin = SecurityOrigin::create(url);
-        m_topDocumentSyncData->documentSecurityOrigin = WTF::move(origin);
-
-        return;
-    }
-
-    if (!settings().siteIsolationEnabled())
+    if (is<LocalFrame>(m_mainFrame))
         return;
 
-    // If this page is hosting the local main frame, make sure the url and origin
-    // match what we expect, then broadcast them out to other processes.
-    RELEASE_ASSERT(url == m_topDocumentSyncData->documentURL);
+    m_topDocumentSyncData->documentURL = url;
+
     if (!origin)
-        RELEASE_ASSERT(!m_topDocumentSyncData->documentSecurityOrigin);
-
-    documentSyncClient().broadcastAllDocumentSyncDataToOtherProcesses(m_topDocumentSyncData.get());
+        origin = SecurityOrigin::create(url);
+    m_topDocumentSyncData->documentSecurityOrigin = WTF::move(origin);
 }
 
 void Page::setIsClosing()


### PR DESCRIPTION
#### 6f6ff1194f537aaca2c444af2e327eb8464a74d7
<pre>
[Site Isolation] When navigating to a new document, LocalFrame::documentURLOrOriginDidChange is called before LocalFrame&apos;s Document gets updated
<a href="https://rdar.apple.com/176301984">rdar://176301984</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=314123">https://bugs.webkit.org/show_bug.cgi?id=314123</a>

Reviewed by NOBODY (OOPS!).

When loading a new document, DocumentWriter::begin first creates a new Document object
before setting it to the existing LocalFrame:

bool DocumentWriter::begin(...)
{
    [...]

    // Create a new document before clearing the frame, because it may need to
    // inherit an aliased security context.
    Ref document = createDocument(url, documentIdentifier);
    [...]

    frame-&gt;setDocument(document.copyRef());
    [...]
}

Document&apos;s constructor calls Document::setURL() -&gt; LocalFrame::documentURLOrOriginDidChange() -&gt;
Page::setMainFrameURLAndOrigin(). But when LocalFrame::documentURLOrOriginDidChange() is called,
the LocalFrame is still referring to the old Document, because its document hasn&apos;t been updated
to the new Document. Hence it calls Page::setMainFrameURLAndOrigin() with the URL and security
origin of the old document.

On a closer look, LocalFrame::documentURLOrOriginDidChange() only calls Page::setMainFrameURLAndOrigin()
if it&apos;s a local main frame. Then Page::setMainFrameURLAndOrigin() doesn&apos;t set anything, it
only checks that the URL and security origin matches what&apos;s in m_topDocumentSyncData before
broadcasting it again. This seems unnecessary, as when the local main frame changes document,
LocalFrame::setDocument() gets called, which calls Page::didChangeMainDocument(), which
updates m_topDocumentSyncData and broadcasts it.

This patch removes this entire codepath as it&apos;s causing these two tests to RELEASE_ASSERT in
Page::setMainFrameURLAndOrigin():

imported/w3c/web-platform-tests/html/browsers/browsing-the-web/history-traversal/pageswap/pageswap-push-with-cross-origin-redirect.sub.html
imported/w3c/web-platform-tests/html/browsers/browsing-the-web/history-traversal/pageswap/pageswap-replace-with-cross-origin-redirect.sub.html

This codepath was added in <a href="https://commits.webkit.org/288038@main">288038@main</a> but it didn&apos;t start to crash until <a href="https://commits.webkit.org/312259@main">312259@main</a>.

No behavior changes, tested by existing test suite.

* Source/WebCore/dom/Document.cpp:
(WebCore::Document::setURL):
(WebCore::Document::securityOriginDidChange):
* Source/WebCore/page/LocalFrame.cpp:
(WebCore::LocalFrame::documentURLOrOriginDidChange): Deleted.
* Source/WebCore/page/LocalFrame.h:
* Source/WebCore/page/Page.cpp:
(WebCore::Page::setMainFrameURLAndOrigin):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6f6ff1194f537aaca2c444af2e327eb8464a74d7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/160934 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/34407 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/27508 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/169837 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/117194 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/162803 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/34508 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/34407 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/124836 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/88093 "1 flakes 1 failures") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/163893 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/27093 "Passed tests") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/144568 "Found 1 new API test failure: TestWebKitAPI.SiteIsolation.MainFrameURLAfterFragmentNavigation (failure)") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/105433 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/26145 "Passed tests") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/24648 "Found 1 new API test failure: TestWebKitAPI.SiteIsolation.MainFrameURLAfterFragmentNavigation (failure)") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/17557 "Built successfully") | | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/135839 "Found 1 new API test failure: TestWebKitAPI.SiteIsolation.MainFrameURLAfterFragmentNavigation (failure)") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/22330 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/172320 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/19341 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/23971 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/133107 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/34081 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/28740 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/133117 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/34065 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/144125 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/95904 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/27693 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/20941 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/33576 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/101001 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/33075 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/33319 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/33224 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->