### PR TITLE
[iOS Simulator] ImageAnalysisTestingUtilities.h:49:61: error: unknown type name 'VKImageOrientation'

### DIFF
--- a/Source/WebCore/PAL/pal/spi/cocoa/VisionKitCoreSPI.h
+++ b/Source/WebCore/PAL/pal/spi/cocoa/VisionKitCoreSPI.h
@@ -28,9 +28,18 @@
 #include <wtf/Compiler.h>
 #include <wtf/Platform.h>
 
-#if !PLATFORM(IOS_SIMULATOR) || !__has_feature(modules) || HAVE(WEBGPU_IOS_SIMULATOR_OPENGL_SUPPORT)
-
 DECLARE_SYSTEM_HEADER
+
+// On iOS Simulator with clang modules (and without WebGPU's simulator OpenGL
+// support), <UIKit/UIKit.h> can't be safely imported: CoreImage -> CoreVideo ->
+// OpenGLES imports C++ modules from inside an extern "C" block. In that
+// configuration, skip the UIKit-dependent portions of this header and fall back
+// to minimal @class forward declarations.
+#if !PLATFORM(IOS_SIMULATOR) || !__has_feature(modules) || HAVE(WEBGPU_IOS_SIMULATOR_OPENGL_SUPPORT)
+#define VK_IMAGE_ANALYSIS_CAN_IMPORT_UIKIT 1
+#else
+#define VK_IMAGE_ANALYSIS_CAN_IMPORT_UIKIT 0
+#endif
 
 #if HAVE(VK_IMAGE_ANALYSIS)
 
@@ -51,12 +60,12 @@ IGNORE_WARNINGS_BEGIN("objc-property-no-attribute")
 #import <VisionKitCore/VisionKitCore.h>
 IGNORE_WARNINGS_END
 
-#else
+#elif defined(__OBJC__)
 
 #import <CoreGraphics/CoreGraphics.h>
 #import <Foundation/Foundation.h>
 
-#if PLATFORM(IOS_FAMILY)
+#if PLATFORM(IOS_FAMILY) && VK_IMAGE_ANALYSIS_CAN_IMPORT_UIKIT
 #import <UIKit/UIKit.h>
 #elif PLATFORM(MAC)
 #import <AppKit/AppKit.h>
@@ -96,7 +105,7 @@ typedef NS_ENUM(NSUInteger, VKImageAnalyzerRequestImageSource) {
     VKImageAnalyzerRequestImageSourceVideoFrame,
 };
 
-#if PLATFORM(IOS_FAMILY)
+#if PLATFORM(IOS_FAMILY) && VK_IMAGE_ANALYSIS_CAN_IMPORT_UIKIT
 
 typedef UIImage VKImageClass;
 typedef UIImageOrientation VKImageOrientation;
@@ -112,7 +121,9 @@ typedef UIImageOrientation VKImageOrientation;
 
 #else
 
+#if PLATFORM(MAC)
 typedef NSImage VKImageClass;
