### PR TITLE
[Build Speed] Reduce the cost of SerializedScriptValue.h and AXObjectCache.h

### DIFF
--- a/Source/WTF/wtf/FastTLS.h
+++ b/Source/WTF/wtf/FastTLS.h
@@ -31,7 +31,6 @@
 
 #include <pthread.h>
 #include <pthread/tsd_private.h>
-#include <wtf/Platform.h>
 
 namespace WTF {
 

--- a/Source/WTF/wtf/FlipBytes.h
+++ b/Source/WTF/wtf/FlipBytes.h
@@ -30,7 +30,6 @@
 #include <bit>
 #include <cstddef>
 #include <type_traits>
-#include <wtf/Compiler.h>
 #include <wtf/Platform.h>
 
 namespace WTF {

--- a/Source/WTF/wtf/Int128.h
+++ b/Source/WTF/wtf/Int128.h
@@ -33,13 +33,11 @@
 
 #pragma once
 
-#include <cassert>
 #include <cmath>
+#include <compare>
 #include <cstdint>
-#include <cstring>
 #include <iosfwd>
 #include <limits>
-#include <utility>
 #include <wtf/ExportMacros.h>
 #include <wtf/Platform.h>
 

--- a/Source/WTF/wtf/RawHex.h
+++ b/Source/WTF/wtf/RawHex.h
@@ -26,7 +26,6 @@
 #pragma once
 
 #include <cstdint>
-#include <wtf/Compiler.h>
 #include <wtf/Platform.h>
 
 namespace WTF {

--- a/Source/WTF/wtf/SaturatedArithmetic.h
+++ b/Source/WTF/wtf/SaturatedArithmetic.h
@@ -34,7 +34,6 @@
 #include <concepts>
 #include <limits>
 #include <stdint.h>
-#include <stdlib.h>
 #include <wtf/Compiler.h>
 #include <wtf/Platform.h>
 

--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -830,6 +830,7 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     accessibility/AXNotifications.h
     accessibility/AXObjectCache.h
     accessibility/AXObjectCacheInlines.h
+    accessibility/AXObjectTypes.h
     accessibility/AXObjectRareData.h
     accessibility/AXRemoteFrame.h
     accessibility/AXSearchManager.h
@@ -972,6 +973,7 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     bindings/js/ScriptWrappable.h
     bindings/js/ScriptWrappableInlines.h
     bindings/js/SerializedScriptValue.h
+    bindings/js/SerializedScriptValueInternals.h
     bindings/js/StringAdaptors.h
     bindings/js/WebAssemblyCachedScriptSourceProvider.h
     bindings/js/WebAssemblyScriptSourceCode.h

--- a/Source/WebCore/Modules/gamepad/Gamepad.cpp
+++ b/Source/WebCore/Modules/gamepad/Gamepad.cpp
@@ -32,6 +32,7 @@
 #include "GamepadHapticActuator.h"
 #include "PlatformGamepad.h"
 #include "ScriptExecutionContext.h"
+#include "SharedGamepadValue.h"
 #include <wtf/text/WTFString.h>
 
 namespace WebCore {

--- a/Source/WebCore/Modules/mediastream/MediaStreamTrackHandle.h
+++ b/Source/WebCore/Modules/mediastream/MediaStreamTrackHandle.h
@@ -32,18 +32,20 @@
 
 namespace WebCore {
 
+struct MediaStreamTrackHandleDataHolder {
+    WTF_MAKE_TZONE_ALLOCATED(MediaStreamTrackHandleDataHolder);
+public:
+    ScriptExecutionContextIdentifier contextIdentifier;
+    WeakPtr<MediaStreamTrack, WeakPtrImplWithEventTargetData> track;
+    Ref<MediaStreamTrack::Keeper> trackKeeper;
+    Ref<MediaStreamTrackPrivateSourceObserver> trackSourceObserver;
+};
+
 class MediaStreamTrackHandle : public RefCounted<MediaStreamTrackHandle> {
 public:
     ~MediaStreamTrackHandle();
 
-    struct DataHolder {
-        WTF_MAKE_TZONE_ALLOCATED(DataHolder);
-    public:
-        ScriptExecutionContextIdentifier contextIdentifier;
-        WeakPtr<MediaStreamTrack, WeakPtrImplWithEventTargetData> track;
-        Ref<MediaStreamTrack::Keeper> trackKeeper;
-        Ref<MediaStreamTrackPrivateSourceObserver> trackSourceObserver;
-    };
+    using DataHolder = MediaStreamTrackHandleDataHolder;
 
     static ExceptionOr<Ref<MediaStreamTrackHandle>> create(MediaStreamTrack&);
     static Ref<MediaStreamTrackHandle> create(DataHolder&&);

--- a/Source/WebCore/Modules/notifications/NotificationResourcesLoader.h
+++ b/Source/WebCore/Modules/notifications/NotificationResourcesLoader.h
@@ -30,6 +30,7 @@
 #include "Notification.h"
 #include "SharedBuffer.h"
 #include "ThreadableLoader.h"
+#include "ThreadableLoaderClient.h"
 #include <wtf/CompletionHandler.h>
 #include <wtf/HashSet.h>
 #include <wtf/TZoneMalloc.h>

--- a/Source/WebCore/Modules/storage/StorageConnection.h
+++ b/Source/WebCore/Modules/storage/StorageConnection.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include <WebCore/FileSystemHandleIdentifier.h>
+#include <WebCore/FileSystemStorageConnection.h>
 #include <WebCore/StorageEstimate.h>
 #include <wtf/CompletionHandler.h>
 #include <wtf/ThreadSafeWeakPtr.h>

--- a/Source/WebCore/Modules/webxr/WebXRGamepad.h
+++ b/Source/WebCore/Modules/webxr/WebXRGamepad.h
@@ -29,6 +29,7 @@
 
 #include "PlatformGamepad.h"
 #include "PlatformXR.h"
+#include "SharedGamepadValue.h"
 #include <wtf/TZoneMalloc.h>
 #include <wtf/Vector.h>
 

--- a/Source/WebCore/accessibility/AXGeometryManager.cpp
+++ b/Source/WebCore/accessibility/AXGeometryManager.cpp
@@ -96,7 +96,11 @@ bool AXGeometryManager::cacheRectIfNeeded(AXID axID, IntRect&& rect)
 #if ENABLE(ACCESSIBILITY_ISOLATED_TREE)
     invalidateHitTestCacheForID(axID);
 
-    RefPtr tree = AXIsolatedTree::treeForFrameID(m_cache->frameID());
+    CheckedPtr cache = m_cache;
+    if (!cache)
+        return false;
+
+    RefPtr tree = AXIsolatedTree::treeForFrameID(cache->frameID());
     if (!tree)
         return false;
     tree->updateFrame(axID, WTF::move(rect));
@@ -148,19 +152,25 @@ void AXGeometryManager::willUpdateObjectRegions()
     if (m_updateObjectRegionsTimer.isActive())
         m_updateObjectRegionsTimer.stop();
 
-    if (!m_cache)
+    CheckedPtr cache = m_cache;
+    if (!cache)
         return;
 
-    if (RefPtr tree = AXIsolatedTree::treeForFrameID(m_cache->frameID()))
+    if (RefPtr tree = AXIsolatedTree::treeForFrameID(cache->frameID()))
         tree->updateRootScreenRelativePosition();
 }
 
 void AXGeometryManager::scheduleRenderingUpdate()
 {
-    if (!m_cache || !m_cache->document())
+    CheckedPtr cache = m_cache;
+    if (!cache)
         return;
 
-    if (RefPtr page = m_cache->document()->page())
+    RefPtr document = cache->document();
+    if (!document)
+        return;
+
+    if (RefPtr page = document->page())
         page->scheduleRenderingUpdate(RenderingUpdateStep::AccessibilityRegionUpdate);
 }
 

--- a/Source/WebCore/accessibility/AXObjectCache.cpp
+++ b/Source/WebCore/accessibility/AXObjectCache.cpp
@@ -983,6 +983,30 @@ AccessibilityObject* AXObjectCache::exportedGetOrCreate(Node& node)
     return getOrCreate(node, IsPartOfRelation::No);
 }
 
+Document* AXObjectCache::document() const
+{
+    return m_document.get();
+}
+
+AccessibilityObject* AXObjectCache::get(Node& node) const
+{
+    if (CheckedPtr document = dynamicDowncast<Document>(node)) [[unlikely]]
+        return get(document->renderView());
+    return m_nodeObjectMapping.get(node);
+}
+
+std::optional<AXID> AXObjectCache::getAXID(RenderObject& renderer) const
+{
+    if (auto* node = renderer.node())
+        return m_nodeIdMapping.getOptional(*node);
+    return m_renderObjectIdMapping.getOptional(const_cast<RenderObject&>(renderer));
+}
+
+void AXObjectCache::onLaidOutInlineContent(const RenderBlockFlow& renderBlock)
+{
+    setDirtyStitchGroups(renderBlock);
+}
+
 AccessibilityObject* AXObjectCache::getOrCreate(Widget& widget)
 {
     if (RefPtr object = get(widget))

--- a/Source/WebCore/accessibility/AXObjectCache.h
+++ b/Source/WebCore/accessibility/AXObjectCache.h
@@ -26,26 +26,23 @@
 #pragma once
 
 #include <WebCore/AXAnnouncementTypes.h>
-#include <WebCore/AXTextMarker.h>
+#include <WebCore/AXObjectTypes.h>
+#include <WebCore/AXTextStateChangeIntent.h>
 #include <WebCore/AXTreeStore.h>
+#include <WebCore/AccessibilityObject.h>
 #include <WebCore/AccessibilityRemoteToken.h>
-#include <WebCore/AffineTransform.h>
-#include <WebCore/Document.h>
-#include <WebCore/RenderView.h>
 #include <WebCore/SimpleRange.h>
 #include <WebCore/StyleChange.h>
 #include <WebCore/Timer.h>
 #include <WebCore/VisibleUnits.h>
-#include <limits.h>
-#include <wtf/CheckedPtr.h>
+#include <wtf/CheckedRef.h>
 #include <wtf/Deque.h>
 #include <wtf/HashMap.h>
 #include <wtf/HashSet.h>
 #include <wtf/ListHashSet.h>
-#include <wtf/Platform.h>
-#include <wtf/ProcessID.h>
 #include <wtf/WeakHashMap.h>
 #include <wtf/WeakHashSet.h>
+#include <wtf/WeakListHashSet.h>
 
 #if PLATFORM(COCOA)
 #include <WebCore/AttributedString.h>
@@ -72,6 +69,7 @@ class AccessibilityRenderObject;
 class AccessibilitySpinButton;
 class Document;
 class HTMLAreaElement;
+class HTMLCanvasElement;
 class HTMLDetailsElement;
 class HTMLSelectElement;
 class HTMLTableElement;
@@ -82,6 +80,10 @@ class RemoteFrame;
 class RenderBlock;
 class RenderBlockFlow;
 class RenderImage;
+
+class AXTextMarker;
+
+namespace Style { struct Difference; }
 class RenderObject;
 class RenderStyle;
 class RenderText;
@@ -101,67 +103,6 @@ enum class AXStreamOptions : uint16_t;
 enum class AXProperty : uint16_t;
 enum class LiveRegionStatus: uint8_t;
 
-enum class AccessibilityMode : uint8_t {
-    // Off MUST be the zero variant - WebPageProxy relies on the default initializer
-    // for an AccessibilityMode to be Off.
-    Off = 0,
-    // Accessibility is enabled but not isolated tree mode.
-    MainThread,
-    // This implies / is equivalent to the notion of isolated tree mode.
-    AXThread,
-    // Equivalent to Off, but remembers what mode we were in before disabling.
-    OffWasMainThread,
-    OffWasAXThread,
-};
-
-inline bool isAccessibilityModeOff(AccessibilityMode mode)
-{
-    return mode == AccessibilityMode::Off
-        || mode == AccessibilityMode::OffWasMainThread
-        || mode == AccessibilityMode::OffWasAXThread;
-}
-
-// Returns the resolved target mode for a requested transition, or std::nullopt
-// if the transition is not allowed. Allowed transitions:
-//   Off (or OffWas*) -> MainThread or AXThread
-//   MainThread       -> AXThread or OffWasMainThread (test mode only)
-//   AXThread         -> OffWasAXThread (test mode only)
-// Transitioning to an Off state is only allowed in test mode.
-// Returns std::nullopt if the transition is not allowed or unnecessary (i.e.
-// the current and requested modes are equal).
-WEBCORE_EXPORT std::optional<AccessibilityMode> resolveAccessibilityModeTransition(AccessibilityMode current, AccessibilityMode requested);
-
-enum class TextMarkerOrigin : uint16_t;
-
-struct CharacterOffset {
-    RefPtr<Node> node;
-    int startIndex;
-    int offset;
-    int remainingOffset;
-
-    CharacterOffset(Node* n = nullptr, int startIndex = 0, int offset = 0, int remaining = 0)
-        : node(n)
-        , startIndex(startIndex)
-        , offset(offset)
-        , remainingOffset(remaining)
-    { }
-
-    int remaining() const { return remainingOffset; }
-    bool isNull() const { return !node; }
-    inline bool isEqual(const CharacterOffset& other) const;
-    inline String debugDescription();
-};
-
-struct VisiblePositionIndex {
-    int value = -1;
-    RefPtr<ContainerNode> scope;
-};
-
-struct VisiblePositionIndexRange {
-    VisiblePositionIndex startIndex;
-    VisiblePositionIndex endIndex;
-    bool isNull() const { return startIndex.value == -1 || endIndex.value == -1; }
-};
 
 struct AXTreeData {
     String liveTree;
@@ -255,11 +196,6 @@ struct AXTextChangeContext {
 
 #if ENABLE(ACCESSIBILITY_LOCAL_FRAME)
 // When this is updated, WebCoreArgumentCoders.serialization.in must be updated as well.
-struct InheritedFrameState {
-    bool isAXHidden { false };
-    bool isInert { false };
-    bool isRenderHidden { false };
-};
 
 // Describes a frame's position and scale on screen for accessibility coordinate conversion.
 // Sent from the UIProcess to the WebProcess via IPC whenever the frame scrolls, moves, or resizes.
@@ -423,22 +359,12 @@ public:
     {
         return node ? get(*node) : nullptr;
     }
-    inline AccessibilityObject* get(Node& node) const
-    {
-        if (CheckedPtr document = dynamicDowncast<Document>(node)) [[unlikely]]
-            return get(document->renderView());
-        return m_nodeObjectMapping.get(node);
-    }
+    AccessibilityObject* get(Node&) const;
     inline AccessibilityObject* get(Element& element) const
     {
         return m_nodeObjectMapping.get(element);
     }
-    inline std::optional<AXID> getAXID(RenderObject& renderer) const
-    {
-        if (auto* node = renderer.node())
-            return m_nodeIdMapping.getOptional(*node);
-        return m_renderObjectIdMapping.getOptional(const_cast<RenderObject&>(renderer));
-    }
+    std::optional<AXID> getAXID(RenderObject&) const;
 
     void remove(RenderObject&);
     void remove(Node&);
@@ -539,7 +465,7 @@ public:
     void onTextRunsChanged(const RenderObject&);
 #endif
 
-    void onLaidOutInlineContent(const RenderBlockFlow& renderBlock) { setDirtyStitchGroups(renderBlock); }
+    void onLaidOutInlineContent(const RenderBlockFlow&);
     const Vector<AXStitchGroup>* stitchGroupsOwnedBy(AccessibilityObject&);
 
     void updateLoadingProgress(double);
@@ -760,7 +686,7 @@ public:
 
     AXComputedObjectAttributeCache* computedObjectAttributeCache() LIFETIME_BOUND { return m_computedObjectAttributeCache.get(); }
 
-    Document* document() const { return m_document; }
+    Document* document() const;
     FrameIdentifier frameID() const { return m_frameID; }
 
     RefPtr<Page> NODELETE page() const;

--- a/Source/WebCore/accessibility/AXObjectTypes.h
+++ b/Source/WebCore/accessibility/AXObjectTypes.h
@@ -1,0 +1,92 @@
+/*
+ * Copyright (C) 2003-2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <optional>
+#include <wtf/ProcessID.h>
+#include <wtf/RefPtr.h>
+
+namespace WebCore {
+
+class ContainerNode;
+class Node;
+
+enum class AccessibilityMode : uint8_t {
+    Off = 0,
+    MainThread,
+    AXThread,
+    OffWasMainThread,
+    OffWasAXThread,
+};
+
+inline bool isAccessibilityModeOff(AccessibilityMode mode)
+{
+    return mode == AccessibilityMode::Off
+        || mode == AccessibilityMode::OffWasMainThread
+        || mode == AccessibilityMode::OffWasAXThread;
+}
+
+WEBCORE_EXPORT std::optional<AccessibilityMode> resolveAccessibilityModeTransition(AccessibilityMode current, AccessibilityMode requested);
+
+enum class TextMarkerOrigin : uint16_t;
+
+struct CharacterOffset {
+    RefPtr<Node> node;
+    int startIndex;
+    int offset;
+    int remainingOffset;
+
+    CharacterOffset(Node* n = nullptr, int startIndex = 0, int offset = 0, int remaining = 0)
+        : node(n)
+        , startIndex(startIndex)
+        , offset(offset)
+        , remainingOffset(remaining)
+    { }
+
+    int remaining() const { return remainingOffset; }
+    bool isNull() const { return !node; }
+    inline bool isEqual(const CharacterOffset& other) const;
+    inline String debugDescription();
+};
+
+struct VisiblePositionIndex {
+    int value = -1;
+    RefPtr<ContainerNode> scope;
+};
+
+struct VisiblePositionIndexRange {
+    VisiblePositionIndex startIndex;
+    VisiblePositionIndex endIndex;
+    bool isNull() const { return startIndex.value == -1 || endIndex.value == -1; }
+};
+
+struct InheritedFrameState {
+    bool isAXHidden { false };
+    bool isInert { false };
+    bool isRenderHidden { false };
+};
+
+} // namespace WebCore

--- a/Source/WebCore/accessibility/AccessibilityNodeObject.h
+++ b/Source/WebCore/accessibility/AccessibilityNodeObject.h
@@ -41,6 +41,8 @@ namespace WebCore {
 class AXObjectCache;
 class Element;
 class HTMLLabelElement;
+class HTMLMediaElement;
+class HTMLVideoElement;
 class Node;
 
 class AccessibilityNodeObject : public AccessibilityObject {

--- a/Source/WebCore/accessibility/ios/WebAccessibilityObjectWrapperIOS.h
+++ b/Source/WebCore/accessibility/ios/WebAccessibilityObjectWrapperIOS.h
@@ -26,6 +26,7 @@
 #if PLATFORM(IOS_FAMILY)
 
 #import "AXObjectCache.h"
+#import "AXTextMarker.h"
 #import "AccessibilityObject.h"
 #import "WAKView.h"
 #import "WebAccessibilityObjectWrapperBase.h"

--- a/Source/WebCore/accessibility/playstation/AXObjectCachePlayStation.cpp
+++ b/Source/WebCore/accessibility/playstation/AXObjectCachePlayStation.cpp
@@ -37,6 +37,7 @@
 #include "LocalFrame.h"
 #include "NodeDocument.h"
 #include "Page.h"
+#include "RenderView.h"
 
 namespace WebCore {
 

--- a/Source/WebCore/bindings/IDLTypes.h
+++ b/Source/WebCore/bindings/IDLTypes.h
@@ -31,9 +31,7 @@
 #include <WebCore/JSDOMPromiseDeferredForward.h>
 #include <WebCore/StringAdaptors.h>
 #include <wtf/Brigand.h>
-#include <wtf/Compiler.h>
 #include <wtf/Markable.h>
-#include <wtf/StdLibExtras.h>
 #include <wtf/URL.h>
 #include <wtf/WallTime.h>
 

--- a/Source/WebCore/bindings/js/DOMWrapperWorld.h
+++ b/Source/WebCore/bindings/js/DOMWrapperWorld.h
@@ -22,10 +22,7 @@
 #pragma once
 
 #include <WebCore/JSDOMGlobalObject.h>
-#include <wtf/Compiler.h>
-#include <wtf/Forward.h>
 #include <wtf/WeakHashSet.h>
-#include <wtf/WeakPtr.h>
 
 namespace WebCore {
 

--- a/Source/WebCore/bindings/js/JSDOMWrapper.h
+++ b/Source/WebCore/bindings/js/JSDOMWrapper.h
@@ -25,9 +25,7 @@
 #include <JavaScriptCore/JSEmbedderArrayLike.h>
 #include <WebCore/JSDOMGlobalObject.h>
 #include <WebCore/NodeType.h>
-#include <wtf/Compiler.h>
 #include <wtf/SignedPtr.h>
-#include <wtf/StdLibExtras.h>
 
 namespace JSC {
 class Structure;

--- a/Source/WebCore/bindings/js/JSDOMWrapperCache.h
+++ b/Source/WebCore/bindings/js/JSDOMWrapperCache.h
@@ -23,7 +23,6 @@
 
 #pragma once
 
-#include <JavaScriptCore/GetVM.h>
 #include <JavaScriptCore/HeapCellInlines.h>
 #include <JavaScriptCore/InternalFunction.h>
 #include <JavaScriptCore/JSArrayBuffer.h>

--- a/Source/WebCore/bindings/js/SerializedScriptValue.cpp
+++ b/Source/WebCore/bindings/js/SerializedScriptValue.cpp
@@ -81,6 +81,7 @@
 #include "JSWritableStream.h"
 #include "ScriptExecutionContext.h"
 #include "SecurityOrigin.h"
+#include "SerializedScriptValueInternals.h"
 #include "SharedBuffer.h"
 #include "WebCodecsEncodedAudioChunk.h"
 #include "WebCodecsEncodedVideoChunk.h"
@@ -156,6 +157,8 @@
 #endif
 
 namespace WebCore {
+
+WTF_MAKE_STRUCT_TZONE_ALLOCATED_IMPL(SerializedScriptValueInternals);
 
 using namespace JSC;
 
@@ -1115,7 +1118,9 @@ template <> bool writeLittleEndian<uint8_t>(Vector<uint8_t>& buffer, std::span<c
 
 Ref<SerializedScriptValue> SerializedScriptValue::createFromWireBytes(Vector<uint8_t>&& data)
 {
-    return adoptRef(*new SerializedScriptValue(WTF::move(data), { }));
+    Internals internals;
+    internals.data = WTF::move(data);
+    return adoptRef(*new SerializedScriptValue(WTF::move(internals)));
 }
 
 class CloneSerializer;
@@ -6342,185 +6347,81 @@ void validateSerializedResult(CloneSerializer& serializer, SerializationReturnCo
 
 SerializedScriptValue::~SerializedScriptValue() = default;
 
-SerializedScriptValue::SerializedScriptValue(Vector<uint8_t>&& buffer
-    , std::unique_ptr<ArrayBufferContentsArray>&& arrayBufferContentsArray
-#if ENABLE(WEB_RTC)
-    , Vector<std::unique_ptr<DetachedRTCDataChannel>>&& detachedRTCDataChannels
-    , Vector<Ref<RTCRtpTransformableFrame>>&& serializedRTCEncodedAudioFrames
-    , Vector<Ref<RTCRtpTransformableFrame>>&& serializedRTCEncodedVideoFrames
-#endif
-#if ENABLE(MEDIA_SOURCE_IN_WORKERS)
-    , Vector<RefPtr<DetachedMediaSourceHandle>>&& detachedMediaSourceHandles
-#endif
-#if ENABLE(WEB_CODECS)
-    , Vector<Ref<WebCodecsEncodedVideoChunkStorage>>&& serializedVideoChunks
-    , Vector<WebCodecsVideoFrameData>&& serializedVideoFrames
-    , Vector<Ref<WebCodecsEncodedAudioChunkStorage>>&& serializedAudioChunks
-    , Vector<WebCodecsAudioInternalData>&& serializedAudioData
-#endif
-#if ENABLE(MEDIA_STREAM)
-    , Vector<std::unique_ptr<MediaStreamTrackDataHolder>>&& detachedMediaStreamTracks
-    , Vector<std::unique_ptr<MediaStreamTrackHandle::DataHolder>>&& detachedMediaStreamTrackHandles
-#endif
-    , uint64_t exposedMessagePortCount
-        )
-    : m_internals {
-        .data = WTF::move(buffer)
-        , .arrayBufferContentsArray = WTF::move(arrayBufferContentsArray)
-#if ENABLE(WEB_RTC)
-        , .detachedRTCDataChannels = WTF::move(detachedRTCDataChannels)
-#endif
-#if ENABLE(WEB_CODECS)
-        , .serializedVideoChunks = WTF::move(serializedVideoChunks)
-        , .serializedAudioChunks = WTF::move(serializedAudioChunks)
-#endif
-        , .exposedMessagePortCount = exposedMessagePortCount
-#if ENABLE(WEB_CODECS)
-        , .serializedVideoFrames = WTF::move(serializedVideoFrames)
-        , .serializedAudioData = WTF::move(serializedAudioData)
-#endif
-#if ENABLE(WEB_RTC)
-        , .serializedRTCEncodedAudioFrames = WTF::move(serializedRTCEncodedAudioFrames)
-        , .serializedRTCEncodedVideoFrames = WTF::move(serializedRTCEncodedVideoFrames)
-#endif
-#if ENABLE(MEDIA_SOURCE_IN_WORKERS)
-        , .detachedMediaSourceHandles = WTF::move(detachedMediaSourceHandles)
-#endif
-#if ENABLE(MEDIA_STREAM)
-        , .detachedMediaStreamTracks = WTF::move(detachedMediaStreamTracks)
-        , .detachedMediaStreamTrackHandles = WTF::move(detachedMediaStreamTrackHandles)
-#endif
-    }
-{
-    m_internals.memoryCost = computeMemoryCost();
-}
-
-SerializedScriptValue::SerializedScriptValue(Vector<uint8_t>&& buffer
-        , Vector<URLKeepingBlobAlive>&& blobHandles
-        , std::unique_ptr<ArrayBufferContentsArray> arrayBufferContentsArray
-        , std::unique_ptr<ArrayBufferContentsArray> sharedBufferContentsArray
-        , Vector<std::optional<DetachedImageBitmap>>&& detachedImageBitmaps
-#if ENABLE(OFFSCREEN_CANVAS_IN_WORKERS)
-        , Vector<std::unique_ptr<DetachedOffscreenCanvas>>&& detachedOffscreenCanvases
-        , Vector<Ref<OffscreenCanvas>>&& inMemoryOffscreenCanvases
-#endif
-        , Vector<Ref<MessagePort>>&& inMemoryMessagePorts
-#if ENABLE(WEB_RTC)
-        , Vector<std::unique_ptr<DetachedRTCDataChannel>>&& detachedRTCDataChannels
-        , Vector<Ref<RTCRtpTransformableFrame>>&& serializedRTCEncodedAudioFrames
-        , Vector<Ref<RTCRtpTransformableFrame>>&& serializedRTCEncodedVideoFrames
-#endif
-#if ENABLE(MEDIA_SOURCE_IN_WORKERS)
-        , Vector<RefPtr<DetachedMediaSourceHandle>>&& detachedMediaSourceHandles
-#endif
-#if ENABLE(WEBASSEMBLY)
-        , WasmModuleArray&& wasmModulesArray
-        , std::unique_ptr<WasmMemoryHandleArray> wasmMemoryHandlesArray
-#endif
-#if ENABLE(WEB_CODECS)
-        , Vector<Ref<WebCodecsEncodedVideoChunkStorage>>&& serializedVideoChunks
-        , Vector<WebCodecsVideoFrameData>&& serializedVideoFrames
-        , Vector<Ref<WebCodecsEncodedAudioChunkStorage>>&& serializedAudioChunks
-        , Vector<WebCodecsAudioInternalData>&& serializedAudioData
-#endif
-#if ENABLE(MEDIA_STREAM)
-        , Vector<std::unique_ptr<MediaStreamTrackDataHolder>>&& detachedMediaStreamTracks
-        , Vector<std::unique_ptr<MediaStreamTrackHandle::DataHolder>>&& detachedMediaStreamTrackHandles
-#endif
-        , uint64_t exposedMessagePortCount
-        )
-    : m_internals {
-        .data = WTF::move(buffer)
-        , .arrayBufferContentsArray = WTF::move(arrayBufferContentsArray)
-#if ENABLE(WEB_RTC)
-        , .detachedRTCDataChannels = WTF::move(detachedRTCDataChannels)
-#endif
-#if ENABLE(WEB_CODECS)
-        , .serializedVideoChunks = WTF::move(serializedVideoChunks)
-        , .serializedAudioChunks = WTF::move(serializedAudioChunks)
-#endif
-        , .exposedMessagePortCount = exposedMessagePortCount
-#if ENABLE(WEB_CODECS)
-        , .serializedVideoFrames = WTF::move(serializedVideoFrames)
-        , .serializedAudioData = WTF::move(serializedAudioData)
-#endif
-#if ENABLE(WEB_RTC)
-        , .serializedRTCEncodedAudioFrames = WTF::move(serializedRTCEncodedAudioFrames)
-        , .serializedRTCEncodedVideoFrames = WTF::move(serializedRTCEncodedVideoFrames)
-#endif
-#if ENABLE(MEDIA_SOURCE_IN_WORKERS)
-        , .detachedMediaSourceHandles = WTF::move(detachedMediaSourceHandles)
-#endif
-#if ENABLE(MEDIA_STREAM)
-        , .detachedMediaStreamTracks = WTF::move(detachedMediaStreamTracks)
-        , .detachedMediaStreamTrackHandles = WTF::move(detachedMediaStreamTrackHandles)
-#endif
-        , .sharedBufferContentsArray = WTF::move(sharedBufferContentsArray)
-        , .detachedImageBitmaps = WTF::move(detachedImageBitmaps)
-#if ENABLE(OFFSCREEN_CANVAS_IN_WORKERS)
-        , .detachedOffscreenCanvases = WTF::move(detachedOffscreenCanvases)
-        , .inMemoryOffscreenCanvases = WTF::move(inMemoryOffscreenCanvases)
-#endif
-        , .inMemoryMessagePorts = WTF::move(inMemoryMessagePorts)
-#if ENABLE(WEBASSEMBLY)
-        , .wasmModulesArray = wasmModulesArray.isEmpty() ? nullptr : makeUnique<WasmModuleArray>(WTF::move(wasmModulesArray))
-        , .wasmMemoryHandlesArray = WTF::move(wasmMemoryHandlesArray)
-#endif
-        , .blobHandles = crossThreadCopy(WTF::move(blobHandles))
-    }
-{
-    m_internals.memoryCost = computeMemoryCost();
-}
-
 SerializedScriptValue::SerializedScriptValue(Internals&& internals)
-    : m_internals(WTF::move(internals))
+    : m_internals(makeUnique<Internals>(WTF::move(internals)))
 {
+    m_internals->memoryCost = computeMemoryCost();
+}
+
+bool SerializedScriptValue::hasBlobURLs() const
+{
+    return !m_internals->blobHandles.isEmpty();
+}
+
+Vector<URLKeepingBlobAlive> SerializedScriptValue::blobHandles() const
+{
+    return crossThreadCopy(m_internals->blobHandles);
+}
+
+const Vector<uint8_t>& SerializedScriptValue::wireBytes() const
+{
+    return m_internals->data;
+}
+
+size_t SerializedScriptValue::memoryCost() const
+{
+    return m_internals->memoryCost;
+}
+
+RefPtr<SerializedScriptValue> SerializedScriptValue::convert(JSGlobalObject& globalObject, JSValue value)
+{
+    return create(globalObject, value, SerializationForStorage::Yes);
 }
 
 size_t SerializedScriptValue::computeMemoryCost() const
 {
-    size_t cost = m_internals.data.size();
+    size_t cost = m_internals->data.size();
 
-    if (m_internals.arrayBufferContentsArray) {
-        for (auto& content : *m_internals.arrayBufferContentsArray)
+    if (m_internals->arrayBufferContentsArray) {
+        for (auto& content : *m_internals->arrayBufferContentsArray)
             cost += content.sizeInBytes();
     }
 
-    if (m_internals.sharedBufferContentsArray) {
-        for (auto& content : *m_internals.sharedBufferContentsArray)
+    if (m_internals->sharedBufferContentsArray) {
+        for (auto& content : *m_internals->sharedBufferContentsArray)
             cost += content.sizeInBytes();
     }
 
-    for (auto& detachedImageBitmap : m_internals.detachedImageBitmaps) {
+    for (auto& detachedImageBitmap : m_internals->detachedImageBitmaps) {
         if (detachedImageBitmap)
             cost += detachedImageBitmap->memoryCost();
     }
 
 #if ENABLE(WEB_RTC)
-    for (auto& channel : m_internals.detachedRTCDataChannels) {
+    for (auto& channel : m_internals->detachedRTCDataChannels) {
         if (channel)
             cost += channel->memoryCost();
     }
 #endif
 #if ENABLE(WEBASSEMBLY)
     // We are not supporting WebAssembly Module memory estimation yet.
-    if (m_internals.wasmMemoryHandlesArray) {
-        for (auto& content : *m_internals.wasmMemoryHandlesArray)
+    if (m_internals->wasmMemoryHandlesArray) {
+        for (auto& content : *m_internals->wasmMemoryHandlesArray)
             cost += content->sizeInBytes(std::memory_order_relaxed);
     }
 #endif
 #if ENABLE(WEB_CODECS)
-    for (auto& chunk : m_internals.serializedVideoChunks)
+    for (auto& chunk : m_internals->serializedVideoChunks)
         cost += chunk->memoryCost();
-    for (auto& frame : m_internals.serializedVideoFrames)
+    for (auto& frame : m_internals->serializedVideoFrames)
         cost += frame.memoryCost();
-    for (auto& chunk : m_internals.serializedAudioChunks)
+    for (auto& chunk : m_internals->serializedAudioChunks)
         cost += chunk->memoryCost();
-    for (auto& data : m_internals.serializedAudioData)
+    for (auto& data : m_internals->serializedAudioData)
         cost += data.memoryCost();
 #endif
 
-    for (auto& handle : m_internals.blobHandles)
+    for (auto& handle : m_internals->blobHandles)
         cost += handle.url().string().sizeInBytes();
 
     return cost;
@@ -7003,38 +6904,46 @@ ExceptionOr<Ref<SerializedScriptValue>> SerializedScriptValue::create(JSGlobalOb
     });
 #endif
 
-    Ref result = adoptRef(*new SerializedScriptValue(WTF::move(buffer), WTF::move(blobHandles), arrayBufferContentsArray.releaseReturnValue(), WTF::move(sharedBuffers), WTF::move(detachedImageBitmaps)
-#if ENABLE(OFFSCREEN_CANVAS_IN_WORKERS)
-                , WTF::move(detachedCanvases)
-                , WTF::move(inMemoryOffscreenCanvases)
-#endif
-                , WTF::move(inMemoryMessagePorts)
+    return adoptRef(*new SerializedScriptValue(Internals {
+        .data = WTF::move(buffer)
+        , .arrayBufferContentsArray = arrayBufferContentsArray.releaseReturnValue()
 #if ENABLE(WEB_RTC)
-                , WTF::move(detachedRTCDataChannels)
-                , WTF::move(serializedRTCEncodedAudioFrameStorages)
-                , WTF::move(serializedRTCEncodedVideoFrameStorages)
-#endif
-#if ENABLE(MEDIA_SOURCE_IN_WORKERS)
-                , WTF::move(detachedMediaSourceHandles)
-#endif
-#if ENABLE(WEBASSEMBLY)
-                , WTF::move(wasmModules)
-                , context == SerializationContext::WorkerPostMessage ? makeUnique<WasmMemoryHandleArray>(wasmMemoryHandles) : nullptr
+        , .detachedRTCDataChannels = WTF::move(detachedRTCDataChannels)
 #endif
 #if ENABLE(WEB_CODECS)
-                , WTF::move(serializedVideoChunks)
-                , WTF::move(serializedVideoFrameData)
-                , WTF::move(serializedAudioChunks)
-                , WTF::move(serializedAudioInternalData)
+        , .serializedVideoChunks = WTF::move(serializedVideoChunks)
+        , .serializedAudioChunks = WTF::move(serializedAudioChunks)
+#endif
+        , .exposedMessagePortCount = exposedMessagePortsCount
+        , .fileSystemHandleTransferTokens = WTF::move(fileSystemHandleTransferTokens)
+#if ENABLE(WEB_CODECS)
+        , .serializedVideoFrames = WTF::move(serializedVideoFrameData)
+        , .serializedAudioData = WTF::move(serializedAudioInternalData)
+#endif
+#if ENABLE(WEB_RTC)
+        , .serializedRTCEncodedAudioFrames = WTF::move(serializedRTCEncodedAudioFrameStorages)
+        , .serializedRTCEncodedVideoFrames = WTF::move(serializedRTCEncodedVideoFrameStorages)
+#endif
+#if ENABLE(MEDIA_SOURCE_IN_WORKERS)
+        , .detachedMediaSourceHandles = WTF::move(detachedMediaSourceHandles)
 #endif
 #if ENABLE(MEDIA_STREAM)
-                , WTF::move(detachedMediaStreamTrackStorages)
-                , WTF::move(detachedMediaStreamTrackHandleStorages)
+        , .detachedMediaStreamTracks = WTF::move(detachedMediaStreamTrackStorages)
+        , .detachedMediaStreamTrackHandles = WTF::move(detachedMediaStreamTrackHandleStorages)
 #endif
-                , exposedMessagePortsCount
-                ));
-    result->m_internals.fileSystemHandleTransferTokens = WTF::move(fileSystemHandleTransferTokens);
-    return result;
+        , .sharedBufferContentsArray = WTF::move(sharedBuffers)
+        , .detachedImageBitmaps = WTF::move(detachedImageBitmaps)
+#if ENABLE(OFFSCREEN_CANVAS_IN_WORKERS)
+        , .detachedOffscreenCanvases = WTF::move(detachedCanvases)
+        , .inMemoryOffscreenCanvases = WTF::move(inMemoryOffscreenCanvases)
+#endif
+        , .inMemoryMessagePorts = WTF::move(inMemoryMessagePorts)
+#if ENABLE(WEBASSEMBLY)
+        , .wasmModulesArray = wasmModules.isEmpty() ? nullptr : makeUnique<WasmModuleArray>(WTF::move(wasmModules))
+        , .wasmMemoryHandlesArray = context == SerializationContext::WorkerPostMessage ? makeUnique<WasmMemoryHandleArray>(wasmMemoryHandles) : nullptr
+#endif
+        , .blobHandles = crossThreadCopy(WTF::move(blobHandles))
+    }));
 }
 
 RefPtr<SerializedScriptValue> SerializedScriptValue::create(StringView string)
@@ -7042,7 +6951,10 @@ RefPtr<SerializedScriptValue> SerializedScriptValue::create(StringView string)
     Vector<uint8_t> buffer;
     if (!CloneSerializer::serialize(string, buffer))
         return nullptr;
-    return adoptRef(*new SerializedScriptValue(WTF::move(buffer), { }));
+
+    Internals internals;
+    internals.data = WTF::move(buffer);
+    return adoptRef(*new SerializedScriptValue(WTF::move(internals)));
 }
 
 RefPtr<SerializedScriptValue> SerializedScriptValue::create(JSContextRef originContext, JSValueRef apiValue, JSValueRef* exception)
@@ -7071,7 +6983,7 @@ Vector<uint8_t> SerializedScriptValue::serializeCryptoKey(const WebCore::CryptoK
 
 String SerializedScriptValue::toString() const
 {
-    return CloneDeserializer::deserializeString(m_internals.data);
+    return CloneDeserializer::deserializeString(m_internals->data);
 }
 
 JSValue SerializedScriptValue::deserialize(JSGlobalObject& lexicalGlobalObject, JSGlobalObject* globalObject, SerializationErrorMode throwExceptions, bool* didFail)
@@ -7092,36 +7004,36 @@ JSValue SerializedScriptValue::deserialize(JSGlobalObject& lexicalGlobalObject, 
     VM& vm = lexicalGlobalObject.vm();
     auto scope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
 
-    DeserializationResult result = CloneDeserializer::deserialize(&lexicalGlobalObject, globalObject, messagePorts, WTF::move(m_internals.detachedImageBitmaps)
+    DeserializationResult result = CloneDeserializer::deserialize(&lexicalGlobalObject, globalObject, messagePorts, WTF::move(m_internals->detachedImageBitmaps)
 #if ENABLE(OFFSCREEN_CANVAS_IN_WORKERS)
-        , WTF::move(m_internals.detachedOffscreenCanvases)
-        , m_internals.inMemoryOffscreenCanvases
+        , WTF::move(m_internals->detachedOffscreenCanvases)
+        , m_internals->inMemoryOffscreenCanvases
 #endif
-        , m_internals.inMemoryMessagePorts
+        , m_internals->inMemoryMessagePorts
 #if ENABLE(WEB_RTC)
-        , WTF::move(m_internals.detachedRTCDataChannels)
-        , WTF::move(m_internals.serializedRTCEncodedAudioFrames)
-        , WTF::move(m_internals.serializedRTCEncodedVideoFrames)
+        , WTF::move(m_internals->detachedRTCDataChannels)
+        , WTF::move(m_internals->serializedRTCEncodedAudioFrames)
+        , WTF::move(m_internals->serializedRTCEncodedVideoFrames)
 #endif
 #if ENABLE(MEDIA_SOURCE_IN_WORKERS)
-        , WTF::move(m_internals.detachedMediaSourceHandles)
+        , WTF::move(m_internals->detachedMediaSourceHandles)
 #endif
-        , m_internals.arrayBufferContentsArray.get(), m_internals.data, blobURLs, blobFilePaths, m_internals.sharedBufferContentsArray.get()
+        , m_internals->arrayBufferContentsArray.get(), m_internals->data, blobURLs, blobFilePaths, m_internals->sharedBufferContentsArray.get()
 #if ENABLE(WEBASSEMBLY)
-        , m_internals.wasmModulesArray.get()
-        , m_internals.wasmMemoryHandlesArray.get()
+        , m_internals->wasmModulesArray.get()
+        , m_internals->wasmMemoryHandlesArray.get()
 #endif
 #if ENABLE(WEB_CODECS)
-        , WTF::move(m_internals.serializedVideoChunks)
-        , WTF::move(m_internals.serializedVideoFrames)
-        , WTF::move(m_internals.serializedAudioChunks)
-        , WTF::move(m_internals.serializedAudioData)
+        , WTF::move(m_internals->serializedVideoChunks)
+        , WTF::move(m_internals->serializedVideoFrames)
+        , WTF::move(m_internals->serializedAudioChunks)
+        , WTF::move(m_internals->serializedAudioData)
 #endif
 #if ENABLE(MEDIA_STREAM)
-        , WTF::move(m_internals.detachedMediaStreamTracks)
-        , WTF::move(m_internals.detachedMediaStreamTrackHandles)
+        , WTF::move(m_internals->detachedMediaStreamTracks)
+        , WTF::move(m_internals->detachedMediaStreamTrackHandles)
 #endif
-        , m_internals.exposedMessagePortCount
+        , m_internals->exposedMessagePortCount
         );
     if (didFail)
         *didFail = result.code != SerializationReturnCode::SuccessfullyCompleted;
@@ -7161,12 +7073,12 @@ JSValueRef SerializedScriptValue::deserialize(JSContextRef destinationContext, J
 
 Ref<SerializedScriptValue> SerializedScriptValue::nullValue()
 {
-    return adoptRef(*new SerializedScriptValue(Vector<uint8_t>(), { }));
+    return adoptRef(*new SerializedScriptValue(Internals { }));
 }
 
 Vector<String> SerializedScriptValue::blobURLs() const
 {
-    return m_internals.blobHandles.map([](auto& handle) {
+    return m_internals->blobHandles.map([](auto& handle) {
         return handle.url().string().isolatedCopy();
     });
 }
@@ -7190,7 +7102,7 @@ void SerializedScriptValue::writeBlobsToDiskForIndexedDB(bool isEphemeral, Compl
             return;
         }
 
-        ASSERT(m_internals.blobHandles.size() == blobFilePaths.size());
+        ASSERT(m_internals->blobHandles.size() == blobFilePaths.size());
 
         completionHandler({ *this, blobURLs(), blobFilePaths });
     });

--- a/Source/WebCore/bindings/js/SerializedScriptValue.h
+++ b/Source/WebCore/bindings/js/SerializedScriptValue.h
@@ -26,39 +26,16 @@
 
 #pragma once
 
-#include <JavaScriptCore/ArrayBuffer.h>
+#include <JavaScriptCore/Forward.h>
 #include <JavaScriptCore/JSCJSValue.h>
-#include <JavaScriptCore/Strong.h>
-#include <WebCore/Blob.h>
-#include <WebCore/DetachedRTCDataChannel.h>
-#include <WebCore/FileSystemStorageConnection.h>
-#include <wtf/FastMalloc.h>
-#include <wtf/Forward.h>
-#include <wtf/Function.h>
-#include <wtf/text/WTFString.h>
-
-#if ENABLE(MEDIA_STREAM)
-#include <WebCore/MediaStreamTrackDataHolder.h>
-#include <WebCore/MediaStreamTrackHandle.h>
-#endif
-#if ENABLE(MEDIA_SOURCE_IN_WORKERS)
-#include <WebCore/MediaSourceHandle.h>
-#endif
-
-#if ENABLE(WEB_CODECS)
-#include <WebCore/WebCodecsAudioData.h>
-#include <WebCore/WebCodecsAudioInternalData.h>
-#include <WebCore/WebCodecsEncodedAudioChunk.h>
-#include <WebCore/WebCodecsEncodedVideoChunk.h>
-#include <WebCore/WebCodecsVideoFrame.h>
-#endif
-
-#if ENABLE(WEB_RTC)
-#include <WebCore/RTCRtpTransformableFrame.h>
-#endif
+#include <wtf/ThreadSafeRefCounted.h>
 
 typedef const struct OpaqueJSContext* JSContextRef;
 typedef const struct OpaqueJSValue* JSValueRef;
+
+namespace IPC {
+template<typename> struct ArgumentCoder;
+}
 
 #if ENABLE(WEBASSEMBLY)
 namespace JSC { namespace Wasm {
@@ -70,6 +47,8 @@ class MemoryHandle;
 namespace JSC {
 class ErrorInstance;
 class JSGlobalObject;
+class JSObject;
+class JSValue;
 }
 
 namespace WebCore {
@@ -83,6 +62,8 @@ class IDBValue;
 class MessagePort;
 class DetachedImageBitmap;
 class FragmentedSharedBuffer;
+class URLKeepingBlobAlive;
+struct SerializedScriptValueInternals;
 template<typename> class ExceptionOr;
 
 enum class SerializationReturnCode;
@@ -90,12 +71,6 @@ enum class SerializationReturnCode;
 enum class SerializationErrorMode { NonThrowing, Throwing };
 enum class SerializationContext { Default, WorkerPostMessage, WindowPostMessage, CloneAcrossWorlds };
 enum class SerializationForStorage : bool { No, Yes };
-
-using ArrayBufferContentsArray = Vector<JSC::ArrayBufferContents>;
-#if ENABLE(WEBASSEMBLY)
-using WasmModuleArray = Vector<Ref<JSC::Wasm::Module>>;
-using WasmMemoryHandleArray = Vector<RefPtr<JSC::SharedArrayBufferContents>>;
-#endif
 
 struct ErrorInformation {
     String errorTypeString;
@@ -115,7 +90,7 @@ class SerializedScriptValue : public ThreadSafeRefCounted<SerializedScriptValue>
 public:
     WEBCORE_EXPORT static ExceptionOr<Ref<SerializedScriptValue>> create(JSC::JSGlobalObject&, JSC::JSValue, Vector<JSC::Strong<JSC::JSObject>>&& transfer, Vector<Ref<MessagePort>>&, SerializationForStorage = SerializationForStorage::No, SerializationContext = SerializationContext::Default);
     WEBCORE_EXPORT static RefPtr<SerializedScriptValue> create(JSC::JSGlobalObject&, JSC::JSValue, SerializationForStorage = SerializationForStorage::No, SerializationErrorMode = SerializationErrorMode::Throwing, SerializationContext = SerializationContext::Default);
-    static RefPtr<SerializedScriptValue> convert(JSC::JSGlobalObject& globalObject, JSC::JSValue value) { return create(globalObject, value, SerializationForStorage::Yes); }
+    WEBCORE_EXPORT static RefPtr<SerializedScriptValue> convert(JSC::JSGlobalObject&, JSC::JSValue);
 
     WEBCORE_EXPORT static RefPtr<SerializedScriptValue> create(StringView);
 
@@ -132,16 +107,16 @@ public:
     WEBCORE_EXPORT JSValueRef deserialize(JSContextRef, JSValueRef* exception);
     WEBCORE_EXPORT static Vector<uint8_t> serializeCryptoKey(const WebCore::CryptoKey&);
 
-    bool hasBlobURLs() const { return !m_internals.blobHandles.isEmpty(); }
+    WEBCORE_EXPORT bool hasBlobURLs() const;
 
     Vector<String> blobURLs() const;
-    Vector<URLKeepingBlobAlive> blobHandles() const { return crossThreadCopy(m_internals.blobHandles); }
+    WEBCORE_EXPORT Vector<URLKeepingBlobAlive> blobHandles() const;
     void writeBlobsToDiskForIndexedDB(bool isEphemeral, CompletionHandler<void(IDBValue&&)>&&);
     IDBValue writeBlobsToDiskForIndexedDBSynchronously(bool isEphemeral, JSC::VM&);
     WEBCORE_EXPORT static Ref<SerializedScriptValue> createFromWireBytes(Vector<uint8_t>&&);
-    const Vector<uint8_t>& wireBytes() const LIFETIME_BOUND { return m_internals.data; }
+    WEBCORE_EXPORT const Vector<uint8_t>& wireBytes() const LIFETIME_BOUND;
 
-    size_t memoryCost() const { return m_internals.memoryCost; }
+    WEBCORE_EXPORT size_t memoryCost() const;
 
     WEBCORE_EXPORT ~SerializedScriptValue();
 
@@ -152,107 +127,10 @@ private:
     friend struct IPC::ArgumentCoder<SerializedScriptValue>;
 
     static ExceptionOr<Ref<SerializedScriptValue>> create(JSC::JSGlobalObject&, JSC::JSValue, Vector<JSC::Strong<JSC::JSObject>>&& transfer, Vector<Ref<MessagePort>>&, SerializationForStorage, SerializationErrorMode, SerializationContext);
-    WEBCORE_EXPORT SerializedScriptValue(Vector<unsigned char>&&
-        , std::unique_ptr<ArrayBufferContentsArray>&& = nullptr
-#if ENABLE(WEB_RTC)
-        , Vector<std::unique_ptr<DetachedRTCDataChannel>>&& = { }
-        , Vector<Ref<RTCRtpTransformableFrame>>&& = { }
-        , Vector<Ref<RTCRtpTransformableFrame>>&& = { }
-#endif
-#if ENABLE(MEDIA_SOURCE_IN_WORKERS)
-        , Vector<RefPtr<DetachedMediaSourceHandle>>&& = { }
-#endif
-#if ENABLE(WEB_CODECS)
-        , Vector<Ref<WebCodecsEncodedVideoChunkStorage>>&& = { }
-        , Vector<WebCodecsVideoFrameData>&& = { }
-        , Vector<Ref<WebCodecsEncodedAudioChunkStorage>>&& = { }
-        , Vector<WebCodecsAudioInternalData>&& = { }
-#endif
-#if ENABLE(MEDIA_STREAM)
-        , Vector<std::unique_ptr<MediaStreamTrackDataHolder>>&& = { }
-        , Vector<std::unique_ptr<MediaStreamTrackHandle::DataHolder>>&& = { }
-#endif
-        , uint64_t exposedMessagePortCount = 0
-        );
-
-    SerializedScriptValue(Vector<unsigned char>&&
-        , Vector<URLKeepingBlobAlive>&& blobHandles
-        , std::unique_ptr<ArrayBufferContentsArray>
-        , std::unique_ptr<ArrayBufferContentsArray> sharedBuffers
-        , Vector<std::optional<DetachedImageBitmap>>&&
-#if ENABLE(OFFSCREEN_CANVAS_IN_WORKERS)
-        , Vector<std::unique_ptr<DetachedOffscreenCanvas>>&& = { }
-        , Vector<Ref<OffscreenCanvas>>&& = { }
-#endif
-        , Vector<Ref<MessagePort>>&& = { }
-#if ENABLE(WEB_RTC)
-        , Vector<std::unique_ptr<DetachedRTCDataChannel>>&& = { }
-        , Vector<Ref<RTCRtpTransformableFrame>>&& = { }
-        , Vector<Ref<RTCRtpTransformableFrame>>&& = { }
-#endif
-#if ENABLE(MEDIA_SOURCE_IN_WORKERS)
-        , Vector<RefPtr<DetachedMediaSourceHandle>>&& = { }
-#endif
-#if ENABLE(WEBASSEMBLY)
-        , WasmModuleArray&& = { }
-        , std::unique_ptr<WasmMemoryHandleArray> = nullptr
-#endif
-#if ENABLE(WEB_CODECS)
-        , Vector<Ref<WebCodecsEncodedVideoChunkStorage>>&& = { }
-        , Vector<WebCodecsVideoFrameData>&& = { }
-        , Vector<Ref<WebCodecsEncodedAudioChunkStorage>>&& = { }
-        , Vector<WebCodecsAudioInternalData>&& = { }
-#endif
-#if ENABLE(MEDIA_STREAM)
-        , Vector<std::unique_ptr<MediaStreamTrackDataHolder>>&& = { }
-        , Vector<std::unique_ptr<MediaStreamTrackHandle::DataHolder>>&& = { }
-#endif
-        , uint64_t exposedMessagePortCount = 0
-        );
 
     size_t computeMemoryCost() const;
 
-    struct Internals {
-        Vector<unsigned char> data;
-        std::unique_ptr<ArrayBufferContentsArray> arrayBufferContentsArray;
-#if ENABLE(WEB_RTC)
-        Vector<std::unique_ptr<DetachedRTCDataChannel>> detachedRTCDataChannels;
-#endif
-#if ENABLE(WEB_CODECS)
-        Vector<Ref<WebCodecsEncodedVideoChunkStorage>> serializedVideoChunks;
-        Vector<Ref<WebCodecsEncodedAudioChunkStorage>> serializedAudioChunks;
-#endif
-        uint64_t exposedMessagePortCount;
-        Vector<FileSystemHandleTransferToken> fileSystemHandleTransferTokens { };
-#if ENABLE(WEB_CODECS)
-        Vector<WebCodecsVideoFrameData> serializedVideoFrames { };
-        Vector<WebCodecsAudioInternalData> serializedAudioData { };
-#endif
-#if ENABLE(WEB_RTC)
-        Vector<Ref<RTCRtpTransformableFrame>> serializedRTCEncodedAudioFrames { };
-        Vector<Ref<RTCRtpTransformableFrame>> serializedRTCEncodedVideoFrames { };
-#endif
-#if ENABLE(MEDIA_SOURCE_IN_WORKERS)
-        Vector<RefPtr<DetachedMediaSourceHandle>> detachedMediaSourceHandles { };
-#endif
-#if ENABLE(MEDIA_STREAM)
-        Vector<std::unique_ptr<MediaStreamTrackDataHolder>> detachedMediaStreamTracks { };
-        Vector<std::unique_ptr<MediaStreamTrackHandle::DataHolder>> detachedMediaStreamTrackHandles { };
-#endif
-        std::unique_ptr<ArrayBufferContentsArray> sharedBufferContentsArray { };
-        Vector<std::optional<DetachedImageBitmap>> detachedImageBitmaps { };
-#if ENABLE(OFFSCREEN_CANVAS_IN_WORKERS)
-        Vector<std::unique_ptr<DetachedOffscreenCanvas>> detachedOffscreenCanvases { };
-        Vector<Ref<OffscreenCanvas>> inMemoryOffscreenCanvases { };
-#endif
-        Vector<Ref<MessagePort>> inMemoryMessagePorts { };
-#if ENABLE(WEBASSEMBLY)
-        std::unique_ptr<WasmModuleArray> wasmModulesArray { };
-        std::unique_ptr<WasmMemoryHandleArray> wasmMemoryHandlesArray { };
-#endif
-        Vector<URLKeepingBlobAlive> blobHandles { };
-        uint64_t memoryCost { 0 };
-    };
+    using Internals = SerializedScriptValueInternals;
     friend struct IPC::ArgumentCoder<Internals>;
 
     static Ref<SerializedScriptValue> create(Internals&& internals)
@@ -260,9 +138,14 @@ private:
         return adoptRef(*new SerializedScriptValue(WTF::move(internals)));
     }
 
+    static Ref<SerializedScriptValue> create(std::unique_ptr<Internals>&& internals)
+    {
+        return adoptRef(*new SerializedScriptValue(WTF::move(*internals)));
+    }
+
     WEBCORE_EXPORT explicit SerializedScriptValue(Internals&&);
 
-    Internals m_internals;
+    std::unique_ptr<Internals> m_internals;
 };
 
 }

--- a/Source/WebCore/bindings/js/SerializedScriptValueInternals.h
+++ b/Source/WebCore/bindings/js/SerializedScriptValueInternals.h
@@ -1,0 +1,120 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+
+#pragma once
+
+#include <JavaScriptCore/ArrayBuffer.h>
+#include <WebCore/FileSystemStorageConnection.h>
+#include <WebCore/URLKeepingBlobAlive.h>
+#include <wtf/FastMalloc.h>
+#include <wtf/TZoneMalloc.h>
+#include <wtf/Vector.h>
+
+#if ENABLE(MEDIA_STREAM)
+#include <WebCore/MediaStreamTrackDataHolder.h>
+#include <WebCore/MediaStreamTrackHandle.h>
+#endif
+#if ENABLE(MEDIA_SOURCE_IN_WORKERS)
+#include <WebCore/MediaSourceHandle.h>
+#endif
+
+#if ENABLE(WEB_CODECS)
+#include <WebCore/WebCodecsAudioInternalData.h>
+#include <WebCore/WebCodecsEncodedAudioChunk.h>
+#include <WebCore/WebCodecsEncodedVideoChunk.h>
+#include <WebCore/WebCodecsVideoFrame.h>
+#endif
+
+#if ENABLE(WEB_RTC)
+#include <WebCore/DetachedRTCDataChannel.h>
+#include <WebCore/RTCRtpTransformableFrame.h>
+#endif
+
+#if ENABLE(WEBASSEMBLY)
+namespace JSC { namespace Wasm { class Module; } }
+#endif
+
+namespace WebCore {
+
+class DetachedImageBitmap;
+class MessagePort;
+class OffscreenCanvas;
+
+#if ENABLE(OFFSCREEN_CANVAS_IN_WORKERS)
+class DetachedOffscreenCanvas;
+#endif
+
+#if ENABLE(WEBASSEMBLY)
+using WasmModuleArray = Vector<Ref<::JSC::Wasm::Module>>;
+using WasmMemoryHandleArray = Vector<RefPtr<::JSC::SharedArrayBufferContents>>;
+#endif
+
+using ArrayBufferContentsArray = Vector<::JSC::ArrayBufferContents>;
+
+struct SerializedScriptValueInternals {
+    WTF_MAKE_STRUCT_TZONE_ALLOCATED_EXPORT(SerializedScriptValueInternals, WEBCORE_EXPORT);
+    Vector<unsigned char> data { };
+    std::unique_ptr<ArrayBufferContentsArray> arrayBufferContentsArray { nullptr };
+#if ENABLE(WEB_RTC)
+    Vector<std::unique_ptr<DetachedRTCDataChannel>> detachedRTCDataChannels { };
+#endif
+#if ENABLE(WEB_CODECS)
+    Vector<Ref<WebCodecsEncodedVideoChunkStorage>> serializedVideoChunks { };
+    Vector<Ref<WebCodecsEncodedAudioChunkStorage>> serializedAudioChunks { };
+#endif
+    uint64_t exposedMessagePortCount { 0 };
+    Vector<FileSystemHandleTransferToken> fileSystemHandleTransferTokens { };
+#if ENABLE(WEB_CODECS)
+    Vector<WebCodecsVideoFrameData> serializedVideoFrames { };
+    Vector<WebCodecsAudioInternalData> serializedAudioData { };
+#endif
+#if ENABLE(WEB_RTC)
+    Vector<Ref<RTCRtpTransformableFrame>> serializedRTCEncodedAudioFrames { };
+    Vector<Ref<RTCRtpTransformableFrame>> serializedRTCEncodedVideoFrames { };
+#endif
+#if ENABLE(MEDIA_SOURCE_IN_WORKERS)
+    Vector<RefPtr<DetachedMediaSourceHandle>> detachedMediaSourceHandles { };
+#endif
+#if ENABLE(MEDIA_STREAM)
+    Vector<std::unique_ptr<MediaStreamTrackDataHolder>> detachedMediaStreamTracks { };
+    Vector<std::unique_ptr<MediaStreamTrackHandleDataHolder>> detachedMediaStreamTrackHandles { };
+#endif
+    std::unique_ptr<ArrayBufferContentsArray> sharedBufferContentsArray { nullptr };
+    Vector<std::optional<DetachedImageBitmap>> detachedImageBitmaps { };
+#if ENABLE(OFFSCREEN_CANVAS_IN_WORKERS)
+    Vector<std::unique_ptr<DetachedOffscreenCanvas>> detachedOffscreenCanvases { };
+    Vector<Ref<OffscreenCanvas>> inMemoryOffscreenCanvases { };
+#endif
+    Vector<Ref<MessagePort>> inMemoryMessagePorts { };
+#if ENABLE(WEBASSEMBLY)
+    std::unique_ptr<WasmModuleArray> wasmModulesArray { };
+    std::unique_ptr<WasmMemoryHandleArray> wasmMemoryHandlesArray { };
+#endif
+    Vector<URLKeepingBlobAlive> blobHandles { };
+    uint64_t memoryCost { 0 };
+};
+
+} // namespace WebCore

--- a/Source/WebCore/css/CSSProperty.h
+++ b/Source/WebCore/css/CSSProperty.h
@@ -23,16 +23,14 @@
 
 #include <WebCore/CSSPropertyNames.h>
 #include <WebCore/CSSValue.h>
-#include <WebCore/CSSValueKeywords.h>
 #include <WebCore/IsImportant.h>
-#include <WebCore/WritingMode.h>
 #include <wtf/BitSet.h>
-#include <wtf/RefPtr.h>
 
 namespace WebCore {
 
 class CSSValueList;
 class Settings;
+class WritingMode;
 struct CSSParserContext;
 
 enum class IsImplicit : bool { No, Yes };

--- a/Source/WebCore/css/CSSSelector.h
+++ b/Source/WebCore/css/CSSSelector.h
@@ -24,7 +24,6 @@
 #include <WebCore/CSSSelectorEnums.h>
 #include <WebCore/QualifiedName.h>
 #include <WebCore/RenderStyleConstants.h>
-#include <wtf/EnumTraits.h>
 #include <wtf/FixedVector.h>
 #include <wtf/TZoneMalloc.h>
 #include <wtf/Variant.h>

--- a/Source/WebCore/css/CSSValueList.h
+++ b/Source/WebCore/css/CSSValueList.h
@@ -23,7 +23,6 @@
 #include <WebCore/CSSValue.h>
 #include <array>
 #include <ranges>
-#include <unicode/umachine.h>
 #include <wtf/MallocSpan.h>
 
 namespace WebCore {

--- a/Source/WebCore/css/ImmutableStyleProperties.h
+++ b/Source/WebCore/css/ImmutableStyleProperties.h
@@ -25,6 +25,7 @@
 #pragma once
 
 #include <WebCore/StyleProperties.h>
+#include <wtf/Packed.h>
 
 namespace WebCore {
 

--- a/Source/WebCore/css/StyleProperties.h
+++ b/Source/WebCore/css/StyleProperties.h
@@ -22,6 +22,7 @@
 #pragma once
 
 #include <WebCore/CSSProperty.h>
+#include <wtf/RefCounted.h>
 
 namespace WebCore {
 

--- a/Source/WebCore/css/parser/CSSParserContext.h
+++ b/Source/WebCore/css/parser/CSSParserContext.h
@@ -29,7 +29,6 @@
 #include <WebCore/CSSPropertyNames.h>
 #include <WebCore/LoadedFromOpaqueSource.h>
 #include <WebCore/StyleRuleType.h>
-#include <pal/text/TextEncoding.h>
 #include <wtf/HashFunctions.h>
 #include <wtf/Hasher.h>
 #include <wtf/URL.h>

--- a/Source/WebCore/dom/ActiveDOMObject.h
+++ b/Source/WebCore/dom/ActiveDOMObject.h
@@ -28,8 +28,6 @@
 
 #include <WebCore/ContextDestructionObserver.h>
 #include <WebCore/TaskSource.h>
-#include <wtf/AbstractRefCounted.h>
-#include <wtf/Assertions.h>
 #include <wtf/CancellableTask.h>
 #include <wtf/CurrentThread.h>
 #include <wtf/Forward.h>

--- a/Source/WebCore/dom/Document.h
+++ b/Source/WebCore/dom/Document.h
@@ -61,13 +61,9 @@
 #include <WebCore/ViewportArguments.h>
 #include <wtf/CompletionHandler.h>
 #include <wtf/Deque.h>
-#include <wtf/FixedVector.h>
-#include <wtf/Forward.h>
 #include <wtf/HashSet.h>
 #include <wtf/Logger.h>
-#include <wtf/ObjectIdentifier.h>
 #include <wtf/Observer.h>
-#include <wtf/Platform.h>
 #include <wtf/RobinHoodHashMap.h>
 #include <wtf/TZoneMalloc.h>
 #include <wtf/UniqueRef.h>
@@ -75,7 +71,6 @@
 #include <wtf/WeakHashMap.h>
 #include <wtf/WeakHashSet.h>
 #include <wtf/WeakListHashSet.h>
-#include <wtf/WeakPtr.h>
 #include <wtf/text/AtomStringHash.h>
 
 #if ENABLE(IOS_TOUCH_EVENTS)

--- a/Source/WebCore/dom/EventLoop.h
+++ b/Source/WebCore/dom/EventLoop.h
@@ -26,17 +26,14 @@
 #pragma once
 
 #include <WebCore/TaskSource.h>
-#include <optional>
 #include <wtf/ApproximateTime.h>
 #include <wtf/CheckedRef.h>
 #include <wtf/Function.h>
 #include <wtf/Markable.h>
 #include <wtf/MonotonicTime.h>
 #include <wtf/RefCountedAndCanMakeWeakPtr.h>
-#include <wtf/StdLibExtras.h>
 #include <wtf/TZoneMalloc.h>
 #include <wtf/WeakHashSet.h>
-#include <wtf/WeakPtr.h>
 
 namespace JSC {
 class JSGlobalObject;

--- a/Source/WebCore/dom/EventTarget.h
+++ b/Source/WebCore/dom/EventTarget.h
@@ -35,16 +35,11 @@
 #include <WebCore/EventListenerOptions.h>
 #include <WebCore/PlatformExportMacros.h>
 #include <WebCore/ScriptWrappable.h>
-#include <memory>
 #include <wtf/CanMakeWeakPtr.h>
 #include <wtf/CheckedPtr.h>
-#include <wtf/EnumTraits.h>
 #include <wtf/Forward.h>
 #include <wtf/TZoneMalloc.h>
 #include <wtf/Variant.h>
-#include <wtf/WeakPtr.h>
-#include <wtf/WeakPtrFactory.h>
-#include <wtf/WeakPtrImpl.h>
 
 namespace JSC {
 class JSValue;

--- a/Source/WebCore/dom/Exception.h
+++ b/Source/WebCore/dom/Exception.h
@@ -27,9 +27,6 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #pragma once
 
 #include <WebCore/ExceptionCode.h>
-#include <span>
-#include <utility>
-#include <wtf/StdLibExtras.h>
 #include <wtf/text/WTFString.h>
 
 namespace WebCore {

--- a/Source/WebCore/dom/ExceptionOr.h
+++ b/Source/WebCore/dom/ExceptionOr.h
@@ -27,10 +27,8 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #pragma once
 
 #include <WebCore/Exception.h>
-#include <utility>
 #include <wtf/CrossThreadCopier.h>
 #include <wtf/Expected.h>
-#include <wtf/StdLibExtras.h>
 
 namespace WebCore {
 

--- a/Source/WebCore/dom/MessagePort.h
+++ b/Source/WebCore/dom/MessagePort.h
@@ -32,6 +32,7 @@
 #include <WebCore/MessagePortChannel.h>
 #include <WebCore/MessagePortIdentifier.h>
 #include <WebCore/MessageWithMessagePorts.h>
+#include <wtf/ThreadSafeWeakPtr.h>
 #include <wtf/WeakPtr.h>
 
 namespace JSC {

--- a/Source/WebCore/dom/Node.h
+++ b/Source/WebCore/dom/Node.h
@@ -27,30 +27,19 @@
 #include <WebCore/EventTarget.h>
 #include <WebCore/NodeIdentifier.h>
 #include <WebCore/NodeType.h>
-#include <WebCore/PlatformExportMacros.h>
-#include <WebCore/RenderStyleConstants.h>
 #include <WebCore/StyleValidity.h>
-#include <bit>
-#include <compare>
-#include <new>
 #include <wtf/CheckedPtr.h>
 #include <wtf/CheckedRef.h>
 #include <wtf/CompactPointerTuple.h>
 #include <wtf/CompactUniquePtrTuple.h>
-#include <wtf/FastMalloc.h>
 #include <wtf/FixedVector.h>
 #include <wtf/Forward.h>
 #include <wtf/ListHashSet.h>
-#include <wtf/MainThread.h>
 #include <wtf/OptionSet.h>
-#include <wtf/RefCounted.h>
 #include <wtf/RobinHoodHashSet.h>
-#include <wtf/StdLibExtras.h>
 #include <wtf/TZoneMalloc.h>
 #include <wtf/TypeCasts.h>
 #include <wtf/URLHash.h>
-#include <wtf/WeakPtr.h>
-#include <wtf/text/ASCIILiteral.h>
 
 namespace WTF {
 class TextStream;
@@ -77,6 +66,8 @@ class NodeList;
 class NodeListsNodeData;
 class NodeRareData;
 class QualifiedName;
+
+enum class PseudoElementType : uint8_t;
 class RenderBox;
 class RenderBoxModelObject;
 class RenderObject;

--- a/Source/WebCore/dom/NodeList.h
+++ b/Source/WebCore/dom/NodeList.h
@@ -25,7 +25,6 @@
 
 #include <JavaScriptCore/EmbedderArrayLike.h>
 #include <WebCore/ScriptWrappable.h>
-#include <wtf/Forward.h>
 #include <wtf/TZoneMalloc.h>
 
 namespace WebCore {

--- a/Source/WebCore/dom/ScriptExecutionContext.h
+++ b/Source/WebCore/dom/ScriptExecutionContext.h
@@ -32,11 +32,9 @@
 #include <WebCore/SecurityContext.h>
 #include <WebCore/ServiceWorkerIdentifier.h>
 #include <WebCore/Timer.h>
-#include <wtf/Forward.h>
 #include <wtf/Function.h>
 #include <wtf/HashSet.h>
 #include <wtf/ListHashSet.h>
-#include <wtf/ObjectIdentifier.h>
 #include <wtf/ThreadSafeWeakHashSet.h>
 #include <wtf/WeakHashSet.h>
 #include <wtf/text/WTFString.h>

--- a/Source/WebCore/dom/TreeScope.h
+++ b/Source/WebCore/dom/TreeScope.h
@@ -27,7 +27,6 @@
 #pragma once
 
 #include <WebCore/HitTestSource.h>
-#include <memory>
 #include <wtf/CheckedRef.h>
 #include <wtf/Forward.h>
 #include <wtf/NoVirtualDestructorBase.h>

--- a/Source/WebCore/dom/UserGestureIndicator.h
+++ b/Source/WebCore/dom/UserGestureIndicator.h
@@ -35,7 +35,6 @@
 #include <wtf/UUID.h>
 #include <wtf/Vector.h>
 #include <wtf/WeakHashSet.h>
-#include <wtf/WeakPtr.h>
 
 namespace JSC {
 class VM;

--- a/Source/WebCore/editing/AlternativeTextController.cpp
+++ b/Source/WebCore/editing/AlternativeTextController.cpp
@@ -42,6 +42,8 @@
 #include "EventLoop.h"
 #include "FloatQuad.h"
 #include "FrameDestructionObserverInlines.h"
+#include "HTMLElement.h"
+#include "HTMLTextFormControlElement.h"
 #include "LocalFrameInlines.h"
 #include "LocalFrameView.h"
 #include "Page.h"

--- a/Source/WebCore/editing/ApplyBlockElementCommand.cpp
+++ b/Source/WebCore/editing/ApplyBlockElementCommand.cpp
@@ -31,6 +31,7 @@
 #include "HTMLBRElement.h"
 #include "HTMLNames.h"
 #include "RenderElement.h"
+#include "RenderText.h"
 #include "RenderStyle+GettersInlines.h"
 #include "Text.h"
 #include "VisibleUnits.h"

--- a/Source/WebCore/editing/CompositeEditCommand.h
+++ b/Source/WebCore/editing/CompositeEditCommand.h
@@ -26,7 +26,7 @@
 
 #pragma once
 
-#include "AXObjectCache.h"
+#include "AXObjectTypes.h"
 #include "EditCommand.h"
 #include "CSSPropertyNames.h"
 #include "UndoStep.h"
@@ -36,6 +36,7 @@
 
 namespace WebCore {
 
+class AXObjectCache;
 class EditingStyle;
 class DataTransfer;
 class HTMLElement;

--- a/Source/WebCore/editing/DeleteSelectionCommand.cpp
+++ b/Source/WebCore/editing/DeleteSelectionCommand.cpp
@@ -42,6 +42,7 @@
 #include "HTMLNames.h"
 #include "HTMLStyleElement.h"
 #include "HTMLTableElement.h"
+#include "HTMLTextFormControlElement.h"
 #include "LocalFrame.h"
 #include "NodeTraversal.h"
 #include "Range.h"

--- a/Source/WebCore/editing/FormatBlockCommand.cpp
+++ b/Source/WebCore/editing/FormatBlockCommand.cpp
@@ -35,6 +35,7 @@
 #include "HTMLNames.h"
 #include "MutableStyleProperties.h"
 #include "NodeName.h"
+#include "SimpleRange.h"
 #include "VisibleUnits.h"
 #include <wtf/NeverDestroyed.h>
 #include <wtf/RobinHoodHashSet.h>

--- a/Source/WebCore/editing/InsertListCommand.cpp
+++ b/Source/WebCore/editing/InsertListCommand.cpp
@@ -39,6 +39,7 @@
 #include "PositionInlines.h"
 #include "Range.h"
 #include "RenderStyle+GettersInlines.h"
+#include "SimpleRange.h"
 #include "VisibleUnits.h"
 
 namespace WebCore {

--- a/Source/WebCore/editing/InsertNestedListCommand.cpp
+++ b/Source/WebCore/editing/InsertNestedListCommand.cpp
@@ -31,6 +31,8 @@
 #include "HTMLNames.h"
 #include "InsertListCommand.h"
 #include "ModifySelectionListLevel.h"
+#include "SimpleRange.h"
+#include "RenderObjectInlines.h"
 
 namespace WebCore {
 

--- a/Source/WebCore/editing/InsertTextCommand.cpp
+++ b/Source/WebCore/editing/InsertTextCommand.cpp
@@ -40,6 +40,7 @@
 #include "MutableStyleProperties.h"
 #include "PositionInlines.h"
 #include "Text.h"
+#include "TextIterator.h"
 #include "TextListParser.h"
 #include "VisibleUnits.h"
 #include <wtf/text/StringToIntegerConversion.h>

--- a/Source/WebCore/editing/ModifySelectionListLevel.cpp
+++ b/Source/WebCore/editing/ModifySelectionListLevel.cpp
@@ -36,6 +36,8 @@
 #include "LocalFrame.h"
 #include "LocalFrameInlines.h"
 #include "RenderObject.h"
+#include "SimpleRange.h"
+#include "RenderObjectInlines.h"
 
 namespace WebCore {
 

--- a/Source/WebCore/editing/RemoveFormatCommand.cpp
+++ b/Source/WebCore/editing/RemoveFormatCommand.cpp
@@ -35,6 +35,8 @@
 #include "LocalFrame.h"
 #include "MutableStyleProperties.h"
 #include "NodeName.h"
+#include "SimpleRange.h"
+#include "RenderObjectInlines.h"
 #include <wtf/NeverDestroyed.h>
 #include <wtf/RobinHoodHashSet.h>
 

--- a/Source/WebCore/editing/ReplaceRangeWithTextCommand.h
+++ b/Source/WebCore/editing/ReplaceRangeWithTextCommand.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include "CompositeEditCommand.h"
+#include "SimpleRange.h"
 
 namespace WebCore {
 

--- a/Source/WebCore/editing/SimplifyMarkupCommand.cpp
+++ b/Source/WebCore/editing/SimplifyMarkupCommand.cpp
@@ -29,6 +29,7 @@
 #include "ContainerNodeInlines.h"
 #include "NodeRenderStyle.h"
 #include "NodeTraversal.h"
+#include "RenderObjectInlines.h"
 #include "RenderInline.h"
 #include "RenderObject.h"
 #include "RenderStyle.h"

--- a/Source/WebCore/editing/SpellingCorrectionCommand.h
+++ b/Source/WebCore/editing/SpellingCorrectionCommand.h
@@ -27,6 +27,7 @@
 
 #include "CompositeEditCommand.h"
 #include "DocumentFragment.h"
+#include "SimpleRange.h"
 
 namespace WebCore {
 

--- a/Source/WebCore/editing/TypingCommand.h
+++ b/Source/WebCore/editing/TypingCommand.h
@@ -25,6 +25,7 @@
 
 #pragma once
 
+#include "SimpleRange.h"
 #include "TextInsertionBaseCommand.h"
 #include <wtf/CheckedRef.h>
 

--- a/Source/WebCore/editing/WritingToolsCompositionCommand.cpp
+++ b/Source/WebCore/editing/WritingToolsCompositionCommand.cpp
@@ -29,6 +29,7 @@
 #include "FrameSelection.h"
 #include "ReplaceSelectionCommand.h"
 #include "TextIterator.h"
+#include "VisibleUnits.h"
 
 namespace WebCore {
 

--- a/Source/WebCore/editing/WritingToolsCompositionCommand.h
+++ b/Source/WebCore/editing/WritingToolsCompositionCommand.h
@@ -26,9 +26,11 @@
 #pragma once
 
 #include "CompositeEditCommand.h"
+#include "SimpleRange.h"
 
 namespace WebCore {
 
+class DocumentFragment;
 struct AttributedString;
 
 // A Writing Tools Composition command is essentially a wrapper around a group of Replace Selection commands,

--- a/Source/WebCore/fileapi/NetworkSendQueue.h
+++ b/Source/WebCore/fileapi/NetworkSendQueue.h
@@ -27,12 +27,10 @@
 
 #include <WebCore/ContextDestructionObserver.h>
 #include <WebCore/ExceptionCode.h>
-#include <span>
 #include <wtf/Deque.h>
 #include <wtf/Function.h>
 #include <wtf/RefCounted.h>
 #include <wtf/UniqueRef.h>
-#include <wtf/WeakPtr.h>
 #include <wtf/text/CString.h>
 
 namespace JSC {

--- a/Source/WebCore/history/CachedFrame.cpp
+++ b/Source/WebCore/history/CachedFrame.cpp
@@ -26,6 +26,7 @@
 #include "config.h"
 #include "CachedFrame.h"
 
+#include "ActiveDOMObject.h"
 #include "BackForwardCache.h"
 #include "CachedFramePlatformData.h"
 #include "CachedPage.h"

--- a/Source/WebCore/html/HTMLElement.h
+++ b/Source/WebCore/html/HTMLElement.h
@@ -24,7 +24,6 @@
 
 #include <WebCore/HTMLNames.h>
 #include <WebCore/StyledElement.h>
-#include <wtf/Platform.h>
 
 namespace WebCore {
 

--- a/Source/WebCore/inspector/FrameDebugger.cpp
+++ b/Source/WebCore/inspector/FrameDebugger.cpp
@@ -26,6 +26,7 @@
 #include "config.h"
 #include "FrameDebugger.h"
 
+#include "ActiveDOMObject.h"
 #include "CommonVM.h"
 #include "DOMWrapperWorld.h"
 #include "Document.h"

--- a/Source/WebCore/page/DOMTimer.cpp
+++ b/Source/WebCore/page/DOMTimer.cpp
@@ -37,6 +37,7 @@
 #include "ScheduledAction.h"
 #include "ScriptExecutionContextInlines.h"
 #include "Settings.h"
+#include "UserGestureIndicator.h"
 #include <wtf/CryptographicallyRandomNumber.h>
 #include <wtf/HashMap.h>
 #include <wtf/MathExtras.h>

--- a/Source/WebCore/page/DOMTimer.h
+++ b/Source/WebCore/page/DOMTimer.h
@@ -28,13 +28,8 @@
 
 #include <WebCore/ActiveDOMObject.h>
 #include <WebCore/EventLoop.h>
-#include <WebCore/UserGestureIndicator.h>
-#include <memory>
-#include <wtf/MonotonicTime.h>
-#include <wtf/RefCountedAndCanMakeWeakPtr.h>
 #include <wtf/Seconds.h>
 #include <wtf/TZoneMalloc.h>
-#include <wtf/WeakPtr.h>
 
 namespace WebCore {
 
@@ -42,6 +37,7 @@ class DOMTimerFireState;
 class Document;
 class ImminentlyScheduledWorkScope;
 class ScheduledAction;
+class UserGestureToken;
 
 class DOMTimer final : public RefCounted<DOMTimer>, public ActiveDOMObject {
     WTF_MAKE_NONCOPYABLE(DOMTimer);

--- a/Source/WebCore/page/Frame.h
+++ b/Source/WebCore/page/Frame.h
@@ -30,7 +30,6 @@
 #include <WebCore/FrameTreeSyncData.h>
 #include <WebCore/PageIdentifier.h>
 #include <wtf/CheckedRef.h>
-#include <wtf/Ref.h>
 #include <wtf/RefCountedAndCanMakeWeakPtr.h>
 #include <wtf/UniqueRef.h>
 #include <wtf/WeakHashSet.h>

--- a/Source/WebCore/page/LocalFrame.h
+++ b/Source/WebCore/page/LocalFrame.h
@@ -31,9 +31,7 @@
 #include <WebCore/Frame.h>
 #include <WebCore/HitTestRequest.h>
 #include <WebCore/ScrollbarMode.h>
-#include <wtf/CheckedRef.h>
 #include <wtf/HashSet.h>
-#include <wtf/Platform.h>
 #include <wtf/UniqueRef.h>
 #include <wtf/WeakRef.h>
 

--- a/Source/WebCore/page/LocalFrameView.h
+++ b/Source/WebCore/page/LocalFrameView.h
@@ -36,13 +36,9 @@
 #include <WebCore/PaintPhase.h>
 #include <WebCore/RenderPtr.h>
 #include <WebCore/SimpleRange.h>
-#include <memory>
-#include <wtf/Forward.h>
 #include <wtf/Function.h>
 #include <wtf/HashSet.h>
 #include <wtf/ListHashSet.h>
-#include <wtf/OptionSet.h>
-#include <wtf/Platform.h>
 #include <wtf/TZoneMalloc.h>
 #include <wtf/WeakHashSet.h>
 #include <wtf/WeakRef.h>

--- a/Source/WebCore/page/Page.h
+++ b/Source/WebCore/page/Page.h
@@ -46,18 +46,12 @@
 #include <WebCore/Supplementable.h>
 #include <WebCore/Timer.h>
 #include <WebCore/UserInterfaceLayoutDirection.h>
-#include <memory>
 #include <pal/SessionID.h>
-#include <wtf/Assertions.h>
 #include <wtf/CheckedPtr.h>
-#include <wtf/Forward.h>
 #include <wtf/Function.h>
 #include <wtf/HashSet.h>
 #include <wtf/Noncopyable.h>
-#include <wtf/OptionSet.h>
-#include <wtf/Platform.h>
 #include <wtf/ProcessID.h>
-#include <wtf/Ref.h>
 #include <wtf/RefCountedAndCanMakeWeakPtr.h>
 #include <wtf/RobinHoodHashSet.h>
 #include <wtf/TZoneMalloc.h>
@@ -65,7 +59,6 @@
 #include <wtf/UniqueRef.h>
 #include <wtf/WeakHashMap.h>
 #include <wtf/WeakHashSet.h>
-#include <wtf/WeakPtr.h>
 #include <wtf/text/WTFString.h>
 
 #if ENABLE(APPLICATION_MANIFEST)

--- a/Source/WebCore/page/RemoteFrame.h
+++ b/Source/WebCore/page/RemoteFrame.h
@@ -25,15 +25,12 @@
 
 #pragma once
 
+#include <WebCore/AXObjectTypes.h>
 #include <WebCore/Frame.h>
 #include <WebCore/LayerHostingContextIdentifier.h>
 #include <wtf/RefPtr.h>
 #include <wtf/TypeCasts.h>
 #include <wtf/UniqueRef.h>
-
-#if ENABLE(ACCESSIBILITY_LOCAL_FRAME)
-#include <WebCore/AXObjectCache.h>
-#endif
 
 namespace WebCore {
 
@@ -43,6 +40,7 @@ class RemoteFrameClient;
 class RemoteFrameView;
 class WeakPtrImplWithEventTargetData;
 class ResourceTiming;
+
 
 enum class AdvancedPrivacyProtections : uint16_t;
 enum class AutoplayPolicy : uint8_t;

--- a/Source/WebCore/page/RemoteFrameClient.h
+++ b/Source/WebCore/page/RemoteFrameClient.h
@@ -25,14 +25,11 @@
 
 #pragma once
 
+#include <WebCore/AXObjectTypes.h>
 #include <WebCore/FrameLoaderClient.h>
 #include <WebCore/LayerTreeAsTextOptions.h>
 #include <WebCore/ScrollTypes.h>
 #include <wtf/TZoneMallocInlines.h>
-
-#if ENABLE(ACCESSIBILITY_LOCAL_FRAME)
-#include <WebCore/AXObjectCache.h>
-#endif
 
 namespace WebCore {
 
@@ -42,6 +39,7 @@ class GraphicsContext;
 class IntSize;
 class ResourceTiming;
 class SecurityOriginData;
+
 
 enum class FocusDirection : uint8_t;
 enum class FoundElementInRemoteFrame : bool;

--- a/Source/WebCore/page/SecurityOrigin.h
+++ b/Source/WebCore/page/SecurityOrigin.h
@@ -29,8 +29,6 @@
 #pragma once
 
 #include <WebCore/SecurityOriginData.h>
-#include <wtf/ArgumentCoder.h>
-#include <wtf/Hasher.h>
 #include <wtf/ThreadSafeRefCounted.h>
 #include <wtf/text/WTFString.h>
 

--- a/Source/WebCore/platform/Logging.h
+++ b/Source/WebCore/platform/Logging.h
@@ -26,9 +26,6 @@
 #pragma once
 
 #include <WebCore/WebCoreLogDefinitions.h>
-#include <wtf/Assertions.h>
-#include <wtf/Forward.h>
-#include <wtf/StdLibExtras.h>
 
 #define COMMA() ,
 #define OPTIONAL_ARGS(...) __VA_OPT__(COMMA() SAFE_PRINTF_TYPE(__VA_ARGS__))

--- a/Source/WebCore/platform/RectEdges.h
+++ b/Source/WebCore/platform/RectEdges.h
@@ -30,7 +30,6 @@
 #include <WebCore/WritingMode.h>
 #include <array>
 #include <concepts>
-#include <wtf/OptionSet.h>
 #include <wtf/text/TextStream.h>
 
 namespace WebCore {

--- a/Source/WebCore/platform/RegistrableDomain.h
+++ b/Source/WebCore/platform/RegistrableDomain.h
@@ -32,8 +32,6 @@
 #include <wtf/TZoneMallocInlines.h>
 #include <wtf/URL.h>
 #include <wtf/text/StringConcatenate.h>
-#include <wtf/text/StringHash.h>
-#include <wtf/text/WTFString.h>
 
 namespace WebCore {
 

--- a/Source/WebCore/platform/SharedBuffer.h
+++ b/Source/WebCore/platform/SharedBuffer.h
@@ -27,20 +27,14 @@
 #pragma once
 
 #include <JavaScriptCore/Forward.h>
-#include <span>
-#include <utility>
 #include <wtf/FileSystem.h>
-#include <wtf/Forward.h>
 #include <wtf/Function.h>
 #include <wtf/MappedFileData.h>
-#include <wtf/RawPtrTraits.h>
 #include <wtf/TZoneMalloc.h>
 #include <wtf/ThreadSafeRefCounted.h>
 #include <wtf/TypeCasts.h>
-#include <wtf/TypeTraits.h>
 #include <wtf/Variant.h>
 #include <wtf/Vector.h>
-#include <wtf/text/WTFString.h>
 
 #if USE(CF)
 #include <wtf/RetainPtr.h>

--- a/Source/WebCore/platform/Supplementable.h
+++ b/Source/WebCore/platform/Supplementable.h
@@ -29,7 +29,6 @@
 #include <wtf/Assertions.h>
 #include <wtf/CurrentThread.h>
 #include <wtf/HashMap.h>
-#include <wtf/MainThread.h>
 #include <wtf/text/ASCIILiteral.h>
 
 namespace WebCore {

--- a/Source/WebCore/platform/Timer.h
+++ b/Source/WebCore/platform/Timer.h
@@ -26,15 +26,11 @@
 #pragma once
 
 #include <WebCore/ThreadTimers.h>
-#include <functional>
 #include <wtf/AbstractCanMakeCheckedPtr.h>
-#include <wtf/CheckedRef.h>
-#include <wtf/CompactRefPtrTuple.h>
 #include <wtf/CurrentThread.h>
 #include <wtf/Function.h>
 #include <wtf/MonotonicTime.h>
 #include <wtf/Noncopyable.h>
-#include <wtf/Platform.h>
 #include <wtf/RunLoop.h>
 #include <wtf/Seconds.h>
 #include <wtf/TZoneMalloc.h>

--- a/Source/WebCore/platform/gamepad/PlatformGamepad.h
+++ b/Source/WebCore/platform/gamepad/PlatformGamepad.h
@@ -28,19 +28,16 @@
 #if ENABLE(GAMEPAD)
 
 #include <WebCore/GamepadHapticEffectType.h>
-#include <WebCore/SharedGamepadValue.h>
+#include <wtf/CanMakeWeakPtr.h>
 #include <wtf/CheckedRef.h>
 #include <wtf/CompletionHandler.h>
-#include <wtf/Forward.h>
 #include <wtf/MonotonicTime.h>
 #include <wtf/TZoneMallocInlines.h>
-#include <wtf/WeakHashMap.h>
-#include <wtf/WeakHashSet.h>
-#include <wtf/WeakPtr.h>
 #include <wtf/text/WTFString.h>
 
 namespace WebCore {
 
+class SharedGamepadValue;
 struct GamepadEffectParameters;
 
 class PlatformGamepad : public CanMakeWeakPtr<PlatformGamepad>, public CanMakeCheckedPtr<PlatformGamepad> {

--- a/Source/WebCore/platform/gamepad/cocoa/GameControllerGamepad.h
+++ b/Source/WebCore/platform/gamepad/cocoa/GameControllerGamepad.h
@@ -29,6 +29,7 @@
 
 #include "GameControllerHapticEngines.h"
 #include <WebCore/PlatformGamepad.h>
+#include <WebCore/SharedGamepadValue.h>
 #include <wtf/RetainPtr.h>
 #include <wtf/TZoneMalloc.h>
 

--- a/Source/WebCore/platform/gamepad/libwpe/GamepadLibWPE.cpp
+++ b/Source/WebCore/platform/gamepad/libwpe/GamepadLibWPE.cpp
@@ -32,6 +32,7 @@
 #if WPE_CHECK_VERSION(1, 13, 90)
 
 #include "GamepadProviderLibWPE.h"
+#include "SharedGamepadValue.h"
 #include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {

--- a/Source/WebCore/platform/gamepad/mac/HIDGamepad.h
+++ b/Source/WebCore/platform/gamepad/mac/HIDGamepad.h
@@ -32,6 +32,7 @@
 #include <WebCore/HIDDevice.h>
 #include <WebCore/HIDGamepadElement.h>
 #include <WebCore/PlatformGamepad.h>
+#include <WebCore/SharedGamepadValue.h>
 #include <wtf/HashMap.h>
 #include <wtf/TZoneMalloc.h>
 

--- a/Source/WebCore/platform/gamepad/mac/MultiGamepadProvider.h
+++ b/Source/WebCore/platform/gamepad/mac/MultiGamepadProvider.h
@@ -30,9 +30,12 @@
 #include <WebCore/GamepadProvider.h>
 #include <WebCore/GamepadProviderClient.h>
 #include <WebCore/PlatformGamepad.h>
+#include <WebCore/SharedGamepadValue.h>
 #include <wtf/Forward.h>
 #include <wtf/HashSet.h>
 #include <wtf/TZoneMalloc.h>
+#include <wtf/WeakHashMap.h>
+#include <wtf/WeakPtr.h>
 
 namespace WebCore {
 

--- a/Source/WebCore/platform/gamepad/manette/ManetteGamepad.cpp
+++ b/Source/WebCore/platform/gamepad/manette/ManetteGamepad.cpp
@@ -29,6 +29,7 @@
 #if ENABLE(GAMEPAD) && OS(LINUX)
 
 #include "ManetteGamepadProvider.h"
+#include "SharedGamepadValue.h"
 #include <linux/input-event-codes.h>
 #include <wtf/HexNumber.h>
 #include <wtf/TZoneMallocInlines.h>

--- a/Source/WebCore/platform/graphics/Color.h
+++ b/Source/WebCore/platform/graphics/Color.h
@@ -28,20 +28,10 @@
 #include <WebCore/ColorConversion.h>
 #include <WebCore/ColorSpace.h>
 #include <WebCore/ColorUtilities.h>
-#include <WebCore/DestinationColorSpace.h>
-#include <bit>
-#include <functional>
-#include <utility>
-#include <wtf/Assertions.h>
-#include <wtf/Compiler.h>
-#include <wtf/Forward.h>
-#include <wtf/GetPtr.h>
 #include <wtf/HashFunctions.h>
 #include <wtf/Hasher.h>
 #include <wtf/OptionSet.h>
-#include <wtf/Platform.h>
 #include <wtf/Ref.h>
-#include <wtf/StdLibExtras.h>
 #include <wtf/TZoneMalloc.h>
 #include <wtf/ThreadSafeRefCounted.h>
 #include <wtf/Variant.h>
@@ -57,6 +47,8 @@ WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_END
 #endif
 
 namespace WebCore {
+
+class DestinationColorSpace;
 
 struct OutOfLineColorDataForIPC {
     ColorSpace colorSpace;

--- a/Source/WebCore/platform/graphics/FloatPoint.h
+++ b/Source/WebCore/platform/graphics/FloatPoint.h
@@ -31,7 +31,6 @@
 #include <WebCore/IntPoint.h>
 #include <wtf/Hasher.h>
 #include <wtf/MathExtras.h>
-#include <wtf/Platform.h>
 #include <wtf/TZoneMalloc.h>
 
 #if USE(CG)

--- a/Source/WebCore/platform/graphics/FloatSize.h
+++ b/Source/WebCore/platform/graphics/FloatSize.h
@@ -32,8 +32,6 @@
 #include <WebCore/IntPoint.h>
 #include <wtf/JSONValues.h>
 #include <wtf/MathExtras.h>
-#include <wtf/Platform.h>
-#include <wtf/text/WTFString.h>
 
 #if PLATFORM(IOS_FAMILY)
 #include <CoreGraphics/CoreGraphics.h>

--- a/Source/WebCore/platform/graphics/GraphicsContext.h
+++ b/Source/WebCore/platform/graphics/GraphicsContext.h
@@ -35,7 +35,6 @@
 #include <WebCore/GraphicsContextState.h>
 #include <WebCore/Image.h>
 #include <WebCore/ImageBufferFormat.h>
-#include <WebCore/ImageOrientation.h>
 #include <WebCore/ImagePaintingOptions.h>
 #include <WebCore/IntRect.h>
 #include <WebCore/Pattern.h>
@@ -43,7 +42,6 @@
 #include <WebCore/RenderingMode.h>
 #include <wtf/Function.h>
 #include <wtf/Noncopyable.h>
-#include <wtf/OptionSet.h>
 #include <wtf/TZoneMalloc.h>
 
 namespace WebCore {

--- a/Source/WebCore/platform/graphics/Image.h
+++ b/Source/WebCore/platform/graphics/Image.h
@@ -34,7 +34,6 @@
 #include <WebCore/ImagePaintingOptions.h>
 #include <WebCore/ImageTypes.h>
 #include <wtf/RefCountedAndCanMakeWeakPtr.h>
-#include <wtf/RefPtr.h>
 #include <wtf/RetainPtr.h>
 #include <wtf/TypeCasts.h>
 #include <wtf/text/WTFString.h>

--- a/Source/WebCore/platform/graphics/IntSize.h
+++ b/Source/WebCore/platform/graphics/IntSize.h
@@ -32,7 +32,6 @@
 #include <wtf/JSONValues.h>
 #include <wtf/Forward.h>
 #include <wtf/MathExtras.h>
-#include <wtf/Platform.h>
 
 #if USE(CG)
 typedef struct CGSize CGSize;

--- a/Source/WebCore/platform/graphics/NativeImage.h
+++ b/Source/WebCore/platform/graphics/NativeImage.h
@@ -29,12 +29,10 @@
 
 #include <WebCore/GainMap.h>
 #include <WebCore/ImageTypes.h>
-#include <WebCore/PlatformExportMacros.h>
 #include <WebCore/PlatformImage.h>
 #include <WebCore/RenderingResource.h>
 #include <wtf/CheckedRef.h>
 #include <wtf/TZoneMalloc.h>
-#include <wtf/UniqueRef.h>
 
 #if USE(SKIA)
 class GrDirectContext;

--- a/Source/WebCore/platform/graphics/TextRun.h
+++ b/Source/WebCore/platform/graphics/TextRun.h
@@ -27,7 +27,6 @@
 #include <WebCore/TextFlags.h>
 #include <WebCore/TextSpacing.h>
 #include <WebCore/WritingMode.h>
-#include <wtf/CheckedRef.h>
 #include <wtf/TZoneMalloc.h>
 #include <wtf/text/StringView.h>
 

--- a/Source/WebCore/platform/graphics/filters/FEDropShadow.h
+++ b/Source/WebCore/platform/graphics/filters/FEDropShadow.h
@@ -21,6 +21,7 @@
 #pragma once
 
 #include <WebCore/Color.h>
+#include <WebCore/DestinationColorSpace.h>
 #include <WebCore/FilterEffect.h>
 
 namespace WebCore {

--- a/Source/WebCore/platform/graphics/filters/FEFlood.h
+++ b/Source/WebCore/platform/graphics/filters/FEFlood.h
@@ -23,6 +23,7 @@
 #pragma once
 
 #include <WebCore/Color.h>
+#include <WebCore/DestinationColorSpace.h>
 #include <WebCore/FilterEffect.h>
 
 namespace WebCore {

--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBufferExternalOES.cpp
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBufferExternalOES.cpp
@@ -42,6 +42,7 @@
 
 #if USE(SKIA)
 WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_BEGIN
+#include <skia/core/SkColorSpace.h>
 #include <skia/core/SkImage.h>
 #include <skia/gpu/ganesh/GrBackendSurface.h>
 #include <skia/gpu/ganesh/SkImageGanesh.h>

--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBufferRGB.cpp
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBufferRGB.cpp
@@ -35,6 +35,7 @@
 #if USE(SKIA)
 WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_BEGIN
 #include <skia/core/SkColorFilter.h>
+#include <skia/core/SkColorSpace.h>
 #include <skia/core/SkImage.h>
 #include <skia/gpu/ganesh/GrBackendSurface.h>
 #include <skia/gpu/ganesh/SkImageGanesh.h>

--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBufferYUV.cpp
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBufferYUV.cpp
@@ -33,6 +33,7 @@
 
 #if USE(SKIA)
 WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_BEGIN
+#include <skia/core/SkColorSpace.h>
 #include <skia/core/SkImage.h>
 #include <skia/core/SkYUVAInfo.h>
 #include <skia/gpu/ganesh/GrBackendSurface.h>

--- a/Source/WebCore/platform/image-decoders/skia/ImageBackingStoreSkia.cpp
+++ b/Source/WebCore/platform/image-decoders/skia/ImageBackingStoreSkia.cpp
@@ -27,6 +27,7 @@
 #include "ImageBackingStore.h"
 
 WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_BEGIN
+#include <skia/core/SkColorSpace.h>
 #include <skia/core/SkPixmap.h>
 WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_END
 

--- a/Source/WebCore/platform/text/TextChecking.h
+++ b/Source/WebCore/platform/text/TextChecking.h
@@ -34,9 +34,7 @@
 #include <WebCore/CharacterRange.h>
 #include <WebCore/TextCheckingRequestIdentifier.h>
 #include <wtf/CrossThreadCopier.h>
-#include <wtf/ObjectIdentifier.h>
 #include <wtf/OptionSet.h>
-#include <wtf/Platform.h>
 #include <wtf/Vector.h>
 #include <wtf/text/WTFString.h>
 

--- a/Source/WebCore/platform/text/TextFlags.h
+++ b/Source/WebCore/platform/text/TextFlags.h
@@ -26,10 +26,8 @@
 #pragma once
 
 #include <WebCore/FontTaggedSettings.h>
-#include <optional>
-#include <vector>
-#include <wtf/Hasher.h>
 #include <wtf/Markable.h>
+#include <wtf/text/WTFString.h>
 
 namespace WTF {
 class TextStream;

--- a/Source/WebCore/style/StyleExtractorCustom.h
+++ b/Source/WebCore/style/StyleExtractorCustom.h
@@ -75,6 +75,7 @@
 #include "StyleTransformFunction.h"
 #include "StyleTransformResolver.h"
 #include "WebAnimationUtilities.h"
+#include "WritingMode.h"
 
 namespace WebCore {
 namespace Style {

--- a/Source/WebCore/style/values/StyleValueTypes.h
+++ b/Source/WebCore/style/values/StyleValueTypes.h
@@ -29,8 +29,6 @@
 #include <WebCore/CSSValueTypes.h>
 #include <optional>
 #include <tuple>
-#include <utility>
-#include <wtf/StdLibExtras.h>
 
 namespace WebCore {
 

--- a/Source/WebCore/svg/SVGElement.h
+++ b/Source/WebCore/svg/SVGElement.h
@@ -37,6 +37,8 @@ class AffineTransform;
 class Document;
 class SVGAnimatedPropertyBase;
 class SVGAnimatedString;
+
+enum class ColorInterpolation : uint8_t;
 class SVGAttributeAnimator;
 class SVGConditionalProcessingAttributes;
 class SVGDocumentExtensions;

--- a/Source/WebCore/testing/MockGamepad.h
+++ b/Source/WebCore/testing/MockGamepad.h
@@ -28,6 +28,7 @@
 #if ENABLE(GAMEPAD)
 
 #include <WebCore/PlatformGamepad.h>
+#include <WebCore/SharedGamepadValue.h>
 #include <wtf/TZoneMalloc.h>
 
 namespace WebCore {

--- a/Source/WebCore/testing/MockGamepadProvider.h
+++ b/Source/WebCore/testing/MockGamepadProvider.h
@@ -31,6 +31,7 @@
 #include <WebCore/MockGamepad.h>
 #include <wtf/HashMap.h>
 #include <wtf/HashSet.h>
+#include <wtf/WeakHashMap.h>
 #include <wtf/text/WTFString.h>
 
 namespace WebCore {

--- a/Source/WebCore/workers/WorkerGlobalScopeProxy.h
+++ b/Source/WebCore/workers/WorkerGlobalScopeProxy.h
@@ -37,12 +37,15 @@
 #include <wtf/Function.h>
 #include <wtf/MonotonicTime.h>
 
+namespace PAL { class SessionID; }
+
 namespace WebCore {
 
 class ContentSecurityPolicyResponseHeaders;
 class ScriptBuffer;
 class ScriptExecutionContext;
 class Worker;
+struct CrossOriginEmbedderPolicy;
 struct WorkerInitializationData;
 enum class ReferrerPolicy : uint8_t;
 enum class WorkerType : bool;

--- a/Source/WebCore/workers/shared/SharedWorkerGlobalScope.cpp
+++ b/Source/WebCore/workers/shared/SharedWorkerGlobalScope.cpp
@@ -26,6 +26,7 @@
 #include "config.h"
 #include "SharedWorkerGlobalScope.h"
 
+#include "Blob.h"
 #include "EventNames.h"
 #include "IDBConnectionProxy.h"
 #include "Logging.h"

--- a/Source/WebKit/Shared/SerializedNode.serialization.in
+++ b/Source/WebKit/Shared/SerializedNode.serialization.in
@@ -43,6 +43,7 @@
     Variant<String, URL> documentURI;
     String contentType;
 };
+header: <WebCore/Document.h>
 [Nested] enum class WebCore::ClonedDocumentType : uint8_t {
     XMLDocument,
     XHTMLDocument,

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -7984,7 +7984,7 @@ using WebCore::RiceSocket = std::pair<String, WebCore::RTCIceProtocol>;
 };
 #endif
 
-headers: <JavaScriptCore/WasmModule.h> <WebCore/ImageBitmap.h> <WebCore/MessagePort.h> <WebCore/OffscreenCanvas.h>
+headers: <JavaScriptCore/WasmModule.h> <WebCore/ImageBitmap.h> <WebCore/MessagePort.h> <WebCore/OffscreenCanvas.h> <WebCore/SerializedScriptValue.h> <WebCore/SerializedScriptValueInternals.h>
 [Nested] class WebCore::SerializedScriptValue::Internals {
     Vector<uint8_t> data;
     std::unique_ptr<Vector<JSC::ArrayBufferContents>> arrayBufferContentsArray;
@@ -8028,7 +8028,7 @@ headers: <JavaScriptCore/WasmModule.h> <WebCore/ImageBitmap.h> <WebCore/MessageP
 };
 
 [RefCounted] class WebCore::SerializedScriptValue {
-    WebCore::SerializedScriptValue::Internals m_internals;
+    std::unique_ptr<WebCore::SerializedScriptValueInternals> m_internals;
 };
 
 header: <WebCore/SharedBuffer.h>

--- a/Source/WebKitLegacy/mac/WebCoreSupport/WebFrameLoaderClient.mm
+++ b/Source/WebKitLegacy/mac/WebCoreSupport/WebFrameLoaderClient.mm
@@ -31,6 +31,7 @@
 #import "BackForwardList.h"
 #import "DOMElementInternal.h"
 #import "DOMHTMLFormElementInternal.h"
+#import <WebCore/ResourceHandle.h>
 #import "WebBackForwardList.h"
 #import "WebBasePluginPackage.h"
 #import "WebCachedFramePlatformData.h"


### PR DESCRIPTION
#### c1781e4c96e876267a65d2bd977f23ecfba0c886
<pre>
[Build Speed] Reduce the cost of SerializedScriptValue.h and AXObjectCache.h
<a href="https://rdar.apple.com/176421722">rdar://176421722</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=314279">https://bugs.webkit.org/show_bug.cgi?id=314279</a>

Reviewed by Geoffrey Garen.

Slim WebCore headers to reduce build times

Reduce frontend parsing time by ~352s (2.5%) across a full debug build
by removing unnecessary includes from widely-used headers, replacing
heavy includes with forward declarations, and extracting inner structures
into separate headers.

Key changes:

- SerializedScriptValue.h: Extract Internals struct to a separate
  private header (SerializedScriptValueInternals.h) behind a
  unique_ptr. Reduces per-include cost from 578ms to 7ms (62 includers).

- AXObjectCache.h: Remove Document.h and RenderView.h includes by
  moving inline functions out-of-line. Extract lightweight types to new
  AXObjectTypes.h. Reduce inclusion count from 145 to 55 (saves ~166s).

- Remove unnecessary AXObjectCache.h from RemoteFrame.h,
  RemoteFrameClient.h, and CompositeEditCommand.h, replacing with
  lightweight AXObjectTypes.h or forward declarations.

- Remove redundant includes from Color.h, Node.h, Timer.h,
  EventTarget.h, Document.h, Page.h, LocalFrameView.h, GraphicsContext.h,
  SharedBuffer.h, and ~20 other widely-included headers.

- Use forward declarations for DestinationColorSpace, WritingMode,
  PseudoElementType, UserGestureToken, SharedGamepadValue, and
  ColorInterpolation where only pointers/references are needed.

- Add compensating includes to .cpp files that relied on transitive
  includes through the slimmed headers.

CBA measurements (full debug build, arm64e):
  Baseline: 14160.8s frontend parsing
  Branch:   13808.8s frontend parsing
  Saved:    352.0s (2.5%)

Canonical link: <a href="https://commits.webkit.org/312862@main">https://commits.webkit.org/312862@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b2d338e8384295963f260ca1f1e5fc8ff7c86d12

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/161313 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/34786 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/27887 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/170216 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/117684 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/94359ab5-e5f1-48c5-9579-c69a6113cbaa) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/163182 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/34887 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/34787 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/125130 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/117684 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/7f22aed0-599c-4c14-a7d8-2207405ad512) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/164272 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/27419 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/144899 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/105727 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/fd0b7807-c4cb-4892-8e9c-81048d9be5f2) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/26467 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/24976 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/17936 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/153370 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/136161 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/22659 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/172699 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/22151 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/19720 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/24300 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/133413 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/34460 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/29069 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/133421 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36029 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/34445 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/144454 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/96310 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/27959 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/21272 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/193712 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/33955 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/101380 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/49907 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/33454 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/33698 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/33603 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->