### PR TITLE
Convert image numeric primitive components to strong CSS/Style types

### DIFF
--- a/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
@@ -147,7 +147,6 @@ bridge/runtime_root.cpp
 crypto/parameters/CryptoAlgorithmRsaKeyGenParams.h
 css/CSSCounterStyleDescriptors.cpp
 css/CSSCounterStyleRule.h
-css/CSSCursorImageValue.cpp
 css/CSSFontFace.cpp
 css/CSSFontFaceRule.cpp
 css/CSSFontValue.cpp

--- a/Source/WebCore/css/CSSCrossfadeValue.cpp
+++ b/Source/WebCore/css/CSSCrossfadeValue.cpp
@@ -29,39 +29,42 @@
 
 #include "StyleBuilderState.h"
 #include "StyleCrossfadeImage.h"
+#include "StylePrimitiveNumericTypes+Conversions.h"
 #include <wtf/text/MakeString.h>
 
 namespace WebCore {
 
-inline CSSCrossfadeValue::CSSCrossfadeValue(Ref<CSSValue>&& fromValueOrNone, Ref<CSSValue>&& toValueOrNone, Ref<CSSPrimitiveValue>&& percentageValue, bool isPrefixed)
+inline CSSCrossfadeValue::CSSCrossfadeValue(Ref<CSSValue>&& fromValueOrNone, Ref<CSSValue>&& toValueOrNone, Progress&& progress, bool isPrefixed)
     : CSSValue { ClassType::Crossfade }
     , m_fromValueOrNone { WTF::move(fromValueOrNone) }
     , m_toValueOrNone { WTF::move(toValueOrNone) }
-    , m_percentageValue { WTF::move(percentageValue) }
+    , m_progress { WTF::move(progress) }
     , m_isPrefixed { isPrefixed }
 {
 }
 
-Ref<CSSCrossfadeValue> CSSCrossfadeValue::create(Ref<CSSValue>&& fromValueOrNone, Ref<CSSValue>&& toValueOrNone, Ref<CSSPrimitiveValue>&& percentageValue, bool isPrefixed)
+Ref<CSSCrossfadeValue> CSSCrossfadeValue::create(Ref<CSSValue>&& fromValueOrNone, Ref<CSSValue>&& toValueOrNone, Progress&& progress, bool isPrefixed)
 {
-    return adoptRef(*new CSSCrossfadeValue(WTF::move(fromValueOrNone), WTF::move(toValueOrNone), WTF::move(percentageValue), isPrefixed));
+    return adoptRef(*new CSSCrossfadeValue(WTF::move(fromValueOrNone), WTF::move(toValueOrNone), WTF::move(progress), isPrefixed));
 }
 
 CSSCrossfadeValue::~CSSCrossfadeValue() = default;
 
 bool CSSCrossfadeValue::equals(const CSSCrossfadeValue& other) const
 {
-    return equalInputImages(other) && compareCSSValue(m_percentageValue, other.m_percentageValue);
+    return equalInputImages(other)
+        && m_progress == other.m_progress;
 }
 
 bool CSSCrossfadeValue::equalInputImages(const CSSCrossfadeValue& other) const
 {
-    return compareCSSValue(m_fromValueOrNone, other.m_fromValueOrNone) && compareCSSValue(m_toValueOrNone, other.m_toValueOrNone);
+    return compareCSSValue(m_fromValueOrNone, other.m_fromValueOrNone)
+        && compareCSSValue(m_toValueOrNone, other.m_toValueOrNone);
 }
 
 String CSSCrossfadeValue::customCSSText(const CSS::SerializationContext& context) const
 {
-    return makeString(m_isPrefixed ? "-webkit-"_s : ""_s, "cross-fade("_s, m_fromValueOrNone->cssText(context), ", "_s, m_toValueOrNone->cssText(context), ", "_s, m_percentageValue->cssText(context), ')');
+    return makeString(m_isPrefixed ? "-webkit-"_s : ""_s, "cross-fade("_s, m_fromValueOrNone->cssText(context), ", "_s, m_toValueOrNone->cssText(context), ", "_s, CSS::serializationForCSS(context, m_progress), ')');
 }
 
 RefPtr<Style::Image> CSSCrossfadeValue::createStyleImage(const Style::BuilderState& state) const
@@ -69,7 +72,7 @@ RefPtr<Style::Image> CSSCrossfadeValue::createStyleImage(const Style::BuilderSta
     return Style::CrossfadeImage::create(
         state.createStyleImage(m_fromValueOrNone),
         state.createStyleImage(m_toValueOrNone),
-        clampTo<double>(m_percentageValue->valueDividingBy100IfPercentage<double>(state.cssToLengthConversionData()), 0, 1),
+        Style::toStyle(m_progress, state),
         m_isPrefixed
     );
 }

--- a/Source/WebCore/css/CSSCrossfadeValue.h
+++ b/Source/WebCore/css/CSSCrossfadeValue.h
@@ -25,7 +25,7 @@
 
 #pragma once
 
-#include "CSSPrimitiveValue.h"
+#include "CSSPrimitiveNumericTypes.h"
 #include "CSSValue.h"
 #include <wtf/Function.h>
 
@@ -38,7 +38,9 @@ class Image;
 
 class CSSCrossfadeValue final : public CSSValue {
 public:
-    static Ref<CSSCrossfadeValue> NODELETE create(Ref<CSSValue>&& fromValueOrNone, Ref<CSSValue>&& toValueOrNone, Ref<CSSPrimitiveValue>&& percentageValue, bool isPrefixed = false);
+    using Progress = CSS::NumberOrPercentageResolvedToNumber<CSS::ClosedUnitRangeClampBoth, CSS::ClosedPercentageRangeClampBoth>;
+
+    static Ref<CSSCrossfadeValue> create(Ref<CSSValue>&& fromValueOrNone, Ref<CSSValue>&& toValueOrNone, Progress&&, bool isPrefixed);
 
     ~CSSCrossfadeValue();
 
@@ -56,17 +58,15 @@ public:
             return IterationStatus::Done;
         if (func(m_toValueOrNone.get()) == IterationStatus::Done)
             return IterationStatus::Done;
-        if (func(m_percentageValue.get()) == IterationStatus::Done)
-            return IterationStatus::Done;
         return IterationStatus::Continue;
     }
 
 private:
-    CSSCrossfadeValue(Ref<CSSValue>&& fromValueOrNone, Ref<CSSValue>&& toValueOrNone, Ref<CSSPrimitiveValue>&& percentageValue, bool isPrefixed);
+    CSSCrossfadeValue(Ref<CSSValue>&& fromValueOrNone, Ref<CSSValue>&& toValueOrNone, Progress&&, bool isPrefixed);
 
     const Ref<CSSValue> m_fromValueOrNone;
     const Ref<CSSValue> m_toValueOrNone;
-    const Ref<CSSPrimitiveValue> m_percentageValue;
+    const Progress m_progress;
     bool m_isPrefixed;
 };
 

