### PR TITLE
[YARR] `containsCapturingTerms` should guard against stack overflow

### DIFF
--- a/JSTests/stress/regexp-dot-star-enclosure-contains-capturing-terms-out-of-stack.js
+++ b/JSTests/stress/regexp-dot-star-enclosure-contains-capturing-terms-out-of-stack.js
@@ -1,0 +1,21 @@
+// This tests that containsCapturingTerms() used by the DotStarEnclosure optimization
+// throws when we run out of stack space instead of crashing.
+//@ exclusive!
+//@ requireOptions("-e", "let depth=25000") if $memoryLimited
+
+depth = typeof(depth) === 'undefined' ? 200000 : depth;
+
+let expectedException = "SyntaxError: Invalid regular expression: regular expression too large";
+
+function test(source)
+{
+    try {
+        new RegExp(source);
+    } catch (e) {
+        if (e != expectedException)
+            throw "Expected \"" + expectedException + "\", but got \"" + e + "\" for: " + source.slice(0, 30) + "...";
+    }
+}
+
+test(".*" + "(?:".repeat(depth) + "a" + ")".repeat(depth) + ".*");
+test("^.*" + "(?:".repeat(depth) + "a" + ")".repeat(depth) + ".*$");

--- a/Source/JavaScriptCore/yarr/YarrPattern.cpp
+++ b/Source/JavaScriptCore/yarr/YarrPattern.cpp
@@ -2053,8 +2053,13 @@ public:
         }
     }
 
-    bool NODELETE containsCapturingTerms(PatternAlternative* alternative, size_t firstTermIndex, size_t endIndex)
+    bool containsCapturingTerms(PatternAlternative* alternative, size_t firstTermIndex, size_t endIndex)
     {
+        if (!isSafeToRecurse()) [[unlikely]] {
+            m_error = ErrorCode::PatternTooLarge;
+            return true;
+        }
+
         Vector<PatternTerm>& terms = alternative->m_terms;
 
         ASSERT(endIndex <= terms.size());


### PR DESCRIPTION
#### d73a66dd5be2ea63a69bc48be7c7789ba358da9a
<pre>
[YARR] `containsCapturingTerms` should guard against stack overflow
<a href="https://bugs.webkit.org/show_bug.cgi?id=314475">https://bugs.webkit.org/show_bug.cgi?id=314475</a>

Reviewed by Yusuke Suzuki.

optimizeDotStarWrappedExpressions() calls containsCapturingTerms() to decide
whether the DotStarEnclosure optimization can be applied. That helper walks
the pattern tree recursively into nested ParenthesesSubpattern disjunctions,
but unlike the other recursive methods in YarrPatternConstructor (e.g.
setupDisjunctionOffsets, copyDisjunction, copyTerm) it had no isSafeToRecurse()
stack guard. A deeply nested pattern such as:

    new RegExp(&quot;.*&quot; + &quot;(?:&quot;.repeat(200000) + &quot;a&quot; + &quot;)&quot;.repeat(200000) + &quot;.*&quot;)

therefore overflowed the stack and crashed with SIGSEGV while compiling the
regular expression.

Add the same isSafeToRecurse() check used by the other recursive helpers. When
unsafe, set ErrorCode::PatternTooLarge and conservatively return true so the
optimization is skipped; YarrPattern::compile() then reports the error as a
&quot;regular expression too large&quot; SyntaxError instead of crashing.

Test: JSTests/stress/regexp-dot-star-enclosure-contains-capturing-terms-out-of-stack.js

* JSTests/stress/regexp-dot-star-enclosure-contains-capturing-terms-out-of-stack.js: Added.
(test):
* Source/JavaScriptCore/yarr/YarrPattern.cpp:
(JSC::Yarr::YarrPatternConstructor::containsCapturingTerms):

Canonical link: <a href="https://commits.webkit.org/312978@main">https://commits.webkit.org/312978@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8be37a0a5859e4f3dc5e8a17382618030660f760

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/161674 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/35148 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/28251 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/170577 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/118045 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/35249 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/35149 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/125429 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/88352 "1 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/164633 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/27736 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/145217 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/106025 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/26785 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/25294 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/18298 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/153731 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/136478 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/22972 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/173065 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/22512 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/20106 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/24613 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/133721 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/34822 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/29387 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/133726 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36130 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/34806 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/144767 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/96793 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/28258 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/21587 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/194073 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/34316 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/101761 "Built successfully") | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/50011 "Found 1 new JSC stress test failure: stress/regexp-dot-star-enclosure-contains-capturing-terms-out-of-stack.js.bytecode-cache (failure)") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/33816 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/34059 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/33965 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->