### PR TITLE
[Site Isolation] Fix CachedFrame ASSERT for RemoteFrame-backed parent frames

### DIFF
--- a/Source/WebCore/history/CachedFrame.cpp
+++ b/Source/WebCore/history/CachedFrame.cpp
@@ -252,6 +252,10 @@ void CachedFrame::open()
 
 void CachedFrame::clear()
 {
+    // Always clear children, even for RemoteFrame-backed CachedFrames.
+    for (int i = m_childFrames.size() - 1; i >= 0; --i)
+        m_childFrames[i]->clear();
+
     if (!m_document)
         return;
 
@@ -263,9 +267,6 @@ void CachedFrame::clear()
     ASSERT(m_view);
     ASSERT(!m_document->frame() || m_document->frame() == &m_view->frame());
 
-    for (int i = m_childFrames.size() - 1; i >= 0; --i)
-        m_childFrames[i]->clear();
-
     m_document = nullptr;
     m_view = nullptr;
     m_url = URL();
@@ -276,6 +277,11 @@ void CachedFrame::clear()
 
 void CachedFrame::destroy()
 {
+    // Always destroy children first, even for RemoteFrame-backed CachedFrames
+    // whose m_document is null. Children may be LocalFrames with documents.
+    for (int i = m_childFrames.size() - 1; i >= 0; --i)
+        m_childFrames[i]->destroy();
+
     RefPtr document = m_document;
     if (!document)
         return;
@@ -294,9 +300,6 @@ void CachedFrame::destroy()
             localFrame->loader().detachViewsAndDocumentLoader();
         frame->detachFromPage();
     }
-    
-    for (int i = m_childFrames.size() - 1; i >= 0; --i)
-        m_childFrames[i]->destroy();
 
     if (m_cachedFramePlatformData)
         m_cachedFramePlatformData->clear();


### PR DESCRIPTION
#### c6c2fea6a7f94b4361e61762fec8ff2a937438e4
<pre>
[Site Isolation] Fix CachedFrame ASSERT for RemoteFrame-backed parent frames
<a href="https://bugs.webkit.org/show_bug.cgi?id=314238">https://bugs.webkit.org/show_bug.cgi?id=314238</a>
<a href="https://rdar.apple.com/176395663">rdar://176395663</a>

Reviewed by Per Arne Vollan and Ryosuke Niwa.

In multi-process BFCache with Site Isolation, an iframe process&apos;s CachedPage
has a RemoteFrame as its main frame (null document) with LocalFrame children
that have documents. CachedFrame::destroy() and clear() both returned early
when m_document was null, skipping recursive child cleanup. This caused child
CachedFrames to be destroyed without their destroy()/clear() methods being
called, triggering ASSERT(!m_document) in the destructor.

Fix by moving the child frame iteration before the early return guard. Child
cleanup has no dependency on the parent&apos;s document and is safe to call
unconditionally.

Covered by existing tests.

* Source/WebCore/history/CachedFrame.cpp:
(WebCore::CachedFrame::clear):
(WebCore::CachedFrame::destroy):

Canonical link: <a href="https://commits.webkit.org/312856@main">https://commits.webkit.org/312856@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/059ac194c8d2b414f7780951d5c70e505b377e74

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/161161 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/34634 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/27735 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/170064 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/117532 "Build is in progress. Recent messages:") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/3a9e7a05-9929-4a80-b0b1-8dc6d47d4bb5) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/163030 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/34735 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/34635 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/125010 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 win-tests](https://ews-build.webkit.org/#/builders/59/builds/117532 "Build is in progress. Recent messages:") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/4aef9c55-cef6-4c89-8e09-5159e655633c) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/164120 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/27290 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/144762 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/105607 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/404dcec6-bfcf-4f06-acfc-e49c688c8ee1) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/26338 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/24837 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/17784 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/136032 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/22523 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/172547 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/19568 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/24164 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/133289 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/34308 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/28930 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/133299 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36024 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/34292 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/144318 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/96148 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/27846 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/21136 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/33803 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/101228 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/33302 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/33546 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/33451 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->