### PR TITLE
[JSC] Implement `String#match` in C++

### DIFF
--- a/JSTests/microbenchmarks/regexp-match-digit-cached.js
+++ b/JSTests/microbenchmarks/regexp-match-digit-cached.js
@@ -1,0 +1,14 @@
+// Hot-path microbenchmark for String.prototype.match with a cached primordial
+// RegExp argument. The DFG StringMatch node is converted to RegExpMatchFast in
+// fixup, guarded by a CheckStructure on the primordial RegExp structure.
+
+function match(string, regexp)
+{
+    return string.match(regexp);
+}
+noInline(match);
+
+var string = "abc1def2ghi3jkl4mno5";
+var regexp = /[0-9]/g;
+for (var i = 0; i < 1e6; ++i)
+    match(string, regexp);

--- a/JSTests/microbenchmarks/regexp-match-digit-literal.js
+++ b/JSTests/microbenchmarks/regexp-match-digit-literal.js
@@ -1,0 +1,13 @@
+// Hot-path microbenchmark for String.prototype.match with a RegExp literal
+// allocated on every call. Stresses the primordial-RegExp fast path together
+// with regex allocation.
+
+function match(string)
+{
+    return string.match(/[0-9]/g);
+}
+noInline(match);
+
+var string = "abc1def2ghi3jkl4mno5";
+for (var i = 0; i < 1e6; ++i)
+    match(string);

--- a/JSTests/microbenchmarks/string-match-digit-short.js
+++ b/JSTests/microbenchmarks/string-match-digit-short.js
@@ -1,0 +1,14 @@
+// Hot-path microbenchmark for String.prototype.match with a short literal
+// string regexp source. This exercises the DFG StringMatch fast path for the
+// common case where the regexp arg is a string and gets coerced via
+// RegExp construction.
+
+function match(string, regexp)
+{
+    return string.match(regexp);
+}
+noInline(match);
+
+var string = "abc1def2ghi3jkl4mno5";
+for (var i = 0; i < 1e7; ++i)
+    match(string, "[0-9]");

--- a/JSTests/microbenchmarks/string-match-letter-short.js
+++ b/JSTests/microbenchmarks/string-match-letter-short.js
@@ -1,0 +1,12 @@
+// Hot-path microbenchmark for String.prototype.match with a single-char
+// literal pattern. Targets the simple non-global match fast path.
+
+function match(string, regexp)
+{
+    return string.match(regexp);
+}
+noInline(match);
+
+var string = "alpha bravo charlie delta echo foxtrot golf";
+for (var i = 0; i < 1e7; ++i)
+    match(string, "a");

--- a/JSTests/stress/string-prototype-match-edge-cases.js
+++ b/JSTests/stress/string-prototype-match-edge-cases.js
@@ -1,0 +1,180 @@
+// Exercises edge cases of String.prototype.match across the LLInt/Baseline/DFG/FTL
+// tiers, in particular around the C++ host function and the StringMatch DFG node.
+
+function shouldBe(actual, expected) {
+    var a = JSON.stringify(actual);
+    var e = JSON.stringify(expected);
+    if (a !== e)
+        throw new Error("expected " + e + " but got " + a);
+}
+
+function shouldThrow(fn, expectedMessage) {
+    var threw = false;
+    try {
+        fn();
+    } catch (e) {
+        threw = true;
+        if (expectedMessage && String(e).indexOf(expectedMessage) === -1)
+            throw new Error("expected error message to contain " + JSON.stringify(expectedMessage) + " but got " + JSON.stringify(String(e)));
+    }
+    if (!threw)
+        throw new Error("expected exception but none was thrown");
+}
+
+// ----- |this| coercion -----
+shouldBe("abc1".match(/[0-9]/), ["1"]);
+shouldBe(String.prototype.match.call(12345, /3/), ["3"]);
+shouldBe(String.prototype.match.call(true, /ru/), ["ru"]);
+shouldBe(String.prototype.match.call({ toString() { return "obj1"; } }, /[0-9]/), ["1"]);
+shouldThrow(() => String.prototype.match.call(null, /a/), "TypeError");
+shouldThrow(() => String.prototype.match.call(undefined, /a/), "TypeError");
+
+// ----- regexp argument types -----
+// undefined / no argument: RegExpCreate(undefined, undefined) -> /(?:)/
+shouldBe("abc".match(), [""]);
+shouldBe("abc".match(undefined), [""]);
+// null -> /null/
+shouldBe("anull".match(null), ["null"]);
+shouldBe("abc".match(null), null);
+// number -> /123/
+shouldBe("a123b".match(123), ["123"]);
+// boolean -> /true/
+shouldBe("xtruey".match(true), ["true"]);
+// string regexp pattern
+shouldBe("abc1def2".match("[0-9]"), ["1"]);
+shouldBe("aaa".match("a+"), ["aaa"]);
+// invalid regexp pattern from string -> SyntaxError
+shouldThrow(() => "abc".match("["), "SyntaxError");
+shouldThrow(() => "abc".match("(?"), "SyntaxError");
+// Symbol cannot be coerced to a string when constructing the regexp.
+shouldThrow(() => "abc".match(Symbol("s")), "TypeError");
+
+// ----- flag combinations -----
+shouldBe("abc1def2ghi3".match(/[0-9]/g), ["1", "2", "3"]);
+shouldBe("abc1def2".match(/[0-9]/), ["1"]);
+shouldBe("1abc".match(/[0-9]/y), ["1"]);
+shouldBe("abc1".match(/[0-9]/y), null);
+shouldBe("ABC".match(/abc/i), ["ABC"]);
+shouldBe("a\nb".match(/^b/m), ["b"]);
+shouldBe("a\u{1F600}b".match(/./gu), ["a", "\u{1F600}", "b"]);
+shouldBe("a\u{1F600}b".match(/./gv), ["a", "\u{1F600}", "b"]);
+// Capture groups
+shouldBe("ab".match(/(a)(b)/), ["ab", "a", "b"]);
+shouldBe("ab".match(/(?<x>a)(?<y>b)/).groups, { x: "a", y: "b" });
+
+// ----- lastIndex behavior -----
+{
+    var g = /[0-9]/g;
+    g.lastIndex = 5;
+    // RegExp.prototype[@@match] sets lastIndex to 0 for global regexps before iterating.
+    shouldBe("1a2b3".match(g), ["1", "2", "3"]);
+    shouldBe(g.lastIndex, 0);
+}
+{
+    var y = /[0-9]/y;
+    y.lastIndex = 3;
+    shouldBe("abc1def".match(y), ["1"]);
+    shouldBe(y.lastIndex, 4);
+}
+{
+    // Non-numeric lastIndex must not break the spec semantics: the watchpoint fast
+    // path bails out and the full lookup path is used.
+    var g2 = /[0-9]/g;
+    g2.lastIndex = { valueOf() { return 0; } };
+    shouldBe("1a2b3".match(g2), ["1", "2", "3"]);
+}
+
+// ----- per-instance @@match override on a RegExp -----
+{
+    var re = /a/;
+    re[Symbol.match] = function (s) { return ["instance-override", s]; };
+    shouldBe("hello".match(re), ["instance-override", "hello"]);
+}
+// per-instance @@match deleted -> falls back to RegExp.prototype[@@match]
+{
+    var re2 = /[0-9]/;
+    re2[Symbol.match] = undefined;
+    // GetMethod returns undefined -> falls through to step 3-5: ToString(/[0-9]/) = "/[0-9]/"
+    // and "abc1" matched against /\/[0-9]\// (literal slash) -> null
+    shouldBe("abc1".match(re2), null);
+    shouldBe("/3/x".match(re2), ["/3/"]);
+}
+{
+    var re3 = /[0-9]/;
+    re3[Symbol.match] = null;
+    // GetMethod returns undefined for null too -> same as above
+    shouldBe("/3/x".match(re3), ["/3/"]);
+}
+{
+    var re4 = /[0-9]/;
+    re4[Symbol.match] = "not callable";
+    shouldThrow(() => "abc1".match(re4), "TypeError");
+}
+
+// ----- @@match on a plain object (custom matcher) -----
+{
+    var obj = { [Symbol.match](s) { return [s, "custom"]; } };
+    shouldBe("hello".match(obj), ["hello", "custom"]);
+}
+{
+    var obj2 = { [Symbol.match]: 42 };
+    shouldThrow(() => "hello".match(obj2), "TypeError");
+}
+// @@match getter side effects
+{
+    var log = [];
+    var obj3 = {
+        get [Symbol.match]() {
+            log.push("get @@match");
+            return function (s) { log.push("call @@match"); return [s]; };
+        }
+    };
+    shouldBe("hi".match(obj3), ["hi"]);
+    shouldBe(log, ["get @@match", "call @@match"]);
+}
+
+// ----- Subclassed RegExp -----
+{
+    class MyRegExp extends RegExp { }
+    var mr = new MyRegExp("[0-9]", "g");
+    shouldBe("a1b2c3".match(mr), ["1", "2", "3"]);
+}
+{
+    class MyRegExp2 extends RegExp {
+        [Symbol.match](s) { return ["subclass", s]; }
+    }
+    var mr2 = new MyRegExp2("a");
+    shouldBe("hello".match(mr2), ["subclass", "hello"]);
+}
+
+// ----- flags getter side effects via custom regexp object -----
+{
+    var log = [];
+    var fake = {
+        [Symbol.match]: RegExp.prototype[Symbol.match],
+        get flags() { log.push("flags"); return "g"; },
+        get global() { log.push("global"); return true; },
+        get hasIndices() { return false; },
+        get ignoreCase() { return false; },
+        get multiline() { return false; },
+        get sticky() { return false; },
+        get unicode() { return false; },
+        get unicodeSets() { return false; },
+        get dotAll() { return false; },
+        lastIndex: 0,
+        exec(s) {
+            log.push("exec");
+            if (this.lastIndex >= s.length) return null;
+            var idx = this.lastIndex;
+            this.lastIndex = idx + 1;
+            return Object.assign([s[idx]], { index: idx, input: s });
+        }
+    };
+    shouldBe("ab".match(fake), ["a", "b"]);
+    if (log.indexOf("flags") === -1)
+        throw new Error("custom flags getter must be invoked");
+    if (log.indexOf("exec") === -1)
+        throw new Error("custom exec must be invoked");
+}
+
+print("PASSED");

