### PR TITLE
Make option and optgroup match :disabled inside disabled select

### DIFF
--- a/LayoutTests/fast/forms/select/optgroup-disabled-expected.txt
+++ b/LayoutTests/fast/forms/select/optgroup-disabled-expected.txt
@@ -26,11 +26,11 @@ PASS $("listbox_optgroup_disabled").disabled is true
 PASS $("listbox_optgroup_enabled").disabled is false
 PASS $("menulist_optgroup_disabled").disabled is true
 PASS $("menulist_optgroup_enabled").disabled is false
-select.disabled doesn't affect pseudo-class :disabled
+select.disabled affects pseudo-class :disabled
 PASS disabledSet["listbox_optgroup_disabled"] is true
 PASS disabledSet["menulist_optgroup_disabled"] is true
-PASS disabledSet["listbox_optgroup_enabled"] is undefined.
-PASS disabledSet["menulist_optgroup_enabled"] is undefined.
+PASS disabledSet["listbox_optgroup_enabled"] is true
+PASS disabledSet["menulist_optgroup_enabled"] is true
 form.disabled doesn't affect optgroup.disabled
 PASS $("listbox_optgroup_disabled").disabled is true
 PASS $("listbox_optgroup_enabled").disabled is false
@@ -39,8 +39,8 @@ PASS $("menulist_optgroup_enabled").disabled is false
 form.disabled doesn't affect pseudo-class :disabled
 PASS disabledSet["listbox_optgroup_disabled"] is true
 PASS disabledSet["menulist_optgroup_disabled"] is true
-PASS disabledSet["listbox_optgroup_enabled"] is undefined.
-PASS disabledSet["menulist_optgroup_enabled"] is undefined.
+PASS disabledSet["listbox_optgroup_enabled"] is true
+PASS disabledSet["menulist_optgroup_enabled"] is true
 Check IDL [Reflect]
 PASS $("listbox_optgroup_disabled").disabled is false
 PASS $("menulist_optgroup_disabled").disabled is false

--- a/LayoutTests/fast/forms/select/optgroup-disabled.html
+++ b/LayoutTests/fast/forms/select/optgroup-disabled.html
@@ -85,12 +85,12 @@ shouldBeFalse('$("listbox_optgroup_enabled").disabled');
 shouldBeTrue('$("menulist_optgroup_disabled").disabled');
 shouldBeFalse('$("menulist_optgroup_enabled").disabled');
 
-debug("select.disabled doesn't affect pseudo-class :disabled");
+debug("select.disabled affects pseudo-class :disabled");
 disabledSet = querySelectorAll(':disabled');
 shouldBeTrue('disabledSet["listbox_optgroup_disabled"]');
 shouldBeTrue('disabledSet["menulist_optgroup_disabled"]');
-shouldBeUndefined('disabledSet["listbox_optgroup_enabled"]');
-shouldBeUndefined('disabledSet["menulist_optgroup_enabled"]');
+shouldBeTrue('disabledSet["listbox_optgroup_enabled"]');
+shouldBeTrue('disabledSet["menulist_optgroup_enabled"]');
 
 debug("form.disabled doesn't affect optgroup.disabled");
 $("form").disabled = true;
@@ -104,8 +104,8 @@ debug("form.disabled doesn't affect pseudo-class :disabled");
 disabledSet = querySelectorAll(':disabled');
 shouldBeTrue('disabledSet["listbox_optgroup_disabled"]');
 shouldBeTrue('disabledSet["menulist_optgroup_disabled"]');
-shouldBeUndefined('disabledSet["listbox_optgroup_enabled"]');
-shouldBeUndefined('disabledSet["menulist_optgroup_enabled"]');
+shouldBeTrue('disabledSet["listbox_optgroup_enabled"]');
+shouldBeTrue('disabledSet["menulist_optgroup_enabled"]');
 
 debug("Check IDL [Reflect]");
 $("listbox_optgroup_disabled").removeAttribute("disabled");

