### PR TITLE
[Site Isolation] Web Inspector: Implement per-frame CSS functions without DOM or node id support

### DIFF
--- a/LayoutTests/http/tests/site-isolation/inspector/css/css-stylesheet-commands-frame-target-expected.txt
+++ b/LayoutTests/http/tests/site-isolation/inspector/css/css-stylesheet-commands-frame-target-expected.txt
@@ -7,3 +7,38 @@ Test that CSS stylesheet commands work correctly on frame targets under site iso
 PASS: Should find a child frame target.
 PASS: Child frame target should have a CSSAgent.
 
+-- Running test case: SiteIsolation.CSS.StyleSheetCommands.FrameTarget.GetAllStyleSheets
+PASS: Should have at least one stylesheet.
+PASS: Stylesheet should have an id.
+
+-- Running test case: SiteIsolation.CSS.StyleSheetCommands.FrameTarget.GetStyleSheet
+PASS: Should get stylesheet body.
+PASS: Returned stylesheet id should match.
+
+-- Running test case: SiteIsolation.CSS.StyleSheetCommands.FrameTarget.GetStyleSheetText
+PASS: Stylesheet text should contain the .test-class rule.
+PASS: Stylesheet text should contain 'color: red'.
+
+-- Running test case: SiteIsolation.CSS.StyleSheetCommands.FrameTarget.SetStyleSheetText
+PASS: Stylesheet text should be updated.
+
+-- Running test case: SiteIsolation.CSS.StyleSheetCommands.FrameTarget.CreateStyleSheet
+PASS: Should get a new stylesheet id.
+PASS: New stylesheet id should differ from the existing one.
+
+-- Running test case: SiteIsolation.CSS.StyleSheetCommands.FrameTarget.GetSupportedCSSProperties
+PASS: Should return at least one CSS property.
+PASS: Should include the 'display' property.
+PASS: Should include the 'color' property.
+PASS: 'color' should be marked as inherited.
+
+-- Running test case: SiteIsolation.CSS.StyleSheetCommands.FrameTarget.StyleSheetChangedEvent
+PASS: styleSheetChanged event should fire with the correct stylesheet id.
+
+-- Running test case: SiteIsolation.CSS.StyleSheetCommands.FrameTarget.StyleSheetAddedEvent
+PASS: styleSheetAdded event should fire.
+PASS: Added stylesheet should have an id.
+
+-- Running test case: SiteIsolation.CSS.StyleSheetCommands.FrameTarget.StyleSheetRemovedEvent
+PASS: styleSheetRemoved event should fire with the removed stylesheet id.
+

--- a/LayoutTests/http/tests/site-isolation/inspector/css/css-stylesheet-commands-frame-target.html
+++ b/LayoutTests/http/tests/site-isolation/inspector/css/css-stylesheet-commands-frame-target.html
@@ -20,6 +20,150 @@
             }
         });
 
