### PR TITLE
[libpas] Allow in-place realloc for segregated case

### DIFF
--- a/Source/bmalloc/libpas/libpas.xcodeproj/project.pbxproj
+++ b/Source/bmalloc/libpas/libpas.xcodeproj/project.pbxproj
@@ -551,6 +551,7 @@
 		2B2E2FD12949A41100F85C38 /* pas_malloc_stack_logging.c in Sources */ = {isa = PBXBuildFile; fileRef = 2B2E2FCF2949A41100F85C38 /* pas_malloc_stack_logging.c */; };
 		2B2E2FD22949A41100F85C38 /* pas_malloc_stack_logging.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B2E2FD02949A41100F85C38 /* pas_malloc_stack_logging.h */; };
 		2B6055E42805368B00C8BDAC /* BmallocTests.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B6055E32805368B00C8BDAC /* BmallocTests.cpp */; };
+		2BA7F3C12E1C000000000002 /* ReallocFastPathTests.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2BA7F3C12E1C000000000001 /* ReallocFastPathTests.cpp */; };
 		2BDF4F4529E8B36F0056BF50 /* pas_report_crash.h in Headers */ = {isa = PBXBuildFile; fileRef = 2BDF4F4429E8B36F0056BF50 /* pas_report_crash.h */; };
 		2BDF4F4729E8B3AD0056BF50 /* pas_report_crash.c in Sources */ = {isa = PBXBuildFile; fileRef = 2BDF4F4829E8B5510056BF50 /* pas_report_crash.c */; };
 		2BE4B7CB2D2D845E0099B3C5 /* pas_small_medium_bootstrap_free_heap.h in Headers */ = {isa = PBXBuildFile; fileRef = 2BE4B7C72D2D845E0099B3C5 /* pas_small_medium_bootstrap_free_heap.h */; };
@@ -1268,6 +1269,7 @@
 		2B2E2FCF2949A41100F85C38 /* pas_malloc_stack_logging.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = pas_malloc_stack_logging.c; sourceTree = "<group>"; };
 		2B2E2FD02949A41100F85C38 /* pas_malloc_stack_logging.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = pas_malloc_stack_logging.h; sourceTree = "<group>"; };
 		2B6055E32805368B00C8BDAC /* BmallocTests.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = BmallocTests.cpp; sourceTree = "<group>"; };
+		2BA7F3C12E1C000000000001 /* ReallocFastPathTests.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ReallocFastPathTests.cpp; sourceTree = "<group>"; };
 		2BDF4F4429E8B36F0056BF50 /* pas_report_crash.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = pas_report_crash.h; sourceTree = "<group>"; };
 		2BDF4F4829E8B5510056BF50 /* pas_report_crash.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = pas_report_crash.c; sourceTree = "<group>"; };
 		2BE4B7C72D2D845E0099B3C5 /* pas_small_medium_bootstrap_free_heap.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = pas_small_medium_bootstrap_free_heap.h; sourceTree = "<group>"; };
@@ -1442,6 +1444,7 @@
 				0FD22D0722CD8A7500B21841 /* MinHeapTests.cpp */,
 				2B2A589B2742D815005EE07C /* PGMTests.cpp */,
 				0F5E483923D69F610046DA5C /* RaceTests.cpp */,
+				2BA7F3C12E1C000000000001 /* ReallocFastPathTests.cpp */,
 				0FF08F3522A59DB300386575 /* RedBlackTreeTests.cpp */,
 				0FA18545236B3C82003609A7 /* ScavengerExternalWorkTests.cpp */,
 				0FDE52552342B7C400A0808F /* SuspendScavenger.h */,
@@ -2714,6 +2717,7 @@
 				0FD22D0822CD8A7500B21841 /* MinHeapTests.cpp in Sources */,
 				2B2A589C2742D815005EE07C /* PGMTests.cpp in Sources */,
 				0F5E483A23D69F610046DA5C /* RaceTests.cpp in Sources */,
+				2BA7F3C12E1C000000000002 /* ReallocFastPathTests.cpp in Sources */,
 				0FF08F3622A59DB300386575 /* RedBlackTreeTests.cpp in Sources */,
 				0FA18546236B3C82003609A7 /* ScavengerExternalWorkTests.cpp in Sources */,
 				0FC681ED21127A19003C6A13 /* TestHarness.cpp in Sources */,

