### PR TITLE
Regression(312484@main): WKWebView.MessageHandlerFromIframe times out under site isolation

### DIFF
--- a/Source/WebKit/UIProcess/Cocoa/NavigationState.mm
+++ b/Source/WebKit/UIProcess/Cocoa/NavigationState.mm
@@ -432,17 +432,23 @@ static void trySOAuthorization(Ref<API::NavigationAction>&& navigationAction, We
 {
 #if HAVE(APP_SSO)
     if (!navigationAction->shouldPerformSOAuthorization()) {
-        completionHandler(false);
+        callOnMainRunLoop([completionHandler = WTF::move(completionHandler)] mutable {
+            completionHandler(false);
+        });
         return;
     }
     // URLs with a registered WKURLSchemeHandler are handled locally and should not go through SSO.
     if (page.urlSchemeHandlerForScheme(navigationAction->request().url().protocol())) {
-        completionHandler(false);
+        callOnMainRunLoop([completionHandler = WTF::move(completionHandler)] mutable {
+            completionHandler(false);
+        });
         return;
     }
     protect(page.websiteDataStore())->soAuthorizationCoordinator(page).tryAuthorize(WTF::move(navigationAction), page, WTF::move(completionHandler));
 #else
-    completionHandler(false);
+    callOnMainRunLoop([completionHandler = WTF::move(completionHandler)] mutable {
+        completionHandler(false);
+    });
 #endif
 }
 
@@ -498,14 +504,19 @@ static void tryInterceptNavigation(Ref<API::NavigationAction>&& navigationAction
 {
     // URLs with a registered WKURLSchemeHandler are handled locally and should not be intercepted by app links or SSO.
     if (page.urlSchemeHandlerForScheme(navigationAction->request().url().protocol())) {
-        completionHandler(false);
+        callOnMainRunLoop([completionHandler = WTF::move(completionHandler)] mutable {
+            completionHandler(false);
+        });
         return;
     }
 
 #if HAVE(MARKETPLACE_KIT)
     if (isMarketplaceKitURL(navigationAction->request().url())) {
         interceptMarketplaceKitNavigation(WTF::move(navigationAction), page);
-        return completionHandler(true /* interceptedNavigation */);
+        callOnMainRunLoop([completionHandler = WTF::move(completionHandler)] mutable {
+            completionHandler(true /* interceptedNavigation */);
+        });
+        return;
     }
 #endif // HAVE(MARKETPLACE_KIT)
 


### PR DESCRIPTION
#### cee12a6fe9683a77b23bc7461e5969a7aab2c948
<pre>
Regression(312484@main): WKWebView.MessageHandlerFromIframe times out under site isolation
<a href="https://bugs.webkit.org/show_bug.cgi?id=314288">https://bugs.webkit.org/show_bug.cgi?id=314288</a>

Reviewed by Ryosuke Niwa.

After 312484@main, trySOAuthorization() and tryInterceptNavigation() could
start calling their completionHandler synchronously, which confuses some
of the callers. To address the issue, always call the completionHandler
asynchronously, even in the new fast paths.

No new tests, covered by existing API test.

* Source/WebKit/UIProcess/Cocoa/NavigationState.mm:
(WebKit::trySOAuthorization):
(WebKit::tryInterceptNavigation):

Canonical link: <a href="https://commits.webkit.org/312794@main">https://commits.webkit.org/312794@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/163b14969f3dab7443fbcad6ad8c658892fb426a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/161069 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/34542 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/27643 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/169972 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/117329 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/34643 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/34542 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/124933 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/117329 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/164028 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/27211 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/144667 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/105530 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/26260 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/24758 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/17692 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/135954 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/172455 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/19476 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/24070 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/133213 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/34216 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/28851 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/133223 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35988 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/34200 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/144224 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/96039 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/27773 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/21042 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/33711 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/101136 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/33210 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/33454 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/33359 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->