### PR TITLE
[Media Testing] Add Audio+Video synthetic webm + mp4 media-source tests

### DIFF
--- a/LayoutTests/media/media-source/media-source-real-audio-append-buffer-expected.txt
+++ b/LayoutTests/media/media-source/media-source-real-audio-append-buffer-expected.txt
@@ -1,0 +1,15 @@
+
+EVENT(sourceopen)
+EXPECTED (sourceBuffer.updating == 'true') OK
+EVENT(updateend)
+EXPECTED (sourceBuffer.updating == 'false') OK
+EXPECTED (sourceBuffer.updating == 'true') OK
+EVENT(updateend)
+EXPECTED (sourceBuffer.updating == 'false') OK
+EXPECTED (sourceBuffer.buffered.length == '1') OK
+EXPECTED (sourceBuffer.buffered.start(0) == '0') OK
+EXPECTED (sourceBuffer.buffered.end(0) == '4') OK
+EXPECTED (sourceBuffer.audioTracks.length == '1') OK
+EXPECTED (source.activeSourceBuffers.length == '1') OK
+END OF TEST
+

--- a/LayoutTests/media/media-source/media-source-real-audio-append-buffer.html
+++ b/LayoutTests/media/media-source/media-source-real-audio-append-buffer.html
@@ -1,0 +1,74 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>media-source-real-audio-append-buffer</title>
+    <script src="mp4-generator.js"></script>
+    <script src="../video-test.js"></script>
+    <script>
+    // Tests basic audio-only MSE append through the real MP4/AAC parser pipeline.
+    // The audio path through AudioVideoRendererAVFObjC has its own set of bugs
+    // (rate change flush, encryption key serialization) distinct from video.
+
+    var source;
+    var sourceBuffer;
+
+    async function runTest() {
+        findMediaElement();
+
+        if (!MediaSource.isTypeSupported(MP4.AUDIO_TYPE)) {
+            consoleWrite('SKIPPED: ' + MP4.AUDIO_TYPE + ' is not supported');
+            return;
+        }
+
+        source = new MediaSource();
+        video.src = URL.createObjectURL(source);
+        await waitFor(source, 'sourceopen');
+
+        sourceBuffer = source.addSourceBuffer(MP4.AUDIO_TYPE);
+
+        var initData = MP4.initSegment({
+            timescale: 44100,
+            tracks: [{ id: 1, type: 'audio', timescale: 44100 }]
+        });
+        sourceBuffer.appendBuffer(initData);
+        testExpected('sourceBuffer.updating', true);
+        await waitFor(sourceBuffer, 'updateend');
+        testExpected('sourceBuffer.updating', false);
+
+        // 4 audio frames, each 1024 samples at 44100 Hz (~23.2ms each, ~93ms total)
+        // Use round durations in timescale units for clean buffered ranges.
+        var media = MP4.mediaSegment({
+            sequenceNumber: 1,
+            tracks: [{
+                id: 1, type: 'audio', baseDecodeTime: 0,
+                samples: [
+                    { duration: 44100, isSync: true },
+                    { duration: 44100, isSync: true },
+                    { duration: 44100, isSync: true },
+                    { duration: 44100, isSync: true },
+                ]
+            }]
+        });
+        sourceBuffer.appendBuffer(media);
+        testExpected('sourceBuffer.updating', true);
+        await waitFor(sourceBuffer, 'updateend');
+        testExpected('sourceBuffer.updating', false);
+
+        // 4 frames × 44100 samples / 44100 Hz = 4 seconds
+        testExpected('sourceBuffer.buffered.length', 1);
+        testExpectedEqualWithTolerance('sourceBuffer.buffered.start(0)', 0, 0.05);
+        testExpectedEqualWithTolerance('sourceBuffer.buffered.end(0)', 4, 0.05);
+
+        testExpected('sourceBuffer.audioTracks.length', 1);
+        testExpected('source.activeSourceBuffers.length', 1);
+    }
+
+    window.addEventListener('load', event => {
+        runTest().then(endTest).catch(failTest);
+    });
+    </script>
+</head>
+<body>
+    <video></video>
+</body>
+</html>

--- a/LayoutTests/media/media-source/media-source-real-audio-remove-expected.txt
+++ b/LayoutTests/media/media-source/media-source-real-audio-remove-expected.txt
@@ -1,0 +1,14 @@
+
+EVENT(sourceopen)
+EVENT(updateend)
+EVENT(updateend)
+EXPECTED (sourceBuffer.buffered.length == '1') OK
+EXPECTED (sourceBuffer.buffered.end(0) == '8') OK
+EVENT(updateend)
+EXPECTED (sourceBuffer.buffered.length == '2') OK
+EXPECTED (sourceBuffer.buffered.start(0) == '0') OK
+EXPECTED (sourceBuffer.buffered.end(0) == '2') OK
+EXPECTED (sourceBuffer.buffered.start(1) == '6') OK
+EXPECTED (sourceBuffer.buffered.end(1) == '8') OK
+END OF TEST
+

--- a/LayoutTests/media/media-source/media-source-real-audio-remove.html
+++ b/LayoutTests/media/media-source/media-source-real-audio-remove.html
@@ -1,0 +1,68 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>media-source-real-audio-remove</title>
+    <script src="mp4-generator.js"></script>
+    <script src="../video-test.js"></script>
+    <script>
+    // Tests remove() on an audio-only SourceBuffer. All audio frames are sync
+    // frames (AAC frames are independently decodable), so removal should be
+    // exact rather than extending to a sync frame boundary.
+
+    var source;
+    var sourceBuffer;
+
+    async function runTest() {
+        findMediaElement();
+
+        if (!MediaSource.isTypeSupported(MP4.AUDIO_TYPE)) {
+            consoleWrite('SKIPPED: ' + MP4.AUDIO_TYPE + ' is not supported');
+            return;
+        }
+
+        source = new MediaSource();
+        video.src = URL.createObjectURL(source);
+        await waitFor(source, 'sourceopen');
+
+        sourceBuffer = source.addSourceBuffer(MP4.AUDIO_TYPE);
+
+        sourceBuffer.appendBuffer(MP4.initSegment({
+            timescale: 44100,
+            tracks: [{ id: 1, type: 'audio', timescale: 44100 }]
+        }));
+        await waitFor(sourceBuffer, 'updateend');
+
+        // 8 seconds of audio
+        var samples = [];
+        for (var i = 0; i < 8; i++)
+            samples.push({ duration: 44100, isSync: true });
+        sourceBuffer.appendBuffer(MP4.mediaSegment({
+            sequenceNumber: 1,
+            tracks: [{ id: 1, type: 'audio', baseDecodeTime: 0, samples }]
+        }));
+        await waitFor(sourceBuffer, 'updateend');
+
+        testExpected('sourceBuffer.buffered.length', 1);
+        testExpectedEqualWithTolerance('sourceBuffer.buffered.end(0)', 8, 0.05);
+
+        // Remove [2, 6) — since all audio frames are sync, removal should be
+        // exact (no need to extend to next sync frame like video)
+        sourceBuffer.remove(2, 6);
+        await waitFor(sourceBuffer, 'updateend');
+
+        testExpected('sourceBuffer.buffered.length', 2);
+        testExpectedEqualWithTolerance('sourceBuffer.buffered.start(0)', 0, 0.05);
+        testExpectedEqualWithTolerance('sourceBuffer.buffered.end(0)', 2, 0.05);
+        testExpectedEqualWithTolerance('sourceBuffer.buffered.start(1)', 6, 0.05);
+        testExpectedEqualWithTolerance('sourceBuffer.buffered.end(1)', 8, 0.05);
+    }
+
+    window.addEventListener('load', event => {
+        runTest().then(endTest).catch(failTest);
+    });
+    </script>
+</head>
+<body>
+    <video></video>
+</body>
+</html>

--- a/LayoutTests/media/media-source/media-source-real-audio-sequential-expected.txt
+++ b/LayoutTests/media/media-source/media-source-real-audio-sequential-expected.txt
@@ -1,0 +1,13 @@
+
+EVENT(sourceopen)
+EVENT(updateend)
+EVENT(updateend)
+EVENT(updateend)
+EVENT(updateend)
+EXPECTED (sourceBuffer.buffered.length == '1') OK
+EXPECTED (sourceBuffer.buffered.start(0) == '0') OK
+EXPECTED (sourceBuffer.buffered.end(0) == '6') OK
+EXPECTED (source.readyState == 'ended') OK
+EXPECTED (source.duration == '6') OK
+END OF TEST
+

--- a/LayoutTests/media/media-source/media-source-real-audio-sequential.html
+++ b/LayoutTests/media/media-source/media-source-real-audio-sequential.html
@@ -1,0 +1,66 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>media-source-real-audio-sequential</title>
+    <script src="mp4-generator.js"></script>
+    <script src="../video-test.js"></script>
+    <script>
+    // Tests sequential audio segment appends and endOfStream through the
+    // real parser. This exercises the audio sample enqueue path that had
+    // bugs during the re-architecture (missing flush notifications, rate
+    // change issues).
+
+    var source;
+    var sourceBuffer;
+
+    async function runTest() {
+        findMediaElement();
+
+        if (!MediaSource.isTypeSupported(MP4.AUDIO_TYPE)) {
+            consoleWrite('SKIPPED: ' + MP4.AUDIO_TYPE + ' is not supported');
+            return;
+        }
+
+        source = new MediaSource();
+        video.src = URL.createObjectURL(source);
+        await waitFor(source, 'sourceopen');
+
+        sourceBuffer = source.addSourceBuffer(MP4.AUDIO_TYPE);
+
+        sourceBuffer.appendBuffer(MP4.initSegment({
+            timescale: 44100,
+            tracks: [{ id: 1, type: 'audio', timescale: 44100 }]
+        }));
+        await waitFor(sourceBuffer, 'updateend');
+
+        // Append 3 contiguous 2-second segments
+        for (var seg = 0; seg < 3; seg++) {
+            var samples = [];
+            for (var i = 0; i < 2; i++)
+                samples.push({ duration: 44100, isSync: true });
+            sourceBuffer.appendBuffer(MP4.mediaSegment({
+                sequenceNumber: seg + 1,
+                tracks: [{ id: 1, type: 'audio', baseDecodeTime: seg * 2 * 44100, samples }]
+            }));
+            await waitFor(sourceBuffer, 'updateend');
+        }
+
+        // Should have one contiguous range [0, 6)
+        testExpected('sourceBuffer.buffered.length', 1);
+        testExpectedEqualWithTolerance('sourceBuffer.buffered.start(0)', 0, 0.05);
+        testExpectedEqualWithTolerance('sourceBuffer.buffered.end(0)', 6, 0.05);
+
+        source.endOfStream();
+        testExpected('source.readyState', 'ended');
+        testExpectedEqualWithTolerance('source.duration', 6, 0.05);
+    }
+
+    window.addEventListener('load', event => {
+        runTest().then(endTest).catch(failTest);
+    });
+    </script>
+</head>
+<body>
+    <video></video>
+</body>
+</html>

