### PR TITLE
[libpas] Fix `pas_all_heaps` standalone build

### DIFF
--- a/Source/bmalloc/libpas/src/libpas/pas_all_heaps.c
+++ b/Source/bmalloc/libpas/src/libpas/pas_all_heaps.c
@@ -30,7 +30,22 @@
 #include "pas_all_heaps.h"
 
 #include "bmalloc_heap_innards.h"
+#if PAS_ENABLE_HOTBIT
+#include "hotbit_heap_innards.h"
+#endif
+#if PAS_ENABLE_ISO
+#include "iso_heap_innards.h"
+#endif
+#if PAS_ENABLE_ISO_TEST
+#include "iso_test_heap.h"
+#endif
 #include "jit_heap.h"
+#if PAS_ENABLE_MINALIGN32
+#include "minalign32_heap.h"
+#endif
+#if PAS_ENABLE_PAGESIZE64K
+#include "pagesize64k_heap.h"
+#endif
 #include "pas_bitfit_heap.h"
 #include "pas_heap.h"
 #include "pas_heap_lock.h"
@@ -39,6 +54,9 @@
 #include "pas_segregated_heap.h"
 #include "pas_utility_heap.h"
 #include "pas_utility_heap_config.h"
+#if PAS_ENABLE_THINGY
+#include "thingy_heap.h"
+#endif
 
 pas_heap* pas_all_heaps_first_heap = NULL;
 size_t pas_all_heaps_count = 0;


### PR DESCRIPTION
#### 5dd73a1f99dc3d03ff52ee52ca8f24801f6b1988
<pre>
[libpas] Fix `pas_all_heaps` standalone build
<a href="https://bugs.webkit.org/show_bug.cgi?id=314265">https://bugs.webkit.org/show_bug.cgi?id=314265</a>

Reviewed by Yusuke Suzuki.

312743@main ([Build Speed] Reduce unnecessary includes in libpas code)
removed seven includes from pas_all_heaps.c. The declarations they
brought in are still referenced by the file inside #if PAS_ENABLE_THINGY
/ #if PAS_ENABLE_ISO / etc. blocks. When libpas is built with
PAS_BMALLOC defined (the bmalloc.framework configuration used by
build-jsc and the WebKit framework build), all of those flags are 0 and
the references preprocess away, so the build is unaffected and CI stays
green.

The libpas standalone Xcode project (Source/bmalloc/libpas/libpas.xcodeproj),
used by Source/bmalloc/libpas/build.sh, defines neither PAS_BMALLOC nor
PAS_LIBMALLOC. pas_config.h sets every PAS_ENABLE_* to 1 in that case
and compiling the pas target (libpas.dylib) fails:

    pas_all_heaps.c:58: error: use of undeclared identifier &apos;thingy_primitive_heap&apos;
    pas_all_heaps.c:60: error: use of undeclared identifier &apos;thingy_utility_heap&apos;
    pas_all_heaps.c:65: error: use of undeclared identifier &apos;iso_common_primitive_heap&apos;
    pas_all_heaps.c:70: error: use of undeclared identifier &apos;iso_test_common_primitive_heap&apos;
    pas_all_heaps.c:75: error: use of undeclared identifier &apos;minalign32_common_primitive_heap&apos;
    pas_all_heaps.c:80: error: use of undeclared identifier &apos;pagesize64k_common_primitive_heap&apos;
    pas_all_heaps.c:90: error: use of undeclared identifier &apos;hotbit_common_primitive_heap&apos;

Restore the six headers that declare those symbols, gated on the same
PAS_ENABLE_* flags as the corresponding usage so the build-time win
from 312743@main is preserved when the flags are 0. The seventh removed
include (pas_scavenger.h) is genuinely unused by this file and stays
out.

Verified with:

    Source/bmalloc/libpas/build.sh -c Debug -s macosx -v all

* Source/bmalloc/libpas/src/libpas/pas_all_heaps.c:

Canonical link: <a href="https://commits.webkit.org/312762@main">https://commits.webkit.org/312762@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/92c6bf603efb3e50f0bf2275467ca1e28d095b03

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/161012 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/34485 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/27586 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/169915 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/117272 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/34586 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/34485 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/124891 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/117272 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/163971 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/27156 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/144620 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/105488 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/26205 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/24708 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/17635 "Built successfully") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/20/builds/153068 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/135899 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/22382 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/172398 "Built successfully") | 
| [  ~~🛠 🧪 jsc-debug-arm64~~](https://ews-build.webkit.org/#/builders/171/builds/21850 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/24023 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/133166 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/34159 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/28801 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/133176 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35961 "Built successfully and passed tests") | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/34143 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/144177 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/95982 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/160/builds/34143 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/20995 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/193411 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/33654 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/49808 "Passed tests") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/33153 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/33397 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/33302 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->