### PR TITLE
AX: VoiceOver's Skip redundant labels setting not respected on https://marconius.com/fun/wordBop/

### DIFF
--- a/LayoutTests/accessibility/mac/serves-as-title-for-ui-elements-expected.txt
+++ b/LayoutTests/accessibility/mac/serves-as-title-for-ui-elements-expected.txt
@@ -1,0 +1,13 @@
+This test verifies that label elements expose AXServesAsTitleForUIElements.
+
+PASS: label1.allAttributes().includes('AXServesAsTitleForUIElements') === true
+PASS: label1.labelForElementAtIndex(0).domIdentifier === 'input1'
+PASS: label2.allAttributes().includes('AXServesAsTitleForUIElements') === true
+PASS: label2.labelForElementAtIndex(0).domIdentifier === 'input2'
+PASS: notALabel.allAttributes().includes('AXServesAsTitleForUIElements') === false
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+Username  Password
+Not a label

--- a/LayoutTests/accessibility/mac/serves-as-title-for-ui-elements.html
+++ b/LayoutTests/accessibility/mac/serves-as-title-for-ui-elements.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="../../resources/accessibility-helper.js"></script>
+<script src="../../resources/js-test.js"></script>
+</head>
+<body>
+
+<label for="input1">Username</label>
+<input id="input1" type="text">
+
+<label for="input2">Password</label>
+<input id="input2" type="password">
+
+<div id="not-a-label">Not a label</div>
+
+<script>
+var output = "This test verifies that label elements expose AXServesAsTitleForUIElements.\n\n";
+
+if (window.accessibilityController) {
+    var input1 = accessibilityController.accessibleElementById("input1");
+    var label1 = input1.titleUIElement();
+    output += expect("label1.allAttributes().includes('AXServesAsTitleForUIElements')", "true");
+    output += expect("label1.labelForElementAtIndex(0).domIdentifier", "'input1'");
+
+    var input2 = accessibilityController.accessibleElementById("input2");
+    var label2 = input2.titleUIElement();
+    output += expect("label2.allAttributes().includes('AXServesAsTitleForUIElements')", "true");
+    output += expect("label2.labelForElementAtIndex(0).domIdentifier", "'input2'");
+
+    var notALabel = accessibilityController.accessibleElementById("not-a-label");
+    output += expect("notALabel.allAttributes().includes('AXServesAsTitleForUIElements')", "false");
+
+    debug(output);
+}
+</script>
+</body>
+</html>

--- a/Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperMac.mm
+++ b/Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperMac.mm
@@ -600,6 +600,9 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_END
     if (backingObject->errorMessageObjects().size())
         [additional addObject:NSAccessibilityErrorMessageElementsAttribute];
 
+    if (backingObject->labelForObjects().size())
+        [additional addObject:NSAccessibilityServesAsTitleForUIElementsAttribute];
+
     if (!backingObject->keyShortcuts().isEmpty())
         [additional addObject:NSAccessibilityKeyShortcutsAttribute];
 
@@ -2212,6 +2215,11 @@ static id handleErrorMessageElementsAttribute(WebAccessibilityObjectWrapper*, AX
     return makeNSArray(backingObject.errorMessageObjects());
 }
 
