### PR TITLE
REGRESSION(310189@main): SwipeProgressTracker::displayLinkFired() can assert under WeakRef::get() on the CVDisplayLink thread

### DIFF
--- a/Source/WebKit/UIProcess/mac/SwipeProgressTrackerMac.h
+++ b/Source/WebKit/UIProcess/mac/SwipeProgressTrackerMac.h
@@ -87,6 +87,7 @@ private:
 
     WeakRef<ViewGestureController> m_viewGestureController;
     WeakRef<WebPageProxy> m_webPageProxy;
+    WebPageProxyIdentifier m_pageIdentifier;
 };
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/mac/SwipeProgressTrackerMac.mm
+++ b/Source/WebKit/UIProcess/mac/SwipeProgressTrackerMac.mm
@@ -57,6 +57,7 @@ static double easeOutCubic(double t)
 SwipeProgressTracker::SwipeProgressTracker(WebPageProxy& webPageProxy, ViewGestureController& viewGestureController)
     : m_viewGestureController(viewGestureController)
     , m_webPageProxy(webPageProxy)
+    , m_pageIdentifier(webPageProxy.identifier())
 {
 }
 
@@ -226,12 +227,8 @@ void SwipeProgressTracker::endAnimation()
 
 void SwipeProgressTracker::displayLinkFired(WebCore::PlatformDisplayID, WebCore::DisplayUpdate, bool, bool)
 {
-    RefPtr page = m_webPageProxy.get();
-    if (!page)
-        return;
-
-    RunLoop::mainSingleton().dispatch([pageID = page->identifier()]() {
-        RefPtr controller = ViewGestureController::controllerForPage(pageID);
+    RunLoop::mainSingleton().dispatch([pageIdentifier = m_pageIdentifier] {
+        RefPtr controller = ViewGestureController::controllerForPage(pageIdentifier);
         if (controller && controller->swipeProgressTracker())
             protect(*controller->swipeProgressTracker())->animationTimerFired();
     });


### PR DESCRIPTION
#### f067dde25fd8e9c4492f2922bee96168c1778813
<pre>
REGRESSION(310189@main): SwipeProgressTracker::displayLinkFired() can assert under WeakRef::get() on the CVDisplayLink thread
<a href="https://bugs.webkit.org/show_bug.cgi?id=314462">https://bugs.webkit.org/show_bug.cgi?id=314462</a>
<a href="https://rdar.apple.com/176624705">rdar://176624705</a>

Reviewed by Richard Robinson.

SwipeProgressTracker::displayLinkFired may be called off the main
thread, but it dereferences a WeakRef&lt;WebPageProxy&gt; instance which has
main-thread assertions. Since we only access the WeakRef to obtain the
page identifier for dispatching to the main runloop, this patch stores
the identifier as a member at creation time and uses it directly in the
callback, matching precedent set by RemoteLayerTreeDisplayLinkClient.

* Source/WebKit/UIProcess/mac/SwipeProgressTrackerMac.h:
* Source/WebKit/UIProcess/mac/SwipeProgressTrackerMac.mm:
(WebKit::SwipeProgressTracker::SwipeProgressTracker):
(WebKit::SwipeProgressTracker::displayLinkFired):

Canonical link: <a href="https://commits.webkit.org/312958@main">https://commits.webkit.org/312958@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/edda0e040f935b23baed5bdc66063e3aa9814f41

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/161551 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/35025 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/28128 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/170454 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/117922 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/5b8620e9-f950-4e2b-97db-6d2d375a4cc4) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/35126 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/35026 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/125332 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/88268 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/8aa46829-2d64-4e5c-a8de-18b7a73b2c0d) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/164510 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/27631 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/145113 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/105928 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/2da7b6ca-effa-41ba-bebd-8005c5ddf586) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/26680 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/25192 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/18175 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/136374 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/172942 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/19983 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/24511 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/133621 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/34699 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/29287 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/133627 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/34683 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/144665 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/96590 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/24554 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/28153 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/21484 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/34193 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/101638 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/33693 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/33936 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/33842 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->