### PR TITLE
[WKTR] InjectedBundlePage::willSendRequestForFrame should indicate when it returns null due to setWillSendRequestReturnsNull

### DIFF
--- a/LayoutTests/fast/loader/onload-willSendRequest-null-for-frame-expected.txt
+++ b/LayoutTests/fast/loader/onload-willSendRequest-null-for-frame-expected.txt
@@ -1,3 +1,4 @@
+Returning null for request to http://www.example.com/
 Test for window.onload never fires if page contains an <iframe> with a bad scheme or whose load is cancelled by returning null from resource load delegate's willSendRequest. If the test passes, you should see the word "PASSED" below.
 
 PASSED

--- a/LayoutTests/fast/loader/onload-willSendRequest-null-for-script-expected.txt
+++ b/LayoutTests/fast/loader/onload-willSendRequest-null-for-script-expected.txt
@@ -1,3 +1,4 @@
+Returning null for request to http://www.example.com/
 Test for Bug 33687: window.onload never fires if page contains a <script src=foo> whose load is cancelled by resource load delegate returning null from willSendRequest. If the test passes, you should see the word "PASSED" below.
 
 PASSED

--- a/LayoutTests/fast/loader/subresource-willSendRequest-null-expected.txt
+++ b/LayoutTests/fast/loader/subresource-willSendRequest-null-expected.txt
@@ -1,2 +1,3 @@
+Returning null for request to local resources
 https://bugs.webkit.org/show_bug.cgi?id=49693
 Ensure loads that go through our scheduler and are cancelled by willSendRequest() don't cause us to crash.

--- a/LayoutTests/fast/loader/willSendRequest-null-for-preload-expected.txt
+++ b/LayoutTests/fast/loader/willSendRequest-null-for-preload-expected.txt
@@ -1,1 +1,3 @@
+Returning null for request to local resources
+Returning null for request to http://www.example.org/
 Test for Bug 53123: Crashes loading pages when cancelling subresource loads through WebKit. If the test doesn't crash, then it has passed. It must be run in DRT.

--- a/LayoutTests/http/tests/cache/willsendrequest-returns-null-for-memory-cache-load-expected.txt
+++ b/LayoutTests/http/tests/cache/willsendrequest-returns-null-for-memory-cache-load-expected.txt
@@ -5,6 +5,7 @@ http://127.0.0.1:8000/misc/resources/compass.jpg - didFinishLoading
 http://127.0.0.1:8000/cache/resources/cached-image.html - willSendRequest <NSURLRequest URL http://127.0.0.1:8000/cache/resources/cached-image.html, main document URL http://127.0.0.1:8000/cache/willsendrequest-returns-null-for-memory-cache-load.html, http method GET> redirectResponse (null)
 http://127.0.0.1:8000/cache/resources/cached-image.html - didReceiveResponse <NSURLResponse http://127.0.0.1:8000/cache/resources/cached-image.html, http status code 200>
 http://127.0.0.1:8000/misc/resources/compass.jpg - willSendRequest <NSURLRequest URL http://127.0.0.1:8000/misc/resources/compass.jpg, main document URL (null), http method GET> redirectResponse (null)
+Returning null for request to http://127.0.0.1:8000/misc/resources/compass.jpg
 http://127.0.0.1:8000/misc/resources/compass.jpg - didFailLoadingWithError: <NSError domain NSURLErrorDomain, code -999, failing URL "http://127.0.0.1:8000/misc/resources/compass.jpg">
 http://127.0.0.1:8000/cache/resources/cached-image.html - didFinishLoading
 

--- a/LayoutTests/http/tests/media/media-blocked-by-willsendrequest-expected.txt
+++ b/LayoutTests/http/tests/media/media-blocked-by-willsendrequest-expected.txt
@@ -1,3 +1,7 @@
+Returning null for request to blob:http://127.0.0.1:8000/e953bd0e-779a-4f0f-b943-9bc1f15da5f1
+Returning null for request to http://127.0.0.1:8000/media/resources/test.mp4
+Returning null for request to http://127.0.0.1:8000/media/resources/test.mp4
+Returning null for request to blob:http://127.0.0.1:8000/e953bd0e-779a-4f0f-b943-9bc1f15da5f1
 
 Test to ensure that a media file blocked by the resource load delegate generates an error and does not block the document's 'load' event.
 

