### PR TITLE
Regression(312195@main): Crash in SWRegistrationDatabase when importing registrations for an origin with no records

### DIFF
--- a/Source/WebCore/workers/service/server/SWRegistrationDatabase.cpp
+++ b/Source/WebCore/workers/service/server/SWRegistrationDatabase.cpp
@@ -373,6 +373,18 @@ std::optional<Vector<ServiceWorkerContextData>> SWRegistrationDatabase::importRe
 
 std::optional<Vector<ServiceWorkerContextData>> SWRegistrationDatabase::importRegistrations(const SecurityOriginData& topOrigin)
 {
+    auto result = importRegistrationsImpl(topOrigin);
+    if (result && result->isEmpty() && m_database) {
+        // No registrations for this origin; clean up the database file if it has no records for any origin.
+        if (auto count = recordsCount(); count && !count.value())
+            deleteAllFiles();
+    }
+
+    return result;
+}
+
+std::optional<Vector<ServiceWorkerContextData>> SWRegistrationDatabase::importRegistrationsImpl(const SecurityOriginData& topOrigin)
+{
     if (!prepareDatabase(ShouldCreateIfNotExists::No))
         return std::nullopt;
 
@@ -393,14 +405,7 @@ std::optional<Vector<ServiceWorkerContextData>> SWRegistrationDatabase::importRe
         return std::nullopt;
     }
 
-    auto result = collectRegistrationsFromStatement(*statement);
-    if (result.isEmpty()) {
-        // No registrations for this origin; clean up the database file if it has no records for any origin.
-        if (auto count = recordsCount(); count && !count.value())
-            deleteAllFiles();
-    }
-
-    return result;
+    return collectRegistrationsFromStatement(*statement);
 }
 
 Vector<ServiceWorkerContextData> SWRegistrationDatabase::collectRegistrationsFromStatement(SQLiteStatement& statement)
@@ -522,6 +527,17 @@ Vector<ServiceWorkerContextData> SWRegistrationDatabase::collectRegistrationsFro
 
 std::optional<HashSet<ClientOrigin>> SWRegistrationDatabase::importOrigins()
 {
+    auto result = importOriginsImpl();
+
+    // Clean up the database file if it exists but contains no registrations.
+    if (result && result->isEmpty() && m_database)
+        deleteAllFiles();
+
+    return result;
+}
+
+std::optional<HashSet<ClientOrigin>> SWRegistrationDatabase::importOriginsImpl()
+{
     if (!prepareDatabase(ShouldCreateIfNotExists::No))
         return std::nullopt;
 
@@ -549,10 +565,6 @@ std::optional<HashSet<ClientOrigin>> SWRegistrationDatabase::importOrigins()
 
     if (result != SQLITE_DONE)
         RELEASE_LOG_ERROR(Storage, "SWRegistrationDatabase::importOrigins failed on executing statement (%d) - %s", m_database->lastError(), m_database->lastErrorMsg());
-
-    // Clean up the database file if it exists but contains no registrations.
-    if (origins.isEmpty())
-        deleteAllFiles();
 
     return origins;
 }

--- a/Source/WebCore/workers/service/server/SWRegistrationDatabase.h
+++ b/Source/WebCore/workers/service/server/SWRegistrationDatabase.h
@@ -78,6 +78,8 @@ private:
     bool ensureValidRecordsTable();
     std::optional<uint64_t> recordsCount();
     std::optional<Vector<ServiceWorkerContextData>> importRegistrationsImpl();
+    std::optional<Vector<ServiceWorkerContextData>> importRegistrationsImpl(const SecurityOriginData& topOrigin);
+    std::optional<HashSet<ClientOrigin>> importOriginsImpl();
     Vector<ServiceWorkerContextData> collectRegistrationsFromStatement(SQLiteStatement&);
     std::optional<Vector<ServiceWorkerScripts>> updateRegistrationsImpl(const Vector<ServiceWorkerContextData>&, const Vector<ServiceWorkerRegistrationKey>&);
 

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ServiceWorkerBasic.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ServiceWorkerBasic.mm
@@ -757,6 +757,96 @@ TEST(ServiceWorkers, RestoreFromDisk)
     done = false;
 }
 
