### PR TITLE
Upstream DragAndDropTests.DoNotExposeCrossOriginImageData API test

### DIFF
--- a/Tools/TestWebKitAPI/Resources/cocoa/drag-drop-cross-origin-image.html
+++ b/Tools/TestWebKitAPI/Resources/cocoa/drag-drop-cross-origin-image.html
@@ -1,0 +1,63 @@
+<!DOCTYPE html>
+<html>
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<head>
+<style>
+body {
+    margin: 0;
+}
+
+#target {
+    background: tomato;
+    width: 100px;
+    height: 100px;
+}
+
+img {
+    width: 100px;
+    height: 100px;
+    display: block;
+}
+</style>
+</head>
+<body>
+<h3></h3>
+<img src="crossorigin://test/image" id="cross-origin" alt="Cross origin"/>
+<img src="sameorigin://test/image" id="same-origin" alt="Same origin" />
+<div id="target">Drop here</div>
+<script>
+crossOriginImage = document.getElementById("cross-origin");
+sameOriginImage = document.getElementById("same-origin");
+dropTarget = document.getElementById("target");
+numberOfFiles = new Map;
+inconsistentFilesTypeOnDrop = false;
+
+function handleDragStart(event) {
+    numberOfFiles.clear();
+}
+
+function addDraggableAttribute() {
+    for (let element of [...document.querySelectorAll("img")])
+        element.draggable = true;
+}
+
+function handleDragSessionUpdate(event) {
+    let files = event.dataTransfer.files
+    if (!numberOfFiles.has(event.type))
+        numberOfFiles.set(event.type, files.length);
+
+    if (event.type === "drop" && event.dataTransfer.types.includes("Files") != (files.length > 0))
+        inconsistentFilesTypeOnDrop = true;
+
+    event.stopPropagation();
+    event.preventDefault();
+}
+
+crossOriginImage.addEventListener("dragstart", handleDragStart);
+sameOriginImage.addEventListener("dragstart", handleDragStart);
+dropTarget.addEventListener("dragenter", handleDragSessionUpdate);
+dropTarget.addEventListener("dragover", handleDragSessionUpdate);
+dropTarget.addEventListener("drop", handleDragSessionUpdate);
+</script>
+</body>
+</html>

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/DragAndDropTests.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/DragAndDropTests.mm
@@ -442,8 +442,62 @@ TEST(DragAndDropTests, DragSelectedTextInImageOverlay)
 
 #endif // ENABLE(IMAGE_ANALYSIS)
 
