### PR TITLE
Twitch.tv may stall at ad transition during live streaming.

### DIFF
--- a/LayoutTests/media/media-source/media-source-append-b-frame-tail-overshoot-expected.txt
+++ b/LayoutTests/media/media-source/media-source-append-b-frame-tail-overshoot-expected.txt
@@ -1,0 +1,16 @@
+
+RUN(video.src = URL.createObjectURL(source))
+EVENT(sourceopen)
+RUN(sourceBuffer = source.addSourceBuffer('video/mp4; codecs="avc1.4d401e"'))
+RUN(sourceBuffer.appendBuffer(MP4.concat(init, segment1)))
+EVENT(updateend)
+EXPECTED (sourceBuffer.buffered.length == '1') OK
+EXPECTED (sourceBuffer.buffered.start(0) == '0.1') OK
+EXPECTED (sourceBuffer.buffered.end(0) == '0.2') OK
+RUN(sourceBuffer.appendBuffer(segment2))
+EVENT(updateend)
+EXPECTED (sourceBuffer.buffered.length == '1') OK
+EXPECTED (sourceBuffer.buffered.start(0) == '0') OK
+EXPECTED (sourceBuffer.buffered.end(0) == '0.2') OK
+END OF TEST
+

--- a/LayoutTests/media/media-source/media-source-append-b-frame-tail-overshoot.html
+++ b/LayoutTests/media/media-source/media-source-append-b-frame-tail-overshoot.html
@@ -1,0 +1,107 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>media-source-append-b-frame-tail-overshoot</title>
+    <script src="mp4-generator.js"></script>
+    <script src="../video-test.js"></script>
+    <script>
+    // Regression coverage for a reordered-B-frame-tail pts-overshoot interacting with MSE
+    // "Coded Frame Processing" step 1.14 case B + step 1.15 cascade.
+    //
+    // Setup:
+    //   Segment 1 (init + media): one sync sample at pts=100 dts=100 dur=100.
+    //     presentationEndTime = 200. After append: highest_end_timestamp = 200.
+    //   Segment 2 (media only): its first DTS is 0, below segment 1's last DTS of 100 — this
+    //     fires the step-1.6 DTS-discontinuity reset, which unsets highest_end_timestamp and
+    //     lastDecodeTimestamp. Subsequent samples process in a fresh coded-frame group.
+    //     Samples in decode order:
+    //       - I-frame: dts=0 pts=0 dur=50 (sync). Case-A remove range [0, 50) — nothing in
+    //         the track buffer to remove. After add: highest_end_timestamp = 50.
+    //       - Reordered B-frame: dts=50 pts=80 dur=30 (non-sync, pts > dts).
+    //         frame_end = 110. Case-B condition `highest_end (50) ≤ pts (80)` holds. Erase
+    //         range = [50, 110). The existing content sync at pts=100 lies inside that range.
+    //
+    // Spec-mandated outcome without any targeted fix: 1.14 removes the content sync at 100,
+    // 1.15 cascades any dependents (none here, since content has only the one sample), and
+    // buffered ends at 0.110 — the content's 0.1-to-0.2 span is gone.
+    //
+    // With the fix (shift the existing overlapped sync forward to the incoming frame's
+    // frame_end): the content sync gets re-keyed at pts=110, so 1.14's half-open [50, 110)
+    // no longer catches it. The sync's decodeTime and presentationEndTime (=200) are
+    // preserved; only its start pts moves by the 10 ms overshoot. buffered ends at 0.200.
+    //
+    // The test does NOT call changeType — the reset that enables Case-B to fire against the
+    // existing sync comes from the natural DTS discontinuity between segments 1 and 2.
+
+    var source;
+    var sourceBuffer;
+    var init;
+    var segment1;
+    var segment2;
+
+    async function runTest() {
+        findMediaElement();
+
+        if (!MediaSource.isTypeSupported(MP4.VIDEO_TYPE)) {
+            failTest(`${MP4.VIDEO_TYPE} is not supported`);
+            return;
+        }
+
+        source = new MediaSource();
+        run('video.src = URL.createObjectURL(source)');
+        await waitFor(source, 'sourceopen');
+
+        run(`sourceBuffer = source.addSourceBuffer('${MP4.VIDEO_TYPE}')`);
+
+        // ---- Segment 1: init + one sync sample at pts=100 ----
+        init = MP4.initSegment({
+            timescale: 1000,
+            tracks: [{ id: 1, type: 'video', timescale: 1000 }],
+        });
+        segment1 = MP4.mediaSegment({
+            sequenceNumber: 1,
+            tracks: [{
+                id: 1, type: 'video', baseDecodeTime: 100,
+                samples: [
+                    { duration: 100, compositionTimeOffset: 0, isSync: true },
+                ],
+            }],
+        });
+        run('sourceBuffer.appendBuffer(MP4.concat(init, segment1))');
+        await waitFor(sourceBuffer, 'updateend');
+        testExpected('sourceBuffer.buffered.length', 1);
+        testExpectedEqualWithTolerance('sourceBuffer.buffered.start(0)', 0.1, 0.01);
+        testExpectedEqualWithTolerance('sourceBuffer.buffered.end(0)', 0.2, 0.01);
+
+        // ---- Segment 2: baseDecodeTime = 0 (forces step-1.6 DTS-discontinuity reset);
+        //                ends in a reordered B-frame whose frame_end = 110 lands 10 ms past
+        //                the existing sync at pts=100. No changeType call. ----
+        segment2 = MP4.mediaSegment({
+            sequenceNumber: 2,
+            tracks: [{
+                id: 1, type: 'video', baseDecodeTime: 0,
+                samples: [
+                    { duration: 50, compositionTimeOffset: 0,  isSync: true  },  // I-frame
+                    { duration: 30, compositionTimeOffset: 30, isSync: false },  // B-frame pts=80 end=110
+                ],
+            }],
+        });
+        run('sourceBuffer.appendBuffer(segment2)');
+        await waitFor(sourceBuffer, 'updateend');
+
+        // With the fix: single contiguous buffered range [0, 0.2]. The content sync originally
+        // at pts=0.1 has been shifted to pts=0.11 but retains its presentationEndTime of 0.2.
+        // Without the fix: buffered would end at 0.110 (no content past the ad tail).
+        testExpected('sourceBuffer.buffered.length', 1);
+        testExpectedEqualWithTolerance('sourceBuffer.buffered.start(0)', 0.0, 0.01);
+        testExpectedEqualWithTolerance('sourceBuffer.buffered.end(0)', 0.2, 0.01);
+
+        endTest();
+    }
+
+    </script>
+</head>
+<body onload="runTest()">
+    <video></video>
+</body>
+</html>

