### PR TITLE
Atomics' ensurePointer should only allocate once

### DIFF
--- a/JSTests/stress/comma-in-condition-context.js
+++ b/JSTests/stress/comma-in-condition-context.js
@@ -333,4 +333,3 @@ for (let i = 0; i < 1e3; i++) {
     shouldBe(testSwitch(99, 0), "none");
 }
 
-print("PASS");

--- a/Source/WTF/wtf/Atomics.h
+++ b/Source/WTF/wtf/Atomics.h
@@ -489,21 +489,22 @@ InputAndValue<InputType, ValueType> inputAndValue(InputType input, ValueType val
     return InputAndValue<InputType, ValueType>(input, value);
 }
 
-template<typename T, typename Func>
-ALWAYS_INLINE T& ensurePointer(Atomic<T*>& pointer, const Func& func)
+template<typename T>
+ALWAYS_INLINE T& ensurePointer(Atomic<T*>& pointer, const Invocable<T*()> auto& func)
 {
-    for (;;) {
-        T* oldValue = pointer.load(std::memory_order_relaxed);
-        if (oldValue) {
-            // On all sensible CPUs, we get an implicit dependency-based load-load barrier when
-            // loading this.
-            return *oldValue;
-        }
-        T* newValue = func();
-        if (pointer.compareExchangeWeak(oldValue, newValue))
-            return *newValue;
-        delete newValue;
+    T* oldValue = pointer.load(std::memory_order_relaxed);
+    if (oldValue) {
+        // On all sensible CPUs, we get an implicit dependency-based load-load barrier when
+        // loading this.
+        return *oldValue;
     }
+    T* newValue = func();
+    if (T* actual = pointer.compareExchangeStrong(nullptr, newValue, std::memory_order_release, std::memory_order_relaxed)) {
+        // Someone beat us to it, memory_order_relaxed is fine in this case, we didn't publish newValue to any other thread.
+        delete newValue;
+        return *actual;
+    }
+    return *newValue;
 }
 
 } // namespace WTF


### PR DESCRIPTION
#### 7332074f0ccefdd29a2dc32d146846adc60acfa7
<pre>
Atomics&apos; ensurePointer should only allocate once
<a href="https://bugs.webkit.org/show_bug.cgi?id=314338">https://bugs.webkit.org/show_bug.cgi?id=314338</a>
<a href="https://rdar.apple.com/176486283">rdar://176486283</a>

Reviewed by Yusuke Suzuki.

Right now the new value will get deleted then recreated if the
compareExchangeWeak spuriously fails. This is inefficient, we should
just use compareExchangeStrong instead.

No new tests, covered by existing tests.

* JSTests/stress/comma-in-condition-context.js:
* Source/WTF/wtf/Atomics.h:
(WTF::ensurePointer):

Canonical link: <a href="https://commits.webkit.org/312884@main">https://commits.webkit.org/312884@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/92413c6350777d8e57971a2c5504c84b5f6feb58

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/161224 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/34697 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/27798 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/170127 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/117595 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/786ff245-2c43-410d-b47e-b7134d48e9e5) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/34798 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/34698 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/125074 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/117595 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/129998f3-4ff1-48d9-bef0-0461a2658e19) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/164183 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/27345 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/144821 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/105671 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/16278b98-0af7-4eee-bce3-dee31e3acead) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/26393 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/24901 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/17847 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/153281 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/136087 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/22582 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/172610 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/22062 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/19631 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/24223 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/133354 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/34371 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/28994 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/133363 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/34356 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/144377 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/96221 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/24528 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/27904 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/21195 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/193623 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/33866 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/101291 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/49881 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/33365 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/33609 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/33514 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->