### PR TITLE
Split up IntlDateFormat into const impl ptr

### DIFF
--- a/Source/JavaScriptCore/runtime/IntlDateTimeFormat.cpp
+++ b/Source/JavaScriptCore/runtime/IntlDateTimeFormat.cpp
@@ -64,12 +64,30 @@ void UDateIntervalFormatDeleter::operator()(UDateIntervalFormat* formatter)
 
 const ClassInfo IntlDateTimeFormat::s_info = { "Object"_s, &Base::s_info, nullptr, nullptr, CREATE_METHOD_TABLE(IntlDateTimeFormat) };
 
+WTF_MAKE_TZONE_ALLOCATED_IMPL(IntlDateTimeFormatImpl);
+
 // Approximate sizes of ICU objects for GC memory pressure reporting, measured empirically with udat_open + udat_format.
 static constexpr size_t estimatedUDateFormatSize = 30000;
 static constexpr size_t estimatedUDateIntervalFormatSize = 30000;
 
 namespace IntlDateTimeFormatInternal {
 static constexpr bool verbose = false;
+}
+
+static std::unique_ptr<UDateFormat, UDateFormatDeleter> openDateFormat(const CString& dataLocale, const String& timeZone, std::span<const char16_t> pattern, UErrorCode& status)
+{
+    auto timeZoneView = StringView(timeZone).upconvertedCharacters();
+    auto* dateFormat = udat_open(UDAT_PATTERN, UDAT_PATTERN, dataLocale.data(), timeZoneView.get(), timeZone.length(), pattern.data(), pattern.size(), &status);
+    if (U_FAILURE(status))
+        return nullptr;
+
+    // Gregorian calendar should be used from the beginning of ECMAScript time.
+    // Failure here means unsupported calendar, and can safely be ignored.
+    UErrorCode calStatus = U_ZERO_ERROR;
+    UCalendar* cal = const_cast<UCalendar*>(udat_getCalendar(dateFormat));
+    ucal_setGregorianChange(cal, minECMAScriptTime, &calStatus);
+
+    return std::unique_ptr<UDateFormat, UDateFormatDeleter>(dateFormat);
 }
 
 IntlDateTimeFormat* IntlDateTimeFormat::create(VM& vm, Structure* structure)
@@ -99,7 +117,8 @@ void IntlDateTimeFormat::visitChildrenImpl(JSCell* cell, Visitor& visitor)
 
     visitor.append(thisObject->m_boundFormat);
 
-    if (thisObject->m_dateFormat)
+    // Reported per-instance even when the UDateFormat is cache-shared
+    if (thisObject->m_impl && thisObject->m_impl->m_dateFormat)
         visitor.reportExtraMemoryVisited(estimatedUDateFormatSize);
     if (thisObject->m_dateIntervalFormat)
         visitor.reportExtraMemoryVisited(estimatedUDateIntervalFormatSize);
@@ -183,7 +202,7 @@ static inline unsigned NODELETE skipLiteralText(const Container& container, unsi
     return length - 1;
 }
 
-void IntlDateTimeFormat::setFormatsFromPattern(StringView pattern)
+void IntlDateTimeFormat::setFormatsFromPattern(IntlDateTimeFormatImpl& impl, StringView pattern)
 {
     // Get all symbols from the pattern, and set format fields accordingly.
     // http://unicode.org/reports/tr35/tr35-dates.html#Date_Field_Symbol_Table
@@ -223,56 +242,56 @@ void IntlDateTimeFormat::setFormatsFromPattern(StringView pattern)
         switch (currentCharacter) {
         case 'G':
             if (count <= 3)
-                m_era = Era::Short;
+                impl.m_era = Era::Short;
             else if (count == 4)
-                m_era = Era::Long;
+                impl.m_era = Era::Long;
             else if (count == 5)
-                m_era = Era::Narrow;
+                impl.m_era = Era::Narrow;
             break;
         case 'y':
             if (count == 1)
-                m_year = Year::Numeric;
+                impl.m_year = Year::Numeric;
             else if (count == 2)
-                m_year = Year::TwoDigit;
+                impl.m_year = Year::TwoDigit;
             break;
         case 'M':
         case 'L':
             if (count == 1)
-                m_month = Month::Numeric;
+                impl.m_month = Month::Numeric;
             else if (count == 2)
-                m_month = Month::TwoDigit;
+                impl.m_month = Month::TwoDigit;
             else if (count == 3)
-                m_month = Month::Short;
+                impl.m_month = Month::Short;
             else if (count == 4)
-                m_month = Month::Long;
+                impl.m_month = Month::Long;
             else if (count == 5)
-                m_month = Month::Narrow;
+                impl.m_month = Month::Narrow;
             break;
         case 'E':
         case 'e':
         case 'c':
             if (count <= 3)
-                m_weekday = Weekday::Short;
+                impl.m_weekday = Weekday::Short;
             else if (count == 4)
-                m_weekday = Weekday::Long;
+                impl.m_weekday = Weekday::Long;
             else if (count == 5)
-                m_weekday = Weekday::Narrow;
+                impl.m_weekday = Weekday::Narrow;
             break;
         case 'd':
             if (count == 1)
-                m_day = Day::Numeric;
+                impl.m_day = Day::Numeric;
             else if (count == 2)
-                m_day = Day::TwoDigit;
+                impl.m_day = Day::TwoDigit;
             break;
         case 'a':
         case 'b':
         case 'B':
             if (count <= 3)
-                m_dayPeriod = DayPeriod::Short;
+                impl.m_dayPeriod = DayPeriod::Short;
             else if (count == 4)
-                m_dayPeriod = DayPeriod::Long;
+                impl.m_dayPeriod = DayPeriod::Long;
             else if (count == 5)
-                m_dayPeriod = DayPeriod::Narrow;
+                impl.m_dayPeriod = DayPeriod::Narrow;
             break;
         case 'h':
         case 'H':
@@ -285,46 +304,46 @@ void IntlDateTimeFormat::setFormatsFromPattern(StringView pattern)
             //     new Intl.DateTimeFormat(`de-u-hc-h11`, {
             //         dateStyle: "full"
             //     }).resolvedOptions().hourCycle === undefined
-            m_hourCycle = hourCycleFromSymbol(currentCharacter);
+            impl.m_hourCycle = hourCycleFromSymbol(currentCharacter);
             if (count == 1)
-                m_hour = Hour::Numeric;
+                impl.m_hour = Hour::Numeric;
             else if (count == 2)
-                m_hour = Hour::TwoDigit;
+                impl.m_hour = Hour::TwoDigit;
             break;
         }
         case 'm':
             if (count == 1)
-                m_minute = Minute::Numeric;
+                impl.m_minute = Minute::Numeric;
             else if (count == 2)
-                m_minute = Minute::TwoDigit;
+                impl.m_minute = Minute::TwoDigit;
             break;
         case 's':
             if (count == 1)
-                m_second = Second::Numeric;
+                impl.m_second = Second::Numeric;
             else if (count == 2)
-                m_second = Second::TwoDigit;
+                impl.m_second = Second::TwoDigit;
             break;
         case 'z':
             if (count == 1)
-                m_timeZoneName = TimeZoneName::Short;
+                impl.m_timeZoneName = TimeZoneName::Short;
             else if (count == 4)
-                m_timeZoneName = TimeZoneName::Long;
+                impl.m_timeZoneName = TimeZoneName::Long;
             break;
         case 'O':
             if (count == 1)
-                m_timeZoneName = TimeZoneName::ShortOffset;
+                impl.m_timeZoneName = TimeZoneName::ShortOffset;
             else if (count == 4)
-                m_timeZoneName = TimeZoneName::LongOffset;
+                impl.m_timeZoneName = TimeZoneName::LongOffset;
             break;
         case 'v':
         case 'V':
             if (count == 1)
-                m_timeZoneName = TimeZoneName::ShortGeneric;
+                impl.m_timeZoneName = TimeZoneName::ShortGeneric;
             else if (count == 4)
-                m_timeZoneName = TimeZoneName::LongGeneric;
+                impl.m_timeZoneName = TimeZoneName::LongGeneric;
             break;
         case 'S':
-            m_fractionalSecondDigits = count;
+            impl.m_fractionalSecondDigits = count;
             break;
         }
     }