--- a/Source/WebCore/Modules/mediasource/SampleMap.cpp
+++ b/Source/WebCore/Modules/mediasource/SampleMap.cpp
@@ -129,6 +129,37 @@ void SampleMap::removeSample(const MediaSample& sample)
     decodeOrder().m_samples.erase(decodeKey);
 }
 
+void SampleMap::replaceSample(const MediaSample& original, Ref<MediaSample>&& replacement)
+{
+    // Swap an already-buffered sample for a replacement carrying nearly-identical
+    // keys (typically a small timing shift). The erase() return iterator is a
+    // valid insertion-point hint for the new entry as long as the replacement's
+    // key still sorts just ahead of the erased position; this holds for the
+    // small shifts that `createCopyWithAdjustedStartTime` produces. A wrong
+    // hint is merely a performance regression, not a correctness issue.
+    // The replacement carries the same payload as the original, so the total
+    // size is unchanged.
+    ASSERT(original.sizeInBytes() == replacement->sizeInBytes());
+    ASSERT(original.trackID() == replacement->trackID());
+
+    MediaTime originalPts = original.presentationTime();
+    auto originalDecodeKey = DecodeOrderSampleMap::KeyType(original.decodeTime(), originalPts);
+    MediaTime replacementPts = replacement->presentationTime();
+    auto replacementDecodeKey = DecodeOrderSampleMap::KeyType(replacement->decodeTime(), replacementPts);
+
+    auto& presentationSamples = presentationOrder().m_samples;
+    if (auto pIt = presentationSamples.find(originalPts); pIt != presentationSamples.end()) {
+        auto hint = presentationSamples.erase(pIt);
+        presentationSamples.insert(hint, { replacementPts, replacement.copyRef() });
+    }
+
+    auto& decodeSamples = decodeOrder().m_samples;
+    if (auto dIt = decodeSamples.find(originalDecodeKey); dIt != decodeSamples.end()) {
+        auto hint = decodeSamples.erase(dIt);
+        decodeSamples.insert(hint, { replacementDecodeKey, WTF::move(replacement) });
+    }
+}
+
 PresentationOrderSampleMap::iterator PresentationOrderSampleMap::findSampleWithPresentationTime(const MediaTime& time) LIFETIME_BOUND
 {
     auto range = m_samples.equal_range(time);

--- a/Source/WebCore/Modules/mediasource/SampleMap.h
+++ b/Source/WebCore/Modules/mediasource/SampleMap.h
@@ -118,6 +118,7 @@ public:
     WEBCORE_EXPORT void clear();
     WEBCORE_EXPORT void addSample(Ref<MediaSample>&&);
     WEBCORE_EXPORT void removeSample(const MediaSample&);
+    WEBCORE_EXPORT void replaceSample(const MediaSample& original, Ref<MediaSample>&& replacement);
     size_t sizeInBytes() const { return m_totalSize; }
 
     template<typename I>

--- a/Source/WebCore/platform/MediaSample.h
+++ b/Source/WebCore/platform/MediaSample.h
@@ -100,6 +100,19 @@ public:
     }
     virtual Ref<MediaSample> createNonDisplayingCopy() const = 0;
 
