### PR TITLE
Convert LayerRepresentation to use a variant

### DIFF
--- a/Source/WebCore/SaferCPPExpectations/ForwardDeclCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/ForwardDeclCheckerExpectations
@@ -47,9 +47,8 @@ inspector/UserGestureEmulationScope.h
 layout/formattingContexts/inline/InlineFormattingContext.h
 layout/formattingContexts/inline/InlineItemsBuilder.cpp
 layout/formattingContexts/inline/InlineLine.h
-[ iOS ] page/cocoa/ContentChangeObserver.h
 page/Page.h
-page/scrolling/ScrollingStateNode.h
+[ iOS ] page/cocoa/ContentChangeObserver.h
 [ Mac ] page/scrolling/ScrollingStateScrollingNode.cpp
 platform/PODRedBlackTree.h
 platform/cocoa/TelephoneNumberDetectorCocoa.cpp
@@ -62,8 +61,8 @@ rendering/RenderLayerBacking.cpp
 rendering/RenderLayerCompositor.cpp
 rendering/RenderTextLineBoxes.h
 rendering/svg/SVGRenderingContext.h
+style/StyleBuilderState.h
 style/StyleExtractorState.h
 style/StyleScope.h
 style/values/images/kinds/StyleCachedImage.cpp
 testing/Internals.cpp
-style/StyleBuilderState.h

--- a/Source/WebCore/page/scrolling/ScrollingStateNode.h
+++ b/Source/WebCore/page/scrolling/ScrollingStateNode.h
@@ -30,6 +30,9 @@
 #include <WebCore/GraphicsLayer.h>
 #include <WebCore/ScrollingCoordinator.h>
 #include <WebCore/ScrollingPlatformLayer.h>
+#if USE(COORDINATED_GRAPHICS)
+#include <WebCore/CoordinatedPlatformLayer.h>
+#endif
 #include <stdint.h>
 #include <wtf/CheckedPtr.h>
 #include <wtf/TZoneMalloc.h>