+        suite.addTestCase({
+            name: "SiteIsolation.CSS.StyleSheetCommands.FrameTarget.GetAllStyleSheets",
+            description: "getAllStyleSheets should return the child frame's stylesheets.",
+            async test() {
+                let { headers } = await childFrameTarget.CSSAgent.getAllStyleSheets();
+                InspectorTest.expectGreaterThanOrEqual(headers.length, 1, "Should have at least one stylesheet.");
+                stylesheetId = headers[0].styleSheetId;
+                InspectorTest.expectNotNull(stylesheetId, "Stylesheet should have an id.");
+            }
+        });
+
+        suite.addTestCase({
+            name: "SiteIsolation.CSS.StyleSheetCommands.FrameTarget.GetStyleSheet",
+            description: "getStyleSheet should return stylesheet details.",
+            async test() {
+                let { styleSheet } = await childFrameTarget.CSSAgent.getStyleSheet(stylesheetId);
+                InspectorTest.expectNotNull(styleSheet, "Should get stylesheet body.");
+                InspectorTest.expectEqual(styleSheet.styleSheetId, stylesheetId, "Returned stylesheet id should match.");
+            }
+        });
+
+        suite.addTestCase({
+            name: "SiteIsolation.CSS.StyleSheetCommands.FrameTarget.GetStyleSheetText",
+            description: "getStyleSheetText should return the stylesheet source text.",
+            async test() {
+                let { text } = await childFrameTarget.CSSAgent.getStyleSheetText(stylesheetId);
+                InspectorTest.expectThat(text.includes(".test-class"), "Stylesheet text should contain the .test-class rule.");
+                InspectorTest.expectThat(text.includes("color: red"), "Stylesheet text should contain 'color: red'.");
+            }
+        });
+
+        suite.addTestCase({
+            name: "SiteIsolation.CSS.StyleSheetCommands.FrameTarget.SetStyleSheetText",
+            description: "setStyleSheetText should update the stylesheet source text.",
+            async test() {
+                let newText = ".test-class { color: blue; }";
+                await childFrameTarget.CSSAgent.setStyleSheetText(stylesheetId, newText);
+
+                let { text } = await childFrameTarget.CSSAgent.getStyleSheetText(stylesheetId);
+                InspectorTest.expectEqual(text, newText, "Stylesheet text should be updated.");
+            }
+        });
+
+        suite.addTestCase({
+            name: "SiteIsolation.CSS.StyleSheetCommands.FrameTarget.CreateStyleSheet",
+            description: "createStyleSheet should create an inspector stylesheet for the frame.",
+            async test() {
+                let { styleSheetId: newId } = await childFrameTarget.CSSAgent.createStyleSheet("");
+                InspectorTest.expectNotNull(newId, "Should get a new stylesheet id.");
+                InspectorTest.expectNotEqual(newId, stylesheetId, "New stylesheet id should differ from the existing one.");
+            }
+        });
+
+        suite.addTestCase({
+            name: "SiteIsolation.CSS.StyleSheetCommands.FrameTarget.GetSupportedCSSProperties",
+            description: "getSupportedCSSProperties should return CSS property metadata.",
+            async test() {
+                let { cssProperties } = await childFrameTarget.CSSAgent.getSupportedCSSProperties();
+                InspectorTest.expectGreaterThan(cssProperties.length, 0, "Should return at least one CSS property.");
+
+                let displayProperty = cssProperties.find((p) => p.name === "display");
+                InspectorTest.expectNotNull(displayProperty, "Should include the 'display' property.");
+
+                let colorProperty = cssProperties.find((p) => p.name === "color");
+                InspectorTest.expectNotNull(colorProperty, "Should include the 'color' property.");
+                InspectorTest.expectThat(colorProperty.inherited, "'color' should be marked as inherited.");
+            }
+        });
+
+        suite.addTestCase({
+            name: "SiteIsolation.CSS.StyleSheetCommands.FrameTarget.StyleSheetChangedEvent",
+            description: "styleSheetChanged event should fire after setStyleSheetText.",
+            async test() {
+                let eventPromise = new Promise((resolve) => {
+                    let original = WI.CSSObserver.prototype.styleSheetChanged;
+                    WI.CSSObserver.prototype.styleSheetChanged = function(id) {
+                        if (this._target === childFrameTarget) {
+                            WI.CSSObserver.prototype.styleSheetChanged = original;
+                            resolve(id);
+                            return;
+                        }
+                        original.call(this, id);
+                    };
+                });
+
+                await childFrameTarget.CSSAgent.setStyleSheetText(stylesheetId, ".test-class { color: green; }");
+                let changedId = await eventPromise;
+                InspectorTest.expectEqual(changedId, stylesheetId, "styleSheetChanged event should fire with the correct stylesheet id.");
+            }
+        });
+
+        suite.addTestCase({
+            name: "SiteIsolation.CSS.StyleSheetCommands.FrameTarget.StyleSheetAddedEvent",
+            description: "styleSheetAdded event should fire when a new stylesheet is added to the frame.",
+            async test() {
+                let eventPromise = new Promise((resolve) => {
+                    let original = WI.CSSObserver.prototype.styleSheetAdded;
+                    WI.CSSObserver.prototype.styleSheetAdded = function(info) {
+                        if (this._target === childFrameTarget) {
+                            WI.CSSObserver.prototype.styleSheetAdded = original;
+                            resolve(info);
+                            return;
+                        }
+                        original.call(this, info);
+                    };
+                });
+
+                await childFrameTarget.RuntimeAgent.evaluate.invoke({
+                    expression: `let s = document.createElement("style"); s.id = "dynamic-style"; s.textContent = ".dynamic { font-size: 20px; }"; document.head.appendChild(s);`,
+                    objectGroup: "test",
+                });
+
+                let addedInfo = await eventPromise;
+                InspectorTest.expectNotNull(addedInfo, "styleSheetAdded event should fire.");
+                InspectorTest.expectNotNull(addedInfo.styleSheetId, "Added stylesheet should have an id.");
+            }
+        });
+
+        suite.addTestCase({
+            name: "SiteIsolation.CSS.StyleSheetCommands.FrameTarget.StyleSheetRemovedEvent",
+            description: "styleSheetRemoved event should fire when a stylesheet is removed from the frame.",
+            async test() {
+                let eventPromise = new Promise((resolve) => {
+                    let original = WI.CSSObserver.prototype.styleSheetRemoved;
+                    WI.CSSObserver.prototype.styleSheetRemoved = function(id) {
+                        if (this._target === childFrameTarget) {
+                            WI.CSSObserver.prototype.styleSheetRemoved = original;
+                            resolve(id);
+                            return;
+                        }
+                        original.call(this, id);
+                    };
+                });
+
+                await childFrameTarget.RuntimeAgent.evaluate.invoke({
+                    expression: `document.getElementById("dynamic-style").remove();`,
+                    objectGroup: "test",
+                });
+
+                let removedId = await eventPromise;
+                InspectorTest.expectNotNull(removedId, "styleSheetRemoved event should fire with the removed stylesheet id.");
+            }
+        });
+
         suite.runTestCasesAndFinish();
     }
 </script>

