### PR TITLE
Digital Credentials: use the requesting document origin for cross-origin iframe request validation, with UI-process-trusted origins

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/digital-credentials/get-cross-site-iframe.https.sub.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/digital-credentials/get-cross-site-iframe.https.sub.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<title>Digital Credential API: get() works from a cross-site iframe (document-origin request validation).</title>
+<link rel="help" href="https://bugs.webkit.org/show_bug.cgi?id=314463">
+<script src="/common/get-host-info.sub.js"></script>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/testdriver.js?feature=bidi"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+<body></body>
+<script type="module">
+  import { makeGetOptions } from "./support/helper.js";
+
+  const hostInfo = get_host_info();
+
+  promise_test(async (t) => {
+    await test_driver.set_virtual_wallet_behavior("respond", "org-iso-mdoc", { value: "cross-site-ok" });
+    t.add_cleanup(() => test_driver.set_virtual_wallet_behavior("clear"));
+
+    const iframe = document.createElement("iframe");
+    iframe.allow = "digital-credentials-get *";
+    t.add_cleanup(() => iframe.remove());
+    await new Promise((resolve) => {
+      iframe.onload = resolve;
+      // Registrably-different site from the top-level document => cross-site sub-frame.
+      iframe.src = new URL("/digital-credentials/support/iframe.html", hostInfo.HTTPS_NOTSAMESITE_ORIGIN).href;
+      document.body.appendChild(iframe);
+    });
+    iframe.focus();
+
+    await test_driver.bless("User activation");
+
+    const options = makeGetOptions({ protocol: "org-iso-mdoc" });
+    const { data: result } = await new Promise((resolve) => {
+      const callback = (e) => {
+        if (e.source === iframe.contentWindow) {
+          window.removeEventListener("message", callback);
+          resolve(e);
+        }
+      };
+      window.addEventListener("message", callback);
+      iframe.contentWindow.postMessage({ action: "get", options, needsActivation: true }, "*");
+    });
+
+    assert_equals(result.protocol, "org-iso-mdoc", `get() should resolve, got: ${JSON.stringify(result)}`);
+    assert_equals(result.data.value, "cross-site-ok");
+  }, "navigator.credentials.get() from a cross-site iframe resolves (request is validated against the iframe's document origin).");
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/digital-credentials/support/iframe.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/digital-credentials/support/iframe.html
@@ -58,6 +58,10 @@
         abortController.abort();
       }
       result = await promise;