--- a/Source/WebCore/css/CSSCursorImageValue.cpp
+++ b/Source/WebCore/css/CSSCursorImageValue.cpp
@@ -23,33 +23,32 @@
 #include "config.h"
 #include "CSSCursorImageValue.h"
 
-#include "CSSImageSetValue.h"
 #include "CSSImageValue.h"
 #include "StyleBuilderState.h"
 #include "StyleCursorImage.h"
-#include <wtf/MathExtras.h>
+#include "StylePrimitiveNumericTypes+Conversions.h"
 #include <wtf/text/MakeString.h>
 #include <wtf/text/WTFString.h>
 
 namespace WebCore {
 
-Ref<CSSCursorImageValue> CSSCursorImageValue::create(Ref<CSSValue>&& value, RefPtr<CSSValue>&& hotSpot)
+Ref<CSSCursorImageValue> CSSCursorImageValue::create(Ref<CSSValue>&& value, std::optional<HotSpot>&& hotSpot)
 {
     auto* imageValue = dynamicDowncast<CSSImageValue>(value.get());
     auto originalURL = imageValue ? imageValue->url() : CSS::URL::none();
     return adoptRef(*new CSSCursorImageValue(WTF::move(value), WTF::move(hotSpot), WTF::move(originalURL)));
 }
 
-Ref<CSSCursorImageValue> CSSCursorImageValue::create(Ref<CSSValue>&& imageValue, RefPtr<CSSValue>&& hotSpot, CSS::URL&& originalURL)
+Ref<CSSCursorImageValue> CSSCursorImageValue::create(Ref<CSSValue>&& imageValue, std::optional<HotSpot>&& hotSpot, CSS::URL&& originalURL)
 {
     return adoptRef(*new CSSCursorImageValue(WTF::move(imageValue), WTF::move(hotSpot), WTF::move(originalURL)));
 }
 
-CSSCursorImageValue::CSSCursorImageValue(Ref<CSSValue>&& imageValue, RefPtr<CSSValue>&& hotSpot, CSS::URL&& originalURL)
+CSSCursorImageValue::CSSCursorImageValue(Ref<CSSValue>&& imageValue, std::optional<HotSpot>&& hotSpot, CSS::URL&& originalURL)
     : CSSValue(ClassType::CursorImage)
-    , m_originalURL(WTF::move(originalURL))
     , m_imageValue(WTF::move(imageValue))
     , m_hotSpot(WTF::move(hotSpot))
+    , m_originalURL(WTF::move(originalURL))
 {
 }
 
@@ -60,13 +59,13 @@ String CSSCursorImageValue::customCSSText(const CSS::SerializationContext& conte
     auto text = m_imageValue->cssText(context);
     if (!m_hotSpot)
         return text;
-    return makeString(text, ' ', m_hotSpot->first().cssText(context), ' ', m_hotSpot->second().cssText(context));
+    return makeString(text, ' ', CSS::serializationForCSS(context, *m_hotSpot));
 }
 
 bool CSSCursorImageValue::equals(const CSSCursorImageValue& other) const
 {
     return compareCSSValue(m_imageValue, other.m_imageValue)
-        && compareCSSValuePtr(m_hotSpot, other.m_hotSpot);
+        && m_hotSpot == other.m_hotSpot;
 }
 
 RefPtr<Style::CursorImage> CSSCursorImageValue::createStyleImage(const Style::BuilderState& state) const
@@ -75,15 +74,11 @@ RefPtr<Style::CursorImage> CSSCursorImageValue::createStyleImage(const Style::Bu
     if (!styleImage)
         return nullptr;
 
-    std::optional<IntPoint> hotSpot;
-    if (m_hotSpot) {
-        // FIXME: Should we clamp or round instead of just casting from double to int?
-        hotSpot = IntPoint {
-            static_cast<int>(downcast<CSSPrimitiveValue>(m_hotSpot->first()).resolveAsNumber(state.cssToLengthConversionData())),
-            static_cast<int>(downcast<CSSPrimitiveValue>(m_hotSpot->second()).resolveAsNumber(state.cssToLengthConversionData()))
-        };
-    }
-    return Style::CursorImage::create(styleImage.releaseNonNull(), hotSpot, Style::toStyle(m_originalURL, state));
+    return Style::CursorImage::create(
+        styleImage.releaseNonNull(),
+        Style::toStyle(m_hotSpot, state),
+        Style::toStyle(m_originalURL, state)
+    );
 }
 
 } // namespace WebCore

