### PR TITLE
[SequesteredMalloc] Support arbitrary-size allocations

### DIFF
--- a/JSTests/stress/many-locals-in-generator-suspension.js
+++ b/JSTests/stress/many-locals-in-generator-suspension.js
@@ -1,0 +1,14 @@
+//@ memoryHog!
+//@ slow!
+//@ $skipModes << "no-llint".to_sym
+
+var source = '(function* generatorFunction() {';
+
+for (var i = 0; i < 32768; ++i)
+    source += `var v_${i} = ${i};\n`;
+
+source += 'yield;\n})';
+
+var generatorFunction = eval(source);
+var generator = generatorFunction();
+generator.next();

--- a/Source/WTF/wtf/DoublyLinkedList.h
+++ b/Source/WTF/wtf/DoublyLinkedList.h
@@ -84,6 +84,7 @@ public:
 
     void push(T*);
     void append(T*);
+    void insertAfter(T* existingNode, T* newNode);
     void remove(T*);
     void append(DoublyLinkedList<T>&);
 
@@ -159,6 +160,19 @@ template<typename T> inline void DoublyLinkedList<T>::append(T* node)
     m_tail->setNext(node);
     node->setPrev(m_tail);
     m_tail = node;
+}
+
+template<typename T> inline void DoublyLinkedList<T>::insertAfter(T* existingNode, T* newNode)
+{
+    ASSERT(existingNode);
+    ASSERT(!newNode->prev() && !newNode->next());
+    newNode->setPrev(existingNode);
+    newNode->setNext(existingNode->next());
+    if (existingNode->next())
+        existingNode->next()->setPrev(newNode);
+    else
+        m_tail = newNode;
+    existingNode->setNext(newNode);
 }
 
 template<typename T> inline DoublyLinkedList<T> DoublyLinkedList<T>::splitAt(size_t toKeep)

--- a/Source/WTF/wtf/SequesteredAllocator.h
+++ b/Source/WTF/wtf/SequesteredAllocator.h
@@ -46,12 +46,12 @@
 
 namespace WTF {
 
-constexpr size_t minArenaGranuleSize { 512 * KB };
+constexpr size_t minArenaGranuleSize { inlineGranuleSize };
 constexpr size_t sequesteredArenaAllocatorAlignment { 128 };
 
 class alignas(sequesteredArenaAllocatorAlignment) SequesteredArenaAllocator {
 private:
-    using AllocationFailureMode = SequesteredImmortalHeap::AllocationFailureMode;
+    using AllocationFailureMode = SequesteredGranuleProvider::AllocationFailureMode;
 
     constexpr static bool verbose { false };
     constexpr static bool trackAllocationDebugInfo { false };
@@ -215,69 +215,69 @@ private:
                 if (!granule)
                     return nullptr;
             }
-
+            if (granule->m_type == GranuleHeader::Type::Large)
+                return granule->payload();
             uintptr_t allocation = m_allocHead;
             m_allocHead = headIncrementedBy(bytes);
             ASSERT(m_allocHead <= m_allocBound);
-
             return reinterpret_cast<void*>(allocation);
         }
 
         template<AllocationFailureMode mode>
         NEVER_INLINE void* alignedAllocateImplSlowPath(size_t alignment, size_t bytes)
         {
-            auto* granule = addGranule<mode>(bytes);
+            auto* granule = addGranule<mode>(alignment + bytes);
             if constexpr (mode == AllocationFailureMode::ReturnNull) {
                 if (!granule)
                     return nullptr;
             }
-
+            if (granule->m_type == GranuleHeader::Type::Large)
+                return granule->payload();
             uintptr_t allocation = headAlignedUpTo(alignment);
             m_allocHead = headIncrementedBy((allocation - m_allocHead) + bytes);
             ASSERT(m_allocHead <= m_allocBound);
-
             return reinterpret_cast<void*>(allocation);
         }
 
         template<AllocationFailureMode mode>