--- a/LayoutTests/inspector/network/client-blocked-load-expected.txt
+++ b/LayoutTests/inspector/network/client-blocked-load-expected.txt
@@ -1,3 +1,4 @@
+Returning null for request to local resources
 Tests that there is no crash when the client blocks a resource load.
 
 

--- a/LayoutTests/media/video-poster-blocked-by-willsendrequest-expected.txt
+++ b/LayoutTests/media/video-poster-blocked-by-willsendrequest-expected.txt
@@ -1,3 +1,4 @@
+Returning null for request to local resources
 
 Test for https://bugs.webkit.org/show_bug.cgi?id=65270.
 Resource load delegate should be able to block poster loading.

--- a/LayoutTests/platform/glib/http/tests/media/media-blocked-by-willsendrequest-expected.txt
+++ b/LayoutTests/platform/glib/http/tests/media/media-blocked-by-willsendrequest-expected.txt
@@ -1,0 +1,15 @@
+Returning null for this request
+Returning null for this request
+
+Test to ensure that a media file blocked by the resource load delegate generates an error and does not block the document's 'load' event.
+
+EXPECTED (video.networkState == '0') OK
+
+EVENT(loadstart)
+EVENT(error)
+EXPECTED (video.error != 'null') OK
+EXPECTED (video.error.code == '4') OK
+EXPECTED (video.networkState == '3') OK
+
+END OF TEST
+

--- a/LayoutTests/platform/ios/ios/fast/loader/subresource-willSendRequest-null-prevents-load-event-expected.txt
+++ b/LayoutTests/platform/ios/ios/fast/loader/subresource-willSendRequest-null-prevents-load-event-expected.txt
@@ -1,3 +1,4 @@
+Returning null for this request
 CONSOLE MESSAGE: PASS
 Ensure that a subresource load that is cancelled by a willSendRequest() delegate does not prevent the load event from firing. On success, 'PASS' will be logged to the console.
 

--- a/LayoutTests/platform/wk2/http/tests/misc/will-send-request-returns-null-on-redirect-expected.txt
+++ b/LayoutTests/platform/wk2/http/tests/misc/will-send-request-returns-null-on-redirect-expected.txt
@@ -1,7 +1,7 @@
 http://127.0.0.1:8000/misc/will-send-request-returns-null-on-redirect.html - didFinishLoading
 http://127.0.0.1:8000/misc/resources/redirect-to-http-url.py - willSendRequest <NSURLRequest URL http://127.0.0.1:8000/misc/resources/redirect-to-http-url.py, main document URL http://127.0.0.1:8000/misc/will-send-request-returns-null-on-redirect.html, http method GET> redirectResponse (null)
 http://127.0.0.1:8000/misc/resources/redirect-to-http-url.py - willSendRequest <NSURLRequest URL http://www.example.com/, main document URL http://127.0.0.1:8000/misc/will-send-request-returns-null-on-redirect.html, http method GET> redirectResponse <NSURLResponse http://127.0.0.1:8000/misc/resources/redirect-to-http-url.py, http status code 302>
-Returning null for this redirect
+Returning null for redirect to http://127.0.0.1:8000/misc/resources/redirect-to-http-url.py
 http://127.0.0.1:8000/misc/resources/redirect-to-http-url.py - didFailLoadingWithError: <NSError domain NSURLErrorDomain, code -999>
 https://bugs.webkit.org/show_bug.cgi?id=27595
 This test checks to make sure that things behave as expected when the resource load delegate returns null in response to willSendRequest.

