### PR TITLE
Cache Intl.DateTimeFormat

### DIFF
--- a/JSTests/microbenchmarks/date-time-complex.js
+++ b/JSTests/microbenchmarks/date-time-complex.js
@@ -1,0 +1,14 @@
+// Toggle `complex` by hand to measure alternating-locale constructions.
+const complex = false;
+const iterations = 1000000;
+let dtf;
+
+if (!complex) {
+    for (let i = 0; i < iterations; i++) {
+        dtf = new Intl.DateTimeFormat();
+    }
+} else {
+    for (let i = 0; i < iterations; i++) {
+        dtf = new Intl.DateTimeFormat(i % 2 ? "en-US" : "en-GB");
+    }
+}

--- a/JSTests/stress/intl-datetimeformat-cache-observability.js
+++ b/JSTests/stress/intl-datetimeformat-cache-observability.js
@@ -1,0 +1,53 @@
+// The impl cache must never elide a spec-mandated user-visible side effect on a
+// repeated construction: any shape that is not a plain string/undefined locale
+// with undefined options is non-cacheable and must re-run its observable steps
+// (Proxy traps, getters, indexed reads) on every call.
+
+function twiceMustObserve(label, makeArgs)
+{
+    let calls = 0;
+    const bump = () => { ++calls; };
+    new Intl.DateTimeFormat(...makeArgs(bump));
+    const afterFirst = calls;
+    if (!afterFirst)
+        throw new Error(`${label}: no observable side effect on first construction`);
+    new Intl.DateTimeFormat(...makeArgs(bump));
+    if (calls === afterFirst)
+        throw new Error(`${label}: cache hit elided the side effect on second construction`);
+}
+
+// Proxy on the locales argument (a Proxy is not a plain string, so non-cacheable).
+twiceMustObserve("proxy locales", (bump) =>
+    [new Proxy(["en-US"], { get(t, p, r) { bump(); return Reflect.get(t, p, r); } })]);
+
+// Proxy on the options argument.
+twiceMustObserve("proxy options", (bump) =>
+    ["en-US", new Proxy({}, { get(t, p, r) { bump(); return Reflect.get(t, p, r); } })]);
+
+// Getter on a plain options object.
+twiceMustObserve("getter options", (bump) => {
+    const opts = {};
+    Object.defineProperty(opts, "hour", { enumerable: true, get() { bump(); return "numeric"; } });
+    return ["en-US", opts];
+});
+
+// Array locales with an indexed getter.
+twiceMustObserve("array indexed getter", (bump) => {
+    const arr = [];
+    Object.defineProperty(arr, "0", { get() { bump(); return "en-US"; }, configurable: true });
+    Object.defineProperty(arr, "length", { value: 1 });
+    return [arr];
+});
+
+// null locales must throw on every call, never short-circuit to a cached success.
+for (let i = 0; i < 2; ++i) {
+    let threw = false;
+    try { new Intl.DateTimeFormat(null); } catch { threw = true; }
+    if (!threw)
+        throw new Error(`null locales: expected throw on call ${i}`);
+}
+
+// Empty options resolves identically to absent options (a swallowed `options` would break this).
+if (new Intl.DateTimeFormat("en-US", {}).resolvedOptions().locale
+    !== new Intl.DateTimeFormat("en-US").resolvedOptions().locale)
+    throw new Error("empty options did not resolve like absent options");

--- a/JSTests/stress/intl-datetimeformat-cache-tz-watcher.js
+++ b/JSTests/stress/intl-datetimeformat-cache-tz-watcher.js
@@ -1,0 +1,36 @@
+//@ runDefault("--useDollarVM=1")
+//@ skip if $hostOS == "playstation"
+
+// This is an end-to-end test for the time zone change notification. It verifies that
+// we respond to the notification and that the new tz takes effect when the spec says it should.
+
+function expect(label, got, want)
+{
+    if (got !== want)
+        throw new Error(`${label}: expected "${want}", got "${got}"`);
+}
+
+function cacheableTZ()
+{
+    return new Intl.DateTimeFormat().resolvedOptions().timeZone;
+}
+
+function slowTZ()
+{
+    return new Intl.DateTimeFormat(undefined, {}).resolvedOptions().timeZone;
+}
+
+const beforeCacheable = cacheableTZ();
+const beforeSlow = slowTZ();
+expect("baseline: matches", beforeCacheable, beforeSlow);
+
+if (!$vm.setHostTimeZone("Pacific/Kiritimati"))
+    throw new Error("Failed to set host time zone to Pacific/Kiritimati");
+
+// Get outside the VMEntryScope
+setTimeout(() => {
+    const afterInvalidate = cacheableTZ();
+    const afterInvalidateSlow = slowTZ();
+    expect("after notification fires: cacheable matches slow", afterInvalidate, afterInvalidateSlow);
+    expect("after notification fires: new TZ in effect", afterInvalidateSlow, "Pacific/Kiritimati");
+}, 100);

--- a/JSTests/stress/intl-datetimeformat-cache-undefined-locales.js
+++ b/JSTests/stress/intl-datetimeformat-cache-undefined-locales.js
@@ -1,0 +1,73 @@
+// `new Intl.DateTimeFormat()` and `new Intl.DateTimeFormat(undefined, {})` must
+// produce equivalent resolutions: anything else means an engine optimization
+// path silently disagrees with its own slow path.
+
+function expect(label, got, want)
+{
+    if (got !== want)
+        throw new Error(`${label}: expected "${want}", got "${got}"`);
+}
+
+const a = new Intl.DateTimeFormat();
+const b = new Intl.DateTimeFormat();
+const c = new Intl.DateTimeFormat(undefined);
+
+if (a === b || b === c || a === c)
+    throw new Error("constructions returned the same JS wrapper");
+
+const reference = new Intl.DateTimeFormat(undefined, {});
+const oa = a.resolvedOptions();
+const ob = b.resolvedOptions();
+const oc = c.resolvedOptions();
+const oref = reference.resolvedOptions();
+
+for (const key of ["locale", "calendar", "numberingSystem", "timeZone"]) {
+    expect(`a.${key} == reference.${key}`, oa[key], oref[key]);
+    expect(`b.${key} == reference.${key}`, ob[key], oref[key]);
+    expect(`c.${key} == reference.${key}`, oc[key], oref[key]);
+}
+
+expect("a.format == reference.format", a.format(0), reference.format(0));
+expect("b.format == reference.format", b.format(0), reference.format(0));
+expect("c.format == reference.format", c.format(0), reference.format(0));
+
+// Distinct locale arguments must keep distinct resolutions.
+const stringForm = new Intl.DateTimeFormat("en-US");
+const stringAgain = new Intl.DateTimeFormat("en-US");
+expect("explicit en-US locale", stringForm.resolvedOptions().locale, "en-US");
+expect("explicit en-US locale (re-query)", stringAgain.resolvedOptions().locale, "en-US");
+expect("explicit en-US format stable",
+    stringForm.format(0), stringAgain.format(0));
+
+// Many distinct locales — each must resolve to its own request.
+const tags = ["en-US", "ja", "fr", "de", "ko", "es", "it", "pt", "ru", "zh", "ar", "hi"];
+for (const tag of tags)
+    expect(`flood: ${tag}`,
+        new Intl.DateTimeFormat(tag).resolvedOptions().locale.startsWith(tag.split("-")[0]),
+        true);
+
+// Re-querying earlier locales must still recover the same resolution.
+expect("re-query en-US after flood",
+    new Intl.DateTimeFormat("en-US").format(0), stringForm.format(0));
+expect("re-query undefined after flood",
+    new Intl.DateTimeFormat().format(0), reference.format(0));
+
+// The cache key must include the required/defaults components. The three no-arg
+// Date.prototype.toLocale* shapes construct their per-global default formatter with
+// undefined options, differing only in those fields; dropping them from the key
+// would collapse the three formatters onto whichever was built first.
+const date = new Date(0); // date-only, time-only, and date+time renderings all differ.
+const localeAll = date.toLocaleString();
+const localeDate = date.toLocaleDateString();
+const localeTime = date.toLocaleTimeString();
+if (localeDate === localeTime)
+    throw new Error(`toLocaleDateString and toLocaleTimeString collapsed: "${localeDate}"`);
+if (localeDate === localeAll)
+    throw new Error(`toLocaleDateString and toLocaleString collapsed: "${localeDate}"`);
+if (localeTime === localeAll)
+    throw new Error(`toLocaleTimeString and toLocaleString collapsed: "${localeTime}"`);
+for (let i = 0; i < 3; ++i) {
+    expect(`toLocaleDateString stable ${i}`, date.toLocaleDateString(), localeDate);
+    expect(`toLocaleTimeString stable ${i}`, date.toLocaleTimeString(), localeTime);
+    expect(`toLocaleString stable ${i}`, date.toLocaleString(), localeAll);
+}

