### PR TITLE
[Swift GTK] Add VFS and other options for Swift import

### DIFF
--- a/Source/WebKit/CMakeLists.txt
+++ b/Source/WebKit/CMakeLists.txt
@@ -833,6 +833,95 @@ set(WebKit_SWIFT_INTEROP_MODULE_PATH "${WEBKIT_DIR}/Modules/Internal")
 WEBKIT_FRAMEWORK_DECLARE(WebKit)
 WEBKIT_INCLUDE_CONFIG_FILES_IF_EXISTS()
 
+# The full WebKit_Internal C++ module pulls in WebPageProxy.h and friends, which
+# quote-include across the entire WebKit/WebCore/JSC private header set. Mirror
+# the C++ target's include directories to swiftc's Clang importer so those
+# resolve. cmakeconfig.h is force-included because the headers assume the
+# project's prefix header has already defined ENABLE()/HAVE() values.
+set(WebKit_SWIFT_CLANG_INCLUDE_DIRS
+    ${CMAKE_BINARY_DIR}
+    ${WebKit_FRAMEWORK_HEADERS_DIR}
+    ${WebKit_DERIVED_SOURCES_DIR}
+    ${WebCore_PRIVATE_FRAMEWORK_HEADERS_DIR}
+    ${JavaScriptCore_FRAMEWORK_HEADERS_DIR}
+    ${JavaScriptCore_PRIVATE_FRAMEWORK_HEADERS_DIR}
+    ${WTF_FRAMEWORK_HEADERS_DIR}
+    ${bmalloc_FRAMEWORK_HEADERS_DIR}
+    ${PAL_FRAMEWORK_HEADERS_DIR}
+    ${ICU_INCLUDE_DIRS}
+    ${WebKit_CMAKE_MODULEMAP_DIR}
+    ${WebKit_PRIVATE_INCLUDE_DIRECTORIES}
+)
+
+if (NOT APPLE AND SWIFT_REQUIRED)
+    # Export macro stubs – on Linux these expand to __attribute__((visibility))
+    # but per-module PCM compiles don't pull in the config headers that define them.
+    # Define as empty so C++ headers compile cleanly in isolation.
+    set(WebKit_SWIFT_CLANG_FLAG_PAIRS
+        "-Xcc -DJS_EXPORT_PRIVATE="
+        "-Xcc -DPAL_EXPORT="
+        "-Xcc -DWEBCORE_EXPORT="
+        "-Xcc -DWEBCORE_TESTSUPPORT_EXPORT="
+        "-Xcc -DWK_EXPORT="
+        "-Xcc -DWK_SUPPORTS_SWIFT_OBJCXX_INTEROP=1"
+        "-Xcc -DWTF_EXPORT_PRIVATE="
+
+        # NODELETE expands to [[clang::annotate_type(...)]], a type attribute.
+        # Clang 21 (Swift 6.3 embedded clang) rejects it on function declarations;
+        # nullify it for the Swift module importer since the annotation is only
+        # meaningful to Apple's static analyser.
+        "-Xcc -DNODELETE="
+
+        # libstdc++ gates coroutine support in <bits/version.h> behind
+        # __glibcxx_want_coroutine.  Swift's Clang 21 compiles <bits/version.h>
+        # as a PCM before that flag is set, so __cpp_lib_coroutine stays
+        # undefined and std::coroutine_handle is not available.  Pre-defining
+        # the flag ensures the PCM gets the right feature-test value.
+        # rdar://175928621
+        "-Xcc -D__glibcxx_want_coroutine=1"
+        "-Xcc -fmodule-map-file=${WTF_FRAMEWORK_HEADERS_DIR}/wtf/module.modulemap"
+    )
+    # Mirror cmake config variables as -Xcc -D so ENABLE()/HAVE() macros in
+    # C++ headers agree with the regular C++ compilation when the Clang importer
+    # compiles them as part of Swift's C++ interop modules.
+    GET_WEBKIT_CONFIG_VARIABLES(_swift_clang_config_vars)
+    list(REMOVE_DUPLICATES _swift_clang_config_vars)
+    foreach (_var IN LISTS _swift_clang_config_vars)
+        if (${${_var}})
+            list(APPEND WebKit_SWIFT_CLANG_FLAG_PAIRS "-Xcc -D${_var}=1")
+        else ()
+            list(APPEND WebKit_SWIFT_CLANG_FLAG_PAIRS "-Xcc -D${_var}=0")
+        endif ()
+    endforeach ()
+    unset(_swift_clang_config_vars)
+    foreach (_dir IN LISTS WebKit_SWIFT_CLANG_INCLUDE_DIRS)
+        list(APPEND WebKit_SWIFT_CLANG_FLAG_PAIRS "-Xcc -I${_dir}")
+    endforeach ()
+    # VFS overlay: inject module.modulemap files for Linux system libraries
+    # (glib, libsoup, etc.) that do not ship their own modulemaps.  The overlay
+    # makes them appear inside /usr/include/glib-2.0/ etc. without modifying
+    # the real filesystem.  Both the -typecheck/-emit-clang-header custom command
+    # and the per-file Swift compilation receive the flag via SWIFT_EXTRA_OPTIONS
+    # and target_compile_options respectively.
+    set(_linux_mm_src "${CMAKE_SOURCE_DIR}/Source/cmake/linux-modulemaps")
+    set(_linux_mm_dir "${CMAKE_BINARY_DIR}/linux-modulemaps")
+    file(MAKE_DIRECTORY "${_linux_mm_dir}")
+    configure_file("${_linux_mm_src}/glib.modulemap"    "${_linux_mm_dir}/glib.modulemap"    COPYONLY)
+    configure_file("${_linux_mm_src}/libsoup.modulemap" "${_linux_mm_dir}/libsoup.modulemap" COPYONLY)
+    set(_vfs_glib_modulemap    "${_linux_mm_dir}/glib.modulemap")
+    set(_vfs_libsoup_modulemap "${_linux_mm_dir}/libsoup.modulemap")
+    configure_file("${_linux_mm_src}/vfs-overlay.yaml.in" "${_linux_mm_dir}/vfs-overlay.yaml" @ONLY)
+    set(_vfs_overlay "${_linux_mm_dir}/vfs-overlay.yaml")
+    list(APPEND WebKit_SWIFT_CLANG_FLAG_PAIRS "-Xcc -ivfsoverlay")
+    list(APPEND WebKit_SWIFT_CLANG_FLAG_PAIRS "-Xcc ${_vfs_overlay}")
+
+    foreach (_pair IN LISTS WebKit_SWIFT_CLANG_FLAG_PAIRS)
+        target_compile_options(WebKit PRIVATE "$<$<COMPILE_LANGUAGE:Swift>:SHELL:${_pair}>")
+        string(REPLACE " " ";" _split "${_pair}")
+        list(APPEND WebKit_SWIFT_EXTRA_OPTIONS ${_split})
+    endforeach ()
+endif ()
+
 WEBKIT_SETUP_SWIFT_AND_GENERATE_SWIFT_CPP_INTEROP_HEADER(WebKit WebKit
     "${WebKit_SWIFT_INTEROP_MODULE_PATH}"
     "${WebKit_DERIVED_SOURCES_DIR}/WebKit-Swift-CPP.h")

