### PR TITLE
CSS Zoom interacts oddly with explicit font-size and font-variant on iPad

### DIFF
--- a/LayoutTests/fast/text-autosizing/ios/idempotentmode/text-size-adjust-with-css-zoom-expected.txt
+++ b/LayoutTests/fast/text-autosizing/ios/idempotentmode/text-size-adjust-with-css-zoom-expected.txt
@@ -1,0 +1,22 @@
+Verifies that text-size-adjust: none preserves CSS zoom and text zoom for rendered font metrics.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS renderedHeight('zoom-none') is renderedHeight('zoom-auto')
+PASS renderedHeight('zoom-none') is renderedHeight('no-zoom-32')
+PASS renderedHeight('zoom-pct') is renderedHeight('no-zoom-auto')
+PASS renderedHeight('diff-zoom-none') is renderedHeight('diff-zoom-ref')
+PASS renderedHeight('diff-zoom-pct') is renderedHeight('no-zoom-8-zoom6')
+PASS renderedHeight('no-zoom-none') is renderedHeight('no-zoom-auto')
+PASS renderedHeight('tzoom-none') is renderedHeight('tzoom-auto')
+PASS renderedHeight('tzoom-pct') is renderedHeight('tzoom-8px')
+PASS successfullyParsed is true
+
+TEST COMPLETE
+Tests that text-size-adjust: none correctly preserves CSS zoom and text zoom for font rendering.
+
+X X X
+X X X
+X X X X
+X X X X

--- a/LayoutTests/fast/text-autosizing/ios/idempotentmode/text-size-adjust-with-css-zoom.html
+++ b/LayoutTests/fast/text-autosizing/ios/idempotentmode/text-size-adjust-with-css-zoom.html
@@ -1,0 +1,89 @@
+<!DOCTYPE html><!-- webkit-test-runner [ useFlexibleViewport=true contentMode=desktop ] -->
+<html>
+<head>
+<meta name="viewport" content="initial-scale=1">
+<script>
+if (window.internals) {
+    window.internals.settings.setTextAutosizingEnabled(true);
+    window.internals.settings.setTextAutosizingUsesIdempotentMode(true);
+    window.internals.settings.setIdempotentModeAutosizingOnlyHonorsPercentages(true);
+}
+</script>
+<script src="../../../../resources/js-test.js"></script>
+<style>
+.measure { display: inline-block; font-family: Ahem; }
+</style>
+</head>
+<body>
+<p>Tests that text-size-adjust: none correctly preserves CSS zoom and text zoom for font rendering.</p>
+
+<!-- Case 1: Inherited CSS zoom (same as parent) -->
+<div style="zoom: 2;">
+    <span class="measure" id="zoom-auto" style="font-size: 16px;">X</span>
+    <span class="measure" id="zoom-none" style="-webkit-text-size-adjust: none; font-size: 16px;">X</span>
+    <span class="measure" id="zoom-pct" style="-webkit-text-size-adjust: 50%; font-size: 16px;">X</span>
+</div>
+
+<!-- Case 2: Element has different zoom than parent -->
+<div style="zoom: 2;">
+    <span class="measure" id="diff-zoom-pct" style="zoom: 3; -webkit-text-size-adjust: 50%; font-size: 16px;">X</span>
+    <span class="measure" id="diff-zoom-none" style="zoom: 3; -webkit-text-size-adjust: none; font-size: 16px;">X</span>
+    <span class="measure" id="diff-zoom-ref" style="zoom: 3; font-size: 16px;">X</span>
+</div>
+
+<!-- Case 3: Text zoom (page-level) with text-size-adjust -->
+<div id="text-zoom-container">
+    <span class="measure" id="tzoom-auto" style="font-size: 16px;">X</span>
+    <span class="measure" id="tzoom-none" style="-webkit-text-size-adjust: none; font-size: 16px;">X</span>
+    <span class="measure" id="tzoom-pct" style="-webkit-text-size-adjust: 50%; font-size: 16px;">X</span>
+    <span class="measure" id="tzoom-8px" style="font-size: 8px;">X</span>
+</div>
+
+<!-- References without zoom -->
+<div>
+    <span class="measure" id="no-zoom-auto" style="font-size: 16px;">X</span>
+    <span class="measure" id="no-zoom-none" style="-webkit-text-size-adjust: none; font-size: 16px;">X</span>
+    <span class="measure" id="no-zoom-32" style="font-size: 32px;">X</span>
+    <span class="measure" id="no-zoom-8-zoom6" style="zoom: 6; font-size: 8px;">X</span>
+</div>
+
+<script>
+description("Verifies that text-size-adjust: none preserves CSS zoom and text zoom for rendered font metrics.");
+
+function renderedHeight(id) {
+    return document.getElementById(id).getBoundingClientRect().height;
+}
+
+// Inherited CSS zoom: text-size-adjust:none should render same as auto (zoom preserved).
+shouldBe("renderedHeight('zoom-none')", "renderedHeight('zoom-auto')");
+
+// Inherited CSS zoom: zoom:2 + 16px should render same as 32px without zoom.
+shouldBe("renderedHeight('zoom-none')", "renderedHeight('no-zoom-32')");
+
+// Inherited CSS zoom: text-size-adjust:50% in zoom:2 gives 16*0.5*2=16, same as 16px without zoom.
+shouldBe("renderedHeight('zoom-pct')", "renderedHeight('no-zoom-auto')");
+
+// Different zoom than parent: text-size-adjust:none should render same as auto.
+shouldBe("renderedHeight('diff-zoom-none')", "renderedHeight('diff-zoom-ref')");
+
+// Different zoom than parent: text-size-adjust:50% on 16px with total zoom 6 should
+// render same as 8px with zoom 6 (since 16*0.5=8 is the adjusted size before zoom).
+shouldBe("renderedHeight('diff-zoom-pct')", "renderedHeight('no-zoom-8-zoom6')");
+
+// Without zoom: text-size-adjust:none matches auto.
+shouldBe("renderedHeight('no-zoom-none')", "renderedHeight('no-zoom-auto')");
+
+// Now apply page-level text zoom and verify it's preserved with text-size-adjust.
+if (window.eventSender) {
+    eventSender.textZoomIn(); // 1.2x text zoom
+
+    // With text zoom active, text-size-adjust:none should still render same as auto.
+    shouldBe("renderedHeight('tzoom-none')", "renderedHeight('tzoom-auto')");
+
+    // text-size-adjust:50% with text zoom should render same as 8px with text zoom
+    // (since 16*0.5=8 is the adjusted size, and both get the same text zoom applied).
+    shouldBe("renderedHeight('tzoom-pct')", "renderedHeight('tzoom-8px')");
+}
+</script>
+</body>
+</html>