-#if USE(APPLE_INTERNAL_SDK) && __has_include(<WebKitAdditions/DragAndDropTestsAdditions.mm>)
-#import <WebKitAdditions/DragAndDropTestsAdditions.mm>
-#endif
+// FIXME: Re-enable this test once webkit.org/b/314562 is resolved.
+TEST(DragAndDropTests, DISABLED_DoNotExposeCrossOriginImageData)
+{
+    RetainPtr markupData = [NSData dataWithContentsOfURL:[NSBundle.test_resourcesBundle URLForResource:@"drag-drop-cross-origin-image" withExtension:@"html"]];
+    RetainPtr imageData = [NSData dataWithContentsOfURL:[NSBundle.test_resourcesBundle URLForResource:@"icon" withExtension:@"png"]];
+
+    RetainPtr handler = adoptNS([TestURLSchemeHandler new]);
+    [handler setStartURLSchemeTaskHandler:^(WKWebView *, id<WKURLSchemeTask> task) {
+        RetainPtr<NSString> path = task.request.URL.path;
+        RetainPtr<NSString> type;
+        RetainPtr<NSData> result;
+        if ([path isEqualToString:@"/main"]) {
+            result = markupData;
+            type = @"text/html";
+        } else if ([path isEqualToString:@"/image"]) {
+            result = imageData;
+            type = @"image/png";
+        }
+
+        if (!result) {
+            [task didFailWithError:[NSError errorWithDomain:@"DoNotExposeCrossOriginImageData" code:1 userInfo:nil]];
+            return;
+        }
+
+        RetainPtr response = adoptNS([[NSURLResponse alloc] initWithURL:task.request.URL MIMEType:type expectedContentLength:[result length] textEncodingName:nil]);
+        [task didReceiveResponse:response];
+        [task didReceiveData:result];
+        [task didFinish];
+    }];
+
+    RetainPtr configuration = adoptNS([WKWebViewConfiguration new]);
+    [configuration setURLSchemeHandler:handler forURLScheme:@"crossorigin"];
+    [configuration setURLSchemeHandler:handler forURLScheme:@"sameorigin"];
+
+    RetainPtr simulator = adoptNS([[DragAndDropSimulator alloc] initWithWebViewFrame:CGRectMake(0, 0, 400, 400) configuration:configuration]);
+    [[simulator webView] synchronouslyLoadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"sameorigin://test/main"]]];
+
+    auto runDragAndDropTests = [&] {
+        // Drag and drop the cross-origin image first.
+        [simulator runFrom:CGPointMake(50, 50) to:CGPointMake(50, 250)];
+        EXPECT_EQ(0, [[[simulator webView] objectByEvaluatingJavaScript:@"numberOfFiles.get('dragenter')"] intValue]);
+        EXPECT_EQ(0, [[[simulator webView] objectByEvaluatingJavaScript:@"numberOfFiles.get('dragover')"] intValue]);
+        EXPECT_EQ(0, [[[simulator webView] objectByEvaluatingJavaScript:@"numberOfFiles.get('drop')"] intValue]);
+        EXPECT_FALSE([[[simulator webView] objectByEvaluatingJavaScript:@"inconsistentFilesTypeOnDrop"] boolValue]);
+
+        // Next, drag and drop the same-origin image.
+        [simulator runFrom:CGPointMake(50, 150) to:CGPointMake(50, 250)];
+        EXPECT_EQ(0, [[[simulator webView] objectByEvaluatingJavaScript:@"numberOfFiles.get('dragenter')"] intValue]);
+        EXPECT_EQ(0, [[[simulator webView] objectByEvaluatingJavaScript:@"numberOfFiles.get('dragover')"] intValue]);
+        EXPECT_EQ(1, [[[simulator webView] objectByEvaluatingJavaScript:@"numberOfFiles.get('drop')"] intValue]);
+        EXPECT_FALSE([[[simulator webView] objectByEvaluatingJavaScript:@"inconsistentFilesTypeOnDrop"] boolValue]);
+    };
+
+    runDragAndDropTests();
+    [[simulator webView] objectByEvaluatingJavaScript:@"addDraggableAttribute()"];
+    runDragAndDropTests();
+}
 
 #endif // ENABLE(DRAG_SUPPORT) && !PLATFORM(MACCATALYST)


### PR DESCRIPTION
#### 77a30c7ddef2e00f99e5c02383e401fe1d898bf6
<pre>
Upstream DragAndDropTests.DoNotExposeCrossOriginImageData API test
<a href="https://bugs.webkit.org/show_bug.cgi?id=314447">https://bugs.webkit.org/show_bug.cgi?id=314447</a>
<a href="https://rdar.apple.com/176602163">rdar://176602163</a>

Reviewed by Richard Robinson.

This patch simply upstreams the API test in question -- which was
originally coverage for 254380@main -- as well as the associated test
resource.

We disable the test for now so as to not introduce noise in EWS -- the
test fail is tracked in webkit.org/b/314562.

* Tools/TestWebKitAPI/Resources/cocoa/drag-drop-cross-origin-image.html: Added.
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/DragAndDropTests.mm:
(TEST(DragAndDropTests, DISABLED_DoNotExposeCrossOriginImageData)):

Canonical link: <a href="https://commits.webkit.org/313025@main">https://commits.webkit.org/313025@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c9152032f6623e1eb9d453278ee42d8b51d8995c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/161858 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/35332 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/28435 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/170761 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/118229 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/3be402b8-4519-4efc-a8b1-359d1c1dbf22) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/163727 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/35434 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/35334 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/125586 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/88499 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/79bd63a0-8a16-43d1-8696-4f6cbcaffd89) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/164817 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/27903 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/145383 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/106182 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/8761ebc5-c7b1-42e9-9551-7657748308ed) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/26952 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/25466 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/18482 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/136645 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/23138 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/173250 "Built successfully") | | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/24779 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/133885 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/35006 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/29552 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/133890 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/34990 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/144933 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/97083 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/24584 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/28419 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/21756 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/34500 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/34000 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/34243 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/34149 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->