--- a/LayoutTests/imported/w3c/web-platform-tests/css/selectors/invalidation/option-disabled-when-ancestor-changes-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/selectors/invalidation/option-disabled-when-ancestor-changes-expected.txt
@@ -1,0 +1,12 @@
+
+
+
+
+
+
+
+PASS option :disabled and :has(option:disabled) invalidate when ancestor select disabled toggles
+PASS optgroup :disabled and :has(optgroup:disabled) invalidate when ancestor select disabled toggles
+PASS option :disabled and :has(option:disabled) invalidate when ancestor fieldset disabled toggles
+PASS optgroup :disabled and :has(optgroup:disabled) invalidate when ancestor fieldset disabled toggles
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/selectors/invalidation/option-disabled-when-ancestor-changes.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/selectors/invalidation/option-disabled-when-ancestor-changes.html
@@ -1,0 +1,120 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Selectors Invalidation: option/optgroup :disabled when ancestor select or fieldset disabled changes</title>
+<link rel="help" href="https://html.spec.whatwg.org/multipage/semantics-other.html#selector-disabled">
+<link rel="help" href="https://github.com/whatwg/html/pull/12205">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<style>
+  option, optgroup { color: black }
+  option:disabled, optgroup:disabled { color: red }
+
+  #select_subject_option:has(option:disabled) { background-color: green }
+  #select_subject_optgroup:has(optgroup:disabled) { background-color: blue }
+  #fieldset_subject_option:has(option:disabled) { background-color: green }
+  #fieldset_subject_optgroup:has(optgroup:disabled) { background-color: blue }
+</style>
+
+<div id="select_subject_option">
+  <select id="select_a">
+    <option id="option_a">a</option>
+  </select>
+</div>
+
+<div id="select_subject_optgroup">
+  <select id="select_b">
+    <optgroup id="optgroup_b" label="group"></optgroup>
+  </select>
+</div>
+
+<fieldset id="fieldset_a">
+  <div id="fieldset_subject_option">
+    <select>
+      <option id="option_c">c</option>
+    </select>
+  </div>
+</fieldset>
+
+<fieldset id="fieldset_b">
+  <div id="fieldset_subject_optgroup">
+    <select>
+      <optgroup id="optgroup_d" label="group"></optgroup>
+    </select>
+  </div>
+</fieldset>
+
+<script>
+const black = "rgb(0, 0, 0)";
+const red = "rgb(255, 0, 0)";
+const green = "rgb(0, 128, 0)";
+const blue = "rgb(0, 0, 255)";
+const transparent = "rgba(0, 0, 0, 0)";
+
+function colorOf(element) {
+  return getComputedStyle(element).color;
+}
+
+function backgroundColorOf(element) {
+  return getComputedStyle(element).backgroundColor;
+}
+
+test(t => {
+  t.add_cleanup(() => { select_a.disabled = false; });
+
+  assert_equals(colorOf(option_a), black, "option color before");
+  assert_equals(backgroundColorOf(select_subject_option), transparent, ":has(option:disabled) before");
+
+  select_a.disabled = true;
+  assert_equals(colorOf(option_a), red, "option color after disabling select");
+  assert_equals(backgroundColorOf(select_subject_option), green, ":has(option:disabled) after disabling select");
+
+  select_a.disabled = false;
+  assert_equals(colorOf(option_a), black, "option color after re-enabling select");
+  assert_equals(backgroundColorOf(select_subject_option), transparent, ":has(option:disabled) after re-enabling select");
+}, "option :disabled and :has(option:disabled) invalidate when ancestor select disabled toggles");
+
+test(t => {
+  t.add_cleanup(() => { select_b.disabled = false; });
+
+  assert_equals(colorOf(optgroup_b), black, "optgroup color before");
+  assert_equals(backgroundColorOf(select_subject_optgroup), transparent, ":has(optgroup:disabled) before");
+
+  select_b.disabled = true;
+  assert_equals(colorOf(optgroup_b), red, "optgroup color after disabling select");
+  assert_equals(backgroundColorOf(select_subject_optgroup), blue, ":has(optgroup:disabled) after disabling select");
+
+  select_b.disabled = false;
+  assert_equals(colorOf(optgroup_b), black, "optgroup color after re-enabling select");
+  assert_equals(backgroundColorOf(select_subject_optgroup), transparent, ":has(optgroup:disabled) after re-enabling select");
+}, "optgroup :disabled and :has(optgroup:disabled) invalidate when ancestor select disabled toggles");
+
+test(t => {
+  t.add_cleanup(() => { fieldset_a.disabled = false; });
+
+  assert_equals(colorOf(option_c), black, "option color before");
+  assert_equals(backgroundColorOf(fieldset_subject_option), transparent, ":has(option:disabled) before");
+
+  fieldset_a.disabled = true;
+  assert_equals(colorOf(option_c), red, "option color after disabling fieldset");
+  assert_equals(backgroundColorOf(fieldset_subject_option), green, ":has(option:disabled) after disabling fieldset");
+
+  fieldset_a.disabled = false;
+  assert_equals(colorOf(option_c), black, "option color after re-enabling fieldset");
+  assert_equals(backgroundColorOf(fieldset_subject_option), transparent, ":has(option:disabled) after re-enabling fieldset");
+}, "option :disabled and :has(option:disabled) invalidate when ancestor fieldset disabled toggles");
+
+test(t => {
+  t.add_cleanup(() => { fieldset_b.disabled = false; });
+
+  assert_equals(colorOf(optgroup_d), black, "optgroup color before");
+  assert_equals(backgroundColorOf(fieldset_subject_optgroup), transparent, ":has(optgroup:disabled) before");
+
+  fieldset_b.disabled = true;
+  assert_equals(colorOf(optgroup_d), red, "optgroup color after disabling fieldset");
+  assert_equals(backgroundColorOf(fieldset_subject_optgroup), blue, ":has(optgroup:disabled) after disabling fieldset");
+
+  fieldset_b.disabled = false;
+  assert_equals(colorOf(optgroup_d), black, "optgroup color after re-enabling fieldset");
+  assert_equals(backgroundColorOf(fieldset_subject_optgroup), transparent, ":has(optgroup:disabled) after re-enabling fieldset");
+}, "optgroup :disabled and :has(optgroup:disabled) invalidate when ancestor fieldset disabled toggles");
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/option-disabled-optgroup-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/option-disabled-optgroup-expected.txt
@@ -5,4 +5,5 @@ PASS nested optgroup
 PASS disabled select
 PASS select in optgroup
 PASS nested options
