### PR TITLE
Gate quick tier up on num cpus

### DIFF
--- a/Source/JavaScriptCore/bytecode/CodeBlock.cpp
+++ b/Source/JavaScriptCore/bytecode/CodeBlock.cpp
@@ -2866,15 +2866,13 @@ bool CodeBlock::shouldReoptimizeFromLoopNow()
 
 void CodeBlock::didInstallDFGCode()
 {
-#if PLATFORM(MAC)
-    // Always reset — allows quick tier-up recovery after reinstall.
-    // Enable this only on macOS due to perf regression on iOS.
-    unlinkedCodeBlock()->setQuickDFGTierUp(TriState::True);
-#else
-    // Restore old one-shot behavior — once failed, stays disabled.
-    if (!unlinkedCodeBlock()->hasQuickDFGTierUpUpdated())
+    // High-core-count devices retry quick DFG tier-up on each reinstall.
+    // Lower-core-count devices regress if retried, so keep it one-shot:
+    // once disabled, leave it off.
+    if (WTF::numberOfProcessorCores() > 6)
         unlinkedCodeBlock()->setQuickDFGTierUp(TriState::True);
-#endif
+    else if (!unlinkedCodeBlock()->hasQuickDFGTierUpUpdated())
+        unlinkedCodeBlock()->setQuickDFGTierUp(TriState::True);
 }
 
 void CodeBlock::didDFGJettison(Profiler::JettisonReason reason)

--- a/Source/JavaScriptCore/bytecode/CodeBlock.h
+++ b/Source/JavaScriptCore/bytecode/CodeBlock.h
@@ -740,7 +740,7 @@ public:
     bool NODELETE shouldReoptimizeNow();
     bool NODELETE shouldReoptimizeFromLoopNow();
 
-    void NODELETE didInstallDFGCode();
+    void didInstallDFGCode();
     void NODELETE didDFGJettison(Profiler::JettisonReason);
     void NODELETE didFailDFGCompilation();
 

--- a/Source/JavaScriptCore/runtime/Options.h
+++ b/Source/JavaScriptCore/runtime/Options.h
@@ -31,6 +31,7 @@
 #include <stdint.h>
 #include <wtf/ForbidHeapAllocation.h>
 #include <wtf/Noncopyable.h>
+#include <wtf/NumberOfCores.h>
 #include <wtf/ScopedLambda.h>
 #include <wtf/StdLibExtras.h>
 
@@ -177,27 +178,21 @@ private:
     static constexpr bool ipintEnabledByDefault() { return isARM64() || isARM64E() || isX86_64(); }
     static double defaultQuickDFGTierUpThresholdFactor()
     {
-#if PLATFORM(MAC)
-        return 0.15;
-#else
+        if (WTF::numberOfProcessorCores() > 6)
+            return 0.15;
         return 0.2;
-#endif
     }
     static double defaultRelaxedProfileCoverageFactorForQuickDFGTierUp()
     {
-#if PLATFORM(MAC)
-        return 0.85;
-#else
+        if (WTF::numberOfProcessorCores() > 6)
+            return 0.85;
         return 1.0;
-#endif
     }
     static double defaultQuickFTLTierUpThresholdFactor()
     {
-#if PLATFORM(MAC)
-        return 0.15;
-#else
+        if (WTF::numberOfProcessorCores() > 6)
+            return 0.15;
         return 1.0;
-#endif
     }
 };
 


### PR DESCRIPTION
#### 78e435741c3520efa9e2c122d843edeb178fe89d
<pre>
Gate quick tier up on num cpus
<a href="https://bugs.webkit.org/show_bug.cgi?id=314262">https://bugs.webkit.org/show_bug.cgi?id=314262</a>
<a href="https://rdar.apple.com/176406085">rdar://176406085</a>

Reviewed by NOBODY (OOPS!).

Quick tier up was gated on macOS vs. iOS.
Instead, gate on number of CPU cores so that low CPU count devices
running macOS don&apos;t do quick tier up.

* Source/JavaScriptCore/bytecode/CodeBlock.cpp:
(JSC::CodeBlock::didInstallDFGCode):
* Source/JavaScriptCore/runtime/Options.h:
(JSC::Options::defaultQuickDFGTierUpThresholdFactor):
(JSC::Options::defaultRelaxedProfileCoverageFactorForQuickDFGTierUp):
(JSC::Options::defaultQuickFTLTierUpThresholdFactor):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/78e435741c3520efa9e2c122d843edeb178fe89d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/161097 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/34570 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/27671 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/170000 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/117357 "Built successfully") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/34671 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/34571 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/124958 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/88128 "1 failures") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/164056 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/27234 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/144706 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/105555 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/26283 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/24784 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/17720 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/153153 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/135977 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/22467 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/172483 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/21935 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/19504 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/24108 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/133236 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/34244 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/28877 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/133246 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/34228 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/144262 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/96067 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/27799 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/21080 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/193496 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/33739 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/101164 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/49844 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/33238 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/33482 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/33387 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->