### PR TITLE
Render text children of annotation

### DIFF
--- a/LayoutTests/imported/w3c/resources/resource-files.json
+++ b/LayoutTests/imported/w3c/resources/resource-files.json
@@ -13457,6 +13457,7 @@
         "web-platform-tests/mathml/relations/html5-tree/unique-identifier-3-ref.html",
         "web-platform-tests/mathml/relations/text-and-math/mi-automatic-italic-with-default-font-ref.html",
         "web-platform-tests/mathml/relations/text-and-math/mo-glyph-height-with-default-font-ref.html",
+        "web-platform-tests/mathml/relations/text-and-math/non-mathml-children-in-annotation.tentative-ref.html",
         "web-platform-tests/mathml/relations/text-and-math/use-typo-metrics-1-ref.html",
         "web-platform-tests/mediacapture-record/support/MediaRecorder-iframe.html",
         "web-platform-tests/mediacapture-streams/iframe-enumerate-cleared.html",

--- a/LayoutTests/imported/w3c/web-platform-tests/mathml/relations/text-and-math/non-mathml-children-in-annotation.tentative-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/mathml/relations/text-and-math/non-mathml-children-in-annotation.tentative-expected.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Non-MathML children of annotation and annotation-xml (reference)</title>
+    <meta charset="utf-8"/>
+    <style>
+      annotation-xml, annotation { display: initial; }
+    </style>
+  </head>
+  <body>
+    <math>
+      <mtext>annotation</mtext>
+    </math>
+    <math>
+      <mtext>annotation-xml</mtext>
+    </math>
+  </body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/mathml/relations/text-and-math/non-mathml-children-in-annotation.tentative-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/mathml/relations/text-and-math/non-mathml-children-in-annotation.tentative-ref.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Non-MathML children of annotation and annotation-xml (reference)</title>
+    <meta charset="utf-8"/>
+    <style>
+      annotation-xml, annotation { display: initial; }
+    </style>
+  </head>
+  <body>
+    <math>
+      <mtext>annotation</mtext>
+    </math>
+    <math>
+      <mtext>annotation-xml</mtext>
+    </math>
+  </body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/mathml/relations/text-and-math/non-mathml-children-in-annotation.tentative.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/mathml/relations/text-and-math/non-mathml-children-in-annotation.tentative.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html><!-- webkit-test-runner [ CoreMathMLEnabled=true ] -->
+<html>
+  <head>
+    <title>Non-MathML children of annotation and annotation-xml</title>
+    <meta charset="utf-8"/>
+    <meta name="assert" content="Non-MathML children of annotation and annotation-xml elements are rendered."/>
+    <link rel="help" href="https://w3c.github.io/mathml-core/#dfn-annotation"/>
+    <link rel="match" href="non-mathml-children-in-annotation.tentative-ref.html"/>
+    <style>
+      annotation-xml, annotation { display: initial; }
+    </style>
+  </head>
+  <body>
+    <math>
+      <semantics>
+        <mtext></mtext>
+        <annotation>annotation</annotation>
+      </semantics>
+    </math>
+    <math>
+      <semantics>
+        <mtext></mtext>
+        <annotation-xml encoding="text/html"><span>annotation-xml</span></annotation-xml>
+      </semantics>
+    </math>
+  </body>
+</html>

--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/html/syntax/parsing/html-integration-point-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/html/syntax/parsing/html-integration-point-expected.txt
@@ -1,3 +1,4 @@
+&lt;/xmp&gt;&lt;img>
 
 
 

--- a/Source/WebCore/mathml/MathMLAnnotationElement.cpp
+++ b/Source/WebCore/mathml/MathMLAnnotationElement.cpp
@@ -69,9 +69,6 @@ RenderPtr<RenderElement> MathMLAnnotationElement::createElementRenderer(RenderSt
 
 bool MathMLAnnotationElement::childShouldCreateRenderer(const Node& child) const
 {
-    if (document().settings().coreMathMLEnabled())
-        return MathMLElement::childShouldCreateRenderer(child);
-
     // For <annotation>, only text children are allowed.
     if (hasTagName(MathMLNames::annotationTag))
         return child.isTextNode();


### PR DESCRIPTION
#### f2a772441b208ae6240df7c690e2be4dfec77422
<pre>
Render text children of annotation
<a href="https://bugs.webkit.org/show_bug.cgi?id=314081">https://bugs.webkit.org/show_bug.cgi?id=314081</a>

Reviewed by NOBODY (OOPS!).

Revert a change from #51387 to show &quot;invalid&quot; children of annotation
again. The spec is not clear what to do in this case, but this behaviour
follows what other browsers are doing, and it is the intended case of the
tag in MathML 3.

* Source/WebCore/mathml/MathMLAnnotationElement.cpp:
(WebCore::MathMLAnnotationElement::childShouldCreateRenderer const):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b9a0cb1c5733e4e5933df3d6418205f376551dfc

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/162531 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/36007 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/29132 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/171469 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/118976 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/164400 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/36111 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/36011 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/126136 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/88852 "18 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/165490 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/28483 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/146016 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/106714 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/27529 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/26056 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/19169 "Built successfully") | 
| [⏳ 🛠 🧪 jsc ](https://ews-build.webkit.org/#/builders/JSC-Tests-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/137233 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/23746 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/173973 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/21286 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/25391 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/134445 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/35681 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/30147 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/134443 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/35665 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/145542 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/97965 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/28978 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/22375 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/35175 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/102926 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/34676 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/34921 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/34824 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->