--- a/JSTests/stress/intl-datetimeformat-cache-zoneddatetime-tolocalestring.js
+++ b/JSTests/stress/intl-datetimeformat-cache-zoneddatetime-tolocalestring.js
@@ -1,0 +1,45 @@
+//@ requireOptions("--useTemporal=1")
+
+// Temporal.ZonedDateTime.prototype.toLocaleString must format in each
+// ZonedDateTime's own time zone, even when (locales, options) are identical
+// across calls, and must agree with its own explicit-options slow path.
+
+function expect(label, got, want)
+{
+    if (got !== want)
+        throw new Error(`${label}: expected ${JSON.stringify(want)}, got ${JSON.stringify(got)}`);
+}
+
+const instant = Temporal.Instant.from("2024-01-15T12:00:00Z");
+const newYork = instant.toZonedDateTimeISO("America/New_York");
+const tokyo = instant.toZonedDateTimeISO("Asia/Tokyo");
+
+// Same instant, different zones: the rendered wall-clock time must differ.
+{
+    const newYorkString = newYork.toLocaleString("en-US");
+    const tokyoString = tokyo.toLocaleString("en-US");
+    if (newYorkString === tokyoString)
+        throw new Error(`different time zones rendered identically: "${newYorkString}"`);
+}
+
+// Same shape with undefined locales.
+{
+    const newYorkString = newYork.toLocaleString();
+    const tokyoString = tokyo.toLocaleString();
+    if (newYorkString === tokyoString)
+        throw new Error(`different time zones rendered identically (undefined locales): "${newYorkString}"`);
+}
+
+// Each must agree with the explicit-empty-options construction shape.
+expect("newYork toLocaleString agrees with empty-options shape",
+    newYork.toLocaleString("en-US"), newYork.toLocaleString("en-US", {}));
+expect("tokyo toLocaleString agrees with empty-options shape",
+    tokyo.toLocaleString("en-US"), tokyo.toLocaleString("en-US", {}));
+
+// Interleaving zones must not leak one zone's rendering into the other.
+for (let i = 0; i < 4; ++i) {
+    expect(`interleaved newYork (round ${i})`,
+        newYork.toLocaleString("en-US"), newYork.toLocaleString("en-US", {}));
+    expect(`interleaved tokyo (round ${i})`,
+        tokyo.toLocaleString("en-US"), tokyo.toLocaleString("en-US", {}));
+}

--- a/JSTests/stress/intl-datetimeformat-cross-instance.js
+++ b/JSTests/stress/intl-datetimeformat-cross-instance.js
@@ -1,0 +1,38 @@
+//@ runDefault
+
+// Two instances built the same way share one const impl through the cache, but
+// must stay independent to JS: same input formats the same, resolvedOptions()
+// returns fresh mutable objects, and mutating one must not perturb the shared
+// impl or the other instance.
+
+function expect(label, got, want)
+{
+    if (got !== want)
+        throw new Error(`${label}: expected "${want}", got "${got}"`);
+}
+
+const A = new Intl.DateTimeFormat("en-US");
+const B = new Intl.DateTimeFormat("en-US");
+if (A === B)
+    throw new Error("two constructions returned the same JS object");
+
+const ts1 = 0, ts2 = 1577836800000; // 1970-01-01 and 2020-01-01, both UTC.
+
+// Same input formats identically; interleaving B must not perturb A.
+expect("A.format(ts1) == B.format(ts1)", A.format(ts1), B.format(ts1));
+const aBefore = A.format(ts1);
+B.format(ts2);
+expect("A.format(ts1) stable under interleaved B.format()", A.format(ts1), aBefore);
+
+// resolvedOptions() returns independent objects; mutating one poisons nothing.
+const oa = A.resolvedOptions();
+const ob = B.resolvedOptions();
+if (oa === ob)
+    throw new Error("resolvedOptions() returned the same JS object for two instances");
+oa.locale = "MUTATED";
+oa.timeZone = "MUTATED";
+expect("mutating A's options doesn't affect B", ob.locale, "en-US");
+expect("mutating A's options doesn't poison the shared impl (A re-query)",
+    A.resolvedOptions().locale, "en-US");
+expect("mutating A's options doesn't poison the shared impl (B re-query)",
+    B.resolvedOptions().locale, "en-US");

--- a/JSTests/stress/intl-datetimeformat-cross-realm.js
+++ b/JSTests/stress/intl-datetimeformat-cross-realm.js
@@ -1,0 +1,52 @@
+// Construction in a fresh realm must agree with construction in the original
+// realm at every observation point. Skipped on engines without a realm hook.
+
+const makeGlobal = (typeof newGlobal === "function")
+    ? newGlobal
+    : (typeof $vm !== "undefined" && typeof $vm.createGlobalObject === "function")
+        ? () => $vm.createGlobalObject()
+        : null;
+if (!makeGlobal)
+    quit();
+
+function expect(label, got, want)
+{
+    if (got !== want)
+        throw new Error(`${label}: expected ${JSON.stringify(want)}, got ${JSON.stringify(got)}`);
+}
+
+// (1) Same locale across realms must produce equal user-visible resolution.
+const a = new Intl.DateTimeFormat("en-US");
+const g = makeGlobal();
+const bResolvedJSON = g.eval(`JSON.stringify(new Intl.DateTimeFormat("en-US").resolvedOptions())`);
+const bFormatted = g.eval(`new Intl.DateTimeFormat("en-US").format(0)`);
+
+const aResolvedJSON = JSON.stringify(a.resolvedOptions());
+expect("cross-realm en-US resolvedOptions agree", bResolvedJSON, aResolvedJSON);
+expect("cross-realm en-US format(0) agrees", bFormatted, a.format(0));
+
+// (2) Reverse direction: populate from realm B first, then construct in main.
+const g2 = makeGlobal();
+const cResolvedJSON = g2.eval(`JSON.stringify(new Intl.DateTimeFormat("ja").resolvedOptions())`);
+const dResolvedJSON = JSON.stringify(new Intl.DateTimeFormat("ja").resolvedOptions());
+expect("cross-realm ja resolvedOptions agree (B first)", dResolvedJSON, cResolvedJSON);
+
+// (3) Distinct locales must render distinctly even when both realms have used them.
+const eFormat = new Intl.DateTimeFormat("en-US").format(0);
+const fFormat = g.eval(`new Intl.DateTimeFormat("ja").format(0)`);
+if (eFormat === fFormat)
+    throw new Error(`distinct locales rendered identically across realms: en-US="${eFormat}" ja="${fFormat}"`);
+
+// (4) Re-querying after cross-realm constructions of many distinct locales must
+// still return realm-consistent resolutions.
+for (const tag of ["fr", "de", "es", "it", "pt"])
+    g.eval(`new Intl.DateTimeFormat(${JSON.stringify(tag)})`);
+for (const tag of ["ko", "zh", "ar"])
+    new Intl.DateTimeFormat(tag);
+
+const reAEnUS = new Intl.DateTimeFormat("en-US");
+expect("re-query en-US in main: locale", reAEnUS.resolvedOptions().locale, a.resolvedOptions().locale);
+expect("re-query en-US in main: format", reAEnUS.format(0), a.format(0));
+const reBJa = JSON.parse(g2.eval(`JSON.stringify(new Intl.DateTimeFormat("ja").resolvedOptions())`));
+const refJa = JSON.parse(cResolvedJSON);
+expect("re-query ja in g2: locale", reBJa.locale, refJa.locale);

--- a/JSTests/stress/intl-datetimeformat-default-formatter-stale-across-language-change.js
+++ b/JSTests/stress/intl-datetimeformat-default-formatter-stale-across-language-change.js
@@ -1,0 +1,52 @@
+//@ skip
+// FIXME: https://bugs.webkit.org/show_bug.cgi?id=318362
+// Skipped: exposes a known, deferred bug, the language-change flavor of
+// intl-datetimeformat-default-formatter-stale-across-tz-change.js. The
+// per-global default formatters (JSGlobalObject::m_defaultDateTimeFormat /
+// m_defaultDateFormat / m_defaultTimeFormat) backing the no-argument
+// Date.prototype.toLocale*String paths are initialized once and never
+// invalidated, so after a user-preferred-language change they keep the old
+// locale while every other construction shape re-resolves.
+//
+// Remove the //@ skip (and add the runDefault("--useDollarVM=1") directive the
+// sibling language-change tests use) once the default formatters are
+// invalidated on language change.
+
+if (typeof $vm === "undefined" || typeof $vm.setUserPreferredLanguages !== "function")
+    quit();
+
+function expect(label, got, want)
+{
+    if (got !== want)
+        throw new Error(`${label}: expected ${JSON.stringify(want)}, got ${JSON.stringify(got)}`);
+}
+
+$vm.setUserPreferredLanguages(["en-US"]);
+
+setTimeout(() => {
+    const d = new Date(Date.UTC(2024, 5, 15, 0, 0));
+
+    // Initialize all three per-global default formatters under en-US. Each
+    // no-argument call must agree with its explicit-empty-options shape, which
+    // builds a fresh formatter with the same required/defaults.
+    expect("en-US toLocaleString agrees with slow path",
+        d.toLocaleString(), d.toLocaleString(undefined, {}));
+    expect("en-US toLocaleDateString agrees with slow path",
+        d.toLocaleDateString(), d.toLocaleDateString(undefined, {}));
+    expect("en-US toLocaleTimeString agrees with slow path",
+        d.toLocaleTimeString(), d.toLocaleTimeString(undefined, {}));
+
+    $vm.setUserPreferredLanguages(["ja-JP"]);
+
+    setTimeout(() => {
+        expect("post-change locale moved",
+            new Intl.DateTimeFormat(undefined, {}).resolvedOptions().locale.startsWith("ja"), true);
+
+        expect("ja-JP toLocaleString agrees with slow path",
+            d.toLocaleString(), d.toLocaleString(undefined, {}));
+        expect("ja-JP toLocaleDateString agrees with slow path",
+            d.toLocaleDateString(), d.toLocaleDateString(undefined, {}));
+        expect("ja-JP toLocaleTimeString agrees with slow path",
+            d.toLocaleTimeString(), d.toLocaleTimeString(undefined, {}));
+    }, 0);
+}, 0);

