### PR TITLE
[iOS] fast/forms/select/base/select-pagedown-pageup-vertical.html is a constant text failure

### DIFF
--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -8575,8 +8575,6 @@ imported/w3c/web-platform-tests/css/css-highlight-api/highlight-text-across-elem
 pdf/annotations [ Skip ]
 pdf/pdf-in-iframe-with-text-annotation.html [ Skip ]
 
-webkit.org/b/312496 fast/forms/select/base/select-pagedown-pageup-vertical.html [ Pass Failure ]
-
 webkit.org/b/312499 imported/w3c/web-platform-tests/shadow-dom/reference-target/tentative/form.html [ Pass Failure ]
 
 webkit.org/b/309173 imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/module/modulepreload-referrerpolicy.html [ Pass Failure ]

--- a/LayoutTests/platform/ios/fast/forms/select/base/select-pagedown-pageup-vertical-expected.txt
+++ b/LayoutTests/platform/ios/fast/forms/select/base/select-pagedown-pageup-vertical-expected.txt
@@ -32,7 +32,7 @@ FAIL focusedOptionNumber() should be 100. Was 1.
 FAIL Page Up did not make progress: was 100, now 100
 FAIL focusedOptionNumber() should be 1. Was 100.
 PASS focusedOptionNumber() === pageDownTarget is true
-FAIL focusedOptionNumber() === pageUpTarget should be true. Was false.
+PASS focusedOptionNumber() === pageUpTarget is true
 PASS successfullyParsed is true
 Some tests failed.
 


### PR DESCRIPTION
#### 80e83d507df611a050c366cf5d4c52fe47eee387
<pre>
[iOS] fast/forms/select/base/select-pagedown-pageup-vertical.html is a constant text failure
<a href="https://rdar.apple.com/174938412">rdar://174938412</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=312496">https://bugs.webkit.org/show_bug.cgi?id=312496</a>

Unreviewed progression rebaseline.

* LayoutTests/platform/ios/TestExpectations:
* LayoutTests/platform/ios/fast/forms/select/base/select-pagedown-pageup-vertical-expected.txt:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/80e83d507df611a050c366cf5d4c52fe47eee387

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/160964 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/34437 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/27538 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/169867 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/117224 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/34538 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/34437 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/124863 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/88104 "2 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/163923 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/27121 "Exiting early after 10 failures. 10 tests run. 1 failures") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/144595 "Found 1 new API test failure: TestWebKitAPI.WKInspectorExtension.EvaluateScriptInExtensionTabCanReturnPromises (failure)") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/105460 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/26172 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/24674 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/17587 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/135866 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/22357 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/172350 "Built successfully") | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/23998 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/133135 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/34111 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/28767 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/133145 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/34095 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/144152 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/95934 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/27714 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/20970 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/33606 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/33105 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/33349 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/33254 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->