### PR TITLE
Dynamically inserting `<img>` elements with `src` attribute is slow

### DIFF
--- a/PerformanceTests/Bindings/insert-img-with-src.html
+++ b/PerformanceTests/Bindings/insert-img-with-src.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html>
+<body>
+<div id="container" style="display:none"></div>
+<script src="../resources/runner.js"></script>
+<script>
+const COUNT = 1000;
+const container = document.getElementById("container");
+
+const urls = new Array(COUNT);
+for (let i = 0; i < COUNT; ++i) {
+    const a = (Math.random() * 0xffffffff >>> 0).toString(16).padStart(8, "0");
+    const b = (Math.random() * 0xffffffff >>> 0).toString(16).padStart(8, "0");
+    urls[i] = "https://example.com/" + a + b + "-" + i + ".jpg";
+}
+
+PerfTestRunner.measureTime({
+    description: "Time to insert " + COUNT + " <img> elements with unique src URLs into the DOM.",
+    setup: function () {
+        container.replaceChildren();
+    },
+    run: function () {
+        for (let i = 0; i < COUNT; ++i) {
+            const img = document.createElement("img");
+            img.src = urls[i];
+            container.appendChild(img);
+        }
+    }
+});
+</script>
+</body>
+</html>

--- a/Source/WebCore/contentextensions/ContentExtension.cpp
+++ b/Source/WebCore/contentextensions/ContentExtension.cpp
@@ -47,6 +47,7 @@ ContentExtension::ContentExtension(const String& identifier, Ref<CompiledContent
     : m_identifier(identifier)
     , m_compiledExtension(WTF::move(compiledExtension))
     , m_extensionBaseURL(WTF::move(extensionBaseURL))
+    , m_urlFiltersInterpreter(m_compiledExtension->urlFiltersBytecode(), DFABytecodeInterpreter::EnableResumeCache::Yes)
 {
     DFABytecodeInterpreter interpreter(m_compiledExtension->urlFiltersBytecode());
     m_universalActions = copyToVector(interpreter.actionsMatchingEverything());
@@ -54,6 +55,11 @@ ContentExtension::ContentExtension(const String& identifier, Ref<CompiledContent
     if (shouldCompileCSS == ShouldCompileCSS::Yes)
         compileGlobalDisplayNoneStyleSheet();
     m_universalActions.shrinkToFit();
+}
+
+DFABytecodeInterpreter::Actions ContentExtension::interpretURLFilters(const String& url, ResourceFlags flags) const
+{
+    return m_urlFiltersInterpreter.interpret(url, flags);
 }
 
 uint32_t ContentExtension::findFirstIgnoreRule() const

--- a/Source/WebCore/contentextensions/ContentExtension.h
+++ b/Source/WebCore/contentextensions/ContentExtension.h
@@ -51,6 +51,7 @@ public:
     const DFABytecodeInterpreter::Actions& topURLActions(const URL& topURL) const;
     const DFABytecodeInterpreter::Actions& frameURLActions(const URL& frameURL) const;
     const Vector<uint64_t>& universalActions() const LIFETIME_BOUND { return m_universalActions; }
+    DFABytecodeInterpreter::Actions interpretURLFilters(const String& url, ResourceFlags) const;
 
 private:
     ContentExtension(const String& identifier, Ref<CompiledContentExtension>&&, URL&&, ShouldCompileCSS);
@@ -72,6 +73,7 @@ private:
     mutable DFABytecodeInterpreter::Actions m_cachedFrameURLActions;
 
     Vector<uint64_t> m_universalActions;
+    mutable DFABytecodeInterpreter m_urlFiltersInterpreter;
 };
 
 } // namespace ContentExtensions