@@ -643,6 +662,8 @@ void IntlDateTimeFormat::initializeDateTimeFormat(JSGlobalObject* globalObject, 
     JSObject* options = intlCoerceOptionsToObject(globalObject, originalOptions);
     RETURN_IF_EXCEPTION(scope, void());
 
+    Ref<IntlDateTimeFormatImpl> impl = IntlDateTimeFormatImpl::create();
+
     ResolveLocaleOptions localeOptions;
 
     LocaleMatcher localeMatcher = intlOption<LocaleMatcher>(globalObject, options, vm.propertyNames->localeMatcher, { { "lookup"_s, LocaleMatcher::Lookup }, { "best fit"_s, LocaleMatcher::BestFit } }, "localeMatcher must be either \"lookup\" or \"best fit\""_s, LocaleMatcher::BestFit);
@@ -685,8 +706,8 @@ void IntlDateTimeFormat::initializeDateTimeFormat(JSGlobalObject* globalObject, 
     const auto& availableLocales = intlDateTimeFormatAvailableLocales();
     auto resolved = resolveLocale(globalObject, availableLocales, requestedLocales, localeMatcher, localeOptions, { RelevantExtensionKey::Ca, RelevantExtensionKey::Hc, RelevantExtensionKey::Nu }, localeData);
 
-    m_locale = resolved.locale;
-    if (m_locale.isEmpty()) {
+    impl->m_locale = resolved.locale;
+    if (impl->m_locale.isEmpty()) {
         throwTypeError(globalObject, scope, "failed to initialize DateTimeFormat due to invalid locale"_s);
         return;
     }
@@ -700,21 +721,21 @@ void IntlDateTimeFormat::initializeDateTimeFormat(JSGlobalObject* globalObject, 
             if (calendar == "islamicc"_s)
                 calendar = "islamic-civil"_s;
         }
-        m_calendar = WTF::move(calendar);
+        impl->m_calendar = WTF::move(calendar);
     }
 
     hourCycle = parseHourCycle(resolved.extensions[static_cast<unsigned>(RelevantExtensionKey::Hc)]);
-    m_numberingSystem = resolved.extensions[static_cast<unsigned>(RelevantExtensionKey::Nu)];
-    m_dataLocale = resolved.dataLocale;
+    impl->m_numberingSystem = resolved.extensions[static_cast<unsigned>(RelevantExtensionKey::Nu)];
+    impl->m_dataLocale = resolved.dataLocale;
 
     StringBuilder localeBuilder;
-    localeBuilder.append(m_dataLocale);
-    if (!m_calendar.isNull() || !m_numberingSystem.isNull()) {
+    localeBuilder.append(impl->m_dataLocale);
+    if (!impl->m_calendar.isNull() || !impl->m_numberingSystem.isNull()) {
         localeBuilder.append("-u"_s);
-        if (!m_calendar.isNull())
-            localeBuilder.append("-ca-"_s, m_calendar);
-        if (!m_numberingSystem.isNull())
-            localeBuilder.append("-nu-"_s, m_numberingSystem);
+        if (!impl->m_calendar.isNull())
+            localeBuilder.append("-ca-"_s, impl->m_calendar);
+        if (!impl->m_numberingSystem.isNull())
+            localeBuilder.append("-nu-"_s, impl->m_numberingSystem);
     }
     CString dataLocaleWithExtensions = localeBuilder.toString().utf8();
 
@@ -746,8 +767,8 @@ void IntlDateTimeFormat::initializeDateTimeFormat(JSGlobalObject* globalObject, 
         tz = vm.dateCache.defaultTimeZone();
         tzForResolvedOptions = tz.toString();
     }
-    m_timeZone = tz;
-    m_timeZoneForResolvedOptions = WTF::move(tzForResolvedOptions);
+    impl->m_timeZone = tz;
+    impl->m_timeZoneForResolvedOptions = WTF::move(tzForResolvedOptions);
 
     Weekday weekday = intlOption<Weekday>(globalObject, options, vm.propertyNames->weekday, { { "narrow"_s, Weekday::Narrow }, { "short"_s, Weekday::Short }, { "long"_s, Weekday::Long } }, "weekday must be \"narrow\", \"short\", or \"long\""_s, Weekday::None);
     RETURN_IF_EXCEPTION(scope, void());
@@ -785,14 +806,14 @@ void IntlDateTimeFormat::initializeDateTimeFormat(JSGlobalObject* globalObject, 
     intlStringOption(globalObject, options, vm.propertyNames->formatMatcher, { "basic"_s, "best fit"_s }, "formatMatcher must be either \"basic\" or \"best fit\""_s, "best fit"_s);
     RETURN_IF_EXCEPTION(scope, void());
 
-    m_dateStyle = intlOption<DateTimeStyle>(globalObject, options, vm.propertyNames->dateStyle, { { "full"_s, DateTimeStyle::Full }, { "long"_s, DateTimeStyle::Long }, { "medium"_s, DateTimeStyle::Medium }, { "short"_s, DateTimeStyle::Short } }, "dateStyle must be \"full\", \"long\", \"medium\", or \"short\""_s, DateTimeStyle::None);
+    impl->m_dateStyle = intlOption<DateTimeStyle>(globalObject, options, vm.propertyNames->dateStyle, { { "full"_s, DateTimeStyle::Full }, { "long"_s, DateTimeStyle::Long }, { "medium"_s, DateTimeStyle::Medium }, { "short"_s, DateTimeStyle::Short } }, "dateStyle must be \"full\", \"long\", \"medium\", or \"short\""_s, DateTimeStyle::None);
     RETURN_IF_EXCEPTION(scope, void());
 
-    m_timeStyle = intlOption<DateTimeStyle>(globalObject, options, vm.propertyNames->timeStyle, { { "full"_s, DateTimeStyle::Full }, { "long"_s, DateTimeStyle::Long }, { "medium"_s, DateTimeStyle::Medium }, { "short"_s, DateTimeStyle::Short } }, "timeStyle must be \"full\", \"long\", \"medium\", or \"short\""_s, DateTimeStyle::None);
+    impl->m_timeStyle = intlOption<DateTimeStyle>(globalObject, options, vm.propertyNames->timeStyle, { { "full"_s, DateTimeStyle::Full }, { "long"_s, DateTimeStyle::Long }, { "medium"_s, DateTimeStyle::Medium }, { "short"_s, DateTimeStyle::Short } }, "timeStyle must be \"full\", \"long\", \"medium\", or \"short\""_s, DateTimeStyle::None);
     RETURN_IF_EXCEPTION(scope, void());
 
     Vector<char16_t, 32> patternBuffer;
-    if (m_dateStyle != DateTimeStyle::None || m_timeStyle != DateTimeStyle::None) {
+    if (impl->m_dateStyle != DateTimeStyle::None || impl->m_timeStyle != DateTimeStyle::None) {
         // 30. For each row in Table 1, except the header row, do
         //     i. Let prop be the name given in the Property column of the row.
         //     ii. Let p be opt.[[<prop>]].
@@ -819,12 +840,12 @@ void IntlDateTimeFormat::initializeDateTimeFormat(JSGlobalObject* globalObject, 
             return UDAT_NONE;
         };
 
-        if (required == RequiredComponent::Date && m_timeStyle != DateTimeStyle::None) [[unlikely]] {
+        if (required == RequiredComponent::Date && impl->m_timeStyle != DateTimeStyle::None) [[unlikely]] {
             throwTypeError(globalObject, scope, "timeStyle is specified while formatting date is requested"_s);
             return;
         }
 
-        if (required == RequiredComponent::Time && m_dateStyle != DateTimeStyle::None) [[unlikely]] {
+        if (required == RequiredComponent::Time && impl->m_dateStyle != DateTimeStyle::None) [[unlikely]] {
             throwTypeError(globalObject, scope, "dateStyle is specified while formatting time is requested"_s);
             return;
         }
@@ -833,9 +854,9 @@ void IntlDateTimeFormat::initializeDateTimeFormat(JSGlobalObject* globalObject, 
         // First, we create UDateFormat via dateStyle and timeStyle. And then convert it to pattern string.
         // After updating this pattern string with hourCycle, we create a final UDateFormat with the updated pattern string.
         UErrorCode status = U_ZERO_ERROR;
-        String timeZoneForICU = m_timeZone.toICUString();
+        String timeZoneForICU = impl->m_timeZone.toICUString();
         StringView timeZoneView(timeZoneForICU);
-        auto dateFormatFromStyle = std::unique_ptr<UDateFormat, UDateFormatDeleter>(udat_open(parseUDateFormatStyle(m_timeStyle), parseUDateFormatStyle(m_dateStyle), dataLocaleWithExtensions.data(), timeZoneView.upconvertedCharacters(), timeZoneView.length(), nullptr, -1, &status));
+        auto dateFormatFromStyle = std::unique_ptr<UDateFormat, UDateFormatDeleter>(udat_open(parseUDateFormatStyle(impl->m_timeStyle), parseUDateFormatStyle(impl->m_dateStyle), dataLocaleWithExtensions.data(), timeZoneView.upconvertedCharacters(), timeZoneView.length(), nullptr, -1, &status));
         if (U_FAILURE(status)) {
             throwTypeError(globalObject, scope, "failed to initialize DateTimeFormat"_s);
             return;
@@ -857,7 +878,7 @@ void IntlDateTimeFormat::initializeDateTimeFormat(JSGlobalObject* globalObject, 
         // We do not care about h11 vs. h12 and h23 vs. h24 difference here since this will be later adjusted by replaceHourCycleInPattern.
         //
         // test262/test/intl402/DateTimeFormat/prototype/format/timedatestyle-en.js includes the test for this behavior.
-        if (m_timeStyle != DateTimeStyle::None && (hourCycle != HourCycle::None || hour12 != TriState::Indeterminate)) {
+        if (impl->m_timeStyle != DateTimeStyle::None && (hourCycle != HourCycle::None || hour12 != TriState::Indeterminate)) {
             auto isHour12 = [](HourCycle hourCycle) {
                 return hourCycle == HourCycle::H11 || hourCycle == HourCycle::H12;
             };
@@ -929,25 +950,20 @@ void IntlDateTimeFormat::initializeDateTimeFormat(JSGlobalObject* globalObject, 
         replaceHourCycleInPattern(patternBuffer, hourCycle);
 
     StringView pattern(patternBuffer.span());
-    setFormatsFromPattern(pattern);
+    setFormatsFromPattern(impl, pattern);
 
-    dataLogLnIf(IntlDateTimeFormatInternal::verbose, "locale:(", m_locale, "),dataLocale:(", dataLocaleWithExtensions, "),pattern:(", pattern, ")");
+    dataLogLnIf(IntlDateTimeFormatInternal::verbose, "locale:(", impl->m_locale, "),dataLocale:(", dataLocaleWithExtensions, "),pattern:(", pattern, ")");
 
     UErrorCode status = U_ZERO_ERROR;
-    String timeZoneForICU = m_timeZone.toICUString();
-    StringView timeZoneView(timeZoneForICU);
-    m_dateFormat = std::unique_ptr<UDateFormat, UDateFormatDeleter>(udat_open(UDAT_PATTERN, UDAT_PATTERN, dataLocaleWithExtensions.data(), timeZoneView.upconvertedCharacters(), timeZoneView.length(), pattern.upconvertedCharacters(), pattern.length(), &status));
+    String timeZoneForICU = impl->m_timeZone.toICUString();
+    impl->m_dateFormat = openDateFormat(dataLocaleWithExtensions, timeZoneForICU, patternBuffer.span(), status);
     if (U_FAILURE(status)) {
         throwTypeError(globalObject, scope, "failed to initialize DateTimeFormat"_s);
         return;
     }
 
     vm.heap.reportExtraMemoryAllocated(this, estimatedUDateFormatSize);
-
-    // Gregorian calendar should be used from the beginning of ECMAScript time.
-    // Failure here means unsupported calendar, and can safely be ignored.
-    UCalendar* cal = const_cast<UCalendar*>(udat_getCalendar(m_dateFormat.get()));
-    ucal_setGregorianChange(cal, minECMAScriptTime, &status);
+    m_impl = WTF::move(impl);
 }
 
 ASCIILiteral IntlDateTimeFormat::hourCycleString(HourCycle hourCycle)
@@ -1163,61 +1179,61 @@ JSObject* IntlDateTimeFormat::resolvedOptions(JSGlobalObject* globalObject) cons
 {
     VM& vm = globalObject->vm();
 
-    if (m_calendar.isNull())
-        m_calendar = defaultCalendarForLocale(m_dataLocale);
-    if (m_numberingSystem.isNull())
-        m_numberingSystem = defaultNumberingSystemForLocale(m_dataLocale);
+    if (m_impl->m_calendar.isNull())
+        m_impl->m_calendar = defaultCalendarForLocale(m_impl->m_dataLocale);
+    if (m_impl->m_numberingSystem.isNull())
+        m_impl->m_numberingSystem = defaultNumberingSystemForLocale(m_impl->m_dataLocale);
 
     JSObject* options = constructEmptyObject(globalObject);
-    options->putDirect(vm, vm.propertyNames->locale, jsNontrivialString(vm, m_locale));
-    options->putDirect(vm, vm.propertyNames->calendar, jsNontrivialString(vm, m_calendar));
-    options->putDirect(vm, vm.propertyNames->numberingSystem, jsNontrivialString(vm, m_numberingSystem));
-    options->putDirect(vm, vm.propertyNames->timeZone, jsNontrivialString(vm, m_timeZoneForResolvedOptions));
+    options->putDirect(vm, vm.propertyNames->locale, jsNontrivialString(vm, m_impl->m_locale));
+    options->putDirect(vm, vm.propertyNames->calendar, jsNontrivialString(vm, m_impl->m_calendar));
+    options->putDirect(vm, vm.propertyNames->numberingSystem, jsNontrivialString(vm, m_impl->m_numberingSystem));
+    options->putDirect(vm, vm.propertyNames->timeZone, jsNontrivialString(vm, m_impl->m_timeZoneForResolvedOptions));
 
-    if (m_hourCycle != HourCycle::None) {
-        options->putDirect(vm, vm.propertyNames->hourCycle, jsNontrivialString(vm, hourCycleString(m_hourCycle)));
-        options->putDirect(vm, vm.propertyNames->hour12, jsBoolean(m_hourCycle == HourCycle::H11 || m_hourCycle == HourCycle::H12));
+    if (m_impl->m_hourCycle != HourCycle::None) {
+        options->putDirect(vm, vm.propertyNames->hourCycle, jsNontrivialString(vm, hourCycleString(m_impl->m_hourCycle)));
+        options->putDirect(vm, vm.propertyNames->hour12, jsBoolean(m_impl->m_hourCycle == HourCycle::H11 || m_impl->m_hourCycle == HourCycle::H12));
     }
 
-    if (m_dateStyle == DateTimeStyle::None && m_timeStyle == DateTimeStyle::None) {
-        if (m_weekday != Weekday::None)
-            options->putDirect(vm, vm.propertyNames->weekday, jsNontrivialString(vm, weekdayString(m_weekday)));
+    if (m_impl->m_dateStyle == DateTimeStyle::None && m_impl->m_timeStyle == DateTimeStyle::None) {
+        if (m_impl->m_weekday != Weekday::None)
+            options->putDirect(vm, vm.propertyNames->weekday, jsNontrivialString(vm, weekdayString(m_impl->m_weekday)));
 
-        if (m_era != Era::None)
-            options->putDirect(vm, vm.propertyNames->era, jsNontrivialString(vm, eraString(m_era)));
+        if (m_impl->m_era != Era::None)
+            options->putDirect(vm, vm.propertyNames->era, jsNontrivialString(vm, eraString(m_impl->m_era)));
 
-        if (m_year != Year::None)
-            options->putDirect(vm, vm.propertyNames->year, jsNontrivialString(vm, yearString(m_year)));
+        if (m_impl->m_year != Year::None)
+            options->putDirect(vm, vm.propertyNames->year, jsNontrivialString(vm, yearString(m_impl->m_year)));
 
-        if (m_month != Month::None)
-            options->putDirect(vm, vm.propertyNames->month, jsNontrivialString(vm, monthString(m_month)));
+        if (m_impl->m_month != Month::None)
+            options->putDirect(vm, vm.propertyNames->month, jsNontrivialString(vm, monthString(m_impl->m_month)));
 
-        if (m_day != Day::None)
-            options->putDirect(vm, vm.propertyNames->day, jsNontrivialString(vm, dayString(m_day)));
+        if (m_impl->m_day != Day::None)
+            options->putDirect(vm, vm.propertyNames->day, jsNontrivialString(vm, dayString(m_impl->m_day)));
 
-        if (m_dayPeriod != DayPeriod::None)
-            options->putDirect(vm, vm.propertyNames->dayPeriod, jsNontrivialString(vm, dayPeriodString(m_dayPeriod)));
+        if (m_impl->m_dayPeriod != DayPeriod::None)
+            options->putDirect(vm, vm.propertyNames->dayPeriod, jsNontrivialString(vm, dayPeriodString(m_impl->m_dayPeriod)));
 
-        if (m_hour != Hour::None)
-            options->putDirect(vm, vm.propertyNames->hour, jsNontrivialString(vm, hourString(m_hour)));
+        if (m_impl->m_hour != Hour::None)
+            options->putDirect(vm, vm.propertyNames->hour, jsNontrivialString(vm, hourString(m_impl->m_hour)));
 
-        if (m_minute != Minute::None)
-            options->putDirect(vm, vm.propertyNames->minute, jsNontrivialString(vm, minuteString(m_minute)));
+        if (m_impl->m_minute != Minute::None)
+            options->putDirect(vm, vm.propertyNames->minute, jsNontrivialString(vm, minuteString(m_impl->m_minute)));
 
-        if (m_second != Second::None)
-            options->putDirect(vm, vm.propertyNames->second, jsNontrivialString(vm, secondString(m_second)));
+        if (m_impl->m_second != Second::None)
+            options->putDirect(vm, vm.propertyNames->second, jsNontrivialString(vm, secondString(m_impl->m_second)));
 
-        if (m_fractionalSecondDigits)
-            options->putDirect(vm, vm.propertyNames->fractionalSecondDigits, jsNumber(m_fractionalSecondDigits));
+        if (m_impl->m_fractionalSecondDigits)
+            options->putDirect(vm, vm.propertyNames->fractionalSecondDigits, jsNumber(m_impl->m_fractionalSecondDigits));
 
-        if (m_timeZoneName != TimeZoneName::None)
-            options->putDirect(vm, vm.propertyNames->timeZoneName, jsNontrivialString(vm, timeZoneNameString(m_timeZoneName)));
+        if (m_impl->m_timeZoneName != TimeZoneName::None)
+            options->putDirect(vm, vm.propertyNames->timeZoneName, jsNontrivialString(vm, timeZoneNameString(m_impl->m_timeZoneName)));
     } else {
-        if (m_dateStyle != DateTimeStyle::None)
-            options->putDirect(vm, vm.propertyNames->dateStyle, jsNontrivialString(vm, formatStyleString(m_dateStyle)));
+        if (m_impl->m_dateStyle != DateTimeStyle::None)
+            options->putDirect(vm, vm.propertyNames->dateStyle, jsNontrivialString(vm, formatStyleString(m_impl->m_dateStyle)));
 
-        if (m_timeStyle != DateTimeStyle::None)
-            options->putDirect(vm, vm.propertyNames->timeStyle, jsNontrivialString(vm, formatStyleString(m_timeStyle)));
+        if (m_impl->m_timeStyle != DateTimeStyle::None)
+            options->putDirect(vm, vm.propertyNames->timeStyle, jsNontrivialString(vm, formatStyleString(m_impl->m_timeStyle)));
     }
 
     return options;
@@ -1246,7 +1262,7 @@ static void NODELETE replaceNarrowNoBreakSpaceOrThinSpaceWithNormalSpace(Contain
 // https://tc39.es/ecma402/#sec-formatdatetime
 JSValue IntlDateTimeFormat::format(JSGlobalObject* globalObject, double value) const
 {
-    ASSERT(m_dateFormat);
+    ASSERT(m_impl->m_dateFormat);
 
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
@@ -1255,7 +1271,7 @@ JSValue IntlDateTimeFormat::format(JSGlobalObject* globalObject, double value) c
         return throwRangeError(globalObject, scope, "date value is not finite in DateTimeFormat format()"_s);
 
     Vector<char16_t, 32> result;
-    auto status = callBufferProducingFunction(udat_format, m_dateFormat.get(), value, result, nullptr);
+    auto status = callBufferProducingFunction(udat_format, m_impl->m_dateFormat.get(), value, result, nullptr);
     if (U_FAILURE(status))
         return throwTypeError(globalObject, scope, "failed to format date value"_s);
     replaceNarrowNoBreakSpaceOrThinSpaceWithNormalSpace(result);
@@ -1329,7 +1345,7 @@ static ASCIILiteral partTypeString(UDateFormatField field)
 // https://tc39.es/ecma402/#sec-formatdatetimetoparts
 JSValue IntlDateTimeFormat::formatToParts(JSGlobalObject* globalObject, double value, JSString* sourceType) const
 {
-    ASSERT(m_dateFormat);
+    ASSERT(m_impl->m_dateFormat);
 
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
@@ -1343,7 +1359,7 @@ JSValue IntlDateTimeFormat::formatToParts(JSGlobalObject* globalObject, double v
         return throwTypeError(globalObject, scope, "failed to open field position iterator"_s);
 
     Vector<char16_t, 32> result;
-    status = callBufferProducingFunction(udat_formatForFields, m_dateFormat.get(), value, result, fields.get());
+    status = callBufferProducingFunction(udat_formatForFields, m_impl->m_dateFormat.get(), value, result, fields.get());
     if (U_FAILURE(status))
         return throwTypeError(globalObject, scope, "failed to format date value"_s);
     replaceNarrowNoBreakSpaceOrThinSpaceWithNormalSpace(result);
@@ -1390,7 +1406,7 @@ JSValue IntlDateTimeFormat::formatToParts(JSGlobalObject* globalObject, double v
 
 UDateIntervalFormat* IntlDateTimeFormat::createDateIntervalFormatIfNecessary(JSGlobalObject* globalObject)
 {
-    ASSERT(m_dateFormat);
+    ASSERT(m_impl->m_dateFormat);
 
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
@@ -1400,7 +1416,7 @@ UDateIntervalFormat* IntlDateTimeFormat::createDateIntervalFormatIfNecessary(JSG
 
     Vector<char16_t, 32> pattern;
     {
-        auto status = callBufferProducingFunction(udat_toPattern, m_dateFormat.get(), false, pattern);
+        auto status = callBufferProducingFunction(udat_toPattern, m_impl->m_dateFormat.get(), false, pattern);
         if (U_FAILURE(status)) {
             throwTypeError(globalObject, scope, "failed to initialize DateIntervalFormat"_s);
             return nullptr;
@@ -1421,20 +1437,20 @@ UDateIntervalFormat* IntlDateTimeFormat::createDateIntervalFormatIfNecessary(JSG
     // While the pattern is including right HourCycle patterns, UDateIntervalFormat does not follow.
     // We need to enforce HourCycle by setting "hc" extension if it is specified.
     StringBuilder localeBuilder;
-    localeBuilder.append(m_dataLocale);
-    if (!m_calendar.isNull() || !m_numberingSystem.isNull() || m_hourCycle != HourCycle::None) {
+    localeBuilder.append(m_impl->m_dataLocale);
+    if (!m_impl->m_calendar.isNull() || !m_impl->m_numberingSystem.isNull() || m_impl->m_hourCycle != HourCycle::None) {
         localeBuilder.append("-u"_s);
-        if (!m_calendar.isNull())
-            localeBuilder.append("-ca-"_s, m_calendar);
-        if (!m_numberingSystem.isNull())
-            localeBuilder.append("-nu-"_s, m_numberingSystem);
-        if (m_hourCycle != HourCycle::None)
-            localeBuilder.append("-hc-"_s, hourCycleString(m_hourCycle));
+        if (!m_impl->m_calendar.isNull())
+            localeBuilder.append("-ca-"_s, m_impl->m_calendar);
+        if (!m_impl->m_numberingSystem.isNull())
+            localeBuilder.append("-nu-"_s, m_impl->m_numberingSystem);
+        if (m_impl->m_hourCycle != HourCycle::None)
+            localeBuilder.append("-hc-"_s, hourCycleString(m_impl->m_hourCycle));
     }
     CString dataLocaleWithExtensions = localeBuilder.toString().utf8();
 
     UErrorCode status = U_ZERO_ERROR;
-    String timeZoneForICU = m_timeZone.toICUString();
+    String timeZoneForICU = m_impl->m_timeZone.toICUString();
     StringView timeZoneView(timeZoneForICU);
     m_dateIntervalFormat = std::unique_ptr<UDateIntervalFormat, UDateIntervalFormatDeleter>(udtitvfmt_open(dataLocaleWithExtensions.data(), skeleton.span().data(), skeleton.size(), timeZoneView.upconvertedCharacters(), timeZoneView.length(), &status));
     if (U_FAILURE(status)) {
@@ -1447,7 +1463,7 @@ UDateIntervalFormat* IntlDateTimeFormat::createDateIntervalFormatIfNecessary(JSG
     return m_dateIntervalFormat.get();
 }
 
-static std::unique_ptr<UFormattedDateInterval, ICUDeleter<udtitvfmt_closeResult>> formattedValueFromDateRange(UDateIntervalFormat& dateIntervalFormat, UDateFormat& dateFormat, double startDate, double endDate, UErrorCode& status)
+static std::unique_ptr<UFormattedDateInterval, ICUDeleter<udtitvfmt_closeResult>> formattedValueFromDateRange(UDateIntervalFormat& dateIntervalFormat, const UDateFormat& dateFormat, double startDate, double endDate, UErrorCode& status)
 {
     auto result = std::unique_ptr<UFormattedDateInterval, ICUDeleter<udtitvfmt_closeResult>>(udtitvfmt_openResult(&status));
     if (U_FAILURE(status))
@@ -1527,7 +1543,7 @@ static bool dateFieldsPracticallyEqual(const UFormattedValue* formattedValue, UE
 
 JSValue IntlDateTimeFormat::formatRange(JSGlobalObject* globalObject, double startDate, double endDate)
 {
-    ASSERT(m_dateFormat);
+    ASSERT(m_impl->m_dateFormat);
 
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
@@ -1544,7 +1560,7 @@ JSValue IntlDateTimeFormat::formatRange(JSGlobalObject* globalObject, double sta
     RETURN_IF_EXCEPTION(scope, { });
 
     UErrorCode status = U_ZERO_ERROR;
-    auto result = formattedValueFromDateRange(*dateIntervalFormat, *m_dateFormat, startDate, endDate, status);
+    auto result = formattedValueFromDateRange(*dateIntervalFormat, *m_impl->m_dateFormat, startDate, endDate, status);
     if (U_FAILURE(status)) {
         throwTypeError(globalObject, scope, "Failed to format date interval"_s);
         return { };
@@ -1584,7 +1600,7 @@ JSValue IntlDateTimeFormat::formatRange(JSGlobalObject* globalObject, double sta
 
 JSValue IntlDateTimeFormat::formatRangeToParts(JSGlobalObject* globalObject, double startDate, double endDate)
 {
-    ASSERT(m_dateFormat);
+    ASSERT(m_impl->m_dateFormat);
 
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
@@ -1601,7 +1617,7 @@ JSValue IntlDateTimeFormat::formatRangeToParts(JSGlobalObject* globalObject, dou
     RETURN_IF_EXCEPTION(scope, { });
 
     UErrorCode status = U_ZERO_ERROR;
-    auto result = formattedValueFromDateRange(*dateIntervalFormat, *m_dateFormat, startDate, endDate, status);
+    auto result = formattedValueFromDateRange(*dateIntervalFormat, *m_impl->m_dateFormat, startDate, endDate, status);
     if (U_FAILURE(status)) {
         throwTypeError(globalObject, scope, "Failed to format date interval"_s);
         return { };

--- a/Source/JavaScriptCore/runtime/IntlDateTimeFormat.h
+++ b/Source/JavaScriptCore/runtime/IntlDateTimeFormat.h
@@ -43,6 +43,10 @@ struct UDateIntervalFormatDeleter {
     JS_EXPORT_PRIVATE void operator()(UDateIntervalFormat*);
 };
 
+using UDateFormatDeleter = ICUDeleter<udat_close>;
+
+class IntlDateTimeFormatImpl;
+
 class IntlDateTimeFormat final : public JSNonFinalObject {
 public:
     using Base = JSNonFinalObject;
@@ -69,6 +73,8 @@ public:
 
     enum class RequiredComponent : uint8_t { Date, Time, Any };
     enum class Defaults : uint8_t { Date, Time, All };
+    enum class HourCycle : uint8_t { None, H11, H12, H23, H24 };
+
     void initializeDateTimeFormat(JSGlobalObject*, JSValue locales, JSValue options, RequiredComponent, Defaults);
     JSValue format(JSGlobalObject*, double value) const;
     JSValue formatToParts(JSGlobalObject*, double value, JSString* sourceType = nullptr) const;
@@ -81,10 +87,14 @@ public:
 
     static IntlDateTimeFormat* unwrapForOldFunctions(JSGlobalObject*, JSValue);
 
-    enum class HourCycle : uint8_t { None, H11, H12, H23, H24 };
     static HourCycle NODELETE hourCycleFromPattern(const Vector<char16_t, 32>&);
 
+    const IntlDateTimeFormatImpl& impl() const LIFETIME_BOUND { return *m_impl; }
+    void setImpl(Ref<const IntlDateTimeFormatImpl>&& impl) { m_impl = WTF::move(impl); }
+
 private:
+    friend class IntlDateTimeFormatImpl;
+
     IntlDateTimeFormat(VM&, Structure*);
     DECLARE_DEFAULT_FINISH_CREATION;
 
@@ -104,7 +114,7 @@ private:
     enum class TimeZoneName : uint8_t { None, Short, Long, ShortOffset, LongOffset, ShortGeneric, LongGeneric };
     enum class DateTimeStyle : uint8_t { None, Full, Long, Medium, Short };
 
-    void NODELETE setFormatsFromPattern(StringView);
+    static void NODELETE setFormatsFromPattern(IntlDateTimeFormatImpl&, StringView);
     static ASCIILiteral hourCycleString(HourCycle);
     static ASCIILiteral weekdayString(Weekday);
     static ASCIILiteral eraString(Era);
@@ -124,11 +134,16 @@ private:
     static void NODELETE replaceHourCycleInPattern(Vector<char16_t, 32>&, HourCycle);
     static String buildSkeleton(Weekday, Era, Year, Month, Day, TriState, HourCycle, Hour, DayPeriod, Minute, Second, unsigned, TimeZoneName);
 
-    using UDateFormatDeleter = ICUDeleter<udat_close>;
-
     WriteBarrier<JSBoundFunction> m_boundFormat;
-    std::unique_ptr<UDateFormat, UDateFormatDeleter> m_dateFormat;
     std::unique_ptr<UDateIntervalFormat, UDateIntervalFormatDeleter> m_dateIntervalFormat;
+    RefPtr<const IntlDateTimeFormatImpl> m_impl;
+};
+
+class IntlDateTimeFormatImpl : public RefCounted<IntlDateTimeFormatImpl> {
+    WTF_MAKE_TZONE_ALLOCATED(IntlDateTimeFormatImpl);
+    WTF_MAKE_NONCOPYABLE(IntlDateTimeFormatImpl);
+public:
+    static Ref<IntlDateTimeFormatImpl> create() { return adoptRef(*new IntlDateTimeFormatImpl); }
 
     String m_locale;
     String m_dataLocale;
@@ -141,20 +156,24 @@ private:
     // this is the canonical "+HH:MM" form. m_timeZone holds the canonicalized
     // primary used for ICU formatting.
     String m_timeZoneForResolvedOptions;
-    HourCycle m_hourCycle { HourCycle::None };
-    Weekday m_weekday { Weekday::None };
-    Era m_era { Era::None };
-    Year m_year { Year::None };
-    Month m_month { Month::None };
-    Day m_day { Day::None };
-    DayPeriod m_dayPeriod { DayPeriod::None };
-    Hour m_hour { Hour::None };
-    Minute m_minute { Minute::None };
-    Second m_second { Second::None };
+    IntlDateTimeFormat::HourCycle m_hourCycle { IntlDateTimeFormat::HourCycle::None };
+    IntlDateTimeFormat::Weekday m_weekday { IntlDateTimeFormat::Weekday::None };
+    IntlDateTimeFormat::Era m_era { IntlDateTimeFormat::Era::None };
+    IntlDateTimeFormat::Year m_year { IntlDateTimeFormat::Year::None };
+    IntlDateTimeFormat::Month m_month { IntlDateTimeFormat::Month::None };
+    IntlDateTimeFormat::Day m_day { IntlDateTimeFormat::Day::None };
+    IntlDateTimeFormat::DayPeriod m_dayPeriod { IntlDateTimeFormat::DayPeriod::None };
+    IntlDateTimeFormat::Hour m_hour { IntlDateTimeFormat::Hour::None };
+    IntlDateTimeFormat::Minute m_minute { IntlDateTimeFormat::Minute::None };
+    IntlDateTimeFormat::Second m_second { IntlDateTimeFormat::Second::None };
     uint8_t m_fractionalSecondDigits { 0 };
-    TimeZoneName m_timeZoneName { TimeZoneName::None };
-    DateTimeStyle m_dateStyle { DateTimeStyle::None };
-    DateTimeStyle m_timeStyle { DateTimeStyle::None };
+    IntlDateTimeFormat::TimeZoneName m_timeZoneName { IntlDateTimeFormat::TimeZoneName::None };
+    IntlDateTimeFormat::DateTimeStyle m_dateStyle { IntlDateTimeFormat::DateTimeStyle::None };
+    IntlDateTimeFormat::DateTimeStyle m_timeStyle { IntlDateTimeFormat::DateTimeStyle::None };
+    std::unique_ptr<UDateFormat, UDateFormatDeleter> m_dateFormat;
+
+private:
+    IntlDateTimeFormatImpl() = default;
 };
 
 } // namespace JSC


### PR DESCRIPTION
#### 895301e145c41668c94837c36e071fa3c448af86
<pre>
Split up IntlDateFormat into const impl ptr
<a href="https://bugs.webkit.org/show_bug.cgi?id=314419">https://bugs.webkit.org/show_bug.cgi?id=314419</a>

Reviewed by Yusuke Suzuki.

This gets split up into an immutable core, a lazy mutable
calendar/numberingSystem, and the JS wrapper.

This involves some ugly m_impl verbosity, but it makes a bunch of stuff
actually const, which I think is logically correct.

A follow-up could replace the mutable fields with some kind of frozen
or lazy abstraction.

The motivation for this patch is to make it possible to share and cache
these impl pointers.

* Source/JavaScriptCore/runtime/IntlDateTimeFormat.cpp:
(JSC::openDateFormat):
(JSC::IntlDateTimeFormat::visitChildrenImpl):
(JSC::IntlDateTimeFormat::setFormatsFromPattern):
(JSC::IntlDateTimeFormat::initializeDateTimeFormat):
(JSC::IntlDateTimeFormat::resolvedOptions const):
(JSC::IntlDateTimeFormat::format const):
(JSC::IntlDateTimeFormat::formatToParts const):
(JSC::IntlDateTimeFormat::createDateIntervalFormatIfNecessary):
(JSC::formattedValueFromDateRange):
(JSC::IntlDateTimeFormat::formatRange):
(JSC::IntlDateTimeFormat::formatRangeToParts):
* Source/JavaScriptCore/runtime/IntlDateTimeFormat.h:
(JSC::IntlDateTimeFormatImpl::create):

Canonical link: <a href="https://commits.webkit.org/313158@main">https://commits.webkit.org/313158@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9c098eff52cd5f29578ea4a6e95853cc54fbb32e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/161906 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/35380 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/28483 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/170809 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/118277 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/35482 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/35382 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/125620 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/88638 "1 flakes 17 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/164865 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/27944 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/145425 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/106216 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/26993 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/25507 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/18530 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/153965 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/137031 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/23180 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/173298 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/22744 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/20390 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/24821 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/133921 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/35054 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/29594 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/133926 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36238 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/35038 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/144975 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/97133 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/28458 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/21798 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/194305 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/34548 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/102033 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/50072 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/34049 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/34291 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/34197 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->