### PR TITLE
[Site Isolation] fast/scrolling/mac/nested-overflow-proxy-node.html fails

### DIFF
--- a/LayoutTests/fast/scrolling/mac/nested-overflow-proxy-node.html
+++ b/LayoutTests/fast/scrolling/mac/nested-overflow-proxy-node.html
@@ -55,8 +55,6 @@
             shouldBe('horizontalOverflowScrollEventCount', '0');
             shouldBeTrue('verticalOverflowScrollEventCount > 0', 'true');
             shouldBe('windowScrollEventCount', '0');
-            
-            finishJSTest();
         }
 
         async function scrollTest()

--- a/LayoutTests/platform/mac-site-isolation/TestExpectations
+++ b/LayoutTests/platform/mac-site-isolation/TestExpectations
@@ -160,7 +160,6 @@ fast/loader/stateobjects/no-popstate-when-back-to-stateless-entry-with-page-cach
 fast/loader/stateobjects/popstate-does-not-fire-with-page-cache.html [ Failure ]
 fast/mediastream/RTCPeerConnection-page-cache.html [ Failure ]
 fast/overflow/horizontal-scroll-after-back.html [ Failure ]
-fast/scrolling/mac/nested-overflow-proxy-node.html [ Failure ]
 fast/workers/worker-page-cache.html [ Failure ]
 http/tests/cache-storage/page-cache-domcache-pending-promise.html [ Failure ]
 http/tests/cache-storage/page-cache-domcachestorage-pending-promise.html [ Failure ]


### PR DESCRIPTION
#### 3cfb4baa52af582ace8ea8012c82c343962bab11
<pre>
[Site Isolation] fast/scrolling/mac/nested-overflow-proxy-node.html fails
<a href="https://bugs.webkit.org/show_bug.cgi?id=314233">https://bugs.webkit.org/show_bug.cgi?id=314233</a>
<a href="https://rdar.apple.com/176394945">rdar://176394945</a>

Reviewed by Ryosuke Niwa.

The test is showing additional lines that say &quot;TEST COMPLETE&quot;
and &quot;PASS successfullyParsed is true&quot; from the second call to
finishJSTest.

Without site isolation, the first call to finishJSTest reports it&apos;s
messages and ends the test before the second call to finishJSTest.
In the site isolation case, the additional IPC overhead allows for both
functions to report their messages.

To fix this issue, I removed the first redundant call to finishJSTest.

* LayoutTests/fast/scrolling/mac/nested-overflow-proxy-node.html:
* LayoutTests/platform/mac-site-isolation/TestExpectations:

Canonical link: <a href="https://commits.webkit.org/312806@main">https://commits.webkit.org/312806@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/13b68ace9f9e45d8c11a3a4d5003243fbdbe8011

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/160939 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/34412 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/27513 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/169842 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/117199 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/233537c6-10ff-4137-b426-68a5073d6129) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/34513 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/34412 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/124834 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/117199 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/0a616561-976d-4a0d-bb84-05c57d89c894) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/163898 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/27095 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/144565 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/105431 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/84f1bb21-2266-4e51-95df-bd695f1b6024) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/26147 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/24649 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/17562 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/135841 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/22327 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/172325 "Built successfully") | | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/23968 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/133108 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/34086 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/28741 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/133118 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35995 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/34070 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/144122 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/95909 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/27700 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/20938 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/33581 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/33080 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/33324 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/33229 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->