### PR TITLE
sibling-index() in @keyframes doesn't re-resolve when siblings change

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-values/tree-counting/sibling-index-keyframe-font-style-dynamic-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-values/tree-counting/sibling-index-keyframe-font-style-dynamic-expected.txt
@@ -1,4 +1,4 @@
 
 PASS Initially, the sibling-index() is 3 for #target
-FAIL Removing a preceding sibling of #target reduces the sibling-index() assert_equals: expected "oblique 10deg" but got "oblique 15deg"
+PASS Removing a preceding sibling of #target reduces the sibling-index()
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-values/tree-counting/sibling-index-keyframe-font-variation-settings-dynamic-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-values/tree-counting/sibling-index-keyframe-font-variation-settings-dynamic-expected.txt
@@ -1,4 +1,4 @@
 
 PASS Initially, the sibling-index() is 3 for #target
-FAIL Removing a preceding sibling of #target reduces the sibling-index() assert_equals: expected "\"wght\" 2" but got "\"wght\" 3"
+PASS Removing a preceding sibling of #target reduces the sibling-index()
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-values/tree-counting/sibling-index-keyframe-font-weight-dynamic-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-values/tree-counting/sibling-index-keyframe-font-weight-dynamic-expected.txt
@@ -1,4 +1,4 @@
 
 PASS Initially, the sibling-index() is 3 for #target
-FAIL Removing a preceding sibling of #target reduces the sibling-index() assert_equals: expected "200" but got "300"
+PASS Removing a preceding sibling of #target reduces the sibling-index()
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-values/tree-counting/sibling-index-keyframe-length-value-dynamic-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-values/tree-counting/sibling-index-keyframe-length-value-dynamic-expected.txt
@@ -1,4 +1,4 @@
 
 PASS Initially, the sibling-index() is 2 for #target
-FAIL Removing a preceding sibling of #target reduces the sibling-index() assert_equals: expected "100px" but got "200px"
+PASS Removing a preceding sibling of #target reduces the sibling-index()
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-values/tree-counting/sibling-index-keyframe-registered-properties-dynamic-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-values/tree-counting/sibling-index-keyframe-registered-properties-dynamic-expected.txt
@@ -9,14 +9,14 @@ PASS Initially, the sibling-index() is 3 for --length
 PASS Initially, the sibling-index() is 3 for --length-percentage
 FAIL Initially, the sibling-index() is 3 for --color assert_equals: expected "color(srgb 0 0.6 0)" but got "oklab(0.591738 -0.159734 0.122589)"
 PASS Initially, the sibling-index() is 3 for --list
-FAIL Removing a preceding sibling of #target reduces the sibling-index() for --time assert_equals: expected "4s" but got "6s"
-FAIL Removing a preceding sibling of #target reduces the sibling-index() for --angle assert_equals: expected "60deg" but got "90deg"
-FAIL Removing a preceding sibling of #target reduces the sibling-index() for --resolution assert_equals: expected "2dppx" but got "3dppx"
-FAIL Removing a preceding sibling of #target reduces the sibling-index() for --percentage assert_equals: expected "100%" but got "150%"
-FAIL Removing a preceding sibling of #target reduces the sibling-index() for --number assert_equals: expected "2" but got "3"
-FAIL Removing a preceding sibling of #target reduces the sibling-index() for --integer assert_equals: expected "2" but got "3"
-FAIL Removing a preceding sibling of #target reduces the sibling-index() for --length assert_equals: expected "14px" but got "21px"
-FAIL Removing a preceding sibling of #target reduces the sibling-index() for --length-percentage assert_equals: expected "calc(10% + 16px)" but got "calc(15% + 24px)"
-FAIL Removing a preceding sibling of #target reduces the sibling-index() for --color assert_equals: expected "color(srgb 0 0.4 0)" but got "oklab(0.591738 -0.159734 0.122589)"
-FAIL Removing a preceding sibling of #target reduces the sibling-index() for --list assert_equals: expected "13 2" but got "13 3"
+PASS Removing a preceding sibling of #target reduces the sibling-index() for --time
+PASS Removing a preceding sibling of #target reduces the sibling-index() for --angle
+PASS Removing a preceding sibling of #target reduces the sibling-index() for --resolution
+PASS Removing a preceding sibling of #target reduces the sibling-index() for --percentage
+PASS Removing a preceding sibling of #target reduces the sibling-index() for --number
+PASS Removing a preceding sibling of #target reduces the sibling-index() for --integer
+PASS Removing a preceding sibling of #target reduces the sibling-index() for --length
+PASS Removing a preceding sibling of #target reduces the sibling-index() for --length-percentage
+FAIL Removing a preceding sibling of #target reduces the sibling-index() for --color assert_equals: expected "color(srgb 0 0.4 0)" but got "oklab(0.442125 -0.119348 0.091594)"
+PASS Removing a preceding sibling of #target reduces the sibling-index() for --list
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-values/tree-counting/sibling-index-keyframe-rotate-dynamic-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-values/tree-counting/sibling-index-keyframe-rotate-dynamic-expected.txt
@@ -1,4 +1,4 @@
 
 PASS Initially, the sibling-index() is 3 for #target