--- a/Source/WebCore/contentextensions/ContentExtensionsBackend.cpp
+++ b/Source/WebCore/contentextensions/ContentExtensionsBackend.cpp
@@ -111,8 +111,7 @@ auto ContentExtensionsBackend::actionsFromContentRuleList(const ContentExtension
 
     const auto& compiledExtension = contentExtension.compiledExtension();
 
-    DFABytecodeInterpreter interpreter(compiledExtension.urlFiltersBytecode());
-    auto actionLocations = interpreter.interpret(urlString, flags);
+    auto actionLocations = contentExtension.interpretURLFilters(urlString, flags);
     auto& topURLActions = contentExtension.topURLActions(resourceLoadInfo.mainDocumentURL);
     auto& frameURLActions = contentExtension.frameURLActions(resourceLoadInfo.frameURL);
 

--- a/Source/WebCore/contentextensions/DFABytecodeInterpreter.cpp
+++ b/Source/WebCore/contentextensions/DFABytecodeInterpreter.cpp
@@ -28,11 +28,14 @@
 
 #include "ContentExtensionsDebugging.h"
 #include <wtf/StdLibExtras.h>
+#include <wtf/TZoneMallocInlines.h>
 #include <wtf/text/CString.h>
 
 #if ENABLE(CONTENT_EXTENSIONS)
 
 namespace WebCore::ContentExtensions {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(DFABytecodeInterpreter);
 
 template <typename IntType>
 static IntType NODELETE getBits(std::span<const uint8_t> bytecode, uint32_t index)
@@ -246,6 +249,13 @@ auto DFABytecodeInterpreter::actionsMatchingEverything() -> Actions
     return actions;
 }
 
+DFABytecodeInterpreter::DFABytecodeInterpreter(std::span<const uint8_t> bytecode, EnableResumeCache enableCache)
+    : m_bytecode(bytecode)
+{
+    if (enableCache == EnableResumeCache::Yes)
+        m_resumeCache = makeUnique<ResumeSlots>();
+}
+
 auto DFABytecodeInterpreter::interpret(const String& urlString, ResourceFlags flags) -> Actions
 {
     CString urlCString;
@@ -258,9 +268,45 @@ auto DFABytecodeInterpreter::interpret(const String& urlString, ResourceFlags fl
         url = byteCast<Latin1Character>(urlCString.span());
     }
     ASSERT(url.data());
-    
+
+    uint32_t checkpointURLIndex = 0;
+    auto urlView = StringView(urlString);
+    if (auto schemeEnd = urlView.find("://"_s); schemeEnd != notFound) {
+        if (auto slash = urlView.find('/', schemeEnd + 3); slash != notFound && slash < std::numeric_limits<uint32_t>::max())
+            checkpointURLIndex = static_cast<uint32_t>(slash);
+    }
+
+    bool canResume = false;
+    if (checkpointURLIndex && m_resumeCache) {
+        auto& cache = *m_resumeCache;
+        if (cache.isEmpty())
+            cache.grow(4);
+        auto urlPrefix = urlView.left(checkpointURLIndex + 1);
+        for (size_t i = 0; i < cache.size(); ++i) {
+            auto& slot = cache[i];
+            if (slot.flags == flags && !slot.perDFA.isEmpty() && StringView(slot.url).startsWith(urlPrefix)) {
+                if (i)
+                    std::swap(cache[0], slot);
+                canResume = true;
+                break;
+            }
+        }
+        if (!canResume) {
+            for (size_t i = cache.size() - 1; i > 0; --i)
+                cache[i] = WTF::move(cache[i - 1]);
+            cache[0] = { urlString, flags, { } };
+        }
+    }
+
     Actions actions;
-    
+    size_t dfaIndex = 0;
+    Actions dfaDelta;
+
+    auto recordCheckpoint = [&](uint32_t pc) {
+        if (m_resumeCache && checkpointURLIndex && !canResume)
+            (*m_resumeCache)[0].perDFA.append({ pc, dfaDelta });
+    };
+
     uint32_t programCounter = 0;
     while (programCounter < m_bytecode.size()) {
 
@@ -269,30 +315,49 @@ auto DFABytecodeInterpreter::interpret(const String& urlString, ResourceFlags fl
         uint32_t dfaBytecodeLength = getBits<uint32_t>(m_bytecode, programCounter);
         programCounter += sizeof(uint32_t);
 
-        // Skip the actions without flags on the DFA root. These are accessed via actionsMatchingEverything.
-        if (!dfaStart) {
+        uint32_t urlIndex = 0;
+        bool snapshottedThisDFA = false;
+        dfaDelta.clear();
+
+        if (canResume && dfaIndex < (*m_resumeCache)[0].perDFA.size()) {
+            const auto& checkpoint = (*m_resumeCache)[0].perDFA[dfaIndex];
+            actions.addAll(checkpoint.actions);
+            if (checkpoint.programCounter == DFACheckpoint::terminatedBeforeCheckpoint)
+                goto nextDFA;
+            programCounter = checkpoint.programCounter;
+            urlIndex = checkpointURLIndex;
+            snapshottedThisDFA = true;
+        } else if (!dfaStart) {
+            // Skip the actions without flags on the DFA root. These are accessed via actionsMatchingEverything.
             while (programCounter < dfaBytecodeLength) {
                 DFABytecodeInstruction instruction = getInstruction(m_bytecode, programCounter);
                 if (instruction == DFABytecodeInstruction::AppendAction) {
                     auto instructionLocation = programCounter++;
                     consumeAction(m_bytecode, programCounter, instructionLocation);
                 } else if (instruction == DFABytecodeInstruction::TestFlagsAndAppendAction)
-                    interpretTestFlagsAndAppendAction(programCounter, flags, actions);
+                    interpretTestFlagsAndAppendAction(programCounter, flags, dfaDelta);
                 else
                     break;
             }
-            if (programCounter >= m_bytecode.size())
-                return actions;
+            if (programCounter >= m_bytecode.size()) {
+                recordCheckpoint(DFACheckpoint::terminatedBeforeCheckpoint);
+                actions.addAll(dfaDelta);
+                break;
+            }
         } else {
             ASSERT_WITH_MESSAGE(getInstruction(m_bytecode, programCounter) != DFABytecodeInstruction::AppendAction
                 && getInstruction(m_bytecode, programCounter) != DFABytecodeInstruction::TestFlagsAndAppendAction,
                 "Triggers that match everything should only be in the first DFA.");
         }
-        
+
         // Interpret the bytecode from this DFA.
         // This should always terminate if interpreting correctly compiled bytecode.
-        uint32_t urlIndex = 0;
         while (true) {
+            if (!snapshottedThisDFA && checkpointURLIndex && urlIndex >= checkpointURLIndex) {
+                recordCheckpoint(programCounter);
+                snapshottedThisDFA = true;
+            }
+
             ASSERT(programCounter <= m_bytecode.size());
             switch (getInstruction(m_bytecode, programCounter)) {
 
@@ -388,11 +453,11 @@ auto DFABytecodeInterpreter::interpret(const String& urlString, ResourceFlags fl
             }
                     
             case DFABytecodeInstruction::AppendAction:
-                interpretAppendAction(programCounter, actions);
+                interpretAppendAction(programCounter, dfaDelta);
                 break;
-                    
+
             case DFABytecodeInstruction::TestFlagsAndAppendAction:
-                interpretTestFlagsAndAppendAction(programCounter, flags, actions);
+                interpretTestFlagsAndAppendAction(programCounter, flags, dfaDelta);
                 break;
                     
             default:
@@ -403,9 +468,14 @@ auto DFABytecodeInterpreter::interpret(const String& urlString, ResourceFlags fl
         }
         RELEASE_ASSERT_NOT_REACHED(); // The while loop can only be exited using goto nextDFA.
         nextDFA:
+        if (!snapshottedThisDFA)
+            recordCheckpoint(DFACheckpoint::terminatedBeforeCheckpoint);
+        actions.addAll(dfaDelta);
+        ++dfaIndex;
         ASSERT(dfaBytecodeLength);
         programCounter = dfaStart + dfaBytecodeLength;
     }
+
     return actions;
 }
 

--- a/Source/WebCore/contentextensions/DFABytecodeInterpreter.h
+++ b/Source/WebCore/contentextensions/DFABytecodeInterpreter.h
@@ -36,11 +36,24 @@
 namespace WebCore::ContentExtensions {
 
 class DFABytecodeInterpreter {
+    WTF_MAKE_TZONE_ALLOCATED_EXPORT(DFABytecodeInterpreter, WEBCORE_EXPORT);
 public:
-    DFABytecodeInterpreter(std::span<const uint8_t> bytecode)
-        : m_bytecode(bytecode) { }
+    enum class EnableResumeCache : bool { No, Yes };
+    WEBCORE_EXPORT DFABytecodeInterpreter(std::span<const uint8_t> bytecode, EnableResumeCache = EnableResumeCache::No);
 
     using Actions = HashSet<uint64_t, DefaultHash<uint64_t>, WTF::UnsignedWithZeroKeyHashTraits<uint64_t>>;
+
+    struct DFACheckpoint {
+        static constexpr uint32_t terminatedBeforeCheckpoint = std::numeric_limits<uint32_t>::max();
+        uint32_t programCounter { 0 };
+        Actions actions;
+    };
+    struct ResumeSlot {
+        String url;
+        ResourceFlags flags { 0 };
+        Vector<DFACheckpoint> perDFA;
+    };
+    using ResumeSlots = Vector<ResumeSlot, 4>;
 
     WEBCORE_EXPORT Actions interpret(const String&, ResourceFlags);
     WEBCORE_EXPORT Actions actionsMatchingEverything();
@@ -53,6 +66,7 @@ private:
     void NODELETE interpretJumpTable(std::span<const Latin1Character> url, uint32_t& urlIndex, uint32_t& programCounter);
 
     const std::span<const uint8_t> m_bytecode;
+    std::unique_ptr<ResumeSlots> m_resumeCache;
 };
 
 } // namespace WebCore::ContentExtensions

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ContentRuleListNotification.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ContentRuleListNotification.mm
@@ -656,3 +656,47 @@ TEST(ContentRuleList, RedirectBeforeBlock)
     [webView loadRequest:server.request("/to-be-blocked"_s)];
     EXPECT_WK_STREQ([webView _test_waitForAlert], "Redirected!");
 }
+
+TEST(ContentRuleList, InterpretURLFilterCacheDoesNotConfuseSameStartDomains)
+{
+    NSString *ruleSource = @"[{\"action\":{\"type\":\"block\"},\"trigger\":{\"url-filter\":\"^apitest://example\\\\.com/\"}}]";
+    NSString *attackerURL = @"apitest://example.com.evil.com/test.html";
+    NSString *legitURL = @"apitest://example.com/test.html";
+    static unsigned counter = 0;
+
+    auto makeWebView = [&]() -> RetainPtr<WKWebView> {
+        NSString *identifier = [NSString stringWithFormat:@"sameStartDomains-%u", counter++];
+        RetainPtr delegate = adoptNS([[ContentRuleListNotificationDelegate alloc] init]);
+        RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+        [[configuration userContentController] addContentRuleList:makeContentRuleList(ruleSource, identifier).get()];
+        [configuration setURLSchemeHandler:delegate.get() forURLScheme:@"apitest"];
+        RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSZeroRect configuration:configuration.get()]);
+        [webView setNavigationDelegate:delegate.get()];
+        [webView setUIDelegate:delegate.get()];
+        return webView;
+    };
+
+    auto fetchIsBlocked = [](WKWebView *webView, NSString *urlString) -> bool {
+        notificationList.clear();
+        receivedAlert = false;
+        NSString *html = [NSString stringWithFormat:@"<script>fetch('%@',{mode:'no-cors'}).then(()=>alert('l')).catch(()=>alert('b'))</script>", urlString];
+        [webView loadHTMLString:html baseURL:[NSURL URLWithString:@"apitest:///"]];
+        TestWebKitAPI::Util::run(&receivedAlert);
+        for (const Notification& notification : notificationList) {
+            if (notification.url == String(urlString) && notification.blockedLoad)
+                return true;
+        }
+        return false;
+    };
+
+    auto checkSequence = [&](NSArray<NSString *> *urls) {
+        RetainPtr cached = makeWebView();
+        for (NSString *url in urls) {
+            RetainPtr fresh = makeWebView();
+            EXPECT_EQ(fetchIsBlocked(fresh.get(), url), fetchIsBlocked(cached.get(), url));
+        }
+    };
+
+    checkSequence(@[attackerURL, legitURL, attackerURL, legitURL]);
+    checkSequence(@[legitURL, attackerURL, legitURL, attackerURL]);
+}


### PR DESCRIPTION
#### 42a531abe63602f463a4b02b82c7b4386284d61f
<pre>
Dynamically inserting `&lt;img&gt;` elements with `src` attribute is slow
<a href="https://bugs.webkit.org/show_bug.cgi?id=314251">https://bugs.webkit.org/show_bug.cgi?id=314251</a>
<a href="https://rdar.apple.com/166201075">rdar://166201075</a>

Reviewed by Chris Dumez.

Dynamically inserting &lt;img&gt; elements with src was exceedingly slow due to
DFABytecodeInterpreter, which re-walks the full URL from byte 0 on every
call.

Since DFA state at byte N is a function of url[0..N], we checkpoint
each DFA&apos;s program counter and accumulated actions at the first &apos;/&apos; after
&apos;://&apos; in a 4-slot LRU on ContentExtension. Subsequent same-origin URLs resume
from the checkpoint instead of re-walking the prefix.

The included performance test progresses from a mean of 84 ms to 4 ms when
testing locally. An APITest is included to ensure that we do not regress
behavior when dealing with domains with the same starting characters.

* PerformanceTests/Bindings/insert-img-with-src.html: Added.
* Source/WebCore/contentextensions/ContentExtension.cpp:
(WebCore::ContentExtensions::ContentExtension::ContentExtension):
(WebCore::ContentExtensions::ContentExtension::interpretURLFilters const):
* Source/WebCore/contentextensions/ContentExtension.h:
* Source/WebCore/contentextensions/ContentExtensionsBackend.cpp:
(WebCore::ContentExtensions::ContentExtensionsBackend::actionsFromContentRuleList const):
* Source/WebCore/contentextensions/DFABytecodeInterpreter.cpp:
(WebCore::ContentExtensions::DFABytecodeInterpreter::DFABytecodeInterpreter):
(WebCore::ContentExtensions::DFABytecodeInterpreter::interpret):
* Source/WebCore/contentextensions/DFABytecodeInterpreter.h:
(WebCore::ContentExtensions::DFABytecodeInterpreter::DFABytecodeInterpreter): Deleted.
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ContentRuleListNotification.mm:
(TEST(ContentRuleList, InterpretURLFilterCacheDoesNotConfuseSameStartDomains)):

Canonical link: <a href="https://commits.webkit.org/313268@main">https://commits.webkit.org/313268@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c1baad696fbe9e1b10a11fd776c2067d47288806

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/162439 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/35915 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/29031 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/171377 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/118884 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/164308 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/36019 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/35917 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/126056 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/88819 "2 flakes 18 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/165398 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/28405 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/145924 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/106634 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/27451 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/25974 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/19077 "Built successfully") | 
| [⏳ 🛠 🧪 jsc ](https://ews-build.webkit.org/#/builders/JSC-Tests-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/137154 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/23655 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/173881 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/21194 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/25299 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/134363 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/35589 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/30064 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/134363 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36294 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/35573 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/145451 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/97828 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/28894 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/22283 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/35082 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/102834 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/34584 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/34829 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/34732 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->