### PR TITLE
[JSC] A bit better heuristics for create_this for class via public / private fields

### DIFF
--- a/Source/JavaScriptCore/runtime/FunctionRareData.cpp
+++ b/Source/JavaScriptCore/runtime/FunctionRareData.cpp
@@ -26,8 +26,10 @@
 #include "config.h"
 #include "FunctionRareData.h"
 
+#include "BuiltinNames.h"
 #include "JSCInlines.h"
 #include "ObjectAllocationProfileInlines.h"
+#include "UnlinkedFunctionExecutable.h"
 
 namespace JSC {
 
@@ -86,6 +88,41 @@ FunctionRareData::~FunctionRareData() = default;
 void FunctionRareData::initializeObjectAllocationProfile(VM& vm, JSGlobalObject* globalObject, JSObject* prototype, size_t inlineCapacity, JSFunction* constructor)
 {
     initializeAllocationProfileWatchpointSet();
+    // For class constructors, we deploy a heuristics which counts private and public fields as a part of inlineCapacity.
+    // Right now, static-analyzer in the BytecodeGenerator cannot know these properties because they are separate CodeBlock
+    // from the normal constructors. This offers a bit better heuristics than just directly using inlineCapacity
+    if (constructor) {
+        size_t fieldCount = 0;
+        JSObject* current = constructor;
+        constexpr size_t maxSuperDepth = 32;
+        for (size_t depth = 0; current && depth < maxSuperDepth; ++depth) {
+            JSFunction* currentFunction = dynamicDowncast<JSFunction>(current);
+            if (!currentFunction)
+                break;
+
+            FunctionExecutable* executable = currentFunction->jsExecutable();
+            if (!executable || !executable->isClassConstructorFunction())
+                break;
+
+            JSValue initializerValue = currentFunction->getDirect(vm, vm.propertyNames->builtinNames().instanceFieldInitializerPrivateName());
+            if (initializerValue) {
+                if (JSFunction* initializerFunction = dynamicDowncast<JSFunction>(initializerValue)) {
+                    if (FunctionExecutable* initializerExec = initializerFunction->jsExecutable()) {
+                        if (UnlinkedFunctionExecutable* unlinkedExec = initializerExec->unlinkedExecutable()) {
+                            if (const auto* defs = unlinkedExec->classElementDefinitions())
+                                fieldCount += defs->size();
+                        }
+                    }
+                }
+            }
+
+            JSValue prototype = currentFunction->getPrototypeDirect();
+            if (!prototype)
+                break;
+            current = dynamicDowncast<JSObject>(prototype);
+        }
+        inlineCapacity = std::max(fieldCount, inlineCapacity);
+    }
     m_objectAllocationProfile.initializeProfile(vm, globalObject, this, prototype, inlineCapacity, constructor, this);
 }
 


### PR DESCRIPTION
#### d00fbef294334b312fbffa54e9d07d96ab64fb08
<pre>
[JSC] A bit better heuristics for create_this for class via public / private fields
<a href="https://bugs.webkit.org/show_bug.cgi?id=314349">https://bugs.webkit.org/show_bug.cgi?id=314349</a>
<a href="https://rdar.apple.com/176499667">rdar://176499667</a>

Reviewed by Yijia Huang.

When you have a class like this,

    class A {
        field0 = 42;
    }

    class B extends A {
        field1 = 42;
        field2 = 42;

        constructor()
        {
        }
    }

These field0-2 are instance fields and set to the created object.
However these are set in class&apos; instanceFieldInitializer which is
separate from the normal constructor&apos;s CodeBlock. As a result,
BytecodeGenerator cannot notice existence of these properties, and
static-property-analyzer will report fewer number of properties for the
object. Which causes repeated wasteful allocation of butterfly as our
heuristics is not working well.

This patch improves this by adding a heuristics. When crafting
AllocationProfile, we traverse class heirarchy dynamically and collect
number of properties defined by these fields. This offers much better
heuristics while this is still not perfect.

* Source/JavaScriptCore/runtime/FunctionRareData.cpp:
(JSC::FunctionRareData::initializeObjectAllocationProfile):

Canonical link: <a href="https://commits.webkit.org/312849@main">https://commits.webkit.org/312849@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4e225092c8a81dd4c582c2bec481fa653938f4cf

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/161253 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/34726 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/27827 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/170156 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/117624 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/34827 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/34727 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/125080 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/117624 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/54e179d7-c850-47b8-8c75-809bb7a7ea39) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/164212 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/27362 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/144837 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/105677 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/6db4ded5-2c0f-473a-a586-a62d6bad5e33) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/26410 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/24917 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/17876 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/153310 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/136104 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/22597 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/172639 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/22091 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/19660 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/24238 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/133358 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/34400 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/29010 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/133367 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/34385 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/144392 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/96250 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/24519 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/27916 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/21210 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/193652 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/33895 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/101320 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/49885 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/33394 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/33638 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/33543 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->