### PR TITLE
Throttle time-based website data eviction to run once per week

### DIFF
--- a/Source/WebKit/NetworkProcess/NetworkProcess.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkProcess.cpp
@@ -698,6 +698,17 @@ void NetworkProcess::registrableDomainsWithLastAccessedTime(PAL::SessionID sessi
     completionHandler(std::nullopt);
 }
 
+void NetworkProcess::diskCacheOriginAccessTimes(PAL::SessionID sessionID, CompletionHandler<void(HashMap<WebCore::RegistrableDomain, WallTime>&&)>&& completionHandler)
+{
+    if (CheckedPtr session = networkSession(sessionID)) {
+        if (RefPtr cache = session->cache()) {
+            cache->fetchOriginAccessTimes(WTF::move(completionHandler));
+            return;
+        }
+    }
+    completionHandler({ });
+}
+
 void NetworkProcess::registrableDomainsExemptFromWebsiteDataDeletion(PAL::SessionID sessionID, CompletionHandler<void(HashSet<RegistrableDomain>)>&& completionHandler)
 {
     if (CheckedPtr session = networkSession(sessionID)) {

--- a/Source/WebKit/NetworkProcess/NetworkProcess.h
+++ b/Source/WebKit/NetworkProcess/NetworkProcess.h
@@ -242,6 +242,7 @@ public:
     void addWebsiteDataStore(WebsiteDataStoreParameters&&);
 
     void registrableDomainsWithLastAccessedTime(PAL::SessionID, CompletionHandler<void(std::optional<HashMap<RegistrableDomain, WallTime>>&&)>&&);
+    void diskCacheOriginAccessTimes(PAL::SessionID, CompletionHandler<void(HashMap<WebCore::RegistrableDomain, WallTime>&&)>&&);
     void registrableDomainsExemptFromWebsiteDataDeletion(PAL::SessionID, CompletionHandler<void(HashSet<RegistrableDomain>)>&&);
     void clearPrevalentResource(PAL::SessionID, RegistrableDomain&&, CompletionHandler<void()>&&);
     void clearUserInteraction(PAL::SessionID, RegistrableDomain&&, CompletionHandler<void()>&&);

--- a/Source/WebKit/NetworkProcess/NetworkSession.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkSession.cpp
@@ -135,7 +135,7 @@ static Ref<NetworkStorageManager> createNetworkStorageManager(NetworkProcess& ne
     String serviceWorkerStorageDirectory;
     serviceWorkerStorageDirectory = parameters.serviceWorkerRegistrationDirectory;
     SandboxExtension::consumePermanently(parameters.serviceWorkerRegistrationDirectoryExtensionHandle);
-    return NetworkStorageManager::create(networkProcess, parameters.sessionID, parameters.dataStoreIdentifier, connectionID, parameters.generalStorageDirectory, parameters.localStorageDirectory, parameters.indexedDBDirectory, parameters.cacheStorageDirectory, serviceWorkerStorageDirectory, parameters.perOriginStorageQuota, parameters.originQuotaRatio, parameters.totalQuotaRatio, parameters.standardVolumeCapacity, parameters.volumeCapacityOverride, parameters.unifiedOriginStorageLevel, parameters.storageSiteValidationEnabled, parameters.shouldPerformTimeBasedEviction, parameters.timeBasedEvictionThreshold, parameters.lastModificationTimeUpdateIntervalOverride);
+    return NetworkStorageManager::create(networkProcess, parameters.sessionID, parameters.dataStoreIdentifier, connectionID, parameters.generalStorageDirectory, parameters.localStorageDirectory, parameters.indexedDBDirectory, parameters.cacheStorageDirectory, serviceWorkerStorageDirectory, parameters.perOriginStorageQuota, parameters.originQuotaRatio, parameters.totalQuotaRatio, parameters.standardVolumeCapacity, parameters.volumeCapacityOverride, parameters.unifiedOriginStorageLevel, parameters.storageSiteValidationEnabled, parameters.shouldPerformTimeBasedEviction, parameters.timeBasedEvictionThreshold, parameters.lastModificationTimeUpdateIntervalOverride, parameters.timeBasedEvictionIntervalOverride);
 }
 
 #if ENABLE(WEB_PUSH_NOTIFICATIONS)

--- a/Source/WebKit/NetworkProcess/NetworkSessionCreationParameters.h
+++ b/Source/WebKit/NetworkProcess/NetworkSessionCreationParameters.h
@@ -129,6 +129,7 @@ struct NetworkSessionCreationParameters {
     bool shouldPerformTimeBasedEviction { false };
     Seconds timeBasedEvictionThreshold { 180 * 24_h };
     std::optional<Seconds> lastModificationTimeUpdateIntervalOverride;
+    std::optional<Seconds> timeBasedEvictionIntervalOverride;
 #if ENABLE(DECLARATIVE_WEB_PUSH)
     bool isDeclarativeWebPushEnabled { false };
 #endif

--- a/Source/WebKit/NetworkProcess/NetworkSessionCreationParameters.serialization.in
+++ b/Source/WebKit/NetworkProcess/NetworkSessionCreationParameters.serialization.in
@@ -103,6 +103,7 @@ enum class WebKit::AllowsCellularAccess : bool;
     bool shouldPerformTimeBasedEviction;
     Seconds timeBasedEvictionThreshold;
     std::optional<Seconds> lastModificationTimeUpdateIntervalOverride;
+    std::optional<Seconds> timeBasedEvictionIntervalOverride;
 #if ENABLE(DECLARATIVE_WEB_PUSH)
     bool isDeclarativeWebPushEnabled;
 #endif

--- a/Source/WebKit/NetworkProcess/cache/NetworkCache.cpp
+++ b/Source/WebKit/NetworkProcess/cache/NetworkCache.cpp
@@ -763,6 +763,24 @@ void Cache::fetchData(bool shouldComputeSize, CompletionHandler<void(Vector<Webs
     });
 }
 
+void Cache::fetchOriginAccessTimes(CompletionHandler<void(HashMap<WebCore::RegistrableDomain, WallTime>&&)>&& completionHandler)
+{
+    HashMap<WebCore::RegistrableDomain, WallTime> originAccessTimes;
+    m_storage->traverse(resourceType(), { Storage::TraverseFlag::LastAccessedRecordPerPartition }, [completionHandler = WTF::move(completionHandler), originAccessTimes = WTF::move(originAccessTimes)](const Storage::Record* record, const Storage::RecordInfo& recordInfo) mutable {
+        if (!record) {
+            completionHandler(WTF::move(originAccessTimes));
+            return;
+        }
+
+        auto& partition = record->key.partition();
+        if (partition.isEmpty())
+            return;
+
+        auto domain = WebCore::RegistrableDomain::uncheckedCreateFromRegistrableDomainString(partition);
+        originAccessTimes.set(WTF::move(domain), recordInfo.lastAccessTime);
+    });
+}
+
 void Cache::deleteData(const Vector<WebCore::SecurityOriginData>& origins, CompletionHandler<void()>&& completionHandler)
 {
     HashSet<WebCore::SecurityOriginData> originSet;

--- a/Source/WebKit/NetworkProcess/cache/NetworkCache.h
+++ b/Source/WebKit/NetworkProcess/cache/NetworkCache.h
@@ -233,6 +233,7 @@ public:
     PAL::SessionID sessionID() const { return m_sessionID; }
     const String& storageDirectory() const LIFETIME_BOUND { return m_storageDirectory; }
     void fetchData(bool shouldComputeSize, CompletionHandler<void(Vector<WebsiteData::Entry>&&)>&&);
+    void fetchOriginAccessTimes(CompletionHandler<void(HashMap<WebCore::RegistrableDomain, WallTime>&&)>&&);
     void deleteData(const Vector<WebCore::SecurityOriginData>&, CompletionHandler<void()>&&);
     void deleteDataForRegistrableDomains(const Vector<WebCore::RegistrableDomain>&, CompletionHandler<void(HashSet<WebCore::RegistrableDomain>&&)>&&);
 

--- a/Source/WebKit/NetworkProcess/cache/NetworkCacheStorage.cpp
+++ b/Source/WebKit/NetworkProcess/cache/NetworkCacheStorage.cpp
@@ -281,6 +281,16 @@ public:
         });
     }
 
