### PR TITLE
Rework ParkingLot's spinloop

### DIFF
--- a/Source/WTF/wtf/LockAlgorithmInlines.h
+++ b/Source/WTF/wtf/LockAlgorithmInlines.h
@@ -28,7 +28,9 @@
 #include <wtf/DataLog.h>
 #include <wtf/LockAlgorithm.h>
 #include <wtf/ParkingLot.h>
+#include <wtf/Platform.h>
 #include <wtf/Threading.h>
+#include <wtf/simde/simde.h>
 
 // It's a good idea to avoid including this header in too many places, so that it's possible to change
 // the lock algorithm slow path without recompiling the world. Right now this should be included in two
@@ -39,8 +41,76 @@ namespace WTF {
 template<typename LockType, LockType isHeldBit, LockType hasParkedBit, typename Hooks>
 void LockAlgorithm<LockType, isHeldBit, hasParkedBit, Hooks>::lockSlow(Atomic<LockType>& lock)
 {
-    // This magic number turns out to be optimal based on past JikesRVM experiments.
+    // These values were selected empirically.
+    // The balancing act here lies in speeding up the "semi-contended" case
+    // without too strongly disadvantaging the "heavily-contended" case
+    // (the uncontended case of course never hits the spinloop).
+    // There are a few variables to consider:
+    //
+    //   * Time-to-park: the total CPU time of a full spinloop
+    //     ~= spinLimit * (nopCount + 1/yieldInterval)
+    //     Increases with spinLimit, nopCount; decreases with yieldInterval.
+    //     Higher is better (to a point) for semi-contended,
+    //     but significantly worse for heavily-contended, as we pay
+    //     the full cost of the spinloop on ~every attempt to acquire.
+    //
+    //   * Niceness: (vaguely) how often we yield vs. run on core
+    //     ~= 1 / (yieldInterval * nopCount)
+    //     Higher is better for heavily-contended, as it means that high-
+    //     priority threads will 'make room' for other threads as they
+    //     spin, rather than taking up high-priority CPU time on a spinloop.
+    //     However, it's worse for the semi-contended case, as when we
+    //     do acquire the spinlock the priority depression can last
+    //     for some time, meaning it could take a few quanta to get
+    //     back to 'full speed'.
+    //
+    //   * Poll-rate: the rate at which we read the atomic lock bit
+    //     ~= 1 / (nopCount + 1/yieldInterval)
+    //     This affects performance in two different ways.
+    //     The first is that, if the lock does become available, we
+    //     may be in the middle of a nop-spin, and therefore have to
+    //     execute the remaining nops before we check again.
+    //     Therefore, in the semi-contended case we want a higher frequency.
+    //     However, the higher the frequency, the more often we hammer the
+    //     lock's cache line. In sparse contention regimes this is relatively
+    //     OK: e.g. if there's only a single waiter, then the cache-line
+    //     stays local. With multiple waiters, however, then the line
+    //     can ping between cores, hurting performance.
+    //     Therefore, in the heavily-contended case it's better for this
+    //     to be lower.
+    //
+    // In general, the gains for the semi-contended case are modest, but
+    // show up across the board. On the flipside, hits to the heavily-
+    // contended case tend to be localized to a few scenarios, but have
+    // a very large effect-size; heavy contention is very rare
+    // (by design, from how WebKit uses locks), but very sensitive
+    // because spinlocks are poorly-adapted for that regime. E.g.
+    // omitting sched-yield entirely can more than double the runtime
+    // of certain benchmarks!
+    //
+    // N.b.: there are of course more considerations than just the above three.
+    // Fairness suffers as time-to-park increases, while all three can have
+    // deleterious effects on the rest of the system (e.g. scheduler churn,
+    // wasting memory bandwidth, etc.) depending on the details. But since
+    // those factors are harder to frame neatly I'm leaving them to this
+    // appendix.
+#if CPU(ARM64) && OS(MACOS)
+    static constexpr unsigned spinLimit = 80;
+    static constexpr unsigned nopCount = 512;
+    static constexpr unsigned yieldInterval = 16;
+#elif CPU(ARM64) && OS(IOS_FAMILY)
     static constexpr unsigned spinLimit = 40;
+    static constexpr unsigned nopCount = 1024;
+    static constexpr unsigned yieldInterval = 4;
+#else
+    static constexpr unsigned spinLimit = 40;
+    // The tuning necessary to determine the optimal values
+    // for other platforms has not yet been done, so we
+    // retain the old sched-yield loop to avoid
+    // possible regressions.
+    static constexpr unsigned nopCount = 0;
+    static constexpr unsigned yieldInterval = 1;
+#endif
     
     unsigned spinCount = 0;
     
@@ -57,7 +127,21 @@ void LockAlgorithm<LockType, isHeldBit, hasParkedBit, Hooks>::lockSlow(Atomic<Lo
         // If there is nobody parked and we haven't spun too much, we can just try to spin around.
         if (!(currentValue & hasParkedBit) && spinCount < spinLimit) {
             spinCount++;
-            Thread::yield();
+            // It's important that we check this after incrementing,
+            // as we want to avoid yielding for the first few spins.
+            // This makes it more likely that we can acquire the lock
+            // without having depressed our own priority beforehand.
+            if (!(spinCount % yieldInterval))
+                Thread::yield();
+            for (unsigned i = 0; i < nopCount; i++) {
+#if CPU(ARM64)
+                // FIXME: replace with simde_mm_pause and recompute the
+                // nopCount to match.
+                asm volatile ("yield");
+#else
+                simde_mm_pause();
+#endif
+            }
             continue;
         }
 


### PR DESCRIPTION
#### d17da45094f8eb45a42da3807fe417cead594374
<pre>
Rework ParkingLot&apos;s spinloop
<a href="https://bugs.webkit.org/show_bug.cgi?id=314101">https://bugs.webkit.org/show_bug.cgi?id=314101</a>
<a href="https://rdar.apple.com/176237718">rdar://176237718</a>

Reviewed by Yusuke Suzuki.

This includes three main changes:
 1. Only call sched_yield once every N
    loop iterations, and don&apos;t call it at all
    for the first N.
 2. Add a blind inner loop which unconditionally
    executes M yields per outer loop iteration.
 3. Tuning the above M, N, and the overall spin-count
    O on a per-platform basis.
By doing so, it improves performance in the semi-contended
regime without impairing it in the heavily-contended case.

This tuning was not exhaustive, so there are likely still
opportunities for further improvement, e.g. via some sort
of exponential backoff, or even by tuning the parameters
per-SoC, rather than per-platform.

There are a few variables to consider:
  * Time-to-park: the total CPU time of a full spinloop
    ~= spinLimit * (nopCount + 1/yieldInterval)
    Increases with spinLimit, nopCount; decreases with yieldInterval.
    Higher is better (to a point) for semi-contended,
    but significantly worse for heavily-contended, as we pay
    the full cost of the spinloop on ~every attempt to acquire.
  * Niceness: (vaguely) how often we yield vs. run on core
    ~= 1 / (yieldInterval * nopCount)
    Higher is better for heavily-contended, as it means that high-
    priority threads will &apos;make room&apos; for other threads as they
    spin, rather than taking up high-priority CPU time on a spinloop.
    However, it&apos;s worse for the semi-contended case, as when we
    do acquire the spinlock the priority depression can last
    for some time, meaning it could take a few quanta to get
    back to &apos;full speed&apos;.
  * Poll-rate: the rate at which we read the atomic lock bit
    ~= 1 / (nopCount + 1/yieldInterval)
    This affects performance in two different ways.
    The first is that, if the lock does become available, we
    may be in the middle of a nop-spin, and therefore have to
    execute the remaining nops before we check again.
    Therefore, in the semi-contended case we want a higher frequency.
    However, the higher the frequency, the more often we hammer the
    lock&apos;s cache line. In sparse contention regimes this is relatively
    OK: e.g. if there&apos;s only a single waiter, then the cache-line
    stays local. With multiple waiters, however, then the line
    can ping between cores, hurting performance.
    Therefore, in the heavily-contended case it&apos;s better for this
    to be lower.

In general, the gains for the semi-contended case are modest, but
show up across the board. On the flipside, hits to the heavily-
contended case tend to be localized to a few scenarios, but have
a very large effect-size; heavy contention is very rare
(by design, from how WebKit uses locks), but very sensitive
because spinlocks are poorly-adapted for that regime. E.g.
omitting sched-yield entirely can more than double the runtime
of certain benchmarks!

No new tests because existing tests cover changes to lock behavior.

Canonical link: <a href="https://commits.webkit.org/313051@main">https://commits.webkit.org/313051@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/63bcf58c6d46c825c37e24ea6ecb42779515ea6f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/161946 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/35421 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/28525 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/170849 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/118317 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/3931fce3-2b7b-400c-b255-f2d4d7b3c803) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/35523 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/35422 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/125658 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/88550 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/d9c49232-7aec-4e56-b9e4-ff8f106ec404) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/164905 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/27975 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/145454 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/106248 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/27024 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/25537 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/18570 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/154005 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/136717 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/23208 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/173338 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/22784 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/20433 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/24849 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/133956 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/35094 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/29623 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/133961 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36170 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/35078 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/145003 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/97176 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/28488 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/21828 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/194347 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/34588 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/102073 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/50086 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/34089 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/34331 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/34237 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->