@@ -55,152 +58,101 @@ class ScrollingStateTree;
 class LayerRepresentation {
 public:
     enum Type {
-        EmptyRepresentation,
         GraphicsLayerRepresentation,
         PlatformLayerRepresentation,
         PlatformLayerIDRepresentation
     };
 
+#if PLATFORM(COCOA)
+    using PlatformLayerHolder = PlatformLayerContainer;
+#elif USE(COORDINATED_GRAPHICS)
+    using PlatformLayerHolder = RefPtr<CoordinatedPlatformLayer>;
+#endif
+
     LayerRepresentation() = default;
 
     LayerRepresentation(GraphicsLayer* graphicsLayer)
-        : m_graphicsLayer(graphicsLayer)
-        , m_layerID(graphicsLayer ? std::optional { graphicsLayer->primaryLayerID() } : std::nullopt)
-        , m_representation(GraphicsLayerRepresentation)
+        : m_data(GraphicsLayerData { graphicsLayer, graphicsLayer ? std::optional { graphicsLayer->primaryLayerID() } : std::nullopt })
     { }
 
     LayerRepresentation(ScrollingPlatformLayer* platformLayer)
-        : m_typelessPlatformLayer(makePlatformLayerTypeless(platformLayer))
-        , m_representation(PlatformLayerRepresentation)
-    {
-        retainPlatformLayer(m_typelessPlatformLayer);
-    }
+        : m_data(PlatformLayerHolder { platformLayer })
+    { }
 
     LayerRepresentation(std::optional<PlatformLayerIdentifier> layerID)
-        : m_layerID(layerID)
-        , m_representation(PlatformLayerIDRepresentation)
-    {
-    }
-
-    LayerRepresentation(const LayerRepresentation& other)
-        : m_typelessPlatformLayer(other.m_typelessPlatformLayer)
-        , m_layerID(other.m_layerID)
-        , m_representation(other.m_representation)
-    {
-        if (m_representation == PlatformLayerRepresentation)
-            retainPlatformLayer(m_typelessPlatformLayer);
-    }
-
-    ~LayerRepresentation()
-    {
-        if (m_representation == PlatformLayerRepresentation)
-            releasePlatformLayer(m_typelessPlatformLayer);
-    }
+        : m_data(Markable<PlatformLayerIdentifier> { layerID })
+    { }
 
     explicit operator GraphicsLayer*() const
     {
-        ASSERT(m_representation == GraphicsLayerRepresentation);
-        return m_graphicsLayer.get();
+        ASSERT(std::holds_alternative<GraphicsLayerData>(m_data));
+        return std::get<GraphicsLayerData>(m_data).graphicsLayer.get();
     }
 
     explicit operator ScrollingPlatformLayer*() const
     {
-        ASSERT(m_representation == PlatformLayerRepresentation);
-        return makePlatformLayerTyped(m_typelessPlatformLayer);
+        ASSERT(std::holds_alternative<PlatformLayerHolder>(m_data));
+        return std::get<PlatformLayerHolder>(m_data).get();
     }
-    
+
     std::optional<PlatformLayerIdentifier> layerID() const
     {
-        return m_layerID.asOptional();
-    }
-
-    LayerRepresentation& operator=(const LayerRepresentation& other)
-    {
-        if (this == &other)
-            return *this;
-
-        if (m_representation == PlatformLayerRepresentation && other.m_representation == PlatformLayerRepresentation) {
-            retainPlatformLayer(other.m_typelessPlatformLayer);
-            releasePlatformLayer(m_typelessPlatformLayer);
-        } else if (m_representation == PlatformLayerRepresentation)
-            releasePlatformLayer(m_typelessPlatformLayer);
-        else if (other.m_representation == PlatformLayerRepresentation)
-            retainPlatformLayer(other.m_typelessPlatformLayer);
-
-        m_graphicsLayer = other.m_graphicsLayer;
-        m_typelessPlatformLayer = other.m_typelessPlatformLayer;
-        m_layerID = other.m_layerID;
-        m_representation = other.m_representation;
-
-        return *this;
+        return WTF::switchOn(m_data,
+            [](const GraphicsLayerData& data) -> std::optional<PlatformLayerIdentifier> { return data.layerID.asOptional(); },
+            [](const Markable<PlatformLayerIdentifier>& layerID) -> std::optional<PlatformLayerIdentifier> { return layerID.asOptional(); },
+            [](const auto&) -> std::optional<PlatformLayerIdentifier> { return std::nullopt; }
+        );
     }
 
     explicit operator bool() const
     {
-        switch (m_representation) {
-        case EmptyRepresentation:
-            return false;
-        case GraphicsLayerRepresentation:
-            return !!m_graphicsLayer;
-        case PlatformLayerRepresentation:
-            return !!m_typelessPlatformLayer;
-        case PlatformLayerIDRepresentation:
-            return !!m_layerID;
-        }
-        ASSERT_NOT_REACHED();
-        return false;
+        return WTF::switchOn(m_data,
+            [](std::monostate) { return false; },
+            [](const GraphicsLayerData& data) { return !!data.graphicsLayer; },
+            [](const PlatformLayerHolder& holder) { return !!holder; },
+            [](const Markable<PlatformLayerIdentifier>& layerID) { return !!layerID; }
+        );
     }
 
-    bool operator==(const LayerRepresentation& other) const
-    {
-        if (m_representation != other.m_representation)
-            return false;
-        switch (m_representation) {
-        case EmptyRepresentation:
-            return true;
-        case GraphicsLayerRepresentation:
-            return m_graphicsLayer == other.m_graphicsLayer
-                && m_layerID == other.m_layerID;
-        case PlatformLayerRepresentation:
-            return m_typelessPlatformLayer == other.m_typelessPlatformLayer;
-        case PlatformLayerIDRepresentation:
-            return m_layerID == other.m_layerID;
-        }
-        ASSERT_NOT_REACHED();
-        return true;
-    }
-    
+    bool operator==(const LayerRepresentation& other) const = default;
+
     LayerRepresentation toRepresentation(Type representation) const
     {
         switch (representation) {
-        case EmptyRepresentation:
-            return LayerRepresentation();
-        case GraphicsLayerRepresentation:
-            ASSERT(m_representation == GraphicsLayerRepresentation);
-            return LayerRepresentation(m_graphicsLayer.get());
-        case PlatformLayerRepresentation:
-            return m_graphicsLayer ? platformLayerFromGraphicsLayer(Ref { *m_graphicsLayer }) : nullptr;
+        case GraphicsLayerRepresentation: {
+            ASSERT(std::holds_alternative<GraphicsLayerData>(m_data));
+            auto& data = std::get<GraphicsLayerData>(m_data);
+            return LayerRepresentation(data.graphicsLayer.get());
+        }
+        case PlatformLayerRepresentation: {
+            if (std::holds_alternative<GraphicsLayerData>(m_data)) {
+                auto& data = std::get<GraphicsLayerData>(m_data);
+                if (data.graphicsLayer)
+                    return platformLayerFromGraphicsLayer(Ref { *data.graphicsLayer });
+            }
+            return static_cast<ScrollingPlatformLayer*>(nullptr);
+        }
         case PlatformLayerIDRepresentation:
-            return LayerRepresentation(m_layerID);
+            return LayerRepresentation(layerID());
         }
         ASSERT_NOT_REACHED();
         return LayerRepresentation();
     }
 
-    bool representsGraphicsLayer() const { return m_representation == GraphicsLayerRepresentation; }
-    bool representsPlatformLayerID() const { return m_representation == PlatformLayerIDRepresentation; }
-    
+    bool representsGraphicsLayer() const { return std::holds_alternative<GraphicsLayerData>(m_data); }
+    bool representsPlatformLayerID() const { return std::holds_alternative<Markable<PlatformLayerIdentifier>>(m_data); }
+
 private:
-    WEBCORE_EXPORT static void retainPlatformLayer(void* typelessPlatformLayer);
-    WEBCORE_EXPORT static void releasePlatformLayer(void* typelessPlatformLayer);
-    WEBCORE_EXPORT static ScrollingPlatformLayer* makePlatformLayerTyped(void* typelessPlatformLayer);
-    WEBCORE_EXPORT static void* makePlatformLayerTypeless(ScrollingPlatformLayer*);
+    struct GraphicsLayerData {
+        RefPtr<GraphicsLayer> graphicsLayer;
+        Markable<PlatformLayerIdentifier> layerID;
+
+        friend bool operator==(const GraphicsLayerData&, const GraphicsLayerData&) = default;
+    };
+
     WEBCORE_EXPORT static ScrollingPlatformLayer* platformLayerFromGraphicsLayer(GraphicsLayer&);
 
-    RefPtr<GraphicsLayer> m_graphicsLayer;
-    void* m_typelessPlatformLayer { nullptr };
-    Markable<PlatformLayerIdentifier> m_layerID;
-    Type m_representation { EmptyRepresentation };
+    Variant<std::monostate, GraphicsLayerData, PlatformLayerHolder, Markable<PlatformLayerIdentifier>> m_data;
 };
 
 enum class ScrollingStateNodeProperty : uint64_t {

--- a/Source/WebCore/page/scrolling/ScrollingStateStickyNode.h
+++ b/Source/WebCore/page/scrolling/ScrollingStateStickyNode.h
@@ -56,7 +56,7 @@ private:
     ScrollingStateStickyNode(ScrollingStateTree&, ScrollingNodeID);
     ScrollingStateStickyNode(const ScrollingStateStickyNode&, ScrollingStateTree&);
 
-    FloatPoint NODELETE computeClippingLayerPosition(const LayoutRect& viewportRect) const;
+    FloatPoint computeClippingLayerPosition(const LayoutRect& viewportRect) const;
     FloatPoint computeAnchorLayerPosition(const LayoutRect& viewportRect) const;
     void reconcileLayerPositionForViewportRect(const LayoutRect& viewportRect, ScrollingLayerPositionAction) final;
     FloatSize scrollDeltaSinceLastCommit(const LayoutRect& viewportRect) const;
@@ -64,7 +64,7 @@ private:
     void dumpProperties(WTF::TextStream&, OptionSet<ScrollingStateTreeAsTextBehavior>) const final;
     OptionSet<ScrollingStateNode::Property> applicableProperties() const final;
 
-    bool NODELETE hasViewportClippingLayer() const;
+    bool hasViewportClippingLayer() const;
 
     StickyPositionViewportConstraints m_constraints;
     LayerRepresentation m_viewportAnchorLayer;

--- a/Source/WebCore/page/scrolling/cocoa/ScrollingStateNode.mm
+++ b/Source/WebCore/page/scrolling/cocoa/ScrollingStateNode.mm
@@ -30,28 +30,6 @@
 
 namespace WebCore {
 
-void LayerRepresentation::retainPlatformLayer(void* typelessLayer)
-{
-    if (typelessLayer)
-        CFRetain(typelessLayer);
-}
-
-void LayerRepresentation::releasePlatformLayer(void* typelessLayer)
-{
-    if (typelessLayer)
-        CFRelease(typelessLayer);
-}
-
-CALayer *NODELETE LayerRepresentation::makePlatformLayerTyped(void* typelessLayer)
-{
-    return (__bridge CALayer *)typelessLayer;
-}
-
-void* LayerRepresentation::makePlatformLayerTypeless(CALayer *layer)
-{
-    return (__bridge void*)layer;
-}
-
 CALayer* LayerRepresentation::platformLayerFromGraphicsLayer(GraphicsLayer& graphicsLayer)
 {
     return graphicsLayer.platformLayer();

--- a/Source/WebCore/page/scrolling/coordinated/ScrollingStateNodeCoordinated.cpp
+++ b/Source/WebCore/page/scrolling/coordinated/ScrollingStateNodeCoordinated.cpp
@@ -28,32 +28,9 @@
 #include "ScrollingStateNode.h"
 
 #if ENABLE(ASYNC_SCROLLING) && USE(COORDINATED_GRAPHICS)
-#include "CoordinatedPlatformLayer.h"
 #include "GraphicsLayerCoordinated.h"
 
 namespace WebCore {
-
-void LayerRepresentation::retainPlatformLayer(void* typelessLayer)
-{
-    if (auto* layer = makePlatformLayerTyped(typelessLayer))
-        layer->ref();
-}
-
-void LayerRepresentation::releasePlatformLayer(void* typelessLayer)
-{
-    if (auto* layer = makePlatformLayerTyped(typelessLayer))
-        layer->deref();
-}
-
-CoordinatedPlatformLayer* LayerRepresentation::makePlatformLayerTyped(void* typelessLayer)
-{
-    return static_cast<CoordinatedPlatformLayer*>(typelessLayer);
-}
-
-void* LayerRepresentation::makePlatformLayerTypeless(CoordinatedPlatformLayer* layer)
-{
-    return layer;
-}
 
 CoordinatedPlatformLayer* LayerRepresentation::platformLayerFromGraphicsLayer(GraphicsLayer& graphicsLayer)
 {


### PR DESCRIPTION
#### a5b860e05c652460c5caa88c10512b427dbb1151
<pre>
Convert LayerRepresentation to use a variant
<a href="https://rdar.apple.com/176512851">rdar://176512851</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=314363">https://bugs.webkit.org/show_bug.cgi?id=314363</a>

Reviewed by Abrar Rahman Protyasha and Sam Weinig.

LayerRepresentation is basically a variant&lt;&gt; in disguise, so make it use one
internally (hiding clients from dealing with the ugliness of variant&lt;&gt; directly).
This removes the error-prone manual ref-counting.

* Source/WebCore/SaferCPPExpectations/ForwardDeclCheckerExpectations:
* Source/WebCore/page/scrolling/ScrollingStateNode.h:
(WebCore::LayerRepresentation::LayerRepresentation):
(WebCore::LayerRepresentation::operator GraphicsLayer* const):
(WebCore::LayerRepresentation::operator ScrollingPlatformLayer* const):
(WebCore::LayerRepresentation::layerID const):
(WebCore::LayerRepresentation::operator bool const):
(WebCore::LayerRepresentation::toRepresentation const):
(WebCore::LayerRepresentation::representsGraphicsLayer const):
(WebCore::LayerRepresentation::representsPlatformLayerID const):
(WebCore::LayerRepresentation::m_representation): Deleted.
(WebCore::LayerRepresentation::~LayerRepresentation): Deleted.
(WebCore::LayerRepresentation::operator=): Deleted.
(WebCore::LayerRepresentation::operator== const):
* Source/WebCore/page/scrolling/ScrollingStateStickyNode.h:
* Source/WebCore/page/scrolling/cocoa/ScrollingStateNode.mm:
(WebCore::LayerRepresentation::retainPlatformLayer): Deleted.
(WebCore::LayerRepresentation::releasePlatformLayer): Deleted.
(WebCore::LayerRepresentation::makePlatformLayerTyped): Deleted.
(WebCore::LayerRepresentation::makePlatformLayerTypeless): Deleted.
* Source/WebCore/page/scrolling/coordinated/ScrollingStateNodeCoordinated.cpp:
(WebCore::LayerRepresentation::retainPlatformLayer): Deleted.
(WebCore::LayerRepresentation::releasePlatformLayer): Deleted.
(WebCore::LayerRepresentation::makePlatformLayerTyped): Deleted.
(WebCore::LayerRepresentation::makePlatformLayerTypeless): Deleted.

Canonical link: <a href="https://commits.webkit.org/313219@main">https://commits.webkit.org/313219@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f4240c99d338a870f7c874cee5a761085a942a09

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/162375 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/35851 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/28967 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/171313 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/118820 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/164244 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/35955 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/35853 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/126003 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/118820 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/165334 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/28338 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/145860 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/106581 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/27385 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/25917 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/19013 "Built successfully") | | 
| [⏳ 🛠 🧪 jsc ](https://ews-build.webkit.org/#/builders/JSC-Tests-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/137088 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/23593 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/173817 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/21130 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/25237 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/134311 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/35525 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/30006 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/134311 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36269 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/35509 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/145389 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/97764 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/28845 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/22220 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/35018 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/102770 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/34520 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/34765 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/34668 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->