### PR TITLE
[YARR] body-alternative scan must not start a match attempt inside a surrogate pair

### DIFF
--- a/JSTests/stress/regexp-body-alternative-scan-surrogate-middle.js
+++ b/JSTests/stress/regexp-body-alternative-scan-surrogate-middle.js
@@ -1,0 +1,53 @@
+// The YARR body-alternative scan must not start a match attempt in the middle of a surrogate
+// pair in Unicode (/u and /v) mode. When the last alternative fails at a position whose first
+// character is a non-BMP code point, the scan retries the first alternative at the next position.
+// Previously the interpreter advanced by a single code unit (landing on the trail surrogate),
+// and the ARM64 JIT advanced matchStart by firstCharacterAdditionalReadSize but did not advance
+// the index register to match. If the first alternative is a zero-width assertion like \B that
+// can match at a trail-surrogate position, this produced a match with end < start.
+
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error(`Expected ${String(expected)} but got: ${String(actual)}`);
+}
+
+function shouldBeArray(actual, expected) {
+    if (!Array.isArray(actual))
+        throw new Error(`Expected an array but got: ${String(actual)}`);
+    if (actual.length !== expected.length)
+        throw new Error(`Expected array of length ${expected.length} but got: ${JSON.stringify(actual)}`);
+    for (let i = 0; i < expected.length; ++i)
+        shouldBe(actual[i], expected[i]);
+}
+
+// alt1 = \B (zero-width, min size 0), alt2 = x{1,2}? (min size 1).
+// At pos 1 (the lead surrogate), alt2 reads the surrogate pair and fails;
+// the scan must retry alt1 at pos 3 (the next code-point boundary), never pos 2.
+shouldBeArray("a\u{10ffff}b".split(/\B|x{1,2}?/u), ["a\u{10ffff}b"]);
+shouldBeArray("a\u{10000}b".split(/\B|x{1,2}?/u), ["a\u{10000}b"]);
+shouldBeArray("a\u{10ffff}b".split(/\B|x{1,2}?/v), ["a\u{10ffff}b"]);
+
+// Every code-point boundary in "a\u{10ffff}b" is a word boundary, so there is no match.
+shouldBe(/\B|x{1,2}?/u.exec("a\u{10ffff}b"), null);
+shouldBe(/\B|x{1,2}?/u.exec("z\u{10000}z"), null);
+shouldBe(/\B|x{1,2}?/u.exec("z\u{10ffff}z\u{10000}z"), null);
+
+// Adjacent non-BMP non-word code points: \B must match at the code-point
+// boundary between them (pos 3), never at the surrogate middle (pos 2).
+{
+    let m = /\B|x{1,2}?/u.exec("z\u{10000}\u{10001}z");
+    shouldBe(m !== null, true);
+    shouldBe(m.index, 3);
+    shouldBe(m[0], "");
+}
+
+// A longer input mixing BMP, non-BMP, and lone surrogates.
+{
+    let s = "b7\u{dc00}cu\u{10ffff}\u{dc00}da\u{45d9d}c7k\u{bad30}h";
+    let parts = s.split(/\B|x{1,2}?/u);
+    shouldBe(parts.join(""), s);
+    for (let p of parts) {
+        if (p.length > s.length)
+            throw new Error(`Piece length ${p.length} exceeds input length ${s.length}`);
+    }
+}

--- a/Source/JavaScriptCore/yarr/YarrInterpreter.cpp
+++ b/Source/JavaScriptCore/yarr/YarrInterpreter.cpp
@@ -285,6 +285,14 @@ public:
             ++pos;
         }
 
+        // In Unicode mode, match attempts only start at code-point boundaries (AdvanceStringIndex).
+        void NODELETE advanceToNextPotentialMatchStart()
+        {
+            ++pos;
+            if (decodeSurrogatePairs && pos < length && U16_IS_TRAIL(input[pos]) && U16_IS_LEAD(input[pos - 1]))
+                ++pos;
+        }
+
         void NODELETE rewind(unsigned amount)
         {
             ASSERT(pos >= amount);
@@ -2068,7 +2076,7 @@ public:
                 return JSRegExpResult::NoMatch;
             }
 
-            input.next();
+            input.advanceToNextPotentialMatchStart();
 
             context->matchBegin = input.getPos();
 

