### PR TITLE
Fix the sizeInBytes of NativeImage and the ImageFrame

### DIFF
--- a/Source/WebCore/platform/graphics/BitmapImageSource.cpp
+++ b/Source/WebCore/platform/graphics/BitmapImageSource.cpp
@@ -491,7 +491,7 @@ void BitmapImageSource::cacheNativeImageAtIndex(unsigned index, SubsamplingLevel
     destroyNativeImageAtIndex(index, options.shouldDecodeToHDR());
 
     // Do not cache NativeImage if adding its sizeInBytes to MemoryCache will cause numerical overflow.
-    auto sizeInBytes = nativeImage->size().unclampedArea() * sizeof(uint32_t);
+    auto sizeInBytes = nativeImage->sizeInBytes();
     if (!isInBounds<unsigned>(sizeInBytes + m_decodedSize))
         return;
 

--- a/Source/WebCore/platform/graphics/ImageFrame.cpp
+++ b/Source/WebCore/platform/graphics/ImageFrame.cpp
@@ -67,7 +67,12 @@ DecodingStatus ImageFrame::decodingStatus() const
     return m_decodingStatus;
 }
 
-unsigned ImageFrame::clearSourceImage(ShouldDecodeToHDR shouldDecodeToHDR)
+size_t ImageFrame::sizeInBytes() const
+{
+    return CheckedSize(m_source.sizeInBytes()) + m_hdrSource.sizeInBytes();
+}
+
+size_t ImageFrame::clearSourceImage(ShouldDecodeToHDR shouldDecodeToHDR)
 {
     auto& source = this->source(shouldDecodeToHDR);
     if (!source.hasNativeImage())
@@ -77,10 +82,9 @@ unsigned ImageFrame::clearSourceImage(ShouldDecodeToHDR shouldDecodeToHDR)
     return sizeInBytes();
 }
 
-unsigned ImageFrame::clearImage(std::optional<ShouldDecodeToHDR> shouldDecodeToHDR)
+size_t ImageFrame::clearImage(std::optional<ShouldDecodeToHDR> shouldDecodeToHDR)
 {
-
-    unsigned frameBytes = 0;
+    CheckedSize frameBytes = 0;
     if (!shouldDecodeToHDR || *shouldDecodeToHDR == ShouldDecodeToHDR::No)
         frameBytes += clearSourceImage(ShouldDecodeToHDR::No);
 
@@ -90,11 +94,11 @@ unsigned ImageFrame::clearImage(std::optional<ShouldDecodeToHDR> shouldDecodeToH
     return frameBytes;
 }
 
-unsigned ImageFrame::clear()
+size_t ImageFrame::clear()
 {
-    unsigned frameBytes = clearImage();
+    auto sizeInBytes = clearImage();
     *this = ImageFrame();
-    return frameBytes;
+    return sizeInBytes;
 }
 
 bool ImageFrame::hasNativeImage(ShouldDecodeToHDR shouldDecodeToHDR, SubsamplingLevel subsamplingLevel) const

--- a/Source/WebCore/platform/graphics/ImageFrame.h
+++ b/Source/WebCore/platform/graphics/ImageFrame.h
@@ -52,9 +52,9 @@ public:
 
     ImageFrame& operator=(const ImageFrame&);
 
-    unsigned clearSourceImage(ShouldDecodeToHDR);
-    unsigned clearImage(std::optional<ShouldDecodeToHDR> = std::nullopt);
-    unsigned clear();
+    size_t clearSourceImage(ShouldDecodeToHDR);
+    size_t clearImage(std::optional<ShouldDecodeToHDR> = std::nullopt);
+    size_t clear();
 
     void NODELETE setDecodingStatus(DecodingStatus);
     DecodingStatus NODELETE decodingStatus() const;
@@ -66,7 +66,7 @@ public:
     void setSize(const IntSize& size) { m_size = size; }
     IntSize size() const { return m_size; }
 
-    unsigned sizeInBytes() const { return (size().area() * sizeof(uint32_t)).value(); }
+    size_t sizeInBytes() const;
 
     void setDensity(const FloatSize& density) { m_density = density; }
     FloatSize density() const { return m_density; }
@@ -111,6 +111,13 @@ private:
         bool hasDecodedNativeImageCompatibleWithOptions(const DecodingOptions& decodingOptions) const
         {
             return hasNativeImage() && this->decodingOptions.isCompatibleWith(decodingOptions);
+        }
+
+        size_t sizeInBytes() const
+        {
+            if (RefPtr nativeImage = this->nativeImage)
+                return nativeImage->sizeInBytes();
+            return 0;
         }
 
         void clear()

--- a/Source/WebCore/platform/graphics/NativeImage.cpp
+++ b/Source/WebCore/platform/graphics/NativeImage.cpp
@@ -97,6 +97,11 @@ void NativeImage::replacePlatformImage(PlatformImagePtr&& platformImage) const
 }
 
 #if !USE(CG)
