### PR TITLE
[libpas] Fix race in `pas_bitfit_directory_take_last_empty`

### DIFF
--- a/Source/bmalloc/libpas/src/libpas/pas_bitfit_directory.c
+++ b/Source/bmalloc/libpas/src/libpas/pas_bitfit_directory.c
@@ -37,6 +37,7 @@
 #include "pas_free_granules.h"
 #include "pas_heap_lock.h"
 #include "pas_page_sharing_pool.h"
+#include "pas_race_test_hooks.h"
 #include "pas_segregated_heap.h"
 #include "pas_stream.h"
 
@@ -391,7 +392,7 @@ pas_page_sharing_pool_take_result pas_bitfit_directory_take_last_empty(
     const pas_bitfit_page_config* page_config;
     size_t num_granules;
 
-    last_empty_plus_one_value = pas_versioned_field_read(&directory->last_empty_plus_one);
+    last_empty_plus_one_value = pas_versioned_field_read_to_watch(&directory->last_empty_plus_one);
 
     page_config = pas_bitfit_page_config_kind_get_config(directory->config_kind);
     num_granules = page_config->base.page_size / page_config->base.granule_size;
@@ -547,10 +548,12 @@ pas_page_sharing_pool_take_result pas_bitfit_directory_take_last_empty(
         return pas_page_sharing_pool_take_success;
     }
 
+    pas_race_test_hook(pas_race_test_hook_bitfit_directory_take_last_empty_after_loop);
+
     pas_versioned_field_try_write(&directory->last_empty_plus_one,
                                   last_empty_plus_one_value,
                                   0);
-    
+
     return pas_page_sharing_pool_take_none_available;
 }
 

--- a/Source/bmalloc/libpas/src/libpas/pas_race_test_hooks.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_race_test_hooks.h
@@ -32,7 +32,8 @@ PAS_BEGIN_EXTERN_C;
 
 enum pas_race_test_hook_kind {
     pas_race_test_hook_local_allocator_stop_before_did_stop_allocating,
-    pas_race_test_hook_local_allocator_stop_before_unlock
+    pas_race_test_hook_local_allocator_stop_before_unlock,
+    pas_race_test_hook_bitfit_directory_take_last_empty_after_loop
 };
 
 typedef enum pas_race_test_hook_kind pas_race_test_hook_kind;
@@ -44,6 +45,8 @@ static inline const char* pas_race_test_hook_kind_get_string(pas_race_test_hook_
         return "local_allocator_stop_before_did_stop_allocating";
     case pas_race_test_hook_local_allocator_stop_before_unlock:
         return "local_allocator_stop_before_unlock";
+    case pas_race_test_hook_bitfit_directory_take_last_empty_after_loop:
+        return "bitfit_directory_take_last_empty_after_loop";
     }
     PAS_ASSERT_NOT_REACHED();
     return NULL;

--- a/Source/bmalloc/libpas/src/test/BitfitTests.cpp
+++ b/Source/bmalloc/libpas/src/test/BitfitTests.cpp
@@ -29,10 +29,16 @@
 
 #include "iso_heap.h"
 #include "iso_heap_innards.h"
+#include "pas_bitfit_directory.h"
 #include "pas_bitfit_heap.h"
 #include "pas_bitfit_size_class.h"
+#include "pas_deferred_decommit_log.h"
 #include "pas_heap.h"
+#include "pas_race_test_hooks.h"
+#include "pas_scavenger.h"
+#include "pas_versioned_field.h"
 #include <algorithm>
+#include <functional>
 #include <vector>
 
 using namespace std;
@@ -155,6 +161,75 @@ void testAllocateAlignedSmallerThanSizeClassAndSmallerThanLargestAvailable(
     assertSizeClasses(fillerObjectSize, firstSize);
 }
 