+PASS nesting options and optgroups in disabled select
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/option-disabled-optgroup.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/option-disabled-optgroup.html
@@ -47,10 +47,13 @@ test(() => {
 test(() => {
   const select = document.createElement('select');
   const option = document.createElement('option');
+  const optgroup = document.createElement('optgroup');
   select.appendChild(option);
+  select.appendChild(optgroup);
   select.disabled = true;
 
-  assert_false(option.matches(':disabled'));
+  assert_true(option.matches(':disabled'));
+  assert_true(optgroup.matches(':disabled'));
 }, 'disabled select');
 
 test(() => {
@@ -75,4 +78,41 @@ test(() => {
   assert_true(parentOption.matches(':disabled'), 'parent option');
   assert_false(childOption.matches(':disabled'), 'child option');
 }, 'nested options');
+
+test(() => {
+  const select = document.createElement('select');
+  select.disabled = true;
+
+  const optgroup = document.createElement('optgroup');
+  select.appendChild(optgroup);
+  const optionInOptgroup = document.createElement('option');
+  optgroup.appendChild(optionInOptgroup);
+  const optgroupInOptgroup = document.createElement('optgroup');
+  optgroup.appendChild(optgroupInOptgroup);
+  const optionInNestedOptgroup = document.createElement('option');
+  optgroupInOptgroup.appendChild(optionInNestedOptgroup);
+  assert_true(optgroup.matches(':disabled'), 'optgroup');
+  assert_false(optgroupInOptgroup.matches(':disabled'), 'nested optgroup');
+  assert_true(optionInOptgroup.matches(':disabled'), 'option in optgroup');
+  assert_false(optionInNestedOptgroup.matches(':disabled'), 'option in nested optgroup');
+
+  const option = document.createElement('option');
+  select.appendChild(option);
+  const optgroupInOption = document.createElement('optgroup');
+  option.appendChild(optgroupInOption);
+  const optionInOption = document.createElement('option');
+  option.appendChild(optionInOption);
+  assert_true(option.matches(':disabled'), 'option');
+  assert_false(optgroupInOption.matches(':disabled'), 'optgroup in option');
+  assert_false(optionInOption.matches(':disabled'), 'nested option');
+
+  const hr = document.createElement('hr');
+  select.appendChild(hr);
+  const optionInHr = document.createElement('option');
+  hr.appendChild(optionInHr);
+  const optgroupInHr = document.createElement('optgroup');
+  hr.appendChild(optgroup);
+  assert_false(optionInHr.matches(':disabled'), 'option in hr');
+  assert_false(optgroupInHr.matches(':disabled'), 'optgroup in hr');
+}, 'nesting options and optgroups in disabled select');
 </script>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/selectors/pseudo-classes/WEB_FEATURES.yml
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/selectors/pseudo-classes/WEB_FEATURES.yml
@@ -14,7 +14,26 @@ features:
   files:
   - checked-indeterminate.window.js
   - indeterminate*
+- name: input-selectors
+  files:
+  - checked-001-manual.html
+  - checked-type-change.html
+  - checked.html
+  - disabled.html
+  - enabled.html
+- name: placeholder-shown
+  files:
+  - placeholder-shown-type-change.html
 - name: read-write-pseudos
   files:
   - readwrite-readonly-type-change.html
   - readwrite-readonly.html
+- name: form-validity-pseudos
+  files:
+  - valid-invalid.html
+  - valid-invalid-fieldset-disconnected.html
+  - invalid-after-clone.html
+  - required-optional.html
+  - required-optional-hidden.html
+  - inrange-outofrange.html
+  - inrange-outofrange-type-change.html

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/selectors/pseudo-classes/disabled.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/selectors/pseudo-classes/disabled.html
@@ -76,5 +76,5 @@
     </fieldset>
   `;
   document.getElementById("fieldset2").appendChild(fieldset);
-  testSelectorIdsMatch("#fieldset2 :disabled", ["clubname", "clubnum", "fieldset_nested", "input_nested", "button_nested", "select_nested", "textarea_nested", "fieldset_nested2", "input_nested2"], "':disabled' should match elements that are appended to a disabled fieldset dynamically");
+  testSelectorIdsMatch("#fieldset2 :disabled", ["clubname", "clubnum", "fieldset_nested", "input_nested", "button_nested", "select_nested", "optgroup_nested", "option_nested", "textarea_nested", "fieldset_nested2", "input_nested2"], "':disabled' should match elements that are appended to a disabled fieldset dynamically");
 </script>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/selectors/pseudo-classes/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/selectors/pseudo-classes/w3c-import.log
@@ -37,6 +37,7 @@ List of files:
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/selectors/pseudo-classes/indeterminate-type-change.html
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/selectors/pseudo-classes/indeterminate.html
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/selectors/pseudo-classes/input-checkbox-switch.tentative.window.js
+/LayoutTests/imported/w3c/web-platform-tests/html/semantics/selectors/pseudo-classes/inrange-outofrange-time-reversed.html
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/selectors/pseudo-classes/inrange-outofrange-type-change.html
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/selectors/pseudo-classes/inrange-outofrange.html
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/selectors/pseudo-classes/invalid-after-clone.html

--- a/Source/WebCore/html/HTMLOptGroupElement.cpp
+++ b/Source/WebCore/html/HTMLOptGroupElement.cpp
@@ -169,6 +169,14 @@ bool HTMLOptGroupElement::isDisabledFormControl() const
     return m_isDisabled;
 }
 
+bool HTMLOptGroupElement::isActuallyDisabled() const
+{
+    if (HTMLElement::isActuallyDisabled())
+        return true;
+    RefPtr select = ownerSelectElement();
+    return select && select->isDisabledFormControl();
+}
+
 bool HTMLOptGroupElement::isFocusable() const
 {
     RefPtr select = ownerSelectElement();

--- a/Source/WebCore/html/HTMLOptGroupElement.h
+++ b/Source/WebCore/html/HTMLOptGroupElement.h
@@ -37,6 +37,7 @@ public:
     static Ref<HTMLOptGroupElement> create(const QualifiedName&, Document&);
 
     bool isDisabledFormControl() const final;
+    bool isActuallyDisabled() const final;
     WEBCORE_EXPORT HTMLSelectElement* NODELETE ownerSelectElement() const;
     
     WEBCORE_EXPORT String groupLabelText() const;

--- a/Source/WebCore/html/HTMLOptionElement.cpp
+++ b/Source/WebCore/html/HTMLOptionElement.cpp
@@ -584,6 +584,14 @@ bool HTMLOptionElement::isDisabledFormControl() const
     return false;
 }
 
+bool HTMLOptionElement::isActuallyDisabled() const
+{
+    if (HTMLElement::isActuallyDisabled())
+        return true;
+    RefPtr select = ownerSelectElement();
+    return select && select->isDisabledFormControl();
+}
+
 String HTMLOptionElement::collectOptionInnerText() const
 {
     StringBuilder text;

--- a/Source/WebCore/html/HTMLOptionElement.h
+++ b/Source/WebCore/html/HTMLOptionElement.h
@@ -69,6 +69,7 @@ public:
     bool ownElementDisabled() const { return m_disabled; }
 
     WEBCORE_EXPORT bool isDisabledFormControl() const final;
+    bool isActuallyDisabled() const final;
 
     String textIndentedToRespectGroupLabel() const;
 

--- a/Source/WebCore/html/HTMLSelectElement.cpp
+++ b/Source/WebCore/html/HTMLSelectElement.cpp
@@ -580,6 +580,28 @@ void HTMLSelectElement::attributeChanged(const QualifiedName& name, const AtomSt
     }
 }
 
+void HTMLSelectElement::setDisabledInternal(bool disabled, bool disabledByAncestorFieldset)
+{
+    bool newDisabledState = disabled || disabledByAncestorFieldset;
+    if (newDisabledState == isDisabled()) {
+        ValidatedFormListedElement::setDisabledInternal(disabled, disabledByAncestorFieldset);
+        return;
+    }
+
+    Vector<Style::PseudoClassChangeInvalidation> descendantInvalidations;
+    for (Ref descendant : descendantsOfType<HTMLElement>(*this)) {
+        if (!isAnyOf<HTMLOptionElement, HTMLOptGroupElement>(descendant.get()))
+            continue;
+        bool newDescendantDisabled = newDisabledState || descendant->isDisabledFormControl();
+        descendantInvalidations.append({ descendant.get(), {
+            { CSSSelector::PseudoClass::Disabled, newDescendantDisabled },
+            { CSSSelector::PseudoClass::Enabled, !newDescendantDisabled },
+        } });
+    }
+
+    ValidatedFormListedElement::setDisabledInternal(disabled, disabledByAncestorFieldset);
+}
+
 int HTMLSelectElement::defaultTabIndex() const
 {
     return 0;

--- a/Source/WebCore/html/HTMLSelectElement.h
+++ b/Source/WebCore/html/HTMLSelectElement.h
@@ -233,6 +233,8 @@ private:
 
     void attributeChanged(const QualifiedName&, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason) final;
 
+    void setDisabledInternal(bool disabled, bool disabledByAncestorFieldset) final;
+
     bool hasPresentationalHintsForAttribute(const QualifiedName&) const final;
 
     bool childShouldCreateRenderer(const Node&) const final;

--- a/Source/WebCore/html/ValidatedFormListedElement.h
+++ b/Source/WebCore/html/ValidatedFormListedElement.h
@@ -120,9 +120,10 @@ protected:
     void syncWithFieldsetAncestors(ContainerNode* insertionNode);
     void restoreFormControlStateIfNecessary();
 
+    virtual void setDisabledInternal(bool disabled, bool disabledByAncestorFieldset);
+
 private:
     bool computeIsDisabledByFieldsetAncestor() const;
-    void setDisabledInternal(bool disabled, bool disabledByAncestorFieldset);
     virtual HTMLElement* validationAnchorElement() = 0;
 
     void startDelayingUpdateValidity() { ++m_delayedUpdateValidityCount; }


### PR DESCRIPTION
#### 2e9b35cc8d053cf076021aa09048099b7b7e1736
<pre>
Make option and optgroup match :disabled inside disabled select
<a href="https://bugs.webkit.org/show_bug.cgi?id=313974">https://bugs.webkit.org/show_bug.cgi?id=313974</a>

Reviewed by Tim Nguyen.

Align with this change to the HTML standard and corresponding test
changes:

    <a href="https://github.com/whatwg/html/pull/12205">https://github.com/whatwg/html/pull/12205</a>

To do pseudo-class invalidation correctly we make
ValidatedFormListedElement::setDisabledInternal protected so
HTMLSelectElement can augment it with its own logic.

Test: imported/w3c/web-platform-tests/css/selectors/invalidation/option-disabled-when-ancestor-changes.html

Upstream: <a href="https://github.com/web-platform-tests/wpt/pull/59747">https://github.com/web-platform-tests/wpt/pull/59747</a>
Canonical link: <a href="https://commits.webkit.org/312890@main">https://commits.webkit.org/312890@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/75c54b1849b100ba3b85f66e36c6ddba7f8db062

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/161332 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/34805 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/27906 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/170235 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/117703 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/163201 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/34906 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/34806 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/125149 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/117703 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/164291 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/27438 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/144918 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/105746 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/26486 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/24996 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/17955 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/136180 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/22678 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/172718 "Built successfully") | | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/22170 "Build is in progress. Recent messages:") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/19739 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/24319 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/133431 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/34479 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/29088 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/133439 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/34464 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/144473 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/96329 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/24533 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/27978 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/21292 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/33974 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/101399 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/33473 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/33717 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/33622 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->