--- a/LayoutTests/media/media-source/media-source-real-currenttime-progression-expected.txt
+++ b/LayoutTests/media/media-source/media-source-real-currenttime-progression-expected.txt
@@ -1,0 +1,12 @@
+
+EVENT(sourceopen)
+EVENT(updateend)
+EVENT(updateend)
+RUN(video.currentTime = 0)
+RUN(video.play())
+EVENT(playing)
+EXPECTED (video.currentTime > '0') OK
+EXPECTED (time2 > time1 == 'true') OK
+RUN(video.pause())
+END OF TEST
+

--- a/LayoutTests/media/media-source/media-source-real-currenttime-progression.html
+++ b/LayoutTests/media/media-source/media-source-real-currenttime-progression.html
@@ -1,0 +1,77 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>media-source-real-currenttime-progression</title>
+    <script src="mp4-generator.js"></script>
+    <script src="../video-test.js"></script>
+    <script>
+    // Verifies that currentTime advances during playback. Catches regressions
+    // where cross-process time reporting stalls or returns stepwise jumps:
+    //   - TimeProgressEstimator interpolation (bug 307515)
+    //   - currentTime polling frequency (bug 307495 / Paramount+)
+
+    var source;
+    var sourceBuffer;
+    var time1;
+    var time2;
+
+    async function runTest() {
+        findMediaElement();
+
+        source = new MediaSource();
+        video.src = URL.createObjectURL(source);
+        await waitFor(source, 'sourceopen');
+
+        sourceBuffer = source.addSourceBuffer(MP4.VIDEO_TYPE);
+
+        var initData = MP4.initSegment({
+            timescale: 1000,
+            tracks: [{ id: 1, type: 'video', timescale: 1000 }]
+        });
+        sourceBuffer.appendBuffer(initData);
+        await waitFor(sourceBuffer, 'updateend');
+
+        // 4 seconds of all-sync video so every frame decodes independently.
+        var samples = [];
+        for (var i = 0; i < 4; i++) {
+            samples.push({
+                duration: 1000,
+                compositionTimeOffset: 0,
+                isSync: true,
+            });
+        }
+        var media = MP4.mediaSegment({
+            sequenceNumber: 1,
+            tracks: [{ id: 1, type: 'video', baseDecodeTime: 0, samples }]
+        });
+        sourceBuffer.appendBuffer(media);
+        await waitFor(sourceBuffer, 'updateend');
+
+        source.endOfStream();
+
+        run('video.currentTime = 0');
+        run('video.play()');
+        await waitFor(video, 'playing');
+
+        // Wait for currentTime to advance past 0.
+        await testExpectedEventually('video.currentTime', 0, '>', 5000);
+
+        time1 = video.currentTime;
+
+        await new Promise(resolve => setTimeout(resolve, 500));
+
+        time2 = video.currentTime;
+        testExpected('time2 > time1', true);
+
+        run('video.pause()');
+    }
+
+    window.addEventListener('load', event => {
+        runTest().then(endTest).catch(failTest);
+    });
+    </script>
+</head>
+<body>
+    <video></video>
+</body>
+</html>

--- a/LayoutTests/media/media-source/media-source-real-discontinuity-expected.txt
+++ b/LayoutTests/media/media-source/media-source-real-discontinuity-expected.txt
@@ -1,0 +1,14 @@
+
+EVENT(sourceopen)
+EVENT(updateend)
+EVENT(updateend)
+EXPECTED (sourceBuffer.buffered.length == '1') OK
+EXPECTED (sourceBuffer.buffered.end(0) == '2') OK
+EVENT(updateend)
+EXPECTED (sourceBuffer.buffered.length == '2') OK
+EXPECTED (sourceBuffer.buffered.start(0) == '0') OK
+EXPECTED (sourceBuffer.buffered.end(0) == '2') OK
+EXPECTED (sourceBuffer.buffered.start(1) == '10') OK
+EXPECTED (sourceBuffer.buffered.end(1) == '12') OK
+END OF TEST
+

--- a/LayoutTests/media/media-source/media-source-real-discontinuity.html
+++ b/LayoutTests/media/media-source/media-source-real-discontinuity.html
@@ -1,0 +1,77 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>media-source-real-discontinuity</title>
+    <script src="mp4-generator.js"></script>
+    <script src="../video-test.js"></script>
+    <script>
+    // Tests discontinuity detection in the coded frame processing algorithm.
+    // MSE spec section 3.3.1: when the gap between decode timestamps exceeds
+    // 2x the last frame duration, a new coded frame group starts and a
+    // discontinuity is detected.
+    //
+    // This is completely untested per our spec coverage analysis.
+
+    var source;
+    var sourceBuffer;
+
+    async function runTest() {
+        findMediaElement();
+
+        source = new MediaSource();
+        video.src = URL.createObjectURL(source);
+        await waitFor(source, 'sourceopen');
+
+        sourceBuffer = source.addSourceBuffer(MP4.VIDEO_TYPE);
+
+        var initData = MP4.initSegment({
+            timescale: 1000,
+            tracks: [{ id: 1, type: 'video', timescale: 1000 }]
+        });
+        sourceBuffer.appendBuffer(initData);
+        await waitFor(sourceBuffer, 'updateend');
+
+        // Segment 1: 2 seconds [0, 2) with 1-second samples
+        var media1 = MP4.mediaSegment({
+            sequenceNumber: 1,
+            tracks: [{ id: 1, type: 'video', baseDecodeTime: 0, samples: [
+                { duration: 1000, compositionTimeOffset: 0, isSync: true },
+                { duration: 1000, compositionTimeOffset: 0, isSync: false },
+            ]}]
+        });
+        sourceBuffer.appendBuffer(media1);
+        await waitFor(sourceBuffer, 'updateend');
+
+        testExpected('sourceBuffer.buffered.length', 1);
+        testExpectedEqualWithTolerance('sourceBuffer.buffered.end(0)', 2, 0.01);
+
+        // Segment 2: starts at DTS=10s — gap of 8s is >> 2x frame duration (1s).
+        // This should create a discontinuity / new coded frame group,
+        // resulting in two disjoint buffered ranges.
+        var media2 = MP4.mediaSegment({
+            sequenceNumber: 2,
+            tracks: [{ id: 1, type: 'video', baseDecodeTime: 10000, samples: [
+                { duration: 1000, compositionTimeOffset: 0, isSync: true },
+                { duration: 1000, compositionTimeOffset: 0, isSync: false },
+            ]}]
+        });
+        sourceBuffer.appendBuffer(media2);
+        await waitFor(sourceBuffer, 'updateend');
+
+        // Should have two disjoint ranges: [0, 2) and [10, 12)
+        testExpected('sourceBuffer.buffered.length', 2);
+        testExpectedEqualWithTolerance('sourceBuffer.buffered.start(0)', 0, 0.01);
+        testExpectedEqualWithTolerance('sourceBuffer.buffered.end(0)', 2, 0.01);
+        testExpectedEqualWithTolerance('sourceBuffer.buffered.start(1)', 10, 0.01);
+        testExpectedEqualWithTolerance('sourceBuffer.buffered.end(1)', 12, 0.01);
+    }
+
+    window.addEventListener('load', event => {
+        runTest().then(endTest).catch(failTest);
+    });
+    </script>
+</head>
+<body>
+    <video></video>
+</body>
+</html>

--- a/LayoutTests/media/media-source/media-source-real-playbackrate-change-expected.txt
+++ b/LayoutTests/media/media-source/media-source-real-playbackrate-change-expected.txt
@@ -1,0 +1,18 @@
+
+EVENT(sourceopen)
+EVENT(updateend)
+EVENT(updateend)
+RUN(video.play())
+EVENT(playing)
+EXPECTED (video.currentTime > '0') OK
+RUN(video.playbackRate = 2)
+EXPECTED (video.paused == 'false') OK
+EXPECTED (video.currentTime > timeBeforeRateChange == 'true') OK
+EXPECTED (video.paused == 'false') OK
+RUN(video.playbackRate = 1)
+EXPECTED (video.currentTime > timeAfterRestore == 'true') OK
+EXPECTED (video.paused == 'false') OK
+EXPECTED (video.error == 'null') OK
+RUN(video.pause())
+END OF TEST
+

--- a/LayoutTests/media/media-source/media-source-real-playbackrate-change.html
+++ b/LayoutTests/media/media-source/media-source-real-playbackrate-change.html
@@ -1,0 +1,86 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>media-source-real-playbackrate-change</title>
+    <script src="mp4-generator.js"></script>
+    <script src="../video-test.js"></script>
+    <script>
+    // Verifies that changing playbackRate during playback does not stall or
+    // error. Catches regressions where the GPU process flushes audio/video
+    // renderers on rate change but the WebContent process is never notified:
+    //   - Audio stops on rate change (bug 308952)
+
+    var source;
+    var sourceBuffer;
+    var timeBeforeRateChange;
+    var timeAfterRestore;
+
+    async function runTest() {
+        findMediaElement();
+
+        source = new MediaSource();
+        video.src = URL.createObjectURL(source);
+        await waitFor(source, 'sourceopen');
+
+        sourceBuffer = source.addSourceBuffer(MP4.VIDEO_TYPE);
+
+        var initData = MP4.initSegment({
+            timescale: 1000,
+            tracks: [{ id: 1, type: 'video', timescale: 1000 }]
+        });
+        sourceBuffer.appendBuffer(initData);
+        await waitFor(sourceBuffer, 'updateend');
+
+        // 6 seconds of all-sync video.
+        var samples = [];
+        for (var i = 0; i < 6; i++) {
+            samples.push({
+                duration: 1000,
+                compositionTimeOffset: 0,
+                isSync: true,
+            });
+        }
+        var media = MP4.mediaSegment({
+            sequenceNumber: 1,
+            tracks: [{ id: 1, type: 'video', baseDecodeTime: 0, samples }]
+        });
+        sourceBuffer.appendBuffer(media);
+        await waitFor(sourceBuffer, 'updateend');
+
+        source.endOfStream();
+
+        run('video.play()');
+        await waitFor(video, 'playing');
+        await testExpectedEventually('video.currentTime', 0, '>', 5000);
+
+        // Change rate to 2x
+        timeBeforeRateChange = video.currentTime;
+        run('video.playbackRate = 2');
+        testExpected('video.paused', false);
+
+        await new Promise(resolve => setTimeout(resolve, 500));
+        testExpected('video.currentTime > timeBeforeRateChange', true);
+        testExpected('video.paused', false);
+
+        // Change rate back to 1x
+        run('video.playbackRate = 1');
+        timeAfterRestore = video.currentTime;
+
+        await new Promise(resolve => setTimeout(resolve, 500));
+        testExpected('video.currentTime > timeAfterRestore', true);
+        testExpected('video.paused', false);
+
+        testExpected('video.error', null);
+
+        run('video.pause()');
+    }
+
+    window.addEventListener('load', event => {
+        runTest().then(endTest).catch(failTest);
+    });
+    </script>
+</head>
+<body>
+    <video></video>
+</body>
+</html>