+    struct PartitionEntry {
+        String recordPath;
+        WallTime lastAccessTime;
+    };
+    HashMap<String, PartitionEntry>& ensurePartitionMap()
+    {
+        ASSERT(!isMainRunLoop());
+        return m_partitionMap;
+    }
+
 private:
     explicit TraverseOperation(Storage::TraverseHandler&& handler)
         : m_handler(WTF::move(handler))
@@ -290,6 +300,7 @@ private:
     Lock m_lock;
     Condition m_activeCondition;
     unsigned m_activityCount WTF_GUARDED_BY_LOCK(m_lock) { 0 };
+    HashMap<String, PartitionEntry> m_partitionMap;
 };
 
 static String makeCachePath(const String& baseCachePath)
@@ -1133,6 +1144,20 @@ void Storage::traverseWithinRootPath(const String& rootPath, const String& type,
                 return;
 
             auto recordPath = FileSystem::pathByAppendingComponent(recordDirectoryPath, fileName);
+
+            if (flags & TraverseFlag::LastAccessedRecordPerPartition) {
+                ASSERT(!flags.containsAny({ TraverseFlag::ComputeWorth, TraverseFlag::ShareCount }));
+                auto mtime = FileSystem::fileModificationTime(recordPath);
+                auto it = traverseOperation->ensurePartitionMap().find(recordDirectoryPath);
+                if (it == traverseOperation->ensurePartitionMap().end())
+                    traverseOperation->ensurePartitionMap().set(recordDirectoryPath, TraverseOperation::PartitionEntry { recordPath, mtime.value_or(WallTime { }) });
+                else if (mtime && *mtime > it->value.lastAccessTime) {
+                    it->value.recordPath = recordPath;
+                    it->value.lastAccessTime = *mtime;
+                }
+                return;
+            }
+
             double worth = -1;
             if (flags & TraverseFlag::ComputeWorth)
                 worth = computeRecordWorth(fileTimes(recordPath));
@@ -1158,13 +1183,31 @@ void Storage::traverseWithinRootPath(const String& rootPath, const String& type,
                         static_cast<size_t>(metaData.bodySize),
                         worth,
                         bodyShareCount,
-                        String::fromUTF8(SHA1::hexDigest(metaData.bodyHash).span())
+                        String::fromUTF8(SHA1::hexDigest(metaData.bodyHash).span()),
+                        { }
                     };
                     traverseOperation->invokeHandler(&record, info);
                 }
                 traverseOperation->decrementActivityCount();
             });
         });
+
+        if (flags & TraverseFlag::LastAccessedRecordPerPartition) {
+            for (auto& [directoryPath, entry] : traverseOperation->ensurePartitionMap()) {
+                traverseOperation->waitAndIncrementActivityCount();
+                auto channel = IOChannel::open(WTF::move(entry.recordPath), IOChannel::Type::Read);
+                channel->read(0, std::numeric_limits<size_t>::max(), WorkQueue::mainSingleton(), [this, protectedThis, traverseOperation, accessTime = entry.lastAccessTime](auto fileData, int) {
+                    RecordMetaData metaData;
+                    Data headerData;
+                    if (decodeRecordHeader(fileData, metaData, headerData, m_salt)) {
+                        Record record { metaData.key, metaData.timeStamp, headerData, { }, metaData.bodyHash };
+                        RecordInfo info { static_cast<size_t>(metaData.bodySize), -1, 0, String { }, accessTime };
+                        traverseOperation->invokeHandler(&record, info);
+                    }
+                    traverseOperation->decrementActivityCount();
+                });
+            }
+        }
 
         traverseOperation->waitUntilActivitiesFinished();
         RunLoop::mainSingleton().dispatch([traverseOperation = WTF::move(traverseOperation)]() mutable {

--- a/Source/WebKit/NetworkProcess/cache/NetworkCacheStorage.h
+++ b/Source/WebKit/NetworkProcess/cache/NetworkCacheStorage.h
@@ -114,10 +114,12 @@ public:
         double worth; // 0-1 where 1 is the most valuable.
         unsigned bodyShareCount;
         String bodyHash;
+        WallTime lastAccessTime;
     };
     enum class TraverseFlag : uint8_t {
         ComputeWorth = 1 << 0,
         ShareCount = 1 << 1,
+        LastAccessedRecordPerPartition = 1 << 2,
     };
     using TraverseHandler = Function<void (const Record*, const RecordInfo&)>;
     // Null record signals end.

--- a/Source/WebKit/NetworkProcess/storage/NetworkStorageManager.cpp
+++ b/Source/WebKit/NetworkProcess/storage/NetworkStorageManager.cpp
@@ -84,6 +84,8 @@ static constexpr double defaultThirdPartyOriginQuotaRatio = 0.1; // third-party_
 static constexpr uint64_t defaultVolumeCapacityUnit = 1 * GB;
 static constexpr auto persistedFileName = "persisted"_s;
 static constexpr Seconds originLastModificationTimeUpdateInterval = 30_s;
+static constexpr auto lastTimeBasedEvictionTimestampFileName = "lastTimeBasedEvictionTimestamp"_s;
+static constexpr Seconds defaultTimeBasedEvictionInterval = 7 * 24_h;
 
 // FIXME: Remove this if rdar://104754030 is fixed.
 static HashMap<String, ThreadSafeWeakPtr<NetworkStorageManager>>& NODELETE activePaths()
@@ -162,9 +164,9 @@ String NetworkStorageManager::persistedFilePath(const WebCore::ClientOrigin& ori
     return FileSystem::pathByAppendingComponent(directory, persistedFileName);
 }
 
-Ref<NetworkStorageManager> NetworkStorageManager::create(NetworkProcess& process, PAL::SessionID sessionID, Markable<WTF::UUID> identifier, std::optional<IPC::Connection::UniqueID> connection, const String& path, const String& customLocalStoragePath, const String& customIDBStoragePath, const String& customCacheStoragePath, const String& customServiceWorkerStoragePath, uint64_t defaultOriginQuota, std::optional<double> originQuotaRatio, std::optional<double> totalQuotaRatio, std::optional<uint64_t> standardVolumeCapacity, std::optional<uint64_t> volumeCapacityOverride, UnifiedOriginStorageLevel level, bool storageSiteValidationEnabled, bool shouldPerformTimeBasedEviction, Seconds timeBasedEvictionThreshold, std::optional<Seconds> lastModificationTimeUpdateIntervalOverride)
+Ref<NetworkStorageManager> NetworkStorageManager::create(NetworkProcess& process, PAL::SessionID sessionID, Markable<WTF::UUID> identifier, std::optional<IPC::Connection::UniqueID> connection, const String& path, const String& customLocalStoragePath, const String& customIDBStoragePath, const String& customCacheStoragePath, const String& customServiceWorkerStoragePath, uint64_t defaultOriginQuota, std::optional<double> originQuotaRatio, std::optional<double> totalQuotaRatio, std::optional<uint64_t> standardVolumeCapacity, std::optional<uint64_t> volumeCapacityOverride, UnifiedOriginStorageLevel level, bool storageSiteValidationEnabled, bool shouldPerformTimeBasedEviction, Seconds timeBasedEvictionThreshold, std::optional<Seconds> lastModificationTimeUpdateIntervalOverride, std::optional<Seconds> timeBasedEvictionIntervalOverride)
 {
-    return adoptRef(*new NetworkStorageManager(process, sessionID, identifier, connection, path, customLocalStoragePath, customIDBStoragePath, customCacheStoragePath, customServiceWorkerStoragePath, defaultOriginQuota, originQuotaRatio, totalQuotaRatio, standardVolumeCapacity, volumeCapacityOverride, level, storageSiteValidationEnabled, shouldPerformTimeBasedEviction, timeBasedEvictionThreshold, lastModificationTimeUpdateIntervalOverride));
+    return adoptRef(*new NetworkStorageManager(process, sessionID, identifier, connection, path, customLocalStoragePath, customIDBStoragePath, customCacheStoragePath, customServiceWorkerStoragePath, defaultOriginQuota, originQuotaRatio, totalQuotaRatio, standardVolumeCapacity, volumeCapacityOverride, level, storageSiteValidationEnabled, shouldPerformTimeBasedEviction, timeBasedEvictionThreshold, lastModificationTimeUpdateIntervalOverride, timeBasedEvictionIntervalOverride));
 }
 
 static ASCIILiteral queueName(PAL::SessionID sessionID)
@@ -174,7 +176,7 @@ static ASCIILiteral queueName(PAL::SessionID sessionID)
     return "com.apple.WebKit.Storage.persistent"_s;
 }
 
