### PR TITLE
[JSC] Optimize `RegExp#@@split` for atom patterns

### DIFF
--- a/JSTests/microbenchmarks/regexp-split-comma-atom.js
+++ b/JSTests/microbenchmarks/regexp-split-comma-atom.js
@@ -1,0 +1,13 @@
+// Hot-path microbenchmark for String.prototype.split with a literal-atom
+// RegExp separator. Stresses the SpecificPattern::Atom fast path that
+// dispatches to the cached string-separator split.
+
+function split(string)
+{
+    return string.split(/,/);
+}
+noInline(split);
+
+var string = "alpha,bravo,charlie,delta,echo,foxtrot,golf";
+for (var i = 0; i < 1e6; ++i)
+    split(string);

--- a/JSTests/microbenchmarks/regexp-split-multichar-atom.js
+++ b/JSTests/microbenchmarks/regexp-split-multichar-atom.js
@@ -1,0 +1,13 @@
+// Hot-path microbenchmark for String.prototype.split with a multi-character
+// literal-atom RegExp separator. Exercises the SpecificPattern::Atom fast
+// path with a separator longer than one character.
+
+function split(string)
+{
+    return string.split(/--/);
+}
+noInline(split);
+
+var string = "alpha--bravo--charlie--delta--echo--foxtrot--golf";
+for (var i = 0; i < 1e6; ++i)
+    split(string);

--- a/JSTests/microbenchmarks/regexp-split-slash-atom.js
+++ b/JSTests/microbenchmarks/regexp-split-slash-atom.js
@@ -1,0 +1,13 @@
+// Hot-path microbenchmark for String.prototype.split with a literal-atom
+// RegExp separator splitting a path-like string. Mirrors the pattern seen
+// in JetStream3 path-handling code.
+
+function split(string)
+{
+    return string.split(/\//);
+}
+noInline(split);
+
+var string = "a/b/c/d/e/f/g/h/i/j/k/l/m/n/o/p";
+for (var i = 0; i < 1e6; ++i)
+    split(string);

--- a/Source/JavaScriptCore/runtime/RegExpPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/RegExpPrototype.cpp
@@ -37,6 +37,7 @@
 #include "RegExpObject.h"
 #include "RegExpObjectInlines.h"
 #include "RegExpPrototypeInlines.h"
+#include "StringPrototype.h"
 #include "StringRecursionChecker.h"
 #include "YarrFlags.h"
 #include <wtf/text/StringBuilder.h>
@@ -670,6 +671,23 @@ JSCell* regExpSplitFast(JSGlobalObject* globalObject, RegExpObject* regexpObject
             result->putDirectIndex(globalObject, 0, inputString);
             RETURN_IF_EXCEPTION(scope, { });
         }
+        return result;
+    }
+
+    if (regexp->specificPattern() == Yarr::SpecificPattern::Atom) {
+        const String& atomStr = regexp->atom();
+        ASSERT(!atomStr.isEmpty());
+        unsigned atomLength = atomStr.length();
+
+        JSString* separatorJSString = jsString(vm, AtomString { atomStr });
+        RETURN_IF_EXCEPTION(scope, { });
+
+        JSCell* result = stringSplitFast(globalObject, inputString, separatorJSString, limit);
+        RETURN_IF_EXCEPTION(scope, { });
+
+        size_t lastMatchPos = input->reverseFind(atomStr);
+        if (lastMatchPos != notFound)
+            globalObject->regExpGlobalData().recordMatch(vm, globalObject, regexp, inputString, MatchResult(lastMatchPos, lastMatchPos + atomLength), false);
         return result;
     }
 


### PR DESCRIPTION
#### 372aede44fa3a4e364c0f02e1dfc0ab398069f64
<pre>
[JSC] Optimize `RegExp#@@split` for atom patterns
<a href="https://bugs.webkit.org/show_bug.cgi?id=314370">https://bugs.webkit.org/show_bug.cgi?id=314370</a>

Reviewed by NOBODY (OOPS!).

Route SpecificPattern::Atom RegExps through stringSplitFast to reuse the
StringSplitCache fast path.

                                     TipOfTree                  Patched

regexp-split-multichar-atom      104.5076+-8.9275     ^     23.7495+-1.0436        ^ definitely 4.4004x faster
regexp-split-comma-atom          104.4760+-3.7781     ^     20.9884+-0.4553        ^ definitely 4.9778x faster
regexp-split-slash-atom          205.4747+-6.1158     ^     19.3040+-0.2439        ^ definitely 10.6441x faster

Tests: JSTests/microbenchmarks/regexp-split-comma-atom.js
       JSTests/microbenchmarks/regexp-split-multichar-atom.js
       JSTests/microbenchmarks/regexp-split-slash-atom.js

* JSTests/microbenchmarks/regexp-split-comma-atom.js: Added.
(split):
* JSTests/microbenchmarks/regexp-split-multichar-atom.js: Added.
(split):
* JSTests/microbenchmarks/regexp-split-slash-atom.js: Added.
(split):
* Source/JavaScriptCore/runtime/RegExpPrototype.cpp:
(JSC::regExpSplitFast):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/372aede44fa3a4e364c0f02e1dfc0ab398069f64

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/161336 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/34809 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/27910 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/170239 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/117707 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/34910 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/34810 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/125152 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/88191 "1 flakes 2 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/164295 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/27441 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/144921 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/105749 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/26489 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/24998 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/17959 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/153393 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/136183 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/22681 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/172722 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/22174 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/19743 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/24322 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/133435 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/34483 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/29090 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/133443 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/34468 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/144476 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/96335 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/27981 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/21295 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/193735 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/33978 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/101403 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/49915 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/33477 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/33721 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/33626 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->