### PR TITLE
DOMMatrix constructor accepts scale(sign(1em)) instead of throwing SyntaxError

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/geometry/DOMMatrix-001-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/geometry/DOMMatrix-001-expected.txt
@@ -23,7 +23,7 @@ PASS new DOMMatrix("scale(2) translateX(5px) translateY(5px) rotate(5deg) rotate
 PASS new DOMMatrix("translateX    (5px)")
 PASS new DOMMatrix("scale(2 2) translateX(5) translateY(5)")
 PASS new DOMMatrix("scale(2, 2), translateX(5)  ,translateY(5)")
-FAIL new DOMMatrix("scale(sign(1em))") assert_throws_dom: function "function() { new self[constr](string); }" did not throw
+PASS new DOMMatrix("scale(sign(1em))")
 PASS new DOMMatrix("scale(sibling-index())")
 PASS new DOMMatrix("translateX(5em)")
 PASS new DOMMatrix("translateX(5ex)")
@@ -92,7 +92,7 @@ PASS new DOMMatrixReadOnly("scale(2) translateX(5px) translateY(5px) rotate(5deg
 PASS new DOMMatrixReadOnly("translateX    (5px)")
 PASS new DOMMatrixReadOnly("scale(2 2) translateX(5) translateY(5)")
 PASS new DOMMatrixReadOnly("scale(2, 2), translateX(5)  ,translateY(5)")
-FAIL new DOMMatrixReadOnly("scale(sign(1em))") assert_throws_dom: function "function() { new self[constr](string); }" did not throw
+PASS new DOMMatrixReadOnly("scale(sign(1em))")
 PASS new DOMMatrixReadOnly("scale(sibling-index())")
 PASS new DOMMatrixReadOnly("translateX(5em)")
 PASS new DOMMatrixReadOnly("translateX(5ex)")

--- a/Source/WebCore/css/calc/CSSCalcTree+Simplification.cpp
+++ b/Source/WebCore/css/calc/CSSCalcTree+Simplification.cpp
@@ -143,6 +143,28 @@ constexpr bool NODELETE magnitudeComparable(const NonCanonicalDimension&, const 
     return true;
 }
 
+// MARK: Predicate: signKnowable
+
+constexpr bool NODELETE signKnowable(const Number&, const SimplificationOptions&)
+{
+    return true;
+}
+
+static bool NODELETE signKnowable(const Percentage&, const SimplificationOptions& options)
+{
+    return !percentageResolveToDimension(options);
+}
+
+constexpr bool NODELETE signKnowable(const CanonicalDimension&, const SimplificationOptions&)
+{
+    return true;
+}
+
+static bool NODELETE signKnowable(const NonCanonicalDimension&, const SimplificationOptions& options)
+{
+    return options.conversionData.has_value();
+}
+
 // MARK: Predicate: fullyResolved
 
 constexpr bool NODELETE fullyResolved(const Number&, const SimplificationOptions&)
@@ -1304,7 +1326,7 @@ std::optional<Child> simplify(Sign& root, const SimplificationOptions& options)
 {
     return WTF::switchOn(root.a,
         [&]<Numeric T>(const T& a) -> std::optional<Child> {
-            if (!magnitudeComparable(a, options))
+            if (!signKnowable(a, options))
                 return { };
             return makeChild(Number { .value = executeMathOperation<Sign>(a.value) });
         },


### PR DESCRIPTION
#### 304ce91f6ea9a5ad6454de54f76806dcfb117653
<pre>
DOMMatrix constructor accepts scale(sign(1em)) instead of throwing SyntaxError
<a href="https://bugs.webkit.org/show_bug.cgi?id=314381">https://bugs.webkit.org/show_bug.cgi?id=314381</a>
<a href="https://rdar.apple.com/176536179">rdar://176536179</a>

Reviewed by NOBODY (OOPS!).

This patch aligns WebKit with Blink / Chromium.

parseTransformRaw() detects relative units via
canResolveDependenciesWithConversionData() on the simplified calc
tree. magnitudeComparable(NonCanonicalDimension) returned true
unconditionally, so simplify(Sign&amp;) folded sign(1em) to Number{1} at
parse time, erasing the em dependency before the gate could see it.

Tightening magnitudeComparable directly would also disable valid
parse-time simplification of abs(1em) and clamp(1em, 2em, 3em), where
the result is knowable without conversionData. Only Sign needs the
unit&apos;s sign, which for a NonCanonicalDimension may be 0 when the unit
value is 0.

Add a narrower signKnowable predicate, used only by simplify(Sign&amp;).
Its NonCanonicalDimension overload requires conversionData.

* LayoutTests/imported/w3c/web-platform-tests/css/geometry/DOMMatrix-001-expected.txt: Progression
* Source/WebCore/css/calc/CSSCalcTree+Simplification.cpp:
(WebCore::CSSCalc::signKnowable): Added.
(WebCore::CSSCalc::simplify): Use signKnowable for Sign.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/304ce91f6ea9a5ad6454de54f76806dcfb117653

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/161352 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/34825 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/27926 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/170255 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/117723 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/50d8cdd4-9a0e-44ba-899e-fe3158778c17) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/163221 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/34926 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/34831 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/125164 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/88198 "1 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/2d29cd37-d257-4cac-b936-c25f1ab847eb) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/164311 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/27455 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/144939 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/105761 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/1132b351-fa22-4d0a-88c1-79a783150e08) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/26503 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/25016 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/17975 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/136197 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/22698 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/172738 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/19771 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/24339 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/133447 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/34499 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/29108 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/133455 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/34484 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/144493 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/96356 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/27992 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/21312 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/33994 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/101430 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/33493 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/33737 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/33642 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->