### PR TITLE
Reduce run-webkit-tests startup overhead for faster iteration

### DIFF
--- a/Tools/Scripts/libraries/webkitcorepy/webkitcorepy/mocks/__init__.py
+++ b/Tools/Scripts/libraries/webkitcorepy/webkitcorepy/mocks/__init__.py
@@ -20,11 +20,44 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-from webkitcorepy.mocks.context_stack import ContextStack
-from webkitcorepy.mocks.time_ import Time
-from webkitcorepy.mocks.subprocess import ProcessCompletion, Subprocess
+import importlib
 
-from webkitcorepy.mocks.requests_ import Response, Requests
-from webkitcorepy.mocks.terminal import Terminal
-from webkitcorepy.mocks.file_lock import FileLock
-from webkitcorepy.mocks.environment import Environment
+from webkitcorepy.call_by_need import CallByNeed
+
+# ContextStack is a base class for OutputCapture, OutputDuplicate, and PartialProxy, all
+# of which webkitcorepy/__init__.py loads eagerly, so it's effectively never lazy.
+from webkitcorepy.mocks.context_stack import ContextStack
+
+
+def _lazy(module_path, attr_name):
+    return CallByNeed(lambda: getattr(importlib.import_module(module_path), attr_name))
+
+
+# Other symbols load lazily — see __getattr__ — so callers importing only ContextStack
+# don't pay for time_/subprocess/requests_/etc.
+_LAZY = {
+    'Time': _lazy('webkitcorepy.mocks.time_', 'Time'),
+    'ProcessCompletion': _lazy('webkitcorepy.mocks.subprocess', 'ProcessCompletion'),
+    'Subprocess': _lazy('webkitcorepy.mocks.subprocess', 'Subprocess'),
+    'Response': _lazy('webkitcorepy.mocks.requests_', 'Response'),
+    'Requests': _lazy('webkitcorepy.mocks.requests_', 'Requests'),
+    'Terminal': _lazy('webkitcorepy.mocks.terminal', 'Terminal'),
+    'FileLock': _lazy('webkitcorepy.mocks.file_lock', 'FileLock'),
+    'Environment': _lazy('webkitcorepy.mocks.environment', 'Environment'),
+}
+
+
+def __getattr__(name):
+    proxy = _LAZY.get(name)
+    if proxy is None:
+        raise AttributeError("module 'webkitcorepy.mocks' has no attribute {!r}".format(name))
+    # Resolve through CallByNeed and store the real object in globals(), so future
+    # accesses skip __getattr__ and so pickle/isinstance see the underlying class
+    # rather than the proxy.
+    value = proxy.value
+    globals()[name] = value
+    return value
+
+
+def __dir__():
+    return sorted(set(globals()) | set(_LAZY))

--- a/Tools/Scripts/libraries/webkitcorepy/webkitcorepy/partial_proxy.py
+++ b/Tools/Scripts/libraries/webkitcorepy/webkitcorepy/partial_proxy.py
@@ -20,9 +20,12 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-from unittest import mock
+import importlib
 
 from webkitcorepy import mocks
+from webkitcorepy.call_by_need import CallByNeed
+
+mock = CallByNeed(lambda: importlib.import_module('unittest.mock'))
 
 
 class PartialProxy(mocks.ContextStack):

--- a/Tools/Scripts/libraries/webkitcorepy/webkitcorepy/timeout.py
+++ b/Tools/Scripts/libraries/webkitcorepy/webkitcorepy/timeout.py
@@ -22,6 +22,7 @@
 
 import bisect
 import collections
+import importlib
 import math
 import os
 import signal
@@ -29,6 +30,9 @@ import threading
 import time
 
 from webkitcorepy import log, string_utils
+from webkitcorepy.call_by_need import CallByNeed
+
+mock = CallByNeed(lambda: importlib.import_module('unittest.mock'))
 
 ORIGINAL_SLEEP = time.sleep
 

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/__init__.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/__init__.py
@@ -68,6 +68,5 @@ from webkitscmpy.pull_request import PullRequest
 from webkitscmpy.scm_base import ScmBase
 
 from webkitscmpy import local
-from webkitscmpy import mocks
 
 name = 'webkitscmpy'

--- a/Tools/Scripts/webkitpy/common/version_name_map.py
+++ b/Tools/Scripts/webkitpy/common/version_name_map.py
@@ -26,6 +26,12 @@ from webkitcorepy import Version
 
 from webkitpy.common.memoized import memoized
 
+# Authoritative CURRENT_VERSION for the Darwin OS family. DarwinPort imports this as its
+# class attribute; IOSPort/WatchPort/VisionOSPort inherit it. The constant lives here so
+# version_name_map can read it without importing the (heavy) port chain. If the WebKit
+# Darwin OSes ever diverge in version, split this into per-OS constants.
+DARWIN_CURRENT_VERSION = Version(26)
+
 
 PUBLIC_TABLE = 'public'
 INTERNAL_TABLE = 'internal'
