### PR TITLE
[libpas] `fast_large_free_heap` has inverted max-heap invariant checks

### DIFF
--- a/Source/bmalloc/libpas/src/libpas/pas_fast_large_free_heap.c
+++ b/Source/bmalloc/libpas/src/libpas/pas_fast_large_free_heap.c
@@ -215,12 +215,6 @@ static void fast_write_cursor(
 
     if (pas_large_free_size(value) != pas_large_free_size(node->free)) {
         if (pas_large_free_size(value) < pas_large_free_size(node->free)) {
-            pas_fast_large_free_heap_node* parent_node;
-            parent_node = (pas_fast_large_free_heap_node*)
-                pas_compact_cartesian_tree_node_ptr_load(&node->tree_node.parent);
-            need_to_readd_to_tree |= parent_node
-                && pas_large_free_size(value) < pas_large_free_size(parent_node->free);
-        } else {
             pas_fast_large_free_heap_node* left_node;
             pas_fast_large_free_heap_node* right_node;
             left_node = (pas_fast_large_free_heap_node*)
@@ -228,8 +222,14 @@ static void fast_write_cursor(
             right_node = (pas_fast_large_free_heap_node*)
                 pas_compact_cartesian_tree_node_ptr_load(&node->tree_node.right);
             need_to_readd_to_tree |=
-                (left_node && pas_large_free_size(value) > pas_large_free_size(left_node->free)) ||
-                (right_node && pas_large_free_size(value) > pas_large_free_size(right_node->free));
+                (left_node && pas_large_free_size(value) < pas_large_free_size(left_node->free)) ||
+                (right_node && pas_large_free_size(value) < pas_large_free_size(right_node->free));
+        } else {
+            pas_fast_large_free_heap_node* parent_node;
+            parent_node = (pas_fast_large_free_heap_node*)
+                pas_compact_cartesian_tree_node_ptr_load(&node->tree_node.parent);
+            need_to_readd_to_tree |= parent_node
+                && pas_large_free_size(value) > pas_large_free_size(parent_node->free);
         }
     }
 
@@ -286,26 +286,21 @@ static void fast_merge(
         merger = pas_large_free_create_merged_for_sure(merger, right_node->free, config);
     
     if (left_node) {
-        pas_fast_large_free_heap_node* left_left_node;
-        pas_fast_large_free_heap_node* left_right_node;
+        pas_fast_large_free_heap_node* left_parent_node;
         bool need_to_readd_to_tree;
-        
+
         if (right_node)
             remove_node(heap, right_node);
-        
+
         /* Thanks to this fact, we don't have to change left_node's position in the tree! */
         PAS_ASSERT(left_node->free.begin == merger.begin);
         PAS_ASSERT(left_node->free.end < merger.end);
-        
-        left_left_node = (pas_fast_large_free_heap_node*)
-            pas_compact_cartesian_tree_node_ptr_load(&left_node->tree_node.left);
-        left_right_node = (pas_fast_large_free_heap_node*)
-            pas_compact_cartesian_tree_node_ptr_load(&left_node->tree_node.right);
+
+        left_parent_node = (pas_fast_large_free_heap_node*)
+            pas_compact_cartesian_tree_node_ptr_load(&left_node->tree_node.parent);
         need_to_readd_to_tree =
-            (left_left_node
-             && pas_large_free_size(merger) > pas_large_free_size(left_left_node->free)) ||
-            (left_right_node
-             && pas_large_free_size(merger) > pas_large_free_size(left_right_node->free));
+            left_parent_node
+            && pas_large_free_size(merger) > pas_large_free_size(left_parent_node->free);
 
         if (need_to_readd_to_tree)
             pas_cartesian_tree_remove(&heap->tree, &left_node->tree_node, &cartesian_config);

--- a/Source/bmalloc/libpas/src/test/LargeFreeHeapTests.cpp
+++ b/Source/bmalloc/libpas/src/test/LargeFreeHeapTests.cpp
@@ -1109,6 +1109,36 @@ void addLargeFreeHeapTests()
                  },
                  1));
 
+    ADD_TEST(testFastLargeFreeHeap(
+                 {
+                     Action::deallocate(1000, 100),
+                     Action::deallocate(3000, 200),
+                     Action::deallocate(2000, 400),
+                     Action::allocate(350, alignSimple(1), 2000),
+                     Action::allocate(150, alignSimple(1), 3000)
+                 },
+                 {
+                     Free(1000, 1100),
+                     Free(2350, 2400),
+                     Free(3150, 3200)
+                 },
+                 1));
+
+    ADD_TEST(testFastLargeFreeHeap(
+                 {
+                     Action::deallocate(1000, 100),
+                     Action::deallocate(3000, 1000),
+                     Action::deallocate(5000, 200),
+                     Action::deallocate(5200, 3000),
+                     Action::allocate(2000, alignSimple(1), 5000)
+                 },
+                 {
+                     Free(1000, 1100),
+                     Free(3000, 4000),
+                     Free(7000, 8200)
+                 },
+                 1));
+
     ADD_TEST(testBootstrapHeap({ }, { }, 1));
     ADD_TEST(testBootstrapHeap(
                  {


### PR DESCRIPTION
#### 53d5133d6b99b6bd96261e68814a5698ec58fad6
<pre>
[libpas] `fast_large_free_heap` has inverted max-heap invariant checks
<a href="https://bugs.webkit.org/show_bug.cgi?id=314255">https://bugs.webkit.org/show_bug.cgi?id=314255</a>

Reviewed by Yusuke Suzuki.

pas_fast_large_free_heap stores free ranges in a cartesian tree keyed by
size with a max-heap invariant (parent.size &gt;= child.size). Two of the
update paths checked the wrong neighbor when deciding whether the node
needed to be re-inserted to restore the invariant:

* fast_write_cursor compared against the parent on shrink and against
  the children on grow. The relations are the opposite: a shrinking
  node may now be smaller than its children, and a growing node may now
  be larger than its parent.

* fast_merge, which only grows left_node by coalescing the right
  neighbor, compared against left_node&apos;s children. It should compare
  against left_node&apos;s parent.

When the root shrank, or a leaf grew via coalescing, the node stayed
in place with parent.size &lt; child.size, so find_first could not see the
larger free block and the allocator fell through to a redundant
aligned_allocator pull. This affects every pas_large_heap and
pas_large_utility_free_heap (i.e. all TLC allocations).

Add two regression tests in LargeFreeHeapTests, one per code path

* Source/bmalloc/libpas/src/libpas/pas_fast_large_free_heap.c:
(fast_write_cursor):
(fast_merge):
* Source/bmalloc/libpas/src/test/LargeFreeHeapTests.cpp:
(addLargeFreeHeapTests):

Canonical link: <a href="https://commits.webkit.org/312846@main">https://commits.webkit.org/312846@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f7f2d596de8cf4970f9ae27e52ad0e4d86afe883

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/160993 "5 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/34466 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/27567 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/169896 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/117253 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/34567 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/34466 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/124879 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/117253 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/163952 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/27137 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/144618 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/105476 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/26187 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/24692 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/17616 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/153049 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/135881 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/22380 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/172379 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/21831 "Built successfully and passed tests") | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/24021 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/133154 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/34140 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/28785 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/133164 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36019 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/34124 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/144175 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/95963 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/27728 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/20993 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/193392 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/33635 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/49800 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/33134 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/33378 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/33283 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->