### PR TITLE
Remove WorkerAsynchronousURLErrorHandlingEnabled preference

### DIFF
--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -10113,20 +10113,6 @@ WirelessPlaybackTargetAPIEnabled:
       "PLATFORM(VISION)" : false
       default: true
 
-WorkerAsynchronousURLErrorHandlingEnabled:
-  type: bool
-  status: stable
-  category: dom
-  humanReadableName: "Worker asynchronous URL error handling"
-  humanReadableDescription: "Worker asynchronous URL error handling"
-  defaultValue:
-    WebKitLegacy:
-      default: true
-    WebKit:
-      default: true
-    WebCore:
-      default: true
-
 WorkerInSharedWorkerEnabled:
   type: bool
   status: preview

--- a/Source/WebCore/workers/AbstractWorker.cpp
+++ b/Source/WebCore/workers/AbstractWorker.cpp
@@ -70,11 +70,11 @@ ExceptionOr<URL> AbstractWorker::resolveURL(const String& url)
     return scriptURL;
 }
 
-std::optional<Exception> AbstractWorker::validateURL(ScriptExecutionContext& context, const URL& scriptURL)
+bool AbstractWorker::validateURL(ScriptExecutionContext& context, const URL& scriptURL)
 {
     // Per the specification, any same-origin URL (including blob: URLs) can be used. data: URLs can also be used, but they create a worker with an opaque origin.
     if (!protect(context.securityOrigin())->canRequest(scriptURL, OriginAccessPatternsForWebProcess::singleton()) && !scriptURL.protocolIsData())
-        return Exception { ExceptionCode::SecurityError };
+        return false;
 
     ASSERT(context.contentSecurityPolicy());
 
@@ -83,9 +83,9 @@ std::optional<Exception> AbstractWorker::validateURL(ScriptExecutionContext& con
         sourcePosition = document->currentParserSourcePosition();
 
     if (!protect(context.contentSecurityPolicy())->allowWorkerFromSource(scriptURL, WTF::move(sourcePosition)))
-        return Exception { ExceptionCode::SecurityError };
+        return false;
 
-    return { };
+    return true;
 }
 
 } // namespace WebCore

--- a/Source/WebCore/workers/AbstractWorker.h
+++ b/Source/WebCore/workers/AbstractWorker.h
@@ -54,7 +54,7 @@ protected:
     // Helper function that converts a URL to an absolute URL and checks the result for validity.
     ExceptionOr<URL> resolveURL(const String& url);
 
-    static std::optional<Exception> validateURL(ScriptExecutionContext&, const URL&);
+    static bool validateURL(ScriptExecutionContext&, const URL&);
 
     intptr_t asID() const { return reinterpret_cast<intptr_t>(this); }
 

--- a/Source/WebCore/workers/Worker.cpp
+++ b/Source/WebCore/workers/Worker.cpp
@@ -115,9 +115,7 @@ ExceptionOr<Ref<Worker>> Worker::create(ScriptExecutionContext& context, JSC::Ru
         return scriptURLOrException.releaseException();
 
     auto scriptURL = scriptURLOrException.releaseReturnValue();
-    if (auto exception = validateURL(context, scriptURL)) {
-        if (!context.settingsValues().workerAsynchronousURLErrorHandlingEnabled)
-            return Exception { ExceptionCode::SecurityError };
+    if (!validateURL(context, scriptURL)) {
         worker->queueTaskToDispatchEvent(worker.get(), TaskSource::DOMManipulation, Event::create(eventNames().errorEvent, Event::CanBubble::No, Event::IsCancelable::Yes));
         return worker;
     }

--- a/Source/WebCore/workers/shared/SharedWorker.cpp
+++ b/Source/WebCore/workers/shared/SharedWorker.cpp
@@ -115,9 +115,7 @@ ExceptionOr<Ref<SharedWorker>> SharedWorker::create(Document& document, Variant<
     auto sharedWorker = adoptRef(*new SharedWorker(document, key, channel->port1()));
     sharedWorker->suspendIfNeeded();
 
-    if (auto exception = validateURL(document, url)) {
-        if (!document.settings().workerAsynchronousURLErrorHandlingEnabled())
-            return Exception { ExceptionCode::SecurityError, "URL of the shared worker is cross-origin"_s };
+    if (!validateURL(document, url)) {
         sharedWorker->m_isActive = false;
         sharedWorker->queueTaskToDispatchEvent(sharedWorker.get(), TaskSource::DOMManipulation, Event::create(eventNames().errorEvent, Event::CanBubble::No, Event::IsCancelable::Yes));
         return sharedWorker;


### PR DESCRIPTION
#### 5e57d62e0930447d55e22091d387e7dfdbf2ca22
<pre>
Remove WorkerAsynchronousURLErrorHandlingEnabled preference
<a href="https://bugs.webkit.org/show_bug.cgi?id=314404">https://bugs.webkit.org/show_bug.cgi?id=314404</a>

Reviewed by Tim Nguyen.

It&apos;s been stable for close to a year without issue.

Canonical link: <a href="https://commits.webkit.org/312951@main">https://commits.webkit.org/312951@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/98d8ad7d780d35d5565b634c6f7fa3f0d8794258

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/161394 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/34868 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/27968 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/170297 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/117765 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/a63ad520-5aea-408c-a752-c37c0b521e2e) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/163263 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/34968 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/34869 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/125207 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/88212 "1 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/3ca5cf9d-58b2-4de8-9112-530d1b1671f4) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/164353 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/27494 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/144978 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/105803 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/70bb3048-0868-4fd5-83e4-a6b372a2451f) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/26542 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/25053 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/18018 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/153451 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/136236 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/22737 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/172783 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/22232 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/19814 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/24378 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/133493 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/34542 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/29146 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/133500 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/34526 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/144532 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/96421 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/24549 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/28035 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/21351 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/193793 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/34036 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/101477 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/49927 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/33536 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/33779 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/33685 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->