+#endif
 
 typedef NS_ENUM(NSInteger, VKImageOrientation) {
     VKImageOrientationUp,
@@ -126,6 +137,8 @@ typedef NS_ENUM(NSInteger, VKImageOrientation) {
 };
 
 #endif
+
+#if VK_IMAGE_ANALYSIS_CAN_IMPORT_UIKIT || PLATFORM(MAC)
 
 @interface VKImageAnalysis : NSObject <NSSecureCoding>
 - (BOOL)hasResultsForAnalysisTypes:(VKAnalysisTypes)analysisTypes;
@@ -188,9 +201,19 @@ typedef NS_ENUM(NSInteger, VKImageOrientation) {
 #endif
 @end
 
+#else // iOS Simulator + modules: UIKit isn't importable; provide minimal @class declarations.
+
+@class VKImageAnalysis;
+@class VKImageAnalyzer;
+@class VKImageAnalyzerRequest;
+
+#endif
+
 NS_ASSUME_NONNULL_END
 
 #endif
+
+#if defined(__OBJC__) && (VK_IMAGE_ANALYSIS_CAN_IMPORT_UIKIT || PLATFORM(MAC))
 
 @interface VKWKLineInfo (Staging_85139101)
 @property (nonatomic, readonly) NSUInteger layoutDirection;
@@ -202,14 +225,17 @@ NS_ASSUME_NONNULL_END
 @end
 #endif
 
+#endif
+
 #if ENABLE(IMAGE_ANALYSIS_ENHANCEMENTS)
 
 #if __has_include(<VisionKitCore/VKCImageAnalysisTranslation.h>) && !__has_feature(modules)
 #import <VisionKitCore/VKCImageAnalysisTranslation.h>
-#else
+#elif defined(__OBJC__)
 
 NS_ASSUME_NONNULL_BEGIN
 
+#if VK_IMAGE_ANALYSIS_CAN_IMPORT_UIKIT || PLATFORM(MAC)
 @interface VKCTranslatedParagraph : NSObject
 @property (nonatomic, readonly) VKQuad *quad;
 @property (nonatomic, readonly) NSString *text;
@@ -219,6 +245,10 @@ NS_ASSUME_NONNULL_BEGIN
 @interface VKCImageAnalysisTranslation : NSObject
 @property (nonatomic, readonly) NSArray<VKCTranslatedParagraph *> *paragraphs;
 @end
+#else
+@class VKCTranslatedParagraph;
+@class VKCImageAnalysisTranslation;
+#endif
 
 NS_ASSUME_NONNULL_END
 
@@ -226,15 +256,19 @@ NS_ASSUME_NONNULL_END
 
 #if __has_include(<VisionKitCore/VKCImageAnalysis.h>) && !__has_feature(modules)
 #import <VisionKitCore/VKCImageAnalysis.h>
-#else
+#elif defined(__OBJC__)
 
 NS_ASSUME_NONNULL_BEGIN
 
+#if VK_IMAGE_ANALYSIS_CAN_IMPORT_UIKIT || PLATFORM(MAC)
 @interface VKCImageAnalysis : VKImageAnalysis
 - (NSAttributedString *)_attributedStringForRange:(NSRange)range;
 - (void)translateTo:(NSString *)targetLanguage withCompletion:(void (^)(VKCImageAnalysisTranslation *translation, NSError * _Nullable))completion;
 - (void)translateFrom:(NSString *)sourceLanguage to:(NSString *)targetLanguage withCompletion:(void (^)(VKCImageAnalysisTranslation *translation, NSError *))completion;
 @end
+#else
+@class VKCImageAnalysis;
+#endif
 
 NS_ASSUME_NONNULL_END
 
@@ -242,7 +276,7 @@ NS_ASSUME_NONNULL_END
 
 #if __has_include(<VisionKitCore/VKImageClass_Private.h>) && !__has_feature(modules)
 #import <VisionKitCore/VKImageClass_Private.h>
-#else
+#elif defined(__OBJC__)
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -263,10 +297,11 @@ NS_ASSUME_NONNULL_END
 #import <VisionKitCore/VKCRemoveBackgroundRequest.h>
 #import <VisionKitCore/VKCRemoveBackgroundRequestHandler.h>
 #import <VisionKitCore/VKCRemoveBackgroundResult.h>
-#else
+#elif defined(__OBJC__)
 
 NS_ASSUME_NONNULL_BEGIN
 
+#if VK_IMAGE_ANALYSIS_CAN_IMPORT_UIKIT || PLATFORM(MAC)
 @interface VKCRemoveBackgroundResult : NSObject
 @property (nonatomic, readonly) CGRect cropRect;
 - (CGImageRef)createCGImage;
@@ -280,6 +315,11 @@ NS_ASSUME_NONNULL_BEGIN
 @interface VKCRemoveBackgroundRequestHandler : NSObject
 - (void)performRequest:(VKCRemoveBackgroundRequest *)request completion:(void (^)(VKCRemoveBackgroundResult *result, NSError *error))completion;
 @end
+#else
+@class VKCRemoveBackgroundResult;
+@class VKCRemoveBackgroundRequest;
+@class VKCRemoveBackgroundRequestHandler;
+#endif
 
 NS_ASSUME_NONNULL_END
 
@@ -288,10 +328,11 @@ NS_ASSUME_NONNULL_END
 #if __has_include(<VisionKitCore/VKCImageAnalyzer.h>) && !__has_feature(modules)
 #import <VisionKitCore/VKCImageAnalyzer.h>
 #import <VisionKitCore/VKCImageAnalyzerRequest.h>
-#else
+#elif defined(__OBJC__)
 
 NS_ASSUME_NONNULL_BEGIN
 
+#if VK_IMAGE_ANALYSIS_CAN_IMPORT_UIKIT || PLATFORM(MAC)
 @interface VKCImageAnalyzerRequest : NSObject <NSCopying, VKFeedbackAssetsProvider>
 @property (nonatomic, copy, nullable) NSURL *imageURL;
 @property (nonatomic, copy, nullable) NSURL *pageURL;
@@ -307,6 +348,10 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)cancelRequestID:(VKImageAnalysisRequestID)requestID;
 - (VKImageAnalysisRequestID)processRequest:(VKCImageAnalyzerRequest *)request progressHandler:(void (^_Nullable)(double progress))progressHandler completionHandler:(void (^)(VKCImageAnalysis* _Nullable analysis, NSError * _Nullable error))completionHandler;
 @end
+#else
+@class VKCImageAnalyzerRequest;
+@class VKCImageAnalyzer;
+#endif
 
 NS_ASSUME_NONNULL_END
 #endif
@@ -314,7 +359,7 @@ NS_ASSUME_NONNULL_END
 #if PLATFORM(MAC)
 #if __has_include(<VisionKitCore/VKCImageAnalysisOverlayView.h>) && !__has_feature(modules)
 #import <VisionKitCore/VKCImageAnalysisOverlayView.h>
-#else
+#elif defined(__OBJC__)
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -341,10 +386,11 @@ NS_ASSUME_NONNULL_END
 #if PLATFORM(IOS) || PLATFORM(VISION) || PLATFORM(MACCATALYST)
 #if __has_include(<VisionKitCore/VKCImageAnalysisInteraction.h>) && !__has_feature(modules)
 #import <VisionKitCore/VKCImageAnalysisInteraction.h>
-#else
+#elif defined(__OBJC__)
 
 NS_ASSUME_NONNULL_BEGIN
 
+#if VK_IMAGE_ANALYSIS_CAN_IMPORT_UIKIT
 @protocol VKCImageAnalysisInteractionDelegate <NSObject>
 @end
 
@@ -365,6 +411,9 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)resetSelection;
 - (void)setActionInfoViewHidden:(BOOL)hidden animated:(BOOL)animated;
 @end
