### PR TITLE
TestWebKitAPI.WKWebsiteDataStore.FetchPersistentCredentials is flaky

### DIFF
--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKWebsiteDatastore.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKWebsiteDatastore.mm
@@ -50,15 +50,17 @@ static bool usePersistentCredentialStorage = false;
 
 @implementation NavigationTestDelegate {
     bool _hasFinishedNavigation;
+    bool _isFirstChallenge;
 }
 
 - (instancetype)init
 {
     if (!(self = [super init]))
         return nil;
-    
+
     _hasFinishedNavigation = false;
-    
+    _isFirstChallenge = true;
+
     return self;
 }
 
@@ -74,9 +76,8 @@ static bool usePersistentCredentialStorage = false;
 
 - (void)webView:(WKWebView *)webView didReceiveAuthenticationChallenge:(NSURLAuthenticationChallenge *)challenge completionHandler:(void (^)(NSURLSessionAuthChallengeDisposition, NSURLCredential *))completionHandler
 {
-    static bool firstChallenge = true;
-    if (firstChallenge) {
-        firstChallenge = false;
+    if (_isFirstChallenge) {
+        _isFirstChallenge = false;
         persistentCredential = adoptNS([[NSURLCredential alloc] initWithUser:@"username" password:@"password" persistence:(usePersistentCredentialStorage ? NSURLCredentialPersistencePermanent: NSURLCredentialPersistenceForSession)]);
         return completionHandler(NSURLSessionAuthChallengeUseCredential, persistentCredential.get());
     }
@@ -281,12 +282,7 @@ TEST(WKWebsiteDataStore, FetchNonPersistentCredentials)
     TestWebKitAPI::Util::run(&done);
 }
 
-// FIXME when webkit.org/b/309374 is resolved.
-#if PLATFORM(MAC) && !defined(NDEBUG)
-TEST(WKWebsiteDataStore, DISABLED_FetchPersistentCredentials)
-#else
 TEST(WKWebsiteDataStore, FetchPersistentCredentials)
-#endif
 {
     HTTPServer server(HTTPServer::respondWithChallengeThenOK);
 
@@ -302,6 +298,11 @@ TEST(WKWebsiteDataStore, FetchPersistentCredentials)
 
     [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:[NSString stringWithFormat:@"http://127.0.0.1:%d/", server.port()]]]];
     [navigationDelegate waitForDidFinishNavigation];
+
+    // Terminate the network process to clear any session-level credential copies that
+    // NSURLSession may have cached during authentication. The subsequent fetch will start
+    // a fresh network process that only sees the permanent credential in the keychain.
+    [websiteDataStore _terminateNetworkProcess];
 
     __block bool done = false;
     [websiteDataStore fetchDataRecordsOfTypes:[NSSet setWithObject:_WKWebsiteDataTypeCredentials] completionHandler:^(NSArray<WKWebsiteDataRecord *> *dataRecords) {


### PR DESCRIPTION
#### dfdfcf49da912234a4cc023324bf52da4f967c43
<pre>
TestWebKitAPI.WKWebsiteDataStore.FetchPersistentCredentials is flaky
<a href="https://bugs.webkit.org/show_bug.cgi?id=309374">https://bugs.webkit.org/show_bug.cgi?id=309374</a>
<a href="https://rdar.apple.com/171928551">rdar://171928551</a>

Reviewed by Sihui Liu.

The test&apos;s NavigationTestDelegate used a `static bool firstChallenge` shared across all
tests. When FetchPersistentCredentials ran after FetchNonPersistentCredentials, the static
was already false so no credential was provided and the test trivially passed. When it ran
first or in isolation, firstChallenge was true, a permanent credential was stored, and
NSURLSession&apos;s session-level copy appeared in fetchDataRecordsOfTypes (count=1 instead of 0).

Fix by making firstChallenge a per-instance variable so each test gets its own fresh state,
and terminating the network process after navigation to clear any session-level credential
copies before the fetch.

* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKWebsiteDatastore.mm:
(-[NavigationTestDelegate init]):
(-[NavigationTestDelegate webView:didReceiveAuthenticationChallenge:completionHandler:]):
(TestWebKitAPI::(WKWebsiteDataStore, FetchPersistentCredentials)):
(TestWebKitAPI::(WKWebsiteDataStore, DISABLED_FetchPersistentCredentials)(WKWebsiteDataStore, FetchPersistentCredentials)): Deleted.

Canonical link: <a href="https://commits.webkit.org/312850@main">https://commits.webkit.org/312850@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/896f3fc3e7fa8fb8ceb9a530743850008bb8355e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/160974 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/34447 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/27548 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/169877 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/117234 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/0f34c53b-cd7c-4bd9-ae7f-d13f23d14084) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/162843 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/34548 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/34447 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/124869 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/88108 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/bb6d0ac9-c483-42c7-9fc4-06c43dbe840d) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/163933 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/27130 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/144603 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/105466 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/365c2459-bfc3-45b2-bd97-ab419b32df2f) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/26180 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/24681 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/17597 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/135874 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/22365 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/172360 "Built successfully") | | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/24006 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/133145 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/34121 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/28774 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/133155 "Found 1 new API test failure: TestWebKit:WebKit.ResizeWindowAfterCrash (failure)") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/34105 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/144160 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/95944 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/24520 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/27717 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/20978 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/33616 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/33115 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/33359 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/33264 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->