### PR TITLE
[JSC] IPInt fast path for `memory.atomic.wait32`/`wait64` wraps the Memory64 effective address

### DIFF
--- a/JSTests/wasm/stress/memory64-atomic-wait-out-of-bounds.js
+++ b/JSTests/wasm/stress/memory64-atomic-wait-out-of-bounds.js
@@ -1,0 +1,35 @@
+//@ skip if $addressBits <= 32
+//@ runDefaultWasm("-m", "--useWasmMemory64=1")
+import { instantiate } from "../wabt-wrapper.js";
+import * as assert from "../assert.js";
+
+// memory.atomic.wait32/wait64 with a Memory64 pointer + immediate offset that
+// overflows 64 bits. The effective address must be computed without wrapping;
+// an overflowing sum is out of bounds and must trap.
+
+const wat = `
+(module
+    (memory (export "memory") i64 1 1 shared)
+    (func (export "wait32") (param $addr i64) (result i32)
+        (memory.atomic.wait32 offset=8 (local.get $addr) (i32.const 0) (i64.const 0))
+    )
+    (func (export "wait64") (param $addr i64) (result i32)
+        (memory.atomic.wait64 offset=8 (local.get $addr) (i64.const 0) (i64.const 0))
+    )
+)
+`;
+
+const { exports } = await instantiate(wat, {}, { threads: true, memory64: true });
+
+for (let i = 0; i < wasmTestLoopCount; i++) {
+    // 0xFFFF_FFFF_FFFF_FFF8 + 8 wraps to 0; must trap as out of bounds.
+    assert.throws(() => exports.wait32(0xffff_ffff_ffff_fff8n), WebAssembly.RuntimeError, "Out of bounds memory access");
+    assert.throws(() => exports.wait64(0xffff_ffff_ffff_fff8n), WebAssembly.RuntimeError, "Out of bounds memory access");
+
+    // 0xFFFF_FFFF_FFFF_FFFC + 8 wraps to 4; must trap as out of bounds.
+    assert.throws(() => exports.wait32(0xffff_ffff_ffff_fffcn), WebAssembly.RuntimeError, "Out of bounds memory access");
+
+    // In bounds, equal to expected value, timeout 0 -> returns 2 (TimedOut).
+    assert.eq(exports.wait32(0n), 2);
+    assert.eq(exports.wait64(0n), 2);
+}

--- a/Source/JavaScriptCore/llint/InPlaceInterpreter64.asm
+++ b/Source/JavaScriptCore/llint/InPlaceInterpreter64.asm
@@ -10093,7 +10093,7 @@ ipintAtomicOp(_memory_atomic_wait32, macro()
     pushInt32(t0)
     loadq (StackValueSize * 3)[sp], t0
     loadq IPInt::AtomicMemoryAccessMetadata::offset[MC], t1
-    addq t1, t0
+    baddpc(t1, t0, _ipint_throw_OutOfBoundsMemoryAccess)
     storeq t0, (StackValueSize * 3)[sp] # replace pointer with pointer + offset
 
     # Push callee/cfr/PC/MC for debugger; operands shift to args[4..7].
@@ -10123,7 +10123,7 @@ ipintAtomicOp(_memory_atomic_wait64, macro()
     pushInt32(t0)
     loadq (StackValueSize * 3)[sp], t0
     loadq IPInt::AtomicMemoryAccessMetadata::offset[MC], t1
-    addq t1, t0
+    baddpc(t1, t0, _ipint_throw_OutOfBoundsMemoryAccess)
     storeq t0, (StackValueSize * 3)[sp] # replace pointer with pointer + offset
 
     # Push callee/cfr/PC/MC for debugger; operands shift to args[4..7].


### PR DESCRIPTION
#### 370255eb46e7985ff118c66bdd8a9e1e6d739ddd
<pre>
[JSC] IPInt fast path for `memory.atomic.wait32`/`wait64` wraps the Memory64 effective address
<a href="https://bugs.webkit.org/show_bug.cgi?id=314263">https://bugs.webkit.org/show_bug.cgi?id=314263</a>

Reviewed by Keith Miller.

The IPInt assembly for memory.atomic.wait32 and memory.atomic.wait64 computes
the effective address as `pointer + offset` with an unchecked `addq`. For
Memory64, both the i64 address operand and the immediate offset are 64-bit, so
the sum can wrap around. The wrapped address is then handed to the slow path
as a single value, which has no way to detect the overflow and accepts a small
in-bounds address instead of trapping.

Use the existing `baddpc` macro, which adds and branches to the OOB throw
on carry, matching what the regular memory access fast path already does.

Test: JSTests/wasm/stress/memory64-atomic-wait-out-of-bounds.js

* JSTests/wasm/stress/memory64-atomic-wait-out-of-bounds.js: Added.
* Source/JavaScriptCore/llint/InPlaceInterpreter64.asm:

Canonical link: <a href="https://commits.webkit.org/312832@main">https://commits.webkit.org/312832@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8339e88482f9c6f35eaf3e808697f56295566a8e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/161005 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/34478 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/27579 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/169908 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/117265 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/34579 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/34478 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/124885 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/117265 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/163964 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/27155 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/144626 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/105482 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/26204 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/24701 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/17628 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/153061 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/135898 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/22388 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/172391 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/21843 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/19412 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/24029 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/133163 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/34152 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/28794 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/133173 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36008 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/34136 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/144183 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/95975 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/27735 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/21001 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/193404 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/33647 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/101072 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/49805 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/33146 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/33390 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/33295 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->