### PR TITLE
Add some testing-only assertions to diagnose canvas failures in Site Isolation tests

### DIFF
--- a/Source/WebCore/html/canvas/CanvasRenderingContext2DBase.cpp
+++ b/Source/WebCore/html/canvas/CanvasRenderingContext2DBase.cpp
@@ -54,6 +54,7 @@
 #include "ColorSerialization.h"
 #include "DOMMatrix.h"
 #include "DOMMatrix2DInit.h"
+#include "DeprecatedGlobalSettings.h"
 #include "FloatQuad.h"
 #include "FontCascadeFonts.h"
 #include "FontCascadeInlines.h"
@@ -3349,12 +3350,17 @@ RefPtr<ImageBuffer> CanvasRenderingContext2DBase::allocateImageBuffer() const
     if (!canvasBase().validateArea())
         return nullptr;
     RefPtr scriptExecutionContext = canvasBase().scriptExecutionContext();
+    if (DeprecatedGlobalSettings::canvasExportAssertionsEnabled())
+        RELEASE_ASSERT_WITH_MESSAGE(scriptExecutionContext, "CanvasRenderingContext2DBase::allocateImageBuffer: scriptExecutionContext is null");
     if (!scriptExecutionContext)
         return nullptr;
     RenderingMode renderingMode = !willReadFrequently() && canvasBase().shouldAccelerate() ? RenderingMode::Accelerated : RenderingMode::Unaccelerated;
     if (auto renderingModeForTesting = this->renderingModeForTesting())
         renderingMode = *renderingModeForTesting;
-    return ImageBuffer::create(canvasBase().size(), renderingMode, RenderingPurpose::Canvas, 1, colorSpace(), pixelFormat(), scriptExecutionContext->graphicsClient());
+    auto buffer = ImageBuffer::create(canvasBase().size(), renderingMode, RenderingPurpose::Canvas, 1, colorSpace(), pixelFormat(), scriptExecutionContext->graphicsClient());
+    if (DeprecatedGlobalSettings::canvasExportAssertionsEnabled())
+        RELEASE_ASSERT_WITH_MESSAGE(buffer, "CanvasRenderingContext2DBase::allocateImageBuffer: ImageBuffer::create() returned null (size: %dx%d, accelerated: %d)", canvasBase().size().width(), canvasBase().size().height(), renderingMode == RenderingMode::Accelerated);
+    return buffer;
 }
 
 } // namespace WebCore

--- a/Source/WebCore/page/DeprecatedGlobalSettings.h
+++ b/Source/WebCore/page/DeprecatedGlobalSettings.h
@@ -84,6 +84,9 @@ public:
     static void setAttrStyleEnabled(bool isEnabled) { singleton().m_attrStyleEnabled = isEnabled; }
     static bool attrStyleEnabled() { return singleton().m_attrStyleEnabled; }
 
+    static void setCanvasExportAssertionsEnabled(bool isEnabled) { singleton().m_canvasExportAssertionsEnabled = isEnabled; }
+    static bool canvasExportAssertionsEnabled() { return singleton().m_canvasExportAssertionsEnabled; }
+
     static void setWebSQLEnabled(bool isEnabled) { singleton().m_webSQLEnabled = isEnabled; }
     static bool webSQLEnabled() { return singleton().m_webSQLEnabled; }
 
@@ -155,6 +158,7 @@ private:
 
     bool m_isCustomPasteboardDataEnabled { false };
     bool m_attrStyleEnabled { false };
+    bool m_canvasExportAssertionsEnabled { false };
     bool m_webSQLEnabled { false };
 
 #if ENABLE(ATTACHMENT_ELEMENT)

--- a/Source/WebCore/platform/graphics/ImageUtilities.cpp
+++ b/Source/WebCore/platform/graphics/ImageUtilities.cpp
@@ -26,6 +26,7 @@
 #include "config.h"
 #include "ImageUtilities.h"
 
+#include "DeprecatedGlobalSettings.h"
 #include "DestinationColorSpace.h"
 #include "GraphicsContext.h"
 #include "ImageBuffer.h"