--- a/LayoutTests/media/media-source/media-source-real-reinitialize-expected.txt
+++ b/LayoutTests/media/media-source/media-source-real-reinitialize-expected.txt
@@ -1,0 +1,18 @@
+
+EVENT(sourceopen)
+EVENT(updateend)
+EXPECTED (sourceBuffer.videoTracks.length == '1') OK
+EVENT(updateend)
+EXPECTED (sourceBuffer.buffered.length == '1') OK
+EXPECTED (sourceBuffer.buffered.end(0) == '4') OK
+EVENT(updateend)
+EXPECTED (source.readyState == 'open') OK
+EXPECTED (sourceBuffer.videoTracks.length == '1') OK
+EXPECTED (sourceBuffer.buffered.length == '1') OK
+EXPECTED (sourceBuffer.buffered.end(0) == '4') OK
+EVENT(updateend)
+EXPECTED (source.readyState == 'open') OK
+EXPECTED (sourceBuffer.buffered.length == '1') OK
+EXPECTED (sourceBuffer.buffered.end(0) == '6') OK
+END OF TEST
+

--- a/LayoutTests/media/media-source/media-source-real-reinitialize.html
+++ b/LayoutTests/media/media-source/media-source-real-reinitialize.html
@@ -1,0 +1,86 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>media-source-real-reinitialize</title>
+    <script src="mp4-generator.js"></script>
+    <script src="../video-test.js"></script>
+    <script>
+    // Tests that appending a second initialization segment with matching tracks
+    // succeeds and doesn't disrupt existing buffered data.
+    // MSE spec section 3.3.2 "Initialization Segment Received" — when a second
+    // init segment arrives, track count and types must match the first.
+    // Weakly tested — minimal real-parser coverage.
+
+    var source;
+    var sourceBuffer;
+
+    async function runTest() {
+        findMediaElement();
+
+        source = new MediaSource();
+        video.src = URL.createObjectURL(source);
+        await waitFor(source, 'sourceopen');
+
+        sourceBuffer = source.addSourceBuffer(MP4.VIDEO_TYPE);
+
+        var initData = MP4.initSegment({
+            timescale: 1000,
+            tracks: [{ id: 1, type: 'video', timescale: 1000 }]
+        });
+
+        // First init
+        sourceBuffer.appendBuffer(initData);
+        await waitFor(sourceBuffer, 'updateend');
+
+        testExpected('sourceBuffer.videoTracks.length', 1);
+
+        // Append media
+        var media = MP4.mediaSegment({
+            sequenceNumber: 1,
+            tracks: [{ id: 1, type: 'video', baseDecodeTime: 0, samples: [
+                { duration: 1000, compositionTimeOffset: 0, isSync: true },
+                { duration: 1000, compositionTimeOffset: 0, isSync: false },
+                { duration: 1000, compositionTimeOffset: 0, isSync: false },
+                { duration: 1000, compositionTimeOffset: 0, isSync: false },
+            ]}]
+        });
+        sourceBuffer.appendBuffer(media);
+        await waitFor(sourceBuffer, 'updateend');
+
+        testExpected('sourceBuffer.buffered.length', 1);
+        testExpectedEqualWithTolerance('sourceBuffer.buffered.end(0)', 4, 0.01);
+
+        // Second init — same tracks, should succeed without disrupting buffered data
+        sourceBuffer.appendBuffer(initData);
+        await waitFor(sourceBuffer, 'updateend');
+
+        testExpected('source.readyState', 'open');
+        testExpected('sourceBuffer.videoTracks.length', 1);
+        testExpected('sourceBuffer.buffered.length', 1);
+        testExpectedEqualWithTolerance('sourceBuffer.buffered.end(0)', 4, 0.01);
+
+        // Append more media after re-init — should extend the buffer
+        var media2 = MP4.mediaSegment({
+            sequenceNumber: 2,
+            tracks: [{ id: 1, type: 'video', baseDecodeTime: 4000, samples: [
+                { duration: 1000, compositionTimeOffset: 0, isSync: true },
+                { duration: 1000, compositionTimeOffset: 0, isSync: false },
+            ]}]
+        });
+        sourceBuffer.appendBuffer(media2);
+        await waitFor(sourceBuffer, 'updateend');
+
+        testExpected('source.readyState', 'open');
+        testExpected('sourceBuffer.buffered.length', 1);
+        testExpectedEqualWithTolerance('sourceBuffer.buffered.end(0)', 6, 0.01);
+    }
+
+    window.addEventListener('load', event => {
+        runTest().then(endTest).catch(failTest);
+    });
+    </script>
+</head>
+<body>
+    <video></video>
+</body>
+</html>

--- a/LayoutTests/media/media-source/media-source-real-remove-edges-expected.txt
+++ b/LayoutTests/media/media-source/media-source-real-remove-edges-expected.txt
@@ -1,0 +1,24 @@
+
+EVENT(sourceopen)
+EVENT(updateend)
+EVENT(updateend)
+EXPECTED (sourceBuffer.buffered.length == '1') OK
+EXPECTED (sourceBuffer.buffered.end(0) == '6') OK
+Test 1: remove(0, 2) at sync frame boundary
+EVENT(updateend)
+EXPECTED (sourceBuffer.buffered.length == '1') OK
+EXPECTED (sourceBuffer.buffered.start(0) == '2') OK
+Test 2: remove(4, 6) at end of buffer
+EVENT(updateend)
+EXPECTED (sourceBuffer.buffered.length == '1') OK
+EXPECTED (sourceBuffer.buffered.start(0) == '2') OK
+EXPECTED (sourceBuffer.buffered.end(0) == '4') OK
+Test 3: remove(0, Infinity) removes all
+EVENT(updateend)
+EXPECTED (sourceBuffer.buffered.length == '0') OK
+Test 4: remove(0, Infinity) on empty buffer
+EVENT(updateend)
+EXPECTED (sourceBuffer.buffered.length == '0') OK
+EXPECTED (source.readyState == 'open') OK
+END OF TEST
+

--- a/LayoutTests/media/media-source/media-source-real-remove-edges.html
+++ b/LayoutTests/media/media-source/media-source-real-remove-edges.html
@@ -1,0 +1,90 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>media-source-real-remove-edges</title>
+    <script src="mp4-generator.js"></script>
+    <script src="../video-test.js"></script>
+    <script>
+    // Tests remove() at various boundary conditions through the real parser
+    // pipeline. Catches regressions in removeCodedFrames and eviction paths
+    // where invalid iterators or MediaTime::invalidTime comparisons caused
+    // infinite loops or crashes:
+    //   - SampleMap infinite loop with invalidTime (bug 304975)
+    //   - removeCodedFrames with start past end of presentation order (bug 304975)
+
+    var source;
+    var sourceBuffer;
+
+    async function runTest() {
+        findMediaElement();
+
+        source = new MediaSource();
+        video.src = URL.createObjectURL(source);
+        await waitFor(source, 'sourceopen');
+
+        sourceBuffer = source.addSourceBuffer(MP4.VIDEO_TYPE);
+
+        var initData = MP4.initSegment({
+            timescale: 1000,
+            tracks: [{ id: 1, type: 'video', timescale: 1000 }]
+        });
+        sourceBuffer.appendBuffer(initData);
+        await waitFor(sourceBuffer, 'updateend');
+
+        // 6 seconds of video, sync every 2s (at 0, 2, 4)
+        var media = MP4.mediaSegment({
+            sequenceNumber: 1,
+            tracks: [{ id: 1, type: 'video', baseDecodeTime: 0, samples: [
+                { duration: 1000, compositionTimeOffset: 0, isSync: true },
+                { duration: 1000, compositionTimeOffset: 0, isSync: false },
+                { duration: 1000, compositionTimeOffset: 0, isSync: true },
+                { duration: 1000, compositionTimeOffset: 0, isSync: false },
+                { duration: 1000, compositionTimeOffset: 0, isSync: true },
+                { duration: 1000, compositionTimeOffset: 0, isSync: false },
+            ]}]
+        });
+        sourceBuffer.appendBuffer(media);
+        await waitFor(sourceBuffer, 'updateend');
+
+        testExpected('sourceBuffer.buffered.length', 1);
+        testExpectedEqualWithTolerance('sourceBuffer.buffered.end(0)', 6, 0.01);
+
+        // Test 1: Remove exactly at sync frame boundary.
+        consoleWrite('Test 1: remove(0, 2) at sync frame boundary');
+        sourceBuffer.remove(0, 2);
+        await waitFor(sourceBuffer, 'updateend');
+        testExpected('sourceBuffer.buffered.length', 1);
+        testExpectedEqualWithTolerance('sourceBuffer.buffered.start(0)', 2, 0.01);
+
+        // Test 2: Remove at end of buffered data.
+        consoleWrite('Test 2: remove(4, 6) at end of buffer');
+        sourceBuffer.remove(4, 6);
+        await waitFor(sourceBuffer, 'updateend');
+        testExpected('sourceBuffer.buffered.length', 1);
+        testExpectedEqualWithTolerance('sourceBuffer.buffered.start(0)', 2, 0.01);
+        testExpectedEqualWithTolerance('sourceBuffer.buffered.end(0)', 4, 0.01);
+
+        // Test 3: Remove everything remaining.
+        consoleWrite('Test 3: remove(0, Infinity) removes all');
+        sourceBuffer.remove(0, Infinity);
+        await waitFor(sourceBuffer, 'updateend');
+        testExpected('sourceBuffer.buffered.length', 0);
+
+        // Test 4: Remove on empty buffer — should not crash or hang.
+        consoleWrite('Test 4: remove(0, Infinity) on empty buffer');
+        sourceBuffer.remove(0, Infinity);
+        await waitFor(sourceBuffer, 'updateend');
+        testExpected('sourceBuffer.buffered.length', 0);
+
+        testExpected('source.readyState', 'open');
+    }
+
+    window.addEventListener('load', event => {
+        runTest().then(endTest).catch(failTest);
+    });
+    </script>
+</head>
+<body>
+    <video></video>
+</body>
+</html>

