### PR TITLE
[Site Isolation] Web Inspector: Introduce a CSS agent for the frame target

### DIFF
--- a/LayoutTests/http/tests/site-isolation/inspector/css/css-stylesheet-commands-frame-target-expected.txt
+++ b/LayoutTests/http/tests/site-isolation/inspector/css/css-stylesheet-commands-frame-target-expected.txt
@@ -1,0 +1,9 @@
+Test that CSS stylesheet commands work correctly on frame targets under site isolation.
+
+
+
+== Running test suite: SiteIsolation.CSS.StyleSheetCommands.FrameTarget
+-- Running test case: SiteIsolation.CSS.StyleSheetCommands.FrameTarget.Setup
+PASS: Should find a child frame target.
+PASS: Child frame target should have a CSSAgent.
+

--- a/LayoutTests/http/tests/site-isolation/inspector/css/css-stylesheet-commands-frame-target.html
+++ b/LayoutTests/http/tests/site-isolation/inspector/css/css-stylesheet-commands-frame-target.html
@@ -1,0 +1,30 @@
+<script src="../../../inspector/resources/inspector-test.js"></script>
+<script src="../debugger/resources/site-isolation-debugger-test-utilities.js"></script>
+<script>
+    function test() {
+        let suite = InspectorTest.createAsyncSuite("SiteIsolation.CSS.StyleSheetCommands.FrameTarget");
+
+        let childFrameTarget;
+        let stylesheetId;
+
+        suite.addTestCase({
+            name: "SiteIsolation.CSS.StyleSheetCommands.FrameTarget.Setup",
+            description: "Find the child frame target.",
+            async test() {
+                let frameTargets = WI.targets.filter((t) => t.type === WI.TargetType.Frame);
+                let urlTargetMap = await fetchDocumentURLsForTargets(frameTargets);
+                let mainFrameTarget = urlTargetMap.get(WI.networkManager.mainFrame.url);
+                childFrameTarget = frameTargets.find((t) => t !== mainFrameTarget);
+                InspectorTest.expectNotNull(childFrameTarget, "Should find a child frame target.");
+                InspectorTest.expectNotNull(childFrameTarget.CSSAgent, "Child frame target should have a CSSAgent.");
+            }
+        });
+
+        suite.runTestCasesAndFinish();
+    }
+</script>
+
+<body onload="runTest()">
+    <p>Test that CSS stylesheet commands work correctly on frame targets under site isolation.</p>
+    <iframe src="http://localhost:8000/site-isolation/inspector/css/resources/frame-with-stylesheet.html"></iframe>
+</body>

--- a/LayoutTests/http/tests/site-isolation/inspector/css/resources/frame-with-stylesheet.html
+++ b/LayoutTests/http/tests/site-isolation/inspector/css/resources/frame-with-stylesheet.html
@@ -1,0 +1,11 @@
+<style>
+    .test-class {
+        color: red;
+        font-size: 16px;
+    }
+
+    p {
+        margin: 10px;
+    }
+</style>
+<p class="test-class">Cross-origin frame with stylesheet.</p>

--- a/Source/JavaScriptCore/inspector/protocol/CSS.json
+++ b/Source/JavaScriptCore/inspector/protocol/CSS.json
@@ -2,7 +2,7 @@
     "domain": "CSS",
     "description": "This domain exposes CSS read/write operations. All CSS objects, like stylesheets, rules, and styles, have an associated <code>id</code> used in subsequent operations on the related object. Each object type has a specific <code>id</code> structure, and those are not interchangeable between objects of different kinds. CSS objects can be loaded using the <code>get*ForNode()</code> calls (which accept a DOM node id). Alternatively, a client can discover all the existing stylesheets with the <code>getAllStyleSheets()</code> method and subsequently load the required stylesheet contents using the <code>getStyleSheet[Text]()</code> methods.",
     "debuggableTypes": ["itml", "web-page"],