-NetworkStorageManager::NetworkStorageManager(NetworkProcess& process, PAL::SessionID sessionID, Markable<WTF::UUID> identifier, std::optional<IPC::Connection::UniqueID> connection, const String& path, const String& customLocalStoragePath, const String& customIDBStoragePath, const String& customCacheStoragePath, const String& customServiceWorkerStoragePath, uint64_t defaultOriginQuota, std::optional<double> originQuotaRatio, std::optional<double> totalQuotaRatio, std::optional<uint64_t> standardVolumeCapacity, std::optional<uint64_t> volumeCapacityOverride, UnifiedOriginStorageLevel level, bool storageSiteValidationEnabled, bool shouldPerformTimeBasedEviction, Seconds timeBasedEvictionThreshold, std::optional<Seconds> lastModificationTimeUpdateIntervalOverride)
+NetworkStorageManager::NetworkStorageManager(NetworkProcess& process, PAL::SessionID sessionID, Markable<WTF::UUID> identifier, std::optional<IPC::Connection::UniqueID> connection, const String& path, const String& customLocalStoragePath, const String& customIDBStoragePath, const String& customCacheStoragePath, const String& customServiceWorkerStoragePath, uint64_t defaultOriginQuota, std::optional<double> originQuotaRatio, std::optional<double> totalQuotaRatio, std::optional<uint64_t> standardVolumeCapacity, std::optional<uint64_t> volumeCapacityOverride, UnifiedOriginStorageLevel level, bool storageSiteValidationEnabled, bool shouldPerformTimeBasedEviction, Seconds timeBasedEvictionThreshold, std::optional<Seconds> lastModificationTimeUpdateIntervalOverride, std::optional<Seconds> timeBasedEvictionIntervalOverride)
     : m_process(process)
     , m_sessionID(sessionID)
     , m_queue(SuspendableWorkQueue::create(queueName(sessionID), SuspendableWorkQueue::QOS::Default, SuspendableWorkQueue::ShouldLog::Yes))
