### PR TITLE
[JSC] Add strength reduction skipping ArithMod

### DIFF
--- a/JSTests/stress/arith-mod-before-narrow-typed-array-store.js
+++ b/JSTests/stress/arith-mod-before-narrow-typed-array-store.js
@@ -1,0 +1,257 @@
+// Test: `ArithMod` elision before narrow typed-array stores.
+// DFGStrengthReductionPhase rewires the PutByVal's value edge past `ArithMod(x, k*2^W)`
+// to `x` when storing into a W-bit typed array (Int8, Uint8, Int16, Uint16). The
+// semantics match because the store takes the low W bits and `x` agrees with
+// `x % (k*2^W)` modulo 2^W. Uint8ClampedArray saturates, so the mod must NOT be
+// elided there. The ArithMod node itself must not be converted to Identity because
+// other users (e.g. the function's return value) still need `x % k`.
+
+function uint8StoreMod(arr, i, a, b) {
+    arr[i] = (a + b) % 256;
+}
+noInline(uint8StoreMod);
+
+function int8StoreMod(arr, i, a, b) {
+    arr[i] = (a + b) % 256;
+}
+noInline(int8StoreMod);
+
+function uint16StoreMod(arr, i, a, b) {
+    arr[i] = (a + b) % 65536;
+}
+noInline(uint16StoreMod);
+
+function int16StoreMod(arr, i, a, b) {
+    arr[i] = (a + b) % 65536;
+}
+noInline(int16StoreMod);
+
+function uint8StoreModMultiple(arr, i, a, b) {
+    // 256 * 3 = 768 is a multiple of 256; elision still valid.
+    arr[i] = (a + b) % 768;
+}
+noInline(uint8StoreModMultiple);
+
+function uint8StoreNegativeMod(arr, i, a, b) {
+    // Negative divisor: `|k|` == 256, still a multiple of 2^8. Elision valid.
+    arr[i] = (a + b) % -256;
+}
+noInline(uint8StoreNegativeMod);
+
+function uint8StoreSmallMod(arr, i, a, b) {
+    // 100 is not a multiple of 256 so the mod must NOT be elided.
+    // We still require the produced value to be correct.
+    arr[i] = (a + b) % 100;
+}
+noInline(uint8StoreSmallMod);
+
+function clampedStoreMod(arr, i, a, b) {
+    // Uint8ClampedArray saturates (0..255), so `(x % 256)` and `x` differ for
+    // values outside [0,255]. The mod must NOT be elided here.
+    arr[i] = (a + b) % 256;
+}
+noInline(clampedStoreMod);
+
+const INT32_MIN = -2147483648;
+const INT32_MAX = 2147483647;
+
+function toUint8(x) { return ((x % 256) + 256) % 256; }
+function toInt8(x) {
+    const u = toUint8(x);
+    return u >= 128 ? u - 256 : u;
+}
+function toUint16(x) { return ((x % 65536) + 65536) % 65536; }
+function toInt16(x) {
+    const u = toUint16(x);
+    return u >= 32768 ? u - 65536 : u;
+}
+function toUint8Clamped(x) {
+    if (Number.isNaN(x)) return 0;
+    if (x <= 0) return 0;
+    if (x >= 255) return 255;
+    // Round half to even.
+    const f = Math.floor(x);
+    const diff = x - f;
+    if (diff < 0.5) return f;
+    if (diff > 0.5) return f + 1;
+    return (f & 1) ? f + 1 : f;
+}
+
+const testPairs = [
+    [0, 0],
+    [1, 1],
+    [0, -1],
+    [-1, -1],
+    [INT32_MIN, 0],
+    [INT32_MIN, -1],
+    [INT32_MAX, 0],
+    [INT32_MAX, 1],
+    [255, 1],
+    [-255, -1],
+    [256, 0],
+    [-256, 0],
+    [257, -1],
+    [-257, 1],
+    [32767, 1],
+    [-32768, 0],
+    [-32768, -1],
+    [65535, 1],
+    [65536, 0],
+    [-65536, -1],
+    [1_000_000, 123],
+    [-1_000_000, -123],
+];
+
+const u8 = new Uint8Array(1);
+const i8 = new Int8Array(1);
+const u16 = new Uint16Array(1);
+const i16 = new Int16Array(1);
+const clamped = new Uint8ClampedArray(1);
+
+// Warm up so DFG / FTL compile the hot stores and the strength-reduction runs.
+for (let i = 0; i < testLoopCount; ++i) {
+    uint8StoreMod(u8, 0, i, 3);
+    int8StoreMod(i8, 0, i, 3);
+    uint16StoreMod(u16, 0, i, 3);
+    int16StoreMod(i16, 0, i, 3);
+    uint8StoreModMultiple(u8, 0, i, 3);
+    uint8StoreNegativeMod(u8, 0, i, 3);
+    uint8StoreSmallMod(u8, 0, i, 3);
+    clampedStoreMod(clamped, 0, i, 3);
+}
+
+function check(expectFn, storeFn, arr, a, b, label) {
+    storeFn(arr, 0, a, b);
+    const sum = a + b;
+    const expected = expectFn(sum);
+    if (arr[0] !== expected)
+        throw new Error(`${label}(${a}, ${b}): expected ${expected}, got ${arr[0]}`);
+}
+
+for (const [a, b] of testPairs) {
+    check(toUint8, uint8StoreMod, u8, a, b, "uint8StoreMod");
+    check(toInt8, int8StoreMod, i8, a, b, "int8StoreMod");
+    check(toUint16, uint16StoreMod, u16, a, b, "uint16StoreMod");
+    check(toInt16, int16StoreMod, i16, a, b, "int16StoreMod");
+    check(toUint8, uint8StoreModMultiple, u8, a, b, "uint8StoreModMultiple");
+    check(toUint8, uint8StoreNegativeMod, u8, a, b, "uint8StoreNegativeMod");
+
+    // Small mod: the actual stored value must match `(sum % 100)` narrowed to Uint8.
+    const sum = a + b;
+    const expectedSmall = toUint8(sum % 100);
+    uint8StoreSmallMod(u8, 0, a, b);
+    if (u8[0] !== expectedSmall)
+        throw new Error(`uint8StoreSmallMod(${a}, ${b}): expected ${expectedSmall}, got ${u8[0]}`);
+
+    // Clamped: the mod must remain so that saturation sees the already-reduced value.
+    const expectedClamped = toUint8Clamped(sum % 256);
+    clampedStoreMod(clamped, 0, a, b);
+    if (clamped[0] !== expectedClamped)
+        throw new Error(`clampedStoreMod(${a}, ${b}): expected ${expectedClamped}, got ${clamped[0]}`);
+}
+
+// Regression guard for the benchmark pattern: narrow typed array filled in a
+// tight loop with `(i + counter) % width`. Counter is kept live-in and mutated
+// outside the loop so it's not an obvious constant.
+function fillUint8(view, len, counter) {
+    for (let i = 0; i < len; ++i)
+        view[i] = (i + counter) % 256;
+}
+noInline(fillUint8);
+
+const big = new Uint8Array(256);
+for (let iter = 0; iter < testLoopCount; ++iter) {
+    const counter = iter * 7 + 13;
+    fillUint8(big, big.length, counter);
+    for (let i = 0; i < big.length; ++i) {
+        const expected = toUint8(i + counter);
+        if (big[i] !== expected)
+            throw new Error(`fillUint8 iter=${iter} i=${i}: expected ${expected}, got ${big[i]}`);
+    }
+}
+
+// Regression guard: the ArithMod result is used both by a narrow typed-array store
+// AND returned to the caller. The strength reduction must rewire only the
+// PutByVal's value edge — converting the shared ArithMod node to Identity would
+// make the return value observe `x` instead of `x % 256`.
+function sharedMod(arr, x) {
+    let m = x % 256;
+    arr[0] = m;
+    return m;
+}
+noInline(sharedMod);
+
+const sharedArr = new Uint8Array(1);
+for (let i = 0; i < testLoopCount; ++i) {
+    const r = sharedMod(sharedArr, i);
+    const expected = toUint8(i);
+    if (r !== expected)
+        throw new Error(`sharedMod i=${i}: return expected ${expected}, got ${r}`);
+    if (sharedArr[0] !== expected)
+        throw new Error(`sharedMod i=${i}: store expected ${expected}, got ${sharedArr[0]}`);
+}
+
+// Regression guard for the ArithMod -> UInt32ToNumber fallthrough in
+// DFGStrengthReductionPhase: after rewiring past `ArithMod(x, 256)`, the
+// value edge may now point to a `UInt32ToNumber` node that can also be
+// stripped before the narrow-typed-array store. `x >>> 0` reinterprets x as
+// an unsigned 32-bit value, which the DFG wraps in UInt32ToNumber when the
+// high bit may be set.
+function uint8StoreUnsignedShiftMod(arr, x) {
+    arr[0] = (x >>> 0) % 256;
+}
+noInline(uint8StoreUnsignedShiftMod);
+
+const shiftArr = new Uint8Array(1);
+for (let i = 0; i < testLoopCount; ++i) {
+    uint8StoreUnsignedShiftMod(shiftArr, i);
+    const expected = toUint8((i >>> 0) % 256);
+    if (shiftArr[0] !== expected)
+        throw new Error(`uint8StoreUnsignedShiftMod i=${i}: expected ${expected}, got ${shiftArr[0]}`);
+}
+
+for (const x of [-1, -2, -256, -257, INT32_MIN, INT32_MIN + 1, INT32_MAX, -1_000_000]) {
+    uint8StoreUnsignedShiftMod(shiftArr, x);
+    const expected = toUint8((x >>> 0) % 256);
+    if (shiftArr[0] !== expected)
+        throw new Error(`uint8StoreUnsignedShiftMod x=${x}: expected ${expected}, got ${shiftArr[0]}`);
+}
+
+// Regression guard for iterative folding: two nested mods that are both
+// multiples of the array element width should collapse in a single pass.
+// `(x % 65536) % 256` stored into Uint8Array — the outer mod peels, then the
+// inner mod peels, leaving just `x` at the PutByVal value edge.
+function uint8StoreNestedMod(arr, x) {
+    arr[0] = (x % 65536) % 256;
+}
+noInline(uint8StoreNestedMod);
+
+const nestedArr = new Uint8Array(1);
+for (let i = 0; i < testLoopCount; ++i) {
+    uint8StoreNestedMod(nestedArr, i);
+    const expected = toUint8(i);
+    if (nestedArr[0] !== expected)
+        throw new Error(`uint8StoreNestedMod i=${i}: expected ${expected}, got ${nestedArr[0]}`);
+}
+
+for (const x of [0, 1, -1, 255, -255, 256, -256, 32767, -32768, 65535, 65536, -65536, INT32_MIN, INT32_MAX, 1_000_000, -1_000_000]) {
+    uint8StoreNestedMod(nestedArr, x);
+    const expected = toUint8(x);
+    if (nestedArr[0] !== expected)
+        throw new Error(`uint8StoreNestedMod x=${x}: expected ${expected}, got ${nestedArr[0]}`);
+}
+
+// Mixed nesting: ArithMod over UInt32ToNumber over an Int32 value. The outer
+// mod peels first, exposing UInt32ToNumber, which then also peels.
+function uint8StoreModOverUnsignedShift(arr, x) {
+    arr[0] = ((x * 3) >>> 0) % 65536;
+}
+noInline(uint8StoreModOverUnsignedShift);
+
+const mixedArr = new Uint8Array(1);
+for (let i = 0; i < testLoopCount; ++i) {
+    uint8StoreModOverUnsignedShift(mixedArr, i);
+    const expected = toUint8(((i * 3) >>> 0) % 65536);
+    if (mixedArr[0] !== expected)
+        throw new Error(`uint8StoreModOverUnsignedShift i=${i}: expected ${expected}, got ${mixedArr[0]}`);
+}

