### PR TITLE
[YARR] Encode Unicode property tables as `constexpr` data instead of inline construction code

### DIFF
--- a/Source/JavaScriptCore/yarr/YarrPattern.h
+++ b/Source/JavaScriptCore/yarr/YarrPattern.h
@@ -52,7 +52,7 @@ struct CharacterRange {
     char32_t begin { 0 };
     char32_t end { UCHAR_MAX_VALUE };
 
-    CharacterRange(char32_t begin, char32_t end)
+    constexpr CharacterRange(char32_t begin, char32_t end)
         : begin(begin)
         , end(end)
     {

--- a/Source/JavaScriptCore/yarr/generateYarrUnicodePropertyTables.py
+++ b/Source/JavaScriptCore/yarr/generateYarrUnicodePropertyTables.py
@@ -558,16 +558,45 @@ class PropertyData:
             formatter(file, elem)
         file.write("}")
 
-    def convertStringToCppFormat(self, file, utf32String):
-        output = ""
-        for codePoint in utf32String:
-            if codePoint <= '\xff':
-                output += codePoint
-            else:
-                output += "\\x{:x}".format(ord(codePoint))
-        file.write("{{ std::span {{ U\"{}\", {} }}}}".format(output, len(utf32String)))
+    def dumpStringTables(self, file):
+        # Emit a flat constexpr char32_t data array plus a constexpr per-string
+        # length array. createCharacterClassN() reconstructs Vector<Vector<char32_t>>
+        # from these with a small loop instead of thousands of inline Vector ctors,
+        # keeping the data in __TEXT,__const instead of generating hundreds of KB of
+        # construction code in __TEXT,__text.
+        file.write("static constexpr char32_t kStrings{}Data[] = {{\n    ".format(self.index))
+        valuesThisLine = 0
+        firstValue = True
+        for utf32String in self.matchStrings:
+            for codePoint in utf32String:
+                if not firstValue:
+                    file.write(", ")
+                firstValue = False
+                if valuesThisLine >= 16:
+                    file.write("\n    ")
+                    valuesThisLine = 0
+                file.write("0x{:x}".format(ord(codePoint)))
+                valuesThisLine += 1
+        file.write("\n};\n")
+
+        file.write("static constexpr uint8_t kStrings{}Lengths[] = {{\n    ".format(self.index))
+        valuesThisLine = 0
+        firstValue = True
+        for utf32String in self.matchStrings:
+            assert len(utf32String) <= 255, "string length must fit in uint8_t"
+            if not firstValue:
+                file.write(", ")
+            firstValue = False
+            if valuesThisLine >= 24:
+                file.write("\n    ")
+                valuesThisLine = 0
+            file.write("{}".format(len(utf32String)))
+            valuesThisLine += 1
+        file.write("\n};\n")
 
     def dump(self, file, commaAfter):
+        if self.hasStrings:
+            self.dumpStringTables(file)
         file.write("static std::unique_ptr<CharacterClass> {}()\n{{\n".format(self.getCreateFuncName()))
         file.write("    // Name = {},".format(self.name))
         if self.hasStrings:
@@ -576,10 +605,6 @@ class PropertyData:
             file.write(" number of codePoints: {}".format(self.codePointCount))
         file.write("\n")
         file.write("    auto characterClass = makeUnique<CharacterClass>(\n")
-        if self.hasStrings:
-            file.write("        std::initializer_list<Vector<char32_t>>(")
-            self.dumpMatchData(file, 1, self.matchStrings, self.convertStringToCppFormat)
-            file.write("),\n")
         file.write("        std::initializer_list<char32_t>(")
         self.dumpMatchData(file, 8, self.matches, lambda file, match: (file.write("{0:0=#4x}".format(match))))
         file.write("),\n")
@@ -593,10 +618,15 @@ class PropertyData:
         self.dumpMatchData(file, 4, self.unicodeRanges, lambda file, range: (file.write("{{{0:0=#6x}, {1:0=#6x}}}".format(range[0], range[1]))))
         file.write("),\n")
 
-        file.write("        CharacterClassWidths::{}".format(("Unknown", "HasBMPChars", "HasNonBMPChars", "HasBothBMPAndNonBMP")[int(self.hasNonBMPCharacters) * 2 + int(self.hasBMPCharacters)]))
+        file.write("        CharacterClassWidths::{});\n".format(("Unknown", "HasBMPChars", "HasNonBMPChars", "HasBothBMPAndNonBMP")[int(self.hasNonBMPCharacters) * 2 + int(self.hasBMPCharacters)]))
         if self.hasStrings:
-            file.write(",\n        true")  # inCanonicalForm
-        file.write(");\n")
+            file.write("    characterClass->m_strings.reserveInitialCapacity({});\n".format(len(self.matchStrings)))
+            file.write("    const char32_t* data = kStrings{}Data;\n".format(self.index))
+            file.write("    for (uint8_t length : kStrings{}Lengths) {{\n".format(self.index))
+            file.write("        characterClass->m_strings.append(Vector<char32_t>(std::span(data, length)));\n")
+            file.write("        data += length;\n")
+            file.write("    }\n")
+            file.write("    characterClass->m_inCanonicalForm = true;\n")
         file.write("    return characterClass;\n}\n\n")
 
     @classmethod


### PR DESCRIPTION
#### 0aef258bf9a077cad0a2a3ed2201210588d51a63
<pre>
[YARR] Encode Unicode property tables as `constexpr` data instead of inline construction code
<a href="https://bugs.webkit.org/show_bug.cgi?id=314281">https://bugs.webkit.org/show_bug.cgi?id=314281</a>

Reviewed by Yusuke Suzuki.

Yarr&apos;s `\p{...}` character classes are constructed by generated
createCharacterClassN() functions, which together account for ~468 KB of
__TEXT,__text in a Release arm64 build. createCharacterClass367 (RGI_Emoji)
alone is 124 KB.

Two issues:

1. Emoji string sequence classes emit thousands of inline
   Vector&lt;char32_t&gt;(std::span) constructions. Vector is not trivially
   constructible, so each becomes ~38 bytes of code.

2. CharacterRange&apos;s constructor is not constexpr, so
   std::initializer_list&lt;CharacterRange&gt; backing arrays cannot be placed in
   read-only data and are built element-by-element on the stack at runtime.

Fix (1) by emitting a flat constexpr char32_t data array plus a constexpr
per-string length array, and reconstructing m_strings with a small loop.
Fix (2) by marking CharacterRange&apos;s constructor constexpr.

This reduces these functions from ~468 KB to ~63 KB of code, with ~150 KB of
data moving to __TEXT,__const, for a net binary size reduction of ~283 KB.
No change to RegExp matching performance; RegExp compilation of emoji
property escapes is slightly faster.

* Source/JavaScriptCore/yarr/YarrPattern.h:
(JSC::Yarr::CharacterRange::CharacterRange):
* Source/JavaScriptCore/yarr/generateYarrUnicodePropertyTables.py:
(PropertyData.dumpStringTables):
(PropertyData.dump):
(PropertyData.convertStringToCppFormat): Deleted.

Canonical link: <a href="https://commits.webkit.org/312790@main">https://commits.webkit.org/312790@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fb592faded3580d7024fe458dc955d5a83816a38

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/161051 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/34524 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/27625 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/169954 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/117311 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/34625 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/34524 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/124919 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/117311 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/164010 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/27190 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/144662 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/105516 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/26239 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/24740 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/17674 "Built successfully") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/20/builds/153107 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/135933 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/22424 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/172437 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/21889 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/19458 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/24065 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/133198 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/34198 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/28833 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/133208 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35984 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/34182 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/144219 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/96021 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/27763 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/21037 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/193450 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/33693 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/101118 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/49826 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/33192 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/33436 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/33341 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->