### PR TITLE
[css-animations][css-transitions] Add `animation` property to `AnimationEvent` and `TransitionEvent`

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-animations/animationevent-interface-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-animations/animationevent-interface-expected.txt
@@ -40,5 +40,5 @@ PASS elapsedTime cannot be set to 'sample'
 PASS elapsedTime cannot be set to [0.5, 1.0]
 PASS elapsedTime cannot be set to an object
 PASS AnimationEventInit properties set value
-FAIL AnimationEventInit animation property sets value assert_equals: expected (object) object "[object CSSAnimation]" but got (undefined) undefined
+PASS AnimationEventInit animation property sets value
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-animations/animationevent-types-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-animations/animationevent-types-expected.txt
@@ -1,6 +1,6 @@
 Filler Text
 
-FAIL animationstart event is instanceof AnimationEvent assert_idl_attribute: animationstart has animation property property "animation" not found in prototype chain
-FAIL animationend event is instanceof AnimationEvent assert_idl_attribute: animationend has animation property property "animation" not found in prototype chain
-FAIL animationiteration event is instanceof AnimationEvent assert_idl_attribute: animationiteration has animation property property "animation" not found in prototype chain
+PASS animationstart event is instanceof AnimationEvent
+PASS animationend event is instanceof AnimationEvent
+PASS animationiteration event is instanceof AnimationEvent
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-transitions/events-008-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-transitions/events-008-expected.txt
@@ -1,0 +1,5 @@
+
+PASS transitionrun event has animation property and its value is the corresponding CSSTransition object
+PASS transitionstart event has animation property and its value is the corresponding CSSTransition object
+PASS transitionend event has animation property and its value is the corresponding CSSTransition object
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-transitions/events-008.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-transitions/events-008.html
@@ -1,0 +1,57 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<meta name="timeout" content="long">
+<title>CSS Transitions Test: TransitionEvent and animation property</title>
+<link rel="help" href="https://drafts.csswg.org/css-transitions-2/#interface-transitionevent">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<style>
+  #test {
+    transition-property: opacity;
+    transition-duration: 1s;
+    opacity: 0;
+  }
+</style>
+<div id="test"></div>
+<script>
+  const testDiv = document.getElementById("test");
+  let anim = null; // transitionrun sets the animation.
+
+  getComputedStyle(testDiv).opacity;
+  requestAnimationFrame(() => {
+    testDiv.style.opacity = "1";
+  });
+
+  async_test(function(t) {
+    testDiv.addEventListener("transitionrun", t.step_func(function(evt) {
+      assert_idl_attribute(evt, "animation", "transitionrun has animation property");
+
+      assert_true(evt.animation instanceof window.CSSTransition, "animation property is an instance of CSSTransition");
+      assert_equals(evt.animation.transitionProperty, 'opacity', "animation property has a correct transition property");
+
+      t.done();
+    }), true);
+  }, "transitionrun event has animation property and its value is the corresponding CSSTransition object");
+
+  async_test(function(t) {
+    testDiv.addEventListener("transitionstart", t.step_func(function(evt) {
+      assert_idl_attribute(evt, "animation", "transitionstart has animation property");
+
+      assert_true(evt.animation instanceof window.CSSTransition, "animation property is an instance of CSSTransition");
+      assert_equals(evt.animation.transitionProperty, 'opacity', "animation property has a correct transition property");
+
+      t.done();
+    }), true);
+  }, "transitionstart event has animation property and its value is the corresponding CSSTransition object");
+
+  async_test(function(t) {
+    testDiv.addEventListener("transitionend", t.step_func(function(evt) {
+      assert_idl_attribute(evt, "animation", "transitionend has animation property");
+
+      assert_true(evt.animation instanceof window.CSSTransition, "animation property is an instance of CSSTransition");
+      assert_equals(evt.animation.transitionProperty, 'opacity', "animation property has a correct transition property");
+
+      t.done();
+    }), true);
+  }, "transitionend event has animation property and its value is the corresponding CSSTransition object");
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-transitions/transitionevent-interface-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-transitions/transitionevent-interface-expected.txt
@@ -40,4 +40,5 @@ PASS elapsedTime cannot be set to 'sample'
 PASS elapsedTime cannot be set to [0.5, 1.0]
 PASS elapsedTime cannot be set to an object
 PASS TransitionEventInit properties set value