--- a/JSTests/stress/string-prototype-match-strength-reduction.js
+++ b/JSTests/stress/string-prototype-match-strength-reduction.js
@@ -1,0 +1,101 @@
+// Exercises the DFG path where a StringMatch node is converted to RegExpMatchFast
+// in fixup and then further strength-reduced to RegExpMatchFastGlobal /
+// RegExpExecNonGlobalOrSticky for known-flag literal RegExp arguments.
+
+function shouldBe(actual, expected) {
+    var a = JSON.stringify(actual);
+    var e = JSON.stringify(expected);
+    if (a !== e)
+        throw new Error("expected " + e + " but got " + a);
+}
+
+// Global literal: StringMatch -> RegExpMatchFast -> RegExpMatchFastGlobal
+function matchGlobalLiteral(str) {
+    return str.match(/[0-9]/g);
+}
+noInline(matchGlobalLiteral);
+for (var i = 0; i < 1e5; ++i)
+    shouldBe(matchGlobalLiteral("a1b2c3"), ["1", "2", "3"]);
+shouldBe(matchGlobalLiteral("nope"), null);
+
+// Non-global literal: StringMatch -> RegExpMatchFast -> RegExpExec
+function matchNonGlobalLiteral(str) {
+    return str.match(/[0-9]/);
+}
+noInline(matchNonGlobalLiteral);
+for (var i = 0; i < 1e5; ++i)
+    shouldBe(matchNonGlobalLiteral("a1b2c3"), ["1"]);
+shouldBe(matchNonGlobalLiteral("nope"), null);
+
+// Sticky literal: not strength-reduced to global; goes through RegExpExec.
+function matchStickyLiteral(str) {
+    return str.match(/[0-9]/y);
+}
+noInline(matchStickyLiteral);
+for (var i = 0; i < 1e5; ++i)
+    shouldBe(matchStickyLiteral("1abc"), ["1"]);
+shouldBe(matchStickyLiteral("a1bc"), null);
+
+// Unicode global literal exercising surrogate handling.
+function matchUnicodeGlobal(str) {
+    return str.match(/./gu);
+}
+noInline(matchUnicodeGlobal);
+for (var i = 0; i < 1e5; ++i)
+    shouldBe(matchUnicodeGlobal("a\u{1F600}b"), ["a", "\u{1F600}", "b"]);
+
+// Cached RegExp parameter: StringMatch -> RegExpMatchFast (no strength reduction
+// since the regexp is not a constant).
+function matchCached(str, re) {
+    return str.match(re);
+}
+noInline(matchCached);
+var cached = /[0-9]/g;
+for (var i = 0; i < 1e5; ++i)
+    shouldBe(matchCached("a1b2c3", cached), ["1", "2", "3"]);
+
+// Non-global cached.
+var cachedNonGlobal = /[0-9]/;
+for (var i = 0; i < 1e5; ++i)
+    shouldBe(matchCached("a1b2c3", cachedNonGlobal), ["1"]);
+
+// String pattern: StringMatch with StringUse on child2.
+function matchStringPattern(str, pat) {
+    return str.match(pat);
+}
+noInline(matchStringPattern);
+for (var i = 0; i < 1e5; ++i)
+    shouldBe(matchStringPattern("a1b2c3", "[0-9]"), ["1"]);
+
+// Mixed monomorphic: function that sees both global and non-global regexps.
+function matchPoly(str, re) {
+    return str.match(re);
+}
+noInline(matchPoly);
+var g = /[0-9]/g;
+var ng = /[0-9]/;
+for (var i = 0; i < 1e5; ++i) {
+    shouldBe(matchPoly("a1b2c3", g), ["1", "2", "3"]);
+    shouldBe(matchPoly("a1b2c3", ng), ["1"]);
+}
+
+// Result array structure: exec result should be a RegExpMatchesArray.
+{
+    var r = "ab12".match(/(\d)(\d)/);
+    shouldBe(r.length, 3);
+    shouldBe(r.index, 2);
+    shouldBe(r.input, "ab12");
+    shouldBe(r[0], "12");
+    shouldBe(r[1], "1");
+    shouldBe(r[2], "2");
+}
+
+// Legacy properties recorded after a non-global match.
+{
+    "abc1def".match(/[0-9]/);
+    shouldBe(RegExp.lastMatch, "1");
+    shouldBe(RegExp.leftContext, "abc");
+    shouldBe(RegExp.rightContext, "def");
+}
+
+print("PASSED");

