### PR TITLE
[YARR] ParentheticalAssertionEnd.bt should propagate the failures to ParentheticalAssertionBegin.bt

### DIFF
--- a/JSTests/stress/regexp-jit-fixedcount-multialt-assertion-end-fallthrough.js
+++ b/JSTests/stress/regexp-jit-fixedcount-multialt-assertion-end-fallthrough.js
@@ -1,0 +1,56 @@
+//@ runDefault
+
+// Regression test for a YarrJIT crash on patterns where a FixedCount multi-alt
+// parenthesis has an alternative whose content ends with a ParentheticalAssertion.
+//
+// The FixedCount multi-alt mechanism stores a "content backtrack" return address
+// per alternative. When the alternative that just matched completes, its return
+// address is patched to the next sibling alternative's content-backtrack entry
+// label, which is positioned immediately after the sibling's backtrack code.
+// That position then happens to be the first instruction emitted for the
+// assertion's inner disjunction backtrack (a dispatch via frame slot that holds
+// the inner alt's resume address).
+//
+// When the assertion "succeeded" on the forward path via the assertion-success
+// branch (an inverted lookahead whose inner disjunction failed), that frame
+// slot was never written, so dispatching via it jumped to garbage. Fix is to
+// emit an unconditional jump at ParentheticalAssertionEnd.bt so that any
+// control flow reaching that position is redirected past the assertion via
+// ParentheticalAssertionBegin.bt's End-jumps list.
+
+function shouldBe(actual, expected) {
+    if (JSON.stringify(actual) !== JSON.stringify(expected))
+        throw new Error("bad value: actual=" + JSON.stringify(actual) + " expected=" + JSON.stringify(expected));
+}
+
+for (var i = 0; i < 1e4; ++i) {
+    // Minimal reproducer: inverted lookahead with inner disjunction inside a
+    // FixedCount multi-alt paren. Pre-fix, the JIT would SIGSEGV/SIGBUS here.
+    shouldBe(/(^(?!(X|Y))c|Zc){2}/.exec("cccccc"), null);
+    shouldBe(/(^(?!(X|Y))c|Zc){3}/.exec("cccccc"), null);
+    shouldBe(/(^(?!(X|Y))c|(Z)c){3}/.exec("cccccc"), null);
+    shouldBe(/(^(?!d(X|Y))c|(Z)c){3}/.exec("cccccc"), null);
+    shouldBe(/(^(?!(XX|YY))c|Zc){2}/.exec("cccccc"), null);
+    shouldBe(/(^(?!(?:X|Y))c|Zc){2}/.exec("cccccc"), null);
+
+    // Valid matches must still succeed.
+    shouldBe(/(^(?!(X|Y))c|Zc){2}/.exec("ZcZc"), ["ZcZc", "Zc", null]);
+    shouldBe(/(^(?!(X|Y))c|Zc){2}/.exec("cZc"), ["cZc", "Zc", null]);
+
+    // Original crashing test input.
+    var r = new RegExp(unescape(
+        "%28%5E%28%3F%21%64%28%28%3D%28%28%7E%58%28%3F%3C%E2%3E%28%3F%3C%66%3E" +
+        "%29%28%28%28%28%2C%28%28%28%28%28%29%29%29%29%29%29%29%29%29%28%28%28" +
+        "%28%28%28%28%28%28%3E%28%28%28%28%29%29%29%28%28%29%28%29%29%29%29%29" +
+        "%29%29%29%29%29%29%29%29%29%29%29%7C%28%28%28%28%29%28%28%28%28%28%28" +
+        "%28%28%3F%3C%E2%3E%28%28%4D%29%29%29%29%29%29%29%29%29%28%28%28%28%28" +
+        "%28%29%29%29%29%29%29%28%28%28%28%3F%3C%66%3E%28%28%29%29%29%29%29%29" +
+        "%29%28%29%29%28%29%28%28%28%28%28%28%28%28%28%28%28%28%3F%3C%66%35%32" +
+        "%73%3E%28%28%28%29%29%29%28%29%28%28%28%28%29%29%29%29%29%28%28%29%28" +
+        "%29%29%29%29%29%29%29%29%A9%29%29%29%29%29%29%29%29%29%63%7C%28%3E%29" +
+        "%63%7C%28%3A%29%28%28%29%29%29%7B%33%7D%FF%FF%FF%FF%3C"), "dis");
+    "aabbbccc".match(r);
+    "aabbbccc".replace(r, "$1,$2");
+    r.exec("caffeeeee");
+    "cccccccc".match(r);
+}

--- a/Source/JavaScriptCore/yarr/YarrJIT.cpp
+++ b/Source/JavaScriptCore/yarr/YarrJIT.cpp
@@ -5241,6 +5241,10 @@ class YarrGenerator final : public YarrJITInfo {
                     m_backtrackingState.fallthrough();
                 }
                 m_backtrackingState.takeBacktracksToJumpList(op.m_jumps, &m_jit);
