### PR TITLE
AX: Protect against infinite loops in various AXTextMarker functions

### DIFF
--- a/Source/WebCore/accessibility/AXTextMarker.cpp
+++ b/Source/WebCore/accessibility/AXTextMarker.cpp
@@ -611,7 +611,13 @@ String AXTextMarkerRange::toString(IncludeListMarkerText includeListMarkerText, 
         RefPtr current = findObjectWithRuns(*start.isolatedObject(), AXDirection::Next, std::nullopt, emitAuxiliaryText);
         while (current && current->objectID() != end.objectID()) {
             result.append(current->textRuns()->toStringView());
-            current = findObjectWithRuns(*current, AXDirection::Next, std::nullopt, emitAuxiliaryText);
+            RefPtr next = findObjectWithRuns(*current, AXDirection::Next, std::nullopt, emitAuxiliaryText);
+            if (next == current) [[unlikely]] {
+                // findObjectWithRuns returned its input. Would loop forever.
+                AX_ASSERT_NOT_REACHED();
+                break;
+            }
+            current = WTF::move(next);
         }
         result.append(end.runs()->substring(0, end.offset()));
         return result.toString();
@@ -905,6 +911,12 @@ unsigned AXTextMarker::offsetFromRoot() const
                 RefPtr nextObject = currentObject->nextInPreOrder();
                 current = nextObject ? AXTextMarker { *nextObject, 0 } : AXTextMarker();
             }
+
+            if (previous == current) [[unlikely]] {
+                // Advancement returned its input. Would loop forever.
+                AX_ASSERT_NOT_REACHED();
+                break;
+            }
         }
         applyNewlineOffset();
 
@@ -926,11 +938,16 @@ AXTextMarker AXTextMarker::nextMarkerFromOffset(unsigned offset, ForceSingleOffs
 
     auto marker = *this;
     while (offset) {
-        if (auto newMarker = marker.findMarker(AXDirection::Next, CoalesceObjectBreaks::No, IgnoreBRs::No, stopAtID, forceSingleOffsetMovement))
-            marker = WTF::move(newMarker);
-        else
+        auto newMarker = marker.findMarker(AXDirection::Next, CoalesceObjectBreaks::No, IgnoreBRs::No, stopAtID, forceSingleOffsetMovement);
+        if (!newMarker)
             break;
-
+        if (newMarker == marker) [[unlikely]] {
+            // findMarker returned its input. Would loop until offset reaches 0,
+            // returning a wildly wrong marker.
+            AX_ASSERT_NOT_REACHED();
+            break;
+        }
+        marker = WTF::move(newMarker);
         --offset;
     }
     return marker;
@@ -958,6 +975,11 @@ AXTextMarker AXTextMarker::findLastBefore(std::optional<AXID> stopAtID) const
         RefPtr newObject = findObjectWithRuns(*lastObjectWithRuns, AXDirection::Next, stopAtID);
         if (!newObject)
             break;
+        if (newObject == lastObjectWithRuns) [[unlikely]] {
+            // findObjectWithRuns returned its input. Would loop forever.
+            AX_ASSERT_NOT_REACHED();
+            break;
+        }
         lastObjectWithRuns = WTF::move(newObject);
     }
 
@@ -1049,7 +1071,13 @@ FloatRect AXTextMarkerRange::viewportRelativeFrame() const
     RefPtr current = start.isolatedObject();
     while (current && current->objectID() != *end.objectID()) {
         result.unite(viewportRelativeFrameFromRuns(*current, /* offset */ 0));
-        current = findObjectWithRuns(*current, AXDirection::Next, /* stopAtID */ *end.objectID());
+        RefPtr next = findObjectWithRuns(*current, AXDirection::Next, /* stopAtID */ *end.objectID());
+        if (next == current) [[unlikely]] {
+            // findObjectWithRuns returned its input. Would loop forever.
+            AX_ASSERT_NOT_REACHED();
+            break;
+        }
+        current = WTF::move(next);
     }
     result.unite(viewportRelativeFrameFromRuns(*end.isolatedObject(), /* start */ 0, /* end */ end.offset()));
 
@@ -1485,7 +1513,13 @@ AXTextMarker AXTextMarker::toTextRunMarker(std::optional<AXID> stopAtID) const
         if (precedingOffset + totalLength >= offset())
             break;
         precedingOffset += totalLength;
-        current = findObjectWithRuns(*current, AXDirection::Next, stopAtID);
+        RefPtr next = findObjectWithRuns(*current, AXDirection::Next, stopAtID);
+        if (next == current) [[unlikely]] {
+            // findObjectWithRuns returned its input. Would loop forever.
+            AX_ASSERT_NOT_REACHED();
+            break;
+        }
+        current = WTF::move(next);
     }
 
     if (!current)


### PR DESCRIPTION
#### 3238a81fbf2be9bf05ff044416d78a1d52e423ff
<pre>
AX: Protect against infinite loops in various AXTextMarker functions
<a href="https://bugs.webkit.org/show_bug.cgi?id=314360">https://bugs.webkit.org/show_bug.cgi?id=314360</a>
<a href="https://rdar.apple.com/176510664">rdar://176510664</a>

Reviewed by Dominic Mazzoni.

Six functions in AXTextMarker.cpp walk the AX tree forward via findMarker(),
findObjectWithRuns(), or nextInPreOrder() inside a while loop, terminating only
when the walked pointer/marker reaches a target or becomes null. If the
underlying advance ever returns its input each of these loops would spin
forever on the AX thread.

Add a one-branch no-progress guard to each loop: snapshot the previous
pointer/marker, compare to the post-advance value, and break (with
AX_ASSERT_NOT_REACHED to surface the bug in debug builds) if they&apos;re equal. Each
guard is gated with [[unlikely]] since it _should_ never happen.

Functions hardened:

* AXTextMarkerRange::toString — findObjectWithRuns walk to end&apos;s objectID
* AXTextMarker::offsetFromRoot — findMarker / nextInPreOrder walk to *this
* AXTextMarker::nextMarkerFromOffset — findMarker countdown walk
* AXTextMarker::findLastBefore — findObjectWithRuns walk to stopAtID
* AXTextMarkerRange::viewportRelativeFrame — findObjectWithRuns walk to end
* AXTextMarker::toTextRunMarker — findObjectWithRuns walk by accumulator

* Source/WebCore/accessibility/AXTextMarker.cpp:
(WebCore::AXTextMarkerRange::toString const):
(WebCore::AXTextMarker::offsetFromRoot const):
(WebCore::AXTextMarker::nextMarkerFromOffset const):
(WebCore::AXTextMarker::findLastBefore const):
(WebCore::AXTextMarkerRange::viewportRelativeFrame const):
(WebCore::AXTextMarker::toTextRunMarker const):

Canonical link: <a href="https://commits.webkit.org/312879@main">https://commits.webkit.org/312879@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5edd619d1f5cd9959847022aa2d3782abf23c50f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/161294 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/34767 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/27868 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/170197 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/117665 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/e785e9ca-9d86-495d-86cd-df0c29bac42d) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/163163 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/34868 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/34768 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/125113 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/117665 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/164253 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/27401 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/144880 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/105710 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/26449 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/24958 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/17917 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/136143 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/22640 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/172680 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/19701 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/24281 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/133397 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/34441 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/29051 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/133405 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36047 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/34426 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/144435 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/96291 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/27942 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/21253 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/33936 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/101361 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/33435 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/33679 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/33584 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->