--- a/JSTests/stress/string-prototype-match-watchpoint-invalidation.js
+++ b/JSTests/stress/string-prototype-match-watchpoint-invalidation.js
@@ -1,0 +1,178 @@
+// Verifies that String.prototype.match honors dynamic mutations of @@match-related
+// state after DFG/FTL code has been compiled. Each test warms up the fast path,
+// then invalidates one watchpoint or the per-instance state and confirms the
+// override is observed.
+
+function shouldBe(actual, expected) {
+    var a = JSON.stringify(actual);
+    var e = JSON.stringify(expected);
+    if (a !== e)
+        throw new Error("expected " + e + " but got " + a);
+}
+
+// 1. Per-instance @@match override after JIT compilation with a primordial RegExp.
+(function () {
+    function match(str, re) { return str.match(re); }
+    noInline(match);
+    var re = /[0-9]/g;
+    for (var i = 0; i < 1e4; ++i)
+        shouldBe(match("a1b2c3", re), ["1", "2", "3"]);
+    re[Symbol.match] = function (s) { return ["override:" + s]; };
+    shouldBe(match("a1b2c3", re), ["override:a1b2c3"]);
+})();
+
+// 2. RegExp.prototype[@@match] replaced after JIT compilation.
+(function () {
+    function match(str, re) { return str.match(re); }
+    noInline(match);
+    var re = /[0-9]/g;
+    for (var i = 0; i < 1e4; ++i)
+        shouldBe(match("a1b2c3", re), ["1", "2", "3"]);
+    var saved = RegExp.prototype[Symbol.match];
+    RegExp.prototype[Symbol.match] = function (s) { return ["proto:" + s]; };
+    try {
+        shouldBe(match("a1b2c3", re), ["proto:a1b2c3"]);
+    } finally {
+        RegExp.prototype[Symbol.match] = saved;
+    }
+})();
+
+// 3. RegExp.prototype.exec replaced after JIT compilation.
+(function () {
+    function match(str, re) { return str.match(re); }
+    noInline(match);
+    var re = /[0-9]/g;
+    for (var i = 0; i < 1e4; ++i)
+        shouldBe(match("a1b2c3", re), ["1", "2", "3"]);
+    var saved = RegExp.prototype.exec;
+    var execCount = 0;
+    RegExp.prototype.exec = function (s) {
+        execCount++;
+        return saved.call(this, s);
+    };
+    try {
+        shouldBe(match("a1b2c3", re), ["1", "2", "3"]);
+        if (execCount === 0)
+            throw new Error("custom RegExp.prototype.exec must be observed");
+    } finally {
+        RegExp.prototype.exec = saved;
+    }
+})();
+
+// 4. String.prototype[@@match] defined after JIT compilation with a string regexp.
+(function () {
+    function match(str, pat) { return str.match(pat); }
+    noInline(match);
+    for (var i = 0; i < 1e4; ++i)
+        shouldBe(match("abc1def2", "[0-9]"), ["1"]);
+    // Per current spec ("2. If regexp is not Object"), a primitive pattern argument
+    // does NOT trigger a GetMethod(@@match) lookup, so a user-installed
+    // String.prototype[@@match] is not observed for a primitive string pattern.
+    // (See also test262 cstm-matcher-on-string-primitive.js.)
+    Object.defineProperty(String.prototype, Symbol.match, {
+        configurable: true,
+        value: function () { return ["string-proto"]; }
+    });
+    try {
+        shouldBe(match("abc1def2", "[0-9]"), ["1"]);
+        // But a String *object* DOES go through @@match.
+        shouldBe("abc1def2".match(new String("[0-9]")), ["string-proto"]);
+    } finally {
+        delete String.prototype[Symbol.match];
+    }
+})();
+
+// 5. RegExp.prototype.global replaced after JIT compilation.
+(function () {
+    function match(str, re) { return str.match(re); }
+    noInline(match);
+    var re = /[0-9]/g;
+    for (var i = 0; i < 1e4; ++i)
+        shouldBe(match("a1b2c3", re), ["1", "2", "3"]);
+    var savedDescriptor = Object.getOwnPropertyDescriptor(RegExp.prototype, "global");
+    Object.defineProperty(RegExp.prototype, "global", {
+        configurable: true,
+        get() { return false; }
+    });
+    try {
+        // With global=false, RegExp.prototype[@@match] takes the non-global path:
+        // a single RegExpExec(R, S). lastIndex stays 0 after the global resets above.
+        shouldBe(match("a1b2c3", re), ["1"]);
+    } finally {
+        Object.defineProperty(RegExp.prototype, "global", savedDescriptor);
+    }
+})();
+
+// 6. Setting non-numeric lastIndex after JIT compilation.
+(function () {
+    function match(str, re) { return str.match(re); }
+    noInline(match);
+    var re = /[0-9]/g;
+    for (var i = 0; i < 1e4; ++i)
+        shouldBe(match("a1b2c3", re), ["1", "2", "3"]);
+    var valueOfCount = 0;
+    re.lastIndex = { valueOf() { valueOfCount++; return 0; } };
+    shouldBe(match("a1b2c3", re), ["1", "2", "3"]);
+    // The slow path is hit after this since the compiled fast path bailed out.
+})();
+
+// 7. Reflect.setPrototypeOf to a non-RegExp prototype after JIT compilation.
+(function () {
+    function match(str, re) { return str.match(re); }
+    noInline(match);
+    var re = /[0-9]/g;
+    for (var i = 0; i < 1e4; ++i)
+        shouldBe(match("a1b2c3", re), ["1", "2", "3"]);
+    var weird = /[0-9]/g;
+    Object.setPrototypeOf(weird, {
+        [Symbol.match](s) { return ["weird:" + s]; }
+    });
+    shouldBe(match("a1b2c3", weird), ["weird:a1b2c3"]);
+    // The fast path must keep working for normal regexps after seeing one weird instance.
+    shouldBe(match("a1b2c3", re), ["1", "2", "3"]);
+})();
+
+// 8. ToString(this) mutates the regexp instance between the fast-path check and
+//    the C++ RegExpMatchFast engine. Per spec, RegExp.prototype[@@match] reads
+//    R.flags and dispatches to RegExpExec(R, S) *after* S = ToString(string), so
+//    the user-installed exec must be observed.
+(function () {
+    var re = /a/;
+    var receiver = {
+        toString() {
+            re.exec = function () { var r = ["evil"]; r.index = 0; r.input = "abc"; return r; };
+            return "abc";
+        }
+    };
+    shouldBe(String.prototype.match.call(receiver, re), ["evil"]);
+})();
+(function () {
+    // Mutating RegExp.prototype.exec inside ToString fires regExpPrimordialPropertiesWatchpointSet.
+    var re = /a/;
+    var saved = RegExp.prototype.exec;
+    var receiver = {
+        toString() {
+            RegExp.prototype.exec = function () { var r = ["evil"]; r.index = 0; r.input = "abc"; return r; };
+            return "abc";
+        }
+    };
+    try {
+        shouldBe(String.prototype.match.call(receiver, re), ["evil"]);
+    } finally {
+        RegExp.prototype.exec = saved;
+    }
+})();
+(function () {
+    // Mutating lastIndex to a non-number inside ToString.
+    var re = /a/g;
+    var valueOfCount = 0;
+    var receiver = {
+        toString() {
+            re.lastIndex = { valueOf() { valueOfCount++; return 0; } };
+            return "abc";
+        }
+    };
+    shouldBe(String.prototype.match.call(receiver, re), ["a"]);
+})();
+
+print("PASSED");