-        GranuleHeader* addGranule([[maybe_unused]] size_t minSize)
+        GranuleHeader* addGranule(size_t minSizeBytes)
         {
-            ASSERT(minSize <= minArenaGranuleSize);
-            GranuleHeader* granule = reinterpret_cast<GranuleHeader*>(mapGranule<mode>(minArenaGranuleSize));
+            GranuleHeader* granule = parent().mapGranule<mode>(minSizeBytes);
             if constexpr (mode == AllocationFailureMode::ReturnNull) {
                 if (!granule) [[unlikely]]
                     return nullptr;
             }
 
-            m_granules.push(granule);
-            setBoundsFromGranule(granule);
-
-            static_assert(sizeof(GranuleHeader) >= minHeadAlignment);
-            dataLogLnIf(verbose,
-                "Allocator ", parent().id(),
-                ": Arena ", parent().debugIndexOfArena(*this),
-                ": expanded: granule was (", granule->prev(),
-                "), now (", granule,
-                "); allocHead (",
-                RawPointer(reinterpret_cast<void*>(m_allocHead)),
-                "), allocBound (",
-                RawPointer(reinterpret_cast<void*>(m_allocBound)),
-                ")");
+            if (granule->m_type == GranuleHeader::Type::Large) {
+                m_granules.append(granule);
+                dataLogLnIf(verbose,
+                    "Allocator ", parent().id(),
+                    ": Arena ", parent().debugIndexOfArena(*this),
+                    ": large allocation: ", granule->m_largeSize, "B at ",
+                    RawPointer(granule->payload()));
+            } else {
+                m_granules.push(granule);
+                setBoundsFromGranule(granule);
+                dataLogLnIf(verbose,
+                    "Allocator ", parent().id(),
+                    ": Arena ", parent().debugIndexOfArena(*this),
+                    ": expanded: granule was (", granule->prev(),
+                    "), now (", granule,
+                    "); allocHead (",
+                    RawPointer(reinterpret_cast<void*>(m_allocHead)),
+                    "), allocBound (",
+                    RawPointer(reinterpret_cast<void*>(m_allocBound)),
+                    ")");
+            }
 
             return granule;
         }
 
         void setBoundsFromGranule(GranuleHeader* granule)
         {
-            static_assert(sizeof(GranuleHeader) >= minHeadAlignment);
-            m_allocHead = reinterpret_cast<uintptr_t>(granule) + sizeof(GranuleHeader);
-            m_allocBound = reinterpret_cast<uintptr_t>(granule) + (pageSize * (1 + granule->additionalPageCount));
-        }
-
-        template<AllocationFailureMode mode>
-        void* mapGranule(size_t bytes)
-        {
-            return parent().mapGranule<mode>(bytes);
+            auto* base = granule->payload();
+            m_allocHead = reinterpret_cast<uintptr_t>(base);
+            m_allocBound = reinterpret_cast<uintptr_t>(base) + granule->size();
         }
 
         SequesteredArenaAllocator& parent()
@@ -531,9 +531,9 @@ private:
     }
 
     template<AllocationFailureMode mode>
-    void* mapGranule(size_t bytes)
+    GranuleHeader* mapGranule(size_t minSizeBytes)
     {
-        return SequesteredImmortalHeap::instance().mapGranule<mode>(bytes);
+        return SequesteredImmortalHeap::instance().granuleProvider().mapGranule<mode>(minSizeBytes);
     }
 
     void* reallocateInto(void* from, void* to, size_t toSize)

