### PR TITLE
Address multiple-shadow-transitions.html flakiness

### DIFF
--- a/LayoutTests/transitions/resources/transition-test-helpers.js
+++ b/LayoutTests/transitions/resources/transition-test-helpers.js
@@ -192,7 +192,7 @@ function checkExpectedValueCallback(expected, index)
 }
 
 const prefix = "-webkit-";
-const propertiesRequiringPrefix = ["-webkit-text-stroke-color", "-webkit-text-fill-color"];
+const propertiesRequiringPrefix = ["-webkit-box-shadow", "-webkit-text-stroke-color", "-webkit-text-fill-color"];
 
 function pauseTransitionAtTimeOnElement(transitionProperty, time, element)
 {


### PR DESCRIPTION
#### 7afee66099384d808e5573f9f99a49068fcec689
<pre>
Address multiple-shadow-transitions.html flakiness
<a href="https://bugs.webkit.org/show_bug.cgi?id=114187">https://bugs.webkit.org/show_bug.cgi?id=114187</a>
<a href="https://rdar.apple.com/problem/176520800">rdar://problem/176520800</a>

Reviewed by Dan Glastonbury.

The test&apos;s pauseTransitionAtTimeOnElement helper strips the -webkit-
prefix and looks for a CSSTransition with transitionProperty == &quot;box-shadow&quot;,
but -webkit-box-shadow is a cascade alias of box-shadow, which means in
specified style (and animations) it keeps it original name. Since the
CSSTransition cannot be found with the unprefixed name, the test ends up
sampling the transition at an indeterminate time.

* LayoutTests/transitions/resources/transition-test-helpers.js:

Canonical link: <a href="https://commits.webkit.org/312925@main">https://commits.webkit.org/312925@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a03118069bcbd5989f71f93815bd06fa34fa3113

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/161316 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/34789 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/27890 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/170219 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/117687 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/14f60b96-f39e-4ab3-ac40-dbac171f4107) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/34890 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/34790 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/125135 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/88186 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/7d643ba0-f9f6-4ec0-9078-aa7a605d27bb) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/164275 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/27420 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/144903 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/105732 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/3dbe8b95-bafd-4400-a888-558d7165b59c) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/26468 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/24982 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/17939 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/136162 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/22663 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/172702 "Built successfully") | | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/24304 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/133415 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/34463 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/29074 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/133423 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36091 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/34448 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/144458 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/96313 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/27962 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/21276 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/33958 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/33457 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/33701 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/33606 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->