### PR TITLE
[libpas] `pas_scavenger_try_install_foreign_work_callback` leaks `foreign_work.lock` when descriptor table is full

### DIFF
--- a/Source/bmalloc/libpas/src/libpas/pas_scavenger.c
+++ b/Source/bmalloc/libpas/src/libpas/pas_scavenger.c
@@ -445,8 +445,10 @@ bool pas_scavenger_try_install_foreign_work_callback(
     pthread_mutex_lock(&data->foreign_work.lock);
 
     int slot = data->foreign_work.next_open_descriptor;
-    if (slot >= PAS_SCAVENGER_MAX_FOREIGN_WORK_DESCRIPTORS)
+    if (slot >= PAS_SCAVENGER_MAX_FOREIGN_WORK_DESCRIPTORS) {
+        pthread_mutex_unlock(&data->foreign_work.lock);
         return false;
+    }
 
     double requested_period_ms = pow(2.0, period_log2_ms);
     uint32_t requested_ticks = (uint32_t)(requested_period_ms / pas_scavenger_period_in_milliseconds);

--- a/Source/bmalloc/libpas/src/test/ScavengerExternalWorkTests.cpp
+++ b/Source/bmalloc/libpas/src/test/ScavengerExternalWorkTests.cpp
@@ -27,6 +27,7 @@
 
 #include <atomic>
 #include <chrono>
+#include <pthread.h>
 #include <thread>
 
 #include "pas_scavenger.h"
@@ -38,6 +39,26 @@ extern "C" inline bool incrementCounter(void* counter)
     auto* atomic_counter = reinterpret_cast<std::atomic<int>*>(counter);
     (*atomic_counter)++;
     return false;
+}
+
+extern "C" inline bool noopForeignWorkCallback(void*)
+{
+    return false;
+}
+
+inline void testForeignWorkCallbackInstallReleasesLockOnSaturation()
+{
+    // Saturate the descriptor table by installing until one fails. The last
+    // (failing) install exercises the saturated path that previously returned
+    // without releasing foreign_work.lock, leaving the mutex permanently held.
+    while (pas_scavenger_try_install_foreign_work_callback(noopForeignWorkCallback, 1, nullptr)) { }
+
+    // pthread_mutex_trylock would return EBUSY if the mutex were still held.
+    // Avoid calling try_install_foreign_work_callback again here, since under
+    // the unfixed code that call would block forever on the leaked lock.
+    int rc = pthread_mutex_trylock(&pas_scavenger_data_instance->foreign_work.lock);
+    CHECK_EQUAL(rc, 0);
+    pthread_mutex_unlock(&pas_scavenger_data_instance->foreign_work.lock);
 }
 
 inline void testCallbacksAreCalledWhenExpected(int scavenger_on_ms, int scavenger_off_ms)
@@ -69,4 +90,5 @@ inline void testCallbacksAreCalledWhenExpected(int scavenger_on_ms, int scavenge
 void addScavengerExternalWorkTests()
 {
     ADD_TEST(testCallbacksAreCalledWhenExpected(50, 50));
+    ADD_TEST(testForeignWorkCallbackInstallReleasesLockOnSaturation());
 }

--- a/Source/bmalloc/libpas/src/test/TestHarness.cpp
+++ b/Source/bmalloc/libpas/src/test/TestHarness.cpp
@@ -866,6 +866,7 @@ int main(int argc, char** argv)
     ADD_SUITE(PGM);
     ADD_SUITE(Race);
     ADD_SUITE(RedBlackTree);
+    ADD_SUITE(ScavengerExternalWork);
     ADD_SUITE(TLCDecommit);
     ADD_SUITE(TSD);
     ADD_SUITE(Utils);


### PR DESCRIPTION
#### 09c32c0766bbe1a7a396d7c9871415170c139a63
<pre>
[libpas] `pas_scavenger_try_install_foreign_work_callback` leaks `foreign_work.lock` when descriptor table is full
<a href="https://bugs.webkit.org/show_bug.cgi?id=314286">https://bugs.webkit.org/show_bug.cgi?id=314286</a>

Reviewed by Yusuke Suzuki.

pas_scavenger_try_install_foreign_work_callback acquires
foreign_work.lock at entry but, when slot &gt;=
PAS_SCAVENGER_MAX_FOREIGN_WORK_DESCRIPTORS, returned false without
unlocking. Every saturated call permanently wedges the mutex, so the
next install attempt (and the scavenger thread, when it next touches
foreign_work) blocks forever.

Add the missing pthread_mutex_unlock on the saturated path.

While here, register the existing ScavengerExternalWork suite from
main(); it had a forward declaration but no ADD_SUITE call, so the
suite never ran and the existing testCallbacksAreCalledWhenExpected was
dead code.

Add a regression test that saturates the descriptor table and uses
pthread_mutex_trylock on pas_scavenger_data_instance-&gt;foreign_work.lock
to assert the lock was released. Without the fix the trylock returns
EBUSY (16) and the test fails; with the fix it returns 0.

* Source/bmalloc/libpas/src/libpas/pas_scavenger.c:
(pas_scavenger_try_install_foreign_work_callback):
* Source/bmalloc/libpas/src/test/ScavengerExternalWorkTests.cpp:
(noopForeignWorkCallback):
(testForeignWorkCallbackInstallReleasesLockOnSaturation):
(addScavengerExternalWorkTests):
* Source/bmalloc/libpas/src/test/TestHarness.cpp:
(main):

Canonical link: <a href="https://commits.webkit.org/312791@main">https://commits.webkit.org/312791@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d97953a79586b9923aaef54ddbbee13749af49d5

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/161054 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/34527 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/27628 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/169957 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/117314 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/34628 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/34527 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/124921 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/117314 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/164013 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/27192 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/144663 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/105518 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/26241 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/24742 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/17677 "Built successfully") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/20/builds/153110 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/135935 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/22425 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/172440 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/21892 "Built successfully and passed tests") | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/24066 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/133200 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/34201 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/28835 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/133210 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35985 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/34185 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/144220 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/96024 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/27762 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/21038 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/193453 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/33696 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/49828 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/33195 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/33439 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/33344 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->