### PR TITLE
[ANGLE] Fix PoolAllocator ODR violation under sanitizers

### DIFF
--- a/LayoutTests/webgl/compile-shader-no-crash-expected.txt
+++ b/LayoutTests/webgl/compile-shader-no-crash-expected.txt
@@ -1,0 +1,11 @@
+Test that WebGL shader compilation does not crash under ASan.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+TEST COMPLETE: 2 PASS, 0 FAIL
+
+PASS Did not crash.
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/webgl/compile-shader-no-crash.html
+++ b/LayoutTests/webgl/compile-shader-no-crash.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<link rel="stylesheet" href="resources/webgl_test_files/resources/js-test-style.css"/>
+<script src="resources/webgl_test_files/js/js-test-pre.js"></script>
+<script src="resources/webgl_test_files/js/webgl-test-utils.js"></script>
+</head>
+<body onload="test()">
+<div id="description"></div>
+<div id="console"></div>
+<script>
+"use strict";
+description("Test that WebGL shader compilation does not crash under ASan.");
+// Crashes under ASan when PoolAllocator has an ABI mismatch between translation units.
+var wtu = WebGLTestUtils;
+function runTest()
+{
+    var c = document.createElement("canvas");
+    var gl = c.getContext("webgl2");
+    if (gl) {
+        var shader = gl.createShader(gl.VERTEX_SHADER);
+        gl.shaderSource(shader, "void main() { gl_Position = vec4(0.0); }");
+        gl.compileShader(shader);
+        gl.deleteShader(shader);
+    }
+    testPassed("Did not crash.");
+}
+
+function test()
+{
+    runTest();
+    finishTest();
+}
+</script>
+</body>
+</html>

--- a/Source/ThirdParty/ANGLE/src/common/PoolAlloc.h
+++ b/Source/ThirdParty/ANGLE/src/common/PoolAlloc.h
@@ -14,6 +14,8 @@
 #    pragma allow_unsafe_buffers
 #endif
 
+#include "common/platform.h"
+
 #if defined(ANGLE_WITH_ASAN) || defined(ANGLE_WITH_TSAN)
 #    define ANGLE_DISABLE_POOL_ALLOC  // Use system allocator under sanitizers for accurate detection
 #elif !defined(NDEBUG)


### PR DESCRIPTION
#### 79bdc6cbe16a984e588dc2cb7c5266b16451ab70
<pre>
[ANGLE] Fix PoolAllocator ODR violation under sanitizers
<a href="https://bugs.webkit.org/show_bug.cgi?id=314436">https://bugs.webkit.org/show_bug.cgi?id=314436</a>
<a href="https://rdar.apple.com/176458400">rdar://176458400</a>

Reviewed by NOBODY (OOPS!).

<a href="https://commits.webkit.org/312740@main">312740@main</a> checks ANGLE_WITH_ASAN to define ANGLE_DISABLE_POOL_ALLOC, but the check comes before the
include of platform.h (where ANGLE_WITH_ASAN is defined). Whether the macro is visible depends on
whether an earlier header in the translation unit happened to pull in platform.h first.

Compiler.cpp sees platform.h early (indirectly via several headers) so ANGLE_DISABLE_POOL_ALLOC is
defined and PoolAllocator is 24 bytes. PoolAlloc.cpp includes PoolAlloc.h first, misses the macro,
and sees 88 bytes. When TCompiler::compile() stack-allocates a 24-byte PoolAllocator and calls the
out-of-line defaulted constructor (compiled in PoolAlloc.cpp for 88 bytes), it overflows by 64 bytes.

Fix by including platform.h before the check.

Add layout test webgl/compile-shader-no-crash.html which triggers shader compilation and crashes on unpatched ASan builds.

Test: webgl/compile-shader-no-crash.html

* LayoutTests/webgl/compile-shader-no-crash-expected.txt: Added.
* LayoutTests/webgl/compile-shader-no-crash.html: Added.
* Source/ThirdParty/ANGLE/src/common/PoolAlloc.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/79bdc6cbe16a984e588dc2cb7c5266b16451ab70

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/161768 "Failed to checkout and rebase branch from PR 64582") | [❌ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/35242 "Failed to checkout and rebase branch from PR 64582") | [❌ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/28345 "Failed to checkout and rebase branch from PR 64582") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/170671 "Failed to checkout and rebase branch from PR 64582") | [❌ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/118139 "Failed to checkout and rebase branch from PR 64582") | ⏳ 🛠 ios-apple 
| | [❌ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/35343 "Failed to checkout and rebase branch from PR 64582") | [❌ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/35243 "Failed to checkout and rebase branch from PR 64582") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/5/builds/170671 "Failed to checkout and rebase branch from PR 64582") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/59/builds/118139 "Failed to checkout and rebase branch from PR 64582") | ⏳ 🛠 mac-apple 
| [❌ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/164727 "Failed to checkout and rebase branch from PR 64582") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/155/builds/35343 "Failed to checkout and rebase branch from PR 64582") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/168/builds/28345 "Failed to checkout and rebase branch from PR 64582") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/5/builds/170671 "Failed to checkout and rebase branch from PR 64582") | | ⏳ 🛠 vision-apple 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/155/builds/35343 "Failed to checkout and rebase branch from PR 64582") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/156/builds/35243 "Failed to checkout and rebase branch from PR 64582") | [❌ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/18392 "Failed to checkout and rebase branch from PR 64582") | | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/155/builds/35343 "Failed to checkout and rebase branch from PR 64582") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/168/builds/28345 "Failed to checkout and rebase branch from PR 64582") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/173160 "Failed to checkout and rebase branch from PR 64582") | | 
| | | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/168/builds/28345 "Failed to checkout and rebase branch from PR 64582") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/2/builds/173160 "Failed to checkout and rebase branch from PR 64582") | | 
| | [❌ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/34916 "Failed to checkout and rebase branch from PR 64582") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/156/builds/35243 "Failed to checkout and rebase branch from PR 64582") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/2/builds/173160 "Failed to checkout and rebase branch from PR 64582") | | 
| | [❌ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/34900 "Failed to checkout and rebase branch from PR 64582") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/168/builds/28345 "Failed to checkout and rebase branch from PR 64582") | [❌ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/96944 "Failed to checkout and rebase branch from PR 64582") | | 
| | [❌ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/160/builds/34900 "Failed to checkout and rebase branch from PR 64582") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/168/builds/28345 "Failed to checkout and rebase branch from PR 64582") | | | 
| | [❌ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/34410 "Failed to checkout and rebase branch from PR 64582") | | | | 
| | [❌ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/33910 "Failed to checkout and rebase branch from PR 64582") | | | | 
| | [❌ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/34153 "Failed to checkout and rebase branch from PR 64582") | | | | 
| | [❌ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/34059 "Failed to checkout and rebase branch from PR 64582") | | | | 
<!--EWS-Status-Bubble-End-->