--- a/Source/WebCore/css/CSSCursorImageValue.h
+++ b/Source/WebCore/css/CSSCursorImageValue.h
@@ -20,11 +20,10 @@
 
 #pragma once
 
+#include "CSSPrimitiveNumericTypes.h"
 #include "CSSURL.h"
 #include "CSSValue.h"
 #include "CSSValuePair.h"
-#include "IntPoint.h"
-#include <wtf/WeakHashSet.h>
 
 namespace WebCore {
 
@@ -36,8 +35,10 @@ class Image;
 
 class CSSCursorImageValue final : public CSSValue {
 public:
-    static Ref<CSSCursorImageValue> create(Ref<CSSValue>&& imageValue, RefPtr<CSSValue>&& hotSpot);
-    static Ref<CSSCursorImageValue> NODELETE create(Ref<CSSValue>&& imageValue, RefPtr<CSSValue>&& hotSpot, CSS::URL&&);
+    using HotSpot = SpaceSeparatedPoint<CSS::Number<>>;
+
+    static Ref<CSSCursorImageValue> create(Ref<CSSValue>&& imageValue, std::optional<HotSpot>&&);
+    static Ref<CSSCursorImageValue> NODELETE create(Ref<CSSValue>&& imageValue, std::optional<HotSpot>&&, CSS::URL&&);
     ~CSSCursorImageValue();
 
     const CSS::URL& originalURL() const LIFETIME_BOUND { return m_originalURL; }
@@ -53,11 +54,11 @@ public:
     RefPtr<Style::CursorImage> createStyleImage(const Style::BuilderState&) const;
 
 private:
-    CSSCursorImageValue(Ref<CSSValue>&& imageValue, RefPtr<CSSValue>&& hotSpot, CSS::URL&&);
+    CSSCursorImageValue(Ref<CSSValue>&& imageValue, std::optional<HotSpot>&&, CSS::URL&&);
 
-    CSS::URL m_originalURL;
     const Ref<CSSValue> m_imageValue;
-    const RefPtr<CSSValue> m_hotSpot;
+    const std::optional<HotSpot> m_hotSpot;
+    CSS::URL m_originalURL;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/css/parser/CSSPropertyParserConsumer+Image.cpp
+++ b/Source/WebCore/css/parser/CSSPropertyParserConsumer+Image.cpp
@@ -990,15 +990,16 @@ static RefPtr<CSSValue> consumeCrossFade(CSSParserTokenRange& args, CSS::Propert
     if (!toImageValueOrNone || !consumeCommaIncludingWhitespace(args))
         return nullptr;
 
-    auto value = consumePercentageDividedBy100OrNumber(args, state);
-    if (!value)
+    auto numberOrPercentage = MetaConsumer<CSS::Number<CSS::ClosedUnitRangeClampBoth>, CSS::Percentage<CSS::ClosedPercentageRangeClampBoth>>::consume(args, state);
+    if (!numberOrPercentage)
         return nullptr;
 
-    if (value->isNumber()) {
-        if (auto numberValue = value->resolveAsNumberIfNotCalculated(); numberValue && (*numberValue < 0 || *numberValue > 1))
-            value = CSSPrimitiveValue::create(clampTo<double>(*numberValue, 0, 1));
-    }
-    return CSSCrossfadeValue::create(fromImageValueOrNone.releaseNonNull(), toImageValueOrNone.releaseNonNull(), value.releaseNonNull(), functionId == CSSValueWebkitCrossFade);
+    return CSSCrossfadeValue::create(
+        fromImageValueOrNone.releaseNonNull(),
+        toImageValueOrNone.releaseNonNull(),
+        WTF::move(*numberOrPercentage),
+        functionId == CSSValueWebkitCrossFade
+    );
 }
 
 // MARK: <-webkit-canvas()>

--- a/Source/WebCore/css/parser/CSSPropertyParserConsumer+UI.cpp
+++ b/Source/WebCore/css/parser/CSSPropertyParserConsumer+UI.cpp
@@ -30,9 +30,9 @@
 #include "CSSParserContext.h"
 #include "CSSParserTokenRange.h"
 #include "CSSPrimitiveValue.h"
-#include "CSSPropertyParserConsumer+CSSPrimitiveValueResolver.h"
 #include "CSSPropertyParserConsumer+Ident.h"
 #include "CSSPropertyParserConsumer+Image.h"
+#include "CSSPropertyParserConsumer+MetaConsumer.h"
 #include "CSSPropertyParserConsumer+NumberDefinitions.h"
 #include "CSSPropertyParserConsumer+Primitives.h"
 #include "CSSPropertyParserState.h"
@@ -50,12 +50,12 @@ RefPtr<CSSValue> consumeCursor(CSSParserTokenRange& range, CSS::PropertyParserSt
 
     CSSValueListBuilder list;
     while (auto image = consumeImage(range, state, { AllowedImageType::URLFunction, AllowedImageType::ImageSet })) {
-        RefPtr<CSSValuePair> hotSpot;
-        if (auto x = CSSPrimitiveValueResolver<CSS::Number<>>::consumeAndResolve(range, state)) {
-            auto y = CSSPrimitiveValueResolver<CSS::Number<>>::consumeAndResolve(range, state);
+        std::optional<CSSCursorImageValue::HotSpot> hotSpot;
+        if (auto x = MetaConsumer<CSS::Number<>>::consume(range, state)) {
+            auto y = MetaConsumer<CSS::Number<>>::consume(range, state);
             if (!y)
                 return nullptr;
-            hotSpot = CSSValuePair::createNoncoalescing(x.releaseNonNull(), y.releaseNonNull());
+            hotSpot = { WTF::move(*x), WTF::move(*y) };
         }
         list.append(CSSCursorImageValue::create(image.releaseNonNull(), WTF::move(hotSpot)));
         if (!consumeCommaIncludingWhitespace(range))

--- a/Source/WebCore/css/values/primitives/CSSPrimitiveNumericRange.h
+++ b/Source/WebCore/css/values/primitives/CSSPrimitiveNumericRange.h
@@ -122,6 +122,10 @@ inline constexpr auto ClosedPercentageRangeUnzoomed = Range { 0, 100, RangeClamp
 inline constexpr auto ClosedPercentageRangeClampUpper = Range { 0, 100, RangeClampOptions::ClampUpper };
 inline constexpr auto ClosedPercentageRangeClampUpperUnzoomed = Range { 0, 100, RangeClampOptions::ClampUpper, RangeZoomOptions::Unzoomed };
 
+// Constant value for `[0,100(clamp both)]`.
+inline constexpr auto ClosedPercentageRangeClampBoth = Range { 0, 100, RangeClampOptions::ClampBoth };
+inline constexpr auto ClosedPercentageRangeClampBothUnzoomed = Range { 0, 100, RangeClampOptions::ClampBoth, RangeZoomOptions::Unzoomed };
+
 // Clamps a floating point value to within `range`.
 template<Range range, std::floating_point T, typename U> constexpr T clampToRange(U value)
 {

--- a/Source/WebCore/page/EventHandler.cpp
+++ b/Source/WebCore/page/EventHandler.cpp
@@ -137,6 +137,7 @@
 #include "StaticPasteboard.h"
 #include "StyleCachedImage.h"
 #include "StyleCursor.h"
+#include "StylePrimitiveNumericTypes+Evaluation.h"
 #include "Styleable.h"
 #include "TextEvent.h"
 #include "TextIterator.h"
@@ -1719,7 +1720,7 @@ std::optional<Cursor> EventHandler::selectCursor(const HitTestResult& result, bo
                 continue;
             float scale = styleImage->imageScaleFactor();
             // Get hotspot and convert from logical pixels to physical pixels.
-            auto hotSpot = styleCursorImage.hotSpot;
+            auto hotSpot = styleCursorImage.hotSpot ? Style::evaluate<IntPoint>(*styleCursorImage.hotSpot) : IntPoint { -1, -1 };
 
             CheckedPtr renderElement = dynamicDowncast<RenderElement>(renderer);
             if (!renderElement && renderer && renderer->parent())

--- a/Source/WebCore/style/values/images/kinds/StyleCrossfadeImage.cpp
+++ b/Source/WebCore/style/values/images/kinds/StyleCrossfadeImage.cpp
@@ -36,16 +36,18 @@
 #include "CrossfadeGeneratedImage.h"
 #include "RenderElement.h"
 #include "SVGImageForContainer.h"
+#include "StylePrimitiveNumericTypes+Blending.h"
+#include "StylePrimitiveNumericTypes+Conversions.h"
 #include <wtf/PointerComparison.h>
 
 namespace WebCore {
 namespace Style {
 
-CrossfadeImage::CrossfadeImage(RefPtr<Image>&& from, RefPtr<Image>&& to, double percentage, bool isPrefixed)
+CrossfadeImage::CrossfadeImage(RefPtr<Image>&& from, RefPtr<Image>&& to, Progress progress, bool isPrefixed)
     : GeneratedImage { Type::CrossfadeImage, CrossfadeImage::isFixedSize }
     , m_from { WTF::move(from) }
     , m_to { WTF::move(to) }
-    , m_percentage { percentage }
+    , m_progress { progress }
     , m_isPrefixed { isPrefixed }
     , m_inputImagesAreReady { false }
 {
@@ -67,12 +69,14 @@ bool CrossfadeImage::operator==(const Image& other) const
 
 bool CrossfadeImage::equals(const CrossfadeImage& other) const
 {
-    return equalInputImages(other) && m_percentage == other.m_percentage;
+    return equalInputImages(other)
+        && m_progress == other.m_progress;
 }
 
 bool CrossfadeImage::equalInputImages(const CrossfadeImage& other) const
 {
-    return arePointingToEqualData(m_from, other.m_from) && arePointingToEqualData(m_to, other.m_to);
+    return arePointingToEqualData(m_from, other.m_from)
+        && arePointingToEqualData(m_to, other.m_to);
 }
 
 RefPtr<CrossfadeImage> CrossfadeImage::blend(const CrossfadeImage& from, const BlendingContext& context) const
@@ -82,15 +86,21 @@ RefPtr<CrossfadeImage> CrossfadeImage::blend(const CrossfadeImage& from, const B
     if (!m_cachedToImage || !m_cachedFromImage)
         return nullptr;
 
-    auto newPercentage = WebCore::blend(from.m_percentage, m_percentage, context);
-    return CrossfadeImage::create(m_from, m_to, newPercentage, from.m_isPrefixed && m_isPrefixed);
+    auto newProgress = Style::blend(from.m_progress, m_progress, context);
+    return CrossfadeImage::create(m_from, m_to, newProgress, from.m_isPrefixed && m_isPrefixed);
 }
 
 Ref<CSSValue> CrossfadeImage::computedStyleValue(const RenderStyle& style) const
 {
     auto fromComputedValue = m_from ? m_from->computedStyleValue(style) : upcast<CSSValue>(CSSKeywordValue::create(CSSValueNone));
     auto toComputedValue = m_to ? m_to->computedStyleValue(style) : upcast<CSSValue>(CSSKeywordValue::create(CSSValueNone));
-    return CSSCrossfadeValue::create(WTF::move(fromComputedValue), WTF::move(toComputedValue), CSSPrimitiveValue::create(m_percentage), m_isPrefixed);
+
+    return CSSCrossfadeValue::create(
+        WTF::move(fromComputedValue),
+        WTF::move(toComputedValue),
+        toCSS(m_progress, style),
+        m_isPrefixed
+    );
 }
 
 bool CrossfadeImage::isPending() const
@@ -167,7 +177,7 @@ RefPtr<WebCore::Image> CrossfadeImage::image(const RenderElement* renderer, cons
         protectedToImage = SVGImageForContainer::create(toSVGImage.get(), size, 1, toURL);
     }
 
-    return CrossfadeGeneratedImage::create(*protectedFromImage, *protectedToImage, m_percentage, fixedSize(*renderer), size);
+    return CrossfadeGeneratedImage::create(*protectedFromImage, *protectedToImage, m_progress.value.value, fixedSize(*renderer), size);
 }
 
 bool CrossfadeImage::currentFrameIsComplete(const RenderElement* renderer) const
@@ -201,10 +211,10 @@ FloatSize CrossfadeImage::fixedSize(const RenderElement& renderer) const
     if (fromImageSize == toImageSize)
         return fromImageSize;
 
-    float percentage = m_percentage;
-    float inversePercentage = 1 - percentage;
+    float progress = m_progress.value.value;
+    float inverseProgress = 1 - progress;
 
-    return fromImageSize * inversePercentage + toImageSize * percentage;
+    return fromImageSize * inverseProgress + toImageSize * progress;
 }
 
 void CrossfadeImage::imageChanged(WebCore::CachedImage*, const IntRect*)

--- a/Source/WebCore/style/values/images/kinds/StyleCrossfadeImage.h
+++ b/Source/WebCore/style/values/images/kinds/StyleCrossfadeImage.h
@@ -30,6 +30,7 @@
 #include "CachedImageClient.h"
 #include "CachedResourceHandle.h"
 #include "StyleGeneratedImage.h"
+#include "StylePrimitiveNumericTypes.h"
 
 namespace WebCore {
 
@@ -40,9 +41,11 @@ namespace Style {
 class CrossfadeImage final : public GeneratedImage, private CachedImageClient {
     WTF_DEPRECATED_MAKE_FAST_ALLOCATED(CrossfadeImage);
 public:
-    static Ref<CrossfadeImage> create(RefPtr<Image> from, RefPtr<Image> to, double percentage, bool isPrefixed)
+    using Progress = NumberOrPercentageResolvedToNumber<CSS::ClosedUnitRangeClampBoth, CSS::ClosedPercentageRangeClampBoth>;
+
+    static Ref<CrossfadeImage> create(RefPtr<Image> from, RefPtr<Image> to, Progress progress, bool isPrefixed)
     {
-        return adoptRef(*new CrossfadeImage(WTF::move(from), WTF::move(to), percentage, isPrefixed));
+        return adoptRef(*new CrossfadeImage(WTF::move(from), WTF::move(to), progress, isPrefixed));
     }
     virtual ~CrossfadeImage();
 
@@ -59,7 +62,7 @@ public:
     static constexpr bool isFixedSize = true;
 
 private:
-    explicit CrossfadeImage(RefPtr<Image>&&, RefPtr<Image>&&, double, bool);
+    explicit CrossfadeImage(RefPtr<Image>&&, RefPtr<Image>&&, Progress, bool);
 
     Ref<CSSValue> computedStyleValue(const RenderStyle&) const final;
     bool isPending() const final;
@@ -76,7 +79,7 @@ private:
 
     RefPtr<Image> m_from;
     RefPtr<Image> m_to;
-    double m_percentage;
+    Progress m_progress;
     bool m_isPrefixed;
 
     // FIXME: Rather than caching and tracking the input image via WebCore::CachedImages, we should

--- a/Source/WebCore/style/values/images/kinds/StyleCursorImage.cpp
+++ b/Source/WebCore/style/values/images/kinds/StyleCursorImage.cpp
@@ -35,6 +35,7 @@
 #include "StyleBuilderState.h"
 #include "StyleCachedImage.h"
 #include "StyleImageSet.h"
+#include "StylePrimitiveNumericTypes+Conversions.h"
 #include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
@@ -42,17 +43,17 @@ namespace Style {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(CursorImage);
 
-Ref<CursorImage> CursorImage::create(const Ref<Image>& image, std::optional<IntPoint> hotSpot, const URL& originalURL)
+Ref<CursorImage> CursorImage::create(const Ref<Image>& image, std::optional<HotSpot> hotSpot, const URL& originalURL)
 {
     return adoptRef(*new CursorImage(image, hotSpot, originalURL));
 }
 
-Ref<CursorImage> CursorImage::create(Ref<Image>&& image, std::optional<IntPoint> hotSpot, URL&& originalURL)
+Ref<CursorImage> CursorImage::create(Ref<Image>&& image, std::optional<HotSpot> hotSpot, URL&& originalURL)
 {
     return adoptRef(*new CursorImage(WTF::move(image), hotSpot, WTF::move(originalURL)));
 }
 
-CursorImage::CursorImage(const Ref<Image>& image, std::optional<IntPoint> hotSpot, const URL& originalURL)
+CursorImage::CursorImage(const Ref<Image>& image, std::optional<HotSpot> hotSpot, const URL& originalURL)
     : MultiImage { Type::CursorImage }
     , m_image { image }
     , m_hotSpot { hotSpot }
@@ -60,7 +61,7 @@ CursorImage::CursorImage(const Ref<Image>& image, std::optional<IntPoint> hotSpo
 {
 }
 
-CursorImage::CursorImage(Ref<Image>&& image, std::optional<IntPoint> hotSpot, URL&& originalURL)
+CursorImage::CursorImage(Ref<Image>&& image, std::optional<HotSpot> hotSpot, URL&& originalURL)
     : MultiImage { Type::CursorImage }
     , m_image { WTF::move(image) }
     , m_hotSpot { hotSpot }
@@ -88,11 +89,11 @@ bool CursorImage::equalInputImages(const CursorImage& other) const
 
 Ref<CSSValue> CursorImage::computedStyleValue(const RenderStyle& style) const
 {
-    RefPtr<CSSValuePair> hotSpot;
-    if (m_hotSpot)
-        hotSpot = CSSValuePair::createNoncoalescing(CSSPrimitiveValue::create(m_hotSpot->x()), CSSPrimitiveValue::create(m_hotSpot->y()));
-
-    return CSSCursorImageValue::create(m_image->computedStyleValue(style), WTF::move(hotSpot), toCSS(m_originalURL, style));
+    return CSSCursorImageValue::create(
+        m_image->computedStyleValue(style),
+        toCSS(m_hotSpot, style),
+        toCSS(m_originalURL, style)
+    );
 }
 
 ImageWithScale CursorImage::selectBestFitImage(const Document& document)

--- a/Source/WebCore/style/values/images/kinds/StyleCursorImage.h
+++ b/Source/WebCore/style/values/images/kinds/StyleCursorImage.h
@@ -38,8 +38,10 @@ namespace Style {
 class CursorImage final : public MultiImage {
     WTF_MAKE_TZONE_ALLOCATED(CursorImage);
 public:
-    static Ref<CursorImage> create(const Ref<Image>&, std::optional<IntPoint>, const URL&);
-    static Ref<CursorImage> create(Ref<Image>&&, std::optional<IntPoint>, URL&&);
+    using HotSpot = SpaceSeparatedPoint<Number<>>;
+
+    static Ref<CursorImage> create(const Ref<Image>&, std::optional<HotSpot>, const URL&);
+    static Ref<CursorImage> create(Ref<Image>&&, std::optional<HotSpot>, URL&&);
     virtual ~CursorImage();
 
     bool operator==(const Image&) const final;
@@ -48,18 +50,18 @@ public:
 
     bool usesDataProtocol() const final;
 
-    std::optional<IntPoint> hotSpot() const { return m_hotSpot; }
+    std::optional<HotSpot> hotSpot() const { return m_hotSpot; }
 
 private:
-    explicit CursorImage(const Ref<Image>&, std::optional<IntPoint> hotSpot, const URL&);
-    explicit CursorImage(Ref<Image>&&, std::optional<IntPoint> hotSpot, URL&&);
+    explicit CursorImage(const Ref<Image>&, std::optional<HotSpot>, const URL&);
+    explicit CursorImage(Ref<Image>&&, std::optional<HotSpot>, URL&&);
 
     void setContainerContextForRenderer(const RenderElement& renderer, const FloatSize& containerSize, float containerZoom, const WTF::URL& = WTF::URL()) final;
     Ref<CSSValue> computedStyleValue(const RenderStyle&) const final;
     ImageWithScale selectBestFitImage(const Document&) final;
 
     const Ref<Image> m_image;
-    std::optional<IntPoint> m_hotSpot;
+    const std::optional<HotSpot> m_hotSpot;
     URL m_originalURL;
 };
 

--- a/Source/WebCore/style/values/primitives/StylePrimitiveNumericTypes+Evaluation.h
+++ b/Source/WebCore/style/values/primitives/StylePrimitiveNumericTypes+Evaluation.h
@@ -180,6 +180,39 @@ template<CSS::Range nR, CSS::Range pR, typename V, typename Result> struct Evalu
 
 // MARK: - SpaceSeparatedPoint
 
+template<typename T> struct Evaluation<SpaceSeparatedPoint<T>, IntPoint> {
+    auto operator()(const SpaceSeparatedPoint<T>& value) -> IntPoint
+    {
+        return {
+            evaluate<int>(value.x()),
+            evaluate<int>(value.y())
+        };
+    }
+    auto operator()(const SpaceSeparatedPoint<T>& value, IntSize referenceBox) -> IntPoint
+        requires HasTwoParameterEvaluate<T, int, int>
+    {
+        return {
+            evaluate<int>(value.x(), referenceBox.width()),
+            evaluate<int>(value.y(), referenceBox.height())
+        };
+    }
+    auto operator()(const SpaceSeparatedPoint<T>& value, IntSize referenceBox, ZoomNeeded token) -> IntPoint
+        requires HasThreeParameterEvaluate<T, int, int, ZoomNeeded>
+    {
+        return {
+            evaluate<int>(value.x(), referenceBox.width(), token),
+            evaluate<int>(value.y(), referenceBox.height(), token)
+        };
+    }
+    auto operator()(const SpaceSeparatedPoint<T>& value, IntSize referenceBox, ZoomFactor zoom) -> IntPoint
+        requires HasThreeParameterEvaluate<T, int, int, ZoomFactor>
+    {
+        return {
+            evaluate<int>(value.x(), referenceBox.width(), zoom),
+            evaluate<int>(value.y(), referenceBox.height(), zoom)
+        };
+    }
+};
 template<typename T> struct Evaluation<SpaceSeparatedPoint<T>, FloatPoint> {
     auto operator()(const SpaceSeparatedPoint<T>& value, FloatSize referenceBox) -> FloatPoint
         requires HasTwoParameterEvaluate<T, float, float>

--- a/Source/WebCore/style/values/ui/StyleCursor.cpp
+++ b/Source/WebCore/style/values/ui/StyleCursor.cpp
@@ -32,6 +32,7 @@
 #include "StyleCursorImage.h"
 #include "StyleInvalidImage.h"
 #include "StyleKeyword+CSSValueConversion.h"
+#include "StylePrimitiveNumericTypes+Logging.h"
 
 namespace WebCore {
 namespace Style {
@@ -51,18 +52,16 @@ auto CSSValueConversion<Cursor>::operator()(BuilderState& state, const CSSValue&
         Ref item = list->item(index);
         RefPtr image = requiredDowncast<CSSCursorImageValue>(state, item);
         if (!image)
-            return CursorImageAndHotSpot { InvalidImage::create() };
+            return CursorImageAndHotSpot { InvalidImage::create(), std::nullopt };
 
         auto styleImage = image->createStyleImage(state);
         if (!styleImage) {
             state.setCurrentPropertyInvalidAtComputedValueTime();
-            return CursorImageAndHotSpot { InvalidImage::create() };
+            return CursorImageAndHotSpot { InvalidImage::create(), std::nullopt };
         }
 
-        // Point outside the image is how we tell the cursor machinery there is no hot spot, and it should generate one (done in the Cursor class).
-        // FIXME: Would it be better to extend the concept of "no hot spot" deeper, into CursorImage and beyond, rather than using -1/-1 for it?
-        auto hotSpot = styleImage->hotSpot().value_or(IntPoint { -1, -1 });
-        return CursorImageAndHotSpot { styleImage.releaseNonNull(), hotSpot };
+        auto hotSpot = styleImage->hotSpot();
+        return CursorImageAndHotSpot { styleImage.releaseNonNull(), WTF::move(hotSpot) };
     });
 
     return { WTF::move(images), toStyleFromCSSValue<CursorType>(state, list->item(list->size() - 1)) };

--- a/Source/WebCore/style/values/ui/StyleCursor.h
+++ b/Source/WebCore/style/values/ui/StyleCursor.h
@@ -25,9 +25,9 @@
 
 #pragma once
 
-#include <WebCore/IntPoint.h>
 #include <WebCore/RenderStyleConstants.h>
 #include <WebCore/StyleImage.h>
+#include <WebCore/StylePrimitiveNumericTypes.h>
 #include <WebCore/StyleValueTypes.h>
 
 namespace WebCore {
@@ -37,7 +37,7 @@ namespace Style {
 // https://drafts.csswg.org/css-ui-4/#typedef-cursor-cursor-image
 struct CursorImageAndHotSpot {
     Ref<Image> image;
-    IntPoint hotSpot { -1, -1 };
+    std::optional<SpaceSeparatedPoint<Number<>>> hotSpot;
 
     bool operator==(const CursorImageAndHotSpot&) const = default;
 };


### PR DESCRIPTION
#### 13f9d34dc4c17fc2ea9d95e9b46ebab885461df8
<pre>
Convert image numeric primitive components to strong CSS/Style types
<a href="https://bugs.webkit.org/show_bug.cgi?id=314366">https://bugs.webkit.org/show_bug.cgi?id=314366</a>

Reviewed by Darin Adler.

Concert numeric primitives in CSSCrossfadeValue, Style::CrossfadeImage,
CSSCursorImageValue, and Style::CursorImage to use strong css/style
types rather than CSSValue/IntPoint.

For cursor hotspots, this moves moving evaluation to use time.

* Source/WebCore/css/CSSCrossfadeValue.cpp:
* Source/WebCore/css/CSSCrossfadeValue.h:
* Source/WebCore/css/CSSCursorImageValue.cpp:
* Source/WebCore/css/CSSCursorImageValue.h:
* Source/WebCore/css/parser/CSSPropertyParserConsumer+Image.cpp:
* Source/WebCore/css/parser/CSSPropertyParserConsumer+UI.cpp:
* Source/WebCore/css/values/primitives/CSSPrimitiveNumericRange.h:
* Source/WebCore/page/EventHandler.cpp:
* Source/WebCore/style/values/images/kinds/StyleCrossfadeImage.cpp:
* Source/WebCore/style/values/images/kinds/StyleCrossfadeImage.h:
* Source/WebCore/style/values/images/kinds/StyleCursorImage.cpp:
* Source/WebCore/style/values/images/kinds/StyleCursorImage.h:
* Source/WebCore/style/values/primitives/StylePrimitiveNumericTypes+Evaluation.h:
* Source/WebCore/style/values/ui/StyleCursor.cpp:
* Source/WebCore/style/values/ui/StyleCursor.h:

Canonical link: <a href="https://commits.webkit.org/312955@main">https://commits.webkit.org/312955@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8c73403c6c63ba832e3a5be49052b6ea5894da04

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/161468 "3 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/34942 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/28044 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/170371 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/117839 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/163337 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/35043 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/34943 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/125269 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/88230 "2 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/164427 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/27566 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/145047 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/105865 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/26615 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/25123 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/18092 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/136309 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/22804 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/172857 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/19888 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/24445 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/133556 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/34616 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/29218 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/133563 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36116 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/34600 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/144599 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/96500 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/28092 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/21418 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/34110 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/101552 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/33610 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/33853 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/33759 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->