### PR TITLE
[WPE][GTK] Build WebCoreTestSupport only when test targets are enabled

### DIFF
--- a/Source/WebCore/CMakeLists.txt
+++ b/Source/WebCore/CMakeLists.txt
@@ -2780,8 +2780,16 @@ set(WebCoreTestSupport_INTERFACE_INCLUDE_DIRECTORIES
     ${WebCore_PRIVATE_FRAMEWORK_HEADERS_DIR}/WebCoreTestSupport
 )
 
+if (ENABLE_LAYOUT_TESTS OR ENABLE_API_TESTS)
+    set(ENABLE_WEBCORE_TEST_SUPPORT ON)
+else ()
+    set(ENABLE_WEBCORE_TEST_SUPPORT OFF)
+endif ()
+
 WEBKIT_FRAMEWORK_DECLARE(WebCore)
-WEBKIT_LIBRARY_DECLARE(WebCoreTestSupport)
+if (ENABLE_WEBCORE_TEST_SUPPORT)
+    WEBKIT_LIBRARY_DECLARE(WebCoreTestSupport)
+endif ()
 WEBKIT_INCLUDE_CONFIG_FILES_IF_EXISTS()
 
 if (PORT STREQUAL GTK OR PORT STREQUAL WPE)
@@ -2958,11 +2966,16 @@ list(APPEND WebCore_SOURCES ${WebCore_DERIVED_SOURCES_DIR}/Settings.cpp)
 list(APPEND WebCoreTestSupport_SOURCES ${WebCore_DERIVED_SOURCES_DIR}/InternalSettingsGenerated.cpp)
 list(APPEND WebCoreTestSupport_IDL_FILES ${WebCore_DERIVED_SOURCES_DIR}/InternalSettingsGenerated.idl)
 
+set(WebCore_BINDINGS_PP_INPUT_FILES ${WebCore_IDL_FILES} ${WebCore_SUPPLEMENTAL_IDL_FILES})
+if (ENABLE_WEBCORE_TEST_SUPPORT)
+    list(APPEND WebCore_BINDINGS_PP_INPUT_FILES ${WebCoreTestSupport_IDL_FILES})
+endif ()
+
 GENERATE_BINDINGS(WebCoreBindings
     OUTPUT_SOURCE WebCore_SOURCES
     INPUT_FILES ${WebCore_IDL_FILES}
     SUPPLEMENTAL_IDL_FILES ${WebCore_SUPPLEMENTAL_IDL_FILES}
-    PP_INPUT_FILES ${WebCore_IDL_FILES} ${WebCore_SUPPLEMENTAL_IDL_FILES} ${WebCoreTestSupport_IDL_FILES}
+    PP_INPUT_FILES ${WebCore_BINDINGS_PP_INPUT_FILES}
     BASE_DIR ${WEBCORE_DIR}
     FEATURES ${FEATURE_DEFINES_JAVASCRIPT}
     DESTINATION ${WebCore_DERIVED_SOURCES_DIR}
@@ -2989,20 +3002,22 @@ if (ENABLE_WEBINSPECTORUI)
     list(APPEND WebCore_DEPENDENCIES WebInspectorUI)
 endif ()
 
-GENERATE_BINDINGS(WebCoreTestSupportBindings
-    OUTPUT_SOURCE WebCoreTestSupport_SOURCES
-    INPUT_FILES ${WebCoreTestSupport_IDL_FILES}
-    BASE_DIR ${WEBCORE_DIR}
-    INCLUDED_FILES ${WebCore_IDL_FILES} ${WebCore_SUPPLEMENTAL_IDL_FILES}
-    FEATURES ${FEATURE_DEFINES_JAVASCRIPT}
-    DESTINATION ${WebCore_DERIVED_SOURCES_DIR}
-    GENERATOR JS)
+if (ENABLE_WEBCORE_TEST_SUPPORT)
+    GENERATE_BINDINGS(WebCoreTestSupportBindings
+        OUTPUT_SOURCE WebCoreTestSupport_SOURCES
+        INPUT_FILES ${WebCoreTestSupport_IDL_FILES}
+        BASE_DIR ${WEBCORE_DIR}
+        INCLUDED_FILES ${WebCore_IDL_FILES} ${WebCore_SUPPLEMENTAL_IDL_FILES}
+        FEATURES ${FEATURE_DEFINES_JAVASCRIPT}
+        DESTINATION ${WebCore_DERIVED_SOURCES_DIR}
+        GENERATOR JS)
 
-# WebCoreTestSupportBindings needs to have a direct or indirect
-# dependency to WebCoreBindings for CMake Visual Studio generator to
-# eliminate duplicated custom commands. Otherwise,
-# GenerateSettings.rb will be triggered in both projects.
-add_dependencies(WebCoreTestSupportBindings WebCoreBindings)
+    # WebCoreTestSupportBindings needs to have a direct or indirect
+    # dependency to WebCoreBindings for CMake Visual Studio generator to
+    # eliminate duplicated custom commands. Otherwise,
+    # GenerateSettings.rb will be triggered in both projects.
+    add_dependencies(WebCoreTestSupportBindings WebCoreBindings)
+endif ()
 
 # WebCore JS Builtins
 
@@ -3172,7 +3187,9 @@ WEBKIT_SYMLINK_FILES(WebCore_CopyPrivateHeaders
     FLATTENED
 )
 list(APPEND WebCore_INTERFACE_DEPENDENCIES WebCore_CopyPrivateHeaders)
-list(APPEND WebCoreTestSupport_INTERFACE_DEPENDENCIES WebCore_CopyPrivateHeaders)
+if (ENABLE_WEBCORE_TEST_SUPPORT)
+    list(APPEND WebCoreTestSupport_INTERFACE_DEPENDENCIES WebCore_CopyPrivateHeaders)
+endif ()
 
 WEBKIT_FRAMEWORK(WebCore)
 
@@ -3219,20 +3236,22 @@ if (WTF_CPU_ARM AND NOT CMAKE_CROSSCOMPILING)
         SKIP_PRECOMPILE_HEADERS ON)
 endif ()
 