--- a/Source/WTF/wtf/SequesteredImmortalHeap.cpp
+++ b/Source/WTF/wtf/SequesteredImmortalHeap.cpp
@@ -31,6 +31,102 @@
 
 namespace WTF {
 
+GranuleHeader* SequesteredLargeHeap::acquireHeader()
+{
+    if (!m_emptyHeaders.isEmpty())
+        return m_emptyHeaders.removeHead();
+    return reinterpret_cast<GranuleHeader*>(
+        SequesteredImmortalHeap::instance().immortalMalloc(sizeof(GranuleHeader)));
+}
+
+void SequesteredLargeHeap::insertSorted(GranuleHeader* gran)
+{
+    auto base = reinterpret_cast<uintptr_t>(gran->m_largeBase);
+    GranuleHeader* prev = nullptr;
+    for (auto* node = m_decommittedList.head(); node; node = node->next()) {
+        if (reinterpret_cast<uintptr_t>(node->m_largeBase) > base)
+            break;
+        prev = node;
+    }
+    if (prev)
+        m_decommittedList.insertAfter(prev, gran);
+    else
+        m_decommittedList.push(gran);
+}
+
+GranuleHeader* SequesteredLargeHeap::allocate(size_t bytes)
+{
+    Locker lock(m_lock);
+
+    for (auto* node = m_decommittedList.head(); node; node = node->next()) {
+        if (node->m_largeSize >= bytes) {
+            if (node->m_largeSize != bytes) {
+                auto* remainder = acquireHeader();
+                remainder->m_type = GranuleHeader::Type::Large;
+                remainder->m_largeBase = reinterpret_cast<void*>(
+                    reinterpret_cast<uintptr_t>(node->m_largeBase) + bytes);
+                remainder->m_largeSize = node->m_largeSize - bytes;
+
+                m_decommittedList.insertAfter(node, remainder);
+
+                node->m_largeSize = bytes;
+            }
+            m_decommittedList.remove(node);
+
+            while (madvise(node->m_largeBase, bytes, MADV_FREE_REUSE) == -1 && errno == EAGAIN) { }
+            m_liveMap.add(reinterpret_cast<uintptr_t>(node->m_largeBase), node);
+            return node;
+        }
+    }
+
+    mach_vm_address_t addr = 0;
+    auto kr = mach_vm_map(mach_task_self(), &addr, bytes,
+        (size_t(1) << largeAlignShift) - 1, VM_FLAGS_ANYWHERE,
+        MEMORY_OBJECT_NULL, 0, false,
+        VM_PROT_READ | VM_PROT_WRITE,
+        VM_PROT_READ | VM_PROT_WRITE,
+        VM_INHERIT_DEFAULT);
+    if (kr != KERN_SUCCESS)
+        return nullptr;
+
+    auto* gran = acquireHeader();
+    gran->m_type = GranuleHeader::Type::Large;
+    gran->m_largeBase = reinterpret_cast<void*>(addr);
+    gran->m_largeSize = bytes;
+    m_liveMap.add(static_cast<uintptr_t>(addr), gran);
+    return gran;
+}
+
+void SequesteredLargeHeap::decommit(GranuleHeader* gran)
+{
+    Locker lock(m_lock);
+
+    auto it = m_liveMap.find(reinterpret_cast<uintptr_t>(gran->m_largeBase));
+    RELEASE_ASSERT(it != m_liveMap.end());
+    m_liveMap.remove(it);
+
+    while (madvise(gran->m_largeBase, gran->m_largeSize, MADV_FREE_REUSABLE) == -1 && errno == EAGAIN) { }
+
+    insertSorted(gran);
+
+    auto* prev = gran->prev();
+    if (prev && reinterpret_cast<uintptr_t>(prev->m_largeBase) + prev->m_largeSize
+        == reinterpret_cast<uintptr_t>(gran->m_largeBase)) {
+        prev->m_largeSize += gran->m_largeSize;
+        m_decommittedList.remove(gran);
+        releaseHeader(gran);
+        gran = prev;
+    }
+
+    auto* next = gran->next();
+    if (next && reinterpret_cast<uintptr_t>(gran->m_largeBase) + gran->m_largeSize
+        == reinterpret_cast<uintptr_t>(next->m_largeBase)) {
+        gran->m_largeSize += next->m_largeSize;
+        m_decommittedList.remove(next);
+        releaseHeader(next);
+    }
+}
+
 SequesteredImmortalHeap& SequesteredImmortalHeap::instance()
 {
     // FIXME: this storage is not contained within the sequestered region
@@ -46,11 +142,10 @@ void ConcurrentDecommitQueue::decommit()
 {
     auto lst = acquireExclusiveCopyOfGranuleList();
 
-    auto* curr = lst.head();
+    auto* curr = lst.removeHead();
     if (!curr)
         return;
 
-    // FIXME: this should go to a page-provider rather than the SIH
     auto& sih = SequesteredImmortalHeap::instance();
 
     size_t decommitPageCount { 0 };
@@ -59,8 +154,7 @@ void ConcurrentDecommitQueue::decommit()
     UNUSED_VARIABLE(decommitGranuleCount);
 
     do {
-        auto* next = curr->next();
-        auto pages = sih.decommitGranule(curr);
+        auto pages = sih.granuleProvider().decommitGranule(curr);
 
         dataLogLnIf(verbose,
             "ConcurrentDecommitQueue: decommitted granule at (",
@@ -69,7 +163,7 @@ void ConcurrentDecommitQueue::decommit()
         decommitPageCount += pages;
         decommitGranuleCount++;
 
-        curr = next;
+        curr = lst.removeHead();
     } while (curr);
 
     dataLogLnIf(verbose, "ConcurrentDecommitQueue: decommitted ",
@@ -152,28 +246,32 @@ void SequesteredStackAllocator::deallocate(StackHandle* handle)
     m_freeList.push(handle);
 }
 
-GranuleHeader* SequesteredImmortalAllocator::addGranule(size_t minSize)
+GranuleHeader* SequesteredImmortalAllocator::addGranule(size_t minSizeBytes)
 {
-    size_t granuleSize = std::max(minSize, minGranuleSize);
+    RELEASE_ASSERT(minSizeBytes <= inlineGranuleSize - sizeof(GranuleHeader));
+    using AllocationFailureMode = SequesteredGranuleProvider::AllocationFailureMode;
+    GranuleHeader* granule = SequesteredImmortalHeap::instance().granuleProvider().mapGranule<AllocationFailureMode::Assert>(minSizeBytes);
 
-    using AllocationFailureMode = SequesteredImmortalHeap::AllocationFailureMode;
-    GranuleHeader* granule = SequesteredImmortalHeap::instance().mapGranule<AllocationFailureMode::Assert>(granuleSize);
-
-    static_assert(sizeof(GranuleHeader) >= minHeadAlignment);
-    m_allocHead = reinterpret_cast<uintptr_t>(granule) + sizeof(GranuleHeader);
-    m_allocBound = reinterpret_cast<uintptr_t>(granule) + granuleSize;
-    m_granules.push(granule);
-
-    static_assert(sizeof(GranuleHeader) >= minHeadAlignment);
-    dataLogLnIf(verbose,
-        "SequesteredImmortalAllocator at ", RawPointer(this),
-        ": expanded: granule was (", RawPointer(m_granules.head()->next()),
-        "), now (", RawPointer(m_granules.head()),
-        "); allocHead (",
-        RawPointer(reinterpret_cast<void*>(m_allocHead)),
-        "), allocBound (",
-        RawPointer(reinterpret_cast<void*>(m_allocBound)),
-        ")");
+    if (granule->m_type == GranuleHeader::Type::Large) {
+        m_granules.append(granule);
+        dataLogLnIf(verbose,
+            "SequesteredImmortalAllocator at ", RawPointer(this),
+            ": large allocation: ", granule->m_largeSize, "B at ", RawPointer(granule->payload()));
+    } else {
+        m_granules.push(granule);
+        auto* base = granule->payload();
+        m_allocHead = reinterpret_cast<uintptr_t>(base);
+        m_allocBound = reinterpret_cast<uintptr_t>(base) + granule->size();
+        dataLogLnIf(verbose,
+            "SequesteredImmortalAllocator at ", RawPointer(this),
+            ": expanded: granule was (", RawPointer(m_granules.head()->next()),
+            "), now (", RawPointer(m_granules.head()),
+            "); allocHead (",
+            RawPointer(reinterpret_cast<void*>(m_allocHead)),
+            "), allocBound (",
+            RawPointer(reinterpret_cast<void*>(m_allocBound)),
+            ")");
+    }
 
     return granule;
 }

--- a/Source/WTF/wtf/SequesteredImmortalHeap.h
+++ b/Source/WTF/wtf/SequesteredImmortalHeap.h
@@ -44,6 +44,7 @@
 #include <wtf/CurrentThread.h>
 #include <wtf/DataLog.h>
 #include <wtf/DoublyLinkedList.h>
+#include <wtf/HashMap.h>
 #include <wtf/Lock.h>
 #include <wtf/PageBlock.h>
 
@@ -53,14 +54,53 @@
 
 namespace WTF {
 
+static constexpr size_t inlineGranuleSize { 512 * KB };
+
 struct GranuleHeader : public DoublyLinkedListNode<GranuleHeader> {
-    // non-inclusive of the page this is on
-    // so a value of 0 encodes 1 total pages
+    enum class Type : uint8_t { Inline, Large };
+
     GranuleHeader* m_prev;
     GranuleHeader* m_next;
-    size_t additionalPageCount;
+    Type m_type { Type::Inline };
+    void* m_largeBase { nullptr };
+    size_t m_largeSize { 0 };
+
+    void* payload() const
+    {
+        if (m_type == Type::Inline) [[likely]]
+            return reinterpret_cast<void*>(reinterpret_cast<uintptr_t>(this) + sizeof(GranuleHeader));
+        RELEASE_ASSERT(m_type == Type::Large);
+        return m_largeBase;
+    }
+
+    size_t size() const
+    {
+        if (m_type == Type::Inline) [[likely]]
+            return inlineGranuleSize - sizeof(GranuleHeader);
+        RELEASE_ASSERT(m_type == Type::Large);
+        return m_largeSize;
+    }
 };
 using GranuleList = DoublyLinkedList<GranuleHeader>;
+
+static constexpr size_t largeAlignShift = 20; // 1 MiB
+
+class SequesteredLargeHeap {
+public:
+    WTF_EXPORT_PRIVATE GranuleHeader* allocate(size_t bytes);
+    WTF_EXPORT_PRIVATE void decommit(GranuleHeader* gran);
+
+private:
+    WTF_EXPORT_PRIVATE GranuleHeader* acquireHeader();
+    void releaseHeader(GranuleHeader* h) { m_emptyHeaders.push(h); }
+
+    void insertSorted(GranuleHeader*);
+
+    UncheckedKeyHashMap<uintptr_t, GranuleHeader*> m_liveMap;
+    GranuleList m_decommittedList;
+    GranuleList m_emptyHeaders;
+    Lock m_lock;
+};
 
 
 class ConcurrentDecommitQueue {
@@ -98,7 +138,7 @@ private:
 // FIXME: a lot of this, but not all, can be de-duped with SequesteredArenaAllocator::Arena
 class SequesteredImmortalAllocator {
     constexpr static bool verbose { false };
-    constexpr static size_t minGranuleSize { 16 * KB };
+    constexpr static size_t minGranuleSize { inlineGranuleSize };
     constexpr static size_t minHeadAlignment { alignof(std::max_align_t) };
 public:
     SequesteredImmortalAllocator() = default;
@@ -175,30 +215,32 @@ private:
 
     NEVER_INLINE void* allocateImplSlowPath(size_t bytes)
     {
-        addGranule(bytes);
+        // FIXME: routing through the GranuleProvider mixes up concerns.
+        // Extract this into some common logic instead
+        auto* granule = addGranule(bytes);
+        RELEASE_ASSERT(granule->m_type == GranuleHeader::Type::Inline);
 
         uintptr_t allocation = m_allocHead;
         m_allocHead = headIncrementedBy(bytes);
         ASSERT(m_allocHead <= m_allocBound);
-
         return reinterpret_cast<void*>(allocation);
     }
 
     NEVER_INLINE void* alignedAllocateImplSlowPath(size_t alignment, size_t bytes)
     {
-        // FIXME: store granule headers out-of-line to avoid wasting
-        // up to alignment bytes per granule on header padding.
-        addGranule(alignment + bytes);
+        // FIXME: if alignment-wasteage from the inline GranuleHeader
+        // is too high, fall back to large heap instead.
+        auto* granule = addGranule(alignment + bytes);
+        RELEASE_ASSERT(granule->m_type == GranuleHeader::Type::Inline);
 
         alignment = std::max(alignment, minHeadAlignment);
         uintptr_t allocation = WTF::roundUpToMultipleOf(alignment, m_allocHead);
         m_allocHead = headIncrementedBy((allocation - m_allocHead) + bytes);
         ASSERT(m_allocHead <= m_allocBound);
-
         return reinterpret_cast<void*>(allocation);
     }
 
-    WTF_EXPORT_PRIVATE GranuleHeader* addGranule(size_t minSize);
+    WTF_EXPORT_PRIVATE GranuleHeader* addGranule(size_t minSizeBytes);
 
     GranuleList m_granules { };
     uintptr_t m_allocHead { 0 };
@@ -341,6 +383,64 @@ private:
     Lock m_lock;
 };
 
+class SequesteredGranuleProvider {
+public:
+    enum class AllocationFailureMode {
+        Assert,
+        ReturnNull
+    };
+
+    SequesteredGranuleProvider() = default;
+
+    template<AllocationFailureMode mode>
+    GranuleHeader* mapGranule(size_t minSizeBytes)
+    {
+        if (minSizeBytes <= inlineGranuleSize - sizeof(GranuleHeader)) [[likely]]
+            return mapInlineGranule<mode>();
+        return mapLargeGranule(minSizeBytes);
+    }
+
+    size_t decommitGranule(GranuleHeader* gran)
+    {
+        switch (gran->m_type) {
+        case GranuleHeader::Type::Large: {
+            size_t bytes = gran->m_largeSize;
+            m_largeHeap.decommit(gran);
+            return bytes / pageSize();
+        }
+        case GranuleHeader::Type::Inline:
+            munmap(gran, inlineGranuleSize);
+            return inlineGranuleSize / pageSize();
+        }
+        RELEASE_ASSERT_NOT_REACHED();
+    }
+
+private:
+    friend class SequesteredImmortalHeap;
+
+    template<AllocationFailureMode mode>
+    GranuleHeader* mapInlineGranule()
+    {
+        void* p = mmap(nullptr, inlineGranuleSize, PROT_READ | PROT_WRITE,
+            MAP_PRIVATE | MAP_ANON, -1, 0);
+        if (p == MAP_FAILED) [[unlikely]] {
+            if constexpr (mode == AllocationFailureMode::ReturnNull)
+                return nullptr;
+            RELEASE_ASSERT_NOT_REACHED();
+        }
+        auto* gran = reinterpret_cast<GranuleHeader*>(p);
+        gran->m_type = GranuleHeader::Type::Inline;
+        return gran;
+    }
+
+    GranuleHeader* mapLargeGranule(size_t bytes)
+    {
+        return m_largeHeap.allocate(bytes);
+    }
+
+    SequesteredLargeHeap m_largeHeap { };
+};
+
 class alignas(16 * KB) SequesteredImmortalHeap {
     friend class WTF::LazyNeverDestroyed<SequesteredImmortalHeap>;
     friend class SlotManager;
@@ -350,11 +450,6 @@ class alignas(16 * KB) SequesteredImmortalHeap {
 public:
     static constexpr size_t slotSize { 128 };
     static constexpr size_t numSlots { 110 };
-
-    enum class AllocationFailureMode {
-        Assert,
-        ReturnNull
-    };
 
     WTF_EXPORT_PRIVATE static SequesteredImmortalHeap& instance();
 
@@ -389,6 +484,7 @@ public:
     }
 
     SequesteredStackAllocator& stackAllocator() LIFETIME_BOUND { return m_stackAllocator; }
+    SequesteredGranuleProvider& granuleProvider() LIFETIME_BOUND { return m_granuleProvider; }
 
     void* getSlot()
     {
@@ -404,33 +500,6 @@ public:
     {
         auto& sih = instance();
         return sih.scavengeImpl(userdata);
-    }
-
-    template<AllocationFailureMode mode>
-    GranuleHeader* mapGranule(size_t bytes)
-    {
-        void* p = mmap(nullptr, bytes, PROT_READ | PROT_WRITE,
-            MAP_PRIVATE | MAP_ANON, -1, 0);
-        if (p == MAP_FAILED) [[unlikely]] {
-            if constexpr (mode == AllocationFailureMode::ReturnNull)
-                return nullptr;
-            RELEASE_ASSERT_NOT_REACHED();
-        }
-        auto* gran = reinterpret_cast<GranuleHeader*>(p);
-        gran->additionalPageCount = bytes / pageSize() - 1;
-        return gran;
-    }
-
-    size_t decommitGranule(GranuleHeader* gran)
-    {
-        size_t pageCount = 1 + gran->additionalPageCount;
-        size_t bytes = pageCount * pageSize();
-
-        // FIXME: experiment with other decommit strategies
-        auto success = munmap(gran, bytes);
-        RELEASE_ASSERT(!success);
-
-        return pageCount;
     }
 
 private:
@@ -463,6 +532,7 @@ private:
     SequesteredImmortalAllocator m_immortalAllocator { };
     SlotManager m_slotManager { };
     SequesteredStackAllocator m_stackAllocator { };
+    SequesteredGranuleProvider m_granuleProvider { };
 };
 
 }


### PR DESCRIPTION
#### 06c57fbad9f61be9b44101f57764e9257bf700c8
<pre>
[SequesteredMalloc] Support arbitrary-size allocations
<a href="https://bugs.webkit.org/show_bug.cgi?id=313697">https://bugs.webkit.org/show_bug.cgi?id=313697</a>
<a href="https://rdar.apple.com/175894622">rdar://175894622</a>

Reviewed by Yusuke Suzuki.

Previously, the SequesteredArenaAllocator did not support allocations
larger than the 512k granule size.
In order to do so, this patch adds a structure similar to libpas&apos;
large-heap/large-map, with a few key distinctions.
  1. Rather than lazily coalescing free-ranges, we do so eagerly on
     decommit. This means that we don&apos;t have a ready pool of committed
     memory to pull from on alloc, but saves significant complexity,
     and due to the rarity of large allocations in this allocator is
     unlikely to be a performance problem.
     In particular, this means we don&apos;t have a physical sharing pool
     or any analogous structure.
  2. Correspondingly, instead of a cartesian tree, we store freed
     granules in a sorted list, as we don&apos;t need to do range-checks.
     Coalescing happens on insertion.
  3. Unlike libpas, we currently don&apos;t support a mechanism for
     decomitting the handles used for tracking granules when not
     currently in use. This only happens after range-coalescing,
     and even if we presume that all but 1 large allocations are
     allocated with the minimum size and then coalesced, we would
     waste at most 1/8000th of physical memory --
     512k minimum size for a large allocation, 64B per granule header.
  4. The hashmap used for tracking large allocations does not support
     any form of compression. Given the small number of anticipated
     large allocations, this is certainly fine.

Otherwise, the mechanism is rather similar.
Allocations above a certain size are allocated &quot;directly&quot; from mmap,
unless a free range of sufficient size is already available. Each range
so allocated is tracked using a GranuleHeader. To distinguish headers
tracking a single Large object from those tracking potentially many
sub-page ones, this patch adds an enum tag to GranuleHeader which
defines its role.
Maintaining a single &apos;granule&apos; concept allows us to take advantage of
the existing deferred-decommit queue by just tacking these
large-allocations onto it like they were a normal slab of memory.
After allocation, live allocations are tracked in a hashmap. When freed,
they are put on the deferred decommit queue, and when the scavenger gets
around to them they are put onto an ordered free list in the large-map
and coalesced as appropriate.

Canonical link: <a href="https://commits.webkit.org/312809@main">https://commits.webkit.org/312809@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3af5b755297963119e4f9fcd8771995ac4f378ba

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/160968 "3 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/34441 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/27542 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/169871 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/117228 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/34542 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/34441 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/124865 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/117228 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/163927 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/27128 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/144598 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/105462 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/26178 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/24679 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/17591 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/153024 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/135872 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/22360 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/172354 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/21806 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/19375 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/24001 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/133141 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/34115 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/28772 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/133151 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35997 "Built successfully and passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/34099 "Build is in progress. Recent messages:OS: Tahoe (26.2), Xcode: 26.2; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (warnings)") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/144155 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/95938 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/27727 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/20973 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/193367 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/33610 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/101035 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/49792 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/33109 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/33353 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/33258 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->