--- a/LayoutTests/media/media-source/media-source-real-sequence-mode-expected.txt
+++ b/LayoutTests/media/media-source/media-source-real-sequence-mode-expected.txt
@@ -1,0 +1,21 @@
+
+EVENT(sourceopen)
+EXPECTED (sourceBuffer.mode == 'segments') OK
+RUN(sourceBuffer.mode = "sequence")
+EXPECTED (sourceBuffer.mode == 'sequence') OK
+EXPECTED (sourceBuffer.timestampOffset == '0') OK
+EVENT(updateend)
+EVENT(updateend)
+EXPECTED (sourceBuffer.buffered.length == '1') OK
+EXPECTED (sourceBuffer.buffered.start(0) == '0') OK
+EXPECTED (sourceBuffer.buffered.end(0) == '2') OK
+EVENT(updateend)
+EXPECTED (sourceBuffer.buffered.length == '1') OK
+EXPECTED (sourceBuffer.buffered.start(0) == '0') OK
+EXPECTED (sourceBuffer.buffered.end(0) == '4') OK
+EVENT(updateend)
+EXPECTED (sourceBuffer.buffered.length == '1') OK
+EXPECTED (sourceBuffer.buffered.start(0) == '0') OK
+EXPECTED (sourceBuffer.buffered.end(0) == '5') OK
+END OF TEST
+

--- a/LayoutTests/media/media-source/media-source-real-sequence-mode.html
+++ b/LayoutTests/media/media-source/media-source-real-sequence-mode.html
@@ -1,0 +1,96 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>media-source-real-sequence-mode</title>
+    <script src="mp4-generator.js"></script>
+    <script src="../video-test.js"></script>
+    <script>
+    // Tests SourceBuffer "sequence" mode where timestampOffset is automatically
+    // updated after each coded frame group so segments are placed end-to-end.
+    // MSE spec section 3.1.1 and 3.3.1.
+
+    var source;
+    var sourceBuffer;
+
+    async function runTest() {
+        findMediaElement();
+
+        source = new MediaSource();
+        video.src = URL.createObjectURL(source);
+        await waitFor(source, 'sourceopen');
+
+        sourceBuffer = source.addSourceBuffer(MP4.VIDEO_TYPE);
+
+        testExpected('sourceBuffer.mode', 'segments');
+
+        run('sourceBuffer.mode = "sequence"');
+        testExpected('sourceBuffer.mode', 'sequence');
+        testExpected('sourceBuffer.timestampOffset', 0);
+
+        var initData = MP4.initSegment({
+            timescale: 1000,
+            tracks: [{ id: 1, type: 'video', timescale: 1000 }]
+        });
+        sourceBuffer.appendBuffer(initData);
+        await waitFor(sourceBuffer, 'updateend');
+
+        // Append first segment: 2 seconds starting at DTS=0
+        var media1 = MP4.mediaSegment({
+            sequenceNumber: 1,
+            tracks: [{ id: 1, type: 'video', baseDecodeTime: 0, samples: [
+                { duration: 1000, compositionTimeOffset: 0, isSync: true },
+                { duration: 1000, compositionTimeOffset: 0, isSync: false },
+            ]}]
+        });
+        sourceBuffer.appendBuffer(media1);
+        await waitFor(sourceBuffer, 'updateend');
+
+        // First segment: placed at [0, 2).
+        // In sequence mode, timestampOffset is NOT updated on the initial group,
+        // it updates when a new coded frame group starts on the NEXT append.
+        testExpected('sourceBuffer.buffered.length', 1);
+        testExpectedEqualWithTolerance('sourceBuffer.buffered.start(0)', 0, 0.01);
+        testExpectedEqualWithTolerance('sourceBuffer.buffered.end(0)', 2, 0.01);
+
+        // Append second segment: also starts at DTS=0 in the container.
+        // Sequence mode detects this as a new group, sets timestampOffset to
+        // the end of the previous group (2), and places frames at [2, 4).
+        var media2 = MP4.mediaSegment({
+            sequenceNumber: 2,
+            tracks: [{ id: 1, type: 'video', baseDecodeTime: 0, samples: [
+                { duration: 1000, compositionTimeOffset: 0, isSync: true },
+                { duration: 1000, compositionTimeOffset: 0, isSync: false },
+            ]}]
+        });
+        sourceBuffer.appendBuffer(media2);
+        await waitFor(sourceBuffer, 'updateend');
+
+        // Should now have [0, 4) contiguously
+        testExpected('sourceBuffer.buffered.length', 1);
+        testExpectedEqualWithTolerance('sourceBuffer.buffered.start(0)', 0, 0.01);
+        testExpectedEqualWithTolerance('sourceBuffer.buffered.end(0)', 4, 0.01);
+
+        // Append a third segment to confirm the pattern continues
+        var media3 = MP4.mediaSegment({
+            sequenceNumber: 3,
+            tracks: [{ id: 1, type: 'video', baseDecodeTime: 0, samples: [
+                { duration: 1000, compositionTimeOffset: 0, isSync: true },
+            ]}]
+        });
+        sourceBuffer.appendBuffer(media3);
+        await waitFor(sourceBuffer, 'updateend');
+
+        testExpected('sourceBuffer.buffered.length', 1);
+        testExpectedEqualWithTolerance('sourceBuffer.buffered.start(0)', 0, 0.01);
+        testExpectedEqualWithTolerance('sourceBuffer.buffered.end(0)', 5, 0.01);
+    }
+
+    window.addEventListener('load', event => {
+        runTest().then(endTest).catch(failTest);
+    });
+    </script>
+</head>
+<body>
+    <video></video>
+</body>
+</html>

--- a/LayoutTests/media/media-source/media-source-real-sourcebufferlist-events-expected.txt
+++ b/LayoutTests/media/media-source/media-source-real-sourcebufferlist-events-expected.txt
@@ -1,0 +1,11 @@
+
+EVENT(sourceopen)
+EXPECTED (source.sourceBuffers.length == '1') OK
+addsourcebuffer event on sourceBuffers: fired
+EVENT(updateend)
+EXPECTED (source.activeSourceBuffers.length == '1') OK
+RUN(source.removeSourceBuffer(sourceBuffer))
+EXPECTED (source.sourceBuffers.length == '0') OK
+removesourcebuffer event on sourceBuffers: fired
+END OF TEST
+

--- a/LayoutTests/media/media-source/media-source-real-sourcebufferlist-events.html
+++ b/LayoutTests/media/media-source/media-source-real-sourcebufferlist-events.html
@@ -1,0 +1,66 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>media-source-real-sourcebufferlist-events</title>
+    <script src="mp4-generator.js"></script>
+    <script src="../video-test.js"></script>
+    <script>
+    // Tests that SourceBufferList fires addsourcebuffer and removesourcebuffer
+    // events when SourceBuffers are added/removed.
+    // MSE spec section 3.4.3 — event firing and ordering.
+
+    var source;
+    var sourceBuffer;
+
+    async function runTest() {
+        findMediaElement();
+
+        source = new MediaSource();
+        video.src = URL.createObjectURL(source);
+        await waitFor(source, 'sourceopen');
+
+        // Listen for addsourcebuffer on sourceBuffers
+        var addPromise = waitFor(source.sourceBuffers, 'addsourcebuffer', true);
+
+        sourceBuffer = source.addSourceBuffer(MP4.VIDEO_TYPE);
+        testExpected('source.sourceBuffers.length', 1);
+
+        // The event may be synchronous or task-queued; give it a chance to fire
+        var result = await Promise.race([
+            addPromise.then(() => 'fired'),
+            new Promise(resolve => setTimeout(() => resolve('timeout'), 100))
+        ]);
+        consoleWrite('addsourcebuffer event on sourceBuffers: ' + result);
+
+        // Append init to make track active
+        var initData = MP4.initSegment({
+            timescale: 1000,
+            tracks: [{ id: 1, type: 'video', timescale: 1000 }]
+        });
+        sourceBuffer.appendBuffer(initData);
+        await waitFor(sourceBuffer, 'updateend');
+
+        testExpected('source.activeSourceBuffers.length', 1);
+
+        // Listen for removesourcebuffer
+        var removePromise = waitFor(source.sourceBuffers, 'removesourcebuffer', true);
+
+        run('source.removeSourceBuffer(sourceBuffer)');
+        testExpected('source.sourceBuffers.length', 0);
+
+        result = await Promise.race([
+            removePromise.then(() => 'fired'),
+            new Promise(resolve => setTimeout(() => resolve('timeout'), 100))
+        ]);
+        consoleWrite('removesourcebuffer event on sourceBuffers: ' + result);
+    }
+
+    window.addEventListener('load', event => {
+        runTest().then(endTest).catch(failTest);
+    });
+    </script>
+</head>
+<body>
+    <video></video>
+</body>
+</html>

--- a/LayoutTests/media/media-source/media-source-real-state-errors-expected.txt
+++ b/LayoutTests/media/media-source/media-source-real-state-errors-expected.txt
@@ -1,0 +1,22 @@
+
+EVENT(sourceopen)
+Test: appendBuffer while updating must throw InvalidStateError
+EXPECTED (sourceBuffer.updating == 'true') OK
+EXPECTED (thrownError.name == 'InvalidStateError') OK
+Test: remove while updating must throw InvalidStateError
+EXPECTED (thrownError.name == 'InvalidStateError') OK
+EVENT(updateend)
+Test: abort while not updating does not throw
+EXPECTED (thrownError == 'null') OK
+Test: set duration while updating must throw InvalidStateError
+EXPECTED (sourceBuffer.updating == 'true') OK
+EXPECTED (thrownError.name == 'InvalidStateError') OK
+EVENT(updateend)
+Test: endOfStream while updating must throw InvalidStateError
+EXPECTED (thrownError.name == 'InvalidStateError') OK
+EVENT(updateend)
+Test: addSourceBuffer when ended must throw InvalidStateError
+EXPECTED (source.readyState == 'ended') OK
+EXPECTED (thrownError.name == 'InvalidStateError') OK
+END OF TEST
+