+      // A successful get()/create() yields a Credential, which is not structured-cloneable.
+      // Post a cloneable projection so cross-origin callers can read the outcome.
+      if (result && typeof result === "object" && "protocol" in result)
+        result = { protocol: result.protocol, data: result.data };
     } catch (error) {
       result = {
         constructor: error.constructor.name,

--- a/Source/WebCore/Modules/identity/CredentialRequestCoordinator.cpp
+++ b/Source/WebCore/Modules/identity/CredentialRequestCoordinator.cpp
@@ -140,7 +140,7 @@ void CredentialRequestCoordinator::prepareCredentialRequests(const Document& doc
         return rejectTheCredentialRequestWith(Exception { ExceptionCode::AbortError, "Page was destroyed."_s });
 
     auto validatedRequestsOrException = m_client->validateAndParseDigitalCredentialRequests(
-        protect(document.topOrigin()),
+        protect(document.securityOrigin()),
         document,
         unvalidatedRequests);
 

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -11478,10 +11478,19 @@ void WebPageProxy::showDigitalCredentialsChooser(IPC::Connection& connection, st
 #endif
 
 #if HAVE(DIGITAL_CREDENTIALS_UI)
+            RefPtr requestingFrame = frameID ? WebFrameProxy::webFrame(*frameID) : nullptr;
+            // The frame can be gone due to a site isolation race, or frameID absent for a detached
+            // document, so deny rather than treat it as a bad message.
+            if (!requestingFrame) {
+                completionHandler(makeUnexpected(WebCore::ExceptionData { WebCore::ExceptionCode::NotAllowedError, "The digital credential request came from a frame that is no longer present."_s }));
+                return;
+            }
+
+            Ref requestingProcess = WebProcessProxy::fromConnection(connection);
             MESSAGE_CHECK_COMPLETION_BASE(
-                requestData.topOrigin.securityOrigin()->isSameOriginDomain(SecurityOrigin::create(protect(mainFrame())->url())),
+                requestingFrame->page() == this && &requestingFrame->process() == requestingProcess.ptr(),
                 connection,
-                completionHandler(makeUnexpected(WebCore::ExceptionData { WebCore::ExceptionCode::SecurityError, "Digital credentials request is not same-origin with top-level navigable."_s }))
+                completionHandler(makeUnexpected(WebCore::ExceptionData { WebCore::ExceptionCode::SecurityError, "Digital credentials request did not come from a frame hosted in the requesting process."_s }))
             );
 
             auto lastActivationTimestamp = internals().lastActivationTimestamp;
@@ -11492,8 +11501,24 @@ void WebPageProxy::showDigitalCredentialsChooser(IPC::Connection& connection, st
             }
             internals().lastConsumedDigitalCredentialsActivationTimestamp = lastActivationTimestamp;
 
+            RefPtr mainFrame = this->mainFrame();
+            if (!mainFrame) {
+                completionHandler(makeUnexpected(WebCore::ExceptionData { WebCore::ExceptionCode::NotAllowedError, "The digital credential request has no main frame."_s }));
+                return;
+            }
+
+            Ref documentOrigin = requestingFrame->securityOrigin();
+            Ref topOrigin = mainFrame->securityOrigin();
+
+            // Present the request to the wallet with the trusted UI-process origins, not the ones
+            // supplied by the (untrusted) web content, so the wallet UI cannot be made to display a
+            // spoofed origin. FIXME: <rdar://182265208>
+            auto trustedRequestData = requestData;
+            trustedRequestData.topOrigin = topOrigin->data();
+            trustedRequestData.documentOrigin = documentOrigin->data();
+
             LOG(DigitalCredentials, "WebPageProxy::showDigitalCredentialsChooser() - UIProcess: passing to pageClient to present chooser UI");
-            protect(pageClient())->showDigitalCredentialsChooser(requestData, WTF::move(completionHandler));
+            protect(pageClient())->showDigitalCredentialsChooser(trustedRequestData, WTF::move(completionHandler));
 #else
             completionHandler(makeUnexpected(WebCore::ExceptionData { WebCore::ExceptionCode::NotSupportedError, "Digital credentials UI is not supported."_s }));
 #endif

--- a/Source/WebKit/WebProcess/DigitalCredentials/DigitalCredentialsCoordinator.cpp
+++ b/Source/WebKit/WebProcess/DigitalCredentials/DigitalCredentialsCoordinator.cpp
@@ -87,9 +87,9 @@ void DigitalCredentialsCoordinator::showDigitalCredentialsChooser(std::optional<
     }
 }
 
-ExceptionOr<Vector<WebCore::ValidatedDigitalCredentialRequest>> DigitalCredentialsCoordinator::validateAndParseDigitalCredentialRequests(const SecurityOrigin& topOrigin, const Document& document, const Vector<UnvalidatedDigitalCredentialRequest>& unvalidatedRequests)
+ExceptionOr<Vector<WebCore::ValidatedDigitalCredentialRequest>> DigitalCredentialsCoordinator::validateAndParseDigitalCredentialRequests(const SecurityOrigin& documentOrigin, const Document& document, const Vector<UnvalidatedDigitalCredentialRequest>& unvalidatedRequests)
 {
-    auto results = DigitalCredentials::validateRequests(topOrigin, document, unvalidatedRequests);
+    auto results = DigitalCredentials::validateRequests(documentOrigin, document, unvalidatedRequests);
     return WTF::move(results);
 }
 

--- a/Source/WebKit/WebProcess/cocoa/IdentityDocumentServices/DigitalCredentialsRequestValidatorBridge.mm
+++ b/Source/WebKit/WebProcess/cocoa/IdentityDocumentServices/DigitalCredentialsRequestValidatorBridge.mm
@@ -164,9 +164,9 @@ static WebCore::ValidatedMobileDocumentRequest buildValidatedRequest(WKIdentityD
     return validatedRequest;
 }
 
-Vector<WebCore::ValidatedMobileDocumentRequest> DigitalCredentials::validateRequests(const SecurityOrigin &topOrigin, const Document &document, const Vector<WebCore::UnvalidatedDigitalCredentialRequest> &unvalidatedRequests)
+Vector<WebCore::ValidatedMobileDocumentRequest> DigitalCredentials::validateRequests(const SecurityOrigin &documentOrigin, const Document &document, const Vector<WebCore::UnvalidatedDigitalCredentialRequest> &unvalidatedRequests)
 {
-    RetainPtr convertedTopOrigin = topOrigin.toURL().createNSURL().get();
+    RetainPtr convertedOrigin = documentOrigin.toURL().createNSURL().get();
     RetainPtr validator = adoptNS([WebKit::allocWKIdentityDocumentRawRequestValidatorInstance() init]);
 
     Vector<WebCore::ValidatedMobileDocumentRequest> validatedRequests;
@@ -185,7 +185,7 @@ Vector<WebCore::ValidatedMobileDocumentRequest> DigitalCredentials::validateRequ
         RetainPtr iso18013Request = adoptNS([WebKit::allocWKISO18013RequestInstance() initWithEncryptionInfo:convertedEncryptionInfo.get() deviceRequest:convertedDeviceRequest.get()]);
 
         NSError *error = nil;
-        RetainPtr validatedISORequest = [validator validateISO18013Request:iso18013Request.get() origin:convertedTopOrigin.get() error:&error];
+        RetainPtr validatedISORequest = [validator validateISO18013Request:iso18013Request.get() origin:convertedOrigin.get() error:&error];
 
         if (validatedISORequest) {
             auto validatedMobileDocumentRequest = buildValidatedRequest(validatedISORequest.get());


### PR DESCRIPTION
#### 9b6a21462111bdda1152129f3bc58cca16b967fb
<pre>
Digital Credentials: use the requesting document origin for cross-origin iframe request validation, with UI-process-trusted origins

<a href="https://rdar.apple.com/176377059">rdar://176377059</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=314463">https://bugs.webkit.org/show_bug.cgi?id=314463</a>

Reviewed by NOBODY (OOPS!).

Validate digital credential requests against the requesting document (frame)
origin instead of the top-level origin so cross-origin iframe requests work.
In the UI process, derive the requesting and top-level origins from the trusted
WebFrameProxy rather than the web-content-supplied request data, and pass those
to the wallet chooser so the origins it displays cannot be spoofed by a
compromised web content process.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9b6a21462111bdda1152129f3bc58cca16b967fb

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/177723 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/51661 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/45455 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/187331 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/140970 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/179586 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/52953 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/51370 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/138523 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/96338 "1 flakes 3 failures") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/180679 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/42045 "Exiting early after 10 failures. 10 tests run. 1 missing results") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/159263 "Found 1 new API test failure: TestWebKitAPI.UnifiedPDF.PDFHUDMultiplePluginsDoNotInterceptHitTesting (failure)") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/118987 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/40707 "Found 1 new test failure: imported/w3c/web-platform-tests/digital-credentials/get-cross-site-iframe.https.sub.html (failure)") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/39071 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/151113 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/38759 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/35794 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/43446 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/43306 "Found 1 new test failure: imported/w3c/web-platform-tests/digital-credentials/get-cross-site-iframe.https.sub.html (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/189760 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/51328 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/158794 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/147639 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/52010 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/35387 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/147425 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/42135 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/124225 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/118656 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/50518 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/13736 "") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/49914 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/50154 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/49976 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->