### PR TITLE
[macOS Debug] TestWebKitAPI.WKBackForwardList.BackForwardNavigationSkipsItemsWithoutUserGestureFragment is a flaky timeout

### DIFF
--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKBackForwardListTests.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKBackForwardListTests.mm
@@ -392,6 +392,7 @@ TEST(WKBackForwardList, InteractionStateRestorationMultipleItems)
 
 @interface WKBackForwardNavigationDelegate : NSObject <WKNavigationDelegatePrivate>
 - (void)waitForDidFinishNavigationOrDidSameDocumentNavigation;
+- (BOOL)waitForDidFinishNavigationOrDidSameDocumentNavigationWithTimeout:(NSTimeInterval)seconds;
 @end
 
 static RetainPtr<WKNavigation> lastNavigation;
@@ -432,6 +433,12 @@ static RetainPtr<WKNavigation> lastNavigation;
 {
     _navigated = false;
     TestWebKitAPI::Util::run(&_navigated);
+}
+
+- (BOOL)waitForDidFinishNavigationOrDidSameDocumentNavigationWithTimeout:(NSTimeInterval)seconds
+{
+    _navigated = false;
+    return TestWebKitAPI::Util::runFor(&_navigated, Seconds { seconds });
 }
 
 - (void)waitForDidFinishNavigation