--- a/LayoutTests/media/media-source/media-source-real-state-errors.html
+++ b/LayoutTests/media/media-source/media-source-real-state-errors.html
@@ -1,0 +1,85 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>media-source-real-state-errors</title>
+    <script src="mp4-generator.js"></script>
+    <script src="../video-test.js"></script>
+    <script>
+    // Tests that MSE methods throw correct exceptions when called in
+    // invalid states. MSE spec sections 2 and 3.
+
+    var source;
+    var sourceBuffer;
+    var thrownError;
+
+    async function runTest() {
+        findMediaElement();
+
+        source = new MediaSource();
+        video.src = URL.createObjectURL(source);
+        await waitFor(source, 'sourceopen');
+
+        sourceBuffer = source.addSourceBuffer(MP4.VIDEO_TYPE);
+
+        var initData = MP4.initSegment({
+            timescale: 1000,
+            tracks: [{ id: 1, type: 'video', timescale: 1000 }]
+        });
+        sourceBuffer.appendBuffer(initData);
+
+        // --- appendBuffer while updating ---
+        consoleWrite('Test: appendBuffer while updating must throw InvalidStateError');
+        testExpected('sourceBuffer.updating', true);
+        thrownError = null;
+        try { sourceBuffer.appendBuffer(initData); } catch (e) { thrownError = e; }
+        testExpected('thrownError.name', 'InvalidStateError');
+
+        // --- remove while updating ---
+        consoleWrite('Test: remove while updating must throw InvalidStateError');
+        thrownError = null;
+        try { sourceBuffer.remove(0, 1); } catch (e) { thrownError = e; }
+        testExpected('thrownError.name', 'InvalidStateError');
+
+        await waitFor(sourceBuffer, 'updateend');
+
+        // --- abort while not updating is allowed ---
+        consoleWrite('Test: abort while not updating does not throw');
+        thrownError = null;
+        try { sourceBuffer.abort(); } catch (e) { thrownError = e; }
+        testExpected('thrownError', null);
+
+        // --- set duration while updating ---
+        consoleWrite('Test: set duration while updating must throw InvalidStateError');
+        sourceBuffer.appendBuffer(initData);
+        testExpected('sourceBuffer.updating', true);
+        thrownError = null;
+        try { source.duration = 10; } catch (e) { thrownError = e; }
+        testExpected('thrownError.name', 'InvalidStateError');
+        await waitFor(sourceBuffer, 'updateend');
+
+        // --- endOfStream while updating ---
+        consoleWrite('Test: endOfStream while updating must throw InvalidStateError');
+        sourceBuffer.appendBuffer(initData);
+        thrownError = null;
+        try { source.endOfStream(); } catch (e) { thrownError = e; }
+        testExpected('thrownError.name', 'InvalidStateError');
+        await waitFor(sourceBuffer, 'updateend');
+
+        // --- addSourceBuffer when ended ---
+        consoleWrite('Test: addSourceBuffer when ended must throw InvalidStateError');
+        source.endOfStream();
+        testExpected('source.readyState', 'ended');
+        thrownError = null;
+        try { source.addSourceBuffer(MP4.VIDEO_TYPE); } catch (e) { thrownError = e; }
+        testExpected('thrownError.name', 'InvalidStateError');
+    }
+
+    window.addEventListener('load', event => {
+        runTest().then(endTest).catch(failTest);
+    });
+    </script>
+</head>
+<body>
+    <video></video>
+</body>
+</html>

--- a/LayoutTests/media/media-source/media-source-real-webm-currenttime-progression-expected.txt
+++ b/LayoutTests/media/media-source/media-source-real-webm-currenttime-progression-expected.txt
@@ -1,0 +1,12 @@
+
+EVENT(sourceopen)
+EVENT(updateend)
+EVENT(updateend)
+RUN(video.currentTime = 0)
+RUN(video.play())
+EVENT(playing)
+EXPECTED (video.currentTime > '0') OK
+EXPECTED (time2 > time1 == 'true') OK
+RUN(video.pause())
+END OF TEST
+

--- a/LayoutTests/media/media-source/media-source-real-webm-currenttime-progression.html
+++ b/LayoutTests/media/media-source/media-source-real-webm-currenttime-progression.html
@@ -1,0 +1,80 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>media-source-real-webm-currenttime-progression</title>
+    <script src="webm-generator.js"></script>
+    <script src="../video-test.js"></script>
+    <script>
+    // Verifies that currentTime advances during playback. Catches regressions
+    // where cross-process time reporting stalls or returns stepwise jumps:
+    //   - TimeProgressEstimator interpolation (bug 307515)
+    //   - currentTime polling frequency (bug 307495 / Paramount+)
+
+    var source;
+    var sourceBuffer;
+    var time1;
+    var time2;
+
+    async function runTest() {
+        findMediaElement();
+
+        if (!MediaSource.isTypeSupported(WebM.VIDEO_TYPE)) {
+            consoleWrite('SKIPPED: ' + WebM.VIDEO_TYPE + ' is not supported');
+            return;
+        }
+
+        source = new MediaSource();
+        video.src = URL.createObjectURL(source);
+        await waitFor(source, 'sourceopen');
+
+        sourceBuffer = source.addSourceBuffer(WebM.VIDEO_TYPE);
+
+        var initData = WebM.initSegment({
+            tracks: [{ id: 1, type: 'video' }]
+        });
+        sourceBuffer.appendBuffer(initData);
+        await waitFor(sourceBuffer, 'updateend');
+
+        // 4 seconds of all-sync video so every frame decodes independently.
+        var samples = [];
+        for (var i = 0; i < 4; i++) {
+            samples.push({
+                duration: 1000,
+                isSync: true,
+            });
+        }
+        var media = WebM.mediaSegment({
+            sequenceNumber: 1,
+            tracks: [{ id: 1, type: 'video', baseDecodeTime: 0, samples }]
+        });
+        sourceBuffer.appendBuffer(media);
+        await waitFor(sourceBuffer, 'updateend');
+
+        source.endOfStream();
+
+        run('video.currentTime = 0');
+        run('video.play()');
+        await waitFor(video, 'playing');
+
+        // Wait for currentTime to advance past 0.
+        await testExpectedEventually('video.currentTime', 0, '>', 5000);
+
+        time1 = video.currentTime;
+
+        await new Promise(resolve => setTimeout(resolve, 500));
+
+        time2 = video.currentTime;
+        testExpected('time2 > time1', true);
+
+        run('video.pause()');
+    }
+
+    window.addEventListener('load', event => {
+        runTest().then(endTest).catch(failTest);
+    });
+    </script>
+</head>
+<body>
+    <video></video>
+</body>
+</html>

--- a/LayoutTests/media/media-source/media-source-real-webm-discontinuity-expected.txt
+++ b/LayoutTests/media/media-source/media-source-real-webm-discontinuity-expected.txt
@@ -1,0 +1,13 @@
+
+EVENT(sourceopen)
+EVENT(updateend)
+EVENT(updateend)
+EXPECTED (sourceBuffer.buffered.length == '1') OK
+EVENT(updateend)
+EXPECTED (sourceBuffer.buffered.length == '2') OK
+EXPECTED (sourceBuffer.buffered.start(0) == '0') OK
+EXPECTED (sourceBuffer.buffered.end(0) == '2') OK
+EXPECTED (sourceBuffer.buffered.start(1) == '10') OK
+EXPECTED (sourceBuffer.buffered.end(1) == '12') OK
+END OF TEST
+

--- a/LayoutTests/media/media-source/media-source-real-webm-discontinuity.html
+++ b/LayoutTests/media/media-source/media-source-real-webm-discontinuity.html
@@ -1,0 +1,64 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>media-source-real-webm-discontinuity</title>
+    <script src="webm-generator.js"></script>
+    <script src="../video-test.js"></script>
+    <script>
+    var source;
+    var sourceBuffer;
+
+    async function runTest() {
+        findMediaElement();
+
+        if (!MediaSource.isTypeSupported(WebM.VIDEO_TYPE)) {
+            consoleWrite('SKIPPED: ' + WebM.VIDEO_TYPE + ' is not supported');
+            return;
+        }
+
+        source = new MediaSource();
+        video.src = URL.createObjectURL(source);
+        await waitFor(source, 'sourceopen');
+
+        sourceBuffer = source.addSourceBuffer(WebM.VIDEO_TYPE);
+
+        sourceBuffer.appendBuffer(WebM.initSegment({ tracks: [{ id: 1, type: 'video' }] }));
+        await waitFor(sourceBuffer, 'updateend');
+
+        // Segment 1: [0, 2) with 1-second samples
+        sourceBuffer.appendBuffer(WebM.mediaSegment({
+            tracks: [{ id: 1, type: 'video', baseDecodeTime: 0, samples: [
+                { duration: 1000, isSync: true },
+                { duration: 1000, isSync: false },
+            ]}]
+        }));
+        await waitFor(sourceBuffer, 'updateend');
+
+        testExpected('sourceBuffer.buffered.length', 1);
+
+        // Segment 2: starts at 10s — gap of 8s >> 2x frame duration (1s)
+        // This triggers discontinuity detection → new coded frame group
+        sourceBuffer.appendBuffer(WebM.mediaSegment({
+            tracks: [{ id: 1, type: 'video', baseDecodeTime: 10000, samples: [
+                { duration: 1000, isSync: true },
+                { duration: 1000, isSync: false },
+            ]}]
+        }));
+        await waitFor(sourceBuffer, 'updateend');
+
+        testExpected('sourceBuffer.buffered.length', 2);
+        testExpectedEqualWithTolerance('sourceBuffer.buffered.start(0)', 0, 0.01);
+        testExpectedEqualWithTolerance('sourceBuffer.buffered.end(0)', 2, 0.05);
+        testExpectedEqualWithTolerance('sourceBuffer.buffered.start(1)', 10, 0.05);
+        testExpectedEqualWithTolerance('sourceBuffer.buffered.end(1)', 12, 0.05);
+    }
+
+    window.addEventListener('load', event => {
+        runTest().then(endTest).catch(failTest);
+    });
+    </script>
+</head>
+<body>
+    <video></video>
+</body>
+</html>

--- a/LayoutTests/media/media-source/media-source-real-webm-playbackrate-change-expected.txt
+++ b/LayoutTests/media/media-source/media-source-real-webm-playbackrate-change-expected.txt
@@ -1,0 +1,18 @@
+
+EVENT(sourceopen)
+EVENT(updateend)
+EVENT(updateend)
+RUN(video.play())
+EVENT(playing)
+EXPECTED (video.currentTime > '0') OK
+RUN(video.playbackRate = 2)
+EXPECTED (video.paused == 'false') OK
+EXPECTED (video.currentTime > timeBeforeRateChange == 'true') OK
+EXPECTED (video.paused == 'false') OK
+RUN(video.playbackRate = 1)
+EXPECTED (video.currentTime > timeAfterRestore == 'true') OK
+EXPECTED (video.paused == 'false') OK
+EXPECTED (video.error == 'null') OK
+RUN(video.pause())
+END OF TEST
+