+                // Assertions are atomic to backtracking. Once assertion completes, we can do anything at backtracking: since assertion does not consume any characters,
+                // this does not change character position at this place, thus, once it completes, no backtracking exists to change the status to do the following matching again.
+                // Thus, we should just jump to corresponding ParentheticalAssertionBegin's backtracking state.
+                op.m_jumps.append(m_jit.jump());
                 break;
             }
 


### PR DESCRIPTION
#### 753fe26f5b01d2474fc482e1e98e33a9da26941f
<pre>
[YARR] ParentheticalAssertionEnd.bt should propagate the failures to ParentheticalAssertionBegin.bt
<a href="https://bugs.webkit.org/show_bug.cgi?id=314249">https://bugs.webkit.org/show_bug.cgi?id=314249</a>
<a href="https://rdar.apple.com/176255579">rdar://176255579</a>

Reviewed by Sosuke Suzuki.

The following code crashes.

    /(^(?!(X|Y))c|Zc){2}/.exec(&quot;cccccc&quot;)

The pattern is in this way.

    RegExp pattern for /(^(?!(X|Y))c|Zc){2}/:
        callframe size: 9
        alternative #0: minimum size: 0,once through,contains ^
          &lt;   &gt; captured inputPosition 0 subpattern #1 {2},frame location 0
            alternative list,frame location 4
            alternative #0: minimum size: 1,fixed size,starts with ^,contains ^
              &lt;   &gt; BOL
              &lt;   &gt; inputPosition 0 inverted assertion,frame location 5
                minimum size: 1, last alternative
                &lt;   &gt; captured inputPosition 1 subpattern #2,frame location 6
                  alternative list,frame location 8
                  alternative #0: minimum size: 1,fixed size
                    &lt;   &gt; character inputPosition 0 &apos;X&apos;
                  alternative #1: minimum size: 1,fixed size, last alternative
                    &lt;   &gt; character inputPosition 0 &apos;Y&apos;
              &lt;   &gt; character inputPosition 0 &apos;c&apos;
            alternative #1: minimum size: 2,fixed size, last alternative
              &lt;   &gt; character inputPosition 0 &apos;Z&apos;
              &lt;   &gt; character inputPosition 1 &apos;c&apos;
        alternative #1: minimum size: 0
          &lt;   &gt; captured inputPosition 0 subpattern #1 {2},frame location 0
            minimum size: 2,fixed size
            &lt;   &gt; character inputPosition 0 &apos;Z&apos;
            &lt;   &gt; character inputPosition 1 &apos;c&apos;

Problematic part is inverted-assertion `(?!(X|Y))`. When you failed to
match in the 2nd iteration of `(^(?!(X|Y))c|Zc){2}`, we do backtracking
to find a way to fit in the 1st iteration. And backtracking code in `(?!(X|Y))` is generated
in this way.

---- NestedAlternativeNext[0].m_contentBacktrackEntryLabel = HERE (P) ----
    ParentheticalAssertionEnd backtrack     ; (no code emitted for inverted/no-captures)
    SimpleNestedAlternativeEnd backtrack    ; (no code emitted)
    ParenthesesSubpatternOnceEnd backtrack  ; (no code emitted for FixedCount)
    NestedAlternativeEnd backtrack (inner disjunction):
        ldr x16, [fp - inner_returnAddressIndex]
        br  x16

But we have never write any continuation jump target inside `(X|Y)`
alternatives. The reason is this is negative-assertion: so `(X|Y)` is
just failing completely so there is no point to resume backtracking.

And that&apos;s right because assertion is *atomic*: it is not consuming any
characters and it is just look-ahead. This means that any backtracking
inside assertion does not change character position, thus it needs to
skip the backtracking completely. We enter ParentheticalAssertionEnd.bt
only when we once complete the assertion, and in this case, any change in
the ParentheticalAssertion have no effect since it does not consume any
characters, so the subsequent patterns will not see any state change.

Thus, we just immediately propagate the failure to the ParentheticalAssertionBegin.bt.

Test: JSTests/stress/regexp-jit-fixedcount-multialt-assertion-end-fallthrough.js

* JSTests/stress/regexp-jit-fixedcount-multialt-assertion-end-fallthrough.js: Added.
(shouldBe):
(i.shouldBe):
(i.shouldBe.X.Y.c):
(i.shouldBe.d.X.Y.c):
* Source/JavaScriptCore/yarr/YarrJIT.cpp:

Canonical link: <a href="https://commits.webkit.org/312767@main">https://commits.webkit.org/312767@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ad1f1235eacc1703c3bc6575b31ae911a23d4252

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/160987 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/34460 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/27561 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/169890 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/117247 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/34561 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/34460 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/124874 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/117247 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/163946 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/27138 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/144611 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/105471 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/26188 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/24688 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/17610 "Built successfully") | | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/20/builds/153043 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/135882 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/22373 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/172373 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/21825 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/19394 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/24014 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/133150 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/34134 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/28781 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/133160 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/34118 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/144168 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/95957 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/24488 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/27724 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/20986 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/193386 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/33629 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/101054 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/49797 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/33128 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/33372 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/33277 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->