+size_t NativeImage::sizeInBytes() const
+{
+    return size().area() * sizeof(uint32_t);
+}
+
 void NativeImage::computeHeadroom() const
 {
 }

--- a/Source/WebCore/platform/graphics/NativeImage.h
+++ b/Source/WebCore/platform/graphics/NativeImage.h
@@ -72,6 +72,7 @@ public:
     WEBCORE_EXPORT const std::optional<GainMap>& gainMap() const;
     WEBCORE_EXPORT virtual IntSize size() const;
     WEBCORE_EXPORT virtual bool hasAlpha() const;
+    WEBCORE_EXPORT size_t sizeInBytes() const;
     std::optional<Color> singlePixelSolidColor() const;
     WEBCORE_EXPORT virtual DestinationColorSpace colorSpace() const;
     WEBCORE_EXPORT bool hasHDRContent() const;

--- a/Source/WebCore/platform/graphics/cg/NativeImageCG.cpp
+++ b/Source/WebCore/platform/graphics/cg/NativeImageCG.cpp
@@ -35,8 +35,9 @@
 #include <limits>
 #include <pal/spi/cg/CoreGraphicsSPI.h>
 
-namespace WebCore {
+#include "CoreVideoSoftLink.h"
 
+namespace WebCore {
 
 RefPtr<NativeImage> NativeImage::create(PlatformImagePtr&& image, std::optional<GainMap>&& gainMap)
 {
@@ -76,6 +77,15 @@ bool NativeImage::hasAlpha() const
 {
     CGImageAlphaInfo info = CGImageGetAlphaInfo(m_platformImage.get());
     return (info >= kCGImageAlphaPremultipliedLast) && (info <= kCGImageAlphaFirst);
+}
+
+size_t NativeImage::sizeInBytes() const
+{
+    CheckedSize height = CGImageGetHeight(m_platformImage);
+    CheckedSize sizeInBytes = height * CGImageGetBytesPerRow(m_platformImage);
+    if (m_gainMap)
+        sizeInBytes += CVPixelBufferGetDataSize(m_gainMap->gainMapPixelBuffer);
+    return sizeInBytes;
 }
 
 DestinationColorSpace NativeImage::colorSpace() const
@@ -122,7 +132,6 @@ void NativeImage::clearSubimages()
     CGSubimageCacheWithTimer::clearImage(platformImage().get());
 #endif
 }
-
 
 } // namespace WebCore
 


### PR DESCRIPTION
#### c2a0f7a739110d44b44c1cf76e6dc668e3d2b079
<pre>
Fix the sizeInBytes of NativeImage and the ImageFrame
<a href="https://bugs.webkit.org/show_bug.cgi?id=314258">https://bugs.webkit.org/show_bug.cgi?id=314258</a>
<a href="https://rdar.apple.com/176406494">rdar://176406494</a>

Reviewed by Cameron McCormack.

The sizeInBytes is used to tell the memory manager how much memory an image takes.
To fire the memory warning at the right time, the calculation should be accurate.

The sizeInBytes of these objects still multiply the area of the image by 4. This
is not necessarily correct for HDR images. the bitPerChannel can 10 or 16 for
example. Also the size of the CVPixelBuffer gain-map image should be taken into
consideration.

* Source/WebCore/platform/graphics/BitmapImageSource.cpp:
(WebCore::BitmapImageSource::cacheNativeImageAtIndex):
* Source/WebCore/platform/graphics/ImageFrame.cpp:
(WebCore::ImageFrame::sizeInBytes const):
(WebCore::ImageFrame::clearSourceImage):
(WebCore::ImageFrame::clearImage):
(WebCore::ImageFrame::clear):
* Source/WebCore/platform/graphics/ImageFrame.h:
(WebCore::ImageFrame::Source::sizeInBytes const):
(WebCore::ImageFrame::sizeInBytes const): Deleted.
* Source/WebCore/platform/graphics/NativeImage.cpp:
(WebCore::NativeImage::sizeInBytes const):
* Source/WebCore/platform/graphics/NativeImage.h:
* Source/WebCore/platform/graphics/cg/NativeImageCG.cpp:
(WebCore::NativeImage::sizeInBytes const):

Canonical link: <a href="https://commits.webkit.org/312773@main">https://commits.webkit.org/312773@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7e57df67a349994f7e477427db0bb104c4db3945

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/161004 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/34477 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/27578 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/169907 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/117264 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/162873 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/34578 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/34477 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/124889 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/117264 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/163963 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/27154 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/144627 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/105486 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/26203 "Build is in progress. Recent messages:") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/24704 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/17627 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/135897 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/22389 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/172390 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/19411 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/24030 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/133168 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/34151 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/28797 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/133178 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35967 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/34135 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/144184 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/95974 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/27739 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/21002 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/33646 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/101071 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/33145 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/33389 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/33294 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->