### PR TITLE
Digital Credentials: Missing empty-vector guard after request validation allows empty picker presentation

### DIFF
--- a/LayoutTests/http/tests/digital-credentials/digital-credential-all-invalid-requests.https-expected.txt
+++ b/LayoutTests/http/tests/digital-credentials/digital-credential-all-invalid-requests.https-expected.txt
@@ -1,0 +1,14 @@
+CONSOLE MESSAGE: An error occurred validating the incoming 'org-iso-mdoc' request. The request will be ignored. (The given request could not parse into an ISO 18013-7 (Annex C) request.)
+CONSOLE MESSAGE: An error occurred validating the incoming 'org-iso-mdoc' request. The request will be ignored. (The given request could not parse into an ISO 18013-7 (Annex C) request.)
+CONSOLE MESSAGE: An error occurred validating the incoming 'org-iso-mdoc' request. The request will be ignored. (The given request could not parse into an ISO 18013-7 (Annex C) request.)
+Tests that navigator.credentials.get() rejects with TypeError when all org-iso-mdoc requests fail framework validation.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS promise1 rejected promise  with TypeError: No valid credential requests remain after validation.
+PASS promise2 rejected promise  with TypeError: No valid credential requests remain after validation.
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/http/tests/digital-credentials/digital-credential-all-invalid-requests.https.html
+++ b/LayoutTests/http/tests/digital-credentials/digital-credential-all-invalid-requests.https.html
@@ -1,0 +1,64 @@
+<!DOCTYPE html>
+<meta charset="utf-8" />
+<title>Digital Credential API: All requests fail framework validation rejects with TypeError</title>
+<script src="/js-test-resources/js-test.js"></script>
+<body onload="runTests()"></body>
+<script>
+    description("Tests that navigator.credentials.get() rejects with TypeError when all org-iso-mdoc requests fail framework validation.");
+
+    jsTestIsAsync = true;
+
+    async function runTests() {
+        if (document.visibilityState === "hidden") {
+            await new Promise((resolve) => {
+                document.onvisibilitychange = resolve;
+                testRunner.setPageVisibility("visible");
+            });
+        }
+
+        internals.withUserGesture(() => {
+            window.promise1 = navigator.credentials.get({
+                digital: {
+                    requests: [
+                        {
+                            protocol: "org-iso-mdoc",
+                            data: {
+                                deviceRequest: "not-valid-cbor",
+                                encryptionInfo: "also-not-valid",
+                            },
+                        },
+                        {
+                            protocol: "org-iso-mdoc",
+                            data: {
+                                deviceRequest: "AAAA",
+                                encryptionInfo: "BBBB",
+                            },
+                        },
+                    ],
+                },
+                mediation: "required",
+            });
+        });
+        await shouldRejectWithErrorName('promise1', 'TypeError');
+
+        internals.withUserGesture(() => {
+            window.promise2 = navigator.credentials.get({
+                digital: {
+                    requests: [
+                        {
+                            protocol: "org-iso-mdoc",
+                            data: {
+                                deviceRequest: "invalid",
+                                encryptionInfo: "invalid",
+                            },
+                        },
+                    ],
+                },
+                mediation: "required",
+            });
+        });
+        await shouldRejectWithErrorName('promise2', 'TypeError');
+
+        finishJSTest();
+    }
+</script>

--- a/LayoutTests/http/wpt/identity/formats/ISO18013/mixed-requests.https-expected.txt
+++ b/LayoutTests/http/wpt/identity/formats/ISO18013/mixed-requests.https-expected.txt
@@ -1,6 +1,6 @@
 
 PASS All org-iso-mdoc requests invalid: API rejects (no valid request survives).
-PASS Invalid org-iso-mdoc + valid openid4vp: openid4vp request proceeds (abort confirms it was accepted).
+PASS Invalid org-iso-mdoc + unsupported openid4vp: no request survives, rejects with TypeError.
 PASS One valid org-iso-mdoc among garbage: valid request survives, flow proceeds.
 PASS Failed request does not poison the coordinator state for subsequent valid requests.
 PASS 100 invalid org-iso-mdoc requests are handled without hanging.

--- a/LayoutTests/http/wpt/identity/formats/ISO18013/mixed-requests.https.html
+++ b/LayoutTests/http/wpt/identity/formats/ISO18013/mixed-requests.https.html
@@ -44,12 +44,9 @@ promise_test(async (t) => {
   await promise_rejects_js(t, TypeError, navigator.credentials.get(options));
 }, "All org-iso-mdoc requests invalid: API rejects (no valid request survives).");
 
