### PR TITLE
suggestnominations.py should support Canonical-link

### DIFF
--- a/Tools/Scripts/webkitpy/tool/commands/suggestnominations.py
+++ b/Tools/Scripts/webkitpy/tool/commands/suggestnominations.py
@@ -53,7 +53,7 @@ class AbstractCommitLogCommand(Command):
     _patch_by_regexp = re.compile(r'^Patch by (?P<name>.+?)\s+<(?P<email>[^<>]+)> on (?P<date>\d{4}-\d{2}-\d{2})$', re.MULTILINE)
     _committer_regexp = re.compile(r'^Author: (?P<name>.*?) <(?P<email>[^>]+)>$', re.MULTILINE)
     _date_regexp = re.compile(r'^Date:   (?P<date>\d{4}-\d{2}-\d{2}) (?P<time>\d{2}:\d{2}:\d{2}) [\+\-]\d{4}$', re.MULTILINE)
-    _canonical_regexp = re.compile(r'^Canonical link: https://commits.webkit.org/(?P<canonicalid>\d+)@main$', re.MULTILINE)
+    _canonical_regexp = re.compile(r'^Canonical-link: https://commits.webkit.org/(?P<canonicalid>\d+)@main$', re.MULTILINE)
 
     def __init__(self, options=None):
         options = options or []
@@ -102,7 +102,7 @@ class AbstractCommitLogCommand(Command):
             raise CommitLogError
         commit_date = commit_date_match.group('date')
 
-        canonical_match = self._canonical_regexp.search(commit_message)
+        canonical_match = self._canonical_regexp.search(commit_message.replace('\nCanonical link:', '\nCanonical-link:'))
         if not canonical_match:
             raise CommitLogError
         canonical = canonical_match.group('canonicalid')

--- a/Tools/Scripts/webkitpy/tool/commands/suggestnominations_unittest.py
+++ b/Tools/Scripts/webkitpy/tool/commands/suggestnominations_unittest.py
@@ -112,3 +112,24 @@ git-svn-id: https://svn.webkit.org/repository/webkit/trunk@95188 268f45cc-cd09-0
         suggest_nominations._init_options(options=options)
         suggest_nominations._recent_commit_messages = lambda: [self.mock_non_committer_commit_message for _ in range(88)]
         self.assert_execute_outputs(suggest_nominations, [], expected_stdout=expected_stdout, options=options)
+
+    def test_basic_with_space_canonical_link(self):
+        commit_line = "  commit: https://commits.webkit.org/84070@main on 2009-09-15 by Xianzhu Wang (wangxianzhu@chromium.org)\n"
+        expected_stdout = "COMMITTER: Xianzhu Wang (wangxianzhu@chromium.org) has 88 reviewed patches\n" + commit_line * 88 + "\n"
+        options = self._make_options(show_commits=True)
+        suggest_nominations = SuggestNominations()
+        suggest_nominations._init_options(options=options)
+        self.assertIn('Canonical link:', self.mock_non_committer_commit_message)
+        suggest_nominations._recent_commit_messages = lambda: [self.mock_non_committer_commit_message for _ in range(88)]
+        self.assert_execute_outputs(suggest_nominations, [], expected_stdout=expected_stdout, options=options)
+
+    def test_basic_with_hyphenated_canonical_link(self):
+        commit_line = "  commit: https://commits.webkit.org/84070@main on 2009-09-15 by Xianzhu Wang (wangxianzhu@chromium.org)\n"
+        expected_stdout = "COMMITTER: Xianzhu Wang (wangxianzhu@chromium.org) has 88 reviewed patches\n" + commit_line * 88 + "\n"
+        options = self._make_options(show_commits=True)
+        suggest_nominations = SuggestNominations()
+        suggest_nominations._init_options(options=options)
+        self.assertIn('Canonical link:', self.mock_non_committer_commit_message)
+        message = self.mock_non_committer_commit_message.replace('Canonical link:', 'Canonical-link:')
+        suggest_nominations._recent_commit_messages = lambda: [message for _ in range(88)]
+        self.assert_execute_outputs(suggest_nominations, [], expected_stdout=expected_stdout, options=options)


### PR DESCRIPTION
#### 97dc6d9bae017ed1bed707ec191ba35efdf3628b
<pre>
suggestnominations.py should support Canonical-link
<a href="https://bugs.webkit.org/show_bug.cgi?id=301444">https://bugs.webkit.org/show_bug.cgi?id=301444</a>
<a href="https://rdar.apple.com/163364894">rdar://163364894</a>

Reviewed by Elliott Williams.

* Tools/Scripts/webkitpy/tool/commands/suggestnominations.py:
(AbstractCommitLogCommand): Always expect `Canonical-link`.
(AbstractCommitLogCommand._parse_commit_message): Normalize `Canonical link` to `Canonical-link`.
* Tools/Scripts/webkitpy/tool/commands/suggestnominations_unittest.py:
(test_basic_with_space_canonical_link):
(test_basic_with_hyphenated_canonical_link):

Canonical link: <a href="https://commits.webkit.org/314675@main">https://commits.webkit.org/314675@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f9413deda5929f001bd49698374f2e7ebd354cee

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/161519 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/34993 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/28096 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/170422 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/117890 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/6891f259-a91d-4c7b-81c5-cda8e564f7f8) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/163388 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/35094 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/34994 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/125305 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/88250 "2 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/27a0c8b1-aae4-4612-9047-2b54a426109a) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/164478 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/27599 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/145093 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/105901 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/a9e12348-6ef9-4053-b2e7-d9a3e485e008) 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/160839 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/26648 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/25161 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/18143 "Built successfully") | | 
| [⏳ 🛠 🧪 jsc-x86-64 ](https://ews-build.webkit.org/#/builders/JSC-Tests-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/136342 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/22850 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/172909 "Built successfully") | | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/24491 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/133592 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/34667 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/29257 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/133599 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/34651 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/144645 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/96556 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/25394 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/28126 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/21464 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/34161 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/33661 "Built successfully") | [⏳ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/macOS-Sequoia-Release-Site-Isolation-Tests-EWS "Waiting to run tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/33904 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/33810 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->