### PR TITLE
[JSC] StructureAlignedMemoryAllocator does not need to do commit on Windows

### DIFF
--- a/Source/JavaScriptCore/heap/StructureAlignedMemoryAllocator.cpp
+++ b/Source/JavaScriptCore/heap/StructureAlignedMemoryAllocator.cpp
@@ -121,7 +121,7 @@ public:
         m_useSystemHeap = !bmalloc::api::isEnabled();
 #if USE(LIBPAS)
         if (!m_useSystemHeap) [[likely]] {
-#if OS(WINDOWS) || PLATFORM(PLAYSTATION)
+#if PLATFORM(PLAYSTATION)
             // libpas isn't calling pas_page_malloc commit, so we've got to commit the region ourselves
             // https://bugs.webkit.org/show_bug.cgi?id=292771
             OSAllocator::commit((void *) g_jscConfig.startOfStructureHeap, MarkedBlock::blockSize, true, false);
@@ -146,7 +146,7 @@ public:
 #if USE(LIBPAS)
             void* result = bmalloc_try_allocate_auxiliary_with_alignment_inline(&structureHeap, MarkedBlock::blockSize, MarkedBlock::blockSize, pas_always_compact_allocation_mode);
 
-#if OS(WINDOWS) || PLATFORM(PLAYSTATION)
+#if PLATFORM(PLAYSTATION)
             // libpas isn't calling pas_page_malloc commit, so we've got to commit the region ourselves
             // https://bugs.webkit.org/show_bug.cgi?id=292771
             OSAllocator::commit(result, MarkedBlock::blockSize, true, false);

--- a/Source/bmalloc/libpas/src/libpas/jit_heap_config.c
+++ b/Source/bmalloc/libpas/src/libpas/jit_heap_config.c
@@ -102,7 +102,9 @@ static pas_allocation_result page_provider(
 pas_large_heap_physical_page_sharing_cache jit_large_fresh_memory_heap = {
     .free_heap = PAS_SIMPLE_LARGE_FREE_HEAP_INITIALIZER,
     .provider = page_provider,
-    .provider_arg = NULL
+    .provider_arg = NULL,
+    /* page_provider commits each chunk before returning it. */
+    .provider_commit_mode = pas_committed
 };
 
 pas_page_header_table jit_small_page_header_table =

--- a/Source/bmalloc/libpas/src/libpas/pas_create_basic_heap_page_caches_with_reserved_memory.c
+++ b/Source/bmalloc/libpas/src/libpas/pas_create_basic_heap_page_caches_with_reserved_memory.c
@@ -114,12 +114,14 @@ pas_basic_heap_page_caches* pas_create_basic_heap_page_caches_with_reserved_memo
     pas_large_heap_physical_page_sharing_cache_construct(
         &caches->megapage_large_heap_cache,
         pas_reserved_memory_provider_try_allocate,
-        provider);
+        provider,
+        pas_decommitted);
 
     pas_large_heap_physical_page_sharing_cache_construct(
         &caches->large_heap_cache,
         pas_reserved_memory_provider_try_allocate,
-        provider);
+        provider,
+        pas_decommitted);
     
     pas_megapage_cache_construct(
         &caches->small_exclusive_segregated_megapage_cache,

--- a/Source/bmalloc/libpas/src/libpas/pas_large_free_heap_helpers.c
+++ b/Source/bmalloc/libpas/src/libpas/pas_large_free_heap_helpers.c
@@ -87,7 +87,8 @@ static pas_aligned_allocation_result large_utility_aligned_allocator(size_t size
         pas_large_sharing_pool_boot_free(
             pas_range_create(allocation_result.begin, allocation_result.begin + aligned_size),
             pas_physical_memory_is_locked_by_heap_lock,
-            pas_page_flags_none);
+            pas_page_flags_none,
+            pas_committed);
     }
 
     result.result = (void*)allocation_result.begin;