+    // Return a new sample whose presentation time, decode time, and duration have been adjusted by
+    // shifting start forward by `offset` while keeping presentationEndTime() unchanged:
+    // pts' = pts + offset, dts' = dts + offset, duration' = duration - offset. `offset` is clamped
+    // to duration; if offset == duration the shifted copy has zero duration (callers should prefer
+    // removal in that case). Payload, format description, and attachments are copied unchanged.
+    // Callers use this instead of mutating an existing sample, which would alter an object
+    // already referenced by SampleMap keys / enqueued decoders.
+    virtual Ref<MediaSample> createCopyWithAdjustedStartTime(const MediaTime& /*offset*/) const
+    {
+        ASSERT_NOT_REACHED();
+        return const_cast<MediaSample&>(*this);
+    }
+
     enum SampleFlags {
         None = 0,
         IsSync = 1 << 0,

--- a/Source/WebCore/platform/graphics/SourceBufferPrivate.cpp
+++ b/Source/WebCore/platform/graphics/SourceBufferPrivate.cpp
@@ -967,6 +967,13 @@ void SourceBufferPrivate::didReceiveSample(Ref<MediaSample>&& sample)
     assertIsCurrent(m_dispatcher.get());
     DEBUG_LOG(LOGIDENTIFIER, sample.get());
 
+    // Only video tracks produce B-frame reordering (pts > dts); processMediaSample's isBFrame
+    // gate never fires for audio, so audio tails are not tracked.
+    if (!sample->presentationSize().isEmpty()) {
+        auto [entry, inserted] = m_presentationTailPerTrack.try_emplace(sample->trackID(), sample.ptr());
+        if (!inserted && sample->presentationEndTime() > protect(entry->second)->presentationEndTime())
+            entry->second = sample.ptr();
+    }
     m_pendingSamples.append(WTF::move(sample));
 }
 
@@ -1044,7 +1051,8 @@ void SourceBufferPrivate::processPendingMediaSamples()
     if (m_pendingSamples.isEmpty())
         return;
     auto samples = std::exchange(m_pendingSamples, { });