-// --- Mix of invalid org-iso-mdoc with valid openid4vp should still work ---
+// --- Invalid org-iso-mdoc + currently-unsupported openid4vp: nothing survives ---
 
 promise_test(async (t) => {
-  const controller = new AbortController();
-  const { signal } = controller;
-
   const [openidReq] = makeGetOptions({ protocol: "openid4vp-v1-unsigned" }).digital.requests;
 
   const options = {
@@ -59,14 +56,14 @@ promise_test(async (t) => {
         openidReq,
       ]
     },
-    signal,
   };
 
   await test_driver.bless("user activation");
-  const promise = navigator.credentials.get(options);
-  controller.abort();
-  await promise_rejects_dom(t, "AbortError", promise);
-}, "Invalid org-iso-mdoc + valid openid4vp: openid4vp request proceeds (abort confirms it was accepted).");
+  // openid4vp is not yet a supported protocol (webkit.org/b/317545), so it is dropped
+  // during validation; the org-iso-mdoc request is invalid and also dropped. No request
+  // survives validation, so the call rejects with a TypeError.
+  await promise_rejects_js(t, TypeError, navigator.credentials.get(options));
+}, "Invalid org-iso-mdoc + unsupported openid4vp: no request survives, rejects with TypeError.");
 
 // --- Multiple org-iso-mdoc requests: one valid, others garbage ---
 

--- a/Source/WebCore/Modules/identity/CredentialRequestCoordinator.cpp
+++ b/Source/WebCore/Modules/identity/CredentialRequestCoordinator.cpp
@@ -149,6 +149,12 @@ void CredentialRequestCoordinator::prepareCredentialRequests(const Document& doc
 
     auto validatedCredentialRequests = validatedRequestsOrException.releaseReturnValue();
 
+    // FIXME: validatedCredentialRequests only reflects org-iso-mdoc validation, so this
+    // empty check is correct only while mdoc is the sole supported protocol; account for
+    // other protocols' surviving requests once one is added (webkit.org/b/317545).
+    if (validatedCredentialRequests.isEmpty())
+        return rejectTheCredentialRequestWith(Exception { ExceptionCode::TypeError, "No valid credential requests remain after validation"_s });
+
     if (signal) {
         ASSERT(!signal->aborted());
         m_abortSignal = signal;


### PR DESCRIPTION
#### fa01ab0b2a9ca21b9a8228e9da5bf3d58d9283f7
<pre>
Digital Credentials: Missing empty-vector guard after request validation allows empty picker presentation
<a href="https://bugs.webkit.org/show_bug.cgi?id=314382">https://bugs.webkit.org/show_bug.cgi?id=314382</a>
<a href="https://rdar.apple.com/176536555">rdar://176536555</a>

Reviewed by Anne van Kesteren.

Per the Digital Credentials spec&apos;s &quot;prepare credential requests&quot; algorithm, if the
validated requests list is empty (all requests filtered out during validation),
reject with a TypeError before presenting the picker. Implement this guard in
CredentialRequestCoordinator::prepareCredentialRequests, immediately after the
validation step, matching the spec rather than guarding at the WebProcess boundary.

Test: http/tests/digital-credentials/digital-credential-all-invalid-requests.https.html

* LayoutTests/http/tests/digital-credentials/digital-credential-all-invalid-requests.https-expected.txt: Added.
* LayoutTests/http/tests/digital-credentials/digital-credential-all-invalid-requests.https.html: Added.
* Source/WebCore/Modules/identity/CredentialRequestCoordinator.cpp:
(WebCore::CredentialRequestCoordinator::prepareCredentialRequests):
* LayoutTests/http/wpt/identity/formats/ISO18013/mixed-requests.https-expected.txt:
* LayoutTests/http/wpt/identity/formats/ISO18013/mixed-requests.https.html:

Canonical link: <a href="https://commits.webkit.org/317276@main">https://commits.webkit.org/317276@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c36ef1c1e65f84d5f820569ad6a75d3fa3e3376b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/174740 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/48673 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/42454 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/184320 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/132608 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/c6638952-76be-496b-bea7-63d64dc7bc75) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/176605 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/49965 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/48356 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/135974 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/95971 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/177698 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/39405 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/156762 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/116452 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/36b49e73-b22c-4694-aaf6-786e96fb064d) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/38046 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/36427 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/32798 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/148469 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/36254 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-scroll-snap/snap-after-relayout/multiple-aligned-targets/prefer-common-to-both-axes.html (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/186745 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/40086 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/40625 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/144900 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/48340 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/156318 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/144759 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39022 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/49020 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/32875 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/114799 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/39633 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/121063 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/47526 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/11223 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/46928 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/47159 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/46986 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->