+#if PLATFORM(MAC)
+// Regression test for a NetworkProcess crash in SWRegistrationDatabase when the per-origin
+// SW registration database file exists on disk but its Records table is empty. The buggy
+// code called deleteAllFiles() while a SQLiteStatementAutoResetScope / CheckedPtr<SQLiteStatement>
+// was still live on the stack, leaving the cached statement as a zombie and crashing the
+// process with a PAC IB trap when the scope destructor ran on function return.
+TEST(ServiceWorkers, ImportRegistrationsForOriginWithEmptyDatabase)
+{
+    [WKWebsiteDataStore _allowWebsiteDataRecordsForAllOrigins];
+
+    NSURL *generalStorageDirectory = [NSURL fileURLWithPath:[@"~/Library/WebKit/com.apple.WebKit.TestWebKitAPI/ImportRegistrationsWithEmptyDB" stringByExpandingTildeInPath] isDirectory:YES];
+    NSFileManager *fileManager = [NSFileManager defaultManager];
+    [fileManager removeItemAtURL:generalStorageDirectory error:nil];
+
+    TestWebKitAPI::HTTPServer server({
+        { "/first.html"_s, { mainRegisteringWorkerBytes } },
+        { "/sw.js"_s, { { { "Content-Type"_s, "application/javascript"_s } }, scriptBytes } },
+    });
+
+    // Phase 1: register a service worker so the per-origin registration database is written to disk.
+    @autoreleasepool {
+        RetainPtr dataStoreConfiguration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] init]);
+        dataStoreConfiguration.get().generalStorageDirectory = generalStorageDirectory;
+        RetainPtr dataStore = adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:dataStoreConfiguration.get()]);
+        [dataStore _setResourceLoadStatisticsEnabled:NO];
+
+        RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+        configuration.get().websiteDataStore = dataStore.get();
+        RetainPtr<SWMessageHandlerForRestoreFromDiskTest> messageHandler = adoptNS([[SWMessageHandlerForRestoreFromDiskTest alloc] initWithExpectedMessage:@"PASS: Registration was successful and service worker was activated"]);
+        [[configuration userContentController] addScriptMessageHandler:messageHandler.get() name:@"sw"];
+
+        RetainPtr<WKWebView> webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+        done = false;
+        [webView loadRequest:server.request("/first.html"_s)];
+        TestWebKitAPI::Util::run(&done);
+
+        // Give the service worker a moment to be persisted before terminating the network process.
+        TestWebKitAPI::Util::runFor(0.25_s);
+
+        [webView _close];
+        [dataStore _terminateNetworkProcess];
+    }
+    TestWebKitAPI::Util::runFor(0.25_s);
+
+    // Locate the SW registration database file.
+    RetainPtr<NSURL> dbFileURL;
+    NSDirectoryEnumerator *enumerator = [fileManager enumeratorAtURL:generalStorageDirectory includingPropertiesForKeys:nil options:0 errorHandler:nil];
+    for (NSURL *url in enumerator) {
+        if ([url.lastPathComponent isEqualToString:serviceWorkerRegistrationFilename]) {
+            dbFileURL = url;
+            break;
+        }
+    }
+    ASSERT_TRUE(!!dbFileURL);
+
+    // Empty the Records table, leaving a valid but record-less database file on disk.
+    // This mimics the state the crashing device ended up in and exercises the
+    // `result.isEmpty() && recordsCount() == 0 -> deleteAllFiles()` path.
+    RetainPtr task = adoptNS([[NSTask alloc] init]);
+    task.get().launchPath = @"/usr/bin/sqlite3";
+    task.get().arguments = @[dbFileURL.get().path, @"DELETE FROM Records;"];
+    [task.get() launch];
+    [task.get() waitUntilExit];
+    EXPECT_EQ([task.get() terminationStatus], 0);
+    // Also clean up any WAL sidecars so sqlite re-reads from the main file.
+    [fileManager removeItemAtURL:[dbFileURL.get() URLByAppendingPathExtension:@"-wal"] error:nil];
+    [fileManager removeItemAtURL:[dbFileURL.get() URLByAppendingPathExtension:@"-shm"] error:nil];
+
+    // Phase 2: reopen the data store and navigate to the same origin. SWServer start-up runs
+    // importOrigins() on the empty DB, and the subsequent navigation runs
+    // importRegistrations(topOrigin) on it. Both paths used to crash.
+    @autoreleasepool {
+        RetainPtr dataStoreConfiguration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] init]);
+        dataStoreConfiguration.get().generalStorageDirectory = generalStorageDirectory;
+        RetainPtr dataStore = adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:dataStoreConfiguration.get()]);
+        [dataStore _setResourceLoadStatisticsEnabled:NO];
+
+        RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+        configuration.get().websiteDataStore = dataStore.get();
+        RetainPtr<SWMessageHandlerForRestoreFromDiskTest> messageHandler = adoptNS([[SWMessageHandlerForRestoreFromDiskTest alloc] initWithExpectedMessage:@"PASS: Registration was successful and service worker was activated"]);
+        [[configuration userContentController] addScriptMessageHandler:messageHandler.get() name:@"sw"];
+
+        RetainPtr<WKWebView> webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+        done = false;
+        [webView loadRequest:server.request("/first.html"_s)];
+        TestWebKitAPI::Util::run(&done);
+    }
+}
+#endif // PLATFORM(MAC)
+
 // This test verifies that the lazy script loading path in SWServerJobQueue::scriptFetchFinished()
 // works correctly. When service worker registrations are restored from disk, scripts are not loaded
 // during import. When an update check triggers scriptFetchFinished(), the existing worker's scripts

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WebsiteDataStoreCustomPaths.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WebsiteDataStoreCustomPaths.mm
@@ -1891,30 +1891,34 @@ TEST(WKWebsiteDataStore, DeleteEmptyServiceWorkerDirectory)
     websiteDataStoreConfiguration.get().generalStorageDirectory = generalStorageDirectory.get();
     RetainPtr websiteDataStore = adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:websiteDataStoreConfiguration.get()]);
 
