### PR TITLE
Web Extensions popup WKWebView and NSPopover are not released when the popup is dismissed on macOS.

### DIFF
--- a/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionActionCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionActionCocoa.mm
@@ -552,6 +552,8 @@ ALLOW_DEPRECATED_DECLARATIONS_END
     action.setPopupPopoverAppearance(action.popupPopoverAppearance());
 
     [NSNotificationCenter.defaultCenter addObserver:self selector:@selector(_otherPopoverWillShow:) name:NSPopoverWillShowNotification object:nil];
+    [NSNotificationCenter.defaultCenter addObserver:self selector:@selector(popoverWillClose:) name:NSPopoverWillCloseNotification object:self];
+    [NSNotificationCenter.defaultCenter addObserver:self selector:@selector(popoverDidClose:) name:NSPopoverDidCloseNotification object:self];
 
     return self;
 }
@@ -567,6 +569,8 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 - (void)popoverDidClose:(NSNotification *)notification
 {
     ASSERT([self isEqual:notification.object]);
+
+    [NSNotificationCenter.defaultCenter removeObserver:self];
 
     if (RefPtr webExtensionAction = _webExtensionAction.get())
         webExtensionAction->closePopup();

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKWebExtensionAPIAction.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKWebExtensionAPIAction.mm
@@ -192,6 +192,68 @@ TEST(WKWebExtensionAPIAction, PresentPopupForAction)
     [manager run];
 }
 
+#if PLATFORM(MAC)
+TEST(WKWebExtensionAPIAction, PopoverCloseNotificationCallsClosePopup)
+{
+    auto *popupPage = @"<b>Hello World!</b>";
+
+    auto *backgroundScript = Util::constructScript(@[
+        @"browser.test.sendMessage('Test Popup Action')"
+    ]);
+
+    auto *smallToolbarIcon = Util::makePNGData(CGSizeMake(16, 16), @selector(redColor));
+    auto *largeToolbarIcon = Util::makePNGData(CGSizeMake(32, 32), @selector(blueColor));
+
+    auto *resources = @{
+        @"background.js": backgroundScript,
+        @"popup.html": popupPage,
+        @"toolbar-16.png": smallToolbarIcon,
+        @"toolbar-32.png": largeToolbarIcon,
+    };
+
+    auto manager = Util::loadExtension(actionPopupManifest, resources);
+
+    __block int presentCount = 0;
+    __block WKWebView *firstWebView = nil;
+    __block WKWebView *secondWebView = nil;
+
+    manager.get().internalDelegate.presentPopupForAction = ^(WKWebExtensionAction *action) {
+        ++presentCount;
+
+        if (presentCount == 1) {
+            firstWebView = action.popupWebView;
+
+            // Simulate the popup being dismissed by the user (e.g., clicking outside), which posts
+            // NSPopoverDidCloseNotification. This should invoke popoverDidClose: and call closePopup(),
+            // resetting the popup state and allowing the popup to be presented again.
+            [NSNotificationCenter.defaultCenter postNotificationName:NSPopoverDidCloseNotification object:action.popupPopover];
+
+            // Trigger a second presentation to verify closePopup() was called. Without the fix,
+            // m_popupPresented remains true and performActionForTab: is a no-op, so the delegate
+            // is never called a second time.
+            [manager.get().context performActionForTab:manager.get().defaultTab];
+        } else {
+            secondWebView = action.popupWebView;
+            [manager done];
+        }
+    };
+
+    [manager runUntilTestMessage:@"Test Popup Action"];
+
+    [manager.get().context performActionForTab:manager.get().defaultTab];
+
+    [manager run];
+
+    // Verify the popup was presented twice (confirming closePopup() reset the state after the notification).
+    EXPECT_EQ(presentCount, 2);
+
+    // Verify a fresh web view was created for the second presentation (confirming m_popupWebView was cleared).
+    EXPECT_NOT_NULL(firstWebView);
+    EXPECT_NOT_NULL(secondWebView);
+    EXPECT_NE(firstWebView, secondWebView);
+}
+#endif // PLATFORM(MAC)
+
 TEST(WKWebExtensionAPIAction, GetCurrentTabAndWindowFromPopupPage)
 {
     auto *popupScript = Util::constructScript(@[


### PR DESCRIPTION
#### e589b1e7773335a680e6b700a94e7341fd8c13c4
<pre>
Web Extensions popup WKWebView and NSPopover are not released when the popup is dismissed on macOS.
<a href="https://webkit.org/b/314323">https://webkit.org/b/314323</a>
<a href="https://rdar.apple.com/174673022">rdar://174673022</a>

Reviewed by Kiara Rose.

`_WKWebExtensionActionPopover` had `popoverWillClose:` and `popoverDidClose:` methods implemented
but never registered as `NSNotificationCenter` observers, so when AppKit dismissed the popup via
semitransient behavior `closePopup()` was never called, leaving `m_popupWebView` and `m_popupPopover`
set indefinitely. Registering both notifications with `object:self` ensures `closePopup()` is called
on dismissal, and removing all observers in `popoverDidClose:` prevents any double-close.

Test: Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKWebExtensionAPIAction.mm

* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionActionCocoa.mm:
(-[_WKWebExtensionActionPopover initWithWebExtensionAction:]): Added observer registrations for
`NSPopoverWillCloseNotification` and `NSPopoverDidCloseNotification` with `object:self`.
(-[_WKWebExtensionActionPopover popoverDidClose:]): Added `removeObserver:self` before calling
`closePopup()` to clean up all notification observers.
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKWebExtensionAPIAction.mm:
(TestWebKitAPI::TEST(WKWebExtensionAPIAction, PopoverCloseNotificationCallsClosePopup)): Added
test that posts `NSPopoverDidCloseNotification` and verifies `closePopup()` was called by
confirming the popup can be re-presented with a fresh web view.

Canonical link: <a href="https://commits.webkit.org/312900@main">https://commits.webkit.org/312900@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a2c9da34aac4a9445c5055e143249f474a3e5b45

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/161158 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/34631 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/27732 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/170061 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/117529 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/054801ae-1088-4931-85ab-668476c98c6b) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/163027 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/34732 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/34632 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/125007 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/88143 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/e9d0faec-c5f1-46d7-8160-29ee7481a088) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/164117 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/27285 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/144759 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/105604 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/84d4fa16-3eea-4dd6-9247-6cf5e7dadce2) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/26333 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/24835 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/17781 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/136027 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/22520 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/172544 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/19565 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/24161 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/133286 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/34305 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/28928 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/133296 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/34289 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/144315 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/96143 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/24536 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/27844 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/21133 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/33800 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/101225 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/33299 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/33543 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/33448 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->