### PR TITLE
[libpas] `large_utility_aligned_allocator` unconditionally calls give_back on allocation failure

### DIFF
--- a/Source/bmalloc/libpas/src/libpas/pas_large_free_heap_helpers.c
+++ b/Source/bmalloc/libpas/src/libpas/pas_large_free_heap_helpers.c
@@ -72,7 +72,8 @@ static pas_aligned_allocation_result large_utility_aligned_allocator(size_t size
         pas_delegate_allocation);
 
     if (!allocation_result.did_succeed) {
-        pas_physical_page_sharing_pool_give_back(aligned_size);
+        if (pas_large_utility_free_heap_talks_to_large_sharing_pool)
+            pas_physical_page_sharing_pool_give_back(aligned_size);
         return result;
     }
 

--- a/Source/bmalloc/libpas/src/test/LargeFreeHeapTests.cpp
+++ b/Source/bmalloc/libpas/src/test/LargeFreeHeapTests.cpp
@@ -31,7 +31,9 @@
 #include "pas_heap_lock.h"
 #include "pas_large_free.h"
 #include "pas_large_free_heap_config.h"
+#include "pas_large_free_heap_helpers.h"
 #include "pas_page_malloc.h"
+#include "pas_page_sharing_pool.h"
 #include "pas_simple_large_free_heap.h"
 #include <set>
 #include <vector>
@@ -426,6 +428,38 @@ void testBootstrapHeap(const vector<Action>& actions,
 size_t freeListSize(size_t size)
 {
     return PAS_MAX(size, PAS_BOOTSTRAP_FREE_LIST_MINIMUM_SIZE) * sizeof(pas_large_free);
+}
+
+pas_allocation_result failingMemorySource(size_t, pas_alignment, const char*, pas_allocation_kind)
+{
+    return pas_allocation_result_create_failure();
+}
+
+void testGiveBackGuardOnAllocationFailure(bool talksToLargeSharingPool)
+{
+    pas_fast_large_free_heap heap;
+    pas_fast_large_free_heap_construct(&heap);
+    size_t numAllocatedObjectBytes = 0;
+    size_t numAllocatedObjectBytesPeak = 0;
+
+    pas_large_utility_free_heap_talks_to_large_sharing_pool = talksToLargeSharingPool;
+    pas_physical_page_sharing_pool_balancing_enabled = true;
+    pas_physical_page_sharing_pool_balance = 0;
+
+    pas_heap_lock_lock();
+    void* result = pas_large_free_heap_helpers_try_allocate_with_alignment(
+        &heap, failingMemorySource, &numAllocatedObjectBytes, &numAllocatedObjectBytesPeak,
+        100, alignSimple(1), "test-give-back-guard");
+    pas_heap_lock_unlock();
+
+    CHECK(!result);
+
+    // The allocator's failure path must net out to zero against its setup path.
+    // When talks_to_large_sharing_pool is true, take_later subtracts aligned_size
+    // and give_back adds it back. When it is false, take_later is skipped, so
+    // give_back must be skipped too -- otherwise the balance drifts upward by
+    // aligned_size on every failed allocation.
+    CHECK_EQUAL(pas_physical_page_sharing_pool_balance, static_cast<intptr_t>(0));
 }
 
 } // anonymous namespace
@@ -1225,5 +1259,8 @@ void addLargeFreeHeapTests()
                      Free(15200, 16000)
                  },
                  1));
+
+    ADD_TEST(testGiveBackGuardOnAllocationFailure(true));
+    ADD_TEST(testGiveBackGuardOnAllocationFailure(false));
 }
 


### PR DESCRIPTION
#### eccbe3f8845e338d653fde40a925f51d6df7d0aa
<pre>
[libpas] `large_utility_aligned_allocator` unconditionally calls give_back on allocation failure
<a href="https://bugs.webkit.org/show_bug.cgi?id=314368">https://bugs.webkit.org/show_bug.cgi?id=314368</a>

Reviewed by Yusuke Suzuki.

large_utility_aligned_allocator&apos;s setup path only calls
pas_physical_page_sharing_pool_take_later when
pas_large_utility_free_heap_talks_to_large_sharing_pool is set, but the
failure path called pas_physical_page_sharing_pool_give_back
unconditionally. With the flag off, every failed allocation drifts
pas_physical_page_sharing_pool_balance upward by aligned_size, hiding
reclaimable pages from the scavenger.

Add the missing guard and a regression test that drives the failure path
with an always-failing memory source and checks the balance stays at zero
in both flag states.

* Source/bmalloc/libpas/src/libpas/pas_large_free_heap_helpers.c:
(large_utility_aligned_allocator):
* Source/bmalloc/libpas/src/test/LargeFreeHeapTests.cpp:
(std::failingMemorySource):
(std::testGiveBackGuardOnAllocationFailure):
(addLargeFreeHeapTests):

Canonical link: <a href="https://commits.webkit.org/312942@main">https://commits.webkit.org/312942@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e952e5a7d0c5eeeeb76152499ed53fc13667d6e7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/161324 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/34797 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/27898 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/170227 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/117695 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/34898 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/34798 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/125141 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/88185 "1 flakes 2 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/164283 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/27436 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/144906 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/105738 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/26484 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/24988 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/17947 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/153381 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/136178 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/22666 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/172710 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/22162 "Built successfully and passed tests") | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/24307 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/133423 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/34471 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/29080 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/133431 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36108 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/34456 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/144461 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/96321 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/27970 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/21279 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/193723 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/33966 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/49909 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/33465 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/33709 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/33614 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->