-FAIL Removing a preceding sibling of #target reduces the sibling-index() assert_equals: expected "x 20deg" but got "x 30deg"
+PASS Removing a preceding sibling of #target reduces the sibling-index()
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-values/tree-counting/sibling-index-keyframe-scale-dynamic-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-values/tree-counting/sibling-index-keyframe-scale-dynamic-expected.txt
@@ -1,4 +1,4 @@
 
 PASS Initially, the sibling-index() is 3 for #target
-FAIL Removing a preceding sibling of #target reduces the sibling-index() assert_equals: expected "0.7 0.4" but got "0.7 0.6"
+PASS Removing a preceding sibling of #target reduces the sibling-index()
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-values/tree-counting/sibling-index-keyframe-transform-dynamic-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-values/tree-counting/sibling-index-keyframe-transform-dynamic-expected.txt
@@ -1,4 +1,4 @@
 
 PASS Initially, the sibling-index() is 3 for #target
-FAIL Removing a preceding sibling of #target reduces the sibling-index() assert_equals: expected "matrix(1, 0, 0, 1, 20, 0)" but got "matrix(1, 0, 0, 1, 30, 0)"
+PASS Removing a preceding sibling of #target reduces the sibling-index()
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-values/tree-counting/sibling-index-keyframe-value-dynamic-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-values/tree-counting/sibling-index-keyframe-value-dynamic-expected.txt
@@ -2,5 +2,5 @@ You should see a green square below.
 
 
 PASS Initially, the sibling-index() is 3 for #target
-FAIL Removing a preceding sibling of #target reduces the sibling-index() assert_equals: expected "2" but got "3"
+PASS Removing a preceding sibling of #target reduces the sibling-index()
 

--- a/Source/WebCore/animation/BlendingKeyframes.cpp
+++ b/Source/WebCore/animation/BlendingKeyframes.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 1999 Antti Koivisto (koivisto@kde.org)
- * Copyright (C) 2004-2025 Apple Inc. All rights reserved.
+ * Copyright (C) 2004-2026 Apple Inc. All rights reserved.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Library General Public
@@ -285,6 +285,15 @@ bool BlendingKeyframes::usesViewportUnits() const
 {
     for (auto& keyframe : m_keyframes) {
         if (keyframe.style()->usesViewportUnits())
+            return true;
+    }
+    return false;
+}
+
+bool BlendingKeyframes::usesTreeCountingFunctions() const
+{
+    for (auto& keyframe : m_keyframes) {
+        if (keyframe.style()->useTreeCountingFunctions())
             return true;
     }
     return false;

--- a/Source/WebCore/animation/BlendingKeyframes.h
+++ b/Source/WebCore/animation/BlendingKeyframes.h
@@ -2,7 +2,7 @@
  * Copyright (C) 2000 Lars Knoll (knoll@kde.org)
  *           (C) 2000 Antti Koivisto (koivisto@kde.org)
  *           (C) 2000 Dirk Mueller (mueller@kde.org)
- * Copyright (C) 2003, 2005, 2006, 2007, 2008 Apple Inc. All rights reserved.
+ * Copyright (C) 2003-2026 Apple Inc. All rights reserved.
  * Copyright (C) 2006 Graham Dennis (graham.dennis@gmail.com)
  *
  * This library is free software; you can redistribute it and/or
@@ -150,6 +150,7 @@ public:
 
     bool NODELETE usesContainerUnits() const;
     bool usesViewportUnits() const;
+    bool NODELETE usesTreeCountingFunctions() const;
     bool usesRelativeFontWeight() const { return m_usesRelativeFontWeight; }
     bool hasSubstitutionFunctions() const { return m_containsSubstitutionFunctions; }
     bool hasColorSetToCurrentColor() const;

--- a/Source/WebCore/animation/KeyframeEffect.cpp
+++ b/Source/WebCore/animation/KeyframeEffect.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2025 Apple Inc. All rights reserved.
+ * Copyright (C) 2017-2026 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -2241,9 +2241,10 @@ std::optional<KeyframeEffect::RecomputationReason> KeyframeEffect::recomputeKeyf
     }();
 
     auto usesAnchorFunctions = m_blendingKeyframes.usesAnchorFunctions();
