### PR TITLE
Synchronize WPT xhr

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -4082,8 +4082,6 @@ fast/mediacapturefromelement/CanvasCaptureMediaStream-imagebitmaprenderingcontex
 fast/mediacapturefromelement/CanvasCaptureMediaStream-framerate-0.html [ Skip ]
 fast/mediacapturefromelement/CanvasCaptureMediaStream-capture-out-of-DOM-element.html [ Skip ]
 
-webkit.org/b/196274 imported/w3c/web-platform-tests/xhr/send-redirect-post-upload.htm [ Pass Failure ]
-
 # If requestAnimationFrame is invoked before ResizeObserver timer fired, it would pass, otherwise it would fail same as eventloop-expected.txt
 webkit.org/b/157743 imported/w3c/web-platform-tests/resize-observer/eventloop.html [ Pass Failure ]
 

--- a/LayoutTests/imported/w3c/web-platform-tests/xhr/WEB_FEATURES.yml
+++ b/LayoutTests/imported/w3c/web-platform-tests/xhr/WEB_FEATURES.yml
@@ -1,0 +1,30 @@
+features:
+- name: xhr
+  files: "**"
+- name: base
+  files:
+  - open-url-base.htm
+# The classifier for "http-authentication" intentionally overlaps with the
+# above classifier for "xhr" because the boundary between the two features is
+# somewhat subjective.
+- name: http-authentication
+  files:
+  - send-authentication-basic-cors-not-enabled.htm
+  - send-authentication-basic-repeat-no-args.htm
+  - send-authentication-basic-setrequestheader-and-arguments.htm
+  - send-authentication-basic-setrequestheader-existing-session.htm
+  - send-authentication-basic-setrequestheader.htm
+  - send-authentication-basic.htm
+  - send-authentication-competing-names-passwords.htm
+  - send-authentication-existing-session-manual.htm
+  - send-authentication-prompt-2-manual.htm
+  - send-authentication-prompt-manual.htm
+# The classifier for "httpt2" intentionally overlaps with the above classifier
+# for "xhr" because the boundary between the two features is somewhat
+# subjective.
+- name: http2
+  files:
+  - status.h2.window.js
+- name: iframe-sandbox
+  files:
+  - access-control-sandboxed-iframe-*

--- a/LayoutTests/imported/w3c/web-platform-tests/xhr/abort-during-navigation.window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/xhr/abort-during-navigation.window-expected.txt
@@ -1,0 +1,3 @@
+
+FAIL XHR should not fire abort or error events when cancelled by navigation assert_false: error event should not fire expected false got true
+

--- a/LayoutTests/imported/w3c/web-platform-tests/xhr/abort-during-navigation.window.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/xhr/abort-during-navigation.window.html
@@ -1,0 +1,1 @@
+<!-- This file is required for WebKit test infrastructure to run the templated test -->

--- a/LayoutTests/imported/w3c/web-platform-tests/xhr/abort-during-navigation.window.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/xhr/abort-during-navigation.window.js
@@ -1,0 +1,27 @@
+// META: title=XMLHttpRequest: navigation should not fire abort event
+
+async_test(function(t) {
+  var iframe = document.createElement("iframe");
+  var events = [];
+
+  window.addEventListener("message", t.step_func(function(e) {
+    if (e.data.type === "xhr-event") {
+      events.push(e.data.event);
+    }
+    if (e.data.type === "ready") {
+      iframe.src = "/common/blank.html";
+      iframe.onload = t.step_func(function() {
+        t.step_timeout(t.step_func_done(function() {
+          assert_false(events.includes("error"), "error event should not fire");
+          assert_false(events.includes("abort"), "abort event should not fire");
+          assert_false(events.includes("load"), "load event should not fire");
+          assert_false(events.includes("upload.error"), "upload error event should not fire");
+          assert_false(events.includes("upload.abort"), "upload abort event should not fire");
+        }), 500);
+      });
+    }
+  }));
+
+  iframe.src = "/xhr/resources/abort-during-navigation-iframe.html";
+  document.body.appendChild(iframe);
+}, "XHR should not fire abort or error events when cancelled by navigation");

--- a/LayoutTests/imported/w3c/web-platform-tests/xhr/abort-progress-events.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/xhr/abort-progress-events.any-expected.txt
@@ -1,0 +1,4 @@
+
+PASS Events must not fire when state is UNSENT after abort()
+PASS Calling open/abort in readystatechange should not crash
+

--- a/LayoutTests/imported/w3c/web-platform-tests/xhr/abort-progress-events.any.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/xhr/abort-progress-events.any.html
@@ -1,0 +1,1 @@
+<!-- This file is required for WebKit test infrastructure to run the templated test -->

--- a/LayoutTests/imported/w3c/web-platform-tests/xhr/abort-progress-events.any.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/xhr/abort-progress-events.any.js
@@ -1,0 +1,66 @@
+// META: title=XMLHttpRequest: abort() and progress timer race condition
+
+// Test for https://bugzilla.mozilla.org/show_bug.cgi?id=1851832
+// Ensures that readystatechange and progress events don't fire when the
+// state is UNSENT, as required by the spec.
+
+async_test(t => {
+  const xhr = new XMLHttpRequest();
+  let eventsFiredInUnsent = false;
+
+  // Monitor for events firing in UNSENT state
+  xhr.addEventListener('readystatechange', t.step_func(() => {
+    if (xhr.readyState === XMLHttpRequest.UNSENT) {
+      eventsFiredInUnsent = true;
+    }
+  }));
+
+  xhr.addEventListener('progress', t.step_func(() => {
+    if (xhr.readyState === XMLHttpRequest.UNSENT) {
+      eventsFiredInUnsent = true;
+    }
+  }));
+
+  // Start a request and immediately abort it
+  xhr.open('GET', 'resources/pass.txt');
+  xhr.send();
+  xhr.abort();
+
+  // The spec says when abort() is called on a DONE request, state changes
+  // to UNSENT and no readystatechange event is dispatched. Progress events
+  // should also not fire in UNSENT state.
+  assert_equals(xhr.readyState, XMLHttpRequest.UNSENT,
+                'State should be UNSENT immediately after abort');
+
+  // Give time for any progress timer callbacks that might have been queued
+  t.step_timeout(() => {
+    assert_false(eventsFiredInUnsent,
+                 'No events should fire when state is UNSENT');
+    t.done();
+  }, 200);
+}, 'Events must not fire when state is UNSENT after abort()');
+
+async_test(t => {
+  const xhr = new XMLHttpRequest();
+  let callCount = 0;
+
+  // Calling open/abort in a readystatechange handler can trigger
+  // a scenario where the progress timer callback is queued but then
+  // the state becomes UNSENT. This should not cause assertions or crashes.
+  xhr.addEventListener('readystatechange', t.step_func(e => {
+    // Limit recursion to prevent infinite loop
+    if (callCount++ < 5) {
+      e.currentTarget.open('GET', 'resources/pass.txt');
+      e.currentTarget.abort();
+    }
+  }));
+
+  xhr.open('GET', 'resources/pass.txt');
+  xhr.send();
+
+  // Allow time for the test to complete
+  t.step_timeout(() => {
+    assert_true(callCount > 0, 'readystatechange handler should have been called');
+    t.done();
+  }, 200);
+}, 'Calling open/abort in readystatechange should not crash');