@@ -533,39 +540,58 @@ static void runBackForwardNavigationSkipsItemsWithoutUserGestureTest(Function<vo
     RetainPtr url2 = [NSBundle.test_resourcesBundle URLForResource:@"simple2" withExtension:@"html"];
     RetainPtr url3 = [NSBundle.test_resourcesBundle URLForResource:@"simple3" withExtension:@"html"];
 
+    // Waits for the navigation delegate to see didFinishNavigation or didSameDocumentNavigation,
+    // with a finite timeout so that a rare hang (webkit.org/b/313844) surfaces as a fast EXPECT
+    // failure with the context we were waiting for rather than a silent test-framework timeout.
+    // Returns false on timeout so callers can bail out before the next wait also times out,
+    // keeping total runtime bounded.
+    auto waitForNavigation = [&](const char* context) -> bool {
+        if ([navigationDelegate waitForDidFinishNavigationOrDidSameDocumentNavigationWithTimeout:10])
+            return true;
+        NSLog(@"WKBackForwardNavigationDelegate wait timed out (%s); webView.URL = %@", context, [webView URL]);
+        EXPECT_TRUE(false);
+        return false;
+    };
+
     [webView loadRequest:[NSURLRequest requestWithURL:url1.get()]];
-    [navigationDelegate waitForDidFinishNavigationOrDidSameDocumentNavigation];
+    if (!waitForNavigation("loadRequest url1"))
+        return;
 
     [webView loadRequest:[NSURLRequest requestWithURL:url2.get()]];
-    [navigationDelegate waitForDidFinishNavigationOrDidSameDocumentNavigation];
+    if (!waitForNavigation("loadRequest url2"))
+        return;
 
     // Test case:
     // url1 -> url2 -> url2#a (no user gesture) -> url2#b (no user gesture) -> url2#c (no user gesture) -> url3.
 
     // Add back/forward list items without user gestures.
     navigate(webView.get(), "location.pathname + '#a'"_s);
-    [navigationDelegate waitForDidFinishNavigationOrDidSameDocumentNavigation];
+    if (!waitForNavigation("navigate to url2#a"))
+        return;
     EXPECT_FALSE([lastNavigation _isUserInitiated]);
     EXPECT_TRUE(webView.get().backForwardList.currentItem._wasCreatedByJSWithoutUserInteraction);
     RetainPtr expectedURLString = makeString(String([url2 absoluteString]), "#a"_s).createNSString();
     EXPECT_WK_STREQ([lastNavigation _request].URL.absoluteString.UTF8String, expectedURLString.get().UTF8String);
 
     navigate(webView.get(), "location.pathname + '#b'"_s);
-    [navigationDelegate waitForDidFinishNavigationOrDidSameDocumentNavigation];
+    if (!waitForNavigation("navigate to url2#b"))
+        return;
     EXPECT_FALSE([lastNavigation _isUserInitiated]);
     EXPECT_TRUE(webView.get().backForwardList.currentItem._wasCreatedByJSWithoutUserInteraction);
     expectedURLString = makeString(String([url2 absoluteString]), "#b"_s).createNSString();
     EXPECT_WK_STREQ([lastNavigation _request].URL.absoluteString.UTF8String, expectedURLString.get().UTF8String);
 
     navigate(webView.get(), "location.pathname + '#c'"_s);
-    [navigationDelegate waitForDidFinishNavigationOrDidSameDocumentNavigation];
+    if (!waitForNavigation("navigate to url2#c"))
+        return;
     EXPECT_FALSE([lastNavigation _isUserInitiated]);
     EXPECT_TRUE(webView.get().backForwardList.currentItem._wasCreatedByJSWithoutUserInteraction);
     expectedURLString = makeString(String([url2 absoluteString]), "#c"_s).createNSString();
     EXPECT_WK_STREQ([lastNavigation _request].URL.absoluteString.UTF8String, expectedURLString.get().UTF8String);
 
     [webView loadRequest:[NSURLRequest requestWithURL:url3.get()]];
-    [navigationDelegate waitForDidFinishNavigationOrDidSameDocumentNavigation];
+    if (!waitForNavigation("loadRequest url3"))
+        return;
     EXPECT_FALSE([webView backForwardList].currentItem._wasCreatedByJSWithoutUserInteraction);
 
     // url1 -> url2 -> url2#a (no user gesture) -> url2#b (no user gesture) -> url2#c (no user gesture) -> url3 **
@@ -574,7 +600,8 @@ static void runBackForwardNavigationSkipsItemsWithoutUserGestureTest(Function<vo
 
     // We are now on url3. Let's go back.
     [webView goBack];
-    [navigationDelegate waitForDidFinishNavigationOrDidSameDocumentNavigation];
+    if (!waitForNavigation("goBack from url3"))
+        return;
 
     // url1 -> url2 -> url2#a (no user gesture) -> url2#b (no user gesture) -> url2#c (no user gesture) ** -> url3
     expectedURLString = makeString(String([url2 absoluteString]), "#c"_s).createNSString();
@@ -584,7 +611,8 @@ static void runBackForwardNavigationSkipsItemsWithoutUserGestureTest(Function<vo
 
     // Let's go back again.
     [webView goBack];
-    [navigationDelegate waitForDidFinishNavigationOrDidSameDocumentNavigation];
+    if (!waitForNavigation("goBack from url2#c (skipping)"))
+        return;
 
     // We should have skipped over url2#b, url2#a and url2, to end up on url1.
     // url1 ** -> url2 -> url2#a (no user gesture) -> url2#b (no user gesture) -> url2#c (no user gesture) -> url3
@@ -594,7 +622,8 @@ static void runBackForwardNavigationSkipsItemsWithoutUserGestureTest(Function<vo
 
     // Now let's go forward.
     [webView goForward];
-    [navigationDelegate waitForDidFinishNavigationOrDidSameDocumentNavigation];
+    if (!waitForNavigation("goForward from url1"))
+        return;
 
     // We should get to the latest url2 URL, that is url2#c.
     // url1 -> url2 -> url2#a (no user gesture) -> url2#b (no user gesture) -> url2#c (no user gesture) ** -> url3
@@ -605,7 +634,8 @@ static void runBackForwardNavigationSkipsItemsWithoutUserGestureTest(Function<vo
 
     // Let's go forward again.
     [webView goForward];
-    [navigationDelegate waitForDidFinishNavigationOrDidSameDocumentNavigation];
+    if (!waitForNavigation("goForward from url2#c"))
+        return;
 
     // We should now be on url3.
     EXPECT_STREQ([webView URL].absoluteString.UTF8String, [url3 absoluteString].UTF8String);
@@ -615,7 +645,8 @@ static void runBackForwardNavigationSkipsItemsWithoutUserGestureTest(Function<vo
 
     // Navigating via the JS API shouldn't skip those back/forward list items.
     [webView _evaluateJavaScriptWithoutUserGesture:@"history.back();" completionHandler:^(id, NSError *) { }];
-    [navigationDelegate waitForDidFinishNavigationOrDidSameDocumentNavigation];
+    if (!waitForNavigation("history.back() from url3"))
+        return;
 
     expectedURLString = makeString(String([url2 absoluteString]), "#c"_s).createNSString();
     EXPECT_STREQ([webView URL].absoluteString.UTF8String, expectedURLString.get().UTF8String);
@@ -623,7 +654,8 @@ static void runBackForwardNavigationSkipsItemsWithoutUserGestureTest(Function<vo
     EXPECT_EQ([webView backForwardList].forwardList.count, 1U);
 
     [webView _evaluateJavaScriptWithoutUserGesture:@"history.back();" completionHandler:^(id, NSError *) { }];
-    [navigationDelegate waitForDidFinishNavigationOrDidSameDocumentNavigation];
+    if (!waitForNavigation("history.back() from url2#c (same-document)"))
+        return;
     expectedURLString = makeString(String([url2 absoluteString]), "#b"_s).createNSString();
     EXPECT_STREQ([webView URL].absoluteString.UTF8String, expectedURLString.get().UTF8String);
     EXPECT_EQ([webView backForwardList].backList.count, 1U);
@@ -637,12 +669,7 @@ TEST(WKBackForwardList, BackForwardNavigationSkipsItemsWithoutUserGesturePushSta
     });
 }
 
-// FIXME when webkit.org/b/313844 is resolved.
-#if PLATFORM(MAC)
-TEST(WKBackForwardList, DISABLED_BackForwardNavigationSkipsItemsWithoutUserGestureFragment)
-#else
 TEST(WKBackForwardList, BackForwardNavigationSkipsItemsWithoutUserGestureFragment)
-#endif
 {
     runBackForwardNavigationSkipsItemsWithoutUserGestureTest([](WKWebView* webView, ASCIILiteral destination) {
         [webView _evaluateJavaScriptWithoutUserGesture:makeString("location.href = "_s, destination, ";"_s).createNSString().get() completionHandler:nil];


### PR DESCRIPTION
#### 607c5eb1527c31876ab6e916da9a19a6aba399f0
<pre>
[macOS Debug] TestWebKitAPI.WKBackForwardList.BackForwardNavigationSkipsItemsWithoutUserGestureFragment is a flaky timeout
<a href="https://bugs.webkit.org/show_bug.cgi?id=313844">https://bugs.webkit.org/show_bug.cgi?id=313844</a>
<a href="https://rdar.apple.com/176046782">rdar://176046782</a>

Reviewed by Brady Eidson.

The test was disabled on macOS due to flaky timeouts on Intel Debug builds. The
delegate&apos;s waitForDidFinishNavigationOrDidSameDocumentNavigation only wakes on
didFinishNavigation or SessionStatePush/SessionStatePop. If anything upstream
causes that signal to be skipped for one of the same-document navigations in
the test (for example, Navigation API&apos;s innerDispatchNavigateEvent returning
DispatchResult::Aborted), no signal ever fires and the wait hangs until the
test-framework timeout with no actionable diagnostic.

Re-enable the test on macOS and add a finite-timeout variant of the delegate
wait used by this test. The helper now bails out at the first wait that
doesn&apos;t fire within 10 seconds, logging the navigation step that stalled and
the current webView.URL, and records an EXPECT failure. A rare underlying
navigation hang therefore surfaces as a fast, localized failure with context,
rather than as a silent timeout, making the next investigation of the
underlying Navigation API race tractable.

* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKBackForwardListTests.mm:
(-[WKBackForwardNavigationDelegate waitForDidFinishNavigationOrDidSameDocumentNavigationWithTimeout:]):
(runBackForwardNavigationSkipsItemsWithoutUserGestureTest):
(TEST(WKBackForwardList, BackForwardNavigationSkipsItemsWithoutUserGestureFragment)):

Canonical link: <a href="https://commits.webkit.org/313126@main">https://commits.webkit.org/313126@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c11719375c2476050ff12f829bcdfc13b3c622bd

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/162019 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/35494 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/28599 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/170927 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/118390 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/163888 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/35596 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/35495 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/125735 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/88604 "2 flakes 17 failures") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/164978 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/28045 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/145528 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/106317 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/1fa05825-c712-4b58-af20-529749d658ef) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/27094 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/25607 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/18647 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/136787 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/23282 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/173415 "Built successfully") | | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/24923 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/134024 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/35167 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/29692 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/134030 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36220 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/35151 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/145077 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/97288 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/28556 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/21902 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/34661 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/34162 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/34404 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/34310 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->