### PR TITLE
REGRESSION(312552@main): Web Inspector console error icon in tab bar is huge

### DIFF
--- a/Source/WebInspectorUI/UserInterface/Views/TabBar.css
+++ b/Source/WebInspectorUI/UserInterface/Views/TabBar.css
@@ -90,6 +90,11 @@ body.window-inactive .tab-bar > .border {
     padding: 0;
 }
 
+.tab-bar > .navigation-bar > .item.group > .item > img {
+    width: 16px;
+    height: 16px;
+}
+
 .tab-bar > .navigation-bar > .item.group > .item:nth-child(1 of :not(.hidden)) {
     margin-inline-start: 8px;
 }


### PR DESCRIPTION
#### 10cc1f0d1f44f020e6bcfdde9b1ea04f34475d29
<pre>
REGRESSION(<a href="https://commits.webkit.org/312552@main">312552@main</a>): Web Inspector console error icon in tab bar is huge
<a href="https://bugs.webkit.org/show_bug.cgi?id=314361">https://bugs.webkit.org/show_bug.cgi?id=314361</a>
<a href="https://rdar.apple.com/176508343">rdar://176508343</a>

Reviewed by NOBODY (OOPS!).

<a href="https://commits.webkit.org/312552@main">312552@main</a> made &lt;img&gt;&apos;s intrinsic size for an SVG with only a viewBox
follow the specification: 150x150 for an SVG lacking intrinsic
dimensions, instead of the viewBox dimensions.

The console-warnings/errors tab-bar buttons use ImageType.IMG with
IssuesEnabled.svg / ErrorsEnabled.svg (viewBox=&quot;0 0 16 16&quot;, no
width/height). They&apos;re wrapped in a GroupNavigationItem, where
`.tab-bar &gt; .navigation-bar &gt; .item.group &gt; .item { width: auto; }`
overrides the parent&apos;s normal 26px width. With both axes auto-sized,
the img&apos;s `width:100%; height:100%` resolves to auto and falls back to
the SVG&apos;s intrinsic dimensions, so the red errors badge balloons to
150x150.

Constrain the &lt;img&gt; directly in the tab-bar group context. Targeted to
`&gt; img` so SVG-type buttons (which use
&lt;div class=&quot;glyph&quot;&gt;&lt;svg&gt;&lt;/svg&gt;&lt;/div&gt; with inline sizing) are unaffected.

Note: the WebInspectorUI &quot;Copy User Interface Resources&quot; build phase
declares `$(SRCROOT)/UserInterface` as a directory input. Xcode only
notices changes to the directory&apos;s own mtime, not its contents, so
incremental builds silently skip this CSS edit. Touch
Source/WebInspectorUI/Scripts/copy-user-interface-resources.pl to force
the copy.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/10cc1f0d1f44f020e6bcfdde9b1ea04f34475d29

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/161346 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/34819 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/27920 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/170249 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/117717 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/544a75cf-41d3-4b7a-86d4-ca54ba9d3ed1) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/34920 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/34820 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/125160 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/117717 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/618030ae-2f20-4863-be79-0d4d87b8d374) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/164305 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/27449 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/144926 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/105757 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/26497 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/25007 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/17969 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/136191 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/22686 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/172732 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/19753 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/24327 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/133443 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/34493 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/29099 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/133451 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/34478 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/144481 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/96349 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/27988 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/21300 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/33988 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/101413 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/33487 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/33731 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/33636 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->