--- a/Tools/DumpRenderTree/mac/ResourceLoadDelegate.mm
+++ b/Tools/DumpRenderTree/mac/ResourceLoadDelegate.mm
@@ -157,6 +157,28 @@ BOOL canAuthenticateServerTrustAgainstProtectionSpace(NSString *host)
     return isLocalhost(host) || gTestRunner->localhostAliases().contains(host.UTF8String) || (gTestRunner->allowAnyHTTPSCertificateForAllowedHosts() && isAllowedHost(host));
 }
 
+String sanitizeExternalURL(NSURL *url)
+{
+    String result = [url absoluteString];
+    replace(result, JSC::Yarr::RegularExpression("\\?key=[-0123456789abcdefABCDEF]+"_s), "?key=GENERATED_KEY"_s);
+    replace(result, JSC::Yarr::RegularExpression("&key=[-0123456789abcdefABCDEF]+"_s), "&key=GENERATED_KEY"_s);
+    replace(result, JSC::Yarr::RegularExpression("%3Fkey%3D[-0123456789abcdefABCDEF]+"_s), "%3Fkey%3DGENERATED_KEY"_s);
+    replace(result, JSC::Yarr::RegularExpression("%26key%3D[-0123456789abcdefABCDEF]+"_s), "%26key%3DGENERATED_KEY"_s);
+    replace(result, JSC::Yarr::RegularExpression("%253Fkey%253D[-0123456789abcdefABCDEF]+"_s), "%253Fkey%253DGENERATED_KEY"_s);
+    replace(result, JSC::Yarr::RegularExpression("%2526key%253D[-0123456789abcdefABCDEF]+"_s), "%2526key%253DGENERATED_KEY"_s);
+    replace(result, JSC::Yarr::RegularExpression("reportID=[-0123456789abcdefABCDEF]+"_s), "reportID=GENERATED_REPORT_ID"_s);
+    return result;
+}
+
+String urlForWillSendRequestReturnsNullMessage(NSURL *url)
+{
+    NSString *scheme = [url scheme];
+    if ([scheme caseInsensitiveCompare:@"file"])
+        return "local resources"_s;
+
+    return sanitizeExternalURL(url);
+}
+
 -(NSURLRequest *)webView: (WebView *)wv resource:identifier willSendRequest: (NSURLRequest *)request redirectResponse:(NSURLResponse *)redirectResponse fromDataSource:(WebDataSource *)dataSource
 {
     if (!done && gTestRunner->dumpResourceLoadCallbacks()) {
@@ -165,15 +187,18 @@ BOOL canAuthenticateServerTrustAgainstProtectionSpace(NSString *host)
         printf("%s\n", [string UTF8String]);
     }
 
-    if (!done && gTestRunner->willSendRequestReturnsNull())
-        return nil;
+    NSURL *url = [request URL];
 
-    if (!done && gTestRunner->willSendRequestReturnsNullOnRedirect() && redirectResponse) {
-        printf("Returning null for this redirect\n");
+    if (!done && gTestRunner->willSendRequestReturnsNull()) {
+        printf("Returning null for request to %s\n", urlForWillSendRequestReturnsNullMessage(url).utf8().data());
         return nil;
     }
 
-    NSURL *url = [request URL];
+    if (!done && gTestRunner->willSendRequestReturnsNullOnRedirect() && redirectResponse) {
+        printf("Returning null for redirect to %s\n", urlForWillSendRequestReturnsNullMessage(url).utf8().data());
+        return nil;
+    }
+
     NSString *host = [url host];
     if (host && (NSOrderedSame == [[url scheme] caseInsensitiveCompare:@"http"] || NSOrderedSame == [[url scheme] caseInsensitiveCompare:@"https"])) {
         NSString *testURL = [NSString stringWithUTF8String:gTestRunner->testURL().c_str()];
@@ -182,9 +207,7 @@ BOOL canAuthenticateServerTrustAgainstProtectionSpace(NSString *host)
         if ([lowercaseTestURL hasPrefix:@"http:"] || [lowercaseTestURL hasPrefix:@"https:"])
             testHost = [[NSURL URLWithString:testURL] host];
         if (!isLocalhost(host) && !hostIsUsedBySomeTestsToGenerateError(host) && !isAllowedHost(host) && (!testHost || isLocalhost(testHost))) {
-            String blockedURL = [url absoluteString];
-            replace(blockedURL, JSC::Yarr::RegularExpression("&key=[^&]+&"_s), "&key=GENERATED_KEY&"_s);
-            replace(blockedURL, JSC::Yarr::RegularExpression("reportID=[-0123456789abcdefABCDEF]+"_s), "reportID=GENERATED_REPORT_ID"_s);
+            auto blockedURL = sanitizeExternalURL(url);
             auto script = makeString("console.log('Blocked access to external URL "_s, blockedURL, "');"_s);
             auto scriptRef = adopt(JSStringCreateWithUTF8CString(script.utf8().data()));
             JSGlobalContextRef jsContext = [mainFrame globalContext];

--- a/Tools/WebKitTestRunner/InjectedBundle/InjectedBundlePage.cpp
+++ b/Tools/WebKitTestRunner/InjectedBundle/InjectedBundlePage.cpp
@@ -870,6 +870,16 @@ static inline bool isAllowedHost(WKStringRef host)
     return InjectedBundle::singleton().isAllowedHost(host);
 }
 
+String urlForWillSendRequestReturnsNullMessage(WKURLRef url)
+{
+    auto scheme = adoptWK(WKURLCopyScheme(url));
+    if (WKStringIsEqualToUTF8CStringIgnoringCase(scheme.get(), "file"))
+        return "local resources"_s;
+
+    auto urlString = adoptWK(WKURLCopyString(url));
+    return sanitizeExternalURL(urlString.get());
+}
+
 WKURLRequestRef InjectedBundlePage::willSendRequestForFrame(WKBundlePageRef page, WKBundleFrameRef frame, uint64_t identifier, WKURLRequestRef request, WKURLResponseRef response)
 {
     auto& injectedBundle = InjectedBundle::singleton();
@@ -882,16 +892,21 @@ WKURLRequestRef InjectedBundlePage::willSendRequestForFrame(WKBundlePageRef page
         injectedBundle.outputText(stringBuilder.toString());
     }
 
-    if (testRunner && testRunner->willSendRequestReturnsNull())
-        return nullptr;
+    auto url = adoptWK(WKURLRequestCopyURL(request));
 
-    auto redirectURL = adoptWK(WKURLResponseCopyURL(response));
-    if (testRunner && testRunner->willSendRequestReturnsNullOnRedirect() && redirectURL) {
-        injectedBundle.outputText("Returning null for this redirect\n"_s);
+    if (testRunner && testRunner->willSendRequestReturnsNull()) {
+        auto output = makeString("Returning null for request to "_s, urlForWillSendRequestReturnsNullMessage(url.get()), "\n"_s);
+        injectedBundle.outputText(output);
         return nullptr;
     }
 
-    auto url = adoptWK(WKURLRequestCopyURL(request));
+    auto redirectURL = adoptWK(WKURLResponseCopyURL(response));
+    if (testRunner && testRunner->willSendRequestReturnsNullOnRedirect() && redirectURL) {
+        auto output = makeString("Returning null for redirect to "_s, urlForWillSendRequestReturnsNullMessage(redirectURL.get()), "\n"_s);
+        injectedBundle.outputText(output);
+        return nullptr;
+    }
+
     auto host = adoptWK(WKURLCopyHostName(url.get()));
     auto scheme = adoptWK(WKURLCopyScheme(url.get()));
     auto urlString = adoptWK(WKURLCopyString(url.get()));


### PR DESCRIPTION
#### 0fc0177239947d97b3597091ffc4314e9a57415c
<pre>
[WKTR] InjectedBundlePage::willSendRequestForFrame should indicate when it returns null due to setWillSendRequestReturnsNull
<a href="https://rdar.apple.com/176500281">rdar://176500281</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=314352">https://bugs.webkit.org/show_bug.cgi?id=314352</a>

Reviewed by NOBODY (OOPS!).

When the test case uses testRunner.setWillSendRequestReturnsNull() to request that
willSendRequestForFrame returns null, willSendRequestForFrame should indicate in
the test output that it was called and requested to return null. This ensure the
test case actually hits the method.

This was motivated by <a href="https://bugs.webkit.org/show_bug.cgi?id=314346">https://bugs.webkit.org/show_bug.cgi?id=314346</a>, where
fast/loader/onload-willSendRequest-null-for-frame.html loads an external URL
iframe, which gets blocked in Site Isolation mode in a different method. So
willSendRequestForFrame never gets called, but the test still passes because
there&apos;s no indication the method gets called.

* LayoutTests/fast/loader/onload-willSendRequest-null-for-frame-expected.txt:
* LayoutTests/fast/loader/onload-willSendRequest-null-for-script-expected.txt:
* LayoutTests/fast/loader/subresource-willSendRequest-null-expected.txt:
* LayoutTests/fast/loader/willSendRequest-null-for-preload-expected.txt:
* LayoutTests/http/tests/cache/willsendrequest-returns-null-for-memory-cache-load-expected.txt:
* LayoutTests/http/tests/media/media-blocked-by-willsendrequest-expected.txt:
* LayoutTests/inspector/network/client-blocked-load-expected.txt:
* LayoutTests/media/video-poster-blocked-by-willsendrequest-expected.txt:
* LayoutTests/platform/glib/http/tests/media/media-blocked-by-willsendrequest-expected.txt: Copied from LayoutTests/http/tests/media/media-blocked-by-willsendrequest-expected.txt.
* LayoutTests/platform/ios/ios/fast/loader/subresource-willSendRequest-null-prevents-load-event-expected.txt:
* LayoutTests/platform/wk2/http/tests/misc/will-send-request-returns-null-on-redirect-expected.txt:
* Tools/DumpRenderTree/mac/ResourceLoadDelegate.mm:
(sanitizeExternalURL):
(urlForWillSendRequestReturnsNullMessage):
(-[ResourceLoadDelegate webView:resource:willSendRequest:redirectResponse:fromDataSource:]):
* Tools/WebKitTestRunner/InjectedBundle/InjectedBundlePage.cpp:
(WTR::urlForWillSendRequestReturnsNullMessage):
(WTR::InjectedBundlePage::willSendRequestForFrame):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0fc0177239947d97b3597091ffc4314e9a57415c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/161949 "2 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/35424 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/28528 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/170853 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/118320 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/2416bb13-e5b1-4f5a-afd6-d4483117d926) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/163818 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/35526 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/35425 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/125661 "Found 1 new test failure: http/tests/media/media-blocked-by-willsendrequest.html (failure)") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/88552 "18 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/8eea1048-603d-4c88-9b8a-067cb8561f41) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/164908 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/27977 "Found 1 new test failure: platform/ios/ios/fast/loader/subresource-willSendRequest-null-prevents-load-event.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/145453 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/106250 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/7e89700e-3e0f-4385-bdeb-084330dfbeef) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/27026 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/25540 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/18574 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/136719 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/23207 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/173341 "Built successfully") | | 
| | | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/24848 "Found 1 new test failure: http/tests/media/media-blocked-by-willsendrequest.html (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/133957 "Failed to checkout and rebase branch from PR 64502") | | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/161346 "Build is in progress. Recent messages:") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/35097 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/29626 "Found 1 new test failure: http/tests/media/media-blocked-by-willsendrequest.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/133962 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/35081 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/145002 "Build is in progress. Recent messages:OS: Sequoia (15.7.3), Xcode: 26.2; Skipping applying patch since patch_id isn't provided; Checked out pull request; Skipped layout-tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/97179 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/28491 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/21827 "Found 1 new test failure: http/tests/media/media-blocked-by-willsendrequest.html (failure)") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/194349 "Build is in progress. Recent messages:") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/34591 "Built successfully") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/35/builds/194349 "Build is in progress. Recent messages:") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/34092 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/34334 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/34240 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->