### PR TITLE
[GFC][Cleanup] Minor tidying up in TrackSizingAlgorithm code.

### DIFF
--- a/Source/WebCore/layout/formattingContexts/grid/TrackSizingAlgorithm.cpp
+++ b/Source/WebCore/layout/formattingContexts/grid/TrackSizingAlgorithm.cpp
@@ -450,60 +450,8 @@ static void maximizeTracks(UnsizedTracks& unsizedTracks, const AxisConstraint& a
     }
 }
 
-// https://drafts.csswg.org/css-grid-1/#algo-track-sizing
-TrackSizes TrackSizingAlgorithm::sizeTracks(const TrackSizingItemList& trackSizingItems, const TrackSizingFunctionsList& trackSizingFunctions,
-    const AxisConstraint& axisConstraint, const GridItemSizingFunctions& gridItemSizingFunctions,
-    LayoutUnit gapSize, const StyleContentAlignmentData& usedContentAlignment)
-{
-    auto freeSpaceScenario = axisConstraint.scenario();
-    auto availableGridSpace = freeSpaceScenario == AxisConstraint::FreeSpaceScenario::Definite
-        ? std::optional(axisConstraint.availableSpace()) : std::nullopt;
-
-    // 1. Initialize Track Sizes
-    // GridFormattingContext should have transformed a percentage track to auto if there was no
-    // available space so it should not matter what the alternate value we pass in here is.
-    auto unsizedTracks = initializeTrackSizes(trackSizingFunctions, availableGridSpace.value_or(0_lu));
-
-    // 2. Resolve Intrinsic Track Sizes
-    resolveIntrinsicTrackSizes(ResolveIntrinsicTrackSizesContext(trackSizingItems, gridItemSizingFunctions, trackSizingFunctions), unsizedTracks);
-
-    // 3. Maximize Tracks
-    maximizeTracks(unsizedTracks, axisConstraint, gapSize);
-
-    // 4. Expand Flexible Tracks
-    // https://drafts.csswg.org/css-grid-1/#algo-flex-tracks
-    expandFlexibleTracks(unsizedTracks, axisConstraint, gapSize, trackSizingItems, gridItemSizingFunctions);
-
-    // https://drafts.csswg.org/css-grid-1/#algo-stretch
-    // 5. Stretch ‘auto’ Tracks
-    // If the free space is indefinite, but the grid container has a definite min-width/height,
-    // use that size to calculate the free space for this step instead.
-    auto freeSpaceForAutoStretchTracks = [&]() -> std::optional<LayoutUnit> {
-        auto containerMinimumSize = axisConstraint.containerMinimumSize();
-        switch (freeSpaceScenario) {
-        case AxisConstraint::FreeSpaceScenario::Definite:
-            return computeFreeSpace(availableGridSpace, unsizedTracks, gapSize);
-        case AxisConstraint::FreeSpaceScenario::MinContent:
-        case AxisConstraint::FreeSpaceScenario::MaxContent:
-            // If the free space is indefinite, but the grid container has a definite min-width/height, use that size to calculate the free space for this step instead.
-            if (containerMinimumSize)
-                return computeFreeSpace(containerMinimumSize, unsizedTracks, gapSize);
-            return computeFreeSpace(availableGridSpace, unsizedTracks, gapSize);
-        }
-        ASSERT_NOT_REACHED();
-        return { };
-    };
-    stretchAutoTracks(freeSpaceForAutoStretchTracks(), unsizedTracks, usedContentAlignment);
-
-    // Each track has a base size, a <length> which grows throughout the algorithm and
-    // which will eventually be the track’s final size...
-    return unsizedTracks.map([](const UnsizedTrack& unsizedTrack) {
-        return unsizedTrack.baseSize;
-    });
-}
-
 // https://www.w3.org/TR/css-grid-1/#algo-init
