### PR TITLE
[MSE|Cocoa] Power Regression while watching Netflix when a decompression session is in use.

### DIFF
--- a/Source/WebCore/platform/graphics/cocoa/VideoMediaSampleRenderer.h
+++ b/Source/WebCore/platform/graphics/cocoa/VideoMediaSampleRenderer.h
@@ -234,6 +234,8 @@ private:
     bool m_needsFlushing WTF_GUARDED_BY_CAPABILITY(mainThread) { false };
 
     MediaTime m_lastMinimumUpcomingPresentationTime WTF_GUARDED_BY_CAPABILITY(dispatcher().get()) { MediaTime::invalidTime() };
+    bool m_decoderIdledAtHighWaterMark WTF_GUARDED_BY_CAPABILITY(dispatcher().get()) { false };
+    bool m_hasReachedHighWatermark WTF_GUARDED_BY_CAPABILITY(dispatcher().get()) { false };
 
     // Playback Statistics
     std::atomic<unsigned> m_totalVideoFrames { 0 };

--- a/Source/WebCore/platform/graphics/cocoa/VideoMediaSampleRenderer.mm
+++ b/Source/WebCore/platform/graphics/cocoa/VideoMediaSampleRenderer.mm
@@ -78,7 +78,7 @@ static constexpr CMItemCount SampleQueueHighWaterMark = 30;
 static constexpr CMItemCount SampleQueueLowWaterMark = 15;
 
 static constexpr MediaTime DecodeLowWaterMark { 100, 1000 };