-    "targetTypes": ["itml", "page"],
+    "targetTypes": ["itml", "frame", "page"],
     "types": [
         {
             "id": "StyleSheetId",

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -1956,6 +1956,7 @@ inspector/agents/InspectorWorkerAgent.cpp
 inspector/agents/WebConsoleAgent.cpp
 inspector/agents/WebDebuggerAgent.cpp
 inspector/agents/WebHeapAgent.cpp
+inspector/agents/frame/FrameCSSAgent.cpp
 inspector/agents/frame/FrameConsoleAgent.cpp
 inspector/agents/frame/FrameDOMAgent.cpp
 inspector/agents/frame/FrameDOMAgentStubs.cpp

--- a/Source/WebCore/inspector/FrameInspectorController.cpp
+++ b/Source/WebCore/inspector/FrameInspectorController.cpp
@@ -32,6 +32,7 @@
 
 #include "CommonVM.h"
 #include "DocumentPage.h"
+#include "FrameCSSAgent.h"
 #include "FrameConsoleAgent.h"
 #include "FrameDOMAgent.h"
 #include "FrameDebugger.h"
@@ -151,6 +152,7 @@ void FrameInspectorController::createLazyAgents()
     m_agents.append(makeUniqueRef<FrameDebuggerAgent>(context));
     m_agents.append(makeUniqueRef<FrameDOMAgent>(context));
     m_agents.append(makeUniqueRef<FrameRuntimeAgent>(context));
+    m_agents.append(makeUniqueRef<FrameCSSAgent>(context));
     m_agents.append(makeUniqueRef<FrameWorkerAgent>(context));
 }
 

--- a/Source/WebCore/inspector/InstrumentingAgents.h
+++ b/Source/WebCore/inspector/InstrumentingAgents.h
@@ -59,6 +59,7 @@ class InspectorNetworkAgent;
 class InspectorPageAgent;
 class InspectorTimelineAgent;
 class InspectorWorkerAgent;
+class FrameCSSAgent;
 class FrameDOMAgent;
 class FrameDebuggerAgent;
 class FrameRuntimeAgent;
@@ -78,6 +79,7 @@ class WebHeapAgent;
 #define DEFINE_INSPECTOR_AGENT_Canvas(macro, Getter, Setter) DEFINE_INSPECTOR_AGENT(macro, InspectorCanvasAgent, CanvasAgent, Getter, Setter)
 #define DEFINE_INSPECTOR_AGENT_Canvas_Page(macro, Getter, Setter) DEFINE_INSPECTOR_AGENT(macro, PageCanvasAgent, PageCanvasAgent, Getter, Setter)
 #define DEFINE_INSPECTOR_AGENT_CSS(macro, Getter, Setter) DEFINE_INSPECTOR_AGENT(macro, InspectorCSSAgent, CSSAgent, Getter, Setter)
+#define DEFINE_INSPECTOR_AGENT_CSS_Frame(macro, Getter, Setter) DEFINE_INSPECTOR_AGENT(macro, FrameCSSAgent, FrameCSSAgent, Getter, Setter)
 #define DEFINE_INSPECTOR_AGENT_DOM(macro, Getter, Setter) DEFINE_INSPECTOR_AGENT(macro, InspectorDOMAgent, DOMAgent, Getter, Setter)
 #define DEFINE_INSPECTOR_AGENT_DOMDebugger(macro, Getter, Setter) DEFINE_INSPECTOR_AGENT(macro, InspectorDOMDebuggerAgent, DOMDebuggerAgent, Getter, Setter)
 #define DEFINE_INSPECTOR_AGENT_DOMDebugger_Page(macro, Getter, Setter) DEFINE_INSPECTOR_AGENT(macro, PageDOMDebuggerAgent, PageDOMDebuggerAgent, Getter, Setter)
@@ -133,6 +135,7 @@ class WebHeapAgent;
     DEFINE_ENABLED_INSPECTOR_AGENT(macro, Canvas) \
     DEFINE_ENABLED_INSPECTOR_AGENT(macro, Canvas_Page) \
     DEFINE_ENABLED_INSPECTOR_AGENT(macro, CSS) \
+    DEFINE_ENABLED_INSPECTOR_AGENT(macro, CSS_Frame) \
     DEFINE_ENABLED_INSPECTOR_AGENT(macro, Debugger_Frame) \
     DEFINE_ENABLED_INSPECTOR_AGENT(macro, Debugger_Page) \
     DEFINE_ENABLED_INSPECTOR_AGENT(macro, Debugger_Web) \

--- a/Source/WebCore/inspector/agents/frame/FrameCSSAgent.cpp
+++ b/Source/WebCore/inspector/agents/frame/FrameCSSAgent.cpp
@@ -1,0 +1,177 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "FrameCSSAgent.h"
+
+#include "InstrumentingAgents.h"
+#include "LocalFrame.h"
+#include <JavaScriptCore/InspectorFrontendDispatchers.h>
+#include <wtf/TZoneMallocInlines.h>
+
+namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(FrameCSSAgent);
+
+FrameCSSAgent::FrameCSSAgent(FrameAgentContext& context)
+    : InspectorAgentBase("CSS"_s, context)
+    , m_frontendDispatcher(makeUniqueRef<Inspector::CSSFrontendDispatcher>(context.frontendRouter))
+    , m_backendDispatcher(Inspector::CSSBackendDispatcher::create(Ref { context.backendDispatcher }, this))
+    , m_inspectedFrame(context.inspectedFrame)
+{
+}
+
+FrameCSSAgent::~FrameCSSAgent() = default;
+
+void FrameCSSAgent::didCreateFrontendAndBackend()
+{
+}
+
+void FrameCSSAgent::willDestroyFrontendAndBackend(Inspector::DisconnectReason)
+{
+    disable();
+}
+
+Inspector::CommandResult<void> FrameCSSAgent::enable()
+{
+    Ref agents = m_instrumentingAgents.get();
+    if (agents->enabledFrameCSSAgent() == this)
+        return { };
+
+    agents->setEnabledFrameCSSAgent(this);
+
+    return { };
+}
+
+Inspector::CommandResult<void> FrameCSSAgent::disable()
+{
+    Ref { m_instrumentingAgents.get() }->setEnabledFrameCSSAgent(nullptr);
+
+    return { };
+}
+
+Inspector::CommandResult<Ref<JSON::ArrayOf<Inspector::Protocol::CSS::CSSComputedStyleProperty>>> FrameCSSAgent::getComputedStyleForNode(Inspector::Protocol::DOM::NodeId)
+{
+    // FIXME: <https://webkit.org/b/314424>: Implement nodeId-dependent CSS commands for frame targets.
+    return makeUnexpected("Not supported on frame targets"_s);
+}
+
+Inspector::CommandResult<Ref<Inspector::Protocol::CSS::Font>> FrameCSSAgent::getFontDataForNode(Inspector::Protocol::DOM::NodeId)
+{
+    // FIXME: <https://webkit.org/b/314424>: Implement nodeId-dependent CSS commands for frame targets.
+    return makeUnexpected("Not supported on frame targets"_s);
+}
+
+Inspector::CommandResultOf<RefPtr<Inspector::Protocol::CSS::CSSStyle>, RefPtr<Inspector::Protocol::CSS::CSSStyle>> FrameCSSAgent::getInlineStylesForNode(Inspector::Protocol::DOM::NodeId)
+{
+    // FIXME: <https://webkit.org/b/314424>: Implement nodeId-dependent CSS commands for frame targets.
+    return makeUnexpected("Not supported on frame targets"_s);
+}
+
+Inspector::CommandResultOf<RefPtr<JSON::ArrayOf<Inspector::Protocol::CSS::RuleMatch>>, RefPtr<JSON::ArrayOf<Inspector::Protocol::CSS::PseudoIdMatches>>, RefPtr<JSON::ArrayOf<Inspector::Protocol::CSS::InheritedStyleEntry>>> FrameCSSAgent::getMatchedStylesForNode(Inspector::Protocol::DOM::NodeId, std::optional<bool>&&, std::optional<bool>&&)
+{
+    // FIXME: <https://webkit.org/b/314424>: Implement nodeId-dependent CSS commands for frame targets.
+    return makeUnexpected("Not supported on frame targets"_s);
+}
+
+Inspector::CommandResult<Ref<JSON::ArrayOf<Inspector::Protocol::CSS::CSSStyleSheetHeader>>> FrameCSSAgent::getAllStyleSheets()
+{
+    // FIXME: <https://webkit.org/b/314147>: Implement per-frame CSS functions without DOM or node id support.
+    return makeUnexpected("Not supported on frame targets"_s);
+}
+
+Inspector::CommandResult<Ref<Inspector::Protocol::CSS::CSSStyleSheetBody>> FrameCSSAgent::getStyleSheet(const Inspector::Protocol::CSS::StyleSheetId&)
+{
+    // FIXME: <https://webkit.org/b/314147>: Implement per-frame CSS functions without DOM or node id support.
+    return makeUnexpected("Not supported on frame targets"_s);
+}
+
+Inspector::CommandResult<String> FrameCSSAgent::getStyleSheetText(const Inspector::Protocol::CSS::StyleSheetId&)
+{
+    // FIXME: <https://webkit.org/b/314147>: Implement per-frame CSS functions without DOM or node id support.
+    return makeUnexpected("Not supported on frame targets"_s);
+}
+
+Inspector::CommandResult<void> FrameCSSAgent::setStyleSheetText(const Inspector::Protocol::CSS::StyleSheetId&, const String&)
+{
+    // FIXME: <https://webkit.org/b/314147>: Implement per-frame CSS functions without DOM or node id support.
+    return makeUnexpected("Not supported on frame targets"_s);
+}
+
+Inspector::CommandResult<Ref<Inspector::Protocol::CSS::CSSStyle>> FrameCSSAgent::setStyleText(Ref<JSON::Object>&&, const String&)
+{
+    // FIXME: <https://webkit.org/b/316843>: Implement style/rule editing CSS commands for frame targets.
+    return makeUnexpected("Not supported on frame targets"_s);
+}
+
+Inspector::CommandResult<Ref<Inspector::Protocol::CSS::CSSRule>> FrameCSSAgent::setRuleSelector(Ref<JSON::Object>&&, const String&)
+{
+    // FIXME: <https://webkit.org/b/316843>: Implement style/rule editing CSS commands for frame targets.
+    return makeUnexpected("Not supported on frame targets"_s);
+}
+
+Inspector::CommandResult<Ref<Inspector::Protocol::CSS::Grouping>> FrameCSSAgent::setGroupingHeaderText(Ref<JSON::Object>&&, const String&)
+{
+    // FIXME: <https://webkit.org/b/316843>: Implement style/rule editing CSS commands for frame targets.
+    return makeUnexpected("Not supported on frame targets"_s);
+}
+
+Inspector::CommandResult<Inspector::Protocol::CSS::StyleSheetId> FrameCSSAgent::createStyleSheet(const Inspector::Protocol::Network::FrameId&)
+{
+    // FIXME: <https://webkit.org/b/314147>: Implement per-frame CSS functions without DOM or node id support.
+    return makeUnexpected("Not supported on frame targets"_s);
+}
+
+Inspector::CommandResult<Ref<Inspector::Protocol::CSS::CSSRule>> FrameCSSAgent::addRule(const Inspector::Protocol::CSS::StyleSheetId&, const String&)
+{
+    // FIXME: <https://webkit.org/b/316843>: Implement style/rule editing CSS commands for frame targets.
+    return makeUnexpected("Not supported on frame targets"_s);
+}
+
+Inspector::CommandResult<Ref<JSON::ArrayOf<Inspector::Protocol::CSS::CSSPropertyInfo>>> FrameCSSAgent::getSupportedCSSProperties()
+{
+    // FIXME: <https://webkit.org/b/314147>: Implement per-frame CSS functions without DOM or node id support.
+    return makeUnexpected("Not supported on frame targets"_s);
+}
+
+Inspector::CommandResult<Ref<JSON::ArrayOf<String>>> FrameCSSAgent::getSupportedSystemFontFamilyNames()
+{
+    // FIXME: <https://webkit.org/b/316844>: Consider how to deal with global CSS commands.
+    return makeUnexpected("Not supported on frame targets"_s);
+}
+
+Inspector::CommandResult<void> FrameCSSAgent::forcePseudoState(Inspector::Protocol::DOM::NodeId, Ref<JSON::Array>&&)
+{
+    // FIXME: <https://webkit.org/b/314424>: Implement nodeId-dependent CSS commands for frame targets.
+    return makeUnexpected("Not supported on frame targets"_s);
+}
+
+Inspector::CommandResult<void> FrameCSSAgent::setLayoutContextTypeChangedMode(Inspector::Protocol::CSS::LayoutContextTypeChangedMode)
+{
+    // FIXME: <https://webkit.org/b/316844>: Consider how to deal with global CSS commands.
+    return makeUnexpected("Not supported on frame targets"_s);
+}
+
+} // namespace WebCore