--- a/JSTests/stress/intl-datetimeformat-default-formatter-stale-across-tz-change.js
+++ b/JSTests/stress/intl-datetimeformat-default-formatter-stale-across-tz-change.js
@@ -1,0 +1,70 @@
+//@ skip
+// FIXME: https://bugs.webkit.org/show_bug.cgi?id=318362
+// Skipped: exposes a known, deferred bug. Distinct from the DateInstanceData
+// staleness covered by intl-datetimeformat-stale-data-*-across-tz-change.js:
+// there the stale state is a held Date instance's cached GregorianDateTime,
+// while here even a freshly created Date is affected. The per-global default
+// formatters (JSGlobalObject::m_defaultDateTimeFormat / m_defaultDateFormat /
+// m_defaultTimeFormat) backing the no-argument Date.prototype.toLocale*String
+// paths are initialized once and never invalidated, so after a host TZ change
+// they keep formatting in the old time zone while every other construction
+// shape moves.
+//
+// Remove the //@ skip (and add the "skip if $hostOS == playstation" guard the
+// sibling tests use) once the default formatters are invalidated on TZ change.
+
+function expect(label, got, want)
+{
+    if (got !== want)
+        throw new Error(`${label}: expected ${JSON.stringify(want)}, got ${JSON.stringify(got)}`);
+}
+
+if (!$vm.setHostTimeZone("America/Los_Angeles"))
+    throw new Error("Failed to set host time zone to America/Los_Angeles");
+
+setTimeout(() => {
+    // 2024-06-15 00:00 UTC.
+    //   In LA  (PDT, UTC-7): 2024-06-14 17:00 PDT.
+    //   In JST (UTC+9):      2024-06-15 09:00 JST.
+    const ms = Date.UTC(2024, 5, 15, 0, 0);
+    const warm = new Date(ms);
+
+    // Initialize all three per-global default formatters under LA time. Each
+    // no-argument call must agree with its explicit-empty-options shape, which
+    // builds a fresh formatter with the same required/defaults.
+    const laAll = warm.toLocaleString();
+    const laDate = warm.toLocaleDateString();
+    const laTime = warm.toLocaleTimeString();
+    expect("LA toLocaleString agrees with slow path", laAll, warm.toLocaleString(undefined, {}));
+    expect("LA toLocaleDateString agrees with slow path", laDate, warm.toLocaleDateString(undefined, {}));
+    expect("LA toLocaleTimeString agrees with slow path", laTime, warm.toLocaleTimeString(undefined, {}));
+
+    if (!$vm.setHostTimeZone("Asia/Tokyo"))
+        throw new Error("Failed to set host time zone to Asia/Tokyo");
+
+    setTimeout(() => {
+        expect("post-change tz",
+            new Intl.DateTimeFormat().resolvedOptions().timeZone, "Asia/Tokyo");
+
+        // A fresh Date cannot carry stale DateInstanceData; any disagreement
+        // below belongs to the default formatters.
+        const fresh = new Date(ms);
+        expect("fresh JST hours", fresh.getHours(), 9);
+
+        expect("JST toLocaleString agrees with slow path",
+            fresh.toLocaleString(), fresh.toLocaleString(undefined, {}));
+        expect("JST toLocaleDateString agrees with slow path",
+            fresh.toLocaleDateString(), fresh.toLocaleDateString(undefined, {}));
+        expect("JST toLocaleTimeString agrees with slow path",
+            fresh.toLocaleTimeString(), fresh.toLocaleTimeString(undefined, {}));
+
+        // LA and JST renderings differ in both calendar day and hour, so the
+        // no-argument outputs must actually move.
+        if (fresh.toLocaleString() === laAll)
+            throw new Error(`toLocaleString did not move with the TZ change: "${laAll}"`);
+        if (fresh.toLocaleDateString() === laDate)
+            throw new Error(`toLocaleDateString did not move with the TZ change: "${laDate}"`);
+        if (fresh.toLocaleTimeString() === laTime)
+            throw new Error(`toLocaleTimeString did not move with the TZ change: "${laTime}"`);
+    }, 0);
+}, 0);

--- a/JSTests/stress/intl-datetimeformat-failure-not-cached.js
+++ b/JSTests/stress/intl-datetimeformat-failure-not-cached.js
@@ -1,0 +1,58 @@
+// Failed constructions must not be cached as successes: repeated calls with the
+// same bad input must keep throwing, and a good call interleaved with bad ones
+// must keep its own answer.
+
+function expect(label, got, want)
+{
+    if (got !== want)
+        throw new Error(`${label}: expected ${JSON.stringify(want)}, got ${JSON.stringify(got)}`);
+}
+
+function expectThrows(label, fn)
+{
+    let threw = null;
+    try { fn(); } catch (e) { threw = e; }
+    if (!threw)
+        throw new Error(`${label}: expected to throw, returned normally`);
+    return threw;
+}
+
+// (1) Invalid language tag must throw on every call — RangeError per spec.
+const e1 = expectThrows("first call on invalid tag", () => new Intl.DateTimeFormat("en-INVALID-TAG-?"));
+const e2 = expectThrows("second call on invalid tag", () => new Intl.DateTimeFormat("en-INVALID-TAG-?"));
+const e3 = expectThrows("third call on invalid tag", () => new Intl.DateTimeFormat("en-INVALID-TAG-?"));
+
+expect("first throw is RangeError", e1 instanceof RangeError, true);
+expect("second throw is RangeError", e2 instanceof RangeError, true);
+expect("third throw is RangeError", e3 instanceof RangeError, true);
+
+// (2) Successful construction must not be poisoned by interleaved failures.
+const goodA = new Intl.DateTimeFormat("en-US");
+expectThrows("interleaved bad call 1", () => new Intl.DateTimeFormat("xx-INVALID-?"));
+const goodB = new Intl.DateTimeFormat("en-US");
+expectThrows("interleaved bad call 2", () => new Intl.DateTimeFormat("xx-INVALID-?"));
+const goodC = new Intl.DateTimeFormat("en-US");
+
+expect("good resolution stable under interleaved failures (A vs B)",
+    goodA.resolvedOptions().locale, goodB.resolvedOptions().locale);
+expect("good resolution stable under interleaved failures (A vs C)",
+    goodA.resolvedOptions().locale, goodC.resolvedOptions().locale);
+expect("good format stable under interleaved failures",
+    goodA.format(0), goodC.format(0));
+
+// (3) Stress: many repeated bad calls must all throw.
+for (let i = 0; i < 50; ++i)
+    expectThrows(`stress bad call ${i}`, () => new Intl.DateTimeFormat("zz-NOT-A-TAG"));
+
+// (4) Good calls must keep working after a stress of bad ones.
+const goodAfter = new Intl.DateTimeFormat("en-US");
+expect("good resolution survives stress of bad calls",
+    goodAfter.resolvedOptions().locale, goodA.resolvedOptions().locale);
+expect("good format survives stress of bad calls",
+    goodAfter.format(0), goodA.format(0));
+
+// (5) A valid locale sharing a prefix with a failing one must still resolve.
+expectThrows("bad ja-INVALID", () => new Intl.DateTimeFormat("ja-INVALID-?"));
+const goodJa = new Intl.DateTimeFormat("ja");
+expect("ja resolves after sibling failure",
+    goodJa.resolvedOptions().locale.startsWith("ja"), true);