--- a/LayoutTests/imported/w3c/web-platform-tests/xhr/abort-progress-events.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/xhr/abort-progress-events.any.worker-expected.txt
@@ -1,0 +1,4 @@
+
+PASS Events must not fire when state is UNSENT after abort()
+PASS Calling open/abort in readystatechange should not crash
+

--- a/LayoutTests/imported/w3c/web-platform-tests/xhr/abort-progress-events.any.worker.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/xhr/abort-progress-events.any.worker.html
@@ -1,0 +1,1 @@
+<!-- This file is required for WebKit test infrastructure to run the templated test -->

--- a/LayoutTests/imported/w3c/web-platform-tests/xhr/formdata/append.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/xhr/formdata/append.any-expected.txt
@@ -5,5 +5,5 @@ PASS testFormDataAppendUndefined1
 PASS testFormDataAppendUndefined2
 PASS testFormDataAppendNull1
 PASS testFormDataAppendNull2
-FAIL testFormDataAppendEmptyBlob assert_greater_than_equal: expected a "object" but got a "number"
+PASS testFormDataAppendEmptyBlob
 

--- a/LayoutTests/imported/w3c/web-platform-tests/xhr/formdata/append.any.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/xhr/formdata/append.any.js
@@ -19,13 +19,13 @@
         assert_equals(create_formdata(['key', null], ['key', 'value1']).get('key'), "null");
     }, 'testFormDataAppendNull2');
     test(function() {
-        var before = new Date(new Date().getTime() - 2000); // two seconds ago, in case there's clock drift
+        var before = new Date(new Date().getTime() - 2000).getTime(); // two seconds ago, in case there's clock drift
         var fd = create_formdata(['key', new Blob(), 'blank.txt']).get('key');
         assert_equals(fd.name, "blank.txt");
         assert_equals(fd.type, "");
         assert_equals(fd.size, 0);
         assert_greater_than_equal(fd.lastModified, before);
-        assert_less_than_equal(fd.lastModified, new Date());
+        assert_less_than_equal(fd.lastModified, new Date().getTime());
     }, 'testFormDataAppendEmptyBlob');
 
     function create_formdata() {

--- a/LayoutTests/imported/w3c/web-platform-tests/xhr/formdata/append.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/xhr/formdata/append.any.worker-expected.txt
@@ -5,5 +5,5 @@ PASS testFormDataAppendUndefined1
 PASS testFormDataAppendUndefined2
 PASS testFormDataAppendNull1
 PASS testFormDataAppendNull2
-FAIL testFormDataAppendEmptyBlob assert_greater_than_equal: expected a "object" but got a "number"
+PASS testFormDataAppendEmptyBlob
 

--- a/LayoutTests/imported/w3c/web-platform-tests/xhr/resources/abort-during-navigation-iframe.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/xhr/resources/abort-during-navigation-iframe.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<script>
+var xhr = new XMLHttpRequest();
+xhr.onerror = function() {
+  parent.postMessage({type: "xhr-event", event: "error"}, "*");
+};
+xhr.onabort = function() {
+  parent.postMessage({type: "xhr-event", event: "abort"}, "*");
+};
+xhr.onload = function() {
+  parent.postMessage({type: "xhr-event", event: "load"}, "*");
+};
+xhr.onloadend = function() {
+  parent.postMessage({type: "xhr-event", event: "loadend"}, "*");
+};
+xhr.onreadystatechange = function() {
+  parent.postMessage({type: "xhr-event", event: "readystatechange:" + xhr.readyState}, "*");
+};
+xhr.upload.onerror = function() {
+  parent.postMessage({type: "xhr-event", event: "upload.error"}, "*");
+};
+xhr.upload.onabort = function() {
+  parent.postMessage({type: "xhr-event", event: "upload.abort"}, "*");
+};
+xhr.open("GET", "delay.py?ms=10000", true);
+xhr.send();
+parent.postMessage({type: "ready"}, "*");
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/xhr/resources/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/xhr/resources/w3c-import.log
@@ -14,6 +14,7 @@ Property values requiring vendor prefixes:
 None
 ------------------------------------------------------------------------
 List of files:
+/LayoutTests/imported/w3c/web-platform-tests/xhr/resources/abort-during-navigation-iframe.html
 /LayoutTests/imported/w3c/web-platform-tests/xhr/resources/accept-language.py
 /LayoutTests/imported/w3c/web-platform-tests/xhr/resources/accept.py
 /LayoutTests/imported/w3c/web-platform-tests/xhr/resources/access-control-allow-lists.py

--- a/LayoutTests/imported/w3c/web-platform-tests/xhr/send-redirect-bogus-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/xhr/send-redirect-bogus-expected.txt
@@ -1,6 +1,0 @@
-
-PASS XMLHttpRequest: send() - Redirects (bogus Location header) (302: http://example.not)
-PASS XMLHttpRequest: send() - Redirects (bogus Location header) (302: mailto:someone@example.org)
-PASS XMLHttpRequest: send() - Redirects (bogus Location header) (303: http://example.not)
-PASS XMLHttpRequest: send() - Redirects (bogus Location header) (303: foobar:someone@example.org)
-

--- a/LayoutTests/imported/w3c/web-platform-tests/xhr/send-redirect-bogus-sync.sub-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/xhr/send-redirect-bogus-sync.sub-expected.txt
@@ -1,7 +1,7 @@
 
 PASS XMLHttpRequest: send() - Redirects (bogus Location header; sync) (301: foobar://abcd)
-PASS XMLHttpRequest: send() - Redirects (bogus Location header; sync) (302: http://z.)
+PASS XMLHttpRequest: send() - Redirects (bogus Location header; sync) (302: http://nonexistent.web-platform.test)
 PASS XMLHttpRequest: send() - Redirects (bogus Location header; sync) (302: mailto:someone@example.org)
-PASS XMLHttpRequest: send() - Redirects (bogus Location header; sync) (303: http://z.)
+PASS XMLHttpRequest: send() - Redirects (bogus Location header; sync) (303: http://nonexistent.web-platform.test)
 PASS XMLHttpRequest: send() - Redirects (bogus Location header; sync) (303: tel:1234567890)
 

--- a/LayoutTests/imported/w3c/web-platform-tests/xhr/send-redirect-bogus-sync.sub.htm
+++ b/LayoutTests/imported/w3c/web-platform-tests/xhr/send-redirect-bogus-sync.sub.htm
@@ -17,9 +17,9 @@
         }, document.title + " (" + code + ": " + location + ")")
       }
       redirect("301", "foobar://abcd")
-      redirect("302", "http://z.")
+      redirect("302", "http://{{hosts[][nonexistent]}}")
       redirect("302", "mailto:someone@example.org")
-      redirect("303", "http://z.")
+      redirect("303", "http://{{hosts[][nonexistent]}}")
       redirect("303", "tel:1234567890")
     </script>
   </body>

--- a/LayoutTests/imported/w3c/web-platform-tests/xhr/send-redirect-bogus.sub-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/xhr/send-redirect-bogus.sub-expected.txt
@@ -1,0 +1,6 @@
+
+PASS XMLHttpRequest: send() - Redirects (bogus Location header) (302: http://nonexistent.web-platform.test)
+PASS XMLHttpRequest: send() - Redirects (bogus Location header) (302: mailto:someone@example.org)
+PASS XMLHttpRequest: send() - Redirects (bogus Location header) (303: http://nonexistent.web-platform.test)
+PASS XMLHttpRequest: send() - Redirects (bogus Location header) (303: foobar:someone@example.org)
+

--- a/LayoutTests/imported/w3c/web-platform-tests/xhr/send-redirect-bogus.sub.htm
+++ b/LayoutTests/imported/w3c/web-platform-tests/xhr/send-redirect-bogus.sub.htm
@@ -27,9 +27,9 @@
           client.send(null)
         })
       }
-      redirect("302", "http://example.not")
+      redirect("302", "http://{{hosts[][nonexistent]}}")
       redirect("302", "mailto:someone@example.org")
-      redirect("303", "http://example.not")
+      redirect("303", "http://{{hosts[][nonexistent]}}")
       redirect("303", "foobar:someone@example.org")
     </script>
   </body>

--- a/LayoutTests/imported/w3c/web-platform-tests/xhr/setrequestheader-case-insensitive-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/xhr/setrequestheader-case-insensitive-expected.txt
@@ -1,4 +1,4 @@
 
 PASS XMLHttpRequest: setRequestHeader() - headers that differ in case
-FAIL XMLHttpRequest: setRequestHeader() - headers that differ in case 1 assert_equals: expected ["content-TYPE"] but got ["Content-Type"]
+FAIL XMLHttpRequest: setRequestHeader() - headers that differ in case 1 assert_array_equals: expected property 0 to be "content-TYPE" but got "Content-Type" (expected array ["content-TYPE"] got ["Content-Type"])
 

--- a/LayoutTests/imported/w3c/web-platform-tests/xhr/setrequestheader-case-insensitive.htm
+++ b/LayoutTests/imported/w3c/web-platform-tests/xhr/setrequestheader-case-insensitive.htm
@@ -9,28 +9,28 @@
   <body>
     <div id="log"></div>
     <script>
-      test(function() {
-        var client = new XMLHttpRequest()
-        client.open("POST", "resources/inspect-headers.py?filter_value=t1, t2, t3", false)
-        client.setRequestHeader("x-test", "t1")
-        client.setRequestHeader("X-TEST", "t2")
-        client.setRequestHeader("X-teST", "t3")
-        client.send(null)
-        assert_equals(client.responseText, "x-test,")
-      })
+      test(() => {
+        const client = new XMLHttpRequest();
+        client.open("POST", "resources/inspect-headers.py?filter_value=t1, t2, t3", false);
+        client.setRequestHeader("x-test", "t1");
+        client.setRequestHeader("X-TEST", "t2");
+        client.setRequestHeader("X-teST", "t3");
+        client.send(null);
+        assert_equals(client.responseText, "x-test,");
+      });
 
       test(() => {
-        const client = new XMLHttpRequest
-        client.open("GET", "resources/echo-headers.py", false)
-        client.setRequestHeader("THIS-IS-A-TEST", "1")
-        client.setRequestHeader("THIS-is-A-test", "2")
-        client.setRequestHeader("content-TYPE", "x/x")
-        client.send()
-        const contentTypeHeader = client.responseText.match(/content-TYPE/gi)
-        const thisIsATestHeader = client.responseText.match(/THIS-IS-A-TEST: 1, 2/gi)
-        assert_equals(contentTypeHeader, ["content-TYPE"])
-        assert_equals(thisIsATestHeader, ["THIS-IS-A-TEST: 1, 2"])
-      })
+        const client = new XMLHttpRequest();
+        client.open("GET", "resources/echo-headers.py", false);
+        client.setRequestHeader("THIS-IS-A-TEST", "1");
+        client.setRequestHeader("THIS-is-A-test", "2");
+        client.setRequestHeader("content-TYPE", "x/x");
+        client.send();
+        const contentTypeHeader = client.responseText.match(/content-TYPE/gi);
+        const thisIsATestHeader = client.responseText.match(/THIS-IS-A-TEST: 1, 2/gi);
+        assert_array_equals(contentTypeHeader, ["content-TYPE"]);
+        assert_array_equals(thisIsATestHeader, ["THIS-IS-A-TEST: 1, 2"]);
+      });
     </script>
   </body>
 </html>

--- a/LayoutTests/imported/w3c/web-platform-tests/xhr/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/xhr/w3c-import.log
@@ -16,6 +16,7 @@ None
 List of files:
 /LayoutTests/imported/w3c/web-platform-tests/xhr/META.yml
 /LayoutTests/imported/w3c/web-platform-tests/xhr/README.md
+/LayoutTests/imported/w3c/web-platform-tests/xhr/WEB_FEATURES.yml
 /LayoutTests/imported/w3c/web-platform-tests/xhr/XMLHttpRequest-withCredentials.any.js
 /LayoutTests/imported/w3c/web-platform-tests/xhr/abort-after-receive.any.js
 /LayoutTests/imported/w3c/web-platform-tests/xhr/abort-after-send.any.js
@@ -24,6 +25,7 @@ List of files:
 /LayoutTests/imported/w3c/web-platform-tests/xhr/abort-during-done.window.js
 /LayoutTests/imported/w3c/web-platform-tests/xhr/abort-during-headers-received.window.js
 /LayoutTests/imported/w3c/web-platform-tests/xhr/abort-during-loading.window.js
+/LayoutTests/imported/w3c/web-platform-tests/xhr/abort-during-navigation.window.js
 /LayoutTests/imported/w3c/web-platform-tests/xhr/abort-during-open.any.js
 /LayoutTests/imported/w3c/web-platform-tests/xhr/abort-during-readystatechange.any.js
 /LayoutTests/imported/w3c/web-platform-tests/xhr/abort-during-unsent.any.js
@@ -32,6 +34,7 @@ List of files:
 /LayoutTests/imported/w3c/web-platform-tests/xhr/abort-event-listeners.any.js
 /LayoutTests/imported/w3c/web-platform-tests/xhr/abort-event-loadend.any.js
 /LayoutTests/imported/w3c/web-platform-tests/xhr/abort-event-order.htm
+/LayoutTests/imported/w3c/web-platform-tests/xhr/abort-progress-events.any.js
 /LayoutTests/imported/w3c/web-platform-tests/xhr/abort-upload-event-abort.any.js
 /LayoutTests/imported/w3c/web-platform-tests/xhr/abort-upload-event-loadend.any.js
 /LayoutTests/imported/w3c/web-platform-tests/xhr/abort-with-error.any.js
@@ -246,8 +249,8 @@ List of files:
 /LayoutTests/imported/w3c/web-platform-tests/xhr/send-no-response-event-order.htm
 /LayoutTests/imported/w3c/web-platform-tests/xhr/send-non-same-origin.htm
 /LayoutTests/imported/w3c/web-platform-tests/xhr/send-receive-utf16.htm
-/LayoutTests/imported/w3c/web-platform-tests/xhr/send-redirect-bogus-sync.htm
-/LayoutTests/imported/w3c/web-platform-tests/xhr/send-redirect-bogus.htm
+/LayoutTests/imported/w3c/web-platform-tests/xhr/send-redirect-bogus-sync.sub.htm
+/LayoutTests/imported/w3c/web-platform-tests/xhr/send-redirect-bogus.sub.htm
 /LayoutTests/imported/w3c/web-platform-tests/xhr/send-redirect-infinite-sync.htm
 /LayoutTests/imported/w3c/web-platform-tests/xhr/send-redirect-infinite.htm
 /LayoutTests/imported/w3c/web-platform-tests/xhr/send-redirect-no-location.htm
@@ -287,7 +290,7 @@ List of files:
 /LayoutTests/imported/w3c/web-platform-tests/xhr/sync-no-progress.any.js
 /LayoutTests/imported/w3c/web-platform-tests/xhr/sync-no-timeout.any.js
 /LayoutTests/imported/w3c/web-platform-tests/xhr/sync-xhr-and-window-onload.html
-/LayoutTests/imported/w3c/web-platform-tests/xhr/sync-xhr-supported-by-feature-policy.html
+/LayoutTests/imported/w3c/web-platform-tests/xhr/sync-xhr-supported-by-permissions-policy.html
 /LayoutTests/imported/w3c/web-platform-tests/xhr/template-element.html
 /LayoutTests/imported/w3c/web-platform-tests/xhr/thrown-error-in-events.html
 /LayoutTests/imported/w3c/web-platform-tests/xhr/timeout-cors-async.htm
@@ -302,7 +305,7 @@ List of files:
 /LayoutTests/imported/w3c/web-platform-tests/xhr/xmlhttprequest-sync-block-defer-scripts-subframe.html
 /LayoutTests/imported/w3c/web-platform-tests/xhr/xmlhttprequest-sync-block-defer-scripts.html
 /LayoutTests/imported/w3c/web-platform-tests/xhr/xmlhttprequest-sync-block-scripts.html
-/LayoutTests/imported/w3c/web-platform-tests/xhr/xmlhttprequest-sync-default-feature-policy.sub.html
+/LayoutTests/imported/w3c/web-platform-tests/xhr/xmlhttprequest-sync-default-permissions-policy.sub.html
 /LayoutTests/imported/w3c/web-platform-tests/xhr/xmlhttprequest-sync-not-hang-scriptloader-subframe.html
 /LayoutTests/imported/w3c/web-platform-tests/xhr/xmlhttprequest-sync-not-hang-scriptloader.html
 /LayoutTests/imported/w3c/web-platform-tests/xhr/xmlhttprequest-timeout-aborted.html

--- a/LayoutTests/imported/w3c/web-platform-tests/xhr/xmlhttprequest-timeout-aborted_aborted%20immediately%20after%20send()-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/xhr/xmlhttprequest-timeout-aborted_aborted%20immediately%20after%20send()-expected.txt
@@ -1,7 +1,0 @@
-Description
-
-This test validates that the XHR2 timeout property behaves as expected in async cases in document (i.e. non-worker) context.
-
-
-PASS Timeout test: time to abort is -1, timeout set at 2000
-

--- a/LayoutTests/imported/w3c/web-platform-tests/xhr/xmlhttprequest-timeout-aborted_call%20abort()%20after%20TIME_NORMAL_LOAD-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/xhr/xmlhttprequest-timeout-aborted_call%20abort()%20after%20TIME_NORMAL_LOAD-expected.txt
@@ -1,7 +1,0 @@
-Description
-
-This test validates that the XHR2 timeout property behaves as expected in async cases in document (i.e. non-worker) context.
-
-
-PASS Timeout test: time to abort is 5000, timeout set at 2000
-

--- a/LayoutTests/imported/w3c/web-platform-tests/xhr/xmlhttprequest-timeout-aborted_only%20open()ed,%20not%20aborted-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/xhr/xmlhttprequest-timeout-aborted_only%20open()ed,%20not%20aborted-expected.txt
@@ -1,7 +1,0 @@
-Description
-
-This test validates that the XHR2 timeout property behaves as expected in async cases in document (i.e. non-worker) context.
-
-
-PASS Timeout test: No events should fire for an unsent, unaborted request
-

--- a/LayoutTests/imported/w3c/web-platform-tests/xhr/xmlhttprequest-timeout-abortedonmain_abort()%20from%20a%200ms%20timeout-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/xhr/xmlhttprequest-timeout-abortedonmain_abort()%20from%20a%200ms%20timeout-expected.txt
@@ -1,7 +1,0 @@
-Description
-
-This test validates that the XHR2 timeout property behaves as expected in async cases in document (i.e. non-worker) context.
-
-
-PASS Timeout test: time to abort is 0, timeout set at 2000
-

--- a/LayoutTests/imported/w3c/web-platform-tests/xhr/xmlhttprequest-timeout-abortedonmain_aborted%20after%20TIME_DELAY-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/xhr/xmlhttprequest-timeout-abortedonmain_aborted%20after%20TIME_DELAY-expected.txt
@@ -1,7 +1,0 @@
-Description
-
-This test validates that the XHR2 timeout property behaves as expected in async cases in document (i.e. non-worker) context.
-
-
-PASS Timeout test: time to abort is 1000, timeout set at 2000
-

--- a/LayoutTests/imported/w3c/web-platform-tests/xhr/xmlhttprequest-timeout-overrides_timeout%20disabled%20after%20initially%20set-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/xhr/xmlhttprequest-timeout-overrides_timeout%20disabled%20after%20initially%20set-expected.txt
@@ -1,7 +1,0 @@
-Description
-
-This test validates that the XHR2 timeout property behaves as expected in async cases in document (i.e. non-worker) context.
-
-
-PASS Timeout test: timeout disabled after initially set, original timeout at 5000, reset at 2000 to 0
-

--- a/LayoutTests/imported/w3c/web-platform-tests/xhr/xmlhttprequest-timeout-overrides_timeout%20enabled%20after%20initially%20disabled-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/xhr/xmlhttprequest-timeout-overrides_timeout%20enabled%20after%20initially%20disabled-expected.txt
@@ -1,7 +1,0 @@
-Description
-
-This test validates that the XHR2 timeout property behaves as expected in async cases in document (i.e. non-worker) context.
-
-
-PASS Timeout test: timeout enabled after initially disabled, original timeout at 0, reset at 2000 to 50000
-

--- a/LayoutTests/imported/w3c/web-platform-tests/xhr/xmlhttprequest-timeout-overrides_timeout%20overrides%20load%20after%20a%20delay-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/xhr/xmlhttprequest-timeout-overrides_timeout%20overrides%20load%20after%20a%20delay-expected.txt
@@ -1,7 +1,0 @@
-Description
-
-This test validates that the XHR2 timeout property behaves as expected in async cases in document (i.e. non-worker) context.
-
-
-PASS Timeout test: timeout overrides load after a delay, original timeout at 5000, reset at 1000 to 2000
-

--- a/LayoutTests/imported/w3c/web-platform-tests/xhr/xmlhttprequest-timeout-overridesexpires_timeout%20set%20to%20expired%20value%20before%20load%20fires-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/xhr/xmlhttprequest-timeout-overridesexpires_timeout%20set%20to%20expired%20value%20before%20load%20fires-expected.txt
@@ -1,7 +1,0 @@
-Description
-
-This test validates that the XHR2 timeout property behaves as expected in async cases in document (i.e. non-worker) context.
-
-
-PASS Timeout test: timeout set to expired value before load fires, original timeout at 5000, reset at 2000 to 1100
-

--- a/LayoutTests/imported/w3c/web-platform-tests/xhr/xmlhttprequest-timeout-overridesexpires_timeout%20set%20to%20expiring%20value%20after%20load%20fires-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/xhr/xmlhttprequest-timeout-overridesexpires_timeout%20set%20to%20expiring%20value%20after%20load%20fires-expected.txt
@@ -1,7 +1,0 @@
-Description
-
-This test validates that the XHR2 timeout property behaves as expected in async cases in document (i.e. non-worker) context.
-
-
-PASS Timeout test: timeout set to expiring value after load fires, original timeout at 5000, reset at 4000 to 1000
-

--- a/LayoutTests/imported/w3c/web-platform-tests/xhr/xmlhttprequest-timeout-overridesexpires_timeout%20set%20to%20non-expiring%20value%20after%20timeout%20fires-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/xhr/xmlhttprequest-timeout-overridesexpires_timeout%20set%20to%20non-expiring%20value%20after%20timeout%20fires-expected.txt
@@ -1,7 +1,0 @@
-Description
-
-This test validates that the XHR2 timeout property behaves as expected in async cases in document (i.e. non-worker) context.
-
-
-PASS Timeout test: timeout set to non-expiring value after timeout fires, original timeout at 1000, reset at 2000 to 500
-

--- a/LayoutTests/imported/w3c/web-platform-tests/xhr/xmlhttprequest-timeout-simple_load%20fires%20normally-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/xhr/xmlhttprequest-timeout-simple_load%20fires%20normally-expected.txt
@@ -1,7 +1,0 @@
-Description
-
-This test validates that the XHR2 timeout property behaves as expected in async cases in document (i.e. non-worker) context.
-
-
-PASS Timeout test: load fires normally, timeout scheduled at 5000
-

--- a/LayoutTests/imported/w3c/web-platform-tests/xhr/xmlhttprequest-timeout-simple_no%20time%20out%20scheduled,%20load%20fires%20normally-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/xhr/xmlhttprequest-timeout-simple_no%20time%20out%20scheduled,%20load%20fires%20normally-expected.txt
@@ -1,7 +1,0 @@
-Description
-
-This test validates that the XHR2 timeout property behaves as expected in async cases in document (i.e. non-worker) context.
-
-
-PASS Timeout test: no time out scheduled, load fires normally, timeout scheduled at 0
-

--- a/LayoutTests/imported/w3c/web-platform-tests/xhr/xmlhttprequest-timeout-simple_timeout%20hit%20before%20load-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/xhr/xmlhttprequest-timeout-simple_timeout%20hit%20before%20load-expected.txt
@@ -1,7 +1,0 @@
-Description
-
-This test validates that the XHR2 timeout property behaves as expected in async cases in document (i.e. non-worker) context.
-
-
-PASS Timeout test: timeout hit before load, timeout scheduled at 2000
-

--- a/LayoutTests/imported/w3c/web-platform-tests/xhr/xmlhttprequest-timeout-synconmain_timeout%20after%20open-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/xhr/xmlhttprequest-timeout-synconmain_timeout%20after%20open-expected.txt
@@ -1,7 +1,0 @@
-Description
-
-This test validates that the XHR2 timeout property behaves as expected in async cases in document (i.e. non-worker) context.
-
-
-PASS Timeout test: Synchronous XHR must not allow a timeout to be set - setting timeout must throw
-

--- a/LayoutTests/imported/w3c/web-platform-tests/xhr/xmlhttprequest-timeout-synconmain_timeout%20before%20open-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/xhr/xmlhttprequest-timeout-synconmain_timeout%20before%20open-expected.txt
@@ -1,7 +1,0 @@
-Description
-
-This test validates that the XHR2 timeout property behaves as expected in async cases in document (i.e. non-worker) context.
-
-
-PASS Timeout test: Synchronous XHR must not allow a timeout to be set - calling open() after timeout is set must throw
-

--- a/LayoutTests/imported/w3c/web-platform-tests/xhr/xmlhttprequest-timeout-twice_load%20fires%20normally%20with%20no%20timeout%20set,%20twice-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/xhr/xmlhttprequest-timeout-twice_load%20fires%20normally%20with%20no%20timeout%20set,%20twice-expected.txt
@@ -1,7 +1,0 @@
-Description
-
-This test validates that the XHR2 timeout property behaves as expected in async cases in document (i.e. non-worker) context.
-
-
-PASS Timeout test: load fires normally with no timeout set, twice, original timeout at 0, reset at 2000 to 0
-

--- a/LayoutTests/imported/w3c/web-platform-tests/xhr/xmlhttprequest-timeout-twice_load%20fires%20normally%20with%20same%20timeout%20set%20twice-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/xhr/xmlhttprequest-timeout-twice_load%20fires%20normally%20with%20same%20timeout%20set%20twice-expected.txt
@@ -1,7 +1,0 @@
-Description
-
-This test validates that the XHR2 timeout property behaves as expected in async cases in document (i.e. non-worker) context.
-
-
-PASS Timeout test: load fires normally with same timeout set twice, original timeout at 5000, reset at 2000 to 5000
-

--- a/LayoutTests/imported/w3c/web-platform-tests/xhr/xmlhttprequest-timeout-twice_timeout%20fires%20normally%20with%20same%20timeout%20set%20twice-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/xhr/xmlhttprequest-timeout-twice_timeout%20fires%20normally%20with%20same%20timeout%20set%20twice-expected.txt
@@ -1,7 +1,0 @@
-Description
-
-This test validates that the XHR2 timeout property behaves as expected in async cases in document (i.e. non-worker) context.
-
-
-PASS Timeout test: timeout fires normally with same timeout set twice, original timeout at 2000, reset at 1000 to 2000
-

--- a/LayoutTests/imported/w3c/web-platform-tests/xhr/xmlhttprequest-timeout-worker-aborted_aborted%20immediately%20after%20send()-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/xhr/xmlhttprequest-timeout-worker-aborted_aborted%20immediately%20after%20send()-expected.txt
@@ -1,9 +1,0 @@
-Description
-
-This test validates that the XHR2 timeout property behaves as expected in in a worker context.
-
-
-PASS Timeout test: No events should fire for an unsent, unaborted request
-PASS Timeout test: time to abort is -1, timeout set at 2000
-PASS Timeout test: time to abort is 5000, timeout set at 2000
-

--- a/LayoutTests/imported/w3c/web-platform-tests/xhr/xmlhttprequest-timeout-worker-aborted_call%20abort()%20after%20TIME_NORMAL_LOAD-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/xhr/xmlhttprequest-timeout-worker-aborted_call%20abort()%20after%20TIME_NORMAL_LOAD-expected.txt
@@ -1,9 +1,0 @@
-Description
-
-This test validates that the XHR2 timeout property behaves as expected in in a worker context.
-
-
-PASS Timeout test: No events should fire for an unsent, unaborted request
-PASS Timeout test: time to abort is -1, timeout set at 2000
-PASS Timeout test: time to abort is 5000, timeout set at 2000
-

--- a/LayoutTests/imported/w3c/web-platform-tests/xhr/xmlhttprequest-timeout-worker-aborted_only%20open()ed,%20not%20aborted-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/xhr/xmlhttprequest-timeout-worker-aborted_only%20open()ed,%20not%20aborted-expected.txt
@@ -1,9 +1,0 @@
-Description
-
-This test validates that the XHR2 timeout property behaves as expected in in a worker context.
-
-
-PASS Timeout test: No events should fire for an unsent, unaborted request
-PASS Timeout test: time to abort is -1, timeout set at 2000
-PASS Timeout test: time to abort is 5000, timeout set at 2000
-

--- a/LayoutTests/imported/w3c/web-platform-tests/xhr/xmlhttprequest-timeout-worker-overrides_timeout%20disabled%20after%20initially%20set-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/xhr/xmlhttprequest-timeout-worker-overrides_timeout%20disabled%20after%20initially%20set-expected.txt
@@ -1,7 +1,0 @@
-Description
-
-This test validates that the XHR2 timeout property behaves as expected in in a worker context.
-
-
-PASS Timeout test: timeout disabled after initially set, original timeout at 5000, reset at 2000 to 0
-

--- a/LayoutTests/imported/w3c/web-platform-tests/xhr/xmlhttprequest-timeout-worker-overrides_timeout%20enabled%20after%20initially%20disabled-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/xhr/xmlhttprequest-timeout-worker-overrides_timeout%20enabled%20after%20initially%20disabled-expected.txt
@@ -1,7 +1,0 @@
-Description
-
-This test validates that the XHR2 timeout property behaves as expected in in a worker context.
-
-
-PASS Timeout test: timeout enabled after initially disabled, original timeout at 0, reset at 2000 to 50000
-

--- a/LayoutTests/imported/w3c/web-platform-tests/xhr/xmlhttprequest-timeout-worker-overrides_timeout%20overrides%20load%20after%20a%20delay-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/xhr/xmlhttprequest-timeout-worker-overrides_timeout%20overrides%20load%20after%20a%20delay-expected.txt
@@ -1,7 +1,0 @@
-Description
-
-This test validates that the XHR2 timeout property behaves as expected in in a worker context.
-
-
-PASS Timeout test: timeout overrides load after a delay, original timeout at 5000, reset at 1000 to 2000
-

--- a/LayoutTests/imported/w3c/web-platform-tests/xhr/xmlhttprequest-timeout-worker-overridesexpires_timeout%20set%20to%20expired%20value%20before%20load%20fires-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/xhr/xmlhttprequest-timeout-worker-overridesexpires_timeout%20set%20to%20expired%20value%20before%20load%20fires-expected.txt
@@ -1,9 +1,0 @@
-Description
-
-This test validates that the XHR2 timeout property behaves as expected in in a worker context.
-
-
-PASS Timeout test: timeout set to expiring value after load fires, original timeout at 5000, reset at 4000 to 1000
-PASS Timeout test: timeout set to expired value before load fires, original timeout at 5000, reset at 2000 to 1100
-PASS Timeout test: timeout set to non-expiring value after timeout fires, original timeout at 1000, reset at 2000 to 500
-

--- a/LayoutTests/imported/w3c/web-platform-tests/xhr/xmlhttprequest-timeout-worker-overridesexpires_timeout%20set%20to%20expiring%20value%20after%20load%20fires-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/xhr/xmlhttprequest-timeout-worker-overridesexpires_timeout%20set%20to%20expiring%20value%20after%20load%20fires-expected.txt
@@ -1,9 +1,0 @@
-Description
-
-This test validates that the XHR2 timeout property behaves as expected in in a worker context.
-
-
-PASS Timeout test: timeout set to expiring value after load fires, original timeout at 5000, reset at 4000 to 1000
-PASS Timeout test: timeout set to expired value before load fires, original timeout at 5000, reset at 2000 to 1100
-PASS Timeout test: timeout set to non-expiring value after timeout fires, original timeout at 1000, reset at 2000 to 500
-

--- a/LayoutTests/imported/w3c/web-platform-tests/xhr/xmlhttprequest-timeout-worker-overridesexpires_timeout%20set%20to%20non-expiring%20value%20after%20timeout%20fires-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/xhr/xmlhttprequest-timeout-worker-overridesexpires_timeout%20set%20to%20non-expiring%20value%20after%20timeout%20fires-expected.txt
@@ -1,9 +1,0 @@
-Description
-
-This test validates that the XHR2 timeout property behaves as expected in in a worker context.
-
-
-PASS Timeout test: timeout set to expiring value after load fires, original timeout at 5000, reset at 4000 to 1000
-PASS Timeout test: timeout set to expired value before load fires, original timeout at 5000, reset at 2000 to 1100
-PASS Timeout test: timeout set to non-expiring value after timeout fires, original timeout at 1000, reset at 2000 to 500
-

--- a/LayoutTests/imported/w3c/web-platform-tests/xhr/xmlhttprequest-timeout-worker-simple_load%20fires%20normally-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/xhr/xmlhttprequest-timeout-worker-simple_load%20fires%20normally-expected.txt
@@ -1,7 +1,0 @@
-Description
-
-This test validates that the XHR2 timeout property behaves as expected in in a worker context.
-
-
-PASS Timeout test: load fires normally, timeout scheduled at 5000
-

--- a/LayoutTests/imported/w3c/web-platform-tests/xhr/xmlhttprequest-timeout-worker-simple_no%20time%20out%20scheduled,%20load%20fires%20normally-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/xhr/xmlhttprequest-timeout-worker-simple_no%20time%20out%20scheduled,%20load%20fires%20normally-expected.txt
@@ -1,7 +1,0 @@
-Description
-
-This test validates that the XHR2 timeout property behaves as expected in in a worker context.
-
-
-PASS Timeout test: no time out scheduled, load fires normally, timeout scheduled at 0
-

--- a/LayoutTests/imported/w3c/web-platform-tests/xhr/xmlhttprequest-timeout-worker-simple_timeout%20hit%20before%20load-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/xhr/xmlhttprequest-timeout-worker-simple_timeout%20hit%20before%20load-expected.txt
@@ -1,7 +1,0 @@
-Description
-
-This test validates that the XHR2 timeout property behaves as expected in in a worker context.
-
-
-PASS Timeout test: timeout hit before load, timeout scheduled at 2000
-

--- a/LayoutTests/imported/w3c/web-platform-tests/xhr/xmlhttprequest-timeout-worker-synconworker_load%20fires%20normally-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/xhr/xmlhttprequest-timeout-worker-synconworker_load%20fires%20normally-expected.txt
@@ -1,7 +1,0 @@
-Description
-
-This test validates that the XHR2 timeout property behaves as expected in in a worker context.
-
-
-PASS Timeout test: load fires normally, timeout scheduled at 5000
-

--- a/LayoutTests/imported/w3c/web-platform-tests/xhr/xmlhttprequest-timeout-worker-synconworker_no%20time%20out%20scheduled,%20load%20fires%20normally-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/xhr/xmlhttprequest-timeout-worker-synconworker_no%20time%20out%20scheduled,%20load%20fires%20normally-expected.txt
@@ -1,7 +1,0 @@
-Description
-
-This test validates that the XHR2 timeout property behaves as expected in in a worker context.
-
-
-PASS Timeout test: no time out scheduled, load fires normally, timeout scheduled at 0
-

--- a/LayoutTests/imported/w3c/web-platform-tests/xhr/xmlhttprequest-timeout-worker-synconworker_timeout%20hit%20before%20load-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/xhr/xmlhttprequest-timeout-worker-synconworker_timeout%20hit%20before%20load-expected.txt
@@ -1,7 +1,0 @@
-Description
-
-This test validates that the XHR2 timeout property behaves as expected in in a worker context.
-
-
-PASS Timeout test: Unexpected error: TimeoutError: The operation timed out.
-

--- a/LayoutTests/imported/w3c/web-platform-tests/xhr/xmlhttprequest-timeout-worker-twice_load%20fires%20normally%20with%20no%20timeout%20set,%20twice-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/xhr/xmlhttprequest-timeout-worker-twice_load%20fires%20normally%20with%20no%20timeout%20set,%20twice-expected.txt
@@ -1,7 +1,0 @@
-Description
-
-This test validates that the XHR2 timeout property behaves as expected in in a worker context.
-
-
-PASS Timeout test: load fires normally with no timeout set, twice, original timeout at 0, reset at 2000 to 0
-

--- a/LayoutTests/imported/w3c/web-platform-tests/xhr/xmlhttprequest-timeout-worker-twice_load%20fires%20normally%20with%20same%20timeout%20set%20twice-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/xhr/xmlhttprequest-timeout-worker-twice_load%20fires%20normally%20with%20same%20timeout%20set%20twice-expected.txt
@@ -1,7 +1,0 @@
-Description
-
-This test validates that the XHR2 timeout property behaves as expected in in a worker context.
-
-
-PASS Timeout test: load fires normally with same timeout set twice, original timeout at 5000, reset at 2000 to 5000
-

--- a/LayoutTests/imported/w3c/web-platform-tests/xhr/xmlhttprequest-timeout-worker-twice_timeout%20fires%20normally%20with%20same%20timeout%20set%20twice-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/xhr/xmlhttprequest-timeout-worker-twice_timeout%20fires%20normally%20with%20same%20timeout%20set%20twice-expected.txt
@@ -1,7 +1,0 @@
-Description
-
-This test validates that the XHR2 timeout property behaves as expected in in a worker context.
-
-
-PASS Timeout test: timeout fires normally with same timeout set twice, original timeout at 2000, reset at 1000 to 2000
-

--- a/LayoutTests/tests-options.json
+++ b/LayoutTests/tests-options.json
@@ -7214,7 +7214,7 @@
     "imported/w3c/web-platform-tests/xhr/response-data-progress.htm": [
         "slow"
     ],
-    "imported/w3c/web-platform-tests/xhr/send-redirect-bogus.htm": [
+    "imported/w3c/web-platform-tests/xhr/send-redirect-bogus.sub.htm": [
         "slow"
     ],
     "imported/w3c/web-platform-tests/xhr/setrequestheader-content-type.htm": [


### PR DESCRIPTION
#### 17e4625a7c4d43bc5c17f935272623191e2f5ce0
<pre>
Synchronize WPT xhr
<a href="https://bugs.webkit.org/show_bug.cgi?id=314468">https://bugs.webkit.org/show_bug.cgi?id=314468</a>

Reviewed by Brandon Stewart.

Also mark
imported/w3c/web-platform-tests/xhr/send-redirect-post-upload.htm as
passing as the remaining issues had been tackled seven years ago.

We also account for
<a href="https://github.com/web-platform-tests/wpt/pull/59769">https://github.com/web-platform-tests/wpt/pull/59769</a> and for now do not
import the sync-xhr permission policy tests as that is non-standard.

Upstream commit: <a href="https://github.com/web-platform-tests/wpt/commit/d6f9273ecab906dee6e91acfcf45fabc283589cc">https://github.com/web-platform-tests/wpt/commit/d6f9273ecab906dee6e91acfcf45fabc283589cc</a>

Canonical link: <a href="https://commits.webkit.org/312947@main">https://commits.webkit.org/312947@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f377c9474e92fabeef38b6612adbe089c234d804

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/161562 "4 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/35036 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/28139 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/170465 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/117933 "Built successfully") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/35137 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/35037 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/125344 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/88276 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/164521 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/27642 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/145126 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/105940 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/26691 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/25203 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/18186 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/136385 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/22883 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/172953 "Built successfully") | | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/24524 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/133633 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/34710 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/29298 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/133639 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/34694 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/144678 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/96607 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/24547 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/28169 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/21497 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/34204 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/33704 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/33947 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/33853 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->