### PR TITLE
RELEASE ASSERT: http/tests/security/contentSecurityPolicy/multipart-three-part.py is a flaky crash

### DIFF
--- a/Source/WebKit/NetworkProcess/NetworkResourceLoader.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkResourceLoader.cpp
@@ -1047,6 +1047,8 @@ void NetworkResourceLoader::didReceiveResponse(ResourceResponse&& receivedRespon
             connectionToWebProcess().networkProcess().parentProcessConnection()->send(Messages::NetworkProcessProxy::ResourceLoadDidReceiveResponse(webPageProxyID(), resourceLoadInfo, response), 0);
 
         if (willWaitForContinueDidReceiveResponse) {
+            if (m_responseCompletionHandler)
+                m_responseCompletionHandler(PolicyAction::Use);
             m_responseCompletionHandler = WTF::move(completionHandler);
             return;
         }


### PR DESCRIPTION
#### c3b71f0c470498440347a5a022006ccb25260b6f
<pre>
RELEASE ASSERT: http/tests/security/contentSecurityPolicy/multipart-three-part.py is a flaky crash
<a href="https://bugs.webkit.org/show_bug.cgi?id=314243">https://bugs.webkit.org/show_bug.cgi?id=314243</a>
&lt;<a href="https://rdar.apple.com/problem/169360779">rdar://problem/169360779</a>&gt;

Reviewed by NOBODY (OOPS!).

This crash has nothing to do with CSP — it is happening because the multi-part load
receives the (fake) responses in rapid succession, causing the first completion handler
to be dropped when the second arrives. This triggers NSURLSession to fire a release
assert that crashes the network process.

The most conservative (from a loading standpoint) fix is to process the completion
handler when it still exists at the time the next response is received. PolicyAction::Use
is the correct argument (rather than PolicyAction::Ignore) because by the time we get a
follow-up response, we have already run through the Content Policy check and have made
the choice to proceed with the load. We therefore needs to accept the first (and all
subsequent) loads to complete the process.

* Source/WebKit/NetworkProcess/NetworkResourceLoader.cpp:
(WebKit::NetworkResourceLoader::didReceiveResponse): Complete old handler before
storing the new handler.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c3b71f0c470498440347a5a022006ccb25260b6f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/161501 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/34975 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/28078 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/170404 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/117872 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/35a3058f-246d-4872-a511-af3d5147c93c) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/35076 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/34976 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/125294 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/88246 "1 flakes 2 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/16cbe4d4-b0e1-452e-b3a2-dba06dec0db5) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/164460 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/27590 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/145071 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/105890 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/e0ef632f-700a-49b1-8d3c-ee4f0fd2cc91) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/26639 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/25148 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/18125 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/136333 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/172890 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/19933 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/24469 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/133578 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/34649 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/29244 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/133585 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/34633 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/144623 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/96538 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/28114 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/21442 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/34143 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/101588 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/33643 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/33886 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/33792 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->