### PR TITLE
Optimize JavaScriptCore #includes

### DIFF
--- a/Source/JavaScriptCore/API/JSScript.mm
+++ b/Source/JavaScriptCore/API/JSScript.mm
@@ -41,12 +41,10 @@
 #import "JSValuePrivate.h"
 #import "JSVirtualMachineInternal.h"
 #import "Symbol.h"
-#import <sys/stat.h>
 #import <wtf/FileHandle.h>
 #import <wtf/FileSystem.h>
 #import <wtf/SHA1.h>
 #import <wtf/SafeStrerror.h>
-#import <wtf/Scope.h>
 #import <wtf/StdLibExtras.h>
 #import <wtf/WeakObjCPtr.h>
 #import <wtf/spi/darwin/DataVaultSPI.h>

--- a/Source/JavaScriptCore/API/JSStringRefCF.cpp
+++ b/Source/JavaScriptCore/API/JSStringRefCF.cpp
@@ -32,7 +32,6 @@
 #include "JSStringRef.h"
 #include "OpaqueJSString.h"
 #include <wtf/StdLibExtras.h>
-#include <wtf/cf/VectorCF.h>
 
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 

--- a/Source/JavaScriptCore/assembler/JITOperationList.cpp
+++ b/Source/JavaScriptCore/assembler/JITOperationList.cpp
@@ -35,7 +35,6 @@
 #include "WebAssemblyBuiltin.h"
 
 #if HAVE(DLADDR)
-#include <cxxabi.h>
 #include <dlfcn.h>
 #endif
 

--- a/Source/JavaScriptCore/assembler/MacroAssemblerCodeRef.h
+++ b/Source/JavaScriptCore/assembler/MacroAssemblerCodeRef.h
@@ -28,7 +28,6 @@
 #include <JavaScriptCore/ExecutableMemoryHandle.h>
 #include <JavaScriptCore/JSCPtrTag.h>
 #include <wtf/CodePtr.h>
-#include <wtf/DataLog.h>
 #include <wtf/PrintStream.h>
 #include <wtf/RefPtr.h>
 #include <wtf/text/CString.h>

--- a/Source/JavaScriptCore/assembler/PerfLog.cpp
+++ b/Source/JavaScriptCore/assembler/PerfLog.cpp
@@ -32,19 +32,14 @@
 #include "Options.h"
 #include "ProfilerSupport.h"
 #include "SourceProvider.h"
-#include <array>
 #include <fcntl.h>
 #include <mutex>
-#include <sys/stat.h>
-#include <sys/types.h>
 #include <wtf/DataLog.h>
 #include <wtf/FileSystem.h>
-#include <wtf/MonotonicTime.h>
 #include <wtf/PageBlock.h>
 #include <wtf/ProcessID.h>
 #include <wtf/StringPrintStream.h>
 #include <wtf/text/MakeString.h>
-#include <wtf/text/StringConcatenate.h>
 #include <wtf/text/StringConcatenateNumbers.h>
 #include <wtf/TZoneMallocInlines.h>
 

--- a/Source/JavaScriptCore/assembler/SecureARM64EHashPins.cpp
+++ b/Source/JavaScriptCore/assembler/SecureARM64EHashPins.cpp
@@ -29,7 +29,6 @@
 #include "ExecutableAllocator.h"
 #include "FastJITPermissions.h"
 #include "SecureARM64EHashPinsInlines.h"
