### PR TITLE
REGRESSION(311766@main): Textareas can get unnecessary horizontal scrollbar.

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-overflow/fit-content-textarea-with-scrollbar-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-overflow/fit-content-textarea-with-scrollbar-expected.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+.container {
+  width: fit-content;
+  border: 1px solid blue;
+}
+textarea {
+  display: block;
+  overflow-y: scroll;
+}
+</style>
+</head>
+<body>
+<div class=container>
+  <textarea>hello
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+world</textarea>
+</div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-overflow/fit-content-textarea-with-scrollbar-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-overflow/fit-content-textarea-with-scrollbar-ref.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+.container {
+  width: fit-content;
+  border: 1px solid blue;
+}
+textarea {
+  display: block;
+  overflow-y: scroll;
+}
+</style>
+</head>
+<body>
+<div class=container>
+  <textarea>hello
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+world</textarea>
+</div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-overflow/fit-content-textarea-with-scrollbar.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-overflow/fit-content-textarea-with-scrollbar.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="match" href="fit-content-textarea-with-scrollbar-ref.html">
+<link rel="help" href="https://drafts.csswg.org/css-overflow-3/#scrollbar-sizing">
+<style>
+.container {
+  width: fit-content;
+  border: 1px solid blue;
+}
+textarea {
+  display: block;
+}
+</style>
+</head>
+<body>
+<div class=container>
+  <textarea>hello
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+world</textarea>
+</div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-overflow/max-content-nested-textarea-with-scrollbar-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-overflow/max-content-nested-textarea-with-scrollbar-expected.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+.container {
+  width: max-content;
+  border: 1px solid blue;
+}
+.wrapper {
+  display: inline-block;
+}
+textarea {
+  display: block;
+  overflow-y: scroll;
+}
+</style>
+</head>
+<body>
+<div class=container>
+  <div class=wrapper>
+    <textarea>hello
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+world</textarea>
+  </div>
+</div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-overflow/max-content-nested-textarea-with-scrollbar-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-overflow/max-content-nested-textarea-with-scrollbar-ref.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+.container {
+  width: max-content;
+  border: 1px solid blue;
+}
+.wrapper {
+  display: inline-block;
+}
+textarea {
+  display: block;
+  overflow-y: scroll;
+}
+</style>
+</head>
+<body>
+<div class=container>
+  <div class=wrapper>
+    <textarea>hello
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+world</textarea>
+  </div>
+</div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-overflow/max-content-nested-textarea-with-scrollbar.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-overflow/max-content-nested-textarea-with-scrollbar.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="match" href="max-content-nested-textarea-with-scrollbar-ref.html">
+<link rel="help" href="https://drafts.csswg.org/css-overflow-3/#scrollbar-sizing">
+<style>
+.container {
+  width: max-content;
+  border: 1px solid blue;
+}
+.wrapper {
+  display: inline-block;
+}
+textarea {
+  display: block;
+}
+</style>
+</head>
+<body>
+<div class=container>
+  <div class=wrapper>
+    <textarea>hello
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+world</textarea>
+  </div>
+</div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-overflow/max-content-textarea-with-scrollbar-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-overflow/max-content-textarea-with-scrollbar-expected.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+.container {
+  width: max-content;
+  border: 1px solid blue;
+}
+textarea {
+  display: block;
+  overflow-y: scroll;
+}
+</style>
+</head>
+<body>
+<div class=container>
+  <textarea>hello
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+world</textarea>
+</div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-overflow/max-content-textarea-with-scrollbar-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-overflow/max-content-textarea-with-scrollbar-ref.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+.container {
+  width: max-content;
+  border: 1px solid blue;
+}
+textarea {
+  display: block;
+  overflow-y: scroll;
+}
+</style>
+</head>
+<body>
+<div class=container>
+  <textarea>hello
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+world</textarea>
+</div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-overflow/max-content-textarea-with-scrollbar.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-overflow/max-content-textarea-with-scrollbar.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="match" href="max-content-textarea-with-scrollbar-ref.html">
+<link rel="help" href="https://drafts.csswg.org/css-overflow-3/#scrollbar-sizing">
+<style>
+.container {
+  width: max-content;
+  border: 1px solid blue;
+}
+textarea {
+  display: block;
+}
+</style>
+</head>
+<body>
+<div class=container>
+  <textarea>hello
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+world</textarea>
+</div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-overflow/min-content-textarea-with-scrollbar-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-overflow/min-content-textarea-with-scrollbar-expected.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+.container {
+  width: min-content;
+  border: 1px solid blue;
+}
+textarea {
+  display: block;
+  overflow-y: scroll;
+}
+</style>
+</head>
+<body>
+<div class=container>
+  <textarea>hello
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+world</textarea>
+</div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-overflow/min-content-textarea-with-scrollbar-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-overflow/min-content-textarea-with-scrollbar-ref.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+.container {
+  width: min-content;
+  border: 1px solid blue;
+}
+textarea {
+  display: block;
+  overflow-y: scroll;
+}
+</style>
+</head>
+<body>
+<div class=container>
+  <textarea>hello
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+world</textarea>
+</div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-overflow/min-content-textarea-with-scrollbar.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-overflow/min-content-textarea-with-scrollbar.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="match" href="min-content-textarea-with-scrollbar-ref.html">
+<link rel="help" href="https://drafts.csswg.org/css-overflow-3/#scrollbar-sizing">
+<style>
+.container {
+  width: min-content;
+  border: 1px solid blue;
+}
+textarea {
+  display: block;
+}
+</style>
+</head>
+<body>
+<div class=container>
+  <textarea>hello
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+world</textarea>
+</div>
+</body>
+</html>

