### PR TITLE
AX: Interactive elements containing the `<svg>` element which is named by `<title>` element doesn't have accessible name

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/svg-aam/name/comp_host_language_label-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg-aam/name/comp_host_language_label-expected.txt
@@ -22,42 +22,12 @@ PASS circle > title
 PASS rect > title
 PASS polygon > title
 PASS g > title
-FAIL a > circle > title assert_equals: <a href="#" data-expectedlabel="circle label" data-testname="a &gt; circle &gt; title" class="ex">
-  <svg viewBox="0 0 300 100">
-    <title>circle label</title>
-    <circle cx="26" cy="26" r="25"></circle>
-  </svg>
-</a> expected "circle label" but got ""
-FAIL a > rect > title assert_equals: <a href="#" data-expectedlabel="rect label" data-testname="a &gt; rect &gt; title" class="ex">
-  <svg viewBox="0 0 300 100">
-    <title>rect label</title>
-    <rect x="60" y="1" width="50" height="50"></rect>
-  </svg>
-</a> expected "rect label" but got ""
-FAIL a > polygon > title assert_equals: <a href="#" data-expectedlabel="polygon label" data-testname="a &gt; polygon &gt; title" class="ex">
-  <svg viewBox="0 0 300 100">
-    <title>polygon label</title>
-    <polygon points="100,100 150,25 150,75 200,0" fill="none" stroke="black"></polygon>
-  </svg>
-</a> expected "polygon label" but got ""
-FAIL button > circle > title assert_equals: <button href="#" data-expectedlabel="circle label" data-testname="button &gt; circle &gt; title" class="ex">
-  <svg viewBox="0 0 300 100">
-    <title>circle label</title>
-    <circle cx="26" cy="26" r="25"></circle>
-  </svg>
-</button> expected "circle label" but got ""
-FAIL button > rect > title assert_equals: <button href="#" data-expectedlabel="rect label" data-testname="button &gt; rect &gt; title" class="ex">
-  <svg viewBox="0 0 300 100">
-    <title>rect label</title>
-    <rect x="60" y="1" width="50" height="50"></rect>
-  </svg>
-</button> expected "rect label" but got ""
-FAIL button > polygon > title assert_equals: <button href="#" data-expectedlabel="polygon label" data-testname="button &gt; polygon &gt; title" class="ex">
-  <svg viewBox="0 0 300 100">
-    <title>polygon label</title>
-    <polygon points="100,100 150,25 150,75 200,0" fill="none" stroke="black"></polygon>
-  </svg>
-</button> expected "polygon label" but got ""
+PASS a > circle > title
+PASS a > rect > title
+PASS a > polygon > title
+PASS button > circle > title
+PASS button > rect > title
+PASS button > polygon > title
 PASS [xlink:title][href] > circle
 PASS [xlink:title][href] > rect
 PASS [xlink:title][href] > polygon

--- a/Source/WebCore/accessibility/AccessibilityNodeObject.h
+++ b/Source/WebCore/accessibility/AccessibilityNodeObject.h
@@ -186,7 +186,7 @@ public:
     String revealableText() const final;
     bool isHiddenUntilFoundContainer() const final;
     String text() const final;
-    void alternativeText(Vector<AccessibilityText>&) const;
+    virtual void alternativeText(Vector<AccessibilityText>&) const;
     void helpText(Vector<AccessibilityText>&) const;
     String stringValue() const override;
 

--- a/Source/WebCore/accessibility/AccessibilitySVGObject.cpp
+++ b/Source/WebCore/accessibility/AccessibilitySVGObject.cpp
@@ -107,6 +107,18 @@ void AccessibilitySVGObject::accessibilityText(Vector<AccessibilityText>& textOr
         textOrder.append(AccessibilityText(WTF::move(helptext), AccessibilityTextSource::Help));
 }
 
