### PR TITLE
[threaded-animations] animating `offset-path` between `margin-box` and `stroke-box` yields a crash under `AcceleratedEffectValues::AcceleratedEffectValues(WebCore::RenderStyle const&, WebCore::IntRect const&, WebCore::RenderLayerModelObject const*)`

### DIFF
--- a/LayoutTests/webanimations/threaded-animations/threaded-animation-offset-path-margin-box-crash-expected.txt
+++ b/LayoutTests/webanimations/threaded-animations/threaded-animation-offset-path-margin-box-crash-expected.txt
@@ -1,0 +1,2 @@
+Test passes if it does not crash.
+

--- a/LayoutTests/webanimations/threaded-animations/threaded-animation-offset-path-margin-box-crash.html
+++ b/LayoutTests/webanimations/threaded-animations/threaded-animation-offset-path-margin-box-crash.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html><!-- webkit-test-runner [ ThreadedTimeBasedAnimationsEnabled=true ] -->
+<style>
+#target {
+    width: 100px;
+    height: 100px;
+    background-color: black;
+    offset-path: margin-box;
+}
+</style>
+Test passes if it does not crash.
+<div id="target"></div>
+<script>
+(async () => {
+    window.testRunner?.dumpAsText();
+    window.testRunner?.waitUntilDone();
+    const animation = document.getElementById("target").animate(
+        { transform: "translateX(100px)", offsetPath: ["margin-box", "stroke-box"] },
+        1000
+    );
+    await animation.ready;
+    await new Promise(setTimeout);
+    window.testRunner?.notifyDone();
+})();
+</script>

--- a/Source/WebCore/platform/animation/values/paths/AcceleratedEffectCoordBox.h
+++ b/Source/WebCore/platform/animation/values/paths/AcceleratedEffectCoordBox.h
@@ -29,8 +29,13 @@
 
 namespace WebCore {
 
+// FIXME: The Motion Path spec calls for this to be a <coord-box>, not a <geometry-box>, the difference being that the former does not contain "margin-box" as a valid term.
+// However, the spec also has a few examples using "margin-box", so there seems to be some abiguity to be resolved. See: https://github.com/w3c/fxtf-drafts/issues/481
+// We currently parse it as a <geometry-box>, so "margin-box" is included.
+
 enum class AcceleratedEffectCoordBox : uint8_t {
     ContentBox,
+    MarginBox,
     PaddingBox,
     BorderBox,
     FillBox,

--- a/Source/WebCore/style/values/shapes/StylePathOperationWrappers.cpp
+++ b/Source/WebCore/style/values/shapes/StylePathOperationWrappers.cpp
@@ -154,8 +154,9 @@ static std::optional<AcceleratedEffectCoordBox> toAcceleratedEffectCoordBox(CSSB
 {
     switch (boxType) {
     case CSSBoxType::BoxMissing:
-    case CSSBoxType::MarginBox:
         return std::nullopt;
+    case CSSBoxType::MarginBox:
+        return AcceleratedEffectCoordBox::MarginBox;
     case CSSBoxType::BorderBox:
         return AcceleratedEffectCoordBox::BorderBox;
     case CSSBoxType::PaddingBox:

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -6469,6 +6469,7 @@ struct WebCore::AcceleratedEffectOpacity {
 
 enum class WebCore::AcceleratedEffectCoordBox : uint8_t {
     ContentBox,
+    MarginBox,
     PaddingBox,
     BorderBox,
     FillBox,


### PR DESCRIPTION
#### 1b01b6d32c396d50e97c949ac2bf82052dc4bb18
<pre>
[threaded-animations] animating `offset-path` between `margin-box` and `stroke-box` yields a crash under `AcceleratedEffectValues::AcceleratedEffectValues(WebCore::RenderStyle const&amp;, WebCore::IntRect const&amp;, WebCore::RenderLayerModelObject const*)`
<a href="https://bugs.webkit.org/show_bug.cgi?id=314105">https://bugs.webkit.org/show_bug.cgi?id=314105</a>

Reviewed by Antoine Quint.

Add missing support for `margin-box` to AcceleratedEffectCoordBox.

The reason it was originally omitted was due to some spec/name
confusion. The Motion Path spec calls for the use of `&lt;coord-box&gt;`
which does not include &apos;margin-box&apos;, however, we currently parse
and store a `&lt;geometry-box&gt;` value, which does include &apos;margin-box&apos;,
matching a few examples in the spec and WPT. The spec issue is
tracked in <a href="https://github.com/w3c/fxtf-drafts/issues/481.">https://github.com/w3c/fxtf-drafts/issues/481.</a>

Test: webanimations/threaded-animations/threaded-animation-offset-path-margin-box-crash.html
* LayoutTests/webanimations/threaded-animations/threaded-animation-offset-path-margin-box-crash-expected.txt: Added.
* LayoutTests/webanimations/threaded-animations/threaded-animation-offset-path-margin-box-crash.html: Added.
* Source/WebCore/platform/animation/values/paths/AcceleratedEffectCoordBox.h:
* Source/WebCore/style/values/shapes/StylePathOperationWrappers.cpp:
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:

Canonical link: <a href="https://commits.webkit.org/312881@main">https://commits.webkit.org/312881@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fe093573f65354a7eeb47ee4415f4078b0dee343

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/161303 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/34776 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/27877 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/170206 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/117674 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/163172 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/34877 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/34777 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/125119 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/117674 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/164262 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/27406 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/144888 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/105716 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/26454 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/24965 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/17926 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/136148 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/22648 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/172689 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/19710 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/24289 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/133401 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/34450 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/29058 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/133409 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36048 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/34435 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/144443 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/96300 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/27947 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/21261 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/33945 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/101370 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/33444 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/33688 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/33593 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->