+PASS TransitionEventInit animation property sets value
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-transitions/transitionevent-interface.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-transitions/transitionevent-interface.html
@@ -7,6 +7,8 @@
 <script src="/resources/testharnessreport.js"></script>
 <script src="transitionevent-interface.js"></script>
 
+<div id="test"></div>
+
 <script>
 test(function() {
   var event = new TransitionEvent("");
@@ -226,4 +228,17 @@ test(function() {
   assert_equals(event.propertyName, "sample");
   assert_equals(event.elapsedTime, 0.5);
 }, "TransitionEventInit properties set value");
+
+test(function() {
+  var target = document.getElementById('test');
+  target.style.opacity = '0';
+  getComputedStyle(target).opacity;
+  target.style.transition = 'opacity 1s';
+  target.style.opacity = '1';
+  var anim = target.getAnimations()[0];
+
+  var eventInit = {animation: anim};
+  var event = new TransitionEvent("test", eventInit);
+  assert_equals(event.animation, anim);
+}, "TransitionEventInit animation property sets value");
 </script>

--- a/Source/WebCore/animation/AnimationEventBase.cpp
+++ b/Source/WebCore/animation/AnimationEventBase.cpp
@@ -42,8 +42,9 @@ AnimationEventBase::AnimationEventBase(enum EventInterfaceType eventInterface, c
 {
 }
 
-AnimationEventBase::AnimationEventBase(enum EventInterfaceType eventInterface, const AtomString& type, EventInit&& initializer, IsTrusted isTrusted)
+AnimationEventBase::AnimationEventBase(enum EventInterfaceType eventInterface, const AtomString& type, EventInit&& initializer, IsTrusted isTrusted, RefPtr<WebAnimation>&& animation)
     : Event(eventInterface, type, WTF::move(initializer), isTrusted)
+    , m_animation(WTF::move(animation))
 {
 }
 

--- a/Source/WebCore/animation/AnimationEventBase.h
+++ b/Source/WebCore/animation/AnimationEventBase.h
@@ -42,7 +42,7 @@ public:
 
 protected:
     AnimationEventBase(enum EventInterfaceType, const AtomString&, WebAnimation*, std::optional<Seconds> scheduledTime);
-    AnimationEventBase(enum EventInterfaceType, const AtomString&, EventInit&&, IsTrusted);
+    AnimationEventBase(enum EventInterfaceType, const AtomString&, EventInit&&, IsTrusted, RefPtr<WebAnimation>&&);
 
 private:
     const RefPtr<WebAnimation> m_animation;

--- a/Source/WebCore/animation/AnimationPlaybackEvent.cpp
+++ b/Source/WebCore/animation/AnimationPlaybackEvent.cpp
@@ -34,7 +34,7 @@ namespace WebCore {
 WTF_MAKE_TZONE_ALLOCATED_IMPL(AnimationPlaybackEvent);
 
 AnimationPlaybackEvent::AnimationPlaybackEvent(const AtomString& type, Init&& initializer, IsTrusted isTrusted)
-    : AnimationEventBase(EventInterfaceType::AnimationPlaybackEvent, type, WTF::move(initializer), isTrusted)
+    : AnimationEventBase(EventInterfaceType::AnimationPlaybackEvent, type, WTF::move(initializer), isTrusted, nullptr)
     , m_timelineTime(initializer.timelineTime)
     , m_currentTime(initializer.currentTime)
 {

--- a/Source/WebCore/animation/CSSAnimation.idl
+++ b/Source/WebCore/animation/CSSAnimation.idl
@@ -26,7 +26,8 @@
 typedef USVString CSSOMString;
 
 [
-    Exposed=Window
+    Exposed=Window,
+    JSGenerateToNativeObject
 ] interface CSSAnimation : WebAnimation {
     readonly attribute CSSOMString animationName;
 };

--- a/Source/WebCore/animation/CSSAnimationEvent.cpp
+++ b/Source/WebCore/animation/CSSAnimationEvent.cpp
@@ -33,7 +33,7 @@ namespace WebCore {
 WTF_MAKE_TZONE_ALLOCATED_IMPL(CSSAnimationEvent);
 
 CSSAnimationEvent::CSSAnimationEvent(const AtomString& type, Init&& initializer, IsTrusted isTrusted)
-    : StyleOriginatedAnimationEvent(EventInterfaceType::CSSAnimationEvent, type, WTF::move(initializer), isTrusted, initializer.elapsedTime, WTF::move(initializer.pseudoElement))
+    : StyleOriginatedAnimationEvent(EventInterfaceType::CSSAnimationEvent, type, WTF::move(initializer), isTrusted, initializer.elapsedTime, WTF::move(initializer.pseudoElement), WTF::move(initializer.animation))
     , m_animationName(WTF::move(initializer.animationName))
 {
 }

--- a/Source/WebCore/animation/CSSAnimationEvent.h
+++ b/Source/WebCore/animation/CSSAnimationEvent.h
@@ -25,6 +25,7 @@
 
 #pragma once
 
+#include "CSSAnimation.h"
 #include "StyleOriginatedAnimationEvent.h"
 
 namespace WebCore {
@@ -38,6 +39,7 @@ public:
     }
 
     struct Init : EventInit {
+        RefPtr<CSSAnimation> animation;
         String animationName { emptyString() };
         double elapsedTime { 0 };
         String pseudoElement { emptyString() };
@@ -50,6 +52,7 @@ public:
 
     virtual ~CSSAnimationEvent();
 
+    RefPtr<CSSAnimation> cssAnimation() const { return dynamicDowncast<CSSAnimation>(animation()); }
     const String& animationName() const LIFETIME_BOUND { return m_animationName; }
 
 private:

--- a/Source/WebCore/animation/CSSAnimationEvent.idl
+++ b/Source/WebCore/animation/CSSAnimationEvent.idl
@@ -30,6 +30,7 @@
 ] interface CSSAnimationEvent : Event {
     constructor([AtomString] DOMString type, optional AnimationEventInit animationEventInitDict = {});
 
+    [ImplementedAs=cssAnimation] readonly attribute CSSAnimation? animation;
     readonly attribute DOMString animationName;
     readonly attribute double elapsedTime;
     readonly attribute DOMString pseudoElement;
@@ -37,6 +38,7 @@
 
 // https://drafts.csswg.org/css-animations/#dictdef-animationeventinit
 dictionary AnimationEventInit : EventInit {
+    CSSAnimation? animation = null;
     DOMString animationName = "";
     double elapsedTime = 0.0;
     DOMString pseudoElement = "";

--- a/Source/WebCore/animation/CSSTransition.idl
+++ b/Source/WebCore/animation/CSSTransition.idl
@@ -26,7 +26,8 @@
 typedef USVString CSSOMString;
 
 [
-    Exposed=Window
+    Exposed=Window,
+    JSGenerateToNativeObject
 ] interface CSSTransition : WebAnimation {
     readonly attribute CSSOMString transitionProperty;
 };

--- a/Source/WebCore/animation/CSSTransitionEvent.cpp
+++ b/Source/WebCore/animation/CSSTransitionEvent.cpp
@@ -40,7 +40,7 @@ CSSTransitionEvent::CSSTransitionEvent(const AtomString& type, WebAnimation* ani
 }
 
 CSSTransitionEvent::CSSTransitionEvent(const AtomString& type, Init&& initializer, IsTrusted isTrusted)
-    : StyleOriginatedAnimationEvent(EventInterfaceType::CSSTransitionEvent, type, WTF::move(initializer), isTrusted, initializer.elapsedTime, WTF::move(initializer.pseudoElement))
+    : StyleOriginatedAnimationEvent(EventInterfaceType::CSSTransitionEvent, type, WTF::move(initializer), isTrusted, initializer.elapsedTime, WTF::move(initializer.pseudoElement), WTF::move(initializer.animation))
     , m_propertyName(WTF::move(initializer.propertyName))
 {
 }

--- a/Source/WebCore/animation/CSSTransitionEvent.h
+++ b/Source/WebCore/animation/CSSTransitionEvent.h
@@ -26,6 +26,7 @@
 
 #pragma once
 
+#include "CSSTransition.h"
 #include "StyleOriginatedAnimationEvent.h"
 
 namespace WebCore {
@@ -39,6 +40,7 @@ public:
     }
 
     struct Init : EventInit {
+        RefPtr<CSSTransition> animation;
         String propertyName { emptyString() };
         double elapsedTime { 0 };
         String pseudoElement { emptyString() };
@@ -51,6 +53,7 @@ public:
 
     virtual ~CSSTransitionEvent();
 
+    RefPtr<CSSTransition> cssTransition() const { return dynamicDowncast<CSSTransition>(animation()); }
     const String& propertyName() const LIFETIME_BOUND { return m_propertyName; }
 
 private:

--- a/Source/WebCore/animation/CSSTransitionEvent.idl
+++ b/Source/WebCore/animation/CSSTransitionEvent.idl
@@ -31,6 +31,7 @@
 ] interface CSSTransitionEvent : Event {
     constructor([AtomString] DOMString type, optional TransitionEventInit transitionEventInitDict = {});
 
+    [ImplementedAs=cssTransition] readonly attribute CSSTransition? animation;
     readonly attribute DOMString propertyName;
     readonly attribute double elapsedTime;
     readonly attribute DOMString pseudoElement;
@@ -38,6 +39,7 @@
 
 // https://drafts.csswg.org/css-transitions/#dictdef-transitioneventinit
 dictionary TransitionEventInit : EventInit {
+    CSSTransition? animation = null;
     DOMString propertyName = "";
     double elapsedTime = 0.0;
     DOMString pseudoElement = "";

--- a/Source/WebCore/animation/StyleOriginatedAnimationEvent.cpp
+++ b/Source/WebCore/animation/StyleOriginatedAnimationEvent.cpp
@@ -43,8 +43,8 @@ StyleOriginatedAnimationEvent::StyleOriginatedAnimationEvent(enum EventInterface
 {
 }
 
-StyleOriginatedAnimationEvent::StyleOriginatedAnimationEvent(enum EventInterfaceType eventInterface, const AtomString& type, EventInit&& init, IsTrusted isTrusted, double elapsedTime, String&& pseudoElement)
-    : AnimationEventBase(eventInterface, type, WTF::move(init), isTrusted)
+StyleOriginatedAnimationEvent::StyleOriginatedAnimationEvent(enum EventInterfaceType eventInterface, const AtomString& type, EventInit&& init, IsTrusted isTrusted, double elapsedTime, String&& pseudoElement, RefPtr<WebAnimation>&& animation)
+    : AnimationEventBase(eventInterface, type, WTF::move(init), isTrusted, WTF::move(animation))
     , m_elapsedTime(elapsedTime)
     , m_pseudoElement(WTF::move(pseudoElement))
 {

--- a/Source/WebCore/animation/StyleOriginatedAnimationEvent.h
+++ b/Source/WebCore/animation/StyleOriginatedAnimationEvent.h
@@ -41,7 +41,7 @@ public:
 
 protected:
     StyleOriginatedAnimationEvent(enum EventInterfaceType, const AtomString& type, WebAnimation*, std::optional<Seconds> scheduledTime, double, const std::optional<Style::PseudoElementIdentifier>&);
-    StyleOriginatedAnimationEvent(enum EventInterfaceType, const AtomString&, EventInit&&, IsTrusted, double, String&&);
+    StyleOriginatedAnimationEvent(enum EventInterfaceType, const AtomString&, EventInit&&, IsTrusted, double, String&&, RefPtr<WebAnimation>&&);
 
 private:
     double m_elapsedTime;


### PR DESCRIPTION
#### e210992ca8558a1c2f3331d0984a7c1eab6fca08
<pre>
[css-animations][css-transitions] Add `animation` property to `AnimationEvent` and `TransitionEvent`
<a href="https://bugs.webkit.org/show_bug.cgi?id=314325">https://bugs.webkit.org/show_bug.cgi?id=314325</a>

Reviewed by Anne van Kesteren.

The css-animations-2 and css-transitions-2 specs were updated to add a new
`animation` property to the `AnimationEvent` and `TransitionEvent` interfaces in <a href="https://github.com/w3c/csswg-drafts/commit/32d875dcb8e3659f150e2e72d504e6f950f89b6c.">https://github.com/w3c/csswg-drafts/commit/32d875dcb8e3659f150e2e72d504e6f950f89b6c.</a>

Test: imported/w3c/web-platform-tests/css/css-transitions/events-008.html

* LayoutTests/imported/w3c/web-platform-tests/css/css-animations/animationevent-interface-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-animations/animationevent-types-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-transitions/events-008-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-transitions/events-008.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-transitions/transitionevent-interface-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-transitions/transitionevent-interface.html:
* Source/WebCore/animation/AnimationEventBase.cpp:
(WebCore::AnimationEventBase::AnimationEventBase):
* Source/WebCore/animation/AnimationEventBase.h:
* Source/WebCore/animation/AnimationPlaybackEvent.cpp:
(WebCore::AnimationPlaybackEvent::AnimationPlaybackEvent):
* Source/WebCore/animation/CSSAnimation.idl:
* Source/WebCore/animation/CSSAnimationEvent.cpp:
(WebCore::CSSAnimationEvent::CSSAnimationEvent):
* Source/WebCore/animation/CSSAnimationEvent.h:
* Source/WebCore/animation/CSSAnimationEvent.idl:
* Source/WebCore/animation/CSSTransition.idl:
* Source/WebCore/animation/CSSTransitionEvent.cpp:
(WebCore::CSSTransitionEvent::CSSTransitionEvent):
* Source/WebCore/animation/CSSTransitionEvent.h:
* Source/WebCore/animation/CSSTransitionEvent.idl:
* Source/WebCore/animation/StyleOriginatedAnimationEvent.cpp:
(WebCore::StyleOriginatedAnimationEvent::StyleOriginatedAnimationEvent):
* Source/WebCore/animation/StyleOriginatedAnimationEvent.h:

Canonical link: <a href="https://commits.webkit.org/312859@main">https://commits.webkit.org/312859@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8490b25d28b15813c1d2bdf47c58a39a61a998aa

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/161163 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/34636 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/27737 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/170066 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/117534 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/b517a2a7-ebf0-41ef-ac4c-ec549a2a86e0) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/163032 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/34737 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/34637 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/125011 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/117534 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/28e5b101-cfd4-4b19-b1d7-3e023e59f0b9) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/164122 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/27292 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/144763 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/105608 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/7d5bad9a-377a-4f4b-9fb0-4a10b27d816e) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/26340 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/24838 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/17786 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/136034 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/22524 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/172549 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/19570 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/24165 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/133290 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/34310 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/28931 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/133300 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/34294 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/144319 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/96152 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/24522 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/27847 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/21137 "Found 2 new test failures: http/tests/IndexedDB/transaction-stop-during-request-dispatch.html imported/w3c/web-platform-tests/media-source/mediasource-changetype-play-without-codecs-parameter.html (failure)") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/33805 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/101230 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/33304 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/33548 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/33453 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->