--- a/Source/WebCore/rendering/RelayoutScopeForScrollbarChange.cpp
+++ b/Source/WebCore/rendering/RelayoutScopeForScrollbarChange.cpp
@@ -55,7 +55,7 @@ RelayoutScopeForScrollbarChange::~RelayoutScopeForScrollbarChange()
 
     if (m_renderBlock->style().overflowX() == Overflow::Auto || m_renderBlock->style().overflowY() == Overflow::Auto) {
         if (m_inOverflowRelayout == InOverflowRelayout::No) {
-            if (auto& subtreeScrollbarChangesState = m_renderBlock->layoutContext().subtreeScrollbarChangesState()) {
+            if (auto& subtreeScrollbarChangesState = m_renderBlock->layoutContext().subtreeScrollbarChangesState(); subtreeScrollbarChangesState && subtreeScrollbarChangesState->isEligibleForScrollbarHandlingByAncestor(m_renderBlock.get())) {
                 subtreeScrollbarChangesState->renderersWithScrollbarChange.add(m_renderBlock);
                 return;
             }

--- a/Source/WebCore/rendering/SubtreeScrollbarChangesState.cpp
+++ b/Source/WebCore/rendering/SubtreeScrollbarChangesState.cpp
@@ -26,13 +26,21 @@
 #include "config.h"
 #include "SubtreeScrollbarChangesState.h"
 
+#include "HTMLTextAreaElement.h"
 #include "LayoutScope.h"
 #include "LocalFrameViewLayoutContext.h"
 #include "RenderBlock.h"
+#include "RenderElementInlines.h"
 #include "RenderObjectInlines.h"
 #include <wtf/Scope.h>
 
 namespace WebCore {
+
+bool SubtreeScrollbarChangesState::isEligibleForScrollbarHandlingByAncestor(const RenderBlock& renderer)
+{
+    // Textareas have some behavior related to how scrollbars are incorporated into their sizing that needs some investigating.
+    return !is<HTMLTextAreaElement>(renderer.element());
+}
 
 SubtreeScrollbarChangesStateScope::SubtreeScrollbarChangesStateScope(LocalFrameViewLayoutContext& layoutContext, RenderBlock& subtreeRoot)
     : m_layoutContext(layoutContext)
@@ -77,6 +85,11 @@ SubtreeScrollbarChangesHandler::~SubtreeScrollbarChangesHandler()
 
     if (descendantsWithScrollbarChange.isEmpty())
         return;
+
+#if ASSERT_ENABLED
+    for (auto& renderer : descendantsWithScrollbarChange)
+        ASSERT(subtreeScrollbarChangesState->isEligibleForScrollbarHandlingByAncestor(renderer.get()));
+#endif
 
     if (!isSubtreeRootHandlingScrollbarChanges) {
         while (!descendantsWithScrollbarChange.isEmpty()) {

--- a/Source/WebCore/rendering/SubtreeScrollbarChangesState.h
+++ b/Source/WebCore/rendering/SubtreeScrollbarChangesState.h
@@ -35,6 +35,8 @@ class RenderBlock;
 struct SubtreeScrollbarChangesState {
     CheckedRef<RenderBlock> subtreeRoot;
     ListHashSet<CheckedRef<RenderBlock>> renderersWithScrollbarChange;
+
+    static bool isEligibleForScrollbarHandlingByAncestor(const RenderBlock&);
 };
 
 class LocalFrameViewLayoutContext;


### PR DESCRIPTION
#### e5ab13a61ab9938709735cdaead772fff197e483
<pre>
REGRESSION(311766@main): Textareas can get unnecessary horizontal scrollbar.
<a href="https://bugs.webkit.org/show_bug.cgi?id=314412">https://bugs.webkit.org/show_bug.cgi?id=314412</a>
<a href="https://rdar.apple.com/problem/176566654">rdar://problem/176566654</a>

Reviewed by Alan Baradlay.

When a renderer begins tracking scrollbar changes in its descendants, it
is possible for textareas to get an unnecessary horizontal scrollbar if
it is one of those descendants. From an initial investigation this seems
to come from the fact that the renderers associated text areas have
slightly different logic for comes their logical width when compared to
other renderers. While we gather more information to figure out what is
going on and what the proper fix is we should just disable this
functionality for textareas.

Canonical link: <a href="https://commits.webkit.org/312927@main">https://commits.webkit.org/312927@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0eccc40ff6ca7e94f06426b65ccfe66b7e05ae1b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/161451 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/34925 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/28027 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/170354 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/117822 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/163320 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/35026 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/34926 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/125253 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/117822 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/164410 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/27544 "Passed tests") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/145025 "Found 1 new API test failure: TestWebKitAPI.UnifiedPDF.PDFHUDMoveIFrame (failure)") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/105849 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/26593 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/25102 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/18075 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/136287 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/22782 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/172840 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/19871 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/24423 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/133539 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/34599 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/29197 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/133546 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36094 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/34583 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/144577 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/96483 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/28078 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/21396 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/34093 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/101535 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/33593 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/33836 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/33742 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->