### PR TITLE
iOS: <a rel=ar> around a <model> adds extra steps before getting into ARQL and doesn't show AR badge.

### DIFF
--- a/Source/WebCore/Modules/model-element/HTMLModelElement.cpp
+++ b/Source/WebCore/Modules/model-element/HTMLModelElement.cpp
@@ -29,6 +29,7 @@
 
 #if ENABLE(MODEL_ELEMENT)
 
+#include "ARKitBadgeSystemImage.h"
 #include "AbortSignal.h"
 #include "ContainerNodeInlines.h"
 #include "DOMMatrixReadOnly.h"
@@ -47,6 +48,7 @@
 #include "FrameDestructionObserverInlines.h"
 #include "GraphicsLayer.h"
 #include "GraphicsLayerCA.h"
+#include "HTMLAnchorElement.h"
 #include "HTMLModelElementCamera.h"
 #include "HTMLNames.h"
 #include "HTMLParserIdioms.h"
@@ -97,7 +99,7 @@
 #include "DocumentImmersive.h"
 #endif
 
-#if ENABLE(TOUCH_EVENTS) && ENABLE(GPU_PROCESS_MODEL)
+#if ENABLE(TOUCH_EVENTS) && (ENABLE(GPU_PROCESS_MODEL) || ENABLE(MODEL_PROCESS))
 #include <WebCore/TouchEvent.h>
 #endif
 
