### PR TITLE
[Site Isolation] fast/dom/no-assert-for-malformed-js-url-attribute.html fails

### DIFF
--- a/Source/WebCore/loader/FrameLoader.cpp
+++ b/Source/WebCore/loader/FrameLoader.cpp
@@ -2379,8 +2379,15 @@ void FrameLoader::provisionalLoadFailedInAnotherProcess()
     m_provisionalLoadHappeningInAnotherProcess = false;
     m_isComplete = true;
 
-    if (RefPtr localParent = dynamicDowncast<LocalFrame>(m_frame->tree().parent()))
-        localParent->loader().checkCompleted();
+    if (RefPtr localParent = dynamicDowncast<LocalFrame>(m_frame->tree().parent())) {
+        Ref parentLoader = localParent->loader();
+        parentLoader->checkCompleted();
+        // checkCompleted() may short-circuit because the parent's document already finished, but the
+        // parent's FrameLoader state machine can still be stuck in CommittedPage if subframeIsLoading()
+        // was true while waiting for this cross-process load. Drive checkLoadComplete() so that
+        // dispatchDidFinishLoad() can fire on the parent now that subframeIsLoading() is false.
+        parentLoader->checkLoadComplete();
+    }
 }
 
 void FrameLoader::commitProvisionalLoad()


### PR DESCRIPTION
#### 520cf977e28c5565409a1db6741e2fa64827a398
<pre>
[Site Isolation] fast/dom/no-assert-for-malformed-js-url-attribute.html fails
<a href="https://bugs.webkit.org/show_bug.cgi?id=314429">https://bugs.webkit.org/show_bug.cgi?id=314429</a>

Reviewed by Sihui Liu and Brady Eidson.

The test was timing out with site isolation due to the following sequence of events:

  1. The parent&apos;s document reaches complete, so FrameLoader::checkCompleted() sets
     m_isComplete = true and fires the load event handler synchronously via
     checkCallImplicitClose().
  2. That handler (e.g. an iframe src mutation in body.onload) starts a cross-process
     navigation on a subframe, setting m_provisionalLoadHappeningInAnotherProcess to
     true on that subframe&apos;s loader.
  3. checkCompleted() then calls checkLoadComplete(), but checkLoadCompleteForThisFrame()
     for the parent hits isLoadingInAPISense() -&gt; subframeIsLoading() -&gt; true (because of
     the subframe&apos;s flag), so it early-returns at CommittedPage without dispatching
     didFinishLoad. The parent&apos;s FrameLoader state stays at CommittedPage.
  4. The cross-process load eventually finishes/fails. The UI process IPCs
     DidFinishLoadInAnotherProcess to the parent&apos;s WebContent process, which calls
     LocalFrame::didFinishLoadInAnotherProcess() -&gt;
     FrameLoader::provisionalLoadFailedInAnotherProcess(). That clears the cross-process
     flag and calls parent-&gt;checkCompleted().
  5. checkCompleted() short-circuits because m_isComplete is already true - and nothing
     calls checkLoadComplete(). The parent&apos;s state machine never advances to Complete,
     so WebLocalFrameLoaderClient::dispatchDidFinishLoad() is never called. As a result,
     WebKitTestRunner&apos;s injected bundle never sees didFinishLoadForFrame for the main
     frame, topLoadingFrame stays set, and the test times out.

This PR fixes the test by making FrameLoader::provisionalLoadFailedInAnotherProcess call
checkLoadComplete() on the parent, not just checkCompleted(). This unblocks the parent&apos;s
loader state machine when its document had already reached complete while a subframe was
still pending in another process.

Test: fast/dom/no-assert-for-malformed-js-url-attribute.html

* Source/WebCore/loader/FrameLoader.cpp:
(WebCore::FrameLoader::provisionalLoadFailedInAnotherProcess):

Canonical link: <a href="https://commits.webkit.org/312940@main">https://commits.webkit.org/312940@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/052da05c1246c0262a0e12f2b76d29aed53b292b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/161459 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/34933 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/28035 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/170362 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/117830 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/163328 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/35034 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/34934 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/125261 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/88226 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/164418 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/27549 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/145035 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/105857 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/26598 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/25109 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/18083 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/136292 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/22792 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/172848 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/19879 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/24433 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/133546 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/34607 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/29204 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/133553 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/34591 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/144587 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/96491 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/24546 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/28083 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/21406 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/34101 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/101543 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/33601 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/33844 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/33750 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->