+#else
+@class VKCImageAnalysisInteraction;
+#endif
 
 NS_ASSUME_NONNULL_END
 
@@ -374,36 +423,3 @@ NS_ASSUME_NONNULL_END
 #endif // ENABLE(IMAGE_ANALYSIS_ENHANCEMENTS)
 
 #endif // HAVE(VK_IMAGE_ANALYSIS)
-
-#elif defined(__OBJC__)
-
-// iOS Simulator + modules: VisionKitCore.framework headers cannot be imported as modules.
-// Provide minimal declarations so that dependent headers (e.g. ImageAnalysisUtilities.h) compile.
-// Full VisionKit functionality is unavailable in this platform/mode combination.
-
-#import <Foundation/Foundation.h> // NOLINT
-
-#if HAVE(VK_IMAGE_ANALYSIS)
-
-typedef NS_OPTIONS(NSUInteger, VKAnalysisTypes) {
-    VKAnalysisTypeText                 = 1 << 0,
-    VKAnalysisTypeMachineReadableCode  = 1 << 2,
-    VKAnalysisTypeAppClip              = 1 << 3,
-    VKAnalysisTypeVisualSearch         = 1 << 4,
-    VKAnalysisTypeImageSegmentation    = 1 << 5,
-};
-
-@class VKImageAnalysis;
-@class VKImageAnalyzer;
-@class VKImageAnalyzerRequest;
-@class VKCImageAnalysis;
-@class VKCImageAnalyzer;
-@class VKCImageAnalyzerRequest;
-
-#if PLATFORM(IOS_FAMILY)
-@class VKCImageAnalysisInteraction;
-#endif
-
-#endif // HAVE(VK_IMAGE_ANALYSIS)
-
-#endif // !PLATFORM(IOS_SIMULATOR) || !__has_feature(modules) || HAVE(WEBGPU_IOS_SIMULATOR_OPENGL_SUPPORT)