+#if PAS_ENABLE_TESTING
+function<void(pas_race_test_hook_kind)> hookCallback;
+
+void hookCallbackAdapter(pas_race_test_hook_kind kind)
+{
+    hookCallback(kind);
+}
+
+class InstallBitfitRaceHook : public TestScope {
+public:
+    InstallBitfitRaceHook()
+        : TestScope(
+            "install-bitfit-race-hook",
+            [] () {
+                pas_race_test_hook_callback_instance = hookCallbackAdapter;
+            })
+    {
+    }
+};
+
+void testTakeLastEmptyLastEmptyPlusOneWatchRace()
+{
+    pas_scavenger_suspend();
+
+    void* obj = iso_allocate_common_primitive(1056, pas_non_compact_allocation_mode);
+    CHECK(obj);
+
+    pas_bitfit_heap* bitfitHeap = pas_compact_atomic_bitfit_heap_ptr_load_non_null(
+        &iso_common_primitive_heap.segregated_heap.bitfit_heap);
+    pas_bitfit_directory* directory = nullptr;
+    pas_bitfit_page_config_variant variant;
+    for (PAS_EACH_BITFIT_PAGE_CONFIG_VARIANT_ASCENDING(variant)) {
+        pas_bitfit_directory* candidate = pas_bitfit_heap_get_directory(bitfitHeap, variant);
+        if (pas_bitfit_directory_size(candidate)) {
+            directory = candidate;
+            break;
+        }
+    }
+    CHECK(directory);
+    CHECK_GREATER_EQUAL(pas_bitfit_directory_size(directory), 1u);
+
+    pas_bitfit_directory_set_empty_bit_at_index(directory, 0, false);
+    directory->last_empty_plus_one = pas_versioned_field_create(1, 0);
+
+    hookCallback =
+        [directory] (pas_race_test_hook_kind kind) {
+            if (kind != pas_race_test_hook_bitfit_directory_take_last_empty_after_loop)
+                return;
+            pas_bitfit_directory_view_did_become_empty_at_index(directory, 0);
+        };
+
+    pas_deferred_decommit_log log;
+    pas_deferred_decommit_log_construct(&log, nullptr, 0, nullptr);
+    pas_page_sharing_pool_take_result result =
+        pas_bitfit_directory_take_last_empty(directory, &log, pas_lock_is_not_held);
+    pas_deferred_decommit_log_destruct(&log, pas_lock_is_not_held);
+
+    hookCallback = nullptr;
+
+    CHECK_EQUAL(result, pas_page_sharing_pool_take_none_available);
+
+    // The hook re-reported view[0] as empty after the scan but before the final try_write.
+    // If take_last_empty's read of last_empty_plus_one isn't watched, the hook's maximize()
+    // is a no-op, the try_write succeeds, and the directory ends with last_empty_plus_one == 0
+    // while empty_bits[0] is set: a permanently stranded page.
+    CHECK_EQUAL(directory->last_empty_plus_one.value, static_cast<uintptr_t>(1));
+}
+#endif // PAS_ENABLE_TESTING
+
 } // anonymous namespace
 
 #endif // PAS_ENABLE_ISO
@@ -163,8 +238,12 @@ void addBitfitTests()
 {
 #if PAS_ENABLE_ISO
     ForceBitfit forceBitfit;
-    
+
     ADD_TEST(testAllocateAlignedSmallerThanSizeClassAndSmallerThanLargestAvailable(
                  1056, 100, 0, 16, 1024, 100));
+#if PAS_ENABLE_TESTING
+    InstallBitfitRaceHook installBitfitRaceHook;
+    ADD_TEST(testTakeLastEmptyLastEmptyPlusOneWatchRace());
+#endif
 #endif // PAS_ENABLE_ISO
 }


### PR DESCRIPTION
#### 6e299de4c1aeac674d600d988c812acc27cb9f7a
<pre>
[libpas] Fix race in `pas_bitfit_directory_take_last_empty`
<a href="https://bugs.webkit.org/show_bug.cgi?id=314271">https://bugs.webkit.org/show_bug.cgi?id=314271</a>

Reviewed by Marcus Plutowski.

pas_bitfit_directory_take_last_empty read last_empty_plus_one with
pas_versioned_field_read instead of pas_versioned_field_read_to_watch,
so the final pas_versioned_field_try_write could not detect a
concurrent view_did_become_empty_at_index between the scan and the
write. The try_write succeeded on a stale version and zeroed
last_empty_plus_one with empty bits still set, stranding the page.
The matching segregated-directory path already uses read_to_watch.

Add a regression test that uses pas_race_test_hooks to inject the
empty event between the scan and the write.

* Source/bmalloc/libpas/src/libpas/pas_bitfit_directory.c:
(pas_bitfit_directory_take_last_empty):
* Source/bmalloc/libpas/src/libpas/pas_race_test_hooks.h:
(pas_race_test_hook_kind_get_string):
* Source/bmalloc/libpas/src/test/BitfitTests.cpp:
(std::takeLastEmptyRaceHook):
(std::testTakeLastEmptyLastEmptyPlusOneWatchRace):
(addBitfitTests):

Canonical link: <a href="https://commits.webkit.org/312830@main">https://commits.webkit.org/312830@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2ab9863014d157881b1a096ba18a3f9d5bc18f03

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/161018 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/34491 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/27592 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/169921 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/117278 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/34592 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/34491 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/124900 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/117278 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/163977 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/27163 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/144629 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/105497 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/26212 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/24712 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/17641 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/153074 "Built successfully and passed tests") | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/135906 "Found 1 new API test failure: TestWebKitAPI.WritingTools.CompositionWithMultipleChunks (failure)") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/22391 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/172404 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/21856 "Built successfully and passed tests") | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/24032 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/133173 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/34165 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/28805 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/133183 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36007 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/34149 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/144186 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/95988 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/27743 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/21004 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/193417 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/33660 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/49812 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/33159 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/33403 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/33308 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->