### PR TITLE
[Site Isolation] deflake http/tests/security/mixedContent/insecure-css-with-secure-cookies-UpgradeMixedContent.html

### DIFF
--- a/LayoutTests/http/tests/security/mixedContent/resources/frame-with-insecure-css-secure-cookies.html
+++ b/LayoutTests/http/tests/security/mixedContent/resources/frame-with-insecure-css-secure-cookies.html
@@ -5,14 +5,18 @@
     document.cookie = "secureCookie=yes;secure";
     console.log(document.cookie);
 </script>
-<link rel="stylesheet" href="https://127.0.0.1:8443/security/mixedContent/resources/insecure.css">
+<link rel="stylesheet" href="https://127.0.0.1:8443/security/mixedContent/resources/insecure.css" onload="stylesheetLoaded()">
+<script>
+function stylesheetLoaded() {
+    // Force style resolution so the mixed content console message for the cursor URL is generated.
+    getComputedStyle(document.documentElement).cursor;
+    if (window.opener)
+        window.opener.postMessage('done', '*');
+}
+</script>
 </head>
 <body>
 Loading css cursor from insecure source.
-<script>
-if (window.opener)
-  window.opener.postMessage('done', '*');
-</script>
 </body>
 </html>
 


### PR DESCRIPTION
#### a3d8b660f6405841078093118d3db3fa82969b1e
<pre>
[Site Isolation] deflake http/tests/security/mixedContent/insecure-css-with-secure-cookies-UpgradeMixedContent.html
<a href="https://bugs.webkit.org/show_bug.cgi?id=314240">https://bugs.webkit.org/show_bug.cgi?id=314240</a>
<a href="https://rdar.apple.com/176396263">rdar://176396263</a>

Reviewed by Ryosuke Niwa.

The test is failing flakily with the following diff on macOS post-commit bots
http/tests/security/mixedContent/insecure-css-with-secure-cookies-UpgradeMixedContent.html

```
--- /Volumes/Data/worker/Apple-Tahoe-Release-WK2-Site-Isolation-Tree-Tests/build/layout-test-results/http/tests/security/mixedContent/insecure-css-with-secure-cookies-UpgradeMixedContent-expected.txt
+++ /Volumes/Data/worker/Apple-Tahoe-Release-WK2-Site-Isolation-Tree-Tests/build/layout-test-results/http/tests/security/mixedContent/insecure-css-with-secure-cookies-UpgradeMixedContent-actual.txt
@@ -1,4 +1,2 @@
 CONSOLE MESSAGE: secureCookie=yes
-CONSOLE MESSAGE: The page at <a href="https://127.0.0.1">https://127.0.0.1</a>:8443/security/mixedContent/resources/frame-with-insecure-css-secure-cookies.html requested insecure content from <a href="http://127.0.0.1">http://127.0.0.1</a>:8080/security/resources/greenbox-hotspot5-4.cur. This content was automatically upgraded and should be served over HTTPS.
-
 This test opens a window that loads a secure style sheet with insecure cursor content after reading secure cookies. This should be allowed because loading of the insecure cursor does not pose a security risk since it can only affect the display.
```

I wasn&apos;t able to reproduce this failure locally so this patch is a speculative
fix which waits until the stylesheet finishes loading before calling
window.opener.postMessage.
This patch also calls getComputedStyle(...).cursor to force the engine
to resolve the cursor property earlier.

* LayoutTests/http/tests/security/mixedContent/resources/frame-with-insecure-css-secure-cookies.html:

Canonical link: <a href="https://commits.webkit.org/312746@main">https://commits.webkit.org/312746@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2b32f6f67a49b032c61c962add1889dd67abf147

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/160951 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/159/builds/34424 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/27525 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/169854 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/117211 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/34525 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/34424 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/124846 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/117211 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/163910 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/27112 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/144583 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/105443 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/26163 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/24661 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/17574 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/135857 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/22345 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/172337 "Built successfully") | | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/19358 "Build is in progress. Recent messages:") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/23986 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/133121 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/34098 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/28754 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/133131 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35947 "Built successfully and passed tests") | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/34082 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/144140 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/95921 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/160/builds/34082 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/20957 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/33593 "Built successfully") | | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/33092 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/33336 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/33241 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->