--- a/Source/JavaScriptCore/yarr/YarrJIT.cpp
+++ b/Source/JavaScriptCore/yarr/YarrJIT.cpp
@@ -4414,6 +4414,12 @@ class YarrGenerator final : public YarrJITInfo {
                             // already correctly incremented, if more than one then decrement as appropriate.
                             unsigned delta = alternative->m_minimumSize - beginOp->m_alternative->m_minimumSize;
                             ASSERT(delta);
+#if ENABLE(YARR_JIT_UNICODE_EXPRESSIONS) && ENABLE(YARR_JIT_UNICODE_CAN_INCREMENT_INDEX_FOR_NON_BMP)
+                            // matchStart above was advanced past a non-BMP first character via
+                            // firstCharacterAdditionalReadSize; keep index in sync so the reentry stays on a code-point boundary.
+                            if (m_useFirstNonBMPCharacterOptimization)
+                                m_jit.add32(m_regs.firstCharacterAdditionalReadSize, m_regs.index);
+#endif
                             if (delta != 1)
                                 m_jit.sub32(MacroAssembler::Imm32(delta - 1), m_regs.index);
                             m_jit.jump(beginOp->m_reentry);


### PR DESCRIPTION
#### d72b24579bb452b3917b89ab1ae3160297244e4c
<pre>
[YARR] body-alternative scan must not start a match attempt inside a surrogate pair
<a href="https://bugs.webkit.org/show_bug.cgi?id=314467">https://bugs.webkit.org/show_bug.cgi?id=314467</a>

Reviewed by NOBODY (OOPS!).

In Unicode mode, when the last body alternative fails at a non-BMP code
point, the scan retried the first alternative at a trail-surrogate
position. The interpreter advanced by a single code unit, and the ARM64
JIT advanced matchStart by firstCharacterAdditionalReadSize but not the
index register. Zero-width assertions like \B can match there, producing
a result with end &lt; start in the JIT case.

    &quot;a\u{10ffff}b&quot;.split(/\B|x{1,2}?/u)
    // Expected: [&quot;a\u{10ffff}b&quot;]
    // Actual:   [&quot;a\udbff&quot;, &quot;\udfffb&quot;]

Skip trail surrogates when advancing to the next potential match start
in the interpreter, and keep index in sync with matchStart in the JIT.

Test: JSTests/stress/regexp-body-alternative-scan-surrogate-middle.js

* JSTests/stress/regexp-body-alternative-scan-surrogate-middle.js: Added.
(shouldBe):
(u.exec):
* Source/JavaScriptCore/yarr/YarrInterpreter.cpp:
(JSC::Yarr::Interpreter::InputStream::advanceToNextPotentialMatchStart):
(JSC::Yarr::Interpreter::matchDisjunction):
* Source/JavaScriptCore/yarr/YarrJIT.cpp:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d72b24579bb452b3917b89ab1ae3160297244e4c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/161560 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/35034 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/28137 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/170463 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/117931 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/35135 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/35035 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/125343 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/88275 "3 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/164519 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/27641 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/145125 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/105939 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/26690 "Passed tests") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/25201 "Found 1 new API test failure: TestWebKitAPI.ParserYieldTokenTests.AsyncScriptRunsWhenFetched (failure)") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/18184 "Built successfully") | 
| [❌ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/153617 "Found 18 new JSC stress test failures: stress/regexp-body-alternative-scan-surrogate-middle.js.bytecode-cache, stress/regexp-body-alternative-scan-surrogate-middle.js.default, stress/regexp-body-alternative-scan-surrogate-middle.js.dfg-eager, stress/regexp-body-alternative-scan-surrogate-middle.js.dfg-eager-no-cjit-validate, stress/regexp-body-alternative-scan-surrogate-middle.js.eager-jettison-no-cjit, stress/regexp-body-alternative-scan-surrogate-middle.js.ftl-eager, stress/regexp-body-alternative-scan-surrogate-middle.js.ftl-eager-no-cjit, stress/regexp-body-alternative-scan-surrogate-middle.js.ftl-eager-no-cjit-b3o1, stress/regexp-body-alternative-scan-surrogate-middle.js.ftl-no-cjit-b3o0, stress/regexp-body-alternative-scan-surrogate-middle.js.ftl-no-cjit-no-inline-validate ... (failure)") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/136384 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/22882 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/172951 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/22398 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/19992 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/24523 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/133632 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/34708 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/29296 "Found 1 new test failure: imported/w3c/web-platform-tests/fullscreen/model/move-to-fullscreen-iframe.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/133638 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/34692 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/144677 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/96604 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/28165 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/21496 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/193959 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/34202 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/101647 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/49974 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/33702 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/33945 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/33851 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->