@@ -194,7 +196,7 @@ NetworkStorageManager::NetworkStorageManager(NetworkProcess& process, PAL::Sessi
     m_pathNormalizedMainThread = FileSystem::lexicallyNormal(path);
     m_customIDBStoragePathNormalizedMainThread = FileSystem::lexicallyNormal(customIDBStoragePath);
 
-    workQueue().dispatch([this, weakThis = ThreadSafeWeakPtr { *this }, path = path.isolatedCopy(), customLocalStoragePath = crossThreadCopy(customLocalStoragePath), customIDBStoragePath = crossThreadCopy(customIDBStoragePath), customCacheStoragePath = crossThreadCopy(customCacheStoragePath), customServiceWorkerStoragePath = crossThreadCopy(customServiceWorkerStoragePath), defaultOriginQuota, originQuotaRatio, totalQuotaRatio, standardVolumeCapacity, volumeCapacityOverride, level, storageSiteValidationEnabled, shouldPerformTimeBasedEviction, timeBasedEvictionThreshold, lastModificationTimeUpdateIntervalOverride]() mutable {
+    workQueue().dispatch([this, weakThis = ThreadSafeWeakPtr { *this }, path = path.isolatedCopy(), customLocalStoragePath = crossThreadCopy(customLocalStoragePath), customIDBStoragePath = crossThreadCopy(customIDBStoragePath), customCacheStoragePath = crossThreadCopy(customCacheStoragePath), customServiceWorkerStoragePath = crossThreadCopy(customServiceWorkerStoragePath), defaultOriginQuota, originQuotaRatio, totalQuotaRatio, standardVolumeCapacity, volumeCapacityOverride, level, storageSiteValidationEnabled, shouldPerformTimeBasedEviction, timeBasedEvictionThreshold, lastModificationTimeUpdateIntervalOverride, timeBasedEvictionIntervalOverride]() mutable {
         assertIsCurrent(workQueue());
 
         auto protectedThis = weakThis.get();
@@ -239,7 +241,7 @@ NetworkStorageManager::NetworkStorageManager(NetworkProcess& process, PAL::Sessi
 
         IDBStorageManager::createVersionDirectoryIfNeeded(m_customIDBStoragePath);
         if (shouldPerformTimeBasedEviction)
-            performTimeBasedEviction(timeBasedEvictionThreshold);
+            performTimeBasedEviction(timeBasedEvictionThreshold, timeBasedEvictionIntervalOverride);
         RunLoop::mainSingleton().dispatch([protectedThis = WTF::move(protectedThis)] { });
     });
 }
@@ -596,16 +598,75 @@ void NetworkStorageManager::performQuotaBasedEviction(HashMap<WebCore::SecurityO
         IPC::Connection::send(*m_parentConnection, Messages::NetworkProcessProxy::DidPerformEvictionForDomains(m_sessionID, WTF::move(deletedDomains)), 0);
 }
 
-void NetworkStorageManager::performTimeBasedEviction(Seconds threshold)
+bool NetworkStorageManager::shouldPerformTimeBasedEvictionNow(std::optional<Seconds> intervalOverride)
 {
     assertIsCurrent(workQueue());
 
-    RELEASE_LOG(Storage, "%p - NetworkStorageManager::performTimeBasedEviction started sessionID=%" PRIu64 " threshold=%.0f days", this, m_sessionID.toUInt64(), threshold.days());
+    // No need to perform eviction for ephemeral session.
+    if (m_path.isEmpty())
+        return false;
+
+    auto evictionInterval = intervalOverride.value_or(defaultTimeBasedEvictionInterval);
+    auto timestampFilePath = FileSystem::pathByAppendingComponent(m_path, lastTimeBasedEvictionTimestampFileName);
+    auto modificationTime = FileSystem::fileModificationTime(timestampFilePath);
+    if (!modificationTime)
+        return true;
+
+    return WallTime::now() - *modificationTime > evictionInterval;
+}
+
+void NetworkStorageManager::performTimeBasedEviction(Seconds threshold, std::optional<Seconds> evictionIntervalOverride)
+{
+    assertIsCurrent(workQueue());
+
+    if (!shouldPerformTimeBasedEvictionNow(evictionIntervalOverride)) {
+        RELEASE_LOG(Storage, "%p - NetworkStorageManager::performTimeBasedEviction sessionID=%" PRIu64 " throttled", this, m_sessionID.toUInt64());
+        return;
+    }
+
+    RELEASE_LOG(Storage, "%p - NetworkStorageManager::performTimeBasedEviction sessionID=%" PRIu64 " threshold=%.0f days starting", this, m_sessionID.toUInt64(), threshold.days());
+    prepareForTimeBasedEviction(threshold);
+}
+
+void NetworkStorageManager::prepareForTimeBasedEviction(Seconds threshold)
+{
+    assertIsCurrent(workQueue());
+
+    RunLoop::mainSingleton().dispatch([weakThis = ThreadSafeWeakPtr { *this }, threshold]() mutable {
+        RefPtr protectedThis = weakThis;
+        if (!protectedThis || protectedThis->m_closed)
+            return;
+
+        RefPtr process = protectedThis->m_process;
+        if (!process)
+            return;
+
+        process->diskCacheOriginAccessTimes(protectedThis->m_sessionID, [weakThis = WTF::move(weakThis), threshold](auto result) mutable {
+            RefPtr protectedThis = weakThis;
+            if (!protectedThis || protectedThis->m_closed)
+                return;
+
+            protectedThis->workQueue().dispatch([weakThis = WTF::move(weakThis), threshold, result = crossThreadCopy(WTF::move(result))]() mutable {
+                if (RefPtr protectedThis = weakThis)
+                    protectedThis->donePrepareForTimeBasedEviction(threshold, WTF::move(result));
+            });
+        });
+    });
+}
+
+void NetworkStorageManager::donePrepareForTimeBasedEviction(Seconds threshold, HashMap<WebCore::RegistrableDomain, WallTime>&& diskCacheAccessTimes)
+{
+    assertIsCurrent(workQueue());
+
+    if (m_closed)
+        return;
 
     auto startTime = MonotonicTime::now();
     HashMap<WebCore::SecurityOriginData, AccessRecord> originRecords;
     for (auto& origin : getAllOrigins()) {
-        auto accessTime = lastModificationTimeForOrigin(origin, originStorageManager(origin));
+        auto fileAccessTime = lastModificationTimeForOrigin(origin, originStorageManager(origin));
+        auto diskCacheAccessTime = diskCacheAccessTimes.get(WebCore::RegistrableDomain { origin.topOrigin });
+        auto accessTime = std::max(fileAccessTime, diskCacheAccessTime);
 
         auto& record = originRecords.ensure(origin.topOrigin, [&] {
             return AccessRecord { };
@@ -641,6 +702,10 @@ void NetworkStorageManager::performTimeBasedEviction(Seconds threshold)
 
     if (!deletedDomains.isEmpty() && m_parentConnection)
         IPC::Connection::send(*m_parentConnection, Messages::NetworkProcessProxy::DidPerformEvictionForDomains(m_sessionID, WTF::move(deletedDomains)), 0);
+
+    auto timestampFilePath = FileSystem::pathByAppendingComponent(m_path, lastTimeBasedEvictionTimestampFileName);
+    if (!FileSystem::overwriteEntireFile(timestampFilePath, std::span<uint8_t> { }))
+        RELEASE_LOG_ERROR(Storage, "%p - NetworkStorageManager::donePrepareForTimeBasedEviction sessionID=%" PRIu64 " failed to write eviction timestamp file", this, m_sessionID.toUInt64());
 }
 
 OriginQuotaManager::Parameters NetworkStorageManager::originQuotaManagerParameters(const WebCore::ClientOrigin& origin)

--- a/Source/WebKit/NetworkProcess/storage/NetworkStorageManager.h
+++ b/Source/WebKit/NetworkProcess/storage/NetworkStorageManager.h
@@ -105,7 +105,7 @@ class StorageAreaRegistry;
 class NetworkStorageManager final : public IPC::WorkQueueMessageReceiver<WTF::DestructionThread::MainRunLoop> {
     WTF_MAKE_TZONE_ALLOCATED(NetworkStorageManager);
 public:
-    static Ref<NetworkStorageManager> create(NetworkProcess&, PAL::SessionID, Markable<WTF::UUID>, std::optional<IPC::Connection::UniqueID>, const String& path, const String& customLocalStoragePath, const String& customIDBStoragePath, const String& customCacheStoragePath, const String& customServiceWorkerStoragePath, uint64_t defaultOriginQuota, std::optional<double> originQuotaRatio, std::optional<double> totalQuotaRatio, std::optional<uint64_t> standardVolumeCapacity, std::optional<uint64_t> volumeCapacityOverride, UnifiedOriginStorageLevel, bool storageSiteValidationEnabled, bool shouldPerformTimeBasedEviction, Seconds timeBasedEvictionThreshold, std::optional<Seconds> lastModificationTimeUpdateIntervalOverride);
+    static Ref<NetworkStorageManager> create(NetworkProcess&, PAL::SessionID, Markable<WTF::UUID>, std::optional<IPC::Connection::UniqueID>, const String& path, const String& customLocalStoragePath, const String& customIDBStoragePath, const String& customCacheStoragePath, const String& customServiceWorkerStoragePath, uint64_t defaultOriginQuota, std::optional<double> originQuotaRatio, std::optional<double> totalQuotaRatio, std::optional<uint64_t> standardVolumeCapacity, std::optional<uint64_t> volumeCapacityOverride, UnifiedOriginStorageLevel, bool storageSiteValidationEnabled, bool shouldPerformTimeBasedEviction, Seconds timeBasedEvictionThreshold, std::optional<Seconds> lastModificationTimeUpdateIntervalOverride, std::optional<Seconds> timeBasedEvictionIntervalOverride);
     static bool canHandleTypes(OptionSet<WebsiteDataType>);
     static OptionSet<WebsiteDataType> allManagedTypes();
 
@@ -161,7 +161,7 @@ public:
     void queryCacheStorage(WebCore::ClientOrigin&&, WebCore::RetrieveRecordsOptions&&, String&&, CompletionHandler<void(std::optional<WebCore::DOMCacheEngine::Record>&&)>&&);
 
 private:
-    NetworkStorageManager(NetworkProcess&, PAL::SessionID, Markable<WTF::UUID>, std::optional<IPC::Connection::UniqueID>, const String& path, const String& customLocalStoragePath, const String& customIDBStoragePath, const String& customCacheStoragePath, const String& customServiceWorkerStoragePath, uint64_t defaultOriginQuota, std::optional<double> originQuotaRatio, std::optional<double> totalQuotaRatio, std::optional<uint64_t> standardVolumeCapacity, std::optional<uint64_t> volumeCapacityOverride, UnifiedOriginStorageLevel, bool storageSiteValidationEnabled, bool shouldPerformTimeBasedEviction, Seconds timeBasedEvictionThreshold, std::optional<Seconds> lastModificationTimeUpdateIntervalOverride);
+    NetworkStorageManager(NetworkProcess&, PAL::SessionID, Markable<WTF::UUID>, std::optional<IPC::Connection::UniqueID>, const String& path, const String& customLocalStoragePath, const String& customIDBStoragePath, const String& customCacheStoragePath, const String& customServiceWorkerStoragePath, uint64_t defaultOriginQuota, std::optional<double> originQuotaRatio, std::optional<double> totalQuotaRatio, std::optional<uint64_t> standardVolumeCapacity, std::optional<uint64_t> volumeCapacityOverride, UnifiedOriginStorageLevel, bool storageSiteValidationEnabled, bool shouldPerformTimeBasedEviction, Seconds timeBasedEvictionThreshold, std::optional<Seconds> lastModificationTimeUpdateIntervalOverride, std::optional<Seconds> timeBasedEvictionIntervalOverride);
     ~NetworkStorageManager();
 
     std::optional<SharedPreferencesForWebProcess> NODELETE sharedPreferencesForWebProcess(IPC::Connection&) const;
@@ -291,7 +291,10 @@ private:
         Vector<WebCore::SecurityOriginData> clientOrigins;
     };
     void performQuotaBasedEviction(HashMap<WebCore::SecurityOriginData, AccessRecord>&&);
-    void performTimeBasedEviction(Seconds threshold);
+    void performTimeBasedEviction(Seconds threshold, std::optional<Seconds> evictionIntervalOverride);
+    void prepareForTimeBasedEviction(Seconds threshold);
+    void donePrepareForTimeBasedEviction(Seconds threshold, HashMap<WebCore::RegistrableDomain, WallTime>&&);
+    bool shouldPerformTimeBasedEvictionNow(std::optional<Seconds> intervalOverride);
     void performEvictionForOrigin(const WebCore::SecurityOriginData& topOrigin, const AccessRecord&);
     const SuspendableWorkQueue& workQueue() const WTF_RETURNS_CAPABILITY(m_queue.get()) { return m_queue; }
     SuspendableWorkQueue& workQueue() WTF_RETURNS_CAPABILITY(m_queue.get()) { return m_queue; }

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebsiteDataStoreConfiguration.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebsiteDataStoreConfiguration.h
@@ -56,6 +56,7 @@ WK_CLASS_AVAILABLE(macos(10.13), ios(11.0))
 @property (nonatomic) BOOL timeBasedEvictionEnabled;
 @property (nonatomic) NSTimeInterval timeBasedEvictionThreshold;
 @property (nonatomic, nullable, copy) NSNumber *lastModificationTimeUpdateIntervalOverride;
+@property (nonatomic, nullable, copy) NSNumber *timeBasedEvictionIntervalOverride;
 @property (nonatomic, nullable, copy) NSNumber *originQuotaRatio WK_API_AVAILABLE(macos(14.0), ios(17.0));
 @property (nonatomic, nullable, copy) NSNumber *totalQuotaRatio WK_API_AVAILABLE(macos(14.0), ios(17.0));
 @property (nonatomic, nullable, copy) NSNumber *standardVolumeCapacity WK_API_AVAILABLE(macos(14.0), ios(17.0));

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebsiteDataStoreConfiguration.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebsiteDataStoreConfiguration.mm
@@ -539,6 +539,23 @@ static WebKit::UnifiedOriginStorageLevel NODELETE toUnifiedOriginStorageLevel(_W
         _configuration->setLastModificationTimeUpdateIntervalOverride(std::nullopt);
 }
 
+- (NSNumber *)timeBasedEvictionIntervalOverride
+{
+    auto interval = _configuration->timeBasedEvictionIntervalOverride();
+    if (!interval)
+        return nil;
+
+    return [NSNumber numberWithDouble:interval->seconds()];
+}
+
+- (void)setTimeBasedEvictionIntervalOverride:(NSNumber *)seconds
+{
+    if (seconds)
+        _configuration->setTimeBasedEvictionIntervalOverride(Seconds([seconds doubleValue]));
+    else
+        _configuration->setTimeBasedEvictionIntervalOverride(std::nullopt);
+}
+
 - (NSNumber *)originQuotaRatio
 {
     auto ratio = _configuration->originQuotaRatio();

--- a/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.cpp
+++ b/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.cpp
@@ -2251,6 +2251,7 @@ WebsiteDataStoreParameters WebsiteDataStore::parameters()
     networkSessionParameters.shouldPerformTimeBasedEviction = shouldPerformTimeBasedEviction();
     networkSessionParameters.timeBasedEvictionThreshold = m_configuration->timeBasedEvictionThreshold();
     networkSessionParameters.lastModificationTimeUpdateIntervalOverride = m_configuration->lastModificationTimeUpdateIntervalOverride();
+    networkSessionParameters.timeBasedEvictionIntervalOverride = m_configuration->timeBasedEvictionIntervalOverride();
 #if ENABLE(DECLARATIVE_WEB_PUSH)
     networkSessionParameters.isDeclarativeWebPushEnabled = m_configuration->isDeclarativeWebPushEnabled();
 #endif

--- a/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStoreConfiguration.cpp
+++ b/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStoreConfiguration.cpp
@@ -180,6 +180,7 @@ Ref<WebsiteDataStoreConfiguration> WebsiteDataStoreConfiguration::copy() const
     copy->m_timeBasedEvictionEnabled = this->m_timeBasedEvictionEnabled;
     copy->m_timeBasedEvictionThreshold = this->m_timeBasedEvictionThreshold;
     copy->m_lastModificationTimeUpdateIntervalOverride = this->m_lastModificationTimeUpdateIntervalOverride;
+    copy->m_timeBasedEvictionIntervalOverride = this->m_timeBasedEvictionIntervalOverride;
     copy->m_defaultTrackingPreventionEnabledOverride = this->m_defaultTrackingPreventionEnabledOverride;
 
     return copy;

--- a/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStoreConfiguration.h
+++ b/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStoreConfiguration.h
@@ -76,6 +76,8 @@ public:
     void setTimeBasedEvictionThreshold(Seconds threshold) { m_timeBasedEvictionThreshold = threshold; }
     std::optional<Seconds> lastModificationTimeUpdateIntervalOverride() const { return m_lastModificationTimeUpdateIntervalOverride; }
     void setLastModificationTimeUpdateIntervalOverride(std::optional<Seconds> interval) { m_lastModificationTimeUpdateIntervalOverride = interval; }
+    std::optional<Seconds> timeBasedEvictionIntervalOverride() const { return m_timeBasedEvictionIntervalOverride; }
+    void setTimeBasedEvictionIntervalOverride(std::optional<Seconds> interval) { m_timeBasedEvictionIntervalOverride = interval; }
 
     std::optional<double> totalQuotaRatio() const { return m_totalQuotaRatio; }
     void setTotalQuotaRatio(std::optional<double> ratio) { m_totalQuotaRatio = ratio; }
@@ -313,6 +315,7 @@ private:
     bool m_timeBasedEvictionEnabled { false };
     Seconds m_timeBasedEvictionThreshold { 180 * 24_h };
     std::optional<Seconds> m_lastModificationTimeUpdateIntervalOverride;
+    std::optional<Seconds> m_timeBasedEvictionIntervalOverride;
     std::optional<double> m_totalQuotaRatio;
     std::optional<uint64_t> m_standardVolumeCapacity;
     std::optional<uint64_t> m_volumeCapacityOverride;

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKWebsiteDatastore.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKWebsiteDatastore.mm
@@ -128,6 +128,19 @@ static bool usePersistentCredentialStorage = false;
 
 namespace TestWebKitAPI {
 
+static RetainPtr<NSArray<NSString *>> triggerTimeBasedEviction(_WKWebsiteDataStoreConfiguration *configuration)
+{
+    RetainPtr dataStore = adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:configuration]);
+    RetainPtr delegate = adoptNS([[WKWebsiteDataStoreTotalQuotaDelegate alloc] init]);
+    dataStore.get()._delegate = delegate.get();
+    RetainPtr webViewConfig = adoptNS([[WKWebViewConfiguration alloc] init]);
+    [webViewConfig setWebsiteDataStore:dataStore.get()];
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfig.get()]);
+    [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"about:blank"]]];
+    [delegate waitForDataEviction];
+    return [delegate.get().lastEvictedDomains sortedArrayUsingSelector:@selector(compare:)];
+}
+
 TEST(WKWebsiteDataStore, RemoveAndFetchData)
 {
     RetainPtr defaultDataStore = [WKWebsiteDataStore defaultDataStore];
@@ -1526,6 +1539,7 @@ TEST(TimeBasedEviction, Basic)
     RetainPtr websiteDataStoreConfiguration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] initWithIdentifier:uuid.get()]);
     [websiteDataStoreConfiguration setTimeBasedEvictionEnabled:YES];
     [websiteDataStoreConfiguration setTimeBasedEvictionThreshold:2.0];
