### PR TITLE
AX: Bound all indefinite-blocking main-thread retrieval calls from the accessibility thread with timeouts

### DIFF
--- a/Source/WebCore/accessibility/AXCoreObject.h
+++ b/Source/WebCore/accessibility/AXCoreObject.h
@@ -1812,8 +1812,11 @@ constexpr Seconds BoundingBoxTimeout = 25_ms;
 constexpr Seconds GeneralPropertyTimeout = 25_ms;
 constexpr Seconds VisibilityCheckTimeout = 50_ms;
 constexpr Seconds SpellCheckTimeout = 100_ms;
+constexpr Seconds LineRectsAndTextTimeout = 100_ms;
+constexpr Seconds TextMarkerForBoundsTimeout = 100_ms;
 constexpr Seconds InteractiveTimeout = 250_ms;
 constexpr Seconds ImageDataTimeout = 250_ms;
+constexpr Seconds PluginTimeout = 500_ms;
 
 template<typename U>
 inline DidTimeout performFunctionOnMainThreadAndWaitWithTimeout(U&& lambda, Seconds timeout)

--- a/Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.h
+++ b/Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.h
@@ -56,6 +56,8 @@ public:
     static Ref<AXIsolatedObject> create(IsolatedObjectData&&);
     ~AXIsolatedObject();
 
+    RefPtr<AXIsolatedObject> approximateHitTest(const IntPoint&) const;
+
     std::optional<AXTreeID> treeID() const final { return tree().treeID(); }
     String debugDescriptionInternal(bool, std::optional<OptionSet<AXDebugStringOption>> = std::nullopt) const final;
 
@@ -130,8 +132,6 @@ private:
     AXIsolatedObject(IsolatedObjectData&&);
     bool isAXIsolatedObjectInstance() const final { return true; }
     AccessibilityObject* associatedAXObject() const;
-
-    RefPtr<AXIsolatedObject> approximateHitTest(const IntPoint&) const;
 
     void setProperty(AXProperty, AXPropertyValueVariant&&);
     void setPropertyInVector(AXProperty property, AXPropertyValueVariant&& value)

--- a/Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperMac.mm
+++ b/Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperMac.mm
@@ -200,14 +200,16 @@ static inline NSInteger gmtToLocalTimeOffset(DateComponentsType type)
 
 - (id)attachmentView
 {
-    return Accessibility::retrieveAutoreleasedValueFromMainThread<id>([protectedSelf = retainPtr(self)] () -> RetainPtr<id> {
+    auto result = Accessibility::retrieveValueFromMainThreadWithTimeout([protectedSelf = retainPtr(self)] () -> RetainPtr<id> {
         RefPtr<AXCoreObject> backingObject = protectedSelf.get().axBackingObject;
         if (!backingObject)
             return nil;
 
         RefPtr widget = backingObject->widgetForAttachmentView();
         return widget ? NSAccessibilityUnignoredDescendant(widget->platformWidget()) : nil;
-    });
+    }, Accessibility::PluginTimeout);
+
+    return result.value ? (*result.value).autorelease() : nil;
 }
 
 #pragma mark SystemInterface wrappers
