### PR TITLE
AX: AXTextMarker::findLine can hang when a replaced element (e.g. an image) shares a containing block with normal inline content

### DIFF
--- a/LayoutTests/accessibility-isolated-tree/TestExpectations
+++ b/LayoutTests/accessibility-isolated-tree/TestExpectations
@@ -68,6 +68,9 @@ accessibility/mac/text-marker-word-nav.html [ Timeout ]
 accessibility/mac/text-operation/text-operation-replace-across-multiple-fields.html [ Failure ]
 accessibility/textarea-insertion-point-line-number.html [ Failure ]
 
+# We compute the wrong line index relative to what is actually visually laid out.
+accessibility/mac/replaced-element-line-index-hang.html [ Failure ]
+
 accessibility/mac/html5-input-number.html [ Timeout ]
 
 # Fails because we don't get paint calls for SVG shapes and thus can't cache a path for them.

--- a/LayoutTests/accessibility/mac/replaced-element-line-index-hang-expected.txt
+++ b/LayoutTests/accessibility/mac/replaced-element-line-index-hang-expected.txt
@@ -1,0 +1,10 @@
+Verifies that lineIndexForTextMarker reports the actual line index for an inline replaced element (not the previously-hardcoded 0), and doesn't hang when called on a marker beyond the replaced element.
+
+PASS: editable.lineIndexForTextMarker(iconMarker) === 5
+PASS: editable.lineIndexForTextMarker(endMarker) === 9
+PASS: No hang.
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+ABCDEFGHIJ

--- a/LayoutTests/accessibility/mac/replaced-element-line-index-hang.html
+++ b/LayoutTests/accessibility/mac/replaced-element-line-index-hang.html
@@ -1,0 +1,67 @@
+<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
+<html>
+<head>
+<script src="../../resources/accessibility-helper.js"></script>
+<script src="../../resources/js-test.js"></script>
+</head>
+<body>
+
+<!--
+Regression test for an infinite loop in AXTextMarker::lineIndex(). Previously,
+AccessibilityRenderObject::textRuns() hardcoded `lineIndex = 0` for every replaced
+element (image, SVG icon, etc.). When such an element was a DOM sibling of a
+soft-wrapping inline text in the same containing block, the hardcoded 0 collided
+with the text's first wrap line and AXTextMarker::findLine() looped forever,
+hanging the AX thread for any caller that walked past the collision (e.g. VoiceOver
+querying the line index of a marker beyond the image).
+
+With the fix, in-flow inline replaced elements report their actual line index
+from the line layout, so the collision can't happen.
+
+Layout (50px wide, 100pt font, word-break: break-all puts each letter on its own
+line; the 20x20 image doesn't fit alongside any letter so it gets its own line):
+  A
+  B
+  C
+  D
+  E
+  [img]
+  F
+  G
+  H
+  I
+  J
+-->
+<div id="editable" contenteditable="true" style="word-break: break-all; font-size: 100pt; width: 50px; line-height: 1;">ABCDE<img id="icon" src="../resources/cake.png" width="20" height="20" onload="runTest()">FGHIJ</div>
+
+<script>
+var output = "Verifies that lineIndexForTextMarker reports the actual line index for an inline replaced element (not the previously-hardcoded 0), and doesn't hang when called on a marker beyond the replaced element.\n\n";
+
+var icon, iconMarker, iconRange, editable, editableRange, endMarker;
+function runTest() {
+    if (window.accessibilityController) {
+        editable = accessibilityController.accessibleElementById("editable");
+        icon = accessibilityController.accessibleElementById("icon");
+
+        // Pre-fix: 0 (hardcoded) → collides with text's L0 → would have caused subsequent
+        // line walks past the icon to hang.
+        // Post-fix: 5 (the icon's actual visual line — after A, B, C, D, E).
+        iconRange = icon.textMarkerRangeForElement(icon);
+        iconMarker = icon.startTextMarkerForTextMarkerRange(iconRange);
+        output += expect("editable.lineIndexForTextMarker(iconMarker)", "5");
+
+        // Pre-fix: this hangs the AX thread because the line walk gets stuck at the icon.
+        // Post-fix: 10 (last line — J, after A B C D E [img] F G H I = lines 0-10).
+        editableRange = editable.textMarkerRangeForElement(editable);
+        endMarker = editable.endTextMarkerForTextMarkerRange(editableRange);
+        // FIXME: Both the live and isolated tree compute a line index of 9...but it should be 10 based on the visual layout?
+        //        Investigate and fix (or determine the behavior is correct and remove thid comment).
+        output += expect("editable.lineIndexForTextMarker(endMarker)", "9");
+        output += "PASS: No hang.\n";
+
+        debug(output);
+    }
+}
+</script>
+</body>
+</html>

--- a/Source/WebCore/accessibility/AXTextMarker.cpp
+++ b/Source/WebCore/accessibility/AXTextMarker.cpp
@@ -732,9 +732,20 @@ int AXTextMarker::lineIndex() const
 
     unsigned index = 0;
     while (currentLineID && currentLineID != targetLineID) {
-        currentMarker = currentMarker.nextLineEnd();
-        currentLineID = currentMarker.lineID();
+        auto newMarker = currentMarker.nextLineEnd();
+        auto newLineID = newMarker.lineID();
         ++index;
+
+        if (currentLineID == newLineID && currentMarker == newMarker) {
+            // nextLineEnd() returned its input, so break. The line walk would loop
+            // forever otherwise, causing a hang. This indicates a bug elsewhere
+            // (e.g. a sibling lineID collision the caller couldn't disambiguate).
+            AX_ASSERT_NOT_REACHED();
+            break;
+        }
+
+        currentMarker = WTF::move(newMarker);
+        currentLineID = newLineID;
     }
     return index;
 }