@@ -71,7 +72,14 @@ Vector<uint8_t> encodeData(RefPtr<ImageBuffer>&& buffer, const String& mimeType,
 {
     if (!buffer)
         return { };
-    return encodeData(buffer->copyNativeImage(), mimeType, quality);
+    auto image = buffer->copyNativeImage();
+    if (!image) {
+        auto logicalSize = buffer->logicalSize();
+        if (DeprecatedGlobalSettings::canvasExportAssertionsEnabled())
+            RELEASE_ASSERT_WITH_MESSAGE(logicalSize.area() > 4096 * 4096, "encodeData(ImageBuffer): copyNativeImage() returned null for small ImageBuffer (size: %dx%d)", static_cast<int>(logicalSize.width()), static_cast<int>(logicalSize.height()));
+        return { };
+    }
+    return encodeData(*image, mimeType, quality);
 }
 
 String encodeDataURL(const NativeImage& image, const String& mimeType, std::optional<double> quality)
@@ -93,7 +101,14 @@ String encodeDataURL(RefPtr<ImageBuffer>&& buffer, const String& mimeType, std::
 {
     if (!buffer)
         return "data:,"_s;
-    return encodeDataURL(buffer->copyNativeImage(), mimeType, quality);
+    auto image = buffer->copyNativeImage();
+    if (!image) {
+        auto logicalSize = buffer->logicalSize();
+        if (DeprecatedGlobalSettings::canvasExportAssertionsEnabled())
+            RELEASE_ASSERT_WITH_MESSAGE(logicalSize.area() > 4096 * 4096, "encodeDataURL(ImageBuffer): copyNativeImage() returned null for small ImageBuffer (size: %dx%d)", static_cast<int>(logicalSize.width()), static_cast<int>(logicalSize.height()));
+        return "data:,"_s;
+    }
+    return encodeDataURL(*image, mimeType, quality);
 }
 
 }

--- a/Source/WebKit/Shared/WebProcessCreationParameters.h
+++ b/Source/WebKit/Shared/WebProcessCreationParameters.h
@@ -128,6 +128,7 @@ struct WebProcessCreationParameters {
     bool shouldEnableMemoryPressureReliefLogging { false };
     bool shouldSuppressMemoryPressureHandler { false };
     bool disableFontSubpixelAntialiasingForTesting { false };
+    bool canvasExportAssertionsEnabled { false };
     bool fullKeyboardAccessEnabled { false };
 #if HAVE(MOUSE_DEVICE_OBSERVATION)
     bool hasMouseDevice { false };

--- a/Source/WebKit/Shared/WebProcessCreationParameters.serialization.in
+++ b/Source/WebKit/Shared/WebProcessCreationParameters.serialization.in
@@ -70,6 +70,7 @@ using WebCore::SystemSettings::State = WebCore::SystemSettingsState;
     bool shouldEnableMemoryPressureReliefLogging;
     bool shouldSuppressMemoryPressureHandler;
     bool disableFontSubpixelAntialiasingForTesting;
+    bool canvasExportAssertionsEnabled;
     bool fullKeyboardAccessEnabled;
 #if HAVE(MOUSE_DEVICE_OBSERVATION)
     bool hasMouseDevice;

--- a/Source/WebKit/UIProcess/API/C/WKContext.cpp
+++ b/Source/WebKit/UIProcess/API/C/WKContext.cpp
@@ -321,6 +321,11 @@ void WKContextSetDisableFontSubpixelAntialiasingForTesting(WKContextRef contextR
     protect(WebKit::toImpl(contextRef))->setDisableFontSubpixelAntialiasingForTesting(disable);
 }
 
+void WKContextSetCanvasExportAssertionsEnabledForTesting(WKContextRef contextRef, bool enabled)
+{
+    protect(WebKit::toImpl(contextRef))->setCanvasExportAssertionsEnabledForTesting(enabled);
+}
+
 void WKContextSetAllowAXAuthenticationForTesting(WKContextRef contextRef, bool allow)
 {
     protect(WebKit::toImpl(contextRef))->setAllowAXAuthenticationForTesting(allow);

--- a/Source/WebKit/UIProcess/API/C/WKContextPrivate.h
+++ b/Source/WebKit/UIProcess/API/C/WKContextPrivate.h
@@ -50,6 +50,8 @@ WK_EXPORT void WKContextSetAlwaysUsesComplexTextCodePath(WKContextRef context, b
 
 WK_EXPORT void WKContextSetDisableFontSubpixelAntialiasingForTesting(WKContextRef context, bool disable);
 
+WK_EXPORT void WKContextSetCanvasExportAssertionsEnabledForTesting(WKContextRef context, bool enabled);
+
 WK_EXPORT void WKContextRegisterURLSchemeAsSecure(WKContextRef context, WKStringRef urlScheme);
 
 WK_EXPORT void WKContextRegisterURLSchemeAsBypassingContentSecurityPolicy(WKContextRef context, WKStringRef urlScheme);

--- a/Source/WebKit/UIProcess/WebProcessPool.cpp
+++ b/Source/WebKit/UIProcess/WebProcessPool.cpp
@@ -1006,6 +1006,7 @@ void WebProcessPool::initializeNewWebProcess(WebProcessProxy& process, WebsiteDa
 
     parameters.shouldAlwaysUseComplexTextCodePath = m_alwaysUsesComplexTextCodePath;
     parameters.disableFontSubpixelAntialiasingForTesting = m_disableFontSubpixelAntialiasingForTesting;
+    parameters.canvasExportAssertionsEnabled = m_canvasExportAssertionsEnabledForTesting;
 
     parameters.textCheckerState = TextChecker::state();
 
@@ -1582,6 +1583,12 @@ void WebProcessPool::setDisableFontSubpixelAntialiasingForTesting(bool disable)
 {
     m_disableFontSubpixelAntialiasingForTesting = disable;
     sendToAllProcesses(Messages::WebProcess::SetDisableFontSubpixelAntialiasingForTesting(disable));
+}
+
+void WebProcessPool::setCanvasExportAssertionsEnabledForTesting(bool enabled)
+{
+    m_canvasExportAssertionsEnabledForTesting = enabled;
+    sendToAllProcesses(Messages::WebProcess::SetCanvasExportAssertionsEnabledForTesting(enabled));
 }
 
 void WebProcessPool::registerURLSchemeAsEmptyDocument(const String& urlScheme)

--- a/Source/WebKit/UIProcess/WebProcessPool.h
+++ b/Source/WebKit/UIProcess/WebProcessPool.h
@@ -284,6 +284,7 @@ public:
 
     void setAlwaysUsesComplexTextCodePath(bool);
     void setDisableFontSubpixelAntialiasingForTesting(bool);
+    void setCanvasExportAssertionsEnabledForTesting(bool);
     
     void registerURLSchemeAsEmptyDocument(const String&);
     void registerURLSchemeAsSecure(const String&);
@@ -825,6 +826,7 @@ private:
 
     bool m_alwaysUsesComplexTextCodePath { false };
     bool m_disableFontSubpixelAntialiasingForTesting { false };
+    bool m_canvasExportAssertionsEnabledForTesting { false };
 
     Vector<String> m_fontAllowList;
 

--- a/Source/WebKit/WebProcess/WebProcess.cpp
+++ b/Source/WebKit/WebProcess/WebProcess.cpp
@@ -684,6 +684,9 @@ void WebProcess::initializeWebProcess(WebProcessCreationParameters&& parameters,
 
     setDisableFontSubpixelAntialiasingForTesting(parameters.disableFontSubpixelAntialiasingForTesting);
 
+    if (parameters.canvasExportAssertionsEnabled)
+        WebCore::DeprecatedGlobalSettings::setCanvasExportAssertionsEnabled(true);
+
     setMemoryCacheDisabled(parameters.memoryCacheDisabled);
 
     WebCore::DeprecatedGlobalSettings::setAttrStyleEnabled(parameters.attrStyleEnabled);
@@ -973,6 +976,11 @@ void WebProcess::setAlwaysUsesComplexTextCodePath(bool alwaysUseComplexText)
 void WebProcess::setDisableFontSubpixelAntialiasingForTesting(bool disable)
 {
     WebCore::FontCascade::setDisableFontSubpixelAntialiasingForTesting(disable);
+}
+
+void WebProcess::setCanvasExportAssertionsEnabledForTesting(bool enabled)
+{
+    WebCore::DeprecatedGlobalSettings::setCanvasExportAssertionsEnabled(enabled);
 }
 
 void WebProcess::userPreferredLanguagesChanged(const Vector<String>& languages) const

--- a/Source/WebKit/WebProcess/WebProcess.h
+++ b/Source/WebKit/WebProcess/WebProcess.h
@@ -610,6 +610,7 @@ private:
     void NODELETE setDefaultRequestTimeoutInterval(double);
     void NODELETE setAlwaysUsesComplexTextCodePath(bool);
     void NODELETE setDisableFontSubpixelAntialiasingForTesting(bool);
+    void NODELETE setCanvasExportAssertionsEnabledForTesting(bool);
     void setTrackingPreventionEnabled(bool);
     void clearResourceLoadStatistics();
     void flushResourceLoadStatistics();

--- a/Source/WebKit/WebProcess/WebProcess.messages.in
+++ b/Source/WebKit/WebProcess/WebProcess.messages.in
@@ -56,6 +56,7 @@ messages -> WebProcess : AuxiliaryProcess WantsAsyncDispatchMessage {
     SetDefaultRequestTimeoutInterval(double timeoutInterval)
     SetAlwaysUsesComplexTextCodePath(bool alwaysUseComplexText)
     SetDisableFontSubpixelAntialiasingForTesting(bool disable)
+    SetCanvasExportAssertionsEnabledForTesting(bool enabled)
     SetTrackingPreventionEnabled(bool enabled);
     ClearResourceLoadStatistics();
     UserPreferredLanguagesChanged(Vector<String> languages)

--- a/Tools/Scripts/webkitpy/port/driver.py
+++ b/Tools/Scripts/webkitpy/port/driver.py
@@ -584,6 +584,8 @@ class Driver(object):
             cmd.append('--show-cursor')
         if self._port.get_option('accessibility_isolated_tree'):
             cmd.append('--accessibility-isolated-tree')
+        if self._port.get_option('site_isolation'):
+            cmd.append('--canvas-export-assertions')
 
         for allowed_host in self._port.allowed_hosts():
             cmd.append('--allowed-host')

--- a/Tools/WebKitTestRunner/Options.cpp
+++ b/Tools/WebKitTestRunner/Options.cpp
@@ -190,6 +190,12 @@ static bool handleOptionLockdownMode(Options& options, const char*, const char*)
     return true;
 }
 
+static bool handleOptionCanvasExportAssertions(Options& options, const char*, const char*)
+{
+    options.canvasExportAssertions = true;
+    return true;
+}
+
 #if PLATFORM(WPE)
 static bool handleOptionWPELegacyAPI(Options& options, const char*, const char*)
 {
@@ -236,6 +242,7 @@ OptionsHandler::OptionsHandler(Options& o)
     optionList.append(Option("--webcore-logging", "Enable WebCore log channels", handleOptionWebCoreLogging, true));
     optionList.append(Option("--webkit-logging", "Enable WebKit log channels", handleOptionWebKitLogging, true));
     optionList.append(Option("--lockdown-mode", "Enable Lockdown Mode", handleOptionLockdownMode));
+    optionList.append(Option("--canvas-export-assertions", "Enable release assertions for canvas export failures", handleOptionCanvasExportAssertions));
 #if PLATFORM(WPE)
     optionList.append(Option("--wpe-legacy-api", "Use the WPE legacy API (libwpe)", handleOptionWPELegacyAPI));
 #endif

--- a/Tools/WebKitTestRunner/Options.h
+++ b/Tools/WebKitTestRunner/Options.h
@@ -51,6 +51,7 @@ struct Options {
     bool allowAnyHTTPSCertificateForAllowedHosts { false };
     bool enableAllExperimentalFeatures { true };
     bool lockdownModeEnabled { false };
+    bool canvasExportAssertions { false };
 #if PLATFORM(WPE)
     bool useWPELegacyAPI { false };
 #endif

--- a/Tools/WebKitTestRunner/TestController.cpp
+++ b/Tools/WebKitTestRunner/TestController.cpp
@@ -917,6 +917,7 @@ void TestController::initialize(int argc, const char* argv[])
     m_gcBetweenTests = options.gcBetweenTests;
     m_shouldDumpPixelsForAllTests = options.shouldDumpPixelsForAllTests;
     m_forceComplexText = options.forceComplexText;
+    m_canvasExportAssertions = options.canvasExportAssertions;
     m_paths = options.paths;
     m_allowedHosts = options.allowedHosts;
     m_localhostAliases = options.localhostAliases;
@@ -1042,6 +1043,9 @@ WKRetainPtr<WKPageConfigurationRef> TestController::generatePageConfiguration(co
 
         WKContextSetCacheModel(m_context.get(), kWKCacheModelDocumentBrowser);
         WKContextSetDisableFontSubpixelAntialiasingForTesting(TestController::singleton().context(), true);
+
+        if (m_canvasExportAssertions)
+            WKContextSetCanvasExportAssertionsEnabledForTesting(TestController::singleton().context(), true);
 
         platformInitializeContext();
     }

--- a/Tools/WebKitTestRunner/TestController.h
+++ b/Tools/WebKitTestRunner/TestController.h
@@ -807,6 +807,7 @@ private:
     String m_unsupportedPluginMode;
 
     bool m_forceComplexText { false };
+    bool m_canvasExportAssertions { false };
     bool m_shouldLogCanAuthenticateAgainstProtectionSpace { false };
     bool m_shouldLogDownloadCallbacks { false };
     bool m_shouldLogHistoryClientCallbacks { false };


### PR DESCRIPTION
#### 2a7c02c531d38f8f2cfdfe8821ac99acf5f2c4b2
<pre>
Add some testing-only assertions to diagnose canvas failures in Site Isolation tests
<a href="https://bugs.webkit.org/show_bug.cgi?id=314516">https://bugs.webkit.org/show_bug.cgi?id=314516</a>
<a href="https://rdar.apple.com/problem/176747259">rdar://problem/176747259</a>

Reviewed by NOBODY (OOPS!).

In bug 314347 we&apos;ve identified some canvas tests failing on the Site
Isolation post-commit bots, which run tests in --site-isolation mode
(comparing test file with SI enabled to test file with SI disabled).
This doesn&apos;t seem to occur on the regular bots. Since there is no Site
Isolation EWS bot to test with, and pushing EWS runs that do enable
--site-isolation testing mode did not reproduce the problem, we add some
temporary assertions for these canvas failures that will trigger only on
this bot.

* Source/WebCore/html/canvas/CanvasRenderingContext2DBase.cpp:
(WebCore::CanvasRenderingContext2DBase::allocateImageBuffer const):
* Source/WebCore/page/DeprecatedGlobalSettings.h:
(WebCore::DeprecatedGlobalSettings::setCanvasExportAssertionsEnabled):
(WebCore::DeprecatedGlobalSettings::canvasExportAssertionsEnabled):
* Source/WebCore/platform/graphics/ImageUtilities.cpp:
(WebCore::encodeData):
(WebCore::encodeDataURL):
* Source/WebKit/Shared/WebProcessCreationParameters.h:
* Source/WebKit/Shared/WebProcessCreationParameters.serialization.in:
* Source/WebKit/UIProcess/API/C/WKContext.cpp:
(WKContextSetCanvasExportAssertionsEnabledForTesting):
* Source/WebKit/UIProcess/API/C/WKContextPrivate.h:
* Source/WebKit/UIProcess/WebProcessPool.cpp:
(WebKit::WebProcessPool::initializeNewWebProcess):
(WebKit::WebProcessPool::setCanvasExportAssertionsEnabledForTesting):
* Source/WebKit/UIProcess/WebProcessPool.h:
* Source/WebKit/WebProcess/WebProcess.cpp:
(WebKit::WebProcess::initializeWebProcess):
(WebKit::WebProcess::setCanvasExportAssertionsEnabledForTesting):
* Source/WebKit/WebProcess/WebProcess.h:
* Source/WebKit/WebProcess/WebProcess.messages.in:
* Tools/Scripts/webkitpy/port/driver.py:
(Driver.cmd_line):
* Tools/WebKitTestRunner/Options.cpp:
(WTR::handleOptionCanvasExportAssertions):
(WTR::OptionsHandler::OptionsHandler):
* Tools/WebKitTestRunner/Options.h:
* Tools/WebKitTestRunner/TestController.cpp:
(WTR::TestController::initialize):
(WTR::TestController::generatePageConfiguration):
* Tools/WebKitTestRunner/TestController.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2a7c02c531d38f8f2cfdfe8821ac99acf5f2c4b2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/161725 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/35199 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/28302 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/170628 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/118096 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/3ae19763-d220-4485-8e92-9917d6813234) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/163594 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/35300 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/35200 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/125472 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/88393 "1 flakes 2 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/c7cd1057-937a-4ce9-ac77-89aa343da1f1) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/164684 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/27781 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/145264 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/106068 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/1864770f-d1dc-4f7f-9308-b26778340bf3) 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/161045 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/26830 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/25342 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/18349 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/136523 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/23019 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/173117 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/20157 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/24660 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/133765 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/34873 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/29432 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/133770 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/34857 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/144814 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/96878 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/28303 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/21636 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/34367 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/101812 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/33867 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/34110 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/34016 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->