### PR TITLE
Add findIfCached / insert to TinyLRUCache

### DIFF
--- a/Source/WTF/wtf/TinyLRUCache.h
+++ b/Source/WTF/wtf/TinyLRUCache.h
@@ -28,6 +28,7 @@
 #include <algorithm>
 #include <cstddef>
 #include <span>
+#include <wtf/Assertions.h>
 #include <wtf/NeverDestroyed.h>
 
 namespace WTF {
@@ -44,45 +45,195 @@ template<typename KeyType, typename ValueType, size_t capacity = 4, typename Pol
 class TinyLRUCache {
     WTF_DEPRECATED_MAKE_FAST_ALLOCATED(TinyLRUCache);
 public:
+    TinyLRUCache() = default;
+
+    ~TinyLRUCache()
+    {
+        invalidateIterators();
+    }
+
+    TinyLRUCache(const TinyLRUCache& other)
+        : m_cacheBuffer(other.m_cacheBuffer)
+        , m_size(other.m_size)
+    {
+        invalidateIterators();
+        other.invalidateIterators();
+    }
+
+    TinyLRUCache& operator=(const TinyLRUCache& other)
+    {
+        if (this == &other)
+            return *this;
+        invalidateIterators();
+        other.invalidateIterators();
+        m_cacheBuffer = other.m_cacheBuffer;
+        m_size = other.m_size;
+        return *this;
+    }
+
+    TinyLRUCache(TinyLRUCache&&) = delete;
+    TinyLRUCache& operator=(TinyLRUCache&&) = delete;
+
+    class FindResult {
+    public:
+        FindResult() = default;
+
+        FindResult(const FindResult&) = delete;
+
+        FindResult& operator=(const FindResult& other) = delete;
+
+        ~FindResult()
+        {
+            if (m_cache) {
+                ASSERT(m_cache->m_findResult == this);
+                m_cache->invalidateIterators();
+            }
+        }
+
+        explicit operator bool() const
+        {
+            return m_ptr;
+        }
+
+        const ValueType& operator*() const
+        {
+            RELEASE_ASSERT(m_ptr);
+            return *m_ptr;
+        }
+
+        const ValueType* operator->() const
+        {
+            RELEASE_ASSERT(m_ptr);
+            return m_ptr;
+        }
+
+    private:
+        friend class TinyLRUCache;
+
+        using Cache = TinyLRUCache<KeyType, ValueType, capacity, Policy>;
+
+        FindResult(const ValueType* ptr, Cache& cache)
+            : m_ptr(ptr)
+            , m_cache(ptr ? &cache : nullptr)
+        {
+            if (m_cache)
+                m_cache->trackFindResult(this);
+        }
+
+        void assertValid() const
+        {
+            RELEASE_ASSERT_IMPLIES(m_ptr, m_cache);
+        }
+
+        const ValueType* m_ptr { nullptr };
+        Cache* m_cache { nullptr };
+    };
+
     const ValueType& get(const KeyType& key)
     {
+        invalidateIterators();
+
         if (Policy::isKeyNull(key)) {
             static NeverDestroyed<ValueType> valueForNull = Policy::createValueForNullKey();
             return valueForNull;
         }
 
+        if (auto* found = findInternal(key))
+            return *found;
+
+        insertInternal(key, Policy::createValueForKey(key));
+        return cacheBuffer()[m_size - 1].second;
+    }
+
+    FindResult findIfCached(const KeyType& key)
+    {
+        invalidateIterators();
+
+        if (Policy::isKeyNull(key))
+            return { nullptr, *this };
+
+        return { findInternal(key), *this };
+    }
+
+    void insert(const KeyType& key, ValueType&& value)
+    {
+        ASSERT(!Policy::isKeyNull(key));
+#if ASSERT_ENABLED
+        {
+            auto cacheBuffer = this->cacheBuffer();
+            for (size_t i = 0; i < m_size; ++i)
+                ASSERT(!(cacheBuffer[i].first == key));
+        }
+#endif
+        invalidateIterators();
+        insertInternal(key, WTF::move(value));
+    }
+
+    void clear()
+    {
+        invalidateIterators();
+        auto cacheBuffer = this->cacheBuffer();
+        for (size_t i = 0; i < m_size; ++i)
+            cacheBuffer[i] = Entry { };
+        m_size = 0;
+    }
+
+    size_t size() const { return m_size; }
+
+private:
+    void trackFindResult(FindResult* p)
+    {
+        ASSERT(p);
+        ASSERT(m_findResult != p);
+        invalidateIterators();
+        m_findResult = p;
+    }
+
+    void invalidateIterators()
+    {
+        if (m_findResult) {
+            ASSERT(m_findResult->m_cache == this);
+            m_findResult->m_cache = nullptr;
+            m_findResult->m_ptr = nullptr;
+            m_findResult = nullptr;
+        }
+    }
+
+    ALWAYS_INLINE const ValueType* findInternal(const KeyType& key)
+    {
         auto cacheBuffer = this->cacheBuffer();
         for (size_t i = m_size; i-- > 0;) {
             if (cacheBuffer[i].first == key) {
                 if (i < m_size - 1) {
-                    // Move entry to the end of the cache if necessary.
                     auto entry = WTF::move(cacheBuffer[i]);
                     do {
                         cacheBuffer[i] = WTF::move(cacheBuffer[i + 1]);
                     } while (++i < m_size - 1);
                     cacheBuffer[m_size - 1] = WTF::move(entry);
                 }
-                return cacheBuffer[m_size - 1].second;
+                return &cacheBuffer[m_size - 1].second;
             }
         }
+        return nullptr;
+    }
 
-        // cacheBuffer[0] is the LRU entry, so remove it.
+    ALWAYS_INLINE void insertInternal(const KeyType& key, ValueType&& value)
+    {
+        auto cacheBuffer = this->cacheBuffer();
         if (m_size == capacity) {
             for (size_t i = 0; i < m_size - 1; ++i)
                 cacheBuffer[i] = WTF::move(cacheBuffer[i + 1]);
         } else
             ++m_size;
-
-        cacheBuffer[m_size - 1] = std::pair { Policy::createKeyForStorage(key), Policy::createValueForKey(key) };
-        return cacheBuffer[m_size - 1].second;
+        cacheBuffer[m_size - 1] = std::pair { Policy::createKeyForStorage(key), WTF::move(value) };
     }
 
-private:
     using Entry = std::pair<KeyType, ValueType>;
     std::span<Entry, capacity> cacheBuffer() { return m_cacheBuffer; }
 
     alignas(Entry) std::array<Entry, capacity> m_cacheBuffer;
     size_t m_size { 0 };
+    FindResult* m_findResult { nullptr };
 };
 
 } // namespace WTF

