### PR TITLE
Use protect() instead of RetainPtr { } in editing code

### DIFF
--- a/Source/WebCore/editing/cocoa/AttributedString.mm
+++ b/Source/WebCore/editing/cocoa/AttributedString.mm
@@ -51,6 +51,8 @@ OBJC_CLASS NSTextTab;
 
 #if PLATFORM(IOS_FAMILY)
 SPECIALIZE_OBJC_TYPE_TRAITS(UIImage, PAL::getUIImageClassSingleton())
+SPECIALIZE_OBJC_TYPE_TRAITS(NSShadow, PAL::getNSShadowClassSingleton())
+SPECIALIZE_OBJC_TYPE_TRAITS(NSPresentationIntent, PAL::getNSPresentationIntentClassSingleton())
 #endif
 
 namespace WebCore {
@@ -367,14 +369,14 @@ static RetainPtr<id> toNSObject(const AttributedString::AttributeValue& value, I
     }, [] (const TextAttachmentMissingImage& value) -> RetainPtr<id> {
         UNUSED_PARAM(value);
         RetainPtr<NSTextAttachment> attachment = adoptNS([[PlatformNSTextAttachment alloc] initWithData:nil ofType:nil]);
-        attachment.get().image = RetainPtr { webCoreTextAttachmentMissingPlatformImage() }.get();
+        attachment.get().image = protect(webCoreTextAttachmentMissingPlatformImage()).get();
         return attachment;
     }, [] (const TextAttachmentFileWrapper& value) -> RetainPtr<id> {
         RetainPtr<NSData> data = value.data ? bridge_cast((value.data).get()) : nil;
 
         RetainPtr fileWrapper = adoptNS([[NSFileWrapper alloc] initRegularFileWithContents:data.get()]);
         if (!value.preferredFilename.isNull())
-            [fileWrapper setPreferredFilename:RetainPtr { filenameByFixingIllegalCharacters(value.preferredFilename.createNSString().get()) }.get()];
+            [fileWrapper setPreferredFilename:protect(filenameByFixingIllegalCharacters(value.preferredFilename.createNSString().get())).get()];
 
         auto textAttachment = adoptNS([[PlatformNSTextAttachment alloc] initWithFileWrapper:fileWrapper.get()]);
         if (!value.accessibilityLabel.isNull())
@@ -703,15 +705,15 @@ static std::optional<AttributedString::AttributeValue> extractValue(id value, Ta
     if (auto* array = dynamic_objc_cast<NSArray>(value))
         return extractArray(array);
     if (auto* date = dynamic_objc_cast<NSDate>(value))
-        return { { { RetainPtr { date } } } };
-    if ([value isKindOfClass:PlatformNSShadow])
-        return { { { RetainPtr { (NSShadow *)value } } } };
+        return { { { protect(date) } } };
+    if (auto* shadow = dynamic_objc_cast<NSShadow>(value))
+        return { { { protect(shadow) } } };
     if ([value isKindOfClass:PlatformNSParagraphStyle]) {
         auto style = static_cast<NSParagraphStyle *>(value);
         return { { extractParagraphStyle(style, tableIDs, tableBlockIDs, listIDs) } };
     }
-    if ([value isKindOfClass:PlatformNSPresentationIntent])
-        return { { { RetainPtr { (NSPresentationIntent *)value } } } };
+    if (auto* intent = dynamic_objc_cast<NSPresentationIntent>(value))
+        return { { { protect(intent) } } };
 #if ENABLE(MULTI_REPRESENTATION_HEIC)
     if ([value isKindOfClass:PlatformNSAdaptiveImageGlyph]) {
         auto attachment = static_cast<NSAdaptiveImageGlyph *>(value);

--- a/Source/WebCore/editing/cocoa/HTMLConverter.mm
+++ b/Source/WebCore/editing/cocoa/HTMLConverter.mm
@@ -103,7 +103,7 @@ NSFont *WebCore::WebDefaultFont()
         NSFont *font = [NSFont fontWithName:@"Helvetica" size:12];
         if (!font)
             font = [NSFont systemFontOfSize:12];
-        return RetainPtr { font };
+        return protect(font);
     }();
     return defaultFont.get().get();
 }


### PR DESCRIPTION
#### ab767ea6e1b799ade27c2e30237ed8eb9d870ce7
<pre>
Use protect() instead of RetainPtr { } in editing code
<a href="https://bugs.webkit.org/show_bug.cgi?id=314369">https://bugs.webkit.org/show_bug.cgi?id=314369</a>
<a href="https://rdar.apple.com/176524589">rdar://176524589</a>

Reviewed by Ryosuke Niwa.

Mechanical migration from RetainPtr { expr } to protect(expr) in editing
code, aligning with the codebase-wide transition away from brace-initialized
smart pointer temporaries. All instances are NS/ObjC types, which use the
protect() overload for IsNSType&lt;T&gt; in RetainPtr.h.

Also replaces two isKindOfClass + C-style cast patterns with the type-safe
dynamic_objc_cast&lt;&gt; pattern. Because NSShadow and NSPresentationIntent are
soft-linked from UIKit on iOS (see pal/ios/UIKitSoftLink.h), the default
ObjCTypeCastTraits trait that uses [T class] does not work cross-platform.
Adding SPECIALIZE_OBJC_TYPE_TRAITS specializations under #if PLATFORM(IOS_FAMILY)
(next to the existing UIImage specialization) teaches dynamic_objc_cast&lt;&gt; to
use the soft-linked class singletons on iOS while the default [T class]
behavior continues to work on macOS.

No new tests needed (no behavioral change, style-only refactor).

* Source/WebCore/editing/cocoa/AttributedString.mm:
(WebCore::attributedStringFromAttachment):
(WebCore::AttributedString::Range::Range):
* Source/WebCore/editing/cocoa/HTMLConverter.mm:
(WebCore::defaultFontForConversionToAttributedString):

Canonical link: <a href="https://commits.webkit.org/313199@main">https://commits.webkit.org/313199@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/45430ffd1f49ad0425c6314d8dab093ba4315058

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/162188 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/35664 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/28780 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/171096 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/118561 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/164057 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/35768 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/35665 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/125870 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/88735 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/165147 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/28203 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/145819 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/106448 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/27250 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/25765 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/18817 "Built successfully") | | 
| [⏳ 🛠 🧪 jsc ](https://ews-build.webkit.org/#/builders/JSC-Tests-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/136951 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/23430 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/173590 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/20943 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/25073 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/134168 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/35338 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/29853 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/134169 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36259 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/35321 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/145226 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/97528 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/28705 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/22054 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/34831 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/102583 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/34332 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/34577 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/34480 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->