### PR TITLE
Suppress SpanConstChar warning

### DIFF
--- a/Source/WebKit/UIProcess/StdlibExtras.swift
+++ b/Source/WebKit/UIProcess/StdlibExtras.swift
@@ -64,10 +64,8 @@ extension WTF.String {
         // string for the duration that we're using it to construct the WTF::String.
         // The WTF::String will take a copy.
         self = unsafe string.utf8CString.span.withUnsafeBufferPointer { ptr in
-            // Warning here is rdar://163018821
             // swift-format-ignore: NeverForceUnwrap
-            let cppspan = unsafe SpanConstChar(ptr.baseAddress!, string.utf8CString.count)
-            return unsafe WTF.String.fromUTF8(cppspan)
+            unsafe WTF.String.fromUTF8(makeSpanConstChar(ptr.baseAddress!, ptr.count))
         }
     }
 

--- a/Source/WebKit/UIProcess/WebBackForwardListSwiftUtilities.h
+++ b/Source/WebKit/UIProcess/WebBackForwardListSwiftUtilities.h
@@ -45,6 +45,20 @@
 // Workaround for rdar://162358154
 using SpanConstChar = std::span<const char>;
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
+
+// Workaround for rdar://163018821: C++ treats char and signed char as distinct types,
+// so Swift's Span<CChar> (= Span<signed char>) cannot satisfy std::span<const char>'s
+// range constructor. This shim takes raw pointer+count to avoid that mismatch.
+// reinterpret_cast<const char*> is a no-op on all Apple platforms and is well-defined
+// because char* is permitted to alias any object type.
+inline SpanConstChar makeSpanConstChar(const int8_t* data, size_t count)
+{
+    return SpanConstChar { reinterpret_cast<const char*>(data), count };
+}
+
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
+
 // These can't be inline due to rdar://162531519
 void doLog(const WTF::String& msg); // rdar://168139823
 void doLoadingReleaseLog(const WTF::String& msg); // rdar://168139823


### PR DESCRIPTION
#### 0f897eea644e3bc12b618f7ee7875eda7c077c05
<pre>
Suppress SpanConstChar warning
<a href="https://bugs.webkit.org/show_bug.cgi?id=314408">https://bugs.webkit.org/show_bug.cgi?id=314408</a>
<a href="https://rdar.apple.com/176560122">rdar://176560122</a>

Reviewed by NOBODY (OOPS!).

Cease to use a deprecated two-argument form of span construction, which was
emitting a Swift warning. Unfortunately due to <a href="https://rdar.apple.com/163018821">rdar://163018821</a> we can&apos;t solve
this in pure Swift code, so introduce a small C++ shim for the argument
conversion required.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0f897eea644e3bc12b618f7ee7875eda7c077c05

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/161420 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/34894 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/27995 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/170323 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/117791 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/3f79af0c-a028-44e5-8a3b-9b87ebc385a6) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/34995 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/34895 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/125225 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/88215 "2 failures") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/b3542f17-8c38-482e-a61c-1ee702317745) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/164379 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/27516 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/145003 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/105821 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/cb136b6c-56fd-4a4c-a6f3-8d5c27a74ac1) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/26565 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/25072 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/18044 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/136258 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/172809 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/19840 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/24402 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/133511 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/34568 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/29165 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/133518 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/34552 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/144556 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/96452 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/28056 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/21375 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/34062 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/101503 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/33562 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/33805 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/33711 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->