### PR TITLE
[Digital Credentials] Add WebDriver BiDi digitalCredentials module for automated testing

### DIFF
--- a/Source/WebCore/Modules/identity/CredentialRequestCoordinator.cpp
+++ b/Source/WebCore/Modules/identity/CredentialRequestCoordinator.cpp
@@ -44,6 +44,7 @@
 #include "JSDOMPromiseDeferred.h"
 #include "JSDigitalCredential.h"
 #include "JSValueInWrappedObjectInlines.h"
+#include "LocalFrame.h"
 #include "Page.h"
 #include "SecurityOriginData.h"
 #include <JavaScriptCore/JSObject.h>
@@ -175,7 +176,12 @@ void CredentialRequestCoordinator::initiateTheCredentialRequest(const Document& 
 
     auto [requestData, rawRequests] = requestDataAndRawRequests.releaseReturnValue();
 
+    std::optional<FrameIdentifier> requestingFrameID;
+    if (RefPtr frame = document.frame())
+        requestingFrameID = frame->frameID();
+
     m_client->showDigitalCredentialsChooser(
+        requestingFrameID,
         WTF::move(rawRequests),
         requestData,
         [weakThis = WeakPtr { *this }, signal](Expected<DigitalCredentialsResponseData, ExceptionData>&& responseOrException) {
@@ -191,6 +197,11 @@ void CredentialRequestCoordinator::processCredentialChooserResponse(Expected<Dig
         abortTheCredentialRequest(ExceptionOr<JSC::JSValue> { signal->reason().getValue() });
         return;
     }
+
+    // A parked "wait" reply released during abort/teardown can arrive after the
+    // request already left Requesting; it is moot, so return before the guard.
+    if (m_interactionState != InteractionState::Requesting)
+        return;
 
     InteractionStateGuard guard(*this);
 

--- a/Source/WebCore/Modules/identity/CredentialRequestCoordinatorClient.h
+++ b/Source/WebCore/Modules/identity/CredentialRequestCoordinatorClient.h
@@ -29,6 +29,7 @@
 
 #include <WebCore/DigitalCredentialsProtocols.h>
 #include <WebCore/DigitalCredentialsRequestData.h>
+#include <WebCore/FrameIdentifier.h>
 #include <WebCore/UnvalidatedDigitalCredentialRequest.h>
 #include <wtf/CompletionHandler.h>
 #include <wtf/TZoneMalloc.h>
@@ -52,7 +53,7 @@ class CredentialRequestCoordinatorClient : public RefCounted<CredentialRequestCo
 public:
     CredentialRequestCoordinatorClient() = default;
     virtual ~CredentialRequestCoordinatorClient() = default;
-    virtual void showDigitalCredentialsChooser(DigitalCredentialsRawRequests&&, const DigitalCredentialsRequestData&, CompletionHandler<void(Expected<DigitalCredentialsResponseData, ExceptionData>&&)>&&) = 0;
+    virtual void showDigitalCredentialsChooser(std::optional<FrameIdentifier>, DigitalCredentialsRawRequests&&, const DigitalCredentialsRequestData&, CompletionHandler<void(Expected<DigitalCredentialsResponseData, ExceptionData>&&)>&&) = 0;
     virtual void dismissDigitalCredentialsChooser(CompletionHandler<void(bool)>&&) = 0;
     virtual ExceptionOr<Vector<ValidatedDigitalCredentialRequest>> validateAndParseDigitalCredentialRequests(const SecurityOrigin&, const Document&, const Vector<UnvalidatedDigitalCredentialRequest>&) = 0;
 

--- a/Source/WebCore/Modules/identity/dummy/DummyCredentialRequestCoordinatorClient.cpp
+++ b/Source/WebCore/Modules/identity/dummy/DummyCredentialRequestCoordinatorClient.cpp
@@ -45,7 +45,7 @@ Ref<DummyCredentialRequestCoordinatorClient> DummyCredentialRequestCoordinatorCl
     return adoptRef(*new DummyCredentialRequestCoordinatorClient);
 }
 
-void DummyCredentialRequestCoordinatorClient::showDigitalCredentialsChooser(DigitalCredentialsRawRequests&&, const DigitalCredentialsRequestData&, CompletionHandler<void(Expected<DigitalCredentialsResponseData, ExceptionData>&&)>&& completionHandler)
+void DummyCredentialRequestCoordinatorClient::showDigitalCredentialsChooser(std::optional<FrameIdentifier>, DigitalCredentialsRawRequests&&, const DigitalCredentialsRequestData&, CompletionHandler<void(Expected<DigitalCredentialsResponseData, ExceptionData>&&)>&& completionHandler)
 {
     completionHandler(makeUnexpected(WebCore::ExceptionData { WebCore::ExceptionCode::NotSupportedError, "Empty client."_s }));
 }

--- a/Source/WebCore/Modules/identity/dummy/DummyCredentialRequestCoordinatorClient.h
+++ b/Source/WebCore/Modules/identity/dummy/DummyCredentialRequestCoordinatorClient.h
@@ -45,7 +45,7 @@ public:
     static Ref<DummyCredentialRequestCoordinatorClient> create();
 
 private:
-    void showDigitalCredentialsChooser(DigitalCredentialsRawRequests&&, const DigitalCredentialsRequestData&, CompletionHandler<void(Expected<DigitalCredentialsResponseData, ExceptionData>&&)>&&);
+    void showDigitalCredentialsChooser(std::optional<FrameIdentifier>, DigitalCredentialsRawRequests&&, const DigitalCredentialsRequestData&, CompletionHandler<void(Expected<DigitalCredentialsResponseData, ExceptionData>&&)>&&);
     void dismissDigitalCredentialsChooser(CompletionHandler<void(bool)>&&) final;
     ExceptionOr<Vector<ValidatedDigitalCredentialRequest>> validateAndParseDigitalCredentialRequests(const SecurityOrigin&, const Document&, const Vector<UnvalidatedDigitalCredentialRequest>&) final;
 };

--- a/Source/WebCore/loader/EmptyClients.cpp
+++ b/Source/WebCore/loader/EmptyClients.cpp
@@ -497,7 +497,7 @@ public:
         return adoptRef(*new EmptyCredentialRequestCoordinatorClient);
     }
 