--- a/Source/bmalloc/libpas/src/libpas/pas_large_heap_physical_page_sharing_cache.c
+++ b/Source/bmalloc/libpas/src/libpas/pas_large_heap_physical_page_sharing_cache.c
@@ -128,12 +128,16 @@ static pas_aligned_allocation_result large_aligned_allocator(size_t size,
     /* We are likely to introduce more free memory into this heap than the heap can immediately use.
        But we don't want that memory to then immediately get decommitted, since we believe that this
        memory is likely to be used for the very next allocation our of this heap.
-       
-       So we use boot_free, which frees while bumping the epoch. */
+
+       So we use boot_free, which frees while bumping the epoch. The provider_commit_mode tells
+       boot_free whether the memory arriving from the provider is already physically committed (the
+       common case) or merely reserved; in the latter case the next allocate_and_commit emits a
+       real pas_page_malloc_commit before the bytes are made accessible. */
     pas_large_sharing_pool_boot_free(
         pas_range_create(allocation_result.begin, allocation_result.begin + aligned_size),
         pas_physical_memory_is_locked_by_virtual_range_common_lock,
-        data->config->page_flags);
+        data->config->page_flags,
+        data->cache->provider_commit_mode);
     
     result.result = (void*)allocation_result.begin;
     result.result_size = size;
@@ -149,11 +153,13 @@ static pas_aligned_allocation_result large_aligned_allocator(size_t size,
 void pas_large_heap_physical_page_sharing_cache_construct(
     pas_large_heap_physical_page_sharing_cache* cache,
     pas_heap_page_provider provider,
-    void* provider_arg)
+    void* provider_arg,
+    pas_commit_mode provider_commit_mode)
 {
     pas_simple_large_free_heap_construct(&cache->free_heap);
     cache->provider = provider;
     cache->provider_arg = provider_arg;
+    cache->provider_commit_mode = provider_commit_mode;
 }
 
 pas_allocation_result

--- a/Source/bmalloc/libpas/src/libpas/pas_large_heap_physical_page_sharing_cache.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_large_heap_physical_page_sharing_cache.h
@@ -27,6 +27,7 @@
 #define PAS_LARGE_HEAP_PHYSICAL_PAGE_SHARING_CACHE_H
 
 #include "pas_bootstrap_heap_page_provider.h"
+#include "pas_commit_mode.h"
 #include "pas_enumerable_range_list.h"
 #include "pas_simple_large_free_heap.h"
 #include "pas_utils.h"
@@ -42,20 +43,30 @@ struct pas_large_heap_physical_page_sharing_cache {
     pas_simple_large_free_heap free_heap;
     pas_heap_page_provider provider;
     void* provider_arg;
+    /* Commit state of memory that the provider hands back. pas_committed means the provider
+       returns memory that is already physically committed (the common case — e.g. providers
+       backed by the standard page allocator). pas_decommitted means the provider returns
+       memory that is reserved but not yet physically committed (e.g. a provider that hands
+       out chunks of a client-supplied reserved region). The cache passes this through to
+       pas_large_sharing_pool_boot_free as the initial commit mode when registering a new
+       chunk. */
+    pas_commit_mode provider_commit_mode;
 };
 
 #define PAS_MEGAPAGE_LARGE_FREE_HEAP_PHYSICAL_PAGE_SHARING_CACHE_INITIALIZER \
     ((pas_large_heap_physical_page_sharing_cache){ \
          .free_heap = PAS_SIMPLE_LARGE_FREE_HEAP_INITIALIZER, \
          .provider = pas_small_medium_bootstrap_heap_page_provider, \
-         .provider_arg = NULL \
+         .provider_arg = NULL, \
+         .provider_commit_mode = pas_committed \
      })
 
 #define PAS_LARGE_FREE_HEAP_PHYSICAL_PAGE_SHARING_CACHE_INITIALIZER \
     ((pas_large_heap_physical_page_sharing_cache){ \
          .free_heap = PAS_SIMPLE_LARGE_FREE_HEAP_INITIALIZER, \
          .provider = pas_bootstrap_heap_page_provider, \
-         .provider_arg = NULL \
+         .provider_arg = NULL, \
+         .provider_commit_mode = pas_committed \
      })
 
 PAS_API extern pas_enumerable_range_list pas_large_heap_physical_page_sharing_cache_page_list;