--- a/LayoutTests/media/media-source/media-source-real-webm-playbackrate-change.html
+++ b/LayoutTests/media/media-source/media-source-real-webm-playbackrate-change.html
@@ -1,0 +1,89 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>media-source-real-webm-playbackrate-change</title>
+    <script src="webm-generator.js"></script>
+    <script src="../video-test.js"></script>
+    <script>
+    // Verifies that changing playbackRate during playback does not stall or
+    // error. Catches regressions where the GPU process flushes audio/video
+    // renderers on rate change but the WebContent process is never notified:
+    //   - Audio stops on rate change (bug 308952)
+
+    var source;
+    var sourceBuffer;
+    var timeBeforeRateChange;
+    var timeAfterRestore;
+
+    async function runTest() {
+        findMediaElement();
+
+        if (!MediaSource.isTypeSupported(WebM.VIDEO_TYPE)) {
+            consoleWrite('SKIPPED: ' + WebM.VIDEO_TYPE + ' is not supported');
+            return;
+        }
+
+        source = new MediaSource();
+        video.src = URL.createObjectURL(source);
+        await waitFor(source, 'sourceopen');
+
+        sourceBuffer = source.addSourceBuffer(WebM.VIDEO_TYPE);
+
+        var initData = WebM.initSegment({
+            tracks: [{ id: 1, type: 'video' }]
+        });
+        sourceBuffer.appendBuffer(initData);
+        await waitFor(sourceBuffer, 'updateend');
+
+        // 6 seconds of all-sync video.
+        var samples = [];
+        for (var i = 0; i < 6; i++) {
+            samples.push({
+                duration: 1000,
+                isSync: true,
+            });
+        }
+        var media = WebM.mediaSegment({
+            sequenceNumber: 1,
+            tracks: [{ id: 1, type: 'video', baseDecodeTime: 0, samples }]
+        });
+        sourceBuffer.appendBuffer(media);
+        await waitFor(sourceBuffer, 'updateend');
+
+        source.endOfStream();
+
+        run('video.play()');
+        await waitFor(video, 'playing');
+        await testExpectedEventually('video.currentTime', 0, '>', 5000);
+
+        // Change rate to 2x
+        timeBeforeRateChange = video.currentTime;
+        run('video.playbackRate = 2');
+        testExpected('video.paused', false);
+
+        await new Promise(resolve => setTimeout(resolve, 500));
+        testExpected('video.currentTime > timeBeforeRateChange', true);
+        testExpected('video.paused', false);
+
+        // Change rate back to 1x
+        run('video.playbackRate = 1');
+        timeAfterRestore = video.currentTime;
+
+        await new Promise(resolve => setTimeout(resolve, 500));
+        testExpected('video.currentTime > timeAfterRestore', true);
+        testExpected('video.paused', false);
+
+        testExpected('video.error', null);
+
+        run('video.pause()');
+    }
+
+    window.addEventListener('load', event => {
+        runTest().then(endTest).catch(failTest);
+    });
+    </script>
+</head>
+<body>
+    <video></video>
+</body>
+</html>

--- a/LayoutTests/media/media-source/media-source-real-webm-reinitialize-expected.txt
+++ b/LayoutTests/media/media-source/media-source-real-webm-reinitialize-expected.txt
@@ -1,0 +1,18 @@
+
+EVENT(sourceopen)
+EVENT(updateend)
+EXPECTED (sourceBuffer.videoTracks.length == '1') OK
+EVENT(updateend)
+EXPECTED (sourceBuffer.buffered.length == '1') OK
+EXPECTED (sourceBuffer.buffered.end(0) == '4') OK
+EVENT(updateend)
+EXPECTED (source.readyState == 'open') OK
+EXPECTED (sourceBuffer.videoTracks.length == '1') OK
+EXPECTED (sourceBuffer.buffered.length == '1') OK
+EXPECTED (sourceBuffer.buffered.end(0) == '4') OK
+EVENT(updateend)
+EXPECTED (source.readyState == 'open') OK
+EXPECTED (sourceBuffer.buffered.length == '1') OK
+EXPECTED (sourceBuffer.buffered.end(0) == '6') OK
+END OF TEST
+

--- a/LayoutTests/media/media-source/media-source-real-webm-reinitialize.html
+++ b/LayoutTests/media/media-source/media-source-real-webm-reinitialize.html
@@ -1,0 +1,90 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>media-source-real-webm-reinitialize</title>
+    <script src="webm-generator.js"></script>
+    <script src="../video-test.js"></script>
+    <script>
+    // Tests that appending a second initialization segment with matching tracks
+    // succeeds and doesn't disrupt existing buffered data.
+    // MSE spec section 3.3.2 "Initialization Segment Received" — when a second
+    // init segment arrives, track count and types must match the first.
+    // Weakly tested — minimal real-parser coverage.
+
+    var source;
+    var sourceBuffer;
+
+    async function runTest() {
+        findMediaElement();
+
+        if (!MediaSource.isTypeSupported(WebM.VIDEO_TYPE)) {
+            consoleWrite('SKIPPED: ' + WebM.VIDEO_TYPE + ' is not supported');
+            return;
+        }
+
+        source = new MediaSource();
+        video.src = URL.createObjectURL(source);
+        await waitFor(source, 'sourceopen');
+
+        sourceBuffer = source.addSourceBuffer(WebM.VIDEO_TYPE);
+
+        var initData = WebM.initSegment({
+            tracks: [{ id: 1, type: 'video' }]
+        });
+
+        // First init
+        sourceBuffer.appendBuffer(initData);
+        await waitFor(sourceBuffer, 'updateend');
+
+        testExpected('sourceBuffer.videoTracks.length', 1);
+
+        // Append media
+        var media = WebM.mediaSegment({
+            sequenceNumber: 1,
+            tracks: [{ id: 1, type: 'video', baseDecodeTime: 0, samples: [
+                { duration: 1000, isSync: true },
+                { duration: 1000, isSync: false },
+                { duration: 1000, isSync: false },
+                { duration: 1000, isSync: false },
+            ]}]
+        });
+        sourceBuffer.appendBuffer(media);
+        await waitFor(sourceBuffer, 'updateend');
+
+        testExpected('sourceBuffer.buffered.length', 1);
+        testExpectedEqualWithTolerance('sourceBuffer.buffered.end(0)', 4, 0.05);
+
+        // Second init — same tracks, should succeed without disrupting buffered data
+        sourceBuffer.appendBuffer(initData);
+        await waitFor(sourceBuffer, 'updateend');
+
+        testExpected('source.readyState', 'open');
+        testExpected('sourceBuffer.videoTracks.length', 1);
+        testExpected('sourceBuffer.buffered.length', 1);
+        testExpectedEqualWithTolerance('sourceBuffer.buffered.end(0)', 4, 0.05);
+
+        // Append more media after re-init — should extend the buffer
+        var media2 = WebM.mediaSegment({
+            sequenceNumber: 2,
+            tracks: [{ id: 1, type: 'video', baseDecodeTime: 4000, samples: [
+                { duration: 1000, isSync: true },
+                { duration: 1000, isSync: false },
+            ]}]
+        });
+        sourceBuffer.appendBuffer(media2);
+        await waitFor(sourceBuffer, 'updateend');
+
+        testExpected('source.readyState', 'open');
+        testExpected('sourceBuffer.buffered.length', 1);
+        testExpectedEqualWithTolerance('sourceBuffer.buffered.end(0)', 6, 0.05);
+    }
+
+    window.addEventListener('load', event => {
+        runTest().then(endTest).catch(failTest);
+    });
+    </script>
+</head>
+<body>
+    <video></video>
+</body>
+</html>

--- a/LayoutTests/media/media-source/media-source-real-webm-remove-edges-expected.txt
+++ b/LayoutTests/media/media-source/media-source-real-webm-remove-edges-expected.txt
@@ -1,0 +1,24 @@
+
+EVENT(sourceopen)
+EVENT(updateend)
+EVENT(updateend)
+EXPECTED (sourceBuffer.buffered.length == '1') OK
+EXPECTED (sourceBuffer.buffered.end(0) == '6') OK
+Test 1: remove(0, 2) at sync frame boundary
+EVENT(updateend)
+EXPECTED (sourceBuffer.buffered.length == '1') OK
+EXPECTED (sourceBuffer.buffered.start(0) == '2') OK
+Test 2: remove(4, 6) at end of buffer
+EVENT(updateend)
+EXPECTED (sourceBuffer.buffered.length == '1') OK
+EXPECTED (sourceBuffer.buffered.start(0) == '2') OK
+EXPECTED (sourceBuffer.buffered.end(0) == '4') OK
+Test 3: remove(0, Infinity) removes all
+EVENT(updateend)
+EXPECTED (sourceBuffer.buffered.length == '0') OK
+Test 4: remove(0, Infinity) on empty buffer
+EVENT(updateend)
+EXPECTED (sourceBuffer.buffered.length == '0') OK
+EXPECTED (source.readyState == 'open') OK
+END OF TEST
+

