### PR TITLE
REGRESSION (macOS Tahoe): <datalist> completion list background turns white on white text after typing a character when in dark mode

### DIFF
--- a/Source/WebKit/UIProcess/mac/WebDataListSuggestionsDropdownMac.mm
+++ b/Source/WebKit/UIProcess/mac/WebDataListSuggestionsDropdownMac.mm
@@ -145,8 +145,11 @@ void WebDataListSuggestionsDropdownMac::close()
 
     self.hasShadow = YES;
 #if HAVE(LIQUID_GLASS)
-    if (WebKit::isLiquidGlassEnabled())
-        _backdropView = adoptNS([[NSGlassEffectView alloc] initWithFrame:contentRect]);
+    if (WebKit::isLiquidGlassEnabled()) {
+        RetainPtr glassView = adoptNS([[NSGlassEffectView alloc] initWithFrame:contentRect]);
+        [glassView set_adaptiveAppearance:_NSGlassEffectViewAdaptiveAppearanceOff];
+        _backdropView = WTF::move(glassView);
+    }
 #endif
 
     if (!_backdropView) {


### PR DESCRIPTION
#### 5a76e09fdaa304e0d733d9836b355c725e3d551d
<pre>
REGRESSION (macOS Tahoe): &lt;datalist&gt; completion list background turns white on white text after typing a character when in dark mode
<a href="https://bugs.webkit.org/show_bug.cgi?id=314241">https://bugs.webkit.org/show_bug.cgi?id=314241</a>
<a href="https://rdar.apple.com/168676757">rdar://168676757</a>

Reviewed by Tim Horton, Aditya Keerthi, and Abrar Rahman Protyasha.

If a user is in dark mode but the datalist is on a document that has a light
background, the datalist background color initially starts out as dark but turns
to light after the user types a character. When a character is typed,
updateWithInformation is called and refreshes the datalist suggestions.
This function also moves the window and thus, causes it to re-sample the background.

In this case, what is right underneath the datalist is a light color, regardless of
dark or light mode. This was verified by changing the background color of the &lt;body&gt;.
A light gray color on &lt;body&gt; caused the datalist background color to be light, and a
dark gray caused it to be dark.

To prevent this dynamic adjustment for datalists, if liquid glass is used, set NSGlassEffectView
to _NSGlassEffectViewAdaptiveAppearanceOff. After this change, the datalist
remains the same color as the original appearance mode (dark or light). Note that AppKit menus
also use _NSGlassEffectViewAdaptiveAppearanceOff for glass views.

* Source/WebKit/UIProcess/mac/WebDataListSuggestionsDropdownMac.mm:
(-[WKDataListSuggestionWindow initWithContentRect:styleMask:backing:defer:]):

Canonical link: <a href="https://commits.webkit.org/312889@main">https://commits.webkit.org/312889@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b1ce788b6a2cdbc284fe0bb9d3d3248d00bc314d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/160986 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/34459 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/27560 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/169889 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/117246 "Built successfully") | ⏳ 🛠 ios-apple 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/162855 "Build is in progress. Recent messages:") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/34560 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/34459 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/124876 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/88111 "1 flakes 1 failures") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/163945 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/27136 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/144610 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/105473 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/26186 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/24693 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/17609 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/135880 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/172372 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/19393 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/24013 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/133149 "Found 1 new test failure: accessibility/aria-owns-deep-chain-no-timeout.html (failure)") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/34133 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/28786 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/133159 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/34117 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/144167 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/95956 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/24532 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/27722 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/20985 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/33628 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/101053 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/33127 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/33371 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/33276 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->