### PR TITLE
[HDR] Use accelerated backing stores to apply the gain-map image in GPUProcess

### DIFF
--- a/Source/WebCore/platform/graphics/BitmapImageSource.cpp
+++ b/Source/WebCore/platform/graphics/BitmapImageSource.cpp
@@ -335,10 +335,13 @@ bool BitmapImageSource::hasEverAnimated() const
     return m_frameAnimator && m_frameAnimator->hasEverAnimated();
 }
 
-DecodingDestination BitmapImageSource::preferredDecodingDestination(GraphicsContext&, ImagePaintingOptions options) const
+DecodingDestination BitmapImageSource::preferredDecodingDestination(GraphicsContext& context, ImagePaintingOptions options) const
 {
     if (options.drawsHDRContent() == DrawsHDRContent::No || options.dynamicRangeLimit() == PlatformDynamicRangeLimit::standard() || !hasHDRGainMap())
         return DecodingDestination::Base;
+
+    if (options.allowAcceleratedApplyGainMap() == AllowAcceleratedApplyGainMap::Yes && !context.renderingMethod())
+        return DecodingDestination::BaseAndGainMap;
 
     return DecodingDestination::ShouldDecodeToHDR;
 }
@@ -372,9 +375,9 @@ bool BitmapImageSource::isPendingDecodingAtIndex(unsigned index, SubsamplingLeve
     return m_workQueue->isPendingDecodingAtIndex(index, subsamplingLevel, options);
 }
 
-bool BitmapImageSource::isCompatibleWithOptionsAtIndex(unsigned index, SubsamplingLevel subsamplingLevel, const DecodingOptions& options) const
+std::optional<DecodingDestination> BitmapImageSource::compatibleDecodingDestinationWithOptionsAtIndex(unsigned index, SubsamplingLevel subsamplingLevel, const DecodingOptions& options) const
 {
-    return frameAtIndex(index).hasDecodedNativeImageCompatibleWithOptions(options, subsamplingLevel);
+    return frameAtIndex(index).compatibleDecodingDestinationWithOptions(options, subsamplingLevel);
 }
 
 void BitmapImageSource::decode(Function<void(DecodingStatus)>&& decodeCallback)
@@ -389,10 +392,10 @@ void BitmapImageSource::decode(Function<void(DecodingStatus)>&& decodeCallback)
 
     // FIXME: HTMLImageElement.decode() needs a parameter to control whether it should decode SDR or HDR image.
     auto preferredDecodingDestination = hasHDRContent() ? DecodingDestination::ShouldDecodeToHDR : DecodingDestination::Base;
-    auto isCompatibleNativeImage = isCompatibleWithOptionsAtIndex(index, SubsamplingLevel::Default, { DecodingMode::Asynchronous, preferredDecodingDestination });
+    auto compatibleDecodingDestination = compatibleDecodingDestinationWithOptionsAtIndex(index, SubsamplingLevel::Default, { DecodingMode::Asynchronous, preferredDecodingDestination });
 
     RefPtr frameAnimator = this->frameAnimator();
