### PR TITLE
[Cocoa] YouTube caption button flickers and spins main thread at 100%

### DIFF
--- a/Source/WebCore/Modules/mediasession/MediaSession.cpp
+++ b/Source/WebCore/Modules/mediasession/MediaSession.cpp
@@ -171,6 +171,9 @@ MediaSession::MediaSession(Navigator& navigator)
     , m_coordinator(MediaSessionCoordinator::create(protect(navigator.scriptExecutionContext()).get()))
 #endif
 {
+    if (RefPtr document = this->document())
+        m_needsYouTubeCaptionsQuirk = document->quirks().needsYouTubeCaptionsQuirk();
+
     m_logger = Document::sharedLogger();
     m_logIdentifier = nextLogIdentifier();
 #if PLATFORM(COCOA)
@@ -693,18 +696,27 @@ void MediaSession::captionPreferencesChanged()
         return;
 
     auto newDisplayMode = captionPreferences->captionDisplayMode();
-    if (newDisplayMode == captionDisplayMode())
+    if (newDisplayMode == m_captionDisplayMode)
         return;
     m_captionDisplayMode = newDisplayMode;
 
+    if (!m_needsYouTubeCaptionsQuirk)
+        return;
+
     switch (newDisplayMode) {
     case CaptionUserPreferencesDisplayMode::AlwaysOn:
-        if (!m_captionsEnabled)
-            callActionHandler({ .action = MediaSessionAction::Togglecaptions }, { });
+        if (m_captionsEnabled)
+            break;
+
+        ALWAYS_LOG(LOGIDENTIFIER, "newMode: ", newDisplayMode, ", sending toggle action");
+        callActionHandler({ .action = MediaSessionAction::Togglecaptions }, { });
         break;
     case CaptionUserPreferencesDisplayMode::ForcedOnly:
-        if (m_captionsEnabled)
-            callActionHandler({ .action = MediaSessionAction::Togglecaptions }, { });
+        if (!m_captionsEnabled)
+            break;
+
+        ALWAYS_LOG(LOGIDENTIFIER, "newMode: ", newDisplayMode, ", sending toggle action");
+        callActionHandler({ .action = MediaSessionAction::Togglecaptions }, { });
         break;
     case CaptionUserPreferencesDisplayMode::Automatic:
     case CaptionUserPreferencesDisplayMode::Manual:
@@ -728,6 +740,7 @@ CaptionUserPreferencesDisplayMode MediaSession::captionDisplayMode()
 
 void MediaSession::setCaptionTracks(Vector<MediaSessionCaptionTrack>&& tracks)
 {
+    ALWAYS_LOG(LOGIDENTIFIER, "count: ", tracks.size());
     m_captionTracks = WTF::move(tracks);
     if (RefPtr mediaElement = activeMediaElement())
         mediaElement->mediaSessionCaptionTracksChanged();
@@ -735,17 +748,34 @@ void MediaSession::setCaptionTracks(Vector<MediaSessionCaptionTrack>&& tracks)
 
 void MediaSession::setCaptionsEnabled(bool enabled)
 {
+    if (m_captionsEnabled == enabled)
+        return;
     m_captionsEnabled = enabled;
 
-    if (RefPtr captionPreferences = this->captionPreferences()) {
-        auto displayMode = enabled ? CaptionUserPreferences::CaptionDisplayMode::AlwaysOn : CaptionUserPreferences::CaptionDisplayMode::ForcedOnly;
-        captionPreferences->setCaptionDisplayMode(displayMode);
-    }
+    ALWAYS_LOG(LOGIDENTIFIER, enabled);
 
     if (RefPtr mediaElement = activeMediaElement())
         mediaElement->mediaSessionCaptionsEnabledChanged();
 }
 
+void MediaSession::presentationModeChanged()
+{
+    RefPtr mediaElement = activeMediaElement();
+    if (!mediaElement)
+        return;
+
+    auto fullscreenMode = mediaElement->fullscreenMode();
+    if (fullscreenMode == MediaPlayerEnums::VideoFullscreenModeNone)
+        return;
+
+    if (captionDisplayMode() == CaptionUserPreferencesDisplayMode::AlwaysOn && !m_captionsEnabled) {
+        ALWAYS_LOG(LOGIDENTIFIER, "newMode: ", fullscreenMode, ", sending toggle action");
+        callActionHandler({ .action = MediaSessionAction::Togglecaptions }, { });
+    } else if (captionDisplayMode() == CaptionUserPreferencesDisplayMode::ForcedOnly && !m_captionsEnabled) {
+        ALWAYS_LOG(LOGIDENTIFIER, "newMode: ", fullscreenMode, ", sending toggle action");
+        callActionHandler({ .action = MediaSessionAction::Togglecaptions }, { });
+    }
+}
 
 }
 

--- a/Source/WebCore/Modules/mediasession/MediaSession.h
+++ b/Source/WebCore/Modules/mediasession/MediaSession.h
@@ -160,6 +160,8 @@ public:
     void setCaptionsEnabled(bool);
     bool captionsEnabled() const { return m_captionsEnabled; }
 
+    void presentationModeChanged();
+
 private:
     explicit MediaSession(Navigator&);
 
@@ -230,6 +232,7 @@ private:
 #if PLATFORM(COCOA)
     bool m_shouldSuppressMediaSessionPauseActionOnInterruption { false };
 #endif
+    bool m_needsYouTubeCaptionsQuirk { false };
 };
 
 String convertEnumerationToString(MediaSessionPlaybackState);

--- a/Source/WebCore/Modules/modern-media-controls/media/YouTubeCaptionQuirk.js
+++ b/Source/WebCore/Modules/modern-media-controls/media/YouTubeCaptionQuirk.js
@@ -163,7 +163,13 @@
         }
 
         _handlePresentationModeChanged() {
-            this._mirrorTrack.mode = this._video.webkitPresentationMode == 'inline' ? 'hidden' : 'showing';
+            if (this._video.webkitPresentationMode == 'inline') {
+                this._mirrorTrack.mode = 'hidden';
+                return;
+            }
+
+            this._player.loadModule('captions');
+            this._mirrorTrack.mode = 'showing';
         }
 
         _handleMediaSessionAction(details) {


### PR DESCRIPTION
#### f98aa5dda9080082a0bcaa04f99b6f26c6065627
<pre>
[Cocoa] YouTube caption button flickers and spins main thread at 100%
<a href="https://rdar.apple.com/175983249">rdar://175983249</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=314464">https://bugs.webkit.org/show_bug.cgi?id=314464</a>

Reviewed by Eric Carlson.

The YouTube Captions quirk set up a bi-directional communications channel
between the MediaAccessibility framework and YouTube: when MA settings enabled
captions, WebKit would send a command to YouTube to enable their captions, and
when YouTube enabled their own captions, it would notify WebKit which would set
the MA setting to enable captions. Unfortunately in certain degenerate cases this
would set up a neverending storm of enable and disable commands between MA
(mediated by WebKit) and YouTube.

In order to break this cycle, WebKit will tell YouTube to enable captions whenever
MA caption settings change, but enabling or disabling YouTube captions will not
update MA settings. However, to ensure that the caption menu reflects current
MA settings when in native fullscreen modes, WebKit will enable YouTube captions
when entering Fullscreen or PiP, if MA is set to prefer captions. This has the
effect of enabling captions when entering fullscreen modes even if those captions
were not enabled by YouTube during inline modes, if the user prefers &quot;always on&quot;
captions.

* Source/WebCore/Modules/mediasession/MediaSession.cpp:
(WebCore::m_coordinator):
(WebCore::MediaSession::captionPreferencesChanged):
(WebCore::MediaSession::setCaptionTracks):
(WebCore::MediaSession::setCaptionsEnabled):
(WebCore::MediaSession::presentationModeChanged):
* Source/WebCore/Modules/mediasession/MediaSession.h:
* Source/WebCore/Modules/modern-media-controls/media/YouTubeCaptionQuirk.js:
(CaptionMirror.prototype._handlePresentationModeChanged):

Canonical link: <a href="https://commits.webkit.org/312952@main">https://commits.webkit.org/312952@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/effcef9255c0f91af3db6b347a37ee99c9663334

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/161556 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/35030 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/28133 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/170459 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/117927 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/11f6ae70-b1e8-4574-8c89-cc22116e1cd6) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/163425 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/35131 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/35031 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/125339 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/88271 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/88b12532-a5f4-4a56-9773-d68d80deecba) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/164515 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/27638 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/145120 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/105935 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/04285ae2-ecd5-4371-add6-c8fe82efc6c5) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/26687 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/25197 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/18180 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/136381 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/22877 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/172947 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/19988 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/24518 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/133628 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/34704 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/29292 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/133634 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36114 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/34688 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/144672 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/96596 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/28160 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/21491 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/34198 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/101643 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/33698 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/33941 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/33847 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->