### PR TITLE
Code cleanup around traverseVisibleNonCompositedDescendantLayers after 312702@main

### DIFF
--- a/Source/WebCore/rendering/RenderLayerBacking.cpp
+++ b/Source/WebCore/rendering/RenderLayerBacking.cpp
@@ -3292,9 +3292,8 @@ bool RenderLayerBacking::isSimpleContainerCompositingLayer(PaintedContentsInfo& 
 
 // Returning true stops the traversal.
 enum class LayerTraversal { Continue, Stop };
-enum class SharedBackingInclusion { ExcludeSharedBacking, IncludeSharedBacking };
 
-static LayerTraversal traverseVisibleNonCompositedDescendantLayers(RenderLayer& parent, SharedBackingInclusion sharedBackingInclusion, NOESCAPE const Function<LayerTraversal(const RenderLayer&)>& layerFunc)
+static LayerTraversal traverseVisibleNonCompositedDescendantLayers(RenderLayer& parent, NOESCAPE const Function<LayerTraversal(const RenderLayer&)>& layerFunc)
 {
     // FIXME: We shouldn't be called with a stale z-order lists. See bug 85512.
     parent.updateLayerListsIfNeeded();
@@ -3310,20 +3309,8 @@ static LayerTraversal traverseVisibleNonCompositedDescendantLayers(RenderLayer& 
         if (layerFunc(*childLayer) == LayerTraversal::Stop)
             return LayerTraversal::Stop;
 
-        if (traverseVisibleNonCompositedDescendantLayers(*childLayer, SharedBackingInclusion::ExcludeSharedBacking, layerFunc) == LayerTraversal::Stop)
+        if (traverseVisibleNonCompositedDescendantLayers(*childLayer, layerFunc) == LayerTraversal::Stop)
             return LayerTraversal::Stop;
-    }
-
-    if (sharedBackingInclusion == SharedBackingInclusion::IncludeSharedBacking) {
-        if (parent.isComposited() && parent.backing()->hasBackingSharingLayers()) {
-            for (CheckedRef sharingLayer : parent.backing()->backingSharingLayers() | dereferenceView) {
-                if (layerFunc(sharingLayer) == LayerTraversal::Stop)
-                    return LayerTraversal::Stop;
-
-                if (traverseVisibleNonCompositedDescendantLayers(sharingLayer, SharedBackingInclusion::ExcludeSharedBacking, layerFunc) == LayerTraversal::Stop)
-                    return LayerTraversal::Stop;
-            }
-        }
     }
 
     if (parent.isStackingContext() && !parent.hasVisibleDescendant())
@@ -3337,7 +3324,7 @@ static LayerTraversal traverseVisibleNonCompositedDescendantLayers(RenderLayer& 
         if (layerFunc(*childLayer) == LayerTraversal::Stop)
             return LayerTraversal::Stop;
 
-        if (traverseVisibleNonCompositedDescendantLayers(*childLayer, SharedBackingInclusion::ExcludeSharedBacking, layerFunc) == LayerTraversal::Stop)
+        if (traverseVisibleNonCompositedDescendantLayers(*childLayer, layerFunc) == LayerTraversal::Stop)
             return LayerTraversal::Stop;
     }
 
@@ -3348,8 +3335,26 @@ static LayerTraversal traverseVisibleNonCompositedDescendantLayers(RenderLayer& 
         if (layerFunc(*childLayer) == LayerTraversal::Stop)
             return LayerTraversal::Stop;
 
-        if (traverseVisibleNonCompositedDescendantLayers(*childLayer, SharedBackingInclusion::ExcludeSharedBacking, layerFunc) == LayerTraversal::Stop)
+        if (traverseVisibleNonCompositedDescendantLayers(*childLayer, layerFunc) == LayerTraversal::Stop)
             return LayerTraversal::Stop;
+    }
+
+    return LayerTraversal::Continue;
+}
+
+static LayerTraversal traverseLayersForPaintedContentDetection(RenderLayer& backingOwnerLayer, NOESCAPE const Function<LayerTraversal(const RenderLayer&)>& layerFunc)
+{
+    if (traverseVisibleNonCompositedDescendantLayers(backingOwnerLayer, layerFunc) == LayerTraversal::Stop)
+        return LayerTraversal::Stop;
+
+    if (backingOwnerLayer.isComposited() && backingOwnerLayer.backing()->hasBackingSharingLayers()) {
+        for (CheckedRef sharingLayer : backingOwnerLayer.backing()->backingSharingLayers() | dereferenceView) {
+            if (layerFunc(sharingLayer) == LayerTraversal::Stop)
+                return LayerTraversal::Stop;
+
+            if (traverseVisibleNonCompositedDescendantLayers(sharingLayer, layerFunc) == LayerTraversal::Stop)
+                return LayerTraversal::Stop;
+        }
     }
 
     return LayerTraversal::Continue;
@@ -3369,7 +3374,7 @@ static std::optional<bool> intersectsWithAncestor(const RenderLayer& child, cons
 void RenderLayerBacking::determineNonCompositedLayerDescendantsPaintedContent(RenderLayer::PaintedContentRequest& request) const
 {
     bool hasPaintingDescendant = false;
-    traverseVisibleNonCompositedDescendantLayers(m_owningLayer, SharedBackingInclusion::IncludeSharedBacking, [&hasPaintingDescendant, &request, this](const RenderLayer& layer) {
+    traverseLayersForPaintedContentDetection(m_owningLayer, [&hasPaintingDescendant, &request, this](const RenderLayer& layer) {
         auto localRequest = RenderLayer::PaintedContentRequest { };
 #if HAVE(SUPPORT_HDR_DISPLAY)
         localRequest.setHDRRequestState(request.hasHDRContent);
@@ -3392,7 +3397,7 @@ void RenderLayerBacking::determineNonCompositedLayerDescendantsPaintedContent(Re
 bool RenderLayerBacking::hasVisibleNonCompositedDescendants() const
 {
     bool hasVisibleDescendant = false;
-    traverseVisibleNonCompositedDescendantLayers(m_owningLayer, SharedBackingInclusion::ExcludeSharedBacking, [&hasVisibleDescendant](const RenderLayer& layer) {
+    traverseVisibleNonCompositedDescendantLayers(m_owningLayer, [&hasVisibleDescendant](const RenderLayer& layer) {
         hasVisibleDescendant |= layer.hasVisibleContent();
         return hasVisibleDescendant ? LayerTraversal::Stop : LayerTraversal::Continue;
     });


### PR DESCRIPTION
#### 0032f864accb788222571a130b059a20b2770178
<pre>
Code cleanup around traverseVisibleNonCompositedDescendantLayers after 312702@main
<a href="https://bugs.webkit.org/show_bug.cgi?id=314280">https://bugs.webkit.org/show_bug.cgi?id=314280</a>
<a href="https://rdar.apple.com/176422390">rdar://176422390</a>

Reviewed by Dan Glastonbury and Brent Fulgham.

Improve code clarity around the `traverseVisibleNonCompositedDescendantLayers()` call;
instead of pushing the `SharedBackingInclusion` state into that function, add a wrapper
that calls the original version of the function first on `m_owningLayer`, and then on
each of the `backingSharingLayers`.

* Source/WebCore/rendering/RenderLayerBacking.cpp:
(WebCore::traverseVisibleNonCompositedDescendantLayers):
(WebCore::traverseLayersForPaintedContentDetection):
(WebCore::RenderLayerBacking::determineNonCompositedLayerDescendantsPaintedContent const):
(WebCore::RenderLayerBacking::hasVisibleNonCompositedDescendants const):

Canonical link: <a href="https://commits.webkit.org/312801@main">https://commits.webkit.org/312801@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d86b606da53eb596d1245f95e5ed2b0a2a02271e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/161041 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/34514 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/27615 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/169944 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/117301 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/162910 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/34615 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/34514 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/124909 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/117301 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/164000 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/27187 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/144647 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/105506 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/26236 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/24729 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/17664 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/135930 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/22409 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/172427 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/19448 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/24050 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/133187 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/34188 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/28822 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/133197 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35991 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/34172 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/144204 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/96011 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/27757 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/21022 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/33683 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/101108 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/33182 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/33426 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/33331 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->