+void AccessibilitySVGObject::alternativeText(Vector<AccessibilityText>& textOrder) const
+{
+    // https://w3c.github.io/svg-aam/#mapping_additional_nd
+    // Per SVG-AAM §7.1, the accessible name comes from aria-labelledby/aria-label,
+    // a <title> child, xlink:title (on <a>), the <use> target, or alt (on <image>).
+    // Expose this as Alternative text so host-language parents (e.g. <a> or <button>)
+    // pick it up via textUnderElement when deriving their own accname.
+    String descriptionText = description();
+    if (!descriptionText.isEmpty())
+        textOrder.append(AccessibilityText(WTF::move(descriptionText), AccessibilityTextSource::Alternative));
+}
+
 auto AccessibilitySVGObject::matchingTitleAndDescChildren() const -> MatchingLanguageChildren
 {
     RefPtr element = this->element();

--- a/Source/WebCore/accessibility/AccessibilitySVGObject.h
+++ b/Source/WebCore/accessibility/AccessibilitySVGObject.h
@@ -55,6 +55,7 @@ private:
     String description() const final;
     String helpText() const final;
     void accessibilityText(Vector<AccessibilityText>&) const final;
+    void alternativeText(Vector<AccessibilityText>&) const final;
     AccessibilityRole determineAccessibilityRole() override;
     bool inheritsPresentationalRole() const final;
     bool computeIsIgnored() const final;


### PR DESCRIPTION
#### dc550e53da50f856a1a5e6102db067cf6bbd7f7c
<pre>
AX: Interactive elements containing the `&lt;svg&gt;` element which is named by `&lt;title&gt;` element doesn&apos;t have accessible name
<a href="https://bugs.webkit.org/show_bug.cgi?id=309958">https://bugs.webkit.org/show_bug.cgi?id=309958</a>
<a href="https://rdar.apple.com/172559238">rdar://172559238</a>

Reviewed by Tyler Wilcock.

This patch aligns WebKit with Gecko / Firefox and Blink / Chromium.

When an &lt;a&gt; or &lt;button&gt; wraps an &lt;svg&gt; whose name comes from a &lt;title&gt; child,
the host element&apos;s accessible name was empty. Other browsers (and the
svg-aam WPTs) expose the SVG&apos;s title as the interactive element&apos;s name.

WebKit derives the &lt;a&gt;/&lt;button&gt; accname via textUnderElement, which iterates
children and — for each AccessibilityNodeObject child — calls alternativeText()
to see if the child contributes a name alternative before falling back to its
inner text. AccessibilitySVGObject did not override alternativeText, so the
SVG&apos;s &lt;title&gt;/xlink:title/alt/use-target name (already computed by
AccessibilitySVGObject::description()) never reached the parent&apos;s name
computation. The &lt;title&gt; child itself is display:none and has no renderer,
so the textUnderElement fallback also produced nothing.

Fix it by overriding alternativeText in AccessibilitySVGObject to publish
description() as an AccessibilityTextSource::Alternative entry. This mirrors
what accessibilityText() already does for the SVG&apos;s own name, and lets host
elements pick up the SVG name via the existing descendant-traversal path.
To make the override possible, mark AccessibilityNodeObject::alternativeText
as virtual.

* LayoutTests/imported/w3c/web-platform-tests/svg-aam/name/comp_host_language_label-expected.txt:
* Source/WebCore/accessibility/AccessibilityNodeObject.h:
* Source/WebCore/accessibility/AccessibilitySVGObject.cpp:
(WebCore::AccessibilitySVGObject::alternativeText const):
* Source/WebCore/accessibility/AccessibilitySVGObject.h:

Canonical link: <a href="https://commits.webkit.org/312953@main">https://commits.webkit.org/312953@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ec1357d1da68e5b3822a7b469978443749a106d8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/161541 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/35015 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/28118 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/170444 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/117912 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/655fe464-b9ea-4af7-9a73-4da5de74eca5) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/163410 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/35116 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/35016 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/125326 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/88264 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/e57bb2b5-0729-486e-adea-c2887155cda3) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/164500 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/27623 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/145107 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/105922 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/596ad80f-e834-41e7-bfce-ee380ea2551b) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/26672 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/25183 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/18165 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/136366 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/22864 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/172932 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/19973 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/24505 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/133614 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/34689 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/29278 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/133621 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36115 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/34673 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/144659 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/96578 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/28147 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/21478 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/34183 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/101628 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/33683 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/33926 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/33832 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->