--- a/Source/cmake/linux-modulemaps/glib.modulemap
+++ b/Source/cmake/linux-modulemaps/glib.modulemap
@@ -1,0 +1,28 @@
+// Linux system modulemap for GLib / GObject / GModule / GIO (glib-2.0).
+// This file is injected into /usr/include/glib-2.0/ via a VFS overlay
+// (see Source/WebKit/CMakeLists.txt and vfs-overlay.yaml.in).
+//
+// Headers are filled in iteratively: add the minimum set needed to resolve
+// current Swift C++ interop build errors. See the linux-system-modulemaps
+// skill for the overall approach.
+//
+// Authoring rules:
+//   - Honour __GIO_GIO_H_INSIDE__ / __GLIB_H_INSIDE__ guards by listing only
+//     the top-level umbrella headers (gio/gio.h, glib.h), not their children.
+//   - Keep the module flat (no submodules) until submodules are proven necessary.
+
+// [extern_c]: glib is a C library whose headers are often included inside
+// extern "C" { } blocks (e.g. by GStreamer headers). Without this attribute
+// Clang rejects "import of C++ module within extern C linkage specification".
+module glib_2_0 [system] [extern_c] {
+    // Top-level umbrella headers only — each sets an __*_INSIDE__ guard and
+    // pulls in sub-headers in the correct order. Never list individual
+    // sub-headers (e.g. gio/gioenums.h) directly: they depend on context
+    // that only the umbrella header provides.
+    header "glib.h"
+    header "glib-object.h"
+    header "glib-unix.h"
+    header "gmodule.h"
+    header "gio/gio.h"
+    export *
+}