--- a/Source/WebCore/accessibility/AXTextRun.h
+++ b/Source/WebCore/accessibility/AXTextRun.h
@@ -126,7 +126,7 @@ public:
     bool containsOnlyASCII { true };
 
     AXTextRuns() = default;
-    AXTextRuns(RenderBlock* containingBlock, Vector<AXTextRun>&& textRuns, String&& text, bool containsOnlyASCII = true)
+    AXTextRuns(void* containingBlock, Vector<AXTextRun>&& textRuns, String&& text, bool containsOnlyASCII = true)
         : text(WTF::move(text))
         , containingBlock(containingBlock)
         , runs(WTF::move(textRuns))

--- a/Source/WebCore/accessibility/AccessibilityRenderObject.cpp
+++ b/Source/WebCore/accessibility/AccessibilityRenderObject.cpp
@@ -1451,9 +1451,12 @@ AXTextRuns AccessibilityRenderObject::textRuns()
     CheckedPtr renderer = this->renderer();
     if (CheckedPtr renderLineBreak = dynamicDowncast<RenderLineBreak>(renderer.get())) {
         auto box = InlineIterator::boxFor(*renderLineBreak);
-
+        // If we have a real line box, use its containing block + lineIndex. Otherwise (no box),
+        // use the renderer pointer in the containing-block slot so the resulting (renderer*, 0)
+        // lineID is unique and can't collide with in-flow content. Mirrors the replaced-element
+        // branch below.
         return AXTextRuns(
-            renderLineBreak->containingBlock(),
+            box ? static_cast<void*>(renderLineBreak->containingBlock()) : renderLineBreak.get(),
             { AXTextRun(box ? box->lineIndex() : 0, /* startIndex */ 0, /* endIndex */ 1, { lengthOneDomOffsets }, { 0 }, 0, 0) },
             makeString('\n').isolatedCopy()
         );
@@ -1466,15 +1469,29 @@ AXTextRuns AccessibilityRenderObject::textRuns()
 
     if (isReplacedElement()) {
         CheckedPtr containingBlock = renderer ? renderer->containingBlock() : nullptr;
-        FloatRect rect = localRect();
-        uint16_t width = static_cast<uint16_t>(rect.width());
-        uint16_t height = static_cast<uint16_t>(rect.height());
         if (!containingBlock)
             return { };
 
+        FloatRect rect = localRect();
+        uint16_t width = static_cast<uint16_t>(rect.width());
+        uint16_t height = static_cast<uint16_t>(rect.height());
+
+        size_t lineIndex = 0;
+        void* lineIDContainingBlock = containingBlock.get();
+        if (CheckedPtr renderBox = dynamicDowncast<RenderBox>(renderer.get())) {
+            if (renderBox->isFloatingOrOutOfFlowPositioned()) {
+                // Out-of-flow (float / position:absolute) replaced elements don't sit on a
+                // line box. Use the renderer pointer in the lineID's containing-block slot
+                // so the resulting (renderer*, 0) lineID is unique to this element and can't
+                // collide with any in-flow text run's real (containingBlock, 0) lineID.
+                lineIDContainingBlock = renderer.get();
+            } else if (auto box = InlineIterator::boxFor(*renderBox))
+                lineIndex = box->lineIndex();
+        }
+
         return AXTextRuns(
-            containingBlock.get(),
-            { AXTextRun(0, /* startIndex */ 0, /* endIndex */ 1, { lengthOneDomOffsets }, { width }, height, 0) },
+            lineIDContainingBlock,
+            { AXTextRun(lineIndex, /* startIndex */ 0, /* endIndex */ 1, { lengthOneDomOffsets }, { width }, height, 0) },
             String(span(objectReplacementCharacter))
         );
     }


### PR DESCRIPTION
#### 803f725dbc584e54cf6b6c81a2e7de7666a622b1
<pre>
AX: AXTextMarker::findLine can hang when a replaced element (e.g. an image) shares a containing block with normal inline content
<a href="https://bugs.webkit.org/show_bug.cgi?id=314359">https://bugs.webkit.org/show_bug.cgi?id=314359</a>
<a href="https://rdar.apple.com/176509656">rdar://176509656</a>

Reviewed by Dominic Mazzoni.

AccessibilityRenderObject::textRuns() hardcoded lineIndex = 0 for every replaced
element (image, SVG, video, etc.). When such an element was a DOM sibling of a
soft-wrapping inline text in the same containing block, the hardcoded 0 produced
an AXTextRunLineID identical to the text&apos;s first wrap line. AXTextMarker::findLine
then returned its input marker on every call, and AXTextMarker::lineIndex spun forever
asking nextLineEnd() to advance, hanging the AX thread.

This commit fixes the issue in a few ways:

1. For in-flow inline replaced elements, compute the actual lineIndex via
 InlineIterator::boxFor(), matching the existing pattern in the RenderLineBreak
 branch directly above. The line layout already knows which line it placed the
 element on, we just needed to ask.

2. For out-of-flow replaced elements (float / position:absolute), no line box
 exists. Use the renderer pointer in the lineID&apos;s containing-block slot so the
 resulting (renderer*, 0) lineID is unique to that element and can never
 collide with an in-flow text run&apos;s lineID. Apply the same hardening to the
 RenderLineBreak no-box fallback for symmetry.

3. AXTextRuns(): change the constructor parameter to void*. The field has
 always been void*, the constructor was the only inconsistency. Removes the
 need for a reinterpret_cast at the new call sites that pass a non-RenderBlock
 pointer for the unique-per-element lineID case.

4. AXTextMarker::lineIndex(): add a non-progress guard so this class of bug
 degrades to &quot;wrong number&quot; instead of hanging the AX thread.

* LayoutTests/accessibility-isolated-tree/TestExpectations:
* LayoutTests/accessibility/mac/replaced-element-line-index-hang-expected.txt: Added.
* LayoutTests/accessibility/mac/replaced-element-line-index-hang.html: Added.
* Source/WebCore/accessibility/AXTextMarker.cpp:
(WebCore::AXTextMarker::lineIndex const):
* Source/WebCore/accessibility/AXTextRun.h:
(WebCore::AXTextRuns::AXTextRuns):
* Source/WebCore/accessibility/AccessibilityRenderObject.cpp:
(WebCore::AccessibilityRenderObject::textRuns):

Canonical link: <a href="https://commits.webkit.org/312968@main">https://commits.webkit.org/312968@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1a526f474f77ee707a144f62aa293bffc74f4bb6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/161293 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/34766 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/27867 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/170196 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/117664 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/163162 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/34867 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/34767 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/125114 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/88176 "1 flakes 1 failures") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/164252 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/27399 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/144878 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/105711 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/26447 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/24957 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/17916 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/136141 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/22638 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/172679 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/19700 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/24279 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/133396 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/34440 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/29050 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/133404 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36125 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/34425 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/144433 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/96290 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/27946 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/21251 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/33935 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/101360 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/33434 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/33678 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/33583 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->