--- a/LayoutTests/media/media-source/media-source-real-webm-remove-edges.html
+++ b/LayoutTests/media/media-source/media-source-real-webm-remove-edges.html
@@ -1,0 +1,94 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>media-source-real-webm-remove-edges</title>
+    <script src="webm-generator.js"></script>
+    <script src="../video-test.js"></script>
+    <script>
+    // Tests remove() at various boundary conditions through the real parser
+    // pipeline. Catches regressions in removeCodedFrames and eviction paths
+    // where invalid iterators or MediaTime::invalidTime comparisons caused
+    // infinite loops or crashes:
+    //   - SampleMap infinite loop with invalidTime (bug 304975)
+    //   - removeCodedFrames with start past end of presentation order (bug 304975)
+
+    var source;
+    var sourceBuffer;
+
+    async function runTest() {
+        findMediaElement();
+
+        if (!MediaSource.isTypeSupported(WebM.VIDEO_TYPE)) {
+            consoleWrite('SKIPPED: ' + WebM.VIDEO_TYPE + ' is not supported');
+            return;
+        }
+
+        source = new MediaSource();
+        video.src = URL.createObjectURL(source);
+        await waitFor(source, 'sourceopen');
+
+        sourceBuffer = source.addSourceBuffer(WebM.VIDEO_TYPE);
+
+        var initData = WebM.initSegment({
+            tracks: [{ id: 1, type: 'video' }]
+        });
+        sourceBuffer.appendBuffer(initData);
+        await waitFor(sourceBuffer, 'updateend');
+
+        // 6 seconds of video, sync every 2s (at 0, 2, 4)
+        var media = WebM.mediaSegment({
+            sequenceNumber: 1,
+            tracks: [{ id: 1, type: 'video', baseDecodeTime: 0, samples: [
+                { duration: 1000, isSync: true },
+                { duration: 1000, isSync: false },
+                { duration: 1000, isSync: true },
+                { duration: 1000, isSync: false },
+                { duration: 1000, isSync: true },
+                { duration: 1000, isSync: false },
+            ]}]
+        });
+        sourceBuffer.appendBuffer(media);
+        await waitFor(sourceBuffer, 'updateend');
+
+        testExpected('sourceBuffer.buffered.length', 1);
+        testExpectedEqualWithTolerance('sourceBuffer.buffered.end(0)', 6, 0.05);
+
+        // Test 1: Remove exactly at sync frame boundary.
+        consoleWrite('Test 1: remove(0, 2) at sync frame boundary');
+        sourceBuffer.remove(0, 2);
+        await waitFor(sourceBuffer, 'updateend');
+        testExpected('sourceBuffer.buffered.length', 1);
+        testExpectedEqualWithTolerance('sourceBuffer.buffered.start(0)', 2, 0.05);
+
+        // Test 2: Remove at end of buffered data.
+        consoleWrite('Test 2: remove(4, 6) at end of buffer');
+        sourceBuffer.remove(4, 6);
+        await waitFor(sourceBuffer, 'updateend');
+        testExpected('sourceBuffer.buffered.length', 1);
+        testExpectedEqualWithTolerance('sourceBuffer.buffered.start(0)', 2, 0.05);
+        testExpectedEqualWithTolerance('sourceBuffer.buffered.end(0)', 4, 0.05);
+
+        // Test 3: Remove everything remaining.
+        consoleWrite('Test 3: remove(0, Infinity) removes all');
+        sourceBuffer.remove(0, Infinity);
+        await waitFor(sourceBuffer, 'updateend');
+        testExpected('sourceBuffer.buffered.length', 0);
+
+        // Test 4: Remove on empty buffer — should not crash or hang.
+        consoleWrite('Test 4: remove(0, Infinity) on empty buffer');
+        sourceBuffer.remove(0, Infinity);
+        await waitFor(sourceBuffer, 'updateend');
+        testExpected('sourceBuffer.buffered.length', 0);
+
+        testExpected('source.readyState', 'open');
+    }
+
+    window.addEventListener('load', event => {
+        runTest().then(endTest).catch(failTest);
+    });
+    </script>
+</head>
+<body>
+    <video></video>
+</body>
+</html>

--- a/LayoutTests/media/media-source/media-source-real-webm-sequence-mode-expected.txt
+++ b/LayoutTests/media/media-source/media-source-real-webm-sequence-mode-expected.txt
@@ -1,0 +1,21 @@
+
+EVENT(sourceopen)
+EXPECTED (sourceBuffer.mode == 'segments') OK
+RUN(sourceBuffer.mode = "sequence")
+EXPECTED (sourceBuffer.mode == 'sequence') OK
+EXPECTED (sourceBuffer.timestampOffset == '0') OK
+EVENT(updateend)
+EVENT(updateend)
+EXPECTED (sourceBuffer.buffered.length == '1') OK
+EXPECTED (sourceBuffer.buffered.start(0) == '0') OK
+EXPECTED (sourceBuffer.buffered.end(0) == '2') OK
+EVENT(updateend)
+EXPECTED (sourceBuffer.buffered.length == '1') OK
+EXPECTED (sourceBuffer.buffered.start(0) == '0') OK
+EXPECTED (sourceBuffer.buffered.end(0) == '4') OK
+EVENT(updateend)
+EXPECTED (sourceBuffer.buffered.length == '1') OK
+EXPECTED (sourceBuffer.buffered.start(0) == '0') OK
+EXPECTED (sourceBuffer.buffered.end(0) == '5') OK
+END OF TEST
+

--- a/LayoutTests/media/media-source/media-source-real-webm-sequence-mode.html
+++ b/LayoutTests/media/media-source/media-source-real-webm-sequence-mode.html
@@ -1,0 +1,100 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>media-source-real-webm-sequence-mode</title>
+    <script src="webm-generator.js"></script>
+    <script src="../video-test.js"></script>
+    <script>
+    // Tests SourceBuffer "sequence" mode where timestampOffset is automatically
+    // updated after each coded frame group so segments are placed end-to-end.
+    // MSE spec section 3.1.1 and 3.3.1.
+
+    var source;
+    var sourceBuffer;
+
+    async function runTest() {
+        findMediaElement();
+
+        if (!MediaSource.isTypeSupported(WebM.VIDEO_TYPE)) {
+            consoleWrite('SKIPPED: ' + WebM.VIDEO_TYPE + ' is not supported');
+            return;
+        }
+
+        source = new MediaSource();
+        video.src = URL.createObjectURL(source);
+        await waitFor(source, 'sourceopen');
+
+        sourceBuffer = source.addSourceBuffer(WebM.VIDEO_TYPE);
+
+        testExpected('sourceBuffer.mode', 'segments');
+
+        run('sourceBuffer.mode = "sequence"');
+        testExpected('sourceBuffer.mode', 'sequence');
+        testExpected('sourceBuffer.timestampOffset', 0);
+
+        var initData = WebM.initSegment({
+            tracks: [{ id: 1, type: 'video' }]
+        });
+        sourceBuffer.appendBuffer(initData);
+        await waitFor(sourceBuffer, 'updateend');
+
+        // Append first segment: 2 seconds starting at DTS=0
+        var media1 = WebM.mediaSegment({
+            sequenceNumber: 1,
+            tracks: [{ id: 1, type: 'video', baseDecodeTime: 0, samples: [
+                { duration: 1000, isSync: true },
+                { duration: 1000, isSync: false },
+            ]}]
+        });
+        sourceBuffer.appendBuffer(media1);
+        await waitFor(sourceBuffer, 'updateend');
+
+        // First segment: placed at [0, 2).
+        // In sequence mode, timestampOffset is NOT updated on the initial group,
+        // it updates when a new coded frame group starts on the NEXT append.
+        testExpected('sourceBuffer.buffered.length', 1);
+        testExpectedEqualWithTolerance('sourceBuffer.buffered.start(0)', 0, 0.05);
+        testExpectedEqualWithTolerance('sourceBuffer.buffered.end(0)', 2, 0.05);
+
+        // Append second segment: also starts at DTS=0 in the container.
+        // Sequence mode detects this as a new group, sets timestampOffset to
+        // the end of the previous group (2), and places frames at [2, 4).
+        var media2 = WebM.mediaSegment({
+            sequenceNumber: 2,
+            tracks: [{ id: 1, type: 'video', baseDecodeTime: 0, samples: [
+                { duration: 1000, isSync: true },
+                { duration: 1000, isSync: false },
+            ]}]
+        });
+        sourceBuffer.appendBuffer(media2);
+        await waitFor(sourceBuffer, 'updateend');
+
+        // Should now have [0, 4) contiguously
+        testExpected('sourceBuffer.buffered.length', 1);
+        testExpectedEqualWithTolerance('sourceBuffer.buffered.start(0)', 0, 0.05);
+        testExpectedEqualWithTolerance('sourceBuffer.buffered.end(0)', 4, 0.05);
+
+        // Append a third segment to confirm the pattern continues
+        var media3 = WebM.mediaSegment({
+            sequenceNumber: 3,
+            tracks: [{ id: 1, type: 'video', baseDecodeTime: 0, samples: [
+                { duration: 1000, isSync: true },
+            ]}]
+        });
+        sourceBuffer.appendBuffer(media3);
+        await waitFor(sourceBuffer, 'updateend');
+
+        testExpected('sourceBuffer.buffered.length', 1);
+        testExpectedEqualWithTolerance('sourceBuffer.buffered.start(0)', 0, 0.05);
+        testExpectedEqualWithTolerance('sourceBuffer.buffered.end(0)', 5, 0.05);
+    }
+
+    window.addEventListener('load', event => {
+        runTest().then(endTest).catch(failTest);
+    });
+    </script>
+</head>
+<body>
+    <video></video>
+</body>
+</html>

--- a/LayoutTests/media/media-source/media-source-real-webm-sourcebufferlist-events-expected.txt
+++ b/LayoutTests/media/media-source/media-source-real-webm-sourcebufferlist-events-expected.txt
@@ -1,0 +1,11 @@
+
+EVENT(sourceopen)
+EXPECTED (source.sourceBuffers.length == '1') OK
+addsourcebuffer event on sourceBuffers: fired
+EVENT(updateend)
+EXPECTED (source.activeSourceBuffers.length == '1') OK
+RUN(source.removeSourceBuffer(sourceBuffer))
+EXPECTED (source.sourceBuffers.length == '0') OK
+removesourcebuffer event on sourceBuffers: fired
+END OF TEST
+

--- a/LayoutTests/media/media-source/media-source-real-webm-sourcebufferlist-events.html
+++ b/LayoutTests/media/media-source/media-source-real-webm-sourcebufferlist-events.html
@@ -1,0 +1,70 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>media-source-real-webm-sourcebufferlist-events</title>
+    <script src="webm-generator.js"></script>
+    <script src="../video-test.js"></script>
+    <script>
+    // Tests that SourceBufferList fires addsourcebuffer and removesourcebuffer
+    // events when SourceBuffers are added/removed.
+    // MSE spec section 3.4.3 — event firing and ordering.
+
+    var source;
+    var sourceBuffer;
+
+    async function runTest() {
+        findMediaElement();
+
+        if (!MediaSource.isTypeSupported(WebM.VIDEO_TYPE)) {
+            consoleWrite('SKIPPED: ' + WebM.VIDEO_TYPE + ' is not supported');
+            return;
+        }
+
+        source = new MediaSource();
+        video.src = URL.createObjectURL(source);
+        await waitFor(source, 'sourceopen');
+
+        // Listen for addsourcebuffer on sourceBuffers
+        var addPromise = waitFor(source.sourceBuffers, 'addsourcebuffer', true);
+
+        sourceBuffer = source.addSourceBuffer(WebM.VIDEO_TYPE);
+        testExpected('source.sourceBuffers.length', 1);
+
+        // The event may be synchronous or task-queued; give it a chance to fire
+        var result = await Promise.race([
+            addPromise.then(() => 'fired'),
+            new Promise(resolve => setTimeout(() => resolve('timeout'), 100))
+        ]);
+        consoleWrite('addsourcebuffer event on sourceBuffers: ' + result);
+
+        // Append init to make track active
+        var initData = WebM.initSegment({
+            tracks: [{ id: 1, type: 'video' }]
+        });
+        sourceBuffer.appendBuffer(initData);
+        await waitFor(sourceBuffer, 'updateend');
+
+        testExpected('source.activeSourceBuffers.length', 1);
+
+        // Listen for removesourcebuffer
+        var removePromise = waitFor(source.sourceBuffers, 'removesourcebuffer', true);
+
+        run('source.removeSourceBuffer(sourceBuffer)');
+        testExpected('source.sourceBuffers.length', 0);
+
+        result = await Promise.race([
+            removePromise.then(() => 'fired'),
+            new Promise(resolve => setTimeout(() => resolve('timeout'), 100))
+        ]);
+        consoleWrite('removesourcebuffer event on sourceBuffers: ' + result);
+    }
+
+    window.addEventListener('load', event => {
+        runTest().then(endTest).catch(failTest);
+    });
+    </script>
+</head>
+<body>
+    <video></video>
+</body>
+</html>