--- a/JSTests/stress/intl-datetimeformat-language-change-mid-construction.js
+++ b/JSTests/stress/intl-datetimeformat-language-change-mid-construction.js
@@ -1,0 +1,68 @@
+//@ runDefault("--useDollarVM=1")
+
+// A worker changes the user language from another thread while the main thread keeps
+// constructing across VM entries. Language is latched per entry, so a cacheable no-arg
+// formatter can lag the non-cacheable shape within a turn, but a turn boundary must heal
+// it: if it stays pinned across many turns while the non-cacheable shape has moved on, an
+// invalidation was dropped.
+
+if (typeof $vm === "undefined" || typeof $vm.setUserPreferredLanguages !== "function")
+    quit();
+
+const langs = ["fr-FR", "ja-JP", "de-DE", "en-US"];
+
+$.agent.start(`
+    const langs = ${JSON.stringify(langs)};
+    for (let i = 0; i < 400; ++i) {
+        $vm.setUserPreferredLanguages([langs[i % langs.length]]);
+        $.agent.sleep(1);
+    }
+    $.agent.report("done");
+    $.agent.leaving();
+`);
+
+let pinned = 0;
+let lastCached = null;
+const distinctCached = new Set();
+let turns = 0;
+
+function turn()
+{
+    // Fresh VM entry: the cache is reset here if the language changed since the last turn.
+    const cached = new Intl.DateTimeFormat().resolvedOptions().locale;            // cacheable
+    const uncached = new Intl.DateTimeFormat(undefined, {}).resolvedOptions().locale; // not cacheable
+    distinctCached.add(cached);
+
+    if (cached === uncached)
+        pinned = 0;
+    else {
+        // A frozen value is a dropped invalidation; one that keeps moving is just a turn behind.
+        pinned = (cached === lastCached) ? pinned + 1 : 1;
+        if (pinned >= 25)
+            throw new Error(`cacheable resolution pinned at "${cached}" across ${pinned} turns while it should be "${uncached}"`);
+    }
+    lastCached = cached;
+
+    if ($.agent.getReport() !== null) {
+        finish();
+        return;
+    }
+    if (++turns > 1000000)
+        throw new Error("worker never reported");
+    setTimeout(turn, 0);
+}
+
+function finish()
+{
+    // Flips stopped: a final turn must leave the two shapes in agreement.
+    setTimeout(() => {
+        const c = new Intl.DateTimeFormat().resolvedOptions().locale;
+        const u = new Intl.DateTimeFormat(undefined, {}).resolvedOptions().locale;
+        if (c !== u)
+            throw new Error(`did not heal after flips stopped: cacheable "${c}" vs non-cacheable "${u}"`);
+        if (distinctCached.size < 2)
+            throw new Error(`main thread never tracked the worker's changes (only saw ${[...distinctCached]})`);
+    }, 0);
+}
+
+setTimeout(turn, 0);

--- a/JSTests/stress/intl-datetimeformat-language-change.js
+++ b/JSTests/stress/intl-datetimeformat-language-change.js
@@ -1,0 +1,73 @@
+//@ runDefault("--useDollarVM=1")
+
+// IntlDateTimeFormat resolution depends on the user-preferred languages list;
+// when it changes, subsequent constructions must reflect the new list rather
+// than serving a stale resolution.
+
+function expect(label, got, want)
+{
+    if (got !== want)
+        throw new Error(`${label}: expected "${want}", got "${got}"`);
+}
+
+function startsWith(s, prefix)
+{
+    return typeof s === "string" && s.indexOf(prefix) === 0;
+}
+
+const cycles = [
+    { langs: ["fr-FR", "en-US"], prefix: "fr" },
+    { langs: ["ja-JP", "en-US"], prefix: "ja" },
+    { langs: ["de-DE", "en-US"], prefix: "de" },
+    { langs: ["en-US"], prefix: "en" },
+];
+
+let firstResolved = null;
+
+function runCycle(i)
+{
+    if (i >= cycles.length) {
+        afterCycles();
+        return;
+    }
+    const { langs, prefix } = cycles[i];
+    $vm.setUserPreferredLanguages(langs);
+    setTimeout(() => {
+        const undef = new Intl.DateTimeFormat();
+        const undefAgain = new Intl.DateTimeFormat();
+
+        if (!startsWith(undef.resolvedOptions().locale, prefix))
+            throw new Error(`cycle ${i} [${langs}] expected locale to start with "${prefix}", got "${undef.resolvedOptions().locale}"`);
+
+        expect(`cycle ${i} back-to-back constructions agree`,
+            undefAgain.resolvedOptions().locale, undef.resolvedOptions().locale);
+
+        // At least one cycle must move the resolution off the first one we saw.
+        if (firstResolved === null)
+            firstResolved = undef.resolvedOptions().locale;
+        else if (i === cycles.length - 1) {
+            if (firstResolved === undef.resolvedOptions().locale)
+                throw new Error(`cache leaked across language changes — same resolved locale "${firstResolved}" everywhere`);
+        }
+
+        runCycle(i + 1);
+    }, 0);
+}
+
+function afterCycles()
+{
+    // format() output must also move with the language, not just resolvedOptions.
+    $vm.setUserPreferredLanguages(["ja-JP"]);
+    setTimeout(() => {
+        const ja = new Intl.DateTimeFormat().format(0);
+
+        $vm.setUserPreferredLanguages(["en-US"]);
+        setTimeout(() => {
+            const en = new Intl.DateTimeFormat().format(0);
+            if (ja === en)
+                throw new Error(`format() did not change with language: ja="${ja}" en="${en}"`);
+        }, 0);
+    }, 0);
+}
+
+runCycle(0);

--- a/JSTests/stress/intl-datetimeformat-tz-change-consistency.js
+++ b/JSTests/stress/intl-datetimeformat-tz-change-consistency.js
@@ -1,0 +1,43 @@
+//@ runDefault("--useDollarVM=1")
+//@ skip if $hostOS == "playstation"
+
+// The two construction shapes (`new Intl.DateTimeFormat()` and
+// `new Intl.DateTimeFormat(undefined, {})`) must always agree on the resolved time
+// zone across host TZ changes. A host TZ change only takes effect at the next VM
+// entry, so each change is observed across a setTimeout boundary: there the cached
+// no-arg formatter must have moved to the new zone in step with the non-cacheable
+// shape.
+
+function expect(label, got, want)
+{
+    if (got !== want)
+        throw new Error(`${label}: expected ${JSON.stringify(want)}, got ${JSON.stringify(got)}`);
+}
+
+function cacheableTZ() { return new Intl.DateTimeFormat().resolvedOptions().timeZone; }
+function slowTZ() { return new Intl.DateTimeFormat(undefined, {}).resolvedOptions().timeZone; }
+function cacheableFormat(ts) { return new Intl.DateTimeFormat("en-US").format(ts); }
+function slowFormat(ts) { return new Intl.DateTimeFormat("en-US", {}).format(ts); }
+
+const ts = 0; // 1970-01-01T00:00:00Z lands on different calendar days east vs west of UTC.
+expect("baseline cacheable matches slow on TZ", cacheableTZ(), slowTZ());
+expect("baseline cacheable matches slow on format", cacheableFormat(ts), slowFormat(ts));
+
+const tzs = ["Asia/Tokyo", "America/New_York", "Europe/Paris", "UTC", "Australia/Sydney", "UTC"];
+
+function runCycle(i)
+{
+    if (i >= tzs.length)
+        return;
+    const tz = tzs[i];
+    if (!$vm.setHostTimeZone(tz))
+        throw new Error(`Failed to set host time zone to ${tz}`);
+    setTimeout(() => {
+        expect(`after setTZ(${tz}): cacheable moved to new host`, cacheableTZ(), tz);
+        expect(`after setTZ(${tz}): cacheable matches slow on TZ`, cacheableTZ(), slowTZ());
+        expect(`after setTZ(${tz}): cacheable matches slow on format`, cacheableFormat(ts), slowFormat(ts));
+        runCycle(i + 1);
+    }, 0);
+}
+
+runCycle(0);

--- a/JSTests/stress/intl-datetimeformat-tz-change.js
+++ b/JSTests/stress/intl-datetimeformat-tz-change.js
@@ -1,0 +1,58 @@
+//@ runDefault("--useDollarVM=1")
+//@ skip if $hostOS == "playstation"
+
+// Subsequent constructions must observe a host TZ change. Driven across real
+// setTimeout boundaries so the change goes through the production VMEntryScope
+// service path, where the impl cache is invalidated. Chained setTimeout, because
+// async rejections get swallowed in jsc.cpp.
+
+function expect(label, got, want)
+{
+    if (got !== want)
+        throw new Error(`${label}: expected "${want}", got "${got}"`);
+}
+
+const tzs = ["Europe/Paris", "Asia/Tokyo", "America/Los_Angeles", "UTC", "Australia/Sydney"];
+const epoch = 0; // 1970-01-01T00:00:00Z lands on different calendar days east vs west of UTC.
+const formattedByTz = new Map();
+
+function runCycle(i)
+{
+    if (i >= tzs.length) {
+        afterCycles();
+        return;
+    }
+    const tz = tzs[i];
+    if (!$vm.setHostTimeZone(tz))
+        throw new Error(`Failed to set host time zone to ${tz}`);
+    setTimeout(() => {
+        // Cacheable no-arg and string-locale shapes, and a distinct locale, all see the new host.
+        expect(`[${tz}] no-arg ctor sees host`, new Intl.DateTimeFormat().resolvedOptions().timeZone, tz);
+        expect(`[${tz}] string locale sees host`, new Intl.DateTimeFormat("en-US").resolvedOptions().timeZone, tz);
+        expect(`[${tz}] distinct locale sees host`, new Intl.DateTimeFormat("ja").resolvedOptions().timeZone, tz);
+        // Explicit timeZone option always wins over the host.
+        expect(`[${tz}] explicit timeZone wins`,
+            new Intl.DateTimeFormat("en-US", { timeZone: "Asia/Kolkata" }).resolvedOptions().timeZone, "Asia/Kolkata");
+        formattedByTz.set(tz, new Intl.DateTimeFormat("en-US").format(epoch));
+        runCycle(i + 1);
+    }, 0);
+}
+
+function afterCycles()
+{
+    // Distinct host TZs must format the same epoch differently.
+    if (new Set(formattedByTz.values()).size < 2)
+        throw new Error(`format() output never differed across host TZs: ${JSON.stringify([...formattedByTz.entries()])}`);
+
+    // Non-TZ resolved-options fields are unaffected by TZ changes.
+    if (!$vm.setHostTimeZone("UTC"))
+        throw new Error("Failed to set host time zone to UTC");
+    setTimeout(() => {
+        const r = new Intl.DateTimeFormat("en-US").resolvedOptions();
+        expect("locale stable across TZ changes", r.locale, "en-US");
+        expect("calendar stable across TZ changes", r.calendar, "gregory");
+        expect("numberingSystem stable across TZ changes", r.numberingSystem, "latn");
+    }, 0);
+}
+
+runCycle(0);

