### PR TITLE
Refactor AudioSampleBufferConverter so that it takes a Function as input

### DIFF
--- a/Source/WebCore/platform/audio/cocoa/AudioDecoderCocoa.cpp
+++ b/Source/WebCore/platform/audio/cocoa/AudioDecoderCocoa.cpp
@@ -84,7 +84,6 @@ private:
     InternalAudioDecoderCocoa(AudioDecoder::OutputCallback&&);
 
     static WorkQueue& queueSingleton() { return AudioDecoderCocoa::queueSingleton(); }
-    static void decompressedAudioOutputBufferCallback(void*, CMBufferQueueTriggerToken);
     Ref<AudioSampleBufferConverter> converter() const
     {
         assertIsCurrent(queueSingleton());
@@ -218,17 +217,6 @@ void AudioDecoderCocoa::close()
     });
 }
 
-void InternalAudioDecoderCocoa::decompressedAudioOutputBufferCallback(void* object, CMBufferQueueTriggerToken)
-{
-    // We can only be called from the CoreMedia callback if we are still alive.
-    RefPtr decoder = static_cast<class InternalAudioDecoderCocoa*>(object);
-
-    queueSingleton().dispatch([weakDecoder = ThreadSafeWeakPtr { *decoder }] {
-        if (RefPtr protectedDecoder = weakDecoder.get())
-            protectedDecoder->processedDecodedOutputs();
-    });
-}
-
 void InternalAudioDecoderCocoa::processedDecodedOutputs()
 {
     assertIsCurrent(queueSingleton());
@@ -314,7 +302,12 @@ String InternalAudioDecoderCocoa::initialize(const String& codecName, const Audi
         .preSkip = preSkip
     };
 
-    m_converter = AudioSampleBufferConverter::create(decompressedAudioOutputBufferCallback, this, options);
+    m_converter = AudioSampleBufferConverter::create([weakThis = ThreadSafeWeakPtr { *this }] {
+        queueSingleton().dispatch([weakThis] {
+            if (RefPtr protectedThis = weakThis.get())
+                protectedThis->processedDecodedOutputs();
+        });
+    }, options);
     if (!m_converter)
         return "Couldn't create AudioSampleBufferConverter"_s;
 
@@ -397,12 +390,8 @@ void InternalAudioDecoderCocoa::close()
         return;
     m_isClosed = true;
 
-    RefPtr converter = std::exchange(m_converter, { });
-    if (!converter)
-        return;
-    // We keep a reference to ourselves until the converter has been marked as finished. This guarantees that no
-    // callback will occur after we are .
-    converter->finish()->whenSettled(queueSingleton(), [protectedThis = Ref { *this }] { });
+    if (RefPtr converter = std::exchange(m_converter, { }))
+        converter->finish();
 }
 
 } // namespace WebCore

--- a/Source/WebCore/platform/audio/cocoa/AudioEncoderCocoa.cpp
+++ b/Source/WebCore/platform/audio/cocoa/AudioEncoderCocoa.cpp
@@ -86,7 +86,6 @@ public:
 
 private:
     InternalAudioEncoderCocoa(const AudioEncoder::Config&, InternalConfig&&, AudioEncoder::DescriptionCallback&&, AudioEncoder::OutputCallback&&);
-    static void compressedAudioOutputBufferCallback(void*, CMBufferQueueTriggerToken);
     Ref<AudioSampleBufferConverter> NODELETE converter() const { return *m_converter; }
     void processEncodedOutputs();
     AudioEncoder::ActiveConfiguration activeConfiguration(CMSampleBufferRef) const;