--- a/Source/WebCore/style/StyleBuilderState.cpp
+++ b/Source/WebCore/style/StyleBuilderState.cpp
@@ -2,7 +2,7 @@
  * Copyright (C) 1999 Lars Knoll (knoll@kde.org)
  * Copyright (C) 2004-2005 Allan Sandfeld Jensen (kde@carewolf.com)
  * Copyright (C) 2006, 2007 Nicholas Shanks (webkit@nickshanks.com)
- * Copyright (C) 2005-2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2005-2026 Apple Inc. All rights reserved.
  * Copyright (C) 2007 Alexey Proskuryakov <ap@webkit.org>
  * Copyright (C) 2007, 2008 Eric Seidel <eric@webkit.org>
  * Copyright (C) 2008, 2009 Torch Mobile Inc. All rights reserved. (http://www.torchmobile.com/)
@@ -200,10 +200,14 @@ void BuilderState::updateFontForTextSizeAdjust()
         return;
 
     auto newFontDescription = m_style.fontDescription();
+    auto baseSize = newFontDescription.specifiedSize();
     if (!m_style.textSizeAdjust().isNone())
-        newFontDescription.setComputedSize(newFontDescription.specifiedSize() * m_style.textSizeAdjust().multiplier());
-    else
-        newFontDescription.setComputedSize(newFontDescription.specifiedSize());
+        baseSize *= m_style.textSizeAdjust().multiplier();
+
+    float zoomFactor = m_style.usedZoom();
+    if (auto* frame = document().frame(); frame && m_style.textZoom() != TextZoom::Reset)
+        zoomFactor *= frame->textZoomFactor();
+    newFontDescription.setComputedSize(baseSize * zoomFactor, zoomFactor);
 
     m_style.setFontDescriptionWithoutUpdate(WTF::move(newFontDescription));
 }