@@ -937,6 +939,28 @@ void HTMLModelElement::defaultEventHandler(Event& event)
 {
     HTMLElement::defaultEventHandler(event);
 
+#if USE(SYSTEM_PREVIEW)
+    // Swallow synthesized click events on the model body inside an <a rel="ar"> so they don't
+    // bubble to the anchor and trigger AR Quick Look. Taps that land on the badge sub-rect ARE
+    // allowed to reach the anchor (that's how AR is launched). We only intercept click here —
+    // not touchstart/mousedown — so the visionOS gesture system still sees the initial touch
+    // events and can drive stagemode="orbit" interaction. This must run BEFORE the
+    // supportsMouseInteraction early-return below, because on visionOS ModelProcessModelPlayer
+    // inherits supportsMouseInteraction() = false, which would otherwise skip all consumption.
+    if (event.type() == eventNames().clickEvent) {
+        if (RefPtr anchor = dynamicDowncast<HTMLAnchorElement>(parentElement()); anchor && anchor->isSystemPreviewLink()) {
+            FloatPoint localPoint;
+            if (auto* mouseEvent = dynamicDowncast<MouseEvent>(&event))
+                localPoint = FloatPoint(mouseEvent->offsetX(), mouseEvent->offsetY());
+            if (!isPointInSystemPreviewBadge(localPoint)) {
+                event.preventDefault();
+                event.setDefaultHandled();
+                event.stopPropagation();
+            }
+        }
+    }
+#endif
+
     RefPtr modelPlayer = m_modelPlayer;
     if (!modelPlayer || !modelPlayer->supportsMouseInteraction())
         return;
@@ -944,11 +968,16 @@ void HTMLModelElement::defaultEventHandler(Event& event)
     auto type = event.type();
     bool isMouseEvent = type == eventNames().mousedownEvent || type == eventNames().mousemoveEvent || type == eventNames().mouseupEvent;
 
-#if ENABLE(TOUCH_EVENTS) && ENABLE(GPU_PROCESS_MODEL)
+#if ENABLE(TOUCH_EVENTS) && (ENABLE(GPU_PROCESS_MODEL) || ENABLE(MODEL_PROCESS))
     bool isTouchEvent = type == eventNames().touchstartEvent || type == eventNames().touchmoveEvent || type == eventNames().touchendEvent || type == eventNames().touchcancelEvent;
 
     if (isTouchEvent) {
         auto& touchEvent = downcast<TouchEvent>(event);
+
+#if USE(SYSTEM_PREVIEW)
+        if (type == eventNames().touchstartEvent && !m_isDragging && isPointInSystemPreviewBadge(FloatPoint(touchEvent.offsetX(), touchEvent.offsetY())))
+            return;
+#endif
 
         if (type == eventNames().touchstartEvent && !m_isDragging && !event.defaultPrevented() && isInteractive())
             dragDidStart(touchEvent);
@@ -968,6 +997,11 @@ void HTMLModelElement::defaultEventHandler(Event& event)
     if (mouseEvent.button() != MouseButton::Left)
         return;
 
+#if USE(SYSTEM_PREVIEW)
+    if (type == eventNames().mousedownEvent && !m_isDragging && isPointInSystemPreviewBadge(FloatPoint(mouseEvent.offsetX(), mouseEvent.offsetY())))
+        return;
+#endif
+
     if (type == eventNames().mousedownEvent && !m_isDragging && !event.defaultPrevented() && isInteractive())
         dragDidStart(mouseEvent);
     else if (type == eventNames().mousemoveEvent && m_isDragging)
@@ -983,6 +1017,37 @@ LayoutPoint HTMLModelElement::flippedLocationInElementForMouseEvent(WebCore::Mou
         flippedY = renderModel->paddingBoxHeight() - flippedY;
     return { LayoutUnit(event.offsetX()), flippedY };
 }
+
+#if USE(SYSTEM_PREVIEW)
+bool HTMLModelElement::isPointInSystemPreviewBadge(const FloatPoint& localPoint) const
+{
+    if (!document().settings().systemPreviewEnabled())
+        return false;
+
+    RefPtr anchor = dynamicDowncast<HTMLAnchorElement>(parentElement());
+    if (!anchor || !anchor->isSystemPreviewLink())
+        return false;
+
+    CheckedPtr renderModel = dynamicDowncast<RenderModel>(renderer());
+    if (!renderModel)
+        return false;
+
+    using BadgeMetrics = ARKitBadgeSystemImage::BadgeMetrics;
+    float width = renderModel->paddingBoxWidth();
+    float height = renderModel->paddingBoxHeight();
+
+    bool useSmallBadge = width < BadgeMetrics::minimumSizeForLarge || height < BadgeMetrics::minimumSizeForLarge;
+    float badgeDimension = useSmallBadge ? BadgeMetrics::smallDimension : BadgeMetrics::largeDimension;
+    float badgeOffset = useSmallBadge ? BadgeMetrics::smallOffset : BadgeMetrics::largeOffset;
+
+    float minimumDimension = badgeDimension + 2 * badgeOffset;
+    if (width < minimumDimension || height < minimumDimension)
+        return false;
+
+    FloatRect badgeRect { width - badgeDimension - badgeOffset, badgeOffset, badgeDimension, badgeDimension };
+    return badgeRect.contains(localPoint);
+}
+#endif
 
 void HTMLModelElement::dragDidStart(WebCore::MouseRelatedEvent& event)
 {

--- a/Source/WebCore/Modules/model-element/HTMLModelElement.h
+++ b/Source/WebCore/Modules/model-element/HTMLModelElement.h
@@ -62,6 +62,7 @@ class DOMMatrixReadOnly;
 class DOMPointReadOnly;
 class Event;
 class Exception;
+class FloatPoint;
 class GraphicsLayer;
 class LayoutPoint;
 class LayoutSize;
@@ -152,7 +153,7 @@ public:
     void exitImmersivePresentation(CompletionHandler<void()>&&);
 #endif
 
-    bool NODELETE supportsDragging() const;
+    WEBCORE_EXPORT bool supportsDragging() const;
     bool isDraggableIgnoringAttributes() const final;
 
     bool NODELETE isInteractive() const;
@@ -274,6 +275,9 @@ private:
     void dragDidEnd(WebCore::MouseRelatedEvent&);
 
     LayoutPoint flippedLocationInElementForMouseEvent(WebCore::MouseRelatedEvent&);
+#if USE(SYSTEM_PREVIEW)
+    bool isPointInSystemPreviewBadge(const FloatPoint&) const;
+#endif
 
     void setAnimationIsPlaying(bool, DOMPromiseDeferred<void>&&);
 

--- a/Source/WebCore/Modules/system-preview/ARKitBadgeSystemImage.h
+++ b/Source/WebCore/Modules/system-preview/ARKitBadgeSystemImage.h
@@ -46,15 +46,24 @@ namespace WebCore {
 class WEBCORE_EXPORT ARKitBadgeSystemImage final : public SystemImage {
     WTF_MAKE_TZONE_ALLOCATED_EXPORT(ARKitBadgeSystemImage, WEBCORE_EXPORT);
 public:
+    struct BadgeMetrics {
+        static constexpr int largeDimension = 70;
+        static constexpr int largeOffset = 20;
+        static constexpr int smallDimension = 35;
+        static constexpr int smallOffset = 8;
+        static constexpr int minimumSizeForLarge = 240;
+    };
     static Ref<ARKitBadgeSystemImage> create(Image& image)
     {
         return adoptRef(*new ARKitBadgeSystemImage(image));
     }
 
-    static Ref<ARKitBadgeSystemImage> create(RenderingResourceIdentifier renderingResourceIdentifier, FloatSize size)
+    static Ref<ARKitBadgeSystemImage> create(std::optional<RenderingResourceIdentifier> renderingResourceIdentifier, FloatSize size)
     {
         return adoptRef(*new ARKitBadgeSystemImage(renderingResourceIdentifier, size));
     }
+
+    static Ref<ARKitBadgeSystemImage> createWithoutImage();
 
     virtual ~ARKitBadgeSystemImage() = default;
 
@@ -63,7 +72,7 @@ public:
     Image* image() const { return m_image.get(); }
     void setImage(Image& image) { m_image = image; }
 
-    RenderingResourceIdentifier imageIdentifier() const;
+    std::optional<RenderingResourceIdentifier> imageIdentifier() const;
 
 private:
     friend struct IPC::ArgumentCoder<ARKitBadgeSystemImage>;
@@ -74,7 +83,7 @@ private:
     {
     }
 
-    ARKitBadgeSystemImage(RenderingResourceIdentifier renderingResourceIdentifier, FloatSize size)
+    ARKitBadgeSystemImage(std::optional<RenderingResourceIdentifier> renderingResourceIdentifier, FloatSize size)
         : SystemImage(SystemImageType::ARKitBadge)
         , m_renderingResourceIdentifier(renderingResourceIdentifier)
         , m_imageSize(size)

--- a/Source/WebCore/Modules/system-preview/ARKitBadgeSystemImage.mm
+++ b/Source/WebCore/Modules/system-preview/ARKitBadgeSystemImage.mm
@@ -77,9 +77,21 @@ static RetainPtr<CGPDFPageRef> systemPreviewLogo()
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(ARKitBadgeSystemImage);
 
-RenderingResourceIdentifier ARKitBadgeSystemImage::imageIdentifier() const
+Ref<ARKitBadgeSystemImage> ARKitBadgeSystemImage::createWithoutImage()
 {
-    return m_image ? m_image->nativeImage()->renderingResourceIdentifier() : *m_renderingResourceIdentifier;
+    return adoptRef(*new ARKitBadgeSystemImage(std::nullopt, { }));
+}
+
+std::optional<RenderingResourceIdentifier> ARKitBadgeSystemImage::imageIdentifier() const
+{
+    if (m_image) {
+        if (RefPtr nativeImage = m_image->nativeImage())
+            return nativeImage->renderingResourceIdentifier();
+        return std::nullopt;
+    }
+    if (m_renderingResourceIdentifier)
+        return *m_renderingResourceIdentifier;
+    return std::nullopt;
 }
 
 void ARKitBadgeSystemImage::draw(GraphicsContext& graphicsContext, const FloatRect& rect) const
@@ -88,17 +100,9 @@ void ARKitBadgeSystemImage::draw(GraphicsContext& graphicsContext, const FloatRe
     if (!page)
         return;
 
-    static const int largeBadgeDimension = 70;
-    static const int largeBadgeOffset = 20;
-
-    static const int smallBadgeDimension = 35;
-    static const int smallBadgeOffset = 8;
-
-    static const int minimumSizeForLargeBadge = 240;
-
-    bool useSmallBadge = rect.width() < minimumSizeForLargeBadge || rect.height() < minimumSizeForLargeBadge;
-    int badgeOffset = useSmallBadge ? smallBadgeOffset : largeBadgeOffset;
-    int badgeDimension = useSmallBadge ? smallBadgeDimension : largeBadgeDimension;
+    bool useSmallBadge = rect.width() < BadgeMetrics::minimumSizeForLarge || rect.height() < BadgeMetrics::minimumSizeForLarge;
+    int badgeOffset = useSmallBadge ? BadgeMetrics::smallOffset : BadgeMetrics::largeOffset;
+    int badgeDimension = useSmallBadge ? BadgeMetrics::smallDimension : BadgeMetrics::largeDimension;
 
     int minimumDimension = badgeDimension + 2 * badgeOffset;
     if (rect.width() < minimumDimension || rect.height() < minimumDimension)
@@ -108,10 +112,8 @@ void ARKitBadgeSystemImage::draw(GraphicsContext& graphicsContext, const FloatRe
     CGRect insetBadgeRect = CGRectMake(rect.width() - badgeDimension - badgeOffset, badgeOffset, badgeDimension, badgeDimension);
     CGRect badgeRect = CGRectMake(0, 0, badgeDimension, badgeDimension);
 
-    if (!m_image || !m_image->nativeImage())
-        return;
-
-    CIImage *inputImage = [CIImage imageWithCGImage:m_image->nativeImage()->platformImage().get()];
+    RefPtr nativeImage = m_image ? m_image->nativeImage() : nullptr;
+    bool hasBackdropImage = !!nativeImage;
 
     // Create a circle to be used for the clipping path in the badge, as well as the drop shadow.
     RetainPtr<CGPathRef> circle = adoptCF(CGPathCreateWithRoundedRect(absoluteBadgeRect, badgeDimension / 2, badgeDimension / 2, nullptr));
@@ -156,53 +158,57 @@ void ARKitBadgeSystemImage::draw(GraphicsContext& graphicsContext, const FloatRe
 
     CGContextRestoreGState(ctx);
 
-    // Draw the blurred backdrop. Scale from intrinsic size to render size.
-    CGAffineTransform transform = CGAffineTransformIdentity;
-    transform = CGAffineTransformScale(transform, rect.width() / m_imageSize.width(), rect.height() / m_imageSize.height());
-    CIImage *scaledImage = [inputImage imageByApplyingTransform:transform];
-
-    // CoreImage coordinates are y-up, so we need to flip the badge rectangle within the image frame.
-    CGRect flippedInsetBadgeRect = CGRectMake(insetBadgeRect.origin.x, rect.height() - insetBadgeRect.origin.y - insetBadgeRect.size.height, badgeDimension, badgeDimension);
-
-    // Create a cropped region with pixel values extending outwards.
-    CIImage *clampedImage = [scaledImage imageByClampingToRect:flippedInsetBadgeRect];
-
-    // Blur.
-    CIImage *blurredImage = [clampedImage imageByApplyingGaussianBlurWithSigma:10];
-
-    // Saturate.
-    CIFilter *saturationFilter = [CIFilter filterWithName:@"CIColorControls"];
-    [saturationFilter setValue:blurredImage forKey:kCIInputImageKey];
-    [saturationFilter setValue:@1.8 forKey:kCIInputSaturationKey];
-
-    // Tint.
-    CIFilter *tintFilter1 = [CIFilter filterWithName:@"CIConstantColorGenerator"];
-    CIColor *tintColor1 = [CIColor colorWithRed:1 green:1 blue:1 alpha:0.18];
-    [tintFilter1 setValue:tintColor1 forKey:kCIInputColorKey];
-
-    // Blend the tint with the saturated output.
-    CIFilter *sourceOverFilter = [CIFilter filterWithName:@"CISourceOverCompositing"];
-    [sourceOverFilter setValue:tintFilter1.outputImage forKey:kCIInputImageKey];
-    [sourceOverFilter setValue:saturationFilter.outputImage forKey:kCIInputBackgroundImageKey];
-
-    RetainPtr<CIContext> ciContext = [CIContext context];
-
     RetainPtr<CGImageRef> cgImage;
-#if HAVE(IOSURFACE_COREIMAGE_SUPPORT)
-    if (isInGPUProcess()) {
-        // Crop the result to the badge location.
-        CIImage *croppedImage = [sourceOverFilter.outputImage imageByCroppingToRect:flippedInsetBadgeRect];
-        CIImage *translatedImage = [croppedImage imageByApplyingTransform:CGAffineTransformMakeTranslation(-flippedInsetBadgeRect.origin.x, -flippedInsetBadgeRect.origin.y)];
+    if (hasBackdropImage) {
+        CIImage *inputImage = [CIImage imageWithCGImage:nativeImage->platformImage().get()];
 
-        auto surfaceDimension = useSmallBadge ? smallBadgeDimension : largeBadgeDimension;
-        std::unique_ptr<IOSurface> badgeSurface = IOSurface::create(&IOSurfacePool::sharedPoolSingleton(), { surfaceDimension, surfaceDimension }, DestinationColorSpace::SRGB());
-        IOSurfaceRef surface = badgeSurface->surface();
-        [ciContext render:translatedImage toIOSurface:surface bounds:badgeRect colorSpace:sRGBColorSpaceSingleton()];
-        auto surfaceContext = badgeSurface->createPlatformContext();
-        cgImage = badgeSurface->createImage(surfaceContext.get());
-    } else
+        // Draw the blurred backdrop. Scale from intrinsic size to render size.
+        CGAffineTransform transform = CGAffineTransformIdentity;
+        transform = CGAffineTransformScale(transform, rect.width() / m_imageSize.width(), rect.height() / m_imageSize.height());
+        CIImage *scaledImage = [inputImage imageByApplyingTransform:transform];
+
+        // CoreImage coordinates are y-up, so we need to flip the badge rectangle within the image frame.
+        CGRect flippedInsetBadgeRect = CGRectMake(insetBadgeRect.origin.x, rect.height() - insetBadgeRect.origin.y - insetBadgeRect.size.height, badgeDimension, badgeDimension);
+
+        // Create a cropped region with pixel values extending outwards.
+        CIImage *clampedImage = [scaledImage imageByClampingToRect:flippedInsetBadgeRect];
+
+        // Blur.
+        CIImage *blurredImage = [clampedImage imageByApplyingGaussianBlurWithSigma:10];
+
+        // Saturate.
+        CIFilter *saturationFilter = [CIFilter filterWithName:@"CIColorControls"];
+        [saturationFilter setValue:blurredImage forKey:kCIInputImageKey];
+        [saturationFilter setValue:@1.8 forKey:kCIInputSaturationKey];
+
+        // Tint.
+        CIFilter *tintFilter1 = [CIFilter filterWithName:@"CIConstantColorGenerator"];
+        CIColor *tintColor1 = [CIColor colorWithRed:1 green:1 blue:1 alpha:0.18];
+        [tintFilter1 setValue:tintColor1 forKey:kCIInputColorKey];
+
+        // Blend the tint with the saturated output.
+        CIFilter *sourceOverFilter = [CIFilter filterWithName:@"CISourceOverCompositing"];
+        [sourceOverFilter setValue:tintFilter1.outputImage forKey:kCIInputImageKey];
+        [sourceOverFilter setValue:saturationFilter.outputImage forKey:kCIInputBackgroundImageKey];
+
+        RetainPtr<CIContext> ciContext = [CIContext context];
+
+#if HAVE(IOSURFACE_COREIMAGE_SUPPORT)
+        if (isInGPUProcess()) {
+            // Crop the result to the badge location.
+            CIImage *croppedImage = [sourceOverFilter.outputImage imageByCroppingToRect:flippedInsetBadgeRect];
+            CIImage *translatedImage = [croppedImage imageByApplyingTransform:CGAffineTransformMakeTranslation(-flippedInsetBadgeRect.origin.x, -flippedInsetBadgeRect.origin.y)];
+
+            auto surfaceDimension = useSmallBadge ? BadgeMetrics::smallDimension : BadgeMetrics::largeDimension;
+            std::unique_ptr<IOSurface> badgeSurface = IOSurface::create(&IOSurfacePool::sharedPoolSingleton(), { surfaceDimension, surfaceDimension }, DestinationColorSpace::SRGB());
+            IOSurfaceRef surface = badgeSurface->surface();
+            [ciContext render:translatedImage toIOSurface:surface bounds:badgeRect colorSpace:sRGBColorSpaceSingleton()];
+            auto surfaceContext = badgeSurface->createPlatformContext();
+            cgImage = badgeSurface->createImage(surfaceContext.get());
+        } else
 #endif
-    cgImage = adoptCF([ciContext createCGImage:sourceOverFilter.outputImage fromRect:flippedInsetBadgeRect]);
+        cgImage = adoptCF([ciContext createCGImage:sourceOverFilter.outputImage fromRect:flippedInsetBadgeRect]);
+    }
 
     // Before we render the result, we should clip to a circle around the badge rectangle.
     CGContextSaveGState(ctx);
@@ -214,7 +220,17 @@ void ARKitBadgeSystemImage::draw(GraphicsContext& graphicsContext, const FloatRe
     CGContextTranslateCTM(ctx, absoluteBadgeRect.origin.x, absoluteBadgeRect.origin.y);
     CGContextTranslateCTM(ctx, 0, badgeDimension);
     CGContextScaleCTM(ctx, 1, -1);
-    CGContextDrawImage(ctx, badgeRect, cgImage.get());
+
+    if (cgImage)
+        CGContextDrawImage(ctx, badgeRect, cgImage.get());
+    else {
+        // No backdrop image: fill the badge circle with a translucent neutral color so the PDF
+        // logo has a readable backdrop.
+        CGFloat backdropColorComponents[4] = { 1, 1, 1, 0.6 };
+        RetainPtr<CGColorRef> backdropColor = adoptCF(CGColorCreate(sRGBColorSpaceSingleton(), backdropColorComponents));
+        CGContextSetFillColorWithColor(ctx, backdropColor.get());
+        CGContextFillRect(ctx, badgeRect);
+    }
 
     CGSize pdfSize = CGPDFPageGetBoxRect(page.get(), kCGPDFMediaBox).size;
     CGFloat scaleX = badgeDimension / pdfSize.width;

--- a/Source/WebCore/html/HTMLAnchorElement.cpp
+++ b/Source/WebCore/html/HTMLAnchorElement.cpp
@@ -41,6 +41,7 @@
 #include "FrameSelection.h"
 #include "HTMLCanvasElement.h"
 #include "HTMLImageElement.h"
+#include "HTMLModelElement.h"
 #include "HTMLParserIdioms.h"
 #include "HTMLPictureElement.h"
 #include "KeyboardEvent.h"
@@ -382,7 +383,11 @@ bool HTMLAnchorElement::isSystemPreviewLink()
         return false;
 
     if (auto* child = firstElementChild()) {
+#if ENABLE(GPU_PROCESS_MODEL) || ENABLE(MODEL_PROCESS)
+        if (isAnyOf<HTMLImageElement, HTMLPictureElement, HTMLModelElement>(child)) {
+#else
         if (isAnyOf<HTMLImageElement, HTMLPictureElement>(child)) {
+#endif
             auto numChildren = childElementCount();
             // FIXME: We've documented that it should be the only child, but some early demos have two children.
             return numChildren == 1 || numChildren == 2;

--- a/Source/WebCore/page/DragController.cpp
+++ b/Source/WebCore/page/DragController.cpp
@@ -1166,7 +1166,14 @@ bool DragController::startDrag(LocalFrame& src, const DragState& state, OptionSe
         return true;
     }
 
+#if ENABLE(MODEL_ELEMENT)
+    // If the user is dragging a <model> that happens to be wrapped in an <a rel="ar" href=...>,
+    // let the Model drag path below package the USDZ as a rich model pasteboard item instead of
+    // dropping the anchor's href URL (which reduces AR Quick Look to a download-then-preview).
+    if (!linkURL.isEmpty() && m_dragSourceAction.contains(DragSourceAction::Link) && !(state.type.contains(DragSourceAction::Model) && is<HTMLModelElement>(state.source.get()))) {
+#else
     if (!linkURL.isEmpty() && m_dragSourceAction.contains(DragSourceAction::Link)) {
+#endif
         PasteboardWriterData pasteboardWriterData;
 
         String textContentWithSimplifiedWhiteSpace = hitTestResult->textContent().simplifyWhiteSpace(deprecatedIsSpaceOrNewline);

--- a/Source/WebCore/rendering/RenderLayerBacking.cpp
+++ b/Source/WebCore/rendering/RenderLayerBacking.cpp
@@ -36,6 +36,7 @@
 #include "CanvasRenderingContext2DBase.h"
 #include "Chrome.h"
 #include "ContainerNodeInlines.h"
+#include "CornerRadii.h"
 #include "DebugOverlayRegions.h"
 #include "DebugPageOverlays.h"
 #include "DocumentPage.h"
@@ -48,6 +49,7 @@
 #include "GraphicsLayerFloatAnimationValue.h"
 #include "GraphicsLayerKeyframeValueList.h"
 #include "GraphicsLayerTransformAnimationValue.h"
+#include "HTMLAnchorElement.h"
 #include "HTMLBodyElement.h"
 #include "HTMLCanvasElement.h"
 #include "HTMLModelElement.h"
@@ -62,6 +64,7 @@
 #include "Model.h"
 #include "NullGraphicsContext.h"
 #include "Page.h"
+#include "PaintInfo.h"
 #include "PathOperation.h"
 #include "PerformanceLoggingClient.h"
 #include "PluginViewBase.h"
@@ -84,6 +87,7 @@
 #include "RenderModel.h"
 #include "RenderSVGHiddenContainer.h"
 #include "RenderSVGModelObject.h"
+#include "RenderTheme.h"
 #include "RenderVideo.h"
 #include "RenderView.h"
 #include "RenderViewTransitionCapture.h"
@@ -125,6 +129,10 @@
 
 #if ENABLE(MODEL_CONTEXT)
 #include "ModelContext.h"
+#endif
+
+#if USE(SYSTEM_PREVIEW) && ENABLE(MODEL_PROCESS) && ENABLE(INTERACTION_REGIONS_IN_EVENT_REGION)
+#include "ARKitBadgeSystemImage.h"
 #endif
 
 namespace WebCore {
@@ -693,6 +701,10 @@ void RenderLayerBacking::destroyGraphicsLayers()
     GraphicsLayer::unparentAndClear(m_childContainmentLayer);
     GraphicsLayer::unparentAndClear(m_scrollContainerLayer);
     GraphicsLayer::unparentAndClear(m_scrolledContentsLayer);
+#if USE(SYSTEM_PREVIEW) && ENABLE(MODEL_PROCESS)
+    GraphicsLayer::unparentAndClear(m_systemPreviewBadgeLayer);
+    GraphicsLayer::unparentAndClear(m_systemPreviewWrapperLayer);
+#endif
     GraphicsLayer::unparentAndClear(m_graphicsLayer);
 }
 
@@ -1192,6 +1204,14 @@ bool RenderLayerBacking::updateConfiguration(const RenderLayer* compositingAnces
     if (updateForegroundLayer(compositor.needsContentsCompositingLayer(m_owningLayer)))
         layerConfigChanged = true;
 
+#if USE(SYSTEM_PREVIEW) && ENABLE(MODEL_PROCESS)
+    if (updateSystemPreviewBadgeLayer(needsSystemPreviewBadgeLayer())) {
+        // Badge layer needs the contents containment layer to live as its parent so it sits next to m_graphicsLayer.
+        updateContentsContainmentLayer();
+        layerConfigChanged = true;
+    }
+#endif
+
     bool needsDescendantsClippingLayer = false;
     bool usesCompositedScrolling = m_owningLayer.hasCompositedScrollableOverflow();
 
@@ -1603,6 +1623,15 @@ void RenderLayerBacking::updateGeometry(const RenderLayer* compositedAncestor)
 
     setNeedsFixedContainerEdgesUpdateIfNeeded();
 
+#if USE(SYSTEM_PREVIEW) && ENABLE(MODEL_PROCESS)
+    if (m_systemPreviewWrapperLayer) {
+        m_systemPreviewWrapperLayer->setPreserves3D(preserves3D);
+        m_systemPreviewWrapperLayer->setPosition(primaryLayerPosition);
+        primaryLayerPosition = { };
+        m_systemPreviewWrapperLayer->setSize(primaryGraphicsLayerRect.size());
+    }
+#endif
+
     if (m_contentsContainmentLayer) {
         m_contentsContainmentLayer->setPreserves3D(preserves3D);
         m_contentsContainmentLayer->setPosition(primaryLayerPosition);
@@ -1744,6 +1773,10 @@ void RenderLayerBacking::updateGeometry(const RenderLayer* compositedAncestor)
         m_foregroundLayer->setSize(foregroundSize);
         m_foregroundLayer->setOffsetFromRenderer(foregroundOffset, needsDisplayOnOffsetChange);
     }
+
+#if USE(SYSTEM_PREVIEW) && ENABLE(MODEL_PROCESS)
+    updateSystemPreviewBadgeLayerGeometry();
+#endif
 
     if (m_backgroundLayer) {
         FloatPoint backgroundPosition;
@@ -1929,7 +1962,11 @@ void RenderLayerBacking::updateInternalHierarchy()
         lastClippingLayer = m_ancestorClippingStack->lastLayer();
     }
 
+#if USE(SYSTEM_PREVIEW) && ENABLE(MODEL_PROCESS)
+    constexpr size_t maxOrderedLayers = 8;
+#else
     constexpr size_t maxOrderedLayers = 6;
+#endif
     Vector<GraphicsLayer*, maxOrderedLayers> orderedLayers;
 
     if (lastClippingLayer)
@@ -1941,11 +1978,18 @@ void RenderLayerBacking::updateInternalHierarchy()
     if (m_viewportAnchorLayer)
         orderedLayers.append(m_viewportAnchorLayer.get());
 
+#if USE(SYSTEM_PREVIEW) && ENABLE(MODEL_PROCESS)
+    // Insert the system-preview wrapper above the contents containment so the badge layer (added
+    // as a sibling below) composites in front of the model's separated portal subtree.
+    if (m_systemPreviewWrapperLayer)
+        orderedLayers.append(m_systemPreviewWrapperLayer.get());
+#endif
+
     if (m_contentsContainmentLayer) {
         m_contentsContainmentLayer->removeAllChildren();
 
-        ASSERT(m_backgroundLayer);
-        m_contentsContainmentLayer->addChild(*m_backgroundLayer);
+        if (m_backgroundLayer)
+            m_contentsContainmentLayer->addChild(*m_backgroundLayer);
 
         // The loop below will add a second child to the m_contentsContainmentLayer.
         orderedLayers.append(m_contentsContainmentLayer.get());
@@ -1975,6 +2019,14 @@ void RenderLayerBacking::updateInternalHierarchy()
 
         previousLayer = layer;
     }
+
+#if USE(SYSTEM_PREVIEW) && ENABLE(MODEL_PROCESS)
+    // Add the badge as the topmost child of the wrapper, after the loop has already parented
+    // m_contentsContainmentLayer (or m_graphicsLayer) under the wrapper. The badge therefore
+    // composites in front of the model subtree.
+    if (m_systemPreviewWrapperLayer && m_systemPreviewBadgeLayer)
+        m_systemPreviewWrapperLayer->addChild(*m_systemPreviewBadgeLayer);
+#endif
 
     // The clip for child layers does not include space for overflow controls, so they exist as
     // siblings of the clipping layer if we have one. Normal children of this layer are set as
@@ -2210,6 +2262,29 @@ void RenderLayerBacking::updateEventRegion()
     if (m_foregroundLayer)
         updateEventRegionForLayer(*m_foregroundLayer);
 
+#if USE(SYSTEM_PREVIEW) && ENABLE(MODEL_PROCESS) && ENABLE(INTERACTION_REGIONS_IN_EVENT_REGION)
+    // Give the system-preview badge its own interaction region so gaze hover lights it up
+    // the way it would for the (anchor-wrapped) model itself, AND make it click-through
+    // outside the actual badge rect so users can still click the model area for AR launch.
+    if (m_systemPreviewBadgeLayer) {
+        FloatRect layerBounds({ }, m_systemPreviewBadgeLayer->size());
+        // Match ARKitBadgeSystemImage::draw: top-right corner with size 35+8 (small) or 70+20 (large).
+        using BadgeMetrics = ARKitBadgeSystemImage::BadgeMetrics;
+        bool useSmallBadge = layerBounds.width() < BadgeMetrics::minimumSizeForLarge || layerBounds.height() < BadgeMetrics::minimumSizeForLarge;
+        int badgeOffset = useSmallBadge ? BadgeMetrics::smallOffset : BadgeMetrics::largeOffset;
+        int badgeDimension = useSmallBadge ? BadgeMetrics::smallDimension : BadgeMetrics::largeDimension;
+        FloatRect badgeRect(layerBounds.width() - badgeDimension - badgeOffset, badgeOffset, badgeDimension, badgeDimension);
+
+        EventRegion eventRegion;
+        auto eventRegionContext = eventRegion.makeContext();
+        if (visibleToHitTesting)
+            eventRegionContext.unite(FloatRoundedRect(badgeRect, CornerRadii(badgeDimension / 2.0f)), renderer(), renderer().style());
+        eventRegionContext.uniteInteractionRegions(renderer(), badgeRect, { }, std::nullopt);
+        eventRegionContext.copyInteractionRegionsToEventRegion(renderer().document().settings().interactionRegionMinimumCornerRadius());
+        m_systemPreviewBadgeLayer->setEventRegion(WTF::move(eventRegion));
+    }
+#endif
+
     setNeedsEventRegionUpdate(false);
 }
 #endif
@@ -2233,6 +2308,11 @@ void RenderLayerBacking::clearInteractionRegions()
 
     if (m_foregroundLayer)
         clearInteractionRegionsForLayer(*m_foregroundLayer);
+
+#if USE(SYSTEM_PREVIEW) && ENABLE(MODEL_PROCESS)
+    if (m_systemPreviewBadgeLayer)
+        clearInteractionRegionsForLayer(*m_systemPreviewBadgeLayer);
+#endif
 }
 #endif
 
@@ -2757,7 +2837,7 @@ bool RenderLayerBacking::updateBackgroundLayer(bool needsBackgroundLayer)
             m_backgroundLayer->setAnchorPoint(FloatPoint3D());
             layerChanged = true;
         }
-        
+#if !ENABLE(MODEL_PROCESS)
         if (!m_contentsContainmentLayer) {
             auto layerName = makeString(m_owningLayer.name(), " (contents containment)"_s);
             m_contentsContainmentLayer = createGraphicsLayer(layerName);
@@ -2765,22 +2845,139 @@ bool RenderLayerBacking::updateBackgroundLayer(bool needsBackgroundLayer)
             m_graphicsLayer->setAppliesPageScale(false);
             layerChanged = true;
         }
+#endif
     } else {
         if (m_backgroundLayer) {
             willDestroyLayer(m_backgroundLayer.get());
             GraphicsLayer::unparentAndClear(m_backgroundLayer);
             layerChanged = true;
         }
+#if !ENABLE(MODEL_PROCESS)
         if (m_contentsContainmentLayer) {
             willDestroyLayer(m_contentsContainmentLayer.get());
             GraphicsLayer::unparentAndClear(m_contentsContainmentLayer);
             layerChanged = true;
             m_graphicsLayer->setAppliesPageScale(true);
         }
+#endif
     }
+
+#if ENABLE(MODEL_PROCESS)
+    if (updateContentsContainmentLayer())
+        layerChanged = true;
+#endif
 
     return layerChanged;
 }
+
+#if ENABLE(MODEL_PROCESS)
+bool RenderLayerBacking::updateContentsContainmentLayer()
+{
+#if USE(SYSTEM_PREVIEW)
+    bool needsContainment = m_backgroundLayer || m_systemPreviewBadgeLayer;
+#else
+    bool needsContainment = m_backgroundLayer;
+#endif
+    bool layerChanged = false;
+    if (needsContainment) {
+        if (!m_contentsContainmentLayer) {
+            auto layerName = makeString(m_owningLayer.name(), " (contents containment)"_s);
+            m_contentsContainmentLayer = createGraphicsLayer(layerName);
+            m_contentsContainmentLayer->setAppliesPageScale(true);
+            m_graphicsLayer->setAppliesPageScale(false);
+            layerChanged = true;
+        }
+    } else if (m_contentsContainmentLayer) {
+        willDestroyLayer(m_contentsContainmentLayer.get());
+        GraphicsLayer::unparentAndClear(m_contentsContainmentLayer);
+        layerChanged = true;
+        m_graphicsLayer->setAppliesPageScale(true);
+    }
+    return layerChanged;
+}
+#endif
+
+#if USE(SYSTEM_PREVIEW) && ENABLE(MODEL_PROCESS)
+bool RenderLayerBacking::needsSystemPreviewBadgeLayer() const
+{
+#if PLATFORM(VISION)
+    if (!renderer().document().settings().systemPreviewEnabled())
+        return false;
+    CheckedPtr renderModel = dynamicDowncast<RenderModel>(renderer());
+    if (!renderModel)
+        return false;
+    RefPtr anchor = dynamicDowncast<HTMLAnchorElement>(renderModel->modelElement().parentElement());
+    return anchor && anchor->isSystemPreviewLink();
+#else
+    // On other platforms the inline paint in RenderModel::paintReplaced is sufficient.
+    return false;
+#endif
+}
+
+bool RenderLayerBacking::updateSystemPreviewBadgeLayer(bool needsLayer)
+{
+    bool layerChanged = false;
+    if (needsLayer) {
+        if (!m_systemPreviewBadgeLayer) {
+            auto layerName = makeString(m_owningLayer.name(), " (system preview badge)"_s);
+            m_systemPreviewBadgeLayer = createGraphicsLayer(layerName);
+            m_systemPreviewBadgeLayer->setDrawsContent(true);
+            m_systemPreviewBadgeLayer->setAnchorPoint({ });
+#if HAVE(CORE_ANIMATION_SEPARATED_LAYERS)
+            m_systemPreviewBadgeLayer->setIsSeparated(false);
+#endif
+            layerChanged = true;
+        }
+        if (!m_systemPreviewWrapperLayer) {
+            auto layerName = makeString(m_owningLayer.name(), " (system preview wrapper)"_s);
+            m_systemPreviewWrapperLayer = createGraphicsLayer(layerName);
+            m_systemPreviewWrapperLayer->setAnchorPoint({ });
+#if HAVE(CORE_ANIMATION_SEPARATED_LAYERS)
+            m_systemPreviewWrapperLayer->setIsSeparated(false);
+#endif
+            layerChanged = true;
+        }
+    } else {
+        if (m_systemPreviewBadgeLayer) {
+            willDestroyLayer(m_systemPreviewBadgeLayer.get());
+            GraphicsLayer::unparentAndClear(m_systemPreviewBadgeLayer);
+            layerChanged = true;
+        }
+        if (m_systemPreviewWrapperLayer) {
+            willDestroyLayer(m_systemPreviewWrapperLayer.get());
+            GraphicsLayer::unparentAndClear(m_systemPreviewWrapperLayer);
+            layerChanged = true;
+        }
+    }
+    return layerChanged;
+}
+
+void RenderLayerBacking::updateSystemPreviewBadgeLayerGeometry()
+{
+    if (!m_systemPreviewBadgeLayer)
+        return;
+    CheckedPtr renderModel = dynamicDowncast<RenderModel>(renderer());
+    if (!renderModel)
+        return;
+
+    auto contentRect = renderModel->replacedContentRect();
+    auto snapped = snapRectToDevicePixels(contentRect, renderModel->modelElement().document().deviceScaleFactor());
+    m_systemPreviewBadgeLayer->setPosition(snapped.location());
+    m_systemPreviewBadgeLayer->setSize(snapped.size());
+    m_systemPreviewBadgeLayer->setNeedsDisplay();
+}
+
+void RenderLayerBacking::paintSystemPreviewBadgeLayer(GraphicsContext& context, const FloatRect& clip)
+{
+    if (!m_systemPreviewBadgeLayer)
+        return;
+    auto rect = FloatRect({ }, m_systemPreviewBadgeLayer->size());
+    GraphicsContextStateSaver stateSaver(context);
+    context.clip(clip);
+    PaintInfo paintInfo(context, LayoutRect(rect), PaintPhase::Foreground, { });
+    renderer().theme().paintSystemPreviewBadge(paintInfo, rect);
+}
+#endif
 
 // Masking layer is used for masks or clip-path.
 bool RenderLayerBacking::updateMaskingLayer(bool hasMask, bool hasClipPath)
@@ -3721,9 +3918,14 @@ GraphicsLayer* RenderLayerBacking::childForSuperlayersExcludingViewTransitions()
     if (RefPtr viewportConstrainedLayer = viewportClippingOrAnchorLayer())
         return viewportConstrainedLayer.unsafeGet();
 
+#if USE(SYSTEM_PREVIEW) && ENABLE(MODEL_PROCESS)
+    if (m_systemPreviewWrapperLayer)
+        return m_systemPreviewWrapperLayer.get();
+#endif
+
     if (m_contentsContainmentLayer)
         return m_contentsContainmentLayer.get();
-    
+
     return m_graphicsLayer.get();
 }
 
@@ -4319,6 +4521,10 @@ void RenderLayerBacking::paintContents(const GraphicsLayer& graphicsLayer, Graph
         if (visibleDebugOverlayRegions.containsAny({ DebugOverlayRegions::TouchActionRegion, DebugOverlayRegions::TouchEventRegion, DebugOverlayRegions::EditableElementRegion, DebugOverlayRegions::WheelEventHandlerRegion, DebugOverlayRegions::InteractionRegion }))
             paintDebugOverlays(&graphicsLayer, context);
 
+#if USE(SYSTEM_PREVIEW) && ENABLE(MODEL_PROCESS)
+    } else if (&graphicsLayer == m_systemPreviewBadgeLayer.get()) {
+        paintSystemPreviewBadgeLayer(context, clip);
+#endif
     } else if (&graphicsLayer == layerForHorizontalScrollbar()) {
         if (m_owningLayer.hasVisibleContent()) {
             auto* scrollableArea = m_owningLayer.scrollableArea();

--- a/Source/WebCore/rendering/RenderLayerBacking.h
+++ b/Source/WebCore/rendering/RenderLayerBacking.h
@@ -128,6 +128,10 @@ public:
     GraphicsLayer* backgroundLayer() const { return m_backgroundLayer.get(); }
     bool backgroundLayerPaintsFixedRootBackground() const { return m_backgroundLayerPaintsFixedRootBackground; }
 
+#if USE(SYSTEM_PREVIEW) && ENABLE(MODEL_PROCESS)
+    GraphicsLayer* systemPreviewBadgeLayer() const { return m_systemPreviewBadgeLayer.get(); }
+#endif
+
     bool needsRepaintOnCompositedScroll() const;
 
     bool requiresBackgroundLayer() const { return m_requiresBackgroundLayer; }
@@ -349,8 +353,17 @@ private:
     void clearOverflowControlsLayers();
     bool updateForegroundLayer(bool needsForegroundLayer);
     bool updateBackgroundLayer(bool needsBackgroundLayer);
+#if ENABLE(MODEL_PROCESS)
+    bool updateContentsContainmentLayer();
+#endif
     bool updateMaskingLayer(bool hasMask, bool hasClipPath);
     bool updateTransformFlatteningLayer(const RenderLayer* compositingAncestor);
+#if USE(SYSTEM_PREVIEW) && ENABLE(MODEL_PROCESS)
+    bool updateSystemPreviewBadgeLayer(bool needsLayer);
+    bool needsSystemPreviewBadgeLayer() const;
+    void updateSystemPreviewBadgeLayerGeometry();
+    void paintSystemPreviewBadgeLayer(GraphicsContext&, const FloatRect& clip);
+#endif
 
     bool requiresLayerForScrollbar(Scrollbar*) const;
     bool requiresHorizontalScrollbarLayer() const;
@@ -465,6 +478,10 @@ private:
     RefPtr<GraphicsLayer> m_viewportAnchorLayer; // Only used on fixed/sticky elements.
     RefPtr<GraphicsLayer> m_maskLayer; // Only used if we have a mask and/or clip-path.
     RefPtr<GraphicsLayer> m_transformFlatteningLayer;
+#if USE(SYSTEM_PREVIEW) && ENABLE(MODEL_PROCESS)
+    RefPtr<GraphicsLayer> m_systemPreviewWrapperLayer; // Outer wrapper above m_contentsContainmentLayer, parents the model subtree and the badge layer as siblings.
+    RefPtr<GraphicsLayer> m_systemPreviewBadgeLayer; // Sibling of m_contentsContainmentLayer; lifts the AR badge in front of the model's separated portal on visionOS.
+#endif
 
     RefPtr<GraphicsLayer> m_layerForHorizontalScrollbar;
     RefPtr<GraphicsLayer> m_layerForVerticalScrollbar;

--- a/Source/WebCore/rendering/RenderLayerCompositor.cpp
+++ b/Source/WebCore/rendering/RenderLayerCompositor.cpp
@@ -37,8 +37,10 @@
 #include "DocumentFullscreen.h"
 #include "FixedContainerEdges.h"
 #include "GraphicsLayer.h"
+#include "HTMLAnchorElement.h"
 #include "HTMLCanvasElement.h"
 #include "HTMLIFrameElement.h"
+#include "HTMLModelElement.h"
 #include "HTMLNames.h"
 #include "HitTestResult.h"
 #include "InspectorInstrumentation.h"
@@ -4469,6 +4471,17 @@ bool RenderLayerCompositor::needsContentsCompositingLayer(const RenderLayer& lay
         if (negativeZOrderLayer->isComposited() || negativeZOrderLayer->hasCompositingDescendant())
             return true;
     }
+
+#if ENABLE(MODEL_PROCESS)
+    // When a <model> with a hosted contents layer is inside an `<a rel="ar">`, we need a
+    // foreground layer so the AR badge painted in RenderModel::paintReplaced is composited
+    // above the hosted model contents layer.
+    if (CheckedPtr renderModel = dynamicDowncast<RenderModel>(layer.renderer())) {
+        RefPtr anchor = dynamicDowncast<HTMLAnchorElement>(renderModel->modelElement().parentElement());
+        if (anchor && anchor->isSystemPreviewLink())
+            return true;
+    }
+#endif
 
     return false;
 }

--- a/Source/WebCore/rendering/RenderModel.cpp
+++ b/Source/WebCore/rendering/RenderModel.cpp
@@ -28,11 +28,17 @@
 
 #if ENABLE(MODEL_ELEMENT)
 
+#include "HTMLAnchorElement.h"
 #include "HTMLModelElement.h"
+#include "NodeInlines.h"
+#include "PaintInfo.h"
 #include "RenderBoxModelObjectInlines.h"
+#include "RenderLayer.h"
+#include "RenderLayerBacking.h"
 #include "RenderObjectNode.h"
 #include "RenderStyle+GettersInlines.h"
 #include "RenderStyle.h"
+#include "RenderTheme.h"
 #include "StyleDifference.h"
 #include <wtf/TZoneMallocInlines.h>
 
@@ -82,6 +88,35 @@ void RenderModel::update()
 
     contentChanged(ContentChangeType::Model);
 }
+
+#if USE(SYSTEM_PREVIEW)
+void RenderModel::paintReplaced(PaintInfo& paintInfo, const LayoutPoint& paintOffset)
+{
+    if (paintInfo.phase != PaintPhase::Foreground)
+        return;
+
+    if (paintInfo.context().paintingDisabled())
+        return;
+
+    if (!modelElement().document().settings().systemPreviewEnabled())
+        return;
+
+    RefPtr anchor = dynamicDowncast<HTMLAnchorElement>(modelElement().parentElement());
+    if (!anchor || !anchor->isSystemPreviewLink())
+        return;
+
+#if ENABLE(MODEL_PROCESS)
+    // If the backing owns a dedicated badge layer (visionOS separated-portal case), it paints the badge itself.
+    if (CheckedPtr layer = this->layer(); layer && layer->backing() && layer->backing()->systemPreviewBadgeLayer())
+        return;
+#endif
+
+    LayoutRect contentRect = replacedContentRect();
+    contentRect.moveBy(paintOffset);
+    RefPtr document = modelElement().document();
+    theme().paintSystemPreviewBadge(paintInfo, snapRectToDevicePixels(contentRect, document->deviceScaleFactor()));
+}
+#endif
 
 }
 

--- a/Source/WebCore/rendering/RenderModel.h
+++ b/Source/WebCore/rendering/RenderModel.h
@@ -53,6 +53,9 @@ private:
     bool NODELETE requiresLayer() const final;
     void updateFromElement() final;
     void styleDidChange(Style::Difference, const RenderStyle* oldStyle) final;
+#if USE(SYSTEM_PREVIEW)
+    void paintReplaced(PaintInfo&, const LayoutPoint&) final;
+#endif
 
     void update();
 };

--- a/Source/WebCore/rendering/RenderTheme.cpp
+++ b/Source/WebCore/rendering/RenderTheme.cpp
@@ -2187,12 +2187,14 @@ String RenderTheme::fileListNameForWidth(const FileList* fileList, const FontCas
 }
 
 #if USE(SYSTEM_PREVIEW)
-void RenderTheme::paintSystemPreviewBadge(Image& image, const PaintInfo& paintInfo, const FloatRect& rect)
+void RenderTheme::paintSystemPreviewBadge(Image&, const PaintInfo& paintInfo, const FloatRect& rect)
 {
-    // The default implementation paints a small marker
-    // in the upper right corner, as long as the image is big enough.
+    paintSystemPreviewBadge(paintInfo, rect);
+}
 
-    UNUSED_PARAM(image);
+void RenderTheme::paintSystemPreviewBadge(const PaintInfo& paintInfo, const FloatRect& rect)
+{
+    // Default imageless variant: draw the same fallback marker.
     auto& context = paintInfo.context();
 
     GraphicsContextStateSaver stateSaver { context };
@@ -2200,7 +2202,7 @@ void RenderTheme::paintSystemPreviewBadge(Image& image, const PaintInfo& paintIn
     if (rect.width() < 32 || rect.height() < 32)
         return;
 
-    auto markerRect = FloatRect {rect.x() + rect.width() - 24, rect.y() + 8, 16, 16 };
+    auto markerRect = FloatRect { rect.x() + rect.width() - 24, rect.y() + 8, 16, 16 };
     auto roundedMarkerRect = FloatRoundedRect { markerRect, CornerRadii { 8 } };
     context.fillRoundedRect(roundedMarkerRect, Color::red);
 }

--- a/Source/WebCore/rendering/RenderTheme.h
+++ b/Source/WebCore/rendering/RenderTheme.h
@@ -272,6 +272,7 @@ public:
 
 #if USE(SYSTEM_PREVIEW)
     virtual void paintSystemPreviewBadge(Image&, const PaintInfo&, const FloatRect&);
+    virtual void paintSystemPreviewBadge(const PaintInfo&, const FloatRect&);
 #endif
     virtual Seconds switchAnimationVisuallyOnDuration() const { return 0_s; }
     virtual Seconds switchAnimationHeldDuration() const { return 0_s; }

--- a/Source/WebCore/rendering/ios/RenderThemeIOS.h
+++ b/Source/WebCore/rendering/ios/RenderThemeIOS.h
@@ -49,6 +49,7 @@ public:
 
 #if USE(SYSTEM_PREVIEW)
     void paintSystemPreviewBadge(Image&, const PaintInfo&, const FloatRect&) final;
+    void paintSystemPreviewBadge(const PaintInfo&, const FloatRect&) final;
 #endif
 
     using CSSValueToSystemColorMap = HashMap<CSSValueKey, Color>;

--- a/Source/WebCore/rendering/ios/RenderThemeIOS.mm
+++ b/Source/WebCore/rendering/ios/RenderThemeIOS.mm
@@ -1446,6 +1446,11 @@ void RenderThemeIOS::paintSystemPreviewBadge(Image& image, const PaintInfo& pain
 {
     paintInfo.context().drawSystemImage(ARKitBadgeSystemImage::create(image), rect);
 }
+
+void RenderThemeIOS::paintSystemPreviewBadge(const PaintInfo& paintInfo, const FloatRect& rect)
+{
+    paintInfo.context().drawSystemImage(ARKitBadgeSystemImage::createWithoutImage(), rect);
+}
 #endif
 
 constexpr auto checkboxRadioBorderWidth = 1.5f;

--- a/Source/WebKit/GPUProcess/graphics/RemoteGraphicsContext.cpp
+++ b/Source/WebKit/GPUProcess/graphics/RemoteGraphicsContext.cpp
@@ -442,9 +442,11 @@ void RemoteGraphicsContext::drawSystemImage(Ref<SystemImage>&& systemImage, cons
 {
 #if USE(SYSTEM_PREVIEW)
     if (auto* badge = dynamicDowncast<ARKitBadgeSystemImage>(systemImage.get())) {
-        RefPtr nativeImage = resourceCache().cachedNativeImage(badge->imageIdentifier());
-        MESSAGE_CHECK(nativeImage);
-        badge->setImage(BitmapImage::create(nativeImage.releaseNonNull()));
+        if (auto imageIdentifier = badge->imageIdentifier()) {
+            RefPtr nativeImage = resourceCache().cachedNativeImage(*imageIdentifier);
+            MESSAGE_CHECK(nativeImage);
+            badge->setImage(BitmapImage::create(nativeImage.releaseNonNull()));
+        }
     }
 #endif
     context().drawSystemImage(systemImage, destinationRect);

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -4348,7 +4348,7 @@ class WebCore::SpeechRecognitionUpdate {
 
 #if USE(SYSTEM_PREVIEW)
 [RefCounted, AdditionalEncoder=StreamConnectionEncoder] class WebCore::ARKitBadgeSystemImage {
-    WebCore::RenderingResourceIdentifier imageIdentifier();
+    std::optional<WebCore::RenderingResourceIdentifier> imageIdentifier();
     WebCore::FloatSize m_imageSize;
 };
 #endif

--- a/Source/WebKit/WebProcess/WebPage/Cocoa/PositionInformationForWebPage.mm
+++ b/Source/WebKit/WebProcess/WebPage/Cocoa/PositionInformationForWebPage.mm
@@ -627,6 +627,16 @@ InteractionInformationAtPosition positionInformationForWebPage(WebPage& page, co
         focusedElementPositionInformation(page, *page.focusedElement(), request, info);
 
     RefPtr hitTestNode = hitTestResult.innerNonSharedNode();
+
+#if ENABLE(MODEL_ELEMENT)
+    // If the hit lands on a draggable <model>, let the model take precedence over any ancestor
+    // <a rel="ar">. Without this, nodeRespondingToClickEvents walks up to the anchor (because
+    // <model> has no inherent click listeners), which would mark this as a link and trigger the
+    // link preview/context-menu interaction instead of the model's drag gesture on visionOS.
+    if (RefPtr modelElement = dynamicDowncast<WebCore::HTMLModelElement>(hitTestNode); modelElement && modelElement->supportsDragging() && modelElement->model())
+        nodeRespondingToClickEvents = WTF::move(modelElement);
+#endif
+
     if (RefPtr element = dynamicDowncast<WebCore::Element>(nodeRespondingToClickEvents)) {
         elementPositionInformation(page, *element, request, hitTestNode.get(), info);
 


### PR DESCRIPTION
#### 22a99e8c1861ed7eae747c6157b9267f0650016b
<pre>
iOS: &lt;a rel=ar&gt; around a &lt;model&gt; adds extra steps before getting into ARQL and doesn&apos;t show AR badge.
<a href="https://bugs.webkit.org/show_bug.cgi?id=314285">https://bugs.webkit.org/show_bug.cgi?id=314285</a>
<a href="https://rdar.apple.com/176410897">rdar://176410897</a>

Reviewed by Etienne Segonzac.

Add badging to &lt;model&gt; when requested on iOS.

Example usage:
&lt;div class=&quot;ar-card&quot;&gt;
&lt;a rel=&quot;ar&quot; href=&quot;toy_drummer.usdz&quot;&gt;
    &lt;model class=&quot;hero-model&quot; src=&quot;toy_drummer.usdz&quot; stagemode=&quot;orbit&quot; width=&quot;1024&quot; height=&quot;1024&quot;&gt;&lt;/model&gt;
&lt;/a&gt;
&lt;/div&gt;

Also update visionOS code paths to avoid enclosing &lt;a&gt; tags around a &lt;model&gt; from
taking drag-and-drop precedence of the &lt;model&gt;

* Source/WebCore/Modules/model-element/HTMLModelElement.cpp:
(WebCore::HTMLModelElement::defaultEventHandler):
(WebCore::HTMLModelElement::isPointInSystemPreviewBadge const):
* Source/WebCore/Modules/model-element/HTMLModelElement.h:
* Source/WebCore/Modules/system-preview/ARKitBadgeSystemImage.h:
* Source/WebCore/Modules/system-preview/ARKitBadgeSystemImage.mm:
(WebCore::ARKitBadgeSystemImage::createWithoutImage):
(WebCore::ARKitBadgeSystemImage::imageIdentifier const):
(WebCore::ARKitBadgeSystemImage::draw const):
* Source/WebCore/html/HTMLAnchorElement.cpp:
(WebCore::HTMLAnchorElement::isSystemPreviewLink):
(WebCore::HTMLAnchorElement::attributionDestinationURLForPCM const): Deleted.
(WebCore::HTMLAnchorElement::mainDocumentRegistrableDomainForPCM const): Deleted.
(WebCore::HTMLAnchorElement::attributionSourceNonceForPCM const): Deleted.
(WebCore::HTMLAnchorElement::parsePrivateClickMeasurementForSKAdNetwork const): Deleted.
(WebCore::HTMLAnchorElement::parsePrivateClickMeasurement const): Deleted.
(WebCore::HTMLAnchorElement::handleClick): Deleted.
(WebCore::HTMLAnchorElement::effectiveTarget const): Deleted.
(WebCore::HTMLAnchorElement::eventType): Deleted.
(WebCore::HTMLAnchorElement::treatLinkAsLiveForEventType const): Deleted.
(WebCore::isEnterKeyKeydownEvent): Deleted.
(WebCore::shouldProhibitLinks): Deleted.
(WebCore::HTMLAnchorElement::willRespondToMouseClickEventsWithEditability const): Deleted.
(WebCore::rootEditableElementMap): Deleted.
(WebCore::HTMLAnchorElement::rootEditableElementForSelectionOnMouseDown const): Deleted.
(WebCore::HTMLAnchorElement::clearRootEditableElementForSelectionOnMouseDown): Deleted.
(WebCore::HTMLAnchorElement::setRootEditableElementForSelectionOnMouseDown): Deleted.
(WebCore::HTMLAnchorElement::referrerPolicyForBindings const): Deleted.
(WebCore::HTMLAnchorElement::referrerPolicy const): Deleted.
(WebCore::HTMLAnchorElement::insertionSteps): Deleted.
(WebCore::HTMLAnchorElement::postConnectionSteps): Deleted.
(WebCore::HTMLAnchorElement::setFullURL): Deleted.
(WebCore::HTMLAnchorElement::setShouldBePrefetched): Deleted.
(WebCore::HTMLAnchorElement::prefetchEagernessForTesting const): Deleted.
(WebCore::HTMLAnchorElement::checkForSpeculationRules): Deleted.
* Source/WebCore/page/DragController.cpp:
(WebCore::DragController::startDrag):
(WebCore::DragController::doImageDrag): Deleted.
(WebCore::DragController::beginDrag): Deleted.
(WebCore::containingLinkElement): Deleted.
(WebCore::DragController::doSystemDrag): Deleted.
(WebCore::DragController::removeAllDroppedImagePlaceholders): Deleted.
(WebCore::DragController::tryToUpdateDroppedImagePlaceholders): Deleted.
(WebCore::DragController::insertDroppedImagePlaceholdersAtCaret): Deleted.
(WebCore::DragController::finalizeDroppedImagePlaceholder): Deleted.
(WebCore::DragController::placeDragCaret): Deleted.
(WebCore::DragController::shouldUseCachedImageForDragImage const): Deleted.
* Source/WebCore/rendering/RenderLayerBacking.cpp:
(WebCore::RenderLayerBacking::destroyGraphicsLayers):
(WebCore::RenderLayerBacking::updateConfiguration):
(WebCore::RenderLayerBacking::updateGeometry):
(WebCore::RenderLayerBacking::updateInternalHierarchy):
(WebCore::RenderLayerBacking::updateEventRegion):
(WebCore::RenderLayerBacking::clearInteractionRegions):
(WebCore::RenderLayerBacking::updateBackgroundLayer):
(WebCore::RenderLayerBacking::updateContentsContainmentLayer):
(WebCore::RenderLayerBacking::needsSystemPreviewBadgeLayer const):
(WebCore::RenderLayerBacking::updateSystemPreviewBadgeLayer):
(WebCore::RenderLayerBacking::updateSystemPreviewBadgeLayerGeometry):
(WebCore::RenderLayerBacking::paintSystemPreviewBadgeLayer):
(WebCore::RenderLayerBacking::childForSuperlayersExcludingViewTransitions const):
(WebCore::RenderLayerBacking::paintContents):
* Source/WebCore/rendering/RenderLayerBacking.h:
* Source/WebCore/rendering/RenderLayerCompositor.cpp:
(WebCore::RenderLayerCompositor::needsContentsCompositingLayer const):
* Source/WebCore/rendering/RenderModel.cpp:
(WebCore::RenderModel::paintReplaced):
* Source/WebCore/rendering/RenderModel.h:
* Source/WebCore/rendering/RenderTheme.cpp:
(WebCore::RenderTheme::paintSystemPreviewBadge):
* Source/WebCore/rendering/RenderTheme.h:
* Source/WebCore/rendering/ios/RenderThemeIOS.h:
* Source/WebCore/rendering/ios/RenderThemeIOS.mm:
(WebCore::RenderThemeIOS::paintSystemPreviewBadge):
* Source/WebKit/GPUProcess/graphics/RemoteGraphicsContext.cpp:
(WebKit::RemoteGraphicsContext::drawSystemImage):
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:
* Source/WebKit/WebProcess/WebPage/Cocoa/PositionInformationForWebPage.mm:
(WebKit::positionInformationForWebPage):

Canonical link: <a href="https://commits.webkit.org/313047@main">https://commits.webkit.org/313047@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/693ee9dd88e25218db49cd5dd5b6db1229df3dfd

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/161912 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/35386 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/28489 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/170815 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/118283 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/bc6d7344-6794-41dc-a807-d890f9513327) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/163781 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/35488 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/35388 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/125624 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/88528 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/97ee932d-66aa-47a1-abb7-bcbf0d86d75e) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/164871 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/27949 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/145432 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/106220 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/26998 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/25511 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/18536 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/136691 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/23187 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/173304 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/20399 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/24828 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/133925 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/35060 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/29598 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/133930 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36168 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/35044 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/144982 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/97139 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/28463 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/21807 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/34554 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/102039 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/34055 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/34297 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/34203 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->