### PR DESCRIPTION
#### 1f256daa14a4a51149c3ddba15a6876c40d16487
<pre>
[iOS Simulator] ImageAnalysisTestingUtilities.h:49:61: error: unknown type name &apos;VKImageOrientation&apos;
<a href="https://bugs.webkit.org/show_bug.cgi?id=314304">https://bugs.webkit.org/show_bug.cgi?id=314304</a>

Reviewed by Mike Wyrzykowski and Abrar Rahman Protyasha.

311694@main added a minimal fallback block in VisionKitCoreSPI.h for the
iOS simulator + clang-modules configuration, where &lt;UIKit/UIKit.h&gt; can&apos;t
be safely imported: CoreImage -&gt; CoreVideo -&gt; OpenGLES imports C++ modules
from inside an extern &quot;C&quot; block. That fallback declared VKAnalysisTypes
and forward-declared the VK* classes, but it omitted VKImageOrientation,
which is referenced by ImageAnalysisTestingUtilities.h and
ImageAnalysisUtilities.mm:

    Tools/TestWebKitAPI/Helpers/cocoa/ImageAnalysisTestingUtilities.h:49:61:
        error: unknown type name &apos;VKImageOrientation&apos;

Rather than duplicating the VKImageOrientation NS_ENUM in the fallback
block, restructure VisionKitCoreSPI.h so the existing declarations are
reused:

- Introduce a VK_IMAGE_ANALYSIS_CAN_IMPORT_UIKIT helper macro capturing
  the &quot;safe to import UIKit&quot; condition.
- Drop the top-level &quot;!PLATFORM(IOS_SIMULATOR) || !__has_feature(modules)
  || HAVE(WEBGPU_IOS_SIMULATOR_OPENGL_SUPPORT)&quot; wrapper and the separate
  iOS-simulator+modules stub branch.
- In the non-internal-SDK fallback, guard &lt;UIKit/UIKit.h&gt; with the new
  macro. When UIKit can&apos;t be imported, skip the
  typedef UIImage VKImageClass / typedef UIImageOrientation VKImageOrientation
  path and reuse the existing NS_ENUM(NSInteger, VKImageOrientation) that
  was previously Mac-only.
- Similarly, gate the full @interface declarations (which use UIKit types
  like UIMenu / UIViewController / UIInteraction / UIButton) on
  VK_IMAGE_ANALYSIS_CAN_IMPORT_UIKIT || PLATFORM(MAC); otherwise emit
  @class forward declarations. The staging categories and each subsection
  of the ENABLE(IMAGE_ANALYSIS_ENHANCEMENTS) block follow the same
  pattern.

This keeps VisionKit functionality available in all previously-supported
configurations while making VKImageOrientation visible to dependent
headers on iOS simulator + modules, all without a second declaration of
the enum.

* Source/WebCore/PAL/pal/spi/cocoa/VisionKitCoreSPI.h:
Restructure the header to share a single VKImageOrientation NS_ENUM
definition between the Mac fallback and the iOS-simulator+modules
configuration, gating UIKit-dependent declarations behind a new
VK_IMAGE_ANALYSIS_CAN_IMPORT_UIKIT macro.

Canonical link: <a href="https://commits.webkit.org/312866@main">https://commits.webkit.org/312866@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8ac7616180e4c0a25148bcb2603876a0c16055cc

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/161290 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/34763 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/27864 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/170193 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/117661 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/163159 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/34864 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/34764 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/125111 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/117661 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/164249 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/27396 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/144871 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/105708 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/26444 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/24953 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/17913 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/136138 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/22631 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/172676 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/19697 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/24272 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/133393 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/34437 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/29046 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/133401 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36034 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/34422 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/144426 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/96287 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/27938 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/21244 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/33932 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/101357 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/33431 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/33675 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/33580 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->