### PR TITLE
Resync `css/selectors` from WPT Upstream

### DIFF
--- a/LayoutTests/imported/w3c/resources/resource-files.json
+++ b/LayoutTests/imported/w3c/resources/resource-files.json
@@ -10907,6 +10907,7 @@
         "web-platform-tests/css/selectors/selectors-4/details-open-pseudo-001-ref.html",
         "web-platform-tests/css/selectors/selectors-4/details-open-pseudo-003-ref.html",
         "web-platform-tests/css/selectors/selectors-4/lang-000-ref.html",
+        "web-platform-tests/css/selectors/selectors-4/lang-020-ref.html",
         "web-platform-tests/css/selectors/selectors-attr-many-ref.html",
         "web-platform-tests/css/selectors/selectors-attr-white-space-001-ref.html",
         "web-platform-tests/css/selectors/selectors-empty-001-ref.xml",

--- a/LayoutTests/imported/w3c/web-platform-tests/css/selectors/case-insensitive-parent-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/selectors/case-insensitive-parent-ref.html
@@ -7,7 +7,7 @@
     <svg width="500" height="100" xmlns="http://www.w3.org/2000/svg">
       <foreignObject width="500" height="100">
         <span style="color: green">Test passes if the text is green.</span>
-      </foreignobject>
+      </foreignObject>
     </svg>
   </body>
 </html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/selectors/invalidation/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/selectors/invalidation/w3c-import.log
@@ -29,6 +29,7 @@ List of files:
 /LayoutTests/imported/w3c/web-platform-tests/css/selectors/invalidation/defined.html
 /LayoutTests/imported/w3c/web-platform-tests/css/selectors/invalidation/dir-pseudo-class-in-has-expected.xht
 /LayoutTests/imported/w3c/web-platform-tests/css/selectors/invalidation/dir-pseudo-class-in-has.html
+/LayoutTests/imported/w3c/web-platform-tests/css/selectors/invalidation/empty-pseudo-in-has-display-none.html
 /LayoutTests/imported/w3c/web-platform-tests/css/selectors/invalidation/empty-pseudo-in-has.html
 /LayoutTests/imported/w3c/web-platform-tests/css/selectors/invalidation/enabled-disabled.html
 /LayoutTests/imported/w3c/web-platform-tests/css/selectors/invalidation/first-child-last-child.html
@@ -67,6 +68,7 @@ List of files:
 /LayoutTests/imported/w3c/web-platform-tests/css/selectors/invalidation/host-has-shadow-tree-element-at-nonsubject-position.html
 /LayoutTests/imported/w3c/web-platform-tests/css/selectors/invalidation/host-has-shadow-tree-element-at-subject-position.html
 /LayoutTests/imported/w3c/web-platform-tests/css/selectors/invalidation/host-pseudo-class-in-has.html
+/LayoutTests/imported/w3c/web-platform-tests/css/selectors/invalidation/input-in-range-in-has-with-readonly.html
 /LayoutTests/imported/w3c/web-platform-tests/css/selectors/invalidation/input-pseudo-classes-in-has.html
 /LayoutTests/imported/w3c/web-platform-tests/css/selectors/invalidation/insert-sibling-001.html
 /LayoutTests/imported/w3c/web-platform-tests/css/selectors/invalidation/insert-sibling-002.html

--- a/LayoutTests/imported/w3c/web-platform-tests/css/selectors/media/sound-state-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/selectors/media/sound-state-expected.txt
@@ -2,4 +2,5 @@
 
 PASS Test :pseudo-class syntax is supported without throwing a SyntaxError
 PASS Test :muted pseudo-class
+FAIL Test :muted matches .muted for content attribute default assert_true: expected true got false
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/selectors/media/sound-state.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/selectors/media/sound-state.html
@@ -43,5 +43,30 @@
       assert_equals(document.querySelector("video:muted"), video);
       assert_equals(document.querySelector("video:not(:muted)"), null);
     }, "Test :muted pseudo-class");