--- a/Tools/TestWebKitAPI/CMakeLists.txt
+++ b/Tools/TestWebKitAPI/CMakeLists.txt
@@ -136,6 +136,7 @@ set(TestWTF_SOURCES
     Tests/WTF/StringView.cpp
     Tests/WTF/SynchronizedFixedQueue.cpp
     Tests/WTF/TextBreakIterator.cpp
+    Tests/WTF/TinyLRUCache.cpp
     Tests/WTF/ThreadGroup.cpp
     Tests/WTF/ThreadMessages.cpp
     Tests/WTF/Threading.cpp

--- a/Tools/TestWebKitAPI/Tests/WTF/TinyLRUCache.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/TinyLRUCache.cpp
@@ -1,0 +1,355 @@
+/*
+ * Copyright (C) 2026 Igalia S.L.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include <wtf/TinyLRUCache.h>
+
+#include "Helpers/Test.h"
+#include <wtf/RefCounted.h>
+#include <wtf/RefPtr.h>
+
+namespace TestWebKitAPI {
+
+struct CountingPolicy : public WTF::TinyLRUCachePolicy<int, int> {
+    static unsigned createCount;
+    static int createValueForKey(const int& key)
+    {
+        ++createCount;
+        return key * 10;
+    }
+};
+unsigned CountingPolicy::createCount = 0;
+
+TEST(WTF_TinyLRUCache, GetCachesOnHit)
+{
+    CountingPolicy::createCount = 0;
+    WTF::TinyLRUCache<int, int, 4, CountingPolicy> cache;
+    EXPECT_EQ(0u, cache.size());
+
+    EXPECT_EQ(10, cache.get(1));
+    EXPECT_EQ(1u, CountingPolicy::createCount);
+    EXPECT_EQ(1u, cache.size());
+
+    EXPECT_EQ(10, cache.get(1));
+    EXPECT_EQ(1u, CountingPolicy::createCount);
+    EXPECT_EQ(1u, cache.size());
+
+    EXPECT_EQ(20, cache.get(2));
+    EXPECT_EQ(2u, CountingPolicy::createCount);
+    EXPECT_EQ(2u, cache.size());
+}
+
+TEST(WTF_TinyLRUCache, GetEvictsLRU)
+{
+    CountingPolicy::createCount = 0;
+    WTF::TinyLRUCache<int, int, 2, CountingPolicy> cache;
+
+    cache.get(1);
+    cache.get(2);
+    EXPECT_EQ(2u, cache.size());
+
+    cache.get(3); // evicts 1
+    EXPECT_EQ(2u, cache.size());
+
+    cache.get(2);
+    EXPECT_EQ(3u, CountingPolicy::createCount);
+
+    cache.get(1); // re-computed because evicted
+    EXPECT_EQ(4u, CountingPolicy::createCount);
+}
+
+struct NullKeyPolicy : public WTF::TinyLRUCachePolicy<int, int> {
+    static unsigned createCount;
+    static unsigned createNullCount;
+    static bool isKeyNull(const int& key) { return !key; }
+    static int createValueForNullKey()
+    {
+        ++createNullCount;
+        return -1;
+    }
+    static int createValueForKey(const int& key)
+    {
+        ++createCount;
+        return key * 10;
+    }
+};
+unsigned NullKeyPolicy::createCount = 0;
+unsigned NullKeyPolicy::createNullCount = 0;
+
+TEST(WTF_TinyLRUCache, GetWithNullKeyReturnsNullValueAndDoesNotStore)
+{
+    NullKeyPolicy::createCount = 0;
+    NullKeyPolicy::createNullCount = 0;
+    WTF::TinyLRUCache<int, int, 4, NullKeyPolicy> cache;
+
+    EXPECT_EQ(-1, cache.get(0));
+    EXPECT_EQ(0u, cache.size());
+    EXPECT_EQ(0u, NullKeyPolicy::createCount);
+
+    // Repeated null lookups must not grow the cache or re-create the null value.
+    EXPECT_EQ(-1, cache.get(0));
+    EXPECT_EQ(0u, cache.size());
+    EXPECT_EQ(1u, NullKeyPolicy::createNullCount);
+
+    // Non-null keys still work and are unaffected by null-key lookups.
+    EXPECT_EQ(50, cache.get(5));
+    EXPECT_EQ(1u, cache.size());
+    EXPECT_EQ(1u, NullKeyPolicy::createCount);
+
+    // findIfCached must miss for null keys regardless of prior get() calls.
+    EXPECT_FALSE(cache.findIfCached(0));
+}
+
+TEST(WTF_TinyLRUCache, FindIfCachedReturnsNullOnMiss)
+{
+    WTF::TinyLRUCache<int, int, 4> cache;
+    EXPECT_FALSE(cache.findIfCached(42));
+}
+
+TEST(WTF_TinyLRUCache, FindIfCachedHitsAfterInsert)
+{
+    WTF::TinyLRUCache<int, int, 4> cache;
+    cache.insert(1, 100);
+    auto hit = cache.findIfCached(1);
+    ASSERT_TRUE(hit);
+    EXPECT_EQ(100, *hit);
+    EXPECT_EQ(1u, cache.size());
+}
+
+TEST(WTF_TinyLRUCache, InsertEvictsLRU)
+{
+    WTF::TinyLRUCache<int, int, 2> cache;
+    cache.insert(1, 100);
+    cache.insert(2, 200);
+    EXPECT_EQ(2u, cache.size());
+
+    cache.insert(3, 300); // evicts 1
+    EXPECT_EQ(2u, cache.size());
+    EXPECT_FALSE(cache.findIfCached(1));
+    auto two = cache.findIfCached(2);
+    ASSERT_TRUE(two);
+    EXPECT_EQ(200, *two);
+    auto three = cache.findIfCached(3);
+    ASSERT_TRUE(three);
+    EXPECT_EQ(300, *three);
+}
+
+TEST(WTF_TinyLRUCache, FindIfCachedPromotesToMRU)
+{
+    WTF::TinyLRUCache<int, int, 3> cache;
+    cache.insert(1, 100);
+    cache.insert(2, 200);
+    cache.insert(3, 300);
+
+    // Promote 1 to MRU; subsequent insert should evict 2 (now LRU), not 1.
+    EXPECT_TRUE(cache.findIfCached(1));
+
+    cache.insert(4, 400);
+    EXPECT_TRUE(cache.findIfCached(1));
+    EXPECT_FALSE(cache.findIfCached(2));
+    EXPECT_TRUE(cache.findIfCached(3));
+    EXPECT_TRUE(cache.findIfCached(4));
+}
+
+TEST(WTF_TinyLRUCache, ClearReleasesEntriesAndResetsSize)
+{
+    WTF::TinyLRUCache<int, int, 4> cache;
+    cache.insert(1, 100);
+    cache.insert(2, 200);
+    EXPECT_EQ(2u, cache.size());
+    cache.clear();
+    EXPECT_EQ(0u, cache.size());
+    EXPECT_FALSE(cache.findIfCached(1));
+    EXPECT_FALSE(cache.findIfCached(2));
+}
+
+class TrackedRefCounted : public RefCounted<TrackedRefCounted> {
+public:
+    static unsigned aliveCount;
+    static Ref<TrackedRefCounted> create(int value) { return adoptRef(*new TrackedRefCounted(value)); }
+    int value() const { return m_value; }
+    ~TrackedRefCounted() { --aliveCount; }
+private:
+    TrackedRefCounted(int value) : m_value(value) { ++aliveCount; }
+    int m_value;
+};
+unsigned TrackedRefCounted::aliveCount = 0;
+
+TEST(WTF_TinyLRUCache, ClearReleasesRefsImmediately)
+{
+    TrackedRefCounted::aliveCount = 0;
+    {
+        WTF::TinyLRUCache<int, RefPtr<TrackedRefCounted>, 4> cache;
+        cache.insert(1, TrackedRefCounted::create(100).ptr());
+        cache.insert(2, TrackedRefCounted::create(200).ptr());
+        EXPECT_EQ(2u, TrackedRefCounted::aliveCount);
+
+        cache.clear();
+        EXPECT_EQ(0u, TrackedRefCounted::aliveCount);
+    }
+}
+
+TEST(WTF_TinyLRUCache, EvictionViaInsertReleasesRef)
+{
+    TrackedRefCounted::aliveCount = 0;
+    {
+        WTF::TinyLRUCache<int, RefPtr<TrackedRefCounted>, 2> cache;
+        cache.insert(1, TrackedRefCounted::create(100).ptr());
+        cache.insert(2, TrackedRefCounted::create(200).ptr());
+        EXPECT_EQ(2u, TrackedRefCounted::aliveCount);
+
+        // Inserting a third entry into a capacity-2 cache must drop the LRU's ref.
+        cache.insert(3, TrackedRefCounted::create(300).ptr());
+        EXPECT_EQ(2u, TrackedRefCounted::aliveCount);
+    }
+    EXPECT_EQ(0u, TrackedRefCounted::aliveCount);
+}
+
+TEST(WTF_TinyLRUCache, FindIfCachedDoesNotConsumeEntry)
+{
+    WTF::TinyLRUCache<int, int, 4> cache;
+    cache.insert(1, 100);
+    {
+        auto hit = cache.findIfCached(1);
+        ASSERT_TRUE(hit);
+        EXPECT_EQ(100, *hit);
+    }
+    {
+        auto hit = cache.findIfCached(1);
+        ASSERT_TRUE(hit);
+        EXPECT_EQ(100, *hit);
+    }
+    EXPECT_EQ(1u, cache.size());
+}
+
+TEST(WTF_TinyLRUCache, FindIfCachedAfterClearMisses)
+{
+    WTF::TinyLRUCache<int, int, 4> cache;
+    cache.insert(1, 100);
+    cache.clear();
+    EXPECT_FALSE(cache.findIfCached(1));
+    cache.insert(1, 999); // re-insert with different value
+    auto hit = cache.findIfCached(1);
+    ASSERT_TRUE(hit);
+    EXPECT_EQ(999, *hit);
+}
+
+TEST(WTF_TinyLRUCache, FindOrComputeWorkflow)
+{
+    WTF::TinyLRUCache<int, int, 4> cache;
+    int externalContext = 7;
+
+    auto findOrInsert = [&](int key) -> int {
+        if (auto hit = cache.findIfCached(key))
+            return *hit;
+        int value = key * externalContext;
+        cache.insert(key, WTF::move(value));
+        auto hit = cache.findIfCached(key);
+        return hit ? *hit : -1;
+    };
+
+    EXPECT_EQ(7, findOrInsert(1));
+    EXPECT_EQ(14, findOrInsert(2));
+    EXPECT_EQ(7, findOrInsert(1));
+    EXPECT_EQ(14, findOrInsert(2));
+    EXPECT_EQ(2u, cache.size());
+}
+
+TEST(WTF_TinyLRUCache, FindResultSafeAfterCacheDestroyed)
+{
+    WTF::TinyLRUCache<int, int, 4>* cache = new WTF::TinyLRUCache<int, int, 4>();
+    cache->insert(1, 100);
+    auto result = cache->findIfCached(1);
+    ASSERT_TRUE(result);
+    delete cache;
+    EXPECT_FALSE(result);
+}
+
+TEST(WTF_TinyLRUCache, InsertInvalidatesFindResult)
+{
+    WTF::TinyLRUCache<int, int, 4> cache;
+    cache.insert(1, 100);
+    auto result = cache.findIfCached(1);
+    ASSERT_TRUE(result);
+    cache.insert(2, 200);
+    EXPECT_FALSE(result);
+}
+
+TEST(WTF_TinyLRUCache, ClearInvalidatesFindResult)
+{
+    WTF::TinyLRUCache<int, int, 4> cache;
+    cache.insert(1, 100);
+    auto result = cache.findIfCached(1);
+    ASSERT_TRUE(result);
+    cache.clear();
+    EXPECT_FALSE(result);
+}
+
+TEST(WTF_TinyLRUCache, SubsequentFindInvalidatesPriorFindResult)
+{
+    WTF::TinyLRUCache<int, int, 4> cache;
+    cache.insert(1, 100);
+    cache.insert(2, 200);
+    auto result = cache.findIfCached(2);
+    ASSERT_TRUE(result);
+    cache.findIfCached(1);
+    EXPECT_FALSE(result);
+}
+
+TEST(WTF_TinyLRUCacheDeathTest, UseAfterInsertDeathTest)
+{
+    ::testing::FLAGS_gtest_death_test_style = "threadsafe";
+    WTF::TinyLRUCache<int, int, 4> cache;
+    cache.insert(1, 100);
+    auto result = cache.findIfCached(1);
+    ASSERT_TRUE(result);
+    cache.insert(2, 200);
+    ASSERT_DEATH_IF_SUPPORTED(*result, "");
+}
+
+TEST(WTF_TinyLRUCacheDeathTest, UseAfterClearDeathTest)
+{
+    ::testing::FLAGS_gtest_death_test_style = "threadsafe";
+    WTF::TinyLRUCache<int, int, 4> cache;
+    cache.insert(1, 100);
+    auto result = cache.findIfCached(1);
+    ASSERT_TRUE(result);
+    cache.clear();
+    ASSERT_DEATH_IF_SUPPORTED(*result, "");
+}
+
+TEST(WTF_TinyLRUCacheDeathTest, UseAfterSubsequentFindDeathTest)
+{
+    ::testing::FLAGS_gtest_death_test_style = "threadsafe";
+    WTF::TinyLRUCache<int, int, 4> cache;
+    cache.insert(1, 100);
+    cache.insert(2, 200);
+    auto result = cache.findIfCached(2);
+    ASSERT_TRUE(result);
+    cache.findIfCached(1);
+    ASSERT_DEATH_IF_SUPPORTED(*result, "");
+}
+
+} // namespace TestWebKitAPI


### PR DESCRIPTION
#### 9b4ffe1f77999658bdda22d8b76dee99fa6e5c7c
<pre>
Add findIfCached / insert to TinyLRUCache
<a href="https://bugs.webkit.org/show_bug.cgi?id=314417">https://bugs.webkit.org/show_bug.cgi?id=314417</a>

Reviewed by Keith Miller.

This is useful for cases when you need to cache something that can&apos;t
created statically.

We also add a generated test to gently exercise this new code.

We also add a new safe iterator mechanism to ensure that this new API
can&apos;t be used unsafely.

* Source/WTF/wtf/TinyLRUCache.h:
(WTF::TinyLRUCache::~TinyLRUCache):
(WTF::TinyLRUCache::TinyLRUCache):
(WTF::TinyLRUCache::operator=):
(WTF::TinyLRUCache::FindResult::~FindResult):
(WTF::TinyLRUCache::FindResult::operator bool const):
(WTF::TinyLRUCache::FindResult::operator* const):
(WTF::TinyLRUCache::FindResult::operator-&gt; const):
(WTF::TinyLRUCache::FindResult::FindResult):
(WTF::TinyLRUCache::FindResult::assertValid const):
(WTF::TinyLRUCache::get):
(WTF::TinyLRUCache::findIfCached):
(WTF::TinyLRUCache::insert):
(WTF::TinyLRUCache::clear):
(WTF::TinyLRUCache::size const):
(WTF::TinyLRUCache::trackFindResult):
(WTF::TinyLRUCache::invalidateIterators):
(WTF::TinyLRUCache::findInternal):
(WTF::TinyLRUCache::insertInternal):
* Tools/TestWebKitAPI/CMakeLists.txt:
* Tools/TestWebKitAPI/Tests/WTF/TinyLRUCache.cpp: Added.
(TestWebKitAPI::CountingPolicy::createValueForKey):
(TestWebKitAPI::TEST(WTF_TinyLRUCache, GetCachesOnHit)):
(TestWebKitAPI::TEST(WTF_TinyLRUCache, GetEvictsLRU)):
(TestWebKitAPI::NullKeyPolicy::isKeyNull):
(TestWebKitAPI::NullKeyPolicy::createValueForNullKey):
(TestWebKitAPI::NullKeyPolicy::createValueForKey):
(TestWebKitAPI::TEST(WTF_TinyLRUCache, GetWithNullKeyReturnsNullValueAndDoesNotStore)):
(TestWebKitAPI::TEST(WTF_TinyLRUCache, FindIfCachedReturnsNullOnMiss)):
(TestWebKitAPI::TEST(WTF_TinyLRUCache, FindIfCachedHitsAfterInsert)):
(TestWebKitAPI::TEST(WTF_TinyLRUCache, InsertEvictsLRU)):
(TestWebKitAPI::TEST(WTF_TinyLRUCache, FindIfCachedPromotesToMRU)):
(TestWebKitAPI::TEST(WTF_TinyLRUCache, ClearReleasesEntriesAndResetsSize)):
(TestWebKitAPI::TrackedRefCounted::create):
(TestWebKitAPI::TrackedRefCounted::value const):
(TestWebKitAPI::TrackedRefCounted::~TrackedRefCounted):
(TestWebKitAPI::TrackedRefCounted::TrackedRefCounted):
(TestWebKitAPI::TEST(WTF_TinyLRUCache, ClearReleasesRefsImmediately)):
(TestWebKitAPI::TEST(WTF_TinyLRUCache, EvictionViaInsertReleasesRef)):
(TestWebKitAPI::TEST(WTF_TinyLRUCache, FindIfCachedDoesNotConsumeEntry)):
(TestWebKitAPI::TEST(WTF_TinyLRUCache, FindIfCachedAfterClearMisses)):
(TestWebKitAPI::TEST(WTF_TinyLRUCache, FindOrComputeWorkflow)):
(TestWebKitAPI::TEST(WTF_TinyLRUCache, FindResultSafeAfterCacheDestroyed)):
(TestWebKitAPI::TEST(WTF_TinyLRUCache, InsertInvalidatesFindResult)):
(TestWebKitAPI::TEST(WTF_TinyLRUCache, ClearInvalidatesFindResult)):
(TestWebKitAPI::TEST(WTF_TinyLRUCache, SubsequentFindInvalidatesPriorFindResult)):
(TestWebKitAPI::TEST(WTF_TinyLRUCacheDeathTest, UseAfterInsertDeathTest)):
(TestWebKitAPI::TEST(WTF_TinyLRUCacheDeathTest, UseAfterClearDeathTest)):
(TestWebKitAPI::TEST(WTF_TinyLRUCacheDeathTest, UseAfterSubsequentFindDeathTest)):

Canonical link: <a href="https://commits.webkit.org/316148@main">https://commits.webkit.org/316148@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/006206e998e276a0e8aba1166b7701d8c75c1ac7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/163354 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/36837 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/30052 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/172293 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/119801 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/165223 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/37164 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/36837 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/126855 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/89427 "1 flakes 3 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/166313 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/29123 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/146848 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/107422 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/28169 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/26803 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/19995 "Built successfully") | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/20/builds/155499 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/138064 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/26228 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/174797 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/24241 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/27398 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/30902 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/135171 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/36506 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/146367 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/135153 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38252 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/37292 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/23212 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/99246 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/30451 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/108843 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/195756 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/36002 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/1237 "Passed tests") | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/51032 "Found 1 new JSC stress test failure: stress/regexp-dot-star-enclosure-contains-capturing-terms-out-of-stack.js.bytecode-cache (failure)") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/35500 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/35748 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/35648 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->