### PR TITLE
Add test for cleaning up stale web extension origin data after migration

### DIFF
--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKWebExtensionContext.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKWebExtensionContext.mm
@@ -33,9 +33,12 @@
 #import <WebKit/WKFoundation.h>
 #import <WebKit/WKWebExtensionCommand.h>
 #import <WebKit/WKWebExtensionContextPrivate.h>
+#import <WebKit/WKWebExtensionControllerConfigurationPrivate.h>
 #import <WebKit/WKWebExtensionMatchPatternPrivate.h>
 #import <WebKit/WKWebExtensionPermission.h>
 #import <WebKit/WKWebExtensionPrivate.h>
+#import <WebKit/WKWebsiteDataRecord.h>
+#import <WebKit/WKWebsiteDataStorePrivate.h>
 #import <wtf/cocoa/TypeCastsCocoa.h>
 
 #if PLATFORM(IOS_FAMILY)
@@ -1493,6 +1496,79 @@ TEST(WKWebExtensionContext, ConsoleAssertWithoutMessage)
     auto *error = manager.get().context.errors.firstObject;
     EXPECT_EQ(error.code, WKWebExtensionContextErrorScriptExecutionError);
     EXPECT_NS_EQUAL(error.localizedDescription, @"(background.js:2:15)");
+}
+
+TEST(WKWebExtensionContext, CleanUpOldOriginDataAfterMigration)
+{
+    auto *manifest = @{
+        @"manifest_version": @3,
+        @"name": @"Test Extension",
+        @"description": @"Test",
+        @"version": @"1.0",
+        @"background": @{
+            @"scripts": @[ @"background.js" ],
+            @"type": @"module",
+            @"persistent": @NO,
+        },
+    };
+    auto *backgroundScript = Util::constructScript(@[
+        @"localStorage.setItem('testkey', 'testvalue')",
+        @"browser.test.sendMessage('Ready')",
+    ]);
+
+    auto *configuration = WKWebExtensionControllerConfiguration._temporaryConfiguration;
+    auto manager = Util::parseExtension(manifest, @{ @"background.js": backgroundScript }, configuration);
+    manager.get().context.uniqueIdentifier = @"org.webkit.test.extension (76C788B8)";
+
+    [manager load];
+    [manager runUntilTestMessage:@"Ready"];
+
+    auto *oldOriginURL = manager.get().context.baseURL;
+    auto *dataStore = manager.get().controller.configuration.defaultWebsiteDataStore;
+
+    __block NSString *oldLocalStorageDirectoryPath;
+    __block bool done = false;
+    [dataStore _originDirectoryForTesting:oldOriginURL topOrigin:oldOriginURL type:WKWebsiteDataTypeLocalStorage completionHandler:^(NSString *result) {
+        oldLocalStorageDirectoryPath = [result copy];
+        done = true;
+    }];
+    Util::run(&done);
+    EXPECT_TRUE([[NSFileManager defaultManager] fileExistsAtPath:oldLocalStorageDirectoryPath]);
+
+    __block NSString *oldServiceWorkerDirectoryPath;
+    done = false;
+    [dataStore _originDirectoryForTesting:oldOriginURL topOrigin:oldOriginURL type:WKWebsiteDataTypeServiceWorkerRegistrations completionHandler:^(NSString *result) {
+        oldServiceWorkerDirectoryPath = [result copy];
+        done = true;
+    }];
+    Util::run(&done);
+    EXPECT_FALSE([[NSFileManager defaultManager] fileExistsAtPath:oldServiceWorkerDirectoryPath]);
+
+    [manager.get().controller unloadExtensionContext:manager.get().context error:nil];
+    manager.get().context = nil;
+
+    auto *readLocalStorageBackgroundScript = Util::constructScript(@[
+        @"browser.test.assertEq(localStorage.getItem('testkey'), 'testvalue')",
+        @"browser.test.sendMessage('Migrated')",
+    ]);
+
+    auto *newExtension = [[WKWebExtension alloc] _initWithManifestDictionary:manifest resources:@{ @"background.js": readLocalStorageBackgroundScript }];
+    auto *newContext = [[WKWebExtensionContext alloc] initForExtension:newExtension];
+    newContext.uniqueIdentifier = @"org.webkit.test.extension (76C788B8)";
+    EXPECT_FALSE([newContext.baseURL isEqual:oldOriginURL]);
+
+    NSError *error;
+    [manager.get().controller loadExtensionContext:newContext error:&error];
+    EXPECT_NULL(error);
+
+    manager.get().context = newContext;
+    [manager runUntilTestMessage:@"Migrated"];
+
+    EXPECT_FALSE([[NSFileManager defaultManager] fileExistsAtPath:oldLocalStorageDirectoryPath]);
+    EXPECT_FALSE([[NSFileManager defaultManager] fileExistsAtPath:oldServiceWorkerDirectoryPath]);
+
+    auto *oldOriginDirectory = [oldLocalStorageDirectoryPath stringByDeletingLastPathComponent];
+    EXPECT_FALSE([[NSFileManager defaultManager] fileExistsAtPath:oldOriginDirectory]);
 }
 
 } // namespace TestWebKitAPI


### PR DESCRIPTION
#### c3207e5ff92fbb9ba23e880448c3395f0ea468a1
<pre>
Add test for cleaning up stale web extension origin data after migration
<a href="https://bugs.webkit.org/show_bug.cgi?id=314287">https://bugs.webkit.org/show_bug.cgi?id=314287</a>
<a href="https://rdar.apple.com/176421630">rdar://176421630</a>

Reviewed by Timothy Hatcher.

Add a test to verify that when a web extension is reloaded with a new base URL, the website data that belongs to the
old base URL (origin) is removed.

* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKWebExtensionContext.mm:
(TestWebKitAPI::TEST(WKWebExtensionContext, CleanUpOldOriginDataAfterMigration)):

Canonical link: <a href="https://commits.webkit.org/312975@main">https://commits.webkit.org/312975@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d201639bc1f31f9d17564bf14a5806ff3ca2f752

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/161311 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/34784 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/27885 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/170214 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/117682 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/b87c6b72-1709-4166-a2f0-dc533fa8fd13) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/163180 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/34885 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/34785 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/125128 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/88177 "2 failures") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/164270 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/27421 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/144897 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/105725 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/26469 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/24975 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/17934 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/136163 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/22657 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/172697 "Built successfully") | | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/24298 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/133411 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/34458 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/29068 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/133419 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36128 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/34443 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/144452 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/96308 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/27957 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/21270 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/33953 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/33452 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/33696 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/33601 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->