--- a/Source/WebCore/inspector/agents/frame/FrameCSSAgent.h
+++ b/Source/WebCore/inspector/agents/frame/FrameCSSAgent.h
@@ -1,0 +1,81 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "InspectorWebAgentBase.h"
+#include <JavaScriptCore/InspectorBackendDispatchers.h>
+#include <wtf/CheckedPtr.h>
+#include <wtf/TZoneMalloc.h>
+#include <wtf/WeakRef.h>
+
+namespace Inspector {
+class CSSFrontendDispatcher;
+}
+
+namespace WebCore {
+
+class LocalFrame;
+
+class FrameCSSAgent final : public InspectorAgentBase, public Inspector::CSSBackendDispatcherHandler, public CanMakeCheckedPtr<FrameCSSAgent> {
+    WTF_MAKE_NONCOPYABLE(FrameCSSAgent);
+    WTF_MAKE_TZONE_ALLOCATED(FrameCSSAgent);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(FrameCSSAgent);
+public:
+    FrameCSSAgent(FrameAgentContext&);
+    ~FrameCSSAgent();
+
+    // InspectorAgentBase
+    void didCreateFrontendAndBackend() override;
+    void willDestroyFrontendAndBackend(Inspector::DisconnectReason) override;
+
+    // CSSBackendDispatcherHandler
+    Inspector::CommandResult<void> enable() override;
+    Inspector::CommandResult<void> disable() override;
+    Inspector::CommandResult<Ref<JSON::ArrayOf<Inspector::Protocol::CSS::CSSComputedStyleProperty>>> getComputedStyleForNode(Inspector::Protocol::DOM::NodeId) override;
+    Inspector::CommandResult<Ref<Inspector::Protocol::CSS::Font>> getFontDataForNode(Inspector::Protocol::DOM::NodeId) override;
+    Inspector::CommandResultOf<RefPtr<Inspector::Protocol::CSS::CSSStyle>, RefPtr<Inspector::Protocol::CSS::CSSStyle>> getInlineStylesForNode(Inspector::Protocol::DOM::NodeId) override;
+    Inspector::CommandResultOf<RefPtr<JSON::ArrayOf<Inspector::Protocol::CSS::RuleMatch>>, RefPtr<JSON::ArrayOf<Inspector::Protocol::CSS::PseudoIdMatches>>, RefPtr<JSON::ArrayOf<Inspector::Protocol::CSS::InheritedStyleEntry>>> getMatchedStylesForNode(Inspector::Protocol::DOM::NodeId, std::optional<bool>&& includePseudo, std::optional<bool>&& includeInherited) override;
+    Inspector::CommandResult<Ref<JSON::ArrayOf<Inspector::Protocol::CSS::CSSStyleSheetHeader>>> getAllStyleSheets() override;
+    Inspector::CommandResult<Ref<Inspector::Protocol::CSS::CSSStyleSheetBody>> getStyleSheet(const Inspector::Protocol::CSS::StyleSheetId&) override;
+    Inspector::CommandResult<String> getStyleSheetText(const Inspector::Protocol::CSS::StyleSheetId&) override;
+    Inspector::CommandResult<void> setStyleSheetText(const Inspector::Protocol::CSS::StyleSheetId&, const String& text) override;
+    Inspector::CommandResult<Ref<Inspector::Protocol::CSS::CSSStyle>> setStyleText(Ref<JSON::Object>&& styleId, const String& text) override;
+    Inspector::CommandResult<Ref<Inspector::Protocol::CSS::CSSRule>> setRuleSelector(Ref<JSON::Object>&& ruleId, const String& selector) override;
+    Inspector::CommandResult<Ref<Inspector::Protocol::CSS::Grouping>> setGroupingHeaderText(Ref<JSON::Object>&& ruleId, const String& headerText) override;
+    Inspector::CommandResult<Inspector::Protocol::CSS::StyleSheetId> createStyleSheet(const Inspector::Protocol::Network::FrameId&) override;
+    Inspector::CommandResult<Ref<Inspector::Protocol::CSS::CSSRule>> addRule(const Inspector::Protocol::CSS::StyleSheetId&, const String& selector) override;
+    Inspector::CommandResult<Ref<JSON::ArrayOf<Inspector::Protocol::CSS::CSSPropertyInfo>>> getSupportedCSSProperties() override;
+    Inspector::CommandResult<Ref<JSON::ArrayOf<String>>> getSupportedSystemFontFamilyNames() override;
+    Inspector::CommandResult<void> forcePseudoState(Inspector::Protocol::DOM::NodeId, Ref<JSON::Array>&& forcedPseudoClasses) override;
+    Inspector::CommandResult<void> setLayoutContextTypeChangedMode(Inspector::Protocol::CSS::LayoutContextTypeChangedMode) override;
+
+private:
+    UniqueRef<Inspector::CSSFrontendDispatcher> m_frontendDispatcher;
+    Ref<Inspector::CSSBackendDispatcher> m_backendDispatcher;
+    WeakRef<LocalFrame> m_inspectedFrame;
+};
+
+} // namespace WebCore