--- a/Source/bmalloc/libpas/src/libpas/pas_internal_config.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_internal_config.h
@@ -121,6 +121,11 @@
 
 #define PAS_MAX_LARGE_ALIGNMENT_WASTEAGE 1.3
 
+/* If old_size > new_size * PAS_MAX_IN_PLACE_REALLOC_SHRINKAGE, skip the in-place
+   realloc fast path and fall back to allocate+copy+free so the caller doesn't
+   keep an oversized slot pinned for a much smaller request. */
+#define PAS_MAX_IN_PLACE_REALLOC_SHRINKAGE 4
+
 #define PAS_BITS_TTL                     16
 
 #define PAS_NUM_BASELINE_ALLOCATORS      32u

--- a/Source/bmalloc/libpas/src/libpas/pas_mte.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_mte.h
@@ -845,6 +845,9 @@ pas_mte_retag_freed_region_if_tagged(
 // Used to clear the tag before we look up the address in the megapage table when reallocating.
 #define PAS_MTE_HANDLE_REALLOCATE(a) PAS_MTE_CLEAR(a)
 
+// Used to restore the correct tag on the pointer when realloc reuses the existing allocation.
+#define PAS_MTE_HANDLE_REALLOCATE_IN_PLACE(a) PAS_MTE_PURIFY(a)
+
 // Used to restore the correct tag when reallocating something to a new address before copying it.
 #define PAS_MTE_HANDLE_TRY_REALLOCATE_AND_COPY(ptr, old_ptr, size) do { \
         if (PAS_USE_MTE) { \

--- a/Source/bmalloc/libpas/src/libpas/pas_try_reallocate.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_try_reallocate.h
@@ -48,6 +48,20 @@ typedef pas_allocation_result
                                         pas_allocation_mode allocation_mode,
                                         void* arg);
 
+static PAS_ALWAYS_INLINE bool
+pas_try_reallocate_size_fits_in_place(
+    size_t old_size,
+    size_t new_size,
+    pas_heap* source_heap,
+    pas_heap* target_heap)
+{
+    if (!new_size || new_size > old_size || new_size * PAS_MAX_IN_PLACE_REALLOC_SHRINKAGE < old_size)
+        return false;
+    if (source_heap != target_heap)
+        return false;
+    return true;
+}
+
 static PAS_ALWAYS_INLINE pas_allocation_result
 pas_try_allocate_for_reallocate_and_copy(
     pas_heap* source_heap,
@@ -130,25 +144,20 @@ pas_try_reallocate_table_segregated_case(pas_page_base* page_base,
     pas_allocation_result result;
     pas_heap* old_heap;
     pas_segregated_page* page;
-    
+    pas_segregated_size_directory* directory;
+
     page = pas_page_base_get_segregated(page_base);
-    
-    switch (teleport_rule) {
-    case pas_reallocate_allow_heap_teleport:
-        old_size = pas_segregated_page_get_object_size_for_address_in_page(
-            page, begin, segregated_config);
-        old_heap = NULL;
-        break;
-        
-    case pas_reallocate_disallow_heap_teleport: {
-        pas_segregated_size_directory* directory;
-        directory = pas_segregated_page_get_directory_for_address_in_page(
-            page, begin, segregated_config);
-        old_size = directory->object_size;
-        old_heap = pas_heap_for_segregated_heap(directory->heap);
-        break;
-    } }
-    
+    directory = pas_segregated_page_get_directory_for_address_in_page(
+        page, begin, segregated_config);
+    old_size = directory->object_size;
+    old_heap = pas_heap_for_segregated_heap(directory->heap);
+
+    if (pas_try_reallocate_size_fits_in_place(old_size, new_size, old_heap, heap)) {
+        uintptr_t in_place_begin = begin;
+        PAS_MTE_HANDLE(REALLOCATE_IN_PLACE, in_place_begin);
+        return pas_allocation_result_create_success(in_place_begin);
+    }
+
     result = pas_try_allocate_for_reallocate_and_copy(
         old_heap, heap, (void*)begin, old_size, new_size, allocation_mode, teleport_rule,
         allocate_callback, allocate_callback_arg);
@@ -173,23 +182,20 @@ pas_try_reallocate_table_bitfit_case(pas_page_base* page_base,
     pas_allocation_result result;
     pas_bitfit_page* page;
     pas_heap* old_heap;
-    
+
     page = pas_page_base_get_bitfit(page_base);
     old_size = bitfit_config.specialized_page_get_allocation_size_with_page(page, begin);
-    
-    switch (teleport_rule) {
-    case pas_reallocate_allow_heap_teleport:
-        old_heap = NULL;
-        break;
-        
-    case pas_reallocate_disallow_heap_teleport:
-        old_heap = pas_heap_for_segregated_heap(
-            pas_compact_bitfit_directory_ptr_load_non_null(
-                &pas_compact_atomic_bitfit_view_ptr_load_non_null(
-                    &page->owner)->directory)->heap);
-        break;
+    old_heap = pas_heap_for_segregated_heap(
+        pas_compact_bitfit_directory_ptr_load_non_null(
+            &pas_compact_atomic_bitfit_view_ptr_load_non_null(
+                &page->owner)->directory)->heap);
+
+    if (pas_try_reallocate_size_fits_in_place(old_size, new_size, old_heap, heap)) {
+        uintptr_t in_place_begin = begin;
+        PAS_MTE_HANDLE(REALLOCATE_IN_PLACE, in_place_begin);
+        return pas_allocation_result_create_success(in_place_begin);
     }
-    
+
     result = pas_try_allocate_for_reallocate_and_copy(
         old_heap, heap, (void*)begin, old_size, new_size, allocation_mode, teleport_rule,
         allocate_callback, allocate_callback_arg);
@@ -221,22 +227,18 @@ pas_try_reallocate(void* old_ptr,
         size_t old_size;
         pas_allocation_result result;
         pas_heap* old_heap;
+        pas_segregated_size_directory* directory;
 
-        switch (teleport_rule) {
-        case pas_reallocate_allow_heap_teleport:
-            old_size = pas_segregated_page_get_object_size_for_address_and_page_config(
-                begin, config.small_segregated_config);
-            old_heap = NULL;
-            break;
+        directory = pas_segregated_page_get_directory_for_address_and_page_config(
+            begin, config.small_segregated_config);
+        old_size = directory->object_size;
+        old_heap = pas_heap_for_segregated_heap(directory->heap);
 
-        case pas_reallocate_disallow_heap_teleport: {
-            pas_segregated_size_directory* directory;
-            directory = pas_segregated_page_get_directory_for_address_and_page_config(
-                begin, config.small_segregated_config);
-            old_size = directory->object_size;
-            old_heap = pas_heap_for_segregated_heap(directory->heap);
-            break;
-        } }
+        if (pas_try_reallocate_size_fits_in_place(old_size, new_size, old_heap, heap)) {
+            uintptr_t in_place_begin = begin;
+            PAS_MTE_HANDLE(REALLOCATE_IN_PLACE, in_place_begin);
+            return pas_allocation_result_create_success(in_place_begin);
+        }
 
         result = pas_try_allocate_for_reallocate_and_copy(
             old_heap, heap, old_ptr, old_size, new_size, allocation_mode, teleport_rule,

--- a/Source/bmalloc/libpas/src/test/ReallocFastPathTests.cpp
+++ b/Source/bmalloc/libpas/src/test/ReallocFastPathTests.cpp
@@ -1,0 +1,260 @@
+/*
+ * Copyright (c) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "TestHarness.h"
+
+#if PAS_ENABLE_BMALLOC
+
+#include "bmalloc_heap.h"
+#include "bmalloc_heap_config.h"
+#include "bmalloc_heap_utils.h"
+#include "pas_internal_config.h"
+
+#include <algorithm>
+#include <array>
+#include <climits>
+#include <cstring>
+
+using namespace std;
+
+namespace {
+
+void fillPattern(void* ptr, size_t size, uint8_t seed)
+{
+    auto* bytes = static_cast<uint8_t*>(ptr);
+    for (size_t i = 0; i < size; ++i)
+        bytes[i] = static_cast<uint8_t>(seed + (i & 0xff));
+}
+
+void checkPattern(void* ptr, size_t size, uint8_t seed)
+{
+    auto* bytes = static_cast<uint8_t*>(ptr);
+    for (size_t i = 0; i < size; ++i)
+        CHECK_EQUAL(bytes[i], static_cast<uint8_t>(seed + (i & 0xff)));
+}
+
+void testReallocFastPathGrowWithinSizeClass()
+{
+    // A 10-byte request rounds up to some usable size >= 10. As long as the
+    // new request still fits within that slot the fast path must return the
+    // same pointer.
+    void* ptr = bmalloc_try_allocate(10, pas_non_compact_allocation_mode);
+    CHECK(ptr);
+
+    size_t usable = bmalloc_get_allocation_size(ptr);
+    CHECK_GREATER_EQUAL(usable, static_cast<size_t>(10));
+
+    fillPattern(ptr, 10, 0xA1);
+
+    void* grown = bmalloc_try_reallocate(
+        ptr, usable, pas_non_compact_allocation_mode, pas_reallocate_free_if_successful);
+    CHECK_EQUAL(grown, ptr);
+    checkPattern(grown, 10, 0xA1);
+}
+
+void testReallocFastPathShrinkWithinSizeClass()
+{
+    void* ptr = bmalloc_try_allocate(200, pas_non_compact_allocation_mode);
+    CHECK(ptr);
+
+    size_t usable = bmalloc_get_allocation_size(ptr);
+    CHECK_GREATER_EQUAL(usable, static_cast<size_t>(200));
+
+    fillPattern(ptr, 200, 0x5A);
+
+    size_t shrink_to = usable / 2 + 1;
+    void* shrunk = bmalloc_try_reallocate(
+        ptr, shrink_to, pas_non_compact_allocation_mode, pas_reallocate_free_if_successful);
+    CHECK_EQUAL(shrunk, ptr);
+    checkPattern(shrunk, std::min(shrink_to, static_cast<size_t>(200)), 0x5A);
+}
+
+void testReallocFastPathToExactUsableSize()
+{
+    void* ptr = bmalloc_try_allocate(100, pas_non_compact_allocation_mode);
+    CHECK(ptr);
+
+    size_t usable = bmalloc_get_allocation_size(ptr);
+    fillPattern(ptr, usable, 0x33);
+
+    void* result = bmalloc_try_reallocate(
+        ptr, usable, pas_non_compact_allocation_mode, pas_reallocate_free_if_successful);
+    CHECK_EQUAL(result, ptr);
+    checkPattern(result, usable, 0x33);
+}
+
+void testReallocGrowBeyondSizeClassCopiesData()
+{
+    // Force a real move: ask for a new size that clearly does not fit in the
+    // original slot. The fast path must not trigger; data must survive the copy.
+    void* ptr = bmalloc_try_allocate(32, pas_non_compact_allocation_mode);
+    CHECK(ptr);
+
+    size_t usable = bmalloc_get_allocation_size(ptr);
+    fillPattern(ptr, 32, 0xC7);
+
+    size_t grown_size = usable * 16 + 1;
+    void* grown = bmalloc_try_reallocate(
+        ptr, grown_size, pas_non_compact_allocation_mode, pas_reallocate_free_if_successful);
+    CHECK(grown);
+    checkPattern(grown, 32, 0xC7);
+}
+
+void testReallocFastPathSweepAcrossSizes()
+{
+    // For a wide range of sizes, any realloc whose new size stays within the
+    // in-place shrinkage envelope must return the same pointer.
+    const std::array<size_t, 10> request_sizes = {
+        1, 7, 16, 24, 48, 100, 128, 256, 1024, 3000,
+    };
+
+    for (size_t request : request_sizes) {
+        void* ptr = bmalloc_try_allocate(request, pas_non_compact_allocation_mode);
+        CHECK(ptr);
+
+        size_t usable = bmalloc_get_allocation_size(ptr);
+        CHECK_GREATER_EQUAL(usable, request);
+
+        fillPattern(ptr, request, static_cast<uint8_t>(request));
+
+        size_t min_in_place = (usable + PAS_MAX_IN_PLACE_REALLOC_SHRINKAGE - 1)
+            / PAS_MAX_IN_PLACE_REALLOC_SHRINKAGE;
+        for (size_t candidate : { min_in_place, usable / 2 + 1, usable }) {
+            if (!candidate || candidate > usable || candidate < min_in_place)
+                continue;
+            void* after = bmalloc_try_reallocate(
+                ptr, candidate, pas_non_compact_allocation_mode, pas_reallocate_free_if_successful);
+            CHECK_EQUAL(after, ptr);
+        }
+
+        checkPattern(ptr, request, static_cast<uint8_t>(request));
+        bmalloc_deallocate(ptr);
+    }
+}
+
+void testReallocBitfitFastPath()
+{
+    // Bitfit allocations also support the same-usable-size fast path. Force
+    // bitfit by disabling the segregated path.
+    bmalloc_intrinsic_runtime_config.base.max_segregated_object_size = 0;
+    bmalloc_intrinsic_runtime_config.base.max_bitfit_object_size = UINT_MAX;
+    bmalloc_primitive_runtime_config.base.max_segregated_object_size = 0;
+    bmalloc_primitive_runtime_config.base.max_bitfit_object_size = UINT_MAX;
+
+    void* ptr = bmalloc_try_allocate(8192, pas_non_compact_allocation_mode);
+    CHECK(ptr);
+
+    size_t usable = bmalloc_get_allocation_size(ptr);
+    CHECK_GREATER_EQUAL(usable, static_cast<size_t>(8192));
+
+    fillPattern(ptr, 8192, 0x77);
+
+    void* grown = bmalloc_try_reallocate(
+        ptr, usable, pas_non_compact_allocation_mode, pas_reallocate_free_if_successful);
+    CHECK_EQUAL(grown, ptr);
+    checkPattern(grown, 8192, 0x77);
+
+    void* shrunk = bmalloc_try_reallocate(
+        ptr, usable / 2 + 1, pas_non_compact_allocation_mode, pas_reallocate_free_if_successful);
+    CHECK_EQUAL(shrunk, ptr);
+    checkPattern(shrunk, usable / 2 + 1, 0x77);
+}
+
+void testReallocExcessiveShrinkForcesCopy()
+{
+    // Shrinking by more than PAS_MAX_IN_PLACE_REALLOC_SHRINKAGE should skip
+    // the in-place fast path and go through allocate+copy+free so we don't
+    // pin a much larger slot for a tiny request. We can't assert the pointer
+    // moved (the freed slot could be reused), but the data must survive and
+    // the new usable size must actually be smaller than the old slot.
+    void* ptr = bmalloc_try_allocate(4096, pas_non_compact_allocation_mode);
+    CHECK(ptr);
+
+    size_t old_usable = bmalloc_get_allocation_size(ptr);
+    CHECK_GREATER_EQUAL(old_usable, static_cast<size_t>(4096));
+
+    fillPattern(ptr, 64, 0xE3);
+
+    size_t shrink_to = old_usable / (PAS_MAX_IN_PLACE_REALLOC_SHRINKAGE + 1);
+    CHECK_GREATER_EQUAL(shrink_to, static_cast<size_t>(1));
+
+    void* shrunk = bmalloc_try_reallocate(
+        ptr, shrink_to, pas_non_compact_allocation_mode, pas_reallocate_free_if_successful);
+    CHECK(shrunk);
+    checkPattern(shrunk, std::min(shrink_to, static_cast<size_t>(64)), 0xE3);
+
+    size_t new_usable = bmalloc_get_allocation_size(shrunk);
+    CHECK_LESS(new_usable, old_usable);
+
+    bmalloc_deallocate(shrunk);
+}
+
+void testReallocLargeDataPreserved()
+{
+    // Large heap has no in-place fast path today; this regression-guards the
+    // allocate+copy+free path for sizes above the bitfit/segregated tiers.
+    const size_t small_size = 1024 * 1024;
+    const size_t large_size = small_size * 4;
+
+    void* ptr = bmalloc_try_allocate(small_size, pas_non_compact_allocation_mode);
+    CHECK(ptr);
+    fillPattern(ptr, small_size, 0x19);
+
+    void* grown = bmalloc_try_reallocate(
+        ptr, large_size, pas_non_compact_allocation_mode, pas_reallocate_free_if_successful);
+    CHECK(grown);
+    checkPattern(grown, small_size, 0x19);
+}
+
+void testReallocFromNullAllocates()
+{
+    // realloc(NULL, n) must behave like malloc(n); it must not crash on the
+    // same-size-class lookup.
+    void* ptr = bmalloc_try_reallocate(
+        nullptr, 128, pas_non_compact_allocation_mode, pas_reallocate_free_if_successful);
+    CHECK(ptr);
+    fillPattern(ptr, 128, 0x2D);
+    checkPattern(ptr, 128, 0x2D);
+    bmalloc_deallocate(ptr);
+}
+
+} // anonymous namespace
+
+#endif // PAS_ENABLE_BMALLOC
+
+void addReallocFastPathTests()
+{
+#if PAS_ENABLE_BMALLOC
+    ADD_TEST(testReallocFastPathGrowWithinSizeClass());
+    ADD_TEST(testReallocFastPathShrinkWithinSizeClass());
+    ADD_TEST(testReallocFastPathToExactUsableSize());
+    ADD_TEST(testReallocGrowBeyondSizeClassCopiesData());
+    ADD_TEST(testReallocFastPathSweepAcrossSizes());
+    ADD_TEST(testReallocBitfitFastPath());
+    ADD_TEST(testReallocExcessiveShrinkForcesCopy());
+    ADD_TEST(testReallocLargeDataPreserved());
+    ADD_TEST(testReallocFromNullAllocates());
+#endif // PAS_ENABLE_BMALLOC
+}

--- a/Source/bmalloc/libpas/src/test/TestHarness.cpp
+++ b/Source/bmalloc/libpas/src/test/TestHarness.cpp
@@ -381,6 +381,7 @@ void addMinHeapTests();
 void addPGMTests();
 void addRaceTests();
 void addRedBlackTreeTests();
+void addReallocFastPathTests();
 void addScavengerExternalWorkTests();
 void addTLCDecommitTests();
 void addTSDTests();
@@ -866,6 +867,7 @@ int main(int argc, char** argv)
     ADD_SUITE(PGM);
     ADD_SUITE(Race);
     ADD_SUITE(RedBlackTree);
+    ADD_SUITE(ReallocFastPath);
     ADD_SUITE(ScavengerExternalWork);
     ADD_SUITE(TLCDecommit);
     ADD_SUITE(TSD);


### PR DESCRIPTION
#### adf83e7baf07726e9a3834dde26a2db25bacf0ef
<pre>
[libpas] Allow in-place realloc for segregated case
<a href="https://bugs.webkit.org/show_bug.cgi?id=314380">https://bugs.webkit.org/show_bug.cgi?id=314380</a>
<a href="https://rdar.apple.com/176535914">rdar://176535914</a>

Reviewed by Marcus Plutowski.

This patch makes simple realloc efficient: when the current segregated
heap&apos;s slot&apos;s object_size &gt;= requested new_size, then just reuse the
current pointer. For MTE, we add PAS_MTE_HANDLE_REALLOCATE_IN_PLACE,
and it does PAS_MTE_PURIFY(stripped-pointer), which just restores the
current pointer&apos;s tag as we do not need to change anything.

* Source/bmalloc/libpas/libpas.xcodeproj/project.pbxproj:
* Source/bmalloc/libpas/src/libpas/pas_internal_config.h:
* Source/bmalloc/libpas/src/libpas/pas_mte.h:
* Source/bmalloc/libpas/src/libpas/pas_try_reallocate.h:
(pas_try_reallocate_size_fits_in_place):
(pas_try_reallocate_table_segregated_case):
(pas_try_reallocate_table_bitfit_case):
(pas_try_reallocate):
* Source/bmalloc/libpas/src/test/ReallocFastPathTests.cpp: Added.
(std::fillPattern):
(std::checkPattern):
(std::testReallocFastPathGrowWithinSizeClass):
(std::testReallocFastPathShrinkWithinSizeClass):
(std::testReallocFastPathToExactUsableSize):
(std::testReallocGrowBeyondSizeClassCopiesData):
(std::testReallocFastPathSweepAcrossSizes):
(std::testReallocBitfitFastPath):
(std::testReallocExcessiveShrinkForcesCopy):
(std::testReallocLargeDataPreserved):
(std::testReallocFromNullAllocates):
(addReallocFastPathTests):
* Source/bmalloc/libpas/src/test/TestHarness.cpp:
(main):

Canonical link: <a href="https://commits.webkit.org/313062@main">https://commits.webkit.org/313062@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f43cda4dc6fc5975083c25af88586b49068b2c73

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/161966 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/35441 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/28546 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/170874 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/118337 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/c843a343-01e4-48be-8c17-dbfdadf124cf) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/35543 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/35442 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/125683 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/88560 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/fc13de80-4303-4325-b842-8da18194c886) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/164925 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/27993 "Passed tests") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/145478 "Found 1 new API test failure: TestWebKitAPI.WKWebExtensionAPIAction.ClearTabSpecificActionPropertiesOnNavigation (failure)") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/106266 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/0eb3f6cc-6138-4fb0-b19f-3f7d04df405e) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/27042 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/25556 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/18593 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/154025 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/136735 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/23232 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/173362 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/22804 "Built successfully and passed tests") | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/24873 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/133973 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/35114 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/29641 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/133979 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/35098 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/145027 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/97202 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/24602 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/28504 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/21852 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/194366 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/34608 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/50096 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/34109 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/34351 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/34257 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->