### PR TITLE
[Site Isolation] fast/loader/onload-willSendRequest-null-for-frame.html loads an external URL iframe that gets blocked

### DIFF
--- a/LayoutTests/fast/loader/onload-willSendRequest-null-for-frame.html
+++ b/LayoutTests/fast/loader/onload-willSendRequest-null-for-frame.html
@@ -23,6 +23,6 @@
     &lt;iframe> with a bad scheme or whose load is cancelled by returning null from resource load
     delegate's willSendRequest</a>. If the test passes, you should see the word "PASSED" below.</p>
     <div id=result>FAILED</div>
-    <iframe src="http://www.example.com/"></iframe>
+    <iframe src="resources/empty-subframe.html"></iframe>
 </body>
 </html>


### PR DESCRIPTION
#### 4d111a1453f2912a320d2cc7b2a6a302074ab3b6
<pre>
[Site Isolation] fast/loader/onload-willSendRequest-null-for-frame.html loads an external URL iframe that gets blocked
<a href="https://rdar.apple.com/176497077">rdar://176497077</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=314346">https://bugs.webkit.org/show_bug.cgi?id=314346</a>

Reviewed by Ryosuke Niwa.

fast/loader/onload-willSendRequest-null-for-frame.html loads an iframe from an external
URL (<a href="http://example.com).">http://example.com).</a> In Site Isolation mode, this gets blocked by
TestController::decidePolicyForNavigationAction. This has two effects:

1) the test page never reaches InjectedBundlePage::willSendRequestForFrame(), so it can&apos;t
   test that onload fires when willSendRequestForFrame() returns null
2) TestController::decidePolicyForNavigationAction prints &quot;Blocked access to external URL...&quot;
   when the URL is blocked. This only occurs when Site Isolation is enabled, hence the output
   will be different compared to Site Isolation disabled.

Fix this by changing the iframe URL to a local page. I manually confirm that
InjectedBundlePage::willSendRequestForFrame() is still reached and returns null in SI-off and SI-on.

* LayoutTests/fast/loader/onload-willSendRequest-null-for-frame.html:

Canonical link: <a href="https://commits.webkit.org/313105@main">https://commits.webkit.org/313105@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1a49d7122064d4d4baca0cadf91cb7089bb2a88f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/161238 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/34711 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/27812 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/170141 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/117609 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/b82b6470-53df-4cb3-80a0-b911abbd4a08) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/34812 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/34712 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/125069 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/88158 "1 flakes 2 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/1221ae8d-bc15-4edd-824f-355d871404ae) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/164197 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/27352 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/144825 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/105666 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/05c2a0d0-051e-420f-bf38-2a5558473fe5) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/26400 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/24904 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/17861 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/136094 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/22586 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/172624 "Built successfully") | | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/24227 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/133346 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/34385 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/28997 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/133355 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36202 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/34370 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/144381 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/96235 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/27903 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/21199 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/33880 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/33379 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/33623 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/33528 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->