--- a/JSTests/stress/intl-datetimeformat-worker-smoke.js
+++ b/JSTests/stress/intl-datetimeformat-worker-smoke.js
@@ -1,0 +1,60 @@
+//@ runDefault
+
+// Each test262 agent runs in its own VM. Build IntlDateTimeFormat across the
+// common construction shapes in N parallel agents and assert nothing throws.
+
+const N = 4;
+
+const workerCode = `
+function check(label, cond) {
+    if (!cond)
+        throw new Error(label);
+}
+
+try {
+    const a = new Intl.DateTimeFormat("en-US");
+    const ra = a.resolvedOptions();
+    check("worker a.locale", ra.locale === "en-US");
+    check("worker a.timeZone is string", typeof ra.timeZone === "string" && ra.timeZone.length > 0);
+    check("worker a.calendar", ra.calendar === "gregory");
+
+    const b = new Intl.DateTimeFormat("en-US");
+    check("worker a !== b", a !== b);
+    check("worker a.format == b.format same input", a.format(0) === b.format(0));
+    check("worker a.tz == b.tz",
+        a.resolvedOptions().timeZone === b.resolvedOptions().timeZone);
+
+    const c = new Intl.DateTimeFormat("ja");
+    check("worker c.locale", c.resolvedOptions().locale === "ja");
+
+    const d = new Intl.DateTimeFormat("en-US", { timeZone: "Asia/Kolkata" });
+    check("worker d.timeZone explicit", d.resolvedOptions().timeZone === "Asia/Kolkata");
+    check("worker d format works", typeof d.format(0) === "string");
+
+    const e = new Intl.DateTimeFormat("en-US", { hour: "numeric" });
+    check("worker e format works", typeof e.format(0) === "string");
+
+    $.agent.report("ok");
+} catch (e) {
+    $.agent.report("fail: " + String(e));
+}
+$.agent.leaving();
+`;
+
+for (let i = 0; i < N; ++i)
+    $.agent.start(workerCode);
+
+let received = 0;
+const reports = [];
+while (received < N) {
+    const r = waitForReport();
+    if (r === null)
+        throw new Error(`waitForReport returned null after ${received} of ${N} reports`);
+    reports.push(r);
+    ++received;
+}
+
+for (let i = 0; i < N; ++i) {
+    if (reports[i] !== "ok")
+        throw new Error(`worker ${i}: ${reports[i]}`);
+}