--- a/Source/JavaScriptCore/dfg/DFGStrengthReductionPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGStrengthReductionPhase.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2024 Apple Inc. All rights reserved.
+ * Copyright (C) 2013-2026 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -20,7 +20,7 @@
  * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
  * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
- * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. 
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
 #include "config.h"
@@ -1521,15 +1521,50 @@ private:
                 break;
             }
 
+            case Array::Int8Array:
             case Array::Uint8Array:
+            case Array::Int16Array:
             case Array::Uint16Array:
             case Array::Uint32Array: {
                 if (m_node->op() == PutByVal || m_node->op() == PutByValDirect || m_node->op() == PutByValDirectResolved) {
                     Edge& valueEdge = m_graph.child(m_node, 2);
                     if (valueEdge.useKind() == Int32Use) {
-                        if (valueEdge->op() == UInt32ToNumber && valueEdge->child1().useKind() == Int32Use) {
-                            valueEdge = valueEdge->child1();
-                            m_changed = true;
+                        unsigned arrayElementWidth = 0;
+                        switch (m_node->arrayMode().modeForPut().type()) {
+                        case Array::Int8Array:
+                        case Array::Uint8Array:
+                            arrayElementWidth = 1U << 8;
+                            break;
+                        case Array::Int16Array:
+                        case Array::Uint16Array:
+                            arrayElementWidth = 1U << 16;
+                            break;
+                        default:
+                            break;
+                        }
+
+                        while (true) {
+                            if (arrayElementWidth
+                                && valueEdge->op() == ArithMod
+                                && valueEdge->binaryUseKind() == Int32Use
+                                && valueEdge->child2()->isInt32Constant()) {
+                                int32_t modConst = valueEdge->child2()->asInt32();
+                                if (modConst != INT_MIN) {
+                                    // Canonicalize modConst via std::abs as ArithMod(x, -256) and ArithMod(x, 256) are the same.
+                                    int64_t absModConst = std::abs(static_cast<int64_t>(modConst));
+                                    if (absModConst >= arrayElementWidth && absModConst % arrayElementWidth == 0) {
+                                        valueEdge = Edge(valueEdge->child1().node(), Int32Use);
+                                        m_changed = true;
+                                        continue;
+                                    }
+                                }
+                            }
+                            if (valueEdge->op() == UInt32ToNumber && valueEdge->child1().useKind() == Int32Use) {
+                                valueEdge = valueEdge->child1();
+                                m_changed = true;
+                                continue;
+                            }
+                            break;
                         }
                     }
                 }


### PR DESCRIPTION
#### 237fbbea10ddcb1c5aea2a03ecf16c900893eea7
<pre>
[JSC] Add strength reduction skipping ArithMod
<a href="https://bugs.webkit.org/show_bug.cgi?id=314473">https://bugs.webkit.org/show_bug.cgi?id=314473</a>
<a href="https://rdar.apple.com/176645380">rdar://176645380</a>

Reviewed by Yijia Huang.

When we have a code like,

PutByVal(Int8Array, ArithMod(Int32Use:x, 256))

This can be converted to PutByVal(Int8Array, Int32Use:x) because
ArithMod 256 just extract lower 8bit and Int8Array store will just move
this 8bit representation to the array. This is the same to Uint8Array,
Int16Array, Uint16Array. This patch adds strength reduction rule to DFG
for this, which can skip ArithMod.

Test: JSTests/stress/arith-mod-before-narrow-typed-array-store.js

* JSTests/stress/arith-mod-before-narrow-typed-array-store.js: Added.
(uint8StoreMod):
(int8StoreMod):
(uint16StoreMod):
(int16StoreMod):
(uint8StoreModMultiple):
(uint8StoreNegativeMod):
(uint8StoreSmallMod):
(clampedStoreMod):
(toUint8):
(toInt8):
(toUint16):
(toInt16):
(toUint8Clamped):
(check):
(fillUint8):
(sharedMod):
(uint8StoreUnsignedShiftMod):
(uint8StoreNestedMod):
(uint8StoreModOverUnsignedShift):
* Source/JavaScriptCore/dfg/DFGStrengthReductionPhase.cpp:
(JSC::DFG::StrengthReductionPhase::handleNode):

Canonical link: <a href="https://commits.webkit.org/313037@main">https://commits.webkit.org/313037@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/048ef674ca475090f518a7869579f093fd47c509

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/161770 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/35244 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/28347 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/170673 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/118141 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/c6174185-7c7e-4970-8495-bb0f15580a68) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/35345 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/35245 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/125508 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/88427 "1 flakes 17 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/a7d93724-b591-4705-a29b-c2ad1f442ee2) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/164729 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/27819 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/145306 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/106104 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/d294f7d2-6436-42b6-b02f-7a59aee68c54) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/26868 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/25385 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/18394 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/153828 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/136561 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/23061 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/173162 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/22608 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/20202 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/24702 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/133804 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/34918 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/29474 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/133809 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/34902 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/144856 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/96946 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/24588 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/28341 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/21678 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/194169 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/34412 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/101857 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/50041 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/33912 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/34155 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/34061 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->