### PR DESCRIPTION
#### 5ab92977c20e72bb7166a19c9d61b01a967d0507
<pre>
[Site Isolation] Web Inspector: Introduce a CSS agent for the frame target
<a href="https://bugs.webkit.org/show_bug.cgi?id=314144">https://bugs.webkit.org/show_bug.cgi?id=314144</a>

Reviewed by BJ Burg.

As the first step to supporting the CSS functionalities in Web Inspector
under site isolation, following the frame target paradigm and prior
completed domains like Console and Runtime, introduce a FrameCSSAgent.

The FrameCSSAgent does not inherit from InspectorCSSAgent. This is
because InspectorCSSAgent is dedicated to work with the page target,
unlike in the case of Console or Runtime where it&apos;s a super class for
page and workers&apos; agents. Rather than trying to make the target-specific
CSS agents have a similar inheritance relationship to those agents, make
a standalone agent for minimal changes needed and also for an easier
time later when we decide to deprecate the page&apos;s InspectorCSSAgent.

- Trying to inherit FrameCSSAgent from InspectorCSSAgent also ran into a
  design limitation in our agent registry. Filed <a href="https://webkit.org/b/314248">https://webkit.org/b/314248</a>

Test: http/tests/site-isolation/inspector/css/css-stylesheet-commands-frame-target.html

