### PR TITLE
innerText on tables emits spurious trailing newlines and drops row-exit newlines after empty rows

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/html/dom/elements/the-innertext-and-outertext-properties/getter-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/dom/elements/the-innertext-and-outertext-properties/getter-expected.txt
@@ -210,8 +210,8 @@ PASS Tab-separated table cells including trailing empty cells ("<div><table><tr>
 PASS Newline-separated table rows ("<div><table><tr><td>abc<tr><td>def</table>")
 PASS Newlines around table ("<div>abc<table><td>def</table>ghi")
 PASS Tab-separated table cells in a border-collapse table ("<div><table style='border-collapse:collapse'><tr><td>abc<td>def</table>")
-FAIL tfoot not reordered ("<div><table><tfoot>x</tfoot><tbody>y</tbody></table>") assert_equals: innerText expected "xy" but got "xy\n"
-FAIL  ("<table><tfoot><tr><td>footer</tfoot><thead><tr><td style='visibility:collapse'>thead</thead><tbody><tr><td>tbody</tbody></table>") assert_equals: innerText expected "footer\n\ntbody" but got "footer\ntbody"
+PASS tfoot not reordered ("<div><table><tfoot>x</tfoot><tbody>y</tbody></table>")
+PASS  ("<table><tfoot><tr><td>footer</tfoot><thead><tr><td style='visibility:collapse'>thead</thead><tbody><tr><td>tbody</tbody></table>")
 PASS No tab on table-cell itself ("<table><tr><td id=target>abc</td><td>def</td>")
 PASS No newline on table-row itself ("<table><tr id=target><td>abc</td><td>def</td></tr><tr id=target><td>ghi</td><td>jkl</td></tr>")
 PASS Newline between cells and caption ("<div><table><tr><td>abc<caption>def</caption></table>")

--- a/Source/WebCore/editing/TextIterator.cpp
+++ b/Source/WebCore/editing/TextIterator.cpp
@@ -1161,6 +1161,7 @@ void TextIterator::representNodeOffsetZero()
         if (shouldRepresentNodeOffsetZero()) {
             RefPtr parentNode = currentNode->parentNode();
             emitCharacter('\n', WTF::move(parentNode), WTF::move(currentNode), 0, 0);
+            m_isBlockNewline = true;
             // Per the spec, <p> elements require a blank line (2 newlines) before them.
             if (emitsNewlinesPerInnerTextSpec && is<HTMLParagraphElement>(*m_currentNode))
                 m_nodeForAdditionalNewline = m_currentNode.get();
@@ -1169,6 +1170,7 @@ void TextIterator::representNodeOffsetZero()
             // but <p> requires a blank line. Emit one more newline if we don't have enough.
             RefPtr parentNode = currentNode->parentNode();
             emitCharacter('\n', WTF::move(parentNode), WTF::move(currentNode), 0, 0);
+            m_isBlockNewline = true;
             // If the preceding '\n' was a content newline (e.g. from <pre> text) rather
             // than a block-boundary newline, m_consecutiveNewlineCount was reset to 0 by
             // emitText and the single emitCharacter above only brings it to 1. Schedule
@@ -1242,9 +1244,17 @@ void TextIterator::exitNode(Node* exitedNode)
         // use extra newline to represent margin bottom, as needed
         bool addNewline = shouldEmitExtraNewlineForNode(*protect(m_currentNode), m_behaviors.contains(TextIteratorBehavior::EmitsNewlinesPerInnerTextSpec));
 
+        // Per the innerText spec, every non-last table row produces a literal '\n' line
+        // break, independent of surrounding content. So when we reach a <tr> exit whose
+        // row-exit newline hasn't been emitted yet, emit it even if m_lastCharacter is
+        // already '\n' (e.g. from the previous row's exit or from a block inside the cell).
+        bool needsTableRowExitNewline = m_behaviors.contains(TextIteratorBehavior::EmitsNewlinesPerInnerTextSpec)
+            && is<RenderTableRow>(m_currentNode->renderer())
+            && m_lastTableRowEmittedExitNewlineFor.get() != m_currentNode.get();
+
         // FIXME: We need to emit a '\n' as we leave an empty block(s) that
         // contain a VisiblePosition when doing selection preservation.
-        if (m_lastCharacter != '\n') {
+        if (m_lastCharacter != '\n' || needsTableRowExitNewline) {
             // insert a newline with a position following this block's contents.
             emitCharacter('\n', protect(baseNode->parentNode()), baseNode.copyRef(), 1, 1);
             m_isBlockNewline = true;
@@ -1257,6 +1267,9 @@ void TextIterator::exitNode(Node* exitedNode)
             emitCharacter('\n', protect(baseNode->parentNode()), baseNode.copyRef(), 1, 1);
             m_isBlockNewline = true;
         }
+
+        if (needsTableRowExitNewline)
+            m_lastTableRowEmittedExitNewlineFor = m_currentNode.get();
     }
     
     // If nothing was emitted, see if we need to emit a space.

--- a/Source/WebCore/editing/TextIterator.h
+++ b/Source/WebCore/editing/TextIterator.h
@@ -186,6 +186,11 @@ private:
     bool m_hasEmitted { false };
     bool m_isBlockNewline { false };
 
+    // Tracks the last <tr> for which we emitted a row-exit '\n', so consecutive
+    // empty/effectively-empty rows can each contribute their own line break per the
+    // innerText spec, while preventing the same row from emitting twice.
+    WeakPtr<Node, WeakPtrImplWithEventTargetData> m_lastTableRowEmittedExitNewlineFor;
+
     // Used when deciding text fragment created by :first-letter should be looked into.
     bool m_handledFirstLetter { false };
 };


### PR DESCRIPTION
#### 4d337656617bce75dc9af62100298354a0a6944d
<pre>
innerText on tables emits spurious trailing newlines and drops row-exit newlines after empty rows
<a href="https://bugs.webkit.org/show_bug.cgi?id=314399">https://bugs.webkit.org/show_bug.cgi?id=314399</a>

Reviewed by Anne van Kesteren.

Two related failures in the WPT getter.html innerText test when
iterating tables via TextIterator with EmitsNewlinesPerInnerTextSpec:

  1. &quot;&lt;div&gt;&lt;table&gt;&lt;tfoot&gt;x&lt;/tfoot&gt;&lt;tbody&gt;y&lt;/tbody&gt;&lt;/table&gt;&quot; produced
     &quot;xy\n&quot; instead of &quot;xy&quot;. The HTML parser foster-parents &quot;x&quot; and &quot;y&quot;
     out of the table, leaving the table empty. Entering the (empty)
     table emits a leading block newline in representNodeOffsetZero(),
     but that emit was not flagged as a block newline, so plainText()&apos;s
     trailing-block-newline stripper could not remove it.

  2. &quot;&lt;table&gt;&lt;tfoot&gt;&lt;tr&gt;&lt;td&gt;footer&lt;/tfoot&gt;&lt;thead&gt;&lt;tr&gt;&lt;td
     style=&apos;visibility:collapse&apos;&gt;thead&lt;/thead&gt;&lt;tbody&gt;&lt;tr&gt;&lt;td&gt;tbody
     &lt;/tbody&gt;&lt;/table&gt;&quot; produced &quot;footer\ntbody&quot; instead of
     &quot;footer\n\ntbody&quot;. Per the innerText spec, every non-last table row
     appends a literal &apos;\n&apos; independent of surrounding content. exitNode()
     suppressed this emit whenever m_lastCharacter was already &apos;\n&apos;, so
     the collapsed thead row between tfoot and tbody contributed no line
     break of its own.

No new tests, rebaselined existing tests. The 2 subtests that started
passing in WebKit were already passing in Blink and Gecko.

* Source/WebCore/editing/TextIterator.cpp:
(WebCore::TextIterator::representNodeOffsetZero): Mark the entry-block
&apos;\n&apos; (both the standard block-before case and the extra &lt;p&gt; blank-line
case) as a block newline so plainText() can strip it when it becomes
trailing.

(WebCore::TextIterator::exitNode): When exiting a RenderTableRow whose
row-exit &apos;\n&apos; has not yet been emitted, emit it even if m_lastCharacter
is &apos;\n&apos;. Record the row in m_lastTableRowEmittedExitNewlineFor so the
second visit to the same row (going to its sibling) does not
double-emit.

Canonical link: <a href="https://commits.webkit.org/312941@main">https://commits.webkit.org/312941@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d98094d13d15f465f111420d88b3bae7d800b284

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/161388 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/34862 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/27962 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/170291 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/117759 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/7c0d3bcb-4e2e-416c-a264-3e202cf65da7) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/163257 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/34962 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/34863 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/125202 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/88209 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/345177e6-86d8-4881-a818-f432472f3e0e) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/164347 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/27489 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/144971 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/105798 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/cfea45de-901e-4c4c-bcf0-ca6251fb224e) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/26537 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/25047 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/18011 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/136231 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/22730 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/172775 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/19808 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/24371 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/133487 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/34536 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/29140 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/133494 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36106 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/34520 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/144525 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/96407 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/28028 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/21344 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/34030 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/101471 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/33530 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/33773 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/33679 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->