-    // Navigate to the origin whose empty database is on disk. This triggers the lazy per-origin
-    // import, which opens the database, finds it empty, and deletes the files. The navigation
-    // itself may fail (no internet) but the import is triggered regardless.
+    // Start a navigation to the origin whose empty database is on disk. This triggers the lazy
+    // per-origin import on the network process, which opens the database, finds it empty, and
+    // deletes the files. We don't wait for the navigation to finish — webkit.org is a real URL
+    // and the load would hang in offline test environments.
     RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     [configuration setWebsiteDataStore:websiteDataStore.get()];
     RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
-    RetainPtr navigationDelegate = adoptNS([[TestNavigationDelegate alloc] init]);
-    [navigationDelegate setDidFinishNavigation:^(WKWebView *, WKNavigation *) { done = true; }];
-    [navigationDelegate setDidFailProvisionalNavigation:^(WKWebView *, WKNavigation *, NSError *) { done = true; }];
-    [webView setNavigationDelegate:navigationDelegate.get()];
-    done = false;
     [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://webkit.org/"]]];
-    TestWebKitAPI::Util::run(&done);
 
-    // Verify record does not exist with empty database.
+    // Poll until the per-origin import has deleted the empty database and the record count
+    // drops to 0. The import runs asynchronously on the network process' work queue.
     __block RetainPtr<NSArray<WKWebsiteDataRecord *>> records;
     RetainPtr dataTypes = [NSSet setWithObjects:WKWebsiteDataTypeServiceWorkerRegistrations, nil];
-    done = false;
-    [websiteDataStore fetchDataRecordsOfTypes:dataTypes.get() completionHandler:^(NSArray<WKWebsiteDataRecord *> * dataRecords) {
-        records = dataRecords;
-        done = true;
-    }];
-    TestWebKitAPI::Util::run(&done);
-    EXPECT_EQ([records count], 0u);
+    bool reachedZero = false;
+    for (size_t tries = 0; tries < 100; ++tries) {
+        done = false;
+        [websiteDataStore fetchDataRecordsOfTypes:dataTypes.get() completionHandler:^(NSArray<WKWebsiteDataRecord *> * dataRecords) {
+            records = dataRecords;
+            done = true;
+        }];
+        TestWebKitAPI::Util::run(&done);
+        if ([records count] == 0u) {
+            reachedZero = true;
+            break;
+        }
+        TestWebKitAPI::Util::runFor(0.1_s);
+    }
+    EXPECT_TRUE(reachedZero);
 
     // Verify directory is deleted.
     EXPECT_FALSE([fileManager fileExistsAtPath:[serviceWorkerDirectory path]]);


### PR DESCRIPTION
#### 875cda03e034e9a14cd8e43265db5245ea0201d3
<pre>
Regression(312195@main): Crash in SWRegistrationDatabase when importing registrations for an origin with no records
<a href="https://bugs.webkit.org/show_bug.cgi?id=314307">https://bugs.webkit.org/show_bug.cgi?id=314307</a>
<a href="https://rdar.apple.com/176098012">rdar://176098012</a>

Reviewed by Youenn Fablet.

312195@main introduced per-origin lazy import of service worker registrations, adding
SWRegistrationDatabase::importRegistrations(const SecurityOriginData&amp;). When the per-origin
query returned no rows, the function called deleteAllFiles() while the
SQLiteStatementAutoResetScope returned by cachedStatement() and its associated
CheckedPtr&lt;SQLiteStatement&gt; were still live on the stack. deleteAllFiles() calls close(),
which destroys the SQLiteStatement cached in m_cachedStatements. Because outstanding
CheckedPtrs exist, WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR zeros the object rather than freeing
it, but the local SQLiteStatementAutoResetScope destructor still runs reset() on the zombie
SQLiteStatement on return, which ends up calling sqlite3_reset() with a zeroed sqlite3_stmt*
and crashes inside sqlite with a PAC authentication failure.

importOrigins() had the same shape bug: deleteAllFiles() was called at the bottom of the
function while sqlStatement/statement were still in scope.

Fix by following the existing pattern used by importRegistrations() / updateRegistrations():
move the SQL work into an importRegistrationsImpl(topOrigin) / importOriginsImpl() helper
so the statement scopes are destroyed before the empty-database cleanup runs.

TEST: ServiceWorkers.ImportRegistrationsForOriginWithEmptyDatabase

* Source/WebCore/workers/service/server/SWRegistrationDatabase.cpp:
(WebCore::SWRegistrationDatabase::importRegistrations): Now a thin wrapper around
importRegistrationsImpl(topOrigin) that performs the recordsCount() + deleteAllFiles()
cleanup after the inner statement scope has been destroyed.

(WebCore::SWRegistrationDatabase::importRegistrationsImpl): New helper containing the SQL
work previously inline in importRegistrations(topOrigin).

(WebCore::SWRegistrationDatabase::importOrigins): Now a thin wrapper around
importOriginsImpl() that performs the empty-database cleanup after the inner statement
scope has been destroyed.

(WebCore::SWRegistrationDatabase::importOriginsImpl): New helper containing the SQL work
previously inline in importOrigins().

* Source/WebCore/workers/service/server/SWRegistrationDatabase.h:

Canonical link: <a href="https://commits.webkit.org/312873@main">https://commits.webkit.org/312873@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ccda1eb559f5be8dc5def2debba2aa7de95569e7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/161301 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/34774 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/27875 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/170204 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/117672 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/163170 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/34875 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/34775 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/125118 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/117672 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/164260 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/27407 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/144927 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/105715 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/26455 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/24963 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/17924 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/136149 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/22645 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/172687 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/19708 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/24286 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/133400 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/34448 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/29056 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/133408 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36039 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/34433 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/144440 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/96298 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/27945 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/21258 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/33943 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/101368 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/33442 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/33686 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/33591 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->