### PR TITLE
[JSC] Add realloc-and-shift fast path for JSArray unshift

### DIFF
--- a/Source/JavaScriptCore/runtime/ButterflyInlines.h
+++ b/Source/JavaScriptCore/runtime/ButterflyInlines.h
@@ -38,6 +38,11 @@ WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 
 namespace JSC {
 
+inline size_t NODELETE nextLength(size_t length)
+{
+    return length + length / 2;
+}
+
 ALWAYS_INLINE unsigned Butterfly::availableContiguousVectorLength(size_t propertyCapacity, unsigned vectorLength)
 {
     size_t cellSize = totalSize(0, propertyCapacity, true, sizeof(EncodedJSValue) * vectorLength);

--- a/Source/JavaScriptCore/runtime/JSArray.cpp
+++ b/Source/JavaScriptCore/runtime/JSArray.cpp
@@ -24,6 +24,7 @@
 #include "JSArray.h"
 
 #include "ArrayPrototypeInlines.h"
+#include "GCDeferralContextInlines.h"
 #include "JSArrayInlines.h"
 #include "JSCInlines.h"
 #include "PropertyNameArray.h"
@@ -38,6 +39,63 @@ WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 namespace JSC {
 
 STATIC_ASSERT_IS_TRIVIALLY_DESTRUCTIBLE(JSArray);
+
+template<typename ElementType>
+static ALWAYS_INLINE bool tryGrowAndShiftButterflyRight(JSObject* object, VM& vm, Butterfly* butterfly, unsigned oldLength, unsigned newLength, unsigned startIndex, unsigned count)
+{
+    ASSERT(newLength > butterfly->vectorLength());
+    ASSERT(newLength <= MAX_STORAGE_VECTOR_LENGTH);
+
+    Structure* structure = object->structure();
+    unsigned propertyCapacity = structure->outOfLineCapacity();
+    unsigned oldVectorLength = butterfly->vectorLength();
+
+    unsigned availableOldLength = Butterfly::availableContiguousVectorLength(propertyCapacity, oldVectorLength);
+    if (availableOldLength >= newLength)
+        return false;
+
+    void* theBase = butterfly->base(0, propertyCapacity);
+    bool canReallocInPlace = !propertyCapacity && !vm.heap.mutatorShouldBeFenced() && std::bit_cast<HeapCell*>(theBase)->isPreciseAllocation();
+    if (canReallocInPlace)
+        return false;
+
+    unsigned newVectorLength = Butterfly::optimalContiguousVectorLength(propertyCapacity, std::min<size_t>(nextLength(newLength), MAX_STORAGE_VECTOR_LENGTH));
+
+    size_t newPayloadSize = newVectorLength * sizeof(ElementType);
+
+    GCDeferralContext deferralContext(vm);
+    AssertNoGC assertNoGC;
+    constexpr unsigned preCapacity = 0;
+    Butterfly* newButterfly = Butterfly::tryCreateUninitialized(vm, object, preCapacity, propertyCapacity, true, newPayloadSize, &deferralContext);
+    if (!newButterfly) [[unlikely]]
+        return false;
+
+    // Copy property storage + indexing header (the "prefix" that lives before the array data).
+    size_t prefixSize = propertyCapacity * sizeof(EncodedJSValue) + sizeof(IndexingHeader);
+    memcpy(newButterfly->base(0, propertyCapacity), theBase, prefixSize);
+
+    ElementType* oldData = butterfly->indexingPayload<ElementType>();
+    ElementType* newData = newButterfly->indexingPayload<ElementType>();
+
+    // This butterfly is not yet visible to GC markers, so a plain memcpy is safe.
+    if (startIndex)
+        memcpy(newData, oldData, startIndex * sizeof(ElementType));
+
+    for (unsigned i = startIndex; i < startIndex + count; ++i)
+        clearElement(newData[i]);
+
+    if (unsigned moveCount = oldLength - startIndex)
+        memcpy(newData + startIndex + count, oldData + startIndex, moveCount * sizeof(ElementType));
+
+    for (unsigned i = oldLength + count; i < newVectorLength; ++i)
+        clearElement(newData[i]);
+
+    newButterfly->setVectorLength(newVectorLength);
+    newButterfly->setPublicLength(newLength);
+
+    object->setButterfly(vm, newButterfly);
+    return true;
+}
 
 const ClassInfo JSArray::s_info = { "Array"_s, &JSNonFinalObject::s_info, nullptr, nullptr, CREATE_METHOD_TABLE(JSArray) };
 
@@ -1800,7 +1858,7 @@ bool JSArray::unshiftCountWithAnyIndexingType(JSGlobalObject* globalObject, unsi
     case ArrayWithInt32:
     case ArrayWithContiguous: {
         unsigned oldLength = butterfly->publicLength();
-        
+
         // We may have to walk the entire array to do the unshift. We're willing to do so
         // only if it's not horribly slow.
         unsigned moveCount = oldLength - startIndex;
@@ -1817,40 +1875,43 @@ bool JSArray::unshiftCountWithAnyIndexingType(JSGlobalObject* globalObject, unsi
         if (newLength > MAX_STORAGE_VECTOR_LENGTH)
             return false;
 
-        // FIXME: If we create a new butterfly, we should move elements at the same time.
+        // We have to check for holes before we start moving things around so that we don't get halfway
+        // through shifting and then realize we should have been in ArrayStorage mode.
+        if (moveCount && holesMustForwardToPrototype()) [[unlikely]] {
+            auto* buffer = butterfly->contiguous().data() + startIndex;
+            if (containsHole(buffer, moveCount)) [[unlikely]]
+                RELEASE_AND_RETURN(scope, unshiftCountWithArrayStorage(globalObject, startIndex, count, ensureArrayStorage(vm)));
+        }
+
+        if (newLength > butterfly->vectorLength()) {
+            if (tryGrowAndShiftButterflyRight<WriteBarrier<Unknown>>(this, vm, butterfly, oldLength, newLength, startIndex, count))
+                return true;
+        }
+
         if (!ensureLength(vm, newLength)) {
             throwOutOfMemoryError(globalObject, scope);
             return true;
         }
         butterfly = this->butterfly();
 
-        // We have to check for holes before we start moving things around so that we don't get halfway 
-        // through shifting and then realize we should have been in ArrayStorage mode.
-        if (moveCount) {
-            if (holesMustForwardToPrototype()) [[unlikely]] {
-                auto* buffer = butterfly->contiguous().data() + startIndex;
-                if (containsHole(buffer, moveCount)) [[unlikely]]
-                    RELEASE_AND_RETURN(scope, unshiftCountWithArrayStorage(globalObject, startIndex, count, ensureArrayStorage(vm)));
-            }
-
+        if (moveCount)
             gcSafeMemmove(butterfly->contiguous().data() + startIndex + count, butterfly->contiguous().data() + startIndex, moveCount * sizeof(EncodedJSValue));
-        }
 
         // Our memmoving of values around in the array could have concealed some of them from
         // the collector. Let's make sure that the collector scans this object again.
         vm.writeBarrier(this);
-        
+
         // NOTE: we're leaving being garbage in the part of the array that we shifted out
         // of. This is fine because the caller is required to store over that area, and
         // in contiguous mode storing into a hole is guaranteed to behave exactly the same
         // as storing over an existing element.
-        
+
         return true;
     }
-        
+
     case ArrayWithDouble: {
         unsigned oldLength = butterfly->publicLength();
-        
+
         // We may have to walk the entire array to do the unshift. We're willing to do so
         // only if it's not horribly slow.
         unsigned moveCount = oldLength - startIndex;
@@ -1867,32 +1928,35 @@ bool JSArray::unshiftCountWithAnyIndexingType(JSGlobalObject* globalObject, unsi
         if (newLength > MAX_STORAGE_VECTOR_LENGTH)
             return false;
 
-        // FIXME: If we create a new butterfly, we should move elements at the same time.
+        // We have to check for holes before we start moving things around so that we don't get halfway
+        // through shifting and then realize we should have been in ArrayStorage mode.
+        if (moveCount && holesMustForwardToPrototype()) [[unlikely]] {
+            for (unsigned i = oldLength; i-- > startIndex;) {
+                double v = butterfly->contiguousDouble().at(this, i);
+                if (v != v) [[unlikely]]
+                    RELEASE_AND_RETURN(scope, unshiftCountWithArrayStorage(globalObject, startIndex, count, ensureArrayStorage(vm)));
+            }
+        }
+
+        if (newLength > butterfly->vectorLength()) {
+            if (tryGrowAndShiftButterflyRight<double>(this, vm, butterfly, oldLength, newLength, startIndex, count))
+                return true;
+        }
+
         if (!ensureLength(vm, newLength)) {
             throwOutOfMemoryError(globalObject, scope);
             return true;
         }
         butterfly = this->butterfly();
-        
-        // We have to check for holes before we start moving things around so that we don't get halfway 
-        // through shifting and then realize we should have been in ArrayStorage mode.
-        if (moveCount) {
-            if (holesMustForwardToPrototype()) [[unlikely]] {
-                for (unsigned i = oldLength; i-- > startIndex;) {
-                    double v = butterfly->contiguousDouble().at(this, i);
-                    if (v != v) [[unlikely]]
-                        RELEASE_AND_RETURN(scope, unshiftCountWithArrayStorage(globalObject, startIndex, count, ensureArrayStorage(vm)));
-                }
-            }
 
+        if (moveCount)
             gcSafeMemmove(butterfly->contiguousDouble().data() + startIndex + count, butterfly->contiguousDouble().data() + startIndex, moveCount * sizeof(double));
-        }
 
         // NOTE: we're leaving being garbage in the part of the array that we shifted out
         // of. This is fine because the caller is required to store over that area, and
         // in contiguous mode storing into a hole is guaranteed to behave exactly the same
         // as storing over an existing element.
-        
+
         return true;
     }
         

--- a/Source/JavaScriptCore/runtime/JSObject.cpp
+++ b/Source/JavaScriptCore/runtime/JSObject.cpp
@@ -1239,11 +1239,6 @@ void JSObject::notifyPresenceOfIndexedAccessors(VM& vm)
     globalObject->haveABadTime(vm);
 }
 
-static inline size_t NODELETE nextLength(size_t length)
-{
-    return length + length / 2;
-}
-
 Butterfly* JSObject::createInitialIndexedStorage(VM& vm, unsigned length)
 {
     ASSERT(length <= MAX_STORAGE_VECTOR_LENGTH);


### PR DESCRIPTION
#### dde627a1d427e3930c0ef958d16b5d57fb473d19
<pre>
[JSC] Add realloc-and-shift fast path for JSArray unshift
<a href="https://bugs.webkit.org/show_bug.cgi?id=314384">https://bugs.webkit.org/show_bug.cgi?id=314384</a>
<a href="https://rdar.apple.com/176538469">rdar://176538469</a>

Reviewed by Yijia Huang.

We had FIXME: JSArray unshift reallocates the underlying butterfly,
copying the old content to the new one, then shifting the range to
allocate the region. But this is wasteful as it is copying array
elements twice. When we need to reallocate a new butterfly, we should do
copy and shift at the same time.

* Source/JavaScriptCore/runtime/ButterflyInlines.h:
(JSC::nextLength):
* Source/JavaScriptCore/runtime/JSArray.cpp:
(JSC::tryGrowAndShiftButterflyRight):
(JSC::JSArray::unshiftCountWithAnyIndexingType):
* Source/JavaScriptCore/runtime/JSObject.cpp:
(JSC::nextLength): Deleted.

Canonical link: <a href="https://commits.webkit.org/312915@main">https://commits.webkit.org/312915@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/49653f5275db07f7cb5f503a2bdc4bd562b149df

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/161364 "3 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/34838 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/27938 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/170267 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/117735 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/dd2bb3f8-1fde-45dd-a4d8-a0ed5c09d72d) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/34938 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/34839 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/125177 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/117735 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/51445202-2036-46f6-ac8a-17a5044677f8) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/164323 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/27465 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/144946 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/105774 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/6ac80de0-0a59-47af-99eb-6b1e7e6839b6) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/26513 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/25023 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/17987 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/153421 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/136207 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/22705 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/172750 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/22202 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/19784 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/24346 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/133461 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/34511 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/29115 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/133469 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/34496 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/144500 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/96372 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/24541 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/28003 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/21319 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/193763 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/34006 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/101447 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/49921 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/33506 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/33749 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/33655 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->