@@ -212,17 +211,6 @@ InternalAudioEncoderCocoa::InternalAudioEncoderCocoa(const Config& config, Inter
 {
 }
 
-void InternalAudioEncoderCocoa::compressedAudioOutputBufferCallback(void* object, CMBufferQueueTriggerToken)
-{
-    // We can only be called from the CoreMedia callback if we are still alive.
-    RefPtr encoder = static_cast<class InternalAudioEncoderCocoa*>(object);
-
-    InternalAudioEncoderCocoa::queueSingleton().dispatch([weakEncoder = ThreadSafeWeakPtr { *encoder }] {
-        if (auto strongEncoder = weakEncoder.get())
-            strongEncoder->processEncodedOutputs();
-    });
-}
-
 Vector<uint8_t> InternalAudioEncoderCocoa::generateDecoderDescriptionFromSample(CMSampleBufferRef sample) const
 {
     RetainPtr formatDescription = PAL::CMSampleBufferGetFormatDescription(sample);
@@ -339,7 +327,12 @@ Ref<AudioEncoder::EncodePromise> InternalAudioEncoderCocoa::encode(AudioEncoder:
             .packetlossperc = m_internalConfig.packetlossperc,
             .useinbandfec = m_internalConfig.useinbandfec
         };
-        m_converter = AudioSampleBufferConverter::create(compressedAudioOutputBufferCallback, this, options);
+        m_converter = AudioSampleBufferConverter::create([weakThis = ThreadSafeWeakPtr { *this }] {
+            queueSingleton().dispatch([weakThis] {
+                if (auto protectedThis = weakThis.get())
+                    protectedThis->processEncodedOutputs();
+            });
+        }, options);
         if (!m_converter) {
             RELEASE_LOG_ERROR(MediaStream, "InternalAudioEncoderCocoa::encode: creation of converter failed");
             return EncodePromise::createAndReject("InternalAudioEncoderCocoa::encode: creation of converter failed"_s);
@@ -383,12 +376,9 @@ void InternalAudioEncoderCocoa::close()
     assertIsCurrent(queueSingleton());
 
     m_isClosed = true;
-    RefPtr converter = std::exchange(m_converter, { });
-    if (!converter)
-        return;
-    // We keep a reference to ourselves until the converter has been marked as finished. This guarantees that no
-    // callback will occur after we are destructed.
-    converter->finish()->whenSettled(queueSingleton(), [protectedThis = Ref { *this }] { });
+
+    if (RefPtr converter = std::exchange(m_converter, { }))
+        converter->finish();
 }
 
 } // namespace WebCore

--- a/Source/WebCore/platform/audio/cocoa/AudioSampleBufferConverter.h
+++ b/Source/WebCore/platform/audio/cocoa/AudioSampleBufferConverter.h
@@ -65,7 +65,7 @@ public:
         std::optional<bool> useinbandfec { };
         std::optional<bool> usedtx { };
     };
-    static RefPtr<AudioSampleBufferConverter> create(CMBufferQueueTriggerCallback, void* callbackObject, const Options&);
+    static RefPtr<AudioSampleBufferConverter> create(Function<void()>&&, const Options&);
     ~AudioSampleBufferConverter();
 
     bool isEmpty() const;
@@ -79,9 +79,11 @@ public:
     unsigned NODELETE bitRate() const;
     unsigned preSkip() const { return m_preSkip; }
 
+    static void converterOutputBufferCallback(void*, CMBufferQueueTriggerToken);
+
 private:
-    AudioSampleBufferConverter(const Options&);
-    bool initialize(CMBufferQueueTriggerCallback, void* callbackObject);
+    AudioSampleBufferConverter(Function<void()>&&, const Options&);
+    bool initialize();
     UInt32 NODELETE defaultOutputBitRate(const AudioStreamBasicDescription&) const;
 
     static OSStatus audioConverterComplexInputDataProc(AudioConverterRef, UInt32*, AudioBufferList*, AudioStreamPacketDescription**, void*);
@@ -105,6 +107,8 @@ private:
     const RetainPtr<CMBufferQueueRef> m_inputBufferQueue; // initialized on the caller's thread once, never modified after that.
     bool m_isEncoding WTF_GUARDED_BY_CAPABILITY(queue()) { true };
     bool m_isDraining WTF_GUARDED_BY_CAPABILITY(queue()) { false };