+    [websiteDataStoreConfiguration setTimeBasedEvictionIntervalOverride:@0];
     [websiteDataStoreConfiguration setDefaultTrackingPreventionEnabledOverride:@NO];
 
     NSString *idbHTML = @"<script> \
@@ -1576,16 +1590,9 @@ TEST(TimeBasedEviction, Basic)
         TestWebKitAPI::Util::run(&done);
     }
 
-    // Create a new data store — eviction runs on session initialization.
-    // example1.com should be evicted (stale), example2.com should remain (fresh).
-    RetainPtr websiteDataStore2 = adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:websiteDataStoreConfiguration.get()]);
-    done = false;
-    [websiteDataStore2 fetchDataRecordsOfTypes:[WKWebsiteDataStore allWebsiteDataTypes] completionHandler:^(NSArray<WKWebsiteDataRecord *> *records) {
-        EXPECT_EQ(1u, records.count);
-        EXPECT_WK_STREQ(@"example2.com", [[records firstObject] displayName]);
-        done = true;
-    }];
-    TestWebKitAPI::Util::run(&done);
+    auto evictedDomains = triggerTimeBasedEviction(websiteDataStoreConfiguration.get());
+    EXPECT_EQ(1u, evictedDomains.get().count);
+    EXPECT_WK_STREQ(@"example1.com", evictedDomains.get()[0]);
 }
 
 TEST(TimeBasedEviction, IndexedDBReadUpdatesTimestamp)