Add a simple test case to ensure the frame target can enable its new
CSS agent.

* LayoutTests/http/tests/site-isolation/inspector/css/css-stylesheet-commands-frame-target-expected.txt: Added.
* LayoutTests/http/tests/site-isolation/inspector/css/css-stylesheet-commands-frame-target.html: Added.
* LayoutTests/http/tests/site-isolation/inspector/css/resources/frame-with-stylesheet.html: Added.
* Source/JavaScriptCore/inspector/protocol/CSS.json:
* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/inspector/FrameInspectorController.cpp:
(WebCore::FrameInspectorController::createLazyAgents):
* Source/WebCore/inspector/InstrumentingAgents.h:
* Source/WebCore/inspector/agents/frame/FrameCSSAgent.cpp: Added.
(WebCore::FrameCSSAgent::FrameCSSAgent):
(WebCore::m_inspectedFrame):
(WebCore::FrameCSSAgent::didCreateFrontendAndBackend):
(WebCore::FrameCSSAgent::willDestroyFrontendAndBackend):
(WebCore::FrameCSSAgent::enable):
(WebCore::FrameCSSAgent::disable):
(WebCore::FrameCSSAgent::getComputedStyleForNode):
(WebCore::FrameCSSAgent::getFontDataForNode):
(WebCore::FrameCSSAgent::getInlineStylesForNode):
(WebCore::FrameCSSAgent::getMatchedStylesForNode):
(WebCore::FrameCSSAgent::getAllStyleSheets):
(WebCore::FrameCSSAgent::getStyleSheet):
(WebCore::FrameCSSAgent::getStyleSheetText):
(WebCore::FrameCSSAgent::setStyleSheetText):
(WebCore::FrameCSSAgent::setStyleText):
(WebCore::FrameCSSAgent::setRuleSelector):
(WebCore::FrameCSSAgent::setGroupingHeaderText):
(WebCore::FrameCSSAgent::createStyleSheet):
(WebCore::FrameCSSAgent::addRule):
(WebCore::FrameCSSAgent::getSupportedCSSProperties):
(WebCore::FrameCSSAgent::getSupportedSystemFontFamilyNames):
(WebCore::FrameCSSAgent::forcePseudoState):
(WebCore::FrameCSSAgent::setLayoutContextTypeChangedMode):
* Source/WebCore/inspector/agents/frame/FrameCSSAgent.h: Added.

Canonical link: <a href="https://commits.webkit.org/314966@main">https://commits.webkit.org/314966@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8ea1de1f793b253d1a810e01cdec36649818f40f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/167706 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/41203 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/34798 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/176763 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/125387 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/169572 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/41638 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/41216 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/130486 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/125387 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/170665 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/32919 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/150694 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/111003 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/31900 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/30596 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/25496 "Built successfully") | | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/20/builds/160228 "Build is in progress. Recent messages:") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/141887 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/28389 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/179303 "Built successfully") | | 
| [  ~~🛠 🧪 jsc-debug-arm64~~](https://ews-build.webkit.org/#/builders/171/builds/28952 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/32353 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/30107 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/138884 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/41275 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/34754 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/138769 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/41963 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/150181 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/105139 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/25536 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/34045 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/27060 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/200383 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/40467 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/113718 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/53833 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/39864 "Built successfully") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/185/builds/5163 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/40115 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/40009 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->