### PR TITLE
Fix the non-unified macOS build

### DIFF
--- a/Source/WTF/Scripts/generate-unified-source-bundles.py
+++ b/Source/WTF/Scripts/generate-unified-source-bundles.py
@@ -129,6 +129,11 @@ class SourceFile:
         else:
             return str(self._args.derived_sources_path / self.path)
 
+    @property
+    def arc(self) -> bool:
+        # .mm compiles with -fobjc-arc unless the source list marks it @nonARC.
+        return self.path.suffix == '.mm' and not self._non_arc
+
     def bundled_source_form(self) -> str:
         # String form for the --print-bundled-sources list: derived sources are
         # rooted under derived_sources_path, source-tree files stay relative.
@@ -239,6 +244,10 @@ def parse_args():
     mode_group.add_argument('--generate-xcfilelists', action='store_true', default=False,
                             help='Generate .xcfilelist files.')
 
+    parser.add_argument('--print-arc-sources', type=Path, metavar='PATH',
+                        help='Write the ARC .mm sources that are emitted as standalone files '
+                             '(one per line) to PATH. Bundled ARC sources carry their ARC-ness '
+                             'in the -ARC.mm bundle name instead.')
     parser.add_argument('--input-xcfilelist-path', type=Path,
                         help='Path of the generated input .xcfilelist file.')
     parser.add_argument('--output-xcfilelist-path', type=Path,
@@ -304,6 +313,7 @@ def main() -> None:
     input_sources: list[str] = []
     output_sources: list[str] = []
     bundled_members: list[str] = []
+    standalone_arc_sources: list[str] = []
 
     bundle_managers = {
         '.cpp': BundleManager('cpp', '.cpp', args.max_cpp_bundle_count, args, generated_sources, output_sources),
@@ -356,13 +366,19 @@ def main() -> None:
     log(args, "Found sources: {}".format(sorted(source_files, key=SourceFile.sort_key)))
 
     for source_file in sorted(source_files, key=SourceFile.sort_key):
+        bundled = False
         if args.mode in ('GenerateBundles', 'GenerateXCFilelists'):
             process_file_for_unified_source_generation(source_file, args, bundle_managers, generated_sources, input_sources)
-            if args.mode == 'GenerateBundles' and args.print_bundled_sources \
-                    and bundle_managers.get(source_file.bundle_manager_key) and source_file.unifiable:
+            bundled = bool(bundle_managers.get(source_file.bundle_manager_key)) and source_file.unifiable
+            if args.mode == 'GenerateBundles' and args.print_bundled_sources and bundled:
                 bundled_members.append(source_file.bundled_source_form())
         elif args.mode == 'PrintAllSources':
             generated_sources.append(str(source_file))
+
+        # An ARC .mm that is not folded into an -ARC.mm bundle has nothing in its
+        # name to tell CMake it needs -fobjc-arc, so report it separately.
+        if args.print_arc_sources and source_file.arc and not bundled:
+            standalone_arc_sources.append(str(source_file))
 
     if args.mode != 'PrintAllSources':
         for manager in bundle_managers.values():
@@ -394,6 +410,13 @@ def main() -> None:
         with open(args.print_bundled_sources, 'w') as f:
             f.write("\n".join(bundled_members))
             if bundled_members:
+                f.write("\n")
+
+    # Always written, even when empty: CMake reads it with file(STRINGS).
+    if args.print_arc_sources:
+        with open(args.print_arc_sources, 'w') as f:
+            f.write("\n".join(standalone_arc_sources))
+            if standalone_arc_sources:
                 f.write("\n")
 
     # We use stdout to report our unified source list to CMake.

--- a/Source/WebKit/CMakeLists.txt
+++ b/Source/WebKit/CMakeLists.txt
@@ -1431,6 +1431,12 @@ endif ()
 
 list(APPEND WebKit_SOURCES ${WebKit_DERIVED_SOURCES})
 
+# Subtargets #include generated headers (MessageNames.h, *Messages.h, GeneratedSerializers*.h),
+# but CMake only sees the generators feeding the main WebKit target, so a subtarget's prefix
+# header can compile before the generators run. Order every subtarget after them explicitly.
+add_custom_target(WebKit_DerivedSourcesOrder DEPENDS ${WebKit_DERIVED_SOURCES})
+list(APPEND WebKit_DEPENDENCIES WebKit_DerivedSourcesOrder)
+
 WEBKIT_COMPUTE_SOURCES(WebKit)
 if (DEFINED WebKit_SWIFT_INTEROP_SOURCES)
     list(REMOVE_ITEM WebKit_SOURCES ${WebKit_SWIFT_INTEROP_SOURCES})

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKActivatedElementInfoInternal.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKActivatedElementInfoInternal.h
@@ -23,12 +23,13 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+#import <WebKit/_WKActivatedElementInfo.h>
+
 #if PLATFORM(IOS_FAMILY)
 
 #import "InteractionInformationAtPosition.h"
 #import <WebCore/ElementAnimationContext.h>
 #import <WebCore/IntPoint.h>
-#import <WebKit/_WKActivatedElementInfo.h>
 
 namespace WebCore {
 class ShareableBitmap;

--- a/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPITestCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPITestCocoa.mm
@@ -32,8 +32,11 @@
 #import "WebExtensionAPITest.h"
 
 #import "CocoaHelpers.h"
+#import "MessageSenderInlines.h"
 #import "WebExtensionControllerMessages.h"
 #import "WebExtensionControllerProxy.h"
+#import "WebPage.h"
+#import "WebProcess.h"
 
 #if ENABLE(WK_WEB_EXTENSIONS)
 

--- a/Source/WebKitLegacy/mac/WebView/WebPDFRepresentation.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebPDFRepresentation.mm
@@ -40,6 +40,7 @@
 #import "WebView.h"
 #import <wtf/Assertions.h>
 #import <wtf/RetainPtr.h>
+#import <wtf/cocoa/TypeCastsCocoa.h>
 
 @implementation WebPDFRepresentation
 

--- a/Source/WebKitLegacy/mac/WebView/WebView.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebView.mm
@@ -569,7 +569,9 @@ static BOOL s_didSetCacheModel;
 static WebCacheModel s_cacheModel = WebCacheModelDocumentViewer;
 
 const auto WKLockdownModeEnabledKeyCFString = CFSTR(STRINGIZE_VALUE_OF(WKLockdownModeEnabled));
+#if !HAVE(LOCKDOWN_MODE_FRAMEWORK)
 const auto LDMEnabledKey = CFSTR("LDMGlobalEnabled");
+#endif
 
 #if PLATFORM(IOS_FAMILY)
 static Class s_pdfRepresentationClass;

--- a/Source/WebKitLegacy/mac/WebView/WebViewRenderingUpdateScheduler.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebViewRenderingUpdateScheduler.mm
@@ -40,6 +40,10 @@
 
 #if PLATFORM(MAC)
 #import <pal/spi/mac/NSWindowSPI.h>
+
+@interface NSWindow (WebNSWindowDetails)
+- (void)_enableScreenUpdatesIfNeeded;
+@end
 #endif
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(WebViewRenderingUpdateScheduler);

--- a/Source/cmake/WebKitMacros.cmake
+++ b/Source/cmake/WebKitMacros.cmake
@@ -51,6 +51,12 @@ macro(WEBKIT_COMPUTE_SOURCES _framework)
         list(APPEND gusb_args --max-bundle-size ${WEBKIT_MAX_BUNDLE_SIZE} --enforce-cost)
     endif ()
 
+    # ARC .mm sources that the bundler emits standalone (non-unified builds, and
+    # @no-unify/@no-unify-when files in unified builds) have nothing in their name
+    # to distinguish them, so the bundler lists them here.
+    set(_arcSourcesFile "${CMAKE_CURRENT_BINARY_DIR}/${_framework}ARCSources.txt")
+    list(APPEND gusb_args --print-arc-sources "${_arcSourcesFile}")
+
     if (ENABLE_UNIFIED_BUILDS)
         # One pass generates the bundles (stdout = files to compile) and writes the
         # bundled member list to a side file via --print-bundled-sources.
@@ -73,27 +79,6 @@ macro(WEBKIT_COMPUTE_SOURCES _framework)
             list(APPEND ${_framework}_HEADERS ${_sourceFileTmp})
         endforeach ()
         unset(_sourceFileTmp)
-
-        foreach (_file IN LISTS _outputTmp)
-            # Disambiguate top-level generated sources in DerivedSources vs top-level regular sources.
-            get_filename_component(_fileDir "${_file}" DIRECTORY)
-            if (NOT _fileDir AND NOT EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/${_file}")
-                set(_file "${_derivedSourcesPath}/${_file}")
-            endif ()
-            if (_file MATCHES "\\.c$")
-                list(APPEND ${_framework}_C_SOURCES ${_file})
-            elseif (_file MATCHES "-ARC\\.mm$")
-                # generate-unified-source-bundles.rb emits *-ARC.mm and *-nonARC.mm bundles based
-                # on @nonARC annotations in Sources*.txt. The ARC bundles compile in a separate
-                # OBJECT library so the OBJCXX precompiled header agrees on -fobjc-arc.
-                list(APPEND ${_framework}_ARC_SOURCES ${_file})
-            else ()
-                list(APPEND ${_framework}_SOURCES ${_file})
-            endif ()
-        endforeach ()
-
-        unset(_resultTmp)
-        unset(_outputTmp)
     else ()
         execute_process(COMMAND ${Python_EXECUTABLE} ${WTF_SCRIPTS_DIR}/generate-unified-source-bundles.py
             ${gusb_args}
@@ -105,11 +90,35 @@ macro(WEBKIT_COMPUTE_SOURCES _framework)
         if (${_resultTmp})
              message(FATAL_ERROR "generate-unified-source-bundles.py exited with non-zero status, exiting")
         endif ()
-
-        list(APPEND ${_framework}_SOURCES ${_outputTmp})
-        unset(_resultTmp)
-        unset(_outputTmp)
     endif ()
+
+    file(STRINGS "${_arcSourcesFile}" _standaloneARCSources)
+    foreach (_file IN LISTS _outputTmp)
+        if (_file IN_LIST _standaloneARCSources)
+            set(_fileIsARC ON)
+        else ()
+            set(_fileIsARC OFF)
+        endif ()
+        # Disambiguate top-level generated sources in DerivedSources vs top-level regular sources.
+        get_filename_component(_fileDir "${_file}" DIRECTORY)
+        if (NOT _fileDir AND NOT EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/${_file}")
+            set(_file "${_derivedSourcesPath}/${_file}")
+        endif ()
+        if (_file MATCHES "\\.c$")
+            list(APPEND ${_framework}_C_SOURCES ${_file})
+        elseif (_fileIsARC OR _file MATCHES "-ARC\\.mm$")
+            # generate-unified-source-bundles.py emits *-ARC.mm and *-nonARC.mm bundles based
+            # on @nonARC annotations in Sources*.txt. The ARC sources compile in a separate
+            # OBJECT library so the OBJCXX precompiled header agrees on -fobjc-arc.
+            list(APPEND ${_framework}_ARC_SOURCES ${_file})
+        else ()
+            list(APPEND ${_framework}_SOURCES ${_file})
+        endif ()
+    endforeach ()
+
+    unset(_fileIsARC)
+    unset(_resultTmp)
+    unset(_outputTmp)
 endmacro()
 
 macro(WEBKIT_INCLUDE_CONFIG_FILES_IF_EXISTS)

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/AdaptiveImageGlyph.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/AdaptiveImageGlyph.mm
@@ -30,6 +30,7 @@
 #import "Helpers/mac/AppKitSPI.h"
 #import "Helpers/cocoa/DragAndDropSimulator.h"
 #import "Helpers/PlatformUtilities.h"
+#import "Helpers/Test.h"
 #import "TestInputDelegate.h"
 #import "Helpers/cocoa/TestWKWebView.h"
 #import "UIKitSPIForTesting.h"

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/HTTP2Server.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/HTTP2Server.mm
@@ -27,6 +27,7 @@
 
 #if HAVE(NETWORK_FRAMEWORK_HTTP_MESSAGING)
 
+#import "Helpers/PlatformUtilities.h"
 #import "Helpers/Utilities.h"
 #import "Helpers/cocoa/HTTPServer.h"
 #import "Helpers/cocoa/TestUIDelegate.h"

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/HTTP3Server.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/HTTP3Server.mm
@@ -27,6 +27,7 @@
 
 #if HAVE(NETWORK_FRAMEWORK_HTTP_MESSAGING)
 
+#import "Helpers/PlatformUtilities.h"
 #import "Helpers/Utilities.h"
 #import "Helpers/cocoa/HTTPServer.h"
 #import "Helpers/cocoa/TestUIDelegate.h"


### PR DESCRIPTION
#### 1aac40b53412345ce416de6f638ef29fc1dc9331
<pre>
Fix the non-unified macOS build
<a href="https://bugs.webkit.org/show_bug.cgi?id=314413">https://bugs.webkit.org/show_bug.cgi?id=314413</a>
<a href="https://rdar.apple.com/176566837">rdar://176566837</a>

Reviewed by NOBODY (OOPS!).

With ENABLE_UNIFIED_BUILDS=OFF, WEBKIT_COMPUTE_SOURCES sent every source to
${framework}_SOURCES, so the *-ARC.mm routing that gives ARC .mm files their
own -fobjc-arc object library never ran. 101 Source/WebKit .mm files compiled
without ARC: 92 tripped their own #error guard, and 9 compiled silently with
manual retain/release semantics. The same gap reaches the unified iOS build,
where Shared/LogStream.mm is @no-unify-when(bundle&lt;=8) and so stands alone at
iOS&apos;s bundle size of 8.

generate-unified-source-bundles.py now reports the ARC .mm files it emits
standalone through --print-arc-sources, and both branches of
WEBKIT_COMPUTE_SOURCES share one classification loop, so ARC sources reach
${framework}_ARC_SOURCES in either mode.

WebKit subtargets #include generated headers such as MessageNames.h, but CMake
only sees the generators feeding the main WebKit target, so a subtarget&apos;s
prefix header could compile before those generators ran. WebKit_DerivedSourcesOrder
orders the subtargets after them.

The remaining changes add the includes, declarations and guards that unified
bundles were supplying from a neighbouring file in the same translation unit.

* Source/WTF/Scripts/generate-unified-source-bundles.py:
(SourceFile.arc):
(parse_args):
(main):
* Source/WebKit/CMakeLists.txt:
* Source/WebKit/UIProcess/API/Cocoa/_WKActivatedElementInfoInternal.h:
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPITestCocoa.mm:
* Source/WebKitLegacy/mac/WebView/WebPDFRepresentation.mm:
* Source/WebKitLegacy/mac/WebView/WebView.mm:
* Source/WebKitLegacy/mac/WebView/WebViewRenderingUpdateScheduler.mm:
* Source/cmake/WebKitMacros.cmake:
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/AdaptiveImageGlyph.mm:
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/HTTP2Server.mm:
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/HTTP3Server.mm:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1aac40b53412345ce416de6f638ef29fc1dc9331

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/180865 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/54810 "Built successfully") | [❌ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/48608 "Hash 1aac40b5 for PR 64559 does not build (failure)") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/191079 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/145188 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/eb54adfc-92f1-4b7f-acc4-dc1de62fff21) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/182727 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/56108 "Built successfully") | [❌ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/54526 "Hash 1aac40b5 for PR 64559 does not build (failure)") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/141098 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/97791 "1 flakes 7 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/db1633dc-8116-47f5-a821-5e2a03aabd76) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/183820 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/44759 "Passed tests") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/168/builds/48608 "Hash 1aac40b5 for PR 64559 does not build (failure)") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/121549 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/dc994eba-0bd1-4610-801b-7d7987d6b1f1) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/43432 "Passed tests") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/156/builds/54526 "Hash 1aac40b5 for PR 64559 does not build (failure)") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/3515 "Passed tests") | | 
| [❌ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/168/builds/48608 "Hash 1aac40b5 for PR 64559 does not build (failure)") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/153836 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/168/builds/48608 "Hash 1aac40b5 for PR 64559 does not build (failure)") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/2239 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/42139 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/47422 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/156/builds/54526 "Hash 1aac40b5 for PR 64559 does not build (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/193014 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/54476 "Built successfully") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/168/builds/48608 "Hash 1aac40b5 for PR 64559 does not build (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/150478 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/55164 "Built successfully") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/168/builds/48608 "Hash 1aac40b5 for PR 64559 does not build (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/150197 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/44790 "Passed tests") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/127430 "Failed to build and analyze WebKit") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/122748 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/53681 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/168/builds/48608 "Hash 1aac40b5 for PR 64559 does not build (failure)") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/53063 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/53300 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/53128 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->