@@ -1600,6 +1607,7 @@ TEST(TimeBasedEviction, IndexedDBReadUpdatesTimestamp)
     RetainPtr websiteDataStoreConfiguration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] initWithIdentifier:uuid.get()]);
     [websiteDataStoreConfiguration setTimeBasedEvictionEnabled:YES];
     [websiteDataStoreConfiguration setTimeBasedEvictionThreshold:2.0];
+    [websiteDataStoreConfiguration setTimeBasedEvictionIntervalOverride:@0];
     [websiteDataStoreConfiguration setDefaultTrackingPreventionEnabledOverride:@NO];
     [websiteDataStoreConfiguration setLastModificationTimeUpdateIntervalOverride:@0];
 
@@ -1663,16 +1671,10 @@ TEST(TimeBasedEviction, IndexedDBReadUpdatesTimestamp)
         TestWebKitAPI::Util::run(&done);
     }
 
-    // Create a new data store — eviction runs on session initialization.
     // example2.com should be evicted (stale), example1.com should remain (read refreshed its timestamp).
-    RetainPtr websiteDataStore2 = adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:websiteDataStoreConfiguration.get()]);
-    done = false;
-    [websiteDataStore2 fetchDataRecordsOfTypes:[WKWebsiteDataStore allWebsiteDataTypes] completionHandler:^(NSArray<WKWebsiteDataRecord *> *records) {
-        EXPECT_EQ(1u, records.count);
-        EXPECT_WK_STREQ(@"example1.com", [[records firstObject] displayName]);
-        done = true;
-    }];
-    TestWebKitAPI::Util::run(&done);
+    auto evictedDomains = triggerTimeBasedEviction(websiteDataStoreConfiguration.get());
+    EXPECT_EQ(1u, evictedDomains.get().count);
+    EXPECT_WK_STREQ(@"example2.com", evictedDomains.get()[0]);
 }
 
 TEST(TimeBasedEviction, LocalStorageReadUpdatesTimestamp)
@@ -1687,6 +1689,7 @@ TEST(TimeBasedEviction, LocalStorageReadUpdatesTimestamp)
     RetainPtr websiteDataStoreConfiguration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] initWithIdentifier:uuid.get()]);
     [websiteDataStoreConfiguration setTimeBasedEvictionEnabled:YES];
     [websiteDataStoreConfiguration setTimeBasedEvictionThreshold:2.0];
+    [websiteDataStoreConfiguration setTimeBasedEvictionIntervalOverride:@0];
     [websiteDataStoreConfiguration setDefaultTrackingPreventionEnabledOverride:@NO];
     [websiteDataStoreConfiguration setLastModificationTimeUpdateIntervalOverride:@0];
 
@@ -1736,16 +1739,10 @@ TEST(TimeBasedEviction, LocalStorageReadUpdatesTimestamp)
         TestWebKitAPI::Util::run(&done);
     }
 
-    // Create a new data store — eviction runs on session initialization.
     // example2.com should be evicted (stale), example1.com should remain (read refreshed its timestamp).
-    RetainPtr websiteDataStore2 = adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:websiteDataStoreConfiguration.get()]);
-    done = false;
-    [websiteDataStore2 fetchDataRecordsOfTypes:[WKWebsiteDataStore allWebsiteDataTypes] completionHandler:^(NSArray<WKWebsiteDataRecord *> *records) {
-        EXPECT_EQ(1u, records.count);
-        EXPECT_WK_STREQ(@"example1.com", [[records firstObject] displayName]);
-        done = true;
-    }];
-    TestWebKitAPI::Util::run(&done);
+    auto evictedDomains = triggerTimeBasedEviction(websiteDataStoreConfiguration.get());
+    EXPECT_EQ(1u, evictedDomains.get().count);
+    EXPECT_WK_STREQ(@"example2.com", evictedDomains.get()[0]);
 }
 
 TEST(TimeBasedEviction, CacheStorageReadUpdatesTimestamp)
@@ -1760,6 +1757,7 @@ TEST(TimeBasedEviction, CacheStorageReadUpdatesTimestamp)
     RetainPtr websiteDataStoreConfiguration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] initWithIdentifier:uuid.get()]);
     [websiteDataStoreConfiguration setTimeBasedEvictionEnabled:YES];
     [websiteDataStoreConfiguration setTimeBasedEvictionThreshold:2.0];
+    [websiteDataStoreConfiguration setTimeBasedEvictionIntervalOverride:@0];
     [websiteDataStoreConfiguration setDefaultTrackingPreventionEnabledOverride:@NO];
     [websiteDataStoreConfiguration setLastModificationTimeUpdateIntervalOverride:@0];
 
@@ -1819,16 +1817,10 @@ TEST(TimeBasedEviction, CacheStorageReadUpdatesTimestamp)
         TestWebKitAPI::Util::run(&done);
     }
 
-    // Create a new data store — eviction runs on session initialization.
     // example2.com should be evicted (stale), example1.com should remain (read refreshed its timestamp).
-    RetainPtr websiteDataStore2 = adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:websiteDataStoreConfiguration.get()]);
-    done = false;
-    [websiteDataStore2 fetchDataRecordsOfTypes:[WKWebsiteDataStore allWebsiteDataTypes] completionHandler:^(NSArray<WKWebsiteDataRecord *> *records) {
-        EXPECT_EQ(1u, records.count);
-        EXPECT_WK_STREQ(@"example1.com", [[records firstObject] displayName]);
-        done = true;
-    }];
-    TestWebKitAPI::Util::run(&done);
+    auto evictedDomains = triggerTimeBasedEviction(websiteDataStoreConfiguration.get());
+    EXPECT_EQ(1u, evictedDomains.get().count);
+    EXPECT_WK_STREQ(@"example2.com", evictedDomains.get()[0]);
 }
 
 TEST(TimeBasedEviction, FileSystemAPIReadUpdatesTimestamp)
@@ -1843,6 +1835,7 @@ TEST(TimeBasedEviction, FileSystemAPIReadUpdatesTimestamp)
     RetainPtr websiteDataStoreConfiguration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] initWithIdentifier:uuid.get()]);
     [websiteDataStoreConfiguration setTimeBasedEvictionEnabled:YES];
     [websiteDataStoreConfiguration setTimeBasedEvictionThreshold:2.0];
+    [websiteDataStoreConfiguration setTimeBasedEvictionIntervalOverride:@0];
     [websiteDataStoreConfiguration setDefaultTrackingPreventionEnabledOverride:@NO];
     [websiteDataStoreConfiguration setLastModificationTimeUpdateIntervalOverride:@0];
 