+
+    test((t) => {
+      assert_implements(CSS.supports("selector(:muted)"), ":muted is not supported");
+
+      const video = document.createElement("video");
+      document.body.appendChild(video);
+      t.add_cleanup(() => video.remove());
+
+      assert_false(video.muted);
+      assert_false(video.matches(":muted"));
+
+      video.setAttribute("muted", "");
+      assert_true(video.muted);
+      assert_true(video.matches(":muted"));
+
+      video.removeAttribute("muted");
+      assert_false(video.muted);
+      assert_false(video.matches(":muted"));
+
+      video.setAttribute("muted", "");
+      assert_true(video.muted);
+      video.muted = false;
+      assert_false(video.muted);
+      assert_false(video.matches(":muted"));
+    }, "Test :muted matches .muted for content attribute default");
   </script>
 </body>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/selectors/old-tests/css3-modsel-153.xml
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/selectors/old-tests/css3-modsel-153.xml
@@ -11,7 +11,7 @@
   <meta name="flags" content=" namespace" />
  </head>
  <body>
- <address xmlns="http://tests.example.org/xml-only/"></address>
+ <address xmlns="http://tests.example.org/xml-only/"><![CDATA[]]></address>
  <div class="text">This line should have a green background.</div>
  <p>(Note: This test is based on unpublished errata.)</p>
 </body>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/selectors/old-tests/css3-modsel-174a.xml
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/selectors/old-tests/css3-modsel-174a.xml
@@ -12,8 +12,8 @@
  </head>
  <body>
   <tests xmlns="http://css.example.net/" xmlns:test="http://css.example.net/">
-   <testA attribute="pass" test:attribute="fail">This should be green.</testa>
-   <testB attribute="fail" test:attribute="pass">This should be green.</testb>
+   <testA attribute="pass" test:attribute="fail">This should be green.</testA>
+   <testB attribute="fail" test:attribute="pass">This should be green.</testB>
   </tests>
 </body>
 </html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/selectors/old-tests/css3-modsel-174b.xml
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/selectors/old-tests/css3-modsel-174b.xml
@@ -12,8 +12,8 @@
  </head>
  <body>
   <tests xmlns="http://css.example.net/" xmlns:test="http://css.example.net/">
-   <testA attribute="pass" test:attribute="fail">This should be green.</testa>
-   <testB attribute="fail" test:attribute="pass">This should be green.</testb>
+   <testA attribute="pass" test:attribute="fail">This should be green.</testA>
+   <testB attribute="fail" test:attribute="pass">This should be green.</testB>
   </tests>
 </body>
 </html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/selectors/old-tests/css3-modsel-181.xml
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/selectors/old-tests/css3-modsel-181.xml
@@ -25,8 +25,8 @@
  <div class="cs">
    <p>This line should be green.</p>
    <p class="A">This line should be green.</p>
-   <p class="span1"><SPAN>This line should be green.</span></p>
-   <p class="span2"><SPAN>This line should be green.</span></p>
+   <p class="span1"><SPAN>This line should be green.</SPAN></p>
+   <p class="span2"><SPAN>This line should be green.</SPAN></p>
  </div>
 
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/selectors/old-tests/css3-modsel-92.xml
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/selectors/old-tests/css3-modsel-92.xml
@@ -10,7 +10,7 @@ div.myTest *|testA { background-color : lime }]]></style>
  </head>
  <body>
 <div class="myTest">
-<testA xmlns="http://www.example.org/b">This paragraph should have a green background</testa>
+<testA xmlns="http://www.example.org/b">This paragraph should have a green background</testA>
 </div>
 </body>
 </html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/selectors/old-tests/css3-modsel-93.xml
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/selectors/old-tests/css3-modsel-93.xml
@@ -10,6 +10,6 @@
   <meta name="flags" content=" namespace" />
  </head>
  <body>
-<testA xmlns="">This paragraph has no declared namespace and should have a green background.</testa>
+<testA xmlns="">This paragraph has no declared namespace and should have a green background.</testA>
 </body>
 </html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/selectors/old-tests/css3-modsel-96.xml
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/selectors/old-tests/css3-modsel-96.xml
@@ -14,12 +14,12 @@ div.test |* { background-color : lime }]]></style>
  <body>
 <div class="test">
  <p>This line should be unstyled.</p>
- <elementA xmlns="http://www.example.org/a">This line should be unstyled.</elementa>
- <elementB xmlns="http://www.example.org/b">This line should be unstyled.</elementb>
+ <elementA xmlns="http://www.example.org/a">This line should be unstyled.</elementA>
+ <elementB xmlns="http://www.example.org/b">This line should be unstyled.</elementB>
  <div class="green">
   <p xmlns="">This line should have a green background</p>