-WEBKIT_ADD_PREFIX_HEADER(WebCoreTestSupport testing/js/WebCoreTestSupportPrefix.h)
+if (ENABLE_WEBCORE_TEST_SUPPORT)
+    WEBKIT_ADD_PREFIX_HEADER(WebCoreTestSupport testing/js/WebCoreTestSupportPrefix.h)
 
-WEBKIT_COPY_FILES(Copy_WebCoreTestSupportPrivateHeaders
-    DESTINATION ${WebCore_PRIVATE_FRAMEWORK_HEADERS_DIR}/WebCoreTestSupport
-    FILES ${WebCoreTestSupport_PRIVATE_HEADERS}
-    FLATTENED
-)
-list(APPEND WebCoreTestSupport_INTERFACE_DEPENDENCIES Copy_WebCoreTestSupportPrivateHeaders)
+    WEBKIT_COPY_FILES(Copy_WebCoreTestSupportPrivateHeaders
+        DESTINATION ${WebCore_PRIVATE_FRAMEWORK_HEADERS_DIR}/WebCoreTestSupport
+        FILES ${WebCoreTestSupport_PRIVATE_HEADERS}
+        FLATTENED
+    )
+    list(APPEND WebCoreTestSupport_INTERFACE_DEPENDENCIES Copy_WebCoreTestSupportPrivateHeaders)
 
-list(APPEND WebCoreTestSupport_INCLUDE_DIRECTORIES ${WebCore_INCLUDE_DIRECTORIES})
-list(APPEND WebCoreTestSupport_PRIVATE_INCLUDE_DIRECTORIES ${WebCore_PRIVATE_INCLUDE_DIRECTORIES})
-list(APPEND WebCoreTestSupport_SYSTEM_INCLUDE_DIRECTORIES ${WebCore_SYSTEM_INCLUDE_DIRECTORIES})
+    list(APPEND WebCoreTestSupport_INCLUDE_DIRECTORIES ${WebCore_INCLUDE_DIRECTORIES})
+    list(APPEND WebCoreTestSupport_PRIVATE_INCLUDE_DIRECTORIES ${WebCore_PRIVATE_INCLUDE_DIRECTORIES})
+    list(APPEND WebCoreTestSupport_SYSTEM_INCLUDE_DIRECTORIES ${WebCore_SYSTEM_INCLUDE_DIRECTORIES})
 
-WEBKIT_LIBRARY(WebCoreTestSupport)
+    WEBKIT_LIBRARY(WebCoreTestSupport)
+endif ()
 
 if (${WebCore_LIBRARY_TYPE} MATCHES "SHARED")
     # Unquoted empty PROJECT_VERSION_MAJOR makes CMake parse SOVERSION as VERSION's value


### PR DESCRIPTION
#### 15145f0a33b858f23df76b1e7750f60354c67a40
<pre>
[WPE][GTK] Build WebCoreTestSupport only when test targets are enabled
<a href="https://bugs.webkit.org/show_bug.cgi?id=314397">https://bugs.webkit.org/show_bug.cgi?id=314397</a>

Reviewed by Adrian Perez de Castro.

WebCoreTestSupport is test infrastructure used by WebKitTestRunner,
DumpRenderTree, and API test targets. It is currently declared, has
bindings generated, copies private headers, and is compiled even when both
ENABLE_LAYOUT_TESTS and ENABLE_API_TESTS are disabled.

This unnecessary build work can break production cross-builds. For example,
WPE Android builds with NDK r27 fail while compiling WebCoreTestSupport,
even though no layout or API test target is being built.

Add an internal ENABLE_WEBCORE_TEST_SUPPORT helper and use it to build
WebCoreTestSupport only when layout tests or API tests are enabled. Also
avoid passing test-only IDL files to the WebCore bindings preprocessor when
test support is disabled.

No behavior change for configurations that build layout tests or API tests.

* Source/WebCore/CMakeLists.txt:

Canonical link: <a href="https://commits.webkit.org/312996@main">https://commits.webkit.org/312996@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/416a062f67b5b2b28910fc9fa997a18d2325f8ad

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/161713 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/35187 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/28290 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/170616 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/118084 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/163582 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/35288 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/35188 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/125460 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/88384 "1 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/164672 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/27772 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/145253 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/106056 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/26821 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/25332 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/18337 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/136514 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/23008 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/173104 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/20145 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/24649 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/133752 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/34861 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/29423 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/133757 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36140 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/34845 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/144803 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/96861 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/28294 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/21625 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/34355 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/101800 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/33855 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/34098 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/34004 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->