+    auto usesTreeCountingFunctions = m_blendingKeyframes.usesTreeCountingFunctions();
     auto hasPropertiesWithRevert = m_blendingKeyframes.hasPropertiesWithRevertRuleOrLayer();
 
-    if (logicalPropertyChanged || fontSizeChanged() || fontWeightChanged() || cssVariableChanged() || hasPropertyExplicitlySetToInherit() || propertySetToCurrentColorChanged() || usesAnchorFunctions || hasPropertiesWithRevert) {
+    if (logicalPropertyChanged || fontSizeChanged() || fontWeightChanged() || cssVariableChanged() || hasPropertyExplicitlySetToInherit() || propertySetToCurrentColorChanged() || usesAnchorFunctions || usesTreeCountingFunctions || hasPropertiesWithRevert) {
         switch (m_animationType) {
         case WebAnimationType::CSSTransition:
             ASSERT_NOT_REACHED();


### PR DESCRIPTION
#### ef00a2bc79a56bdd9cb2ac27ab3d42662f82deea
<pre>
sibling-index() in @keyframes doesn&apos;t re-resolve when siblings change
<a href="https://bugs.webkit.org/show_bug.cgi?id=314376">https://bugs.webkit.org/show_bug.cgi?id=314376</a>
<a href="https://rdar.apple.com/176531901">rdar://176531901</a>

Reviewed by Antoine Quint.

When a keyframe value uses sibling-index() or sibling-count(), the
resolved keyframe style is frozen at the value computed at animation
start. Adding or removing a preceding sibling correctly invalidates
the target&apos;s style (via ChildrenAffectedBy{Forward,Backward}PositionalRules),
but KeyframeEffect::recomputeKeyframesIfNecessary() had no signal to
re-run styleForKeyframe, so the blended keyframe kept the stale index.

Track tree-counting usage on the keyframe style and recompute keyframes
when it is set, mirroring the existing handling of usesAnchorFunctions.

* Source/WebCore/animation/BlendingKeyframes.cpp:
(WebCore::BlendingKeyframes::usesTreeCountingFunctions const):
* Source/WebCore/animation/BlendingKeyframes.h:
* Source/WebCore/animation/KeyframeEffect.cpp:
(WebCore::KeyframeEffect::recomputeKeyframesIfNecessary): Recompute
blending keyframes when they reference tree-counting functions, so the
target&apos;s style invalidation on sibling change propagates through to the
animated value.

&gt; Progressions:
* LayoutTests/imported/w3c/web-platform-tests/css/css-values/tree-counting/sibling-index-keyframe-font-style-dynamic-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-values/tree-counting/sibling-index-keyframe-font-variation-settings-dynamic-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-values/tree-counting/sibling-index-keyframe-font-weight-dynamic-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-values/tree-counting/sibling-index-keyframe-length-value-dynamic-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-values/tree-counting/sibling-index-keyframe-registered-properties-dynamic-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-values/tree-counting/sibling-index-keyframe-rotate-dynamic-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-values/tree-counting/sibling-index-keyframe-scale-dynamic-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-values/tree-counting/sibling-index-keyframe-transform-dynamic-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-values/tree-counting/sibling-index-keyframe-value-dynamic-expected.txt:

Canonical link: <a href="https://commits.webkit.org/312895@main">https://commits.webkit.org/312895@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/02ff7e55b6f6f167859b84c0779a1fc63397c4a0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/161342 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/34815 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/27916 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/170245 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/117713 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/4f3fd0e5-9fa5-464c-b029-c34f553157cb) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/163211 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/34916 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/34816 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/125157 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/117713 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/01ecf290-cf01-412e-94d4-b59baa61550b) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/164301 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/27442 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/144925 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/105754 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/66a1099b-cc5e-4f6a-88c5-7fc652bcbe1a) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/26490 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/25003 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/17965 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/136184 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/22685 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/172728 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/19749 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/24326 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/133439 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/34489 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/29095 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/133447 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36060 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/34474 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/144480 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/96344 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/27989 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/21299 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/33984 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/101409 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/33483 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/33727 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/33632 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->