### PR TITLE
SVG <use> does not fire load event when href changes to a new external URL after a previous load

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/svg/struct/scripted/use-external-href-change-events-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/struct/scripted/use-external-href-change-events-expected.txt
@@ -1,0 +1,4 @@
+
+PASS 'load' fires for each new external href, not only the first
+PASS 'load' fires after a prior external load failed and href was changed to a valid URL
+

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/struct/scripted/use-external-href-change-events.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/struct/scripted/use-external-href-change-events.html
@@ -1,0 +1,59 @@
+<!doctype html>
+<title>SVG &lt;use> dispatches 'load' and 'error' after an earlier load completes</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<svg></svg>
+<script>
+  const svgNS = 'http://www.w3.org/2000/svg';
+  const svg = document.querySelector('svg');
+
+  function newUseElement() {
+    return svg.appendChild(document.createElementNS(svgNS, 'use'));
+  }
+
+  const cookieBase = Date.now();
+  let counter = 0;
+  function uniqueUrl(fragment) {
+    return `/images/colors.svg?${cookieBase}-${counter++}#${fragment}`;
+  }
+  function nonExistingUrl() {
+    return `/images/this-file-should-not-exist.svg?${cookieBase}-${counter++}#green`;
+  }
+
+  function waitForEvent(element, type) {
+    return new Promise((resolve, reject) => {
+      element.addEventListener('load', e => {
+        type === 'load' ? resolve(e) : reject(new Error('unexpected load'));
+      }, { once: true });
+      element.addEventListener('error', e => {
+        type === 'error' ? resolve(e) : reject(new Error('unexpected error'));
+      }, { once: true });
+    });
+  }
+
+  promise_test(async t => {
+    const use = newUseElement();
+    t.add_cleanup(() => use.remove());
+
+    const firstLoad = waitForEvent(use, 'load');
+    use.setAttribute('href', uniqueUrl('green'));
+    await firstLoad;
+
+    const secondLoad = waitForEvent(use, 'load');
+    use.setAttribute('href', uniqueUrl('red'));
+    await secondLoad;
+  }, "'load' fires for each new external href, not only the first");
+
+  promise_test(async t => {
+    const use = newUseElement();
+    t.add_cleanup(() => use.remove());
+
+    const firstError = waitForEvent(use, 'error');
+    use.setAttribute('href', nonExistingUrl());
+    await firstError;
+
+    const recoveryLoad = waitForEvent(use, 'load');
+    use.setAttribute('href', uniqueUrl('green'));
+    await recoveryLoad;
+  }, "'load' fires after a prior external load failed and href was changed to a valid URL");
+</script>

--- a/Source/WebCore/svg/SVGUseElement.cpp
+++ b/Source/WebCore/svg/SVGUseElement.cpp
@@ -128,7 +128,9 @@ Node::NeedsPostConnectionSteps SVGUseElement::insertionSteps(InsertionType inser
 void SVGUseElement::postConnectionSteps()
 {
     SVGGraphicsElement::postConnectionSteps();
+    resetLoadEventStatus();
     updateExternalDocument();
+    invalidateShadowTree();
 }
 
 void SVGUseElement::removingSteps(RemovalType removalType, ContainerNode& oldParentOfRemovedTree)
@@ -144,6 +146,7 @@ void SVGUseElement::removingSteps(RemovalType removalType, ContainerNode& oldPar
     SVGGraphicsElement::removingSteps(removalType, oldParentOfRemovedTree);
     if (removalType.disconnectedFromDocument) {
         clearShadowTree();
+        resetLoadEventStatus();
         updateExternalDocument();
     }
 }
@@ -211,6 +214,7 @@ void SVGUseElement::svgAttributeChanged(const QualifiedName& attrName)
     }
 
     if (SVGURIReference::isKnownAttribute(attrName)) {
+        resetLoadEventStatus();
         updateExternalDocument();
         invalidateShadowTree();
         invalidateResourceImageBuffersIfNeeded();
@@ -658,6 +662,16 @@ void SVGUseElement::notifyFinished(CachedResource& resource, const NetworkLoadMe
         SVGURIReference::dispatchLoadEvent();
 }
 
+void SVGUseElement::resetLoadEventStatus()
+{
+    // Called by the sites that (re)point this element at a resource, before updateExternalDocument()
+    // initiates a new load. Clearing these lets the new resource dispatch its own load/error event
+    // (dispatchLoadEvent() early-returns while haveFiredLoadEvent() is true) and lets
+    // haveLoadedRequiredResources() reflect the pending load instead of the previous one.
+    m_errorOccurred = false;
+    m_haveFiredLoadEvent = false;
+}
+
 void SVGUseElement::updateExternalDocument()
 {
     URL externalDocumentURL;
@@ -691,8 +705,6 @@ void SVGUseElement::updateExternalDocument()
         if (RefPtr externalDocument = m_externalDocument)
             externalDocument->addClient(*this);
     }
-
-    invalidateShadowTree();
 }
 
 }

