### PR TITLE
(312763@main) minimumUpcomingTime is never set for WebM, causing unbounded decode.

### DIFF
--- a/Source/WebCore/platform/graphics/AudioVideoRenderer.h
+++ b/Source/WebCore/platform/graphics/AudioVideoRenderer.h
@@ -148,7 +148,13 @@ public:
     virtual std::optional<TrackIdentifier> addTrack(TrackType) = 0;
     virtual void removeTrack(TrackIdentifier) = 0;
 
-    virtual void enqueueSample(TrackIdentifier, Ref<MediaSample>&&, std::optional<MediaTime> = std::nullopt) = 0;
+    // Tri-state on minimumUpcomingFrame:
+    //   nullopt            -> Assume content doesn't have b-frame.
+    //   !isFinite()        -> Content with b-frame: a future compressed frame
+    //                         with a lower presentation state may be incoming,
+    //                         not enough frames buffered ahead to make a determination.
+    //   finite MediaTime   -> Minimum upcoming presentation time known.
+    virtual void enqueueSample(TrackIdentifier, Ref<MediaSample>&&, std::optional<MediaTime> minimumUpcomingTime = std::nullopt) = 0;
     virtual bool isReadyForMoreSamples(TrackIdentifier) = 0;
     using RequestPromise = NativePromise<TrackIdentifier, PlatformMediaError>;
     virtual Ref<RequestPromise> requestMediaDataWhenReady(TrackIdentifier) = 0;

--- a/Source/WebCore/platform/graphics/cocoa/VideoMediaSampleRenderer.mm
+++ b/Source/WebCore/platform/graphics/cocoa/VideoMediaSampleRenderer.mm
@@ -512,10 +512,24 @@ void VideoMediaSampleRenderer::decodeNextSampleIfNeeded()
             if (endTime.isValid() && endTime > highWaterMarkTime) {
                 m_hasReachedHighWatermark = true;
                 const auto& [sample, upcomingMinimumOpt, flushId, blocked] = m_compressedSampleQueue.first();
-                if (upcomingMinimumOpt) {
-                    auto upcomingMinimum = std::min(sample->presentationTime(), *upcomingMinimumOpt);
+                // Tri-state on upcomingMinimumOpt:
+                //   nullopt            -> caller did not supply a bound; use
+                //                         sample->presentationTime() as an
+                //                         internal ceiling. Do not publish a
+                //                         floor to AVF — external floors are
+                //                         only promised when a caller has
+                //                         explicitly asserted a lookahead.
+                //   !isFinite()        -> caller marked as unknown
+                //                         (MediaTime::indefiniteTime()); keep
+                //                         decoding unbounded.
+                //   finite MediaTime   -> caller-supplied lookahead bound; use
+                //                         it and publish the floor to AVF.
+                const bool explicitUnknown = upcomingMinimumOpt && !upcomingMinimumOpt->isFinite();
+                if (!explicitUnknown) {
+                    const bool callerSuppliedBound = upcomingMinimumOpt.has_value();
+                    auto upcomingMinimum = callerSuppliedBound ? std::min(sample->presentationTime(), *upcomingMinimumOpt) : sample->presentationTime();
                     if (endTime < upcomingMinimum) {
-                        if (m_lastMinimumUpcomingPresentationTime.isInvalid() || upcomingMinimum != m_lastMinimumUpcomingPresentationTime) {
+                        if (callerSuppliedBound && (m_lastMinimumUpcomingPresentationTime.isInvalid() || upcomingMinimum != m_lastMinimumUpcomingPresentationTime)) {
                             ASSERT(m_lastMinimumUpcomingPresentationTime.isInvalid() || m_lastMinimumUpcomingPresentationTime < upcomingMinimum);
                             m_lastMinimumUpcomingPresentationTime = upcomingMinimum;
                             LogPerformance("VideoMediaSampleRenderer::decodeNextSampleIfNeeded currentTime:%0.2f expectMinimumUpcomingSampleBufferPresentationTime:%0.2f decoded queued:%zu upcoming:%zu high watermark reached", currentTime.toDouble(), m_lastMinimumUpcomingPresentationTime.toDouble(), decodedSamplesCount(), compressedSamplesCount());
@@ -524,11 +538,9 @@ void VideoMediaSampleRenderer::decodeNextSampleIfNeeded()
                         m_decoderIdledAtHighWaterMark = true;
                         return;
                     }
-                    DEBUG_LOG(LOGIDENTIFIER, "Out of order frames detected, forcing extra decode");
+                    if (callerSuppliedBound)
+                        DEBUG_LOG(LOGIDENTIFIER, "Out of order frames detected, forcing extra decode");
                 }
-                // Without a caller lookahead we can't safely publish a floor — a
-                // later-arriving B-frame could have a lower PTS and would be
-                // rejected by the renderer. Fall through and keep decoding.
             }
         }
 


### PR DESCRIPTION
#### f63c6d82be9dbf666e0fe2548511704fa08446f2
<pre>
(312763@main) minimumUpcomingTime is never set for WebM, causing unbounded decode.
<a href="https://bugs.webkit.org/show_bug.cgi?id=314365">https://bugs.webkit.org/show_bug.cgi?id=314365</a>
<a href="https://rdar.apple.com/176522504">rdar://176522504</a>

Reviewed by Gerald Squelart.

minimumUpcomingTime wasn&apos;t supplied by the MediaPlayerPrivateWebM
and so the VideoMediaSampleRenderer would treat it as if future b-frame were
to come, never limiting the decoder.

We now make the minimumUpcomingTime argument a three-state value
instead.

No change in JS observable behaviours. Manually verified through logging
that all was behaving as expected.

* Source/WebCore/platform/graphics/AudioVideoRenderer.h:
* Source/WebCore/platform/graphics/cocoa/VideoMediaSampleRenderer.mm:
(WebCore::VideoMediaSampleRenderer::decodeNextSampleIfNeeded):

Canonical link: <a href="https://commits.webkit.org/312948@main">https://commits.webkit.org/312948@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/628bd88832ede7897740dd80451cdcec6bb95b58

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/161341 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/34814 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/27915 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/170244 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/117712 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/daf254de-7744-440c-a80b-63ab69a13ce9) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/163210 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/34915 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/34815 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/125156 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/88193 "2 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/74bc1ef4-14e7-4d6d-830c-45044bce2c85) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/164300 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/27448 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/144924 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/105753 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/8ba37d56-601a-43c9-9827-dd67564859b6) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/26496 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/25000 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/17964 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/136190 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/22684 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/172727 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/19748 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/24325 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/133438 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/34488 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/29092 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/133446 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36112 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/34473 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/144479 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/96343 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/27987 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/21298 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/33983 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/101408 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/33482 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/33726 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/33631 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->