### PR TITLE
Cherry-pick 312894@main (f5ad6e77a2db). https://bugs.webkit.org/show_bug.cgi?id=309589

### DIFF
--- a/Source/WebCore/loader/FrameLoader.cpp
+++ b/Source/WebCore/loader/FrameLoader.cpp
@@ -459,6 +459,10 @@ void FrameLoader::initForSynthesizedDocument(const URL&)
     m_didCallImplicitClose = true;
     m_isComplete = true;
     m_state = FrameState::Complete;
+    // Synthesized documents bypass setState(FrameState::Complete), which normally
+    // stops recording responses on the DocumentLoader.
+    if (RefPtr documentLoader = m_documentLoader)
+        documentLoader->stopRecordingResponses();
     m_needsClear = true;
 
     m_networkingContext = m_client->createNetworkingContext();

--- a/Source/WebCore/platform/graphics/x11/XErrorTrapper.h
+++ b/Source/WebCore/platform/graphics/x11/XErrorTrapper.h
@@ -27,6 +27,9 @@
 
 #if PLATFORM(X11)
 #include <X11/Xlib.h>
+#ifdef Success
+#undef Success
+#endif
 #include <wtf/Vector.h>
 
 namespace WebCore {

--- a/Source/WebCore/platform/text/hyphen/HyphenationLibHyphen.cpp
+++ b/Source/WebCore/platform/text/hyphen/HyphenationLibHyphen.cpp
@@ -232,6 +232,9 @@ size_t lastHyphenLocation(StringView string, size_t beforeIndex, const AtomStrin
     for (const auto& dictionaryPath : availableLocales().get(lowercaseLocaleIdentifier)) {
         RefPtr<HyphenationDictionary> dictionary = TinyLRUCachePolicy<AtomString, RefPtr<HyphenationDictionary>>::cache().get(AtomString(dictionaryPath));
 
+        if (!dictionary->libhyphenDictionary())
+            continue;
+
         char** replacements = nullptr;
         int* positions = nullptr;
         int* removedCharacterCounts = nullptr;


### PR DESCRIPTION
#### 02dec333499a21f79a66430f87dd40db698b0930
<pre>
Cherry-pick 312894@main (f5ad6e77a2db). <a href="https://bugs.webkit.org/show_bug.cgi?id=309589">https://bugs.webkit.org/show_bug.cgi?id=309589</a>

    Crash in WebCore::lastHyphenLocation
    <a href="https://bugs.webkit.org/show_bug.cgi?id=309589">https://bugs.webkit.org/show_bug.cgi?id=309589</a>

    Reviewed by Adrian Perez de Castro.

    Speculative fix. If the dictionary can&apos;t be opened for whatever reason, we end up
    with a nullptr HyphenDictUniquePtr in HyphenationDictionary. This can be due to
    broken symlinks, corrupted files, etc. Guarding this might fix the crash.

    * Source/WebCore/platform/text/hyphen/HyphenationLibHyphen.cpp:
    (WebCore::lastHyphenLocation):

    Canonical link: <a href="https://commits.webkit.org/312894@main">https://commits.webkit.org/312894@main</a>

Canonical link: <a href="https://commits.webkit.org/305877.484@webkitglib/2.52">https://commits.webkit.org/305877.484@webkitglib/2.52</a>
</pre>
----------------------------------------------------------------------
#### dcae236cd5c5c4b4786331c1e4753c6b6123b44a
<pre>
Cherry-pick 312878@main (959829501d2d). <a href="https://bugs.webkit.org/show_bug.cgi?id=314395">https://bugs.webkit.org/show_bug.cgi?id=314395</a>

    [Swift GTK] Undefined Success
    <a href="https://bugs.webkit.org/show_bug.cgi?id=314395">https://bugs.webkit.org/show_bug.cgi?id=314395</a>

    Reviewed by Adrian Perez de Castro.

    The X11 header defines Success. This causes difficulty when this header is
    transitively included in some Swift/C++ import scenarios, since the definition
    of Success causes problems interpreting the &apos;Success&apos; case of other enums
    across the codebase. Undefine Success since we don&apos;t currently need it.

    Canonical link: <a href="https://commits.webkit.org/312878@main">https://commits.webkit.org/312878@main</a>

Canonical link: <a href="https://commits.webkit.org/305877.483@webkitglib/2.52">https://commits.webkit.org/305877.483@webkitglib/2.52</a>
</pre>
----------------------------------------------------------------------
#### 0e02310d2a2755175ddcb6ae123a7303901e707e
<pre>
Cherry-pick 312779@main (c7cf80229641). <a href="https://bugs.webkit.org/show_bug.cgi?id=314187">https://bugs.webkit.org/show_bug.cgi?id=314187</a>

    [Leak] Service worker fetch() retains ResourceResponses in the remote worker DocumentLoader
    <a href="https://bugs.webkit.org/show_bug.cgi?id=314187">https://bugs.webkit.org/show_bug.cgi?id=314187</a>

    Reviewed by Youenn Fablet.

    Synthesized documents mark their FrameLoader state as Complete directly
    instead of going through setState(FrameState::Complete). That bypasses the
    normal DocumentLoader::stopRecordingResponses() call.

    Remote worker pages used by service workers are initialized this way. When
    service worker fetches go through their backing document loader,
    each response can be recorded in DocumentLoader::m_responses even though the
    document is already complete. This causes ResourceResponses to be retained for
    the lifetime of the remote worker page.

    Call stopRecordingResponses() when initializing synthesized documents so their
    DocumentLoader matches the normal Complete state behavior.

    No new automated test because this retention is only visible through native
    WebContent memory inspection. The Web platform cannot observe
    DocumentLoader::m_responses or m_stopRecordingResponses.

    Manual test: ran a local WKWebView service worker fetch harness before and after
    this change. Before: the remote worker DocumentLoader retained 5059 responses
    and had m_stopRecordingResponses=false. After: the remote worker DocumentLoader
    retained 0 responses and had m_stopRecordingResponses=true.

    * Source/WebCore/loader/FrameLoader.cpp:
    (WebCore::FrameLoader::initForSynthesizedDocument):

    Canonical link: <a href="https://commits.webkit.org/312779@main">https://commits.webkit.org/312779@main</a>

Canonical link: <a href="https://commits.webkit.org/305877.482@webkitglib/2.52">https://commits.webkit.org/305877.482@webkitglib/2.52</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/dfa7dde7468f280ceb9f148b34aab8928bb14d8f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/161490 "Passed style check") | [❌ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/34964 "Unable to build WebKit without PR, please check manually (failure)") | [❌ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/28067 "Unable to build WebKit without PR, please check manually (failure)") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/170393 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/117861 "The change is no longer eligible for processing.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/163359 "Passed tests") | [❌ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/35065 "Unable to build WebKit without PR, please check manually (failure)") | [❌ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/34965 "Unable to build WebKit without PR, please check manually (failure)") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/125281 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/117861 "The change is no longer eligible for processing.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/164449 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/155/builds/35065 "Unable to build WebKit without PR, please check manually (failure)") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/168/builds/28067 "Unable to build WebKit without PR, please check manually (failure)") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/105877 "Passed tests") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/155/builds/35065 "Unable to build WebKit without PR, please check manually (failure)") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/156/builds/34965 "Unable to build WebKit without PR, please check manually (failure)") | [❌ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/18114 "Unable to build WebKit without PR, please check manually (failure)") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/155/builds/35065 "Unable to build WebKit without PR, please check manually (failure)") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/168/builds/28067 "Unable to build WebKit without PR, please check manually (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/172879 "Built successfully") | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/19924 "Build is being retried. Recent messages:OS: Tahoe (26.2), Xcode: 26.2; Checked out pull request; Failed to build and analyze WebKit") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/168/builds/28067 "Unable to build WebKit without PR, please check manually (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/133567 "Passed tests") | 
| | [❌ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/34638 "Unable to build WebKit without PR, please check manually (failure)") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/156/builds/34965 "Unable to build WebKit without PR, please check manually (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/133574 "Passed tests") | 
| | [❌ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/34622 "Unable to build WebKit without PR, please check manually (failure)") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/168/builds/28067 "Unable to build WebKit without PR, please check manually (failure)") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/96527 "The change is no longer eligible for processing.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/24550 "Built successfully and passed tests") | [❌ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/160/builds/34622 "Unable to build WebKit without PR, please check manually (failure)") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/168/builds/28067 "Unable to build WebKit without PR, please check manually (failure)") | | 
| | [❌ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/34132 "Unable to build WebKit without PR, please check manually (failure)") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/101578 "Build is being retried. Recent messages:OS: Tahoe (26.3.1), Xcode: 26.2; Checked out pull request; Failed to build and analyze WebKit") | | 
| | [❌ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/33632 "Unable to build WebKit without PR, please check manually (failure)") | | | 
| | [❌ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/33875 "Unable to build WebKit without PR, please check manually (failure)") | | | 
| | [❌ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/33781 "Unable to build WebKit without PR, please check manually (failure)") | | | 
<!--EWS-Status-Bubble-End-->