### PR TITLE
[GStreamer] Use writable buffers in MediaSampleGStreamer when updating timestamps

### DIFF
--- a/Source/WebCore/platform/graphics/gstreamer/MediaSampleGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/MediaSampleGStreamer.cpp
@@ -23,12 +23,22 @@
 #include "MediaSampleGStreamer.h"
 
 #include "GStreamerCommon.h"
-#include "VideoFrameMetadataGStreamer.h"
 #include <algorithm>
 
 #if ENABLE(VIDEO) && USE(GSTREAMER)
 
+GST_DEBUG_CATEGORY(webkit_media_sample_debug);
+#define GST_CAT_DEFAULT webkit_media_sample_debug
+
 namespace WebCore {
+
+static void ensureMediaSampleDebugCategoryInitialized()
+{
+    static std::once_flag debugRegisteredFlag;
+    std::call_once(debugRegisteredFlag, [] {
+        GST_DEBUG_CATEGORY_INIT(webkit_media_sample_debug, "webkitmediasample", 0, "WebKit Media Sample");
+    });
+}
 
 MediaSampleGStreamer::MediaSampleGStreamer(GRefPtr<GstSample>&& sample, const FloatSize& presentationSize, TrackID trackId)
     : m_pts(MediaTime::zeroTime())
@@ -37,6 +47,7 @@ MediaSampleGStreamer::MediaSampleGStreamer(GRefPtr<GstSample>&& sample, const Fl
     , m_trackId(trackId)
     , m_presentationSize(presentationSize)
 {
+    ensureMediaSampleDebugCategoryInitialized();
     ASSERT(sample);
     m_sample = WTF::move(sample);
     const GstClockTime minimumDuration = 1000; // 1 us
@@ -79,6 +90,7 @@ MediaSampleGStreamer::MediaSampleGStreamer(const FloatSize& presentationSize, Tr
     , m_trackId(trackId)
     , m_presentationSize(presentationSize)
 {
+    ensureMediaSampleDebugCategoryInitialized();
 }
 
 Ref<MediaSampleGStreamer> MediaSampleGStreamer::createFakeSample(GstCaps*, const MediaTime& pts, const MediaTime& dts, const MediaTime& duration, const FloatSize& presentationSize, TrackID trackId)
@@ -93,6 +105,7 @@ Ref<MediaSampleGStreamer> MediaSampleGStreamer::createFakeSample(GstCaps*, const
 
 void MediaSampleGStreamer::extendToTheBeginning()
 {
+    GST_TRACE("Extending to beginning");
     // Only to be used with the first sample, as a hack for lack of support for edit lists.
     // See AppendPipeline::appsinkNewSample()
     ASSERT(m_dts == MediaTime::zeroTime());
@@ -100,26 +113,67 @@ void MediaSampleGStreamer::extendToTheBeginning()
     m_pts = MediaTime::zeroTime();
 }
 
+void MediaSampleGStreamer::updateSampleTimestamps([[maybe_unused]] const String& debugMessage)
+{
+    RELEASE_ASSERT(m_sample);
+    GRefPtr buffer = gst_sample_get_buffer(m_sample.get());
+    RELEASE_ASSERT(buffer);
+
+    auto newPts = toGstClockTime(m_pts);
+    auto newDts = toGstClockTime(m_dts);
+    GST_TRACE("%s, new PTS: %" GST_TIME_FORMAT " (prev: %" GST_TIME_FORMAT "), new DTS: %" GST_TIME_FORMAT " (prev: %" GST_TIME_FORMAT ")", debugMessage.ascii().data(),
+        GST_TIME_ARGS(newPts), GST_TIME_ARGS(GST_BUFFER_PTS(buffer.get())),
+        GST_TIME_ARGS(newDts), GST_TIME_ARGS(GST_BUFFER_DTS(buffer.get())));
+
+    auto writableBuffer = adoptGRef(gst_buffer_make_writable(buffer.leakRef()));
+    GST_BUFFER_PTS(writableBuffer.get()) = newPts;
+    GST_BUFFER_DTS(writableBuffer.get()) = newDts;
+    m_sample = adoptGRef(gst_sample_make_writable(m_sample.leakRef()));
+    gst_sample_set_buffer(m_sample.get(), writableBuffer.get());
+}
+
 void MediaSampleGStreamer::setTimestamps(const MediaTime& presentationTime, const MediaTime& decodeTime)
 {
     m_pts = presentationTime;
     m_dts = decodeTime;
-    if (auto* buffer = gst_sample_get_buffer(m_sample.get())) {
-        GST_BUFFER_PTS(buffer) = toGstClockTime(m_pts);
-        GST_BUFFER_DTS(buffer) = toGstClockTime(m_dts);
-    }
+
+    if (!m_sample)
+        return;
+
+    updateSampleTimestamps("Setting timestamps"_s);
 }
 
 void MediaSampleGStreamer::offsetTimestampsBy(const MediaTime& timestampOffset)
 {
     if (!timestampOffset)
         return;
-    m_pts += timestampOffset;
-    m_dts += timestampOffset;
-    if (auto* buffer = gst_sample_get_buffer(m_sample.get())) {
-        GST_BUFFER_PTS(buffer) = toGstClockTime(m_pts);
-        GST_BUFFER_DTS(buffer) = toGstClockTime(m_dts);
+
+    [[maybe_unused]] bool newPtsIsZero = false;
+    auto newPts = m_pts + timestampOffset;
+    if (newPts.isInvalid() || newPts < MediaTime::zeroTime()) {
+        newPts = MediaTime::zeroTime();
+        newPtsIsZero = true;
     }
+
+    [[maybe_unused]] bool newDtsIsZero = false;
+    auto newDts = m_dts + timestampOffset;
+    if (newDts.isInvalid() || newDts < MediaTime::zeroTime()) {
+        newDts = MediaTime::zeroTime();
+        newDtsIsZero = true;
+    }
+
+    m_pts = newPts;
+    m_dts = newDts;
+
+    if (!m_sample)
+        return;
+
+    auto debugMessage = emptyString();
+#ifndef GST_DISABLE_GST_DEBUG
+    if (gst_debug_category_get_threshold(GST_CAT_DEFAULT) >= GST_LEVEL_TRACE)
+        debugMessage = makeString("Offsetting timestamps by "_s, timestampOffset.toString(), newPtsIsZero ? " negative PTS was reset to 0..."_s : emptyString(), newDtsIsZero ? " negative DTS was reset to 0..."_s : emptyString());
+#endif
+    updateSampleTimestamps(debugMessage);
 }
 
 PlatformSample MediaSampleGStreamer::platformSample() const
@@ -132,14 +186,15 @@ Ref<MediaSample> MediaSampleGStreamer::createNonDisplayingCopy() const
     if (!m_sample)
         return createFakeSample(nullptr, m_pts, m_dts, m_duration, m_presentationSize, m_trackId);
 
-    GstBuffer* buffer = gst_sample_get_buffer(m_sample.get());
-    GST_BUFFER_FLAG_SET(buffer, GST_BUFFER_FLAG_DECODE_ONLY);
+    auto sample = adoptGRef(gst_sample_copy(m_sample.get()));
 
-    GstCaps* caps = gst_sample_get_caps(m_sample.get());
-    GstSegment* segment = gst_sample_get_segment(m_sample.get());
-    const GstStructure* originalInfo = gst_sample_get_info(m_sample.get());
-    GstStructure* info = originalInfo ? gst_structure_copy(originalInfo) : nullptr;
-    GRefPtr<GstSample> sample = adoptGRef(gst_sample_new(buffer, caps, segment, info));
+    GRefPtr buffer = gst_sample_get_buffer(sample.get());
+    RELEASE_ASSERT(buffer);
+    auto writableBuffer = adoptGRef(gst_buffer_make_writable(buffer.leakRef()));
+
+    GST_BUFFER_FLAG_SET(writableBuffer.get(), GST_BUFFER_FLAG_DECODE_ONLY);
+    sample = adoptGRef(gst_sample_make_writable(sample.leakRef()));
+    gst_sample_set_buffer(sample.get(), writableBuffer.get());
 
     return adoptRef(*new MediaSampleGStreamer(WTF::move(sample), m_presentationSize, m_trackId));
 }
@@ -169,5 +224,7 @@ void MediaSampleGStreamer::dump(PrintStream& out) const
 }
 
 } // namespace WebCore.
+
+#undef GST_CAT_DEFAULT
 
 #endif // ENABLE(VIDEO) && USE(GSTREAMER)

--- a/Source/WebCore/platform/graphics/gstreamer/MediaSampleGStreamer.h
+++ b/Source/WebCore/platform/graphics/gstreamer/MediaSampleGStreamer.h
@@ -63,6 +63,8 @@ protected:
 private:
     MediaSampleGStreamer(const FloatSize& presentationSize, TrackID);
 
+    void updateSampleTimestamps(const String&);
+
     MediaTime m_pts;
     MediaTime m_dts;
     MediaTime m_duration;


### PR DESCRIPTION
#### 0fa10661bbf3e4130a133650f45491b2a135aae4
<pre>
[GStreamer] Use writable buffers in MediaSampleGStreamer when updating timestamps
<a href="https://bugs.webkit.org/show_bug.cgi?id=314322">https://bugs.webkit.org/show_bug.cgi?id=314322</a>

Reviewed by Xabier Rodriguez-Calvar.

Metadata updates should be done on writable buffers. Also simplify the createNonDisplayingCopy()
method by using gst_sample_copy() and remove an un-needed header include. Finally, add some
GStreamer logging in several methods.

We also now prevent negative timestamps, those should always be positive in GStreamer, by design.

* Source/WebCore/platform/graphics/gstreamer/MediaSampleGStreamer.cpp:
(WebCore::ensureMediaSampleDebugCategoryInitialized):
(WebCore::MediaSampleGStreamer::MediaSampleGStreamer):
(WebCore::MediaSampleGStreamer::extendToTheBeginning):
(WebCore::MediaSampleGStreamer::updateSampleTimestamps):
(WebCore::MediaSampleGStreamer::setTimestamps):
(WebCore::MediaSampleGStreamer::offsetTimestampsBy):
(WebCore::MediaSampleGStreamer::createNonDisplayingCopy const):
* Source/WebCore/platform/graphics/gstreamer/MediaSampleGStreamer.h:

Canonical link: <a href="https://commits.webkit.org/313145@main">https://commits.webkit.org/313145@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b8d0c0d30dddb1c8b61c43a89eeb5a098de6ecd4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/162249 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/35725 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/28841 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/171157 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/118624 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/164118 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/35829 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/35726 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/125917 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/118624 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/165208 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/28255 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/145755 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/106495 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/27302 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/25816 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/18878 "Built successfully") | 
| [⏳ 🛠 🧪 jsc ](https://ews-build.webkit.org/#/builders/JSC-Tests-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/137004 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/167/builds/23494 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/173651 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/21004 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/25137 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/134213 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/35399 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/29904 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/134214 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36231 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/35382 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/145290 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/97606 "Built successfully") | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/164/builds/28761 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/22119 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/34892 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/102644 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/34393 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/34639 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/34541 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->