### PR TITLE
[:has()] scope selector matching unnecessarily returns documentElement() on failure

### DIFF
--- a/LayoutTests/fast/selectors/has-invalidation-traversal-size-expected.txt
+++ b/LayoutTests/fast/selectors/has-invalidation-traversal-size-expected.txt
@@ -40,4 +40,6 @@
   Traversal count: 7
 .c21 div:is(.other:has(.trigger)) with type in outer compound
   Traversal count: 7
+.c22:has(.trigger22) .target with no .c22 ancestor - skip invalidation
+  Traversal count: 0
 

--- a/LayoutTests/fast/selectors/has-invalidation-traversal-size.html
+++ b/LayoutTests/fast/selectors/has-invalidation-traversal-size.html
@@ -44,6 +44,8 @@
 .c20:is(div:has(.trigger)) .target { color: green; }
 /* :has() inside :is() with type selector in outer compound and class peer in inner */
 .c21 div:is(.other:has(.trigger)) .target { color: green; }
+/* Scope selector has no matching ancestor - invalidation is skipped entirely */
+.c22:has(.trigger22) .target { color: green; }
 </style>
 <script>
 if (window.testRunner)
@@ -244,6 +246,12 @@ runTest(".c21 div:is(.other:has(.trigger)) with type in outer compound", "other"
     trigger.className = "trigger";
     container.appendChild(trigger);
 }, true, { wrapperClass: "c21" });
+
+runTest(".c22:has(.trigger22) .target with no .c22 ancestor - skip invalidation", null, function(container) {
+    var trigger = document.createElement("div");
+    trigger.className = "trigger22";
+    container.appendChild(trigger);
+}, false);
 </script>
 </script>
 </body>

--- a/Source/WebCore/style/StyleInvalidator.cpp
+++ b/Source/WebCore/style/StyleInvalidator.cpp
@@ -401,6 +401,7 @@ void Invalidator::invalidateStyleWithMatchElement(Element& element, MatchElement
         }
         if (matchElement.relation == Relation::Ancestor && hasRelation == HasRelation::Descendant) {
             // .foo:has(.changed) .subject — find outermost ancestor matching any scope selector (.foo) to bound traversal.
+            // If no ancestor matches any ruleset's scope and no ruleset is scope-breaking, no bearer exists and we can skip.
             auto scopeElement = [&] -> RefPtr<Element> {
                 Vector<Element*, 16> ancestors;
                 for (RefPtr ancestor = element.parentElement(); ancestor; ancestor = ancestor->parentElement())
@@ -417,14 +418,14 @@ void Invalidator::invalidateStyleWithMatchElement(Element& element, MatchElement
                         }
                     }
                 }
-                return element.document().documentElement();
+                return { };
             }();
 
-            if (scopeElement) {
-                SelectorMatchingState selectorMatchingState;
-                invalidateStyleForDescendants(*scopeElement, &selectorMatchingState);
+            if (!scopeElement)
                 return;
-            }
+            SelectorMatchingState selectorMatchingState;
+            invalidateStyleForDescendants(*scopeElement, &selectorMatchingState);
+            return;
         }
 
         // Null scopeSelector means scope-breaking: no scope element can be identified.


### PR DESCRIPTION
#### 8e2c2d819bbea8947ff300138f476c94ba4979d5
<pre>
[:has()] scope selector matching unnecessarily returns documentElement() on failure
<a href="https://bugs.webkit.org/show_bug.cgi?id=314318">https://bugs.webkit.org/show_bug.cgi?id=314318</a>
<a href="https://rdar.apple.com/176458407">rdar://176458407</a>

Reviewed by Alan Baradlay.

When no ancestor matches any ruleset&apos;s scope selector and no ruleset is
scope-breaking, no :has() bearer can be affected by the change. Return
null and skip invalidation instead of falling back to documentElement.

This fallback isn&apos;t reached in practice today. It&apos;s a guard for future
changes that thread scope selectors through more invalidation paths.

* LayoutTests/fast/selectors/has-invalidation-traversal-size-expected.txt:
* LayoutTests/fast/selectors/has-invalidation-traversal-size.html:
* Source/WebCore/style/StyleInvalidator.cpp:
(WebCore::Style::Invalidator::invalidateStyleWithMatchElement):

Canonical link: <a href="https://commits.webkit.org/312804@main">https://commits.webkit.org/312804@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/15bc7da03c8d2a1cb5580c4822ce79dc968b70da

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/161153 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/34626 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/27727 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/170056 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/117506 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/a0c9fc9e-4994-4d1e-a6e5-be3f6fa3e1a6) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/163022 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/34727 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/34627 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/125002 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/117506 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/f313bf3d-d377-43e7-98ff-017991e69f26) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/164112 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/27282 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/144754 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/105599 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/98cff515-1a0b-4428-bc97-9690fd499ae6) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/26330 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/24829 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/17776 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/136024 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/22515 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/172539 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/19560 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/24156 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/133281 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/34300 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/28922 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/133291 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35994 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/34284 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/144310 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/96138 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/27839 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/21128 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/33795 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/101220 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/33294 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/33538 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/33443 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->