### PR TITLE
[visionOS] Tubular.app prevents other media apps on device from ever playing

### DIFF
--- a/Source/WTF/wtf/cocoa/RuntimeApplicationChecksCocoa.h
+++ b/Source/WTF/wtf/cocoa/RuntimeApplicationChecksCocoa.h
@@ -142,6 +142,7 @@ enum class SDKAlignedBehavior {
     EnableUserScriptAndUserStyleInterning,
     AllBackForwardItemsWithoutUserGestureInvisibleToUI,
     ExposePartitionFromWKHTTPCookieStoreAPI,
+    MediaSessionPauseOnInterruption,
 
     NumberOfBehaviors
 };
@@ -226,6 +227,7 @@ WTF_EXPORT_PRIVATE bool isUNIQLOApp();
 WTF_EXPORT_PRIVATE bool isDOFUSTouch();
 WTF_EXPORT_PRIVATE bool isMyRideK12();
 WTF_EXPORT_PRIVATE bool isTableau();
+WTF_EXPORT_PRIVATE bool isTubular();
 
 } // IOSApplication
 

--- a/Source/WTF/wtf/cocoa/RuntimeApplicationChecksCocoa.mm
+++ b/Source/WTF/wtf/cocoa/RuntimeApplicationChecksCocoa.mm
@@ -654,6 +654,12 @@ bool IOSApplication::isTableau()
     return isTableau;
 }
 
+bool IOSApplication::isTubular()
+{
+    static bool isTubular = applicationBundleIdentifier().startsWith("com.aaronbrannan.youtubeAVP"_s);
+    return isTubular;
+}
+
 #endif // PLATFORM(IOS_FAMILY)
 
 } // namespace WTF

--- a/Source/WebCore/Modules/mediasession/MediaSession.cpp
+++ b/Source/WebCore/Modules/mediasession/MediaSession.cpp
@@ -31,6 +31,7 @@
 #include "ContextDestructionObserverInlines.h"
 #include "DocumentLoader.h"
 #include "DocumentPage.h"
+#include "DocumentQuirks.h"
 #include "EventLoop.h"
 #include "EventNames.h"
 #include "HTMLMediaElement.h"
@@ -172,6 +173,10 @@ MediaSession::MediaSession(Navigator& navigator)
 {
     m_logger = Document::sharedLogger();
     m_logIdentifier = nextLogIdentifier();
+#if PLATFORM(COCOA)
+    if (RefPtr document = navigator.document())
+        m_shouldSuppressMediaSessionPauseActionOnInterruption = document->quirks().shouldSuppressMediaSessionPauseActionOnInterruption();
+#endif
 
     ALWAYS_LOG(LOGIDENTIFIER);
 }
@@ -637,6 +642,11 @@ void MediaSession::mayResumePlayback(bool shouldResume)
 
 void MediaSession::suspendPlayback()
 {
+#if PLATFORM(COCOA)
+    if (m_shouldSuppressMediaSessionPauseActionOnInterruption)
+        return;
+#endif
+
     ALWAYS_LOG(LOGIDENTIFIER);
     callActionHandler({ MediaSessionAction::Pause });
 }

--- a/Source/WebCore/Modules/mediasession/MediaSession.h
+++ b/Source/WebCore/Modules/mediasession/MediaSession.h
@@ -227,6 +227,9 @@ private:
     std::optional<CaptionUserPreferencesDisplayMode> m_captionDisplayMode;
     Vector<MediaSessionCaptionTrack> m_captionTracks;
     bool m_captionsEnabled { false };
+#if PLATFORM(COCOA)
+    bool m_shouldSuppressMediaSessionPauseActionOnInterruption { false };
+#endif
 };
 
 String convertEnumerationToString(MediaSessionPlaybackState);

--- a/Source/WebCore/page/Quirks.cpp
+++ b/Source/WebCore/page/Quirks.cpp
@@ -2315,6 +2315,13 @@ bool Quirks::shouldSuppressHLSSubtitles() const
     return m_quirksData.quirkIsEnabled(QuirksData::SiteSpecificQuirk::ShouldSuppressHLSSubtitles);
 }
 