-static constexpr MediaTime DecodeHighWaterMark { 133, 1000 };
+static constexpr MediaTime DecodeHighWaterMark { 166, 1000 };
 
 static bool isRendererThreadSafe(WebSampleBufferVideoRendering *renderering)
 {
@@ -498,9 +498,19 @@ void VideoMediaSampleRenderer::decodeNextSampleIfNeeded()
     while (!m_compressedSampleQueue.isEmpty() && !m_isDecodingSample) {
         WebCoreDecompressionSession::DecodingFlags decodingFlags;
 
+        auto endTime = lastDecodedSampleTime();
+
         if (currentTime.isValid() && !m_wasProtected && !m_decompressionSessionWasBlocked) {
-            auto endTime = lastDecodedSampleTime();
+            // Hysteresis: once we stopped at the high watermark, stay idle
+            // until the decoded buffer drains below the low watermark.
+            if (m_decoderIdledAtHighWaterMark) {
+                if (endTime.isValid() && endTime >= lowWaterMarkTime)
+                    return;
+                m_decoderIdledAtHighWaterMark = false;
+            }
+
             if (endTime.isValid() && endTime > highWaterMarkTime) {
+                m_hasReachedHighWatermark = true;
                 const auto& [sample, upcomingMinimumOpt, flushId, blocked] = m_compressedSampleQueue.first();
                 if (upcomingMinimumOpt) {
                     auto upcomingMinimum = std::min(sample->presentationTime(), *upcomingMinimumOpt);
@@ -511,6 +521,7 @@ void VideoMediaSampleRenderer::decodeNextSampleIfNeeded()
                             LogPerformance("VideoMediaSampleRenderer::decodeNextSampleIfNeeded currentTime:%0.2f expectMinimumUpcomingSampleBufferPresentationTime:%0.2f decoded queued:%zu upcoming:%zu high watermark reached", currentTime.toDouble(), m_lastMinimumUpcomingPresentationTime.toDouble(), decodedSamplesCount(), compressedSamplesCount());
                             [rendererOrDisplayLayer() expectMinimumUpcomingSampleBufferPresentationTime:PAL::toCMTime(m_lastMinimumUpcomingPresentationTime)];
                         }
+                        m_decoderIdledAtHighWaterMark = true;
                         return;
                     }
                     DEBUG_LOG(LOGIDENTIFIER, "Out of order frames detected, forcing extra decode");
@@ -519,14 +530,11 @@ void VideoMediaSampleRenderer::decodeNextSampleIfNeeded()
                 // later-arriving B-frame could have a lower PTS and would be
                 // rejected by the renderer. Fall through and keep decoding.
             }
-            if (endTime.isValid() && endTime >= lowWaterMarkTime && playbackRate > 0.9 && playbackRate < 1.1) {
-                LogPerformance("VideoMediaSampleRenderer::decodeNextSampleIfNeeded expectMinimumUpcomingSampleBufferPresentationTime:%0.2f decoded queued:%zu upcoming:%zu currentTime:%0.2f endTime:%0.2f low:%0.2f high:%0.2f low watermark reached", m_lastMinimumUpcomingPresentationTime.toDouble(), decodedSamplesCount(), compressedSamplesCount(), currentTime.toDouble(), endTime.toDouble(), lowWaterMarkTime.toDouble(), highWaterMarkTime.toDouble());
-                decodingFlags.add(WebCoreDecompressionSession::DecodingFlag::RealTime);
-            }
         }
 
         auto [sample, upcomingMinimumOpt, flushId, blocked] = m_compressedSampleQueue.takeFirst();
         m_compressedSamplesCount = m_compressedSampleQueue.size();
+
         maybeBecomeReadyForMoreMediaData();
 
         if (flushId != m_flushId) {
@@ -559,6 +567,21 @@ void VideoMediaSampleRenderer::decodeNextSampleIfNeeded()
             decodingFlags.add(WebCoreDecompressionSession::DecodingFlag::NonDisplaying);
         if (useStereoDecoding())
             decodingFlags.add(WebCoreDecompressionSession::DecodingFlag::EnableStereo);
+        // Mirror AVF's RealTime policy. On iOS-family the flag is set
+        // whenever we're in normal 1x playback and the sample is displaying.
+        // On macOS it is additionally suppressed during the
+        // kVMC2DecayingFromHighWaterLevel state: we have previously crossed
+        // the high watermark at least once since the last flush, and the
+        // decoded buffer has since drained below the low watermark.
+#if PLATFORM(MAC)
+        bool suppressRealTime = m_hasReachedHighWatermark && endTime.isValid() && endTime < lowWaterMarkTime;
+#else
+        bool suppressRealTime = false;
+#endif
+        if (currentTime.isValid() && !sample->isNonDisplaying() && playbackRate > 0.9 && playbackRate < 1.1 && !suppressRealTime) {
+            LogPerformance("VideoMediaSampleRenderer::decodeNextSampleIfNeeded RealTime set currentTime:%0.2f endTime:%0.2f low:%0.2f high:%0.2f reachedHigh:%d", currentTime.toDouble(), endTime.toDouble(), lowWaterMarkTime.toDouble(), highWaterMarkTime.toDouble(), m_hasReachedHighWatermark);
+            decodingFlags.add(WebCoreDecompressionSession::DecodingFlag::RealTime);
+        }
 
         RetainPtr cmSample = sample->platformSample().cmSampleBuffer();
         auto decodePromise = decompressionSession->decodeSample(cmSample.get(), decodingFlags);
@@ -748,6 +771,8 @@ void VideoMediaSampleRenderer::flushDecodedSampleQueue()
     m_lastDisplayedTime.reset();
     m_isDisplayingSample = false;
     m_lastMinimumUpcomingPresentationTime = MediaTime::invalidTime();
+    m_decoderIdledAtHighWaterMark = false;
+    m_hasReachedHighWatermark = false;
 }
 
 void VideoMediaSampleRenderer::cancelTimer()

--- a/Source/WebKit/GPUProcess/media/RemoteAudioVideoRendererProxyManager.cpp
+++ b/Source/WebKit/GPUProcess/media/RemoteAudioVideoRendererProxyManager.cpp
@@ -279,7 +279,7 @@ void RemoteAudioVideoRendererProxyManager::enqueueSample(RemoteAudioVideoRendere
     auto& converter = converterFor(iterator->value, trackIdentifier);
     MESSAGE_CHECK_COMPLETION(!!converter.currentTrackInfo(), completionHandler(false));
     if (RefPtr mediaSample = converter.convert(WTF::move(samplesBlock))) {
-        iterator->value.renderer->enqueueSample(trackIdentifier, mediaSample.releaseNonNull());
+        iterator->value.renderer->enqueueSample(trackIdentifier, mediaSample.releaseNonNull(), minimumPresentationTime);
         completionHandler(iterator->value.renderer->isReadyForMoreSamples(trackIdentifier));
         return;
     }


### PR DESCRIPTION
#### 88ab9766f984b092d29cffad9b898161eb9a59f2
<pre>
[MSE|Cocoa] Power Regression while watching Netflix when a decompression session is in use.
<a href="https://bugs.webkit.org/show_bug.cgi?id=314364">https://bugs.webkit.org/show_bug.cgi?id=314364</a>
<a href="https://rdar.apple.com/176517064">rdar://176517064</a>

Reviewed by Jer Noble.

VideoMediaSampleRenderer logic was to keep a fixed number of decoded frames
ahead of current time (driven by the DecodeHighWaterMark constant: 133ms).
Decoding would then be performed in burst until that number was reached
and stop, a new decode every time a previous sample expired.
An AVSampleBufferDisplayLayer however, uses a low of 100ms and a high of 166ms
watermark logic, driving the decode to be performed in burst instead.
Analysis shows that doing so is more efficient power wise.

We now make the VideoMediaSampleRenderer use a low/high watermark approach
we will decode until we have decoded DecodeHighWaterMark frames and stop
until there&apos;s only DecodeLowWaterMark left.

In addition, we copy AVF&apos;s use of kVTDecodeFrame_1xRealTimePlayback,
withholding kVTDecodeFrame_1xRealTimePlayback during initial fill and stopping
when below low water window; while unconditionally set for iOS family.

Introduce two flags on VideoMediaSampleRenderer:

- m_decoderIdledAtHighWaterMark: set when we pause the decoder on the
    lookahead-confirmed stop branch; cleared inline the next time we see
    endTime drop below the low watermark. Drives the hysteresis gate that
    keeps the decoder idle through the drain window.

- m_hasReachedHighWatermark: set on any crossing of the high watermark,
    cleared only on flush. Used exclusively to mirror AVF&apos;s decay-gate on
    macOS, where RealTime is suppressed when this flag is set AND the
    decoded buffer has since drained below the low watermark. Non-macOS
    platforms set the flag whenever rate is close to 1x and the sample
    is displaying, matching AVF&apos;s iOS policy. Initial fill (before the
    first high crossing) is no longer gated out on any platform, again
    matching AVF.

Both flags are cleared in flushDecodedSampleQueue so seek/track-change
behavior is identical to before. DecodeHighWaterMark is also raised from
133 ms to 166 ms; with the hysteresis in place this produces clean
~167 ms high-to-high pause cycles with 2-3 decodes per burst on 24 fps
4K MSE content, instead of the previous per-frame cadence pinned at the
high mark.

Also fly-by fix a missing IPC parameter forwarding in
RemoteAudioVideoRendererProxyManager::enqueueSample: the
minimumPresentationTime received from the .messages.in was accepted
by the handler but not passed through to renderer-&gt;enqueueSample,
silently defaulting to std::nullopt. As a result, GPU-process MSE
playback never saw the caller&apos;s lookahead hint, which meant the
lookahead-stop branch (and therefore the hysteresis itself) never
engaged for MSE video in the GPU process. Forwarding the parameter
restores the intended flow and is a prerequisite for the hysteresis
work above to take effect on the MSE path.

* Source/WebCore/platform/graphics/cocoa/VideoMediaSampleRenderer.h:
Add m_decoderIdledAtHighWaterMark and m_hasReachedHighWatermark,
both dispatcher-guarded.

* Source/WebCore/platform/graphics/cocoa/VideoMediaSampleRenderer.mm:
(WebCore::VideoMediaSampleRenderer::decodeNextSampleIfNeeded):
Add the hysteresis gate; set m_hasReachedHighWatermark on every
high-watermark crossing; set m_decoderIdledAtHighWaterMark on the
lookahead-confirmed stop; move the RealTime-flag gate below the
sample-consumed block so it can check sample-&gt;isNonDisplaying()
and apply the macOS-only decay suppression via
m_hasReachedHighWatermark. Bump DecodeHighWaterMark from 133 ms to
166 ms.
(WebCore::VideoMediaSampleRenderer::flushDecodedSampleQueue):
Clear both new flags on flush.

* Source/WebKit/GPUProcess/media/RemoteAudioVideoRendererProxyManager.cpp:
(WebKit::RemoteAudioVideoRendererProxyManager::enqueueSample):
Pass the received minimumPresentationTime through to
renderer-&gt;enqueueSample instead of dropping it on the floor and
relying on the std::nullopt default.

Canonical link: <a href="https://commits.webkit.org/312870@main">https://commits.webkit.org/312870@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/96e4add64bbc43d90d89fddf9114b6641241cdd5

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/161366 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/34840 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/27940 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/170269 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/117737 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/d2047cf7-cf12-426e-95f5-3a94ce376840) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/163235 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/34940 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/34841 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/125180 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/117737 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/5f0b304b-e29d-4717-bc40-d760106f96ab) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/164325 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/27467 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/144947 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/105777 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/180af608-cc9b-426c-ae57-62720c4149e3) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/26515 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/25024 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/17989 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/136209 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/22706 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/172752 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/19786 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/24347 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/133462 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/34513 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/29116 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/133470 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36037 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/34498 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/144501 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/96375 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/28004 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/21320 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/34008 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/101449 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/33508 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/33751 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/33657 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->