--- a/JSTests/stress/intl-default-locale.js
+++ b/JSTests/stress/intl-default-locale.js
@@ -14,6 +14,10 @@ shouldBe(Intl.getCanonicalLocales(new Intl.NumberFormat().resolvedOptions().loca
 shouldBe(Intl.getCanonicalLocales(new Intl.Collator().resolvedOptions().locale)[0], new Intl.NumberFormat().resolvedOptions().locale);
 
 $vm.setUserPreferredLanguages([ "fr-FR" ]);
-shouldBe(new Intl.DateTimeFormat().resolvedOptions().locale, 'fr-FR');
-shouldBe(new Intl.NumberFormat().resolvedOptions().locale, 'fr-FR');
-shouldBe(new Intl.Collator().resolvedOptions().locale, 'fr-FR');
+// Intl.DateTimeFormat caches its resolved formatter and only revalidates it on VM entry, so a
+// language change takes effect on the next task turn rather than synchronously within this one.
+setTimeout(() => {
+    shouldBe(new Intl.DateTimeFormat().resolvedOptions().locale, 'fr-FR');
+    shouldBe(new Intl.NumberFormat().resolvedOptions().locale, 'fr-FR');
+    shouldBe(new Intl.Collator().resolvedOptions().locale, 'fr-FR');
+}, 0);

--- a/JSTests/stress/intl-having-a-bad-time.js
+++ b/JSTests/stress/intl-having-a-bad-time.js
@@ -1,0 +1,104 @@
+// Indexed accessors on Object.prototype force every array into a mode where
+// [[Set]] on an index consults the prototype. The spec builds Intl locale lists
+// and formatToParts results with CreateDataPropertyOrThrow, which defines an own
+// data property and must never invoke an inherited setter or read an inherited
+// getter. Matches V8.
+//
+// The parts arrays are appended to at increasing indices, and [[Set]] only
+// consults a prototype accessor at the exact index being written. We poison a
+// whole range so a stray [[Set]] at any element position is observed.
+
+const poisonLimit = 256;
+let getFired = 0, setFired = 0;
+for (let i = 0; i < poisonLimit; ++i) {
+    Object.defineProperty(Object.prototype, i, {
+        get() { ++getFired; return "POISON"; },
+        set() { ++setFired; },
+        configurable: true,
+    });
+}
+
+function run(label, fn)
+{
+    getFired = setFired = 0;
+    const result = fn();
+    if (getFired || setFired)
+        throw new Error(`${label}: fired a user callback (get=${getFired} set=${setFired}); a CreateDataPropertyOrThrow step used [[Set]]`);
+    return result;
+}
+
+function checkParts(label, parts)
+{
+    if (parts.length > poisonLimit)
+        throw new Error(`${label}: ${parts.length} parts exceeds the poisoned range ${poisonLimit}`);
+    // Every element must be a real own part, not a poisoned inherited accessor.
+    for (let i = 0; i < parts.length; ++i) {
+        if (!Object.prototype.hasOwnProperty.call(parts, String(i)))
+            throw new Error(`${label}: element ${i} leaked to Object.prototype[${i}] instead of being an own property`);
+        const part = parts[i];
+        if (typeof part !== "object" || typeof part.type !== "string" || typeof part.value !== "string")
+            throw new Error(`${label}: element ${i} is not a well-formed part: ${JSON.stringify(part)}`);
+    }
+    return parts;
+}
+
+// (1) CanonicalizeLocaleList: every Intl constructor with a string locale.
+run("DateTimeFormat ctor", () => new Intl.DateTimeFormat("en-US"));
+run("NumberFormat ctor", () => new Intl.NumberFormat("en-US"));
+run("Collator ctor", () => new Intl.Collator("en-US"));
+run("PluralRules ctor", () => new Intl.PluralRules("en-US"));
+run("RelativeTimeFormat ctor", () => new Intl.RelativeTimeFormat("en-US"));
+run("DisplayNames ctor", () => new Intl.DisplayNames("en-US", { type: "language" }));
+run("ListFormat ctor", () => new Intl.ListFormat("en-US"));
+run("Segmenter ctor", () => new Intl.Segmenter("en-US"));
+run("Locale ctor", () => new Intl.Locale("en-US"));
+run("getCanonicalLocales", () => Intl.getCanonicalLocales("en-US"));
+run("supportedLocalesOf", () => Intl.DateTimeFormat.supportedLocalesOf("en-US"));
+if (typeof Intl.DurationFormat === "function")
+    run("DurationFormat ctor", () => new Intl.DurationFormat("en-US"));
+
+// The locale still resolves to the argument, not the poisoned prototype value.
+if (new Intl.DateTimeFormat("en-US").resolvedOptions().locale !== "en-US")
+    throw new Error("DateTimeFormat resolved locale is not en-US under a bad time");
+
+// (2) formatToParts result arrays.
+checkParts("NumberFormat.formatToParts",
+    run("NumberFormat.formatToParts", () => new Intl.NumberFormat("en-US").formatToParts(1234.5)));
+checkParts("DateTimeFormat.formatToParts",
+    run("DateTimeFormat.formatToParts", () => new Intl.DateTimeFormat("en-US").formatToParts(0)));
+checkParts("RelativeTimeFormat.formatToParts",
+    run("RelativeTimeFormat.formatToParts", () => new Intl.RelativeTimeFormat("en-US").formatToParts(1, "day")));
+// numeric:"auto" with a value that has a dedicated word ("today") produces the
+// whole result as one literal part, exercising the no-numeric-field path.
+checkParts("RelativeTimeFormat.formatToParts auto",
+    run("RelativeTimeFormat.formatToParts auto", () => new Intl.RelativeTimeFormat("en-US", { numeric: "auto" }).formatToParts(0, "day")));
+checkParts("ListFormat.formatToParts",
+    run("ListFormat.formatToParts", () => new Intl.ListFormat("en-US").formatToParts(["a", "b"])));
+// A Mongolian disjunction appends a suffix after the last element, exercising the
+// trailing-literal flush branch that "and"/"unit" lists never reach.
+checkParts("ListFormat.formatToParts disjunction",
+    run("ListFormat.formatToParts disjunction", () => new Intl.ListFormat("mn", { type: "disjunction" }).formatToParts(["a", "b", "c"])));
+if (typeof Intl.DurationFormat === "function") {
+    checkParts("DurationFormat.formatToParts",
+        run("DurationFormat.formatToParts", () => new Intl.DurationFormat("en-US").formatToParts({ hours: 1, minutes: 2 })));
+    // A digital duration inserts ":" between fields as literal elements.
+    checkParts("DurationFormat.formatToParts digital",
+        run("DurationFormat.formatToParts digital", () => new Intl.DurationFormat("en-US", { hours: "2-digit", minutes: "2-digit", seconds: "2-digit" }).formatToParts({ hours: 1, minutes: 2, seconds: 3 })));
+}
+
+// (3) Range parts variants build the same result arrays.
+{
+    const dtf = new Intl.DateTimeFormat("en-US");
+    if (typeof dtf.formatRangeToParts === "function") {
+        checkParts("DateTimeFormat.formatRangeToParts",
+            run("DateTimeFormat.formatRangeToParts", () => dtf.formatRangeToParts(0, 86400000)));
+        // A full-style Japanese range ends with a literal, exercising the interval
+        // trailing-literal flush branch.
+        checkParts("DateTimeFormat.formatRangeToParts full",
+            run("DateTimeFormat.formatRangeToParts full", () => new Intl.DateTimeFormat("ja-JP", { dateStyle: "full" }).formatRangeToParts(0, 86400000)));
+    }
+    const nf = new Intl.NumberFormat("en-US");
+    if (typeof nf.formatRangeToParts === "function")
+        checkParts("NumberFormat.formatRangeToParts",
+            run("NumberFormat.formatRangeToParts", () => nf.formatRangeToParts(1, 100)));
+}

--- a/Source/JavaScriptCore/runtime/InitializeThreading.cpp
+++ b/Source/JavaScriptCore/runtime/InitializeThreading.cpp
@@ -32,6 +32,7 @@
 #include "AssemblyComments.h"
 #include "AssertInvariants.h"
 #include "ExecutableAllocator.h"
+#include "IntlCache.h"
 #include "JITOperationList.h"
 #include "JSCConfig.h"
 #include "JSCPtrTag.h"
@@ -123,6 +124,8 @@ void initializeWithOptionsCustomization(const ScopedLambda<void()>& optionsCusto
         AssemblyCommentRegistry::initialize();
         LLInt::initialize();
         AssertNoGC::initialize();
+
+        IntlCache::ensureLanguageChangeObserver();
 
         initializeSuperSampler();
         auto& thread = Thread::currentSingleton();

--- a/Source/JavaScriptCore/runtime/IntlCache.cpp
+++ b/Source/JavaScriptCore/runtime/IntlCache.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2020-2023 Apple Inc. All rights reserved.
+ * Copyright (C) 2026 Igalia S.L.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -25,14 +26,37 @@
 
 #include "config.h"
 #include "IntlCache.h"
-#include "IntlObject.h"
 
+#include "IntlDateTimeFormat.h"
+#include "IntlObject.h"
+#include <atomic>
+#include <mutex>
+#include <wtf/Language.h>
 #include <wtf/TZoneMallocInlines.h>
 #include <wtf/Vector.h>
 
 namespace JSC {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(IntlCache);
+
+std::atomic<uint64_t> IntlCache::s_languagesEpoch { 1 };
+
+void IntlCache::ensureLanguageChangeObserver()
+{
+    static std::once_flag onceKey;
+    std::call_once(onceKey, [] {
+        WTF::addLanguageChangeObserver(&s_languagesEpoch, [](void*) {
+            s_languagesEpoch.fetch_add(1, std::memory_order_release);
+        });
+    });
+}
+
+IntlCache::IntlCache()
+    : m_lastSeenLanguagesEpoch(s_languagesEpoch.load(std::memory_order_acquire))
+{
+}
+
+IntlCache::~IntlCache() = default;
 
 UDateTimePatternGenerator* IntlCache::cacheSharedPatternGenerator(const CString& locale, UErrorCode& status)
 {

--- a/Source/JavaScriptCore/runtime/IntlCache.h
+++ b/Source/JavaScriptCore/runtime/IntlCache.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2020-2023 Apple Inc. All rights reserved.
+ * Copyright (C) 2026 Igalia S.L.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -25,10 +26,16 @@
 
 #pragma once
 
+#include "IntlDateTimeFormat.h"
+#include <atomic>
+#include <optional>
 #include <unicode/udatpg.h>
 #include <wtf/HashMap.h>
 #include <wtf/Noncopyable.h>
+#include <wtf/RefPtr.h>
 #include <wtf/TZoneMalloc.h>
+#include <wtf/TinyLRUCache.h>
+#include <wtf/Vector.h>
 #include <wtf/text/CString.h>
 #include <wtf/text/StringHash.h>
 #include <wtf/text/WTFString.h>
@@ -36,18 +43,55 @@
 
 namespace JSC {
 
+struct IntlDateTimeFormatImplKey {
+    std::optional<String> locales;
+    IntlDateTimeFormat::RequiredComponent required { IntlDateTimeFormat::RequiredComponent::Any };
+    IntlDateTimeFormat::Defaults defaults { IntlDateTimeFormat::Defaults::All };
+
+    friend bool operator==(const IntlDateTimeFormatImplKey&, const IntlDateTimeFormatImplKey&) = default;
+};
+
 class IntlCache {
     WTF_MAKE_NONCOPYABLE(IntlCache);
     WTF_MAKE_TZONE_ALLOCATED(IntlCache);
 public:
-    IntlCache() = default;
+    IntlCache();
+    ~IntlCache();
+
+    static void ensureLanguageChangeObserver();
 
     Vector<char16_t, 32> getBestDateTimePattern(const CString& locale, std::span<const char16_t> skeleton, UErrorCode&);
     Vector<char16_t, 32> getFieldDisplayName(const CString& locale, UDateTimePatternField, UDateTimePGDisplayWidth, UErrorCode&);
 
     String canonicalizeUnicodeLocaleID(const String& languageTag);
 
+    // The cache is reset only at the VM entry service scope; get and insert never check.
+    RefPtr<const IntlDateTimeFormatImpl> findCachedDateTimeFormatImpl(const IntlDateTimeFormatImplKey& key)
+    {
+        if (auto cached = m_cachedDateTimeFormatImpls.findIfCached(key))
+            return *cached;
+        return nullptr;
+    }
+
+    void cacheDateTimeFormatImpl(const IntlDateTimeFormatImplKey& key, Ref<const IntlDateTimeFormatImpl>&& impl)
+    {
+        m_cachedDateTimeFormatImpls.insert(key, RefPtr<const IntlDateTimeFormatImpl>(WTF::move(impl)));
+    }
+
+    void clearForTimeZoneChange() { clearDateTimeFormatImplCache(); }
+    bool hasLanguageChange() const { return m_lastSeenLanguagesEpoch != s_languagesEpoch.load(std::memory_order_acquire); }
+    void clearForLanguageChange()
+    {
+        m_lastSeenLanguagesEpoch = s_languagesEpoch.load(std::memory_order_acquire);
+        clearDateTimeFormatImplCache();
+    }
+
 private:
+    void clearDateTimeFormatImplCache() { m_cachedDateTimeFormatImpls.clear(); }
+
+    static constexpr size_t dateTimeFormatImplCacheCapacity = 4;
+    using DateTimeFormatImplCache = WTF::TinyLRUCache<IntlDateTimeFormatImplKey, RefPtr<const IntlDateTimeFormatImpl>, dateTimeFormatImplCacheCapacity>;
+
     UDateTimePatternGenerator* getSharedPatternGenerator(const CString& locale, UErrorCode& status)
     {
         if (m_cachedDateTimePatternGenerator) {
@@ -62,6 +106,11 @@ private:
     std::unique_ptr<UDateTimePatternGenerator, ICUDeleter<udatpg_close>> m_cachedDateTimePatternGenerator;
     CString m_cachedDateTimePatternGeneratorLocale;
     UncheckedKeyHashMap<String, String> m_cachedCanonicalizedLocaleIDs;
+
+    static std::atomic<uint64_t> s_languagesEpoch;
+
+    DateTimeFormatImplCache m_cachedDateTimeFormatImpls;
+    uint64_t m_lastSeenLanguagesEpoch { 0 };
 };
 
 } // namespace JSC

--- a/Source/JavaScriptCore/runtime/IntlDateTimeFormat.cpp
+++ b/Source/JavaScriptCore/runtime/IntlDateTimeFormat.cpp
@@ -1,6 +1,7 @@
 /*
  * Copyright (C) 2015 Andy VanWagoner (andy@vanwagoner.family)
  * Copyright (C) 2016-2025 Apple Inc. All rights reserved.
+ * Copyright (C) 2026 Igalia S.L.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -738,6 +739,22 @@ void IntlDateTimeFormat::initializeDateTimeFormat(JSGlobalObject* globalObject, 
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
+    std::optional<IntlDateTimeFormatImplKey> cacheKey;
+    const bool canCache = originalOptions.isUndefined() && (locales.isUndefined() || locales.isString()) && toLocaleStringTimeZone.isNull();
+    if (canCache) {
+        IntlDateTimeFormatImplKey key { .locales = std::nullopt, .required = required, .defaults = defaults };
+        if (locales.isString()) {
+            key.locales = asString(locales)->value(globalObject);
+            RETURN_IF_EXCEPTION(scope, void());
+        }
+        if (auto cachedImpl = vm.intlCache().findCachedDateTimeFormatImpl(key)) {
+            setImpl(cachedImpl.releaseNonNull());
+            vm.heap.reportExtraMemoryAllocated(this, estimatedUDateFormatSize);
+            return;
+        }
+        cacheKey = WTF::move(key);
+    }
+
     Vector<String> requestedLocales = canonicalizeLocaleList(globalObject, locales);
     RETURN_IF_EXCEPTION(scope, void());
 
@@ -1076,6 +1093,9 @@ void IntlDateTimeFormat::initializeDateTimeFormat(JSGlobalObject* globalObject, 
     }
 
     vm.heap.reportExtraMemoryAllocated(this, estimatedUDateFormatSize);
+
+    if (cacheKey)
+        vm.intlCache().cacheDateTimeFormatImpl(*cacheKey, impl.copyRef());
     m_impl = WTF::move(impl);
 }
 
@@ -1495,7 +1515,7 @@ static JSValue buildFormattedDateTimeParts(JSGlobalObject* globalObject, UDateFo
             JSObject* part = sourceType
                 ? createIntlPartObjectWithSource(globalObject, literalString, value, sourceType)
                 : createIntlPartObject(globalObject, literalString, value);
-            parts->push(globalObject, part);
+            parts->putDirectIndex(globalObject, parts->length(), part);
             RETURN_IF_EXCEPTION(scope, { });
         }
         previousEndIndex = endIndex;
@@ -1506,7 +1526,7 @@ static JSValue buildFormattedDateTimeParts(JSGlobalObject* globalObject, UDateFo
             JSObject* part = sourceType
                 ? createIntlPartObjectWithSource(globalObject, type, value, sourceType)
                 : createIntlPartObject(globalObject, type, value);
-            parts->push(globalObject, part);
+            parts->putDirectIndex(globalObject, parts->length(), part);
             RETURN_IF_EXCEPTION(scope, { });
         }
     }
@@ -1927,7 +1947,7 @@ static JSValue buildFormattedDateIntervalParts(JSGlobalObject* globalObject, con
 
         if (previousEndIndex < beginIndex) {
             JSObject* part = createPart(literalString, previousEndIndex, beginIndex - previousEndIndex);
-            parts->push(globalObject, part);
+            parts->putDirectIndex(globalObject, parts->length(), part);
             RETURN_IF_EXCEPTION(scope, { });
             previousEndIndex = beginIndex;
         }
@@ -1950,14 +1970,14 @@ static JSValue buildFormattedDateIntervalParts(JSGlobalObject* globalObject, con
 
         auto type = jsNontrivialString(vm, partTypeString(UDateFormatField(fieldType)));
         JSObject* part = createPart(type, beginIndex, endIndex - beginIndex);
-        parts->push(globalObject, part);
+        parts->putDirectIndex(globalObject, parts->length(), part);
         RETURN_IF_EXCEPTION(scope, { });
         previousEndIndex = endIndex;
     }
 
     if (previousEndIndex < resultLength) {
         JSObject* part = createPart(literalString, previousEndIndex, resultLength - previousEndIndex);
-        parts->push(globalObject, part);
+        parts->putDirectIndex(globalObject, parts->length(), part);
         RETURN_IF_EXCEPTION(scope, { });
     }
 

--- a/Source/JavaScriptCore/runtime/IntlDurationFormat.cpp
+++ b/Source/JavaScriptCore/runtime/IntlDurationFormat.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2020-2024 Apple Inc. All rights reserved.
+ * Copyright (C) 2026 Igalia S.L.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -840,7 +841,7 @@ JSValue IntlDurationFormat::formatToParts(JSGlobalObject* globalObject, ISO8601:
                 case ElementType::Literal: {
                     JSString* value = jsString(vm, element.m_string);
                     JSObject* part = createPart(literalString, value);
-                    parts->push(globalObject, part);
+                    parts->putDirectIndex(globalObject, parts->length(), part);
                     RETURN_IF_EXCEPTION(scope, void());
                     break;
                 }
@@ -868,7 +869,7 @@ JSValue IntlDurationFormat::formatToParts(JSGlobalObject* globalObject, ISO8601:
         if (previousEndIndex < beginIndex) {
             auto value = jsString(vm, resultStringView.substring(previousEndIndex, beginIndex - previousEndIndex));
             JSObject* part = createPart(literalString, value);
-            parts->push(globalObject, part);
+            parts->putDirectIndex(globalObject, parts->length(), part);
             RETURN_IF_EXCEPTION(scope, { });
         }
         previousEndIndex = endIndex;
@@ -876,10 +877,11 @@ JSValue IntlDurationFormat::formatToParts(JSGlobalObject* globalObject, ISO8601:
         RETURN_IF_EXCEPTION(scope, { });
     }
 
+    ASSERT(previousEndIndex == resultLength);
     if (previousEndIndex < resultLength) {
         auto value = jsString(vm, resultStringView.substring(previousEndIndex, resultLength - previousEndIndex));
         JSObject* part = createPart(literalString, value);
-        parts->push(globalObject, part);
+        parts->putDirectIndex(globalObject, parts->length(), part);
         RETURN_IF_EXCEPTION(scope, { });
     }
 

--- a/Source/JavaScriptCore/runtime/IntlListFormat.cpp
+++ b/Source/JavaScriptCore/runtime/IntlListFormat.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2020-2023 Apple Inc. All rights reserved.
+ * Copyright (C) 2026 Igalia S.L.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -248,21 +249,21 @@ JSValue IntlListFormat::formatToParts(JSGlobalObject* globalObject, JSValue list
         if (previousEndIndex < beginIndex) {
             auto value = jsString(vm, resultStringView.substring(previousEndIndex, beginIndex - previousEndIndex));
             JSObject* part = createPart(literalString, value);
-            parts->push(globalObject, part);
+            parts->putDirectIndex(globalObject, parts->length(), part);
             RETURN_IF_EXCEPTION(scope, { });
         }
         previousEndIndex = endIndex;
 
         auto value = jsString(vm, resultStringView.substring(beginIndex, endIndex - beginIndex));
         JSObject* part = createPart(elementString, value);
-        parts->push(globalObject, part);
+        parts->putDirectIndex(globalObject, parts->length(), part);
         RETURN_IF_EXCEPTION(scope, { });
     }
 
     if (previousEndIndex < resultLength) {
         auto value = jsString(vm, resultStringView.substring(previousEndIndex, resultLength - previousEndIndex));
         JSObject* part = createPart(literalString, value);
-        parts->push(globalObject, part);
+        parts->putDirectIndex(globalObject, parts->length(), part);
         RETURN_IF_EXCEPTION(scope, { });
     }
 

--- a/Source/JavaScriptCore/runtime/IntlNumberFormat.cpp
+++ b/Source/JavaScriptCore/runtime/IntlNumberFormat.cpp
@@ -2,6 +2,7 @@
  * Copyright (C) 2015 Andy VanWagoner (andy@vanwagoner.family)
  * Copyright (C) 2016 Sukolsak Sakshuwong (sukolsak@gmail.com)
  * Copyright (C) 2016-2023 Apple Inc. All rights reserved.
+ * Copyright (C) 2026 Igalia S.L.
  * Copyright (C) 2020 Sony Interactive Entertainment Inc.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -933,7 +934,7 @@ void IntlNumberFormat::formatRangeToPartsInternal(JSGlobalObject* globalObject, 
         auto fieldType = field.m_field;
         auto partType = fieldType == literalField ? literalString : jsNontrivialString(vm, partTypeString(UNumberFormatFields(fieldType), style, sign, numberType));
         JSObject* part = createPart(partType, field.m_range.begin(), field.m_range.distance());
-        parts->push(globalObject, part);
+        parts->putDirectIndex(globalObject, parts->length(), part);
         RETURN_IF_EXCEPTION(scope, void());
     }
 }
@@ -1318,7 +1319,7 @@ void IntlNumberFormat::formatToPartsInternal(JSGlobalObject* globalObject, Style
             part = createIntlPartObjectWithSource(globalObject, partType, partValue, sourceType);
         else
             part = createIntlPartObject(globalObject, partType, partValue);
-        parts->push(globalObject, part);
+        parts->putDirectIndex(globalObject, parts->length(), part);
         RETURN_IF_EXCEPTION(scope, void());
     }
 }

--- a/Source/JavaScriptCore/runtime/IntlObject.cpp
+++ b/Source/JavaScriptCore/runtime/IntlObject.cpp
@@ -762,7 +762,7 @@ Vector<String> canonicalizeLocaleList(JSGlobalObject* globalObject, JSValue loca
             throwOutOfMemoryError(globalObject, scope);
             return { };
         }
-        localesArray->push(globalObject, locales);
+        localesArray->putDirectIndex(globalObject, 0, locales);
         RETURN_IF_EXCEPTION(scope, Vector<String>());
 
         localesObject = localesArray;

--- a/Source/JavaScriptCore/runtime/IntlRelativeTimeFormat.cpp
+++ b/Source/JavaScriptCore/runtime/IntlRelativeTimeFormat.cpp
@@ -1,6 +1,7 @@
 /*
  * Copyright (C) 2020 Sony Interactive Entertainment Inc.
  * Copyright (C) 2021-2023 Apple Inc. All rights reserved.
+ * Copyright (C) 2026 Igalia S.L.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -365,7 +366,7 @@ JSValue IntlRelativeTimeFormat::formatToParts(JSGlobalObject* globalObject, doub
     if (numberStart >= 0) {
         if (numberStart > 0) {
             JSObject* part = createIntlPartObject(globalObject, literalString, jsSubstring(vm, formattedRelativeTime, 0, numberStart));
-            parts->push(globalObject, part);
+            parts->putDirectIndex(globalObject, parts->length(), part);
             RETURN_IF_EXCEPTION(scope, { });
         }
 
@@ -382,13 +383,13 @@ JSValue IntlRelativeTimeFormat::formatToParts(JSGlobalObject* globalObject, doub
         auto stringLength = formattedRelativeTime.length();
         if (static_cast<unsigned>(numberEnd) < stringLength) {
             JSObject* part = createIntlPartObject(globalObject, literalString, jsSubstring(vm, formattedRelativeTime, numberEnd, stringLength - numberEnd));
-            parts->push(globalObject, part);
+            parts->putDirectIndex(globalObject, parts->length(), part);
             RETURN_IF_EXCEPTION(scope, { });
         }
     } else {
         // No numeric field (e.g., numeric: "auto" producing "today", "yesterday").
         JSObject* part = createIntlPartObject(globalObject, literalString, jsString(vm, formattedRelativeTime));
-        parts->push(globalObject, part);
+        parts->putDirectIndex(globalObject, parts->length(), part);
         RETURN_IF_EXCEPTION(scope, { });
     }
 

--- a/Source/JavaScriptCore/runtime/VM.cpp
+++ b/Source/JavaScriptCore/runtime/VM.cpp
@@ -1743,6 +1743,11 @@ NativeExecutable* VM::promiseAnySlowRejectFunctionExecutableSlow()
     return executable;
 }
 
+bool VM::hasLanguageChange()
+{
+    return m_intlCache->hasLanguageChange();
+}
+
 void VM::executeEntryScopeServicesOnEntry()
 {
     if (hasEntryScopeServiceRequest(EntryScopeService::FirePrimitiveGigacageEnabled)) [[unlikely]] {
@@ -1750,8 +1755,13 @@ void VM::executeEntryScopeServicesOnEntry()
         clearEntryScopeService(EntryScopeService::FirePrimitiveGigacageEnabled);
     }
 
-    if (dateCache.hasTimeZoneChange()) [[unlikely]]
+    if (dateCache.hasTimeZoneChange()) [[unlikely]] {
+        intlCache().clearForTimeZoneChange();
         dateCache.clearForTimeZoneChange();
+    }
+
+    if (intlCache().hasLanguageChange()) [[unlikely]]
+        intlCache().clearForLanguageChange();
 
     RefPtr watchdog = this->watchdog();
     if (watchdog) [[unlikely]]

--- a/Source/JavaScriptCore/runtime/VM.h
+++ b/Source/JavaScriptCore/runtime/VM.h
@@ -358,7 +358,7 @@ public:
         NeedStopTheWorld = 1 << 1, // FIXME rdar://161576886
     };
 
-    bool hasAnyEntryScopeServiceRequest() { return m_entryScopeServicesRawBits; }
+    bool hasAnyEntryScopeServiceRequest() { return m_entryScopeServicesRawBits || hasTimeZoneChange() || hasLanguageChange(); }
     void executeEntryScopeServicesOnEntry();
     void executeEntryScopeServicesOnExit();
 
@@ -951,6 +951,7 @@ public:
 #endif
 
     bool hasTimeZoneChange() { return dateCache.hasTimeZoneChange(); }
+    bool hasLanguageChange();
 
     RegExpCache* regExpCache() LIFETIME_BOUND { return m_regExpCache.get(); }
 

--- a/Source/JavaScriptCore/runtime/VMEntryScope.cpp
+++ b/Source/JavaScriptCore/runtime/VMEntryScope.cpp
@@ -51,7 +51,7 @@ void VMEntryScope::setUpSlow()
 #endif
     }
 
-    if (m_vm.hasAnyEntryScopeServiceRequest() || m_vm.hasTimeZoneChange()) [[unlikely]]
+    if (m_vm.hasAnyEntryScopeServiceRequest()) [[unlikely]]
         m_vm.executeEntryScopeServicesOnEntry();
 }
 

--- a/Source/WTF/wtf/Language.cpp
+++ b/Source/WTF/wtf/Language.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2010, 2013, 2016, 2017 Apple Inc. All rights reserved.
+ * Copyright (C) 2026 Igalia S.L.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -56,8 +57,9 @@ static Vector<String>& NODELETE preferredLanguagesOverride() WTF_REQUIRES_LOCK(l
 }
 static std::optional<bool> cachedUserPrefersSimplifiedChinese WTF_GUARDED_BY_LOCK(languagesLock);
 
+static Lock observerMapLock;
 using ObserverMap = HashMap<void*, LanguageChangeObserverFunction>;
-static ObserverMap& NODELETE observerMap()
+static ObserverMap& NODELETE observerMap() WTF_REQUIRES_LOCK(observerMapLock)
 {
     static NeverDestroyed<ObserverMap> map;
     return map.get();
@@ -65,11 +67,13 @@ static ObserverMap& NODELETE observerMap()
 
 void addLanguageChangeObserver(void* context, LanguageChangeObserverFunction customObserver)
 {
+    Locker locker { observerMapLock };
     observerMap().set(context, customObserver);
 }
 
 void removeLanguageChangeObserver(void* context)
 {
+    Locker locker { observerMapLock };
     ASSERT(observerMap().contains(context));
     observerMap().remove(context);
 }
@@ -83,10 +87,9 @@ void languageDidChange()
         cachedUserPrefersSimplifiedChinese = std::nullopt;
     }
 
-    for (auto& observer : copyToVector(observerMap())) {
-        if (observerMap().contains(observer.key))
-            observer.value(observer.key);
-    }
+    Locker locker { observerMapLock };
+    for (auto& observer : copyToVector(observerMap()))
+        observer.value(observer.key);
 }
 
 String defaultLanguage(ShouldMinimizeLanguages shouldMinimizeLanguages)


### PR DESCRIPTION
#### 8d261de036d46e2f57473eb3c8c65f43bbf77324
<pre>
Cache Intl.DateTimeFormat
<a href="https://bugs.webkit.org/show_bug.cgi?id=314337">https://bugs.webkit.org/show_bug.cgi?id=314337</a>

Reviewed by Keith Miller.

We cache new Intl.DateTimeFormat like other engines. A LRU cache keeps
the underlying const impl object cached, and JS wrappers share a reference
to it now.

We also register a new language change observer to invalidate our cache.

We restructure the resetting code a bit so that it is clear when
we are resetting due to TZ or language, even if the actual reset
logic is the same.

date-time-complex.js goes 200-1000x faster (simple vs complex case).

While touching this code, we also fix a related bug: canonicalizeLocaleList
should defineOwnProperty on the resulting array, we shouldn&apos;t observe
this. I added a test for this case too, and now we match v8&apos;s behaviour
with and without this new cache.

Finally, I have included some llm-generated tests to make sure we hit
a bunch of these edge cases. They are a bit verbose for my tastes,
but I figured that including them could still be useful for the fuzzer.

Canonical link: <a href="https://commits.webkit.org/317628@main">https://commits.webkit.org/317628@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/76fe350cb82a16ad0377d307db14725802adbc19

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/175647 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/49580 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/43363 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/185239 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/137825 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/50872 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/49262 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/136782 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/137825 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/178603 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/40207 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/157545 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/117260 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/38849 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/37232 "Passed tests") | [⏳ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/JSC-Tests-WPE-EWS "Waiting to run tests") | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/6054 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/149268 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/37037 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/33709 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/36911 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/41271 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/41438 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/187660 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/49247 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/145751 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39258 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/49927 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/33661 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/145589 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/40406 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/122122 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/115948 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/48434 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/12014 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/47836 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/48068 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/47893 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->