### PR TITLE
[Site Isolation] Web Inspector: Implement nodeId-dependent CSS commands for frame targets

### DIFF
--- a/LayoutTests/http/tests/site-isolation/inspector/css/css-node-commands-frame-target-expected.txt
+++ b/LayoutTests/http/tests/site-isolation/inspector/css/css-node-commands-frame-target-expected.txt
@@ -1,0 +1,30 @@
+Test that CSS node-dependent commands work correctly on frame targets under site isolation.
+
+
+
+== Running test suite: SiteIsolation.CSS.NodeCommands.FrameTarget
+-- Running test case: SiteIsolation.CSS.NodeCommands.FrameTarget.Setup
+PASS: Should find a child frame target.
+PASS: Should find the target element.
+
+-- Running test case: SiteIsolation.CSS.NodeCommands.FrameTarget.GetComputedStyleForNode
+PASS: Should have computed style properties.
+PASS: Should have a font-weight property.
+PASS: font-weight should be '700' (computed from 'bold').
+
+-- Running test case: SiteIsolation.CSS.NodeCommands.FrameTarget.GetInlineStylesForNode
+PASS: Should have an inline style.
+PASS: Inline style should contain font-weight.
+PASS: font-weight value should be 'bold'.
+
+-- Running test case: SiteIsolation.CSS.NodeCommands.FrameTarget.GetMatchedStylesForNode
+PASS: Should have matched CSS rules.
+PASS: Should have a rule matching .test-class.
+
+-- Running test case: SiteIsolation.CSS.NodeCommands.FrameTarget.GetFontDataForNode
+PASS: Should get font data.
+PASS: Font should have a display name.
+
+-- Running test case: SiteIsolation.CSS.NodeCommands.FrameTarget.ForcePseudoState
+PASS: Should have a :hover rule in matched styles after forcing.
+

--- a/LayoutTests/http/tests/site-isolation/inspector/css/css-node-commands-frame-target.html
+++ b/LayoutTests/http/tests/site-isolation/inspector/css/css-node-commands-frame-target.html
@@ -1,0 +1,109 @@
+<script src="../../../inspector/resources/inspector-test.js"></script>
+<script src="../debugger/resources/site-isolation-debugger-test-utilities.js"></script>
+<script>
+    function test() {
+        let suite = InspectorTest.createAsyncSuite("SiteIsolation.CSS.NodeCommands.FrameTarget");
+
+        let childFrameTarget;
+        let targetNodeId;
+
+        // FIXME <https://webkit.org/b/317663>: Simplify this by using DOM.querySelector once it's implemented for frame targets.
+        async function findParagraphInFrame(target) {
+            let frameDoc = WI.domManager.frameTargetDocumentForTarget(target);
+            if (!frameDoc) {
+                let event = await WI.domManager.awaitEvent(WI.DOMManager.Event.FrameDocumentAvailable);
+                frameDoc = event.data.document;
+            }
+            await target.DOMAgent.requestChildNodes(frameDoc.backendNodeId, -1);
+            let body = frameDoc.children[0].children[1]; // html > body
+            return body.children.find((node) => node.nodeName() === "P");
+        }
+
+        suite.addTestCase({
+            name: "SiteIsolation.CSS.NodeCommands.FrameTarget.Setup",
+            description: "Find the child frame target and get a nodeId for the target element.",
+            async test() {
+                let frameTargets = WI.targets.filter((t) => t.type === WI.TargetType.Frame);
+                InspectorTest.assert(frameTargets.length === 2, "Should have exactly main and child frame targets.");
+
+                let urlTargetMap = await fetchDocumentURLsForTargets(frameTargets);
+                let mainFrameTarget = urlTargetMap.get(WI.networkManager.mainFrame.url);
+                childFrameTarget = frameTargets.find((t) => t !== mainFrameTarget);
+                InspectorTest.expectNotNull(childFrameTarget, "Should find a child frame target.");
+                InspectorTest.assert(!childFrameTarget.isProvisional, "Child frame should not be still loading.");
+
+                let targetNode = await findParagraphInFrame(childFrameTarget);
+                InspectorTest.expectNotNull(targetNode, "Should find the target element.");
+                targetNodeId = targetNode.backendNodeId;
+            }
+        });
+
+        suite.addTestCase({
+            name: "SiteIsolation.CSS.NodeCommands.FrameTarget.GetComputedStyleForNode",
+            description: "getComputedStyleForNode should return computed style properties.",
+            async test() {
+                let { computedStyle } = await childFrameTarget.CSSAgent.getComputedStyleForNode(targetNodeId);
+                InspectorTest.expectGreaterThan(computedStyle.length, 0, "Should have computed style properties.");
+                let fontWeight = computedStyle.find((property) => property.name === "font-weight");
+                InspectorTest.expectNotNull(fontWeight, "Should have a font-weight property.");
+                InspectorTest.expectEqual(fontWeight.value, "700", "font-weight should be '700' (computed from 'bold').");
+            }
+        });
+
+        suite.addTestCase({
+            name: "SiteIsolation.CSS.NodeCommands.FrameTarget.GetInlineStylesForNode",
+            description: "getInlineStylesForNode should return the element's inline style.",
+            async test() {
+                let { inlineStyle } = await childFrameTarget.CSSAgent.getInlineStylesForNode(targetNodeId);
+                InspectorTest.expectNotNull(inlineStyle, "Should have an inline style.");
+                let properties = inlineStyle.cssProperties;
+                let fontWeight = properties.find((property) => property.name === "font-weight");
+                InspectorTest.expectNotNull(fontWeight, "Inline style should contain font-weight.");
+                InspectorTest.expectEqual(fontWeight.value, "bold", "font-weight value should be 'bold'.");
+            }
+        });
+
+        suite.addTestCase({
+            name: "SiteIsolation.CSS.NodeCommands.FrameTarget.GetMatchedStylesForNode",
+            description: "getMatchedStylesForNode should return matched CSS rules.",
+            async test() {
+                let { matchedCSSRules } = await childFrameTarget.CSSAgent.getMatchedStylesForNode(targetNodeId);
+                InspectorTest.expectGreaterThan(matchedCSSRules.length, 0, "Should have matched CSS rules.");
+                let ruleSelectors = matchedCSSRules.map((match) => match.rule.selectorList.selectors.map((s) => s.text).join(", "));
+                InspectorTest.expectThat(ruleSelectors.some((s) => s.includes(".test-class")), "Should have a rule matching .test-class.");
+            }
+        });
+
+        suite.addTestCase({
+            name: "SiteIsolation.CSS.NodeCommands.FrameTarget.GetFontDataForNode",
+            description: "getFontDataForNode should return font information.",
+            async test() {
+                let { primaryFont } = await childFrameTarget.CSSAgent.getFontDataForNode(targetNodeId);
+                InspectorTest.expectNotNull(primaryFont, "Should get font data.");
+                InspectorTest.expectNotNull(primaryFont.displayName, "Font should have a display name.");
+            }
+        });
+
+        suite.addTestCase({
+            name: "SiteIsolation.CSS.NodeCommands.FrameTarget.ForcePseudoState",
+            description: "forcePseudoState should force :hover and affect matched styles.",
+            async test() {
+                await childFrameTarget.CSSAgent.forcePseudoState(targetNodeId, ["hover"]);
+
+                let { matchedCSSRules } = await childFrameTarget.CSSAgent.getMatchedStylesForNode(targetNodeId);
+                let ruleSelectors = matchedCSSRules.map((match) => match.rule.selectorList.selectors.map((s) => s.text).join(", "));
+                InspectorTest.expectThat(ruleSelectors.some((s) => s.includes(":hover")), "Should have a :hover rule in matched styles after forcing.");
+
+                // Clear forced state.
+                await childFrameTarget.CSSAgent.forcePseudoState(targetNodeId, []);
+            }
+        });
+
+        suite.runTestCasesAndFinish();
+    }
+</script>
+
+<body onload="runTest()">
+    <p>Test that CSS node-dependent commands work correctly on frame targets under site isolation.</p>
+    <iframe src="http://localhost:8000/site-isolation/inspector/css/resources/frame-with-stylesheet.html"></iframe>
+</body>

