### PR TITLE
prefers-color-scheme in SVG embedded using <img> or background-image is flaky

### DIFF
--- a/LayoutTests/svg/custom/svg-image-dark-mode-prefers-color-scheme-repeat-loads-expected.html
+++ b/LayoutTests/svg/custom/svg-image-dark-mode-prefers-color-scheme-repeat-loads-expected.html
@@ -1,0 +1,27 @@
+<style>
+  #container {
+    display: flex;
+    gap: 10px;
+  }
+
+  .box {
+    width: 50px;
+    height: 50px;
+    background-color: green;
+  }
+</style>
+
+<p>You should not see any red boxes.</p>
+
+<div id="container">
+  <div class="box"></div>
+  <div class="box"></div>
+  <div class="box"></div>
+  <div class="box"></div>
+  <div class="box"></div>
+  <div class="box"></div>
+  <div class="box"></div>
+  <div class="box"></div>
+  <div class="box"></div>
+  <div class="box"></div>
+</div>

--- a/LayoutTests/svg/custom/svg-image-dark-mode-prefers-color-scheme-repeat-loads.html
+++ b/LayoutTests/svg/custom/svg-image-dark-mode-prefers-color-scheme-repeat-loads.html
@@ -1,0 +1,49 @@
+<style>
+  #container {
+    display: flex;
+    gap: 10px;
+  }
+
+  img {
+    width: 50px;
+    height: 50px;
+  }
+</style>
+
+<p>You should not see any red boxes.</p>
+
+<div id="container">
+</div>
+
+<script>
+  function random() {
+    return Math.ceil(Math.random() * 10000).toString();
+  }
+
+  if (window.testRunner) {
+    testRunner.waitUntilDone();
+    testRunner.setUseDarkAppearanceForTesting(true);
+  }
+
+  const imgLoadPromises = [];
+
+  // With the bug, each image have a random chance of being green or red, so load a bunch
+  // of them to make sure at least one hits the bug (is red)
+  for (let i = 0; i < 10; ++i) {
+    const img = document.createElement("img");
+    // Random query string to make sure the images are not loaded from cache.
+    // Otherwise, if this test is run with run-webkit-tests --iteration [larger than 1],
+    // the first iteration would fail, but subsequent iterations would pass because of caching.
+    img.src = `resources/prefers-color-scheme-dark-red-green.svg?${random()}}`;
+
+    const loadPromise = new Promise((resolve) => img.addEventListener("load", resolve));
+    imgLoadPromises.push(loadPromise);
+
+    container.appendChild(img);
+  }
+
+  Promise.allSettled(imgLoadPromises).then(() => {
+    if (window.testRunner)
+      testRunner.notifyDone();
+  });
+</script>

--- a/Source/WebCore/loader/cache/CachedImage.cpp
+++ b/Source/WebCore/loader/cache/CachedImage.cpp
@@ -761,8 +761,11 @@ void CachedImage::scheduleRenderingUpdate(const Image& image)
 bool CachedImage::useSystemDarkAppearance() const
 {
     CachedResourceClientWalker<CachedImageClient> walker(*this);
-    if (RefPtr client = walker.next())
-        return client->useSystemDarkAppearance();
+    while (RefPtr client = walker.next()) {
+        if (client->useSystemDarkAppearance())
+            return true;
+    }
+
     return false;
 }
 


### PR DESCRIPTION
#### 187dd258162fbd1c6ce6b4fbfaa7c3e7e9514468
<pre>
prefers-color-scheme in SVG embedded using &lt;img&gt; or background-image is flaky
<a href="https://rdar.apple.com/176413340">rdar://176413340</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=314270">https://bugs.webkit.org/show_bug.cgi?id=314270</a>

Reviewed by Said Abou-Hallawa.

When an SVG image, using @media (prefers-color-scheme), is embedded using &lt;img src&gt; or
background-image, @media (prefers-color-scheme) evaluates to different results between
reloads. This can be reproduced by reloading LayoutTests/svg/custom/svg-image-dark-mode-initial.html
multiple times, and observing that the &quot;&lt;img&gt; src&quot; and &quot;CSS background-image&quot; images
change between green and red between reloads.

303920@main implements @media (prefers-color-scheme) in SVG images by setting the
appearance of the SVG&apos;s Page from system appearance. The flow to get the system appearance
is SVGImage::dataChanged() -&gt; ImageObserver::useSystemDarkAppearance() (implemented by
CachedImageObserver::useSystemDarkAppearance()) -&gt; CachedImage::useSystemDarkAppearance() -&gt;
calls CachedImageClient::useSystemDarkAppearance() on the first CachedImageClient -&gt;
RenderObject::CachedImageListener::useSystemDarkAppearance(). It&apos;s possible that the first
CachedImageClient is not a RenderObject::CachedImageListener but something else, in which its
useSystemDarkAppearance() is the default implementation in CachedImageClient that returns false.

Fix this by having CachedImage::useSystemDarkAppearance() loop through all clients, and
return true if any client-&gt;useSystemDarkAppearance() is true.

This was found when investigating LayoutTests/svg/custom/svg-image-dark-mode-initial.html failing
in Site Isolation mode, so hopefully this will fix that too.

Test: svg/custom/svg-image-dark-mode-prefers-color-scheme-repeat-loads.html

* LayoutTests/svg/custom/svg-image-dark-mode-prefers-color-scheme-repeat-loads-expected.html: Added.
* LayoutTests/svg/custom/svg-image-dark-mode-prefers-color-scheme-repeat-loads.html: Added.
* Source/WebCore/loader/cache/CachedImage.cpp:
(WebCore::CachedImage::useSystemDarkAppearance const):

Canonical link: <a href="https://commits.webkit.org/313021@main">https://commits.webkit.org/313021@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ea11c2cb82617060a9121c62949fc01c76ef1e7e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/161280 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/34753 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/27854 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/170183 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/117651 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/f1697a95-9d26-4d0e-924a-0ae4653089df) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/163149 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/34854 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/34754 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/125100 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/88171 "2 flakes 1 failures") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/9c5f0a01-7ff6-4e34-a818-bda335868c54) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/164239 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/27395 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/144868 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/105697 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/2737c17b-fa39-403d-9e6f-9e0919846e4a) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/26443 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/24943 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/17903 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/136137 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/22628 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/172666 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/19687 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/24269 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/133384 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/34427 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/29036 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/133392 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36150 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/34412 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/144423 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/96277 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/27934 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/21241 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/33922 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/101347 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/33421 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/33665 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/33570 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->