@@ -213,6 +217,19 @@ void BuilderState::updateFontForZoomChange()
 {
     if (m_style.usedZoom() == parentStyle().usedZoom() && m_style.textZoom() == parentStyle().textZoom())
         return;
+
+#if ENABLE(TEXT_AUTOSIZING)
+    // When text-size-adjust has an active percentage, updateFontForTextSizeAdjust() has already
+    // computed the correct size (incorporating both the multiplier and the current zoom factor).
+    // Skip recalculation here to avoid overwriting that result, which would lose the
+    // text-size-adjust multiplier.
+    if (document().settings().textAutosizingEnabled()
+        && !m_style.textSizeAdjust().isAuto()
+        && !m_style.textSizeAdjust().isNone()
+        && (!document().settings().textAutosizingUsesIdempotentMode()
+            || document().settings().idempotentModeAutosizingOnlyHonorsPercentages()))
+        return;
+#endif
 
     setFontDescriptionFontSize(m_style.fontDescription().specifiedSize());
 }


### PR DESCRIPTION
#### d221d71a6a560cb45bb3e9b23e526b6bcfa9e4b3
<pre>
CSS Zoom interacts oddly with explicit font-size and font-variant on iPad
<a href="https://bugs.webkit.org/show_bug.cgi?id=293617">https://bugs.webkit.org/show_bug.cgi?id=293617</a>
<a href="https://rdar.apple.com/152173269">rdar://152173269</a>

Reviewed by Sammy Gill.

Our efforts to provide a great user experience on iPad with desktop website content had
an unintended consequence that resulted in strange adjustments to fonts during zooming.

updateFontForTextSizeAdjust() was setting computedSize directly from specifiedSize without
accounting for the element&apos;s zoom factor. When CSS zoom is inherited (same as parent),
updateFontForZoomChange() does not fire afterward to re-apply it, leaving the computed
font size without zoom. This caused incorrect font metrics for elements with explicit
text-size-adjust inside zoomed containers, breaking font-variant, font-weight, and
font-style rendering on iPadOS desktop mode.

This change fixes this by computing the zoom factor (usedZoom * textZoomFactor) directly
in updateFontForTextSizeAdjust(), bypassing minimum font size clamping which should not
constrain author-specified text-size-adjust values. We also add an early return in
updateFontForZoomChange() when text-size-adjust has already computed the correct zoomed
size, so it doesn&apos;t overwrite the result when zoom differs from the parent.

Test: fast/text-autosizing/ios/idempotentmode/text-size-adjust-with-css-zoom.html

* LayoutTests/fast/text-autosizing/ios/idempotentmode/text-size-adjust-with-css-zoom-expected.txt: Added.
* LayoutTests/fast/text-autosizing/ios/idempotentmode/text-size-adjust-with-css-zoom.html: Added.
* Source/WebCore/style/StyleBuilderState.cpp:
(WebCore::Style::BuilderState::updateFontForTextSizeAdjust):
(WebCore::Style::BuilderState::updateFontForZoomChange):

Canonical link: <a href="https://commits.webkit.org/312944@main">https://commits.webkit.org/312944@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/446c7d22a73badd33615a3717fbb9173b5d85291

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/161504 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/34978 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/28081 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/170407 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/117875 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/7d67d4ae-0145-4d48-a3ee-908b40e21e39) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/163373 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/35079 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/34979 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/125291 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/88242 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/fb99acab-b18d-4ab8-a7d0-8fac4d89eb27) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/164463 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/27592 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/145074 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/105887 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/0e2f84d1-b055-45f4-8de8-858e96c4eded) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/26641 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/25147 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/18128 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/136335 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/22831 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/172893 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/19936 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/24472 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/133580 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/34652 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/29243 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/133587 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36109 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/34636 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/144626 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/96541 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/28119 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/21445 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/34146 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/101591 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/33646 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/33889 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/33795 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->