--- a/LayoutTests/media/media-source/media-source-real-webm-state-errors-expected.txt
+++ b/LayoutTests/media/media-source/media-source-real-webm-state-errors-expected.txt
@@ -1,0 +1,22 @@
+
+EVENT(sourceopen)
+Test: appendBuffer while updating must throw InvalidStateError
+EXPECTED (sourceBuffer.updating == 'true') OK
+EXPECTED (thrownError.name == 'InvalidStateError') OK
+Test: remove while updating must throw InvalidStateError
+EXPECTED (thrownError.name == 'InvalidStateError') OK
+EVENT(updateend)
+Test: abort while not updating does not throw
+EXPECTED (thrownError == 'null') OK
+Test: set duration while updating must throw InvalidStateError
+EXPECTED (sourceBuffer.updating == 'true') OK
+EXPECTED (thrownError.name == 'InvalidStateError') OK
+EVENT(updateend)
+Test: endOfStream while updating must throw InvalidStateError
+EXPECTED (thrownError.name == 'InvalidStateError') OK
+EVENT(updateend)
+Test: addSourceBuffer when ended must throw InvalidStateError
+EXPECTED (source.readyState == 'ended') OK
+EXPECTED (thrownError.name == 'InvalidStateError') OK
+END OF TEST
+

--- a/LayoutTests/media/media-source/media-source-real-webm-state-errors.html
+++ b/LayoutTests/media/media-source/media-source-real-webm-state-errors.html
@@ -1,0 +1,89 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>media-source-real-webm-state-errors</title>
+    <script src="webm-generator.js"></script>
+    <script src="../video-test.js"></script>
+    <script>
+    // Tests that MSE methods throw correct exceptions when called in
+    // invalid states. MSE spec sections 2 and 3.
+
+    var source;
+    var sourceBuffer;
+    var thrownError;
+
+    async function runTest() {
+        findMediaElement();
+
+        if (!MediaSource.isTypeSupported(WebM.VIDEO_TYPE)) {
+            consoleWrite('SKIPPED: ' + WebM.VIDEO_TYPE + ' is not supported');
+            return;
+        }
+
+        source = new MediaSource();
+        video.src = URL.createObjectURL(source);
+        await waitFor(source, 'sourceopen');
+
+        sourceBuffer = source.addSourceBuffer(WebM.VIDEO_TYPE);
+
+        var initData = WebM.initSegment({
+            tracks: [{ id: 1, type: 'video' }]
+        });
+        sourceBuffer.appendBuffer(initData);
+
+        // --- appendBuffer while updating ---
+        consoleWrite('Test: appendBuffer while updating must throw InvalidStateError');
+        testExpected('sourceBuffer.updating', true);
+        thrownError = null;
+        try { sourceBuffer.appendBuffer(initData); } catch (e) { thrownError = e; }
+        testExpected('thrownError.name', 'InvalidStateError');
+
+        // --- remove while updating ---
+        consoleWrite('Test: remove while updating must throw InvalidStateError');
+        thrownError = null;
+        try { sourceBuffer.remove(0, 1); } catch (e) { thrownError = e; }
+        testExpected('thrownError.name', 'InvalidStateError');
+
+        await waitFor(sourceBuffer, 'updateend');
+
+        // --- abort while not updating is allowed ---
+        consoleWrite('Test: abort while not updating does not throw');
+        thrownError = null;
+        try { sourceBuffer.abort(); } catch (e) { thrownError = e; }
+        testExpected('thrownError', null);
+
+        // --- set duration while updating ---
+        consoleWrite('Test: set duration while updating must throw InvalidStateError');
+        sourceBuffer.appendBuffer(initData);
+        testExpected('sourceBuffer.updating', true);
+        thrownError = null;
+        try { source.duration = 10; } catch (e) { thrownError = e; }
+        testExpected('thrownError.name', 'InvalidStateError');
+        await waitFor(sourceBuffer, 'updateend');
+
+        // --- endOfStream while updating ---
+        consoleWrite('Test: endOfStream while updating must throw InvalidStateError');
+        sourceBuffer.appendBuffer(initData);
+        thrownError = null;
+        try { source.endOfStream(); } catch (e) { thrownError = e; }
+        testExpected('thrownError.name', 'InvalidStateError');
+        await waitFor(sourceBuffer, 'updateend');
+
+        // --- addSourceBuffer when ended ---
+        consoleWrite('Test: addSourceBuffer when ended must throw InvalidStateError');
+        source.endOfStream();
+        testExpected('source.readyState', 'ended');
+        thrownError = null;
+        try { source.addSourceBuffer(WebM.VIDEO_TYPE); } catch (e) { thrownError = e; }
+        testExpected('thrownError.name', 'InvalidStateError');
+    }
+
+    window.addEventListener('load', event => {
+        runTest().then(endTest).catch(failTest);
+    });
+    </script>
+</head>
+<body>
+    <video></video>
+</body>
+</html>


### PR DESCRIPTION
#### 92f8e443137887ccdcf4985ea67dfdaf0b80f017
<pre>
[Media Testing] Add Audio+Video synthetic webm + mp4 media-source tests
<a href="https://rdar.apple.com/176584210">rdar://176584210</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=314434">https://bugs.webkit.org/show_bug.cgi?id=314434</a>

Reviewed by Eric Carlson.

These tests add upon previous synthetic mp4 and webm tests by adding tests for previously
untested or undertested areas, and by adding two-sourcebuffer tests.

* LayoutTests/media/media-source/media-source-real-audio-append-buffer.html: Added.
* LayoutTests/media/media-source/media-source-real-audio-remove.html: Added.
* LayoutTests/media/media-source/media-source-real-audio-sequential.html: Added.
* LayoutTests/media/media-source/media-source-real-currenttime-progression-expected.txt: Added.
* LayoutTests/media/media-source/media-source-real-currenttime-progression.html: Added.
* LayoutTests/media/media-source/media-source-real-discontinuity-expected.txt: Added.
* LayoutTests/media/media-source/media-source-real-discontinuity.html: Added.
* LayoutTests/media/media-source/media-source-real-playbackrate-change-expected.txt: Added.
* LayoutTests/media/media-source/media-source-real-playbackrate-change.html: Added.
* LayoutTests/media/media-source/media-source-real-reinitialize-expected.txt: Added.
* LayoutTests/media/media-source/media-source-real-reinitialize.html: Added.
* LayoutTests/media/media-source/media-source-real-remove-edges-expected.txt: Added.
* LayoutTests/media/media-source/media-source-real-remove-edges.html: Added.
* LayoutTests/media/media-source/media-source-real-sequence-mode-expected.txt: Added.
* LayoutTests/media/media-source/media-source-real-sequence-mode.html: Added.
* LayoutTests/media/media-source/media-source-real-sourcebufferlist-events-expected.txt: Added.
* LayoutTests/media/media-source/media-source-real-sourcebufferlist-events.html: Added.
* LayoutTests/media/media-source/media-source-real-state-errors-expected.txt: Added.
* LayoutTests/media/media-source/media-source-real-state-errors.html: Added.
* LayoutTests/media/media-source/media-source-real-webm-audio-append-buffer-expected.txt: Added.
* LayoutTests/media/media-source/media-source-real-webm-audio-append-buffer.html: Added.
* LayoutTests/media/media-source/media-source-real-webm-audio-remove-expected.txt: Added.
* LayoutTests/media/media-source/media-source-real-webm-audio-remove.html: Added.
* LayoutTests/media/media-source/media-source-real-webm-audio-sequential-expected.txt: Added.
* LayoutTests/media/media-source/media-source-real-webm-audio-sequential.html: Added.
* LayoutTests/media/media-source/media-source-real-webm-currenttime-progression-expected.txt: Added.
* LayoutTests/media/media-source/media-source-real-webm-currenttime-progression.html: Added.
* LayoutTests/media/media-source/media-source-real-webm-discontinuity-expected.txt: Added.
* LayoutTests/media/media-source/media-source-real-webm-discontinuity.html: Added.
* LayoutTests/media/media-source/media-source-real-webm-playbackrate-change-expected.txt: Added.
* LayoutTests/media/media-source/media-source-real-webm-playbackrate-change.html: Added.
* LayoutTests/media/media-source/media-source-real-webm-reinitialize-expected.txt: Added.
* LayoutTests/media/media-source/media-source-real-webm-reinitialize.html: Added.
* LayoutTests/media/media-source/media-source-real-webm-remove-edges-expected.txt: Added.
* LayoutTests/media/media-source/media-source-real-webm-remove-edges.html: Added.
* LayoutTests/media/media-source/media-source-real-webm-sequence-mode-expected.txt: Added.
* LayoutTests/media/media-source/media-source-real-webm-sequence-mode.html: Added.
* LayoutTests/media/media-source/media-source-real-webm-sourcebufferlist-events-expected.txt: Added.
* LayoutTests/media/media-source/media-source-real-webm-sourcebufferlist-events.html: Added.
* LayoutTests/media/media-source/media-source-real-webm-state-errors-expected.txt: Added.
* LayoutTests/media/media-source/media-source-real-webm-state-errors.html: Added.

Canonical link: <a href="https://commits.webkit.org/313439@main">https://commits.webkit.org/313439@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7db2a0da6422bca4707c040918ac8518aa307344

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/162129 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/35604 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/28718 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/171037 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/118502 "Built successfully") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/35709 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/35606 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/125825 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/88687 "1 flakes 17 failures") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/165088 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/28148 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/145623 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/106403 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/27195 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/25712 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/18758 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/136894 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/23369 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/173530 "Built successfully") | | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/25012 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/134121 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/35279 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/29800 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/134122 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36385 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/35262 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/145165 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/97465 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/28651 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/21993 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/34772 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/34272 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/21 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/34517 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/34420 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->