+
+    const Function<void()> m_outputCallback;
 
     AudioConverterRef m_converter WTF_GUARDED_BY_CAPABILITY(queue()) { nullptr };
     AudioStreamBasicDescription m_sourceFormat WTF_GUARDED_BY_CAPABILITY(queue());

--- a/Source/WebCore/platform/audio/cocoa/AudioSampleBufferConverter.mm
+++ b/Source/WebCore/platform/audio/cocoa/AudioSampleBufferConverter.mm
@@ -51,16 +51,17 @@ constexpr uint32_t kNoMoreDataErr = 'MOAR';
 
 namespace WebCore {
 
-RefPtr<AudioSampleBufferConverter> AudioSampleBufferConverter::create(CMBufferQueueTriggerCallback callback, void* callbackObject, const Options& options)
+RefPtr<AudioSampleBufferConverter> AudioSampleBufferConverter::create(Function<void()>&& outputCallback, const Options& options)
 {
-    Ref converter = adoptRef(*new AudioSampleBufferConverter(options));
-    if (!converter->initialize(callback, callbackObject))
+    Ref converter = adoptRef(*new AudioSampleBufferConverter(WTF::move(outputCallback), options));
+    if (!converter->initialize())
         return nullptr;
     return converter;
 }
 
-AudioSampleBufferConverter::AudioSampleBufferConverter(const Options& options)
+AudioSampleBufferConverter::AudioSampleBufferConverter(Function<void()>&& outputCallback, const Options& options)
     : m_serialDispatchQueue(WorkQueue::create("com.apple.AudioSampleBufferConverter"_s))
+    , m_outputCallback(WTF::move(outputCallback))
     , m_destinationFormat(options.description ? *options.description : AudioStreamBasicDescription { })
     , m_currentNativePresentationTimeStamp(PAL::kCMTimeInvalid)
     , m_currentOutputPresentationTimeStamp(PAL::kCMTimeInvalid)
@@ -81,7 +82,14 @@ AudioSampleBufferConverter::~AudioSampleBufferConverter()
     }
 }
 
-bool AudioSampleBufferConverter::initialize(CMBufferQueueTriggerCallback callback, void* callbackObject)
+void AudioSampleBufferConverter::converterOutputBufferCallback(void* object, CMBufferQueueTriggerToken)
+{
+    // CMBufferQueueRemoveTrigger is called in the destructor, so `object` is guaranteed to be alive here.
+    // We do not ref `object` since we might be in destructor.
+    SUPPRESS_UNCOUNTED_ARG static_cast<class AudioSampleBufferConverter*>(object)->m_outputCallback();
+}
+
+bool AudioSampleBufferConverter::initialize()
 {
     CMBufferQueueRef inputBufferQueue;
     if (auto error = PAL::CMBufferQueueCreate(kCFAllocatorDefault, 0, PAL::CMBufferQueueGetCallbacksForUnsortedSampleBuffers(), &inputBufferQueue)) {
@@ -96,7 +104,7 @@ bool AudioSampleBufferConverter::initialize(CMBufferQueueTriggerCallback callbac
         return false;
     }
     lazyInitialize(m_outputBufferQueue, adoptCF(outputBufferQueue));
-    PAL::CMBufferQueueInstallTrigger(m_outputBufferQueue.get(), callback, callbackObject, kCMBufferQueueTrigger_WhenDataBecomesReady, PAL::kCMTimeZero, &m_triggerToken);
+    PAL::CMBufferQueueInstallTrigger(m_outputBufferQueue.get(), converterOutputBufferCallback, this, kCMBufferQueueTrigger_WhenDataBecomesReady, PAL::kCMTimeZero, &m_triggerToken);
 
     return true;
 }

--- a/Source/WebCore/platform/mediarecorder/MediaRecorderPrivateEncoder.cpp
+++ b/Source/WebCore/platform/mediarecorder/MediaRecorderPrivateEncoder.cpp
@@ -128,20 +128,6 @@ static String codecStringForMediaVideoCodecId(FourCharCode codec)
     }
 }
 