@@ -1071,7 +1073,7 @@ static void convertToVector(NSArray* array, AccessibilityObject::AccessibilityCh
     if (!backingObject || !backingObject->hasApplePDFAnnotationAttribute())
         return nil;
 
-    return Accessibility::retrieveAutoreleasedValueFromMainThread<id>([protectedSelf = retainPtr(self)] () -> RetainPtr<id> {
+    auto result = Accessibility::retrieveValueFromMainThreadWithTimeout([protectedSelf = retainPtr(self)] () -> RetainPtr<id> {
         RefPtr<AXCoreObject> backingObject = protectedSelf.get().axBackingObject;
         if (!backingObject || !backingObject->hasApplePDFAnnotationAttribute())
             return nil;
@@ -1083,7 +1085,9 @@ static void convertToVector(NSArray* array, AccessibilityObject::AccessibilityCh
             return nil;
         RefPtr element = backingObject->element();
         return widget->accessibilityAssociatedPluginParentForElement(element.get());
-    });
+    }, Accessibility::PluginTimeout);
+
+    return result.value ? (*result.value).autorelease() : nil;
 }
 
 static void WebTransformCGPathToNSBezierPath(void* info, const CGPathElement *element)
@@ -1727,9 +1731,11 @@ static id handlePathAttribute(WebAccessibilityObjectWrapper* wrapper, AXCoreObje
 
 static id handleLineRectsAndTextAttribute(WebAccessibilityObjectWrapper* wrapper, AXCoreObject&)
 {
-    return Accessibility::retrieveAutoreleasedValueFromMainThread<NSArray *>([protectedSelf = retainPtr(wrapper)] () -> RetainPtr<NSArray> {
+    auto result = Accessibility::retrieveValueFromMainThreadWithTimeout([protectedSelf = retainPtr(wrapper)] () -> RetainPtr<NSArray> {
         return protectedSelf.get().lineRectsAndText;
-    });
+    }, Accessibility::LineRectsAndTextTimeout);
+
+    return result.value ? (*result.value).autorelease() : nil;
 }
 
 static id handleImageOverlayElementsAttribute(WebAccessibilityObjectWrapper*, AXCoreObject& backingObject)
@@ -2736,12 +2742,15 @@ id attributeValueForTesting(const RefPtr<AXCoreObject>& backingObject, NSString 
                 return axObject->remoteFramePlatformElement().autorelease();
         } else if (axObject->isWidget()) {
             // Only call out to the main-thread if this object has a backing widget to query.
-            hit = Accessibility::retrieveAutoreleasedValueFromMainThread<id>([axObject, &point] () -> RetainPtr<id> {
+            auto widgetHitResult = Accessibility::retrieveValueFromMainThreadWithTimeout([axObject, point] () -> RetainPtr<id> {
                 RefPtr widget = axObject->widget();
                 if (is<PluginViewBase>(widget))
                     return widget->accessibilityHitTest(IntPoint(point));
                 return nil;
-            });
+            }, Accessibility::HitTestTimeout);
+
+            if (widgetHitResult.value)
+                hit = *widgetHitResult.value;
         }
 
         if (!hit)
@@ -3690,7 +3699,7 @@ static id handleAttributedStringForTextMarkerRangeAttribute(WebAccessibilityObje
 
 static id handleSelectTextWithCriteriaAttribute(WebAccessibilityObjectWrapper* wrapper, AXCoreObject&, const ParameterizedAttributeContext& context)
 {
-    auto result = Accessibility::retrieveValueFromMainThread<Vector<String>>([protectedDictionary = context.dictionary, protectedSelf = retainPtr(wrapper)] () -> Vector<String> {
+    auto result = Accessibility::retrieveValueFromMainThreadWithTimeoutAndDefault([protectedDictionary = context.dictionary, protectedSelf = retainPtr(wrapper)] () -> Vector<String> {
         RefPtr<AXCoreObject> backingObject = protectedSelf.get().axBackingObject;
         if (!backingObject)
             return Vector<String>();
@@ -3699,7 +3708,7 @@ static id handleSelectTextWithCriteriaAttribute(WebAccessibilityObjectWrapper* w
         criteria.second.textRanges = backingObject->findTextRanges(criteria.first);
         AX_ASSERT(criteria.second.textRanges.size() <= 1);
         return backingObject->performTextOperation(criteria.second);
-    });
+    }, Accessibility::InteractiveTimeout, Vector<String>());
     AX_ASSERT(result.size() <= 1);
     if (result.size() > 0)
         return result[0].createNSString().autorelease();
@@ -3709,7 +3718,7 @@ static id handleSelectTextWithCriteriaAttribute(WebAccessibilityObjectWrapper* w
 static id handleSearchTextWithCriteriaAttribute(WebAccessibilityObjectWrapper* wrapper, AXCoreObject&, const ParameterizedAttributeContext& context)
 {
     auto criteria = accessibilitySearchTextCriteriaForParameterizedAttribute(context.dictionary);
-    return Accessibility::retrieveAutoreleasedValueFromMainThread<NSArray *>([&criteria, protectedSelf = retainPtr(wrapper)] () -> RetainPtr<NSArray> {
+    auto result = Accessibility::retrieveValueFromMainThreadWithTimeout([criteria = WTF::move(criteria), protectedSelf = retainPtr(wrapper)] () -> RetainPtr<NSArray> {
         RefPtr backingObject = downcast<AccessibilityObject>(protectedSelf.get().axBackingObject);
         if (!backingObject)
             return nil;
@@ -3720,12 +3729,14 @@ static id handleSearchTextWithCriteriaAttribute(WebAccessibilityObjectWrapper* w
         return createNSArray(WTF::move(ranges), [&] (SimpleRange&& range) {
             return (id)textMarkerRangeFromRange(cache.get(), WTF::move(range));
         }).autorelease();
-    });
+    }, Accessibility::InteractiveTimeout);
+
+    return result.value ? (*result.value).autorelease() : nil;
 }
 
 static id handleTextOperationAttribute(WebAccessibilityObjectWrapper* wrapper, AXCoreObject&, const ParameterizedAttributeContext& context)
 {
-    auto operationResult = Accessibility::retrieveValueFromMainThread<Vector<String>>([protectedDictionary = context.dictionary, protectedSelf = retainPtr(wrapper)] () -> Vector<String> {
+    auto operationResult = Accessibility::retrieveValueFromMainThreadWithTimeoutAndDefault([protectedDictionary = context.dictionary, protectedSelf = retainPtr(wrapper)] () -> Vector<String> {
         RefPtr backingObject = downcast<AccessibilityObject>(protectedSelf.get().axBackingObject);
         if (!backingObject)
             return Vector<String>();
@@ -3733,7 +3744,7 @@ static id handleTextOperationAttribute(WebAccessibilityObjectWrapper* wrapper, A
         CheckedPtr cache = backingObject->axObjectCache();
         auto textOperation = accessibilityTextOperationForParameterizedAttribute(cache.get(), protectedDictionary.get());
         return backingObject->performTextOperation(textOperation);
-    });
+    }, Accessibility::InteractiveTimeout, Vector<String>());
     if (operationResult.isEmpty())
         return nil;
     return createNSArray(operationResult).autorelease();
@@ -3760,9 +3771,9 @@ static id handleRangesForSearchPredicateAttribute(WebAccessibilityObjectWrapper*
     return nil;
 }
 
-static id handleEndTextMarkerForBoundsAttribute(WebAccessibilityObjectWrapper* wrapper, AXCoreObject&, const ParameterizedAttributeContext& context)
+static id handleEndTextMarkerForBoundsAttribute(WebAccessibilityObjectWrapper* wrapper, AXCoreObject& backingObject, const ParameterizedAttributeContext& context)
 {
-    return Accessibility::retrieveAutoreleasedValueFromMainThread<id>([rect = context.rect, protectedSelf = retainPtr(wrapper)] () -> RetainPtr<id> {
+    auto mainThreadResult = Accessibility::retrieveValueFromMainThreadWithTimeout([rect = context.rect, protectedSelf = retainPtr(wrapper)] () -> RetainPtr<id> {
         RefPtr backingObject = downcast<AccessibilityObject>(protectedSelf.get().axBackingObject);
         CheckedPtr cache = backingObject ? backingObject->axObjectCache() : nullptr;
         if (!cache)
@@ -3772,12 +3783,24 @@ static id handleEndTextMarkerForBoundsAttribute(WebAccessibilityObjectWrapper* w
         CharacterOffset characterOffset = cache->characterOffsetForBounds(webCoreRect, false);
 
         return (id)textMarkerForCharacterOffset(cache.get(), characterOffset, TextMarkerOrigin::EndTextMarkerForBounds);
-    });
+    }, Accessibility::TextMarkerForBoundsTimeout);
+
+    if (mainThreadResult.value)
+        return (*mainThreadResult.value).autorelease();
+
+    // If the main-thread is busy, approximate by hit-testing the trailing edge of the rect
+    // and returning the end of the hit object's text range.
+    if (RefPtr isolatedObject = dynamicDowncast<AXIsolatedObject>(backingObject)) {
+        IntPoint trailingEdge = IntPoint(CGRectGetMaxX(context.rect), CGRectGetMaxY(context.rect));
+        if (RefPtr hitObject = isolatedObject->approximateHitTest(trailingEdge))
+            return hitObject->textMarkerRange().end().platformData().bridgingAutorelease();
+    }
+    return nil;
 }
 
-static id handleStartTextMarkerForBoundsAttribute(WebAccessibilityObjectWrapper* wrapper, AXCoreObject&, const ParameterizedAttributeContext& context)
+static id handleStartTextMarkerForBoundsAttribute(WebAccessibilityObjectWrapper* wrapper, AXCoreObject& backingObject, const ParameterizedAttributeContext& context)
 {
-    return Accessibility::retrieveAutoreleasedValueFromMainThread<id>([rect = context.rect, protectedSelf = retainPtr(wrapper)] () -> RetainPtr<id> {
+    auto mainThreadResult = Accessibility::retrieveValueFromMainThreadWithTimeout([rect = context.rect, protectedSelf = retainPtr(wrapper)] () -> RetainPtr<id> {
         RefPtr backingObject = downcast<AccessibilityObject>(protectedSelf.get().axBackingObject);
         CheckedPtr cache = backingObject ? backingObject->axObjectCache() : nullptr;
         if (!cache)
@@ -3787,7 +3810,19 @@ static id handleStartTextMarkerForBoundsAttribute(WebAccessibilityObjectWrapper*
         CharacterOffset characterOffset = cache->characterOffsetForBounds(webCoreRect, true);
 
         return (id)textMarkerForCharacterOffset(cache.get(), characterOffset, TextMarkerOrigin::StartTextMarkerForBounds);
-    });
+    }, Accessibility::TextMarkerForBoundsTimeout);
+
+    if (mainThreadResult.value)
+        return (*mainThreadResult.value).autorelease();
+
+    // If the main-thread is busy, approximate by hit-testing the leading edge of the rect
+    // and returning the start of the hit object's text range.
+    if (RefPtr isolatedObject = dynamicDowncast<AXIsolatedObject>(backingObject)) {
+        IntPoint leadingEdge = IntPoint(CGRectGetMinX(context.rect), CGRectGetMinY(context.rect));
+        if (RefPtr hitObject = isolatedObject->approximateHitTest(leadingEdge))
+            return hitObject->textMarkerRange().start().platformData().bridgingAutorelease();
+    }
+    return nil;
 }
 
 static id handleLineTextMarkerRangeForTextMarkerAttribute(WebAccessibilityObjectWrapper* wrapper, AXCoreObject&, const ParameterizedAttributeContext& context)
@@ -3797,7 +3832,7 @@ static id handleLineTextMarkerRangeForTextMarkerAttribute(WebAccessibilityObject
 
 static id handleMisspellingTextMarkerRangeAttribute(WebAccessibilityObjectWrapper* wrapper, AXCoreObject&, const ParameterizedAttributeContext& context)
 {
-    return (id)Accessibility::retrieveAutoreleasedValueFromMainThread<AXTextMarkerRangeRef>([protectedDictionary = context.dictionary, protectedSelf = retainPtr(wrapper)] () -> RetainPtr<AXTextMarkerRangeRef> {
+    auto result = Accessibility::retrieveValueFromMainThreadWithTimeout([protectedDictionary = context.dictionary, protectedSelf = retainPtr(wrapper)] () -> RetainPtr<AXTextMarkerRangeRef> {
         RefPtr<AXCoreObject> backingObject = protectedSelf.get().axBackingObject;
         if (!backingObject)
             return nil;
@@ -3819,7 +3854,9 @@ static id handleMisspellingTextMarkerRangeAttribute(WebAccessibilityObjectWrappe
         if (!misspellingRange)
             return nil;
         return misspellingRange->platformData();
-    });
+    }, Accessibility::SpellCheckTimeout);
+
+    return result.value ? (id)(*result.value).autorelease() : nil;
 }
 
 static id handleTextMarkerIsValidAttribute(WebAccessibilityObjectWrapper*, AXCoreObject&, const ParameterizedAttributeContext& context)
@@ -3896,19 +3933,30 @@ static id handleStringForTextMarkerRangeAttribute(WebAccessibilityObjectWrapper*
     return AXTextMarkerRange { context.textMarkerRange }.toString().createNSString().autorelease();
 }
 
-static id handleTextMarkerForPositionAttribute(WebAccessibilityObjectWrapper* wrapper, AXCoreObject&, const ParameterizedAttributeContext& context)
+static id handleTextMarkerForPositionAttribute(WebAccessibilityObjectWrapper* wrapper, AXCoreObject& backingObject, const ParameterizedAttributeContext& context)
 {
     if (!context.pointSet)
         return nil;
     IntPoint webCorePoint = IntPoint(context.point);
 
-    return Accessibility::retrieveAutoreleasedValueFromMainThread<id>([&webCorePoint, protectedSelf = retainPtr(wrapper)] () -> RetainPtr<id> {
+    auto mainThreadResult = Accessibility::retrieveValueFromMainThreadWithTimeout([webCorePoint, protectedSelf = retainPtr(wrapper)] () -> RetainPtr<id> {
         RefPtr<AXCoreObject> backingObject = protectedSelf.get().axBackingObject;
         if (!backingObject)
             return nil;
 
         return AXTextMarker(backingObject->visiblePositionForPoint(webCorePoint), TextMarkerOrigin::Position).platformData().bridgingAutorelease();
-    });
+    }, Accessibility::HitTestTimeout);
+
+    if (mainThreadResult.value)
+        return (*mainThreadResult.value).autorelease();
+
+    // If the main-thread is busy, approximate by hit-testing the point and returning
+    // the start of the hit object's text range.
+    if (RefPtr isolatedObject = dynamicDowncast<AXIsolatedObject>(backingObject)) {
+        if (RefPtr hitObject = isolatedObject->approximateHitTest(webCorePoint))
+            return hitObject->textMarkerRange().start().platformData().bridgingAutorelease();
+    }
+    return nil;
 }
 
 static id handleBoundsForTextMarkerRangeAttribute(WebAccessibilityObjectWrapper* wrapper, AXCoreObject&, const ParameterizedAttributeContext& context)


### PR DESCRIPTION
#### ab00c2fa50938db2ffd3be24d06aad97bbf2b166
<pre>
AX: Bound all indefinite-blocking main-thread retrieval calls from the accessibility thread with timeouts
<a href="https://bugs.webkit.org/show_bug.cgi?id=314367">https://bugs.webkit.org/show_bug.cgi?id=314367</a>
<a href="https://rdar.apple.com/176524311">rdar://176524311</a>

Reviewed by Dominic Mazzoni.

retrieveAutoreleasedValueFromMainThread and retrieveValueFromMainThread block
the AX thread forever via callOnMainThreadAndWait if the main thread is busy
(e.g. long-running JS, layout, synchronous IPC). This can cause assistive
technologies to hang waiting for responses that never come.

Convert all unguarded call sites in WebAccessibilityObjectWrapperMac to use
retrieveValueFromMainThreadWithTimeout (or the WithDefault variant), returning
nil on timeout.

For three operations (text marker for position, start/end text marker for
bounds), add approximate-hit-test fallbacks: when the main thread times out,
use AXIsolatedObject::approximateHitTest to find the element at the relevant
point and return the start/end of its text marker range. This provides a
potentially less accurate, but usable result rather than nothing.

Make AXIsolatedObject::approximateHitTest public so the wrapper can call it
directly for these fallbacks without going through accessibilityHitTest (which
would redundantly attempt the main thread again).

* Source/WebCore/accessibility/AXCoreObject.h:
* Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.h:
* Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperMac.mm:
(-[WebAccessibilityObjectWrapper attachmentView]):
(-[WebAccessibilityObjectWrapper _associatedPluginParentWith:]):
(handleLineRectsAndTextAttribute):
(-[WebAccessibilityObjectWrapper _accessibilityHitTest:returnPlatformElements:]):
(handleSelectTextWithCriteriaAttribute):
(handleSearchTextWithCriteriaAttribute):
(handleTextOperationAttribute):
(handleEndTextMarkerForBoundsAttribute):
(handleStartTextMarkerForBoundsAttribute):
(handleMisspellingTextMarkerRangeAttribute):
(handleTextMarkerForPositionAttribute):

Canonical link: <a href="https://commits.webkit.org/312880@main">https://commits.webkit.org/312880@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/60729d3618fd300b6e2383ae60819466713a6786

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/161322 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/34795 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/27896 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/170225 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/117693 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/163191 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/34896 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/34796 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/125140 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/117693 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/164281 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/27430 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/144914 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/105737 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/26478 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/24986 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/17945 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/136172 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/22674 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/172708 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/19729 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/24315 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/133424 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/34469 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/29078 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/133432 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36046 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/34454 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/144469 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/96319 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/27968 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/21288 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/33964 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/101389 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/33463 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/33707 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/33612 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->