@@ -48,8 +54,6 @@ class VersionNameMap(object):
             platform = SystemHost.get_default().platform
         self.mapping = {}
 
-        from webkitpy.port import darwin, ios, watch, visionos
-
         self.default_system_platform = platform.os_name
         self.mapping[PUBLIC_TABLE] = {
             'mac': {
@@ -71,10 +75,10 @@ class VersionNameMap(object):
                 'Sequoia': Version(15, 0),
                 'Tahoe': Version(26, 0)
             },
-            'ios': self._automap_to_major_version('iOS', minimum=Version(10), maximum=ios.IOSPort.CURRENT_VERSION),
-            'tvos': self._automap_to_major_version('tvOS', minimum=Version(10), maximum=darwin.DarwinPort.CURRENT_VERSION),
-            'watchos': self._automap_to_major_version('watchOS', minimum=Version(1), maximum=watch.WatchPort.CURRENT_VERSION),
-            'visionos': self._automap_to_major_version('visionOS', minimum=Version(1), maximum=visionos.VisionOSPort.CURRENT_VERSION),
+            'ios': self._automap_to_major_version('iOS', minimum=Version(10), maximum=DARWIN_CURRENT_VERSION),
+            'tvos': self._automap_to_major_version('tvOS', minimum=Version(10), maximum=DARWIN_CURRENT_VERSION),
+            'watchos': self._automap_to_major_version('watchOS', minimum=Version(1), maximum=DARWIN_CURRENT_VERSION),
+            'visionos': self._automap_to_major_version('visionOS', minimum=Version(1), maximum=DARWIN_CURRENT_VERSION),
             'win': {
                 'Win10': Version(10),
                 '8.1': Version(6, 3),

--- a/Tools/Scripts/webkitpy/layout_tests/controllers/layout_test_finder_legacy.py
+++ b/Tools/Scripts/webkitpy/layout_tests/controllers/layout_test_finder_legacy.py
@@ -27,6 +27,7 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 import errno
+import functools
 import logging
 import re
 
@@ -60,6 +61,16 @@ class LayoutTestFinder(object):
         self._filesystem = self._port.host.filesystem
         self.LAYOUT_TESTS_DIRECTORY = 'LayoutTests'
         self._test_list_expectations = []
+        # Cache the inner finder per device_type. Bound here, not module-level, so the
+        # cache doesn't outlive this LayoutTestFinder instance.
+        self._inner_finder = functools.cache(self._make_inner_finder)
+
+    def _make_inner_finder(self, device_type=None):
+        return LayoutTestFinder_New(
+            self._port.host.filesystem,
+            self._port.layout_tests_dir(),
+            self._port.baseline_search_path(device_type),
+        )
 
     def find_tests(self, options, args, device_type=None, with_expectations=False):
         paths = self._strip_test_dir_prefixes(args)
@@ -95,30 +106,16 @@ class LayoutTestFinder(object):
 
     def find_tests_by_path(self, paths, device_type=None, with_expectations=False):
         """Return the list of tests found. Both generic and platform-specific tests matching paths should be returned."""
-        finder = LayoutTestFinder_New(
-            self._port.host.filesystem,
-            self._port.layout_tests_dir(),
-            self._port.baseline_search_path(device_type),
-        )
-
-        return list(finder.get_tests(paths))
+        return list(self._inner_finder(device_type).get_tests(paths))
 
     def _is_test_file(self, filesystem, dirname, filename):
-        finder = LayoutTestFinder_New(
-            self._port.host.filesystem,
-            self._port.layout_tests_dir(),
-            self._port.baseline_search_path(),
-        )
+        finder = self._inner_finder()
         return finder.is_test_file(
             dirname, filename
         ) and not self._is_w3c_resource_file(filesystem, dirname, filename)
 
     def _is_w3c_resource_file(self, filesystem, dirname, filename):
-        finder = LayoutTestFinder_New(
-            self._port.host.filesystem,
-            self._port.layout_tests_dir(),
-            self._port.baseline_search_path(),
-        )
+        finder = self._inner_finder()
 
         if dirname:
             dirname = self._filesystem.relpath(dirname, self._port.layout_tests_dir())

--- a/Tools/Scripts/webkitpy/layout_tests/controllers/manager.py
+++ b/Tools/Scripts/webkitpy/layout_tests/controllers/manager.py
@@ -345,12 +345,16 @@ class Manager(object):
         new_test_inputs = self._multiply_test_inputs(test_inputs, self._options.repeat_each, self._options.iterations)
         worker_count = self._runner.get_worker_count(new_test_inputs, int(self._options.child_processes))
         self._options.child_processes = worker_count
+        # Port has a copy of options (see _create_port_for_driver), so sync the effective
+        # worker count for code paths that read it via self.get_option (mac warmup gate,
+        # embedded port device count).
+        self._port.set_option('child_processes', worker_count)
 
     def _set_up_run(self, test_inputs, device_type):
-        # This must be started before we check the system dependencies,
-        # since the helper may do things to make the setup correct.
+        # The helper was kicked off in run() so its ~440 ms warmup overlaps with
+        # _collect_tests; join on it now since check_sys_deps and setup_test_run may use it.
         self._printer.write_update("Starting helper ...")
-        if not self._port.start_helper(pixel_tests=self._options.pixel_tests, prefer_integrated_gpu=self._options.prefer_integrated_gpu):
+        if not self._port.wait_for_helper_ready():
             return False
 
         self._update_worker_count(test_inputs)
@@ -390,6 +394,10 @@ class Manager(object):
 
             self._results_directory = self._port.results_directory()
             self._finder = LayoutTestFinder(self._port, self._options)
+
+            # Kick the helper off in parallel with test discovery and expectations
+            # parsing; _set_up_run will join on it. Saves ~440 ms on Mac.
+            self._port.start_helper_async(pixel_tests=self._options.pixel_tests, prefer_integrated_gpu=self._options.prefer_integrated_gpu)
 
             device_type_list = self._port.supported_device_types()
             tests_to_run_by_device, aggregate_tests_to_skip = self._collect_tests(args, device_type_list, driver_name)
@@ -517,9 +525,6 @@ class Manager(object):
                 if not self._set_up_run(test_inputs, device_type=device_type):
                     return test_run_results.RunDetails(exit_code=-1)
 
-                configuration = self._port.configuration_for_upload(self._port.target_host(0))
-                if not configuration.get('flavor', None):  # The --result-report-flavor argument should override wk1/wk2
-                    configuration['flavor'] = 'wk1' if self._port.is_webkitlegacy() else 'wk2'
                 temp_initial_results, temp_retry_results, temp_enabled_pixel_tests_in_retry = self._run_test_subset(test_inputs, device_type=device_type)
 
                 skipped_results = TestRunResults(self._expectations[(self._current_driver_name, device_type)], len(aggregate_tests_to_skip))
@@ -530,6 +535,9 @@ class Manager(object):
                 temp_initial_results = temp_initial_results.merge(skipped_results)
 
                 if self._options.report_urls:
+                    configuration = self._port.configuration_for_upload(self._port.target_host(0))
+                    if not configuration.get('flavor', None):  # The --result-report-flavor argument should override wk1/wk2
+                        configuration['flavor'] = 'wk1' if self._port.is_webkitlegacy() else 'wk2'
                     self._printer.writeln('\n')
                     self._printer.write_update('Preparing upload data ...')
 

--- a/Tools/Scripts/webkitpy/layout_tests/models/test_expectations.py
+++ b/Tools/Scripts/webkitpy/layout_tests/models/test_expectations.py
@@ -40,6 +40,8 @@ from webkitpy.layout_tests.models.test_configuration import (
 )
 from webkitpy.port.base import Port
 
+_BUG_TOKEN_RE = re.compile(r'Bug\((\w+)\)$')
+
 MYPY = False
 if MYPY:
     # MYPY is True when running Mypy; typing is stdlib only in Py3
@@ -317,7 +319,7 @@ class TestExpectationParser(object):
         else:
             expectation_line.comment = expectation_string[comment_index + 1:]
 
-        remaining_string = re.sub(r"\s+", " ", expectation_string[:comment_index].strip())
+        remaining_string = " ".join(expectation_string[:comment_index].split())
         if len(remaining_string) == 0:
             return expectation_line
 
@@ -344,7 +346,7 @@ class TestExpectationParser(object):
                 if token.startswith(WEBKIT_BUG_PREFIX):
                     bugs.append(token.replace(WEBKIT_BUG_PREFIX, 'BUGWK'))
                 else:
-                    match = re.match(r'Bug\((\w+)\)$', token)
+                    match = _BUG_TOKEN_RE.match(token)
                     if not match:
                         warnings.append('unrecognized bug identifier "%s"' % token)
                         break

--- a/Tools/Scripts/webkitpy/port/base.py
+++ b/Tools/Scripts/webkitpy/port/base.py
@@ -109,7 +109,13 @@ class Port(object):
     # Do test runners support alias hostnames such as web-platform.test
     supports_localhost_aliases = False
 
-    helper = None
+    # LayoutTestHelper state. Read/written by start_helper / start_helper_async /
+    # wait_for_helper_ready / stop_helper. _helper_started signals that the spawn was
+    # attempted, so a None _helper_process means spawn failed rather than no spawn.
+    # _helper_ready signals that we've consumed the 'ready' line.
+    _helper_process = None
+    _helper_started = False
+    _helper_ready = False
     _web_platform_test_server = None
     _websocket_secure_server = None
     _websocket_server = None
@@ -849,6 +855,16 @@ class Port(object):
         method."""
         return True
 
+    def start_helper_async(self, pixel_tests=False, prefer_integrated_gpu=False):
+        """Kick off the helper process without blocking on its readiness.
+        Override along with wait_for_helper_ready to overlap helper warmup
+        with other setup work."""
+        return True
+
+    def wait_for_helper_ready(self):
+        """Block until a previously async-started helper is ready."""
+        return True
+
     def reset_preferences(self):
         """If a port needs to reset platform-specific persistent preference
         storage, it should override this method."""
@@ -966,15 +982,17 @@ class Port(object):
     def stop_helper(self):
         """Shut down the test helper if it is running. Do nothing if
         it isn't, or it isn't available."""
-        if Port.helper:
+        if Port._helper_process:
             _log.debug("Stopping LayoutTestHelper")
             try:
-                Port.helper.stdin.write(b"x\n")
-                Port.helper.stdin.close()
-                Port.helper.wait()
+                Port._helper_process.stdin.write(b"x\n")
+                Port._helper_process.stdin.close()
+                Port._helper_process.wait()
             except IOError as e:
                 _log.debug("IOError raised while stopping helper: %s" % str(e))
-            Port.helper = None
+            Port._helper_process = None
+        Port._helper_started = False
+        Port._helper_ready = False
 
     def stop_http_server(self):
         """Shut down the http server if it is running. Do nothing if it isn't."""

--- a/Tools/Scripts/webkitpy/port/base_unittest.py
+++ b/Tools/Scripts/webkitpy/port/base_unittest.py
@@ -38,6 +38,7 @@ from webkitpy.common.system.executive_mock import MockExecutive2
 from webkitpy.common.system.systemhost_mock import MockSystemHost
 from webkitpy.common.host_mock import MockHost
 from webkitpy.port import Port
+from webkitpy.port.config import Config
 from webkitpy.port.test import add_unit_tests_to_mock_filesystem, TestPort
 from webkitpy.thirdparty.mock import patch
 
@@ -49,6 +50,9 @@ def cmp(a, b):
     return (a > b) - (a < b)
 
 class PortTest(unittest.TestCase):
+    def setUp(self):
+        Config._clear_cache_for_testing()
+
     def make_port(self, executive=None, with_tests=False, port_name=None, **kwargs):
         host = MockHost(create_stub_repository_files=True)
         if executive:
@@ -278,6 +282,7 @@ class PortTest(unittest.TestCase):
         )
         self.assertEqual(port._build_path(), '/my-build-directory/Debug')
 
+        Config._clear_cache_for_testing()
         port = self.make_port(
             executive=MockExecutive2(output='/default-build-path/Debug-embedded-port'),
             options=optparse.Values({'build_directory': '/my-build-directory/'}),

--- a/Tools/Scripts/webkitpy/port/config.py
+++ b/Tools/Scripts/webkitpy/port/config.py
@@ -54,41 +54,50 @@ class Config(object):
         "Release": "--release",
     }
 
+    # Shared across all Config instances: webkit-build-directory is a ~110ms
+    # perl invocation whose result is invariant for given inputs within a run.
+    _build_directories = {}
+
     def __init__(self, executive, filesystem, port_implementation=None, use_cmake=False):
         self._executive = executive
         self._filesystem = filesystem
         self._webkit_finder = webkit_finder.WebKitFinder(self._filesystem)
         self._default_configuration = None
-        self._build_directories = {}
         self._port_implementation = port_implementation
         self._use_cmake = use_cmake
 
+    @classmethod
+    def _clear_cache_for_testing(cls):
+        cls._build_directories = {}
+
     def build_directory(self, configuration, for_host=False):
         """Returns the path to the build directory for the configuration."""
+        port_impl = self._port_implementation if not for_host else None
+        cache_key = (port_impl, configuration or "", for_host, self._use_cmake)
+        if self._build_directories.get(cache_key):
+            return self._build_directories[cache_key]
+
         if configuration:
             flags = ["--configuration", self.flag_for_configuration(configuration)]
         else:
-            configuration = ""
             flags = []
-
-        if self._port_implementation and not for_host:
-            flags.append('--' + self._port_implementation)
-
+        if port_impl:
+            flags.append('--' + port_impl)
         if self._use_cmake:
             flags.append('--cmake')
 
-        cache_key = (configuration, self._use_cmake)
-        if not self._build_directories.get(cache_key):
-            args = ["perl", self._webkit_finder.path_to_script("webkit-build-directory")] + flags
-            output = self._executive.run_command(args, cwd=self._webkit_finder.webkit_base(), return_stderr=False).rstrip()
-            parts = output.split("\n")
-            self._build_directories[cache_key] = parts[0]
+        args = ["perl", self._webkit_finder.path_to_script("webkit-build-directory")] + flags
+        output = self._executive.run_command(args, cwd=self._webkit_finder.webkit_base(), return_stderr=False).rstrip()
+        parts = output.split("\n")
+        self._build_directories[cache_key] = parts[0]
 
-            if len(parts) == 2:
-                default_configuration = parts[1][len(parts[0]):]
-                if default_configuration.startswith("/"):
-                    default_configuration = default_configuration[1:]
-                self._build_directories[(default_configuration, self._use_cmake)] = parts[1]
+        # With no --configuration flag, webkit-build-directory also prints the
+        # default-configuration dir on a second line; cache it for later hits.
+        if len(parts) == 2:
+            default_configuration = parts[1][len(parts[0]):]
+            if default_configuration.startswith("/"):
+                default_configuration = default_configuration[1:]
+            self._build_directories[(port_impl, default_configuration, for_host, self._use_cmake)] = parts[1]
 
         return self._build_directories[cache_key]
 

--- a/Tools/Scripts/webkitpy/port/config_unittest.py
+++ b/Tools/Scripts/webkitpy/port/config_unittest.py
@@ -42,6 +42,9 @@ import webkitpy.port.config as config
 
 
 class ConfigTest(unittest.TestCase):
+    def setUp(self):
+        config.Config._clear_cache_for_testing()
+
     def make_config(self, output='', files=None, exit_code=0, exception=None, run_command_fn=None, stderr='', port_implementation=None, use_cmake=False):
         e = MockExecutive2(output=output, exit_code=exit_code, exception=exception, run_command_fn=run_command_fn, stderr=stderr)
         fs = MockFileSystem(files)
@@ -84,6 +87,7 @@ class ConfigTest(unittest.TestCase):
         self.assertRaises(KeyError, c.build_directory, 'Unknown')
 
         # Test that stderr output from webkit-build-directory won't mangle the build dir
+        config.Config._clear_cache_for_testing()
         c = self.make_config(output='/WebKitBuild/', stderr="mock stderr output from webkit-build-directory")
         self.assertEqual(c.build_directory(None), '/WebKitBuild/')
 

--- a/Tools/Scripts/webkitpy/port/darwin.py
+++ b/Tools/Scripts/webkitpy/port/darwin.py
@@ -37,13 +37,15 @@ from webkitcorepy import decorators, Version
 from webkitexpectationspy.parser import ExpectationParser
 from webkitexpectationspy.suites.api_tests import APITestSuite
 
+from webkitpy.common.version_name_map import DARWIN_CURRENT_VERSION
+
 
 _log = logging.getLogger(__name__)
 
 
 class DarwinPort(ApplePort):
 
-    CURRENT_VERSION = Version(26)
+    CURRENT_VERSION = DARWIN_CURRENT_VERSION
     SDK = None
 
     API_TEST_BINARY_NAMES = ['TestWTF', 'TestWebKitAPI', 'TestIPC', 'TestWGSL']

--- a/Tools/Scripts/webkitpy/port/factory.py
+++ b/Tools/Scripts/webkitpy/port/factory.py
@@ -31,6 +31,7 @@
 """Factory method to retrieve the appropriate port implementation."""
 
 import fnmatch
+import importlib
 import optparse
 import re
 
@@ -78,7 +79,7 @@ def platform_options(use_globs=False):
 
 def configuration_options():
     return [
-        optparse.make_option("-t", "--target", default=config.Config(executive.Executive(), filesystem.FileSystem()).default_configuration(), dest="configuration", help="(DEPRECATED) (default: %default)"),
+        optparse.make_option("-t", "--target", default=None, dest="configuration", help="(DEPRECATED)"),
         optparse.make_option('--debug', action='store_const', const='Debug', dest="configuration",
             help='Set the configuration to Debug'),
         optparse.make_option('--release', action='store_const', const='Release', dest="configuration",
@@ -99,26 +100,34 @@ def configuration_options():
     ]
 
 
+def _load_port_class(port_class_path):
+    module_name, class_name = port_class_path.rsplit('.', 1)
+    module = importlib.import_module('webkitpy.port.{}'.format(module_name))
+    return getattr(module, class_name)
+
+
 class PortFactory(object):
     # Order matters.  For port classes that have a port_name with a
     # common prefix, the more specific port class should be listed
-    # first.
+    # first. The prefix is duplicated from the class's own port_name
+    # so we can match without importing the (often heavy) port module;
+    # FactoryTest.test_port_classes_table_consistency enforces the two stay in sync.
     PORT_CLASSES = (
-        'gtk.GtkPort',
-        'ios_simulator.IOSSimulatorPort',
-        'ios_simulator.IPhoneSimulatorPort',
-        'ios_simulator.IPadSimulatorPort',
-        'ios_device.IOSDevicePort',
-        'watch_simulator.WatchSimulatorPort',
-        'watch_device.WatchDevicePort',
-        'visionos_simulator.VisionOSSimulatorPort',
-        'visionos_device.VisionOSDevicePort',
-        'jsc_only.JscOnlyPort',
-        'mac.MacCatalystPort',
-        'mac.MacPort',
-        'test.TestPort',
-        'win.WinPort',
-        'wpe.WPEPort',
+        ('gtk',                 'gtk.GtkPort'),
+        ('ios-simulator',       'ios_simulator.IOSSimulatorPort'),
+        ('iphone-simulator',    'ios_simulator.IPhoneSimulatorPort'),
+        ('ipad-simulator',      'ios_simulator.IPadSimulatorPort'),
+        ('ios-device',          'ios_device.IOSDevicePort'),
+        ('watchos-simulator',   'watch_simulator.WatchSimulatorPort'),
+        ('watchos-device',      'watch_device.WatchDevicePort'),
+        ('visionos-simulator',  'visionos_simulator.VisionOSSimulatorPort'),
+        ('visionos-device',     'visionos_device.VisionOSDevicePort'),
+        ('jsc-only',            'jsc_only.JscOnlyPort'),
+        ('maccatalyst',         'mac.MacCatalystPort'),
+        ('mac',                 'mac.MacPort'),
+        ('test',                'test.TestPort'),
+        ('win',                 'win.WinPort'),
+        ('wpe',                 'wpe.WPEPort'),
     )
 
     def __init__(self, host):
@@ -139,23 +148,26 @@ class PortFactory(object):
         port_name is None, this routine attempts to guess at the most
         appropriate port on this platform."""
         port_name = port_name or self._default_port()
-        classes = []
-        for port_class in self.PORT_CLASSES:
-            module_name, class_name = port_class.rsplit('.', 1)
-            module = __import__('webkitpy.port.{}'.format(module_name), globals(), locals(), [], 0)
-            cls = module.__dict__.get('port').__dict__.get(module_name).__dict__.get(class_name)
-            if cls:
-                classes.append(cls)
-        if config.apple_additions() and hasattr(config.apple_additions(), 'ports'):
-            classes += config.apple_additions().ports()
 
-        for cls in classes:
-            if port_name.startswith(cls.port_name):
-                port_name = cls.determine_full_port_name(self._host, options, port_name)
-                try:
-                    return cls(self._host, port_name, options=options, **kwargs)
-                except ValueError:
-                    continue
+        for prefix, port_class_path in self.PORT_CLASSES:
+            if not port_name.startswith(prefix):
+                continue
+            cls = _load_port_class(port_class_path)
+            full_name = cls.determine_full_port_name(self._host, options, port_name)
+            try:
+                return cls(self._host, full_name, options=options, **kwargs)
+            except ValueError:
+                continue
+
+        if config.apple_additions() and hasattr(config.apple_additions(), 'ports'):
+            for cls in config.apple_additions().ports():
+                if port_name.startswith(cls.port_name):
+                    full_name = cls.determine_full_port_name(self._host, options, port_name)
+                    try:
+                        return cls(self._host, full_name, options=options, **kwargs)
+                    except ValueError:
+                        continue
+
         raise NotImplementedError('unsupported platform: "%s"' % port_name)
 
     def all_port_names(self, platform=None):

--- a/Tools/Scripts/webkitpy/port/factory_unittest.py
+++ b/Tools/Scripts/webkitpy/port/factory_unittest.py
@@ -74,3 +74,15 @@ class FactoryTest(unittest.TestCase):
 
     def test_unknown_default(self):
         self.assertRaises(NotImplementedError, factory.PortFactory(MockSystemHost(os_name='vms')).get)
+
+    def test_port_classes_table_consistency(self):
+        # The PORT_CLASSES table duplicates each class's port_name so we can
+        # match port names without importing the (often heavy) port module.
+        # If the two ever diverge, prefix matching here would silently behave
+        # differently from the rest of the codebase.
+        for prefix, port_class_path in factory.PortFactory.PORT_CLASSES:
+            cls = factory._load_port_class(port_class_path)
+            self.assertEqual(
+                cls.port_name, prefix,
+                "PORT_CLASSES prefix {!r} doesn't match {}.port_name = {!r}".format(prefix, cls.__name__, cls.port_name),
+            )

--- a/Tools/Scripts/webkitpy/port/mac.py
+++ b/Tools/Scripts/webkitpy/port/mac.py
@@ -293,7 +293,15 @@ class MacPort(DarwinPort):
         return min(supportable_instances, default_count)
 
     def start_helper(self, pixel_tests=False, prefer_integrated_gpu=False):
+        if not self.start_helper_async(pixel_tests=pixel_tests, prefer_integrated_gpu=prefer_integrated_gpu):
+            return False
+        return self.wait_for_helper_ready()
+
+    def start_helper_async(self, pixel_tests=False, prefer_integrated_gpu=False):
         self.stop_helper()
+        # Mark that we *intend* to have a helper so wait_for_helper_ready can distinguish
+        # "never started" from "spawn failed".
+        Port._helper_started = True
 
         helper_path = self._path_to_helper()
         if not helper_path:
@@ -303,13 +311,22 @@ class MacPort(DarwinPort):
         arguments = [helper_path, '--install-color-profile']
         if prefer_integrated_gpu:
             arguments.append('--prefer-integrated-gpu')
-        Port.helper = self._executive.popen(arguments,
+        Port._helper_process = self._executive.popen(arguments,
             stdin=self._executive.PIPE, stdout=self._executive.PIPE, stderr=None)
-        is_ready = Port.helper.stdout.readline()
-        if not is_ready.startswith(b'ready'):
-            _log.error("LayoutTestHelper could not start")
-            return False
         return True
+
+    def wait_for_helper_ready(self):
+        if Port._helper_ready:
+            return True
+        if Port._helper_process:
+            is_ready = Port._helper_process.stdout.readline()
+            if not is_ready.startswith(b'ready'):
+                _log.error("LayoutTestHelper could not start")
+                return False
+            Port._helper_ready = True
+            return True
+        # No helper process: either nobody asked (test ports / non-Mac) or spawn failed.
+        return not Port._helper_started
 
     def reset_preferences(self):
         _log.debug("Resetting persistent preferences")
@@ -376,9 +393,11 @@ class MacPort(DarwinPort):
 
     def setup_test_run(self, device_type=None):
         super(MacPort, self).setup_test_run(device_type)
-        # Warm-up can be disabled with `--no-timeout`. This is useful when trying to avoid debugger
-        # attaching to the warmup process when debugging with `lldb --wait-for --attach-name ...`.
-        if not self.get_option("no_timeout"):
+        # Warm up only when multiple workers will spawn concurrently (webkit.org/b/242106):
+        # with one worker the first real test does the same first-run binary verification.
+        # Also skipped under --no-timeout so `lldb --wait-for --attach-name ...` doesn't
+        # latch onto the warmup process.
+        if self.get_option('child_processes', 1) > 1 and not self.get_option('no_timeout'):
             _log.debug('Warming up the runner ...')
             warmup_driver = self.create_driver(0)
             warmup_driver.run_test(DriverInput('file:///warmup-does-not-exist', 60000., None, should_run_pixel_test=False), stop_when_done=True)


### PR DESCRIPTION
#### 7d4b9ad5fc390e75e6391417c74bff8a5ba74da1
<pre>
Reduce run-webkit-tests startup overhead for faster iteration
<a href="https://bugs.webkit.org/show_bug.cgi?id=314459">https://bugs.webkit.org/show_bug.cgi?id=314459</a>
<a href="https://rdar.apple.com/176618242">rdar://176618242</a>

Reviewed by Sam Sneddon and Jonathan Bedard.

`run-webkit-tests fast/dom/ChildNode-replaceWith.html` wall clock drops from ~5s
to ~2.8s. WebKitTestRunner itself still takes ~1s; the rest is setup overhead
that this change trims.

Each of these improvements was independently measurable:
- LayoutTestHelper&apos;s ~440ms color-profile install now overlaps with test discovery
  instead of blocking _set_up_run.
- configuration_for_upload (which pulls in requests, ~80ms) runs only when
  --report is passed.
- webkit-build-directory perl calls: 4 → 1, via a class-level cache and a lazy
  --target default (~500ms).
- WebKitTestRunner warmup is skipped when child_processes == 1.
- Several production import paths no longer pull in unittest.mock,
  webkitcorepy.mocks submodules, the whole requests stack, or the embedded-port
  chain on a Mac run.
- Misc: cached inner finder, precompiled regex, lazy port-factory table.

* Tools/Scripts/libraries/webkitcorepy/webkitcorepy/mocks/__init__.py:
Load only ContextStack eagerly. Time / Subprocess / Requests / Terminal /
FileLock / Environment are exposed via PEP 562 module-level __getattr__ +
CallByNeed, so callers that only need ContextStack don&apos;t pull in their
dependencies (unittest.mock, requests, etc.). Resolved attributes are written
back into globals() so later access (and pickle/isinstance) skip the proxy.

* Tools/Scripts/libraries/webkitcorepy/webkitcorepy/partial_proxy.py:
* Tools/Scripts/libraries/webkitcorepy/webkitcorepy/timeout.py:
Defer importing unittest.mock to first use via CallByNeed. These modules are
imported on every webkitcorepy load but rarely call into mock at production
runtime.

* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/__init__.py:
Drop the eager `from webkitscmpy import mocks` import; tests that need it import
it explicitly. Cuts an unconditional load of mocks.* from production paths.

* Tools/Scripts/webkitpy/common/version_name_map.py:
Add DARWIN_CURRENT_VERSION = Version(26) as the single source of truth for the
current Darwin major; the ios/tvos/watchos/visionos PUBLIC_TABLE entries already
share Darwin&apos;s value through this constant.

* Tools/Scripts/webkitpy/layout_tests/controllers/layout_test_finder_legacy.py:
(LayoutTestFinder.__init__):
(LayoutTestFinder._make_inner_finder):
(LayoutTestFinder.find_tests_by_path):
(LayoutTestFinder._is_test_file):
(LayoutTestFinder._is_w3c_resource_file):
Memoize the inner LayoutTestFinder_New per device_type with functools.cache
bound to the instance, so repeated lookups don&apos;t redo baseline_search_path()
work. Bound on the instance (not the class) so the cache doesn&apos;t outlive the
LayoutTestFinder.

* Tools/Scripts/webkitpy/layout_tests/controllers/manager.py:
(Manager.run):
Kick start_helper_async off before _collect_tests so the helper warmup overlaps
with test discovery and expectations parsing.
(Manager._set_up_run):
Join on the helper via wait_for_helper_ready instead of start_helper.
(Manager._update_worker_count):
After clamping options.child_processes, sync the value back onto the port via
set_option. Port has its own copy of options (_create_port_for_driver does
optparse.Values copy.copy), so the warmup gate and embedded-port device-count
logic see the effective worker count.
(Manager._end_test_run):
Compute configuration_for_upload only when --report is passed, avoiding an
unconditional import of requests on every run.

* Tools/Scripts/webkitpy/layout_tests/models/test_expectations.py:
(TestExpectationParser._tokenize_line):
Collapse whitespace with `&quot; &quot;.join(s.split())` instead of an `re.sub`, and
precompile _BUG_TOKEN_RE.

* Tools/Scripts/webkitpy/port/base.py:
(Port._helper_process):
(Port._helper_started):
(Port._helper_ready):
Class-level state for the LayoutTestHelper. _helper_started records that the
spawn was attempted, so a None _helper_process is interpreted as a failed spawn
rather than no spawn at all.
(Port.start_helper_async):
(Port.wait_for_helper_ready):
New no-op defaults; MacPort overrides them. Splitting the old start_helper into
a kick-off + join lets the caller overlap helper warmup with other work.
(Port.stop_helper):
Reset _helper_started and _helper_ready so a later run isn&apos;t mistaken for one
whose spawn failed.

* Tools/Scripts/webkitpy/port/config.py:
(Config._build_directories):
(Config._clear_cache_for_testing):
(Config.build_directory):
Cache is class-level now (invariant within a process and shareable across
Config instances) and keyed on
(port_implementation, configuration, for_host, use_cmake).

* Tools/Scripts/webkitpy/port/base_unittest.py:
* Tools/Scripts/webkitpy/port/config_unittest.py:
(PortTest.setUp):
(ConfigTest.setUp):
Clear the class-level Config cache between tests and between phases within
test_build_directory so it doesn&apos;t leak across cases.

* Tools/Scripts/webkitpy/port/darwin.py:
(DarwinPort.CURRENT_VERSION):
Import DARWIN_CURRENT_VERSION from version_name_map instead of duplicating
Version(26).

* Tools/Scripts/webkitpy/port/factory.py:
(_load_port_class):
(PortFactory.PORT_CLASSES):
(PortFactory.get):
Replace the eager loop over all 14 port modules with a table mapping port-name
prefix to a &quot;module.Class&quot; path string. Only the matched port module is
imported, via importlib.import_module + getattr.
(configuration_options):
--target now defaults to None. Port.__init__ already calls
set_option_default(&apos;configuration&apos;, self.default_configuration()) after
parsing, so the old eager Config.default_configuration() call at
option-definition time (one perl invocation every run) is redundant.

* Tools/Scripts/webkitpy/port/factory_unittest.py:
(FactoryTest.test_port_classes_table_consistency):
Assert each prefix in PORT_CLASSES matches the imported class&apos;s port_name so
the duplication cannot silently drift.

* Tools/Scripts/webkitpy/port/mac.py:
(MacPort.setup_test_run):
Skip the WebKitTestRunner warmup when child_processes == 1; the warmup exists
to avoid first-run binary-verification thrash with N parallel workers
(webkit.org/b/242106), which doesn&apos;t apply to a single worker.
(MacPort.start_helper):
Now just start_helper_async + wait_for_helper_ready.
(MacPort.start_helper_async):
(MacPort.wait_for_helper_ready):
Split into non-blocking popen + blocking readline. Track helper state on
Port._helper_process / _helper_started / _helper_ready so wait returns False
for a helper that failed to spawn.

Canonical link: <a href="https://commits.webkit.org/314080@main">https://commits.webkit.org/314080@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f8ceb8e9e4df0883fd445729827b0d2cd56d6411

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/165049 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/38540 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/32117 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/174091 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/122306 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/ca3d46fa-96e5-430b-8a23-a6a09d30f351) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/166917 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/38874 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/38541 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/128263 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/122306 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/94e643f1-31d0-48a9-b966-14ce69460d47) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/168008 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/30573 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/148311 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/108789 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/6f3d85a0-9e8e-40fb-8b0f-b3bc9f434d44) 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/164369 "Passed tests") | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/29620 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/28241 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/21846 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/139515 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/26010 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/176614 "Built successfully") | | 
| | | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/27715 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/136581 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/164453 "Passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/38608 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/32377 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/136525 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36797 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/39298 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/147806 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/101597 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/31797 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/24673 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/37808 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/37205 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/2748 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/37451 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/37349 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->