-UnsizedTracks TrackSizingAlgorithm::initializeTrackSizes(const TrackSizingFunctionsList& trackSizingFunctionsList, LayoutUnit availableGridSpace)
+static UnsizedTracks initializeTrackSizes(const TrackSizingFunctionsList& trackSizingFunctionsList, LayoutUnit availableGridSpace)
 {
     return trackSizingFunctionsList.map([&availableGridSpace](const TrackSizingFunctions& trackSizingFunctions) -> UnsizedTrack {
         // For each track, if the track’s min track sizing function is:
@@ -558,7 +506,7 @@ UnsizedTracks TrackSizingAlgorithm::initializeTrackSizes(const TrackSizingFuncti
     });
 }
 
-FlexTracks TrackSizingAlgorithm::collectFlexTracks(const UnsizedTracks& unsizedTracks)
+static FlexTracks collectFlexTracks(const UnsizedTracks& unsizedTracks)
 {
     FlexTracks flexTracks;
 
@@ -574,14 +522,14 @@ FlexTracks TrackSizingAlgorithm::collectFlexTracks(const UnsizedTracks& unsizedT
     return flexTracks;
 }
 
-bool TrackSizingAlgorithm::hasFlexTracks(const UnsizedTracks& unsizedTracks)
+static bool hasFlexTracks(const UnsizedTracks& unsizedTracks)
 {
     return std::ranges::any_of(unsizedTracks, [](auto& track) {
         return track.trackSizingFunction.max.isFlex();
     });
 }
 
-double TrackSizingAlgorithm::flexFactorSum(const FlexTracks& flexTracks)
+static double flexFactorSum(const FlexTracks& flexTracks)
 {
     double total = 0.0;
     for (auto& track : flexTracks)
@@ -590,7 +538,7 @@ double TrackSizingAlgorithm::flexFactorSum(const FlexTracks& flexTracks)
 }
 
 // https://drafts.csswg.org/css-grid-1/#algo-find-fr-size
-LayoutUnit TrackSizingAlgorithm::findSizeOfFr(const UnsizedTracks& tracks, const LayoutUnit availableSpace, const LayoutUnit gapSize)
+static LayoutUnit findSizeOfFr(const UnsizedTracks& tracks, const LayoutUnit availableSpace, const LayoutUnit gapSize)
 {
     ASSERT(availableSpace >= 0_lu);
 
@@ -667,7 +615,7 @@ static void NODELETE applyFlexFractionToTracks(UnsizedTracks& unsizedTracks, con
 
 // https://drafts.csswg.org/css-grid-1/#algo-flex-tracks
 // "If...sizing the grid container under a min-content constraint, the used flex fraction is zero."
-void TrackSizingAlgorithm::expandFlexibleTracksForMinContent(UnsizedTracks&)
+static void expandFlexibleTracksForMinContent(UnsizedTracks&)
 {
     // The used flex fraction is zero - no changes to track sizes needed.
 }
@@ -679,7 +627,7 @@ void TrackSizingAlgorithm::expandFlexibleTracksForMinContent(UnsizedTracks&)
 //   the result of dividing the track's base size by its flex factor; otherwise, the track's base size.
 // * For each grid item that crosses a flexible track, the result of finding the size of an fr
 //   using all the grid tracks that the item crosses and a space to fill of the item's max-content contribution.
-void TrackSizingAlgorithm::expandFlexibleTracksForMaxContent(UnsizedTracks& unsizedTracks, const FlexTracks& flexTracks,
+static void expandFlexibleTracksForMaxContent(UnsizedTracks& unsizedTracks, const FlexTracks& flexTracks,
     LayoutUnit gapSize, const TrackSizingItemList& trackSizingItems, const PlacedGridItemSpanList& gridItemSpanList,
     const TrackSizingGridItemConstraintList& oppositeAxisConstraints, const GridItemSizingFunctions& gridItemSizingFunctions)
 {
@@ -713,7 +661,7 @@ void TrackSizingAlgorithm::expandFlexibleTracksForMaxContent(UnsizedTracks& unsi
 // Otherwise, if the free space is a definite length:
 // The used flex fraction is the result of finding the size of an fr using all of the
 // grid tracks and a space to fill of the available grid space (minus gutters).
-void TrackSizingAlgorithm::expandFlexibleTracksForDefiniteLength(UnsizedTracks& unsizedTracks, const FlexTracks& flexTracks, std::optional<LayoutUnit> availableGridSpace, const LayoutUnit gapSize)
+static void expandFlexibleTracksForDefiniteLength(UnsizedTracks& unsizedTracks, const FlexTracks& flexTracks, std::optional<LayoutUnit> availableGridSpace, const LayoutUnit gapSize)
 {
     ASSERT(availableGridSpace.has_value());
 
@@ -734,7 +682,7 @@ void TrackSizingAlgorithm::expandFlexibleTracksForDefiniteLength(UnsizedTracks& 
 }
 
 // https://drafts.csswg.org/css-grid-1/#algo-flex-tracks
-void TrackSizingAlgorithm::expandFlexibleTracks(UnsizedTracks& unsizedTracks, const AxisConstraint& axisConstraint,
+static void expandFlexibleTracks(UnsizedTracks& unsizedTracks, const AxisConstraint& axisConstraint,
     LayoutUnit gapSize, const TrackSizingItemList& trackSizingItems, const GridItemSizingFunctions& gridItemSizingFunctions)
 {
     if (!hasFlexTracks(unsizedTracks))
@@ -764,6 +712,60 @@ void TrackSizingAlgorithm::expandFlexibleTracks(UnsizedTracks& unsizedTracks, co
 
     ASSERT(freeSpaceScenario == AxisConstraint::FreeSpaceScenario::Definite);
     expandFlexibleTracksForDefiniteLength(unsizedTracks, flexTracks, availableGridSpace, gapSize);
+}
+
+// https://drafts.csswg.org/css-grid-1/#algo-stretch
+// If the free space is indefinite, but the grid container has a definite min-width/height,
+// use that size to calculate the free space for this step instead.
+static std::optional<LayoutUnit> freeSpaceForStretchAutoTracks(const AxisConstraint& axisConstraint, std::optional<LayoutUnit> availableGridSpace, const UnsizedTracks& unsizedTracks, LayoutUnit gapSize)
+{
+    auto containerMinimumSize = axisConstraint.containerMinimumSize();
+    switch (axisConstraint.scenario()) {
+    case AxisConstraint::FreeSpaceScenario::Definite:
+        return computeFreeSpace(availableGridSpace, unsizedTracks, gapSize);
+    case AxisConstraint::FreeSpaceScenario::MinContent:
+    case AxisConstraint::FreeSpaceScenario::MaxContent:
+        if (containerMinimumSize)
+            return computeFreeSpace(containerMinimumSize, unsizedTracks, gapSize);
+        return computeFreeSpace(availableGridSpace, unsizedTracks, gapSize);
+    }
+    ASSERT_NOT_REACHED();
+    return { };
+}
+
+// https://drafts.csswg.org/css-grid-1/#algo-track-sizing
+TrackSizes TrackSizingAlgorithm::sizeTracks(const TrackSizingItemList& trackSizingItems, const TrackSizingFunctionsList& trackSizingFunctions,
+    const AxisConstraint& axisConstraint, const GridItemSizingFunctions& gridItemSizingFunctions,
+    LayoutUnit gapSize, const StyleContentAlignmentData& usedContentAlignment)
+{
+    auto freeSpaceScenario = axisConstraint.scenario();
+    auto availableGridSpace = freeSpaceScenario == AxisConstraint::FreeSpaceScenario::Definite
+        ? std::optional(axisConstraint.availableSpace()) : std::nullopt;
+
+    // 1. Initialize Track Sizes
+    // GridFormattingContext should have transformed a percentage track to auto if there was no
+    // available space so it should not matter what the alternate value we pass in here is.
+    auto unsizedTracks = initializeTrackSizes(trackSizingFunctions, availableGridSpace.value_or(0_lu));
+
+    // 2. Resolve Intrinsic Track Sizes
+    resolveIntrinsicTrackSizes(ResolveIntrinsicTrackSizesContext(trackSizingItems, gridItemSizingFunctions, trackSizingFunctions), unsizedTracks);
+
+    // 3. Maximize Tracks
+    maximizeTracks(unsizedTracks, axisConstraint, gapSize);
+
+    // 4. Expand Flexible Tracks
+    // https://drafts.csswg.org/css-grid-1/#algo-flex-tracks
+    expandFlexibleTracks(unsizedTracks, axisConstraint, gapSize, trackSizingItems, gridItemSizingFunctions);
+
+    // https://drafts.csswg.org/css-grid-1/#algo-stretch
+    // 5. Stretch ‘auto’ Tracks
+    stretchAutoTracks(freeSpaceForStretchAutoTracks(axisConstraint, availableGridSpace, unsizedTracks, gapSize), unsizedTracks, usedContentAlignment);
+
+    // Each track has a base size, a <length> which grows throughout the algorithm and
+    // which will eventually be the track’s final size...
+    return unsizedTracks.map([](const UnsizedTrack& unsizedTrack) {
+        return unsizedTrack.baseSize;
+    });
 }
 
 } // namespace Layout

--- a/Source/WebCore/layout/formattingContexts/grid/TrackSizingAlgorithm.h
+++ b/Source/WebCore/layout/formattingContexts/grid/TrackSizingAlgorithm.h
@@ -68,25 +68,8 @@ public:
         const AxisConstraint&, const GridItemSizingFunctions&,
         LayoutUnit gapSize, const StyleContentAlignmentData& usedContentAlignment);
 
-private:
-
-    static UnsizedTracks initializeTrackSizes(const TrackSizingFunctionsList&, LayoutUnit availableGridSpace);
-
-    // Flex track infrastructure
-    static FlexTracks collectFlexTracks(const UnsizedTracks&);
-    static bool hasFlexTracks(const UnsizedTracks&);
-    static double NODELETE flexFactorSum(const FlexTracks&);
-    static LayoutUnit findSizeOfFr(const UnsizedTracks&, const LayoutUnit availableSpace, const LayoutUnit gapSize);
-
-    // Expand Flexible Tracks (spec section 11.7)
-    static void expandFlexibleTracks(UnsizedTracks&, const AxisConstraint&, LayoutUnit gapSize,
-        const TrackSizingItemList&, const GridItemSizingFunctions&);
-    static void NODELETE expandFlexibleTracksForMinContent(UnsizedTracks&);
-    static void expandFlexibleTracksForMaxContent(UnsizedTracks&, const FlexTracks&, LayoutUnit gapSize,
-        const TrackSizingItemList&, const PlacedGridItemSpanList&, const TrackSizingGridItemConstraintList&, const GridItemSizingFunctions&);
-    static void expandFlexibleTracksForDefiniteLength(UnsizedTracks&, const FlexTracks&, std::optional<LayoutUnit> availableGridSpace, const LayoutUnit gapSize);
 };
 
-} // namespace WebCore
 } // namespace Layout
+} // namespace WebCore
 


### PR DESCRIPTION
#### e049fa830a7b7800dda7af62989e086e220692ec
<pre>
[GFC][Cleanup] Minor tidying up in TrackSizingAlgorithm code.
<a href="https://bugs.webkit.org/show_bug.cgi?id=314252">https://bugs.webkit.org/show_bug.cgi?id=314252</a>
<a href="https://rdar.apple.com/problem/176403223">rdar://problem/176403223</a>

Reviewed by Vitor Roriz.

1.) We don&apos;t really need the private static member function declarations
in the header.
2.) Move the logic related to determining the free space for when we
want to stretch auto tracks into its own helper function.
3.) Fix up the order of the comments indicating the end of the WebCore
and Layout namespaces.

Canonical link: <a href="https://commits.webkit.org/312826@main">https://commits.webkit.org/312826@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/85cc7b1ce965dd16298479cacc4b991dd79d36c7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/161208 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/34681 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/27782 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/170111 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/117579 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/17db9926-9ca9-44e0-af00-0c6285f7123c) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/163077 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/34782 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/34682 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/125047 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/117579 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/3b1076eb-ac4d-4de4-a2ca-04303c1e44f9) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/164167 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/27325 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/144800 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/105644 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/5bfc52bc-c8e9-4da3-bd3c-828d4188e2ee) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/26373 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/24881 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk3-libwebrtc~~](https://ews-build.webkit.org/#/builders/173/builds/17831 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/136067 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/22561 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/172594 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/19615 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/24202 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/133322 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/34355 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/28974 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/133332 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36006 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/34340 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/144356 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/96205 "Built successfully") | | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/164/builds/27888 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/21174 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/33850 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/101275 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/33349 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/33593 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/33498 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->