@@ -64,7 +75,8 @@ PAS_API void
 pas_large_heap_physical_page_sharing_cache_construct(
     pas_large_heap_physical_page_sharing_cache* cache,
     pas_heap_page_provider provider,
-    void* provider_arg);
+    void* provider_arg,
+    pas_commit_mode provider_commit_mode);
 
 /* NOTE: should_zero should have a consistent value for all calls to try_allocate for a given
    cache. */

--- a/Source/bmalloc/libpas/src/libpas/pas_large_sharing_pool.c
+++ b/Source/bmalloc/libpas/src/libpas/pas_large_sharing_pool.c
@@ -559,7 +559,8 @@ enum splat_command {
     splat_decommit,
     splat_allocate_and_commit,
     splat_free,
-    splat_boot_free
+    splat_boot_free_committed,
+    splat_boot_free_decommitted
 };
 
 typedef enum splat_command splat_command;
@@ -573,8 +574,10 @@ static const char* splat_command_get_string(splat_command command)
         return "allocate_and_commit";
     case splat_free:
         return "free";
-    case splat_boot_free:
-        return "boot_free";
+    case splat_boot_free_committed:
+        return "boot_free_committed";
+    case splat_boot_free_decommitted:
+        return "boot_free_decommitted";
     }
     PAS_ASSERT_NOT_REACHED();
     return NULL;
@@ -589,7 +592,8 @@ static pas_free_mode splat_command_get_free_mode(splat_command command)
     case splat_allocate_and_commit:
         return pas_allocated;
     case splat_free:
-    case splat_boot_free:
+    case splat_boot_free_committed:
+    case splat_boot_free_decommitted:
         return pas_free;
     }
     PAS_ASSERT_NOT_REACHED();