-    m_currentAppendProcessing = protect(m_currentAppendProcessing)->whenSettled(m_dispatcher, [weakThis = ThreadSafeWeakPtr { *this }, samples = WTF::move(samples), abortCount = m_abortCount.load()](auto result) mutable {
+    auto presentationTailPerTrack = std::exchange(m_presentationTailPerTrack, { });
+    m_currentAppendProcessing = protect(m_currentAppendProcessing)->whenSettled(m_dispatcher, [weakThis = ThreadSafeWeakPtr { *this }, samples = WTF::move(samples), presentationTailPerTrack = WTF::move(presentationTailPerTrack), abortCount = m_abortCount.load()](auto result) mutable {
         RefPtr protectedThis = weakThis.get();
         if (!protectedThis || !result)
             return MediaPromise::createAndReject(!result ? result.error() : PlatformMediaError::BufferRemoved);
@@ -1056,14 +1064,16 @@ void SourceBufferPrivate::processPendingMediaSamples()
             return MediaPromise::createAndReject(PlatformMediaError::BufferRemoved);
 
         for (auto& sample : samples) {
-            if (!protectedThis->processMediaSample(*client, WTF::move(sample)))
+            auto it = presentationTailPerTrack.find(sample->trackID());
+            bool isPresentationTail = it != presentationTailPerTrack.end() && sample.ptr() == it->second;
+            if (!protectedThis->processMediaSample(*client, WTF::move(sample), isPresentationTail))
                 return MediaPromise::createAndReject(PlatformMediaError::ParsingError);
         }
         return MediaPromise::createAndResolve();
     });
 }
 
-bool SourceBufferPrivate::processMediaSample(SourceBufferPrivateClient& client, Ref<MediaSample>&& sample)
+bool SourceBufferPrivate::processMediaSample(SourceBufferPrivateClient& client, Ref<MediaSample>&& sample, bool isPresentationTail)
 {
     assertIsCurrent(m_dispatcher.get());
 
@@ -1399,6 +1409,38 @@ bool SourceBufferPrivate::processMediaSample(SourceBufferPrivateClient& client, 
                 MediaTime highestBufferedTime = trackBuffer.maximumBufferedTime();
                 MediaTime eraseBeginTime = trackBuffer.highestPresentationTimestamp();
                 MediaTime eraseEndTime = frameEndTimestamp - contiguousFrameTolerance;
+
+                // If the incoming sample is the **presentation tail for this track** AND a
+                // reordered frame (B-frame: pts > dts), its declared frame_end may be a trun
+                // decode-to-next-decode placeholder that overshoots the next buffered sample's
+                // pts by a small margin. Taken at face value, step 1.14 treats the overshoot as
+                // a real overlap and removes the overlapped frame, leaving a gap in the buffered
+                // range that stalls playback. If the overshoot is less than timeFudgeFactor,
+                // attribute it to the trun placeholder rather than a genuine overlap and shift
+                // the overlapped frame forward by the overshoot: pts and dts shift equally,
+                // duration shrinks, presentationEndTime is preserved. Any larger overshoot is
+                // treated as a real overlap and left to the default path.
+                bool isBFrame = sample->presentationTime() > sample->decodeTime();
+                if (isPresentationTail && isBFrame) {
+                    MediaTime fudge = PlatformTimeRanges::timeFudgeFactor();
+                    if (frameEndTimestamp > fudge) {
+                        auto it = trackBuffer.samples().presentationOrder().findSampleStartingOnOrAfterPresentationTime(frameEndTimestamp - fudge);
+                        auto presentationEnd = trackBuffer.samples().presentationOrder().end();
+                        for (; it != presentationEnd && it->first < frameEndTimestamp; ++it) {
+                            if (it->first <= presentationTimestamp)
+                                continue;
+                            // Overlapped frame: pts ∈ (presentationTimestamp, frameEndTimestamp)
+                            // and within timeFudgeFactor of frame_end. If fully inside the erase
+                            // range, leave it to the default removal. Otherwise shift forward.
+                            Ref original = it->second;
+                            if (original->presentationEndTime() <= frameEndTimestamp)
+                                break;
+                            MediaTime offset = frameEndTimestamp - original->presentationTime();
+                            trackBuffer.adjustSampleStartTime(original.get(), offset);
+                            break;
+                        }
+                    }
+                }
 
                 if (eraseEndTime <= eraseBeginTime)
                     break;

--- a/Source/WebCore/platform/graphics/SourceBufferPrivate.h
+++ b/Source/WebCore/platform/graphics/SourceBufferPrivate.h
@@ -266,7 +266,7 @@ private:
     std::atomic<size_t> m_abortCount { 0 };
 
     void processPendingMediaSamples();
-    bool processMediaSample(SourceBufferPrivateClient&, Ref<MediaSample>&&);
+    bool processMediaSample(SourceBufferPrivateClient&, Ref<MediaSample>&&, bool isPresentationTail);
 
     enum class ComputeEvictionDataRule {
         Default,
@@ -276,6 +276,11 @@ private:
 
     using SamplesVector = Vector<Ref<MediaSample>>;
     SamplesVector m_pendingSamples WTF_GUARDED_BY_CAPABILITY(m_dispatcher.get());
+    // Per video track, the pending sample with the highest presentationEndTime. Maintained
+    // incrementally in didReceiveSample and drained in lockstep with m_pendingSamples so
+    // processPendingMediaSamples does not need to rescan the batch. Raw pointers are valid
+    // while the owning Ref lives in m_pendingSamples.
+    StdUnorderedMap<TrackID, MediaSample*> m_presentationTailPerTrack WTF_GUARDED_BY_CAPABILITY(m_dispatcher.get());
     Ref<MediaPromise> m_currentAppendProcessing WTF_GUARDED_BY_CAPABILITY(m_dispatcher.get()) { MediaPromise::createAndResolve() };
 
     MediaTime m_appendWindowStart WTF_GUARDED_BY_LOCK(m_lock) { MediaTime::zeroTime() };

--- a/Source/WebCore/platform/graphics/TrackBuffer.cpp
+++ b/Source/WebCore/platform/graphics/TrackBuffer.cpp
@@ -84,6 +84,43 @@ void TrackBuffer::addBufferedRange(const MediaTime& start, const MediaTime& end,
     m_buffered.add(start, end, addTimeRangeOption);
 }
 
+void TrackBuffer::adjustSampleStartTime(MediaSample& original, const MediaTime& offset)
+{
+    // Replace an already-buffered sample with a copy whose presentation and
+    // decode timestamps are shifted forward by `offset` (duration shrinks
+    // correspondingly; presentationEndTime is preserved; payload is unchanged).
+    //
+    // Both the SampleMap and m_decodeQueue need to be kept consistent: later
+    // removals look samples up by their current decode key, and leaving the
+    // pre-adjustment entry in the queue would orphan it.
+    Ref replacement = original.createCopyWithAdjustedStartTime(offset);
+
+    MediaTime originalStart = original.presentationTime();
+    MediaTime originalEnd = original.presentationEndTime();
+    DecodeOrderSampleMap::KeyType originalDecodeKey(original.decodeTime(), original.presentationTime());
+
+    MediaTime replacementStart = replacement->presentationTime();
+    MediaTime replacementEnd = replacement->presentationEndTime();
+    DecodeOrderSampleMap::KeyType replacementDecodeKey(replacement->decodeTime(), replacementStart);
+
+    PlatformTimeRanges invertedRange(originalStart, originalEnd);
+    invertedRange.invert();
+    m_buffered.intersectWith(invertedRange);
+
+    m_samples.replaceSample(original, replacement.copyRef());
+
+    addBufferedRange(replacementStart, replacementEnd, AddTimeRangeOption::EliminateSmallGaps);
+
+    // Since `offset` moves the key forward by at most timeFudgeFactor (much
+    // smaller than the typical inter-sample DTS gap), the iterator returned by
+    // erase() is a valid insertion-point hint for the adjusted entry.
+    auto queueIt = m_decodeQueue.find(originalDecodeKey);
+    if (queueIt != m_decodeQueue.end()) {
+        auto hint = m_decodeQueue.erase(queueIt);
+        m_decodeQueue.insert(hint, { replacementDecodeKey, WTF::move(replacement) });
+    }
+}
+
 void TrackBuffer::addSample(MediaSample& sample)
 {
     m_samples.addSample(sample);

--- a/Source/WebCore/platform/graphics/TrackBuffer.h
+++ b/Source/WebCore/platform/graphics/TrackBuffer.h
@@ -52,6 +52,11 @@ public:
     MediaTime NODELETE maximumBufferedTime() const;
     void addBufferedRange(const MediaTime& start, const MediaTime& end, AddTimeRangeOption = AddTimeRangeOption::None);
     void addSample(MediaSample&);
+    // Replace an already-buffered sample with a copy whose presentation and
+    // decode timestamps are shifted forward by `offset` (duration shrinks
+    // accordingly; presentationEndTime is preserved). Updates both the
+    // SampleMap and m_decodeQueue, and adjusts m_buffered to match.
+    void adjustSampleStartTime(MediaSample& original, const MediaTime& offset);
 
     bool reenqueueMediaForTime(const MediaTime&, const MediaTime& timeFudgeFactor, bool isEnded = false);
     MediaTime findSeekTimeForTargetTime(const MediaTime& targetTime, const MediaTime& negativeThreshold, const MediaTime& positiveThreshold);

--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaSampleAVFObjC.h
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaSampleAVFObjC.h
@@ -66,6 +66,7 @@ public:
 
     WEBCORE_EXPORT std::pair<RefPtr<MediaSample>, RefPtr<MediaSample>> divide(const MediaTime& presentationTime, UseEndTime) override;
     WEBCORE_EXPORT Ref<MediaSample> createNonDisplayingCopy() const override;
+    Ref<MediaSample> createCopyWithAdjustedStartTime(const MediaTime& offset) const override;
 
     CMSampleBufferRef sampleBuffer() const { return m_sample.get(); }
 

--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaSampleAVFObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaSampleAVFObjC.mm
@@ -300,6 +300,41 @@ std::pair<RefPtr<MediaSample>, RefPtr<MediaSample>> MediaSampleAVFObjC::divide(c
     return { MediaSampleAVFObjC::create(sampleBefore.get(), m_id), MediaSampleAVFObjC::create(sampleAfter.get(), m_id) };
 }
 
+Ref<MediaSample> MediaSampleAVFObjC::createCopyWithAdjustedStartTime(const MediaTime& offset) const
+{
+    MediaTime clampedOffset = std::max(MediaTime::zeroTime(), std::min(offset, duration()));
+
+    CMItemCount itemCount = 0;
+    if (noErr != PAL::CMSampleBufferGetSampleTimingInfoArray(m_sample.get(), 0, nullptr, &itemCount))
+        return const_cast<MediaSampleAVFObjC&>(*this);
+
+    Vector<CMSampleTimingInfo> timingInfoArray;
+    timingInfoArray.grow(itemCount);
+    if (noErr != PAL::CMSampleBufferGetSampleTimingInfoArray(m_sample.get(), itemCount, timingInfoArray.mutableSpan().data(), nullptr))
+        return const_cast<MediaSampleAVFObjC&>(*this);
+
+    CMTime cmOffset = PAL::toCMTime(clampedOffset);
+
+    for (auto& timing : timingInfoArray) {
+        if (!CMTIME_IS_INVALID(timing.presentationTimeStamp))
+            timing.presentationTimeStamp = PAL::CMTimeAdd(timing.presentationTimeStamp, cmOffset);
+        if (!CMTIME_IS_INVALID(timing.decodeTimeStamp))
+            timing.decodeTimeStamp = PAL::CMTimeAdd(timing.decodeTimeStamp, cmOffset);
+        if (!CMTIME_IS_INVALID(timing.duration)) {
+            CMTime newDuration = PAL::CMTimeSubtract(timing.duration, cmOffset);
+            if (PAL::CMTimeCompare(newDuration, PAL::kCMTimeZero) < 0)
+                newDuration = PAL::kCMTimeZero;
+            timing.duration = newDuration;
+        }
+    }
+
+    CMSampleBufferRef newSampleBuffer = nullptr;
+    if (noErr != PAL::CMSampleBufferCreateCopyWithNewTiming(kCFAllocatorDefault, m_sample.get(), itemCount, timingInfoArray.span().data(), &newSampleBuffer) || !newSampleBuffer)
+        return const_cast<MediaSampleAVFObjC&>(*this);
+
+    return MediaSampleAVFObjC::create(adoptCF(newSampleBuffer).get(), m_id);
+}
+
 Ref<MediaSample> MediaSampleAVFObjC::createNonDisplayingCopy() const
 {
     CMSampleBufferRef newSampleBuffer = 0;

--- a/Source/WebCore/platform/graphics/gstreamer/MediaSampleGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/MediaSampleGStreamer.cpp
@@ -199,6 +199,35 @@ Ref<MediaSample> MediaSampleGStreamer::createNonDisplayingCopy() const
     return adoptRef(*new MediaSampleGStreamer(WTF::move(sample), m_presentationSize, m_trackId));
 }
 
+Ref<MediaSample> MediaSampleGStreamer::createCopyWithAdjustedStartTime(const MediaTime& offset) const
+{
+    MediaTime clampedOffset = std::max(MediaTime::zeroTime(), std::min(offset, m_duration));
+
+    MediaTime newPresentationTime = m_pts + clampedOffset;
+    MediaTime newDecodeTime = m_dts + clampedOffset;
+    MediaTime adjustedDuration = m_duration - clampedOffset;
+
+    if (!m_sample)
+        return createFakeSample(nullptr, newPresentationTime, newDecodeTime, adjustedDuration, m_presentationSize, m_trackId);
+
+    GRefPtr<GstSample> newSample = adoptGRef(gst_sample_copy(m_sample.get()));
+
+    GRefPtr buffer = gst_sample_get_buffer(newSample.get());
+    if (!buffer) [[unlikely]]
+        return createFakeSample(nullptr, newPresentationTime, newDecodeTime, adjustedDuration, m_presentationSize, m_trackId);
+
+    auto newBuffer = adoptGRef(gst_buffer_make_writable(buffer.leakRef()));
+    GST_BUFFER_PTS(newBuffer.get()) = toGstClockTime(newPresentationTime);
+    GST_BUFFER_DTS(newBuffer.get()) = toGstClockTime(newDecodeTime);
+    GST_BUFFER_DURATION(newBuffer.get()) = toGstClockTime(adjustedDuration);
+    newSample = adoptGRef(gst_sample_make_writable(newSample.leakRef()));
+    gst_sample_set_buffer(newSample.get(), newBuffer.get());
+
+    Ref copy = adoptRef(*new MediaSampleGStreamer(WTF::move(newSample), m_presentationSize, m_trackId));
+    copy->m_flags = m_flags;
+    return copy;
+}
+
 void MediaSampleGStreamer::dump(PrintStream& out) const
 {
     out.print("{PTS(", presentationTime(), "), DTS(", decodeTime(), "), duration(", duration(), "), flags(");

--- a/Source/WebCore/platform/graphics/gstreamer/MediaSampleGStreamer.h
+++ b/Source/WebCore/platform/graphics/gstreamer/MediaSampleGStreamer.h
@@ -49,6 +49,7 @@ public:
     void offsetTimestampsBy(const MediaTime&) override;
     void setTimestamps(const MediaTime&, const MediaTime&) override;
     Ref<MediaSample> createNonDisplayingCopy() const override;
+    Ref<MediaSample> createCopyWithAdjustedStartTime(const MediaTime& offset) const override;
     SampleFlags flags() const override { return m_flags; }
     PlatformSample platformSample() const override;
     Type type() const override { return Type::GStreamerSample; }

--- a/Source/WebCore/platform/mock/mediasource/MockBox.h
+++ b/Source/WebCore/platform/mock/mediasource/MockBox.h
@@ -140,6 +140,7 @@ public:
         m_presentationTimestamp = presentationTimestamp;
         m_decodeTimestamp = decodeTimestamp;
     }
+    void setDuration(const MediaTime& duration) { m_duration = duration; }
 
     void clearFlag(uint8_t flag) { m_flags &= ~flag; }
     void setFlag(uint8_t flag) { m_flags |= flag; }

--- a/Source/WebCore/platform/mock/mediasource/MockSourceBufferPrivate.cpp
+++ b/Source/WebCore/platform/mock/mediasource/MockSourceBufferPrivate.cpp
@@ -69,6 +69,7 @@ private:
     void offsetTimestampsBy(const MediaTime& offset) override { m_box.offsetTimestampsBy(offset); }
     void setTimestamps(const MediaTime& presentationTimestamp, const MediaTime& decodeTimestamp) override { m_box.setTimestamps(presentationTimestamp, decodeTimestamp); }
     Ref<MediaSample> createNonDisplayingCopy() const override;
+    Ref<MediaSample> createCopyWithAdjustedStartTime(const MediaTime& offset) const override;
 
     unsigned NODELETE generation() const { return m_box.generation(); }
 
@@ -100,6 +101,16 @@ Ref<MediaSample> MockMediaSample::createNonDisplayingCopy() const
 {
     auto copy = MockMediaSample::create(m_box);
     copy->m_box.setFlag(MockSampleBox::IsNonDisplaying);
+    return copy;
+}
+
+Ref<MediaSample> MockMediaSample::createCopyWithAdjustedStartTime(const MediaTime& offset) const
+{
+    MediaTime clampedOffset = std::max(MediaTime::zeroTime(), std::min(offset, m_box.duration()));
+
+    auto copy = MockMediaSample::create(m_box);
+    copy->m_box.setTimestamps(m_box.presentationTimestamp() + clampedOffset, m_box.decodeTimestamp() + clampedOffset);
+    copy->m_box.setDuration(m_box.duration() - clampedOffset);
     return copy;
 }
 


### PR DESCRIPTION
#### 93e7a14ff5bc2aad775dd5b2d53cc67499adac10
<pre>
Twitch.tv may stall at ad transition during live streaming.
<a href="https://bugs.webkit.org/show_bug.cgi?id=314306">https://bugs.webkit.org/show_bug.cgi?id=314306</a>
<a href="https://rdar.apple.com/176446372">rdar://176446372</a>

Reviewed by Jer Noble

Avoid buffered-range gap when a reordered B-frame tail slightly overshoots
the next buffered sample

To play an ad, Twitch will insert video content over an existing MediaSource.
The last video frame&apos;s timestamp of the ad is then adjusted to provide
continuous playback with the live content.

At the tail of such fMP4 stream, sometimes the last frame to be visible is
a b-frame (pts &gt; dts); the trun.sample_duration of this last-in-
presentation-order sample is a decode-to-next-decode placeholder rather
than a real presentation duration as there&apos;s no sample to present after.
The sample declared frame_end (pts + duration) can overshoot the
next buffered sample&apos;s pts by a few milliseconds — not a true overlap,
just a carryover from the decode grid.

Taken at face value, MSE &quot;Coded Frame Processing&quot; step 1.14 treats the
overshoot as a real overlap and removes the overlapped frame, and step
1.15 extends that removal in dts order up to the next sync sample. The
result is a gap in the buffered range that stalls playback. Observed
repeatedly at Twitch content-to-ad splice boundaries on Safari and
Firefox (Chrome tolerates the overshoot so does not stall).

Fix: if the per-track presentation tail is a B-frame and its overshoot
of the next buffered sample&apos;s pts is less than timeFudgeFactor(), treat
the overshoot as placeholder noise and shift the overlapped sample
forward by the overshoot — pts and dts shift equally, duration shrinks,
presentationEndTime is preserved. Larger overshoots are kept on the
default path.

Implementation:

- Add MediaSample::createCopyWithAdjustedStartTime(const MediaTime&amp; offset):
new virtual producing an immutable copy with pts/dts shifted forward
by `offset` (clamped to duration) and duration correspondingly
shrunk. Overridden in MediaSampleAVFObjC (via
CMSampleBufferCreateCopyWithNewTiming, applying the offset to each
sub-sample&apos;s timing so multi-sample buffers are preserved),
MediaSampleGStreamer (via gst_buffer_copy + timestamp update on the
copy to avoid corrupting the original&apos;s shared GstBuffer), and
MockMediaSample.

- Add TrackBuffer::adjustSampleStartTime(original, offset): creates the
adjusted copy via createCopyWithAdjustedStartTime, subtracts the
original&apos;s [pts, presentationEndTime) from m_buffered, swaps the
sample in the SampleMap and m_decodeQueue (if present), and re-adds
the adjusted range. Keeping m_decodeQueue in sync with the SampleMap
is required so a subsequent step-1.14/1.15 removeSamples cascade —
which erases m_decodeQueue by the current decode key — matches the
adjusted entry rather than leaving the pre-adjustment key behind as
an orphan.

- Add SampleMap::replaceSample: swap an already-buffered sample for an
adjusted copy carrying nearly-identical keys. Uses erase() + insert
with the erase-return iterator as the insertion hint in both the
presentation-order and decode-order submaps, keeping the operation
to two map ops rather than two full find+erase+insert cycles.

- In SourceBufferPrivate::processPendingMediaSamples, compute the
per-track presentation tail (sample with the highest
presentationEndTime in each track) and pass isPresentationTail to
processMediaSample. Per-track keying is required: an audio sample&apos;s
presentationEndTime often exceeds the last video sample&apos;s, and a
global-max tail would deny the video tail its shift-eligibility.

- In processMediaSample, inside the step-1.14 overlap handling: if
the incoming sample is isPresentationTail and reordered (pts &gt; dts),
search the buffered samples whose pts lies in (presentationTimestamp,
frameEndTimestamp) and within timeFudgeFactor of frameEndTimestamp;
if one is found and is not fully overwritten by the incoming frame,
shift it forward via TrackBuffer::adjustSampleStartTime. Fully-
overwritten samples are left to the default 1.14 removal.

Test: media/media-source/media-source-append-b-frame-tail-overshoot.html

* LayoutTests/media/media-source/media-source-append-b-frame-tail-overshoot-expected.txt: Added.
* LayoutTests/media/media-source/media-source-append-b-frame-tail-overshoot.html: Added.

Canonical link: <a href="https://commits.webkit.org/313253@main">https://commits.webkit.org/313253@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/542511cd99438307cac2a74eadec450721fae74a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/162569 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/36045 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/29176 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/171507 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/119014 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/164438 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/36149 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/36049 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/126162 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/119014 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/165528 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/28519 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/146055 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/106740 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/f5cc4b05-61df-401a-90e3-7687011a28cc) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/27565 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/26091 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/19207 "Built successfully") | | 
| [⏳ 🛠 🧪 jsc ](https://ews-build.webkit.org/#/builders/JSC-Tests-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/137269 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/23785 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/174011 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/21324 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/25430 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/134471 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/35719 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/30184 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/134469 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36284 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/35703 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/145581 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/98033 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/29012 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/22415 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/35213 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/102964 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/34714 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/34959 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/34862 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->