### PR TITLE
Clicking an overflow element's scrollbar should not blur the focused element

### DIFF
--- a/LayoutTests/fast/overflow/scrollbar-click-does-not-blur-focused-input-expected.txt
+++ b/LayoutTests/fast/overflow/scrollbar-click-does-not-blur-focused-input-expected.txt
@@ -1,0 +1,11 @@
+This tests that clicking an overflow element's scrollbar does not blur the currently focused input when no focusable ancestor exists.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS document.activeElement.tagName is "INPUT"
+PASS successfullyParsed is true
+
+TEST COMPLETE
+
+

--- a/LayoutTests/fast/overflow/scrollbar-click-does-not-blur-focused-input.html
+++ b/LayoutTests/fast/overflow/scrollbar-click-does-not-blur-focused-input.html
@@ -1,0 +1,51 @@
+<!DOCTYPE html>
+
+<script src="../../resources/js-test.js"></script>
+
+<style>
+    /* Force classic non-overlay scrollbars with known dimensions so eventSender
+       can hit-test them reliably on all platforms (including macOS, where
+       overlay scrollbars are normally invisible until hovered). */
+    .scroller::-webkit-scrollbar { width: 15px; height: 15px; }
+    .scroller::-webkit-scrollbar-track { background: #ccc; }
+    .scroller::-webkit-scrollbar-thumb { background: #888; }
+    .scroller {
+        width: 150px;
+        height: 100px;
+        overflow: scroll;
+        border: 1px solid black;
+        float: left;
+        margin: 5px;
+    }
+    .scroller > div { height: 500px; width: 100%; }
+    input { float: left; margin: 5px; }
+</style>
+
+<input id="input" type="text" value="Focus me">
+<div id="scroller" class="scroller"><div></div></div>
+<div style="clear: both;"></div>
+
+<script>
+if (window.testRunner)
+    testRunner.dumpAsText();
+
+var scrollbarWidth = 15;
+
+function clickVerticalScrollbar(id)
+{
+    var el = document.getElementById(id);
+    var x = el.offsetLeft + el.offsetWidth - scrollbarWidth / 2;
+    var y = el.offsetTop + el.offsetHeight / 2;
+    if (window.eventSender) {
+        eventSender.mouseMoveTo(x, y);
+        eventSender.mouseDown();
+        eventSender.mouseUp();
+    }
+}
+
+description("This tests that clicking an overflow element's scrollbar does not blur the currently focused input when no focusable ancestor exists.");
+
+document.getElementById("input").focus();
+clickVerticalScrollbar("scroller");
+shouldBeEqualToString("document.activeElement.tagName", "INPUT");
+</script>

--- a/Source/WebCore/page/EventHandler.cpp
+++ b/Source/WebCore/page/EventHandler.cpp
@@ -3398,7 +3398,7 @@ bool EventHandler::dispatchMouseEvent(const AtomString& eventType, Node* targetN
     }
 
     // Only change the focus when clicking scrollbars if it can be transferred to a mouse focusable node.
-    if (!element && isInsideScrollbar(flooredIntPoint(platformMouseEvent.position())))
+    if (!element && m_lastScrollbarUnderMouse)
         return false;
 
 #if (!PLATFORM(GTK) && !PLATFORM(WPE))
@@ -3425,17 +3425,6 @@ bool EventHandler::dispatchMouseEvent(const AtomString& eventType, Node* targetN
         element->findTargetAndUpdateFocusAppearance(SelectionRestorationMode::SelectAll);
 
     return true;
-}
-
-bool EventHandler::isInsideScrollbar(const IntPoint& windowPoint) const
-{
-    if (RefPtr document = m_frame->document()) {
-        HitTestResult result { windowPoint };
-        document->hitTest(OptionSet<HitTestRequest::Type> { HitTestRequest::Type::ReadOnly, HitTestRequest::Type::DisallowUserAgentShadowContent }, result);
-        return result.scrollbar();
-    }
-
-    return false;
 }
 
 #if !PLATFORM(MAC)

--- a/Source/WebCore/page/EventHandler.h
+++ b/Source/WebCore/page/EventHandler.h
@@ -493,8 +493,6 @@ private:
     void cancelFakeMouseMoveEvent();
 #endif
 
-    bool isInsideScrollbar(const IntPoint&) const;
-
 #if ENABLE(TOUCH_EVENTS)
     bool dispatchSyntheticTouchEventIfEnabled(const PlatformMouseEvent&);
 #endif


### PR DESCRIPTION
#### e0da60a6b610ee845bafefa0817c2115647b7c08
<pre>
Clicking an overflow element&apos;s scrollbar should not blur the focused element
<a href="https://bugs.webkit.org/show_bug.cgi?id=239524">https://bugs.webkit.org/show_bug.cgi?id=239524</a>
<a href="https://rdar.apple.com/92367314">rdar://92367314</a>

Reviewed by Aditya Keerthi.

When an input was focused and the user clicked the scrollbar of an unrelated
overflow element (e.g. a typeahead suggestions list on linkedin.com), WebKit
cleared focus to the body. Chrome and Firefox preserve focus. No spec
constrains this -- HTML doesn&apos;t classify scrollbars as focusable areas and
CSSOM-View&apos;s elementFromPoint excludes them -- so the behavior is
implementation-defined and we should match the cross-browser convention.

EventHandler::dispatchMouseEvent already had the right check from bug 96335,
but its isInsideScrollbar() helper did a second Document-level hit test that
could see a different world than the press hit test, because
passMousePressEventToScrollbar() runs in between and can flip an overlay
scrollbar&apos;s shouldParticipateInHitTesting() state. handleMousePressEvent
already records the press scrollbar in m_lastScrollbarUnderMouse via
scrollbarForMouseEvent, which detects both frame and overflow scrollbars
and runs before any handler can mutate scrollbar state. Read that cached
value directly. isInsideScrollbar() is now redundant and is removed.

Cases with a mouse-focusable click ancestor (tabindex / contenteditable /
textarea / select) still move focus, preserving the existing
scrollbar-click-retains-focus.html test.

Test: fast/overflow/scrollbar-click-does-not-blur-focused-input.html

* LayoutTests/fast/overflow/scrollbar-click-does-not-blur-focused-input-expected.txt: Added.
* LayoutTests/fast/overflow/scrollbar-click-does-not-blur-focused-input.html: Added.
* Source/WebCore/page/EventHandler.cpp:
(WebCore::EventHandler::dispatchMouseEvent): Use m_lastScrollbarUnderMouse instead of isInsideScrollbar().
(WebCore::EventHandler::isInsideScrollbar const): Deleted.
* Source/WebCore/page/EventHandler.h:

Canonical link: <a href="https://commits.webkit.org/312924@main">https://commits.webkit.org/312924@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2182b148132bb04b1945458c0ab0195dd338d8df

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/161411 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/34885 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/27985 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/170314 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/117782 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/6f08670f-2c97-4335-ae0d-329a4497950c) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/163280 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/34986 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/34886 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/125221 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/117782 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/8f6156c3-80c0-4743-b32c-14844e3aff21) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/164370 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/27511 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/144995 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/105817 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/d476d1f6-1fab-4124-8a26-6a11e7015c02) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/26560 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/25068 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/18035 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/136253 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/22753 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/172800 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/19831 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/24394 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/133508 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/34559 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/29161 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/133515 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36092 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/34543 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/144548 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/96440 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/28046 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/21367 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/34053 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/101494 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/33553 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/33796 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/33702 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->