@@ -1911,13 +1904,171 @@ TEST(TimeBasedEviction, FileSystemAPIReadUpdatesTimestamp)
         TestWebKitAPI::Util::run(&done);
     }
 
-    // Create a new data store — eviction runs on session initialization.
     // example2.com should be evicted (stale), example1.com should remain (read refreshed its timestamp).
-    RetainPtr websiteDataStore2 = adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:websiteDataStoreConfiguration.get()]);
+    auto evictedDomains = triggerTimeBasedEviction(websiteDataStoreConfiguration.get());
+    EXPECT_EQ(1u, evictedDomains.get().count);
+    EXPECT_WK_STREQ(@"example2.com", evictedDomains.get()[0]);
+}
+
+TEST(TimeBasedEviction, DiskCacheAccessUpdatesTimestamp)
+{
+    RetainPtr uuid = adoptNS([[NSUUID alloc] initWithUUIDString:@"68753a44-4d6f-1226-9c60-0050e4c0006d"]);
     done = false;
-    [websiteDataStore2 fetchDataRecordsOfTypes:[WKWebsiteDataStore allWebsiteDataTypes] completionHandler:^(NSArray<WKWebsiteDataRecord *> *records) {
+    [WKWebsiteDataStore _removeDataStoreWithIdentifier:uuid.get() completionHandler:^(NSError *error) {
+        done = true;
+    }];
+    TestWebKitAPI::Util::run(&done);
+
+    HTTPServer server({
+        { "/page"_s, { "<script>fetch('/resource').then(r=>r.text()).then(()=>window.webkit.messageHandlers.testHandler.postMessage('done')).catch(e=>window.webkit.messageHandlers.testHandler.postMessage('error:'+e))</script>"_s } },
+        { "/resource"_s, { {{ "Cache-Control"_s, "max-age=3600"_s }}, "cached-data"_s } },
+    }, HTTPServer::Protocol::HttpsProxy);
+
+    RetainPtr websiteDataStoreConfiguration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] initWithIdentifier:uuid.get()]);
+    [websiteDataStoreConfiguration setTimeBasedEvictionEnabled:YES];
+    [websiteDataStoreConfiguration setTimeBasedEvictionThreshold:2.0];
+    [websiteDataStoreConfiguration setTimeBasedEvictionIntervalOverride:@0];
+    [websiteDataStoreConfiguration setDefaultTrackingPreventionEnabledOverride:@NO];
+    [websiteDataStoreConfiguration setHTTPSProxy:[NSURL URLWithString:[NSString stringWithFormat:@"https://127.0.0.1:%d/", server.port()]]];
+
+    NSString *idbHTML = @"<script> \
+        var request = indexedDB.open('testDB'); \
+        request.onupgradeneeded = function(event) { \
+            event.target.result.createObjectStore('store'); \
+        }; \
+        request.onsuccess = function() { \
+            window.webkit.messageHandlers.testHandler.postMessage('done'); \
+        }; \
+        request.onerror = function() { \
+            window.webkit.messageHandlers.testHandler.postMessage('error'); \
+        }; \
+    </script>";
+
+    RetainPtr websiteDataStore = adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:websiteDataStoreConfiguration.get()]);
+
+    @autoreleasepool {
+        RetainPtr handler = adoptNS([[WKWebsiteDataStoreMessageHandler alloc] init]);
+        RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+        [[configuration userContentController] addScriptMessageHandler:handler.get() name:@"testHandler"];
+        [configuration setWebsiteDataStore:websiteDataStore.get()];
+        RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+        RetainPtr navigationDelegate = adoptNS([[TestNavigationDelegate alloc] init]);
+        [navigationDelegate allowAnyTLSCertificate];
+        [webView setNavigationDelegate:navigationDelegate.get()];
+
+        // Write IDB data for example1.com and example2.com
+        receivedScriptMessage = false;
+        [webView loadHTMLString:idbHTML baseURL:[NSURL URLWithString:@"https://example1.com/"]];
+        TestWebKitAPI::Util::run(&receivedScriptMessage);
+        EXPECT_WK_STREQ(@"done", [lastScriptMessage body]);
+
+        receivedScriptMessage = false;
+        [webView loadHTMLString:idbHTML baseURL:[NSURL URLWithString:@"https://example2.com/"]];
+        TestWebKitAPI::Util::run(&receivedScriptMessage);
+        EXPECT_WK_STREQ(@"done", [lastScriptMessage body]);
+
+        // Wait so both origins become stale.
+        TestWebKitAPI::Util::runFor(2_s);
+
+        // Update disk cache for example1.com.
+        receivedScriptMessage = false;
+        [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://example1.com/page"]]];
+        TestWebKitAPI::Util::run(&receivedScriptMessage);
+        EXPECT_WK_STREQ(@"done", [lastScriptMessage body]);
+
+        // Wait for the disk cache write to flush (NetworkCacheStorage has a 1-second initial write delay).
+        // FIXME: Add an SPI to configure the write delay or to get notification when the write finishes.
+        TestWebKitAPI::Util::runFor(1.5_s);
+    }
+
+    // example2.com should be evicted (stale), example1.com should remain (disk cache access refreshed its timestamp).
+    auto evictedDomains = triggerTimeBasedEviction(websiteDataStoreConfiguration.get());
+    EXPECT_EQ(1u, evictedDomains.get().count);
+    EXPECT_WK_STREQ(@"example2.com", evictedDomains.get()[0]);
+}
+
+TEST(TimeBasedEviction, ThrottledToConfiguredInterval)
+{
+    RetainPtr uuid = adoptNS([[NSUUID alloc] initWithUUIDString:@"68753a44-4d6f-1226-9c60-0050e4c0006e"]);
+    done = false;
+    [WKWebsiteDataStore _removeDataStoreWithIdentifier:uuid.get() completionHandler:^(NSError *error) {
+        done = true;
+    }];
+    TestWebKitAPI::Util::run(&done);
+
+    RetainPtr websiteDataStoreConfiguration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] initWithIdentifier:uuid.get()]);
+    [websiteDataStoreConfiguration setTimeBasedEvictionEnabled:YES];
+    // Set a small eviction threshold so all origins are removed at eviction.
+    [websiteDataStoreConfiguration setTimeBasedEvictionThreshold:0];
+    // Set a small eviction interval so eviction happens at every session initialization.
+    [websiteDataStoreConfiguration setTimeBasedEvictionIntervalOverride:@0];
+    [websiteDataStoreConfiguration setDefaultTrackingPreventionEnabledOverride:@NO];
+
+    NSString *idbHTML = @"<script> \
+        var request = indexedDB.open('testDB'); \
+        request.onupgradeneeded = function(event) { \
+            event.target.result.createObjectStore('store'); \
+        }; \
+        request.onsuccess = function() { \
+            window.webkit.messageHandlers.testHandler.postMessage('done'); \
+        }; \
+        request.onerror = function() { \
+            window.webkit.messageHandlers.testHandler.postMessage('error'); \
+        }; \
+    </script>";
+
+    // First session: write data for example1.com.
+    @autoreleasepool {
+        RetainPtr websiteDataStore = adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:websiteDataStoreConfiguration.get()]);
+        RetainPtr handler = adoptNS([[WKWebsiteDataStoreMessageHandler alloc] init]);
+        RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+        [[configuration userContentController] addScriptMessageHandler:handler.get() name:@"testHandler"];
+        [configuration setWebsiteDataStore:websiteDataStore.get()];
+        RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+
+        receivedScriptMessage = false;
+        [webView loadHTMLString:idbHTML baseURL:[NSURL URLWithString:@"https://example1.com/"]];
+        TestWebKitAPI::Util::run(&receivedScriptMessage);
+        EXPECT_WK_STREQ(@"done", [lastScriptMessage body]);
+    }
+
+    // Second session: eviction runs and example1.com is evicted.
+    @autoreleasepool {
+        RetainPtr websiteDataStore = adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:websiteDataStoreConfiguration.get()]);
+        RetainPtr evictionDelegate = adoptNS([[WKWebsiteDataStoreTotalQuotaDelegate alloc] init]);
+        websiteDataStore.get()._delegate = evictionDelegate.get();
+
+        // Trigger session initialization by loading a page.
+        RetainPtr initConfig = adoptNS([[WKWebViewConfiguration alloc] init]);
+        [initConfig setWebsiteDataStore:websiteDataStore.get()];
+        RetainPtr initWebView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:initConfig.get()]);
+        [initWebView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"about:blank"]]];
+
+        [evictionDelegate waitForDataEviction];
+        NSArray<NSString *> *evictedDomains = [evictionDelegate.get().lastEvictedDomains sortedArrayUsingSelector:@selector(compare:)];
+        EXPECT_EQ(1u, evictedDomains.count);
+        EXPECT_WK_STREQ(@"example1.com", evictedDomains[0]);
+
+        // Write new data for example2.com within this session.
+        RetainPtr handler = adoptNS([[WKWebsiteDataStoreMessageHandler alloc] init]);
+        RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+        [[configuration userContentController] addScriptMessageHandler:handler.get() name:@"testHandler"];
+        [configuration setWebsiteDataStore:websiteDataStore.get()];
+        RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+
+        receivedScriptMessage = false;
+        [webView loadHTMLString:idbHTML baseURL:[NSURL URLWithString:@"https://example2.com/"]];
+        TestWebKitAPI::Util::run(&receivedScriptMessage);
+        EXPECT_WK_STREQ(@"done", [lastScriptMessage body]);
+    }
+
+    // Third session: eviction should NOT run because the eviction interval (3600s) hasn't elapsed.
+    [websiteDataStoreConfiguration setTimeBasedEvictionIntervalOverride:@3600];
+    RetainPtr websiteDataStore3 = adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:websiteDataStoreConfiguration.get()]);
+    done = false;
+    [websiteDataStore3 fetchDataRecordsOfTypes:[NSSet setWithObject:WKWebsiteDataTypeIndexedDBDatabases] completionHandler:^(NSArray<WKWebsiteDataRecord *> *records) {
         EXPECT_EQ(1u, records.count);
-        EXPECT_WK_STREQ(@"example1.com", [[records firstObject] displayName]);
+        EXPECT_WK_STREQ(@"example2.com", [[records firstObject] displayName]);
         done = true;
     }];
     TestWebKitAPI::Util::run(&done);