-  <elementA xmlns="">This line should have a green background</elementa>
-  <elementB xmlns="">This line should have a green background</elementb>
+  <elementA xmlns="">This line should have a green background</elementA>
+  <elementB xmlns="">This line should have a green background</elementB>
  </div>
 </div>
 </body>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/selectors/old-tests/css3-modsel-96b.xml
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/selectors/old-tests/css3-modsel-96b.xml
@@ -14,12 +14,12 @@ div.test |* { background-color : red }]]></style>
  <body>
 <div class="test">
  <p>This line should be unstyled.</p>
- <elementA xmlns="http://www.example.org/a">This line should be unstyled.</elementa>
- <elementB xmlns="http://www.example.org/b">This line should be unstyled.</elementb>
+ <elementA xmlns="http://www.example.org/a">This line should be unstyled.</elementA>
+ <elementB xmlns="http://www.example.org/b">This line should be unstyled.</elementB>
  <div class="green">
   <p xmlns="">This line should have a green background</p>
-  <elementA xmlns="">This line should have a green background</elementa>
-  <elementB xmlns="">This line should have a green background</elementb>
+  <elementA xmlns="">This line should have a green background</elementA>
+  <elementB xmlns="">This line should have a green background</elementB>
  </div>
 </div>
 </body>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/selectors/selectors-4/lang-020-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/selectors/selectors-4/lang-020-ref.html
@@ -1,14 +1,11 @@
 <!DOCTYPE html>
 <html lang="en-US">
 <meta charset="utf-8">
-<title>CSS Selectors 4 - :lang matching</title>
+<title>CSS Selectors 4 - :lang matching reference</title>
 <link rel="author" title="Jonathan Kew" href="mailto:jkew@mozilla.com">
-<link rel="help" href="https://drafts.csswg.org/selectors-4/#the-lang-pseudo">
-<link rel="match" href="lang-020-ref.html">
 
 <style>
-div.test { color: red; }
-:lang("iw") { color: green; }
+div.test { color: green; }
 </style>
 
 <div class="test"><span lang="iw-ase-jpan-basiceng">This should be green</span></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/selectors/selectors-4/lang-singleton-subtag-matching-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/selectors/selectors-4/lang-singleton-subtag-matching-expected.txt
@@ -1,7 +1,8 @@
 
-PASS :lang(fr-x) matches lang="fr-x" and lang="fr-x-xenomorph" (singleton "x" matches)
+PASS :lang(fr-x) matches lang="fr-x" and lang="fr-x-standard" (singleton "x" matches)
 PASS :lang(fr-x) matches the correct elements
-PASS :lang(fr-xenomorph) only matches lang="fr-xenomorph" (not lang="fr-x-xenomorph")
+PASS :lang(fr-standard) only matches lang="fr-standard" (not lang="fr-x-standard")
+FAIL :lang(fr) does not match lang="fr-ninechars" (subtag exceeds 8-char limit) assert_equals: expected 3 but got 4
 PASS :lang(cocoa-1) matches lang="cocoa-1-bar" (singleton "1" matches)
 PASS :lang(cocoa-a) matches lang="cocoa-a-bar" (singleton "a" matches)
 PASS :lang(cocoa-bar) does not match lang="cocoa-1-bar" (cannot skip past singleton "1")

--- a/LayoutTests/imported/w3c/web-platform-tests/css/selectors/selectors-4/lang-singleton-subtag-matching.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/selectors/selectors-4/lang-singleton-subtag-matching.html
@@ -11,8 +11,9 @@
 <body>
 
 <div lang="fr-x"></div>
-<div lang="fr-x-xenomorph"></div>
-<div lang="fr-xenomorph"></div>
+<div lang="fr-x-standard"></div>
+<div lang="fr-standard"></div>
+<div lang="fr-ninechars"></div>
 <div lang="cocoa-1-bar"></div>
 <div lang="cocoa-a-bar"></div>
 <div lang="en-x-private"></div>