-    void showDigitalCredentialsChooser(DigitalCredentialsRawRequests&&, const DigitalCredentialsRequestData&, CompletionHandler<void(Expected<DigitalCredentialsResponseData, ExceptionData>&&)>&& completionHandler)
+    void showDigitalCredentialsChooser(std::optional<FrameIdentifier>, DigitalCredentialsRawRequests&&, const DigitalCredentialsRequestData&, CompletionHandler<void(Expected<DigitalCredentialsResponseData, ExceptionData>&&)>&& completionHandler)
     {
         callOnMainThread([completionHandler = WTF::move(completionHandler)]() mutable {
             completionHandler(makeUnexpected(ExceptionData { ExceptionCode::NotSupportedError, "Empty client."_s }));

--- a/Source/WebKit/CMakeLists.txt
+++ b/Source/WebKit/CMakeLists.txt
@@ -1299,6 +1299,7 @@ add_custom_command(
 set(WebKit_WEBDRIVER_BIDI_PROTOCOL_GENERATOR_INPUTS
     ${WEBKIT_DIR}/UIProcess/Automation/protocol/BidiBrowser.json
     ${WEBKIT_DIR}/UIProcess/Automation/protocol/BidiBrowsingContext.json
+    ${WEBKIT_DIR}/UIProcess/Automation/protocol/BidiDigitalCredentials.json
     ${WEBKIT_DIR}/UIProcess/Automation/protocol/BidiLog.json
     ${WEBKIT_DIR}/UIProcess/Automation/protocol/BidiPermissions.json
     ${WEBKIT_DIR}/UIProcess/Automation/protocol/BidiScript.json

--- a/Source/WebKit/DerivedSources-input.xcfilelist
+++ b/Source/WebKit/DerivedSources-input.xcfilelist
@@ -558,6 +558,7 @@ $(PROJECT_DIR)/UIProcess/Automation/Automation.json
 $(PROJECT_DIR)/UIProcess/Automation/WebAutomationSession.messages.in
 $(PROJECT_DIR)/UIProcess/Automation/protocol/BidiBrowser.json
 $(PROJECT_DIR)/UIProcess/Automation/protocol/BidiBrowsingContext.json
+$(PROJECT_DIR)/UIProcess/Automation/protocol/BidiDigitalCredentials.json
 $(PROJECT_DIR)/UIProcess/Automation/protocol/BidiLog.json
 $(PROJECT_DIR)/UIProcess/Automation/protocol/BidiPermissions.json
 $(PROJECT_DIR)/UIProcess/Automation/protocol/BidiScript.json

--- a/Source/WebKit/DerivedSources.make
+++ b/Source/WebKit/DerivedSources.make
@@ -548,6 +548,7 @@ all : WebAutomationSessionProxyScriptSource.h
 WEBDRIVER_BIDI_PROTOCOL_INPUT_FILES = \
     $(WebKit2)/UIProcess/Automation/protocol/BidiBrowser.json \
     $(WebKit2)/UIProcess/Automation/protocol/BidiBrowsingContext.json \
+    $(WebKit2)/UIProcess/Automation/protocol/BidiDigitalCredentials.json \
     $(WebKit2)/UIProcess/Automation/protocol/BidiLog.json \
     $(WebKit2)/UIProcess/Automation/protocol/BidiPermissions.json \
     $(WebKit2)/UIProcess/Automation/protocol/BidiScript.json \

--- a/Source/WebKit/Sources.txt
+++ b/Source/WebKit/Sources.txt
@@ -590,6 +590,7 @@ UIProcess/Authentication/WebProtectionSpace.cpp
 
 UIProcess/Automation/BidiBrowserAgent.cpp @no-unify-when(bundle<=8)
 UIProcess/Automation/BidiBrowsingContextAgent.cpp @no-unify-when(bundle<=8)
+UIProcess/Automation/BidiDigitalCredentialsAgent.cpp @no-unify-when(bundle<=8)
 UIProcess/Automation/BidiPermissionsAgent.cpp @no-unify-when(bundle<=8)
 UIProcess/Automation/BidiScriptAgent.cpp @no-unify-when(bundle<=8)
 UIProcess/Automation/BidiSessionAgent.cpp @no-unify-when(bundle<=8)

--- a/Source/WebKit/UIProcess/Automation/BidiDigitalCredentialsAgent.cpp
+++ b/Source/WebKit/UIProcess/Automation/BidiDigitalCredentialsAgent.cpp
@@ -1,0 +1,140 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "BidiDigitalCredentialsAgent.h"
+
+#if ENABLE(WEBDRIVER_BIDI)
+
+#include "WebAutomationSession.h"
+#include "WebAutomationSessionMacros.h"
+#include "WebDriverBidiProtocolObjects.h"
+#include <WebCore/DigitalCredentialsResponseData.h>
+#include <WebCore/ExceptionData.h>
+#include <wtf/TZoneMallocInlines.h>
+
+namespace WebKit {
+
+using namespace Inspector;
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(BidiDigitalCredentialsAgent);
+
+static WebCore::DigitalCredentialPresentationProtocol toPresentationProtocol(Inspector::Protocol::BidiDigitalCredentials::DigitalCredentialProtocol protocol)
+{
+    switch (protocol) {
+    case Inspector::Protocol::BidiDigitalCredentials::DigitalCredentialProtocol::OrgIsoMdoc:
+        return WebCore::DigitalCredentialPresentationProtocol::OrgIsoMdoc;
+    }
+    RELEASE_ASSERT_NOT_REACHED();
+}
+
+BidiDigitalCredentialsAgent::BidiDigitalCredentialsAgent(WebAutomationSession& session, BackendDispatcher& backendDispatcher)
+    : m_session(session)
+    , m_digitalCredentialsDomainDispatcher(BidiDigitalCredentialsBackendDispatcher::create(backendDispatcher, this))
+{
+}
+
+BidiDigitalCredentialsAgent::~BidiDigitalCredentialsAgent()
+{
+    cancelAllPendingRequests();
+}
+
+void BidiDigitalCredentialsAgent::setVirtualWalletBehavior(Inspector::Protocol::BidiDigitalCredentials::VirtualWalletAction action, const String& optionalContext, std::optional<Inspector::Protocol::BidiDigitalCredentials::DigitalCredentialProtocol>&& optionalProtocol, RefPtr<JSON::Object>&& optionalResponse, CommandCallback<void>&& callback)
+{
+    RefPtr session = m_session.get();
+    ASYNC_FAIL_WITH_PREDEFINED_ERROR_IF(!session, InternalError);
+
+    using VirtualWalletAction = Inspector::Protocol::BidiDigitalCredentials::VirtualWalletAction;
+
+    auto applyBehavior = [&](VirtualWalletBehavior&& behavior) {
+        if (!optionalContext.isEmpty())
+            m_browsingContextToWalletBehaviors.set(optionalContext, WTF::move(behavior));
+        else
+            m_defaultBehavior = WTF::move(behavior);
+    };
+
+    switch (action) {
+    case VirtualWalletAction::Respond: {
+        ASYNC_FAIL_WITH_PREDEFINED_ERROR_AND_DETAILS_IF(!optionalProtocol, InvalidParameter, "Action 'respond' requires a 'protocol' parameter."_s);
+        ASYNC_FAIL_WITH_PREDEFINED_ERROR_AND_DETAILS_IF(!optionalResponse, InvalidParameter, "Action 'respond' requires a 'response' parameter."_s);
+
+        VirtualWalletBehavior behavior { action, toPresentationProtocol(*optionalProtocol), optionalResponse->toJSONString() };
+        applyBehavior(WTF::move(behavior));
+        break;
+    }
+    case VirtualWalletAction::Decline:
+    case VirtualWalletAction::Wait:
+        ASYNC_FAIL_WITH_PREDEFINED_ERROR_AND_DETAILS_IF(optionalProtocol, InvalidParameter, "Only action 'respond' accepts a 'protocol' parameter."_s);
+        ASYNC_FAIL_WITH_PREDEFINED_ERROR_AND_DETAILS_IF(optionalResponse, InvalidParameter, "Only action 'respond' accepts a 'response' parameter."_s);
+        applyBehavior(VirtualWalletBehavior { action, WebCore::DigitalCredentialPresentationProtocol::OrgIsoMdoc, String() });
+        break;
+    case VirtualWalletAction::Clear:
+        ASYNC_FAIL_WITH_PREDEFINED_ERROR_AND_DETAILS_IF(optionalProtocol, InvalidParameter, "Only action 'respond' accepts a 'protocol' parameter."_s);
+        ASYNC_FAIL_WITH_PREDEFINED_ERROR_AND_DETAILS_IF(optionalResponse, InvalidParameter, "Only action 'respond' accepts a 'response' parameter."_s);
+        if (!optionalContext.isEmpty())
+            m_browsingContextToWalletBehaviors.remove(optionalContext);
+        else
+            m_defaultBehavior = std::nullopt;
+        break;
+    }
+
+    callback({ });
+}
+
+std::optional<VirtualWalletBehavior> BidiDigitalCredentialsAgent::behaviorForContext(const String& browsingContextID) const
+{
+    auto it = m_browsingContextToWalletBehaviors.find(browsingContextID);
+    if (it != m_browsingContextToWalletBehaviors.end())
+        return it->value;
+    return m_defaultBehavior;
+}
+
+void BidiDigitalCredentialsAgent::abortPendingHandler(const String& contextID, ASCIILiteral message)
+{
+    if (auto handler = m_browsingContextToPendingWaitHandlers.take(contextID))
+        handler(makeUnexpected(WebCore::ExceptionData { WebCore::ExceptionCode::AbortError, message }));
+}
+
+void BidiDigitalCredentialsAgent::holdPendingHandler(const String& contextID, DigitalCredentialsPickerCompletionHandler&& handler)
+{
+    abortPendingHandler(contextID, "Superseded by a new credential request."_s);
+    m_browsingContextToPendingWaitHandlers.set(contextID, WTF::move(handler));
+}
+
+void BidiDigitalCredentialsAgent::releasePendingHandler(const String& contextID)
+{
+    abortPendingHandler(contextID, "The credential request was aborted."_s);
+}
+
+void BidiDigitalCredentialsAgent::cancelAllPendingRequests()
+{
+    auto handlers = std::exchange(m_browsingContextToPendingWaitHandlers, { });
+    for (auto& handler : handlers.values())
+        handler(makeUnexpected(WebCore::ExceptionData { WebCore::ExceptionCode::AbortError, "Automation session ended."_s }));
+}
+
+} // namespace WebKit
+
+#endif // ENABLE(WEBDRIVER_BIDI)

--- a/Source/WebKit/UIProcess/Automation/BidiDigitalCredentialsAgent.h
+++ b/Source/WebKit/UIProcess/Automation/BidiDigitalCredentialsAgent.h
@@ -1,0 +1,83 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if ENABLE(WEBDRIVER_BIDI)
+
+#include "WebDriverBidiBackendDispatchers.h"
+#include "WebDriverBidiProtocolObjects.h"
+#include <WebCore/DigitalCredentialPresentationProtocol.h>
+#include <wtf/CompletionHandler.h>
+#include <wtf/Expected.h>
+#include <wtf/HashMap.h>
+#include <wtf/TZoneMalloc.h>
+#include <wtf/WeakPtr.h>
+#include <wtf/text/WTFString.h>
+
+namespace WebCore {
+struct DigitalCredentialsResponseData;
+struct ExceptionData;
+}
+
+namespace WebKit {
+
+class WebAutomationSession;
+
+struct VirtualWalletBehavior {
+    Inspector::Protocol::BidiDigitalCredentials::VirtualWalletAction action;
+    WebCore::DigitalCredentialPresentationProtocol protocol { WebCore::DigitalCredentialPresentationProtocol::OrgIsoMdoc };
+    String responseJSON;
+};
+
+using DigitalCredentialsPickerCompletionHandler = CompletionHandler<void(Expected<WebCore::DigitalCredentialsResponseData, WebCore::ExceptionData>&&)>;
+
+class BidiDigitalCredentialsAgent final : public Inspector::BidiDigitalCredentialsBackendDispatcherHandler {
+    WTF_MAKE_TZONE_ALLOCATED(BidiDigitalCredentialsAgent);
+public:
+    BidiDigitalCredentialsAgent(WebAutomationSession&, Inspector::BackendDispatcher&);
+    ~BidiDigitalCredentialsAgent() override;
+
+    void setVirtualWalletBehavior(Inspector::Protocol::BidiDigitalCredentials::VirtualWalletAction, const String& optionalContext, std::optional<Inspector::Protocol::BidiDigitalCredentials::DigitalCredentialProtocol>&& optionalProtocol, RefPtr<JSON::Object>&& optionalResponse, Inspector::CommandCallback<void>&&) override;
+
+    std::optional<VirtualWalletBehavior> behaviorForContext(const String& browsingContextID) const;
+
+    void holdPendingHandler(const String& contextID, DigitalCredentialsPickerCompletionHandler&&);
+    void releasePendingHandler(const String& contextID);
+    void cancelAllPendingRequests();
+
+private:
+    void abortPendingHandler(const String& contextID, ASCIILiteral message);
+
+    WeakPtr<WebAutomationSession> m_session;
+    Ref<Inspector::BidiDigitalCredentialsBackendDispatcher> m_digitalCredentialsDomainDispatcher;
+    HashMap<String, VirtualWalletBehavior> m_browsingContextToWalletBehaviors;
+    std::optional<VirtualWalletBehavior> m_defaultBehavior;
+    HashMap<String, DigitalCredentialsPickerCompletionHandler> m_browsingContextToPendingWaitHandlers;
+};
+
+} // namespace WebKit
+
+#endif // ENABLE(WEBDRIVER_BIDI)

--- a/Source/WebKit/UIProcess/Automation/WebDriverBidiProcessor.cpp
+++ b/Source/WebKit/UIProcess/Automation/WebDriverBidiProcessor.cpp
@@ -33,6 +33,7 @@
 
 #include "BidiBrowserAgent.h"
 #include "BidiBrowsingContextAgent.h"
+#include "BidiDigitalCredentialsAgent.h"
 #include "BidiPermissionsAgent.h"
 #include "BidiScriptAgent.h"
 #include "BidiSessionAgent.h"
@@ -56,6 +57,7 @@ WebDriverBidiProcessor::WebDriverBidiProcessor(WebAutomationSession& session)
     , m_backendDispatcher(BackendDispatcher::create(m_frontendRouter.copyRef()))
     , m_browserAgent(makeUniqueRef<BidiBrowserAgent>(session, m_backendDispatcher))
     , m_browsingContextAgent(makeUniqueRef<BidiBrowsingContextAgent>(session, m_backendDispatcher))
+    , m_digitalCredentialsAgent(makeUniqueRef<BidiDigitalCredentialsAgent>(session, m_backendDispatcher))
     , m_permissionsAgent(makeUniqueRef<BidiPermissionsAgent>(session, m_backendDispatcher))
     , m_scriptAgent(makeUniqueRef<BidiScriptAgent>(session, m_backendDispatcher))
     , m_sessionAgent(makeUniqueRef<BidiSessionAgent>(session, m_backendDispatcher))

--- a/Source/WebKit/UIProcess/Automation/WebDriverBidiProcessor.h
+++ b/Source/WebKit/UIProcess/Automation/WebDriverBidiProcessor.h
@@ -38,6 +38,7 @@ namespace WebKit {
 
 class BidiBrowserAgent;
 class BidiBrowsingContextAgent;
+class BidiDigitalCredentialsAgent;
 class BidiPermissionsAgent;
 class BidiScriptAgent;
 class BidiSessionAgent;
@@ -55,6 +56,7 @@ public:
     void sendBidiMessage(const String&);
 
     BidiBrowserAgent& browserAgent() const LIFETIME_BOUND { return m_browserAgent; }
+    BidiDigitalCredentialsAgent& digitalCredentialsAgent() const LIFETIME_BOUND { return m_digitalCredentialsAgent; }
     BidiScriptAgent& scriptAgent() const LIFETIME_BOUND { return m_scriptAgent; }
 
     // Inspector::FrontendChannel methods. Domain events sent via WebDriverBidi domain notifiers are packaged up
@@ -78,6 +80,7 @@ private:
 
     const UniqueRef<BidiBrowserAgent> m_browserAgent;
     const UniqueRef<BidiBrowsingContextAgent> m_browsingContextAgent;
+    const UniqueRef<BidiDigitalCredentialsAgent> m_digitalCredentialsAgent;
     const UniqueRef<BidiPermissionsAgent> m_permissionsAgent;
     const UniqueRef<BidiScriptAgent> m_scriptAgent;
     const UniqueRef<BidiSessionAgent> m_sessionAgent;

--- a/Source/WebKit/UIProcess/Automation/protocol/BidiDigitalCredentials.json
+++ b/Source/WebKit/UIProcess/Automation/protocol/BidiDigitalCredentials.json
@@ -1,0 +1,36 @@
+{
+    "domain": "BidiDigitalCredentials",
+    "exposedAs": "digitalCredentials",
+    "condition": "ENABLE(WEBDRIVER_BIDI)",
+    "description": "The digitalCredentials module contains commands for managing virtual wallet behavior during digital credential requests under automation.",
+    "spec": "https://w3c-fedid.github.io/digital-credentials/#automated-testing",
+    "types": [
+        {
+            "id": "VirtualWalletAction",
+            "type": "string",
+            "description": "The action to perform when a digital credential request is made under automation.",
+            "enum": ["decline", "respond", "wait", "clear"]
+        },
+        {
+            "id": "DigitalCredentialProtocol",
+            "type": "string",
+            "description": "A digital credential presentation protocol identifier (the exchange protocol used for the synthetic response).",
+            "enum": ["org-iso-mdoc"]
+        }
+    ],
+    "commands": [
+        {
+            "name": "setVirtualWalletBehavior",
+            "description": "Sets the virtual wallet behavior for the session or a specific browsing context.",
+            "spec": "https://w3c-fedid.github.io/digital-credentials/#the-digitalcredentials-setvirtualwalletbehavior-command",
+            "wpt": "https://github.com/web-platform-tests/wpt/tree/master/digital-credentials/webdriver",
+            "parameters": [
+                { "name": "action", "$ref": "BidiDigitalCredentials.VirtualWalletAction", "description": "The action to take when a credential request occurs." },
+                { "name": "context", "$ref": "BidiBrowsingContext.BrowsingContext", "optional": true, "description": "The browsing context ID to scope this behavior to." },
+                { "name": "protocol", "$ref": "BidiDigitalCredentials.DigitalCredentialProtocol", "optional": true, "description": "The presentation protocol identifier for the synthetic response." },
+                { "name": "response", "type": "object", "optional": true, "description": "The response data for the synthetic credential." }
+            ],
+            "async": true
+        }
+    ]
+}

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -333,6 +333,12 @@
 #include "WebBackForwardListSwiftUtilities.h"
 #endif
 
+#if ENABLE(WEBDRIVER_BIDI)
+#include "BidiDigitalCredentialsAgent.h"
+#include "WebDriverBidiProcessor.h"
+#include "WebDriverBidiProtocolObjects.h"
+#endif
+
 #if PLATFORM(COCOA)
 #include "RemoteScrollingCoordinatorMessages.h"
 #include "RemoteScrollingCoordinatorProxy.h"
@@ -11184,7 +11190,7 @@ void WebPageProxy::showContactPicker(IPC::Connection& connection, ContactsReques
 }
 
 #if ENABLE(WEB_AUTHN)
-void WebPageProxy::showDigitalCredentialsChooser(IPC::Connection& connection, const WebCore::DigitalCredentialsRequestData& requestData, CompletionHandler<void(Expected<WebCore::DigitalCredentialsResponseData, WebCore::ExceptionData>&&)>&& completionHandler)
+void WebPageProxy::showDigitalCredentialsChooser(IPC::Connection& connection, std::optional<WebCore::FrameIdentifier>&& frameID, const WebCore::DigitalCredentialsRequestData& requestData, CompletionHandler<void(Expected<WebCore::DigitalCredentialsResponseData, WebCore::ExceptionData>&&)>&& completionHandler)
 {
     WTF::switchOn(requestData,
         [&](const auto& requestData) {
@@ -11194,6 +11200,50 @@ void WebPageProxy::showDigitalCredentialsChooser(IPC::Connection& connection, co
                 connection,
                 completionHandler(makeUnexpected(WebCore::ExceptionData { WebCore::ExceptionCode::SecurityError, "Digital credentials feature is disabled by preference."_s }))
             );
+
+#if ENABLE(WEBDRIVER_BIDI)
+            if (isControlledByAutomation()) {
+                if (RefPtr automationSession = configuration().processPool().automationSession()) {
+                    auto& agent = automationSession->bidiProcessor().digitalCredentialsAgent();
+                    // Per the Digital Credentials spec (§13.2 "Handle Virtual Wallet Behavior"),
+                    // the behavior is looked up for the requesting global's browsing context,
+                    // falling back to the session default. Resolve the requesting frame to its
+                    // BiDi browsing-context id; this matches the id-space SET uses. The
+                    // end-to-end iframe-scoped test lands with the WKTR actuation bridge
+                    // (webkit.org/b/306292).
+                    String contextID;
+                    if (frameID) {
+                        if (RefPtr frame = WebFrameProxy::webFrame(*frameID); frame && frame->page() == this)
+                            contextID = automationSession->effectiveHandleForWebFrameProxy(*frame);
+                    } else
+                        contextID = automationSession->handleForWebPageProxy(*this);
+                    const auto walletBehavior = agent.behaviorForContext(contextID);
+                    if (walletBehavior) {
+                        using VirtualWalletAction = Inspector::Protocol::BidiDigitalCredentials::VirtualWalletAction;
+                        switch (walletBehavior->action) {
+                        case VirtualWalletAction::Wait:
+                            // FIXME: A concurrent request from a site-isolated cross-origin iframe (separate
+                            // process) can clobber this single slot; only same-process concurrency is
+                            // serialized by prepareCredentialRequests (webkit.org/b/318408).
+                            ASSERT(!m_pendingDigitalCredentialsWaitContextID);
+                            m_pendingDigitalCredentialsWaitContextID = contextID;
+                            agent.holdPendingHandler(contextID, WTF::move(completionHandler));
+                            return;
+                        case VirtualWalletAction::Decline:
+                            completionHandler(makeUnexpected(WebCore::ExceptionData { WebCore::ExceptionCode::NotAllowedError, "Virtual wallet declined the request."_s }));
+                            return;
+                        case VirtualWalletAction::Respond:
+                            completionHandler(WebCore::DigitalCredentialsResponseData { walletBehavior->protocol, walletBehavior->responseJSON });
+                            return;
+                        case VirtualWalletAction::Clear:
+                            // 'clear' removes the stored behavior in the agent, so it is never a stored action here.
+                            ASSERT_NOT_REACHED();
+                            break;
+                        }
+                    }
+                }
+            }
+#endif
 
 #if HAVE(DIGITAL_CREDENTIALS_UI)
             MESSAGE_CHECK_COMPLETION_BASE(
@@ -11227,6 +11277,12 @@ void WebPageProxy::dismissDigitalCredentialsChooser(IPC::Connection& connection,
         completionHandler(false)
     );
 #if ENABLE(WEB_AUTHN)
+#if ENABLE(WEBDRIVER_BIDI)
+    if (auto contextID = std::exchange(m_pendingDigitalCredentialsWaitContextID, std::nullopt)) {
+        if (RefPtr automationSession = configuration().processPool().automationSession())
+            automationSession->bidiProcessor().digitalCredentialsAgent().releasePendingHandler(*contextID);
+    }
+#endif
     protect(pageClient())->dismissDigitalCredentialsChooser(WTF::move(completionHandler));
 #else
     completionHandler(false);

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -2409,7 +2409,7 @@ public:
     // Digital Credentials API
     void dismissDigitalCredentialsChooser(IPC::Connection&, CompletionHandler<void(bool)>&&);
     void fetchRawDigitalCredentialRequests(CompletionHandler<void(WebCore::DigitalCredentialsRawRequests)>&&);
-    void showDigitalCredentialsChooser(IPC::Connection&, const WebCore::DigitalCredentialsRequestData&, CompletionHandler<void(Expected<WebCore::DigitalCredentialsResponseData, WebCore::ExceptionData>&&)>&&);
+    void showDigitalCredentialsChooser(IPC::Connection&, std::optional<WebCore::FrameIdentifier>&&, const WebCore::DigitalCredentialsRequestData&, CompletionHandler<void(Expected<WebCore::DigitalCredentialsResponseData, WebCore::ExceptionData>&&)>&&);
 #endif
 
     using TextManipulationItemCallback = Function<void(const Vector<WebCore::TextManipulationItem>&)>;
@@ -3864,6 +3864,12 @@ private:
 
 #if ENABLE(WEB_AUTHN)
     RefPtr<WebAuthenticatorCoordinatorProxy> m_webAuthnCredentialsMessenger;
+#endif
+
+#if ENABLE(WEBDRIVER_BIDI)
+    // Context of a request parked by a virtual-wallet "wait", so dismiss
+    // can release the handler held in BidiDigitalCredentialsAgent.
+    std::optional<String> m_pendingDigitalCredentialsWaitContextID;
 #endif
 
 #if ENABLE(DATA_DETECTION)

--- a/Source/WebKit/UIProcess/WebPageProxy.messages.in
+++ b/Source/WebKit/UIProcess/WebPageProxy.messages.in
@@ -84,10 +84,10 @@ messages -> WebPageProxy {
 
 #if ENABLE(WEB_AUTHN)
 #if ENABLE(ISO18013_DOCUMENT_REQUEST_INFO)
-    [EnabledBy=DigitalCredentialsEnabled] ShowDigitalCredentialsChooser(Variant<WebCore::DigitalCredentialsMobileDocumentRequestData, WebCore::DigitalCredentialsMobileDocumentRequestDataWithRequestInfo> requestData) -> (Expected<WebCore::DigitalCredentialsResponseData, WebCore::ExceptionData> response)
+    [EnabledBy=DigitalCredentialsEnabled] ShowDigitalCredentialsChooser(std::optional<WebCore::FrameIdentifier> frameID, Variant<WebCore::DigitalCredentialsMobileDocumentRequestData, WebCore::DigitalCredentialsMobileDocumentRequestDataWithRequestInfo> requestData) -> (Expected<WebCore::DigitalCredentialsResponseData, WebCore::ExceptionData> response)
 #endif
 #if !ENABLE(ISO18013_DOCUMENT_REQUEST_INFO)
-    [EnabledBy=DigitalCredentialsEnabled] ShowDigitalCredentialsChooser(Variant<WebCore::DigitalCredentialsMobileDocumentRequestData> requestData) -> (Expected<WebCore::DigitalCredentialsResponseData, WebCore::ExceptionData> response)
+    [EnabledBy=DigitalCredentialsEnabled] ShowDigitalCredentialsChooser(std::optional<WebCore::FrameIdentifier> frameID, Variant<WebCore::DigitalCredentialsMobileDocumentRequestData> requestData) -> (Expected<WebCore::DigitalCredentialsResponseData, WebCore::ExceptionData> response)
 #endif
     [EnabledBy=DigitalCredentialsEnabled] DismissDigitalCredentialsChooser() -> (bool didDismiss)
 #endif

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -1961,6 +1961,8 @@
 		9979659E25310A4900B31AE3 /* WebInspectorUIExtensionControllerMessages.h in Headers */ = {isa = PBXBuildFile; fileRef = 9979659A25310A4800B31AE3 /* WebInspectorUIExtensionControllerMessages.h */; };
 		997965A3253128C700B31AE3 /* _WKInspectorExtensionHost.h in Headers */ = {isa = PBXBuildFile; fileRef = 997965A2253128C700B31AE3 /* _WKInspectorExtensionHost.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		9979CA58237F49F10039EC05 /* _WKInspectorPrivate.h in Headers */ = {isa = PBXBuildFile; fileRef = 9979CA57237F49F00039EC05 /* _WKInspectorPrivate.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		99657F74FE484682A7055097 /* BidiDigitalCredentialsAgent.h in Headers */ = {isa = PBXBuildFile; fileRef = BA0937229E9E469B9278ED67 /* BidiDigitalCredentialsAgent.h */; };
+		2790DB2B37644A61AA0AD21E /* BidiDigitalCredentialsAgent.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 277A87492B55413CB027FECA /* BidiDigitalCredentialsAgent.cpp */; };
 		997EB9DA2E5544FC002CFED7 /* BidiPermissionsAgent.h in Headers */ = {isa = PBXBuildFile; fileRef = 997EB9D82E5544FC002CFED7 /* BidiPermissionsAgent.h */; };
 		997EB9DB2E5544FC002CFED7 /* BidiPermissionsAgent.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 997EB9D92E5544FC002CFED7 /* BidiPermissionsAgent.cpp */; };
 		99996A9F25004BCC004F7559 /* _WKInspectorPrivateForTesting.h in Headers */ = {isa = PBXBuildFile; fileRef = 99996A9D25004BCB004F7559 /* _WKInspectorPrivateForTesting.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -7647,6 +7649,8 @@
 		9979659B25310A4800B31AE3 /* WebInspectorUIExtensionControllerMessageReceiver.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = WebInspectorUIExtensionControllerMessageReceiver.cpp; sourceTree = "<group>"; };
 		997965A2253128C700B31AE3 /* _WKInspectorExtensionHost.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = _WKInspectorExtensionHost.h; sourceTree = "<group>"; };
 		9979CA57237F49F00039EC05 /* _WKInspectorPrivate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = _WKInspectorPrivate.h; sourceTree = "<group>"; };
+		BA0937229E9E469B9278ED67 /* BidiDigitalCredentialsAgent.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = BidiDigitalCredentialsAgent.h; sourceTree = "<group>"; };
+		277A87492B55413CB027FECA /* BidiDigitalCredentialsAgent.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = BidiDigitalCredentialsAgent.cpp; sourceTree = "<group>"; };
 		997EB9D82E5544FC002CFED7 /* BidiPermissionsAgent.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = BidiPermissionsAgent.h; sourceTree = "<group>"; };
 		997EB9D92E5544FC002CFED7 /* BidiPermissionsAgent.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = BidiPermissionsAgent.cpp; sourceTree = "<group>"; };
 		997EB9DC2E554524002CFED7 /* BidiPermissions.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = BidiPermissions.json; sourceTree = "<group>"; };
@@ -15491,6 +15495,8 @@
 				F3EEEE572DB318270038CC1D /* BidiBrowserAgent.h */,
 				F3272B7D2DB997C6007B3A9A /* BidiBrowsingContextAgent.cpp */,
 				F3272B7C2DB997C6007B3A9A /* BidiBrowsingContextAgent.h */,
+				277A87492B55413CB027FECA /* BidiDigitalCredentialsAgent.cpp */,
+				BA0937229E9E469B9278ED67 /* BidiDigitalCredentialsAgent.h */,
 				5EEC72532DC1B32400D012DD /* BidiEventNames.h */,
 				997EB9D92E5544FC002CFED7 /* BidiPermissionsAgent.cpp */,
 				997EB9D82E5544FC002CFED7 /* BidiPermissionsAgent.h */,
@@ -18217,6 +18223,7 @@
 				95C943912523C0D00054F3D5 /* BaseBoardSPI.h in Headers */,
 				F3EEEE592DB318270038CC1D /* BidiBrowserAgent.h in Headers */,
 				F3272B822DB997C6007B3A9A /* BidiBrowsingContextAgent.h in Headers */,
+				99657F74FE484682A7055097 /* BidiDigitalCredentialsAgent.h in Headers */,
 				5EEC72542DC1B32500D012DD /* BidiEventNames.h in Headers */,
 				997EB9DA2E5544FC002CFED7 /* BidiPermissionsAgent.h in Headers */,
 				F3272B832DB997C6007B3A9A /* BidiScriptAgent.h in Headers */,
@@ -22093,6 +22100,7 @@
 				413E5C9229B0CF7C002F4987 /* BackgroundFetchStateCocoa.mm in Sources */,
 				F3EEEE5A2DB318270038CC1D /* BidiBrowserAgent.cpp in Sources */,
 				F3272B802DB997C6007B3A9A /* BidiBrowsingContextAgent.cpp in Sources */,
+				2790DB2B37644A61AA0AD21E /* BidiDigitalCredentialsAgent.cpp in Sources */,
 				997EB9DB2E5544FC002CFED7 /* BidiPermissionsAgent.cpp in Sources */,
 				F3272B812DB997C6007B3A9A /* BidiScriptAgent.cpp in Sources */,
 				5EEC72502DC1B32100D012DD /* BidiSessionAgent.cpp in Sources */,

--- a/Source/WebKit/WebProcess/DigitalCredentials/DigitalCredentialsCoordinator.cpp
+++ b/Source/WebKit/WebProcess/DigitalCredentials/DigitalCredentialsCoordinator.cpp
@@ -61,7 +61,7 @@ Ref<DigitalCredentialsCoordinator> DigitalCredentialsCoordinator::create(WebPage
     return adoptRef(*new DigitalCredentialsCoordinator(webPage));
 }
 
-void DigitalCredentialsCoordinator::showDigitalCredentialsChooser(WebCore::DigitalCredentialsRawRequests&& rawRequests, const WebCore::DigitalCredentialsRequestData& request, WTF::CompletionHandler<void(Expected<WebCore::DigitalCredentialsResponseData, WebCore::ExceptionData>&&)>&& completionHandler)
+void DigitalCredentialsCoordinator::showDigitalCredentialsChooser(std::optional<WebCore::FrameIdentifier> frameID, WebCore::DigitalCredentialsRawRequests&& rawRequests, const WebCore::DigitalCredentialsRequestData& request, WTF::CompletionHandler<void(Expected<WebCore::DigitalCredentialsResponseData, WebCore::ExceptionData>&&)>&& completionHandler)
 {
     WTF::switchOn(m_rawRequests, [](auto& cachedRawRequests) {
         ASSERT(cachedRawRequests.isEmpty());
@@ -69,7 +69,7 @@ void DigitalCredentialsCoordinator::showDigitalCredentialsChooser(WebCore::Digit
     m_rawRequests = WTF::move(rawRequests);
 
     if (RefPtr page = m_page.get()) {
-        page->showDigitalCredentialsChooser(request, [weakThis = WeakPtr { *this }, completionHandler = WTF::move(completionHandler)](Expected<WebCore::DigitalCredentialsResponseData, WebCore::ExceptionData>&& responseOrException) mutable {
+        page->showDigitalCredentialsChooser(frameID, request, [weakThis = WeakPtr { *this }, completionHandler = WTF::move(completionHandler)](Expected<WebCore::DigitalCredentialsResponseData, WebCore::ExceptionData>&& responseOrException) mutable {
             RefPtr protectedThis = weakThis.get();
             if (!protectedThis)
                 return completionHandler(makeUnexpected(WebCore::ExceptionData { WebCore::ExceptionCode::AbortError, "The coordinator is no longer available."_s }));

--- a/Source/WebKit/WebProcess/DigitalCredentials/DigitalCredentialsCoordinator.h
+++ b/Source/WebKit/WebProcess/DigitalCredentials/DigitalCredentialsCoordinator.h
@@ -59,7 +59,7 @@ public:
     void ref() const final { RefCounted::ref(); }
     void deref() const final { RefCounted::deref(); }
 
-    void showDigitalCredentialsChooser(WebCore::DigitalCredentialsRawRequests&&, const WebCore::DigitalCredentialsRequestData&, CompletionHandler<void(Expected<WebCore::DigitalCredentialsResponseData, WebCore::ExceptionData>&&)>&&) final;
+    void showDigitalCredentialsChooser(std::optional<WebCore::FrameIdentifier>, WebCore::DigitalCredentialsRawRequests&&, const WebCore::DigitalCredentialsRequestData&, CompletionHandler<void(Expected<WebCore::DigitalCredentialsResponseData, WebCore::ExceptionData>&&)>&&) final;
     void dismissDigitalCredentialsChooser(CompletionHandler<void(bool)>&&) final;
     WebCore::ExceptionOr<Vector<WebCore::ValidatedDigitalCredentialRequest>> validateAndParseDigitalCredentialRequests(const WebCore::SecurityOrigin&, const WebCore::Document&, const Vector<WebCore::UnvalidatedDigitalCredentialRequest>&) final;
     void provideRawDigitalCredentialRequests(CompletionHandler<void(WebCore::DigitalCredentialsRawRequests&&)>&&);

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp
@@ -1063,7 +1063,7 @@ void WebChromeClient::showContactPicker(WebCore::ContactsRequestData&& requestDa
 void WebChromeClient::showDigitalCredentialsChooser(const WebCore::DigitalCredentialsRequestData& requestData, WTF::CompletionHandler<void(Expected<WebCore::DigitalCredentialsResponseData, WebCore::ExceptionData>&&)>&& callback)
 {
     if (RefPtr page = m_page.get())
-        page->showDigitalCredentialsChooser(requestData, WTF::move(callback));
+        page->showDigitalCredentialsChooser(std::nullopt, requestData, WTF::move(callback));
 }
 
 void WebChromeClient::dismissDigitalCredentialsChooser(WTF::CompletionHandler<void(bool)>&& completionHandler)

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -9110,9 +9110,9 @@ void WebPage::showContactPicker(WebCore::ContactsRequestData&& requestData, Comp
 }
 
 #if ENABLE(WEB_AUTHN)
-void WebPage::showDigitalCredentialsChooser(const WebCore::DigitalCredentialsRequestData& requestData, CompletionHandler<void(Expected<WebCore::DigitalCredentialsResponseData, WebCore::ExceptionData>&&)>&& completionHandler)
+void WebPage::showDigitalCredentialsChooser(std::optional<WebCore::FrameIdentifier> frameID, const WebCore::DigitalCredentialsRequestData& requestData, CompletionHandler<void(Expected<WebCore::DigitalCredentialsResponseData, WebCore::ExceptionData>&&)>&& completionHandler)
 {
-    sendWithAsyncReply(Messages::WebPageProxy::ShowDigitalCredentialsChooser(requestData), WTF::move(completionHandler));
+    sendWithAsyncReply(Messages::WebPageProxy::ShowDigitalCredentialsChooser(frameID, requestData), WTF::move(completionHandler));
 }
 
 void WebPage::dismissDigitalCredentialsChooser(CompletionHandler<void(bool)>&& completionHandler)

--- a/Source/WebKit/WebProcess/WebPage/WebPage.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.h
@@ -1809,7 +1809,7 @@ public:
     void showContactPicker(WebCore::ContactsRequestData&&, CompletionHandler<void(std::optional<Vector<WebCore::ContactInfo>>&&)>&&);
 
 #if ENABLE(WEB_AUTHN)
-    void showDigitalCredentialsChooser(const WebCore::DigitalCredentialsRequestData&, CompletionHandler<void(Expected<WebCore::DigitalCredentialsResponseData, WebCore::ExceptionData>&&)>&&);
+    void showDigitalCredentialsChooser(std::optional<WebCore::FrameIdentifier>, const WebCore::DigitalCredentialsRequestData&, CompletionHandler<void(Expected<WebCore::DigitalCredentialsResponseData, WebCore::ExceptionData>&&)>&&);
     void dismissDigitalCredentialsChooser(CompletionHandler<void(bool)>&&);
 #endif
 

--- a/WebDriverTests/imported/w3c/tools/webdriver/webdriver/bidi/client.py
+++ b/WebDriverTests/imported/w3c/tools/webdriver/webdriver/bidi/client.py
@@ -93,6 +93,7 @@ class BidiSession:
         self.bluetooth = modules.Bluetooth(self)
         self.browser = modules.Browser(self)
         self.browsing_context = modules.BrowsingContext(self)
+        self.digital_credentials = modules.DigitalCredentials(self)
         self.emulation = modules.Emulation(self)
         self.input = modules.Input(self)
         self.network = modules.Network(self)

--- a/WebDriverTests/imported/w3c/tools/webdriver/webdriver/bidi/modules/__init__.py
+++ b/WebDriverTests/imported/w3c/tools/webdriver/webdriver/bidi/modules/__init__.py
@@ -3,6 +3,7 @@
 from .bluetooth import Bluetooth
 from .browser import Browser
 from .browsing_context import BrowsingContext
+from .digital_credentials import DigitalCredentials
 from .emulation import Emulation
 from .input import Input
 from .network import Network

--- a/WebDriverTests/imported/w3c/tools/webdriver/webdriver/bidi/modules/digital_credentials.py
+++ b/WebDriverTests/imported/w3c/tools/webdriver/webdriver/bidi/modules/digital_credentials.py
@@ -1,0 +1,22 @@
+from typing import Any, Optional, Mapping, MutableMapping, Union
+from webdriver.bidi.undefined import UNDEFINED, Undefined
+
+from ._module import BidiModule, command
+
+
+class DigitalCredentials(BidiModule):
+    @command
+    def set_virtual_wallet_behavior(
+        self,
+        action: Union[Optional[str], Undefined] = UNDEFINED,
+        context: Union[Optional[str], Undefined] = UNDEFINED,
+        protocol: Union[Optional[str], Undefined] = UNDEFINED,
+        response: Union[Optional[Mapping[str, Any]], Undefined] = UNDEFINED,
+    ) -> Mapping[str, Any]:
+        params: MutableMapping[str, Any] = {
+            "action": action,
+            "context": context,
+            "protocol": protocol,
+            "response": response,
+        }
+        return params

--- a/WebDriverTests/imported/w3c/webdriver/tests/bidi/external/digital_credentials/set_virtual_wallet_behavior/set_virtual_wallet_behavior.py
+++ b/WebDriverTests/imported/w3c/webdriver/tests/bidi/external/digital_credentials/set_virtual_wallet_behavior/set_virtual_wallet_behavior.py
@@ -1,0 +1,178 @@
+import json
+
+import pytest
+import webdriver.bidi.error as error
+from webdriver.bidi.modules.script import ContextTarget
+
+pytestmark = pytest.mark.asyncio
+
+# ISO/IEC 18013-7 2nd edition Annex C reference vectors (Martijn Haring,
+# ISO/IEC JTC 1/SC 17/WG 10), matching mdoc/valid-roundtrip.https.html.
+VALID_REQUEST = {
+    "deviceRequest": "omd2ZXJzaW9uYzEuMGtkb2NSZXF1ZXN0c4GhbGl0ZW1zUmVxdWVzdNgYWFyiZ2RvY1R5cGV1b3JnLmlzby4xODAxMy41LjEubURMam5hbWVTcGFjZXOhcW9yZy5pc28uMTgwMTMuNS4xomtmYW1pbHlfbmFtZfRvZG9jdW1lbnRfbnVtYmVy9A",
+    "encryptionInfo": "gmVkY2FwaaJlbm9uY2VQuTBR9ybYyMxHk586vsBGt3JyZWNpcGllbnRQdWJsaWNLZXmkAQIgASFYIGDjOSOFBB9RQDBR8kFVMctW3T-ZnHFocBOqxnaLyBh-Ilgg5Y3rj9vpB_fdU2gkVVGjR5b30iFcRAwzm7D3tnvszfo"
+}
+
+VALID_RESPONSE = {
+    "response": "gmVkY2FwaaJjZW5jWEEEWojRgrzl9C76WZQ_MzWdLoqWj_KJ2T5fpES2JDQxZ_6xboz4WN3HaQQHumHUwzgjeoz8895qpnL8YKVXqjL8Z2pjaXBoZXJUZXh0WQZ0BAaypQYA8xz2vVLOT99canhuSsGJgQnuxY3DjkvXz14-8lRNZqdh3Y3znCLw3sJLnylnAAhLiOA_X0sRnwkOkQjFT4PWzkyARAPcW7B35URx1de1rdSV-t5-Ei9v1oRGuvzDHrXRwOHhSaXolE4Sv5O_kSsYscfBcAj2jD6mQRqjND0UDFozBZdZzlCuESx5yoz6bWMGSjiM5iixj6Q0XhJ1WMZX9p-b6xLcNxxDXpZyVVJAmLeBWkT4qKwQyf40NlMRBC6hDsRcQB7dwnZUKowyNY8jaSwjLbdToYtJ-dPQ5vXuf9gmYVsDsm5AYCX-udOhnz70oJyLtkyu5wvRE8BCRrbZiwPPcZjx1JU7ARM7Sf_P3qfyxNDO7HlxVdBOAIColO20_kxmyU-FBTGeRknXHwf4VJY9Fw8wf0sawmjycNgx1lS471cQbZBjkscpBLmtorAsSHfA-Be-8EnSqwRLgWqQe0SjW3p6vMicTKx27x8N74P-4KqwiVAVbUQNFioWtBd5ipiDHs8fpGvB3yBiAoSQzCN32Ax0-cXhzocQdeOM5N4F_abDNV_R01ucVMV6RpK2dBHQEIpmyvBUwgxJi4uMCsuFi43Vw5cuJUOZCap-G1n7MngDMsfZmHq2DxWso9qaYI-NkxddWS_nGMEByzbLIud_OfKzzbr6HRkiy-XWnPLOTEw7q9nbv4z4dIBD4eKeH3TOz1V8WjHlxZi1oowIy-GSh0lenVyeZinizCcVyY8a_CnKngP4X6fjSDRS9hB5v1pcyiR6PpdUr3Ui9A1m4W3DxJCxAl0LvtvASmUDpR_R38RUYXx46VD3cU_r-j7oEcc121zTq0aO-VRwOCj0OTAtS2Z_LxR6wjHvKXP0XAyNcm1PX12kf3eeD6edPVOEnJ11iJ-pNe5uGuTbpLSIjpG1J3qv0YukHvPj74rSRpU4J7mpGJRDnJqb7v_XTqTUFO2OPm-UsmwBfxVg5zqXtmoVXFsZZ9s7izTx-gdQaKdrKXrftEPvKoi4mb4Z_jamrSHhw70fieF9wKwMaeH8ih-fLF6jN5go4s-GRigA_JVEASGO4vwZ3TQPgo20ij8z-mbbZonOkbeyZZA4FIHkuwovft1lPSzecaTeljqE7ntJhmxMzM9c8jGcbq5PxmmnvV53JhOupXzeOu8pre6_k_YWWH0LV-IbUWo4twjGre-OhhmseUPoqCMjDPW9lxJ_mnCyD_EPvdRChOwaRxdfFacIDIE39-qPHrQhZVXhiIMhJlLenBFRbgolfUATS2KuiKNy9PvhFlGdZ_pBfBgPIj3iZBq3Tdr9dTJt_HRDsUZ7Gg15vbQvx3QrKa_NLkMUDRoVtLz0ir3d15pMc3K3GrD6JI8RcfGx4ILbrwbMUgUv-7iBVmf3VNTfTbTXnx0vclGiB69bREb5lJz3zPVw_SIPpc_n79JKyYwpcFZsGeyeo1oCtLYXrSjzsokm-H6QJW462ASkfM6Qy3ww45boPriWnKRzakWi6W8K3ujIBszG1jvkxzwlJS1TcHjTyamBSCOJ5213l0wak8Gfg2dN-eq157ZxqtJ-DDw8c1JtOTg7dLyykQp2re8LfHbUdAkxgccO89u6eyL4_ifGFiUpO4wcx_URQ-hINLSCfbti2jp8946uQn2BByzBWHXS_RZ7bH9vdHukUOMNuTjmgDmpp84z3EuOOTdlbEGB01avgbk4s3APKDwhcvE-YttKkvT7s040KyWqItzxkuA3uJtu6b9z98bonLAjZlNYqvZOVvuwo3VT0D4kqsPbKeKzBPy-pDPpM5eDPrgsZdBRQDxJtyrPYqh0wwtDGEk2VDsa-taG6_pWC-YHTZeGd6WP5zZvZ8HsJeWhzhgmGj9QE-vCDguyhHHgSRRYzIwHLfRGdKTFxRdQ6nG_6fx7criSK-RljLv0i7ETheMGAlAqk3rajCGYZRYEa-qrhoCpYFZJEf92yI65iqYcJJScgg6fVZ4yc7U2F-LTywuufOKA0flzGIFmD-01qzw1xaw3SsQwAwgdWT7Hvwc8TwbJ2NpFwiREUtD37k_TV5s1HLxZP9GCQgPzMvO3rxmf1w5yslTjth86XK-oF5q7G8LqxThLL8mq4pct8Kbj_OHRrVvmClnIrewOybtW1CYrXNIeNE5ld8sItpGe0yTN2gHZ_ct2llLJidFf0rEeuz63q3lnVl0"
+}
+
+
+async def has_digital_credentials_api(bidi_session, context):
+    result = await bidi_session.script.evaluate(
+        expression="'DigitalCredential' in window",
+        target=ContextTarget(context),
+        await_promise=False,
+    )
+    return result["value"]
+
+
+async def test_set_virtual_wallet_behavior_respond(bidi_session, new_tab, url):
+    test_url = url("/common/blank.html", protocol="https")
+    await bidi_session.browsing_context.navigate(
+        context=new_tab["context"],
+        url=test_url,
+        wait="complete",
+    )
+
+    await bidi_session.digital_credentials.set_virtual_wallet_behavior(
+        action="respond",
+        protocol="org-iso-mdoc",
+        response={"documents": [{"docType": "org.iso.18013.5.1.mDL"}]},
+    )
+    # The command is accepted; the full credential round-trip is exercised by
+    # test_set_virtual_wallet_behavior_respond_end_to_end.
+
+
+async def test_set_virtual_wallet_behavior_decline(bidi_session, new_tab, url):
+    test_url = url("/common/blank.html", protocol="https")
+    await bidi_session.browsing_context.navigate(
+        context=new_tab["context"],
+        url=test_url,
+        wait="complete",
+    )
+
+    await bidi_session.digital_credentials.set_virtual_wallet_behavior(
+        action="decline",
+    )
+
+
+async def test_set_virtual_wallet_behavior_wait(bidi_session, new_tab, url):
+    test_url = url("/common/blank.html", protocol="https")
+    await bidi_session.browsing_context.navigate(
+        context=new_tab["context"],
+        url=test_url,
+        wait="complete",
+    )
+
+    await bidi_session.digital_credentials.set_virtual_wallet_behavior(
+        action="wait",
+    )
+
+
+async def test_set_virtual_wallet_behavior_clear(bidi_session, new_tab, url):
+    await bidi_session.digital_credentials.set_virtual_wallet_behavior(
+        action="respond",
+        protocol="org-iso-mdoc",
+        response={"test": "data"},
+    )
+
+    await bidi_session.digital_credentials.set_virtual_wallet_behavior(
+        action="clear",
+    )
+
+
+async def test_set_virtual_wallet_behavior_invalid_respond_no_protocol(bidi_session):
+    with pytest.raises(error.InvalidArgumentException):
+        await bidi_session.digital_credentials.set_virtual_wallet_behavior(
+            action="respond",
+            response={"test": "data"},
+        )
+
+
+async def test_set_virtual_wallet_behavior_invalid_decline_with_response(bidi_session):
+    with pytest.raises(error.InvalidArgumentException):
+        await bidi_session.digital_credentials.set_virtual_wallet_behavior(
+            action="decline",
+            response={"test": "data"},
+        )
+
+
+async def test_set_virtual_wallet_behavior_respond_end_to_end(bidi_session, new_tab, url):
+    test_url = url("/common/blank.html", protocol="https")
+    await bidi_session.browsing_context.navigate(
+        context=new_tab["context"],
+        url=test_url,
+        wait="complete",
+    )
+
+    if not await has_digital_credentials_api(bidi_session, new_tab["context"]):
+        pytest.skip("Digital Credentials API is not supported")
+
+    await bidi_session.digital_credentials.set_virtual_wallet_behavior(
+        action="respond",
+        protocol="org-iso-mdoc",
+        response=VALID_RESPONSE,
+    )
+
+    expression = """(async () => {
+        const request = %s;
+        const credential = await navigator.credentials.get({
+            digital: { requests: [{ protocol: "org-iso-mdoc", data: request }] }
+        });
+        return JSON.stringify({
+            protocol: credential.protocol,
+            type: credential.type,
+            response: credential.data.response,
+        });
+    })()""" % json.dumps(VALID_REQUEST)
+
+    result = await bidi_session.script.evaluate(
+        expression=expression,
+        target=ContextTarget(new_tab["context"]),
+        await_promise=True,
+        user_activation=True,
+    )
+
+    credential = json.loads(result["value"])
+    assert credential["protocol"] == "org-iso-mdoc"
+    assert credential["type"] == "digital"
+    assert credential["response"] == VALID_RESPONSE["response"]
+
+
+async def test_set_virtual_wallet_behavior_wait_is_aborted(bidi_session, new_tab, url):
+    test_url = url("/common/blank.html", protocol="https")
+    await bidi_session.browsing_context.navigate(
+        context=new_tab["context"],
+        url=test_url,
+        wait="complete",
+    )
+
+    if not await has_digital_credentials_api(bidi_session, new_tab["context"]):
+        pytest.skip("Digital Credentials API is not supported")
+
+    await bidi_session.digital_credentials.set_virtual_wallet_behavior(
+        action="wait",
+    )
+
+    # With "wait" the request stays pending; aborting its signal must reject it
+    # rather than leaving the promise unsettled forever.
+    expression = """(async () => {
+        const controller = new AbortController();
+        const request = %s;
+        const outcome = navigator.credentials.get({
+            signal: controller.signal,
+            digital: { requests: [{ protocol: "org-iso-mdoc", data: request }] }
+        }).then(() => "resolved", (error) => error.name);
+        controller.abort();
+        return await outcome;
+    })()""" % json.dumps(VALID_REQUEST)
+
+    result = await bidi_session.script.evaluate(
+        expression=expression,
+        target=ContextTarget(new_tab["context"]),
+        await_promise=True,
+        user_activation=True,
+    )
+
+    assert result["value"] == "AbortError"


### PR DESCRIPTION
#### fc22dff35d852f9e43f4d3f40924fd368b7a29e3
<pre>
[Digital Credentials] Add WebDriver BiDi digitalCredentials module for automated testing
<a href="https://rdar.apple.com/168941907">rdar://168941907</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=306292">https://bugs.webkit.org/show_bug.cgi?id=306292</a>

Reviewed by BJ Burg.

Add a WebDriver BiDi digitalCredentials module that allows automated testing
of the Digital Credentials API by simulating wallet behavior (respond, decline,
wait) without requiring a real credential provider.

The simulated wallet behavior is looked up for the requesting frame&apos;s browsing
context, falling back to the session&apos;s default behavior, matching the Digital
Credentials specification&apos;s &quot;handle virtual wallet behavior&quot; algorithm. To do
this, the requesting frame&apos;s identifier is threaded from the credential request
coordinator down to the UIProcess chooser entry point.

A &quot;wait&quot; behavior parks the chooser completion handler so the request stays
pending. The handler is now released when the request is dismissed on abort or
document teardown, not only when the session ends, so a waiting request cannot
leak past the document that made it. The completion callback also tolerates a
reply that arrives after the request was already aborted.

* Source/WebCore/Modules/identity/CredentialRequestCoordinator.cpp:
(WebCore::CredentialRequestCoordinator::initiateTheCredentialRequest):
(WebCore::CredentialRequestCoordinator::processCredentialChooserResponse):
* Source/WebCore/Modules/identity/CredentialRequestCoordinatorClient.h:
* Source/WebCore/Modules/identity/dummy/DummyCredentialRequestCoordinatorClient.cpp:
(WebCore::DummyCredentialRequestCoordinatorClient::showDigitalCredentialsChooser):
* Source/WebCore/Modules/identity/dummy/DummyCredentialRequestCoordinatorClient.h:
* Source/WebCore/loader/EmptyClients.cpp:
* Source/WebKit/CMakeLists.txt:
* Source/WebKit/DerivedSources-input.xcfilelist:
* Source/WebKit/DerivedSources.make:
* Source/WebKit/Sources.txt:
* Source/WebKit/UIProcess/Automation/BidiDigitalCredentialsAgent.cpp: Added.
(WebKit::toPresentationProtocol):
(WebKit::BidiDigitalCredentialsAgent::BidiDigitalCredentialsAgent):
(WebKit::BidiDigitalCredentialsAgent::~BidiDigitalCredentialsAgent):
(WebKit::BidiDigitalCredentialsAgent::setVirtualWalletBehavior):
(WebKit::BidiDigitalCredentialsAgent::behaviorForContext const):
(WebKit::BidiDigitalCredentialsAgent::abortPendingHandler):
(WebKit::BidiDigitalCredentialsAgent::holdPendingHandler):
(WebKit::BidiDigitalCredentialsAgent::releasePendingHandler):
(WebKit::BidiDigitalCredentialsAgent::cancelAllPendingRequests):
* Source/WebKit/UIProcess/Automation/BidiDigitalCredentialsAgent.h: Added.
* Source/WebKit/UIProcess/Automation/WebDriverBidiProcessor.cpp:
(WebKit::WebDriverBidiProcessor::WebDriverBidiProcessor):
* Source/WebKit/UIProcess/Automation/WebDriverBidiProcessor.h:
* Source/WebKit/UIProcess/Automation/protocol/BidiDigitalCredentials.json: Added.
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::showDigitalCredentialsChooser):
(WebKit::WebPageProxy::dismissDigitalCredentialsChooser):
* Source/WebKit/UIProcess/WebPageProxy.h:
* Source/WebKit/UIProcess/WebPageProxy.messages.in:
* Source/WebKit/WebKit.xcodeproj/project.pbxproj:
* Source/WebKit/WebProcess/DigitalCredentials/DigitalCredentialsCoordinator.cpp:
(WebKit::DigitalCredentialsCoordinator::showDigitalCredentialsChooser):
* Source/WebKit/WebProcess/DigitalCredentials/DigitalCredentialsCoordinator.h:
* Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp:
(WebKit::WebChromeClient::showDigitalCredentialsChooser):
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::showDigitalCredentialsChooser):
* Source/WebKit/WebProcess/WebPage/WebPage.h:
* WebDriverTests/imported/w3c/tools/webdriver/webdriver/bidi/client.py:
(BidiSession.__init__):
* WebDriverTests/imported/w3c/tools/webdriver/webdriver/bidi/modules/__init__.py:
* WebDriverTests/imported/w3c/tools/webdriver/webdriver/bidi/modules/digital_credentials.py: Added.
(DigitalCredentials):
(DigitalCredentials.set_virtual_wallet_behavior):
* WebDriverTests/imported/w3c/webdriver/tests/bidi/external/digital_credentials/__init__.py: Added.
* WebDriverTests/imported/w3c/webdriver/tests/bidi/external/digital_credentials/set_virtual_wallet_behavior/__init__.py: Added.
* WebDriverTests/imported/w3c/webdriver/tests/bidi/external/digital_credentials/set_virtual_wallet_behavior/set_virtual_wallet_behavior.py: Added.
(test_set_virtual_wallet_behavior_respond):
(test_set_virtual_wallet_behavior_decline):
(test_set_virtual_wallet_behavior_wait):
(test_set_virtual_wallet_behavior_clear):
(test_set_virtual_wallet_behavior_invalid_respond_no_protocol):
(test_set_virtual_wallet_behavior_invalid_decline_with_response):
(test_set_virtual_wallet_behavior_respond_end_to_end):
(test_set_virtual_wallet_behavior_wait_is_aborted):

Canonical link: <a href="https://commits.webkit.org/316435@main">https://commits.webkit.org/316435@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/578e63dad21a045f453efae624b64ea908f473f8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/172137 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/46054 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/39472 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/181580 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/129691 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/af37004e-348c-4d0e-8cf1-6523b5a10c31) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/174002 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/47341 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/45694 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/133896 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/94453 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/0d78fc76-8f59-485d-bf5b-9debfcf7141e) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/175095 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/37327 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/154432 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/114369 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/995f450a-a1c1-49d0-b027-bf18ac90919d) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/35958 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/34226 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/30190 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/146384 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/33944 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/184111 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/36725 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/38416 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/142646 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/45721 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/142535 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38520 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/46401 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/30791 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/111079 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/37614 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/118177 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/44919 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/8881 "") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/44319 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/44551 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/44378 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->