### PR TITLE
TestWebKitAPI.NetworkProcess.LaunchOnlyWhenNecessary is flaky

### DIFF
--- a/Source/WebKit/UIProcess/WebProcessPool.cpp
+++ b/Source/WebKit/UIProcess/WebProcessPool.cpp
@@ -1397,10 +1397,6 @@ Ref<WebPageProxy> WebProcessPool::createWebPage(PageClient& pageClient, Ref<API:
     }
 #endif
 
-#if ENABLE(LAUNCHSERVICES_SANDBOX_EXTENSION_BLOCKING)
-    NetworkProcessProxy::ensureDefaultNetworkProcess();
-#endif
-
     return page;
 }
 


### PR DESCRIPTION
#### 450541bb3f7277b186aa211f6006712b1dbefcf7
<pre>
TestWebKitAPI.NetworkProcess.LaunchOnlyWhenNecessary is flaky
<a href="https://bugs.webkit.org/show_bug.cgi?id=314472">https://bugs.webkit.org/show_bug.cgi?id=314472</a>
<a href="https://rdar.apple.com/176587141">rdar://176587141</a>

Reviewed by Per Arne Vollan.

The test was trying to make sure that the network process wasn&apos;t getting
launched unnecessarily. However, the network process was actually launched
unnecessarily when constructing a WKWebView:
```
NetworkProcessProxy::ensureDefaultNetworkProcess(); // in WebProcessPool::createWebPage().
```

However, `NetworkProcessProxy::ensureDefaultNetworkProcess()` doesn&apos;t
store the smart pointer anywhere, it just returns it. As a result, this
was constructing and then destrucing a NetworkProcessProxy in quick
succession, causing the test to be flaky.

To address the issue, stop making this call. The intention seemed to be
launching the network process but it would not happen in practice since
the NetworkProcessProxy would get destroyed right away. Also, the API
test clearly doesn&apos;t expect the network process to get launched in this
case.

* Source/WebKit/UIProcess/WebProcessPool.cpp:
(WebKit::WebProcessPool::createWebPage):

Canonical link: <a href="https://commits.webkit.org/313035@main">https://commits.webkit.org/313035@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6c5b59e252a309fa89a83d60c43b142156e0a570

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/161573 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/35047 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/28150 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/170476 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/117944 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/f44f41c4-a93c-4633-88b9-990afa73c11d) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/35148 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/35048 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/125355 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/88282 "1 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/41aa0c68-d708-4c51-9855-ca562f0da895) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/164532 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/27653 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/145134 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/105951 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/d0626a16-e483-4659-8a4d-2767111ac89a) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/26702 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/25212 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/18197 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/136396 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/172964 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/20005 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/24532 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/133642 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/34721 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/29307 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/133648 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/34705 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/144686 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/96625 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/24586 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/28173 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/21505 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/34215 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/101660 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/33715 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/33958 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/33864 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->