-    if (frameAnimator && (frameAnimator->hasEverAnimated() || isCompatibleNativeImage)) {
+    if (frameAnimator && (frameAnimator->hasEverAnimated() || compatibleDecodingDestination)) {
         // startAnimation() always decodes the nextFrame which is currentFrameIndex + 1.
         // If primaryFrameIndex = 0, then the sequence of decoding is { 1, 2, .., n, 0, 1, ...}.
         if (startAnimation(SubsamplingLevel::Default, DecodingMode::Asynchronous)) {
@@ -401,7 +404,7 @@ void BitmapImageSource::decode(Function<void(DecodingStatus)>&& decodeCallback)
         }
     }
 
-    if (!isCompatibleNativeImage) {
+    if (!compatibleDecodingDestination) {
         LOG(Images, "BitmapImageSource::%s - %p - url: %s. Decoding for frame at index = %d will be requested.", __FUNCTION__, this, sourceUTF8().data(), index);
         requestNativeImageAtIndex(index, SubsamplingLevel::Default, ImageAnimatingState::No, { DecodingMode::Asynchronous, preferredDecodingDestination });
         return;
@@ -557,23 +560,23 @@ DecodingStatus BitmapImageSource::requestNativeImageAtIndex(unsigned index, Subs
     return DecodingStatus::Decoding;
 }
 
-DecodingStatus BitmapImageSource::requestNativeImageAtIndexIfNeeded(unsigned index, SubsamplingLevel subsamplingLevel, ImageAnimatingState animatingState, const DecodingOptions& options)
+Expected<DecodingDestination, DecodingStatus> BitmapImageSource::requestNativeImageAtIndexIfNeeded(unsigned index, SubsamplingLevel subsamplingLevel, ImageAnimatingState animatingState, const DecodingOptions& options)
 {
     if (index >= m_frames.size())
-        return DecodingStatus::Invalid;
+        return makeUnexpected(DecodingStatus::Invalid);
 
     // Never decode the same frame from two different threads.
     if (isPendingDecodingAtIndex(index, subsamplingLevel, options)) {
         LOG(Images, "BitmapImageSource::%s - %p - url: %s. Frame at index = %d is being decoded.", __FUNCTION__, this, sourceUTF8().data(), index);
         ++m_blankDrawCountForTesting;
-        return DecodingStatus::Decoding;
+        return makeUnexpected(DecodingStatus::Decoding);
     }
 
-    // isCompatibleWithOptionsAtIndex() returns true only if the frame is complete.
-    if (isCompatibleWithOptionsAtIndex(index, subsamplingLevel, options))
-        return DecodingStatus::Complete;
+    // compatibleDecodingDestination() returns a DecodingDestination only if the frame is complete.
+    if (auto compatibleDecodingDestination = compatibleDecodingDestinationWithOptionsAtIndex(index, subsamplingLevel, options))
+        return *compatibleDecodingDestination;
 
-    return requestNativeImageAtIndex(index, subsamplingLevel, animatingState, options);
+    return makeUnexpected(requestNativeImageAtIndex(index, subsamplingLevel, animatingState, options));
 }
 
 Expected<Ref<NativeImage>, DecodingStatus> BitmapImageSource::nativeImageAtIndexCacheIfNeeded(unsigned index, SubsamplingLevel subsamplingLevel, const DecodingOptions& options)
@@ -592,18 +595,25 @@ Expected<Ref<NativeImage>, DecodingStatus> BitmapImageSource::nativeImageAtIndex
         return makeUnexpected(DecodingStatus::Decoding);
     }
 
-    if (!isCompatibleWithOptionsAtIndex(index, subsamplingLevel, options)) {
-        DecodingOptions decodingOptions = { DecodingMode::Synchronous, options.decodingDestination() };
-        PlatformImagePtr platformImage = m_decoder->createFrameImageAtIndex(index, subsamplingLevel, decodingOptions);
+    auto decodingDestination = options.decodingDestination();
 
-        RefPtr nativeImage = NativeImage::create(WTF::move(platformImage));
-        if (!nativeImage)
+    if (auto compatibleDecodingDestination = compatibleDecodingDestinationWithOptionsAtIndex(index, subsamplingLevel, options))
+        decodingDestination = *compatibleDecodingDestination;
+    else {
+        auto decodingOptions = DecodingOptions { DecodingMode::Synchronous, decodingDestination };
+
+        auto result = m_decoder->createNativeImageAtIndex(index, subsamplingLevel, decodingOptions);
+        if (!result)
             return makeUnexpected(DecodingStatus::Invalid);
 
-        cacheNativeImageAtIndex(index, subsamplingLevel, decodingOptions, nativeImage.releaseNonNull());
+        Ref nativeImage = WTF::move(std::get<Ref<NativeImage>>(*result));
+        decodingDestination = std::get<DecodingDestination>(*result);
+
+        decodingOptions = { DecodingMode::Synchronous, decodingDestination };
+        cacheNativeImageAtIndex(index, subsamplingLevel, decodingOptions, WTF::move(nativeImage));
     }
 
-    if (RefPtr nativeImage = frameAtIndex(index).nativeImage(options.decodingDestination()))
+    if (RefPtr nativeImage = frameAtIndex(index).nativeImage(decodingDestination))
         return nativeImage.releaseNonNull();
 
     return makeUnexpected(DecodingStatus::Invalid);
@@ -616,11 +626,12 @@ Expected<Ref<NativeImage>, DecodingStatus> BitmapImageSource::nativeImageAtIndex
 
     ASSERT(!isAnimated());
 
-    auto status = requestNativeImageAtIndexIfNeeded(index, subsamplingLevel, ImageAnimatingState::No, options);
-    if (status == DecodingStatus::Invalid || status == DecodingStatus::Decoding)
-        return makeUnexpected(status);
+    auto decodingDestinationOrStatus = requestNativeImageAtIndexIfNeeded(index, subsamplingLevel, ImageAnimatingState::No, options);
+    if (!decodingDestinationOrStatus)
+        return makeUnexpected(decodingDestinationOrStatus.error());
 
-    if (RefPtr nativeImage = frameAtIndex(index).nativeImage(options.decodingDestination()))
+    auto decodingDestination = decodingDestinationOrStatus.value();
+    if (RefPtr nativeImage = frameAtIndex(index).nativeImage(decodingDestination))
         return nativeImage.releaseNonNull();
 
     return makeUnexpected(DecodingStatus::Invalid);

--- a/Source/WebCore/platform/graphics/BitmapImageSource.h
+++ b/Source/WebCore/platform/graphics/BitmapImageSource.h
@@ -75,7 +75,7 @@ public:
     const ImageFrame& primaryImageFrame(const std::optional<SubsamplingLevel>& subsamplingLevel = std::nullopt) final { return frameAtIndexCacheIfNeeded(primaryFrameIndex(), subsamplingLevel); }
 
     // NativeImage
-    DecodingStatus requestNativeImageAtIndexIfNeeded(unsigned index, SubsamplingLevel, ImageAnimatingState, const DecodingOptions&);
+    Expected<DecodingDestination, DecodingStatus> requestNativeImageAtIndexIfNeeded(unsigned index, SubsamplingLevel, ImageAnimatingState, const DecodingOptions&);
 
     RefPtr<NativeImage> primaryNativeImageIfExists() { return frameAtIndex(primaryFrameIndex()).nativeImage(std::nullopt); }
     RefPtr<NativeImage> primaryNativeImage() final { return nativeImageAtIndex(primaryFrameIndex()); }
@@ -124,9 +124,9 @@ private:
 
     // Decoding
     DecodingDestination preferredDecodingDestination(GraphicsContext&, ImagePaintingOptions) const final;
+    std::optional<DecodingDestination> compatibleDecodingDestinationWithOptionsAtIndex(unsigned index, SubsamplingLevel, const DecodingOptions&) const;
     bool isLargeForDecoding() const final;
     bool NODELETE isDecodingWorkQueueIdle() const;
-    bool isCompatibleWithOptionsAtIndex(unsigned index, SubsamplingLevel, const DecodingOptions&) const;
     void stopDecodingWorkQueue() final;
     void decode(Function<void(DecodingStatus)>&& decodeCallback) final;
     void callDecodeCallbacks(DecodingStatus);

--- a/Source/WebCore/platform/graphics/DecodingOptions.h
+++ b/Source/WebCore/platform/graphics/DecodingOptions.h
@@ -36,9 +36,9 @@ enum class DecodingMode : uint8_t {
     Asynchronous
 };
 
-// FIXME: Add and handle the DecodingDestination::BaseAndGainMap
 enum class DecodingDestination : uint8_t {
     Base,
+    BaseAndGainMap,
     ShouldDecodeToHDR
 };
 
@@ -66,8 +66,14 @@ public:
 
     bool isCompatibleWith(const DecodingOptions& other) const
     {
-        if (decodingDestination() != other.decodingDestination())
-            return false;
+        if (decodingDestination() != other.decodingDestination()) {
+            // This is the only exception. A fully decoded HDR image is compatible
+            // with DecodingDestination::BaseAndGainMap request.
+            if (decodingDestination() != DecodingDestination::ShouldDecodeToHDR)
+                return false;
+            if (other.decodingDestination() != DecodingDestination::BaseAndGainMap)
+                return false;
+        }
 
         if (isAuto() || other.isAuto())
             return false;

--- a/Source/WebCore/platform/graphics/GraphicsContext.h
+++ b/Source/WebCore/platform/graphics/GraphicsContext.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2003-2024 Apple Inc. All rights reserved.
+ * Copyright (C) 2003-2026 Apple Inc. All rights reserved.
  * Copyright (C) 2008-2009 Torch Mobile, Inc.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -191,6 +191,8 @@ public:
     virtual bool knownToHaveFloatBasedBacking() const { return false; }
 
     virtual RenderingMode renderingMode() const { return RenderingMode::Unaccelerated; }
+    virtual std::optional<RenderingMethod> renderingMethod() const { return RenderingMethod::Local; }
+
     WEBCORE_EXPORT RenderingMode renderingModeForCompatibleBuffer() const;
 
     // Shapes

--- a/Source/WebCore/platform/graphics/ImageDecoder.cpp
+++ b/Source/WebCore/platform/graphics/ImageDecoder.cpp
@@ -171,4 +171,21 @@ bool ImageDecoder::fetchFrameMetaDataAtIndex(size_t index, SubsamplingLevel subs
     return true;
 }
 
+std::optional<std::tuple<Ref<NativeImage>, DecodingDestination>> ImageDecoder::createNativeImageAtIndex(size_t index, SubsamplingLevel subsamplingLevel, const DecodingOptions& options)
+{
+    DecodingOptions decodingOptions = options;
+
+    auto gainMap = frameGainMapAtIndex(index, decodingOptions);
+    if (!gainMap && decodingOptions.decodingDestination() == DecodingDestination::BaseAndGainMap)
+        decodingOptions = { decodingOptions.decodingMode(), DecodingDestination::ShouldDecodeToHDR, decodingOptions.sizeForDrawing() };
+
+    PlatformImagePtr platformImage = createFrameImageAtIndex(index, subsamplingLevel, decodingOptions);
+    if (!platformImage)
+        return std::nullopt;
+
+    RefPtr nativeImage = NativeImage::create(WTF::move(platformImage), WTF::move(gainMap));
+
+    return { { nativeImage.releaseNonNull(), decodingOptions.decodingDestination() } };
+}
+
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/ImageDecoder.h
+++ b/Source/WebCore/platform/graphics/ImageDecoder.h
@@ -46,6 +46,7 @@ namespace WebCore {
 
 class FragmentedSharedBuffer;
 class ImageFrame;
+class NativeImage;
 
 struct ImageDecoderFrameInfo {
     bool hasAlpha;
@@ -126,6 +127,8 @@ public:
 
     virtual std::optional<GainMap> frameGainMapAtIndex(size_t, const DecodingOptions&) { return std::nullopt; }
     virtual PlatformImagePtr createFrameImageAtIndex(size_t, SubsamplingLevel = SubsamplingLevel::Default, const DecodingOptions& = DecodingOptions(DecodingMode::Synchronous)) = 0;
+
+    std::optional<std::tuple<Ref<NativeImage>, DecodingDestination>> createNativeImageAtIndex(size_t, SubsamplingLevel, const DecodingOptions&);
 
     virtual void setExpectedContentSize(long long) { }
     virtual void setData(const FragmentedSharedBuffer&, bool allDataReceived) = 0;

--- a/Source/WebCore/platform/graphics/ImageFrame.cpp
+++ b/Source/WebCore/platform/graphics/ImageFrame.cpp
@@ -84,6 +84,9 @@ size_t ImageFrame::clearImage(std::optional<DecodingDestination> decodingDestina
     if (!decodingDestination || *decodingDestination == DecodingDestination::Base)
         sizeInBytes += destination(DecodingDestination::Base).clear();
 
+    if (!decodingDestination || *decodingDestination == DecodingDestination::BaseAndGainMap)
+        sizeInBytes += destination(DecodingDestination::BaseAndGainMap).clear();
+
     if (!decodingDestination || *decodingDestination == DecodingDestination::ShouldDecodeToHDR)
         sizeInBytes += destination(DecodingDestination::ShouldDecodeToHDR).clear();
 
@@ -107,9 +110,17 @@ bool ImageFrame::hasFullSizeNativeImage(DecodingDestination decodingDestination,
     return destination(decodingDestination).hasFullSizeNativeImage() && subsamplingLevel >= m_subsamplingLevel;
 }
 
-bool ImageFrame::hasDecodedNativeImageCompatibleWithOptions(const DecodingOptions& decodingOptions, SubsamplingLevel subsamplingLevel) const
+std::optional<DecodingDestination> ImageFrame::compatibleDecodingDestinationWithOptions(const DecodingOptions& decodingOptions, SubsamplingLevel subsamplingLevel) const
 {
-    return isComplete() && destination(decodingOptions.decodingDestination()).hasDecodedNativeImageCompatibleWithOptions(decodingOptions) && subsamplingLevel >= m_subsamplingLevel;
+    if (!isComplete() || subsamplingLevel < m_subsamplingLevel)
+        return std::nullopt;
+
+    for (auto& destination : m_destinations) {
+        if (destination.hasDecodedNativeImageCompatibleWithOptions(decodingOptions))
+            return destination.decodingOptions.decodingDestination();
+    }
+
+    return std::nullopt;
 }
 
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/ImageFrame.h
+++ b/Source/WebCore/platform/graphics/ImageFrame.h
@@ -92,7 +92,7 @@ public:
     bool hasNativeImage(DecodingDestination decodingDestination) const { return m_destinations[decodingDestination].hasNativeImage(); }
     bool NODELETE hasNativeImage(DecodingDestination, SubsamplingLevel) const;
     bool NODELETE hasFullSizeNativeImage(DecodingDestination, SubsamplingLevel) const;
-    bool hasDecodedNativeImageCompatibleWithOptions(const DecodingOptions&, SubsamplingLevel) const;
+    std::optional<DecodingDestination> compatibleDecodingDestinationWithOptions(const DecodingOptions&, SubsamplingLevel) const;
     bool hasMetadata() const { return !size().isEmpty(); }
 
 private:
@@ -136,6 +136,8 @@ private:
     {
         if (m_destinations[DecodingDestination::ShouldDecodeToHDR].hasNativeImage())
             return DecodingDestination::ShouldDecodeToHDR;
+        if (m_destinations[DecodingDestination::BaseAndGainMap].hasNativeImage())
+            return DecodingDestination::BaseAndGainMap;
         return DecodingDestination::Base;
     }
 

--- a/Source/WebCore/platform/graphics/ImageFrameWorkQueue.cpp
+++ b/Source/WebCore/platform/graphics/ImageFrameWorkQueue.cpp
@@ -76,8 +76,15 @@ void ImageFrameWorkQueue::start()
             if (minimumDecodingDuration > 0_s)
                 startingTime = MonotonicTime::now();
 
-            PlatformImagePtr platformImage = protectedDecoder->createFrameImageAtIndex(request.index, request.subsamplingLevel, request.options);
-            RefPtr nativeImage = NativeImage::create(WTF::move(platformImage));
+            RefPtr<NativeImage> nativeImage;
+            DecodingDestination decodingDestination = request.options.decodingDestination();
+
+            if (auto result = protectedDecoder->createNativeImageAtIndex(request.index, request.subsamplingLevel, request.options)) {
+                nativeImage = WTF::move(std::get<Ref<NativeImage>>(*result));
+                decodingDestination = std::get<DecodingDestination>(*result);
+            }
+
+            request.options = { request.options.decodingMode(), decodingDestination, request.options.sizeForDrawing() };
 
             // Pretend as if decoding the frame took minimumDecodingDuration.
             if (minimumDecodingDuration > 0_s) {
@@ -95,7 +102,7 @@ void ImageFrameWorkQueue::start()
                 }
 
                 // The DecodeQueue may have been cleared before the frame was decoded.
-                if (protectedThis->decodeQueue().isEmpty() || protectedThis->decodeQueue().first() != request) {
+                if (protectedThis->decodeQueue().isEmpty() || !request.isCompatibleWith(protectedThis->decodeQueue().first())) {
                     LOG(Images, "ImageFrameWorkQueue::%s - %p - url: %s. DecodeQueue was cleared at index = %d.", __FUNCTION__, protectedThis.ptr(), protectedSource->sourceUTF8().data(), request.index);
                     return;
                 }

--- a/Source/WebCore/platform/graphics/ImageFrameWorkQueue.h
+++ b/Source/WebCore/platform/graphics/ImageFrameWorkQueue.h
@@ -42,7 +42,13 @@ public:
         SubsamplingLevel subsamplingLevel;
         ImageAnimatingState animatingState;
         DecodingOptions options;
-        friend bool operator==(const Request&, const Request&) = default;
+        bool isCompatibleWith(const Request& other) const
+        {
+            return index == other.index
+                && subsamplingLevel == other.subsamplingLevel
+                && animatingState == other.animatingState
+                && options.isCompatibleWith(other.options);
+        }
     };
 
     static Ref<ImageFrameWorkQueue> create(BitmapImageSource&);

--- a/Source/WebCore/platform/graphics/NativeImage.cpp
+++ b/Source/WebCore/platform/graphics/NativeImage.cpp
@@ -63,7 +63,6 @@ NativeImage::NativeImage(PlatformImagePtr&& platformImage, std::optional<GainMap
     , m_gainMap(WTF::move(gainMap))
 {
     computeHeadroom();
-    ASSERT_IMPLIES(m_gainMap, m_headroom == Headroom::None);
 }
 #endif
 
@@ -93,7 +92,6 @@ void NativeImage::replacePlatformImage(PlatformImagePtr&& platformImage) const
     ASSERT(platformImage);
     m_platformImage = WTF::move(platformImage);
     computeHeadroom();
-    ASSERT_IMPLIES(m_gainMap, m_headroom == Headroom::None);
 }
 
 #if !USE(CG)

--- a/Source/WebCore/platform/graphics/NativeImage.h
+++ b/Source/WebCore/platform/graphics/NativeImage.h
@@ -27,6 +27,7 @@
 
 #pragma once
 
+#include <WebCore/DecodingOptions.h>
 #include <WebCore/GainMap.h>
 #include <WebCore/ImageTypes.h>
 #include <WebCore/PlatformImage.h>
@@ -74,7 +75,9 @@ public:
     std::optional<Color> singlePixelSolidColor() const;
     WEBCORE_EXPORT virtual DestinationColorSpace colorSpace() const;
     WEBCORE_EXPORT bool hasHDRContent() const;
-    WEBCORE_EXPORT Headroom NODELETE headroom() const;
+    bool hasHDRGainMap() const { return m_gainMap.has_value(); }
+    Headroom baseImageHeadroom() const { return m_baseImageHeadroom; }
+    Headroom headroom() const { return m_headroom; }
 
     void clearSubimages();
 
@@ -110,6 +113,7 @@ protected:
 
     mutable PlatformImagePtr m_platformImage;
     mutable std::optional<GainMap> m_gainMap;
+    mutable Headroom m_baseImageHeadroom { Headroom::None };
     mutable Headroom m_headroom { Headroom::None };
     mutable WeakHashSet<RenderingResourceObserver> m_observers;
     RenderingResourceIdentifier m_renderingResourceIdentifier { RenderingResourceIdentifier::generate() };

--- a/Source/WebCore/platform/graphics/ShareableBitmap.cpp
+++ b/Source/WebCore/platform/graphics/ShareableBitmap.cpp
@@ -36,10 +36,10 @@ namespace WebCore {
 DECLARE_ALLOCATOR_WITH_HEAP_IDENTIFIER_AND_EXPORT(ShareableBitmap, WTF_INTERNAL);
 DEFINE_ALLOCATOR_WITH_HEAP_IDENTIFIER(ShareableBitmap);
 
-ShareableBitmapConfiguration::ShareableBitmapConfiguration(const IntSize& size, std::optional<DestinationColorSpace> colorSpace, Headroom headroom, bool isOpaque)
+ShareableBitmapConfiguration::ShareableBitmapConfiguration(const IntSize& size, std::optional<DestinationColorSpace> colorSpace, Headroom baseImageHeadroom, bool isOpaque)
     : m_size(size)
     , m_colorSpace(validateColorSpace(colorSpace))
-    , m_headroom(headroom)
+    , m_baseImageHeadroom(baseImageHeadroom)
     , m_isOpaque(isOpaque)
     , m_bitsPerComponent(calculateBitsPerComponent(this->colorSpace()))
     , m_bytesPerPixel(calculateBytesPerPixel(this->colorSpace()))
@@ -52,10 +52,10 @@ ShareableBitmapConfiguration::ShareableBitmapConfiguration(const IntSize& size, 
 #endif
 {
     ASSERT(!m_size.isEmpty());
-    ASSERT(headroom >= Headroom::None);
+    ASSERT(m_baseImageHeadroom >= Headroom::None);
 }
 
-ShareableBitmapConfiguration::ShareableBitmapConfiguration(const IntSize& size, std::optional<DestinationColorSpace> colorSpace, Headroom headroom, bool isOpaque, unsigned bitsPerComponent, unsigned bytesPerPixel, unsigned bytesPerRow
+ShareableBitmapConfiguration::ShareableBitmapConfiguration(const IntSize& size, std::optional<DestinationColorSpace> colorSpace, Headroom baseImageHeadroom, bool isOpaque, unsigned bitsPerComponent, unsigned bytesPerPixel, unsigned bytesPerRow
 #if USE(CG)
     , CGBitmapInfo bitmapInfo
     , std::optional<ShareableGainMap>&& shareableGainMap
@@ -63,7 +63,7 @@ ShareableBitmapConfiguration::ShareableBitmapConfiguration(const IntSize& size, 
 )
     : m_size(size)
     , m_colorSpace(colorSpace)
-    , m_headroom(headroom)
+    , m_baseImageHeadroom(baseImageHeadroom)
     , m_isOpaque(isOpaque)
     , m_bitsPerComponent(bitsPerComponent)
     , m_bytesPerPixel(bytesPerPixel)
@@ -78,7 +78,7 @@ ShareableBitmapConfiguration::ShareableBitmapConfiguration(const IntSize& size, 
 {
     // This constructor is called when decoding ShareableBitmapConfiguration. So this constructor
     // will behave like the default constructor if a null ShareableBitmapHandle was encoded.
-    ASSERT(headroom >= Headroom::None);
+    ASSERT(m_baseImageHeadroom >= Headroom::None);
 }
 
 CheckedUint32 ShareableBitmapConfiguration::calculateSizeInBytes(const IntSize& size, const DestinationColorSpace& colorSpace)
@@ -96,7 +96,7 @@ RefPtr<ShareableBitmap> ShareableBitmap::create(const ShareableBitmapConfigurati
     if (!sharedMemory)
         return nullptr;
 
-    ASSERT(configuration.headroom() >= Headroom::None);
+    ASSERT(configuration.baseImageHeadroom() >= Headroom::None);
     return adoptRef(new ShareableBitmap(configuration, sharedMemory.releaseNonNull()));
 }
 
@@ -176,7 +176,7 @@ ShareableBitmap::ShareableBitmap(const ShareableBitmapConfiguration& configurati
     : m_configuration(configuration)
     , m_sharedMemory(WTF::move(sharedMemory))
 {
-    ASSERT(m_configuration.headroom() >= Headroom::None);
+    ASSERT(m_configuration.baseImageHeadroom() >= Headroom::None);
 }
 
 std::span<const uint8_t> ShareableBitmap::span() const LIFETIME_BOUND

--- a/Source/WebCore/platform/graphics/ShareableBitmap.h
+++ b/Source/WebCore/platform/graphics/ShareableBitmap.h
@@ -78,7 +78,7 @@ public:
     IntSize size() const { return m_size; }
     const DestinationColorSpace& colorSpace() const { return m_colorSpace ? *m_colorSpace : DestinationColorSpace::SRGB(); }
     PlatformColorSpaceValue platformColorSpace() const { return colorSpace().platformColorSpace(); }
-    Headroom headroom() const { return m_headroom; }
+    Headroom baseImageHeadroom() const { return m_baseImageHeadroom; }
     bool isOpaque() const { return m_isOpaque; }
 
     unsigned bitsPerComponent() const { ASSERT(!m_bitsPerComponent.hasOverflowed()); return m_bitsPerComponent; }
@@ -109,7 +109,7 @@ private:
 
     IntSize m_size;
     std::optional<DestinationColorSpace> m_colorSpace;
-    Headroom m_headroom { Headroom::None };
+    Headroom m_baseImageHeadroom { Headroom::None };
     bool m_isOpaque { false };
 
     CheckedUint32 m_bitsPerComponent;

--- a/Source/WebCore/platform/graphics/cairo/NativeImageCairo.cpp
+++ b/Source/WebCore/platform/graphics/cairo/NativeImageCairo.cpp
@@ -51,11 +51,6 @@ DestinationColorSpace NativeImage::colorSpace() const
     return DestinationColorSpace::SRGB();
 }
 
-Headroom NativeImage::headroom() const
-{
-    return Headroom::None;
-}
-
 std::optional<Color> NativeImage::singlePixelSolidColor() const
 {
     if (size() != IntSize(1, 1))

--- a/Source/WebCore/platform/graphics/cg/ImageDecoderCG.cpp
+++ b/Source/WebCore/platform/graphics/cg/ImageDecoderCG.cpp
@@ -635,9 +635,12 @@ bool ImageDecoderCG::fetchFrameMetaDataAtIndex(size_t index, SubsamplingLevel su
     return true;
 }
 
-std::optional<GainMap> ImageDecoderCG::frameGainMapAtIndex(size_t index, const DecodingOptions&)
+std::optional<GainMap> ImageDecoderCG::frameGainMapAtIndex(size_t index, const DecodingOptions& decodingOptions)
 {
 #if HAVE(SUPPORT_HDR_DISPLAY_APIS)
+    if (decodingOptions.decodingDestination() != DecodingDestination::BaseAndGainMap)
+        return std::nullopt;
+
     RetainPtr auxiliaryOptions = adoptCF(CFDictionaryCreateMutable(nullptr, 0, &kCFTypeDictionaryKeyCallBacks, &kCFTypeDictionaryValueCallBacks));
     CFDictionarySetValue(auxiliaryOptions.get(), kCGImageAuxiliaryDataRepresentation, kCGImageAuxiliaryDataRepresentationPixelBuffer);
 
@@ -662,6 +665,7 @@ std::optional<GainMap> ImageDecoderCG::frameGainMapAtIndex(size_t index, const D
     };
 #else
     UNUSED_PARAM(index);
+    UNUSED_PARAM(decodingOptions);
     return std::nullopt;
 #endif
 }

--- a/Source/WebCore/platform/graphics/cg/NativeImageCG.cpp
+++ b/Source/WebCore/platform/graphics/cg/NativeImageCG.cpp
@@ -95,15 +95,22 @@ DestinationColorSpace NativeImage::colorSpace() const
 
 void NativeImage::computeHeadroom() const
 {
+    constexpr float whiteLevel = 203.0; // Default reference white 203 nits
+    constexpr float peakLevel = 1000.0; // Default to 1000 nits
+    constexpr auto gainMapImageHeadroom = Headroom(peakLevel / whiteLevel);
+
 #if HAVE(SUPPORT_HDR_DISPLAY)
     float headroom = CGImageGetContentHeadroom(m_platformImage.get());
-    m_headroom = Headroom(std::max<float>(headroom, Headroom::None));
+    m_baseImageHeadroom = Headroom(std::max<float>(headroom, Headroom::None));
+#else
+    m_baseImageHeadroom = Headroom::None;
 #endif
-}
 
-Headroom NativeImage::headroom() const
-{
-    return m_headroom;
+    if (hasHDRGainMap()) {
+        m_headroom = gainMapImageHeadroom;
+        ASSERT(m_baseImageHeadroom == Headroom::None);
+    } else
+        m_headroom = m_baseImageHeadroom;
 }
 
 std::optional<Color> NativeImage::singlePixelSolidColor() const

--- a/Source/WebCore/platform/graphics/cg/ShareableBitmapCG.mm
+++ b/Source/WebCore/platform/graphics/cg/ShareableBitmapCG.mm
@@ -44,7 +44,7 @@ namespace WebCore {
 ShareableBitmapConfiguration::ShareableBitmapConfiguration(const NativeImage& image)
     : m_size(image.size())
     , m_colorSpace(image.colorSpace())
-    , m_headroom(image.headroom())
+    , m_baseImageHeadroom(image.baseImageHeadroom())
     , m_bitsPerComponent(CGImageGetBitsPerComponent(image.platformImage().get()))
     , m_bytesPerPixel(CGImageGetBitsPerPixel(image.platformImage().get()) / 8)
     , m_bytesPerRow(CGImageGetBytesPerRow(image.platformImage().get()))
@@ -237,16 +237,15 @@ PlatformImagePtr ShareableBitmap::createBasePlatformImage(BackingStoreCopy copyB
     unsigned bytesPerRow = m_configuration.bytesPerRow();
 
 #if HAVE(SUPPORT_HDR_DISPLAY_APIS)
-    if (m_configuration.headroom() > Headroom::None)
-        return adoptCF(CGImageCreateWithContentHeadroom(m_configuration.headroom(), size().width(), size().height(), bitsPerComponent, bitsPerPixel, bytesPerRow, protect(m_configuration.platformColorSpace()).get(), m_configuration.bitmapInfo(), dataProvider.get(), 0, shouldInterpolate == ShouldInterpolate::Yes, kCGRenderingIntentDefault));
+    if (m_configuration.baseImageHeadroom() > Headroom::None)
+        return adoptCF(CGImageCreateWithContentHeadroom(m_configuration.baseImageHeadroom(), size().width(), size().height(), bitsPerComponent, bitsPerPixel, bytesPerRow, protect(m_configuration.platformColorSpace()).get(), m_configuration.bitmapInfo(), dataProvider.get(), 0, shouldInterpolate == ShouldInterpolate::Yes, kCGRenderingIntentDefault));
 #endif
     return adoptCF(CGImageCreate(size().width(), size().height(), bitsPerComponent, bitsPerPixel, bytesPerRow, protect(m_configuration.platformColorSpace()).get(), m_configuration.bitmapInfo(), dataProvider.get(), 0, shouldInterpolate == ShouldInterpolate::Yes, kCGRenderingIntentDefault));
-
 }
 
 PlatformImagePtr ShareableBitmap::createPlatformImage(BackingStoreCopy copyBehavior, ShouldInterpolate shouldInterpolate)
 {
-    auto basePlatformImage = createBasePlatformImage(copyBehavior, shouldInterpolate);
+    RetainPtr basePlatformImage = createBasePlatformImage(copyBehavior, shouldInterpolate);
     if (!basePlatformImage)
         return basePlatformImage;
 
@@ -254,7 +253,7 @@ PlatformImagePtr ShareableBitmap::createPlatformImage(BackingStoreCopy copyBehav
     if (!shareableGainMap)
         return basePlatformImage;
 
-    auto outputPlatformImage = shareableGainMap->applyGainMapToBaseImage(basePlatformImage);
+    RetainPtr outputPlatformImage = shareableGainMap->applyGainMapToBaseImage(basePlatformImage);
     if (!outputPlatformImage)
         return basePlatformImage;
 

--- a/Source/WebCore/platform/graphics/skia/NativeImageSkia.cpp
+++ b/Source/WebCore/platform/graphics/skia/NativeImageSkia.cpp
@@ -88,11 +88,6 @@ DestinationColorSpace NativeImage::colorSpace() const
     return DestinationColorSpace::SRGB();
 }
 
-Headroom NativeImage::headroom() const
-{
-    return Headroom::None;
-}
-
 std::optional<Color> NativeImage::singlePixelSolidColor() const
 {
     if (size() != IntSize(1, 1))

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -8597,7 +8597,7 @@ header: <WebCore/ShareableBitmap.h>
 [CustomHeader] class WebCore::ShareableBitmapConfiguration {
     [Validator='m_size->width() > 0 && m_size->height() > 0'] WebCore::IntSize m_size;
     std::optional<WebCore::DestinationColorSpace> m_colorSpace;
-    WebCore::Headroom m_headroom;
+    WebCore::Headroom m_baseImageHeadroom;
     bool m_isOpaque;
     [Validator='*bitsPerComponent >= 1 && *bitsPerComponent <= 16'] unsigned bitsPerComponent();
     [Validator='*bytesPerPixel >= 1 && *bytesPerPixel <= 8'] unsigned bytesPerPixel();

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextProxy.h
@@ -79,6 +79,7 @@ private:
     bool knownToHaveFloatBasedBacking() const final;
 
     WebCore::RenderingMode renderingMode() const final;
+    std::optional<WebCore::RenderingMethod> renderingMethod() const final { return std::nullopt; }
 
     void save(WebCore::GraphicsContextState::Purpose) final;
     void restore(WebCore::GraphicsContextState::Purpose) final;

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteResourceCacheProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteResourceCacheProxy.cpp
@@ -54,7 +54,7 @@ static std::optional<CreateShareableBitmapResult> createShareableBitmapForNative
 #if USE(CG)
     bitmap = ShareableBitmap::createFromImagePixels(image);
     if (bitmap)
-        platformImage = bitmap->createPlatformImage(DontCopyBackingStore, ShouldInterpolate::Yes);
+        platformImage = bitmap->createBasePlatformImage(DontCopyBackingStore, ShouldInterpolate::Yes);
 #endif
 
     // If we failed to create ShareableBitmap or PlatformImage, fall back to image-draw method.


### PR DESCRIPTION
#### 479c91177422567b22378a1781c15e944eeb1b09
<pre>
[HDR] Use accelerated backing stores to apply the gain-map image in GPUProcess
<a href="https://bugs.webkit.org/show_bug.cgi?id=314452">https://bugs.webkit.org/show_bug.cgi?id=314452</a>
<a href="https://rdar.apple.com/176605566">rdar://176605566</a>

Reviewed by Cameron McCormack.

DecodingDestination::BaseAndGainMap will be chosen to decode an ImageFrame
destination only if the ImageSource has gain-map and the context is remote.

ImageDecoder::createNativeImageAtIndex() can now create a NativeImage with
BaseAndGainMap. This NativeImage will return a calculated Headroom rather
than returning the Headroom of the baseImage which should be Headroom::None.

Decoding a frame may return a destination different from what was preferred.
BitmapImageSource has to account for this and do not assume the returned
NativeImage has to be the requested DecodingDestination.

When comparing DecodingDestinations in DecodingOptions for compatibility,
they have to be equal except one exception: A fully decoded HDR image is
compatible with DecodingDestination::BaseAndGainMap request.

* Source/WebCore/platform/graphics/BitmapImageSource.cpp:
(WebCore::BitmapImageSource::preferredDecodingDestination const):
(WebCore::BitmapImageSource::compatibleDecodingDestinationWithOptionsAtIndex const):
(WebCore::BitmapImageSource::decode):
(WebCore::BitmapImageSource::requestNativeImageAtIndexIfNeeded):
(WebCore::BitmapImageSource::nativeImageAtIndexCacheIfNeeded):
(WebCore::BitmapImageSource::nativeImageAtIndexRequestIfNeeded):
(WebCore::BitmapImageSource::isCompatibleWithOptionsAtIndex const): Deleted.
* Source/WebCore/platform/graphics/BitmapImageSource.h:
* Source/WebCore/platform/graphics/DecodingOptions.h:
(WebCore::DecodingOptions::isCompatibleWith const):
* Source/WebCore/platform/graphics/GraphicsContext.h:
(WebCore::GraphicsContext::renderingMethod const):
* Source/WebCore/platform/graphics/ImageDecoder.cpp:
(WebCore::ImageDecoder::createNativeImageAtIndex):
* Source/WebCore/platform/graphics/ImageDecoder.h:
* Source/WebCore/platform/graphics/ImageFrame.cpp:
(WebCore::ImageFrame::clearImage):
(WebCore::ImageFrame::compatibleDecodingDestinationWithOptions const):
(WebCore::ImageFrame::hasDecodedNativeImageCompatibleWithOptions const): Deleted.
* Source/WebCore/platform/graphics/ImageFrame.h:
(WebCore::ImageFrame::decodingDestinationIfExists const):
* Source/WebCore/platform/graphics/ImageFrameWorkQueue.cpp:
(WebCore::ImageFrameWorkQueue::start):
* Source/WebCore/platform/graphics/ImageFrameWorkQueue.h:
(WebCore::ImageFrameWorkQueue::Request::isCompatibleWith const):
* Source/WebCore/platform/graphics/NativeImage.cpp:
(WebCore::NativeImage::NativeImage):
(WebCore::NativeImage::replacePlatformImage const):
* Source/WebCore/platform/graphics/NativeImage.h:
(WebCore::NativeImage::hasHDRGainMap const):
(WebCore::NativeImage::baseImageHeadroom const):
(WebCore::NativeImage::headroom const):
* Source/WebCore/platform/graphics/ShareableBitmap.cpp:
(WebCore::ShareableBitmapConfiguration::ShareableBitmapConfiguration):
(WebCore::ShareableBitmap::create):
(WebCore::ShareableBitmap::ShareableBitmap):
* Source/WebCore/platform/graphics/ShareableBitmap.h:
(WebCore::ShareableBitmapConfiguration::baseImageHeadroom const):
(WebCore::ShareableBitmapConfiguration::headroom const): Deleted.
* Source/WebCore/platform/graphics/cairo/NativeImageCairo.cpp:
(WebCore::NativeImage::headroom const): Deleted.
* Source/WebCore/platform/graphics/cg/ImageDecoderCG.cpp:
(WebCore::ImageDecoderCG::frameGainMapAtIndex):
* Source/WebCore/platform/graphics/cg/NativeImageCG.cpp:
(WebCore::NativeImage::computeHeadroom const):
(WebCore::NativeImage::headroom const): Deleted.
* Source/WebCore/platform/graphics/cg/ShareableBitmapCG.mm:
(WebCore::ShareableBitmapConfiguration::ShareableBitmapConfiguration):
(WebCore::ShareableBitmap::createBasePlatformImage):
(WebCore::ShareableBitmap::createPlatformImage):
* Source/WebCore/platform/graphics/skia/NativeImageSkia.cpp:
(WebCore::NativeImage::headroom const): Deleted.
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:
* Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextProxy.h:
* Source/WebKit/WebProcess/GPU/graphics/RemoteResourceCacheProxy.cpp:
(WebKit::createShareableBitmapForNativeImage):

Canonical link: <a href="https://commits.webkit.org/313339@main">https://commits.webkit.org/313339@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ac15039421bc7e34056c6a5d8b415179b1b488c0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/162710 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/36186 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/29332 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/171648 "Build is in progress. Recent messages:Printed configuration; Running apply-patch; Checked out pull request; Compiled WebKit") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/119156 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/d53d69c6-4cb9-4de4-ac1f-fc0bb1cd28a1) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/164579 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/36290 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/36190 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/126291 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/88936 "2 flakes 17 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/606ee2d8-05d6-42f5-86b9-2a0460b1b492) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/165669 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/28640 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/146198 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/106868 "Build is in progress. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; run-api-tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/3e75b8e9-f56b-4068-99bd-59f98284d99c) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/27686 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/26217 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/19348 "Built successfully") | | 
| [⏳ 🛠 🧪 jsc ](https://ews-build.webkit.org/#/builders/JSC-Tests-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/137394 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/23927 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/174152 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/21465 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/25572 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/134600 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/35860 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/30314 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/134596 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36336 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/35844 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/145723 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/98226 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/29136 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/22559 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/35354 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/103105 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/34855 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/35100 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/35003 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->