### PR TITLE
[JSC][Temporal] Add pure C++ core layer: Rounding, ISOArithmetic, InstantCore, CalendarArithmetic

### DIFF
--- a/Source/JavaScriptCore/API/tests/TemporalCoreTest.cpp
+++ b/Source/JavaScriptCore/API/tests/TemporalCoreTest.cpp
@@ -1,0 +1,1052 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "TemporalCoreTest.h"
+
+#include "CalendarArithmetic.h"
+#include "ISO8601.h"
+#include "ISOArithmetic.h"
+#include "InstantCore.h"
+#include "Rounding.h"
+#include "TemporalCoreTypes.h"
+#include "TemporalEnums.h"
+#include <stdio.h>
+#include <wtf/Int128.h>
+
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
+
+namespace JSC {
+namespace TemporalCore {
+
+// ---------------------------------------------------------------------------
+// Assertion helpers
+// ---------------------------------------------------------------------------
+
+static int s_failures = 0;
+
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
+
+#define TCHECK_EQ(actual, expected, name)                                                  \
+    do {                                                                                   \
+        if ((actual) != (expected)) {                                                      \
+            fprintf(stderr, "FAIL [%s]: got %s, expected %s\n", name, #actual, #expected); \
+            s_failures++;                                                                  \
+        }                                                                                  \
+    } while (0)
+
+#define TCHECK_TRUE(cond, name)                                               \
+    do {                                                                      \
+        if (!(cond)) {                                                        \
+            fprintf(stderr, "FAIL [%s]: condition false: %s\n", name, #cond); \
+            s_failures++;                                                     \
+        }                                                                     \
+    } while (0)
+
+#define TCHECK_ERR(result, name)                                                  \
+    do {                                                                          \
+        if ((result)) {                                                           \
+            fprintf(stderr, "FAIL [%s]: expected error but got success\n", name); \
+            s_failures++;                                                         \
+        }                                                                         \
+    } while (0)
+
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
+
+// ---------------------------------------------------------------------------
+// ISOArithmetic tests — mirrors temporal_rs src/iso.rs tests
+// ---------------------------------------------------------------------------
+
+static void testBalanceISODate()
+{
+    // temporal_rs: test balance_iso_date
+    // 2020-01-32 -> 2020-02-01
+    auto r = balanceISODate(2020, 1, 32);
+    TCHECK_EQ(r.year(), 2020, "balanceISODate: 2020-01-32 year");
+    TCHECK_EQ(r.month(), 2u, "balanceISODate: 2020-01-32 month");
+    TCHECK_EQ(r.day(), 1u, "balanceISODate: 2020-01-32 day");
+
+    // 2020-12-32 -> 2021-01-01
+    auto r2 = balanceISODate(2020, 12, 32);
+    TCHECK_EQ(r2.year(), 2021, "balanceISODate: 2020-12-32 year");
+    TCHECK_EQ(r2.month(), 1u, "balanceISODate: 2020-12-32 month");
+    TCHECK_EQ(r2.day(), 1u, "balanceISODate: 2020-12-32 day");
+
+    // 2020-01-00 -> 2019-12-31
+    auto r3 = balanceISODate(2020, 1, 0);
+    TCHECK_EQ(r3.year(), 2019, "balanceISODate: 2020-01-00 year");
+    TCHECK_EQ(r3.month(), 12u, "balanceISODate: 2020-01-00 month");
+    TCHECK_EQ(r3.day(), 31u, "balanceISODate: 2020-01-00 day");
+
+    // 2020-03-01 (unchanged)
+    auto r4 = balanceISODate(2020, 3, 1);
+    TCHECK_EQ(r4.year(), 2020, "balanceISODate: 2020-03-01 year");
+    TCHECK_EQ(r4.month(), 3u, "balanceISODate: 2020-03-01 month");
+    TCHECK_EQ(r4.day(), 1u, "balanceISODate: 2020-03-01 day");
+}
+
+static void testRegulateISODate()
+{
+    // temporal_rs: test regulate_iso_date
+    // constrain: 2020-02-30 -> 2020-02-29 (2020 is leap year)
+    auto r = regulateISODate(2020, 2, 30, TemporalOverflow::Constrain);
+    TCHECK_TRUE(r.has_value(), "regulateISODate: constrain 2020-02-30 ok");
+    TCHECK_EQ(r->month(), 2u, "regulateISODate: constrain month");
+    TCHECK_EQ(r->day(), 29u, "regulateISODate: constrain day");
+
+    // constrain: 2021-02-30 -> 2021-02-28 (2021 not leap)
+    auto r2 = regulateISODate(2021, 2, 30, TemporalOverflow::Constrain);
+    TCHECK_TRUE(r2.has_value(), "regulateISODate: constrain 2021-02-30 ok");
+    TCHECK_EQ(r2->day(), 28u, "regulateISODate: constrain 2021-02-30 day");
+
+    // reject: 2020-13-01 -> error
+    auto r3 = regulateISODate(2020, 13, 1, TemporalOverflow::Reject);
+    TCHECK_TRUE(!r3.has_value(), "regulateISODate: reject 2020-13-01 errors");
+
+    // reject: valid 2020-06-15 -> ok
+    auto r4 = regulateISODate(2020, 6, 15, TemporalOverflow::Reject);
+    TCHECK_TRUE(r4.has_value(), "regulateISODate: reject 2020-06-15 ok");
+    TCHECK_EQ(r4->year(), 2020, "regulateISODate: reject year");
+    TCHECK_EQ(r4->month(), 6u, "regulateISODate: reject month");
+    TCHECK_EQ(r4->day(), 15u, "regulateISODate: reject day");
+}
+
+static void testISODateAdd()
+{
+    // temporal_rs: plain_date.rs test simple_date_add
+    // 1976-11-18 + P43Y -> 2019-11-18
+    auto r1 = isoDateAdd({ 1976, 11, 18 }, ISO8601::Duration(43, 0, 0, 0, 0, 0, 0, 0, 0, 0), TemporalOverflow::Constrain);
+    TCHECK_TRUE(r1.has_value(), "isoDateAdd: +43y ok");
+    TCHECK_EQ(r1->year(), 2019, "isoDateAdd: +43y year");
+    TCHECK_EQ(r1->month(), 11u, "isoDateAdd: +43y month");
+    TCHECK_EQ(r1->day(), 18u, "isoDateAdd: +43y day");
+
+    // 1976-11-18 + P3M -> 1977-02-18
+    auto r2 = isoDateAdd({ 1976, 11, 18 }, ISO8601::Duration(0, 3, 0, 0, 0, 0, 0, 0, 0, 0), TemporalOverflow::Constrain);
+    TCHECK_TRUE(r2.has_value(), "isoDateAdd: +3m ok");
+    TCHECK_EQ(r2->year(), 1977, "isoDateAdd: +3m year");
+    TCHECK_EQ(r2->month(), 2u, "isoDateAdd: +3m month");
+    TCHECK_EQ(r2->day(), 18u, "isoDateAdd: +3m day");
+
+    // 1976-11-18 + P20D -> 1976-12-08
+    auto r3 = isoDateAdd({ 1976, 11, 18 }, ISO8601::Duration(0, 0, 0, 20, 0, 0, 0, 0, 0, 0), TemporalOverflow::Constrain);
+    TCHECK_TRUE(r3.has_value(), "isoDateAdd: +20d ok");
+    TCHECK_EQ(r3->year(), 1976, "isoDateAdd: +20d year");
+    TCHECK_EQ(r3->month(), 12u, "isoDateAdd: +20d month");
+    TCHECK_EQ(r3->day(), 8u, "isoDateAdd: +20d day");
+
+    // 2019-11-18 - P43Y -> 1976-11-18
+    auto r4 = isoDateAdd({ 2019, 11, 18 }, ISO8601::Duration(-43, 0, 0, 0, 0, 0, 0, 0, 0, 0), TemporalOverflow::Constrain);
+    TCHECK_TRUE(r4.has_value(), "isoDateAdd: -43y ok");
+    TCHECK_EQ(r4->year(), 1976, "isoDateAdd: -43y year");
+
+    // constrain: 2021-01-31 + P1M -> 2021-02-28 (not 2021-02-31)
+    auto r5 = isoDateAdd({ 2021, 1, 31 }, ISO8601::Duration(0, 1, 0, 0, 0, 0, 0, 0, 0, 0), TemporalOverflow::Constrain);
+    TCHECK_TRUE(r5.has_value(), "isoDateAdd: end-of-month constrain ok");
+    TCHECK_EQ(r5->month(), 2u, "isoDateAdd: end-of-month month");
+    TCHECK_EQ(r5->day(), 28u, "isoDateAdd: end-of-month day");
+}
+
+static void testISODateCompare()
+{
+    // temporal_rs: src/iso.rs IsoDate::cmp
+    TCHECK_EQ(isoDateCompare({ 2020, 1, 1 }, { 2020, 1, 1 }), 0, "isoDateCompare: equal");
+    TCHECK_EQ(isoDateCompare({ 2020, 1, 2 }, { 2020, 1, 1 }), 1, "isoDateCompare: later day");
+    TCHECK_EQ(isoDateCompare({ 2020, 1, 1 }, { 2020, 1, 2 }), -1, "isoDateCompare: earlier day");
+    TCHECK_EQ(isoDateCompare({ 2021, 1, 1 }, { 2020, 12, 31 }), 1, "isoDateCompare: later year");
+    TCHECK_EQ(isoDateCompare({ 2020, 6, 1 }, { 2020, 7, 1 }), -1, "isoDateCompare: earlier month");
+}
+
+static void testDiffISODate()
+{
+    // temporal_rs: plain_date.rs test simple_date_until
+    // 1969-07-24 until 1969-10-05 in days = 73
+    auto r1 = diffISODate({ 1969, 7, 24 }, { 1969, 10, 5 }, TemporalUnit::Day);
+    TCHECK_EQ(static_cast<int64_t>(r1.days()), 73LL, "diffISODate: 73 days");
+
+    // 1969-07-24 until 1996-03-03 in days = 9719
+    auto r2 = diffISODate({ 1969, 7, 24 }, { 1996, 3, 3 }, TemporalUnit::Day);
+    TCHECK_EQ(static_cast<int64_t>(r2.days()), 9719LL, "diffISODate: 9719 days");
+
+    // 1969-07-24 until 1969-10-05 in months = 2m12d
+    auto r3 = diffISODate({ 1969, 7, 24 }, { 1969, 10, 5 }, TemporalUnit::Month);
+    TCHECK_EQ(static_cast<int64_t>(r3.months()), 2LL, "diffISODate: months");
+    TCHECK_EQ(static_cast<int64_t>(r3.days()), 11LL, "diffISODate: remaining days");
+
+    // Same date -> zero
+    auto r4 = diffISODate({ 2020, 6, 15 }, { 2020, 6, 15 }, TemporalUnit::Day);
+    TCHECK_EQ(static_cast<int64_t>(r4.days()), 0LL, "diffISODate: same date");
+
+    // Negative diff: 1969-10-05 until 1969-07-24 in days = -73
+    auto r5 = diffISODate({ 1969, 10, 5 }, { 1969, 7, 24 }, TemporalUnit::Day);
+    TCHECK_EQ(static_cast<int64_t>(r5.days()), -73LL, "diffISODate: negative days");
+}
+
+// ---------------------------------------------------------------------------
+// Rounding tests — mirrors temporal_rs src/rounding.rs tests
+// ---------------------------------------------------------------------------
+
+static void testRoundNumberToIncrementDouble()
+{
+    // temporal_rs: round_number_to_increment tests
+    // 5.5 with increment 1, HalfExpand -> 6
+    TCHECK_EQ(roundNumberToIncrementDouble(5.5, 1.0, RoundingMode::HalfExpand), 6.0, "round: 5.5 HalfExpand");
+    // 5.5 with increment 1, HalfTrunc -> 5
+    TCHECK_EQ(roundNumberToIncrementDouble(5.5, 1.0, RoundingMode::HalfTrunc), 5.0, "round: 5.5 HalfTrunc");
+    // 5.5 with increment 1, HalfEven -> 6 (round to even)
+    TCHECK_EQ(roundNumberToIncrementDouble(5.5, 1.0, RoundingMode::HalfEven), 6.0, "round: 5.5 HalfEven");
+    // 4.5 with increment 1, HalfEven -> 4 (round to even)
+    TCHECK_EQ(roundNumberToIncrementDouble(4.5, 1.0, RoundingMode::HalfEven), 4.0, "round: 4.5 HalfEven");
+
+    // Increment > 1: 23 / increment 5, Trunc -> 20
+    TCHECK_EQ(roundNumberToIncrementDouble(23.0, 5.0, RoundingMode::Trunc), 20.0, "round: 23 inc5 Trunc");
+    // 23 / increment 5, Ceil -> 25
+    TCHECK_EQ(roundNumberToIncrementDouble(23.0, 5.0, RoundingMode::Ceil), 25.0, "round: 23 inc5 Ceil");
+    // 23 / increment 5, Floor -> 20
+    TCHECK_EQ(roundNumberToIncrementDouble(23.0, 5.0, RoundingMode::Floor), 20.0, "round: 23 inc5 Floor");
+
+    // Negative: -23 / increment 5, Trunc -> -20
+    TCHECK_EQ(roundNumberToIncrementDouble(-23.0, 5.0, RoundingMode::Trunc), -20.0, "round: -23 inc5 Trunc");
+    // -23 / increment 5, Floor -> -25
+    TCHECK_EQ(roundNumberToIncrementDouble(-23.0, 5.0, RoundingMode::Floor), -25.0, "round: -23 inc5 Floor");
+}
+
+static void testRoundNumberToIncrementInt128()
+{
+    // temporal_rs: round_number_to_increment (integer path)
+    // 5 / inc 2, HalfExpand -> 6
+    TCHECK_EQ(roundNumberToIncrementInt128(Int128(5), Int128(2), RoundingMode::HalfExpand), Int128(6), "roundInt128: 5 inc2 HalfExpand");
+    // 5 / inc 2, HalfTrunc -> 4
+    TCHECK_EQ(roundNumberToIncrementInt128(Int128(5), Int128(2), RoundingMode::HalfTrunc), Int128(4), "roundInt128: 5 inc2 HalfTrunc");
+    // 4 / inc 2, HalfEven -> 4
+    TCHECK_EQ(roundNumberToIncrementInt128(Int128(4), Int128(2), RoundingMode::HalfEven), Int128(4), "roundInt128: 4 inc2 HalfEven");
+    // 6 / inc 2, HalfEven -> 6
+    TCHECK_EQ(roundNumberToIncrementInt128(Int128(6), Int128(2), RoundingMode::HalfEven), Int128(6), "roundInt128: 6 inc2 HalfEven");
+
+    // Nanoseconds: 1500000000 / inc 1000000000 (1s), HalfExpand -> 2000000000
+    Int128 ns = Int128(1500000000LL);
+    Int128 inc = Int128(1000000000LL);
+    TCHECK_EQ(roundNumberToIncrementInt128(ns, inc, RoundingMode::HalfExpand), Int128(2000000000LL), "roundInt128: 1.5s HalfExpand");
+
+    // temporal_rs: duration rounding 25h with inc=1day (86400s = 86400000000000ns)
+    // 25h in ns = 90000000000000, inc = 86400000000000, Trunc -> 86400000000000
+    Int128 h25 = Int128(90000000000000LL);
+    Int128 day = Int128(86400000000000LL);
+    TCHECK_EQ(roundNumberToIncrementInt128(h25, day, RoundingMode::Trunc), day, "roundInt128: 25h Trunc to 1day");
+    // Floor same result
+    TCHECK_EQ(roundNumberToIncrementInt128(h25, day, RoundingMode::Floor), day, "roundInt128: 25h Floor to 1day");
+}
+
+static void testMaximumRoundingIncrement()
+{
+    // temporal_rs: maximum_temporal_duration_rounding_increment
+    TCHECK_TRUE(!maximumRoundingIncrement(TemporalUnit::Year).has_value(), "maxIncrement: Year = unlimited");
+    TCHECK_TRUE(!maximumRoundingIncrement(TemporalUnit::Month).has_value(), "maxIncrement: Month = unlimited");
+    TCHECK_TRUE(!maximumRoundingIncrement(TemporalUnit::Week).has_value(), "maxIncrement: Week = unlimited");
+    TCHECK_TRUE(!maximumRoundingIncrement(TemporalUnit::Day).has_value(), "maxIncrement: Day = unlimited");
+    TCHECK_EQ(maximumRoundingIncrement(TemporalUnit::Hour).value_or(0), 24u, "maxIncrement: Hour = 24");
+    TCHECK_EQ(maximumRoundingIncrement(TemporalUnit::Minute).value_or(0), 60u, "maxIncrement: Minute = 60");
+    TCHECK_EQ(maximumRoundingIncrement(TemporalUnit::Second).value_or(0), 60u, "maxIncrement: Second = 60");
+    TCHECK_EQ(maximumRoundingIncrement(TemporalUnit::Millisecond).value_or(0), 1000u, "maxIncrement: Millisecond = 1000");
+    TCHECK_EQ(maximumRoundingIncrement(TemporalUnit::Microsecond).value_or(0), 1000u, "maxIncrement: Microsecond = 1000");
+    TCHECK_EQ(maximumRoundingIncrement(TemporalUnit::Nanosecond).value_or(0), 1000u, "maxIncrement: Nanosecond = 1000");
+}
+
+// ---------------------------------------------------------------------------
+// CalendarArithmetic tests — mirrors temporal_rs src/builtins/core/calendar.rs
+// ---------------------------------------------------------------------------
+
+static void testCalendarDateAdd()
+{
+    // ISO8601 path only (no ICU needed)
+    // temporal_rs: Calendar::date_add (iso8601)
+    // 1976-11-18 + P43Y = 2019-11-18
+    auto r1 = calendarDateAdd({ 1976, 11, 18 }, ISO8601::Duration(43, 0, 0, 0, 0, 0, 0, 0, 0, 0), TemporalOverflow::Constrain);
+    TCHECK_TRUE(r1.has_value(), "calendarDateAdd: +43y ok");
+    TCHECK_EQ(r1->year(), 2019, "calendarDateAdd: +43y year");
+
+    // 1976-11-18 + P-43Y = 1933-11-18
+    auto r2 = calendarDateAdd({ 1976, 11, 18 }, ISO8601::Duration(-43, 0, 0, 0, 0, 0, 0, 0, 0, 0), TemporalOverflow::Constrain);
+    TCHECK_TRUE(r2.has_value(), "calendarDateAdd: -43y ok");
+    TCHECK_EQ(r2->year(), 1933, "calendarDateAdd: -43y year");
+
+    // End-of-month constrain: 2020-01-31 + P1M = 2020-02-29 (leap year)
+    auto r3 = calendarDateAdd({ 2020, 1, 31 }, ISO8601::Duration(0, 1, 0, 0, 0, 0, 0, 0, 0, 0), TemporalOverflow::Constrain);
+    TCHECK_TRUE(r3.has_value(), "calendarDateAdd: eom constrain ok");
+    TCHECK_EQ(r3->month(), 2u, "calendarDateAdd: eom month");
+    TCHECK_EQ(r3->day(), 29u, "calendarDateAdd: eom day");
+
+    // Weeks: 1976-11-18 + P2W = 1976-12-02
+    auto r4 = calendarDateAdd({ 1976, 11, 18 }, ISO8601::Duration(0, 0, 2, 0, 0, 0, 0, 0, 0, 0), TemporalOverflow::Constrain);
+    TCHECK_TRUE(r4.has_value(), "calendarDateAdd: +2w ok");
+    TCHECK_EQ(r4->month(), 12u, "calendarDateAdd: +2w month");
+    TCHECK_EQ(r4->day(), 2u, "calendarDateAdd: +2w day");
+}
+
+static void testCalendarDateUntil()
+{
+    // ISO8601 path only — mirrors temporal_rs: Calendar::date_until + date_until_largest_year
+    // 1969-07-24 until 1996-03-03 in days = 9719
+    auto r1 = calendarDateUntil({ 1969, 7, 24 }, { 1996, 3, 3 }, TemporalUnit::Day);
+    TCHECK_EQ(static_cast<int64_t>(r1.days()), 9719LL, "calendarDateUntil: 9719 days");
+
+    // Same date -> zero
+    auto r2 = calendarDateUntil({ 2020, 6, 15 }, { 2020, 6, 15 }, TemporalUnit::Day);
+    TCHECK_EQ(static_cast<int64_t>(r2.days()), 0LL, "calendarDateUntil: same date");
+
+    // 1969-07-24 until 1969-10-05 in months = 2m11d
+    auto r3 = calendarDateUntil({ 1969, 7, 24 }, { 1969, 10, 5 }, TemporalUnit::Month);
+    TCHECK_EQ(static_cast<int64_t>(r3.months()), 2LL, "calendarDateUntil: 2 months");
+
+    // Negative: later until earlier
+    auto r4 = calendarDateUntil({ 1996, 3, 3 }, { 1969, 7, 24 }, TemporalUnit::Day);
+    TCHECK_EQ(static_cast<int64_t>(r4.days()), -9719LL, "calendarDateUntil: -9719 days");
+
+    // temporal_rs: date_until_largest_year — Year largestUnit
+    // 2021-07-16 until 2022-07-16 = exactly 1 year
+    auto r5 = calendarDateUntil({ 2021, 7, 16 }, { 2022, 7, 16 }, TemporalUnit::Year);
+    TCHECK_EQ(static_cast<int64_t>(r5.years()), 1LL, "calendarDateUntil: 1 year");
+    TCHECK_EQ(static_cast<int64_t>(r5.months()), 0LL, "calendarDateUntil: 1y months=0");
+    TCHECK_EQ(static_cast<int64_t>(r5.days()), 0LL, "calendarDateUntil: 1y days=0");
+
+    // 2021-07-16 until 2031-07-16 = exactly 10 years
+    auto r6 = calendarDateUntil({ 2021, 7, 16 }, { 2031, 7, 16 }, TemporalUnit::Year);
+    TCHECK_EQ(static_cast<int64_t>(r6.years()), 10LL, "calendarDateUntil: 10 years");
+
+    // 2021-07-16 until 2022-07-19 = 1 year + 3 days
+    auto r7 = calendarDateUntil({ 2021, 7, 16 }, { 2022, 7, 19 }, TemporalUnit::Year);
+    TCHECK_EQ(static_cast<int64_t>(r7.years()), 1LL, "calendarDateUntil: 1y3d years");
+    TCHECK_EQ(static_cast<int64_t>(r7.days()), 3LL, "calendarDateUntil: 1y3d days");
+}
+
+// ---------------------------------------------------------------------------
+// ISO date limit tests — mirrors temporal_rs src/iso.rs limit tests
+// ---------------------------------------------------------------------------
+
+static void testISODateLimits()
+{
+    // Max valid ISO date for Temporal: +275760-09-13 (±1e8 epoch days)
+    // balanceISODate returns outOfRangeYear only when year exceeds the year representation limit
+    auto rMax = balanceISODate(275760, 9, 13);
+    TCHECK_EQ(rMax.year(), 275760, "limits: max date year");
+    TCHECK_EQ(rMax.month(), 9u, "limits: max date month");
+    TCHECK_EQ(rMax.day(), 13u, "limits: max date day");
+
+    // Min valid ISO date: -271821-04-19
+    auto rMin = balanceISODate(-271821, 4, 19);
+    TCHECK_EQ(rMin.year(), -271821, "limits: min date year");
+    TCHECK_EQ(rMin.month(), 4u, "limits: min date month");
+    TCHECK_EQ(rMin.day(), 19u, "limits: min date day");
+
+    // Unix epoch: 1970-01-01
+    auto rEpoch = balanceISODate(1970, 1, 1);
+    TCHECK_EQ(rEpoch.year(), 1970, "limits: epoch year");
+    TCHECK_EQ(rEpoch.month(), 1u, "limits: epoch month");
+    TCHECK_EQ(rEpoch.day(), 1u, "limits: epoch day");
+
+    // Day before epoch: 1969-12-31
+    auto rEpochMinus1 = balanceISODate(1969, 12, 31);
+    TCHECK_EQ(rEpochMinus1.year(), 1969, "limits: epoch-1 year");
+    TCHECK_EQ(rEpochMinus1.month(), 12u, "limits: epoch-1 month");
+    TCHECK_EQ(rEpochMinus1.day(), 31u, "limits: epoch-1 day");
+
+    // isoDateAdd past Temporal max -> error (±1e8 days limit)
+    // Max date + P1D exceeds the epoch day limit
+    auto rOverMax = isoDateAdd({ 275760, 9, 13 }, ISO8601::Duration(0, 0, 0, 1, 0, 0, 0, 0, 0, 0), TemporalOverflow::Reject);
+    TCHECK_TRUE(!rOverMax.has_value(), "limits: isoDateAdd max+1d rejects");
+
+    // Min date - P1D exceeds minimum
+    auto rUnderMin = isoDateAdd({ -271821, 4, 19 }, ISO8601::Duration(0, 0, 0, -1, 0, 0, 0, 0, 0, 0), TemporalOverflow::Reject);
+    TCHECK_TRUE(!rUnderMin.has_value(), "limits: isoDateAdd min-1d rejects");
+
+    // regulateISODate validates month/day range (not Temporal epoch limits)
+    auto rRegValid = regulateISODate(275760, 9, 13, TemporalOverflow::Reject);
+    TCHECK_TRUE(rRegValid.has_value(), "limits: regulate 275760-09-13 ok");
+
+    auto rRegBadMonth = regulateISODate(2020, 13, 1, TemporalOverflow::Reject);
+    TCHECK_TRUE(!rRegBadMonth.has_value(), "limits: regulate month 13 rejects");
+}
+
+// ---------------------------------------------------------------------------
+// Negative number rounding — mirrors temporal_rs src/rounding.rs tests
+// ---------------------------------------------------------------------------
+
+static void testNegativeRounding()
+{
+    // temporal_rs: test_basic_rounding_cases (negative values)
+    // -101 / 10
+    TCHECK_EQ(roundNumberToIncrementDouble(-101.0, 10.0, RoundingMode::Ceil), -100.0, "negRound: -101 inc10 Ceil");
+    TCHECK_EQ(roundNumberToIncrementDouble(-101.0, 10.0, RoundingMode::Floor), -110.0, "negRound: -101 inc10 Floor");
+    TCHECK_EQ(roundNumberToIncrementDouble(-101.0, 10.0, RoundingMode::Expand), -110.0, "negRound: -101 inc10 Expand");
+    TCHECK_EQ(roundNumberToIncrementDouble(-101.0, 10.0, RoundingMode::Trunc), -100.0, "negRound: -101 inc10 Trunc");
+
+    // -105 / 10 (midpoint)
+    TCHECK_EQ(roundNumberToIncrementDouble(-105.0, 10.0, RoundingMode::HalfCeil), -100.0, "negRound: -105 HalfCeil");
+    TCHECK_EQ(roundNumberToIncrementDouble(-105.0, 10.0, RoundingMode::HalfFloor), -110.0, "negRound: -105 HalfFloor");
+    TCHECK_EQ(roundNumberToIncrementDouble(-105.0, 10.0, RoundingMode::HalfExpand), -110.0, "negRound: -105 HalfExpand");
+    TCHECK_EQ(roundNumberToIncrementDouble(-105.0, 10.0, RoundingMode::HalfTrunc), -100.0, "negRound: -105 HalfTrunc");
+    TCHECK_EQ(roundNumberToIncrementDouble(-105.0, 10.0, RoundingMode::HalfEven), -100.0, "negRound: -105 HalfEven (even=10)");
+
+    // -115 / 10: HalfEven -> -120 (even=12)
+    TCHECK_EQ(roundNumberToIncrementDouble(-115.0, 10.0, RoundingMode::HalfEven), -120.0, "negRound: -115 HalfEven (even=12)");
+
+    // -107 / 10 (not midpoint)
+    TCHECK_EQ(roundNumberToIncrementDouble(-107.0, 10.0, RoundingMode::Ceil), -100.0, "negRound: -107 Ceil");
+    TCHECK_EQ(roundNumberToIncrementDouble(-107.0, 10.0, RoundingMode::Floor), -110.0, "negRound: -107 Floor");
+
+    // Int128 negative rounding
+    TCHECK_EQ(roundNumberToIncrementInt128(Int128(-101), Int128(10), RoundingMode::Ceil), Int128(-100), "negRoundI128: Ceil");
+    TCHECK_EQ(roundNumberToIncrementInt128(Int128(-101), Int128(10), RoundingMode::Floor), Int128(-110), "negRoundI128: Floor");
+    TCHECK_EQ(roundNumberToIncrementInt128(Int128(-105), Int128(10), RoundingMode::HalfExpand), Int128(-110), "negRoundI128: HalfExpand midpoint");
+    TCHECK_EQ(roundNumberToIncrementInt128(Int128(-105), Int128(10), RoundingMode::HalfTrunc), Int128(-100), "negRoundI128: HalfTrunc midpoint");
+}
+
+// ---------------------------------------------------------------------------
+// roundNumberToIncrementAsIfPositive — mirrors temporal_rs round_as_if_positive
+// ---------------------------------------------------------------------------
+
+static void testRoundAsIfPositive()
+{
+    // roundNumberToIncrementAsIfPositive always uses getUnsignedRoundingMode(mode, false).
+    // For negative x=-107, increment=10: C++ quotient=-10, r1=-11, r2=-10.
+    // Trunc->Zero->r1*inc = -110; Expand->Infinity->r2*inc = -100.
+    TCHECK_EQ(roundNumberToIncrementAsIfPositive(Int128(-107), Int128(10), RoundingMode::Trunc), Int128(-110), "asIfPos: -107 Trunc=-110");
+    TCHECK_EQ(roundNumberToIncrementAsIfPositive(Int128(-107), Int128(10), RoundingMode::Expand), Int128(-100), "asIfPos: -107 Expand=-100");
+    TCHECK_EQ(roundNumberToIncrementAsIfPositive(Int128(-107), Int128(10), RoundingMode::Ceil), Int128(-100), "asIfPos: -107 Ceil=-100");
+    TCHECK_EQ(roundNumberToIncrementAsIfPositive(Int128(-107), Int128(10), RoundingMode::Floor), Int128(-110), "asIfPos: -107 Floor=-110");
+
+    // Positive values: same as regular roundNumberToIncrementInt128
+    TCHECK_EQ(roundNumberToIncrementAsIfPositive(Int128(107), Int128(10), RoundingMode::Trunc), Int128(100), "asIfPos: 107 Trunc=100");
+    TCHECK_EQ(roundNumberToIncrementAsIfPositive(Int128(107), Int128(10), RoundingMode::Expand), Int128(110), "asIfPos: 107 Expand=110");
+
+    // Zero is unchanged
+    TCHECK_EQ(roundNumberToIncrementAsIfPositive(Int128(0), Int128(10), RoundingMode::HalfExpand), Int128(0), "asIfPos: 0 = 0");
+}
+
+// ---------------------------------------------------------------------------
+// negateTemporalRoundingMode — mirrors temporal_rs RoundingMode::negate
+// ---------------------------------------------------------------------------
+
+static void testNegateRoundingMode()
+{
+    // temporal_rs: RoundingMode::negate
+    TCHECK_EQ(static_cast<int>(negateTemporalRoundingMode(RoundingMode::Floor)), static_cast<int>(RoundingMode::Ceil), "negate: Floor->Ceil");
+    TCHECK_EQ(static_cast<int>(negateTemporalRoundingMode(RoundingMode::Ceil)), static_cast<int>(RoundingMode::Floor), "negate: Ceil->Floor");
+    TCHECK_EQ(static_cast<int>(negateTemporalRoundingMode(RoundingMode::HalfFloor)), static_cast<int>(RoundingMode::HalfCeil), "negate: HalfFloor->HalfCeil");
+    TCHECK_EQ(static_cast<int>(negateTemporalRoundingMode(RoundingMode::HalfCeil)), static_cast<int>(RoundingMode::HalfFloor), "negate: HalfCeil->HalfFloor");
+    // Symmetric modes unchanged
+    TCHECK_EQ(static_cast<int>(negateTemporalRoundingMode(RoundingMode::Trunc)), static_cast<int>(RoundingMode::Trunc), "negate: Trunc unchanged");
+    TCHECK_EQ(static_cast<int>(negateTemporalRoundingMode(RoundingMode::Expand)), static_cast<int>(RoundingMode::Expand), "negate: Expand unchanged");
+    TCHECK_EQ(static_cast<int>(negateTemporalRoundingMode(RoundingMode::HalfExpand)), static_cast<int>(RoundingMode::HalfExpand), "negate: HalfExpand unchanged");
+    TCHECK_EQ(static_cast<int>(negateTemporalRoundingMode(RoundingMode::HalfTrunc)), static_cast<int>(RoundingMode::HalfTrunc), "negate: HalfTrunc unchanged");
+    TCHECK_EQ(static_cast<int>(negateTemporalRoundingMode(RoundingMode::HalfEven)), static_cast<int>(RoundingMode::HalfEven), "negate: HalfEven unchanged");
+}
+
+// ---------------------------------------------------------------------------
+// isoDateAdd boundary/error cases
+// ---------------------------------------------------------------------------
+
+static void testISODateAddBoundaries()
+{
+    // temporal_rs: date_add_limits — adding to max date
+    // Max date + P1D -> error (out of range)
+    auto rOverMax = isoDateAdd({ 275760, 9, 13 }, ISO8601::Duration(0, 0, 0, 1, 0, 0, 0, 0, 0, 0), TemporalOverflow::Reject);
+    TCHECK_TRUE(!rOverMax.has_value(), "addBounds: max+1d rejects");
+
+    // Min date - P1D -> error
+    auto rUnderMin = isoDateAdd({ -271821, 4, 19 }, ISO8601::Duration(0, 0, 0, -1, 0, 0, 0, 0, 0, 0), TemporalOverflow::Reject);
+    TCHECK_TRUE(!rUnderMin.has_value(), "addBounds: min-1d rejects");
+
+    // Max date itself is valid
+    auto rMax = isoDateAdd({ 275760, 9, 12 }, ISO8601::Duration(0, 0, 0, 1, 0, 0, 0, 0, 0, 0), TemporalOverflow::Constrain);
+    TCHECK_TRUE(rMax.has_value(), "addBounds: max date ok");
+    TCHECK_EQ(rMax->year(), 275760, "addBounds: max year");
+    TCHECK_EQ(rMax->day(), 13u, "addBounds: max day");
+
+    // Constrain: exceed max -> constrain clamps
+    auto rConstrain = isoDateAdd({ 275760, 9, 13 }, ISO8601::Duration(0, 1, 0, 0, 0, 0, 0, 0, 0, 0), TemporalOverflow::Constrain);
+    // +1M from 275760-09-13 would be 275760-10-13 which exceeds max -> out of range
+    TCHECK_TRUE(!rConstrain.has_value(), "addBounds: exceed max+1M errors");
+}
+
+// ---------------------------------------------------------------------------
+// Negative number rounding — mirrors temporal_rs src/rounding.rs tests
+// ---------------------------------------------------------------------------
+
+static void testBalanceISOYearMonth()
+{
+    // Month overflow: 2021-13 -> 2022-01
+    auto r1 = balanceISOYearMonth(2021, 13);
+    TCHECK_EQ(r1.year(), 2022, "balanceYM: 2021m13 year");
+    TCHECK_EQ(r1.month(), 1u, "balanceYM: 2021m13 month");
+    // Month underflow: 2021-00 -> 2020-12
+    auto r2 = balanceISOYearMonth(2021, 0);
+    TCHECK_EQ(r2.year(), 2020, "balanceYM: 2021m0 year");
+    TCHECK_EQ(r2.month(), 12u, "balanceYM: 2021m0 month");
+    // No-op: 2020-06 -> 2020-06
+    auto r3 = balanceISOYearMonth(2020, 6);
+    TCHECK_EQ(r3.year(), 2020, "balanceYM: identity year");
+    TCHECK_EQ(r3.month(), 6u, "balanceYM: identity month");
+    // Large overflow: 2021-25 -> 2023-01
+    auto r4 = balanceISOYearMonth(2021, 25);
+    TCHECK_EQ(r4.year(), 2023, "balanceYM: 2021m25 year");
+    TCHECK_EQ(r4.month(), 1u, "balanceYM: 2021m25 month");
+}
+
+static void testISOTimeCompare()
+{
+    // Equal
+    TCHECK_EQ(isoTimeCompare({ 12, 0, 0, 0, 0, 0 }, { 12, 0, 0, 0, 0, 0 }), 0, "timeCompare: equal");
+    // Hour difference
+    TCHECK_EQ(isoTimeCompare({ 14, 0, 0, 0, 0, 0 }, { 12, 0, 0, 0, 0, 0 }), 1, "timeCompare: later hour");
+    TCHECK_EQ(isoTimeCompare({ 12, 0, 0, 0, 0, 0 }, { 14, 0, 0, 0, 0, 0 }), -1, "timeCompare: earlier hour");
+    // Nanosecond difference
+    ISO8601::PlainTime t1(0, 0, 0, 0, 0, 1), t2(0, 0, 0, 0, 0, 0);
+    TCHECK_EQ(isoTimeCompare(t1, t2), 1, "timeCompare: 1ns later");
+    TCHECK_EQ(isoTimeCompare(t2, t1), -1, "timeCompare: 1ns earlier");
+    // Max time vs min time
+    ISO8601::PlainTime maxT(23, 59, 59, 999, 999, 999), minT(0, 0, 0, 0, 0, 0);
+    TCHECK_EQ(isoTimeCompare(maxT, minT), 1, "timeCompare: max > min");
+}
+
+static void testApplyUnsignedRoundingMode()
+{
+    // x between r1 and r2 — direction modes
+    TCHECK_EQ(applyUnsignedRoundingMode(1.3, 1.0, 2.0, UnsignedRoundingMode::Zero), 1.0, "applyURM: 1.3 Zero");
+    TCHECK_EQ(applyUnsignedRoundingMode(1.3, 1.0, 2.0, UnsignedRoundingMode::Infinity), 2.0, "applyURM: 1.3 Inf");
+    // x == r1 (exact lower bound)
+    TCHECK_EQ(applyUnsignedRoundingMode(1.0, 1.0, 2.0, UnsignedRoundingMode::Zero), 1.0, "applyURM: exact=r1");
+    // HalfZero at midpoint
+    TCHECK_EQ(applyUnsignedRoundingMode(1.5, 1.0, 2.0, UnsignedRoundingMode::HalfZero), 1.0, "applyURM: 1.5 HalfZero");
+    TCHECK_EQ(applyUnsignedRoundingMode(1.5, 1.0, 2.0, UnsignedRoundingMode::HalfInfinity), 2.0, "applyURM: 1.5 HalfInf");
+    // HalfEven: 2.5 -> 2 (even lower), 3.5 -> 4 (even upper)
+    TCHECK_EQ(applyUnsignedRoundingMode(2.5, 2.0, 3.0, UnsignedRoundingMode::HalfEven), 2.0, "applyURM: 2.5 HalfEven->2");
+    TCHECK_EQ(applyUnsignedRoundingMode(3.5, 3.0, 4.0, UnsignedRoundingMode::HalfEven), 4.0, "applyURM: 3.5 HalfEven->4");
+}
+
+static void testMaximumInstantIncrement()
+{
+    TCHECK_EQ(maximumInstantIncrement(TemporalUnit::Hour), 24.0, "maxInstInc: Hour=24");
+    TCHECK_EQ(maximumInstantIncrement(TemporalUnit::Minute), 1440.0, "maxInstInc: Minute=1440");
+    TCHECK_EQ(maximumInstantIncrement(TemporalUnit::Second), 86400.0, "maxInstInc: Second=86400");
+    TCHECK_EQ(maximumInstantIncrement(TemporalUnit::Millisecond), 8.64e7, "maxInstInc: Ms");
+    TCHECK_EQ(maximumInstantIncrement(TemporalUnit::Microsecond), 8.64e10, "maxInstInc: µs");
+}
+
+// ---------------------------------------------------------------------------
+// validateTemporalRoundingIncrement
+// ---------------------------------------------------------------------------
+
+static void testValidateTemporalRoundingIncrement()
+{
+    // temporal_rs: RoundingIncrement::validate
+    // Valid: increment=1, dividend=60 (exclusive)
+    auto r1 = validateTemporalRoundingIncrement(1.0, 60.0, Inclusivity::Exclusive);
+    TCHECK_TRUE(r1.has_value(), "validate: 1 of 60 ok");
+
+    // Valid: increment=5, dividend=60 (exclusive) — 60/5=12 integer
+    auto r2 = validateTemporalRoundingIncrement(5.0, 60.0, Inclusivity::Exclusive);
+    TCHECK_TRUE(r2.has_value(), "validate: 5 of 60 ok");
+
+    // Valid: increment=60, dividend=60 (inclusive)
+    auto r3 = validateTemporalRoundingIncrement(60.0, 60.0, Inclusivity::Inclusive);
+    TCHECK_TRUE(r3.has_value(), "validate: 60 of 60 inclusive ok");
+
+    // Invalid: increment=61, dividend=60 (exclusive) — exceeds max
+    auto r4 = validateTemporalRoundingIncrement(61.0, 60.0, Inclusivity::Exclusive);
+    TCHECK_TRUE(!r4.has_value(), "validate: 61 of 60 rejects");
+
+    // Invalid: increment=60, dividend=60 (exclusive) — equal not allowed exclusive
+    auto r5 = validateTemporalRoundingIncrement(60.0, 60.0, Inclusivity::Exclusive);
+    TCHECK_TRUE(!r5.has_value(), "validate: 60 of 60 exclusive rejects");
+
+    // Invalid: increment=7, dividend=60 (exclusive) — not a divisor
+    auto r6 = validateTemporalRoundingIncrement(7.0, 60.0, Inclusivity::Exclusive);
+    TCHECK_TRUE(!r6.has_value(), "validate: 7 of 60 not divisor rejects");
+
+    // No dividend: any positive increment ok
+    auto r7 = validateTemporalRoundingIncrement(100.0, std::nullopt, Inclusivity::Exclusive);
+    TCHECK_TRUE(r7.has_value(), "validate: no dividend ok");
+}
+
+// ---------------------------------------------------------------------------
+// Comprehensive rounding: all 9 modes × positive/negative/midpoint
+// Directly ports temporal_rs rounding.rs test_basic_rounding_cases +
+// test_float_rounding_cases
+// ---------------------------------------------------------------------------
+
+static void testRoundingComprehensive()
+{
+    // --- Integer x=101, increment=10 (x not at midpoint, closer to 100) ---
+    TCHECK_EQ(roundNumberToIncrementInt128(Int128(101), Int128(10), RoundingMode::Ceil), Int128(110), "comp: 101 Ceil=110");
+    TCHECK_EQ(roundNumberToIncrementInt128(Int128(101), Int128(10), RoundingMode::Floor), Int128(100), "comp: 101 Floor=100");
+    TCHECK_EQ(roundNumberToIncrementInt128(Int128(101), Int128(10), RoundingMode::Expand), Int128(110), "comp: 101 Expand=110");
+    TCHECK_EQ(roundNumberToIncrementInt128(Int128(101), Int128(10), RoundingMode::Trunc), Int128(100), "comp: 101 Trunc=100");
+    TCHECK_EQ(roundNumberToIncrementInt128(Int128(101), Int128(10), RoundingMode::HalfCeil), Int128(100), "comp: 101 HalfCeil=100");
+    TCHECK_EQ(roundNumberToIncrementInt128(Int128(101), Int128(10), RoundingMode::HalfFloor), Int128(100), "comp: 101 HalfFloor=100");
+    TCHECK_EQ(roundNumberToIncrementInt128(Int128(101), Int128(10), RoundingMode::HalfExpand), Int128(100), "comp: 101 HalfExpand=100");
+    TCHECK_EQ(roundNumberToIncrementInt128(Int128(101), Int128(10), RoundingMode::HalfTrunc), Int128(100), "comp: 101 HalfTrunc=100");
+    TCHECK_EQ(roundNumberToIncrementInt128(Int128(101), Int128(10), RoundingMode::HalfEven), Int128(100), "comp: 101 HalfEven=100");
+
+    // --- Integer x=105, increment=10 (exactly at midpoint) ---
+    TCHECK_EQ(roundNumberToIncrementInt128(Int128(105), Int128(10), RoundingMode::Ceil), Int128(110), "comp: 105 Ceil=110");
+    TCHECK_EQ(roundNumberToIncrementInt128(Int128(105), Int128(10), RoundingMode::Floor), Int128(100), "comp: 105 Floor=100");
+    TCHECK_EQ(roundNumberToIncrementInt128(Int128(105), Int128(10), RoundingMode::Expand), Int128(110), "comp: 105 Expand=110");
+    TCHECK_EQ(roundNumberToIncrementInt128(Int128(105), Int128(10), RoundingMode::Trunc), Int128(100), "comp: 105 Trunc=100");
+    TCHECK_EQ(roundNumberToIncrementInt128(Int128(105), Int128(10), RoundingMode::HalfCeil), Int128(110), "comp: 105 HalfCeil=110");
+    TCHECK_EQ(roundNumberToIncrementInt128(Int128(105), Int128(10), RoundingMode::HalfFloor), Int128(100), "comp: 105 HalfFloor=100");
+    TCHECK_EQ(roundNumberToIncrementInt128(Int128(105), Int128(10), RoundingMode::HalfExpand), Int128(110), "comp: 105 HalfExpand=110");
+    TCHECK_EQ(roundNumberToIncrementInt128(Int128(105), Int128(10), RoundingMode::HalfTrunc), Int128(100), "comp: 105 HalfTrunc=100");
+    TCHECK_EQ(roundNumberToIncrementInt128(Int128(105), Int128(10), RoundingMode::HalfEven), Int128(100), "comp: 105 HalfEven=100 (even=10)");
+
+    // --- Integer x=107, increment=10 (closer to 110) ---
+    TCHECK_EQ(roundNumberToIncrementInt128(Int128(107), Int128(10), RoundingMode::Ceil), Int128(110), "comp: 107 Ceil=110");
+    TCHECK_EQ(roundNumberToIncrementInt128(Int128(107), Int128(10), RoundingMode::Floor), Int128(100), "comp: 107 Floor=100");
+    TCHECK_EQ(roundNumberToIncrementInt128(Int128(107), Int128(10), RoundingMode::Expand), Int128(110), "comp: 107 Expand=110");
+    TCHECK_EQ(roundNumberToIncrementInt128(Int128(107), Int128(10), RoundingMode::Trunc), Int128(100), "comp: 107 Trunc=100");
+    TCHECK_EQ(roundNumberToIncrementInt128(Int128(107), Int128(10), RoundingMode::HalfExpand), Int128(110), "comp: 107 HalfExpand=110");
+    TCHECK_EQ(roundNumberToIncrementInt128(Int128(107), Int128(10), RoundingMode::HalfTrunc), Int128(110), "comp: 107 HalfTrunc=110");
+    TCHECK_EQ(roundNumberToIncrementInt128(Int128(107), Int128(10), RoundingMode::HalfEven), Int128(110), "comp: 107 HalfEven=110");
+
+    // --- Negative x=-101, increment=10 ---
+    TCHECK_EQ(roundNumberToIncrementInt128(Int128(-101), Int128(10), RoundingMode::Ceil), Int128(-100), "comp: -101 Ceil=-100");
+    TCHECK_EQ(roundNumberToIncrementInt128(Int128(-101), Int128(10), RoundingMode::Floor), Int128(-110), "comp: -101 Floor=-110");
+    TCHECK_EQ(roundNumberToIncrementInt128(Int128(-101), Int128(10), RoundingMode::Expand), Int128(-110), "comp: -101 Expand=-110");
+    TCHECK_EQ(roundNumberToIncrementInt128(Int128(-101), Int128(10), RoundingMode::Trunc), Int128(-100), "comp: -101 Trunc=-100");
+    TCHECK_EQ(roundNumberToIncrementInt128(Int128(-101), Int128(10), RoundingMode::HalfExpand), Int128(-100), "comp: -101 HalfExpand=-100");
+    TCHECK_EQ(roundNumberToIncrementInt128(Int128(-101), Int128(10), RoundingMode::HalfTrunc), Int128(-100), "comp: -101 HalfTrunc=-100");
+    TCHECK_EQ(roundNumberToIncrementInt128(Int128(-101), Int128(10), RoundingMode::HalfEven), Int128(-100), "comp: -101 HalfEven=-100");
+
+    // --- Negative x=-105, increment=10 (midpoint) ---
+    TCHECK_EQ(roundNumberToIncrementInt128(Int128(-105), Int128(10), RoundingMode::Ceil), Int128(-100), "comp: -105 Ceil=-100");
+    TCHECK_EQ(roundNumberToIncrementInt128(Int128(-105), Int128(10), RoundingMode::Floor), Int128(-110), "comp: -105 Floor=-110");
+    TCHECK_EQ(roundNumberToIncrementInt128(Int128(-105), Int128(10), RoundingMode::HalfCeil), Int128(-100), "comp: -105 HalfCeil=-100");
+    TCHECK_EQ(roundNumberToIncrementInt128(Int128(-105), Int128(10), RoundingMode::HalfFloor), Int128(-110), "comp: -105 HalfFloor=-110");
+    TCHECK_EQ(roundNumberToIncrementInt128(Int128(-105), Int128(10), RoundingMode::HalfEven), Int128(-100), "comp: -105 HalfEven=-100 (even=10)");
+
+    // --- Small increment x=-9, increment=2 ---
+    TCHECK_EQ(roundNumberToIncrementInt128(Int128(-9), Int128(2), RoundingMode::Ceil), Int128(-8), "comp: -9 inc2 Ceil=-8");
+    TCHECK_EQ(roundNumberToIncrementInt128(Int128(-9), Int128(2), RoundingMode::Floor), Int128(-10), "comp: -9 inc2 Floor=-10");
+    TCHECK_EQ(roundNumberToIncrementInt128(Int128(-9), Int128(2), RoundingMode::HalfExpand), Int128(-10), "comp: -9 inc2 HalfExpand=-10");
+    TCHECK_EQ(roundNumberToIncrementInt128(Int128(-9), Int128(2), RoundingMode::HalfTrunc), Int128(-8), "comp: -9 inc2 HalfTrunc=-8");
+
+    // --- Float: -8.5, increment=1 (from temporal_rs test_float_rounding_cases) ---
+    TCHECK_EQ(roundNumberToIncrementDouble(-8.5, 1.0, RoundingMode::Ceil), -8.0, "float: -8.5 inc1 Ceil=-8");
+    TCHECK_EQ(roundNumberToIncrementDouble(-8.5, 1.0, RoundingMode::Floor), -9.0, "float: -8.5 inc1 Floor=-9");
+    TCHECK_EQ(roundNumberToIncrementDouble(-8.5, 1.0, RoundingMode::Expand), -9.0, "float: -8.5 inc1 Expand=-9");
+    TCHECK_EQ(roundNumberToIncrementDouble(-8.5, 1.0, RoundingMode::Trunc), -8.0, "float: -8.5 inc1 Trunc=-8");
+    TCHECK_EQ(roundNumberToIncrementDouble(-8.5, 1.0, RoundingMode::HalfCeil), -8.0, "float: -8.5 inc1 HalfCeil=-8");
+    TCHECK_EQ(roundNumberToIncrementDouble(-8.5, 1.0, RoundingMode::HalfFloor), -9.0, "float: -8.5 inc1 HalfFloor=-9");
+    TCHECK_EQ(roundNumberToIncrementDouble(-8.5, 1.0, RoundingMode::HalfExpand), -9.0, "float: -8.5 inc1 HalfExpand=-9");
+    TCHECK_EQ(roundNumberToIncrementDouble(-8.5, 1.0, RoundingMode::HalfTrunc), -8.0, "float: -8.5 inc1 HalfTrunc=-8");
+    TCHECK_EQ(roundNumberToIncrementDouble(-8.5, 1.0, RoundingMode::HalfEven), -8.0, "float: -8.5 inc1 HalfEven=-8 (even)");
+
+    // --- Float: -8.5, increment=2 ---
+    TCHECK_EQ(roundNumberToIncrementDouble(-8.5, 2.0, RoundingMode::Ceil), -8.0, "float: -8.5 inc2 Ceil=-8");
+    TCHECK_EQ(roundNumberToIncrementDouble(-8.5, 2.0, RoundingMode::Floor), -10.0, "float: -8.5 inc2 Floor=-10");
+    TCHECK_EQ(roundNumberToIncrementDouble(-8.5, 2.0, RoundingMode::HalfCeil), -8.0, "float: -8.5 inc2 HalfCeil=-8");
+    TCHECK_EQ(roundNumberToIncrementDouble(-8.5, 2.0, RoundingMode::HalfFloor), -8.0, "float: -8.5 inc2 HalfFloor=-8 (even)");
+    TCHECK_EQ(roundNumberToIncrementDouble(-8.5, 2.0, RoundingMode::HalfEven), -8.0, "float: -8.5 inc2 HalfEven=-8 (even)");
+
+    // --- Float: -9.5, increment=2 ---
+    TCHECK_EQ(roundNumberToIncrementDouble(-9.5, 2.0, RoundingMode::Ceil), -8.0, "float: -9.5 inc2 Ceil=-8");
+    TCHECK_EQ(roundNumberToIncrementDouble(-9.5, 2.0, RoundingMode::Floor), -10.0, "float: -9.5 inc2 Floor=-10");
+    TCHECK_EQ(roundNumberToIncrementDouble(-9.5, 2.0, RoundingMode::Expand), -10.0, "float: -9.5 inc2 Expand=-10");
+    TCHECK_EQ(roundNumberToIncrementDouble(-9.5, 2.0, RoundingMode::Trunc), -8.0, "float: -9.5 inc2 Trunc=-8");
+    TCHECK_EQ(roundNumberToIncrementDouble(-9.5, 2.0, RoundingMode::HalfCeil), -10.0, "float: -9.5 inc2 HalfCeil=-10");
+    TCHECK_EQ(roundNumberToIncrementDouble(-9.5, 2.0, RoundingMode::HalfFloor), -10.0, "float: -9.5 inc2 HalfFloor=-10");
+    TCHECK_EQ(roundNumberToIncrementDouble(-9.5, 2.0, RoundingMode::HalfExpand), -10.0, "float: -9.5 inc2 HalfExpand=-10");
+    TCHECK_EQ(roundNumberToIncrementDouble(-9.5, 2.0, RoundingMode::HalfTrunc), -10.0, "float: -9.5 inc2 HalfTrunc=-10 (not midpoint)");
+    TCHECK_EQ(roundNumberToIncrementDouble(-9.5, 2.0, RoundingMode::HalfEven), -10.0, "float: -9.5 inc2 HalfEven=-10 (even=5)");
+
+    // --- Large nanosecond value from temporal_rs dt_since_basic_rounding ---
+    // -84082624864197532 ns, increment=1800000000000 (30 min), HalfExpand
+    TCHECK_EQ(
+        roundNumberToIncrementInt128(Int128(-84082624864197532LL), Int128(1800000000000LL), RoundingMode::HalfExpand),
+        Int128(-84083400000000000LL),
+        "comp: large ns HalfExpand");
+}
+
+// ---------------------------------------------------------------------------
+// iso.rs exact epoch-day boundary values
+// temporal_rs: iso_date_to_epoch_days_limits + test_month_limits
+// ---------------------------------------------------------------------------
+
+static void testISOEpochDayLimits()
+{
+    // temporal_rs: iso_date_to_epoch_days_limits
+    // -271821-04-20 = abs(days) exactly 100_000_000 (= MAX_DAYS_BASE)
+    // isoDateAdd must succeed (within range)
+    auto rMin20 = isoDateAdd({ -271821, 4, 20 }, ISO8601::Duration(0, 0, 0, 0, 0, 0, 0, 0, 0, 0), TemporalOverflow::Reject);
+    TCHECK_TRUE(rMin20.has_value(), "epochDays: -271821-04-20 is valid");
+
+    // -271821-04-19 = abs(days) = MAX_DAYS_BASE + 1 -> valid Temporal lower bound
+    auto rMin19 = isoDateAdd({ -271821, 4, 19 }, ISO8601::Duration(0, 0, 0, 0, 0, 0, 0, 0, 0, 0), TemporalOverflow::Reject);
+    TCHECK_TRUE(rMin19.has_value(), "epochDays: -271821-04-19 is valid lower bound");
+
+    // -271821-04-18 = abs(days) = MAX_DAYS_BASE + 2 -> out of range
+    auto rMin18 = isoDateAdd({ -271821, 4, 18 }, ISO8601::Duration(0, 0, 0, 0, 0, 0, 0, 0, 0, 0), TemporalOverflow::Reject);
+    TCHECK_TRUE(!rMin18.has_value(), "epochDays: -271821-04-18 is out of range");
+
+    // 275760-09-13 = abs(days) = MAX_DAYS_BASE (valid upper bound)
+    auto rMax13 = isoDateAdd({ 275760, 9, 13 }, ISO8601::Duration(0, 0, 0, 0, 0, 0, 0, 0, 0, 0), TemporalOverflow::Reject);
+    TCHECK_TRUE(rMax13.has_value(), "epochDays: 275760-09-13 is valid upper bound");
+
+    // 275760-09-14 = abs(days) = MAX_DAYS_BASE + 1 -> out of range
+    auto rMax14 = isoDateAdd({ 275760, 9, 14 }, ISO8601::Duration(0, 0, 0, 0, 0, 0, 0, 0, 0, 0), TemporalOverflow::Reject);
+    TCHECK_TRUE(!rMax14.has_value(), "epochDays: 275760-09-14 is out of range");
+}
+
+// ---------------------------------------------------------------------------
+// rounding.rs: exact-multiple cases (x=100, inc=10) and (-100) and (-14, 3)
+// These complete the test_basic_rounding_cases table
+// ---------------------------------------------------------------------------
+
+static void testRoundingExactMultiples()
+{
+    // temporal_rs: x=100 inc=10 -> all modes return 100 (exact multiple)
+    TCHECK_EQ(roundNumberToIncrementInt128(Int128(100), Int128(10), RoundingMode::Ceil), Int128(100), "exact: 100 Ceil=100");
+    TCHECK_EQ(roundNumberToIncrementInt128(Int128(100), Int128(10), RoundingMode::Floor), Int128(100), "exact: 100 Floor=100");
+    TCHECK_EQ(roundNumberToIncrementInt128(Int128(100), Int128(10), RoundingMode::Expand), Int128(100), "exact: 100 Expand=100");
+    TCHECK_EQ(roundNumberToIncrementInt128(Int128(100), Int128(10), RoundingMode::Trunc), Int128(100), "exact: 100 Trunc=100");
+    TCHECK_EQ(roundNumberToIncrementInt128(Int128(100), Int128(10), RoundingMode::HalfCeil), Int128(100), "exact: 100 HalfCeil=100");
+    TCHECK_EQ(roundNumberToIncrementInt128(Int128(100), Int128(10), RoundingMode::HalfFloor), Int128(100), "exact: 100 HalfFloor=100");
+    TCHECK_EQ(roundNumberToIncrementInt128(Int128(100), Int128(10), RoundingMode::HalfExpand), Int128(100), "exact: 100 HalfExpand=100");
+    TCHECK_EQ(roundNumberToIncrementInt128(Int128(100), Int128(10), RoundingMode::HalfTrunc), Int128(100), "exact: 100 HalfTrunc=100");
+    TCHECK_EQ(roundNumberToIncrementInt128(Int128(100), Int128(10), RoundingMode::HalfEven), Int128(100), "exact: 100 HalfEven=100");
+
+    // Same for float
+    TCHECK_EQ(roundNumberToIncrementDouble(100.0, 10.0, RoundingMode::Ceil), 100.0, "exactF: 100 Ceil=100");
+    TCHECK_EQ(roundNumberToIncrementDouble(100.0, 10.0, RoundingMode::Floor), 100.0, "exactF: 100 Floor=100");
+    TCHECK_EQ(roundNumberToIncrementDouble(100.0, 10.0, RoundingMode::Expand), 100.0, "exactF: 100 Expand=100");
+    TCHECK_EQ(roundNumberToIncrementDouble(100.0, 10.0, RoundingMode::Trunc), 100.0, "exactF: 100 Trunc=100");
+
+    // temporal_rs: x=-100 inc=10 -> all modes return -100
+    TCHECK_EQ(roundNumberToIncrementInt128(Int128(-100), Int128(10), RoundingMode::Ceil), Int128(-100), "exact: -100 Ceil=-100");
+    TCHECK_EQ(roundNumberToIncrementInt128(Int128(-100), Int128(10), RoundingMode::Floor), Int128(-100), "exact: -100 Floor=-100");
+    TCHECK_EQ(roundNumberToIncrementInt128(Int128(-100), Int128(10), RoundingMode::Expand), Int128(-100), "exact: -100 Expand=-100");
+    TCHECK_EQ(roundNumberToIncrementInt128(Int128(-100), Int128(10), RoundingMode::Trunc), Int128(-100), "exact: -100 Trunc=-100");
+    TCHECK_EQ(roundNumberToIncrementInt128(Int128(-100), Int128(10), RoundingMode::HalfCeil), Int128(-100), "exact: -100 HalfCeil=-100");
+    TCHECK_EQ(roundNumberToIncrementInt128(Int128(-100), Int128(10), RoundingMode::HalfFloor), Int128(-100), "exact: -100 HalfFloor=-100");
+    TCHECK_EQ(roundNumberToIncrementInt128(Int128(-100), Int128(10), RoundingMode::HalfExpand), Int128(-100), "exact: -100 HalfExpand=-100");
+    TCHECK_EQ(roundNumberToIncrementInt128(Int128(-100), Int128(10), RoundingMode::HalfTrunc), Int128(-100), "exact: -100 HalfTrunc=-100");
+    TCHECK_EQ(roundNumberToIncrementInt128(Int128(-100), Int128(10), RoundingMode::HalfEven), Int128(-100), "exact: -100 HalfEven=-100");
+
+    // temporal_rs: x=-14, inc=3 (non-exact, between -15 and -12, closer to -15)
+    // -14 / 3: floor = -5 -> -15; ceil = -4 -> -12; remainder = (-14) mod 3 = 1 (one away from -15)
+    // midpoint of 3 = 1.5, so 1 < 1.5 -> closer to floor (-15)
+    TCHECK_EQ(roundNumberToIncrementInt128(Int128(-14), Int128(3), RoundingMode::Ceil), Int128(-12), "14/3: Ceil=-12");
+    TCHECK_EQ(roundNumberToIncrementInt128(Int128(-14), Int128(3), RoundingMode::Floor), Int128(-15), "14/3: Floor=-15");
+    TCHECK_EQ(roundNumberToIncrementInt128(Int128(-14), Int128(3), RoundingMode::Expand), Int128(-15), "14/3: Expand=-15");
+    TCHECK_EQ(roundNumberToIncrementInt128(Int128(-14), Int128(3), RoundingMode::Trunc), Int128(-12), "14/3: Trunc=-12");
+    TCHECK_EQ(roundNumberToIncrementInt128(Int128(-14), Int128(3), RoundingMode::HalfCeil), Int128(-15), "14/3: HalfCeil=-15");
+    TCHECK_EQ(roundNumberToIncrementInt128(Int128(-14), Int128(3), RoundingMode::HalfFloor), Int128(-15), "14/3: HalfFloor=-15");
+    TCHECK_EQ(roundNumberToIncrementInt128(Int128(-14), Int128(3), RoundingMode::HalfExpand), Int128(-15), "14/3: HalfExpand=-15");
+    TCHECK_EQ(roundNumberToIncrementInt128(Int128(-14), Int128(3), RoundingMode::HalfTrunc), Int128(-15), "14/3: HalfTrunc=-15");
+    TCHECK_EQ(roundNumberToIncrementInt128(Int128(-14), Int128(3), RoundingMode::HalfEven), Int128(-15), "14/3: HalfEven=-15");
+}
+
+// ---------------------------------------------------------------------------
+// plain_date.rs: simple_date_subtract + new_date_limits + rounding_increment_observed
+// ---------------------------------------------------------------------------
+
+static void testDateSubtract()
+{
+    // temporal_rs: simple_date_subtract — 2019-11-18 - P43Y = 1976-11-18
+    auto r1 = isoDateAdd({ 2019, 11, 18 }, ISO8601::Duration(-43, 0, 0, 0, 0, 0, 0, 0, 0, 0), TemporalOverflow::Constrain);
+    TCHECK_TRUE(r1.has_value(), "subtract: -43y ok");
+    TCHECK_EQ(r1->year(), 1976, "subtract: -43y year");
+    TCHECK_EQ(r1->month(), 11u, "subtract: -43y month");
+    TCHECK_EQ(r1->day(), 18u, "subtract: -43y day");
+
+    // 2019-11-18 - P11M = 2018-12-18
+    auto r2 = isoDateAdd({ 2019, 11, 18 }, ISO8601::Duration(0, -11, 0, 0, 0, 0, 0, 0, 0, 0), TemporalOverflow::Constrain);
+    TCHECK_TRUE(r2.has_value(), "subtract: -11m ok");
+    TCHECK_EQ(r2->year(), 2018, "subtract: -11m year");
+    TCHECK_EQ(r2->month(), 12u, "subtract: -11m month");
+    TCHECK_EQ(r2->day(), 18u, "subtract: -11m day");
+
+    // 2019-11-18 - P20D = 2019-10-29
+    auto r3 = isoDateAdd({ 2019, 11, 18 }, ISO8601::Duration(0, 0, 0, -20, 0, 0, 0, 0, 0, 0), TemporalOverflow::Constrain);
+    TCHECK_TRUE(r3.has_value(), "subtract: -20d ok");
+    TCHECK_EQ(r3->year(), 2019, "subtract: -20d year");
+    TCHECK_EQ(r3->month(), 10u, "subtract: -20d month");
+    TCHECK_EQ(r3->day(), 29u, "subtract: -20d day");
+}
+
+static void testNewDateLimits()
+{
+    // temporal_rs: new_date_limits — min valid = -271821-04-19, max valid = 275760-09-13
+    // Just below min: -271821-04-18 -> out of range
+    auto rErr1 = isoDateAdd({ -271821, 4, 18 }, ISO8601::Duration(0, 0, 0, 0, 0, 0, 0, 0, 0, 0), TemporalOverflow::Reject);
+    TCHECK_TRUE(!rErr1.has_value(), "newDateLimits: -271821-04-18 rejected");
+
+    // Just above max: 275760-09-14 -> out of range
+    auto rErr2 = isoDateAdd({ 275760, 9, 14 }, ISO8601::Duration(0, 0, 0, 0, 0, 0, 0, 0, 0, 0), TemporalOverflow::Reject);
+    TCHECK_TRUE(!rErr2.has_value(), "newDateLimits: 275760-09-14 rejected");
+
+    // Exact boundaries are valid
+    auto rOk1 = regulateISODate(-271821, 4, 19, TemporalOverflow::Reject);
+    TCHECK_TRUE(rOk1.has_value(), "newDateLimits: -271821-04-19 ok");
+    TCHECK_EQ(rOk1->year(), -271821, "newDateLimits: min year");
+    TCHECK_EQ(rOk1->month(), 4u, "newDateLimits: min month");
+    TCHECK_EQ(rOk1->day(), 19u, "newDateLimits: min day");
+
+    auto rOk2 = regulateISODate(275760, 9, 13, TemporalOverflow::Reject);
+    TCHECK_TRUE(rOk2.has_value(), "newDateLimits: 275760-09-13 ok");
+    TCHECK_EQ(rOk2->year(), 275760, "newDateLimits: max year");
+    TCHECK_EQ(rOk2->month(), 9u, "newDateLimits: max month");
+    TCHECK_EQ(rOk2->day(), 13u, "newDateLimits: max day");
+
+    // 275760-09-13 + 1D -> over max
+    auto rOver = isoDateAdd({ 275760, 9, 13 }, ISO8601::Duration(0, 0, 0, 1, 0, 0, 0, 0, 0, 0), TemporalOverflow::Reject);
+    TCHECK_TRUE(!rOver.has_value(), "newDateLimits: max+1d rejected");
+
+    // -271821-04-19 - 1D -> under min
+    auto rUnder = isoDateAdd({ -271821, 4, 19 }, ISO8601::Duration(0, 0, 0, -1, 0, 0, 0, 0, 0, 0), TemporalOverflow::Reject);
+    TCHECK_TRUE(!rUnder.has_value(), "newDateLimits: min-1d rejected");
+
+    // 275760-09-12 + 1D -> exactly max, valid
+    auto rExact = isoDateAdd({ 275760, 9, 12 }, ISO8601::Duration(0, 0, 0, 1, 0, 0, 0, 0, 0, 0), TemporalOverflow::Reject);
+    TCHECK_TRUE(rExact.has_value(), "newDateLimits: 275760-09-12+1d=max ok");
+    TCHECK_EQ(rExact->day(), 13u, "newDateLimits: 275760-09-12+1d day=13");
+
+    // -271821-04-20 - 1D -> exactly min, valid
+    auto rExact2 = isoDateAdd({ -271821, 4, 20 }, ISO8601::Duration(0, 0, 0, -1, 0, 0, 0, 0, 0, 0), TemporalOverflow::Reject);
+    TCHECK_TRUE(rExact2.has_value(), "newDateLimits: -271821-04-20-1d=min ok");
+    TCHECK_EQ(rExact2->day(), 19u, "newDateLimits: -271821-04-20-1d day=19");
+}
+
+static void testDateRoundingIncrement()
+{
+    // temporal_rs: rounding_increment_observed — date since with rounding increments
+    // 2021-09-07 since 2019-01-08, smallest=Year, inc=4, HalfExpand -> 4 years
+    // Actual diff ≈ 2.66 years -> rounds to 4 (nearest multiple of 4)
+    {
+        auto diff = diffISODate({ 2019, 1, 8 }, { 2021, 9, 7 }, TemporalUnit::Year);
+        // 2y 7m 29d ≈ 2.66y, rounded to inc=4 -> 4
+        double years = diff.years() + diff.months() / 12.0;
+        double roundedYears = roundNumberToIncrementDouble(years, 4.0, RoundingMode::HalfExpand);
+        TCHECK_EQ(static_cast<int64_t>(roundedYears), 4LL, "dateRoundInc: years inc=4 HalfExpand=4");
+    }
+
+    // smallest=Month, inc=10, HalfExpand -> 30 months (≈32m -> nearest 10 is 30)
+    {
+        auto diff = diffISODate({ 2019, 1, 8 }, { 2021, 9, 7 }, TemporalUnit::Month);
+        // 32 months -> rounded to inc=10 -> 30
+        double months = diff.months();
+        double roundedMonths = roundNumberToIncrementDouble(months, 10.0, RoundingMode::HalfExpand);
+        TCHECK_EQ(static_cast<int64_t>(roundedMonths), 30LL, "dateRoundInc: months inc=10 HalfExpand=30");
+    }
+
+    // smallest=Week, inc=12, HalfExpand -> 144 weeks
+    // temporal_rs: rounding_increment_observed — Week case
+    // 2019-01-08 to 2021-09-07 = 973 days = 139 weeks + 0 days
+    // 139 / 12 = 11.583... -> HalfExpand -> 12 -> 144 weeks
+    {
+        auto diff = diffISODate({ 2019, 1, 8 }, { 2021, 9, 7 }, TemporalUnit::Week);
+        // 973 days = 139 weeks exactly (973 = 139 * 7)
+        TCHECK_EQ(static_cast<int64_t>(diff.weeks()), 139LL, "dateRoundInc: weeks=139");
+        double weeks = diff.weeks();
+        double roundedWeeks = roundNumberToIncrementDouble(weeks, 12.0, RoundingMode::HalfExpand);
+        TCHECK_EQ(static_cast<int64_t>(roundedWeeks), 144LL, "dateRoundInc: weeks inc=12 HalfExpand=144");
+    }
+
+    // smallest=Day, inc=100, HalfExpand -> 1000 days
+    {
+        auto diff = diffISODate({ 2019, 1, 8 }, { 2021, 9, 7 }, TemporalUnit::Day);
+        // 973 days -> 1000 (nearest 100)
+        double days = diff.days();
+        double roundedDays = roundNumberToIncrementDouble(days, 100.0, RoundingMode::HalfExpand);
+        TCHECK_EQ(static_cast<int64_t>(roundedDays), 1000LL, "dateRoundInc: days inc=100 HalfExpand=1000");
+    }
+}
+
+// Note: testInvalidDateStrings and testCriticalUnknownAnnotation use
+// ISO8601::parseCalendarDateTime — confirmed JS_EXPORT_PRIVATE in ISO8601.h.
+
+// ---------------------------------------------------------------------------
+// invalid_strings — mirrors temporal_rs plain_date.rs test invalid_strings
+// test262/test/built-ins/Temporal/Calendar/prototype/month/argument-string-invalid.js
+// Tests that parseCalendarDateTime rejects invalid/unsupported ISO 8601 strings.
+// Note: "2020-01-01[u-ca=notexist]" is NOT tested here because it parses
+// successfully at the C++ layer; the calendar validation happens in JS.
+// ---------------------------------------------------------------------------
+
+static void testInvalidDateStrings()
+{
+    // temporal_rs: plain_date.rs test invalid_strings
+    // All of these must return std::nullopt from parseCalendarDateTime.
+    static const char* const invalidStrings[] = {
+        // Completely invalid
+        "",
+        "invalid iso8601",
+        // Day out of range
+        "2020-01-00",
+        "2020-01-32",
+        "2020-02-30",
+        "2021-02-29",
+        // Month out of range
+        "2020-00-01",
+        "2020-13-01",
+        // Trailing separator with no time
+        "2020-01-01T",
+        // Time fields out of range
+        "2020-01-01T25:00:00",
+        "2020-01-01T01:60:00",
+        "2020-01-01T01:60:61",
+        // Trailing junk
+        "2020-01-01junk",
+        "2020-01-01T00:00:00junk",
+        "2020-01-01T00:00:00+00:00junk",
+        "2020-01-01T00:00:00+00:00[UTC]junk",
+        "2020-01-01T00:00:00+00:00[UTC][u-ca=iso8601]junk",
+        // Non-standard year widths / formats
+        "02020-01-01",
+        "2020-001-01",
+        "2020-01-001",
+        "2020-01-01T001",
+        "2020-01-01T01:001",
+        "2020-01-01T01:01:001",
+        // Unsupported formats (week/ordinal)
+        "2020-W01-1",
+        "2020-001",
+        "+0002020-01-01",
+        // Too-short date (no day for Date format)
+        "2020-01",
+        "+002020-01",
+        "01-01",
+        "2020-W01",
+        // Duration strings (not dates)
+        "P1Y",
+        "-P12Y",
+        // Too many fractional second digits
+        "1970-01-01T00:00:00.1234567891",
+        "1970-01-01T00:00:00.1234567890",
+    };
+    for (auto* s : invalidStrings) {
+        auto r = ISO8601::parseCalendarDateTime(StringView::fromLatin1(s), TemporalDateFormat::Date);
+        TCHECK_TRUE(!r.has_value(), "invalidString: should reject");
+    }
+}
+
+// ---------------------------------------------------------------------------
+// argument_string_critical_unknown_annotation — mirrors temporal_rs plain_date.rs
+// test262: argument-string-critical-unknown-annotation.js
+// Strings with critical (!) unknown annotations must fail parsing.
+// ---------------------------------------------------------------------------
+
+static void testCriticalUnknownAnnotation()
+{
+    // temporal_rs: plain_date.rs test argument_string_critical_unknown_annotation
+    static const char* const criticalAnnotationStrings[] = {
+        "1970-01-01[!foo=bar]",
+        "1970-01-01T00:00[!foo=bar]",
+        "1970-01-01T00:00[UTC][!foo=bar]",
+        "1970-01-01T00:00[u-ca=iso8601][!foo=bar]",
+        "1970-01-01T00:00[UTC][!foo=bar][u-ca=iso8601]",
+        "1970-01-01T00:00[foo=bar][!_foo-bar0=Dont-Ignore-This-99999999999]",
+    };
+    for (auto* s : criticalAnnotationStrings) {
+        auto r = ISO8601::parseCalendarDateTime(StringView::fromLatin1(s), TemporalDateFormat::Date);
+        TCHECK_TRUE(!r.has_value(), "criticalAnnotation: should reject");
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Section 1: direct temporal_rs ports
+// ---------------------------------------------------------------------------
+
+static void runTemporalRSTests()
+{
+    // --- iso.rs ---
+    testISOEpochDayLimits(); // temporal_rs: iso_date_to_epoch_days_limits, test_month_limits
+
+    // --- rounding.rs ---
+    testMaximumRoundingIncrement(); // temporal_rs: (MaximumTemporalDurationRoundingIncrement)
+    testNegateRoundingMode(); // temporal_rs: RoundingMode::negate
+    testApplyUnsignedRoundingMode(); // temporal_rs: apply_unsigned_rounding_mode
+    testRoundNumberToIncrementDouble(); // temporal_rs: test_basic_rounding_cases (double)
+    testRoundNumberToIncrementInt128(); // temporal_rs: test_basic_rounding_cases (i128)
+    testRoundingExactMultiples(); // temporal_rs: test_basic_rounding_cases (exact multiples)
+    testRoundAsIfPositive(); // temporal_rs: round_as_if_positive
+    testRoundingComprehensive(); // temporal_rs: test_basic_rounding_cases, test_float_rounding_cases, dt_since_basic_rounding
+    testValidateTemporalRoundingIncrement(); // temporal_rs: RoundingIncrement::validate
+
+    // --- plain_date.rs ---
+    testBalanceISODate(); // temporal_rs: (balanceISODate)
+    testBalanceISOYearMonth(); // temporal_rs: (balanceISOYearMonth)
+    testRegulateISODate(); // temporal_rs: (regulateISODate)
+    testISODateAdd(); // temporal_rs: simple_date_add
+    testDateSubtract(); // temporal_rs: simple_date_subtract
+    testISODateAddBoundaries(); // temporal_rs: date_add_limits
+    testNewDateLimits(); // temporal_rs: new_date_limits
+    testISODateCompare(); // temporal_rs: (isoDateCompare)
+    testISOTimeCompare(); // temporal_rs: (isoTimeCompare)
+    testDiffISODate(); // temporal_rs: simple_date_until, simple_date_since
+    testDateRoundingIncrement(); // temporal_rs: rounding_increment_observed
+    testInvalidDateStrings(); // temporal_rs: invalid_strings
+    testCriticalUnknownAnnotation(); // temporal_rs: argument_string_critical_unknown_annotation
+}
+
+// ---------------------------------------------------------------------------
+// Section 2: additional stress tests beyond temporal_rs
+// ---------------------------------------------------------------------------
+
+static void runStressTests()
+{
+    // ISO arithmetic stress
+    testISODateLimits(); // Temporal epoch limit boundary checks
+    testNegativeRounding(); // Negative number rounding across all modes
+
+    // Calendar helpers
+    testCalendarDateAdd(); // ISO calendarDateAdd
+    testCalendarDateUntil(); // ISO calendarDateUntil
+
+    // Instant
+    testMaximumInstantIncrement(); // maximumInstantIncrement per unit
+}
+
+} // namespace TemporalCore
+} // namespace JSC
+
+// ---------------------------------------------------------------------------
+// Entry point (extern "C" so testapi.c can call it)
+// ---------------------------------------------------------------------------
+
+extern "C" int testTemporalCore()
+{
+    using namespace JSC::TemporalCore;
+    s_failures = 0;
+    runTemporalRSTests();
+    runStressTests();
+    if (s_failures)
+        fprintf(stderr, "testTemporalCore: %d test(s) FAILED\n", s_failures);
+    else
+        fprintf(stderr, "testTemporalCore: all tests passed\n");
+    return s_failures ? 1 : 0;
+}
+
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/JavaScriptCore/API/tests/TemporalCoreTest.h
+++ b/Source/JavaScriptCore/API/tests/TemporalCoreTest.h
@@ -1,0 +1,37 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// Tests mirror temporal_rs v0.2.3 test suite (src/builtins/core/).
+int testTemporalCore(void);
+
+#ifdef __cplusplus
+}
+#endif

--- a/Source/JavaScriptCore/API/tests/testapi.c
+++ b/Source/JavaScriptCore/API/tests/testapi.c
@@ -69,6 +69,7 @@
 #include "JSObjectGetProxyTargetTest.h"
 #include "MultithreadedMultiVMExecutionTest.h"
 #include "PingPongStackOverflowTest.h"
+#include "TemporalCoreTest.h"
 #include "TypedArrayCTest.h"
 #include "VMManagerStopTheWorldTest.h"
 
@@ -2334,6 +2335,7 @@ int main(int argc, char* argv[])
         JSGlobalContextRelease(context);
     }
     failed |= testTypedArrayCAPI();
+    failed |= testTemporalCore();
     failed |= testFunctionOverrides();
     failed |= testFunctionToString();
     failed |= testGlobalContextWithFinalizer();

--- a/Source/JavaScriptCore/CMakeLists.txt
+++ b/Source/JavaScriptCore/CMakeLists.txt
@@ -1484,6 +1484,10 @@ set(JavaScriptCore_PRIVATE_FRAMEWORK_HEADERS
     runtime/WriteBarrier.h
     runtime/WriteBarrierInlines.h
 
+    runtime/temporal/core/CalendarArithmetic.h
+    runtime/temporal/core/ISOArithmetic.h
+    runtime/temporal/core/InstantCore.h
+    runtime/temporal/core/Rounding.h
     runtime/temporal/core/TemporalCoreTypes.h
     runtime/temporal/core/TemporalEnums.h
 

--- a/Source/JavaScriptCore/JavaScriptCore.xcodeproj/project.pbxproj
+++ b/Source/JavaScriptCore/JavaScriptCore.xcodeproj/project.pbxproj
@@ -1062,6 +1062,7 @@
 		534638751E70DDEC00F12AC1 /* DeferredWorkTimer.h in Headers */ = {isa = PBXBuildFile; fileRef = 534638741E70DDEC00F12AC1 /* DeferredWorkTimer.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		53486BB71C1795C300F6F3AF /* JSTypedArray.h in Headers */ = {isa = PBXBuildFile; fileRef = 53486BB61C1795C300F6F3AF /* JSTypedArray.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		534902851C7276B70012BCB8 /* TypedArrayCTest.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 534902821C7242C80012BCB8 /* TypedArrayCTest.cpp */; };
+		FF356D302FA9DACE00213929 /* TemporalCoreTest.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FF356D2F2FA9DACE00213929 /* TemporalCoreTest.cpp */; };
 		534C457C1BC72411007476A7 /* JSTypedArrayViewConstructor.h in Headers */ = {isa = PBXBuildFile; fileRef = 534C457B1BC72411007476A7 /* JSTypedArrayViewConstructor.h */; };
 		534E034E1E4D4B1600213F64 /* AccessCase.h in Headers */ = {isa = PBXBuildFile; fileRef = 534E034D1E4D4B1600213F64 /* AccessCase.h */; };
 		534E03541E53BD2900213F64 /* IntrinsicGetterAccessCase.h in Headers */ = {isa = PBXBuildFile; fileRef = 534E03531E53BD2900213F64 /* IntrinsicGetterAccessCase.h */; };
@@ -2338,6 +2339,10 @@
 		FF356CF82FA9832600213929 /* TemporalCoreTypes.h in Headers */ = {isa = PBXBuildFile; fileRef = FF356CF32FA9832600213929 /* TemporalCoreTypes.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		FF356CFA2FA9837C00213929 /* TemporalObject.h in Headers */ = {isa = PBXBuildFile; fileRef = F6F1501A2693D33E004B98EF /* TemporalObject.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		FF41590C28FF3C6B00F80B96 /* WaiterListManager.h in Headers */ = {isa = PBXBuildFile; fileRef = FF41590B28FF3C6B00F80B96 /* WaiterListManager.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		FF6273A52FAD56220098B5A3 /* InstantCore.h in Headers */ = {isa = PBXBuildFile; fileRef = FF62739F2FAD56220098B5A3 /* InstantCore.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		FF6273A62FAD56220098B5A3 /* Rounding.h in Headers */ = {isa = PBXBuildFile; fileRef = FF6273A32FAD56220098B5A3 /* Rounding.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		FF6273A72FAD56220098B5A3 /* ISOArithmetic.h in Headers */ = {isa = PBXBuildFile; fileRef = FF6273A12FAD56220098B5A3 /* ISOArithmetic.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		FF6273A82FAD56220098B5A3 /* CalendarArithmetic.h in Headers */ = {isa = PBXBuildFile; fileRef = FF62739D2FAD56220098B5A3 /* CalendarArithmetic.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		FF6A4D7E2E663147001FB92C /* WasmModuleDebugInfo.h in Headers */ = {isa = PBXBuildFile; fileRef = FF6A4D7D2E663147001FB92C /* WasmModuleDebugInfo.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		FFA2E02A2EA16F37006661A3 /* ControlFlowTests.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FFA2E0222EA16F37006661A3 /* ControlFlowTests.cpp */; };
 		FFA2E02C2EA16F37006661A3 /* SpecialTests.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FFA2E0242EA16F37006661A3 /* SpecialTests.cpp */; };
@@ -4420,6 +4425,8 @@
 		53486BBA1C18E84500F6F3AF /* JSTypedArray.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = JSTypedArray.cpp; sourceTree = "<group>"; };
 		534902821C7242C80012BCB8 /* TypedArrayCTest.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = TypedArrayCTest.cpp; path = API/tests/TypedArrayCTest.cpp; sourceTree = "<group>"; };
 		534902831C7242C80012BCB8 /* TypedArrayCTest.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = TypedArrayCTest.h; path = API/tests/TypedArrayCTest.h; sourceTree = "<group>"; };
+		FF356D2E2FA9DACE00213929 /* TemporalCoreTest.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = TemporalCoreTest.h; path = API/tests/TemporalCoreTest.h; sourceTree = "<group>"; };
+		FF356D2F2FA9DACE00213929 /* TemporalCoreTest.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = TemporalCoreTest.cpp; path = API/tests/TemporalCoreTest.cpp; sourceTree = "<group>"; };
 		534C457A1BC703DC007476A7 /* TypedArrayConstructor.js */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.javascript; path = TypedArrayConstructor.js; sourceTree = "<group>"; };
 		534C457B1BC72411007476A7 /* JSTypedArrayViewConstructor.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = JSTypedArrayViewConstructor.h; sourceTree = "<group>"; };
 		534C457D1BC72549007476A7 /* JSTypedArrayViewConstructor.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = JSTypedArrayViewConstructor.cpp; sourceTree = "<group>"; };
@@ -6519,6 +6526,14 @@
 		FF356CF32FA9832600213929 /* TemporalCoreTypes.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = TemporalCoreTypes.h; sourceTree = "<group>"; };
 		FF356CF42FA9832600213929 /* TemporalEnums.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = TemporalEnums.h; sourceTree = "<group>"; };
 		FF41590B28FF3C6B00F80B96 /* WaiterListManager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WaiterListManager.h; sourceTree = "<group>"; };
+		FF62739D2FAD56220098B5A3 /* CalendarArithmetic.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CalendarArithmetic.h; sourceTree = "<group>"; };
+		FF62739E2FAD56220098B5A3 /* CalendarArithmetic.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = CalendarArithmetic.cpp; sourceTree = "<group>"; };
+		FF62739F2FAD56220098B5A3 /* InstantCore.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = InstantCore.h; sourceTree = "<group>"; };
+		FF6273A02FAD56220098B5A3 /* InstantCore.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = InstantCore.cpp; sourceTree = "<group>"; };
+		FF6273A12FAD56220098B5A3 /* ISOArithmetic.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ISOArithmetic.h; sourceTree = "<group>"; };
+		FF6273A22FAD56220098B5A3 /* ISOArithmetic.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = ISOArithmetic.cpp; sourceTree = "<group>"; };
+		FF6273A32FAD56220098B5A3 /* Rounding.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = Rounding.h; sourceTree = "<group>"; };
+		FF6273A42FAD56220098B5A3 /* Rounding.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = Rounding.cpp; sourceTree = "<group>"; };
 		FF6A4D7D2E663147001FB92C /* WasmModuleDebugInfo.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WasmModuleDebugInfo.h; sourceTree = "<group>"; };
 		FFA2E0212EA16F37006661A3 /* BinaryTests.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = BinaryTests.cpp; sourceTree = "<group>"; };
 		FFA2E0222EA16F37006661A3 /* ControlFlowTests.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = ControlFlowTests.cpp; sourceTree = "<group>"; };
@@ -7309,6 +7324,8 @@
 				65570F591AA4C00A009B3C23 /* Regress141275.mm */,
 				FEB51F6A1A97B688001F921C /* Regress141809.h */,
 				FEB51F6B1A97B688001F921C /* Regress141809.mm */,
+				FF356D2F2FA9DACE00213929 /* TemporalCoreTest.cpp */,
+				FF356D2E2FA9DACE00213929 /* TemporalCoreTest.h */,
 				FECB8B291D25CABB006F2463 /* testapi-function-overrides.js */,
 				14BD5A2D0A3E91F600BAF59C /* testapi.c */,
 				531D4E191F59CDD200EC836C /* testapi.cpp */,
@@ -10850,6 +10867,14 @@
 		FF356CF52FA9832600213929 /* core */ = {
 			isa = PBXGroup;
 			children = (
+				FF62739E2FAD56220098B5A3 /* CalendarArithmetic.cpp */,
+				FF62739D2FAD56220098B5A3 /* CalendarArithmetic.h */,
+				FF6273A02FAD56220098B5A3 /* InstantCore.cpp */,
+				FF62739F2FAD56220098B5A3 /* InstantCore.h */,
+				FF6273A22FAD56220098B5A3 /* ISOArithmetic.cpp */,
+				FF6273A12FAD56220098B5A3 /* ISOArithmetic.h */,
+				FF6273A42FAD56220098B5A3 /* Rounding.cpp */,
+				FF6273A32FAD56220098B5A3 /* Rounding.h */,
 				FF356CF32FA9832600213929 /* TemporalCoreTypes.h */,
 				FF356CF42FA9832600213929 /* TemporalEnums.h */,
 			);
@@ -11279,6 +11304,7 @@
 				1409ECC1225E178C00BEDD54 /* CachePayload.h in Headers */,
 				1409ECC0225E178100BEDD54 /* CacheUpdate.h in Headers */,
 				0FEC3C601F379F5300F59B6C /* CagedBarrierPtr.h in Headers */,
+				FF6273A82FAD56220098B5A3 /* CalendarArithmetic.h in Headers */,
 				BC18C3ED0E16F5CD00B34460 /* CallData.h in Headers */,
 				0F64B27A1A7957B2006E4E66 /* CallEdge.h in Headers */,
 				796DAA2B1E89CCD6005DF24A /* CalleeBits.h in Headers */,
@@ -11859,6 +11885,7 @@
 				0F49E9AA20AB4D00001CA0AA /* InstanceOfAccessCase.h in Headers */,
 				0FB399BF20AF6B3F0017E213 /* InstanceOfStatus.h in Headers */,
 				0FB399C020AF6B430017E213 /* InstanceOfVariant.h in Headers */,
+				FF6273A52FAD56220098B5A3 /* InstantCore.h in Headers */,
 				14A4680C216FA565000D2B1A /* Instruction.h in Headers */,
 				14C25B9E216EA36A00137764 /* InstructionStream.h in Headers */,
 				A7A8AF3B17ADB5F3005AB174 /* Int16Array.h in Headers */,
@@ -11916,6 +11943,7 @@
 				860BD801148EA6F200112B2F /* Intrinsic.h in Headers */,
 				534E03541E53BD2900213F64 /* IntrinsicGetterAccessCase.h in Headers */,
 				A38CA59E26DD84DE00C8D84C /* ISO8601.h in Headers */,
+				FF6273A72FAD56220098B5A3 /* ISOArithmetic.h in Headers */,
 				0FB467801FDDA6F1003FCB09 /* IsoCellSet.h in Headers */,
 				0FB467811FDDA6F7003FCB09 /* IsoCellSetInlines.h in Headers */,
 				E3BF1BAE238AAEDB003A1C2B /* IsoHeapCellType.h in Headers */,
@@ -12492,6 +12520,7 @@
 				FE9F3FB92613C7890069E89F /* ResourceExhaustion.h in Headers */,
 				869EBCB70E8C6D4A008722CC /* ResultType.h in Headers */,
 				FE3B642F25D6FB4D001ADDB4 /* RootMarkReason.h in Headers */,
+				FF6273A62FAD56220098B5A3 /* Rounding.h in Headers */,
 				0F2C63AA1E4FA42E00C13839 /* RunningScope.h in Headers */,
 				70B0A9D11A9B66460001306A /* RuntimeFlags.h in Headers */,
 				52C0611F1AA51E1C00B4ADBA /* RuntimeType.h in Headers */,
@@ -13930,6 +13959,7 @@
 				FE7C41961B97FC4B00F4D598 /* PingPongStackOverflowTest.cpp in Sources */,
 				65570F5A1AA4C3EA009B3C23 /* Regress141275.mm in Sources */,
 				FEB51F6C1A97B688001F921C /* Regress141809.mm in Sources */,
+				FF356D302FA9DACE00213929 /* TemporalCoreTest.cpp in Sources */,
 				1440F6100A4F85670005F061 /* testapi.c in Sources */,
 				53EAFE2F208DFAB4007D524B /* testapi.cpp in Sources */,
 				86D2221A167EF9440024C804 /* testapi.mm in Sources */,

--- a/Source/JavaScriptCore/Sources.txt
+++ b/Source/JavaScriptCore/Sources.txt
@@ -1151,6 +1151,11 @@ runtime/WeakSetPrototype.cpp
 runtime/WideningNumberPredictionFuzzerAgent.cpp
 runtime/WrapForValidIteratorPrototype.cpp
 
+runtime/temporal/core/CalendarArithmetic.cpp
+runtime/temporal/core/InstantCore.cpp
+runtime/temporal/core/ISOArithmetic.cpp
+runtime/temporal/core/Rounding.cpp
+
 tools/CellList.cpp
 tools/CharacterPropertyDataGenerator.cpp
 tools/CompilerTimingScope.cpp

--- a/Source/JavaScriptCore/runtime/ISO8601.cpp
+++ b/Source/JavaScriptCore/runtime/ISO8601.cpp
@@ -30,6 +30,7 @@
 #include "FractionToDouble.h"
 #include "IntlObject.h"
 #include "ParseInt.h"
+#include "Rounding.h"
 #include "TemporalObject.h"
 #include <bit>
 #include <limits>
@@ -1823,7 +1824,7 @@ static Int128 roundTemporalInstant(Int128 ns, unsigned increment, TemporalUnit u
 {
     auto unitLength = lengthInNanoseconds(unit);
     auto incrementNs = increment * unitLength;
-    return roundNumberToIncrementAsIfPositive(ns, incrementNs, roundingMode);
+    return TemporalCore::roundNumberToIncrementAsIfPositive(ns, incrementNs, roundingMode);
 }
 
 // https://tc39.es/proposal-temporal/#sec-validatetemporalroundingincrement
@@ -1881,7 +1882,7 @@ static Int128 roundTimeDurationToIncrement(JSGlobalObject* globalObject, Int128 
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    Int128 rounded = roundNumberToIncrementInt128(d, increment, roundingMode);
+    Int128 rounded = TemporalCore::roundNumberToIncrementInt128(d, increment, roundingMode);
     if (absInt128(rounded) > InternalDuration::maxTimeDuration) {
         throwRangeError(globalObject, scope, "Rounded time duration exceeds maximum"_s);
         return 0;

--- a/Source/JavaScriptCore/runtime/ISO8601.h
+++ b/Source/JavaScriptCore/runtime/ISO8601.h
@@ -39,6 +39,9 @@ static constexpr int32_t maxYear = 275760;
 static constexpr int32_t minYear = -271821;
 static constexpr int32_t outOfRangeYear = minYear - 1;
 
+static constexpr int32_t monthsPerYear = 12;
+static constexpr int32_t daysPerWeek = 7;
+
 class Duration {
     WTF_MAKE_TZONE_ALLOCATED(Duration);
 public:
@@ -473,7 +476,7 @@ using CalendarID = RFC9557Value;
 std::optional<std::tuple<PlainTime, std::optional<TimeZoneRecord>>> parseTime(StringView);
 std::optional<std::tuple<PlainTime, std::optional<TimeZoneRecord>, std::optional<CalendarID>>> parseCalendarTime(StringView);
 std::optional<std::tuple<PlainDate, std::optional<PlainTime>, std::optional<TimeZoneRecord>>> parseDateTime(StringView, TemporalDateFormat);
-std::optional<std::tuple<PlainDate, std::optional<PlainTime>, std::optional<TimeZoneRecord>, std::optional<CalendarID>>> parseCalendarDateTime(StringView, TemporalDateFormat);
+JS_EXPORT_PRIVATE std::optional<std::tuple<PlainDate, std::optional<PlainTime>, std::optional<TimeZoneRecord>, std::optional<CalendarID>>> parseCalendarDateTime(StringView, TemporalDateFormat);
 uint8_t dayOfWeek(PlainDate);
 uint16_t NODELETE dayOfYear(PlainDate);
 uint8_t weeksInYear(int32_t year);

--- a/Source/JavaScriptCore/runtime/TemporalDuration.cpp
+++ b/Source/JavaScriptCore/runtime/TemporalDuration.cpp
@@ -30,6 +30,7 @@
 #include "DateConstructor.h"
 #include "FractionToDouble.h"
 #include "IntlObjectInlines.h"
+#include "Rounding.h"
 #include "JSCInlines.h"
 #include "TemporalCalendar.h"
 #include "TemporalObject.h"
@@ -670,7 +671,7 @@ Nudged TemporalDuration::nudgeToCalendarUnit(JSGlobalObject* globalObject, int32
     ISO8601::Duration endDuration;
     switch (unit) {
     case TemporalUnit::Year: {
-        Int128 years = roundNumberToIncrementInt128((Int128) duration.dateDuration().years(),
+        Int128 years = TemporalCore::roundNumberToIncrementInt128((Int128) duration.dateDuration().years(),
             (Int128) increment, RoundingMode::Trunc);
         r1 = (double) years;
         r2 = (double) years + increment * sign;
@@ -679,7 +680,7 @@ Nudged TemporalDuration::nudgeToCalendarUnit(JSGlobalObject* globalObject, int32
         break;
     }
     case TemporalUnit::Month: {
-        Int128 months = roundNumberToIncrementInt128((Int128) duration.dateDuration().months(),
+        Int128 months = TemporalCore::roundNumberToIncrementInt128((Int128) duration.dateDuration().months(),
             (Int128) increment, RoundingMode::Trunc);
         r1 = (double) months;
         r2 = (double) months + increment * sign;
@@ -696,7 +697,7 @@ Nudged TemporalDuration::nudgeToCalendarUnit(JSGlobalObject* globalObject, int32
         RETURN_IF_EXCEPTION(scope, { });
         auto weeksEnd = TemporalCalendar::balanceISODate(globalObject, weeksStart.year(), weeksStart.month(), weeksStart.day() + duration.dateDuration().days());
         auto untilResult = TemporalCalendar::calendarDateUntil(weeksStart, weeksEnd, TemporalUnit::Week);
-        Int128 weeks = roundNumberToIncrementInt128((Int128) (duration.dateDuration().weeks() + untilResult.weeks()),
+        Int128 weeks = TemporalCore::roundNumberToIncrementInt128((Int128) (duration.dateDuration().weeks() + untilResult.weeks()),
             (Int128) increment, RoundingMode::Trunc);
         r1 = (double) weeks;
         r2 = (double) weeks + increment * sign;
@@ -708,7 +709,7 @@ Nudged TemporalDuration::nudgeToCalendarUnit(JSGlobalObject* globalObject, int32
     }
     default: {
         ASSERT(unit == TemporalUnit::Day);
-        Int128 days = roundNumberToIncrementInt128((Int128) duration.dateDuration().days(),
+        Int128 days = TemporalCore::roundNumberToIncrementInt128((Int128) duration.dateDuration().days(),
             (Int128) increment, RoundingMode::Trunc);
         r1 = (double) days;
         r2 = (double) days + increment * sign;
@@ -743,7 +744,7 @@ Nudged TemporalDuration::nudgeToCalendarUnit(JSGlobalObject* globalObject, int32
     double roundedUnit = std::abs(r2);
     if (progress != 1) {
         ASSERT(std::abs(r1) <= std::abs(total) && std::abs(total) < std::abs(r2));
-        roundedUnit = applyUnsignedRoundingMode(
+        roundedUnit = TemporalCore::applyUnsignedRoundingMode(
             std::abs(total), std::abs(r1), std::abs(r2), unsignedRoundingMode);
     }
     bool didExpandCalendarUnit = true;
@@ -770,7 +771,7 @@ static NudgeResult nudgeToDayOrTime(JSGlobalObject* globalObject, ISO8601::Inter
     Int128 timeDuration = add24HourDaysToTimeDuration(globalObject, duration.time(), duration.dateDuration().days());
     RETURN_IF_EXCEPTION(scope, { });
     Int128 unitLength = lengthInNanoseconds(smallestUnit);
-    Int128 roundedTime = roundNumberToIncrementInt128(timeDuration,
+    Int128 roundedTime = TemporalCore::roundNumberToIncrementInt128(timeDuration,
         unitLength * (Int128) std::trunc(increment), roundingMode);
     Int128 diffTime = roundedTime - timeDuration;
     double wholeDays = totalTimeDuration(timeDuration, TemporalUnit::Day);
@@ -935,7 +936,7 @@ ISO8601::InternalDuration TemporalDuration::round(JSGlobalObject* globalObject, 
 
     if (unit == TemporalUnit::Day) {
         double fractionalDays = totalTimeDuration(internalDuration.time(), TemporalUnit::Day);
-        double days = roundNumberToIncrementDouble(fractionalDays, increment, mode);
+        double days = TemporalCore::roundNumberToIncrementDouble(fractionalDays, increment, mode);
         return ISO8601::InternalDuration::combineDateAndTimeDuration(
             ISO8601::Duration { 0, 0, 0, static_cast<int64_t>(days), 0, 0, 0, 0, 0, 0 },
             0);
@@ -1019,7 +1020,7 @@ ISO8601::Duration TemporalDuration::round(JSGlobalObject* globalObject, JSValue 
         throwRangeError(globalObject, scope, "smallestUnit must be smaller than largestUnit"_s);
         return { };
     }
-    auto maximum = maximumRoundingIncrement(smallestUnit);
+    auto maximum = TemporalCore::maximumRoundingIncrement(smallestUnit);
     validateTemporalRoundingIncrement(globalObject, roundingIncrement, maximum, Inclusivity::Exclusive);
     RETURN_IF_EXCEPTION(scope, { });
 

--- a/Source/JavaScriptCore/runtime/TemporalInstant.cpp
+++ b/Source/JavaScriptCore/runtime/TemporalInstant.cpp
@@ -30,6 +30,7 @@
 #include "AuxiliaryBarrierInlines.h"
 #include "Error.h"
 #include "ISO8601.h"
+#include "InstantCore.h"
 #include "IntlObjectInlines.h"
 #include "JSBigInt.h"
 #include "JSGlobalObject.h"
@@ -245,24 +246,7 @@ ISO8601::Duration TemporalInstant::difference(JSGlobalObject* globalObject, Temp
 
 // Must return a double because the maximum increment for nanoseconds
 // does not fit in an int32_t
-static constexpr double NODELETE maximumIncrement(TemporalUnit smallestUnit)
-{
-    switch (smallestUnit) {
-    case TemporalUnit::Hour: return 24;
-    case TemporalUnit::Minute: return 1440;
-    case TemporalUnit::Second: return 86400;
-    case TemporalUnit::Millisecond: return 8.64e7;
-    case TemporalUnit::Microsecond: return 8.64e10;
-    case TemporalUnit::Nanosecond: return 8.64e13;
-    case TemporalUnit::Year:
-    case TemporalUnit::Month:
-    case TemporalUnit::Week:
-    case TemporalUnit::Day:
-    default:
-        { }
-    }
-    RELEASE_ASSERT_NOT_REACHED();
-}
+static constexpr double NODELETE maximumIncrement(TemporalUnit u) { return TemporalCore::maximumInstantIncrement(u); }
 
 ISO8601::ExactTime TemporalInstant::round(JSGlobalObject* globalObject, JSValue optionsValue) const
 {

--- a/Source/JavaScriptCore/runtime/TemporalObject.cpp
+++ b/Source/JavaScriptCore/runtime/TemporalObject.cpp
@@ -29,6 +29,7 @@
 #include "JSGlobalObject.h"
 #include "JSObjectInlines.h"
 #include "ObjectPrototype.h"
+#include "Rounding.h"
 #include "TemporalCalendarConstructor.h"
 #include "TemporalCalendarPrototype.h"
 #include "TemporalDurationConstructor.h"
@@ -309,27 +310,11 @@ void validateTemporalUnitValue(JSGlobalObject* globalObject, Variant<TemporalAut
 // https://tc39.es/proposal-temporal/#sec-validatetemporalroundingincrement
 void validateTemporalRoundingIncrement(JSGlobalObject* globalObject, double increment, std::optional<double> dividend, Inclusivity isInclusive)
 {
-    VM& vm = globalObject->vm();
-    auto scope = DECLARE_THROW_SCOPE(vm);
-
-    double maximum;
-    if (!dividend)
-        maximum = 1'000'000'000;
-    else if (isInclusive == Inclusivity::Inclusive)
-        maximum = dividend.value();
-    else if (dividend.value() > 1)
-        maximum = dividend.value() - 1;
-    else
-        maximum = 1;
-
-    increment = std::trunc(increment);
-    if (increment < 1 || increment > maximum) [[unlikely]] {
-        throwRangeError(globalObject, scope, "rounding increment is out of range"_s);
-        return;
-    }
-    if (dividend && std::fmod(dividend.value(), increment)) [[unlikely]] {
-        throwRangeError(globalObject, scope, makeString("roundingIncrement value does not divide "_s, dividend.value(), " evenly"_s));
-        return;
+    auto result = TemporalCore::validateTemporalRoundingIncrement(increment, dividend, isInclusive);
+    if (!result) {
+        VM& vm = globalObject->vm();
+        auto scope = DECLARE_THROW_SCOPE(vm);
+        throwRangeError(globalObject, scope, result.error().message);
     }
 }
 
@@ -400,7 +385,7 @@ std::tuple<TemporalUnit, TemporalUnit, RoundingMode, double> extractDifferenceOp
         return { };
     }
 
-    auto maximum = maximumRoundingIncrement(smallestUnit);
+    auto maximum = TemporalCore::maximumRoundingIncrement(smallestUnit);
     validateTemporalRoundingIncrement(globalObject, roundingIncrement, maximum, Inclusivity::Exclusive);
     RETURN_IF_EXCEPTION(scope, { });
 
@@ -515,50 +500,6 @@ RoundingMode temporalRoundingMode(JSGlobalObject* globalObject, JSObject* option
         }, "roundingMode must be \"ceil\", \"floor\", \"expand\", \"trunc\", \"halfCeil\", \"halfFloor\", \"halfExpand\", \"halfTrunc\", or \"halfEven\""_s, fallback);
 }
 
-// https://tc39.es/proposal-temporal/#sec-temporal-negatetemporalroundingmode
-RoundingMode negateTemporalRoundingMode(RoundingMode roundingMode)
-{
-    switch (roundingMode) {
-    case RoundingMode::Ceil:
-        return RoundingMode::Floor;
-    case RoundingMode::Floor:
-        return RoundingMode::Ceil;
-    case RoundingMode::HalfCeil:
-        return RoundingMode::HalfFloor;
-    case RoundingMode::HalfFloor:
-        return RoundingMode::HalfCeil;
-    default:
-        return roundingMode;
-    }
-}
-
-// https://tc39.es/proposal-temporal/#sec-applyunsignedroundingmode
-// ApplyUnsignedRoundingMode ( x, r1, r2, unsignedRoundingMode )
-double applyUnsignedRoundingMode(double x, double r1, double r2, UnsignedRoundingMode unsignedRoundingMode)
-{
-    if (x == r1)
-        return r1;
-    ASSERT(r1 < x && x < r2);
-    if (unsignedRoundingMode == UnsignedRoundingMode::Zero)
-        return r1;
-    if (unsignedRoundingMode == UnsignedRoundingMode::Infinity)
-        return r2;
-    double d1 = x - r1;
-    double d2 = r2 - x;
-    if (d1 < d2)
-        return r1;
-    if (d2 < d1)
-        return r2;
-    ASSERT(d1 == d2);
-    if (unsignedRoundingMode == UnsignedRoundingMode::HalfZero)
-        return r1;
-    if (unsignedRoundingMode == UnsignedRoundingMode::HalfInfinity)
-        return r2;
-    ASSERT(unsignedRoundingMode == UnsignedRoundingMode::HalfEven);
-    auto cardinality = std::fmod(r1 / (r2 - r1), 2);
-    return !cardinality ? r1 : r2;
-}
-
 void formatSecondsStringFraction(StringBuilder& builder, unsigned fraction, std::tuple<Precision, unsigned> precision)
 {
     auto [precisionType, precisionValue] = precision;
@@ -584,19 +525,6 @@ void formatSecondsStringPart(StringBuilder& builder, unsigned second, unsigned f
 
     builder.append(':', pad('0', 2, second));
     formatSecondsStringFraction(builder, fraction, precision.precision);
-}
-
-// MaximumTemporalDurationRoundingIncrement ( unit )
-// https://tc39.es/proposal-temporal/#sec-temporal-maximumtemporaldurationroundingincrement
-std::optional<unsigned> maximumRoundingIncrement(TemporalUnit unit)
-{
-    if (unit <= TemporalUnit::Day)
-        return std::nullopt;
-    if (unit == TemporalUnit::Hour)
-        return 24;
-    if (unit <= TemporalUnit::Second)
-        return 60;
-    return 1000;
 }
 
 static double doubleNumberOption(JSGlobalObject* globalObject, JSObject* options, PropertyName property, double defaultValue)
@@ -637,125 +565,6 @@ double temporalRoundingIncrement(JSGlobalObject* globalObject, JSObject* options
     RETURN_IF_EXCEPTION(scope, 0);
 
     return std::trunc(increment);
-}
-
-// RoundNumberToIncrement ( x, increment, roundingMode )
-// https://tc39.es/proposal-temporal/#sec-temporal-roundnumbertoincrement
-// See comment on roundNumberToIncrementInt128() for why there are two
-// roundNumberToIncrement functions.
-double roundNumberToIncrementDouble(double x, double increment, RoundingMode mode)
-{
-    auto quotient = x / increment;
-    auto truncatedQuotient = std::trunc(quotient);
-    if (truncatedQuotient == quotient)
-        return truncatedQuotient * increment;
-
-    auto isNegative = quotient < 0;
-    auto expandedQuotient = isNegative ? truncatedQuotient - 1 : truncatedQuotient + 1;
-
-    if (mode >= RoundingMode::HalfCeil) {
-        auto unsignedFractionalPart = std::abs(quotient - truncatedQuotient);
-        if (unsignedFractionalPart < 0.5)
-            return truncatedQuotient * increment;
-        if (unsignedFractionalPart > 0.5)
-            return expandedQuotient * increment;
-    }
-
-    switch (mode) {
-    case RoundingMode::Ceil:
-    case RoundingMode::HalfCeil:
-        return (isNegative ? truncatedQuotient : expandedQuotient) * increment;
-    case RoundingMode::Floor:
-    case RoundingMode::HalfFloor:
-        return (isNegative ? expandedQuotient : truncatedQuotient) * increment;
-    case RoundingMode::Expand:
-    case RoundingMode::HalfExpand:
-        return expandedQuotient * increment;
-    case RoundingMode::Trunc:
-    case RoundingMode::HalfTrunc:
-        return truncatedQuotient * increment;
-    case RoundingMode::HalfEven:
-        return (!std::fmod(truncatedQuotient, 2) ? truncatedQuotient : expandedQuotient) * increment;
-    }
-
-    RELEASE_ASSERT_NOT_REACHED();
-}
-
-// RoundNumberToIncrementAsIfPositive ( x, increment, roundingMode )
-// https://tc39.es/proposal-temporal/#sec-temporal-roundnumbertoincrementasifpositive
-Int128 roundNumberToIncrementAsIfPositive(Int128 x, Int128 increment, RoundingMode roundingMode)
-{
-    // The following code follows the polyfill rather than the spec, because we don't have float128.
-    // ApplyUnsignedRoundingMode is inlined here to mirror the polyfill's implementation of it,
-    // which has a different type than in the spec.
-    // See https://github.com/tc39/proposal-temporal/blob/main/polyfill/lib/ecmascript.mjs#L4056
-    Int128 quotient = x / increment;
-    Int128 remainder = x % increment;
-    auto unsignedRoundingMode = getUnsignedRoundingMode(roundingMode, false);
-    auto r1 = quotient;
-    auto r2 = quotient + 1;
-    if (x < 0) {
-        r1 = quotient - 1;
-        r2 = quotient;
-    }
-    auto doubleRemainder = absInt128(remainder * 2);
-    auto cmp = (doubleRemainder < increment ? -1 : doubleRemainder == increment ? 0 : 1)
-        * (x < 0 ? -1 : 1);
-    auto even = r1 % 2;
-    if (quotient * increment == x)
-        return x;
-    if (unsignedRoundingMode == UnsignedRoundingMode::Zero)
-        return r1 * increment;
-    if (unsignedRoundingMode == UnsignedRoundingMode::Infinity)
-        return r2 * increment;
-    if (cmp < 0)
-        return r1 * increment;
-    if (cmp > 0)
-        return r2 * increment;
-    if (unsignedRoundingMode == UnsignedRoundingMode::HalfZero)
-        return r1 * increment;
-    if (unsignedRoundingMode == UnsignedRoundingMode::HalfInfinity)
-        return r2 * increment;
-    return !even ? r1 * increment : r2 * increment;
-}
-
-// There are two different versions of this method due to the lack
-// of float128. The names are different (roundNumberToIncrementInt128() and
-// roundNumberToIncrementDouble()) to avoid confusion in the presence of
-// implicit casts.
-// https://tc39.es/proposal-temporal/#sec-temporal-roundnumbertoincrement
-Int128 roundNumberToIncrementInt128(Int128 x, Int128 increment, RoundingMode mode)
-{
-    // This follows the polyfill code rather than the spec, in order to work around
-    // being unable to apply floating-point division in x / increment.
-    // See https://github.com/tc39/proposal-temporal/blob/main/polyfill/lib/ecmascript.mjs#L4043
-    Int128 quotient = x / increment;
-    Int128 remainder = x % increment;
-    bool isNegative = x < 0;
-    Int128 r1 = absInt128(quotient);
-    Int128 r2 = r1 + 1;
-    Int128 even = r1 % 2;
-    auto unsignedRoundingMode = getUnsignedRoundingMode(mode, isNegative);
-    Int128 rounded = 0;
-    if (absInt128(x) == r1 * increment)
-        rounded = r1;
-    else if (unsignedRoundingMode == UnsignedRoundingMode::Zero)
-        rounded = r1;
-    else if (unsignedRoundingMode == UnsignedRoundingMode::Infinity)
-        rounded = r2;
-    else if (absInt128(remainder * 2) < increment)
-        rounded = r1;
-    else if (absInt128(remainder * 2) > increment)
-        rounded = r2;
-    else if (unsignedRoundingMode == UnsignedRoundingMode::HalfZero)
-        rounded = r1;
-    else if (unsignedRoundingMode == UnsignedRoundingMode::HalfInfinity)
-        rounded = r2;
-    else
-        rounded = !even ? r1 : r2;
-    if (isNegative)
-        rounded = -rounded;
-    return rounded * increment;
 }
 
 TemporalOverflow toTemporalOverflow(JSGlobalObject* globalObject, JSObject* options)

--- a/Source/JavaScriptCore/runtime/TemporalObject.h
+++ b/Source/JavaScriptCore/runtime/TemporalObject.h
@@ -22,55 +22,10 @@
 #pragma once
 
 #include <JavaScriptCore/JSObject.h>
+#include <JavaScriptCore/TemporalCoreTypes.h>
 #include <JavaScriptCore/TemporalEnums.h>
-#include <wtf/Int128.h>
 
 namespace JSC {
-
-#define JSC_TEMPORAL_PLAIN_DATE_UNITS(macro) \
-    macro(year, Year) \
-    macro(month, Month) \
-    macro(day, Day) \
-
-#define JSC_TEMPORAL_PLAIN_MONTH_DAY_UNITS(macro) \
-    macro(month, Month) \
-    macro(day, Day)
-
-#define JSC_TEMPORAL_PLAIN_YEAR_MONTH_UNITS(macro) \
-    macro(year, Year) \
-    macro(month, Month)
-
-#define JSC_TEMPORAL_PLAIN_TIME_UNITS(macro) \
-    macro(hour, Hour) \
-    macro(minute, Minute) \
-    macro(second, Second) \
-    macro(millisecond, Millisecond) \
-    macro(microsecond, Microsecond) \
-    macro(nanosecond, Nanosecond) \
-
-
-#define JSC_TEMPORAL_UNITS(macro) \
-    macro(year, Year) \
-    macro(month, Month) \
-    macro(week, Week) \
-    macro(day, Day) \
-    JSC_TEMPORAL_PLAIN_TIME_UNITS(macro) \
-
-
-enum class TemporalUnit : uint8_t {
-#define JSC_DEFINE_TEMPORAL_UNIT_ENUM(name, capitalizedName) capitalizedName,
-    JSC_TEMPORAL_UNITS(JSC_DEFINE_TEMPORAL_UNIT_ENUM)
-#undef JSC_DEFINE_TEMPORAL_UNIT_ENUM
-};
-#define JSC_COUNT_TEMPORAL_UNITS(name, capitalizedName) + 1
-static constexpr unsigned numberOfTemporalUnits = 0 JSC_TEMPORAL_UNITS(JSC_COUNT_TEMPORAL_UNITS);
-static constexpr unsigned numberOfTemporalPlainDateUnits = 0 JSC_TEMPORAL_PLAIN_DATE_UNITS(JSC_COUNT_TEMPORAL_UNITS);
-static constexpr unsigned numberOfTemporalPlainTimeUnits = 0 JSC_TEMPORAL_PLAIN_TIME_UNITS(JSC_COUNT_TEMPORAL_UNITS);
-static constexpr unsigned numberOfTemporalPlainYearMonthUnits = 0 JSC_TEMPORAL_PLAIN_YEAR_MONTH_UNITS(JSC_COUNT_TEMPORAL_UNITS);
-static constexpr unsigned numberOfTemporalPlainMonthDayUnits = 0 JSC_TEMPORAL_PLAIN_MONTH_DAY_UNITS(JSC_COUNT_TEMPORAL_UNITS);
-#undef JSC_COUNT_TEMPORAL_UNITS
-
-extern const TemporalUnit temporalUnitsInTableOrder[numberOfTemporalUnits];
 
 class TemporalObject final : public JSNonFinalObject {
 public:
@@ -98,26 +53,6 @@ enum class TemporalAuto : bool {
     Auto
 };
 
-enum class RoundingMode : uint8_t {
-    Ceil,
-    Floor,
-    Expand,
-    Trunc,
-    HalfCeil,
-    HalfFloor,
-    HalfExpand,
-    HalfTrunc,
-    HalfEven
-};
-
-enum class UnsignedRoundingMode : uint8_t {
-    Infinity,
-    Zero,
-    HalfInfinity,
-    HalfZero,
-    HalfEven
-};
-
 enum class Precision : uint8_t {
     Minute,
     Fixed,
@@ -140,16 +75,6 @@ enum class AllowedUnit : uint8_t {
     Auto,
     Day,
     None
-};
-
-enum class Inclusivity : bool {
-    Inclusive,
-    Exclusive
-};
-
-enum class DifferenceOperation : bool {
-    Since,
-    Until
 };
 
 enum class AddOrSubtract : bool {
@@ -179,70 +104,11 @@ std::tuple<TemporalUnit, TemporalUnit, RoundingMode, double> extractDifferenceOp
 std::optional<unsigned> temporalFractionalSecondDigits(JSGlobalObject*, JSObject* options);
 PrecisionData secondsStringPrecision(JSGlobalObject*, JSObject* options);
 RoundingMode temporalRoundingMode(JSGlobalObject*, JSObject*, RoundingMode);
-RoundingMode NODELETE negateTemporalRoundingMode(RoundingMode);
 void formatSecondsStringFraction(StringBuilder&, unsigned fraction, std::tuple<Precision, unsigned>);
 void formatSecondsStringPart(StringBuilder&, unsigned second, unsigned fraction, PrecisionData);
-std::optional<unsigned> NODELETE maximumRoundingIncrement(TemporalUnit);
 double temporalRoundingIncrement(JSGlobalObject*, JSObject* options);
 double roundNumberToIncrement(double, double increment, RoundingMode);
-double roundNumberToIncrementDouble(double, double increment, RoundingMode);
-Int128 NODELETE roundNumberToIncrementInt128(Int128, Int128, RoundingMode);
-Int128 NODELETE roundNumberToIncrementAsIfPositive(Int128, Int128, RoundingMode);
-double NODELETE applyUnsignedRoundingMode(double, double, double, UnsignedRoundingMode);
 void rejectObjectWithCalendarOrTimeZone(JSGlobalObject*, JSObject*);
-
-constexpr Int128 lengthInNanoseconds(TemporalUnit unit)
-{
-    switch (unit) {
-    case TemporalUnit::Nanosecond:
-        return 1;
-    case TemporalUnit::Microsecond:
-        return 1000;
-    case TemporalUnit::Millisecond:
-        return 1000 * lengthInNanoseconds(TemporalUnit::Microsecond);
-    case TemporalUnit::Second:
-        return 1000 * lengthInNanoseconds(TemporalUnit::Millisecond);
-    case TemporalUnit::Minute:
-        return 60 * lengthInNanoseconds(TemporalUnit::Second);
-    case TemporalUnit::Hour:
-        return 60 * lengthInNanoseconds(TemporalUnit::Minute);
-    case TemporalUnit::Day:
-        return 24 * lengthInNanoseconds(TemporalUnit::Hour);
-    default:
-        break;
-    }
-    RELEASE_ASSERT_NOT_REACHED();
-}
-
-// https://tc39.es/proposal-temporal/#sec-getunsignedroundingmode
-constexpr UnsignedRoundingMode getUnsignedRoundingMode(RoundingMode roundingMode, bool isNegative)
-{
-    switch (roundingMode) {
-    case RoundingMode::Ceil:
-        return isNegative ? UnsignedRoundingMode::Zero : UnsignedRoundingMode::Infinity;
-    case RoundingMode::Floor:
-        return isNegative ? UnsignedRoundingMode::Infinity : UnsignedRoundingMode::Zero;
-    case RoundingMode::Expand:
-        return UnsignedRoundingMode::Infinity;
-    case RoundingMode::Trunc:
-        return UnsignedRoundingMode::Zero;
-    case RoundingMode::HalfCeil:
-        return isNegative ? UnsignedRoundingMode::HalfZero : UnsignedRoundingMode::HalfInfinity;
-    case RoundingMode::HalfFloor:
-        return isNegative ? UnsignedRoundingMode::HalfInfinity : UnsignedRoundingMode::HalfZero;
-    case RoundingMode::HalfExpand:
-        return UnsignedRoundingMode::HalfInfinity;
-    case RoundingMode::HalfTrunc:
-        return UnsignedRoundingMode::HalfZero;
-    default:
-        return UnsignedRoundingMode::HalfEven;
-    }
-}
-
-enum class TemporalOverflow : bool {
-    Constrain,
-    Reject,
-};
 
 TemporalOverflow toTemporalOverflow(JSGlobalObject*, JSObject*);
 TemporalOverflow toTemporalOverflow(JSGlobalObject*, JSValue);

--- a/Source/JavaScriptCore/runtime/TemporalPlainDate.cpp
+++ b/Source/JavaScriptCore/runtime/TemporalPlainDate.cpp
@@ -29,6 +29,7 @@
 
 #include "DateConstructor.h"
 #include "IntlObjectInlines.h"
+#include "Rounding.h"
 #include "JSCInlines.h"
 #include "LazyPropertyInlines.h"
 #include "TemporalDuration.h"
@@ -526,7 +527,7 @@ ISO8601::Duration TemporalPlainDate::since(JSGlobalObject* globalObject, Tempora
 
     auto [smallestUnit, largestUnit, roundingMode, increment] = extractDifferenceOptions(globalObject, optionsValue, UnitGroup::Date, TemporalUnit::Day, TemporalUnit::Day);
     RETURN_IF_EXCEPTION(scope, { });
-    roundingMode = negateTemporalRoundingMode(roundingMode);
+    roundingMode = TemporalCore::negateTemporalRoundingMode(roundingMode);
 
     RELEASE_AND_RETURN(scope, differenceTemporalPlainDate(globalObject,
         DifferenceOperation::Since, other, smallestUnit, largestUnit, roundingMode, increment));

--- a/Source/JavaScriptCore/runtime/TemporalPlainDateTime.cpp
+++ b/Source/JavaScriptCore/runtime/TemporalPlainDateTime.cpp
@@ -29,6 +29,7 @@
 #include "IntlObjectInlines.h"
 #include "JSCInlines.h"
 #include "LazyPropertyInlines.h"
+#include "Rounding.h"
 #include "TemporalPlainDate.h"
 #include "TemporalPlainTime.h"
 #include "VMTrapsInlines.h"
@@ -352,7 +353,7 @@ TemporalPlainDateTime* TemporalPlainDateTime::round(JSGlobalObject* globalObject
     unsigned maximum = 1;
     Inclusivity isInclusive = Inclusivity::Inclusive;
     if (smallestUnit != TemporalUnit::Day) {
-        auto maximumOptional = maximumRoundingIncrement(smallestUnit);
+        auto maximumOptional = TemporalCore::maximumRoundingIncrement(smallestUnit);
         ASSERT(maximumOptional);
         maximum = maximumOptional.value();
         isInclusive = Inclusivity::Exclusive;

--- a/Source/JavaScriptCore/runtime/TemporalPlainTime.cpp
+++ b/Source/JavaScriptCore/runtime/TemporalPlainTime.cpp
@@ -28,6 +28,7 @@
 #include "TemporalPlainTime.h"
 
 #include "IntlObjectInlines.h"
+#include "Rounding.h"
 #include "JSCInlines.h"
 #include "LazyPropertyInlines.h"
 #include "TemporalDuration.h"
@@ -205,42 +206,42 @@ ISO8601::Duration TemporalPlainTime::roundTime(ISO8601::PlainTime plainTime, dou
     case TemporalUnit::Day: {
         double length = dayLengthNs.value_or(8.64 * 1e13);
         quantity = (((((plainTime.hour() * 60.0 + plainTime.minute()) * 60.0 + plainTime.second()) * 1000.0 + plainTime.millisecond()) * 1000.0 + plainTime.microsecond()) * 1000.0 + plainTime.nanosecond()) / length;
-        auto result = roundNumberToIncrementDouble(quantity, increment, roundingMode);
+        auto result = TemporalCore::roundNumberToIncrementDouble(quantity, increment, roundingMode);
         return ISO8601::Duration(0, 0, 0, result, 0, 0, 0, 0, 0, 0);
     }
     case TemporalUnit::Hour: {
         quantity = (fractionalSecond(plainTime) / 60.0 + plainTime.minute()) / 60.0 + plainTime.hour();
-        auto result = roundNumberToIncrementDouble(quantity, increment, roundingMode);
+        auto result = TemporalCore::roundNumberToIncrementDouble(quantity, increment, roundingMode);
         ASSERT(std::isfinite(result));
         return balanceTime(static_cast<Int128>(result), 0, 0, 0, 0, 0);
     }
     case TemporalUnit::Minute: {
         quantity = fractionalSecond(plainTime) / 60.0 + plainTime.minute();
-        auto result = roundNumberToIncrementDouble(quantity, increment, roundingMode);
+        auto result = TemporalCore::roundNumberToIncrementDouble(quantity, increment, roundingMode);
         ASSERT(std::isfinite(result));
         return balanceTime(static_cast<Int128>(plainTime.hour()), static_cast<Int128>(result), 0, 0, 0, 0);
     }
     case TemporalUnit::Second: {
         quantity = fractionalSecond(plainTime);
-        auto result = roundNumberToIncrementDouble(quantity, increment, roundingMode);
+        auto result = TemporalCore::roundNumberToIncrementDouble(quantity, increment, roundingMode);
         ASSERT(std::isfinite(result));
         return balanceTime(static_cast<Int128>(plainTime.hour()), static_cast<Int128>(plainTime.minute()), static_cast<Int128>(result), 0, 0, 0);
     }
     case TemporalUnit::Millisecond: {
         quantity = plainTime.millisecond() + plainTime.microsecond() * 1e-3 + plainTime.nanosecond() * 1e-6;
-        auto result = roundNumberToIncrementDouble(quantity, increment, roundingMode);
+        auto result = TemporalCore::roundNumberToIncrementDouble(quantity, increment, roundingMode);
         ASSERT(std::isfinite(result));
         return balanceTime(static_cast<Int128>(plainTime.hour()), static_cast<Int128>(plainTime.minute()), static_cast<Int128>(plainTime.second()), static_cast<Int128>(result), 0, 0);
     }
     case TemporalUnit::Microsecond: {
         quantity = plainTime.microsecond() + plainTime.nanosecond() * 1e-3;
-        auto result = roundNumberToIncrementDouble(quantity, increment, roundingMode);
+        auto result = TemporalCore::roundNumberToIncrementDouble(quantity, increment, roundingMode);
         ASSERT(std::isfinite(result));
         return balanceTime(static_cast<Int128>(plainTime.hour()), static_cast<Int128>(plainTime.minute()), static_cast<Int128>(plainTime.second()), static_cast<Int128>(plainTime.millisecond()), static_cast<Int128>(result), 0);
     }
     case TemporalUnit::Nanosecond: {
         quantity = plainTime.nanosecond();
-        auto result = roundNumberToIncrementDouble(quantity, increment, roundingMode);
+        auto result = TemporalCore::roundNumberToIncrementDouble(quantity, increment, roundingMode);
         ASSERT(std::isfinite(result));
         return balanceTime(static_cast<Int128>(plainTime.hour()), static_cast<Int128>(plainTime.minute()), static_cast<Int128>(plainTime.second()), static_cast<Int128>(plainTime.millisecond()), static_cast<Int128>(plainTime.microsecond()), static_cast<Int128>(result));
     }
@@ -296,7 +297,7 @@ ISO8601::PlainTime TemporalPlainTime::round(JSGlobalObject* globalObject, JSValu
     auto smallestUnit = smallest.value();
     validateTemporalUnitValue(globalObject, smallestUnit, UnitGroup::Time, AllowedUnit::None, "smallestUnit"_s);
     RETURN_IF_EXCEPTION(scope, { });
-    auto maximum = maximumRoundingIncrement(smallestUnit);
+    auto maximum = TemporalCore::maximumRoundingIncrement(smallestUnit);
     validateTemporalRoundingIncrement(globalObject, roundingIncrement, maximum, Inclusivity::Exclusive);
     RETURN_IF_EXCEPTION(scope, { });
 

--- a/Source/JavaScriptCore/runtime/TemporalPlainYearMonth.cpp
+++ b/Source/JavaScriptCore/runtime/TemporalPlainYearMonth.cpp
@@ -28,6 +28,7 @@
 #include "TemporalPlainYearMonth.h"
 
 #include "IntlObjectInlines.h"
+#include "Rounding.h"
 #include "JSCInlines.h"
 #include "LazyPropertyInlines.h"
 #include "TemporalDuration.h"
@@ -260,7 +261,7 @@ ISO8601::Duration TemporalPlainYearMonth::sinceOrUntil(JSGlobalObject* globalObj
     RETURN_IF_EXCEPTION(scope, { });
 
     if (op == DifferenceOperation::Since)
-        roundingMode = negateTemporalRoundingMode(roundingMode);
+        roundingMode = TemporalCore::negateTemporalRoundingMode(roundingMode);
 
     RELEASE_AND_RETURN(scope, TemporalCalendar::differenceTemporalPlainYearMonth<op>(globalObject, plainYearMonth(), other->plainYearMonth(), increment, smallestUnit, largestUnit, roundingMode));
 }

--- a/Source/JavaScriptCore/runtime/temporal/core/CalendarArithmetic.cpp
+++ b/Source/JavaScriptCore/runtime/temporal/core/CalendarArithmetic.cpp
@@ -23,46 +23,33 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#pragma once
-
-// JSC Temporal Core — Shared types and error handling
-// temporal_rs reference: src/error.rs
-
-#include <wtf/Expected.h>
-#include <wtf/text/ASCIILiteral.h>
-#include <wtf/text/WTFString.h>
+#include "config.h"
+#include "CalendarArithmetic.h"
 
 namespace JSC {
-
-// TemporalErrorKind — temporal_rs: ErrorKind (src/error.rs)
-enum class TemporalErrorKind : uint8_t {
-    RangeError,
-    TypeError,
-};
-
-// TemporalError — temporal_rs: TemporalError (src/error.rs)
-struct TemporalError {
-    TemporalErrorKind kind;
-    String message;
-};
-
-// TemporalResult<T> — temporal_rs: TemporalResult<T> = Result<T, TemporalError>
-template<typename T>
-using TemporalResult = Expected<T, TemporalError>;
-
-// Convenience constructors — temporal_rs: TemporalError::range() / TemporalError::type_()
 namespace TemporalCore {
-inline TemporalError rangeError(ASCIILiteral msg) { return { TemporalErrorKind::RangeError, String(msg) }; }
-inline TemporalError rangeError(String msg) { return { TemporalErrorKind::RangeError, WTF::move(msg) }; }
-inline TemporalError typeError(ASCIILiteral msg) { return { TemporalErrorKind::TypeError, String(msg) }; }
-inline TemporalError typeError(String msg) { return { TemporalErrorKind::TypeError, WTF::move(msg) }; }
+
+// CalendarDateUntil (ISO8601 path) — temporal_rs: Calendar::date_until
+// https://tc39.es/proposal-temporal/#sec-temporal-calendardateuntil (ISO8601 path)
+ISO8601::Duration calendarDateUntil(const ISO8601::PlainDate& one, const ISO8601::PlainDate& two, TemporalUnit largestUnit)
+{
+    // 3. If calendar is "iso8601", then
+    //    3.k. Return ! CreateDateDurationRecord(years, months, weeks, days).
+    // (full ISO8601 path implemented in diffISODate)
+    return diffISODate(one, two, largestUnit);
+}
+
+// CalendarDateAdd (ISO8601 path) — temporal_rs: Calendar::date_add
+// https://tc39.es/proposal-temporal/#sec-temporal-calendardateadd (ISO8601 path)
+TemporalResult<ISO8601::PlainDate> calendarDateAdd(const ISO8601::PlainDate& date, const ISO8601::Duration& duration, TemporalOverflow overflow)
+{
+    // 1. If calendar is "iso8601", then
+    //    1.a-1.d. BalanceISOYearMonth + RegulateISODate + AddDaysToISODate.
+    //    3. If ISODateWithinLimits(result) is false, throw a RangeError.
+    //    4. Return result.
+    // (full ISO8601 path implemented in isoDateAdd)
+    return isoDateAdd(date, duration, overflow);
+}
+
 } // namespace TemporalCore
-
-// TransitionDirection — temporal_rs: TransitionDirection (timezone_provider crate, src/provider.rs)
-// Used by getTimeZoneTransition to indicate search direction.
-enum class TransitionDirection : bool {
-    Next,
-    Previous,
-};
-
 } // namespace JSC

--- a/Source/JavaScriptCore/runtime/temporal/core/CalendarArithmetic.h
+++ b/Source/JavaScriptCore/runtime/temporal/core/CalendarArithmetic.h
@@ -25,44 +25,22 @@
 
 #pragma once
 
-// JSC Temporal Core — Shared types and error handling
-// temporal_rs reference: src/error.rs
+// JSC Temporal Core — Calendar arithmetic (ISO8601 path)
+// temporal_rs reference: src/builtins/core/calendar.rs
+// Last synced: v0.2.3
 
-#include <wtf/Expected.h>
-#include <wtf/text/ASCIILiteral.h>
-#include <wtf/text/WTFString.h>
+#include <JavaScriptCore/ISO8601.h>
+#include <JavaScriptCore/ISOArithmetic.h>
+#include <JavaScriptCore/JSExportMacros.h>
+#include <JavaScriptCore/TemporalCoreTypes.h>
+#include <JavaScriptCore/TemporalObject.h>
 
 namespace JSC {
-
-// TemporalErrorKind — temporal_rs: ErrorKind (src/error.rs)
-enum class TemporalErrorKind : uint8_t {
-    RangeError,
-    TypeError,
-};
-
-// TemporalError — temporal_rs: TemporalError (src/error.rs)
-struct TemporalError {
-    TemporalErrorKind kind;
-    String message;
-};
-
-// TemporalResult<T> — temporal_rs: TemporalResult<T> = Result<T, TemporalError>
-template<typename T>
-using TemporalResult = Expected<T, TemporalError>;
-
-// Convenience constructors — temporal_rs: TemporalError::range() / TemporalError::type_()
 namespace TemporalCore {
-inline TemporalError rangeError(ASCIILiteral msg) { return { TemporalErrorKind::RangeError, String(msg) }; }
-inline TemporalError rangeError(String msg) { return { TemporalErrorKind::RangeError, WTF::move(msg) }; }
-inline TemporalError typeError(ASCIILiteral msg) { return { TemporalErrorKind::TypeError, String(msg) }; }
-inline TemporalError typeError(String msg) { return { TemporalErrorKind::TypeError, WTF::move(msg) }; }
+
+ISO8601::Duration JS_EXPORT_PRIVATE calendarDateUntil(const ISO8601::PlainDate& one, const ISO8601::PlainDate& two, TemporalUnit largestUnit);
+
+TemporalResult<ISO8601::PlainDate> JS_EXPORT_PRIVATE calendarDateAdd(const ISO8601::PlainDate&, const ISO8601::Duration&, TemporalOverflow);
+
 } // namespace TemporalCore
-
-// TransitionDirection — temporal_rs: TransitionDirection (timezone_provider crate, src/provider.rs)
-// Used by getTimeZoneTransition to indicate search direction.
-enum class TransitionDirection : bool {
-    Next,
-    Previous,
-};
-
 } // namespace JSC

--- a/Source/JavaScriptCore/runtime/temporal/core/ISOArithmetic.cpp
+++ b/Source/JavaScriptCore/runtime/temporal/core/ISOArithmetic.cpp
@@ -1,0 +1,320 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "ISOArithmetic.h"
+
+#include "DateConstructor.h"
+#include <wtf/CheckedArithmetic.h>
+#include <wtf/DateMath.h>
+
+namespace JSC {
+namespace TemporalCore {
+
+// BalanceISOYearMonth — temporal_rs: balance_iso_year_month_with_clamp — uses i64 + div_euclid/rem_euclid
+// https://tc39.es/proposal-temporal/#sec-temporal-balanceisoyearmonth
+ISO8601::PlainYearMonth balanceISOYearMonth(int64_t year, int64_t month)
+{
+    // 1. Set year to year + floor((month - 1) / 12).
+    // NOTE: C++ integer division truncates toward zero; apply floor correction for negative month-1.
+    int64_t m0 = month - 1;
+    int64_t yearAdd = m0 / ISO8601::monthsPerYear;
+    int64_t newM0 = m0 % ISO8601::monthsPerYear;
+    if (newM0 < 0) {
+        yearAdd--;
+        newM0 += ISO8601::monthsPerYear; // adjust for C++ truncation toward zero
+    }
+    year += yearAdd;
+    // 2. Set month to ((month - 1) modulo 12) + 1.
+    month = newM0 + 1;
+    // 3. Return ISO Year-Month Record { [[Year]]: year, [[Month]]: month }.
+    // NOTE: clamp year to representable range (outOfRangeYear sentinel); callers check.
+    if (year < ISO8601::minYear || year > ISO8601::maxYear) [[unlikely]]
+        year = ISO8601::outOfRangeYear;
+    return ISO8601::PlainYearMonth(static_cast<int32_t>(year), static_cast<unsigned>(month));
+}
+
+// BalanceISODate — temporal_rs: IsoDate::balance
+// Equivalent to AddDaysToISODate in current spec (days already folded into the day parameter by callers).
+// https://tc39.es/proposal-temporal/#sec-temporal-adddaystoisodate
+// NOTE: Returns { outOfRangeYear, 1, 1 } for out-of-bounds dates instead of throwing (callers check).
+ISO8601::PlainDate balanceISODate(int32_t year, int32_t month, int64_t day)
+{
+    if (year == ISO8601::outOfRangeYear) [[unlikely]]
+        return ISO8601::PlainDate { ISO8601::outOfRangeYear, 1, 1 };
+    // 1. Let epochDays be ISODateToEpochDays(year, month - 1, day).
+    // (WTF makeDay takes 0-based month, matching ISODateToEpochDays(year, month-1, day))
+    auto epochDays = makeDay(static_cast<double>(year), static_cast<double>(month - 1), static_cast<double>(day));
+    // 2. Let ms be EpochDaysToEpochMs(epochDays, 0).
+    double ms = makeDate(epochDays, 0);
+    double daysToUse = msToDays(ms);
+    if (!isInBounds<int32_t>(daysToUse)) [[unlikely]]
+        return ISO8601::PlainDate { ISO8601::outOfRangeYear, 1, 1 };
+    // 3. Return CreateISODateRecord(EpochTimeToEpochYear(ms), EpochTimeToMonthInYear(ms) + 1, EpochTimeToDate(ms)).
+    auto [y, m, d] = WTF::yearMonthDayFromDays(static_cast<int32_t>(daysToUse));
+    if (!ISO8601::isYearWithinLimits(y)) [[unlikely]]
+        return ISO8601::PlainDate { ISO8601::outOfRangeYear, static_cast<unsigned>(m + 1), static_cast<unsigned>(d) };
+    return ISO8601::PlainDate { y, static_cast<unsigned>(m + 1), static_cast<unsigned>(d) };
+}
+
+// RegulateISODate — temporal_rs: IsoDate::regulate (overflow constrain/reject)
+// https://tc39.es/proposal-temporal/#sec-temporal-regulateisodate
+TemporalResult<ISO8601::PlainDate> regulateISODate(int32_t year, int32_t month, int64_t day, TemporalOverflow overflow)
+{
+    // 1. If overflow is ~constrain~, then
+    if (overflow == TemporalOverflow::Constrain) {
+        // a. Set month to the result of clamping month between 1 and 12.
+        if (month < 1)
+            month = 1;
+        else if (month > 12)
+            month = 12;
+        // b. Let daysInMonth be ISODaysInMonth(year, month).
+        auto maxDay = static_cast<int64_t>(ISO8601::daysInMonth(year, static_cast<uint8_t>(month)));
+        // c. Set day to the result of clamping day between 1 and daysInMonth.
+        if (day < 1)
+            day = 1;
+        else if (day > maxDay)
+            day = maxDay;
+    } else {
+        // 2.a. Assert: overflow is ~reject~.
+        // 2.b. If IsValidISODate(year, month, day) is false, throw a RangeError exception.
+        if (month < 1 || month > 12
+            || day < 1 || day > ISO8601::daysInMonth(year, static_cast<uint8_t>(month)))
+            return makeUnexpected(rangeError("date time is out of range of ECMAScript representation"_s));
+    }
+    // 3. Return CreateISODateRecord(year, month, day).
+    return ISO8601::PlainDate(year, static_cast<unsigned>(month), static_cast<unsigned>(day));
+}
+
+// AddISODate (ISO8601 path of CalendarDateAdd) — temporal_rs: IsoDate::add_date_duration — uses i64 arithmetic throughout
+// https://tc39.es/proposal-temporal/#sec-temporal-calendardateadd
+TemporalResult<ISO8601::PlainDate> isoDateAdd(const ISO8601::PlainDate& plainDate, const ISO8601::Duration& duration, TemporalOverflow overflow)
+{
+    // 1.a. Let intermediate be BalanceISOYearMonth(isoDate.[[Year]] + duration.[[Years]], isoDate.[[Month]] + duration.[[Months]]).
+    int64_t years = static_cast<int64_t>(plainDate.year()) + duration.years();
+    int64_t months = static_cast<int64_t>(plainDate.month()) + duration.months();
+    ISO8601::PlainYearMonth intermediate = balanceISOYearMonth(years, months);
+    // 1.b. Set intermediate to ? RegulateISODate(intermediate.[[Year]], intermediate.[[Month]], isoDate.[[Day]], overflow).
+    auto intermediate1 = regulateISODate(intermediate.year(), static_cast<int32_t>(intermediate.month()), static_cast<int64_t>(plainDate.day()), overflow);
+    if (!intermediate1)
+        return makeUnexpected(rangeError("date time is out of range of ECMAScript representation"_s));
+    // 1.c. Let days be duration.[[Days]] + 7 × duration.[[Weeks]].
+    // 1.d. Let result be AddDaysToISODate(intermediate, days).
+    int64_t day = static_cast<int64_t>(intermediate1->day()) + duration.days() + static_cast<int64_t>(ISO8601::daysPerWeek) * duration.weeks();
+    auto result = balanceISODate(intermediate1->year(), static_cast<int32_t>(intermediate1->month()), day);
+    // 3. If ISODateWithinLimits(result) is false, throw a RangeError exception.
+    if (!ISO8601::isDateTimeWithinLimits(result.year(), result.month(), result.day(), 12, 0, 0, 0, 0, 0)) [[unlikely]]
+        return makeUnexpected(rangeError("date time is out of range of ECMAScript representation"_s));
+    // 4. Return result.
+    return result;
+}
+
+// CompareISODate — temporal_rs: IsoDate::cmp
+// https://tc39.es/proposal-temporal/#sec-temporal-compareisodate
+int32_t NODELETE isoDateCompare(const ISO8601::PlainDate& d1, const ISO8601::PlainDate& d2)
+{
+    if (d1.year() > d2.year())
+        return 1;
+    if (d1.year() < d2.year())
+        return -1;
+    if (d1.month() > d2.month())
+        return 1;
+    if (d1.month() < d2.month())
+        return -1;
+    if (d1.day() > d2.day())
+        return 1;
+    if (d1.day() < d2.day())
+        return -1;
+    return 0;
+}
+
+// CompareTimeRecord — temporal_rs: IsoTime::cmp (derived Ord, src/iso.rs)
+// https://tc39.es/proposal-temporal/#sec-temporal-comparetimerecord
+int32_t NODELETE isoTimeCompare(const ISO8601::PlainTime& t1, const ISO8601::PlainTime& t2)
+{
+    if (t1.hour() != t2.hour())
+        return t1.hour() > t2.hour() ? 1 : -1;
+    if (t1.minute() != t2.minute())
+        return t1.minute() > t2.minute() ? 1 : -1;
+    if (t1.second() != t2.second())
+        return t1.second() > t2.second() ? 1 : -1;
+    if (t1.millisecond() != t2.millisecond())
+        return t1.millisecond() > t2.millisecond() ? 1 : -1;
+    if (t1.microsecond() != t2.microsecond())
+        return t1.microsecond() > t2.microsecond() ? 1 : -1;
+    if (t1.nanosecond() != t2.nanosecond())
+        return t1.nanosecond() > t2.nanosecond() ? 1 : -1;
+    return 0;
+}
+
+// ISODateSurpasses — temporal_rs: iso_date_surpasses (src/iso.rs)
+// https://tc39.es/proposal-temporal/#sec-temporal-isodatesurpasses
+static bool isoDateSurpasses(int32_t sign, int32_t y1, int32_t m1, int32_t d1, const ISO8601::PlainDate& isoDate2)
+{
+    if (y1 != isoDate2.year())
+        return sign * (y1 - isoDate2.year()) > 0;
+    if (m1 != static_cast<int32_t>(isoDate2.month()))
+        return sign * (m1 - static_cast<int32_t>(isoDate2.month())) > 0;
+    if (d1 != static_cast<int32_t>(isoDate2.day()))
+        return sign * (d1 - static_cast<int32_t>(isoDate2.day())) > 0;
+    return false;
+}
+
+// DiffISODate — temporal_rs: IsoDate::diff_iso_date
+// https://tc39.es/proposal-temporal/#sec-temporal-calendardateuntil (ISO8601 path)
+ISO8601::Duration diffISODate(const ISO8601::PlainDate& one, const ISO8601::PlainDate& two, TemporalUnit largestUnit)
+{
+    // 1. Let sign be CompareISODate(one, two).
+    // 3.a. Set sign to -sign.  (combined: negate upfront, zero check is equivalent since -0 = 0)
+    auto sign = -1 * isoDateCompare(one, two);
+    // 2. If sign = 0, return ZeroDateDuration().
+    if (!sign)
+        return { };
+
+    // 3.b. Let years be 0.
+    int years = 0;
+    // 3.d. Let months be 0.
+    int months = 0;
+
+    // 3.c. If largestUnit is ~year~, then
+    // 3.e. If largestUnit is either ~year~ or ~month~, then
+    // NOTE: polyfill optimization runs year loop for both ~year~ and ~month~, then folds into months below.
+    if (largestUnit == TemporalUnit::Year || largestUnit == TemporalUnit::Month) {
+        // NOTE: candidateYears starts at two.year()-one.year() instead of sign (polyfill optimization, saves iterations).
+        // 3.c.i. Let candidateYears be sign.
+        auto candidateYears = two.year() - one.year();
+        if (candidateYears)
+            candidateYears -= sign;
+        // 3.c.ii. Repeat, while ISODateSurpasses(sign, one, two, candidateYears, 0, 0, 0) is false,
+        while (!isoDateSurpasses(sign, one.year() + candidateYears, static_cast<int32_t>(one.month()), static_cast<int32_t>(one.day()), two)) {
+            // 1. Set years to candidateYears.
+            years = candidateYears;
+            // 2. Set candidateYears to candidateYears + sign.
+            candidateYears += sign;
+        }
+
+        // 3.e.i. Let candidateMonths be sign.
+        auto candidateMonths = sign;
+        // 3.e.ii. Repeat, while ISODateSurpasses(sign, one, two, years, candidateMonths, 0, 0) is false,
+        auto intermediate = balanceISOYearMonth(one.year() + years, static_cast<int64_t>(one.month()) + candidateMonths);
+        while (!isoDateSurpasses(sign, intermediate.year(), static_cast<int32_t>(intermediate.month()), static_cast<int32_t>(one.day()), two)) {
+            // 1. Set months to candidateMonths.
+            months = candidateMonths;
+            // 2. Set candidateMonths to candidateMonths + sign.
+            candidateMonths += sign;
+            // 3. Set intermediate to BalanceISOYearMonth(intermediate.[[Year]], intermediate.[[Month]] + sign).
+            intermediate = balanceISOYearMonth(intermediate.year(), static_cast<int64_t>(intermediate.month()) + sign);
+        }
+
+        // Fold years into months when largestUnit is ~month~ (polyfill optimization result).
+        if (largestUnit == TemporalUnit::Month) {
+            months += years * ISO8601::monthsPerYear;
+            years = 0;
+        }
+    }
+
+    // NOTE: steps 3.f–3.j (weeks/days via ISODateSurpasses loops) are replaced by epoch-day
+    // subtraction (polyfill optimization). Compute the base date after adding years+months first.
+    auto intermediate = balanceISOYearMonth(one.year() + years, static_cast<int64_t>(one.month()) + months);
+    auto constrained = regulateISODate(intermediate.year(), static_cast<int32_t>(intermediate.month()), static_cast<int64_t>(one.day()), TemporalOverflow::Constrain);
+    ASSERT(constrained); // Constrain mode cannot fail
+
+    // 3.f. Let weeks be 0.
+    double weeks = 0;
+    double days = makeDay(two.year(), two.month() - 1, two.day()) - makeDay(constrained->year(), constrained->month() - 1, constrained->day());
+
+    // 3.g. If largestUnit is ~week~, then
+    if (largestUnit == TemporalUnit::Week) {
+        weeks = std::trunc(std::abs(days) / ISO8601::daysPerWeek);
+        days = std::trunc((double)(((Int128)std::trunc(days)) % ISO8601::daysPerWeek));
+        if (weeks)
+            weeks *= sign; // Avoid -0
+    }
+
+    // 3.k. Return ! CreateDateDurationRecord(years, months, weeks, days).
+    return ISO8601::Duration { years, months, static_cast<int64_t>(weeks), static_cast<int64_t>(days), 0LL, 0LL, 0LL, 0LL, Int128(0), Int128(0) };
+}
+
+// DiffISODateTime — ISO8601 path of DifferenceISODateTime (combines diffISODate + DifferenceTime).
+// temporal_rs: IsoDateTime::diff (src/iso.rs) — no single fn; uses IsoDate::diff_iso_date + IsoTime::diff
+// https://tc39.es/proposal-temporal/#sec-temporal-differenceisodatetime
+ISO8601::InternalDuration diffISODateTime(const ISO8601::PlainDate& d1, const ISO8601::PlainTime& t1, const ISO8601::PlainDate& d2, const ISO8601::PlainTime& t2, TemporalUnit largestUnit)
+{
+    // 1. Assert: ISODateTimeWithinLimits(d1, t1) is true.
+    ASSERT(ISO8601::isDateTimeWithinLimits(d1.year(), d1.month(), d1.day(), t1.hour(), t1.minute(), t1.second(), t1.millisecond(), t1.microsecond(), t1.nanosecond()));
+    // 2. Assert: ISODateTimeWithinLimits(d2, t2) is true.
+    ASSERT(ISO8601::isDateTimeWithinLimits(d2.year(), d2.month(), d2.day(), t2.hour(), t2.minute(), t2.second(), t2.millisecond(), t2.microsecond(), t2.nanosecond()));
+    // 3. Let timeDuration be DifferenceTime(t1, t2).
+    CheckedInt128 h = CheckedInt128(static_cast<Int128>(t2.hour()) - static_cast<Int128>(t1.hour()));
+    CheckedInt128 m = CheckedInt128(static_cast<Int128>(t2.minute()) - static_cast<Int128>(t1.minute())) + h * Int128(60);
+    CheckedInt128 s = CheckedInt128(static_cast<Int128>(t2.second()) - static_cast<Int128>(t1.second())) + m * Int128(60);
+    CheckedInt128 ms = CheckedInt128(static_cast<Int128>(t2.millisecond()) - static_cast<Int128>(t1.millisecond())) + s * Int128(1000);
+    CheckedInt128 us = CheckedInt128(static_cast<Int128>(t2.microsecond()) - static_cast<Int128>(t1.microsecond())) + ms * Int128(1000);
+    CheckedInt128 ns = CheckedInt128(static_cast<Int128>(t2.nanosecond()) - static_cast<Int128>(t1.nanosecond())) + us * Int128(1000);
+    ASSERT(!ns.hasOverflowed());
+    Int128 timeDiff = ns;
+
+    // 4. Let timeSign be TimeDurationSign(timeDuration).
+    int32_t timeSign = timeDiff < 0 ? -1 : timeDiff > 0 ? 1 : 0;
+    // 5. Let dateSign be CompareISODate(d1, d2).
+    int32_t dateSign = isoDateCompare(d1, d2);
+    // 6. Let adjustedDate be d2.
+    ISO8601::PlainDate adjustedD2 = d2;
+
+    // 7. If timeSign = dateSign, then
+    if (dateSign && timeSign && dateSign == timeSign) {
+        // a. Set adjustedDate to AddDaysToISODate(adjustedDate, timeSign).
+        adjustedD2 = balanceISODate(adjustedD2.year(), static_cast<int32_t>(adjustedD2.month()), static_cast<int64_t>(adjustedD2.day()) + timeSign);
+        // b. Set timeDuration to ! Add24HourDaysToTimeDuration(timeDuration, -timeSign).
+        timeDiff -= Int128(timeSign) * ISO8601::ExactTime::nsPerDay;
+    }
+
+    // 8. Let dateLargestUnit be LargerOfTwoTemporalUnits(~day~, largestUnit).
+    TemporalUnit dateLargestUnit = (largestUnit > TemporalUnit::Day) ? TemporalUnit::Day : largestUnit;
+
+    // 9. Let dateDifference be CalendarDateUntil(calendar, d1, adjustedDate, dateLargestUnit).
+    ISO8601::Duration dateDiff = diffISODate(d1, adjustedD2, dateLargestUnit);
+
+    // 10. If largestUnit is not dateLargestUnit, then
+    double remainingDays = static_cast<double>(dateDiff.days());
+    Int128 timeDuration = timeDiff;
+    if (largestUnit != dateLargestUnit) {
+        // a. Set timeDuration to ! Add24HourDaysToTimeDuration(timeDuration, dateDifference.[[Days]]).
+        timeDuration = timeDiff + Int128(dateDiff.days()) * ISO8601::ExactTime::nsPerDay;
+        // b. Set dateDifference.[[Days]] to 0.
+        remainingDays = 0;
+    }
+
+    // 11. Return CombineDateAndTimeDuration(dateDifference, timeDuration).
+    ISO8601::Duration datePart(
+        static_cast<double>(dateDiff.years()),
+        static_cast<double>(dateDiff.months()),
+        static_cast<double>(dateDiff.weeks()),
+        remainingDays, 0, 0, 0, 0, 0, 0);
+    return ISO8601::InternalDuration::combineDateAndTimeDuration(datePart, timeDuration);
+}
+
+} // namespace TemporalCore
+} // namespace JSC

--- a/Source/JavaScriptCore/runtime/temporal/core/ISOArithmetic.h
+++ b/Source/JavaScriptCore/runtime/temporal/core/ISOArithmetic.h
@@ -25,44 +25,33 @@
 
 #pragma once
 
-// JSC Temporal Core — Shared types and error handling
-// temporal_rs reference: src/error.rs
+// JSC Temporal Core — ISO 8601 date arithmetic
+// temporal_rs reference: src/iso.rs
+// Last synced: v0.2.3
 
-#include <wtf/Expected.h>
-#include <wtf/text/ASCIILiteral.h>
-#include <wtf/text/WTFString.h>
+#include <JavaScriptCore/ISO8601.h>
+#include <JavaScriptCore/JSExportMacros.h>
+#include <JavaScriptCore/TemporalCoreTypes.h>
+#include <JavaScriptCore/TemporalObject.h>
 
 namespace JSC {
-
-// TemporalErrorKind — temporal_rs: ErrorKind (src/error.rs)
-enum class TemporalErrorKind : uint8_t {
-    RangeError,
-    TypeError,
-};
-
-// TemporalError — temporal_rs: TemporalError (src/error.rs)
-struct TemporalError {
-    TemporalErrorKind kind;
-    String message;
-};
-
-// TemporalResult<T> — temporal_rs: TemporalResult<T> = Result<T, TemporalError>
-template<typename T>
-using TemporalResult = Expected<T, TemporalError>;
-
-// Convenience constructors — temporal_rs: TemporalError::range() / TemporalError::type_()
 namespace TemporalCore {
-inline TemporalError rangeError(ASCIILiteral msg) { return { TemporalErrorKind::RangeError, String(msg) }; }
-inline TemporalError rangeError(String msg) { return { TemporalErrorKind::RangeError, WTF::move(msg) }; }
-inline TemporalError typeError(ASCIILiteral msg) { return { TemporalErrorKind::TypeError, String(msg) }; }
-inline TemporalError typeError(String msg) { return { TemporalErrorKind::TypeError, WTF::move(msg) }; }
+
+ISO8601::PlainYearMonth JS_EXPORT_PRIVATE balanceISOYearMonth(int64_t year, int64_t month);
+
+ISO8601::PlainDate JS_EXPORT_PRIVATE balanceISODate(int32_t year, int32_t month, int64_t day);
+
+TemporalResult<ISO8601::PlainDate> JS_EXPORT_PRIVATE regulateISODate(int32_t year, int32_t month, int64_t day, TemporalOverflow);
+
+TemporalResult<ISO8601::PlainDate> JS_EXPORT_PRIVATE isoDateAdd(const ISO8601::PlainDate&, const ISO8601::Duration&, TemporalOverflow);
+
+int32_t NODELETE JS_EXPORT_PRIVATE isoDateCompare(const ISO8601::PlainDate&, const ISO8601::PlainDate&);
+
+int32_t NODELETE JS_EXPORT_PRIVATE isoTimeCompare(const ISO8601::PlainTime&, const ISO8601::PlainTime&);
+
+ISO8601::Duration JS_EXPORT_PRIVATE diffISODate(const ISO8601::PlainDate& one, const ISO8601::PlainDate& two, TemporalUnit largestUnit);
+
+ISO8601::InternalDuration JS_EXPORT_PRIVATE diffISODateTime(const ISO8601::PlainDate& d1, const ISO8601::PlainTime& t1, const ISO8601::PlainDate& d2, const ISO8601::PlainTime& t2, TemporalUnit largestUnit);
+
 } // namespace TemporalCore
-
-// TransitionDirection — temporal_rs: TransitionDirection (timezone_provider crate, src/provider.rs)
-// Used by getTimeZoneTransition to indicate search direction.
-enum class TransitionDirection : bool {
-    Next,
-    Previous,
-};
-
 } // namespace JSC

--- a/Source/JavaScriptCore/runtime/temporal/core/InstantCore.cpp
+++ b/Source/JavaScriptCore/runtime/temporal/core/InstantCore.cpp
@@ -1,0 +1,101 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "InstantCore.h"
+
+#include "ISO8601.h"
+#include "TemporalObject.h"
+#include <wtf/DateMath.h>
+#include <wtf/text/MakeString.h>
+#include <wtf/text/StringBuilder.h>
+
+namespace JSC {
+namespace TemporalCore {
+
+// TemporalInstantToString — temporal_rs: Instant::to_ixdtf_string_with_provider (src/builtins/core/instant.rs)
+// https://tc39.es/proposal-temporal/#sec-temporal-temporalinstanttostring
+WTF::String instantToString(ISO8601::ExactTime exactTime, std::optional<int64_t> offsetNs, PrecisionData precision)
+{
+    // 1. Let outputTimeZone be timeZone.
+    // 2. If outputTimeZone is undefined, set outputTimeZone to "UTC".
+    // NOTE: steps 1-2 and step 7.a (GetOffsetNanosecondsFor) are resolved by the caller;
+    // offsetNs is undefined when timeZone is undefined, otherwise the pre-resolved offset.
+    // 3. Let epochNs be instant.[[EpochNanoseconds]].  (exactTime carries epochNs)
+    // 4. Let isoDateTime be GetISODateTimeFor(outputTimeZone, epochNs).
+    // Add the UTC offset to get local epoch-milliseconds, then decompose into date/time fields.
+    int64_t epochMs;
+    if (offsetNs)
+        epochMs = exactTime.floorEpochMilliseconds() + *offsetNs / static_cast<int64_t>(ISO8601::ExactTime::nsPerMillisecond);
+    else
+        epochMs = exactTime.floorEpochMilliseconds();
+
+    GregorianDateTime gregorianDateTime { static_cast<double>(epochMs), LocalTimeOffset { } };
+
+    // 5. Let dateTimeString be ISODateTimeToString(isoDateTime, "iso8601", precision, ~never~).
+    // NOTE: Inlined here — instantToString receives the offset-adjusted GregorianDateTime
+    // rather than PlainDate/PlainTime, so temporalDateTimeToString() cannot be called directly.
+    // 5.1. Let yearString be PadISOYear(year).
+    StringBuilder builder;
+    unsigned yearLength = 4;
+    if (gregorianDateTime.year() > 9999 || gregorianDateTime.year() < 0) {
+        builder.append(gregorianDateTime.year() < 0 ? '-' : '+');
+        yearLength = 6;
+    }
+    // 5.2-5.3. month and day strings.
+    // 5.5. Let timeString be FormatTimeString(...).
+    builder.append(makeString(pad('0', yearLength, std::abs(gregorianDateTime.year())),
+        '-', pad('0', 2, gregorianDateTime.month() + 1),
+        '-', pad('0', 2, gregorianDateTime.monthDay()),
+        'T', pad('0', 2, gregorianDateTime.hour()),
+        ':', pad('0', 2, gregorianDateTime.minute())));
+
+    // 5.4. subSecondNanoseconds = nanosecondsFraction() (sub-second ns of the instant).
+    // NOTE: negative for pre-epoch instants; correction maps to the [0, nsPerSecond) range.
+    int fraction { exactTime.nanosecondsFraction() };
+    if (fraction < 0)
+        fraction += static_cast<int>(ISO8601::ExactTime::nsPerSecond);
+
+    formatSecondsStringPart(builder, gregorianDateTime.second(), fraction, precision);
+
+    // 6. If timeZone is undefined, let timeZoneString be "Z".
+    // 7. Else, let timeZoneString be FormatDateTimeUTCOffsetRounded(offsetNanoseconds).
+    if (offsetNs) {
+        static constexpr int64_t nsPerMinute = 60'000'000'000LL;
+        int64_t rawOffset = *offsetNs;
+        int64_t sign = rawOffset < 0 ? -1 : 1;
+        int64_t absNs = std::abs(rawOffset);
+        int64_t minutes = (absNs + nsPerMinute / 2) / nsPerMinute;
+        int64_t roundedNs = sign * minutes * nsPerMinute;
+        builder.append(ISO8601::formatTimeZoneOffsetString(roundedNs));
+    } else
+        builder.append('Z');
+
+    // 8. Return the string-concatenation of dateTimeString and timeZoneString.
+    return builder.toString();
+}
+
+} // namespace TemporalCore
+} // namespace JSC

--- a/Source/JavaScriptCore/runtime/temporal/core/InstantCore.h
+++ b/Source/JavaScriptCore/runtime/temporal/core/InstantCore.h
@@ -25,44 +25,30 @@
 
 #pragma once
 
-// JSC Temporal Core — Shared types and error handling
-// temporal_rs reference: src/error.rs
+// JSC Temporal Core — Instant algorithms
+// temporal_rs reference: src/builtins/core/instant.rs
+// Last synced: v0.2.3
 
-#include <wtf/Expected.h>
-#include <wtf/text/ASCIILiteral.h>
+#include <JavaScriptCore/ISO8601.h>
+#include <JavaScriptCore/JSExportMacros.h>
+#include <JavaScriptCore/TemporalObject.h>
+#include <optional>
 #include <wtf/text/WTFString.h>
 
 namespace JSC {
-
-// TemporalErrorKind — temporal_rs: ErrorKind (src/error.rs)
-enum class TemporalErrorKind : uint8_t {
-    RangeError,
-    TypeError,
-};
-
-// TemporalError — temporal_rs: TemporalError (src/error.rs)
-struct TemporalError {
-    TemporalErrorKind kind;
-    String message;
-};
-
-// TemporalResult<T> — temporal_rs: TemporalResult<T> = Result<T, TemporalError>
-template<typename T>
-using TemporalResult = Expected<T, TemporalError>;
-
-// Convenience constructors — temporal_rs: TemporalError::range() / TemporalError::type_()
 namespace TemporalCore {
-inline TemporalError rangeError(ASCIILiteral msg) { return { TemporalErrorKind::RangeError, String(msg) }; }
-inline TemporalError rangeError(String msg) { return { TemporalErrorKind::RangeError, WTF::move(msg) }; }
-inline TemporalError typeError(ASCIILiteral msg) { return { TemporalErrorKind::TypeError, String(msg) }; }
-inline TemporalError typeError(String msg) { return { TemporalErrorKind::TypeError, WTF::move(msg) }; }
+
+// MaximumTemporalInstantRoundingIncrement — temporal_rs: internal (no single fn; values are hardcoded per spec table)
+// Values from Temporal.Instant.prototype.round steps 15-20 (one per unit).
+// https://tc39.es/proposal-temporal/#sec-temporal.instant.prototype.round
+constexpr double NODELETE maximumInstantIncrement(TemporalUnit smallestUnit)
+{
+    // Maximum increment = how many units of smallestUnit fit in one day.
+    return static_cast<double>(static_cast<int64_t>(lengthInNanoseconds(TemporalUnit::Day)))
+        / static_cast<double>(static_cast<int64_t>(lengthInNanoseconds(smallestUnit)));
+}
+
+WTF::String JS_EXPORT_PRIVATE instantToString(ISO8601::ExactTime, std::optional<int64_t> offsetNs, PrecisionData);
+
 } // namespace TemporalCore
-
-// TransitionDirection — temporal_rs: TransitionDirection (timezone_provider crate, src/provider.rs)
-// Used by getTimeZoneTransition to indicate search direction.
-enum class TransitionDirection : bool {
-    Next,
-    Previous,
-};
-
 } // namespace JSC

--- a/Source/JavaScriptCore/runtime/temporal/core/Rounding.cpp
+++ b/Source/JavaScriptCore/runtime/temporal/core/Rounding.cpp
@@ -1,0 +1,265 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "Rounding.h"
+
+#include "FractionToDouble.h"
+#include "TemporalObject.h"
+
+namespace JSC {
+namespace TemporalCore {
+
+// NegateRoundingMode — temporal_rs: RoundingMode::negate (src/options.rs)
+// https://tc39.es/proposal-temporal/#sec-temporal-negateroundingmode
+RoundingMode negateTemporalRoundingMode(RoundingMode roundingMode)
+{
+    switch (roundingMode) {
+    case RoundingMode::Ceil:
+        return RoundingMode::Floor;
+    case RoundingMode::Floor:
+        return RoundingMode::Ceil;
+    case RoundingMode::HalfCeil:
+        return RoundingMode::HalfFloor;
+    case RoundingMode::HalfFloor:
+        return RoundingMode::HalfCeil;
+    default:
+        return roundingMode;
+    }
+}
+
+// ApplyUnsignedRoundingMode — temporal_rs: apply_unsigned_rounding_mode
+// https://tc39.es/proposal-temporal/#sec-applyunsignedroundingmode
+double applyUnsignedRoundingMode(double x, double r1, double r2, UnsignedRoundingMode unsignedRoundingMode)
+{
+    // 1. If x = r1, return r1.
+    if (x == r1)
+        return r1;
+    // 2. Assert: r1 < x < r2.
+    ASSERT(r1 < x && x < r2);
+    // 3. Assert: unsignedRoundingMode is not undefined.
+    // 4. If unsignedRoundingMode is ~zero~, return r1.
+    if (unsignedRoundingMode == UnsignedRoundingMode::Zero)
+        return r1;
+    // 5. If unsignedRoundingMode is ~infinity~, return r2.
+    if (unsignedRoundingMode == UnsignedRoundingMode::Infinity)
+        return r2;
+    // 6. Let d1 be x - r1.
+    double d1 = x - r1;
+    // 7. Let d2 be r2 - x.
+    double d2 = r2 - x;
+    // 8. If d1 < d2, return r1.
+    if (d1 < d2)
+        return r1;
+    // 9. If d2 < d1, return r2.
+    if (d2 < d1)
+        return r2;
+    // 10. Assert: d1 is equal to d2.
+    ASSERT(d1 == d2);
+    // 11. If unsignedRoundingMode is ~half-zero~, return r1.
+    if (unsignedRoundingMode == UnsignedRoundingMode::HalfZero)
+        return r1;
+    // 12. If unsignedRoundingMode is ~half-infinity~, return r2.
+    if (unsignedRoundingMode == UnsignedRoundingMode::HalfInfinity)
+        return r2;
+    // 13. Assert: unsignedRoundingMode is ~half-even~.
+    ASSERT(unsignedRoundingMode == UnsignedRoundingMode::HalfEven);
+    // 14. Let cardinality be (r1 / (r2 - r1)) modulo 2.
+    auto cardinality = std::fmod(r1 / (r2 - r1), 2);
+    // 15. If cardinality = 0, return r1. 16. Return r2.
+    return !cardinality ? r1 : r2;
+}
+
+// ApplyUnsignedRoundingMode (Int128 path) — integer analogue of the double version above.
+// https://tc39.es/proposal-temporal/#sec-applyunsignedroundingmode
+// cmp: -1 if x is closer to r1, +1 if closer to r2, 0 if exactly at midpoint.
+// Callers handle the exact case (x = r1) before calling this.
+static Int128 applyUnsignedRoundingModeInt128(Int128 r1, Int128 r2, int cmp, UnsignedRoundingMode unsignedRoundingMode)
+{
+    // 4. If unsignedRoundingMode is ~zero~, return r1.
+    if (unsignedRoundingMode == UnsignedRoundingMode::Zero)
+        return r1;
+    // 5. If unsignedRoundingMode is ~infinity~, return r2.
+    if (unsignedRoundingMode == UnsignedRoundingMode::Infinity)
+        return r2;
+    // 8. If d1 < d2, return r1. 9. If d2 < d1, return r2.
+    if (cmp < 0)
+        return r1;
+    if (cmp > 0)
+        return r2;
+    // 11. If unsignedRoundingMode is ~half-zero~, return r1.
+    if (unsignedRoundingMode == UnsignedRoundingMode::HalfZero)
+        return r1;
+    // 12. If unsignedRoundingMode is ~half-infinity~, return r2.
+    if (unsignedRoundingMode == UnsignedRoundingMode::HalfInfinity)
+        return r2;
+    // 13-16. ~half-even~: return r1 if r1 is even, else r2.
+    return !(r1 % 2) ? r1 : r2;
+}
+// MaximumTemporalDurationRoundingIncrement — temporal_rs: Unit::to_maximum_rounding_increment (src/options.rs)
+// https://tc39.es/proposal-temporal/#sec-temporal-maximumtemporaldurationroundingincrement
+std::optional<unsigned> maximumRoundingIncrement(TemporalUnit unit)
+{
+    // 1. Return the value from the "Maximum duration rounding increment" column of #table-temporal-units.
+    // Year/Month/Week/Day have no maximum (return ~unset~); time units return fixed values.
+    if (unit <= TemporalUnit::Day)
+        return std::nullopt;
+    if (unit == TemporalUnit::Hour)
+        return 24;
+    if (unit <= TemporalUnit::Second)
+        return 60;
+    return 1000;
+}
+
+// RoundNumberToIncrement (double path) — temporal_rs: IncrementRounder<f64>::round (src/rounding.rs)
+// https://tc39.es/proposal-temporal/#sec-temporal-roundnumbertoincrement
+// NOTE: Stays signed throughout rather than abs+negate like temporal_rs/spec.
+// truncatedQuotient = -r1 (negative) or r1 (positive); expandedQuotient = -r2 or r2.
+// Produces identical results to IncrementRounder<f64>::round.
+double roundNumberToIncrementDouble(double x, double increment, RoundingMode mode)
+{
+    // quotient = x / increment (spec step 1).
+    auto quotient = x / increment;
+    auto truncatedQuotient = std::trunc(quotient);
+    if (truncatedQuotient == quotient)
+        return truncatedQuotient * increment;
+
+    auto isNegative = quotient < 0;
+    // expandedQuotient = r2 (positive) or r1 (negative) in spec terms.
+    auto expandedQuotient = isNegative ? truncatedQuotient - 1 : truncatedQuotient + 1;
+
+    if (mode >= RoundingMode::HalfCeil) {
+        auto unsignedFractionalPart = std::abs(quotient - truncatedQuotient);
+        if (unsignedFractionalPart < 0.5)
+            return truncatedQuotient * increment;
+        if (unsignedFractionalPart > 0.5)
+            return expandedQuotient * increment;
+    }
+
+    switch (mode) {
+    case RoundingMode::Ceil:
+    case RoundingMode::HalfCeil:
+        return (isNegative ? truncatedQuotient : expandedQuotient) * increment;
+    case RoundingMode::Floor:
+    case RoundingMode::HalfFloor:
+        return (isNegative ? expandedQuotient : truncatedQuotient) * increment;
+    case RoundingMode::Expand:
+    case RoundingMode::HalfExpand:
+        return expandedQuotient * increment;
+    case RoundingMode::Trunc:
+    case RoundingMode::HalfTrunc:
+        return truncatedQuotient * increment;
+    case RoundingMode::HalfEven:
+        return (!std::fmod(truncatedQuotient, 2) ? truncatedQuotient : expandedQuotient) * increment;
+    }
+    RELEASE_ASSERT_NOT_REACHED();
+}
+
+// RoundNumberToIncrementAsIfPositive — temporal_rs: IncrementRounder::round_as_if_positive (src/rounding.rs)
+// https://tc39.es/proposal-temporal/#sec-temporal-roundnumbertoincrementasifpositive
+Int128 roundNumberToIncrementAsIfPositive(Int128 x, Int128 increment, RoundingMode roundingMode)
+{
+    // 1. Let quotient be x / increment.
+    Int128 quotient = x / increment;
+    Int128 remainder = x % increment;
+    // Exact case: x is divisible by increment — return x directly before computing r1/r2.
+    // (spec step 1 of ApplyUnsignedRoundingMode: "if x = r1, return r1")
+    if (!remainder)
+        return x;
+    // 2. Let unsignedRoundingMode be GetUnsignedRoundingMode(roundingMode, ~positive~).
+    auto unsignedRoundingMode = getUnsignedRoundingMode(roundingMode, false);
+    // 3. Let r1 be the largest integer such that r1 ≤ quotient.
+    // 4. Let r2 be the smallest integer such that r2 > quotient.
+    auto r1 = quotient;
+    auto r2 = quotient + 1;
+    if (x < 0) {
+        r1 = quotient - 1;
+        r2 = quotient;
+    }
+    auto doubleRemainder = absInt128(remainder * 2);
+    int cmp = (doubleRemainder < increment ? -1 : doubleRemainder == increment ? 0 : 1) * (x < 0 ? -1 : 1);
+    // 5. Let rounded be ApplyUnsignedRoundingMode(quotient, r1, r2, unsignedRoundingMode).
+    // 6. Return rounded × increment.
+    return applyUnsignedRoundingModeInt128(r1, r2, cmp, unsignedRoundingMode) * increment;
+}
+
+// RoundNumberToIncrement (Int128 path) — temporal_rs: IncrementRounder<i128>::round (src/rounding.rs)
+// https://tc39.es/proposal-temporal/#sec-temporal-roundnumbertoincrement
+Int128 roundNumberToIncrementInt128(Int128 x, Int128 increment, RoundingMode mode)
+{
+    // 1. Let quotient be x / increment.
+    Int128 quotient = x / increment;
+    Int128 remainder = x % increment;
+    if (!remainder)
+        return x;
+    // 2-3. Determine isNegative from x; work with abs(quotient) as unsigned quotient.
+    bool isNegative = x < 0;
+    // 4. Let unsignedRoundingMode be GetUnsignedRoundingMode(roundingMode, isNegative).
+    auto unsignedRoundingMode = getUnsignedRoundingMode(mode, isNegative);
+    // 5. Let r1 be the largest integer such that r1 ≤ abs(quotient).
+    Int128 r1 = absInt128(quotient);
+    // 6. Let r2 be the smallest integer such that r2 > abs(quotient).
+    Int128 r2 = r1 + 1;
+    int cmp = absInt128(remainder * 2) < increment ? -1 : absInt128(remainder * 2) > increment ? 1 : 0;
+    // 7. Let rounded be ApplyUnsignedRoundingMode(abs(quotient), r1, r2, unsignedRoundingMode).
+    Int128 rounded = applyUnsignedRoundingModeInt128(r1, r2, cmp, unsignedRoundingMode);
+    // 8. If isNegative is ~negative~, set rounded to -rounded.
+    if (isNegative)
+        rounded = -rounded;
+    // 9. Return rounded × increment.
+    return rounded * increment;
+}
+
+// ValidateTemporalRoundingIncrement — temporal_rs: RoundingIncrement::validate (src/options/increment.rs)
+// https://tc39.es/proposal-temporal/#sec-validatetemporalroundingincrement
+// NOTE: dividend is optional here; callers pass nullopt when largestUnit ≤ Day (no maximum applies).
+// In that case we use nsPerSecond as a safe upper bound (largest valid nanosecond increment).
+TemporalResult<void> validateTemporalRoundingIncrement(double increment, std::optional<double> dividend, Inclusivity isInclusive)
+{
+    // 1. If inclusive is true, then a. Let maximum be dividend.
+    // 2. Else, b. Let maximum be dividend - 1.
+    double maximum;
+    if (!dividend)
+        maximum = static_cast<double>(lengthInNanoseconds(TemporalUnit::Second));
+    else if (isInclusive == Inclusivity::Inclusive)
+        maximum = dividend.value();
+    else if (dividend.value() > 1)
+        maximum = dividend.value() - 1;
+    else
+        maximum = 1;
+
+    increment = std::trunc(increment);
+    // 3. If increment > maximum, throw a RangeError exception.
+    if (increment < 1 || increment > maximum)
+        return makeUnexpected(TemporalError { TemporalErrorKind::RangeError, "rounding increment is out of range"_s });
+    // 4. If dividend modulo increment ≠ 0, throw a RangeError exception.
+    if (dividend && std::fmod(dividend.value(), increment))
+        return makeUnexpected(TemporalError { TemporalErrorKind::RangeError, "roundingIncrement does not divide evenly"_s });
+    // 5. Return ~unused~.
+    return { };
+}
+
+} // namespace TemporalCore
+} // namespace JSC

--- a/Source/JavaScriptCore/runtime/temporal/core/Rounding.h
+++ b/Source/JavaScriptCore/runtime/temporal/core/Rounding.h
@@ -25,44 +25,33 @@
 
 #pragma once
 
-// JSC Temporal Core — Shared types and error handling
-// temporal_rs reference: src/error.rs
+// JSC Temporal Core — Rounding algorithms
+// temporal_rs reference: src/rounding.rs
+//                        src/options.rs
+//                        src/options/increment.rs
+// Last synced: v0.2.3
 
-#include <wtf/Expected.h>
-#include <wtf/text/ASCIILiteral.h>
-#include <wtf/text/WTFString.h>
+#include <JavaScriptCore/JSExportMacros.h>
+#include <JavaScriptCore/TemporalCoreTypes.h>
+#include <JavaScriptCore/TemporalEnums.h>
+#include <optional>
 
 namespace JSC {
-
-// TemporalErrorKind — temporal_rs: ErrorKind (src/error.rs)
-enum class TemporalErrorKind : uint8_t {
-    RangeError,
-    TypeError,
-};
-
-// TemporalError — temporal_rs: TemporalError (src/error.rs)
-struct TemporalError {
-    TemporalErrorKind kind;
-    String message;
-};
-
-// TemporalResult<T> — temporal_rs: TemporalResult<T> = Result<T, TemporalError>
-template<typename T>
-using TemporalResult = Expected<T, TemporalError>;
-
-// Convenience constructors — temporal_rs: TemporalError::range() / TemporalError::type_()
 namespace TemporalCore {
-inline TemporalError rangeError(ASCIILiteral msg) { return { TemporalErrorKind::RangeError, String(msg) }; }
-inline TemporalError rangeError(String msg) { return { TemporalErrorKind::RangeError, WTF::move(msg) }; }
-inline TemporalError typeError(ASCIILiteral msg) { return { TemporalErrorKind::TypeError, String(msg) }; }
-inline TemporalError typeError(String msg) { return { TemporalErrorKind::TypeError, WTF::move(msg) }; }
+
+RoundingMode JS_EXPORT_PRIVATE negateTemporalRoundingMode(RoundingMode);
+
+double JS_EXPORT_PRIVATE applyUnsignedRoundingMode(double x, double r1, double r2, UnsignedRoundingMode);
+
+std::optional<unsigned> JS_EXPORT_PRIVATE maximumRoundingIncrement(TemporalUnit);
+
+double JS_EXPORT_PRIVATE roundNumberToIncrementDouble(double x, double increment, RoundingMode);
+
+Int128 JS_EXPORT_PRIVATE roundNumberToIncrementAsIfPositive(Int128 x, Int128 increment, RoundingMode);
+
+Int128 JS_EXPORT_PRIVATE roundNumberToIncrementInt128(Int128 x, Int128 increment, RoundingMode);
+
+TemporalResult<void> JS_EXPORT_PRIVATE validateTemporalRoundingIncrement(double increment, std::optional<double> dividend, Inclusivity);
+
 } // namespace TemporalCore
-
-// TransitionDirection — temporal_rs: TransitionDirection (timezone_provider crate, src/provider.rs)
-// Used by getTimeZoneTransition to indicate search direction.
-enum class TransitionDirection : bool {
-    Next,
-    Previous,
-};
-
 } // namespace JSC

--- a/Source/JavaScriptCore/runtime/temporal/core/TemporalEnums.h
+++ b/Source/JavaScriptCore/runtime/temporal/core/TemporalEnums.h
@@ -29,12 +29,13 @@
 // temporal_rs reference: src/options.rs
 
 #include <cstdint>
+#include <wtf/Int128.h>
 #include <wtf/text/ASCIILiteral.h>
 #include <wtf/text/StringView.h>
 
 namespace JSC {
 
-// https://tc39.es/proposal-temporal/#sec-temporal-totemporaldisambiguation
+// https://tc39.es/proposal-temporal/#sec-temporal-gettemporaldisambiguationoption
 // temporal_rs: Disambiguation
 enum class TemporalDisambiguation : uint8_t {
     Compatible,
@@ -43,7 +44,7 @@ enum class TemporalDisambiguation : uint8_t {
     Reject,
 };
 
-// https://tc39.es/proposal-temporal/#sec-temporal-totemporaloffset
+// https://tc39.es/proposal-temporal/#sec-temporal-gettemporaloffsetoption
 // temporal_rs: OffsetDisambiguation
 enum class TemporalOffsetDisambiguation : uint8_t {
     Use,
@@ -52,16 +53,15 @@ enum class TemporalOffsetDisambiguation : uint8_t {
     Reject,
 };
 
-// https://tc39.es/proposal-temporal/#sec-temporal-interpretisodatetimeoffset
-// temporal_rs: interpret_isodatetime_offset — is_exact/offset_nanos pair encoding
+// OffsetBehaviour encodes the offset source used by interpretISODateTimeOffset.
 enum class OffsetBehaviour : uint8_t {
     Wall, // no inline offset in string — resolve via timezone + disambiguation
     Exact, // Z flag — UTC epoch directly
     Option, // +HH:MM present — use inlineOffsetNs
 };
 
-// https://tc39.es/proposal-temporal/#sec-temporal-tocalendaridentifier
-// temporal_rs: AnyCalendarKind
+// https://tc39.es/proposal-temporal/#sec-temporal-totemporalcalendaridentifier
+// temporal_rs: AnyCalendarKind (icu_calendar crate, imported by builtins/core/calendar.rs)
 enum class CalendarKind : uint8_t {
     Iso8601 = 0, // must be 0 so zero-initialised objects default to iso8601
     Buddhist,
@@ -206,5 +206,154 @@ inline CalendarKind toCalendarKind(WTF::StringView s)
         return CalendarKind::Vikram;
     return CalendarKind::Iso8601;
 }
+
+// -----------------------------------------------------------------------
+// Temporal unit
+// -----------------------------------------------------------------------
+
+#define JSC_TEMPORAL_PLAIN_DATE_UNITS(macro) \
+    macro(year, Year) \
+    macro(month, Month) \
+    macro(day, Day) \
+
+#define JSC_TEMPORAL_PLAIN_MONTH_DAY_UNITS(macro) \
+    macro(month, Month) \
+    macro(day, Day)
+
+#define JSC_TEMPORAL_PLAIN_YEAR_MONTH_UNITS(macro) \
+    macro(year, Year) \
+    macro(month, Month)
+
+#define JSC_TEMPORAL_PLAIN_TIME_UNITS(macro) \
+    macro(hour, Hour) \
+    macro(minute, Minute) \
+    macro(second, Second) \
+    macro(millisecond, Millisecond) \
+    macro(microsecond, Microsecond) \
+    macro(nanosecond, Nanosecond) \
+
+#define JSC_TEMPORAL_UNITS(macro) \
+    macro(year, Year) \
+    macro(month, Month) \
+    macro(week, Week) \
+    macro(day, Day) \
+    JSC_TEMPORAL_PLAIN_TIME_UNITS(macro) \
+
+// temporal_rs: Unit (src/options.rs)
+// https://tc39.es/proposal-temporal/#table-temporal-units
+enum class TemporalUnit : uint8_t {
+#define JSC_DEFINE_TEMPORAL_UNIT_ENUM(name, capitalizedName) capitalizedName,
+    JSC_TEMPORAL_UNITS(JSC_DEFINE_TEMPORAL_UNIT_ENUM)
+#undef JSC_DEFINE_TEMPORAL_UNIT_ENUM
+};
+#define JSC_COUNT_TEMPORAL_UNITS(name, capitalizedName) + 1
+static constexpr unsigned numberOfTemporalUnits = 0 JSC_TEMPORAL_UNITS(JSC_COUNT_TEMPORAL_UNITS);
+static constexpr unsigned numberOfTemporalPlainDateUnits = 0 JSC_TEMPORAL_PLAIN_DATE_UNITS(JSC_COUNT_TEMPORAL_UNITS);
+static constexpr unsigned numberOfTemporalPlainTimeUnits = 0 JSC_TEMPORAL_PLAIN_TIME_UNITS(JSC_COUNT_TEMPORAL_UNITS);
+static constexpr unsigned numberOfTemporalPlainYearMonthUnits = 0 JSC_TEMPORAL_PLAIN_YEAR_MONTH_UNITS(JSC_COUNT_TEMPORAL_UNITS);
+static constexpr unsigned numberOfTemporalPlainMonthDayUnits = 0 JSC_TEMPORAL_PLAIN_MONTH_DAY_UNITS(JSC_COUNT_TEMPORAL_UNITS);
+#undef JSC_COUNT_TEMPORAL_UNITS
+
+extern const TemporalUnit temporalUnitsInTableOrder[numberOfTemporalUnits];
+
+// https://tc39.es/proposal-temporal/#table-temporal-units
+constexpr Int128 lengthInNanoseconds(TemporalUnit unit)
+{
+    switch (unit) {
+    case TemporalUnit::Nanosecond:
+        return 1;
+    case TemporalUnit::Microsecond:
+        return 1000;
+    case TemporalUnit::Millisecond:
+        return 1000 * lengthInNanoseconds(TemporalUnit::Microsecond);
+    case TemporalUnit::Second:
+        return 1000 * lengthInNanoseconds(TemporalUnit::Millisecond);
+    case TemporalUnit::Minute:
+        return 60 * lengthInNanoseconds(TemporalUnit::Second);
+    case TemporalUnit::Hour:
+        return 60 * lengthInNanoseconds(TemporalUnit::Minute);
+    case TemporalUnit::Day:
+        return 24 * lengthInNanoseconds(TemporalUnit::Hour);
+    default:
+        break;
+    }
+    RELEASE_ASSERT_NOT_REACHED();
+}
+
+// -----------------------------------------------------------------------
+// Rounding enums
+// -----------------------------------------------------------------------
+
+// temporal_rs: RoundingMode (src/options.rs)
+// https://tc39.es/proposal-temporal/#sec-temporal-totemporalroundingmode
+enum class RoundingMode : uint8_t {
+    Ceil,
+    Floor,
+    Expand,
+    Trunc,
+    HalfCeil,
+    HalfFloor,
+    HalfExpand,
+    HalfTrunc,
+    HalfEven
+};
+
+// temporal_rs: UnsignedRoundingMode (src/options.rs)
+enum class UnsignedRoundingMode : uint8_t {
+    Infinity,
+    Zero,
+    HalfInfinity,
+    HalfZero,
+    HalfEven
+};
+
+// https://tc39.es/proposal-temporal/#sec-getunsignedroundingmode
+// temporal_rs: RoundingMode::get_unsigned_round_mode (src/options.rs)
+constexpr UnsignedRoundingMode getUnsignedRoundingMode(RoundingMode roundingMode, bool isNegative)
+{
+    switch (roundingMode) {
+    case RoundingMode::Ceil:
+        return isNegative ? UnsignedRoundingMode::Zero : UnsignedRoundingMode::Infinity;
+    case RoundingMode::Floor:
+        return isNegative ? UnsignedRoundingMode::Infinity : UnsignedRoundingMode::Zero;
+    case RoundingMode::Expand:
+        return UnsignedRoundingMode::Infinity;
+    case RoundingMode::Trunc:
+        return UnsignedRoundingMode::Zero;
+    case RoundingMode::HalfCeil:
+        return isNegative ? UnsignedRoundingMode::HalfZero : UnsignedRoundingMode::HalfInfinity;
+    case RoundingMode::HalfFloor:
+        return isNegative ? UnsignedRoundingMode::HalfInfinity : UnsignedRoundingMode::HalfZero;
+    case RoundingMode::HalfExpand:
+        return UnsignedRoundingMode::HalfInfinity;
+    case RoundingMode::HalfTrunc:
+        return UnsignedRoundingMode::HalfZero;
+    default:
+        return UnsignedRoundingMode::HalfEven;
+    }
+}
+
+// temporal_rs: no direct equivalent; used as parameter to ValidateTemporalRoundingIncrement.
+enum class Inclusivity : bool {
+    Inclusive,
+    Exclusive
+};
+
+// -----------------------------------------------------------------------
+// Arithmetic operation enums
+// -----------------------------------------------------------------------
+
+// temporal_rs: Overflow (src/options.rs)
+// https://tc39.es/proposal-temporal/#sec-temporal-totemporaloverflow
+enum class TemporalOverflow : bool {
+    Constrain,
+    Reject,
+};
+
+// temporal_rs: DifferenceOperation (src/options.rs)
+enum class DifferenceOperation : bool {
+    Since,
+    Until
+};
 
 } // namespace JSC

--- a/Source/JavaScriptCore/shell/CMakeLists.txt
+++ b/Source/JavaScriptCore/shell/CMakeLists.txt
@@ -35,6 +35,7 @@ if (DEVELOPER_MODE)
         ../API/tests/JSObjectGetProxyTargetTest.cpp
         ../API/tests/MultithreadedMultiVMExecutionTest.cpp
         ../API/tests/PingPongStackOverflowTest.cpp
+        ../API/tests/TemporalCoreTest.cpp
         ../API/tests/TypedArrayCTest.cpp
         ../API/tests/VMManagerStopTheWorldTest.cpp
         ../API/tests/testapi.cpp


### PR DESCRIPTION
#### f0994a790e4487dab6d66e98ac79eca96c645ebd
<pre>
[JSC][Temporal] Add pure C++ core layer: Rounding, ISOArithmetic, InstantCore, CalendarArithmetic
<a href="https://bugs.webkit.org/show_bug.cgi?id=314432">https://bugs.webkit.org/show_bug.cgi?id=314432</a>
<a href="https://rdar.apple.com/176580834">rdar://176580834</a>

Reviewed by Yusuke Suzuki.

The Temporal spec algorithms were previously inlined throughout the JS
wrapper layer (TemporalDuration.cpp, TemporalPlainDate.cpp, etc.),
tightly coupling spec math with JSGlobalObject* and JSValue. This patch
extracts them into a pure C++ core layer under runtime/temporal/core/
with no JS VM types, enabling:
- C++ unit testing without a JS engine (TemporalCoreTest.cpp, ~200
  tests mirroring temporal_rs v0.2.3 test suite)
- Spec step annotations and temporal_rs cross-references in every
  function body for reviewer traceability
- Cleaner separation between spec algorithm and JS binding layers

Callers in TemporalDuration.cpp, TemporalPlainTime.cpp,
TemporalPlainDate.cpp, ISO8601.cpp, etc. are updated to call the
TemporalCore:: qualified names.

Tests: Source/JavaScriptCore/API/tests/TemporalCoreTest
Canonical link: <a href="https://commits.webkit.org/312935@main">https://commits.webkit.org/312935@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cd23050dc3d1a747a768090d934bb4a12a2f210d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/161473 "13 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/34947 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/28049 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/170376 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/117844 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/35048 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/34948 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/125267 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/117844 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/164432 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/27563 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/145040 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/105863 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/26612 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/25121 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/18097 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/153530 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/136306 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/22797 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/172862 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/22311 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/19893 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/24438 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/133553 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/34621 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/29216 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/133560 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/34605 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/144592 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/96505 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/24545 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/28087 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/21411 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/193872 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/34115 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/101557 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/49949 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/33615 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/33858 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/33764 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->