--- a/Source/JavaScriptCore/inspector/protocol/CSS.json
+++ b/Source/JavaScriptCore/inspector/protocol/CSS.json
@@ -437,9 +437,9 @@
         {
             "name": "createStyleSheet",
             "description": "Creates a new special \"inspector\" stylesheet in the frame with given <code>frameId</code>.",
-            "targetTypes": ["page"],
+            "targetTypes": ["frame", "page"],
             "parameters": [
-                { "name": "frameId", "$ref": "Network.FrameId", "description": "Identifier of the frame where the new \"inspector\" stylesheet should be created." }
+                { "name": "frameId", "$ref": "Network.FrameId", "description": "Identifier of the frame where the new \"inspector\" stylesheet should be created. Ignored when dispatched to a FrameTarget; the receiving frame is used implicitly." }
             ],
             "returns": [
                 { "name": "styleSheetId", "$ref": "StyleSheetId", "description": "Identifier of the created \"inspector\" stylesheet." }
@@ -505,7 +505,7 @@
         {
             "name": "styleSheetAdded",
             "description": "Fired whenever an active document stylesheet is added.",
-            "targetTypes": ["page"],
+            "targetTypes": ["frame", "page"],
             "parameters": [
                 { "name": "header", "$ref": "CSSStyleSheetHeader", "description": "Added stylesheet metainfo." }
             ]
@@ -513,7 +513,7 @@
         {
             "name": "styleSheetRemoved",
             "description": "Fired whenever an active document stylesheet is removed.",
-            "targetTypes": ["page"],
+            "targetTypes": ["frame", "page"],
             "parameters": [
                 { "name": "styleSheetId", "$ref": "StyleSheetId", "description": "Identifier of the removed stylesheet." }
             ]

--- a/Source/WebCore/inspector/InspectorInstrumentation.cpp
+++ b/Source/WebCore/inspector/InspectorInstrumentation.cpp
@@ -39,6 +39,8 @@
 #include "Document.h"
 #include "DocumentLoader.h"
 #include "Event.h"
+#include "EventTargetInlines.h"
+#include "FrameCSSAgent.h"
 #include "FrameDOMAgent.h"
 #include "FrameDebuggerAgent.h"
 #include "FrameInspectorController.h"
@@ -279,6 +281,11 @@ void InspectorInstrumentation::documentDetachedImpl(InstrumentingAgents& instrum
 {
     if (CheckedPtr cssAgent = instrumentingAgents.enabledCSSAgent())
         cssAgent->documentDetached(document);
+
+    if (RefPtr frame = document.frame()) {
+        if (CheckedPtr frameCSSAgent = frame->inspectorController().instrumentingAgents().enabledFrameCSSAgent())
+            frameCSSAgent->documentDetached(document);
+    }
 }
 
 void InspectorInstrumentation::frameWindowDiscardedImpl(InstrumentingAgents& instrumentingAgents, LocalDOMWindow* window)
@@ -293,16 +300,26 @@ void InspectorInstrumentation::frameWindowDiscardedImpl(InstrumentingAgents& ins
         consoleAgent->frameWindowDiscarded(*window);
 }
 
-void InspectorInstrumentation::mediaQueryResultChangedImpl(InstrumentingAgents& instrumentingAgents)
+void InspectorInstrumentation::mediaQueryResultChangedImpl(InstrumentingAgents& instrumentingAgents, Document& document)
 {
     if (CheckedPtr cssAgent = instrumentingAgents.enabledCSSAgent())
         cssAgent->mediaQueryResultChanged();
+
+    if (RefPtr frame = document.frame()) {
+        if (CheckedPtr frameCSSAgent = frame->inspectorController().instrumentingAgents().enabledFrameCSSAgent())
+            frameCSSAgent->mediaQueryResultChanged();
+    }
 }
 
 void InspectorInstrumentation::activeStyleSheetsUpdatedImpl(InstrumentingAgents& instrumentingAgents, Document& document)
 {
     if (CheckedPtr cssAgent = instrumentingAgents.enabledCSSAgent())
         cssAgent->activeStyleSheetsUpdated(document);
+
+    if (RefPtr frame = document.frame()) {
+        if (CheckedPtr frameCSSAgent = frame->inspectorController().instrumentingAgents().enabledFrameCSSAgent())
+            frameCSSAgent->activeStyleSheetsUpdated(document);
+    }
 }
 
 void InspectorInstrumentation::didPushShadowRootImpl(InstrumentingAgents& instrumentingAgents, Element& host, ShadowRoot& root)

--- a/Source/WebCore/inspector/InspectorInstrumentation.h
+++ b/Source/WebCore/inspector/InspectorInstrumentation.h
@@ -375,7 +375,7 @@ private:
     static void didInvalidateStyleAttrImpl(InstrumentingAgents&, Element&);
     static void documentDetachedImpl(InstrumentingAgents&, Document&);
     static void frameWindowDiscardedImpl(InstrumentingAgents&, LocalDOMWindow*);
-    static void mediaQueryResultChangedImpl(InstrumentingAgents&);
+    static void mediaQueryResultChangedImpl(InstrumentingAgents&, Document&);
     static void activeStyleSheetsUpdatedImpl(InstrumentingAgents&, Document&);
     static void didPushShadowRootImpl(InstrumentingAgents&, Element& host, ShadowRoot&);
     static void willPopShadowRootImpl(InstrumentingAgents&, Element& host, ShadowRoot&);
@@ -690,7 +690,7 @@ inline void InspectorInstrumentation::mediaQueryResultChanged(Document& document
 {
     FAST_RETURN_IF_NO_FRONTENDS(void());
     if (RefPtr agents = instrumentingAgents(document))
-        mediaQueryResultChangedImpl(*agents);
+        mediaQueryResultChangedImpl(*agents, document);
 }
 
 inline void InspectorInstrumentation::activeStyleSheetsUpdated(Document& document)

--- a/Source/WebCore/inspector/agents/frame/FrameCSSAgent.cpp
+++ b/Source/WebCore/inspector/agents/frame/FrameCSSAgent.cpp
@@ -26,9 +26,31 @@
 #include "config.h"
 #include "FrameCSSAgent.h"
 
+#include "CSSImportRule.h"
+#include "CSSParserContext.h"
+#include "CSSProperty.h"
+#include "CSSPropertyNames.h"
+#include "CSSPropertyParserState.h"
+#include "CSSPropertyParsing.h"
+#include "CSSStyleSheet.h"
+#include "CSSValueKeywords.h"
+#include "CommonAtomStrings.h"
+#include "ContentSecurityPolicy.h"
+#include "Document.h"
+#include "HTMLHeadElement.h"
+#include "HTMLStyleElement.h"
+#include "InspectorDOMAgent.h"
+#include "InspectorIdentifierRegistry.h"
 #include "InstrumentingAgents.h"
 #include "LocalFrame.h"
+#include "Page.h"
+#include "PageInspectorController.h"
+#include "StyleDocumentScope.h"
+#include "StylePropertyShorthand.h"
+#include "StyleScope.h"
+#include "StyleSheetContents.h"
 #include <JavaScriptCore/InspectorFrontendDispatchers.h>
+#include <JavaScriptCore/InspectorProtocolObjects.h>
 #include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
@@ -62,12 +84,17 @@ Inspector::CommandResult<void> FrameCSSAgent::enable()
 
     agents->setEnabledFrameCSSAgent(this);
 
+    if (RefPtr document = m_inspectedFrame->document())
+        activeStyleSheetsUpdated(*document);
+
     return { };
 }
 
 Inspector::CommandResult<void> FrameCSSAgent::disable()
 {
     Ref { m_instrumentingAgents.get() }->setEnabledFrameCSSAgent(nullptr);
+
+    reset();
 
     return { };
 }
@@ -98,26 +125,69 @@ Inspector::CommandResultOf<RefPtr<JSON::ArrayOf<Inspector::Protocol::CSS::RuleMa
 
 Inspector::CommandResult<Ref<JSON::ArrayOf<Inspector::Protocol::CSS::CSSStyleSheetHeader>>> FrameCSSAgent::getAllStyleSheets()
 {
-    // FIXME: <https://webkit.org/b/314147>: Implement per-frame CSS functions without DOM or node id support.
-    return makeUnexpected("Not supported on frame targets"_s);
+    auto headers = JSON::ArrayOf<Inspector::Protocol::CSS::CSSStyleSheetHeader>::create();
+
+    RefPtr document = m_inspectedFrame->document();
+    if (!document)
+        return headers;
+
+    Vector<CSSStyleSheet*> cssStyleSheets;
+    collectAllDocumentStyleSheets(*document, cssStyleSheets);
+
+    for (RefPtr cssStyleSheet : cssStyleSheets) {
+        Ref inspectorStyleSheet = bindStyleSheet(cssStyleSheet.get());
+        if (auto header = inspectorStyleSheet->buildObjectForStyleSheetInfo())
+            headers->addItem(header.releaseNonNull());
+    }
+
+    return headers;
 }
 
-Inspector::CommandResult<Ref<Inspector::Protocol::CSS::CSSStyleSheetBody>> FrameCSSAgent::getStyleSheet(const Inspector::Protocol::CSS::StyleSheetId&)
+Inspector::CommandResult<Ref<Inspector::Protocol::CSS::CSSStyleSheetBody>> FrameCSSAgent::getStyleSheet(const Inspector::Protocol::CSS::StyleSheetId& styleSheetId)
 {
-    // FIXME: <https://webkit.org/b/314147>: Implement per-frame CSS functions without DOM or node id support.
-    return makeUnexpected("Not supported on frame targets"_s);
+    Inspector::Protocol::ErrorString errorString;
+
+    RefPtr inspectorStyleSheet = assertStyleSheetForId(errorString, styleSheetId);
+    if (!inspectorStyleSheet)
+        return makeUnexpected(errorString);
+
+    auto styleSheet = inspectorStyleSheet->buildObjectForStyleSheet();
+    if (!styleSheet)
+        return makeUnexpected("Internal error: missing style sheet"_s);
+
+    return styleSheet.releaseNonNull();
 }
 
-Inspector::CommandResult<String> FrameCSSAgent::getStyleSheetText(const Inspector::Protocol::CSS::StyleSheetId&)
+Inspector::CommandResult<String> FrameCSSAgent::getStyleSheetText(const Inspector::Protocol::CSS::StyleSheetId& styleSheetId)
 {
-    // FIXME: <https://webkit.org/b/314147>: Implement per-frame CSS functions without DOM or node id support.
-    return makeUnexpected("Not supported on frame targets"_s);
+    Inspector::Protocol::ErrorString errorString;
+
+    RefPtr inspectorStyleSheet = assertStyleSheetForId(errorString, styleSheetId);
+    if (!inspectorStyleSheet)
+        return makeUnexpected(errorString);
+
+    auto text = inspectorStyleSheet->text();
+    if (text.hasException())
+        return makeUnexpected(InspectorDOMAgent::toErrorString(text.releaseException()));
+
+    return text.releaseReturnValue();
 }
 
-Inspector::CommandResult<void> FrameCSSAgent::setStyleSheetText(const Inspector::Protocol::CSS::StyleSheetId&, const String&)
+Inspector::CommandResult<void> FrameCSSAgent::setStyleSheetText(const Inspector::Protocol::CSS::StyleSheetId& styleSheetId, const String& text)
 {
-    // FIXME: <https://webkit.org/b/314147>: Implement per-frame CSS functions without DOM or node id support.
-    return makeUnexpected("Not supported on frame targets"_s);
+    Inspector::Protocol::ErrorString errorString;
+
+    RefPtr inspectorStyleSheet = assertStyleSheetForId(errorString, styleSheetId);
+    if (!inspectorStyleSheet)
+        return makeUnexpected(errorString);
+
+    // FIXME <https://webkit.org/b/314244>: Integrate with InspectorHistory for undo/redo support.
+    auto result = inspectorStyleSheet->setText(text);
+    if (result.hasException())
+        return makeUnexpected(InspectorDOMAgent::toErrorString(result.releaseException()));
+
+    inspectorStyleSheet->reparseStyleSheet(text);
+    return { };
 }
 
 Inspector::CommandResult<Ref<Inspector::Protocol::CSS::CSSStyle>> FrameCSSAgent::setStyleText(Ref<JSON::Object>&&, const String&)
@@ -140,8 +210,15 @@ Inspector::CommandResult<Ref<Inspector::Protocol::CSS::Grouping>> FrameCSSAgent:
 
 Inspector::CommandResult<Inspector::Protocol::CSS::StyleSheetId> FrameCSSAgent::createStyleSheet(const Inspector::Protocol::Network::FrameId&)
 {
-    // FIXME: <https://webkit.org/b/314147>: Implement per-frame CSS functions without DOM or node id support.
-    return makeUnexpected("Not supported on frame targets"_s);
+    RefPtr document = m_inspectedFrame->document();
+    if (!document)
+        return makeUnexpected("No document for frame"_s);
+
+    RefPtr inspectorStyleSheet = createInspectorStyleSheetForDocument(*document);
+    if (!inspectorStyleSheet)
+        return makeUnexpected("Could not create stylesheet for document"_s);
+
+    return inspectorStyleSheet->id();
 }
 
 Inspector::CommandResult<Ref<Inspector::Protocol::CSS::CSSRule>> FrameCSSAgent::addRule(const Inspector::Protocol::CSS::StyleSheetId&, const String&)
@@ -152,8 +229,73 @@ Inspector::CommandResult<Ref<Inspector::Protocol::CSS::CSSRule>> FrameCSSAgent::
 
 Inspector::CommandResult<Ref<JSON::ArrayOf<Inspector::Protocol::CSS::CSSPropertyInfo>>> FrameCSSAgent::getSupportedCSSProperties()
 {
-    // FIXME: <https://webkit.org/b/314147>: Implement per-frame CSS functions without DOM or node id support.
-    return makeUnexpected("Not supported on frame targets"_s);
+    RefPtr page = m_inspectedFrame->page();
+    if (!page)
+        return makeUnexpected("No page for frame"_s);
+
+    auto cssProperties = JSON::ArrayOf<Inspector::Protocol::CSS::CSSPropertyInfo>::create();
+
+    auto& settings = page->settings();
+    auto parserContext = CSSParserContext { settings };
+
+    for (auto propertyID : allCSSProperties()) {
+        if (!isExposed(propertyID, &settings))
+            continue;
+
+        auto property = Inspector::Protocol::CSS::CSSPropertyInfo::create()
+            .setName(nameString(propertyID))
+            .release();
+
+        auto aliases = CSSProperty::aliasesForProperty(propertyID);
+        if (!aliases.isEmpty()) {
+            auto aliasesArray = JSON::ArrayOf<String>::create();
+            for (auto& alias : aliases)
+                aliasesArray->addItem(alias);
+            property->setAliases(WTF::move(aliasesArray));
+        }
+
+        auto shorthand = shorthandForProperty(propertyID);
+        if (shorthand.length()) {
+            auto longhands = JSON::ArrayOf<String>::create();
+            for (auto longhand : shorthand) {
+                if (isExposed(longhand, &settings))
+                    longhands->addItem(nameString(longhand));
+            }
+            if (longhands->length())
+                property->setLonghands(WTF::move(longhands));
+        }
+
+        if (CSSPropertyParsing::isKeywordFastPathEligibleStyleProperty(propertyID)) {
+            auto propertyParserState = CSS::PropertyParserState {
+                .context = parserContext,
+            };
+            auto values = JSON::ArrayOf<String>::create();
+            for (auto valueID : allCSSValueKeywords()) {
+                if (CSSPropertyParsing::isKeywordValidForStyleProperty(propertyID, valueID, propertyParserState))
+                    values->addItem(nameString(valueID));
+            }
+            if (values->length())
+                property->setValues(WTF::move(values));
+        } else {
+            auto validKeywords = CSSProperty::validKeywordsForProperty(propertyID);
+            if (!validKeywords.empty()) {
+                auto values = JSON::ArrayOf<String>::create();
+                for (auto valueID : validKeywords) {
+                    if (CSSProperty::isKeywordValidForPropertyValues(propertyID, valueID, parserContext))
+                        values->addItem(nameString(valueID));
+                }
+                if (values->length())
+                    property->setValues(WTF::move(values));
+            }
+        }
+
+        if (CSSProperty::isInheritedProperty(propertyID))
+            property->setInherited(true);
+
+        cssProperties->addItem(WTF::move(property));
+    }
+
+    return cssProperties;
 }
 
 Inspector::CommandResult<Ref<JSON::ArrayOf<String>>> FrameCSSAgent::getSupportedSystemFontFamilyNames()
@@ -172,6 +314,182 @@ Inspector::CommandResult<void> FrameCSSAgent::setLayoutContextTypeChangedMode(In
 {
     // FIXME: <https://webkit.org/b/316844>: Consider how to deal with global CSS commands.
     return makeUnexpected("Not supported on frame targets"_s);
+}
+
+void FrameCSSAgent::styleSheetChanged(InspectorStyleSheet* inspectorStyleSheet)
+{
+    if (!inspectorStyleSheet)
+        return;
+
+    m_frontendDispatcher->styleSheetChanged(inspectorStyleSheet->id());
+}
+
+void FrameCSSAgent::documentDetached(Document& document)
+{
+    Vector<CSSStyleSheet*> emptyList;
+    setActiveStyleSheetsForDocument(document, emptyList);
+    m_documentToKnownCSSStyleSheets.remove(&document);
+}
+
+void FrameCSSAgent::mediaQueryResultChanged()
+{
+    m_frontendDispatcher->mediaQueryResultChanged();
+}
+
+void FrameCSSAgent::activeStyleSheetsUpdated(Document& document)
+{
+    Vector<CSSStyleSheet*> cssStyleSheets;
+    collectAllDocumentStyleSheets(document, cssStyleSheets);
+    setActiveStyleSheetsForDocument(document, cssStyleSheets);
+}
+
+void FrameCSSAgent::reset()
+{
+    m_idToInspectorStyleSheet.clear();
+    m_cssStyleSheetToInspectorStyleSheet.clear();
+    m_documentToInspectorStyleSheet.clear();
+    m_documentToKnownCSSStyleSheets.clear();
+}
+
+InspectorStyleSheet& FrameCSSAgent::bindStyleSheet(CSSStyleSheet* styleSheet)
+{
+    auto it = m_cssStyleSheetToInspectorStyleSheet.find(styleSheet);
+    if (it != m_cssStyleSheetToInspectorStyleSheet.end())
+        return it->value;
+
+    auto id = String::number(m_lastStyleSheetId++);
+    RefPtr document = styleSheet->ownerDocument();
+    Ref inspectorStyleSheet = InspectorStyleSheet::create(protect(m_inspectedFrame->page()->inspectorController().identifierRegistry()), id, styleSheet, detectOrigin(styleSheet, document.get()), InspectorDOMAgent::documentURLString(document.get()), this);
+    m_idToInspectorStyleSheet.set(id, inspectorStyleSheet);
+    if (m_creatingViaInspectorStyleSheet && document)
+        m_documentToInspectorStyleSheet.add(document.releaseNonNull(), Vector<Ref<InspectorStyleSheet>>()).iterator->value.append(inspectorStyleSheet);
+    return m_cssStyleSheetToInspectorStyleSheet.set(styleSheet, WTF::move(inspectorStyleSheet)).iterator->value;
+}
+
+InspectorStyleSheet* FrameCSSAgent::assertStyleSheetForId(Inspector::Protocol::ErrorString& errorString, const String& styleSheetId)
+{
+    auto it = m_idToInspectorStyleSheet.find(styleSheetId);
+    if (it == m_idToInspectorStyleSheet.end()) {
+        errorString = "Missing style sheet for given styleSheetId"_s;
+        return nullptr;
+    }
+    return it->value.ptr();
+}
+
+void FrameCSSAgent::collectAllDocumentStyleSheets(Document& document, Vector<CSSStyleSheet*>& result)
+{
+    auto cssStyleSheets = document.styleScope().activeStyleSheetsForInspector();
+    for (auto& cssStyleSheet : cssStyleSheets)
+        collectStyleSheets(cssStyleSheet.ptr(), result);
+}
+
+void FrameCSSAgent::collectStyleSheets(CSSStyleSheet* styleSheet, Vector<CSSStyleSheet*>& result)
+{
+    result.append(styleSheet);
+
+    for (unsigned i = 0, size = styleSheet->length(); i < size; ++i) {
+        if (RefPtr rule = dynamicDowncast<CSSImportRule>(styleSheet->item(i))) {
+            if (RefPtr importedStyleSheet = rule->styleSheet())
+                collectStyleSheets(importedStyleSheet.get(), result);
+        }
+    }
+}
+
+void FrameCSSAgent::setActiveStyleSheetsForDocument(Document& document, Vector<CSSStyleSheet*>& activeStyleSheets)
+{
+    HashSet<CSSStyleSheet*>& previouslyKnownActiveStyleSheets = m_documentToKnownCSSStyleSheets.add(&document, HashSet<CSSStyleSheet*>()).iterator->value;
+
+    HashSet<CSSStyleSheet*> removedStyleSheets(previouslyKnownActiveStyleSheets);
+    Vector<CSSStyleSheet*> addedStyleSheets;
+    for (auto& activeStyleSheet : activeStyleSheets) {
+        if (removedStyleSheets.contains(activeStyleSheet))
+            removedStyleSheets.remove(activeStyleSheet);
+        else
+            addedStyleSheets.append(activeStyleSheet);
+    }
+
+    for (RefPtr cssStyleSheet : removedStyleSheets) {
+        previouslyKnownActiveStyleSheets.remove(cssStyleSheet.get());
+        RefPtr<InspectorStyleSheet> inspectorStyleSheet = m_cssStyleSheetToInspectorStyleSheet.get(cssStyleSheet.get());
+        if (inspectorStyleSheet && m_idToInspectorStyleSheet.contains(inspectorStyleSheet->id())) {
+            auto id = inspectorStyleSheet->id();
+            m_idToInspectorStyleSheet.remove(id);
+            m_cssStyleSheetToInspectorStyleSheet.remove(cssStyleSheet.get());
+            m_frontendDispatcher->styleSheetRemoved(id);
+        }
+    }
+
+    for (RefPtr cssStyleSheet : addedStyleSheets) {
+        previouslyKnownActiveStyleSheets.add(cssStyleSheet.get());
+        if (!m_cssStyleSheetToInspectorStyleSheet.contains(cssStyleSheet.get())) {
+            Ref inspectorStyleSheet = bindStyleSheet(cssStyleSheet.get());
+            if (auto header = inspectorStyleSheet->buildObjectForStyleSheetInfo())
+                m_frontendDispatcher->styleSheetAdded(header.releaseNonNull());
+        }
+    }
+}
+
+InspectorStyleSheet* FrameCSSAgent::createInspectorStyleSheetForDocument(Document& document)
+{
+    if (!document.isHTMLDocument() && !document.isSVGDocument())
+        return nullptr;
+
+    auto styleElement = HTMLStyleElement::create(document);
+    styleElement->setAttributeWithoutSynchronization(HTMLNames::typeAttr, cssContentTypeAtom());
+
+    ContainerNode* targetNode;
+    if (auto* head = document.head())
+        targetNode = head;
+    else if (auto* body = document.bodyOrFrameset())
+        targetNode = body;
+    else
+        return nullptr;
+
+    m_creatingViaInspectorStyleSheet = true;
+    document.contentSecurityPolicy()->setOverrideAllowInlineStyle(true);
+    auto appendResult = targetNode->appendChild(styleElement);
+    document.styleScope().flushPendingUpdate();
+    document.contentSecurityPolicy()->setOverrideAllowInlineStyle(false);
+    m_creatingViaInspectorStyleSheet = false;
+    if (appendResult.hasException())
+        return nullptr;
+
+    auto iterator = m_documentToInspectorStyleSheet.find(document);
+    ASSERT(iterator != m_documentToInspectorStyleSheet.end());
+    if (iterator == m_documentToInspectorStyleSheet.end())
+        return nullptr;
+
+    auto& inspectorStyleSheetsForDocument = iterator->value;
+    ASSERT(!inspectorStyleSheetsForDocument.isEmpty());
+    if (inspectorStyleSheetsForDocument.isEmpty())
+        return nullptr;
+
+    return inspectorStyleSheetsForDocument.last().ptr();
+}
+
+Inspector::Protocol::CSS::StyleSheetOrigin FrameCSSAgent::detectOrigin(CSSStyleSheet* pageStyleSheet, Document* ownerDocument)
+{
+    if (m_creatingViaInspectorStyleSheet)
+        return Inspector::Protocol::CSS::StyleSheetOrigin::Inspector;
+
+    if (pageStyleSheet && !pageStyleSheet->ownerNode() && pageStyleSheet->href().isEmpty())
+        return Inspector::Protocol::CSS::StyleSheetOrigin::UserAgent;
+
+    if (pageStyleSheet && pageStyleSheet->contents().isUserStyleSheet())
+        return Inspector::Protocol::CSS::StyleSheetOrigin::User;
+
+    if (!ownerDocument)
+        return Inspector::Protocol::CSS::StyleSheetOrigin::Author;
+
+    auto iterator = m_documentToInspectorStyleSheet.find(*ownerDocument);
+    if (iterator != m_documentToInspectorStyleSheet.end()) {
+        for (auto& inspectorStyleSheet : iterator->value) {
+            if (inspectorStyleSheet->pageStyleSheet() == pageStyleSheet)
+                return Inspector::Protocol::CSS::StyleSheetOrigin::Inspector;
+        }
+    }
+
+    return Inspector::Protocol::CSS::StyleSheetOrigin::Author;
 }
 
 } // namespace WebCore

--- a/Source/WebCore/inspector/agents/frame/FrameCSSAgent.h
+++ b/Source/WebCore/inspector/agents/frame/FrameCSSAgent.h
@@ -25,9 +25,12 @@
 
 #pragma once
 
+#include "InspectorStyleSheet.h"
 #include "InspectorWebAgentBase.h"
 #include <JavaScriptCore/InspectorBackendDispatchers.h>
 #include <wtf/CheckedPtr.h>
+#include <wtf/HashMap.h>
+#include <wtf/HashSet.h>
 #include <wtf/TZoneMalloc.h>
 #include <wtf/WeakRef.h>
 
@@ -37,9 +40,11 @@ class CSSFrontendDispatcher;
 
 namespace WebCore {
 
+class CSSStyleSheet;
+class Document;
 class LocalFrame;
 
-class FrameCSSAgent final : public InspectorAgentBase, public Inspector::CSSBackendDispatcherHandler, public CanMakeCheckedPtr<FrameCSSAgent> {
+class FrameCSSAgent final : public InspectorAgentBase, public Inspector::CSSBackendDispatcherHandler, public InspectorStyleSheet::Listener, public CanMakeCheckedPtr<FrameCSSAgent> {
     WTF_MAKE_NONCOPYABLE(FrameCSSAgent);
     WTF_MAKE_TZONE_ALLOCATED(FrameCSSAgent);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(FrameCSSAgent);
@@ -72,10 +77,34 @@ public:
     Inspector::CommandResult<void> forcePseudoState(Inspector::Protocol::DOM::NodeId, Ref<JSON::Array>&& forcedPseudoClasses) override;
     Inspector::CommandResult<void> setLayoutContextTypeChangedMode(Inspector::Protocol::CSS::LayoutContextTypeChangedMode) override;
 
+    // InspectorStyleSheet::Listener
+    void styleSheetChanged(InspectorStyleSheet*) override;
+
+    // InspectorInstrumentation
+    void documentDetached(Document&);
+    void mediaQueryResultChanged();
+    void activeStyleSheetsUpdated(Document&);
+
 private:
+    void reset();
+    InspectorStyleSheet& bindStyleSheet(CSSStyleSheet*);
+    InspectorStyleSheet* assertStyleSheetForId(Inspector::Protocol::ErrorString&, const Inspector::Protocol::CSS::StyleSheetId&);
+    void collectAllDocumentStyleSheets(Document&, Vector<CSSStyleSheet*>&);
+    void collectStyleSheets(CSSStyleSheet*, Vector<CSSStyleSheet*>&);
+    void setActiveStyleSheetsForDocument(Document&, Vector<CSSStyleSheet*>&);
+    InspectorStyleSheet* createInspectorStyleSheetForDocument(Document&);
+    Inspector::Protocol::CSS::StyleSheetOrigin detectOrigin(CSSStyleSheet*, Document*);
+
     UniqueRef<Inspector::CSSFrontendDispatcher> m_frontendDispatcher;
     Ref<Inspector::CSSBackendDispatcher> m_backendDispatcher;
     WeakRef<LocalFrame> m_inspectedFrame;
+
+    HashMap<Inspector::Protocol::CSS::StyleSheetId, Ref<InspectorStyleSheet>> m_idToInspectorStyleSheet;
+    HashMap<CSSStyleSheet*, Ref<InspectorStyleSheet>> m_cssStyleSheetToInspectorStyleSheet;
+    HashMap<Ref<Document>, Vector<Ref<InspectorStyleSheet>>> m_documentToInspectorStyleSheet;
+    HashMap<Document*, HashSet<CSSStyleSheet*>> m_documentToKnownCSSStyleSheets;
+    int m_lastStyleSheetId { 1 };
+    bool m_creatingViaInspectorStyleSheet { false };
 };
 
 } // namespace WebCore

--- a/Source/WebInspectorUI/UserInterface/Controllers/CSSManager.js
+++ b/Source/WebInspectorUI/UserInterface/Controllers/CSSManager.js
@@ -352,6 +352,10 @@ WI.CSSManager = class CSSManager extends WI.Object
     set layoutContextTypeChangedMode(layoutContextTypeChangedMode)
     {
         for (let target of WI.targets) {
+            // FIXME <https://webkit.org/b/314148> Use FrameCSSAgent in the frontend.
+            if (target instanceof WI.FrameTarget)
+                continue;
+
             // COMPATIBILITY (iOS 14.5): CSS.setLayoutContextTypeChangedMode did not exist.
             if (target.hasCommand("CSS.setLayoutContextTypeChangedMode"))
                 target.CSSAgent.setLayoutContextTypeChangedMode(layoutContextTypeChangedMode);
@@ -586,7 +590,12 @@ WI.CSSManager = class CSSManager extends WI.Object
 
     styleSheetAdded(styleSheetInfo)
     {
-        console.assert(!this._styleSheetIdentifierMap.has(styleSheetInfo.styleSheetId), "Attempted to add a CSSStyleSheet but identifier was already in use");
+        // FIXME <https://webkit.org/b/310164>: Under Site Isolation, different targets independently generate
+        // stylesheet IDs starting from "1", causing collisions. Skip duplicates to avoid overwriting an existing
+        // stylesheet with data from a different target. This will be resolved by deterministic process-qualified IDs.
+        if (this._styleSheetIdentifierMap.has(styleSheetInfo.styleSheetId))
+            return;
+
         let styleSheet = this.styleSheetForIdentifier(styleSheetInfo.styleSheetId);
         let parentFrame = WI.networkManager.frameForIdentifier(styleSheetInfo.frameId);
         let origin = WI.CSSManager.protocolStyleSheetOriginToEnum(styleSheetInfo.origin);

--- a/Source/WebInspectorUI/UserInterface/Protocol/CSSObserver.js
+++ b/Source/WebInspectorUI/UserInterface/Protocol/CSSObserver.js
@@ -29,21 +29,37 @@ WI.CSSObserver = class CSSObserver extends InspectorBackend.Dispatcher
 
     mediaQueryResultChanged()
     {
+        // FIXME <https://webkit.org/b/314148> Use FrameCSSAgent in the frontend.
+        if (this._target instanceof WI.FrameTarget)
+            return;
+
         WI.cssManager.mediaQueryResultChanged();
     }
 
     styleSheetChanged(styleSheetId)
     {
+        // FIXME <https://webkit.org/b/314148> Use FrameCSSAgent in the frontend.
+        if (this._target instanceof WI.FrameTarget)
+            return;
+
         WI.cssManager.styleSheetChanged(styleSheetId);
     }
 
     styleSheetAdded(styleSheetInfo)
     {
+        // FIXME <https://webkit.org/b/314148> Use FrameCSSAgent in the frontend.
+        if (this._target instanceof WI.FrameTarget)
+            return;
+
         WI.cssManager.styleSheetAdded(styleSheetInfo);
     }
 
     styleSheetRemoved(id)
     {
+        // FIXME <https://webkit.org/b/314148> Use FrameCSSAgent in the frontend.
+        if (this._target instanceof WI.FrameTarget)
+            return;
+
         WI.cssManager.styleSheetRemoved(id);
     }
 


### PR DESCRIPTION
#### 2a28bec3f68717cab638b01095971d3b0a5846d9
<pre>
[Site Isolation] Web Inspector: Implement per-frame CSS functions without DOM or node id support
<a href="https://bugs.webkit.org/show_bug.cgi?id=314147">https://bugs.webkit.org/show_bug.cgi?id=314147</a>

Reviewed by BJ Burg.

Implement the style-sheet-related commands of the CSS domain for frame
targets: getAllStyleSheets, getStyleSheet, getStyleSheetText,
setStyleSheetText, createStyleSheet, and getSupportedCSSProperties.
These operate on stylesheets, which don&apos;t require DOM nodeId binding and
FrameDOMAgent integration. FrameCSSAgent now also manages its own style
sheet lifecycle: it fires styleSheetAdded, styleSheetRemoved, and
styleSheetChanged events.

- setStyleSheetText bypasses InspectorHistory and does not have
  undo/redo support yet. The undo infrastructure is currently tightly
  coupled to InspectorDOMAgent&apos;s page-level history. Address this later
  separately (<a href="https://webkit.org/b/314244).">https://webkit.org/b/314244).</a>

- FrameCSSAgent keeps the document-to-data mappings like in
  InspectorCSSAgent, m_documentToInspectorStyleSheet and
  m_documentToKnownCSSStyleSheets but for a different reason.
  InspectorCSSAgent needs them because a page hosts many documents
  simultaneously: the main frame plus every subframe. FrameCSSAgent
  inspects only one frame, but the frame (and this agent attached to it)
  outlives any single document there. Document-keyed state is still
  required to scope commands to the right document across time.

The production frontend does not yet consume these frame-target CSS
events or route commands to frame targets: CSSObserver and CSSManager
explicitly ignore frame targets for now. The plan is to build out more
of FrameCSSAgent&apos;s remaining commands (node-dependent queries and rule
editing commands), then integrate the frontend in a single switchover
patch once the agent is mature enough to fully replace
InspectorCSSAgent&apos;s role under site isolation. (<a href="https://webkit.org/b/314148)">https://webkit.org/b/314148)</a>

Test: http/tests/site-isolation/inspector/css/css-stylesheet-commands-frame-target.html

Add test cases for these new commands despite the frame target&apos;s CSS
agent is not yet used by the frontend.

* LayoutTests/http/tests/site-isolation/inspector/css/css-stylesheet-commands-frame-target-expected.txt:
* LayoutTests/http/tests/site-isolation/inspector/css/css-stylesheet-commands-frame-target.html:
* Source/JavaScriptCore/inspector/protocol/CSS.json:
* Source/WebCore/inspector/InspectorInstrumentation.cpp:
(WebCore::InspectorInstrumentation::documentDetachedImpl):
(WebCore::InspectorInstrumentation::mediaQueryResultChangedImpl):
(WebCore::InspectorInstrumentation::activeStyleSheetsUpdatedImpl):
* Source/WebCore/inspector/InspectorInstrumentation.h:
(WebCore::InspectorInstrumentation::mediaQueryResultChanged):
* Source/WebCore/inspector/agents/frame/FrameCSSAgent.cpp:
(WebCore::FrameCSSAgent::enable):
(WebCore::FrameCSSAgent::disable):
(WebCore::FrameCSSAgent::getAllStyleSheets):
(WebCore::FrameCSSAgent::getStyleSheet):
(WebCore::FrameCSSAgent::getStyleSheetText):
(WebCore::FrameCSSAgent::setStyleSheetText):
(WebCore::FrameCSSAgent::createStyleSheet):
(WebCore::FrameCSSAgent::getSupportedCSSProperties):
(WebCore::FrameCSSAgent::styleSheetChanged):
(WebCore::FrameCSSAgent::documentDetached):
(WebCore::FrameCSSAgent::mediaQueryResultChanged):
(WebCore::FrameCSSAgent::activeStyleSheetsUpdated):
(WebCore::FrameCSSAgent::reset):
(WebCore::FrameCSSAgent::bindStyleSheet):
(WebCore::FrameCSSAgent::assertStyleSheetForId):
(WebCore::FrameCSSAgent::collectAllDocumentStyleSheets):
(WebCore::FrameCSSAgent::collectStyleSheets):
(WebCore::FrameCSSAgent::setActiveStyleSheetsForDocument):
(WebCore::FrameCSSAgent::createInspectorStyleSheetForDocument):
(WebCore::FrameCSSAgent::detectOrigin):
* Source/WebCore/inspector/agents/frame/FrameCSSAgent.h:
* Source/WebInspectorUI/UserInterface/Controllers/CSSManager.js:
(WI.CSSManager.prototype.set layoutContextTypeChangedMode):
(WI.CSSManager.prototype.styleSheetAdded):
* Source/WebInspectorUI/UserInterface/Protocol/CSSObserver.js:
(WI.CSSObserver.prototype.mediaQueryResultChanged):
(WI.CSSObserver.prototype.styleSheetChanged):
(WI.CSSObserver.prototype.styleSheetAdded):
(WI.CSSObserver.prototype.styleSheetRemoved):

Canonical link: <a href="https://commits.webkit.org/314983@main">https://commits.webkit.org/314983@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5254a4a4cbf2a1c9f609b8c9662e7ae4ad584455

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/167732 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/41229 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/34824 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/176789 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/125413 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/169598 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/41664 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/41242 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/130504 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/125413 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/170691 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/32938 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/150716 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/111021 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/31919 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/30619 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/25522 "Built successfully") | | 
| [  ~~🛠 🧪 jsc-x86-64~~](https://ews-build.webkit.org/#/builders/20/builds/160322 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/141907 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/28411 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/179331 "Built successfully") | | 
| [  ~~🛠 🧪 jsc-debug-arm64~~](https://ews-build.webkit.org/#/builders/171/builds/28978 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/32379 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/30129 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/138906 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/41301 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/34776 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/138791 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/41989 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/150203 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/105172 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/25545 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/34062 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/27082 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/200409 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/40493 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/113744 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/53840 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/39890 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/5185 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/40141 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/40035 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->