--- a/LayoutTests/http/tests/site-isolation/inspector/css/resources/frame-with-stylesheet.html
+++ b/LayoutTests/http/tests/site-isolation/inspector/css/resources/frame-with-stylesheet.html
@@ -4,8 +4,12 @@
         font-size: 16px;
     }
 
+    .test-class:hover {
+        color: green;
+    }
+
     p {
         margin: 10px;
     }
 </style>
-<p class="test-class">Cross-origin frame with stylesheet.</p>
+<p id="target" class="test-class" style="font-weight: bold">Cross-origin frame with stylesheet.</p>

--- a/Source/JavaScriptCore/inspector/protocol/CSS.json
+++ b/Source/JavaScriptCore/inspector/protocol/CSS.json
@@ -356,7 +356,7 @@
         {
             "name": "getFontDataForNode",
             "description": "Returns the primary font of the computed font cascade for a DOM node identified by <code>nodeId</code>.",
-            "targetTypes": ["page"],
+            "targetTypes": ["frame", "page"],
             "parameters": [
                 { "name": "nodeId", "$ref": "DOM.NodeId" }
             ],
@@ -475,7 +475,7 @@
         {
             "name": "forcePseudoState",
             "description": "Ensures that the given node will have specified pseudo-classes whenever its style is computed by the browser.",
-            "targetTypes": ["page"],
+            "targetTypes": ["frame", "page"],
             "parameters": [
                 { "name": "nodeId", "$ref": "DOM.NodeId", "description": "The element id for which to force the pseudo state." },
                 { "name": "forcedPseudoClasses", "type": "array", "items": { "$ref": "ForceablePseudoClass" }, "description": "Element pseudo classes to force when computing the element's style." }

--- a/Source/WebCore/Scripts/generate-unified-sources.sh
+++ b/Source/WebCore/Scripts/generate-unified-sources.sh
@@ -14,7 +14,7 @@ UnifiedSourceCppFileCount=530
 UnifiedSourceCFileCount=0
 UnifiedSourceMmFileCount=1
 UnifiedSourceNonARCMmFileCount=62
-UnifiedSourceHeaderGroupFileCount=78
+UnifiedSourceHeaderGroupFileCount=79
 
 if [ $# -eq 0 ]; then
     echo "Using unified source list files: Sources.txt, SourcesCocoa.txt, platform/SourcesLibWebRTC.txt"

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -1958,7 +1958,7 @@ inspector/agents/InspectorWorkerAgent.cpp
 inspector/agents/WebConsoleAgent.cpp
 inspector/agents/WebDebuggerAgent.cpp
 inspector/agents/WebHeapAgent.cpp
-inspector/agents/frame/FrameCSSAgent.cpp
+inspector/agents/frame/FrameCSSAgent.cpp @header:RenderStyleGetters
 inspector/agents/frame/FrameConsoleAgent.cpp
 inspector/agents/frame/FrameDOMAgent.cpp
 inspector/agents/frame/FrameDOMAgentStubs.cpp

--- a/Source/WebCore/UnifiedSources-output.xcfilelist
+++ b/Source/WebCore/UnifiedSources-output.xcfilelist
@@ -643,6 +643,7 @@ $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/unified-sources/UnifiedSource77-hea
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/unified-sources/UnifiedSource77.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/unified-sources/UnifiedSource78-header-RenderStyleGetters.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/unified-sources/UnifiedSource78.cpp
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/unified-sources/UnifiedSource79-header-RenderStyleGetters.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/unified-sources/UnifiedSource79.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/unified-sources/UnifiedSource8-header-RenderStyleGetters.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/unified-sources/UnifiedSource8-nonARC.mm

--- a/Source/WebCore/inspector/InspectorInstrumentation.cpp
+++ b/Source/WebCore/inspector/InspectorInstrumentation.cpp
@@ -397,6 +397,11 @@ bool InspectorInstrumentation::forcePseudoStateImpl(InstrumentingAgents& instrum
 {
     if (CheckedPtr cssAgent = instrumentingAgents.enabledCSSAgent())
         return cssAgent->forcePseudoState(element, pseudoState);
+
+    if (RefPtr frame = element.document().frame()) {
+        if (CheckedPtr frameCSSAgent = frame->inspectorController().instrumentingAgents().enabledFrameCSSAgent())
+            return frameCSSAgent->forcePseudoState(element, pseudoState);
+    }
     return false;
 }
 

--- a/Source/WebCore/inspector/agents/frame/FrameCSSAgent.cpp
+++ b/Source/WebCore/inspector/agents/frame/FrameCSSAgent.cpp
@@ -26,18 +26,27 @@
 #include "config.h"
 #include "FrameCSSAgent.h"
 
+#include "CSSComputedStyleDeclaration.h"
 #include "CSSImportRule.h"
 #include "CSSParserContext.h"
 #include "CSSProperty.h"
 #include "CSSPropertyNames.h"
 #include "CSSPropertyParserState.h"
 #include "CSSPropertyParsing.h"
+#include "CSSStyleRule.h"
 #include "CSSStyleSheet.h"
 #include "CSSValueKeywords.h"
 #include "CommonAtomStrings.h"
 #include "ContentSecurityPolicy.h"
 #include "Document.h"
+#include "DocumentInlines.h"
 #include "DocumentPage.h"
+#include "ElementAncestorIteratorInlines.h"
+#include "ExtensionStyleSheets.h"
+#include "Font.h"
+#include "FontCascadeInlines.h"
+#include "FontPlatformData.h"
+#include "FrameDOMAgent.h"
 #include "HTMLHeadElement.h"
 #include "HTMLStyleElement.h"
 #include "InspectorDOMAgent.h"
@@ -47,10 +56,19 @@
 #include "LocalFrameInlines.h"
 #include "Page.h"
 #include "PageInspectorController.h"
+#include "PseudoElement.h"
+#include "PseudoElementIdentifier.h"
+#include "RenderStyleConstants.h"
+#include "SelectorChecker.h"
+#include "StyleDisplay.h"
 #include "StyleDocumentScope.h"
+#include "StyleProperties.h"
 #include "StylePropertyShorthand.h"
+#include "StyleResolver.h"
+#include "StyleRule.h"
 #include "StyleScope.h"
 #include "StyleSheetContents.h"
+#include "StyledElement.h"
 #include <JavaScriptCore/InspectorFrontendDispatchers.h>
 #include <JavaScriptCore/InspectorProtocolObjects.h>
 #include <wtf/TZoneMallocInlines.h>
@@ -58,6 +76,67 @@
 namespace WebCore {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(FrameCSSAgent);
+
+static std::optional<Inspector::Protocol::CSS::PseudoId> protocolValueForPseudoElementType(PseudoElementType pseudoElementType)
+{
+    switch (pseudoElementType) {
+    case PseudoElementType::FirstLine:
+        return Inspector::Protocol::CSS::PseudoId::FirstLine;
+    case PseudoElementType::FirstLetter:
+        return Inspector::Protocol::CSS::PseudoId::FirstLetter;
+    case PseudoElementType::GrammarError:
+        return Inspector::Protocol::CSS::PseudoId::GrammarError;
+    case PseudoElementType::Marker:
+        return Inspector::Protocol::CSS::PseudoId::Marker;
+    case PseudoElementType::Backdrop:
+        return Inspector::Protocol::CSS::PseudoId::Backdrop;
+    case PseudoElementType::Before:
+        return Inspector::Protocol::CSS::PseudoId::Before;
+    case PseudoElementType::After:
+        return Inspector::Protocol::CSS::PseudoId::After;
+    case PseudoElementType::Selection:
+        return Inspector::Protocol::CSS::PseudoId::Selection;
+    case PseudoElementType::Highlight:
+        return Inspector::Protocol::CSS::PseudoId::Highlight;
+    case PseudoElementType::SpellingError:
+        return Inspector::Protocol::CSS::PseudoId::SpellingError;
+    case PseudoElementType::TargetText:
+        return Inspector::Protocol::CSS::PseudoId::TargetText;
+    case PseudoElementType::Checkmark:
+        return Inspector::Protocol::CSS::PseudoId::Checkmark;
+    case PseudoElementType::PickerIcon:
+        return Inspector::Protocol::CSS::PseudoId::PickerIcon;
+    case PseudoElementType::ViewTransition:
+        return Inspector::Protocol::CSS::PseudoId::ViewTransition;
+    case PseudoElementType::ViewTransitionGroup:
+        return Inspector::Protocol::CSS::PseudoId::ViewTransitionGroup;
+    case PseudoElementType::ViewTransitionImagePair:
+        return Inspector::Protocol::CSS::PseudoId::ViewTransitionImagePair;
+    case PseudoElementType::ViewTransitionOld:
+        return Inspector::Protocol::CSS::PseudoId::ViewTransitionOld;
+    case PseudoElementType::ViewTransitionNew:
+        return Inspector::Protocol::CSS::PseudoId::ViewTransitionNew;
+    case PseudoElementType::WebKitResizer:
+        return Inspector::Protocol::CSS::PseudoId::WebKitResizer;
+    case PseudoElementType::WebKitScrollbar:
+        return Inspector::Protocol::CSS::PseudoId::WebKitScrollbar;
+    case PseudoElementType::WebKitScrollbarThumb:
+        return Inspector::Protocol::CSS::PseudoId::WebKitScrollbarThumb;
+    case PseudoElementType::WebKitScrollbarButton:
+        return Inspector::Protocol::CSS::PseudoId::WebKitScrollbarButton;
+    case PseudoElementType::WebKitScrollbarTrack:
+        return Inspector::Protocol::CSS::PseudoId::WebKitScrollbarTrack;
+    case PseudoElementType::WebKitScrollbarTrackPiece:
+        return Inspector::Protocol::CSS::PseudoId::WebKitScrollbarTrackPiece;
+    case PseudoElementType::WebKitScrollbarCorner:
+        return Inspector::Protocol::CSS::PseudoId::WebKitScrollbarCorner;
+    case PseudoElementType::InternalWritingSuggestions:
+        return { };
+    default:
+        ASSERT_NOT_REACHED();
+        return { };
+    }
+}
 
 FrameCSSAgent::FrameCSSAgent(FrameAgentContext& context)
     : InspectorAgentBase("CSS"_s, context)
@@ -101,28 +180,146 @@ Inspector::CommandResult<void> FrameCSSAgent::disable()
     return { };
 }
 
-Inspector::CommandResult<Ref<JSON::ArrayOf<Inspector::Protocol::CSS::CSSComputedStyleProperty>>> FrameCSSAgent::getComputedStyleForNode(Inspector::Protocol::DOM::NodeId)
+Inspector::CommandResult<Ref<JSON::ArrayOf<Inspector::Protocol::CSS::CSSComputedStyleProperty>>> FrameCSSAgent::getComputedStyleForNode(Inspector::Protocol::DOM::NodeId nodeId)
 {
-    // FIXME: <https://webkit.org/b/314424>: Implement nodeId-dependent CSS commands for frame targets.
-    return makeUnexpected("Not supported on frame targets"_s);
+    Inspector::Protocol::ErrorString errorString;
+
+    RefPtr element = elementForId(errorString, nodeId);
+    if (!element)
+        return makeUnexpected(errorString);
+
+    if (!element->isConnected())
+        return makeUnexpected("Element for given nodeId was not connected to DOM tree."_s);
+
+    auto computedStyleInfo = CSSComputedStyleDeclaration::create(*element, CSSComputedStyleDeclaration::AllowVisited::Yes);
+    auto inspectorStyle = InspectorStyle::create(InspectorCSSId(), WTF::move(computedStyleInfo), nullptr);
+    return inspectorStyle->buildArrayForComputedStyle();
 }
 
-Inspector::CommandResult<Ref<Inspector::Protocol::CSS::Font>> FrameCSSAgent::getFontDataForNode(Inspector::Protocol::DOM::NodeId)
+Inspector::CommandResult<Ref<Inspector::Protocol::CSS::Font>> FrameCSSAgent::getFontDataForNode(Inspector::Protocol::DOM::NodeId nodeId)
 {
-    // FIXME: <https://webkit.org/b/314424>: Implement nodeId-dependent CSS commands for frame targets.
-    return makeUnexpected("Not supported on frame targets"_s);
+    Inspector::Protocol::ErrorString errorString;
+    RefPtr element = elementForId(errorString, nodeId);
+    if (!element)
+        return makeUnexpected(errorString);
+
+    CheckedPtr computedStyle = element->computedStyle();
+    if (!computedStyle)
+        return makeUnexpected("No computed style for node."_s);
+
+    Ref font = protect(computedStyle->fontCascade())->primaryFont();
+    auto& fontPlatformData = font->platformData();
+
+    auto resultVariationAxes = JSON::ArrayOf<Inspector::Protocol::CSS::FontVariationAxis>::create();
+    for (auto& variationAxis : fontPlatformData.variationAxes(ShouldLocalizeAxisNames::Yes)) {
+        auto axis = Inspector::Protocol::CSS::FontVariationAxis::create()
+            .setTag(variationAxis.tag())
+            .setMinimumValue(variationAxis.minimumValue())
+            .setMaximumValue(variationAxis.maximumValue())
+            .setDefaultValue(variationAxis.defaultValue())
+            .release();
+        if (variationAxis.name().length() && variationAxis.name() != variationAxis.tag())
+            axis->setName(variationAxis.name());
+        resultVariationAxes->addItem(WTF::move(axis));
+    }
+
+    auto protocolFont = Inspector::Protocol::CSS::Font::create()
+        .setDisplayName(fontPlatformData.familyName())
+        .setVariationAxes(WTF::move(resultVariationAxes))
+        .release();
+    protocolFont->setSynthesizedBold(fontPlatformData.syntheticBold());
+    protocolFont->setSynthesizedOblique(fontPlatformData.syntheticOblique());
+
+    return protocolFont;
 }
 
-Inspector::CommandResultOf<RefPtr<Inspector::Protocol::CSS::CSSStyle>, RefPtr<Inspector::Protocol::CSS::CSSStyle>> FrameCSSAgent::getInlineStylesForNode(Inspector::Protocol::DOM::NodeId)
+Inspector::CommandResultOf<RefPtr<Inspector::Protocol::CSS::CSSStyle>, RefPtr<Inspector::Protocol::CSS::CSSStyle>> FrameCSSAgent::getInlineStylesForNode(Inspector::Protocol::DOM::NodeId nodeId)
 {
-    // FIXME: <https://webkit.org/b/314424>: Implement nodeId-dependent CSS commands for frame targets.
-    return makeUnexpected("Not supported on frame targets"_s);
+    Inspector::Protocol::ErrorString errorString;
+
+    RefPtr element = elementForId(errorString, nodeId);
+    if (!element)
+        return makeUnexpected(errorString);
+
+    RefPtr styledElement = dynamicDowncast<StyledElement>(*element);
+    if (!styledElement)
+        return { { nullptr, nullptr } };
+
+    Ref styleSheet = asInspectorStyleSheet(*styledElement);
+    return { { styleSheet->buildObjectForStyle(protect(styledElement->cssomStyle()).ptr()), buildObjectForAttributesStyle(*styledElement) } };
 }
 
-Inspector::CommandResultOf<RefPtr<JSON::ArrayOf<Inspector::Protocol::CSS::RuleMatch>>, RefPtr<JSON::ArrayOf<Inspector::Protocol::CSS::PseudoIdMatches>>, RefPtr<JSON::ArrayOf<Inspector::Protocol::CSS::InheritedStyleEntry>>> FrameCSSAgent::getMatchedStylesForNode(Inspector::Protocol::DOM::NodeId, std::optional<bool>&&, std::optional<bool>&&)
+Inspector::CommandResultOf<RefPtr<JSON::ArrayOf<Inspector::Protocol::CSS::RuleMatch>>, RefPtr<JSON::ArrayOf<Inspector::Protocol::CSS::PseudoIdMatches>>, RefPtr<JSON::ArrayOf<Inspector::Protocol::CSS::InheritedStyleEntry>>> FrameCSSAgent::getMatchedStylesForNode(Inspector::Protocol::DOM::NodeId nodeId, std::optional<bool>&& includePseudo, std::optional<bool>&& includeInherited)
 {
-    // FIXME: <https://webkit.org/b/314424>: Implement nodeId-dependent CSS commands for frame targets.
-    return makeUnexpected("Not supported on frame targets"_s);
+    Inspector::Protocol::ErrorString errorString;
+
+    RefPtr element = elementForId(errorString, nodeId);
+    if (!element)
+        return makeUnexpected(errorString);
+
+    if (!element->isConnected())
+        return makeUnexpected("Element for given nodeId was not connected to DOM tree."_s);
+
+    RefPtr originalElement = element;
+    auto elementPseudoId = element->pseudoElementIdentifier();
+    if (elementPseudoId) {
+        element = downcast<PseudoElement>(*element).hostElement();
+        if (!element)
+            return makeUnexpected("Missing parent of pseudo-element node for given nodeId"_s);
+    }
+
+    Ref styleResolver = element->styleResolver();
+    auto matchedRules = styleResolver->pseudoStyleRulesForElement(element, elementPseudoId, Style::Resolver::AllCSSRules);
+    auto matchedCSSRules = buildArrayForMatchedRuleList(matchedRules, styleResolver, *element, elementPseudoId);
+    RefPtr<JSON::ArrayOf<Inspector::Protocol::CSS::PseudoIdMatches>> pseudoElements;
+    RefPtr<JSON::ArrayOf<Inspector::Protocol::CSS::InheritedStyleEntry>> inherited;
+
+    if (!originalElement->isPseudoElement()) {
+        if (!includePseudo || *includePseudo) {
+            pseudoElements = JSON::ArrayOf<Inspector::Protocol::CSS::PseudoIdMatches>::create();
+            for (auto pseudoElementType : allPseudoElementTypes) {
+                if (pseudoElementType == PseudoElementType::Marker && element->computedStyle()->display() != Style::DisplayType::BlockFlowListItem)
+                    continue;
+                if (pseudoElementType == PseudoElementType::Backdrop && !element->isInTopLayer())
+                    continue;
+                if (pseudoElementType == PseudoElementType::ViewTransition && (!element->document().activeViewTransition() || element != element->document().documentElement()))
+                    continue;
+
+                auto pseudoElementIdentifier = Style::PseudoElementIdentifier { pseudoElementType };
+                if (isNamedViewTransitionPseudoElement(pseudoElementIdentifier))
+                    continue;
+
+                if (auto protocolPseudoId = protocolValueForPseudoElementType(pseudoElementType)) {
+                    auto pseudoRules = styleResolver->pseudoStyleRulesForElement(element, pseudoElementType, Style::Resolver::AllCSSRules);
+                    if (!pseudoRules.isEmpty()) {
+                        auto matches = Inspector::Protocol::CSS::PseudoIdMatches::create()
+                            .setPseudoId(protocolPseudoId.value())
+                            .setMatches(buildArrayForMatchedRuleList(pseudoRules, styleResolver, *element, pseudoElementIdentifier))
+                            .release();
+                        pseudoElements->addItem(WTF::move(matches));
+                    }
+                }
+            }
+        }
+
+        if (!includeInherited || *includeInherited) {
+            inherited = JSON::ArrayOf<Inspector::Protocol::CSS::InheritedStyleEntry>::create();
+            for (Ref ancestor : ancestorsOfType<Element>(*element)) {
+                Ref parentStyleResolver = ancestor->styleResolver();
+                auto parentMatchedRules = parentStyleResolver->styleRulesForElement(ancestor.ptr(), Style::Resolver::AllCSSRules);
+                auto entry = Inspector::Protocol::CSS::InheritedStyleEntry::create()
+                    .setMatchedCSSRules(buildArrayForMatchedRuleList(parentMatchedRules, styleResolver, ancestor, { }))
+                    .release();
+                if (RefPtr styledElement = dynamicDowncast<StyledElement>(ancestor); styledElement && protect(styledElement->cssomStyle())->length()) {
+                    Ref inlineStyleSheet = asInspectorStyleSheet(*styledElement);
+                    entry->setInlineStyle(inlineStyleSheet->buildObjectForStyle(protect(inlineStyleSheet->styleForId(InspectorCSSId(inlineStyleSheet->id(), 0)))));
+                }
+                inherited->addItem(WTF::move(entry));
+            }
+        }
+    }
+
+    return { { WTF::move(matchedCSSRules), WTF::move(pseudoElements), WTF::move(inherited) } };
 }
 
 Inspector::CommandResult<Ref<JSON::ArrayOf<Inspector::Protocol::CSS::CSSStyleSheetHeader>>> FrameCSSAgent::getAllStyleSheets()
@@ -306,10 +503,79 @@ Inspector::CommandResult<Ref<JSON::ArrayOf<String>>> FrameCSSAgent::getSupported
     return makeUnexpected("Not supported on frame targets"_s);
 }
 
-Inspector::CommandResult<void> FrameCSSAgent::forcePseudoState(Inspector::Protocol::DOM::NodeId, Ref<JSON::Array>&&)
+Inspector::CommandResult<void> FrameCSSAgent::forcePseudoState(Inspector::Protocol::DOM::NodeId nodeId, Ref<JSON::Array>&& forcedPseudoClasses)
 {
-    // FIXME: <https://webkit.org/b/314424>: Implement nodeId-dependent CSS commands for frame targets.
-    return makeUnexpected("Not supported on frame targets"_s);
+    Inspector::Protocol::ErrorString errorString;
+
+    RefPtr element = elementForId(errorString, nodeId);
+    if (!element)
+        return makeUnexpected(errorString);
+
+    PseudoClassHashSet forcedPseudoClassesToSet;
+    for (const auto& pseudoClassValue : forcedPseudoClasses.get()) {
+        auto pseudoClassString = pseudoClassValue->asString();
+        if (!pseudoClassString)
+            return makeUnexpected("Unexpected non-string value in given forcedPseudoClasses"_s);
+
+        auto pseudoClass = Inspector::Protocol::Helpers::parseEnumValueFromString<Inspector::Protocol::CSS::ForceablePseudoClass>(pseudoClassString);
+        if (!pseudoClass)
+            return makeUnexpected(makeString("Unknown forcedPseudoClass: "_s, pseudoClassString));
+
+        switch (*pseudoClass) {
+        case Inspector::Protocol::CSS::ForceablePseudoClass::Active:
+            forcedPseudoClassesToSet.add(CSSSelector::PseudoClass::Active);
+            break;
+        case Inspector::Protocol::CSS::ForceablePseudoClass::Hover:
+            forcedPseudoClassesToSet.add(CSSSelector::PseudoClass::Hover);
+            break;
+        case Inspector::Protocol::CSS::ForceablePseudoClass::Focus:
+            forcedPseudoClassesToSet.add(CSSSelector::PseudoClass::Focus);
+            break;
+        case Inspector::Protocol::CSS::ForceablePseudoClass::FocusVisible:
+            forcedPseudoClassesToSet.add(CSSSelector::PseudoClass::FocusVisible);
+            break;
+        case Inspector::Protocol::CSS::ForceablePseudoClass::FocusWithin:
+            forcedPseudoClassesToSet.add(CSSSelector::PseudoClass::FocusWithin);
+            break;
+        case Inspector::Protocol::CSS::ForceablePseudoClass::Target:
+            forcedPseudoClassesToSet.add(CSSSelector::PseudoClass::Target);
+            break;
+        case Inspector::Protocol::CSS::ForceablePseudoClass::Visited:
+            forcedPseudoClassesToSet.add(CSSSelector::PseudoClass::Visited);
+            break;
+        }
+    }
+
+    if (!forcedPseudoClassesToSet.isEmpty()) {
+        m_nodeIdToForcedPseudoState.set(nodeId, WTF::move(forcedPseudoClassesToSet));
+        m_documentsWithForcedPseudoStates.add(&element->document());
+    } else {
+        if (!m_nodeIdToForcedPseudoState.remove(nodeId))
+            return { };
+        if (m_nodeIdToForcedPseudoState.isEmpty())
+            m_documentsWithForcedPseudoStates.clear();
+    }
+
+    element->document().styleScope().didChangeStyleSheetEnvironment();
+
+    return { };
+}
+
+bool FrameCSSAgent::forcePseudoState(const Element& element, CSSSelector::PseudoClass pseudoClass)
+{
+    if (m_nodeIdToForcedPseudoState.isEmpty())
+        return false;
+
+    Ref agents = m_instrumentingAgents.get();
+    CheckedPtr domAgent = agents->persistentFrameDOMAgent();
+    if (!domAgent)
+        return false;
+
+    auto nodeId = domAgent->boundNodeId(&element);
+    if (!nodeId)
+        return false;
+
+    return m_nodeIdToForcedPseudoState.get(nodeId).contains(pseudoClass);
 }
 
 Inspector::CommandResult<void> FrameCSSAgent::setLayoutContextTypeChangedMode(Inspector::Protocol::CSS::LayoutContextTypeChangedMode)
@@ -351,6 +617,110 @@ void FrameCSSAgent::reset()
     m_cssStyleSheetToInspectorStyleSheet.clear();
     m_documentToInspectorStyleSheet.clear();
     m_documentToKnownCSSStyleSheets.clear();
+    m_nodeToInspectorStyleSheet.clear();
+
+    for (auto& document : m_documentsWithForcedPseudoStates)
+        document->styleScope().didChangeStyleSheetEnvironment();
+    m_nodeIdToForcedPseudoState.clear();
+    m_documentsWithForcedPseudoStates.clear();
+}
+
+RefPtr<Element> FrameCSSAgent::elementForId(Inspector::Protocol::ErrorString& errorString, Inspector::Protocol::DOM::NodeId nodeId)
+{
+    Ref agents = m_instrumentingAgents.get();
+    CheckedPtr domAgent = agents->persistentFrameDOMAgent();
+    if (!domAgent) {
+        errorString = "DOM domain must be enabled"_s;
+        return nullptr;
+    }
+    RefPtr node = domAgent->nodeForId(nodeId);
+    if (!node) {
+        errorString = "Missing node for given nodeId"_s;
+        return nullptr;
+    }
+    RefPtr element = dynamicDowncast<Element>(*node);
+    if (!element)
+        errorString = "Node for given nodeId is not an element"_s;
+    return element;
+}
+
+InspectorStyleSheetForInlineStyle& FrameCSSAgent::asInspectorStyleSheet(StyledElement& element)
+{
+    auto it = m_nodeToInspectorStyleSheet.find(&element);
+    if (it != m_nodeToInspectorStyleSheet.end())
+        return it->value;
+
+    auto id = String::number(m_lastStyleSheetId++);
+    Ref identifierRegistry = protect(protect(m_inspectedFrame->page())->inspectorController())->identifierRegistry();
+    auto inspectorStyleSheet = InspectorStyleSheetForInlineStyle::create(identifierRegistry, id, element, Inspector::Protocol::CSS::StyleSheetOrigin::Author, this);
+    m_idToInspectorStyleSheet.set(id, inspectorStyleSheet.copyRef());
+    return m_nodeToInspectorStyleSheet.set(&element, WTF::move(inspectorStyleSheet)).iterator->value;
+}
+
+RefPtr<Inspector::Protocol::CSS::CSSStyle> FrameCSSAgent::buildObjectForAttributesStyle(StyledElement& element)
+{
+    RefPtr presentationalHintStyle = element.presentationalHintStyle();
+    if (!presentationalHintStyle)
+        return nullptr;
+    auto mutableStyle = presentationalHintStyle->mutableCopy();
+    auto inspectorStyle = InspectorStyle::create(InspectorCSSId(), mutableStyle->ensureCSSStyleProperties(), nullptr);
+    return inspectorStyle->buildObjectForStyle();
+}
+
+RefPtr<Inspector::Protocol::CSS::CSSRule> FrameCSSAgent::buildObjectForRule(const StyleRule* styleRule, Style::Resolver& styleResolver, Element& element)
+{
+    if (!styleRule)
+        return nullptr;
+
+    Ref document = element.document();
+    styleResolver.inspectorCSSOMWrappers().collectDocumentWrappers(protect(document->extensionStyleSheets()));
+    styleResolver.inspectorCSSOMWrappers().collectScopeWrappers(document->styleScope());
+    if (RefPtr shadowRoot = element.shadowRoot())
+        styleResolver.inspectorCSSOMWrappers().collectScopeWrappers(protect(shadowRoot->styleScope()));
+
+    return buildObjectForRule(protect(styleResolver.inspectorCSSOMWrappers().getWrapperForRuleInSheets(styleRule)));
+}
+
+RefPtr<Inspector::Protocol::CSS::CSSRule> FrameCSSAgent::buildObjectForRule(CSSStyleRule* rule)
+{
+    if (!rule)
+        return nullptr;
+    ASSERT(rule->parentStyleSheet());
+    return protect(bindStyleSheet(protect(rule->parentStyleSheet())))->buildObjectForRule(protect(rule));
+}
+
+Ref<JSON::ArrayOf<Inspector::Protocol::CSS::RuleMatch>> FrameCSSAgent::buildArrayForMatchedRuleList(const Vector<Ref<const StyleRule>>& matchedRules, Style::Resolver& styleResolver, Element& element, std::optional<Style::PseudoElementIdentifier> pseudoElementIdentifier)
+{
+    auto result = JSON::ArrayOf<Inspector::Protocol::CSS::RuleMatch>::create();
+
+    SelectorChecker::CheckingContext context(SelectorChecker::Mode::CollectingRules);
+    if (pseudoElementIdentifier)
+        context.setRequestedPseudoElement(*pseudoElementIdentifier);
+    SelectorChecker selectorChecker(element.document());
+
+    for (auto& matchedRule : matchedRules) {
+        RefPtr ruleObject = buildObjectForRule(matchedRule.ptr(), styleResolver, element);
+        if (!ruleObject)
+            continue;
+
+        auto matchingSelectors = JSON::ArrayOf<int>::create();
+        const CSSSelectorList& selectorList = matchedRule->selectorList();
+        int index = 0;
+        for (auto& selector : selectorList) {
+            bool matched = selectorChecker.match(selector, element, context);
+            if (matched)
+                matchingSelectors->addItem(index);
+            ++index;
+        }
+
+        auto match = Inspector::Protocol::CSS::RuleMatch::create()
+            .setRule(ruleObject.releaseNonNull())
+            .setMatchingSelectors(WTF::move(matchingSelectors))
+            .release();
+        result->addItem(WTF::move(match));
+    }
+
+    return result;
 }
 
 InspectorStyleSheet& FrameCSSAgent::bindStyleSheet(CSSStyleSheet* styleSheet)

--- a/Source/WebCore/inspector/agents/frame/FrameCSSAgent.h
+++ b/Source/WebCore/inspector/agents/frame/FrameCSSAgent.h
@@ -25,6 +25,7 @@
 
 #pragma once
 
+#include "CSSSelector.h"
 #include "InspectorStyleSheet.h"
 #include "InspectorWebAgentBase.h"
 #include <JavaScriptCore/InspectorBackendDispatchers.h>
@@ -40,9 +41,19 @@ class CSSFrontendDispatcher;
 
 namespace WebCore {
 
+class CSSStyleRule;
 class CSSStyleSheet;
 class Document;
+class Element;
 class LocalFrame;
+class Node;
+class StyledElement;
+class StyleRule;
+
+namespace Style {
+class Resolver;
+struct PseudoElementIdentifier;
+}
 
 class FrameCSSAgent final : public InspectorAgentBase, public Inspector::CSSBackendDispatcherHandler, public InspectorStyleSheet::Listener, public CanMakeCheckedPtr<FrameCSSAgent> {
     WTF_MAKE_NONCOPYABLE(FrameCSSAgent);
@@ -81,14 +92,21 @@ public:
     void styleSheetChanged(InspectorStyleSheet*) override;
 
     // InspectorInstrumentation
+    bool forcePseudoState(const Element&, CSSSelector::PseudoClass);
     void documentDetached(Document&);
     void mediaQueryResultChanged();
     void activeStyleSheetsUpdated(Document&);
 
 private:
     void reset();
+    RefPtr<Element> elementForId(Inspector::Protocol::ErrorString&, Inspector::Protocol::DOM::NodeId);
     InspectorStyleSheet& bindStyleSheet(CSSStyleSheet*);
     InspectorStyleSheet* assertStyleSheetForId(Inspector::Protocol::ErrorString&, const Inspector::Protocol::CSS::StyleSheetId&);
+    InspectorStyleSheetForInlineStyle& asInspectorStyleSheet(StyledElement&);
+    RefPtr<Inspector::Protocol::CSS::CSSStyle> buildObjectForAttributesStyle(StyledElement&);
+    RefPtr<Inspector::Protocol::CSS::CSSRule> buildObjectForRule(const StyleRule*, Style::Resolver&, Element&);
+    RefPtr<Inspector::Protocol::CSS::CSSRule> buildObjectForRule(CSSStyleRule*);
+    Ref<JSON::ArrayOf<Inspector::Protocol::CSS::RuleMatch>> buildArrayForMatchedRuleList(const Vector<Ref<const StyleRule>>&, Style::Resolver&, Element&, std::optional<Style::PseudoElementIdentifier>);
     void collectAllDocumentStyleSheets(Document&, Vector<CSSStyleSheet*>&);
     void collectStyleSheets(CSSStyleSheet*, Vector<CSSStyleSheet*>&);
     void setActiveStyleSheetsForDocument(Document&, Vector<CSSStyleSheet*>&);
@@ -103,6 +121,10 @@ private:
     HashMap<CSSStyleSheet*, Ref<InspectorStyleSheet>> m_cssStyleSheetToInspectorStyleSheet;
     HashMap<Ref<Document>, Vector<Ref<InspectorStyleSheet>>> m_documentToInspectorStyleSheet;
     HashMap<Document*, HashSet<CSSStyleSheet*>> m_documentToKnownCSSStyleSheets;
+    HashMap<Node*, Ref<InspectorStyleSheetForInlineStyle>> m_nodeToInspectorStyleSheet;
+    using PseudoClassHashSet = HashSet<CSSSelector::PseudoClass, IntHash<CSSSelector::PseudoClass>, WTF::StrongEnumHashTraits<CSSSelector::PseudoClass>>;
+    HashMap<Inspector::Protocol::DOM::NodeId, PseudoClassHashSet> m_nodeIdToForcedPseudoState;
+    HashSet<Document*> m_documentsWithForcedPseudoStates;
     int m_lastStyleSheetId { 1 };
     bool m_creatingViaInspectorStyleSheet { false };
 };


### PR DESCRIPTION
#### 55ede1c42fd15bcd9b846e5d0282bd73ae6cc150
<pre>
[Site Isolation] Web Inspector: Implement nodeId-dependent CSS commands for frame targets
<a href="https://bugs.webkit.org/show_bug.cgi?id=314424">https://bugs.webkit.org/show_bug.cgi?id=314424</a>

Reviewed by BJ Burg.

Implement getComputedStyleForNode, getFontDataForNode,
getInlineStylesForNode, getMatchedStylesForNode, and forcePseudoState in
FrameCSSAgent. These commands resolve DOM nodeIds through FrameDOMAgent
and compute CSS information using the frame&apos;s local StyleResolver. No
cross-process communication is needed since styles are computed locally
within the frame&apos;s WebContent process.

The helper methods (buildObjectForRule, buildArrayForMatchedRuleList,
etc.) are intentionally duplicated from InspectorCSSAgent rather than
shared, following the same standalone-agent pattern as FrameDOMAgent.
This keeps the two agents fully decoupled, as InspectorCSSAgent will
eventually be silenced under site isolation when the frontend switches
to frame targets.

Test: http/tests/site-isolation/inspector/css/css-node-commands-frame-target.html

* Source/WebCore/Scripts/generate-unified-sources.sh:
* Source/WebCore/Sources.txt:
* Source/WebCore/UnifiedSources-output.xcfilelist:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
These changes were needed in place of adding `#include &quot;StyleComputedStyle+GettersInlines.h&quot;`
in FrameCSSAgent. Adding the #include runs into the style bot error:
  Source/WebCore/inspector/agents/frame/FrameCSSAgent.cpp:63: error:
    [build/include/computed-style-inlines] StyleComputedStyle+GettersInlines.h adds 6
    seconds of compile time per translation unit, and should only be used in core rendering
    engine code. Consider an out of line helper function instead.

* LayoutTests/http/tests/site-isolation/inspector/css/css-node-commands-frame-target-expected.txt: Added.
* LayoutTests/http/tests/site-isolation/inspector/css/css-node-commands-frame-target.html: Added.
* LayoutTests/http/tests/site-isolation/inspector/css/resources/frame-with-stylesheet.html:
* Source/JavaScriptCore/inspector/protocol/CSS.json:
* Source/WebCore/inspector/InspectorInstrumentation.cpp:
(WebCore::InspectorInstrumentation::forcePseudoStateImpl):
* Source/WebCore/inspector/agents/frame/FrameCSSAgent.cpp:
(WebCore::protocolValueForPseudoElementType):
(WebCore::FrameCSSAgent::getComputedStyleForNode):
(WebCore::FrameCSSAgent::getFontDataForNode):
(WebCore::FrameCSSAgent::getInlineStylesForNode):
(WebCore::FrameCSSAgent::getMatchedStylesForNode):
(WebCore::FrameCSSAgent::forcePseudoState):
(WebCore::FrameCSSAgent::reset):
(WebCore::FrameCSSAgent::elementForId):
(WebCore::FrameCSSAgent::asInspectorStyleSheet):
(WebCore::FrameCSSAgent::buildObjectForAttributesStyle):
(WebCore::FrameCSSAgent::buildObjectForRule):
(WebCore::FrameCSSAgent::buildArrayForMatchedRuleList):
* Source/WebCore/inspector/agents/frame/FrameCSSAgent.h:

Canonical link: <a href="https://commits.webkit.org/315703@main">https://commits.webkit.org/315703@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/48220d41e8fd34400f2cf7ecdec56496a6322939

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/169813 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/159/builds/43735 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/37125 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/179172 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/127525 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/2dd77739-9e85-4170-b08c-71c336726613) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/171679 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/44801 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/43365 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/132346 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/127525 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/b0f61217-bfae-4f1f-a2ec-af123cf765b0) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/172772 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/44801 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/152751 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/112848 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/5d6264cb-94d4-4817-a2c5-5956286cee37) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/44801 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/32485 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/27870 "Built successfully") | | 
| [  ~~🧪 jsc-x86-64~~](https://ews-build.webkit.org/#/builders/218/builds/1168 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/44801 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/32150 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/181771 "Built successfully") | | 
| [  ~~🛠 🧪 jsc-debug-arm64~~](https://ews-build.webkit.org/#/builders/171/builds/31068 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/34479 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/36651 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/140796 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/43391 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/152221 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/140627 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/44080 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/29130 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/108375 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/25872 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/35893 "Passed tests") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/115845 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/202492 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/42591 "Built successfully") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/185/builds/7230 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/54278 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/41983 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/42238 "Built successfully") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/42126 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->