-void MediaRecorderPrivateEncoder::compressedAudioOutputBufferCallback(void* MediaRecorderPrivateEncoder, CMBufferQueueTriggerToken)
-{
-    // We can only be called from the CoreMedia callback if we are still alive.
-    RefPtr encoder = static_cast<class MediaRecorderPrivateEncoder*>(MediaRecorderPrivateEncoder);
-
-    queueSingleton().dispatch([weakEncoder = ThreadSafeWeakPtr { *encoder }] {
-        if (auto strongEncoder = weakEncoder.get()) {
-            assertIsCurrent(queueSingleton());
-            strongEncoder->enqueueCompressedAudioSampleBuffers();
-            strongEncoder->partiallyFlushEncodedQueues();
-        }
-    });
-}
-
 bool MediaRecorderPrivateEncoder::initialize(const MediaRecorderPrivateOptions& options, UniqueRef<MediaRecorderPrivateWriter>&& writer)
 {
     assertIsMainThread();
@@ -351,7 +337,15 @@ void MediaRecorderPrivateEncoder::audioSamplesDescriptionChanged(const AudioStre
         .outputBitRate = m_audioBitsPerSecond ? std::optional { m_audioBitsPerSecond } : std::nullopt,
         .generateTimestamp = true
     };
-    m_audioConverter = AudioSampleBufferConverter::create(compressedAudioOutputBufferCallback, this, options);
+    m_audioConverter = AudioSampleBufferConverter::create([weakThis = ThreadSafeWeakPtr { *this }] {
+        queueSingleton().dispatch([weakThis] {
+            if (auto protectedThis = weakThis.get()) {
+                assertIsCurrent(queueSingleton());
+                protectedThis->enqueueCompressedAudioSampleBuffers();
+                protectedThis->partiallyFlushEncodedQueues();
+            }
+        });
+    }, options);
     if (!m_audioConverter) {
         RELEASE_LOG_ERROR(MediaStream, "MediaRecorderPrivateEncoder::audioSamplesDescriptionChanged: creation of converter failed");
         m_hadError = true;

--- a/Source/WebCore/platform/mediarecorder/MediaRecorderPrivateEncoder.h
+++ b/Source/WebCore/platform/mediarecorder/MediaRecorderPrivateEncoder.h
@@ -98,8 +98,6 @@ private:
     void flushDataBuffer();
     bool segmentsMustStartWithVideoKeyframe() const;
 
-    static void compressedAudioOutputBufferCallback(void*, CMBufferQueueTriggerToken);
-
     Ref<FragmentedSharedBuffer> takeData();
 
     MediaTime lastMuxedSampleTime() const;


### PR DESCRIPTION
#### e522465fce971a5e3b9ed3b3bd48314164f1e053
<pre>
Refactor AudioSampleBufferConverter so that it takes a Function as input
<a href="https://rdar.apple.com/176445671">rdar://176445671</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=314305">https://bugs.webkit.org/show_bug.cgi?id=314305</a>

Reviewed by Jean-Yves Avenard.

We update AudioSampleBufferConverter to take a Function instead of a C function and a pointer.
This allows to align with safer CPP guidelines by using the classic weak pointer/ref approach in the Function.
We make sure to keep the existing safety mechanisms, in particular when calling the callback.

Covered by existing tests.

Canonical link: <a href="https://commits.webkit.org/313066@main">https://commits.webkit.org/313066@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bfffb16f0ea70ca64a761325fd389201bc6dc5ad

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/162015 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/35490 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/28595 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/170923 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/118386 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/0f79cf39-4cb9-46bf-afb6-3568dbc21063) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/163884 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/35592 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/35491 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/125727 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/88600 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/164974 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/28040 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/145525 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/106309 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/8a5a116f-5a68-4dfd-bf01-5de589ad1698) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/27089 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/25603 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/18643 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/136782 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/23279 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/173411 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/20502 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/24920 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/134018 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/35163 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/29688 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/134024 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36179 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/35147 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/145074 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/97282 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/28550 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/21899 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/34657 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/102142 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/34158 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/34400 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/34306 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->