@@ -26,18 +27,22 @@
 
 test(function() {
     assert_equals(document.querySelectorAll(':lang(fr-x)').length, 2);
-}, ':lang(fr-x) matches lang="fr-x" and lang="fr-x-xenomorph" (singleton "x" matches)');
+}, ':lang(fr-x) matches lang="fr-x" and lang="fr-x-standard" (singleton "x" matches)');
 
 test(function() {
     assert_equals(document.querySelectorAll(':lang(fr-x)').length, 2);
     var matched = document.querySelectorAll(':lang(fr-x)');
     assert_equals(matched[0].getAttribute('lang'), 'fr-x');
-    assert_equals(matched[1].getAttribute('lang'), 'fr-x-xenomorph');
+    assert_equals(matched[1].getAttribute('lang'), 'fr-x-standard');
 }, ':lang(fr-x) matches the correct elements');
 
 test(function() {
-    assert_equals(document.querySelectorAll(':lang(fr-xenomorph)').length, 1);
-}, ':lang(fr-xenomorph) only matches lang="fr-xenomorph" (not lang="fr-x-xenomorph")');
+    assert_equals(document.querySelectorAll(':lang(fr-standard)').length, 1);
+}, ':lang(fr-standard) only matches lang="fr-standard" (not lang="fr-x-standard")');
+
+test(function() {
+    assert_equals(document.querySelectorAll(':lang(fr)').length, 3);
+}, ':lang(fr) does not match lang="fr-ninechars" (subtag exceeds 8-char limit)');
 
 test(function() {
     assert_equals(document.querySelectorAll(':lang(cocoa-1)').length, 1);

--- a/LayoutTests/imported/w3c/web-platform-tests/css/selectors/selectors-4/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/selectors/selectors-4/w3c-import.log
@@ -65,6 +65,7 @@ List of files:
 /LayoutTests/imported/w3c/web-platform-tests/css/selectors/selectors-4/lang-019-expected.html
 /LayoutTests/imported/w3c/web-platform-tests/css/selectors/selectors-4/lang-019.html
 /LayoutTests/imported/w3c/web-platform-tests/css/selectors/selectors-4/lang-020-expected.html
+/LayoutTests/imported/w3c/web-platform-tests/css/selectors/selectors-4/lang-020-ref.html
 /LayoutTests/imported/w3c/web-platform-tests/css/selectors/selectors-4/lang-020.html
 /LayoutTests/imported/w3c/web-platform-tests/css/selectors/selectors-4/lang-021-expected.html
 /LayoutTests/imported/w3c/web-platform-tests/css/selectors/selectors-4/lang-021.html
@@ -76,3 +77,4 @@ List of files:
 /LayoutTests/imported/w3c/web-platform-tests/css/selectors/selectors-4/lang-024.html
 /LayoutTests/imported/w3c/web-platform-tests/css/selectors/selectors-4/lang-025-expected.html
 /LayoutTests/imported/w3c/web-platform-tests/css/selectors/selectors-4/lang-025.html
+/LayoutTests/imported/w3c/web-platform-tests/css/selectors/selectors-4/lang-singleton-subtag-matching.html

--- a/LayoutTests/imported/w3c/web-platform-tests/css/selectors/selectors-attr-many-2-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/selectors/selectors-attr-many-2-expected.txt
@@ -1,0 +1,4 @@
+This text should be green.
+
+PASS Selectors: Many attribute selectors, and one that is only set
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/selectors/selectors-attr-many-2.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/selectors/selectors-attr-many-2.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<title>Selectors: Many attribute selectors, and one that is only set</title>
+<link rel="help" href="https://crbug.com/502249092"/>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<style>
+  [x="y"], [x="y"], [x="y"], [x="y"], [x="y"], [x="y"], [x="y"], [x="y"],
+  [x="y"], [x="y"], [x="y"], [x="y"], [x="y"], [x="y"], [x="y"], [x="y"],
+  [x="y"], [x="y"], [x="y"], [x="y"], [x="y"], [x="y"], [x="y"], [x="y"],
+  [x="y"], [x="y"], [x="y"], [x="y"], [x="y"], [x="y"], [x="y"], [x="y"],
+  [x="y"], [x="y"], [x="y"], [x="y"], [x="y"], [x="y"], [x="y"], [x="y"],
+  [x="y"], [x="y"], [x="y"], [x="y"], [x="y"], [x="y"], [x="y"], [x="y"],
+  [x="y"], [x="y"], [x="y"], [x="y"], [x="y"], [x="y"], [x="y"], [x="y"],
+  [a="b"][x] { color: green; }
+</style>
+<div id="target" a="b" x="z">This text should be green.</div>
+<script>
+  test(() => {
+    let target = document.getElementById('target');
+    assert_equals(getComputedStyle(target).color, 'rgb(0, 128, 0)');
+  });
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/selectors/toplayer-transition-001.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/selectors/toplayer-transition-001.html
@@ -21,7 +21,7 @@
 </div>
 
 <script>
-test(t => {
+promise_test(async t => {
   t.add_cleanup(() => { if (popover.matches(':popover-open')) popover.hidePopover(); });
 
   input.focus();
@@ -35,6 +35,7 @@ test(t => {
   assert_false(document.body.matches(':focus-within'), 'body should not match :focus-within after showPopover');
 
   popover.hidePopover();
+  await new Promise(requestAnimationFrame);
   assert_true(input.matches(':focus'), 'input should still be focused after hidePopover');
   assert_true(container.matches(':focus-within'), 'container should match :focus-within after hidePopover');
   assert_true(document.body.matches(':focus-within'), 'body should match :focus-within after hidePopover');
@@ -58,6 +59,7 @@ promise_test(async t => {
   assert_false(document.body.matches(':hover'), 'body should not match :hover after showPopover');
 
   popover.hidePopover();
+  await new Promise(requestAnimationFrame);
   assert_true(hoverTarget.matches(':hover'), 'hoverTarget should still match :hover after hidePopover');
   assert_true(container.matches(':hover'), 'container should match :hover after hidePopover');
   assert_true(document.body.matches(':hover'), 'body should match :hover after hidePopover');

--- a/LayoutTests/imported/w3c/web-platform-tests/css/selectors/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/selectors/w3c-import.log
@@ -460,6 +460,7 @@ List of files:
 /LayoutTests/imported/w3c/web-platform-tests/css/selectors/selector-structural-pseudo-root-expected.html
 /LayoutTests/imported/w3c/web-platform-tests/css/selectors/selector-structural-pseudo-root-ref.html
 /LayoutTests/imported/w3c/web-platform-tests/css/selectors/selector-structural-pseudo-root.html
+/LayoutTests/imported/w3c/web-platform-tests/css/selectors/selectors-attr-many-2.html
 /LayoutTests/imported/w3c/web-platform-tests/css/selectors/selectors-attr-many-expected.html
 /LayoutTests/imported/w3c/web-platform-tests/css/selectors/selectors-attr-many-ref.html
 /LayoutTests/imported/w3c/web-platform-tests/css/selectors/selectors-attr-many.html

--- a/LayoutTests/imported/w3c/web-platform-tests/css/selectors/webkit-pseudo-element-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/selectors/webkit-pseudo-element-expected.txt
@@ -2,5 +2,7 @@
 PASS rules include webkit-prefixed pseudo-element should be cascaded
 PASS webkit-prefixed pseudo-element selectors should be accessible from CSSOM
 PASS qS and qSA shouldn't throw exception
+PASS User-action pseudo-classes are valid
+PASS Nested pseudos are invalid
 PASS webkit-prefix without dash is invalid
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/selectors/webkit-pseudo-element.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/selectors/webkit-pseudo-element.html
@@ -39,6 +39,15 @@ span::-webkit-something-invalid, #test, ::-WeBkIt-sOmEtHiNg-NoNeXiSt123, ::-webk
   }, "qS and qSA shouldn't throw exception");
 
   test(() => {
+    document.querySelectorAll("span::-webkit-something-invalid:active");
+    document.querySelectorAll("span::-webkit-something-invalid:hover");
+  }, "User-action pseudo-classes are valid");
+
+  test(() => {
+    assert_throws_dom("SyntaxError", () => document.querySelector("span::-webkit-something-invalid::before"));
+  }, "Nested pseudos are invalid");
+
+  test(() => {
     let sheet = document.getElementById("style").sheet;
     assert_equals(sheet.cssRules.length, 2);
     assert_throws_dom("SyntaxError", () => document.querySelector("span::-webkitfoo"));

--- a/LayoutTests/imported/w3c/web-platform-tests/css/selectors/xml-class-selector-ref.xml
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/selectors/xml-class-selector-ref.xml
@@ -7,7 +7,7 @@
     <Boxes xmlns="http://foo">
       <box>.classname selector</box>
       <box>*[class~="classname"] selector</box>
-    </boxes>
+    </Boxes>
 
     <style>
       box {background:green;}


### PR DESCRIPTION
#### 5f300b43ead2f8f2b0460cd6183a77554357ea0f
<pre>
Resync `css/selectors` from WPT Upstream
<a href="https://bugs.webkit.org/show_bug.cgi?id=314290">https://bugs.webkit.org/show_bug.cgi?id=314290</a>

Reviewed by Vitor Roriz, Brandon Stewart, and Tim Nguyen.

Upstream commit: <a href="https://github.com/web-platform-tests/wpt/commit/18099a9f2e19ae86a7ae6c0b187f0bd03728fee6">https://github.com/web-platform-tests/wpt/commit/18099a9f2e19ae86a7ae6c0b187f0bd03728fee6</a>

* LayoutTests/imported/w3c/resources/resource-files.json:
* LayoutTests/imported/w3c/web-platform-tests/css/selectors/case-insensitive-parent-ref.html:
* LayoutTests/imported/w3c/web-platform-tests/css/selectors/invalidation/w3c-import.log:
* LayoutTests/imported/w3c/web-platform-tests/css/selectors/media/sound-state-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/selectors/media/sound-state.html:
* LayoutTests/imported/w3c/web-platform-tests/css/selectors/old-tests/css3-modsel-153.xml:
* LayoutTests/imported/w3c/web-platform-tests/css/selectors/old-tests/css3-modsel-174a.xml:
* LayoutTests/imported/w3c/web-platform-tests/css/selectors/old-tests/css3-modsel-174b.xml:
* LayoutTests/imported/w3c/web-platform-tests/css/selectors/old-tests/css3-modsel-181.xml:
* LayoutTests/imported/w3c/web-platform-tests/css/selectors/old-tests/css3-modsel-92.xml:
* LayoutTests/imported/w3c/web-platform-tests/css/selectors/old-tests/css3-modsel-93.xml:
* LayoutTests/imported/w3c/web-platform-tests/css/selectors/old-tests/css3-modsel-96.xml:
* LayoutTests/imported/w3c/web-platform-tests/css/selectors/old-tests/css3-modsel-96b.xml:
* LayoutTests/imported/w3c/web-platform-tests/css/selectors/selectors-4/lang-020-ref.html: Copied from LayoutTests/imported/w3c/web-platform-tests/css/selectors/selectors-4/lang-020.html.
* LayoutTests/imported/w3c/web-platform-tests/css/selectors/selectors-4/lang-020.html:
* LayoutTests/imported/w3c/web-platform-tests/css/selectors/selectors-4/lang-singleton-subtag-matching-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/selectors/selectors-4/lang-singleton-subtag-matching.html:
* LayoutTests/imported/w3c/web-platform-tests/css/selectors/selectors-4/w3c-import.log:
* LayoutTests/imported/w3c/web-platform-tests/css/selectors/selectors-attr-many-2-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/selectors/selectors-attr-many-2.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/selectors/toplayer-transition-001.html:
* LayoutTests/imported/w3c/web-platform-tests/css/selectors/w3c-import.log:
* LayoutTests/imported/w3c/web-platform-tests/css/selectors/webkit-pseudo-element-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/selectors/webkit-pseudo-element.html:
* LayoutTests/imported/w3c/web-platform-tests/css/selectors/xml-class-selector-ref.xml:

Canonical link: <a href="https://commits.webkit.org/312815@main">https://commits.webkit.org/312815@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ec31cfe20f6d444723b4abcf94afc2b96d1031ec

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/161070 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/34543 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/27644 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/169973 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/117330 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/34644 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/34543 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/124935 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/117330 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/164029 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/27205 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/144686 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/105532 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/26254 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/24757 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/17693 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/135948 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/22448 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/172456 "Built successfully") | | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/24089 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/133214 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/34217 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/28850 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/133224 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36002 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/34201 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/144243 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/96040 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/27775 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/21061 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/33712 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/33211 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/33455 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/33360 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->