--- a/Source/cmake/linux-modulemaps/libsoup.modulemap
+++ b/Source/cmake/linux-modulemaps/libsoup.modulemap
@@ -1,0 +1,9 @@
+// Linux system modulemap for libsoup-3.0.
+// This file is injected into /usr/include/libsoup-3.0/ via a VFS overlay
+// (see Source/WebKit/CMakeLists.txt and vfs-overlay.yaml.in).
+//
+// Headers are filled in iteratively. See the linux-system-modulemaps skill.
+
+module libsoup_3_0 [system] {
+    export *
+}

--- a/Source/cmake/linux-modulemaps/vfs-overlay.yaml.in
+++ b/Source/cmake/linux-modulemaps/vfs-overlay.yaml.in
@@ -1,0 +1,21 @@
+{
+  "version": 0,
+  "roots": [
+    {
+      "name": "/usr/include/glib-2.0",
+      "type": "directory",
+      "contents": [
+        { "name": "module.modulemap", "type": "file",
+          "external-contents": "@_vfs_glib_modulemap@" }
+      ]
+    },
+    {
+      "name": "/usr/include/libsoup-3.0",
+      "type": "directory",
+      "contents": [
+        { "name": "module.modulemap", "type": "file",
+          "external-contents": "@_vfs_libsoup_modulemap@" }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
#### 1c0131ffaa33a8c7813a9c306d593b73d2b2cbc2
<pre>
[Swift GTK] Add VFS and other options for Swift import
<a href="https://bugs.webkit.org/show_bug.cgi?id=314393">https://bugs.webkit.org/show_bug.cgi?id=314393</a>

Reviewed by Richard Robinson.

cmake WebKit builds do not yet support full Swift/C++ interoperability. Although
the Swift demo logo uses this feature, it intentionally does not attempt to
import the full complexity of WebKit&apos;s C++ APIs into Swift. To move further with
Swift in WebKit on cmake platforms (for example to enable the Swift Back Forward
List) we need to do that.

This change provides various options to the Swift compiler to enable it to cope
with importing WebKit&apos;s C++ APIs on cmake platforms. It&apos;s one of several
changes gradually being raised as PRs, but is probably the most substantial.

In particular:
- we provide modulemap files for libsoup and glib (this is the major part of
  this change)
- we define the various EXPORT macros
- we define NODELETE

These changes are likely fairly particular to GTK builds - future changes will
make them more flexible and adaptable to other cmake platforms.

Canonical link: <a href="https://commits.webkit.org/313174@main">https://commits.webkit.org/313174@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f7454d394db0626cda12639edc77d4d7a2b99320

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/161381 "9 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/34855 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/27955 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/170284 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/117752 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/00764d44-ebac-4228-baf0-400f9b7d611f) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/34955 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/34856 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/125194 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/88204 "2 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/5459d914-ef69-4553-a91e-c91c5ff9d4ce) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/164340 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/27482 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/144986 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/105791 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/fd1a8f35-bf4d-4c2b-9701-59587e37345e) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/26530 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/25040 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/18004 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/153438 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/136224 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/172768 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/22219 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/19801 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/24362 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/133479 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/34529 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/29132 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/133487 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36247 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/34513 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/144516 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/96396 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/28019 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/21335 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/193780 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/34023 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/101464 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/49925 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/33523 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/33766 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/33672 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->