--- a/Source/WebCore/svg/SVGUseElement.h
+++ b/Source/WebCore/svg/SVGUseElement.h
@@ -81,6 +81,7 @@ private:
 
     Document* NODELETE externalDocument() const;
     void updateExternalDocument();
+    void resetLoadEventStatus();
 
     FloatRect getBBox(StyleUpdateStrategy = StyleUpdateStrategy::Allow) final;
 


### PR DESCRIPTION
#### 4a033dc4cf9449f4625474bbf9a642cd89e99f4a
<pre>
SVG &lt;use&gt; does not fire load event when href changes to a new external URL after a previous load
<a href="https://bugs.webkit.org/show_bug.cgi?id=314355">https://bugs.webkit.org/show_bug.cgi?id=314355</a>
<a href="https://rdar.apple.com/176504018">rdar://176504018</a>

Reviewed by NOBODY (OOPS!).

After an &lt;use&gt; element finished loading an external document, changing its href
to a new external URL did not dispatch a &apos;load&apos; (or &apos;error&apos;) event:
m_haveFiredLoadEvent stayed true from the previous load, so
SVGURIReference::dispatchLoadEvent() early-returned, and
haveLoadedRequiredResources() kept reporting the stale &quot;done&quot; state mid-fetch.

Reset m_errorOccurred and m_haveFiredLoadEvent when the element is (re)pointed at
a resource, so the new load can fire its own events. The reset lives in a
dedicated, explicitly-named resetLoadEventStatus() called by the sites that
update the reference (postConnectionSteps(), removingSteps() and the href branch
of svgAttributeChanged()), rather than as a hidden side effect of
updateExternalDocument() — which now only updates m_externalDocument from the
URL. The reset runs before updateExternalDocument() starts the fetch, so a
synchronous notifyFinished() for an already-cached resource still fires its load
event. invalidateShadowTree() is likewise moved out of updateExternalDocument():
postConnectionSteps() now invalidates explicitly, svgAttributeChanged() already
did, and removingSteps() clears the shadow tree instead.

* Source/WebCore/svg/SVGUseElement.cpp:
(WebCore::SVGUseElement::postConnectionSteps):
(WebCore::SVGUseElement::removingSteps):
(WebCore::SVGUseElement::svgAttributeChanged):
(WebCore::SVGUseElement::resetLoadEventStatus):
(WebCore::SVGUseElement::updateExternalDocument):
* Source/WebCore/svg/SVGUseElement.h:
* LayoutTests/imported/w3c/web-platform-tests/svg/struct/scripted/use-external-href-change-events-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/svg/struct/scripted/use-external-href-change-events.html: Added.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4a033dc4cf9449f4625474bbf9a642cd89e99f4a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/169434 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/43356 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/36647 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/178791 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/127146 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/63786921-43e0-4402-a133-2051a15ddda4) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/171300 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/43597 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/42984 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/131987 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/92921 "9 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/3acf739f-0990-4bd3-9616-c0fdec557665) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/172393 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/34654 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/152301 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/112491 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/b5eac441-54ac-4087-aec8-3eb50e7dc3d8) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/33637 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/32128 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/27490 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/143627 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/31701 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/181391 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/34100 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/36296 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/140437 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/43012 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/151772 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/140273 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/43701 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/28678 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/107797 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/35548 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/115466 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/42211 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/6766 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/41604 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/41859 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/41747 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->