### PR TITLE
[webkitcorepy] Add structured logging with color and stream splitting

### DIFF
--- a/Tools/Scripts/libraries/webkitcorepy/webkitcorepy/arguments.py
+++ b/Tools/Scripts/libraries/webkitcorepy/webkitcorepy/arguments.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2020-2023 Apple Inc. All rights reserved.
+# Copyright (C) 2020-2026 Apple Inc. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -58,7 +58,7 @@ def CallbackAction(action, callback=lambda namespace: None):
     return Action
 
 
-def LoggingGroup(parser, loggers=None, default=logging.WARNING, help='{} amount of logging'):
+def LoggingGroup(parser, loggers=None, log_config=None, default=logging.WARNING, help='{} amount of logging'):
     if not isinstance(parser, argparse.ArgumentParser):
         raise ValueError('Provided parser is not a {}'.format(type(argparse.ArgumentParser)))
 
@@ -75,6 +75,9 @@ def LoggingGroup(parser, loggers=None, default=logging.WARNING, help='{} amount 
 
         for logger in loggers:
             logger.setLevel(log_level)
+
+        if log_config:
+            log_config.set_verbose(log_level <= logging.DEBUG)
 
     group = parser.add_argument_group('Logging')
     group.add_argument(

--- a/Tools/Scripts/libraries/webkitcorepy/webkitcorepy/log_config.py
+++ b/Tools/Scripts/libraries/webkitcorepy/webkitcorepy/log_config.py
@@ -1,0 +1,81 @@
+# Copyright (C) 2026 Apple Inc. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1.  Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+# 2.  Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS'' AND ANY
+# EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR ANY
+# DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+# ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+from __future__ import annotations
+
+import logging
+import sys
+
+from webkitcorepy import Terminal
+
+
+class ColorFormatter(logging.Formatter):
+    def __init__(self, fmt: str, use_color: bool = True) -> None:
+        super().__init__(fmt)
+        self._use_color = use_color
+
+    def format(self, record: logging.LogRecord) -> str:
+        if self._use_color:
+            if record.levelno >= logging.ERROR:
+                color = Terminal.Text.red
+            elif record.levelno >= logging.WARNING:
+                color = Terminal.Text.yellow
+            else:
+                color = None
+            if color:
+                record = logging.makeLogRecord(record.__dict__)
+                record.levelname = f'{color}{record.levelname}{Terminal.Text.reset}'
+                record.msg = f'{color}{record.msg}{Terminal.Text.reset}'
+        return super().format(record)
+
+
+class LogConfig:
+    DEFAULT_FORMAT = '%(asctime)s - %(levelname)s - %(message)s'
+    VERBOSE_FORMAT = '%(asctime)s - %(levelname)s - %(module)s.%(funcName)s:%(lineno)d - %(message)s'
+
+    def __init__(self, name: str) -> None:
+        use_color = Terminal.supports_color(sys.stderr)
+
+        self._default_fmt = ColorFormatter(self.DEFAULT_FORMAT, use_color=use_color)
+        self._verbose_fmt = ColorFormatter(self.VERBOSE_FORMAT, use_color=use_color)
+
+        self._logger = logging.getLogger(name)
+        self._logger.propagate = False
+
+        stdout_handler = logging.StreamHandler(sys.stdout)
+        stdout_handler.addFilter(lambda record: record.levelno < logging.WARNING)
+        stdout_handler.setFormatter(self._default_fmt)
+        self._logger.addHandler(stdout_handler)
+
+        stderr_handler = logging.StreamHandler(sys.stderr)
+        stderr_handler.addFilter(lambda record: record.levelno >= logging.WARNING)
+        stderr_handler.setFormatter(self._default_fmt)
+        self._logger.addHandler(stderr_handler)
+
+    @property
+    def logger(self) -> logging.Logger:
+        return self._logger
+
+    def set_verbose(self, enabled: bool) -> None:
+        fmt = self._verbose_fmt if enabled else self._default_fmt
+        for handler in self._logger.handlers:
+            handler.setFormatter(fmt)


### PR DESCRIPTION
#### 8bf2d9c9faab99aa9dff1322acbe47c8283ee010
<pre>
[webkitcorepy] Add structured logging with color and stream splitting
<a href="https://rdar.apple.com/176580263">rdar://176580263</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=314431">https://bugs.webkit.org/show_bug.cgi?id=314431</a>

Reviewed by Jonathan Bedard.

Add ColorFormatter and LogConfig to webkitcorepy. Tools opt in by
creating a LogConfig(&apos;&lt;logger-name&gt;&apos;) in their entry point, which
configures handlers on the named logger:

- Clean format: 2026-05-08 10:30:00 - WARNING - message
- Stream splitting: INFO/DEBUG to stdout, WARNING+ to stderr
- Color: yellow warnings, red errors (TTY only)
- Verbose toggle via set_verbose(): switches format to
  timestamp - LEVEL - module.func:line - message

* Tools/Scripts/libraries/webkitcorepy/webkitcorepy/arguments.py:
(LoggingGroup):
(LoggingGroup.verbose_callback):
* Tools/Scripts/libraries/webkitcorepy/webkitcorepy/log_config.py: Added.
(ColorFormatter):
(ColorFormatter.__init__):
(ColorFormatter.format):
(LogConfig):
(LogConfig.__init__):
(LogConfig.logger):
(LogConfig.set_verbose):

Canonical link: <a href="https://commits.webkit.org/313202@main">https://commits.webkit.org/313202@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7c624a8c93968047a6c35514e734e29487c0b0b7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/162321 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/35797 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/28913 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/171229 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/118766 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/164190 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/35901 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/35799 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/125971 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/118766 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/165280 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/28310 "Passed tests") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/145817 "Found 1 new API test failure: TestWebKitAPI.WKWebExtensionAPIAction.ClearTabSpecificActionPropertiesOnNavigation (failure)") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/106549 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/161641 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/27357 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/25877 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/18950 "Built successfully") | 
| [⏳ 🛠 🧪 jsc ](https://ews-build.webkit.org/#/builders/JSC-Tests-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/137060 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/23551 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/173723 "Built successfully") | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/25195 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/134272 "Passed tests") | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/161718 "Passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/35471 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/29965 "Found 5 new test failures: http/tests/site-isolation/inspector/console/message-from-iframe.html http/tests/site-isolation/inspector/debugger/provisional-frame-target-pausing.html http/tests/site-isolation/inspector/target/target-cross-origin-page-navigation.html http/tests/site-isolation/inspector/target/target.html http/tests/site-isolation/inspector/worker/worker-in-cross-origin-iframe.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/134273 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36260 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/35455 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/145347 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/97713 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/28812 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/22177 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/34964 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/34466 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/34711 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/34614 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->