### PR TITLE
window.open() with javascript: URL runs synchronously instead of queuing a task

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/navigating-across-documents/javascript-url-task-queuing-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/navigating-across-documents/javascript-url-task-queuing-expected.txt
@@ -4,5 +4,5 @@ PASS Navigating an iframe via location.href to a javascript: URL must queue a ta
 PASS Navigating an iframe via src="" to a javascript: URL before insertion must queue a task
 PASS Navigating an iframe via src="" to a javascript: URL after insertion must queue a task
 PASS Navigating an opened window via location.href to a javascript: URL must queue a task
-FAIL Navigating an opened window as part of creation to a javascript: URL must queue a task assert_equals: Must not run sync expected (undefined) undefined but got (boolean) true
+PASS Navigating an opened window as part of creation to a javascript: URL must queue a task
 

--- a/Source/WebCore/page/LocalDOMWindow.cpp
+++ b/Source/WebCore/page/LocalDOMWindow.cpp
@@ -2895,11 +2895,18 @@ ExceptionOr<RefPtr<Frame>> LocalDOMWindow::createWindow(const String& urlString,
         prepareDialogFunction(*protect(localNewFrame->document()->window()));
 
     if (created == CreatedNewPage::Yes) {
-        ResourceRequest resourceRequest { WTF::move(completedURL), referrer, ResourceRequestCachePolicy::UseProtocolCachePolicy };
-        FrameLoader::addSameSiteInfoToRequestIfNeeded(resourceRequest, openerDocument.get());
-        FrameLoadRequest frameLoadRequest { protect(activeWindow.document()).releaseNonNull(), protect(protect(activeWindow.document())->securityOrigin()), WTF::move(resourceRequest), selfTargetFrameName(), initiatedByMainFrame };
-        frameLoadRequest.setShouldOpenExternalURLsPolicy(activeDocument->shouldOpenExternalURLsPolicyToPropagate());
-        newFrame->changeLocation(WTF::move(frameLoadRequest));
+        // HTML navigate algorithm step 20: javascript: URLs must be dispatched
+        // via a queued task, not synchronously inside window.open().
+        if (completedURL.protocolIsJavaScript()) {
+            LockHistory lockHistory = UserGestureIndicator::processingUserGesture() ? LockHistory::No : LockHistory::Yes;
+            protect(newFrame->navigationScheduler())->scheduleLocationChange(*activeDocument, protect(activeDocument->securityOrigin()), completedURL, referrer, lockHistory, LockBackForwardList::No);
+        } else {
+            ResourceRequest resourceRequest { WTF::move(completedURL), referrer, ResourceRequestCachePolicy::UseProtocolCachePolicy };
+            FrameLoader::addSameSiteInfoToRequestIfNeeded(resourceRequest, openerDocument.get());
+            FrameLoadRequest frameLoadRequest { protect(activeWindow.document()).releaseNonNull(), protect(protect(activeWindow.document())->securityOrigin()), WTF::move(resourceRequest), selfTargetFrameName(), initiatedByMainFrame };
+            frameLoadRequest.setShouldOpenExternalURLsPolicy(activeDocument->shouldOpenExternalURLsPolicyToPropagate());
+            newFrame->changeLocation(WTF::move(frameLoadRequest));
+        }
     } else if (!urlString.isEmpty()) {
         LockHistory lockHistory = UserGestureIndicator::processingUserGesture() ? LockHistory::No : LockHistory::Yes;
         protect(newFrame->navigationScheduler())->scheduleLocationChange(*activeDocument, protect(activeDocument->securityOrigin()), completedURL, referrer, lockHistory, LockBackForwardList::No);


### PR DESCRIPTION
#### 9edc5e2439d8f5ef36c9ed3581b9b3e0f4f44a65
<pre>
window.open() with javascript: URL runs synchronously instead of queuing a task
<a href="https://bugs.webkit.org/show_bug.cgi?id=314474">https://bugs.webkit.org/show_bug.cgi?id=314474</a>
<a href="https://rdar.apple.com/176645817">rdar://176645817</a>

Reviewed by NOBODY (OOPS!).

Per the HTML navigate algorithm [1]:

    20. If url&apos;s scheme is &quot;javascript&quot;, then:
        Queue a global task on the navigation and traversal task source
        given navigable&apos;s active window to navigate to a javascript: URL
        given navigable, url, historyHandling, sourceSnapshotParams,
        initiatorOriginSnapshot, userInvolvement, cspNavigationType,
        initialInsertion, and navigationId.

LocalDOMWindow::setLocation (location.href= / location.assign) and
SubframeLoader::loadOrRedirectSubframe (iframe.src= against an existing
content frame) already queue this task via
NavigationScheduler::scheduleLocationChange. The window.open() new-page
branch in LocalDOMWindow::createWindow called FrameLoader::changeLocation
directly, so executeJavaScriptURL ran synchronously inside window.open()
before it returned.

Route javascript: URLs in the new-page branch through
NavigationScheduler::scheduleLocationChange, matching the existing
non-new-page branch a few lines below.

NOTE: Anchor activation (HTMLAnchorElement::handleClick) reaches
FrameLoader::loadWithNavigationAction directly and has the same
synchronous-execution bug; that path is left for a follow-up.

[1] <a href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#navigate">https://html.spec.whatwg.org/multipage/browsing-the-web.html#navigate</a>

* LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/navigating-across-documents/javascript-url-task-queuing-expected.txt: Progression
* Source/WebCore/page/LocalDOMWindow.cpp:
(WebCore::LocalDOMWindow::createWindow):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9edc5e2439d8f5ef36c9ed3581b9b3e0f4f44a65

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/161692 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/35166 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/28269 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/170595 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/118063 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/3b3beb2d-3bde-401e-b4f1-be5553e773d4) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/163561 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/35267 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/35167 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/125446 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/88369 "3 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/8a9deb2e-d06f-4b41-889a-6f5e81eddfea) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/164651 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/27754 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/145235 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/106042 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/a785ac1c-4a24-46bb-90c0-d815c2c5e44f) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/26803 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/25313 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/18316 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/136496 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/22990 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/173083 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/20124 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/24631 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/133738 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/34840 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/29405 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/133743 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/34824 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/144785 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/96825 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/28276 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/21605 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/34334 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/101779 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/33834 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/34077 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/33983 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->