+bool Quirks::shouldSuppressMediaSessionPauseActionOnInterruption() const
+{
+    QUIRKS_EARLY_RETURN_IF_DISABLED_WITH_VALUE(false);
+
+    return m_quirksData.quirkIsEnabled(QuirksData::SiteSpecificQuirk::ShouldSuppressMediaSessionPauseActionOnInterruption);
+}
+
 // spotify.com rdar://140707449
 bool Quirks::shouldAvoidStartingSelectionOnMouseDownOverPointerCursor(const Node& target) const
 {
@@ -3734,6 +3741,11 @@ static void handleYouTubeQuirks(QuirksData& quirksData, const URL& quirksURL, co
             QuirksData::SiteSpecificQuirk::NeedsYouTubeMouseOutQuirk
         });
     }
+#endif
+
+#if PLATFORM(IOS_FAMILY)
+    if (WTF::IOSApplication::isTubular())
+        quirksData.enableQuirk(QuirksData::SiteSpecificQuirk::ShouldSuppressMediaSessionPauseActionOnInterruption);
 #endif
 
     UNUSED_PARAM(quirksURL);

--- a/Source/WebCore/page/Quirks.h
+++ b/Source/WebCore/page/Quirks.h
@@ -340,6 +340,8 @@ public:
     bool shouldLimitHLSPlaybackRate() const;
     bool shouldSuppressHLSSubtitles() const;
 
+    bool shouldSuppressMediaSessionPauseActionOnInterruption() const;
+
     void determineRelevantQuirks();
 
 private:

--- a/Source/WebCore/page/QuirksData.h
+++ b/Source/WebCore/page/QuirksData.h
@@ -260,6 +260,7 @@ struct QuirksData {
         ShouldLimitHLSPlaybackRate,
         ShouldDeferIntersectionObserversDuringResize,
         ShouldSuppressHLSSubtitles,
+        ShouldSuppressMediaSessionPauseActionOnInterruption,
 
         NumberOfQuirks
     };


### PR DESCRIPTION
#### d04cdc84f0acd5fdee19f2974b661f3ea62cd60e
<pre>
[visionOS] Tubular.app prevents other media apps on device from ever playing
<a href="https://rdar.apple.com/175030498">rdar://175030498</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=314264">https://bugs.webkit.org/show_bug.cgi?id=314264</a>

Reviewed by Eric Carlson.

The Tubular app replaces HTMLMediaElement.prototype.pause with its own version that
only allows pausing to work when the video has ended, or when it determines there the
user clicked the play button. In all other circumstances, it issues the pause(), but
follows it immediately with play().

When WebKit receives a system interruption, we let the page know by issuing a
MediaSession pause action; this allows pages&apos; internal state machine to be in sync
with the video element. But when Tubular calls play() during a system interruption,
this causes WebKit to &quot;steal&quot; the audio session from the other media playback application.
What&apos;s worse, this Tubular behavior even occurs if the video isn&apos;t actually playing,
so this stealing will happen even if media inside Tubular is not playing.

Add a quirk that disables the MediaSession pause action, just for the Tubular app.

* Source/WTF/wtf/cocoa/RuntimeApplicationChecksCocoa.h:
* Source/WTF/wtf/cocoa/RuntimeApplicationChecksCocoa.mm:
(WTF::IOSApplication::isTubular):
* Source/WebCore/Modules/mediasession/MediaSession.cpp:
(WebCore::m_coordinator):
* Source/WebCore/Modules/mediasession/MediaSession.h:
* Source/WebCore/page/Quirks.cpp:
* Source/WebCore/page/Quirks.h:
* Source/WebCore/page/QuirksData.h:

Canonical link: <a href="https://commits.webkit.org/312861@main">https://commits.webkit.org/312861@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cef4086c47d0898a3a0605e6ab4c1d2ad5c94d81

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/161314 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/34787 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/27888 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/170217 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/117685 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/8dbbbfa6-69af-40a0-acd4-1e10fca70cc7) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/163183 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/34888 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/34788 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/125132 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/117685 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/15748b9f-ae53-4bb1-b1ae-2287b071b388) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/164273 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/27423 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/144900 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/105729 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/60c8c331-e908-4f96-b626-e49c385c1b02) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/26471 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/24977 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/17937 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/153371 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/136165 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/22660 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/172700 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/22152 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/19721 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/24301 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/133410 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/34461 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/29070 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/133418 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36030 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/34446 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/144455 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/96311 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/27960 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/21273 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/193713 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/33956 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/101381 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/49908 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/33455 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/33699 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/33604 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->