+static id handleServesAsTitleForUIElementsAttribute(WebAccessibilityObjectWrapper*, AXCoreObject& backingObject)
+{
+    return makeNSArray(backingObject.labelForObjects());
+}
+
 static id handleFocusableAncestorAttribute(WebAccessibilityObjectWrapper*, AXCoreObject& backingObject)
 {
     RefPtr object = backingObject.focusableAncestor();
@@ -2413,6 +2421,7 @@ static MemoryCompactLookupOnlyRobinHoodHashMap<String, AttributeHandlerEntry> cr
         { NSAccessibilityIsInDescriptionListTermAttribute, { handleIsInDescriptionListTermAttribute, { } } },
         { NSAccessibilityDetailsElementsAttribute, { handleDetailsElementsAttribute, { } } },
         { NSAccessibilityErrorMessageElementsAttribute, { handleErrorMessageElementsAttribute, { } } },
+        { NSAccessibilityServesAsTitleForUIElementsAttribute, { handleServesAsTitleForUIElementsAttribute, { } } },
         { NSAccessibilityFocusableAncestorAttribute, { handleFocusableAncestorAttribute, { } } },
         { NSAccessibilityEditableAncestorAttribute, { handleEditableAncestorAttribute, { } } },
         { NSAccessibilityHighestEditableAncestorAttribute, { handleHighestEditableAncestorAttribute, { } } },
@@ -2561,9 +2570,6 @@ id attributeValueForTesting(const RefPtr<AXCoreObject>& backingObject, NSString 
 
     if ([attributeName isEqualToString:NSAccessibilityLabelledByAttribute])
         return makeNSArray(backingObject->labeledByObjects());
-
-    if ([attributeName isEqualToString:NSAccessibilityLabelForAttribute])
-        return makeNSArray(backingObject->labelForObjects());
 
     if ([attributeName isEqualToString:NSAccessibilityOwnersAttribute])
         return makeNSArray(backingObject->owners());

--- a/Tools/WebKitTestRunner/InjectedBundle/mac/AccessibilityUIElementMac.mm
+++ b/Tools/WebKitTestRunner/InjectedBundle/mac/AccessibilityUIElementMac.mm
@@ -738,7 +738,7 @@ RefPtr<AccessibilityUIElement> AccessibilityUIElementMac::ariaLabelledByElementA
 
 RefPtr<AccessibilityUIElement> AccessibilityUIElementMac::labelForElementAtIndex(unsigned index)
 {
-    return elementForAttributeAtIndex(@"AXLabelFor", index);
+    return elementForAttributeAtIndex(@"AXServesAsTitleForUIElements", index);
 }
 
 RefPtr<AccessibilityUIElement> AccessibilityUIElementMac::ownerElementAtIndex(unsigned index)


### PR DESCRIPTION
#### 9d2e9e5acc36482814373ee381ef2e1ca3c941e4
<pre>
AX: VoiceOver&apos;s Skip redundant labels setting not respected on <a href="https://marconius.com/fun/wordBop/">https://marconius.com/fun/wordBop/</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=314120">https://bugs.webkit.org/show_bug.cgi?id=314120</a>
<a href="https://rdar.apple.com/176297111">rdar://176297111</a>

Reviewed by Dominic Mazzoni and Chris Fleizach.

WebKit should expose whether an object is a label for another via the
existing NSAccessibilityServesAsTitleForUIElementsAttribute. VoiceOver
can then use this to identify whether a label is redundant (because the
labelled item will have the label as part of its accessible name).

* LayoutTests/accessibility/mac/serves-as-title-for-ui-elements-expected.txt: Added.
* LayoutTests/accessibility/mac/serves-as-title-for-ui-elements.html: Added.
* Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperMac.mm:
(-[WebAccessibilityObjectWrapper _additionalAccessibilityAttributeNames:]):
(handleServesAsTitleForUIElementsAttribute):
(createAttributeHandlerMap):
(attributeValueForTesting):
* Tools/WebKitTestRunner/InjectedBundle/mac/AccessibilityUIElementMac.mm:
(WTR::AccessibilityUIElementMac::labelForElementAtIndex):

Canonical link: <a href="https://commits.webkit.org/312967@main">https://commits.webkit.org/312967@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b0750c54df4a84447cd36428a5924b52bf8ff7d1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/160941 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/34414 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/27515 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/169844 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/117201 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/6326ccf8-91fd-4fe4-a1ea-58b2a7b8ee35) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/162810 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/34515 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/34414 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/124838 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/88096 "1 flakes 2 failures") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/163900 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/27099 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/144569 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/105435 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/309363f9-3cc6-4f9c-830d-efd0a67775fe) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/26151 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/24651 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/17564 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/135845 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/22331 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/172327 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/19348 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/23972 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/133110 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/34088 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/28743 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/133120 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36126 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/34072 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/144126 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/95911 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/27695 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/20942 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/33583 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/101008 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/33082 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/33326 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/33231 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->