@@ -676,7 +680,7 @@ static bool try_splat_impl(pas_range range,
 
         max_node = successor(min_node);
         if (pas_range_size(max_node->range) == page_size
-            && (command == splat_free || command == splat_boot_free || max_node->is_committed)) {
+            && (command == splat_free || command == splat_boot_free_committed || max_node->is_committed)) {
             PAS_ASSERT(max_node->range.begin < range.end);
             PAS_ASSERT(max_node->range.end >= range.end);
             remove_from_min_heap(min_node);
@@ -752,9 +756,10 @@ static bool try_splat_impl(pas_range range,
         desired_commit_mode = pas_committed;
         do_commit_stuff = true;
         break;
-        
+
     case splat_free:
-    case splat_boot_free:
+    case splat_boot_free_committed:
+    case splat_boot_free_decommitted:
         break;
     }
 
@@ -900,7 +905,16 @@ static bool try_splat_impl(pas_range range,
             break;
 
         case splat_free:
-        case splat_boot_free:
+        case splat_boot_free_committed:
+            splat_live_bytes(
+                node,
+                pas_range_size(pas_range_create_intersection(node->range, range)),
+                pas_free);
+            break;
+
+        case splat_boot_free_decommitted:
+            PAS_ASSERT(pas_range_subsumes(range, node->range));
+            node->is_committed = pas_decommitted;
             splat_live_bytes(
                 node,
                 pas_range_size(pas_range_create_intersection(node->range, range)),
@@ -916,7 +930,8 @@ static bool try_splat_impl(pas_range range,
             PAS_ASSERT(node->page_flags == page_flags);
             break;
 
-        case splat_boot_free:
+        case splat_boot_free_committed:
+        case splat_boot_free_decommitted:
             PAS_ASSERT(
                 node->synchronization_style
                 == pas_physical_memory_is_locked_by_virtual_range_common_lock);
@@ -957,7 +972,8 @@ done:
                     >= pas_range_size(pas_range_create_intersection(node->range, range)));
                 break;
             case splat_free:
-            case splat_boot_free:
+            case splat_boot_free_committed:
+            case splat_boot_free_decommitted:
                 PAS_ASSERT(
                     pas_range_size(node->range) - node->num_live_bytes
                     >= pas_range_size(pas_range_create_intersection(node->range, range)));
@@ -1027,18 +1043,34 @@ static void splat(pas_range range,
 void pas_large_sharing_pool_boot_free(
     pas_range range,
     pas_physical_memory_synchronization_style synchronization_style,
-    pas_page_flags page_flags)
+    pas_page_flags page_flags,
+    pas_commit_mode initial_commit_mode)
 {
+    splat_command command;
     uint64_t epoch;
+    size_t page_size;
 
     PAS_PROFILE(LARGE_SHARING_POOL_BOOT_FREE, range.begin, range.end);
     PAS_MTE_HANDLE(LARGE_SHARING_POOL_BOOT_FREE, range.begin, range.end);
 
+    page_size = pas_page_malloc_alignment();
+    PAS_ASSERT(pas_is_aligned(range.begin, page_size));
+    PAS_ASSERT(pas_is_aligned(range.end, page_size));
+
     if (!pas_large_sharing_pool_enabled)
         return;
-    
+
+    switch (initial_commit_mode) {
+    case pas_committed:
+        command = splat_boot_free_committed;
+        break;
+    case pas_decommitted:
+        command = splat_boot_free_decommitted;
+        break;
+    }
+
     epoch = pas_get_epoch();
-    splat(range, splat_boot_free, epoch, NULL, NULL, NULL, synchronization_style, page_flags);
+    splat(range, command, epoch, NULL, NULL, NULL, synchronization_style, page_flags);
 }
 
 void pas_large_sharing_pool_free(pas_range range,

--- a/Source/bmalloc/libpas/src/libpas/pas_large_sharing_pool.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_large_sharing_pool.h
@@ -158,11 +158,14 @@ PAS_API extern bool pas_large_sharing_pool_validate_each_splat;
 
 PAS_API extern pas_large_sharing_pool_epoch_update_mode pas_large_sharing_pool_epoch_update_mode_setting;
 
-/* This makes the memory free and also bumps the epoch. */
+/* Registers the range as free in the tracker and bumps the epoch. The range MUST be
+   page-aligned at both ends - the splat needs to carve it into whole-page nodes, and the
+   per-node is_committed bit cannot represent a half-decommitted boundary. */
 PAS_API void pas_large_sharing_pool_boot_free(
     pas_range range,
     pas_physical_memory_synchronization_style synchronization_style,
-    pas_page_flags page_flags);
+    pas_page_flags page_flags,
+    pas_commit_mode initial_commit_mode);
 
 PAS_API void pas_large_sharing_pool_free(
     pas_range range,

--- a/Source/bmalloc/libpas/src/test/LargeSharingPoolTests.cpp
+++ b/Source/bmalloc/libpas/src/test/LargeSharingPoolTests.cpp
@@ -143,18 +143,20 @@ void testGoodCoalesceEpochUpdate()
     pas_large_sharing_pool_boot_free(
         pas_range_create(10 * PG, 20 * PG),
         pas_physical_memory_is_locked_by_virtual_range_common_lock,
-        pas_page_flags_none);
+        pas_page_flags_none,
+        pas_committed);
     pas_heap_lock_unlock();
 
     assertState({ Range(0, 10 * PG, pas_committed, 10 * PG, 0),
                   Range(10 * PG, 20 * PG, pas_committed, 0, 1),
                   Range(20 * PG, END, pas_committed, END - 20 * PG, 0) });
-    
+
     pas_heap_lock_lock();
     pas_large_sharing_pool_boot_free(
         pas_range_create(20 * PG, 30 * PG),
         pas_physical_memory_is_locked_by_virtual_range_common_lock,
-        pas_page_flags_none);
+        pas_page_flags_none,
+        pas_committed);
     pas_heap_lock_unlock();
 
     assertState({ Range(0, 10 * PG, pas_committed, 10 * PG, 0),


### PR DESCRIPTION
#### b88796d4c16ff46ca816b569ddd51ed9c76b8390
<pre>
[JSC] StructureAlignedMemoryAllocator does not need to do commit on Windows
<a href="https://bugs.webkit.org/show_bug.cgi?id=314272">https://bugs.webkit.org/show_bug.cgi?id=314272</a>
<a href="https://rdar.apple.com/176416356">rdar://176416356</a>

Reviewed by Marcus Plutowski.

As Windows libpas uses symmetric commit / decommit, we do not need
explicit commit for StructureAlignedMemoryAllocator. However, we need to
change libpas around reserved memory region.

When reserved memory is registered in libpas heap, we allocate it from
cache and register it to large-sharing-pool. But at that time, we
are registering them as committed memory. We skip calling commit for
them and this is not compatible to Windows, and that&apos;s a reason why
Windows cannot use Gigacage in practice.

This patch adds provider_commit_mode which tells whether the provider
allocated page is committed or decommitted. Later this changes splat
call mode splat_boot_free_committed v.s. splat_boot_free_decommitted.
And this controls committed / decommitted state in large-sharing-pool.

* Source/JavaScriptCore/heap/StructureAlignedMemoryAllocator.cpp:
(JSC::StructureMemoryManager::StructureMemoryManager):
(JSC::StructureMemoryManager::tryMallocStructureBlock):
* Source/bmalloc/libpas/src/libpas/jit_heap_config.c:
* Source/bmalloc/libpas/src/libpas/pas_create_basic_heap_page_caches_with_reserved_memory.c:
(pas_create_basic_heap_page_caches_with_reserved_memory):
* Source/bmalloc/libpas/src/libpas/pas_large_free_heap_helpers.c:
(large_utility_aligned_allocator):
* Source/bmalloc/libpas/src/libpas/pas_large_heap_physical_page_sharing_cache.c:
(large_aligned_allocator):
(pas_large_heap_physical_page_sharing_cache_construct):
* Source/bmalloc/libpas/src/libpas/pas_large_heap_physical_page_sharing_cache.h:
* Source/bmalloc/libpas/src/libpas/pas_large_sharing_pool.c:
(splat_command_get_string):
(splat_command_get_free_mode):
(try_splat_impl):
(pas_large_sharing_pool_boot_free):
* Source/bmalloc/libpas/src/libpas/pas_large_sharing_pool.h:
* Source/bmalloc/libpas/src/test/LargeSharingPoolTests.cpp:
(std::testGoodCoalesceEpochUpdate):

Canonical link: <a href="https://commits.webkit.org/313052@main">https://commits.webkit.org/313052@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/eaf2aa755b958e3fe0bd1158726609076c228915

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/161046 "2 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/34519 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/27620 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/169949 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/117306 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/673a10ae-fa5d-42de-813c-5655ee4f34be) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/34620 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/34519 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/124914 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/88124 "1 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/3a863d5b-be4f-4982-b132-dfb384723dc4) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/164005 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/27191 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/144655 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/105511 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/fbedf4da-e303-41a3-8a3a-a91a0e1487bf) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/26240 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/24736 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/17669 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/153102 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/135934 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/22417 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/172432 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/21884 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/19453 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/24058 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/133192 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/34193 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/28829 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/133202 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/34177 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/144212 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/96016 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/24596 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/27758 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/21030 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/193445 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/33688 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/101113 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/49824 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/33187 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/33431 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/33336 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->