### PR TITLE
[win] Fix windows debug build errors

### DIFF
--- a/Source/WTF/wtf/win/DbgHelperWin.cpp
+++ b/Source/WTF/wtf/win/DbgHelperWin.cpp
@@ -43,7 +43,7 @@ static void initializeSymbols(HANDLE hProc)
     static std::once_flag onceFlag;
     std::call_once(onceFlag, [&]() {
         if (!SymInitialize(hProc, nullptr, TRUE))
-            LOG_ERROR("Failed to initialze symbol information %d", GetLastError());
+            LOG_ERROR("Failed to initialze symbol information %lu", GetLastError());
     });
 }
 

--- a/Source/WTF/wtf/win/ThreadingWin.cpp
+++ b/Source/WTF/wtf/win/ThreadingWin.cpp
@@ -159,7 +159,7 @@ bool Thread::establishHandle(NewThreadContext& data, StackAllocationSpecificatio
     unsigned initFlag = stackSize ? STACK_SIZE_PARAM_IS_A_RESERVATION : 0;
     HANDLE threadHandle = reinterpret_cast<HANDLE>(_beginthreadex(nullptr, stackSize, wtfThreadEntryPoint, &data, initFlag, &threadIdentifier));
     if (!threadHandle) {
-        LOG_ERROR("Failed to create thread at entry point %p with data %p: %ld", wtfThreadEntryPoint, &data, errno);
+        LOG_ERROR("Failed to create thread at entry point %p with data %p: %d", wtfThreadEntryPoint, &data, errno);
         return false;
     }
     establishPlatformSpecificHandle(threadHandle, threadIdentifier);

--- a/Tools/TestRunnerShared/TestFeatures.cpp
+++ b/Tools/TestRunnerShared/TestFeatures.cpp
@@ -315,7 +315,7 @@ static std::optional<TestFeatures> parseTestHeaderString(const std::string& pair
         size_t equalsLocation = pairString.find("=", pairStart);
         if (equalsLocation == std::string::npos) {
             if (!path.empty())
-                LOG_ERROR("Malformed option in test header (could not find '=' character) in %s", path.c_str());
+                LOG_ERROR("Malformed option in test header (could not find '=' character) in %ls", path.c_str());
             else
                 LOG_ERROR("Malformed option in --additional-header option value (could not find '=' character)");
             break;
@@ -325,7 +325,7 @@ static std::optional<TestFeatures> parseTestHeaderString(const std::string& pair
 
         if (!parseTestHeaderFeature(features, key, value, path, keyTypeMap)) {
             if (!path.empty())
-                LOG_ERROR("Unknown key, '%s', in test header in %s", key.c_str(), path.c_str());
+                LOG_ERROR("Unknown key, '%s', in test header in %ls", key.c_str(), path.c_str());
             else
                 LOG_ERROR("Unknown key, '%s', in --additional-header option value", key.c_str());
         }
@@ -343,7 +343,7 @@ static TestFeatures parseTestHeader(std::filesystem::path path, const std::unord
 
     std::ifstream file(path);
     if (!file.good()) {
-        LOG_ERROR("Could not open file to inspect test headers in %s", path.c_str());
+        LOG_ERROR("Could not open file to inspect test headers in %ls", path.c_str());
         return { };
     }
 
@@ -356,7 +356,7 @@ static TestFeatures parseTestHeader(std::filesystem::path path, const std::unord
         return { };
     size_t endLocation = options.find(endString, beginLocation);
     if (endLocation == std::string::npos) {
-        LOG_ERROR("Could not find end of test header in %s", path.c_str());
+        LOG_ERROR("Could not find end of test header in %ls", path.c_str());
         return { };
     }
     std::string pairString = options.substr(beginLocation + beginString.size(), endLocation - (beginLocation + beginString.size()));


### PR DESCRIPTION

<pre>
[win] Fix windows debug build errors
<a href="https://bugs.webkit.org/show_bug.cgi?id=314362">https://bugs.webkit.org/show_bug.cgi?id=314362</a>

Reviewed by NOBODY (OOPS!).

some format specifiers type mismatch in error logging.

</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3786b1da03a9604236abb63c82f6383c051f607a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/161297 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/34770 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/27871 "Built successfully") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/170200 "Hash 3786b1da for PR 64514 does not build (failure)") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/117668 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/163166 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/34871 "Built successfully") | [❌ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/34771 "Hash 3786b1da for PR 64514 does not build (failure)") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/5/builds/170200 "Hash 3786b1da for PR 64514 does not build (failure)") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/88175 "1 flakes 1 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/164256 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/27402 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/144883 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/5/builds/170200 "Hash 3786b1da for PR 64514 does not build (failure)") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/26450 "Passed tests") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/156/builds/34771 "Hash 3786b1da for PR 64514 does not build (failure)") | [❌ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/17920 "Hash 3786b1da for PR 64514 does not build (failure)") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/153354 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/136144 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/22643 "Passed tests") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/172683 "Hash 3786b1da for PR 64514 does not build (failure)") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/22135 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/19704 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/24284 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/2/builds/172683 "Hash 3786b1da for PR 64514 does not build (failure)") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/34444 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/156/builds/34771 "Hash 3786b1da for PR 64514 does not build (failure)") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/2/builds/172683 "Hash 3786b1da for PR 64514 does not build (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/34429 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/144438 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/96294 "The change is no longer eligible for processing.") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/27943 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/21256 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/193696 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/33939 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/101364 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/49901 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/33438 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/33682 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/33587 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->