-#include <wtf/Condition.h>
 #include <wtf/Lock.h>
 
 namespace JSC {

--- a/Source/JavaScriptCore/b3/B3LowerMacros.cpp
+++ b/Source/JavaScriptCore/b3/B3LowerMacros.cpp
@@ -73,7 +73,6 @@
 #include "WasmTypeDefinition.h"
 #include "WebAssemblyFunctionBase.h"
 #include "WebAssemblyGCStructure.h"
-#include <cmath>
 #include <numeric>
 #include <wtf/BitVector.h>
 

--- a/Source/JavaScriptCore/b3/B3Opcode.cpp
+++ b/Source/JavaScriptCore/b3/B3Opcode.cpp
@@ -28,8 +28,6 @@
 
 #if ENABLE(B3_JIT)
 
-#include <wtf/PrintStream.h>
-
 #if !ASSERT_ENABLED
 IGNORE_RETURN_TYPE_WARNINGS_BEGIN
 #endif

--- a/Source/JavaScriptCore/b3/B3PatchpointSpecial.cpp
+++ b/Source/JavaScriptCore/b3/B3PatchpointSpecial.cpp
@@ -34,8 +34,6 @@
 #include "B3StackmapGenerationParams.h"
 #include "B3ValueInlines.h"
 
-#include <wtf/ListDump.h>
-
 namespace JSC { namespace B3 {
 
 using Arg = Air::Arg;

--- a/Source/JavaScriptCore/b3/B3Width.cpp
+++ b/Source/JavaScriptCore/b3/B3Width.cpp
@@ -28,8 +28,6 @@
 
 #if ENABLE(B3_JIT)
 
-#include <wtf/PrintStream.h>
-
 namespace JSC { namespace B3 {
 
 Type bestType(Bank bank, Width width)

--- a/Source/JavaScriptCore/b3/air/AirAllocateRegistersAndStackAndGenerateCode.cpp
+++ b/Source/JavaScriptCore/b3/air/AirAllocateRegistersAndStackAndGenerateCode.cpp
@@ -38,7 +38,6 @@
 #include "CCallHelpers.h"
 #include "DisallowMacroScratchRegisterUsage.h"
 #include "Reg.h"
-#include <wtf/ListDump.h>
 #include <wtf/SequesteredMalloc.h>
 #include <wtf/TZoneMallocInlines.h>
 

--- a/Source/JavaScriptCore/b3/air/AirTmpWidth.cpp
+++ b/Source/JavaScriptCore/b3/air/AirTmpWidth.cpp
@@ -31,7 +31,6 @@
 #include "AirCode.h"
 #include "AirInstInlines.h"
 #include "AirTmpWidthInlines.h"
-#include <wtf/ListDump.h>
 
 namespace JSC { namespace B3 { namespace Air {
 

--- a/Source/JavaScriptCore/b3/testb3_2.cpp
+++ b/Source/JavaScriptCore/b3/testb3_2.cpp
@@ -25,7 +25,6 @@
 
 #include "config.h"
 #include "testb3.h"
-#include <array>
 
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 

--- a/Source/JavaScriptCore/b3/testb3_8.cpp
+++ b/Source/JavaScriptCore/b3/testb3_8.cpp
@@ -27,7 +27,6 @@
 #include "testb3.h"
 
 #include <wtf/Int128.h>
-#include <wtf/UniqueArray.h>
 
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 

--- a/Source/JavaScriptCore/bytecode/BytecodeDumper.cpp
+++ b/Source/JavaScriptCore/bytecode/BytecodeDumper.cpp
@@ -36,7 +36,6 @@
 #include "UnlinkedMetadataTableInlines.h"
 #include "WasmModuleInformation.h"
 #include "WasmTypeDefinitionInlines.h"
-#include <wtf/text/MakeString.h>
 
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 

--- a/Source/JavaScriptCore/bytecode/CallLinkInfo.cpp
+++ b/Source/JavaScriptCore/bytecode/CallLinkInfo.cpp
@@ -26,6 +26,7 @@
 #include "config.h"
 #include "CallLinkInfo.h"
 
+#include "BaselineJITRegisters.h"
 #include "CCallHelpers.h"
 #include "CallFrameShuffleData.h"
 #include "DFGJITCode.h"

--- a/Source/JavaScriptCore/bytecode/CallLinkInfo.h
+++ b/Source/JavaScriptCore/bytecode/CallLinkInfo.h
@@ -25,7 +25,6 @@
 
 #pragma once
 
-#include <JavaScriptCore/BaselineJITRegisters.h>
 #include <JavaScriptCore/CallFrame.h>
 #include <JavaScriptCore/CallFrameShuffleData.h>
 #include <JavaScriptCore/CallLinkInfoBase.h>
@@ -36,7 +35,6 @@
 #include <JavaScriptCore/PolymorphicCallStubRoutine.h>
 #include <JavaScriptCore/WriteBarrier.h>
 #include <wtf/ScopedLambda.h>
-#include <wtf/SentinelLinkedList.h>
 
 namespace JSC {
 namespace DFG {

--- a/Source/JavaScriptCore/bytecode/CodeOrigin.h
+++ b/Source/JavaScriptCore/bytecode/CodeOrigin.h
@@ -29,10 +29,7 @@
 #include <JavaScriptCore/JSExportMacros.h>
 
 #include <limits.h>
-#include <wtf/HashMap.h>
-#include <wtf/MathExtras.h>
 #include <wtf/PrintStream.h>
-#include <wtf/StdLibExtras.h>
 #include <wtf/TZoneMalloc.h>
 #include <wtf/Vector.h>
 

--- a/Source/JavaScriptCore/bytecode/ExecutableInfo.h
+++ b/Source/JavaScriptCore/bytecode/ExecutableInfo.h
@@ -25,6 +25,7 @@
 
 #pragma once
 
+#include <JavaScriptCore/ConstructorKind.h>
 #include <JavaScriptCore/ParserModes.h>
 
 namespace JSC {

--- a/Source/JavaScriptCore/bytecode/ExitKind.cpp
+++ b/Source/JavaScriptCore/bytecode/ExitKind.cpp
@@ -26,10 +26,6 @@
 #include "config.h"
 #include "ExitKind.h"
 
-#include <wtf/Assertions.h>
-#include <wtf/PrintStream.h>
-#include <wtf/text/ASCIILiteral.h>
-
 namespace JSC {
 
 bool exitKindMayJettison(ExitKind kind)

--- a/Source/JavaScriptCore/bytecode/ExpressionInfo.cpp
+++ b/Source/JavaScriptCore/bytecode/ExpressionInfo.cpp
@@ -30,7 +30,6 @@
 #include <numeric>
 #include <wtf/DataLog.h>
 #include <wtf/StringPrintStream.h>
-#include <wtf/UniqueRef.h>
 
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 

--- a/Source/JavaScriptCore/bytecode/InlineCacheCompiler.cpp
+++ b/Source/JavaScriptCore/bytecode/InlineCacheCompiler.cpp
@@ -30,6 +30,7 @@
 
 #include "AccessCaseSnippetParams.h"
 #include "BaselineJITCode.h"
+#include "BaselineJITRegisters.h"
 #include "BinarySwitch.h"
 #include "CCallHelpers.h"
 #include "CacheableIdentifierInlines.h"

--- a/Source/JavaScriptCore/bytecode/InlineCacheCompiler.h
+++ b/Source/JavaScriptCore/bytecode/InlineCacheCompiler.h
@@ -34,7 +34,6 @@
 #include "MacroAssembler.h"
 #include "PropertyInlineCacheClearingWatchpoint.h"
 #include "ScratchRegisterAllocator.h"
-#include <wtf/FixedVector.h>
 #include <wtf/Vector.h>
 
 namespace JSC {

--- a/Source/JavaScriptCore/bytecode/InternalFunctionAllocationProfile.h
+++ b/Source/JavaScriptCore/bytecode/InternalFunctionAllocationProfile.h
@@ -26,7 +26,6 @@
 #pragma once
 
 #include <JavaScriptCore/JSGlobalObject.h>
-#include <JavaScriptCore/SlotVisitor.h>
 #include <JavaScriptCore/WriteBarrier.h>
 
 namespace JSC {

--- a/Source/JavaScriptCore/bytecode/ObjectPropertyCondition.h
+++ b/Source/JavaScriptCore/bytecode/ObjectPropertyCondition.h
@@ -27,7 +27,6 @@
 
 #include <JavaScriptCore/JSObject.h>
 #include <JavaScriptCore/PropertyCondition.h>
-#include <wtf/HashMap.h>
 
 namespace JSC {
 

--- a/Source/JavaScriptCore/bytecode/PropertyInlineCache.h
+++ b/Source/JavaScriptCore/bytecode/PropertyInlineCache.h
@@ -29,7 +29,6 @@
 #include "CodeBlock.h"
 #include "CodeOrigin.h"
 #include "InlineCacheCompiler.h"
-#include "Instruction.h"
 #include "JITStubRoutine.h"
 #include "MacroAssembler.h"
 #include "Options.h"
@@ -37,8 +36,6 @@
 #include "PropertyInlineCacheSummary.h"
 #include "RegisterSet.h"
 #include "Structure.h"
-#include "StructureSet.h"
-#include <wtf/Box.h>
 #include <wtf/Lock.h>
 #include <wtf/TZoneMalloc.h>
 

--- a/Source/JavaScriptCore/bytecode/PropertyInlineCacheClearingWatchpoint.h
+++ b/Source/JavaScriptCore/bytecode/PropertyInlineCacheClearingWatchpoint.h
@@ -32,7 +32,6 @@
 #include "ObjectPropertyCondition.h"
 #include "PackedCellPtr.h"
 #include "Watchpoint.h"
-#include <wtf/Bag.h>
 #include <wtf/Noncopyable.h>
 #include <wtf/TZoneMalloc.h>
 

--- a/Source/JavaScriptCore/dfg/DFGDoesGCCheck.h
+++ b/Source/JavaScriptCore/dfg/DFGDoesGCCheck.h
@@ -27,7 +27,6 @@
 
 #include <JavaScriptCore/JSExportMacros.h>
 #include <cstdint>
-#include <wtf/Assertions.h>
 
 namespace JSC {
 

--- a/Source/JavaScriptCore/dfg/DFGLoopUnrollingPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGLoopUnrollingPhase.cpp
@@ -38,7 +38,6 @@
 #include "DFGNodeType.h"
 #include "DFGPhase.h"
 #include "FunctionAllowlist.h"
-#include <wtf/IndexMap.h>
 
 namespace JSC {
 namespace DFG {

--- a/Source/JavaScriptCore/dfg/DFGObjectAllocationSinkingPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGObjectAllocationSinkingPhase.cpp
@@ -52,7 +52,6 @@
 #include "JSSetIterator.h"
 #include "JSStringIterator.h"
 #include "JSWrapForValidIterator.h"
-#include <wtf/StdList.h>
 
 namespace JSC { namespace DFG {
 

--- a/Source/JavaScriptCore/dfg/DFGOperations.cpp
+++ b/Source/JavaScriptCore/dfg/DFGOperations.cpp
@@ -105,7 +105,6 @@
 #include "WeakMapImplInlines.h"
 #include "WeakMapPrototype.h"
 #include "WeakSetPrototype.h"
-#include <wtf/text/MakeString.h>
 
 #if ENABLE(JIT)
 #if ENABLE(DFG_JIT)

--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT64.cpp
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT64.cpp
@@ -31,6 +31,7 @@ WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 #if ENABLE(DFG_JIT)
 
 #include "AtomicsObject.h"
+#include "BaselineJITRegisters.h"
 #include "CallFrameShuffler.h"
 #include "ClonedArguments.h"
 #include "DFGAbstractInterpreterInlines.h"

--- a/Source/JavaScriptCore/dfg/DFGStrengthReductionPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGStrengthReductionPhase.cpp
@@ -46,7 +46,6 @@
 #include "WasmCallingConvention.h"
 #include "WebAssemblyFunction.h"
 #include <cstdlib>
-#include <wtf/text/MakeString.h>
 #include <wtf/text/StringBuilder.h>
 
 namespace JSC { namespace DFG {

--- a/Source/JavaScriptCore/dfg/testdfg.cpp
+++ b/Source/JavaScriptCore/dfg/testdfg.cpp
@@ -30,7 +30,6 @@
 #include "DFGAbstractValue.h"
 #include "InitializeThreading.h"
 #include <wtf/DataLog.h>
-#include <wtf/Threading.h>
 #include <wtf/WTFProcess.h>
 #include <wtf/text/StringCommon.h>
 

--- a/Source/JavaScriptCore/ftl/FTLCompile.cpp
+++ b/Source/JavaScriptCore/ftl/FTLCompile.cpp
@@ -48,8 +48,6 @@
 #include "Options.h"
 #include "PCToCodeOriginMap.h"
 #include "ThunkGenerators.h"
-#include <wtf/RecursableLambda.h>
-#include <wtf/SetForScope.h>
 
 namespace JSC { namespace FTL {
 

--- a/Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp
+++ b/Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp
@@ -36,6 +36,7 @@
 #include "B3PatchpointValue.h"
 #include "B3SlotBaseValue.h"
 #include "B3StackmapGenerationParams.h"
+#include "BaselineJITRegisters.h"
 #include "B3ValueInlines.h"
 #include "ButterflyInlines.h"
 #include "CPUInlines.h"

--- a/Source/JavaScriptCore/ftl/FTLOSRExitCompiler.cpp
+++ b/Source/JavaScriptCore/ftl/FTLOSRExitCompiler.cpp
@@ -44,8 +44,6 @@
 #include "OperandsInlines.h"
 #include "ProbeContext.h"
 
-#include <wtf/Scope.h>
-
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 
 namespace JSC { namespace FTL {

--- a/Source/JavaScriptCore/heap/Allocator.h
+++ b/Source/JavaScriptCore/heap/Allocator.h
@@ -26,8 +26,6 @@
 #pragma once
 
 #include <JavaScriptCore/AllocationFailureMode.h>
-#include <climits>
-#include <cstdint>
 
 namespace JSC {
 

--- a/Source/JavaScriptCore/heap/BlockDirectory.h
+++ b/Source/JavaScriptCore/heap/BlockDirectory.h
@@ -25,7 +25,6 @@
 
 #pragma once
 
-#include <JavaScriptCore/AllocationFailureMode.h>
 #include <JavaScriptCore/BlockDirectoryBits.h>
 #include <JavaScriptCore/CellAttributes.h>
 #include <JavaScriptCore/FreeList.h>
@@ -34,9 +33,7 @@
 #include <JavaScriptCore/MarkedBlock.h>
 #include <wtf/DataLog.h>
 #include <wtf/DebugHeap.h>
-#include <wtf/FastBitVector.h>
 #include <wtf/Lock.h>
-#include <wtf/MonotonicTime.h>
 #include <wtf/SharedTask.h>
 #include <wtf/Vector.h>
 

--- a/Source/JavaScriptCore/heap/CellContainerInlines.h
+++ b/Source/JavaScriptCore/heap/CellContainerInlines.h
@@ -26,7 +26,6 @@
 #pragma once
 
 #include <JavaScriptCore/CellContainer.h>
-#include <JavaScriptCore/JSCast.h>
 #include <JavaScriptCore/MarkedBlock.h>
 #include <JavaScriptCore/PreciseAllocation.h>
 #include <JavaScriptCore/VM.h>

--- a/Source/JavaScriptCore/heap/CellState.h
+++ b/Source/JavaScriptCore/heap/CellState.h
@@ -25,8 +25,6 @@
 
 #pragma once
 
-#include <wtf/Assertions.h>
-
 namespace JSC {
 
 // The CellState of a cell is a kind of hint about what the state of the cell is.

--- a/Source/JavaScriptCore/heap/CompleteSubspace.h
+++ b/Source/JavaScriptCore/heap/CompleteSubspace.h
@@ -25,6 +25,7 @@
 
 #pragma once
 
+#include <JavaScriptCore/AllocatorForMode.h>
 #include <JavaScriptCore/Subspace.h>
 
 namespace JSC {

--- a/Source/JavaScriptCore/heap/FreeList.h
+++ b/Source/JavaScriptCore/heap/FreeList.h
@@ -28,7 +28,6 @@
 #include <JavaScriptCore/JSExportMacros.h>
 #include <wtf/Compiler.h>
 #include <wtf/MathExtras.h>
-#include <wtf/Noncopyable.h>
 #include <wtf/PrintStream.h>
 
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN

--- a/Source/JavaScriptCore/heap/GCSegmentedArray.h
+++ b/Source/JavaScriptCore/heap/GCSegmentedArray.h
@@ -29,7 +29,6 @@
 #include <wtf/Compiler.h>
 #include <wtf/DebugHeap.h>
 #include <wtf/DoublyLinkedList.h>
-#include <wtf/FastMalloc.h>
 #include <wtf/Forward.h>
 #include <wtf/Noncopyable.h>
 #include <wtf/TZoneMalloc.h>

--- a/Source/JavaScriptCore/heap/GigacageAlignedMemoryAllocator.cpp
+++ b/Source/JavaScriptCore/heap/GigacageAlignedMemoryAllocator.cpp
@@ -30,8 +30,6 @@
 #include <wtf/text/MakeString.h>
 #endif
 
-#include <wtf/text/StringView.h>
-
 namespace JSC {
 
 GigacageAlignedMemoryAllocator::GigacageAlignedMemoryAllocator(Gigacage::Kind kind)

--- a/Source/JavaScriptCore/heap/Heap.h
+++ b/Source/JavaScriptCore/heap/Heap.h
@@ -29,7 +29,6 @@
 #include <JavaScriptCore/DeleteAllCodeEffort.h>
 #include <JavaScriptCore/GCConductor.h>
 #include <JavaScriptCore/GCIncomingRefCountedSet.h>
-#include <JavaScriptCore/GCMemoryOperations.h>
 #include <JavaScriptCore/GCRequest.h>
 #include <JavaScriptCore/HandleSet.h>
 #include <JavaScriptCore/HeapFinalizerCallback.h>
@@ -43,7 +42,7 @@
 #include <JavaScriptCore/MarkedSpace.h>
 #include <JavaScriptCore/MutatorState.h>
 #include <JavaScriptCore/PreciseSubspace.h>
-#include <JavaScriptCore/StructureID.h>
+#include <JavaScriptCore/SubspaceAccess.h>
 #include <JavaScriptCore/Synchronousness.h>
 #include <JavaScriptCore/WeakHandleOwner.h>
 #include <wtf/AutomaticThread.h>

--- a/Source/JavaScriptCore/heap/IsoSubspace.h
+++ b/Source/JavaScriptCore/heap/IsoSubspace.h
@@ -26,10 +26,9 @@
 #pragma once
 
 #include <JavaScriptCore/AlignedMemoryAllocator.h>
+#include <JavaScriptCore/AllocatorForMode.h>
 #include <JavaScriptCore/BlockDirectory.h>
 #include <JavaScriptCore/Subspace.h>
-#include <JavaScriptCore/SubspaceAccess.h>
-#include <wtf/SinglyLinkedListWithTail.h>
 #include <wtf/TZoneMalloc.h>
 
 namespace JSC {

--- a/Source/JavaScriptCore/heap/IsoSubspaceInlines.h
+++ b/Source/JavaScriptCore/heap/IsoSubspaceInlines.h
@@ -28,7 +28,6 @@
 #include <JavaScriptCore/AllocationFailureMode.h>
 #include <JavaScriptCore/IsoSubspace.h>
 #include <JavaScriptCore/VM.h>
-#include <cstdint>
 #include <wtf/Compiler.h>
 
 namespace JSC {

--- a/Source/JavaScriptCore/heap/MarkedBlockInlines.h
+++ b/Source/JavaScriptCore/heap/MarkedBlockInlines.h
@@ -26,7 +26,6 @@
 #pragma once
 
 #include <JavaScriptCore/BlockDirectory.h>
-#include <JavaScriptCore/JSCast.h>
 #include <JavaScriptCore/MarkedBlock.h>
 #include <JavaScriptCore/MarkedSpace.h>
 #include <JavaScriptCore/Scribble.h>

--- a/Source/JavaScriptCore/heap/MarkedSpace.h
+++ b/Source/JavaScriptCore/heap/MarkedSpace.h
@@ -26,11 +26,9 @@
 #include <JavaScriptCore/MarkedBlockSet.h>
 #include <JavaScriptCore/PreciseAllocation.h>
 #include <array>
-#include <wtf/Bag.h>
 #include <wtf/HashSet.h>
 #include <wtf/IterationStatus.h>
 #include <wtf/Noncopyable.h>
-#include <wtf/RetainPtr.h>
 #include <wtf/SentinelLinkedList.h>
 #include <wtf/SinglyLinkedListWithTail.h>
 #include <wtf/Vector.h>

--- a/Source/JavaScriptCore/heap/MarkingConstraintSet.cpp
+++ b/Source/JavaScriptCore/heap/MarkingConstraintSet.cpp
@@ -30,7 +30,6 @@
 #include "Options.h"
 #include "SimpleMarkingConstraint.h"
 #include "SuperSampler.h"
-#include <wtf/Function.h>
 #include <wtf/TZoneMallocInlines.h>
 
 namespace JSC {

--- a/Source/JavaScriptCore/heap/PackedCellPtr.h
+++ b/Source/JavaScriptCore/heap/PackedCellPtr.h
@@ -25,9 +25,6 @@
 
 #pragma once
 
-#include <JavaScriptCore/IsoSubspace.h>
-#include <JavaScriptCore/MarkedBlock.h>
-#include <JavaScriptCore/MarkedSpace.h>
 #include <wtf/Packed.h>
 
 namespace JSC {

--- a/Source/JavaScriptCore/heap/PreciseSubspace.h
+++ b/Source/JavaScriptCore/heap/PreciseSubspace.h
@@ -26,7 +26,6 @@
 #pragma once
 
 #include <JavaScriptCore/Subspace.h>
-#include <JavaScriptCore/SubspaceAccess.h>
 
 namespace JSC {
 

--- a/Source/JavaScriptCore/heap/SlotVisitor.h
+++ b/Source/JavaScriptCore/heap/SlotVisitor.h
@@ -26,7 +26,6 @@
 #pragma once
 
 #include <JavaScriptCore/AbstractSlotVisitor.h>
-#include <JavaScriptCore/HandleTypes.h>
 #include <wtf/Forward.h>
 #include <wtf/IterationStatus.h>
 #include <wtf/MonotonicTime.h>

--- a/Source/JavaScriptCore/heap/StructureAlignedMemoryAllocator.cpp
+++ b/Source/JavaScriptCore/heap/StructureAlignedMemoryAllocator.cpp
@@ -41,11 +41,7 @@ WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 #include <bmalloc/bmalloc_heap_config.h>
 #include <bmalloc/bmalloc_heap_inlines.h>
 #include <bmalloc/bmalloc_heap_ref.h>
-#include <bmalloc/pas_page_sharing_pool.h>
 #include <bmalloc/pas_primitive_heap_ref.h>
-#include <bmalloc/pas_probabilistic_guard_malloc_allocator.h>
-#include <bmalloc/pas_scavenger.h>
-#include <bmalloc/pas_thread_local_cache.h>
 #elif USE(MIMALLOC)
 #include <bmalloc/mimalloc.h>
 #endif
@@ -53,10 +49,6 @@ WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 #endif
 
 #include <wtf/OSAllocator.h>
-
-#if OS(UNIX) && ASSERT_ENABLED
-#include <sys/mman.h>
-#endif
 
 namespace JSC {
 

--- a/Source/JavaScriptCore/heap/Subspace.h
+++ b/Source/JavaScriptCore/heap/Subspace.h
@@ -25,9 +25,7 @@
 
 #pragma once
 
-#include <JavaScriptCore/AllocationFailureMode.h>
 #include <JavaScriptCore/Allocator.h>
-#include <JavaScriptCore/AllocatorForMode.h>
 #include <JavaScriptCore/MarkedBlock.h>
 #include <JavaScriptCore/MarkedSpace.h>
 #include <wtf/TZoneMalloc.h>

--- a/Source/JavaScriptCore/heap/Weak.h
+++ b/Source/JavaScriptCore/heap/Weak.h
@@ -25,9 +25,7 @@
 
 #pragma once
 
-#include <JavaScriptCore/JSExportMacros.h>
 #include <cstddef>
-#include <wtf/Atomics.h>
 #include <wtf/GetPtr.h>
 #include <wtf/HashTraits.h>
 #include <wtf/Noncopyable.h>

--- a/Source/JavaScriptCore/heap/WeakInlines.h
+++ b/Source/JavaScriptCore/heap/WeakInlines.h
@@ -29,7 +29,6 @@
 
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 
-#include <JavaScriptCore/JSCast.h>
 #include <JavaScriptCore/WeakSetInlines.h>
 #include <wtf/Assertions.h>
 

--- a/Source/JavaScriptCore/heap/WeakSetInlines.h
+++ b/Source/JavaScriptCore/heap/WeakSetInlines.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include <JavaScriptCore/CellContainerInlines.h>
+#include <JavaScriptCore/JSCell.h>
 #include <JavaScriptCore/MarkedBlock.h>
 
 namespace JSC {

--- a/Source/JavaScriptCore/inspector/JSInjectedScriptHost.cpp
+++ b/Source/JavaScriptCore/inspector/JSInjectedScriptHost.cpp
@@ -67,7 +67,6 @@
 #include "SourceCode.h"
 #include "StructureCreateInlines.h"
 #include <wtf/Function.h>
-#include <wtf/HashFunctions.h>
 #include <wtf/HashMap.h>
 #include <wtf/HashSet.h>
 #include <wtf/Lock.h>

--- a/Source/JavaScriptCore/inspector/remote/RemoteInspector.cpp
+++ b/Source/JavaScriptCore/inspector/remote/RemoteInspector.cpp
@@ -33,7 +33,6 @@
 #include "RemoteInspectionTarget.h"
 #include "RemoteInspectorConstants.h"
 #include <wtf/MainThread.h>
-#include <wtf/text/WTFString.h>
 
 namespace Inspector {
 

--- a/Source/JavaScriptCore/interpreter/Register.h
+++ b/Source/JavaScriptCore/interpreter/Register.h
@@ -29,7 +29,6 @@
 #pragma once
 
 #include <JavaScriptCore/EncodedValueDescriptor.h>
-#include <wtf/Assertions.h>
 #include <wtf/TZoneMalloc.h>
 #include <wtf/VectorTraits.h>
 

--- a/Source/JavaScriptCore/jit/CallFrameShuffler.h
+++ b/Source/JavaScriptCore/jit/CallFrameShuffler.h
@@ -31,6 +31,7 @@
 #include "CallFrameShuffleData.h"
 #include "MacroAssembler.h"
 #include "RegisterSet.h"
+#include <wtf/Bag.h>
 #include <wtf/TZoneMalloc.h>
 #include <wtf/Vector.h>
 

--- a/Source/JavaScriptCore/jit/ExecutableAllocator.cpp
+++ b/Source/JavaScriptCore/jit/ExecutableAllocator.cpp
@@ -32,7 +32,6 @@
 #include "JITOperationValidation.h"
 #include "LinkBuffer.h"
 #include <bit>
-#include <wtf/ByteOrder.h>
 #include <wtf/CryptographicallyRandomNumber.h>
 #include <wtf/FastBitVector.h>
 #include <wtf/FileSystem.h>

--- a/Source/JavaScriptCore/jit/GCAwareJITStubRoutine.h
+++ b/Source/JavaScriptCore/jit/GCAwareJITStubRoutine.h
@@ -29,6 +29,7 @@
 #include <JavaScriptCore/JITStubRoutine.h>
 #include <JavaScriptCore/JSObject.h>
 #include <JavaScriptCore/WriteBarrier.h>
+#include <wtf/Bag.h>
 #include <wtf/FixedVector.h>
 #include <wtf/Hasher.h>
 #include <wtf/Vector.h>

--- a/Source/JavaScriptCore/jit/GdbJIT.cpp
+++ b/Source/JavaScriptCore/jit/GdbJIT.cpp
@@ -35,14 +35,9 @@
 #include "CallFrameInlines.h"
 #include "Options.h"
 #include "ProfilerSupport.h"
-#include <array>
 #include <fcntl.h>
 #include <mutex>
-#include <sys/stat.h>
-#include <sys/types.h>
 #include <wtf/DataLog.h>
-#include <wtf/MonotonicTime.h>
-#include <wtf/PageBlock.h>
 #include <wtf/ProcessID.h>
 #include <wtf/RefCountedAndCanMakeWeakPtr.h>
 #include <wtf/StringPrintStream.h>

--- a/Source/JavaScriptCore/jit/JIT.cpp
+++ b/Source/JavaScriptCore/jit/JIT.cpp
@@ -53,7 +53,6 @@
 #include "ThunkGenerators.h"
 #include "TypeProfilerLog.h"
 #include <wtf/BubbleSort.h>
-#include <wtf/GraphNodeWorklist.h>
 #include <wtf/SequesteredMalloc.h>
 #include <wtf/SimpleStats.h>
 #include <wtf/text/MakeString.h>

--- a/Source/JavaScriptCore/jit/JITPlan.cpp
+++ b/Source/JavaScriptCore/jit/JITPlan.cpp
@@ -41,7 +41,6 @@
 #include <wtf/StringPrintStream.h>
 #include <wtf/SystemTracing.h>
 #include <wtf/text/MakeString.h>
-#include <wtf/text/StringConcatenate.h>
 
 namespace JSC {
 

--- a/Source/JavaScriptCore/jit/JITPropertyAccess.cpp
+++ b/Source/JavaScriptCore/jit/JITPropertyAccess.cpp
@@ -42,7 +42,6 @@
 #include "SlowPathCall.h"
 #include "ThunkGenerators.h"
 #include <wtf/ScopedLambda.h>
-#include <wtf/StringPrintStream.h>
 
 namespace JSC {
 

--- a/Source/JavaScriptCore/jit/JITSizeStatistics.cpp
+++ b/Source/JavaScriptCore/jit/JITSizeStatistics.cpp
@@ -31,7 +31,6 @@
 #include "CCallHelpers.h"
 #include "JITPlan.h"
 #include "LinkBuffer.h"
-#include <wtf/BubbleSort.h>
 #include <wtf/TZoneMallocInlines.h>
 
 namespace JSC {

--- a/Source/JavaScriptCore/jit/JITWorklist.cpp
+++ b/Source/JavaScriptCore/jit/JITWorklist.cpp
@@ -35,7 +35,6 @@
 #include "JITWorklistThread.h"
 #include "SlotVisitorInlines.h"
 #include "VMInlines.h"
-#include <wtf/CompilationThread.h>
 #include <wtf/TZoneMallocInlines.h>
 
 namespace JSC {

--- a/Source/JavaScriptCore/llint/LLIntData.cpp
+++ b/Source/JavaScriptCore/llint/LLIntData.cpp
@@ -35,7 +35,6 @@
 #include "Opcode.h"
 
 #if PLATFORM(COCOA)
-#include <wtf/ResourceUsage.h>
 #include <wtf/cocoa/Entitlements.h>
 #endif
 

--- a/Source/JavaScriptCore/llint/LLIntData.h
+++ b/Source/JavaScriptCore/llint/LLIntData.h
@@ -27,7 +27,6 @@
 
 #include "GPRInfo.h"
 #include "Instruction.h"
-#include "JSCJSValue.h"
 #include "MacroAssemblerCodeRef.h"
 #include "Opcode.h"
 

--- a/Source/JavaScriptCore/lol/LOLJIT.cpp
+++ b/Source/JavaScriptCore/lol/LOLJIT.cpp
@@ -60,10 +60,6 @@
 #include "StackAlignment.h"
 #include "ThunkGenerators.h"
 #include "TypeProfilerLog.h"
-#include <wtf/BubbleSort.h>
-#include <wtf/GraphNodeWorklist.h>
-#include <wtf/SequesteredMalloc.h>
-#include <wtf/SimpleStats.h>
 #include <wtf/text/MakeString.h>
 
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN

--- a/Source/JavaScriptCore/parser/ParserModes.h
+++ b/Source/JavaScriptCore/parser/ParserModes.h
@@ -26,9 +26,7 @@
 #pragma once
 
 #include <JavaScriptCore/ConstructAbility.h>
-#include <JavaScriptCore/ConstructorKind.h>
 #include <JavaScriptCore/Identifier.h>
-#include <JavaScriptCore/InlineAttribute.h>
 
 namespace JSC {
 

--- a/Source/JavaScriptCore/parser/SourceProvider.h
+++ b/Source/JavaScriptCore/parser/SourceProvider.h
@@ -38,7 +38,6 @@ WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 #include <JavaScriptCore/SourceOrigin.h>
 #include <JavaScriptCore/SourceTaintedOrigin.h>
 #include <wtf/Lock.h>
-#include <wtf/RefCounted.h>
 #include <wtf/text/TextPosition.h>
 #include <wtf/text/WTFString.h>
 

--- a/Source/JavaScriptCore/runtime/ArgList.h
+++ b/Source/JavaScriptCore/runtime/ArgList.h
@@ -23,7 +23,6 @@
 
 #include <JavaScriptCore/CallFrame.h>
 #include <JavaScriptCore/MarkedVector.h>
-#include <wtf/HashSet.h>
 
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 

--- a/Source/JavaScriptCore/runtime/ArrayBuffer.cpp
+++ b/Source/JavaScriptCore/runtime/ArrayBuffer.cpp
@@ -36,7 +36,6 @@
 #include <wtf/MathExtras.h>
 #include <wtf/OSAllocator.h>
 #include <wtf/PageBlock.h>
-#include <wtf/SafeStrerror.h>
 
 #if ENABLE(WEBASSEMBLY)
 #include "WasmMemory.h"

--- a/Source/JavaScriptCore/runtime/ArrayBuffer.h
+++ b/Source/JavaScriptCore/runtime/ArrayBuffer.h
@@ -34,17 +34,13 @@ WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 #include <JavaScriptCore/GCIncomingRefCounted.h>
 #include <JavaScriptCore/Watchpoint.h>
 #include <JavaScriptCore/Weak.h>
-#include <JavaScriptCore/WeakImpl.h>
 #include <wtf/CagedPtr.h>
 #include <wtf/CheckedArithmetic.h>
-#include <wtf/PackedRefPtr.h>
 #include <wtf/SharedTask.h>
-#include <wtf/StdIntExtras.h>
 #include <wtf/StdLibExtras.h>
 #include <wtf/TZoneMalloc.h>
 #include <wtf/ThreadSafeRefCounted.h>
 #include <wtf/WeakPtr.h>
-#include <wtf/text/WTFString.h>
 
 namespace JSC {
 

--- a/Source/JavaScriptCore/runtime/ArrayStorage.h
+++ b/Source/JavaScriptCore/runtime/ArrayStorage.h
@@ -25,7 +25,6 @@
 
 #pragma once
 
-#include <JavaScriptCore/ArrayConventions.h>
 #include <JavaScriptCore/Butterfly.h>
 #include <JavaScriptCore/IndexingHeader.h>
 #include <JavaScriptCore/MarkedSpace.h>

--- a/Source/JavaScriptCore/runtime/AtomicsObject.cpp
+++ b/Source/JavaScriptCore/runtime/AtomicsObject.cpp
@@ -32,7 +32,6 @@
 #include "ReleaseHeapAccessScope.h"
 #include "TypedArrayController.h"
 #include "WaiterListManager.h"
-#include <wtf/SIMDHelpers.h>
 
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 

--- a/Source/JavaScriptCore/runtime/BufferMemoryHandle.cpp
+++ b/Source/JavaScriptCore/runtime/BufferMemoryHandle.cpp
@@ -30,9 +30,7 @@
 #include "Options.h"
 #include "WasmFaultSignalHandler.h"
 #include <cstring>
-#include <limits>
 #include <mutex>
-#include <wtf/CheckedArithmetic.h>
 #include <wtf/DataLog.h>
 #include <wtf/FastMalloc.h>
 #include <wtf/Lock.h>
@@ -40,7 +38,6 @@
 #include <wtf/OSAllocator.h>
 #include <wtf/Platform.h>
 #include <wtf/PrintStream.h>
-#include <wtf/SafeStrerror.h>
 #include <wtf/TZoneMallocInlines.h>
 #include <wtf/Vector.h>
 

--- a/Source/JavaScriptCore/runtime/BufferMemoryHandle.h
+++ b/Source/JavaScriptCore/runtime/BufferMemoryHandle.h
@@ -29,20 +29,15 @@
 #include <JavaScriptCore/PageCount.h>
 
 #include <atomic>
-#include <set>
 
 #include <wtf/CagedPtr.h>
-#include <wtf/Expected.h>
-#include <wtf/Function.h>
 #include <wtf/Lock.h>
 #include <wtf/RAMSize.h>
-#include <wtf/RefCounted.h>
-#include <wtf/RefPtr.h>
 #include <wtf/StdSet.h>
 #include <wtf/TZoneMalloc.h>
+#include <wtf/ThreadSafeRefCounted.h>
 #include <wtf/ThreadSafeWeakHashSet.h>
 #include <wtf/Vector.h>
-#include <wtf/WeakPtr.h>
 
 namespace WTF {
 class PrintStream;

--- a/Source/JavaScriptCore/runtime/BundlePath.mm
+++ b/Source/JavaScriptCore/runtime/BundlePath.mm
@@ -27,7 +27,6 @@
 #import "BundlePath.h"
 
 #import <Foundation/Foundation.h>
-#import <string>
 
 @interface JSJavaScriptCoreFinder : NSObject
 @end

--- a/Source/JavaScriptCore/runtime/Butterfly.h
+++ b/Source/JavaScriptCore/runtime/Butterfly.h
@@ -28,7 +28,6 @@
 #include <JavaScriptCore/IndexingHeader.h>
 #include <JavaScriptCore/IndexingType.h>
 #include <JavaScriptCore/PropertyStorage.h>
-#include <wtf/FastMalloc.h>
 #include <wtf/Noncopyable.h>
 
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN

--- a/Source/JavaScriptCore/runtime/ButterflyInlines.h
+++ b/Source/JavaScriptCore/runtime/ButterflyInlines.h
@@ -28,6 +28,7 @@
 #include <JavaScriptCore/ArrayStorageInlines.h>
 #include <JavaScriptCore/Butterfly.h>
 #include <JavaScriptCore/ButterflyInlinesLight.h>
+#include <JavaScriptCore/GCMemoryOperations.h>
 #include <JavaScriptCore/HeapCellInlines.h>
 #include <JavaScriptCore/JSObject.h>
 #include <JavaScriptCore/Structure.h>

--- a/Source/JavaScriptCore/runtime/CachedBytecode.h
+++ b/Source/JavaScriptCore/runtime/CachedBytecode.h
@@ -27,7 +27,6 @@
 
 #include <JavaScriptCore/CacheUpdate.h>
 #include <JavaScriptCore/LeafExecutable.h>
-#include <JavaScriptCore/ParserModes.h>
 #include <wtf/MallocSpan.h>
 #include <wtf/Noncopyable.h>
 #include <wtf/RefCounted.h>

--- a/Source/JavaScriptCore/runtime/CachedTypes.cpp
+++ b/Source/JavaScriptCore/runtime/CachedTypes.cpp
@@ -44,14 +44,11 @@
 #include "UnlinkedProgramCodeBlock.h"
 #include <wtf/FileHandle.h>
 #include <wtf/InlineMap.h>
-#include <wtf/MallocPtr.h>
 #include <wtf/MallocSpan.h>
 #include <wtf/Packed.h>
-#include <wtf/RobinHoodHashMap.h>
 #include <wtf/StdLibExtras.h>
 #include <wtf/UUID.h>
 #include <wtf/text/AtomStringImpl.h>
-#include <wtf/text/ParsingUtilities.h>
 
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 

--- a/Source/JavaScriptCore/runtime/ClonedArguments.h
+++ b/Source/JavaScriptCore/runtime/ClonedArguments.h
@@ -31,6 +31,8 @@
 
 namespace JSC {
 
+struct InlineCallFrame;
+
 // This is an Arguments-class object that we create when you do function.arguments, or you say
 // "arguments" inside a function in strict mode. It behaves almpst entirely like an ordinary
 // JavaScript object. All of the arguments values are simply copied from the stack (possibly via

--- a/Source/JavaScriptCore/runtime/ConcurrentJSLock.h
+++ b/Source/JavaScriptCore/runtime/ConcurrentJSLock.h
@@ -28,7 +28,6 @@
 #include <JavaScriptCore/DeferGC.h>
 #include <wtf/Lock.h>
 #include <wtf/Locker.h>
-#include <wtf/NoLock.h>
 
 namespace JSC {
 

--- a/Source/JavaScriptCore/runtime/ConsoleTypes.h
+++ b/Source/JavaScriptCore/runtime/ConsoleTypes.h
@@ -25,8 +25,6 @@
 
 #pragma once
 
-#include <wtf/Forward.h>
-
 namespace JSC {
 
 enum class MessageSource : uint8_t {

--- a/Source/JavaScriptCore/runtime/Error.h
+++ b/Source/JavaScriptCore/runtime/Error.h
@@ -25,12 +25,9 @@
 #include <JavaScriptCore/ErrorInstance.h>
 #include <JavaScriptCore/ErrorType.h>
 #include <JavaScriptCore/Exception.h>
-#include <JavaScriptCore/InternalFunction.h>
 #include <JavaScriptCore/JSObject.h>
 #include <JavaScriptCore/LineColumn.h>
 #include <JavaScriptCore/ThrowScope.h>
-#include <stdint.h>
-
 
 namespace JSC {
 

--- a/Source/JavaScriptCore/runtime/EvacuatedStack.cpp
+++ b/Source/JavaScriptCore/runtime/EvacuatedStack.cpp
@@ -34,7 +34,6 @@
 #include "NativeCallee.h"
 #include "WasmCallee.h"
 
-#include <wtf/PtrTag.h>
 #include <wtf/StringPrintStream.h>
 #include <wtf/text/MakeString.h>
 

--- a/Source/JavaScriptCore/runtime/FunctionHasExecutedCache.h
+++ b/Source/JavaScriptCore/runtime/FunctionHasExecutedCache.h
@@ -28,7 +28,6 @@
 #include <JavaScriptCore/SourceID.h>
 #include <wtf/GenericHashKey.h>
 #include <wtf/HashMap.h>
-#include <wtf/HashTraits.h>
 #include <wtf/Vector.h>
 
 namespace JSC {

--- a/Source/JavaScriptCore/runtime/ISO8601.cpp
+++ b/Source/JavaScriptCore/runtime/ISO8601.cpp
@@ -38,7 +38,6 @@
 #include <wtf/WallTime.h>
 #include <wtf/text/MakeString.h>
 #include <wtf/text/StringParsingBuffer.h>
-#include <wtf/unicode/CharacterNames.h>
 
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 

--- a/Source/JavaScriptCore/runtime/IdentifierInlines.h
+++ b/Source/JavaScriptCore/runtime/IdentifierInlines.h
@@ -25,8 +25,8 @@
 
 #pragma once
 
-#include <JavaScriptCore/CallFrame.h>
 #include <JavaScriptCore/Identifier.h>
+#include <JavaScriptCore/JSString.h>
 #include <JavaScriptCore/Symbol.h>
 #include <JavaScriptCore/VM.h>
 

--- a/Source/JavaScriptCore/runtime/IndexingType.h
+++ b/Source/JavaScriptCore/runtime/IndexingType.h
@@ -29,7 +29,6 @@
 #include <wtf/Forward.h>
 #include <wtf/LockAlgorithm.h>
 #include <wtf/PrintStream.h>
-#include <wtf/StdLibExtras.h>
 
 namespace JSC {
 

--- a/Source/JavaScriptCore/runtime/IntlDisplayNames.cpp
+++ b/Source/JavaScriptCore/runtime/IntlDisplayNames.cpp
@@ -31,7 +31,6 @@
 #include "JSCInlines.h"
 #include "ObjectConstructor.h"
 #include <unicode/ucurr.h>
-#include <unicode/uloc.h>
 #include <wtf/unicode/icu/ICUHelpers.h>
 
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN

--- a/Source/JavaScriptCore/runtime/IntlLocale.cpp
+++ b/Source/JavaScriptCore/runtime/IntlLocale.cpp
@@ -32,7 +32,6 @@
 #include "JSCInlines.h"
 #include <unicode/ucal.h>
 #include <unicode/ucol.h>
-#include <unicode/udat.h>
 #include <unicode/udatpg.h>
 #include <unicode/uloc.h>
 #include <unicode/unumsys.h>

--- a/Source/JavaScriptCore/runtime/IntlSegmentIterator.cpp
+++ b/Source/JavaScriptCore/runtime/IntlSegmentIterator.cpp
@@ -30,9 +30,6 @@
 #include "IteratorOperations.h"
 #include "JSCInlines.h"
 #include "ObjectConstructor.h"
-#include <unicode/ucurr.h>
-#include <unicode/uloc.h>
-#include <wtf/unicode/icu/ICUHelpers.h>
 
 namespace JSC {
 

--- a/Source/JavaScriptCore/runtime/IntlSegments.cpp
+++ b/Source/JavaScriptCore/runtime/IntlSegments.cpp
@@ -32,9 +32,6 @@
 #include "IntlWorkaround.h"
 #include "JSCInlines.h"
 #include "ObjectConstructor.h"
-#include <unicode/ucurr.h>
-#include <unicode/uloc.h>
-#include <wtf/unicode/icu/ICUHelpers.h>
 
 namespace JSC {
 

--- a/Source/JavaScriptCore/runtime/JSArray.h
+++ b/Source/JavaScriptCore/runtime/JSArray.h
@@ -25,7 +25,6 @@
 #include <JavaScriptCore/Butterfly.h>
 #include <JavaScriptCore/JSCell.h>
 #include <JavaScriptCore/JSObject.h>
-#include <JavaScriptCore/ResourceExhaustion.h>
 
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 

--- a/Source/JavaScriptCore/runtime/JSArrayBufferView.h
+++ b/Source/JavaScriptCore/runtime/JSArrayBufferView.h
@@ -27,7 +27,6 @@
 
 #include <JavaScriptCore/AuxiliaryBarrier.h>
 #include <JavaScriptCore/JSObject.h>
-#include <wtf/TaggedArrayStoragePtr.h>
 
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 

--- a/Source/JavaScriptCore/runtime/JSArrayInlines.h
+++ b/Source/JavaScriptCore/runtime/JSArrayInlines.h
@@ -27,6 +27,7 @@
 #include <JavaScriptCore/JSArray.h>
 #include <JavaScriptCore/JSCellInlines.h>
 #include <JavaScriptCore/JSObjectInlines.h>
+#include <JavaScriptCore/ResourceExhaustion.h>
 #include <JavaScriptCore/ScopedArguments.h>
 #include <JavaScriptCore/Structure.h>
 #include <JavaScriptCore/StructureArrayStorageInlines.h>

--- a/Source/JavaScriptCore/runtime/JSBigInt.h
+++ b/Source/JavaScriptCore/runtime/JSBigInt.h
@@ -26,15 +26,11 @@
 
 #pragma once
 
-#include <JavaScriptCore/CPU.h>
 #include <JavaScriptCore/Error.h>
-#include <JavaScriptCore/ExceptionHelpers.h>
 #include <JavaScriptCore/JSCJSValueCell.h>
 #include <JavaScriptCore/JSObject.h>
 #include <JavaScriptCore/MathCommon.h>
-#include <wtf/CagedUniquePtr.h>
 #include <wtf/Int128.h>
-#include <wtf/text/StringBuilder.h>
 #include <wtf/text/StringView.h>
 #include <wtf/text/WTFString.h>
 

--- a/Source/JavaScriptCore/runtime/JSCConfig.cpp
+++ b/Source/JavaScriptCore/runtime/JSCConfig.cpp
@@ -25,7 +25,6 @@
 
 #include "config.h"
 #include "JSCConfig.h"
-#include <wtf/WTFConfig.h>
 
 namespace JSC {
 

--- a/Source/JavaScriptCore/runtime/JSCJSValueInlines.h
+++ b/Source/JavaScriptCore/runtime/JSCJSValueInlines.h
@@ -29,7 +29,6 @@
 
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 
-#include <JavaScriptCore/ExceptionEventLocation.h>
 #include <JavaScriptCore/Identifier.h>
 #include <JavaScriptCore/JSBigInt.h>
 #include <JavaScriptCore/JSCJSValue.h>

--- a/Source/JavaScriptCore/runtime/JSCJSValuePropertyInlines.h
+++ b/Source/JavaScriptCore/runtime/JSCJSValuePropertyInlines.h
@@ -35,7 +35,6 @@
 #include <JavaScriptCore/JSCJSValueCell.h>
 #include <JavaScriptCore/JSObject.h>
 #include <JavaScriptCore/JSString.h>
-#include <JavaScriptCore/Symbol.h>
 
 namespace JSC {
 

--- a/Source/JavaScriptCore/runtime/JSCPtrTag.h
+++ b/Source/JavaScriptCore/runtime/JSCPtrTag.h
@@ -26,7 +26,6 @@
 #pragma once
 
 #include <JavaScriptCore/JITOperationList.h>
-#include <JavaScriptCore/JITOperationValidation.h>
 #include <wtf/PtrTag.h>
 
 #if ENABLE(JIT_CAGE)

--- a/Source/JavaScriptCore/runtime/JSCellInlines.h
+++ b/Source/JavaScriptCore/runtime/JSCellInlines.h
@@ -31,20 +31,16 @@ WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 
 #include <JavaScriptCore/AllocatorForMode.h>
 #include <JavaScriptCore/AllocatorInlines.h>
-#include <JavaScriptCore/CPU.h>
 #include <JavaScriptCore/CallFrameInlines.h>
 #include <JavaScriptCore/CompleteSubspaceInlines.h>
 #include <JavaScriptCore/DeferGCInlines.h>
 #include <JavaScriptCore/FreeListInlines.h>
-#include <JavaScriptCore/Handle.h>
 #include <JavaScriptCore/HeapInlines.h>
 #include <JavaScriptCore/IsoSubspaceInlines.h>
 #include <JavaScriptCore/JSBigInt.h>
 #include <JavaScriptCore/JSCast.h>
 #include <JavaScriptCore/JSDestructibleObject.h>
 #include <JavaScriptCore/JSFunction.h>
-#include <JavaScriptCore/JSHeapDouble.h>
-#include <JavaScriptCore/JSHeapInt32.h>
 #include <JavaScriptCore/JSObject.h>
 #include <JavaScriptCore/JSString.h>
 #include <JavaScriptCore/LocalAllocatorInlines.h>

--- a/Source/JavaScriptCore/runtime/JSDateMath.h
+++ b/Source/JavaScriptCore/runtime/JSDateMath.h
@@ -50,7 +50,6 @@
 #include <wtf/DateMath.h>
 #include <wtf/GregorianDateTime.h>
 #include <wtf/Platform.h>
-#include <wtf/SaturatedArithmetic.h>
 #include <wtf/TZoneMalloc.h>
 
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN

--- a/Source/JavaScriptCore/runtime/JSFunctionInlines.h
+++ b/Source/JavaScriptCore/runtime/JSFunctionInlines.h
@@ -25,6 +25,7 @@
 
 #pragma once
 
+#include <JavaScriptCore/ExceptionHelpers.h>
 #include <JavaScriptCore/ExecutableBaseInlines.h>
 #include <JavaScriptCore/FunctionExecutable.h>
 #include <JavaScriptCore/JSBoundFunction.h>

--- a/Source/JavaScriptCore/runtime/JSGenerator.h
+++ b/Source/JavaScriptCore/runtime/JSGenerator.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include <JavaScriptCore/JSInternalFieldObjectImpl.h>
+#include <wtf/EnumClassOperatorOverloads.h>
 
 namespace JSC {
 

--- a/Source/JavaScriptCore/runtime/JSGenericTypedArrayView.h
+++ b/Source/JavaScriptCore/runtime/JSGenericTypedArrayView.h
@@ -27,7 +27,6 @@
 
 #include <JavaScriptCore/JSArrayBufferView.h>
 #include <JavaScriptCore/ThrowScope.h>
-#include <wtf/CheckedArithmetic.h>
 
 namespace JSC {
 

--- a/Source/JavaScriptCore/runtime/JSGlobalObject.cpp
+++ b/Source/JavaScriptCore/runtime/JSGlobalObject.cpp
@@ -325,10 +325,8 @@
 #include "WrapForValidIteratorPrototypeInlines.h"
 #include "runtime/VM.h"
 #include <wtf/CryptographicallyRandomNumber.h>
-#include <wtf/FileHandle.h>
 #include <wtf/FixedVector.h>
 #include <wtf/SystemTracing.h>
-#include <wtf/WeakHashSet.h>
 #include <wtf/text/MakeString.h>
 
 #if ENABLE(REMOTE_INSPECTOR)

--- a/Source/JavaScriptCore/runtime/JSGlobalObjectDebuggable.cpp
+++ b/Source/JavaScriptCore/runtime/JSGlobalObjectDebuggable.cpp
@@ -35,7 +35,6 @@
 #include "JSLock.h"
 #include "RemoteInspector.h"
 #include <wtf/TZoneMallocInlines.h>
-#include <wtf/threads/BinarySemaphore.h>
 
 using namespace Inspector;
 

--- a/Source/JavaScriptCore/runtime/JSGlobalObjectFunctions.h
+++ b/Source/JavaScriptCore/runtime/JSGlobalObjectFunctions.h
@@ -24,7 +24,6 @@
 #pragma once
 
 #include <JavaScriptCore/JSCJSValue.h>
-#include <unicode/uchar.h>
 
 namespace JSC {
 

--- a/Source/JavaScriptCore/runtime/JSHeapDouble.cpp
+++ b/Source/JavaScriptCore/runtime/JSHeapDouble.cpp
@@ -31,7 +31,6 @@
 #include "JSObjectInlines.h"
 
 #include <JavaScriptCore/VMManager.h>
-#include <mutex>
 
 namespace JSC {
 

--- a/Source/JavaScriptCore/runtime/JSLock.h
+++ b/Source/JavaScriptCore/runtime/JSLock.h
@@ -21,9 +21,7 @@
 #pragma once
 
 #include <JavaScriptCore/JSExportMacros.h>
-#include <mutex>
 #include <wtf/Assertions.h>
-#include <wtf/ForbidHeapAllocation.h>
 #include <wtf/Lock.h>
 #include <wtf/Noncopyable.h>
 #include <wtf/RefPtr.h>

--- a/Source/JavaScriptCore/runtime/JSModuleLoader.h
+++ b/Source/JavaScriptCore/runtime/JSModuleLoader.h
@@ -41,6 +41,7 @@ class JSModuleNamespaceObject;
 class JSModuleRecord;
 class JSSourceCode;
 class ModuleRegistryEntry;
+class SourceOrigin;
 
 class JSModuleLoader final : public JSCell {
 public:

--- a/Source/JavaScriptCore/runtime/JSONAtomStringCache.h
+++ b/Source/JavaScriptCore/runtime/JSONAtomStringCache.h
@@ -25,7 +25,6 @@
 
 #pragma once
 
-#include <unicode/umachine.h>
 #include <wtf/text/AtomStringImpl.h>
 
 namespace JSC {

--- a/Source/JavaScriptCore/runtime/JSObject.h
+++ b/Source/JavaScriptCore/runtime/JSObject.h
@@ -25,9 +25,7 @@
 #include <JavaScriptCore/ArrayConventions.h>
 #include <JavaScriptCore/ArrayStorage.h>
 #include <JavaScriptCore/Butterfly.h>
-#include <JavaScriptCore/CPU.h>
 #include <JavaScriptCore/CagedBarrierPtr.h>
-#include <JavaScriptCore/CallFrame.h>
 #include <JavaScriptCore/ClassInfo.h>
 #include <JavaScriptCore/CustomGetterSetter.h>
 #include <JavaScriptCore/DOMAttributeGetterSetter.h>
@@ -35,6 +33,7 @@
 #include <JavaScriptCore/Heap.h>
 #include <JavaScriptCore/IndexingHeaderInlines.h>
 #include <JavaScriptCore/Intrinsic.h>
+#include <JavaScriptCore/JSCJSValueCell.h>
 #include <JavaScriptCore/JSCast.h>
 #include <JavaScriptCore/MathCommon.h>
 #include <JavaScriptCore/PropertySlot.h>

--- a/Source/JavaScriptCore/runtime/JSRunLoopTimer.h
+++ b/Source/JavaScriptCore/runtime/JSRunLoopTimer.h
@@ -31,7 +31,6 @@
 #include <wtf/HashSet.h>
 #include <wtf/Lock.h>
 #include <wtf/RefPtr.h>
-#include <wtf/RetainPtr.h>
 #include <wtf/RunLoop.h>
 #include <wtf/SharedTask.h>
 #include <wtf/TZoneMalloc.h>

--- a/Source/JavaScriptCore/runtime/JSSegmentedVariableObject.h
+++ b/Source/JavaScriptCore/runtime/JSSegmentedVariableObject.h
@@ -28,9 +28,7 @@
 
 #pragma once
 
-#include <JavaScriptCore/ConcurrentJSLock.h>
 #include <JavaScriptCore/JSSymbolTableObject.h>
-#include <JavaScriptCore/SymbolTable.h>
 #include <wtf/SegmentedVector.h>
 
 namespace JSC {

--- a/Source/JavaScriptCore/runtime/JSString.h
+++ b/Source/JavaScriptCore/runtime/JSString.h
@@ -23,10 +23,7 @@
 #pragma once
 
 #include <JavaScriptCore/ArgList.h>
-#include <JavaScriptCore/CallFrame.h>
 #include <JavaScriptCore/CommonIdentifiers.h>
-#include <JavaScriptCore/EnsureStillAliveHere.h>
-#include <JavaScriptCore/ExceptionEventLocation.h>
 #include <JavaScriptCore/GCOwnedDataScope.h>
 #include <JavaScriptCore/GetVM.h>
 #include <JavaScriptCore/Identifier.h>
@@ -34,10 +31,8 @@
 #include <JavaScriptCore/PropertySlot.h>
 #include <JavaScriptCore/Structure.h>
 #include <JavaScriptCore/ThrowScope.h>
-#include <array>
 #include <wtf/CheckedArithmetic.h>
 #include <wtf/ForbidHeapAllocation.h>
-#include <wtf/MathExtras.h>
 #include <wtf/UnalignedAccess.h>
 #include <wtf/text/StringView.h>
 

--- a/Source/JavaScriptCore/runtime/KeyAtomStringCache.h
+++ b/Source/JavaScriptCore/runtime/KeyAtomStringCache.h
@@ -26,7 +26,6 @@
 #pragma once
 
 #include <array>
-#include <wtf/text/AtomStringImpl.h>
 
 namespace JSC {
 

--- a/Source/JavaScriptCore/runtime/KeyAtomStringCacheInlines.h
+++ b/Source/JavaScriptCore/runtime/KeyAtomStringCacheInlines.h
@@ -25,7 +25,6 @@
 
 #pragma once
 
-#include <JavaScriptCore/Identifier.h>
 #include <JavaScriptCore/JSString.h>
 #include <JavaScriptCore/KeyAtomStringCache.h>
 #include <JavaScriptCore/SmallStrings.h>

--- a/Source/JavaScriptCore/runtime/LiteralParser.cpp
+++ b/Source/JavaScriptCore/runtime/LiteralParser.cpp
@@ -35,7 +35,6 @@
 #include "ObjectConstructor.h"
 #include <wtf/ASCIICType.h>
 #include <wtf/Range.h>
-#include <wtf/dtoa.h>
 #include <wtf/text/FastCharacterComparison.h>
 #include <wtf/text/MakeString.h>
 

--- a/Source/JavaScriptCore/runtime/MarkedVector.h
+++ b/Source/JavaScriptCore/runtime/MarkedVector.h
@@ -21,7 +21,6 @@
 
 #pragma once
 
-#include <JavaScriptCore/JSCast.h>
 #include <JavaScriptCore/VM.h>
 #include <wtf/CheckedArithmetic.h>
 #include <wtf/ForbidHeapAllocation.h>

--- a/Source/JavaScriptCore/runtime/MathCommon.h
+++ b/Source/JavaScriptCore/runtime/MathCommon.h
@@ -26,12 +26,10 @@
 #pragma once
 
 #include <JavaScriptCore/CPU.h>
-#include <JavaScriptCore/JITOperationValidation.h>
 #include <JavaScriptCore/OperationResult.h>
 #include <climits>
 #include <cmath>
 #include <optional>
-#include <wtf/MathExtras.h>
 
 namespace JSC {
 

--- a/Source/JavaScriptCore/runtime/MemoryMode.cpp
+++ b/Source/JavaScriptCore/runtime/MemoryMode.cpp
@@ -27,7 +27,6 @@
 #include "MemoryMode.h"
 
 #include <wtf/Assertions.h>
-#include <wtf/DataLog.h>
 #include <wtf/PrintStream.h>
 
 namespace WTF {

--- a/Source/JavaScriptCore/runtime/MicrotaskQueue.cpp
+++ b/Source/JavaScriptCore/runtime/MicrotaskQueue.cpp
@@ -38,7 +38,6 @@
 #include "MicrotaskQueueInlines.h"
 #include "ScriptProfilingScope.h"
 #include "SlotVisitorInlines.h"
-#include <wtf/SetForScope.h>
 #include <wtf/TZoneMallocInlines.h>
 
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN

--- a/Source/JavaScriptCore/runtime/OptionsList.h
+++ b/Source/JavaScriptCore/runtime/OptionsList.h
@@ -27,8 +27,6 @@
 
 #include <JavaScriptCore/GCLogging.h>
 #include <JavaScriptCore/JSExportMacros.h>
-#include <JavaScriptCore/OSCheck.h>
-#include <wtf/MathExtras.h>
 
 #if OS(DARWIN)
 #include <mach/vm_param.h>

--- a/Source/JavaScriptCore/runtime/ProfilerSupport.cpp
+++ b/Source/JavaScriptCore/runtime/ProfilerSupport.cpp
@@ -28,8 +28,6 @@
 
 #include "Options.h"
 #include <fcntl.h>
-#include <sys/stat.h>
-#include <sys/types.h>
 #include <wtf/FileHandle.h>
 #include <wtf/FileSystem.h>
 #include <wtf/MonotonicTime.h>

--- a/Source/JavaScriptCore/runtime/PropertyTable.h
+++ b/Source/JavaScriptCore/runtime/PropertyTable.h
@@ -25,11 +25,9 @@
 #include <JavaScriptCore/Structure.h>
 #include <JavaScriptCore/VM.h>
 #include <JavaScriptCore/WriteBarrier.h>
-#include <wtf/HashTable.h>
 #include <wtf/MathExtras.h>
 #include <wtf/StdLibExtras.h>
 #include <wtf/Vector.h>
-#include <wtf/text/AtomStringImpl.h>
 
 
 #define DUMP_PROPERTYMAP_STATS 0

--- a/Source/JavaScriptCore/runtime/RegExp.h
+++ b/Source/JavaScriptCore/runtime/RegExp.h
@@ -21,11 +21,11 @@
 
 #pragma once
 
-#include <JavaScriptCore/ConcurrentJSLock.h>
 #include <JavaScriptCore/MatchResult.h>
 #include <JavaScriptCore/RegExpKey.h>
 #include <JavaScriptCore/Structure.h>
 #include <JavaScriptCore/Yarr.h>
+#include <JavaScriptCore/YarrErrorCode.h>
 #include <wtf/Forward.h>
 #include <wtf/text/WTFString.h>
 

--- a/Source/JavaScriptCore/runtime/RuntimeTZoneImpls.cpp
+++ b/Source/JavaScriptCore/runtime/RuntimeTZoneImpls.cpp
@@ -30,7 +30,6 @@
 #include "StructureTransitionTable.h"
 #include "WeakGCMap.h"
 #include <wtf/TZoneMallocInlines.h>
-#include <wtf/text/SymbolImpl.h>
 
 namespace JSC {
 

--- a/Source/JavaScriptCore/runtime/RuntimeType.h
+++ b/Source/JavaScriptCore/runtime/RuntimeType.h
@@ -26,7 +26,6 @@
 
 #pragma once
 
-#include <JavaScriptCore/VM.h>
 #include <wtf/text/WTFString.h>
 
 namespace JSC {

--- a/Source/JavaScriptCore/runtime/SamplingProfiler.cpp
+++ b/Source/JavaScriptCore/runtime/SamplingProfiler.cpp
@@ -46,7 +46,6 @@
 #include "VMTrapsInlines.h"
 #include "WasmCallee.h"
 #include "WasmCapabilities.h"
-#include <wtf/CommaPrinter.h>
 #include <wtf/FilePrintStream.h>
 #include <wtf/HashSet.h>
 #include <wtf/JSONValues.h>

--- a/Source/JavaScriptCore/runtime/StringSplitCache.h
+++ b/Source/JavaScriptCore/runtime/StringSplitCache.h
@@ -28,7 +28,6 @@
 
 #include <array>
 #include <wtf/DebugHeap.h>
-#include <wtf/FastMalloc.h>
 #include <wtf/Noncopyable.h>
 #include <wtf/RefPtr.h>
 #include <wtf/TZoneMalloc.h>

--- a/Source/JavaScriptCore/runtime/Structure.h
+++ b/Source/JavaScriptCore/runtime/Structure.h
@@ -30,7 +30,6 @@
 #include <JavaScriptCore/ConcurrentJSLock.h>
 #include <JavaScriptCore/IndexingType.h>
 #include <JavaScriptCore/JSCJSValue.h>
-#include <JavaScriptCore/JSCJSValueCell.h>
 #include <JavaScriptCore/JSCast.h>
 #include <JavaScriptCore/JSTypeInfo.h>
 #include <JavaScriptCore/PropertyName.h>

--- a/Source/JavaScriptCore/runtime/StructureCreateInlines.h
+++ b/Source/JavaScriptCore/runtime/StructureCreateInlines.h
@@ -31,7 +31,6 @@
 // (BigIntPrototype.h, StringPrototype.h, SymbolPrototype.h, BrandedStructure.h,
 // WebAssemblyGCStructure.h, JSArrayBufferView.h, PropertyTable.h, etc.).
 
-#include <JavaScriptCore/JSCJSValueStructure.h>
 #include <JavaScriptCore/JSCellInlines.h>
 #include <JavaScriptCore/JSGlobalProxy.h>
 #include <JavaScriptCore/Structure.h>

--- a/Source/JavaScriptCore/runtime/StructureID.h
+++ b/Source/JavaScriptCore/runtime/StructureID.h
@@ -29,7 +29,6 @@
 #include <JavaScriptCore/MarkedBlock.h>
 #include <compare>
 #include <wtf/HashTraits.h>
-#include <wtf/StdIntExtras.h>
 
 namespace JSC {
 

--- a/Source/JavaScriptCore/runtime/StructureRareData.h
+++ b/Source/JavaScriptCore/runtime/StructureRareData.h
@@ -25,7 +25,6 @@
 
 #pragma once
 
-#include <JavaScriptCore/ClassInfo.h>
 #include <JavaScriptCore/JSCast.h>
 #include <JavaScriptCore/JSTypeInfo.h>
 #include <JavaScriptCore/PropertyOffset.h>

--- a/Source/JavaScriptCore/runtime/StructureRareDataInlines.h
+++ b/Source/JavaScriptCore/runtime/StructureRareDataInlines.h
@@ -32,6 +32,7 @@
 #include <JavaScriptCore/StructureChain.h>
 #include <JavaScriptCore/StructureRareData.h>
 #include <JavaScriptCore/VM.h>
+#include <wtf/Bag.h>
 
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 

--- a/Source/JavaScriptCore/runtime/Symbol.h
+++ b/Source/JavaScriptCore/runtime/Symbol.h
@@ -27,7 +27,6 @@
 #pragma once
 
 #include <JavaScriptCore/ErrorType.h>
-#include <JavaScriptCore/JSString.h>
 #include <JavaScriptCore/PrivateName.h>
 #include <wtf/Expected.h>
 

--- a/Source/JavaScriptCore/runtime/SymbolTable.h
+++ b/Source/JavaScriptCore/runtime/SymbolTable.h
@@ -41,7 +41,6 @@
 #include <JavaScriptCore/Watchpoint.h>
 #include <memory>
 #include <wtf/HashTraits.h>
-#include <wtf/text/SymbolImpl.h>
 
 namespace JSC {
 

--- a/Source/JavaScriptCore/runtime/TypeError.h
+++ b/Source/JavaScriptCore/runtime/TypeError.h
@@ -25,7 +25,6 @@
 
 #pragma once
 
-#include <JavaScriptCore/CallFrame.h>
 #include <JavaScriptCore/Error.h>
 
 namespace JSC {

--- a/Source/JavaScriptCore/runtime/TypeInfoBlob.h
+++ b/Source/JavaScriptCore/runtime/TypeInfoBlob.h
@@ -28,7 +28,6 @@
 #include <JavaScriptCore/CellState.h>
 #include <JavaScriptCore/IndexingType.h>
 #include <JavaScriptCore/JSTypeInfo.h>
-#include <JavaScriptCore/StructureID.h>
 
 namespace JSC {
 

--- a/Source/JavaScriptCore/runtime/TypedArrayAdaptors.h
+++ b/Source/JavaScriptCore/runtime/TypedArrayAdaptors.h
@@ -30,7 +30,6 @@
 #include <JavaScriptCore/MathCommon.h>
 #include <JavaScriptCore/TypedArrayAdaptersForwardDeclarations.h>
 #include <JavaScriptCore/TypedArrayType.h>
-#include <wtf/MathExtras.h>
 
 namespace JSC {
 

--- a/Source/JavaScriptCore/runtime/TypedArrayType.h
+++ b/Source/JavaScriptCore/runtime/TypedArrayType.h
@@ -27,7 +27,6 @@
 
 #include <JavaScriptCore/JSExportMacros.h>
 #include <JavaScriptCore/JSType.h>
-#include <wtf/Float16.h>
 #include <wtf/PrintStream.h>
 
 namespace JSC {

--- a/Source/JavaScriptCore/runtime/UGPRPair.h
+++ b/Source/JavaScriptCore/runtime/UGPRPair.h
@@ -25,7 +25,6 @@
 
 #pragma once
 
-#include <JavaScriptCore/CPU.h>
 #include <wtf/StdLibExtras.h>
 
 namespace JSC {

--- a/Source/JavaScriptCore/runtime/VMEntryScope.cpp
+++ b/Source/JavaScriptCore/runtime/VMEntryScope.cpp
@@ -33,7 +33,6 @@
 #include "WasmCapabilities.h"
 #include "WasmMachineThreads.h"
 #include "Watchdog.h"
-#include <wtf/WTFConfig.h>
 
 namespace JSC {
 

--- a/Source/JavaScriptCore/runtime/VMTraps.h
+++ b/Source/JavaScriptCore/runtime/VMTraps.h
@@ -27,10 +27,7 @@
 
 #include <JavaScriptCore/JSExportMacros.h>
 #include <JavaScriptCore/StackManager.h>
-#include <wtf/AutomaticThread.h>
 #include <wtf/Box.h>
-#include <wtf/Expected.h>
-#include <wtf/HashSet.h>
 #include <wtf/Lock.h>
 #include <wtf/Locker.h>
 #include <wtf/RefPtr.h>

--- a/Source/JavaScriptCore/runtime/VarOffset.h
+++ b/Source/JavaScriptCore/runtime/VarOffset.h
@@ -28,7 +28,6 @@
 #include <JavaScriptCore/DirectArgumentsOffset.h>
 #include <JavaScriptCore/ScopeOffset.h>
 #include <JavaScriptCore/VirtualRegister.h>
-#include <wtf/HashMap.h>
 
 namespace JSC {
 

--- a/Source/JavaScriptCore/runtime/WeakGCSet.h
+++ b/Source/JavaScriptCore/runtime/WeakGCSet.h
@@ -28,7 +28,6 @@
 #include <JavaScriptCore/WeakGCHashTable.h>
 #include <JavaScriptCore/WeakInlines.h>
 #include <wtf/HashSet.h>
-#include <wtf/TZoneMalloc.h>
 
 namespace JSC {
 

--- a/Source/JavaScriptCore/runtime/WriteBarrier.h
+++ b/Source/JavaScriptCore/runtime/WriteBarrier.h
@@ -26,7 +26,6 @@
 #pragma once
 
 #include <JavaScriptCore/GCAssertions.h>
-#include <JavaScriptCore/HandleTypes.h>
 #include <JavaScriptCore/StructureID.h>
 #include <type_traits>
 #include <wtf/RawPtrTraits.h>

--- a/Source/JavaScriptCore/tools/CharacterPropertyDataGenerator.cpp
+++ b/Source/JavaScriptCore/tools/CharacterPropertyDataGenerator.cpp
@@ -29,9 +29,7 @@
 
 #include <wtf/BitSet.h>
 #include <wtf/DataLog.h>
-#include <wtf/StdLibExtras.h>
 #include <wtf/text/MakeString.h>
-#include <wtf/text/StringConcatenate.h>
 #include <wtf/text/TextBreakIterator.h>
 
 namespace JSC {

--- a/Source/JavaScriptCore/tools/CompilerTimingScope.cpp
+++ b/Source/JavaScriptCore/tools/CompilerTimingScope.cpp
@@ -31,7 +31,6 @@
 #include <wtf/Lock.h>
 #include <wtf/TZoneMallocInlines.h>
 #include <wtf/Vector.h>
-#include <wtf/text/WTFString.h>
 
 namespace JSC {
 

--- a/Source/JavaScriptCore/tools/FunctionOverrides.cpp
+++ b/Source/JavaScriptCore/tools/FunctionOverrides.cpp
@@ -36,7 +36,6 @@
 #include <wtf/text/CString.h>
 #include <wtf/text/MakeString.h>
 #include <wtf/text/StringBuilder.h>
-#include <wtf/text/StringHash.h>
 
 namespace JSC {
 

--- a/Source/JavaScriptCore/tools/JSDollarVM.cpp
+++ b/Source/JavaScriptCore/tools/JSDollarVM.cpp
@@ -72,7 +72,6 @@
 #include <bmalloc/BPlatform.h>
 #include <unicode/uversion.h>
 #include <wtf/ApproximateTime.h>
-#include <wtf/Atomics.h>
 #include <wtf/CPUTime.h>
 #include <wtf/DataLog.h>
 #include <wtf/Language.h>

--- a/Source/JavaScriptCore/tools/VMInspector.cpp
+++ b/Source/JavaScriptCore/tools/VMInspector.cpp
@@ -36,7 +36,6 @@
 #include "StackVisitor.h"
 #include "VMEntryRecord.h"
 #include "VMManager.h"
-#include <mutex>
 #include <wtf/Expected.h>
 #include <wtf/TZoneMallocInlines.h>
 

--- a/Source/JavaScriptCore/wasm/WasmBBQJIT.cpp
+++ b/Source/JavaScriptCore/wasm/WasmBBQJIT.cpp
@@ -66,10 +66,7 @@
 #include <wtf/Assertions.h>
 #include <wtf/Compiler.h>
 #include <wtf/HashFunctions.h>
-#include <wtf/HashMap.h>
 #include <wtf/MathExtras.h>
-#include <wtf/PlatformRegisters.h>
-#include <wtf/SmallSet.h>
 #include <wtf/StdLibExtras.h>
 #include <wtf/text/MakeString.h>
 

--- a/Source/JavaScriptCore/wasm/WasmBBQJIT64.cpp
+++ b/Source/JavaScriptCore/wasm/WasmBBQJIT64.cpp
@@ -68,11 +68,7 @@ WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 #include <bit>
 #include <wtf/Assertions.h>
 #include <wtf/Compiler.h>
-#include <wtf/HashFunctions.h>
-#include <wtf/HashMap.h>
 #include <wtf/MathExtras.h>
-#include <wtf/PlatformRegisters.h>
-#include <wtf/SmallSet.h>
 #include <wtf/StdLibExtras.h>
 
 namespace JSC { namespace Wasm { namespace BBQJITImpl {

--- a/Source/JavaScriptCore/wasm/WasmCalleeGroup.cpp
+++ b/Source/JavaScriptCore/wasm/WasmCalleeGroup.cpp
@@ -34,7 +34,6 @@
 #include "WasmIPIntPlan.h"
 #include "WasmMachineThreads.h"
 #include "WasmWorklist.h"
-#include <wtf/text/MakeString.h>
 
 namespace JSC { namespace Wasm {
 

--- a/Source/JavaScriptCore/wasm/WasmCompilationMode.cpp
+++ b/Source/JavaScriptCore/wasm/WasmCompilationMode.cpp
@@ -27,7 +27,6 @@
 #include "WasmCompilationMode.h"
 
 #include "Options.h"
-#include <wtf/Assertions.h>
 
 namespace JSC { namespace Wasm {
 

--- a/Source/JavaScriptCore/wasm/WasmFaultSignalHandler.cpp
+++ b/Source/JavaScriptCore/wasm/WasmFaultSignalHandler.cpp
@@ -41,7 +41,6 @@
 #include "WasmMemory.h"
 #include "WasmThunks.h"
 #include <wtf/CodePtr.h>
-#include <wtf/HashSet.h>
 #include <wtf/Lock.h>
 #include <wtf/threads/Signals.h>
 

--- a/Source/JavaScriptCore/wasm/WasmFormat.cpp
+++ b/Source/JavaScriptCore/wasm/WasmFormat.cpp
@@ -33,7 +33,6 @@
 #include "JSWebAssemblyArray.h"
 #include "JSWebAssemblyStruct.h"
 #include "WasmCallee.h"
-#include <wtf/CheckedArithmetic.h>
 #include <wtf/FastMalloc.h>
 #include <wtf/text/MakeString.h>
 

--- a/Source/JavaScriptCore/wasm/WasmIPIntGenerator.cpp
+++ b/Source/JavaScriptCore/wasm/WasmIPIntGenerator.cpp
@@ -40,10 +40,8 @@
 #include "WasmFunctionParser.h"
 #include "WasmModuleDebugInfo.h"
 #include <wtf/Assertions.h>
-#include <wtf/CompletionHandler.h>
-#include <wtf/RefPtr.h>
 
-/* 
+/*
  * WebAssembly in-place interpreter metadata generator
  * 
  * docs by Daniel Liu <daniel_liu4@apple.com / danlliu@umich.edu>; 2023 intern project

--- a/Source/JavaScriptCore/wasm/WasmMemory.cpp
+++ b/Source/JavaScriptCore/wasm/WasmMemory.cpp
@@ -39,15 +39,9 @@
 #include <wtf/Lock.h>
 #include <wtf/Platform.h>
 #include <wtf/PrintStream.h>
-#include <wtf/RAMSize.h>
-#include <wtf/SafeStrerror.h>
-#include <wtf/StdSet.h>
 #include <wtf/TZoneMallocInlines.h>
-#include <wtf/Vector.h>
 
 #include <cstring>
-#include <limits>
-#include <mutex>
 
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 

--- a/Source/JavaScriptCore/wasm/WasmOperations.cpp
+++ b/Source/JavaScriptCore/wasm/WasmOperations.cpp
@@ -56,7 +56,6 @@
 #include "WasmOperationsInlines.h"
 #include "WasmWorklist.h"
 #include <bit>
-#include <wtf/CheckedArithmetic.h>
 #include <wtf/DataLog.h>
 #include <wtf/Locker.h>
 #include <wtf/StdLibExtras.h>

--- a/Source/JavaScriptCore/wasm/WasmTypeDefinition.cpp
+++ b/Source/JavaScriptCore/wasm/WasmTypeDefinition.cpp
@@ -41,7 +41,6 @@
 #include <wtf/CommaPrinter.h>
 #include <wtf/DataLog.h>
 #include <wtf/FastMalloc.h>
-#include <wtf/ReferenceWrapperVector.h>
 #include <wtf/StringPrintStream.h>
 #include <wtf/TZoneMallocInlines.h>
 

--- a/Source/JavaScriptCore/wasm/debugger/WasmBreakpointManager.cpp
+++ b/Source/JavaScriptCore/wasm/debugger/WasmBreakpointManager.cpp
@@ -32,7 +32,6 @@ WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 
 #include "Options.h"
 #include <wtf/DataLog.h>
-#include <wtf/RawPointer.h>
 #include <wtf/TZoneMallocInlines.h>
 
 namespace JSC {

--- a/Source/JavaScriptCore/wasm/debugger/WasmDebugServer.cpp
+++ b/Source/JavaScriptCore/wasm/debugger/WasmDebugServer.cpp
@@ -56,16 +56,12 @@ WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 #include <sys/socket.h>
 #include <unistd.h>
 #endif
-#include <wtf/ASCIICType.h>
 #include <wtf/Assertions.h>
 #include <wtf/DataLog.h>
 #include <wtf/HexNumber.h>
 #include <wtf/Lock.h>
 #include <wtf/NeverDestroyed.h>
-#include <wtf/Scope.h>
 #include <wtf/Threading.h>
-#include <wtf/text/MakeString.h>
-#include <wtf/text/StringBuilder.h>
 
 namespace JSC {
 namespace Wasm {

--- a/Source/JavaScriptCore/wasm/debugger/WasmExecutionHandler.cpp
+++ b/Source/JavaScriptCore/wasm/debugger/WasmExecutionHandler.cpp
@@ -57,7 +57,6 @@ WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 #include <wtf/DataLog.h>
 #include <wtf/TZoneMallocInlines.h>
 #include <wtf/text/StringBuilder.h>
-#include <wtf/text/StringParsingBuffer.h>
 #include <wtf/text/WTFString.h>
 
 namespace JSC {

--- a/Source/JavaScriptCore/wasm/debugger/WasmModuleManager.cpp
+++ b/Source/JavaScriptCore/wasm/debugger/WasmModuleManager.cpp
@@ -39,9 +39,7 @@ WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 #include "WasmModule.h"
 #include "WasmModuleInformation.h"
 #include <wtf/DataLog.h>
-#include <wtf/HashMap.h>
 #include <wtf/HexNumber.h>
-#include <wtf/IterationStatus.h>
 #include <wtf/TZoneMallocInlines.h>
 #include <wtf/text/StringBuilder.h>
 #include <wtf/text/WTFString.h>

--- a/Source/JavaScriptCore/wasm/debugger/WasmQueryHandler.cpp
+++ b/Source/JavaScriptCore/wasm/debugger/WasmQueryHandler.cpp
@@ -50,8 +50,6 @@ WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 #include "WasmVirtualAddress.h"
 #include <cstring>
 #include <wtf/DataLog.h>
-#include <wtf/HexNumber.h>
-#include <wtf/StdLibExtras.h>
 #include <wtf/TZoneMallocInlines.h>
 #include <wtf/text/StringBuilder.h>
 #include <wtf/text/WTFString.h>

--- a/Source/JavaScriptCore/wasm/js/JSToWasm.cpp
+++ b/Source/JavaScriptCore/wasm/js/JSToWasm.cpp
@@ -26,8 +26,6 @@
 #include "config.h"
 #include "JSToWasm.h"
 #include "WasmCallee.h"
-#include <wtf/FastMalloc.h>
-#include <wtf/WTFConfig.h>
 
 #if ENABLE(WEBASSEMBLY) && ENABLE(JIT)
 

--- a/Source/JavaScriptCore/wasm/js/JSWebAssemblyStruct.cpp
+++ b/Source/JavaScriptCore/wasm/js/JSWebAssemblyStruct.cpp
@@ -32,7 +32,6 @@
 #include "JSWebAssemblyInstance.h"
 #include "WasmFormat.h"
 #include "WasmModuleInformation.h"
-#include <wtf/ScopedPrintStream.h>
 
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 

--- a/Source/JavaScriptCore/wasm/js/WasmToJS.cpp
+++ b/Source/JavaScriptCore/wasm/js/WasmToJS.cpp
@@ -28,6 +28,7 @@
 
 #if ENABLE(WEBASSEMBLY) && ENABLE(JIT)
 
+#include "BaselineJITRegisters.h"
 #include "CCallHelpers.h"
 #include "JSCJSValueInlines.h"
 #include "JSWebAssemblyInstance.h"

--- a/Source/JavaScriptCore/wasm/js/WebAssemblyFunction.cpp
+++ b/Source/JavaScriptCore/wasm/js/WebAssemblyFunction.cpp
@@ -52,8 +52,6 @@
 #include "WasmModuleInformation.h"
 #include "WasmOperations.h"
 #include "WasmTypeDefinitionInlines.h"
-#include <wtf/StackPointer.h>
-#include <wtf/SystemTracing.h>
 
 namespace JSC {
 

--- a/Source/JavaScriptCore/wasm/js/WebAssemblySuspending.cpp
+++ b/Source/JavaScriptCore/wasm/js/WebAssemblySuspending.cpp
@@ -40,8 +40,6 @@
 #include "JSWebAssemblySuspendError.h"
 #include "PinballCompletion.h"
 
-#include <wtf/HexNumber.h>
-
 #if ASAN_ENABLED
 #include <sanitizer/asan_interface.h>
 #endif

--- a/Source/JavaScriptCore/yarr/Yarr.h
+++ b/Source/JavaScriptCore/yarr/Yarr.h
@@ -27,7 +27,6 @@
 
 #pragma once
 
-#include <JavaScriptCore/YarrErrorCode.h>
 #include <climits>
 #include <limits>
 

--- a/Source/JavaScriptCore/yarr/YarrInterpreter.cpp
+++ b/Source/JavaScriptCore/yarr/YarrInterpreter.cpp
@@ -39,7 +39,6 @@
 #include <wtf/DataLog.h>
 #include <wtf/StackCheck.h>
 #include <wtf/TZoneMallocInlines.h>
-#include <wtf/text/WTFString.h>
 
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 

--- a/Source/JavaScriptCore/yarr/YarrJIT.cpp
+++ b/Source/JavaScriptCore/yarr/YarrJIT.cpp
@@ -43,11 +43,9 @@
 #include "YarrMatchingContextHolder.h"
 #include <wtf/ASCIICType.h>
 #include <wtf/BitVector.h>
-#include <wtf/HexNumber.h>
 #include <wtf/ListDump.h>
 #include <wtf/MathExtras.h>
 #include <wtf/TZoneMallocInlines.h>
-#include <wtf/Threading.h>
 #include <wtf/text/MakeString.h>
 
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN

--- a/Source/JavaScriptCore/yarr/YarrJIT.h
+++ b/Source/JavaScriptCore/yarr/YarrJIT.h
@@ -37,7 +37,6 @@
 #include <JavaScriptCore/YarrPattern.h>
 #include <wtf/Atomics.h>
 #include <wtf/BitSet.h>
-#include <wtf/FixedVector.h>
 #include <wtf/StackCheck.h>
 #include <wtf/TZoneMalloc.h>
 #include <wtf/UniqueRef.h>

--- a/Source/JavaScriptCore/yarr/YarrUnicodeProperties.cpp
+++ b/Source/JavaScriptCore/yarr/YarrUnicodeProperties.cpp
@@ -28,7 +28,6 @@
 
 #include "Yarr.h"
 #include "YarrPattern.h"
-#include <string_view>
 #include <wtf/text/WTFString.h>
 
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN

--- a/Source/WebCore/Modules/encryptedmedia/MediaKeyStatusMap.h
+++ b/Source/WebCore/Modules/encryptedmedia/MediaKeyStatusMap.h
@@ -33,6 +33,7 @@
 #include "BufferSource.h"
 #include "CDMKeyID.h"
 #include "MediaKeyStatus.h"
+#include <JavaScriptCore/JSCJSValue.h>
 #include <wtf/RefCounted.h>
 
 namespace WebCore {


### PR DESCRIPTION
#### b58929972f71447120a9c858407301e9b027cd45
<pre>
Optimize JavaScriptCore #includes
<a href="https://bugs.webkit.org/show_bug.cgi?id=314250">https://bugs.webkit.org/show_bug.cgi?id=314250</a>
&lt;<a href="https://rdar.apple.com/problem/176402499">rdar://problem/176402499</a>&gt;

Reviewed by Jer Noble.

Mechanically removed redundant #includes in JavaScriptCore using a
script + claude.

(I&apos;ll post the claude plugin as a separate patch.)

Canonical link: <a href="https://commits.webkit.org/312814@main">https://commits.webkit.org/312814@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/56698eb1db1c11e6473df8e19629bb7437c998ef

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/161187 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/159/builds/34660 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/27761 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/170090 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/117558 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/163056 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/34761 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/156/builds/34661 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/170090 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/117558 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/164146 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/34761 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/144786 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/170090 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/34761 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/156/builds/34661 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk3-libwebrtc~~](https://ews-build.webkit.org/#/builders/173/builds/17810 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/20/builds/153243 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/34761 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/167/builds/22547 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/172573 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/22025 "Built successfully and passed tests") | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/19594 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/24188 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/172573 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/34334 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/156/builds/34661 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/172573 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/34319 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/144342 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/96184 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/24507 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/160/builds/34319 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/21160 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 jsc-armv7~~](https://ews-build.webkit.org/#/builders/35/builds/193586 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/33829 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/101254 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/35/builds/193586 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/33328 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/33572 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/33477 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->