### PR TITLE
Empty <msqrt> is misaligned vertically relative to <msqrt><mrow></mrow></msqrt>

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -2157,7 +2157,6 @@ imported/w3c/web-platform-tests/mathml/presentation-markup/mrow/legacy-mrow-like
 imported/w3c/web-platform-tests/mathml/presentation-markup/mrow/semantics-002.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/mathml/presentation-markup/mrow/semantics-003.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/mathml/presentation-markup/mrow/semantics-005.html [ ImageOnlyFailure ]
-imported/w3c/web-platform-tests/mathml/presentation-markup/radicals/empty-msqrt.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/mathml/presentation-markup/scripts/munder-mover-align-accent-false.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/mathml/presentation-markup/scripts/munder-mover-align-accent-true.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/mathml/presentation-markup/scripts/munderover-align-accent-false.html [ ImageOnlyFailure ]

--- a/Source/WebCore/rendering/mathml/RenderMathMLRoot.cpp
+++ b/Source/WebCore/rendering/mathml/RenderMathMLRoot.cpp
@@ -128,7 +128,7 @@ RenderMathMLRoot::HorizontalParameters RenderMathMLRoot::horizontalParameters(La
     return parameters;
 }
 
-RenderMathMLRoot::VerticalParameters RenderMathMLRoot::verticalParameters()
+RenderMathMLRoot::VerticalParameters RenderMathMLRoot::verticalParameters() const
 {
     VerticalParameters parameters;
     // We try and read constants to draw the radical from the OpenType MATH and use fallback values otherwise.
@@ -287,6 +287,19 @@ void RenderMathMLRoot::layoutBlock(RelayoutChildren relayoutChildren, LayoutUnit
     updateLogicalHeight();
 
     layoutOutOfFlowBoxes(relayoutChildren);
+}
+
+std::optional<LayoutUnit> RenderMathMLRoot::firstLineBaseline() const
+{
+    // Per MathML Core, an empty <msqrt> renders as if it had a single empty <mrow> child.
+    // Synthesize the baseline of that implicit mrow so that the empty square root aligns
+    // with its non-empty counterpart on the line.
+    if (rootType() == RootType::SquareRoot && !firstInFlowChildBox()) {
+        auto vertical = verticalParameters();
+        return vertical.verticalGap + vertical.ruleThickness + vertical.extraAscender + borderAndPaddingBefore();
+    }
+
+    return RenderMathMLRow::firstLineBaseline();
 }
 
 void RenderMathMLRoot::paint(PaintInfo& info, const LayoutPoint& paintOffset)

--- a/Source/WebCore/rendering/mathml/RenderMathMLRoot.h
+++ b/Source/WebCore/rendering/mathml/RenderMathMLRoot.h
@@ -61,6 +61,7 @@ private:
     void computePreferredLogicalWidths() final;
     void layoutBlock(RelayoutChildren, LayoutUnit pageLogicalHeight = 0_lu) final;
     void paint(PaintInfo&, const LayoutPoint&) final;
+    std::optional<LayoutUnit> firstLineBaseline() const final;
 
     struct HorizontalParameters {
         LayoutUnit kernBeforeDegree;
@@ -73,7 +74,7 @@ private:
         LayoutUnit extraAscender;
         float degreeBottomRaisePercent;
     };
-    VerticalParameters verticalParameters();
+    VerticalParameters verticalParameters() const;
 
     MathOperator m_radicalOperator;
     LayoutUnit m_radicalOperatorTop;


### PR DESCRIPTION
#### 1b116eac12b99e00c6f202d8dc0d6f330285dee4
<pre>
Empty &lt;msqrt&gt; is misaligned vertically relative to &lt;msqrt&gt;&lt;mrow&gt;&lt;/mrow&gt;&lt;/msqrt&gt;
<a href="https://bugs.webkit.org/show_bug.cgi?id=302662">https://bugs.webkit.org/show_bug.cgi?id=302662</a>
<a href="https://rdar.apple.com/165365714">rdar://165365714</a>

Reviewed by Frédéric Wang Nélar.

Per MathML Core, an empty &lt;msqrt&gt; must render as if it had a single empty
&lt;mrow&gt; child (<a href="https://w3c.github.io/mathml-core/#radicals-msqrt-mroot).">https://w3c.github.io/mathml-core/#radicals-msqrt-mroot).</a> While
layout produces the same box, the baseline reported by the renderer does not:
RenderMathMLRow::firstLineBaseline() returns nullopt when there are no
in-flow children, so the inline-block fallback uses the box&apos;s bottom edge.
The reference case with an explicit empty &lt;mrow&gt; child instead reports a
baseline at radicalAscent, which is where the implicit mrow sits above the
radical&apos;s rule line. The two forms therefore sit at different vertical
positions on the line (offset by radicalDescent, which is non-zero whenever
the stretched radical operator is taller than verticalGap + ruleThickness).

Override firstLineBaseline() in RenderMathMLRoot to synthesize the baseline
of the implicit empty mrow when the root is a SquareRoot with no in-flow
child. With no base content, baseAscent is zero, so the synthesized ascent
collapses to verticalGap + ruleThickness + extraAscender (plus border and
padding before). Compute this on demand from verticalParameters() rather
than caching it in a member, and make verticalParameters() const so it can
be called from firstLineBaseline().

RootType::RootWithIndex with a missing child is !isValid() and already falls
through to plain row layout, where the default baseline is correct, so it
does not need special handling.

* LayoutTests/TestExpectations: Progression
* Source/WebCore/rendering/mathml/RenderMathMLRoot.cpp:
(WebCore::RenderMathMLRoot::verticalParameters const):
(WebCore::RenderMathMLRoot::firstLineBaseline const):
* Source/WebCore/rendering/mathml/RenderMathMLRoot.h:

Canonical link: <a href="https://commits.webkit.org/313000@main">https://commits.webkit.org/313000@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/980f4e41da815b43c208c5a5842ced2d1a732f24

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/161800 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/35274 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/28377 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/170703 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/118171 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/248cc7ef-7f0d-4c46-80f1-c8bfb3cf2bee) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/163669 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/35375 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/35275 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/125538 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/88453 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/37e506fc-9c93-4f12-978e-bc885bce388a) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/164759 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/27852 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/145331 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/106134 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/291cca6a-b4be-4491-9c5e-f7e2029ac3fd) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/26901 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/25416 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/18424 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/136594 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/23086 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/173192 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/20232 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/24727 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/133834 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/34948 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/29504 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/133839 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36144 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/34932 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/144881 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/96989 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/28372 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/21704 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/34442 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/101887 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/33942 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/34185 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/34091 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->