### PR TITLE
[BFCache] Share SuspendedPageProxy across same-process BFCache entries

### DIFF
--- a/Source/WebKit/Shared/WebBackForwardListItem.cpp
+++ b/Source/WebKit/Shared/WebBackForwardListItem.cpp
@@ -140,6 +140,13 @@ void WebBackForwardListItem::setBackForwardCacheEntry(RefPtr<WebBackForwardCache
     m_backForwardCacheEntry = WTF::move(backForwardCacheEntry);
 }
 
+WebBackForwardCacheEntry* WebBackForwardListItem::backForwardCacheEntryForProcess(WebCore::ProcessIdentifier processIdentifier) const
+{
+    if (m_backForwardCacheEntry && m_backForwardCacheEntry->processIdentifier() == processIdentifier)
+        return m_backForwardCacheEntry.get();
+    return nullptr;
+}
+
 SuspendedPageProxy* WebBackForwardListItem::suspendedPage() const
 {
     return m_backForwardCacheEntry ? m_backForwardCacheEntry->suspendedPage() : nullptr;

--- a/Source/WebKit/Shared/WebBackForwardListItem.h
+++ b/Source/WebKit/Shared/WebBackForwardListItem.h
@@ -30,6 +30,7 @@
 #include "SessionState.h"
 #include "WebPageProxyIdentifier.h"
 #include "WebsiteDataStore.h"
+#include <WebCore/ProcessIdentifier.h>
 #include <wtf/CheckedPtr.h>
 #include <wtf/Ref.h>
 #include <wtf/SwiftBridging.h>
@@ -84,6 +85,7 @@ public:
     void wasRemovedFromBackForwardList();
 
     WebBackForwardCacheEntry* backForwardCacheEntry() const { return m_backForwardCacheEntry.get(); }
+    WebBackForwardCacheEntry* NODELETE backForwardCacheEntryForProcess(WebCore::ProcessIdentifier) const;
 
     SuspendedPageProxy* NODELETE suspendedPage() const;
 

--- a/Source/WebKit/UIProcess/WebBackForwardCache.cpp
+++ b/Source/WebKit/UIProcess/WebBackForwardCache.cpp
@@ -108,6 +108,15 @@ void WebBackForwardCache::addEntry(WebBackForwardListItem& item, Ref<WebBackForw
 void WebBackForwardCache::addEntry(WebBackForwardListItem& item, Ref<SuspendedPageProxy>&& suspendedPage)
 {
     auto coreProcessIdentifier = suspendedPage->process().coreProcessIdentifier();
+
+    // Share the SuspendedPageProxy with existing entries in the same process.
+    // When a process is suspended, ALL items cached in that process need access
+    // to the SuspendedPageProxy to unsuspend it during back/forward navigation.
+    for (RefPtr otherItem : m_itemsWithCachedPage) {
+        if (RefPtr entry = otherItem->backForwardCacheEntryForProcess(coreProcessIdentifier); entry && !entry->suspendedPage())
+            entry->setSuspendedPage(suspendedPage.copyRef());
+    }
+
     addEntry(item, WebBackForwardCacheEntry::create(*this, item.identifier(), item.mainFrameItem().identifier(), coreProcessIdentifier, WTF::move(suspendedPage)));
 }
 
@@ -137,7 +146,20 @@ Ref<SuspendedPageProxy> WebBackForwardCache::takeSuspendedPage(WebBackForwardLis
 
     ASSERT(m_itemsWithCachedPage.contains(item));
     ASSERT(item.backForwardCacheEntry());
+
+    auto processIdentifier = item.backForwardCacheEntry()->processIdentifier();
     Ref suspendedPage = protect(item.backForwardCacheEntry())->takeSuspendedPage();
+
+    // Clear SuspendedPageProxy from other entries in the same process.
+    // The process is about to be unsuspended, so these entries become
+    // regular in-process BFCache entries.
+    for (RefPtr otherItem : m_itemsWithCachedPage) {
+        if (otherItem.get() == &item)
+            continue;
+        if (RefPtr entry = otherItem->backForwardCacheEntryForProcess(processIdentifier); entry && entry->suspendedPage())
+            entry->clearSuspendedPage();
+    }
+
     removeEntry(item);
     return suspendedPage;
 }

--- a/Source/WebKit/UIProcess/WebBackForwardCacheEntry.cpp
+++ b/Source/WebKit/UIProcess/WebBackForwardCacheEntry.cpp
@@ -58,7 +58,12 @@ WebBackForwardCacheEntry::WebBackForwardCacheEntry(WebBackForwardCache& backForw
 
 WebBackForwardCacheEntry::~WebBackForwardCacheEntry()
 {
-    if (m_backForwardFrameItemID && !m_suspendedPage) {
+    // m_backForwardFrameItemID is cleared by takeSuspendedPage(), so this
+    // correctly skips on the BFCache restore path. On capacity eviction we
+    // must still clear the cached page even when a SuspendedPageProxy is
+    // held, since the SPP may be shared with other entries in the same
+    // process and won't be destroyed by this drop.
+    if (m_backForwardFrameItemID) {
         if (auto process = this->process())
             process->sendWithAsyncReply(Messages::WebProcess::ClearCachedPage(*m_backForwardFrameItemID), [] { });
     }
@@ -67,6 +72,16 @@ WebBackForwardCacheEntry::~WebBackForwardCacheEntry()
 WebBackForwardCache* WebBackForwardCacheEntry::backForwardCache() const
 {
     return m_backForwardCache.get();
+}
+
+void WebBackForwardCacheEntry::setSuspendedPage(Ref<SuspendedPageProxy>&& suspendedPage)
+{
+    m_suspendedPage = WTF::move(suspendedPage);
+}
+
+void WebBackForwardCacheEntry::clearSuspendedPage()
+{
+    m_suspendedPage = nullptr;
 }
 
 Ref<SuspendedPageProxy> WebBackForwardCacheEntry::takeSuspendedPage()

--- a/Source/WebKit/UIProcess/WebBackForwardCacheEntry.h
+++ b/Source/WebKit/UIProcess/WebBackForwardCacheEntry.h
@@ -51,6 +51,8 @@ public:
     WebBackForwardCache* NODELETE backForwardCache() const;
 
     SuspendedPageProxy* suspendedPage() const { return m_suspendedPage.get(); }
+    void setSuspendedPage(Ref<SuspendedPageProxy>&&);
+    void clearSuspendedPage();
     Ref<SuspendedPageProxy> takeSuspendedPage();
     WebCore::ProcessIdentifier processIdentifier() const { return m_processIdentifier; }
     RefPtr<WebProcessProxy> process() const;

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ProcessSwapOnNavigation.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ProcessSwapOnNavigation.mm
@@ -3683,6 +3683,94 @@ TEST(ProcessSwap, BackForwardCacheSkipBackForwardListItem)
     EXPECT_WK_STREQ(@"pson://www.webkit.org/main.html#foo", [[webView URL] absoluteString]);
 }
 
+TEST(ProcessSwap, BackForwardCacheRestoreSkippedSameProcessItem)
+{
+    auto processPoolConfiguration = psonProcessPoolConfiguration();
+    RetainPtr processPool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration.get()]);
+
+    RetainPtr webViewConfiguration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    [webViewConfiguration setProcessPool:processPool.get()];
+    RetainPtr handler = adoptNS([[PSONScheme alloc] init]);
+    [handler addMappingFromURLString:@"pson://www.webkit.org/main1.html" toData:pageCache1Bytes];
+    [handler addMappingFromURLString:@"pson://www.webkit.org/main2.html" toData:pageCache1Bytes];
+    [handler addMappingFromURLString:@"pson://www.apple.com/main.html" toData:pageCache1Bytes];
+    [webViewConfiguration setURLSchemeHandler:handler.get() forURLScheme:@"PSON"];
+
+    RetainPtr messageHandler = adoptNS([[PSONMessageHandler alloc] init]);
+    [[webViewConfiguration userContentController] addScriptMessageHandler:messageHandler.get() name:@"pson"];
+
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
+
+    // FIXME: Remove once the back-forward cache is enabled for site isolation: rdar://161762363.
+    if (!isUsingBackForwardCache(webView.get())) {
+        NSLog(@"ProcessSwap.BackForwardCacheRestoreSkippedSameProcessItem: Test is skipped as back-forward cache is disabled");
+        return;
+    }
+
+    RetainPtr delegate = adoptNS([[PSONNavigationDelegate alloc] init]);
+    [webView setNavigationDelegate:delegate.get()];
+
+    // 1. Load pson://www.webkit.org/main1.html (this becomes the "skipped" item a/1).
+    NSURLRequest *request = [NSURLRequest requestWithURL:[NSURL URLWithString:@"pson://www.webkit.org/main1.html"]];
+    [webView loadRequest:request];
+    TestWebKitAPI::Util::run(&done);
+    done = false;
+
+    auto webkitPID = [webView _webProcessIdentifier];
+
+    // 2. Load pson://www.webkit.org/main2.html (same-site cross-document; a/1's document is
+    //    placed into PageCache. This becomes a/2 — the item that triggers the cross-site swap
+    //    and originally received the SuspendedPageProxy).
+    request = [NSURLRequest requestWithURL:[NSURL URLWithString:@"pson://www.webkit.org/main2.html"]];
+    [webView loadRequest:request];
+    TestWebKitAPI::Util::run(&done);
+    done = false;
+
+    EXPECT_EQ(webkitPID, [webView _webProcessIdentifier]);
+    EXPECT_EQ(1U, [[[webView backForwardList] backList] count]);
+
+    // 3. Load pson://www.apple.com/main.html (cross-site swap — SuspendedPageProxy created on
+    //    the webkit process). The fix shares the SPP with a/1 (already in BFCache).
+    request = [NSURLRequest requestWithURL:[NSURL URLWithString:@"pson://www.apple.com/main.html"]];
+    [webView loadRequest:request];
+    TestWebKitAPI::Util::run(&done);
+    done = false;
+
+    auto applePID = [webView _webProcessIdentifier];
+    EXPECT_NE(webkitPID, applePID);
+    EXPECT_WK_STREQ(@"pson://www.apple.com/main.html", [[webView URL] absoluteString]);
+    EXPECT_EQ(2U, [[[webView backForwardList] backList] count]);
+
+    // 4. Go directly back to a/1 (skipping a/2). Pre-fix, only a/2 had the SuspendedPageProxy
+    //    so this lookup misses Path A, falls through to Path B, and removeEntriesForPageAndProcess
+    //    drops the SPP and tears down the WebPage — resulting in a full reload (no pageshow.persisted).
+    //    Post-fix, the SPP is shared with a/1, Path A succeeds, and the page is restored from BFCache.
+    [webView goToBackForwardListItem:[[webView backForwardList] itemAtIndex:-2]];
+    TestWebKitAPI::Util::run(&receivedMessage);
+    receivedMessage = false;
+    TestWebKitAPI::Util::run(&done);
+    done = false;
+
+    EXPECT_EQ(webkitPID, [webView _webProcessIdentifier]);
+    EXPECT_WK_STREQ(@"pson://www.webkit.org/main1.html", [[webView URL] absoluteString]);
+    EXPECT_EQ(1U, [receivedMessages count]);
+    EXPECT_TRUE([receivedMessages.get()[0] isEqualToString:@"Was persisted"]);
+
+    // 5. Go forward to a/2. This must also be restored from BFCache — verifies that taking
+    //    the SPP for a/1 correctly cleared it from a/2 too (so the symmetric clear logic in
+    //    takeSuspendedPage works and a/2 can still be restored as an in-process BFCache entry).
+    [webView goForward];
+    TestWebKitAPI::Util::run(&receivedMessage);
+    receivedMessage = false;
+    TestWebKitAPI::Util::run(&done);
+    done = false;
+
+    EXPECT_EQ(webkitPID, [webView _webProcessIdentifier]);
+    EXPECT_WK_STREQ(@"pson://www.webkit.org/main2.html", [[webView URL] absoluteString]);
+    EXPECT_EQ(2U, [receivedMessages count]);
+    EXPECT_TRUE([receivedMessages.get()[1] isEqualToString:@"Was persisted"]);
+}
+
 TEST(ProcessSwap, ClearWebsiteDataWithSuspendedPage)
 {
     auto processPoolConfiguration = psonProcessPoolConfiguration();


### PR DESCRIPTION
#### 4f0e36f521e9f70b230734dc726cb0960af22b4c
<pre>
[BFCache] Share SuspendedPageProxy across same-process BFCache entries
<a href="https://bugs.webkit.org/show_bug.cgi?id=314237">https://bugs.webkit.org/show_bug.cgi?id=314237</a>
<a href="https://rdar.apple.com/176395569">rdar://176395569</a>

Reviewed by Sihui Liu.

This bug affects both Site-Isolation and non-Site-Isolation environments. In
either case it manifests as a full reload of an otherwise-cacheable page on
certain back-navigation patterns, and additionally destroys every other BFCache
entry living in the same WebProcess.

Repro: navigate a/1 -&gt; a/2 (same-site, a/1 enters in-process BFCache during the
commit) -&gt; b/1 (cross-site swap; a SuspendedPageProxy is created and attached
only to a/2&apos;s BackForwardListItem) -&gt; goBack directly to a/1.

Pre-fix, a/1&apos;s BFCache entry has no SuspendedPageProxy, so Path A of
WebProcessPool::processForNavigationInternal misses. The lastProcessIdentifier
fallback returns the suspended a process without SPP context, and
WebPageProxy::decidePolicyForNavigationActionAsyncShared then calls
removeEntriesForPageAndProcess. That drops the only Ref to the
SuspendedPageProxy, tears down the existing WebPage in the a process, and
forces a full reload of a/1 -- losing a/2&apos;s BFCache entry as collateral.

Fix by sharing the SuspendedPageProxy with all same-process BFCache entries
when it is added, and clearing it from all same-process entries when it is
taken for unsuspension. The new test exercises the four-step navigation above
and verifies both back-restoration of a/1 and forward-restoration of a/2 arrive
via pageshow.persisted=true.

Also relax the ~WebBackForwardCacheEntry guard so ClearCachedPage is still
sent on capacity eviction when a SuspendedPageProxy is held. With sharing the
SPP is retained by other entries and is not destroyed by this drop, so the
previous `!m_suspendedPage` skip would leak the evicted frame&apos;s cached data
in the suspended WebProcess. m_backForwardFrameItemID is still cleared by
takeSuspendedPage(), so the restore path remains a no-op.

Test: Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ProcessSwapOnNavigation.mm
* Source/WebKit/Shared/WebBackForwardListItem.cpp:
(WebKit::WebBackForwardListItem::backForwardCacheEntryForProcess const):
* Source/WebKit/Shared/WebBackForwardListItem.h:
* Source/WebKit/UIProcess/WebBackForwardCache.cpp:
(WebKit::WebBackForwardCache::addEntry):
(WebKit::WebBackForwardCache::takeSuspendedPage):
* Source/WebKit/UIProcess/WebBackForwardCacheEntry.cpp:
(WebKit::WebBackForwardCacheEntry::~WebBackForwardCacheEntry):
(WebKit::WebBackForwardCacheEntry::setSuspendedPage):
(WebKit::WebBackForwardCacheEntry::clearSuspendedPage):
* Source/WebKit/UIProcess/WebBackForwardCacheEntry.h:
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ProcessSwapOnNavigation.mm:
((ProcessSwap, BackForwardCacheRestoreSkippedSameProcessItem)):

Canonical link: <a href="https://commits.webkit.org/313096@main">https://commits.webkit.org/313096@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7b2920380b095326e627d95c831f5d4315738130

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/162004 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/35479 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/28584 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/170912 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/118375 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/0a3eb2c8-ba2b-4da3-8b4b-dd39040a8cc6) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/163873 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/35581 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/35480 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/125719 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/88590 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/a23cf6bc-7238-41cd-af34-662e6f99fec4) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/164963 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/28031 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/145515 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/106301 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/27080 "Passed tests") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/25592 "Found 1 new API test failure: TestWebKitAPI.TextManipulation.CompleteTextManipulationForTitleElement (failure)") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/18632 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/136773 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/23269 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/173400 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/20491 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/24910 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/134010 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/35152 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/29677 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/134016 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36193 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/35136 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/145064 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/97259 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/28542 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/21889 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/34646 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/102131 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/34147 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/34389 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/34295 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->