--- a/Source/JavaScriptCore/builtins/StringPrototype.js
+++ b/Source/JavaScriptCore/builtins/StringPrototype.js
@@ -25,24 +25,6 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-function match(regexp)
-{
-    "use strict";
-
-    if (@isUndefinedOrNull(this))
-        @throwTypeError("String.prototype.match requires that |this| not be null or undefined");
-
-    if (@isObject(regexp)) {
-        var matcher = regexp.@@match;
-        if (!@isUndefinedOrNull(matcher))
-            return matcher.@call(regexp, this);
-    }
-
-    var thisString = @toString(this);
-    var createdRegExp = @regExpCreate(regexp, @undefined);
-    return createdRegExp.@@match(thisString);
-}
-
 function matchAll(arg)
 {
     "use strict";

--- a/Source/JavaScriptCore/dfg/DFGAbstractInterpreterInlines.h
+++ b/Source/JavaScriptCore/dfg/DFGAbstractInterpreterInlines.h
@@ -2704,6 +2704,11 @@ bool AbstractInterpreter<AbstractStateType>::executeEffects(unsigned clobberLimi
             setTypeForNode(node, SpecArray);
         break;
 
+    case StringMatch:
+        clobberWorld();
+        makeHeapTopForNode(node);
+        break;
+
     case StringFromCharCode: {
         if (node->child1().useKind() == Int32Use || node->child1().useKind() == KnownInt32Use) {
             if (node->child1()->isInt32Constant() && node->child1()->asUInt32() <= maxSingleCharacterString) {

--- a/Source/JavaScriptCore/dfg/DFGBackwardsPropagationPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGBackwardsPropagationPhase.cpp
@@ -375,6 +375,12 @@ private:
             break;
         }
 
+        case StringMatch: {
+            node->child1()->mergeFlags(NodeBytecodeUsesAsValue);
+            node->child2()->mergeFlags(NodeBytecodeUsesAsValue);
+            break;
+        }
+
         case StringSlice:
         case StringSubstring: {
             node->child1()->mergeFlags(NodeBytecodeUsesAsValue);

--- a/Source/JavaScriptCore/dfg/DFGByteCodeParser.cpp
+++ b/Source/JavaScriptCore/dfg/DFGByteCodeParser.cpp
@@ -3225,6 +3225,30 @@ auto ByteCodeParser::handleIntrinsicCall(Node* callee, Operand resultOperand, Ca
             return CallOptimizationResult::Inlined;
         }
 
+        case StringPrototypeMatchIntrinsic: {
+            if (argumentCountIncludingThis < 2)
+                return CallOptimizationResult::DidNothing;
+
+            if (m_inlineStackTop->m_exitProfile.hasExitSite(m_currentIndex, BadType))
+                return CallOptimizationResult::DidNothing;
+
+            if (m_inlineStackTop->m_exitProfile.hasExitSite(m_currentIndex, BadConstantValue))
+                return CallOptimizationResult::DidNothing;
+
+            if (m_inlineStackTop->m_exitProfile.hasExitSite(m_currentIndex, BadCache))
+                return CallOptimizationResult::DidNothing;
+
+            if (!m_graph.isWatchingStringSymbolMatchWatchpoint(currentCodeOrigin()))
+                return CallOptimizationResult::DidNothing;
+
+            insertChecks();
+            Node* thisValue = get(virtualRegisterForArgumentIncludingThis(0, registerOffset));
+            Node* regexp = get(virtualRegisterForArgumentIncludingThis(1, registerOffset));
+            Node* result = addToGraph(StringMatch, thisValue, regexp);
+            setResult(result);
+            return CallOptimizationResult::Inlined;
+        }
+
         case StringPrototypeStartsWithIntrinsic:
         case StringPrototypeEndsWithIntrinsic: {
             if (argumentCountIncludingThis < 2)

--- a/Source/JavaScriptCore/dfg/DFGClobberize.h
+++ b/Source/JavaScriptCore/dfg/DFGClobberize.h
@@ -2301,6 +2301,7 @@ void clobberize(Graph& graph, Node* node, const ReadFunctor& read, const WriteFu
         return;
 
     case StringSplit:
+    case StringMatch:
         clobberTop();
         return;
 

--- a/Source/JavaScriptCore/dfg/DFGCloneHelper.h
+++ b/Source/JavaScriptCore/dfg/DFGCloneHelper.h
@@ -349,6 +349,7 @@ BasicBlock* CloneHelper::cloneBlock(BasicBlock* const block, const CustomizeSucc
     CLONE_STATUS(StringReplaceString, Common) \
     CLONE_STATUS(StringSlice, Common) \
     CLONE_STATUS(StringSplit, Common) \
+    CLONE_STATUS(StringMatch, Common) \
     CLONE_STATUS(StringSubstring, Common) \
     CLONE_STATUS(StrCat, Common) \
     CLONE_STATUS(Switch, Special) \

--- a/Source/JavaScriptCore/dfg/DFGDoesGC.cpp
+++ b/Source/JavaScriptCore/dfg/DFGDoesGC.cpp
@@ -497,6 +497,7 @@ bool doesGC(Graph& graph, Node* node)
     case StringStartsWith:
     case StringEndsWith:
     case StringSplit:
+    case StringMatch:
     case ResolvePromiseFirstResolving:
     case RejectPromiseFirstResolving:
     case FulfillPromiseFirstResolving:

--- a/Source/JavaScriptCore/dfg/DFGFixupPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGFixupPhase.cpp
@@ -1169,6 +1169,32 @@ private:
             break;
         }
 
+        case StringMatch: {
+            if (node->child2()->shouldSpeculateRegExpObject()) {
+                if (m_graph.isWatchingRegExpPrimordialPropertiesWatchpoint(node)) {
+                    addStringMatchPrimordialChecks(node->child2().node());
+
+                    JSGlobalObject* globalObject = m_graph.globalObjectFor(node->origin.semantic);
+                    Node* globalObjectNode = m_insertionSet.insertNode(
+                        m_indexInBlock, SpecObjectOther, JSConstant, node->origin,
+                        OpInfo(m_graph.freeze(globalObject)));
+
+                    node->convertToRegExpMatchFast(globalObjectNode);
+
+                    fixEdge<KnownCellUse>(node->child1());
+                    fixEdge<RegExpObjectUse>(node->child2());
+                    fixEdge<StringUse>(node->child3());
+                    break;
+                }
+                fixEdge<StringUse>(node->child1());
+                fixEdge<RegExpObjectUse>(node->child2());
+                break;
+            }
+            fixEdge<StringUse>(node->child1());
+            fixEdge<StringUse>(node->child2());
+            break;
+        }
+
         case EnumeratorGetByVal: {
             fixEdge<KnownInt32Use>(m_graph.varArgChild(node, 3));
             fixEdge<KnownInt32Use>(m_graph.varArgChild(node, 4));
@@ -4535,6 +4561,27 @@ private:
         emitPrimordialCheckFor(globalObject->regExpProtoUnicodeSetsGetter(), vm().propertyNames->unicodeSets.impl());
         // Check that searchRegExp[Symbol.replace] is the primordial RegExp.prototype[Symbol.replace]
         emitPrimordialCheckFor(globalObject->regExpProtoSymbolReplaceFunction(), vm().propertyNames->replaceSymbol.impl());
+    }
+
+    void addStringMatchPrimordialChecks(Node* regExp)
+    {
+        Node* node = m_currentNode;
+        JSGlobalObject* globalObject = m_graph.globalObjectFor(node->origin.semantic);
+
+        m_insertionSet.insertNode(
+            m_indexInBlock, SpecNone, Check, node->origin,
+            Edge(regExp, RegExpObjectUse));
+        m_insertionSet.insertNode(
+            m_indexInBlock, SpecNone, CheckStructure, node->origin,
+            OpInfo(m_graph.addStructureSet(globalObject->regExpStructure())),
+            Edge(regExp, KnownCellUse));
+
+        Node* lastIndexProperty = m_insertionSet.insertNode(
+            m_indexInBlock, SpecNone, GetRegExpObjectLastIndex, node->origin,
+            Edge(regExp, RegExpObjectUse));
+        m_insertionSet.insertNode(
+            m_indexInBlock, SpecNone, Check, node->origin,
+            Edge(lastIndexProperty, NumberUse));
     }
 
     void addRegExpSearchPrimordialChecks(Node* searchRegExp)

--- a/Source/JavaScriptCore/dfg/DFGGraph.h
+++ b/Source/JavaScriptCore/dfg/DFGGraph.h
@@ -999,6 +999,13 @@ public:
         return isWatchingGlobalObjectWatchpoint(globalObject, set, LinkerIR::Type::StringValueOfWatchpointSet);
     }
 
+    bool isWatchingStringSymbolMatchWatchpoint(const CodeOrigin& semanticOrigin)
+    {
+        JSGlobalObject* globalObject = globalObjectFor(semanticOrigin);
+        InlineWatchpointSet& set = globalObject->stringSymbolMatchWatchpointSet();
+        return isWatchingGlobalObjectWatchpoint(globalObject, set, LinkerIR::Type::StringSymbolMatchWatchpointSet);
+    }
+
     bool isWatchingStringSymbolReplaceWatchpoint(const CodeOrigin& semanticOrigin)
     {
         JSGlobalObject* globalObject = globalObjectFor(semanticOrigin);

--- a/Source/JavaScriptCore/dfg/DFGJITCode.cpp
+++ b/Source/JavaScriptCore/dfg/DFGJITCode.cpp
@@ -53,6 +53,7 @@ JITData::JITData(unsigned propertyCacheSize, unsigned poolSize, const JITCode& j
         case LinkerIR::Type::StructureCacheClearedWatchpointSet:
         case LinkerIR::Type::StringToStringWatchpointSet:
         case LinkerIR::Type::StringValueOfWatchpointSet:
+        case LinkerIR::Type::StringSymbolMatchWatchpointSet:
         case LinkerIR::Type::StringSymbolReplaceWatchpointSet:
         case LinkerIR::Type::StringSymbolSplitWatchpointSet:
         case LinkerIR::Type::StringSymbolToPrimitiveWatchpointSet:
@@ -172,6 +173,11 @@ bool JITData::tryInitialize(VM& vm, CodeBlock* codeBlock, const JITCode& jitCode
         case LinkerIR::Type::StringValueOfWatchpointSet: {
             auto& watchpoint = m_watchpoints[indexOfWatchpoints++];
             success &= attemptToWatch(codeBlock, m_globalObject->stringValueOfWatchpointSet(), watchpoint);
+            break;
+        }
+        case LinkerIR::Type::StringSymbolMatchWatchpointSet: {
+            auto& watchpoint = m_watchpoints[indexOfWatchpoints++];
+            success &= attemptToWatch(codeBlock, m_globalObject->stringSymbolMatchWatchpointSet(), watchpoint);
             break;
         }
         case LinkerIR::Type::StringSymbolReplaceWatchpointSet: {

--- a/Source/JavaScriptCore/dfg/DFGJITCode.h
+++ b/Source/JavaScriptCore/dfg/DFGJITCode.h
@@ -101,6 +101,7 @@ public:
         StructureCacheClearedWatchpointSet,
         StringToStringWatchpointSet,
         StringValueOfWatchpointSet,
+        StringSymbolMatchWatchpointSet,
         StringSymbolReplaceWatchpointSet,
         StringSymbolSplitWatchpointSet,
         StringSymbolToPrimitiveWatchpointSet,

--- a/Source/JavaScriptCore/dfg/DFGNode.cpp
+++ b/Source/JavaScriptCore/dfg/DFGNode.cpp
@@ -367,6 +367,15 @@ void Node::convertToRegExpMatchFastGlobalWithoutChecks(FrozenValue* regExp)
     m_opInfo = regExp;
 }
 
+void Node::convertToRegExpMatchFast(Node* globalObjectNode)
+{
+    ASSERT(op() == StringMatch);
+    Edge stringEdge = child1();
+    Edge regExpEdge = child2();
+    setOpAndDefaultFlags(RegExpMatchFast);
+    children = AdjacencyList(AdjacencyList::Fixed, Edge(globalObjectNode), regExpEdge, stringEdge);
+}
+
 void Node::convertToDefineDataProperty(Graph& graph, Edge base, Edge property, Edge value, Edge attributes)
 {
     ASSERT(op() == ObjectDefinePropertyFromFields);

--- a/Source/JavaScriptCore/dfg/DFGNode.h
+++ b/Source/JavaScriptCore/dfg/DFGNode.h
@@ -961,6 +961,7 @@ public:
 
     void NODELETE convertToRegExpExecNonGlobalOrStickyWithoutChecks(FrozenValue* regExp);
     void NODELETE convertToRegExpMatchFastGlobalWithoutChecks(FrozenValue* regExp);
+    void NODELETE convertToRegExpMatchFast(Node* globalObjectNode);
     void NODELETE convertToRegExpTestInline(FrozenValue* globalObject, FrozenValue* regExp);
 
     enum DescriptorSlot : unsigned {

--- a/Source/JavaScriptCore/dfg/DFGNodeType.h
+++ b/Source/JavaScriptCore/dfg/DFGNodeType.h
@@ -369,6 +369,7 @@ namespace JSC { namespace DFG {
     macro(StringStartsWith, NodeResultBoolean) \
     macro(StringEndsWith, NodeResultBoolean) \
     macro(StringSplit, NodeResultJS | NodeMustGenerate) \
+    macro(StringMatch, NodeResultJS | NodeMustGenerate) \
     \
     /* Optimizations for string access */ \
     macro(StringAt, NodeResultJS) \

--- a/Source/JavaScriptCore/dfg/DFGOperations.cpp
+++ b/Source/JavaScriptCore/dfg/DFGOperations.cpp
@@ -3903,6 +3903,44 @@ JSC_DEFINE_JIT_OPERATION(operationStringSplitRegExp, EncodedJSValue, (JSGlobalOb
     OPERATION_RETURN(scope, JSValue::encode(stringSplitFast(globalObject, thisString, separatorString, limit)));
 }
 
+JSC_DEFINE_JIT_OPERATION(operationStringMatch, EncodedJSValue, (JSGlobalObject* globalObject, JSString* thisString, JSString* regexpString))
+{
+    VM& vm = globalObject->vm();
+    CallFrame* callFrame = DECLARE_CALL_FRAME(vm);
+    JITOperationPrologueCallFrameTracer tracer(vm, callFrame);
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
+    OPERATION_RETURN(scope, JSValue::encode(stringMatchSlow(globalObject, thisString, regexpString)));
+}
+
+JSC_DEFINE_JIT_OPERATION(operationStringMatchRegExp, EncodedJSValue, (JSGlobalObject* globalObject, JSString* thisString, RegExpObject* regexp))
+{
+    VM& vm = globalObject->vm();
+    CallFrame* callFrame = DECLARE_CALL_FRAME(vm);
+    JITOperationPrologueCallFrameTracer tracer(vm, callFrame);
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
+    if (regexp->isSymbolMatchFastAndNonObservable()) [[likely]]
+        OPERATION_RETURN(scope, JSValue::encode(regExpMatchFast(globalObject, regexp, thisString)));
+
+    JSValue matcher = regexp->get(globalObject, vm.propertyNames->matchSymbol);
+    OPERATION_RETURN_IF_EXCEPTION(scope, encodedJSValue());
+    if (!matcher.isUndefinedOrNull()) {
+        auto callData = JSC::getCallData(matcher);
+        if (callData.type == CallData::Type::None) [[unlikely]] {
+            throwTypeError(globalObject, scope, "@@match method is not callable"_s);
+            OPERATION_RETURN(scope, encodedJSValue());
+        }
+        std::array<EncodedJSValue, 1> args { {
+            JSValue::encode(thisString),
+        } };
+        JSValue result = call(globalObject, matcher, callData, regexp, ArgList { args.data(), args.size() });
+        OPERATION_RETURN_IF_EXCEPTION(scope, encodedJSValue());
+        OPERATION_RETURN(scope, JSValue::encode(result));
+    }
+    OPERATION_RETURN(scope, JSValue::encode(stringMatchSlow(globalObject, thisString, regexp)));
+}
+
 JSC_DEFINE_JIT_OPERATION(operationStringProtoFuncReplaceGeneric, JSCell*, (JSGlobalObject* globalObject, EncodedJSValue thisValue, EncodedJSValue searchValue, EncodedJSValue replaceValue))
 {
     VM& vm = globalObject->vm();

--- a/Source/JavaScriptCore/dfg/DFGOperations.h
+++ b/Source/JavaScriptCore/dfg/DFGOperations.h
@@ -313,6 +313,8 @@ JSC_DECLARE_JIT_OPERATION(operationStringEndsWith, bool, (JSGlobalObject*, JSStr
 JSC_DECLARE_JIT_OPERATION(operationStringEndsWithWithEndPosition, bool, (JSGlobalObject*, JSString*, JSString*, int32_t));
 JSC_DECLARE_JIT_OPERATION(operationStringSplit, JSCell*, (JSGlobalObject*, JSString*, JSString*, EncodedJSValue));
 JSC_DECLARE_JIT_OPERATION(operationStringSplitRegExp, EncodedJSValue, (JSGlobalObject*, JSString*, RegExpObject*, EncodedJSValue));
+JSC_DECLARE_JIT_OPERATION(operationStringMatch, EncodedJSValue, (JSGlobalObject*, JSString*, JSString*));
+JSC_DECLARE_JIT_OPERATION(operationStringMatchRegExp, EncodedJSValue, (JSGlobalObject*, JSString*, RegExpObject*));
 
 JSC_DECLARE_JIT_OPERATION(operationStringProtoFuncReplaceGeneric, JSCell*, (JSGlobalObject*, EncodedJSValue thisValue, EncodedJSValue searchValue, EncodedJSValue replaceValue));
 JSC_DECLARE_JIT_OPERATION(operationStringProtoFuncReplaceAllGeneric, JSCell*, (JSGlobalObject*, EncodedJSValue thisValue, EncodedJSValue searchValue, EncodedJSValue replaceValue));

--- a/Source/JavaScriptCore/dfg/DFGPredictionPropagationPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGPredictionPropagationPhase.cpp
@@ -1221,6 +1221,11 @@ private:
             break;
         }
 
+        case StringMatch: {
+            setPrediction(SpecOther | SpecArray);
+            break;
+        }
+
         case StringLocaleCompare: {
             setPrediction(SpecInt32Only);
             break;

--- a/Source/JavaScriptCore/dfg/DFGSafeToExecute.h
+++ b/Source/JavaScriptCore/dfg/DFGSafeToExecute.h
@@ -641,6 +641,7 @@ bool safeToExecute(AbstractStateType& state, Graph& graph, Node* node, bool igno
     case RegExpMatchFast:
     case RegExpMatchFastGlobal:
     case RegExpSearch:
+    case StringMatch:
     case Call:
     case DirectCall:
     case TailCallInlinedCaller:

--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp
@@ -17861,7 +17861,6 @@ void SpeculativeJIT::compileStringSplit(Node* node)
         JSValueRegsFlushedCallResult result(this);
         JSValueRegs resultRegs = result.regs();
         callOperation(operationStringSplitRegExp, resultRegs, LinkableConstant::globalObject(*this, node), baseGPR, separatorGPR, limitRegs);
-        exceptionCheck();
         jsValueResult(resultRegs, node);
         return;
     }
@@ -17881,8 +17880,37 @@ void SpeculativeJIT::compileStringSplit(Node* node)
     GPRFlushedCallResult result(this);
     GPRReg resultGPR = result.gpr();
     callOperation(operationStringSplit, resultGPR, LinkableConstant::globalObject(*this, node), baseGPR, separatorGPR, limitRegs);
-    exceptionCheck();
     cellResult(resultGPR, node);
+}
+
+void SpeculativeJIT::compileStringMatch(Node* node)
+{
+    SpeculateCellOperand base(this, node->child1());
+    SpeculateCellOperand regexp(this, node->child2());
+
+    GPRReg baseGPR = base.gpr();
+    GPRReg regexpGPR = regexp.gpr();
+
+    speculateString(node->child1(), baseGPR);
+
+    if (node->child2().useKind() == RegExpObjectUse) {
+        speculateRegExpObject(node->child2(), regexpGPR);
+
+        flushRegisters();
+        JSValueRegsFlushedCallResult result(this);
+        JSValueRegs resultRegs = result.regs();
+        callOperation(operationStringMatchRegExp, resultRegs, LinkableConstant::globalObject(*this, node), baseGPR, regexpGPR);
+        jsValueResult(resultRegs, node);
+        return;
+    }
+
+    speculateString(node->child2(), regexpGPR);
+
+    flushRegisters();
+    JSValueRegsFlushedCallResult result(this);
+    JSValueRegs resultRegs = result.regs();
+    callOperation(operationStringMatch, resultRegs, LinkableConstant::globalObject(*this, node), baseGPR, regexpGPR);
+    jsValueResult(resultRegs, node);
 }
 
 void SpeculativeJIT::compileStringLastIndexOf(Node* node)

--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.h
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.h
@@ -1804,6 +1804,7 @@ public:
     void compileStringLastIndexOf(Node*);
     void compileStringStartsOrEndsWith(Node*);
     void compileStringSplit(Node*);
+    void compileStringMatch(Node*);
     void compileDateGet(Node*);
     void compileDateSet(Node*);
     void compileGlobalIsNaN(Node*);

--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT32_64.cpp
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT32_64.cpp
@@ -3172,6 +3172,11 @@ void SpeculativeJIT::compile(Node* node)
         break;
     }
 
+    case StringMatch: {
+        compileStringMatch(node);
+        break;
+    }
+
     case StringLastIndexOf: {
         compileStringLastIndexOf(node);
         break;

--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT64.cpp
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT64.cpp
@@ -3789,6 +3789,11 @@ void SpeculativeJIT::compile(Node* node)
         break;
     }
 
+    case StringMatch: {
+        compileStringMatch(node);
+        break;
+    }
+
     case StringLastIndexOf: {
         compileStringLastIndexOf(node);
         break;

--- a/Source/JavaScriptCore/ftl/FTLCapabilities.cpp
+++ b/Source/JavaScriptCore/ftl/FTLCapabilities.cpp
@@ -179,6 +179,7 @@ inline CapabilityLevel canCompile(Node* node)
     case StringStartsWith:
     case StringEndsWith:
     case StringSplit:
+    case StringMatch:
     case AllocatePropertyStorage:
     case ReallocatePropertyStorage:
     case NukeStructureAndSetButterfly:

--- a/Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp
+++ b/Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp
@@ -1404,6 +1404,9 @@ private:
         case StringSplit:
             compileStringSplit();
             break;
+        case StringMatch:
+            compileStringMatch();
+            break;
         case GetByOffset:
         case GetGetterSetterByOffset:
             compileGetByOffset();
@@ -12102,6 +12105,19 @@ IGNORE_CLANG_WARNINGS_END
         }
         LValue separator = lowString(m_node->child2());
         setJSValue(vmCall(pointerType(), operationStringSplit, weakPointer(globalObject), base, separator, limit));
+    }
+
+    void compileStringMatch()
+    {
+        LValue base = lowString(m_node->child1());
+        auto* globalObject = m_graph.globalObjectFor(m_origin.semantic);
+        if (m_node->child2().useKind() == RegExpObjectUse) {
+            LValue regexp = lowRegExpObject(m_node->child2());
+            setJSValue(vmCall(Int64, operationStringMatchRegExp, weakPointer(globalObject), base, regexp));
+            return;
+        }
+        LValue regexp = lowString(m_node->child2());
+        setJSValue(vmCall(Int64, operationStringMatch, weakPointer(globalObject), base, regexp));
     }
 
     void compileStringLastIndexOf()

--- a/Source/JavaScriptCore/runtime/Intrinsic.h
+++ b/Source/JavaScriptCore/runtime/Intrinsic.h
@@ -130,6 +130,7 @@ namespace JSC {
     macro(StringPrototypeEndsWithIntrinsic) \
     macro(StringPrototypeLocaleCompareIntrinsic) \
     macro(StringPrototypeValueOfIntrinsic) \
+    macro(StringPrototypeMatchIntrinsic) \
     macro(StringPrototypeReplaceIntrinsic) \
     macro(StringPrototypeReplaceAllIntrinsic) \
     macro(StringPrototypeSplitIntrinsic) \

--- a/Source/JavaScriptCore/runtime/JSGlobalObject.cpp
+++ b/Source/JavaScriptCore/runtime/JSGlobalObject.cpp
@@ -2289,6 +2289,8 @@ capitalName ## Constructor* lowerName ## Constructor = featureFlag ? capitalName
     installObjectPropertyChangeAdaptiveWatchpoint(setupAdaptiveWatchpoint(this, m_promiseConstructor.get(), vm.propertyNames->resolve), m_promiseResolveWatchpointSet);
 
     // Detect property absence.
+    installObjectAdaptiveStructureWatchpoint(setupAbsenceAdaptiveWatchpoint(this, m_stringPrototype.get(), vm.propertyNames->matchSymbol, objectPrototype()), m_stringSymbolMatchWatchpointSet);
+    installObjectAdaptiveStructureWatchpoint(setupAbsenceAdaptiveWatchpoint(this, m_objectPrototype.get(), vm.propertyNames->matchSymbol, nullptr), m_stringSymbolMatchWatchpointSet);
     installObjectAdaptiveStructureWatchpoint(setupAbsenceAdaptiveWatchpoint(this, m_stringPrototype.get(), vm.propertyNames->replaceSymbol, objectPrototype()), m_stringSymbolReplaceWatchpointSet);
     installObjectAdaptiveStructureWatchpoint(setupAbsenceAdaptiveWatchpoint(this, m_objectPrototype.get(), vm.propertyNames->replaceSymbol, nullptr), m_stringSymbolReplaceWatchpointSet);
     installObjectAdaptiveStructureWatchpoint(setupAbsenceAdaptiveWatchpoint(this, m_stringPrototype.get(), vm.propertyNames->splitSymbol, objectPrototype()), m_stringSymbolSplitWatchpointSet);

--- a/Source/JavaScriptCore/runtime/JSGlobalObject.h
+++ b/Source/JavaScriptCore/runtime/JSGlobalObject.h
@@ -512,6 +512,7 @@ public:
     InlineWatchpointSet m_mapIteratorProtocolWatchpointSet { IsWatched };
     InlineWatchpointSet m_setIteratorProtocolWatchpointSet { IsWatched };
     InlineWatchpointSet m_stringIteratorProtocolWatchpointSet { IsWatched };
+    InlineWatchpointSet m_stringSymbolMatchWatchpointSet { IsWatched };
     InlineWatchpointSet m_stringSymbolReplaceWatchpointSet { IsWatched };
     InlineWatchpointSet m_stringSymbolSplitWatchpointSet { IsWatched };
     InlineWatchpointSet m_stringSymbolToPrimitiveWatchpointSet { IsWatched };
@@ -588,6 +589,7 @@ public:
     InlineWatchpointSet& mapIteratorProtocolWatchpointSet() LIFETIME_BOUND { return m_mapIteratorProtocolWatchpointSet; }
     InlineWatchpointSet& setIteratorProtocolWatchpointSet() LIFETIME_BOUND { return m_setIteratorProtocolWatchpointSet; }
     InlineWatchpointSet& stringIteratorProtocolWatchpointSet() LIFETIME_BOUND { return m_stringIteratorProtocolWatchpointSet; }
+    InlineWatchpointSet& stringSymbolMatchWatchpointSet() LIFETIME_BOUND { return m_stringSymbolMatchWatchpointSet; }
     InlineWatchpointSet& stringSymbolReplaceWatchpointSet() LIFETIME_BOUND { return m_stringSymbolReplaceWatchpointSet; }
     InlineWatchpointSet& stringSymbolSplitWatchpointSet() LIFETIME_BOUND { return m_stringSymbolSplitWatchpointSet; }
     InlineWatchpointSet& stringSymbolToPrimitiveWatchpointSet() LIFETIME_BOUND { return m_stringSymbolToPrimitiveWatchpointSet; }

--- a/Source/JavaScriptCore/runtime/RegExpConstructor.cpp
+++ b/Source/JavaScriptCore/runtime/RegExpConstructor.cpp
@@ -309,7 +309,7 @@ inline OptionSet<Yarr::Flags> toFlags(JSGlobalObject* globalObject, JSValue flag
     return result.value();
 }
 
-static JSObject* regExpCreate(JSGlobalObject* globalObject, JSValue newTarget, JSValue patternArg, JSValue flagsArg)
+JSObject* regExpCreate(JSGlobalObject* globalObject, JSValue newTarget, JSValue patternArg, JSValue flagsArg)
 {
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);

--- a/Source/JavaScriptCore/runtime/RegExpConstructor.h
+++ b/Source/JavaScriptCore/runtime/RegExpConstructor.h
@@ -54,6 +54,7 @@ private:
 STATIC_ASSERT_ISO_SUBSPACE_SHARABLE(RegExpConstructor, InternalFunction);
 
 JSObject* constructRegExp(JSGlobalObject*, const ArgList&, JSObject* callee = nullptr, JSValue newTarget = JSValue());
+JSObject* regExpCreate(JSGlobalObject*, JSValue newTarget, JSValue patternArg, JSValue flagsArg);
 
 ALWAYS_INLINE bool isRegExp(VM&, JSGlobalObject*, JSValue); // Defined in RegExpConstructorInlines.h
 

--- a/Source/JavaScriptCore/runtime/RegExpObject.h
+++ b/Source/JavaScriptCore/runtime/RegExpObject.h
@@ -111,6 +111,7 @@ public:
     MatchResult match(JSGlobalObject*, JSString*);
     JSValue matchGlobal(JSGlobalObject*, JSString*);
 
+    bool isSymbolMatchFastAndNonObservable();
     bool isSymbolReplaceFastAndNonObservable();
     bool isSymbolSplitFastAndNonObservable();
 

--- a/Source/JavaScriptCore/runtime/RegExpObjectInlines.h
+++ b/Source/JavaScriptCore/runtime/RegExpObjectInlines.h
@@ -34,6 +34,34 @@
 
 namespace JSC {
 
+ALWAYS_INLINE bool RegExpObject::isSymbolMatchFastAndNonObservable()
+{
+    JSGlobalObject* globalObject = this->realm();
+    if (!globalObject->regExpPrimordialPropertiesWatchpointSet().isStillValid())
+        return false;
+
+    if (!globalObject->stringSymbolMatchWatchpointSet().isStillValid())
+        return false;
+
+    if (!getLastIndex().isNumber())
+        return false;
+
+    Structure* structure = this->structure();
+    if (structure == globalObject->regExpStructure()) [[likely]]
+        return true;
+
+    if (structure->hasPolyProto())
+        return false;
+
+    if (structure->storedPrototype() != globalObject->regExpPrototype())
+        return false;
+
+    if (hasCustomProperties())
+        return false;
+
+    return true;
+}
+
 ALWAYS_INLINE bool RegExpObject::isSymbolReplaceFastAndNonObservable()
 {
     JSGlobalObject* globalObject = this->realm();

--- a/Source/JavaScriptCore/runtime/RegExpPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/RegExpPrototype.cpp
@@ -190,13 +190,18 @@ JSC_DEFINE_HOST_FUNCTION(regExpProtoFuncExec, (JSGlobalObject* globalObject, Cal
     RELEASE_AND_RETURN(scope, JSValue::encode(regexp->exec(globalObject, string)));
 }
 
+JSValue regExpMatchFast(JSGlobalObject* globalObject, RegExpObject* regExpObject, JSString* string)
+{
+    if (!regExpObject->regExp()->global())
+        return regExpObject->exec(globalObject, string);
+    return regExpObject->matchGlobal(globalObject, string);
+}
+
 JSC_DEFINE_HOST_FUNCTION(regExpProtoFuncMatchFast, (JSGlobalObject* globalObject, CallFrame* callFrame))
 {
     RegExpObject* thisObject = uncheckedDowncast<RegExpObject>(callFrame->thisValue());
     JSString* string = uncheckedDowncast<JSString>(callFrame->uncheckedArgument(0));
-    if (!thisObject->regExp()->global())
-        return JSValue::encode(thisObject->exec(globalObject, string));
-    return JSValue::encode(thisObject->matchGlobal(globalObject, string));
+    return JSValue::encode(regExpMatchFast(globalObject, thisObject, string));
 }
 
 JSC_DEFINE_HOST_FUNCTION(regExpProtoFuncCompile, (JSGlobalObject* globalObject, CallFrame* callFrame))

--- a/Source/JavaScriptCore/runtime/RegExpPrototype.h
+++ b/Source/JavaScriptCore/runtime/RegExpPrototype.h
@@ -59,6 +59,7 @@ JSC_DECLARE_HOST_FUNCTION(regExpProtoFuncSplitFast);
 class RegExpObject;
 class JSString;
 
+JSValue regExpMatchFast(JSGlobalObject*, RegExpObject*, JSString* inputString);
 JSCell* regExpSplitFast(JSGlobalObject*, RegExpObject*, JSString* inputString, unsigned limit);
 
 } // namespace JSC

--- a/Source/JavaScriptCore/runtime/StringPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/StringPrototype.cpp
@@ -113,7 +113,6 @@ const ClassInfo StringPrototype::s_info = { "String"_s, &StringObject::s_info, &
 
 /* Source for StringConstructor.lut.h
 @begin stringPrototypeTable
-    match         JSBuiltin                      DontEnum|Function 1
     matchAll      JSBuiltin                      DontEnum|Function 1
     search        JSBuiltin                      DontEnum|Function 1
     anchor        stringProtoFuncAnchor          DontEnum|Function 1
@@ -169,6 +168,7 @@ void StringPrototype::finishCreation(VM& vm, JSGlobalObject* globalObject)
     JSC_NATIVE_INTRINSIC_FUNCTION_WITHOUT_TRANSITION("startsWith"_s, stringProtoFuncStartsWith, static_cast<unsigned>(PropertyAttribute::DontEnum), 1, ImplementationVisibility::Public, StringPrototypeStartsWithIntrinsic);
     JSC_NATIVE_INTRINSIC_FUNCTION_WITHOUT_TRANSITION("endsWith"_s, stringProtoFuncEndsWith, static_cast<unsigned>(PropertyAttribute::DontEnum), 1, ImplementationVisibility::Public, StringPrototypeEndsWithIntrinsic);
     JSC_NATIVE_INTRINSIC_FUNCTION_WITHOUT_TRANSITION("includes"_s, stringProtoFuncIncludes, static_cast<unsigned>(PropertyAttribute::DontEnum), 1, ImplementationVisibility::Public, StringPrototypeIncludesIntrinsic);
+    JSC_NATIVE_INTRINSIC_FUNCTION_WITHOUT_TRANSITION("match"_s, stringProtoFuncMatch, static_cast<unsigned>(PropertyAttribute::DontEnum), 1, ImplementationVisibility::Public, StringPrototypeMatchIntrinsic);
     JSC_NATIVE_INTRINSIC_FUNCTION_WITHOUT_TRANSITION("split"_s, stringProtoFuncSplit, static_cast<unsigned>(PropertyAttribute::DontEnum), 2, ImplementationVisibility::Public, StringPrototypeSplitIntrinsic);
     JSC_NATIVE_FUNCTION_WITHOUT_TRANSITION("normalize"_s, stringProtoFuncNormalize, static_cast<unsigned>(PropertyAttribute::DontEnum), 0, ImplementationVisibility::Public);
     JSC_NATIVE_INTRINSIC_FUNCTION_WITHOUT_TRANSITION(vm.propertyNames->builtinNames().charCodeAtPrivateName(), stringProtoFuncCharCodeAt, static_cast<unsigned>(PropertyAttribute::DontEnum), 1, ImplementationVisibility::Public, CharCodeAtIntrinsic);
@@ -1305,6 +1305,81 @@ JSC_DEFINE_HOST_FUNCTION(stringProtoFuncSplit, (JSGlobalObject* globalObject, Ca
     RETURN_IF_EXCEPTION(scope, { });
 
     RELEASE_AND_RETURN(scope, JSValue::encode(stringSplitFast(globalObject, thisString, separatorString, limit)));
+}
+
+JSValue stringMatchSlow(JSGlobalObject* globalObject, JSString* thisString, JSValue regexpValue)
+{
+    VM& vm = globalObject->vm();
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
+    JSObject* createdRegExp = regExpCreate(globalObject, JSValue(), regexpValue, jsUndefined());
+    RETURN_IF_EXCEPTION(scope, { });
+
+    if (auto* regExpObject = dynamicDowncast<RegExpObject>(createdRegExp); regExpObject && regExpObject->isSymbolMatchFastAndNonObservable()) [[likely]]
+        RELEASE_AND_RETURN(scope, regExpMatchFast(globalObject, regExpObject, thisString));
+
+    JSValue matcher = createdRegExp->get(globalObject, vm.propertyNames->matchSymbol);
+    RETURN_IF_EXCEPTION(scope, { });
+    auto callData = JSC::getCallData(matcher);
+    if (callData.type == CallData::Type::None) [[unlikely]] {
+        auto description = errorDescriptionForValue(globalObject, matcher);
+        RETURN_IF_EXCEPTION(scope, { });
+        throwTypeError(globalObject, scope, makeString(description, " is not a function"_s));
+        return { };
+    }
+    std::array<EncodedJSValue, 1> args { {
+        JSValue::encode(thisString),
+    } };
+    RELEASE_AND_RETURN(scope, call(globalObject, matcher, callData, createdRegExp, ArgList { args.data(), args.size() }));
+}
+
+JSC_DEFINE_HOST_FUNCTION(stringProtoFuncMatch, (JSGlobalObject* globalObject, CallFrame* callFrame))
+{
+    VM& vm = globalObject->vm();
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
+    JSValue thisValue = callFrame->thisValue();
+    if (!checkObjectCoercible(thisValue)) [[unlikely]]
+        return throwVMTypeError(globalObject, scope, "String.prototype.match requires that |this| not be null or undefined"_s);
+
+    JSValue regexpValue = callFrame->argument(0);
+
+    if (regexpValue.isObject()) {
+        if (auto* regExpObject = dynamicDowncast<RegExpObject>(regexpValue); regExpObject && regExpObject->isSymbolMatchFastAndNonObservable()) [[likely]] {
+            JSString* thisString = thisValue.toString(globalObject);
+            RETURN_IF_EXCEPTION(scope, { });
+            if (regExpObject->isSymbolMatchFastAndNonObservable()) [[likely]]
+                RELEASE_AND_RETURN(scope, JSValue::encode(regExpMatchFast(globalObject, regExpObject, thisString)));
+            JSValue matcher = globalObject->linkTimeConstant(LinkTimeConstant::regExpPrototypeSymbolMatch);
+            auto callData = JSC::getCallData(matcher);
+            ASSERT(callData.type != CallData::Type::None);
+            std::array<EncodedJSValue, 1> args { {
+                JSValue::encode(thisString),
+            } };
+            RELEASE_AND_RETURN(scope, JSValue::encode(call(globalObject, matcher, callData, regExpObject, ArgList { args.data(), args.size() })));
+        }
+
+        JSValue matcher = asObject(regexpValue)->get(globalObject, vm.propertyNames->matchSymbol);
+        RETURN_IF_EXCEPTION(scope, { });
+
+        if (!matcher.isUndefinedOrNull()) {
+            auto callData = JSC::getCallData(matcher);
+            if (callData.type == CallData::Type::None) [[unlikely]] {
+                auto description = errorDescriptionForValue(globalObject, matcher);
+                RETURN_IF_EXCEPTION(scope, { });
+                return throwVMTypeError(globalObject, scope, makeString(description, " is not a function"_s));
+            }
+            std::array<EncodedJSValue, 1> args { {
+                JSValue::encode(thisValue),
+            } };
+            RELEASE_AND_RETURN(scope, JSValue::encode(call(globalObject, matcher, callData, regexpValue, ArgList { args.data(), args.size() })));
+        }
+    }
+
+    JSString* thisString = thisValue.toString(globalObject);
+    RETURN_IF_EXCEPTION(scope, { });
+
+    RELEASE_AND_RETURN(scope, JSValue::encode(stringMatchSlow(globalObject, thisString, regexpValue)));
 }
 
 JSC_DEFINE_HOST_FUNCTION(stringProtoFuncSubstr, (JSGlobalObject* globalObject, CallFrame* callFrame))

--- a/Source/JavaScriptCore/runtime/StringPrototype.h
+++ b/Source/JavaScriptCore/runtime/StringPrototype.h
@@ -60,6 +60,8 @@ JSString* replaceUsingRegExpSearch(VM&, JSGlobalObject*, JSString*, JSValue sear
 JSString* replaceUsingRegExpSearch(VM&, JSGlobalObject*, JSString*, JSValue searchValue, JSValue replaceValue);
 
 JSC_DECLARE_HOST_FUNCTION(stringProtoFuncRepeatCharacter);
+JSC_DECLARE_HOST_FUNCTION(stringProtoFuncMatch);
+JSValue stringMatchSlow(JSGlobalObject*, JSString* thisString, JSValue regexpValue);
 JSC_DECLARE_HOST_FUNCTION(stringProtoFuncSplit);
 JSCell* stringSplitFast(JSGlobalObject*, JSString* thisString, JSString* separatorString, unsigned limit);
 JSC_DECLARE_HOST_FUNCTION(stringProtoFuncSubstring);


### PR DESCRIPTION
#### 1440f8619f8200437d51173a3a53aeb4b6f8de99
<pre>
[JSC] Implement `String#match` in C++
<a href="https://bugs.webkit.org/show_bug.cgi?id=314466">https://bugs.webkit.org/show_bug.cgi?id=314466</a>

Reviewed by Yusuke Suzuki.

Move String.prototype.match from a JS builtin to a C++ host function and add
a StringMatch DFG node, mirroring the String#split work in 312843@main.

Notes:

* StringMatch is converted to RegExpMatchFast in fixup so the existing
  RegExpMatchFastGlobal / RegExpExec strength reductions apply.

* addStringMatchPrimordialChecks uses a single CheckStructure instead of the
  TryGetById chain in addStringReplacePrimordialChecks. Fixup-inserted
  TryGetByIds have no bytecode profile and never specialise, so they stay as
  repeated vmCalls. CheckStructure is stricter (subclasses OSR exit) but
  matches isSymbolMatchFastAndNonObservable, and the parser bails on BadCache.

* isSymbolMatchFastAndNonObservable mirrors the replace variant: lastIndex must
  be a number since RegExp.prototype[@@match] reads it. No species watchpoint
  is needed since @@match does not use SpeciesConstructor.

* stringProtoFuncMatch re-validates after ToString(this), since a user toString
  can mutate the regexp before RegExp.prototype[@@match] reads flags/exec.

                                    TipOfTree                  Patched

regexp-match-digit-literal       64.9662+-0.6089     ^     62.2319+-0.5453        ^ definitely 1.0439x faster
string-match-digit-short        273.6600+-0.7725     ^    269.4541+-1.5833        ^ definitely 1.0156x faster
global-atom-match-one-char        0.7787+-0.0359     ^      0.5617+-0.0209        ^ definitely 1.3863x faster

Tests: JSTests/microbenchmarks/regexp-match-digit-cached.js
       JSTests/microbenchmarks/regexp-match-digit-literal.js
       JSTests/microbenchmarks/string-match-digit-short.js
       JSTests/microbenchmarks/string-match-letter-short.js
       JSTests/stress/string-prototype-match-edge-cases.js
       JSTests/stress/string-prototype-match-strength-reduction.js
       JSTests/stress/string-prototype-match-watchpoint-invalidation.js

* JSTests/microbenchmarks/regexp-match-digit-cached.js: Added.
(match):
* JSTests/microbenchmarks/regexp-match-digit-literal.js: Added.
(match):
* JSTests/microbenchmarks/string-match-digit-short.js: Added.
(match):
* JSTests/microbenchmarks/string-match-letter-short.js: Added.
(match):
* JSTests/stress/string-prototype-match-edge-cases.js: Added.
(shouldBe):
(shouldThrow):
(shouldBe.String.prototype.match.call.toString):
(shouldBe.string_appeared_here.match.x.a):
(shouldBe.re.Symbol.match):
(shouldThrow.obj3.get Symbol):
(shouldBe.MyRegExp):
(shouldBe.MyRegExp2.prototype.Symbol.match):
(shouldBe.MyRegExp2):
(shouldBe.fake.get flags):
(shouldBe.fake.get global):
(shouldBe.fake.get hasIndices):
(shouldBe.fake.get ignoreCase):
(shouldBe.fake.get multiline):
(shouldBe.fake.get sticky):
(shouldBe.fake.get unicode):
(shouldBe.fake.get unicodeSets):
(shouldBe.fake.get dotAll):
* JSTests/stress/string-prototype-match-strength-reduction.js: Added.
(shouldBe):
(matchGlobalLiteral):
(matchNonGlobalLiteral):
(matchStickyLiteral):
(matchUnicodeGlobal):
(matchCached):
(matchStringPattern):
(matchPoly):
(shouldBe.matchPoly):
* JSTests/stress/string-prototype-match-watchpoint-invalidation.js: Added.
(shouldBe):
(match):
(re.Symbol.match):
(RegExp.prototype.Symbol.match):
(RegExp.prototype.exec):
(value):
(receiver.toString.re.exec):
(receiver.toString.RegExp.prototype.exec):
(get return):
* Source/JavaScriptCore/builtins/StringPrototype.js:
(match): Deleted.
* Source/JavaScriptCore/dfg/DFGAbstractInterpreterInlines.h:
(JSC::DFG::AbstractInterpreter&lt;AbstractStateType&gt;::executeEffects):
* Source/JavaScriptCore/dfg/DFGBackwardsPropagationPhase.cpp:
(JSC::DFG::BackwardsPropagationPhase::propagate):
* Source/JavaScriptCore/dfg/DFGByteCodeParser.cpp:
(JSC::DFG::ByteCodeParser::handleIntrinsicCall):
* Source/JavaScriptCore/dfg/DFGClobberize.h:
(JSC::DFG::clobberize):
* Source/JavaScriptCore/dfg/DFGCloneHelper.h:
* Source/JavaScriptCore/dfg/DFGDoesGC.cpp:
(JSC::DFG::doesGC):
* Source/JavaScriptCore/dfg/DFGFixupPhase.cpp:
(JSC::DFG::FixupPhase::fixupNode):
(JSC::DFG::FixupPhase::addStringMatchPrimordialChecks):
* Source/JavaScriptCore/dfg/DFGGraph.h:
* Source/JavaScriptCore/dfg/DFGJITCode.cpp:
(JSC::DFG::JITData::JITData):
(JSC::DFG::JITData::tryInitialize):
* Source/JavaScriptCore/dfg/DFGJITCode.h:
* Source/JavaScriptCore/dfg/DFGNodeType.h:
* Source/JavaScriptCore/dfg/DFGOperations.cpp:
(JSC::DFG::JSC_DEFINE_JIT_OPERATION):
* Source/JavaScriptCore/dfg/DFGOperations.h:
* Source/JavaScriptCore/dfg/DFGPredictionPropagationPhase.cpp:
* Source/JavaScriptCore/dfg/DFGSafeToExecute.h:
(JSC::DFG::safeToExecute):
* Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp:
* Source/JavaScriptCore/dfg/DFGSpeculativeJIT.h:
* Source/JavaScriptCore/dfg/DFGSpeculativeJIT32_64.cpp:
(JSC::DFG::SpeculativeJIT::compile):
* Source/JavaScriptCore/dfg/DFGSpeculativeJIT64.cpp:
(JSC::DFG::SpeculativeJIT::compile):
* Source/JavaScriptCore/ftl/FTLCapabilities.cpp:
(JSC::FTL::canCompile):
* Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp:
(JSC::FTL::DFG::LowerDFGToB3::compileNode):
(JSC::FTL::DFG::LowerDFGToB3::compileStringMatch):
* Source/JavaScriptCore/runtime/Intrinsic.h:
* Source/JavaScriptCore/runtime/JSGlobalObject.cpp:
(JSC::JSGlobalObject::init):
* Source/JavaScriptCore/runtime/JSGlobalObject.h:
* Source/JavaScriptCore/runtime/RegExpConstructor.cpp:
(JSC::regExpCreate):
* Source/JavaScriptCore/runtime/RegExpConstructor.h:
* Source/JavaScriptCore/runtime/RegExpObject.h:
* Source/JavaScriptCore/runtime/RegExpObjectInlines.h:
(JSC::RegExpObject::isSymbolMatchFastAndNonObservable):
* Source/JavaScriptCore/runtime/RegExpPrototype.cpp:
(JSC::regExpMatchFast):
(JSC::JSC_DEFINE_HOST_FUNCTION):
* Source/JavaScriptCore/runtime/RegExpPrototype.h:
* Source/JavaScriptCore/runtime/StringPrototype.cpp:
(JSC::StringPrototype::finishCreation):
(JSC::stringMatchSlow):
(JSC::JSC_DEFINE_HOST_FUNCTION):
* Source/JavaScriptCore/runtime/StringPrototype.h:

Canonical link: <a href="https://commits.webkit.org/313363@main">https://commits.webkit.org/313363@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d2fd50496d95cd700e9a49dc240ebbb05f69e201

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/162566 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/36042 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/29173 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/171504 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/119011 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/36146 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/36046 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/126164 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/88868 "2 flakes 17 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/165525 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/28520 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/146056 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/106742 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/27566 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/26092 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/19204 "Built successfully") | 
| [⏳ 🛠 🧪 jsc ](https://ews-build.webkit.org/#/builders/JSC-Tests-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/137270 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/23786 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/174008 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/23405 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/21321 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/25431 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/134473 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/35716 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/30185 "Found 2 new test failures: http/tests/ssl/applepay/ApplePayButton.html imported/w3c/web-platform-tests/IndexedDB/interleaved-cursors-small.any.serviceworker.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/134471 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36350 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/35700 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/145582 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/98030 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/29014 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/22416 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/194967 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/35210 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/102961 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/50396 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/34711 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/34956 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/34859 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->