### PR DESCRIPTION
#### 0e2fcbe8a2a403c36b31eab8cd9bfad6ed5ced89
<pre>
Throttle time-based website data eviction to run once per week
<a href="https://bugs.webkit.org/show_bug.cgi?id=314277">https://bugs.webkit.org/show_bug.cgi?id=314277</a>
<a href="https://rdar.apple.com/176418771">rdar://176418771</a>

Reviewed by Ben Nham.

Throttle eviction to run at most once per configured interval (default 7 days), controlled by a timestamp file that is
written after each eviction attempt. Introduce timeBasedEvictionIntervalOverride SPI on _WKWebsiteDataStoreConfiguration
for testing.

Additionally, to make the access time more accurate, the eviction now takes disk cache last access time into account
when deciding whether to evict an origin&apos;s data.

Tests: TimeBasedEviction.DiskCacheAccessUpdatesTimestamp
       TimeBasedEviction.ThrottledToConfiguredInterval

Some existing tests are also updated since time-based eviction happens asynchronously now (after fetching orgin access
time from disk cache).

* Source/WebKit/NetworkProcess/NetworkProcess.cpp:
(WebKit::NetworkProcess::diskCacheOriginAccessTimes):
* Source/WebKit/NetworkProcess/NetworkProcess.h:
* Source/WebKit/NetworkProcess/NetworkSession.cpp:
(WebKit::createNetworkStorageManager):
* Source/WebKit/NetworkProcess/NetworkSessionCreationParameters.h:
* Source/WebKit/NetworkProcess/NetworkSessionCreationParameters.serialization.in:
* Source/WebKit/NetworkProcess/cache/NetworkCache.cpp:
(WebKit::NetworkCache::Cache::fetchOriginAccessTimes):
* Source/WebKit/NetworkProcess/cache/NetworkCache.h:
* Source/WebKit/NetworkProcess/cache/NetworkCacheStorage.cpp:
(WebKit::NetworkCache::Storage::traverseWithinRootPath):
* Source/WebKit/NetworkProcess/cache/NetworkCacheStorage.h:
* Source/WebKit/NetworkProcess/storage/NetworkStorageManager.cpp:
(WebKit::NetworkStorageManager::create):
(WebKit::NetworkStorageManager::NetworkStorageManager):
(WebKit::NetworkStorageManager::shouldPerformTimeBasedEvictionNow):
(WebKit::NetworkStorageManager::performTimeBasedEviction):
(WebKit::NetworkStorageManager::prepareForTimeBasedEviction):
(WebKit::NetworkStorageManager::donePrepareForTimeBasedEviction):
* Source/WebKit/NetworkProcess/storage/NetworkStorageManager.h:
* Source/WebKit/UIProcess/API/Cocoa/_WKWebsiteDataStoreConfiguration.h:
* Source/WebKit/UIProcess/API/Cocoa/_WKWebsiteDataStoreConfiguration.mm:
(-[_WKWebsiteDataStoreConfiguration timeBasedEvictionIntervalOverride]):
(-[_WKWebsiteDataStoreConfiguration setTimeBasedEvictionIntervalOverride:]):
* Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.cpp:
(WebKit::WebsiteDataStore::parameters):
* Source/WebKit/UIProcess/WebsiteData/WebsiteDataStoreConfiguration.cpp:
(WebKit::WebsiteDataStoreConfiguration::copy const):
* Source/WebKit/UIProcess/WebsiteData/WebsiteDataStoreConfiguration.h:
(WebKit::WebsiteDataStoreConfiguration::timeBasedEvictionIntervalOverride const):
(WebKit::WebsiteDataStoreConfiguration::setTimeBasedEvictionIntervalOverride):
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKWebsiteDatastore.mm:
(TestWebKitAPI::triggerTimeBasedEviction):
(TestWebKitAPI::(TimeBasedEviction, Basic)):
(TestWebKitAPI::(TimeBasedEviction, IndexedDBReadUpdatesTimestamp)):
(TestWebKitAPI::(TimeBasedEviction, LocalStorageReadUpdatesTimestamp)):
(TestWebKitAPI::(TimeBasedEviction, CacheStorageReadUpdatesTimestamp)):
(TestWebKitAPI::(TimeBasedEviction, FileSystemAPIReadUpdatesTimestamp)):
(TestWebKitAPI::(TimeBasedEviction, DiskCacheAccessUpdatesTimestamp)):
(TestWebKitAPI::(TimeBasedEviction, ThrottledToConfiguredInterval)):

Canonical link: <a href="https://commits.webkit.org/313024@main">https://commits.webkit.org/313024@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ef2cf9df0852956867ce7f28a5494876a761f7ac

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/161855 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/35329 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/28432 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/170758 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/118226 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/66dc4c36-f0ed-47b1-bf49-f6289b82c3b6) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/163724 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/35431 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/35331 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/125585 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/88501 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/87fe9396-e246-4661-b825-0cf368301699) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/164814 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/27901 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/145382 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/106181 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/f5d57321-f56a-497c-ac03-c7abcc863112) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/26950 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/25465 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/18479 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/136643 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/23137 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/173247 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/20334 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/24778 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/133884 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/35003 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/29551 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/133889 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36154 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/34987 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/144932 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/97080 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/28418 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/21755 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/34497 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/101978 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/33997 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/34240 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/34146 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->