### PR TITLE
[WTF] Add OrderedHashTable

### DIFF
--- a/Source/JavaScriptCore/runtime/AbstractModuleRecord.h
+++ b/Source/JavaScriptCore/runtime/AbstractModuleRecord.h
@@ -31,7 +31,7 @@
 #include <JavaScriptCore/ModuleMap.h>
 #include <JavaScriptCore/ScriptFetchParameters.h>
 #include <JavaScriptCore/ScriptFetcher.h>
-#include <wtf/ListHashSet.h>
+#include <wtf/OrderedHashSet.h>
 #include <wtf/RefPtr.h>
 
 namespace JSC {
@@ -102,7 +102,7 @@ public:
         Identifier localName;
     };
 
-    typedef WTF::ListHashSet<RefPtr<UniquedStringImpl>, IdentifierRepHash> OrderedIdentifierSet;
+    typedef WTF::OrderedHashSet<RefPtr<UniquedStringImpl>, IdentifierRepHash> OrderedIdentifierSet;
     typedef UncheckedKeyHashMap<RefPtr<UniquedStringImpl>, ImportEntry, IdentifierRepHash, HashTraits<RefPtr<UniquedStringImpl>>> ImportEntries;
     typedef UncheckedKeyHashMap<RefPtr<UniquedStringImpl>, ExportEntry, IdentifierRepHash, HashTraits<RefPtr<UniquedStringImpl>>> ExportEntries;
 

--- a/Source/WTF/WTF.xcodeproj/project.pbxproj
+++ b/Source/WTF/WTF.xcodeproj/project.pbxproj
@@ -305,6 +305,9 @@
 		DD3DC86627A4BF8E007E5B61 /* CheckedArithmetic.h in Headers */ = {isa = PBXBuildFile; fileRef = A8A4726A151A825A004123FF /* CheckedArithmetic.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		DD3DC86727A4BF8E007E5B61 /* SynchronizedFixedQueue.h in Headers */ = {isa = PBXBuildFile; fileRef = 5597F82C1D94B9970066BC21 /* SynchronizedFixedQueue.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		DD3DC86827A4BF8E007E5B61 /* OrderMaker.h in Headers */ = {isa = PBXBuildFile; fileRef = 0F9495831C571CC900413A48 /* OrderMaker.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		18916AA77E524C80912930B8 /* OrderedHashMap.h in Headers */ = {isa = PBXBuildFile; fileRef = CF0D7A729EEE4CC582E83B30 /* OrderedHashMap.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		39D12598FEA545039883C96C /* OrderedHashSet.h in Headers */ = {isa = PBXBuildFile; fileRef = B6397A84DB2844D9A8644961 /* OrderedHashSet.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		4677959411F147AFBC01B2EA /* OrderedHashTable.h in Headers */ = {isa = PBXBuildFile; fileRef = 2D069A1267BB4822AF40B04C /* OrderedHashTable.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		DD3DC86927A4BF8E007E5B61 /* BubbleSort.h in Headers */ = {isa = PBXBuildFile; fileRef = 0F4570441BE834410062A629 /* BubbleSort.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		DD3DC86B27A4BF8E007E5B61 /* IteratorRange.h in Headers */ = {isa = PBXBuildFile; fileRef = 7CDD7FF9186D2A54007433CD /* IteratorRange.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		DD3DC86C27A4BF8E007E5B61 /* NumberOfCores.h in Headers */ = {isa = PBXBuildFile; fileRef = A8A472D6151A825B004123FF /* NumberOfCores.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -1188,6 +1191,9 @@
 		0F93274A1C17F4B700CF6564 /* Box.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Box.h; sourceTree = "<group>"; };
 		0F93274A1C17F4B700CF6566 /* BoxPtr.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BoxPtr.h; sourceTree = "<group>"; };
 		0F9495831C571CC900413A48 /* OrderMaker.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OrderMaker.h; sourceTree = "<group>"; };
+		CF0D7A729EEE4CC582E83B30 /* OrderedHashMap.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OrderedHashMap.h; sourceTree = "<group>"; };
+		B6397A84DB2844D9A8644961 /* OrderedHashSet.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OrderedHashSet.h; sourceTree = "<group>"; };
+		2D069A1267BB4822AF40B04C /* OrderedHashTable.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OrderedHashTable.h; sourceTree = "<group>"; };
 		0F95B63120CB4B7700479635 /* DebugHeap.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = DebugHeap.h; sourceTree = "<group>"; };
 		0F95B63220CB4B7700479635 /* DebugHeap.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = DebugHeap.cpp; sourceTree = "<group>"; };
 		0F95B63420CB53C100479635 /* Vector.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Vector.cpp; sourceTree = "<group>"; };
@@ -2618,6 +2624,9 @@
 				07C913F22F820E86003A09D8 /* OptionCountedSet.h */,
 				1A4656181C7FC68E00F5920F /* OptionSet.h */,
 				275DFB6B238BDF72001230E2 /* OptionSetHash.h */,
+				CF0D7A729EEE4CC582E83B30 /* OrderedHashMap.h */,
+				B6397A84DB2844D9A8644961 /* OrderedHashSet.h */,
+				2D069A1267BB4822AF40B04C /* OrderedHashTable.h */,
 				0F9495831C571CC900413A48 /* OrderMaker.h */,
 				A8A472D7151A825B004123FF /* OSAllocator.h */,
 				7CBBA07319BB7FDC00BBF025 /* OSObjectPtr.h */,
@@ -3784,6 +3793,9 @@
 				07C913F32F820E86003A09D8 /* OptionCountedSet.h in Headers */,
 				DD3DC92E27A4BF8E007E5B61 /* OptionSet.h in Headers */,
 				DD3DC90927A4BF8E007E5B61 /* OptionSetHash.h in Headers */,
+				18916AA77E524C80912930B8 /* OrderedHashMap.h in Headers */,
+				39D12598FEA545039883C96C /* OrderedHashSet.h in Headers */,
+				4677959411F147AFBC01B2EA /* OrderedHashTable.h in Headers */,
 				DD3DC86827A4BF8E007E5B61 /* OrderMaker.h in Headers */,
 				DDF307DC27C086DF006A526F /* OrdinalNumber.h in Headers */,
 				DD3DC8F427A4BF8E007E5B61 /* OSAllocator.h in Headers */,

--- a/Source/WTF/wtf/CMakeLists.txt
+++ b/Source/WTF/wtf/CMakeLists.txt
@@ -222,6 +222,9 @@ set(WTF_PUBLIC_HEADERS
     OptionalOrReference.h
     OptionSetHash.h
     OrderMaker.h
+    OrderedHashMap.h
+    OrderedHashSet.h
+    OrderedHashTable.h
     OverflowHandler.h
     OverflowPolicy.h
     Packed.h

--- a/Source/WTF/wtf/Forward.h
+++ b/Source/WTF/wtf/Forward.h
@@ -201,6 +201,8 @@ template<typename KeyArg, typename MappedArg, typename KeyHash = DefaultHash<Key
 using UncheckedKeyHashMap = HashMap<KeyArg, MappedArg, KeyHash, KeyTraits, MappedTraits, HashTraits, ShouldValidateKey::No, Malloc>;
 template<typename ValueArg, typename = DefaultHash<ValueArg>, typename = HashTraits<ValueArg>, typename = HashTableTraits, ShouldValidateKey = ShouldValidateKey::Yes> class HashSet;
 template<typename ValueArg, typename = DefaultHash<ValueArg>> class ListHashSet;
+template<typename KeyArg, typename MappedArg, typename = DefaultHash<KeyArg>, typename = HashTraits<KeyArg>, typename = HashTraits<MappedArg>, typename = HashTableMalloc> class OrderedHashMap;
+template<typename ValueArg, typename = DefaultHash<ValueArg>, typename = HashTraits<ValueArg>, typename = HashTableMalloc> class OrderedHashSet;
 template<typename ValueArg, typename HashArg = DefaultHash<ValueArg>, typename TraitsArg = HashTraits<ValueArg>, typename TableTraitsArg = HashTableTraits>
 using UncheckedKeyHashSet = HashSet<ValueArg, HashArg, TraitsArg, TableTraitsArg, ShouldValidateKey::No>;
 template<typename ResolveValueT, typename RejectValueT, unsigned options = 0> class NativePromise;
@@ -293,6 +295,8 @@ using WTF::ObjectIdentifier;
 using WTF::ObjectIdentifierGeneric;
 using WTF::Observer;
 using WTF::OptionSet;
+using WTF::OrderedHashMap;
+using WTF::OrderedHashSet;
 using WTF::OrdinalNumber;
 using WTF::PrintStream;
 using WTF::RawPtrTraits;

--- a/Source/WTF/wtf/OrderedHashMap.h
+++ b/Source/WTF/wtf/OrderedHashMap.h
@@ -1,0 +1,518 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <initializer_list>
+#include <wtf/Forward.h>
+#include <wtf/HashMap.h>
+#include <wtf/HashTraits.h>
+#include <wtf/IteratorRange.h>
+#include <wtf/KeyValuePair.h>
+#include <wtf/OrderedHashTable.h>
+
+namespace WTF {
+
+template<typename TableType, typename KeyType, typename MappedType>
+struct OrderedHashTableConstKeysIterator;
+template<typename TableType, typename KeyType, typename MappedType>
+struct OrderedHashTableKeysIterator;
+template<typename TableType, typename KeyType, typename MappedType>
+struct OrderedHashTableConstValuesIterator;
+template<typename TableType, typename KeyType, typename MappedType>
+struct OrderedHashTableValuesIterator;
+
+// Iterator adapters for OrderedHashMap (KeyValuePair specialization)
+
+template<typename HashTableType, typename KeyType, typename MappedType>
+struct OrderedHashTableConstIteratorAdapter {
+    using iterator_category = std::forward_iterator_tag;
+    using value_type = KeyValuePair<KeyType, MappedType>;
+    using difference_type = ptrdiff_t;
+    using pointer = const value_type*;
+    using reference = const value_type&;
+    using ValueType = KeyValuePair<KeyType, MappedType>;
+
+    using Keys = OrderedHashTableConstKeysIterator<HashTableType, KeyType, MappedType>;
+    using Values = OrderedHashTableConstValuesIterator<HashTableType, KeyType, MappedType>;
+
+    OrderedHashTableConstIteratorAdapter() = default;
+    OrderedHashTableConstIteratorAdapter(const typename HashTableType::const_iterator& impl)
+        : m_impl(impl)
+    { }
+
+    const ValueType* get() const { return m_impl.get(); }
+    const ValueType& operator*() const { return *get(); }
+    const ValueType* operator->() const { return get(); }
+
+    OrderedHashTableConstIteratorAdapter& operator++() { ++m_impl; return *this; }
+
+    Keys keys() { return Keys(*this); }
+    Values values() { return Values(*this); }
+
+    typename HashTableType::const_iterator m_impl;
+};
+
+template<typename HashTableType, typename KeyType, typename MappedType>
+struct OrderedHashTableIteratorAdapter {
+    using iterator_category = std::forward_iterator_tag;
+    using value_type = KeyValuePair<KeyType, MappedType>;
+    using difference_type = ptrdiff_t;
+    using pointer = value_type*;
+    using reference = value_type&;
+    using ValueType = KeyValuePair<KeyType, MappedType>;
+
+    using Keys = OrderedHashTableKeysIterator<HashTableType, KeyType, MappedType>;
+    using Values = OrderedHashTableValuesIterator<HashTableType, KeyType, MappedType>;
+
+    OrderedHashTableIteratorAdapter() = default;
+    OrderedHashTableIteratorAdapter(const typename HashTableType::iterator& impl)
+        : m_impl(impl)
+    { }
+
+    ValueType* get() const { return m_impl.get(); }
+    ValueType& operator*() const { return *get(); }
+    ValueType* operator->() const { return get(); }
+
+    OrderedHashTableIteratorAdapter& operator++() { ++m_impl; return *this; }
+
+    operator OrderedHashTableConstIteratorAdapter<HashTableType, KeyType, MappedType>() const
+    {
+        return OrderedHashTableConstIteratorAdapter<HashTableType, KeyType, MappedType>(m_impl);
+    }
+
+    Keys keys() { return Keys(*this); }
+    Values values() { return Values(*this); }
+
+    typename HashTableType::iterator m_impl;
+};
+
+template<typename T, typename U, typename V>
+inline bool operator==(const OrderedHashTableConstIteratorAdapter<T, U, V>& a, const OrderedHashTableConstIteratorAdapter<T, U, V>& b)
+{
+    return a.m_impl == b.m_impl;
+}
+
+template<typename T, typename U, typename V>
+inline bool operator==(const OrderedHashTableIteratorAdapter<T, U, V>& a, const OrderedHashTableIteratorAdapter<T, U, V>& b)
+{
+    return a.m_impl == b.m_impl;
+}
+
+// Const/non-const comparison
+template<typename T, typename U, typename V>
+inline bool operator==(const OrderedHashTableIteratorAdapter<T, U, V>& a, const OrderedHashTableConstIteratorAdapter<T, U, V>& b)
+{
+    return OrderedHashTableConstIteratorAdapter<T, U, V>(a) == b;
+}
+
+template<typename T, typename U, typename V>
+inline bool operator==(const OrderedHashTableConstIteratorAdapter<T, U, V>& a, const OrderedHashTableIteratorAdapter<T, U, V>& b)
+{
+    return a == OrderedHashTableConstIteratorAdapter<T, U, V>(b);
+}
+
+// Keys iterators
+
+template<typename HashTableType, typename KeyType, typename MappedType>
+struct OrderedHashTableConstKeysIterator {
+    using iterator_category = std::forward_iterator_tag;
+    using value_type = KeyType;
+    using difference_type = ptrdiff_t;
+    using pointer = const value_type*;
+    using reference = const value_type&;
+
+    OrderedHashTableConstKeysIterator() = default;
+    OrderedHashTableConstKeysIterator(const OrderedHashTableConstIteratorAdapter<HashTableType, KeyType, MappedType>& impl)
+        : m_impl(impl)
+    { }
+
+    const KeyType* get() const { return &(m_impl.get()->key); }
+    const KeyType& operator*() const { return *get(); }
+    const KeyType* operator->() const { return get(); }
+
+    OrderedHashTableConstKeysIterator& operator++() { ++m_impl; return *this; }
+
+    OrderedHashTableConstIteratorAdapter<HashTableType, KeyType, MappedType> m_impl;
+};
+
+template<typename HashTableType, typename KeyType, typename MappedType>
+struct OrderedHashTableKeysIterator {
+    using iterator_category = std::forward_iterator_tag;
+    using value_type = KeyType;
+    using difference_type = ptrdiff_t;
+    using pointer = value_type*;
+    using reference = value_type&;
+
+    OrderedHashTableKeysIterator() = default;
+    OrderedHashTableKeysIterator(const OrderedHashTableIteratorAdapter<HashTableType, KeyType, MappedType>& impl)
+        : m_impl(impl)
+    { }
+
+    KeyType* get() const { return &(m_impl.get()->key); }
+    KeyType& operator*() const { return *get(); }
+    KeyType* operator->() const { return get(); }
+
+    OrderedHashTableKeysIterator& operator++() { ++m_impl; return *this; }
+
+    operator OrderedHashTableConstKeysIterator<HashTableType, KeyType, MappedType>() const
+    {
+        return OrderedHashTableConstKeysIterator<HashTableType, KeyType, MappedType>(m_impl);
+    }
+
+    OrderedHashTableIteratorAdapter<HashTableType, KeyType, MappedType> m_impl;
+};
+
+// Values iterators
+
+template<typename HashTableType, typename KeyType, typename MappedType>
+struct OrderedHashTableConstValuesIterator {
+    using iterator_category = std::forward_iterator_tag;
+    using value_type = MappedType;
+    using difference_type = ptrdiff_t;
+    using pointer = const value_type*;
+    using reference = const value_type&;
+
+    OrderedHashTableConstValuesIterator() = default;
+    OrderedHashTableConstValuesIterator(const OrderedHashTableConstIteratorAdapter<HashTableType, KeyType, MappedType>& impl)
+        : m_impl(impl)
+    { }
+
+    const MappedType* get() const { return std::addressof(m_impl.get()->value); }
+    const MappedType& operator*() const { return *get(); }
+    const MappedType* operator->() const { return get(); }
+
+    OrderedHashTableConstValuesIterator& operator++() { ++m_impl; return *this; }
+
+    OrderedHashTableConstIteratorAdapter<HashTableType, KeyType, MappedType> m_impl;
+};
+
+template<typename HashTableType, typename KeyType, typename MappedType>
+struct OrderedHashTableValuesIterator {
+    using iterator_category = std::forward_iterator_tag;
+    using value_type = MappedType;
+    using difference_type = ptrdiff_t;
+    using pointer = value_type*;
+    using reference = value_type&;
+
+    OrderedHashTableValuesIterator() = default;
+    OrderedHashTableValuesIterator(const OrderedHashTableIteratorAdapter<HashTableType, KeyType, MappedType>& impl)
+        : m_impl(impl)
+    { }
+
+    MappedType* get() const { return std::addressof(m_impl.get()->value); }
+    MappedType& operator*() const { return *get(); }
+    MappedType* operator->() const { return get(); }
+
+    OrderedHashTableValuesIterator& operator++() { ++m_impl; return *this; }
+
+    operator OrderedHashTableConstValuesIterator<HashTableType, KeyType, MappedType>() const
+    {
+        return OrderedHashTableConstValuesIterator<HashTableType, KeyType, MappedType>(m_impl);
+    }
+
+    OrderedHashTableIteratorAdapter<HashTableType, KeyType, MappedType> m_impl;
+};
+
+template<typename T, typename U, typename V>
+inline bool operator==(const OrderedHashTableConstKeysIterator<T, U, V>& a, const OrderedHashTableConstKeysIterator<T, U, V>& b)
+{
+    return a.m_impl == b.m_impl;
+}
+
+template<typename T, typename U, typename V>
+inline bool operator==(const OrderedHashTableKeysIterator<T, U, V>& a, const OrderedHashTableKeysIterator<T, U, V>& b)
+{
+    return a.m_impl == b.m_impl;
+}
+
+template<typename T, typename U, typename V>
+inline bool operator==(const OrderedHashTableConstValuesIterator<T, U, V>& a, const OrderedHashTableConstValuesIterator<T, U, V>& b)
+{
+    return a.m_impl == b.m_impl;
+}
+
+template<typename T, typename U, typename V>
+inline bool operator==(const OrderedHashTableValuesIterator<T, U, V>& a, const OrderedHashTableValuesIterator<T, U, V>& b)
+{
+    return a.m_impl == b.m_impl;
+}
+
+// OrderedHashMap
+
+template<typename KeyArg, typename MappedArg, typename HashArg, typename KeyTraitsArg, typename MappedTraitsArg, typename Malloc>
+class OrderedHashMap final {
+    WTF_DEPRECATED_MAKE_FAST_ALLOCATED(OrderedHashMap);
+private:
+    using KeyTraits = KeyTraitsArg;
+    using MappedTraits = MappedTraitsArg;
+
+    struct KeyValuePairTraits : KeyValuePairHashTraits<KeyTraits, MappedTraits> {
+        static constexpr bool hasIsEmptyValueFunction = true;
+        static bool isEmptyValue(const typename KeyValuePairHashTraits<KeyTraits, MappedTraits>::TraitType& value)
+        {
+            return isHashTraitsEmptyValue<KeyTraits>(value.key);
+        }
+    };
+
+public:
+    using KeyType = typename KeyTraits::TraitType;
+    using MappedType = typename MappedTraits::TraitType;
+    using KeyValuePairType = typename KeyValuePairTraits::TraitType;
+
+private:
+    using MappedPeekType = typename MappedTraits::PeekType;
+    using MappedTakeType = typename MappedTraits::TakeType;
+
+    using HashFunctions = HashArg;
+
+    using HashTableType = OrderedHashTable<KeyType, KeyValuePairType, KeyValuePairKeyExtractor<KeyValuePairType>, HashFunctions, KeyValuePairTraits, KeyTraits, Malloc>;
+
+public:
+    struct AddResult {
+        using IteratorType = OrderedHashTableIteratorAdapter<HashTableType, KeyType, MappedType>;
+        IteratorType iterator;
+        bool isNewEntry;
+    };
+
+    using iterator = OrderedHashTableIteratorAdapter<HashTableType, KeyType, MappedType>;
+    using const_iterator = OrderedHashTableConstIteratorAdapter<HashTableType, KeyType, MappedType>;
+
+    using KeysIteratorRange = SizedIteratorRange<OrderedHashMap, typename iterator::Keys>;
+    using KeysConstIteratorRange = SizedIteratorRange<OrderedHashMap, typename const_iterator::Keys>;
+    using ValuesIteratorRange = SizedIteratorRange<OrderedHashMap, typename iterator::Values>;
+    using ValuesConstIteratorRange = SizedIteratorRange<OrderedHashMap, typename const_iterator::Values>;
+
+    OrderedHashMap() = default;
+
+    OrderedHashMap(std::initializer_list<KeyValuePairType> initializerList)
+    {
+        reserveInitialCapacity(initializerList.size());
+        for (const auto& keyValuePair : initializerList)
+            add(keyValuePair.key, keyValuePair.value);
+    }
+
+    void swap(OrderedHashMap& other) { m_impl.swap(other.m_impl); }
+
+    unsigned size() const { return m_impl.size(); }
+    unsigned capacity() const { return m_impl.capacity(); }
+    bool isEmpty() const { return m_impl.isEmpty(); }
+
+    void reserveInitialCapacity(unsigned keyCount) { m_impl.reserveInitialCapacity(keyCount); }
+
+    iterator begin() LIFETIME_BOUND { return m_impl.begin(); }
+    iterator end() LIFETIME_BOUND { return m_impl.end(); }
+    const_iterator begin() const LIFETIME_BOUND { return m_impl.begin(); }
+    const_iterator end() const LIFETIME_BOUND { return m_impl.end(); }
+
+    KeysIteratorRange keys() LIFETIME_BOUND { return makeSizedIteratorRange(*this, begin().keys(), end().keys()); }
+    const KeysConstIteratorRange keys() const LIFETIME_BOUND { return makeSizedIteratorRange(*this, begin().keys(), end().keys()); }
+
+    ValuesIteratorRange values() LIFETIME_BOUND { return makeSizedIteratorRange(*this, begin().values(), end().values()); }
+    const ValuesConstIteratorRange values() const LIFETIME_BOUND { return makeSizedIteratorRange(*this, begin().values(), end().values()); }
+
+    iterator find(const KeyType& key) LIFETIME_BOUND { return m_impl.find(key); }
+    const_iterator find(const KeyType& key) const LIFETIME_BOUND { return m_impl.find(key); }
+    bool contains(const KeyType& key) const { return m_impl.contains(key); }
+
+    MappedPeekType get(const KeyType& key) const
+    {
+        auto* entry = m_impl.lookup(key);
+        if (!entry)
+            return MappedTraits::peek(MappedTraits::emptyValue());
+        return MappedTraits::peek(entry->value);
+    }
+
+    std::optional<MappedType> getOptional(const KeyType& key) const
+    {
+        auto* entry = m_impl.lookup(key);
+        if (!entry)
+            return { };
+        return { entry->value };
+    }
+
+    MappedPeekType inlineGet(const KeyType& key) const { return get(key); }
+
+    template<typename V>
+    AddResult set(const KeyType& key, V&& value) LIFETIME_BOUND
+    {
+        return inlineSet(key, std::forward<V>(value));
+    }
+
+    template<typename V>
+    AddResult set(KeyType&& key, V&& value) LIFETIME_BOUND
+    {
+        return inlineSet(std::forward<KeyType>(key), std::forward<V>(value));
+    }
+
+    template<typename V>
+    AddResult add(const KeyType& key, V&& value) LIFETIME_BOUND
+    {
+        return inlineAdd(key, std::forward<V>(value));
+    }
+
+    template<typename V>
+    AddResult add(KeyType&& key, V&& value) LIFETIME_BOUND
+    {
+        return inlineAdd(std::forward<KeyType>(key), std::forward<V>(value));
+    }
+
+    AddResult ensure(const KeyType& key, NOESCAPE const Invocable<MappedType()> auto& functor) LIFETIME_BOUND
+    {
+        return inlineEnsure(key, functor);
+    }
+
+    AddResult ensure(KeyType&& key, NOESCAPE const Invocable<MappedType()> auto& functor) LIFETIME_BOUND
+    {
+        return inlineEnsure(std::forward<KeyType>(key), functor);
+    }
+
+    bool remove(const KeyType& key)
+    {
+        auto it = find(key);
+        if (it == end())
+            return false;
+        remove(it);
+        return true;
+    }
+
+    bool remove(iterator it)
+    {
+        if (it == end())
+            return false;
+        m_impl.remove(it.m_impl);
+        return true;
+    }
+
+    bool removeIf(NOESCAPE const Invocable<bool(KeyValuePairType&)> auto& functor)
+    {
+        return m_impl.removeIf(functor);
+    }
+
+    void clear() { m_impl.clear(); }
+
+    MappedTakeType take(const KeyType& key)
+    {
+        return take(find(key));
+    }
+
+    MappedTakeType take(iterator it)
+    {
+        if (it == end())
+            return MappedTraits::take(MappedTraits::emptyValue());
+        auto value = MappedTraits::take(WTF::move(it->value));
+        remove(it);
+        return value;
+    }
+
+    std::optional<MappedType> takeOptional(const KeyType& key)
+    {
+        auto it = find(key);
+        if (it == end())
+            return std::nullopt;
+        return take(it);
+    }
+
+    MappedTakeType takeFirst() { return take(begin()); }
+
+    // HashTranslator versions
+    template<typename HashTranslator, typename T>
+    iterator find(const T& key) LIFETIME_BOUND
+    {
+        return m_impl.template find<HashTranslator>(key);
+    }
+
+    template<typename HashTranslator, typename T>
+    const_iterator find(const T& key) const LIFETIME_BOUND
+    {
+        return m_impl.template find<HashTranslator>(key);
+    }
+
+    template<typename HashTranslator, typename T>
+    bool contains(const T& key) const
+    {
+        return m_impl.template contains<HashTranslator>(key);
+    }
+
+    template<typename HashTranslator, typename T>
+    MappedPeekType get(const T& key) const
+    {
+        auto* entry = m_impl.template lookup<HashTranslator>(key);
+        if (!entry)
+            return MappedTraits::peek(MappedTraits::emptyValue());
+        return MappedTraits::peek(entry->value);
+    }
+
+    static bool isValidKey(const KeyType& key)
+    {
+        if (KeyTraits::isDeletedValue(key))
+            return false;
+        if constexpr (HashFunctions::safeToCompareToEmptyOrDeleted) {
+            if (key == KeyTraits::emptyValue())
+                return false;
+        } else {
+            if (isHashTraitsEmptyValue<KeyTraits>(key))
+                return false;
+        }
+        return true;
+    }
+
+private:
+    template<typename K, typename V>
+    AddResult inlineSet(K&& key, V&& value)
+    {
+        auto tableResult = m_impl.add(key, [&]() ALWAYS_INLINE_LAMBDA -> KeyValuePairType {
+            return KeyValuePairType(std::forward<K>(key), std::forward<V>(value));
+        });
+        auto it = iterator(tableResult.iterator);
+        if (!tableResult.isNewEntry)
+            it->value = std::forward<V>(value);
+        return { it, tableResult.isNewEntry };
+    }
+
+    template<typename K, typename V>
+    AddResult inlineAdd(K&& key, V&& value)
+    {
+        auto tableResult = m_impl.add(key, [&]() ALWAYS_INLINE_LAMBDA -> KeyValuePairType {
+            return KeyValuePairType(std::forward<K>(key), std::forward<V>(value));
+        });
+        return { iterator(tableResult.iterator), tableResult.isNewEntry };
+    }
+
+    template<typename K>
+    AddResult inlineEnsure(K&& key, NOESCAPE const Invocable<MappedType()> auto& functor)
+    {
+        auto tableResult = m_impl.add(key, [&]() ALWAYS_INLINE_LAMBDA -> KeyValuePairType {
+            return KeyValuePairType(std::forward<K>(key), functor());
+        });
+        return { iterator(tableResult.iterator), tableResult.isNewEntry };
+    }
+
+    HashTableType m_impl;
+};
+
+} // namespace WTF
+
+using WTF::OrderedHashMap;

--- a/Source/WTF/wtf/OrderedHashSet.h
+++ b/Source/WTF/wtf/OrderedHashSet.h
@@ -1,0 +1,193 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <initializer_list>
+#include <wtf/Forward.h>
+#include <wtf/HashFunctions.h>
+#include <wtf/HashSet.h>
+#include <wtf/HashTraits.h>
+#include <wtf/OrderedHashTable.h>
+
+namespace WTF {
+
+template<typename ValueArg, typename HashArg, typename TraitsArg, typename Malloc>
+class OrderedHashSet final {
+    WTF_DEPRECATED_MAKE_FAST_ALLOCATED(OrderedHashSet);
+private:
+    using HashFunctions = HashArg;
+    using ValueTraits = TraitsArg;
+    using TakeType = typename ValueTraits::TakeType;
+
+public:
+    using ValueType = typename ValueTraits::TraitType;
+
+private:
+    using HashTableType = OrderedHashTable<ValueType, ValueType, IdentityExtractor, HashFunctions, ValueTraits, ValueTraits, Malloc>;
+
+public:
+    struct AddResult {
+        using IteratorType = OrderedHashTableConstIterator<HashTableType, ValueType>;
+        IteratorType iterator;
+        bool isNewEntry;
+    };
+
+    using iterator = OrderedHashTableConstIterator<HashTableType, ValueType>;
+    using const_iterator = OrderedHashTableConstIterator<HashTableType, ValueType>;
+    using reverse_iterator = OrderedHashTableConstReverseIterator<HashTableType, ValueType>;
+    using const_reverse_iterator = OrderedHashTableConstReverseIterator<HashTableType, ValueType>;
+
+    OrderedHashSet() = default;
+
+    OrderedHashSet(std::initializer_list<ValueArg> initializerList)
+    {
+        if (!initializerList.size())
+            return;
+        reserveInitialCapacity(initializerList.size());
+        for (auto&& value : initializerList)
+            add(std::forward<decltype(value)>(value));
+    }
+
+    template<typename ContainerType>
+    explicit OrderedHashSet(ContainerType&& container)
+    {
+        if (!container.size())
+            return;
+        reserveInitialCapacity(container.size());
+        for (auto&& value : std::forward<ContainerType>(container))
+            add(std::forward<decltype(value)>(value));
+    }
+
+    void swap(OrderedHashSet& other) { m_impl.swap(other.m_impl); }
+
+    unsigned size() const { return m_impl.size(); }
+    unsigned capacity() const { return m_impl.capacity(); }
+    bool isEmpty() const { return m_impl.isEmpty(); }
+
+    void reserveInitialCapacity(unsigned keyCount) { m_impl.reserveInitialCapacity(keyCount); }
+
+    iterator begin() const LIFETIME_BOUND { return m_impl.begin(); }
+    iterator end() const LIFETIME_BOUND { return m_impl.end(); }
+
+    reverse_iterator rbegin() const LIFETIME_BOUND { return m_impl.rbegin(); }
+    reverse_iterator rend() const LIFETIME_BOUND { return m_impl.rend(); }
+
+    iterator find(const ValueType& value) const LIFETIME_BOUND { return m_impl.find(value); }
+    bool contains(const ValueType& value) const { return m_impl.contains(value); }
+
+    template<typename HashTranslator, typename T>
+    iterator find(const T& value) const LIFETIME_BOUND
+    {
+        return m_impl.template find<HashTranslator>(value);
+    }
+
+    template<typename HashTranslator, typename T>
+    bool contains(const T& value) const
+    {
+        return m_impl.template contains<HashTranslator>(value);
+    }
+
+    AddResult add(const ValueType& value) LIFETIME_BOUND
+    {
+        auto result = m_impl.add(value, [&]() ALWAYS_INLINE_LAMBDA -> ValueType { return value; });
+        return { result.iterator, result.isNewEntry };
+    }
+
+    AddResult add(ValueType&& value) LIFETIME_BOUND
+    {
+        auto result = m_impl.add(value, [&]() ALWAYS_INLINE_LAMBDA -> ValueType { return std::forward<ValueType>(value); });
+        return { result.iterator, result.isNewEntry };
+    }
+
+    void addVoid(const ValueType& value) { add(value); }
+    void addVoid(ValueType&& value) { add(std::forward<ValueType>(value)); }
+
+    template<typename ContainerType>
+    bool addAll(ContainerType&& container)
+    {
+        bool changed = false;
+        for (auto&& item : std::forward<ContainerType>(container))
+            changed |= add(std::forward<decltype(item)>(item)).isNewEntry;
+        return changed;
+    }
+
+    bool remove(const ValueType& value)
+    {
+        return remove(find(value));
+    }
+
+    bool remove(iterator it)
+    {
+        if (it == end())
+            return false;
+        m_impl.remove(it);
+        return true;
+    }
+
+    bool removeIf(NOESCAPE const Invocable<bool(const ValueType&)> auto& functor)
+    {
+        return m_impl.removeIf(functor);
+    }
+
+    void clear() { m_impl.clear(); }
+
+    TakeType take(const ValueType& value)
+    {
+        return take(find(value));
+    }
+
+    TakeType take(iterator it)
+    {
+        if (it == end())
+            return ValueTraits::take(ValueTraits::emptyValue());
+        auto result = ValueTraits::take(WTF::move(const_cast<ValueType&>(*it)));
+        remove(it);
+        return result;
+    }
+
+    TakeType takeAny() { return take(begin()); }
+
+    static bool isValidValue(const ValueType& value)
+    {
+        if (ValueTraits::isDeletedValue(value))
+            return false;
+        if constexpr (HashFunctions::safeToCompareToEmptyOrDeleted) {
+            if (value == ValueTraits::emptyValue())
+                return false;
+        } else {
+            if (isHashTraitsEmptyValue<ValueTraits>(value))
+                return false;
+        }
+        return true;
+    }
+
+private:
+    HashTableType m_impl;
+};
+
+} // namespace WTF
+
+using WTF::OrderedHashSet;

--- a/Source/WTF/wtf/OrderedHashTable.h
+++ b/Source/WTF/wtf/OrderedHashTable.h
@@ -1,0 +1,866 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <algorithm>
+#include <cstdint>
+#include <cstring>
+#include <iterator>
+#include <utility>
+#include <wtf/Compiler.h>
+#include <wtf/FastMalloc.h>
+#include <wtf/Forward.h>
+#include <wtf/HashTraits.h>
+#include <wtf/StdLibExtras.h>
+
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
+
+namespace WTF {
+
+template<typename Key, typename Value, typename Extractor, typename HashFunctions, typename Traits, typename KeyTraits, typename Malloc>
+class OrderedHashTable;
+
+template<typename TableType, typename ValueType>
+class OrderedHashTableIterator;
+
+template<typename TableType, typename ValueType>
+class OrderedHashTableConstIterator;
+
+template<typename TableType, typename ValueType>
+class OrderedHashTableReverseIterator;
+
+template<typename TableType, typename ValueType>
+class OrderedHashTableConstReverseIterator;
+
+template<typename Key, typename Value, typename Extractor, typename HashFunctions, typename Traits, typename KeyTraits, typename Malloc>
+class OrderedHashTable final {
+    WTF_DEPRECATED_MAKE_FAST_ALLOCATED(OrderedHashTable);
+public:
+    using KeyType = Key;
+    using ValueType = Value;
+
+    struct AddResult {
+        using IteratorType = OrderedHashTableIterator<OrderedHashTable, ValueType>;
+        IteratorType iterator;
+        bool isNewEntry;
+    };
+
+    using iterator = OrderedHashTableIterator<OrderedHashTable, ValueType>;
+    using const_iterator = OrderedHashTableConstIterator<OrderedHashTable, ValueType>;
+    using reverse_iterator = OrderedHashTableReverseIterator<OrderedHashTable, ValueType>;
+    using const_reverse_iterator = OrderedHashTableConstReverseIterator<OrderedHashTable, ValueType>;
+
+    OrderedHashTable() = default;
+
+    OrderedHashTable(const OrderedHashTable& other)
+    {
+        if (other.m_liveCount) {
+            uint32_t newBucketCount = bucketCountForKeyCount(other.m_liveCount);
+            initializeBuckets(newBucketCount);
+            allocateEntries(entriesCapacityFromBucketCount(newBucketCount));
+            for (uint32_t i = 0; i < other.m_entriesLength; ++i) {
+                if (!isDeletedEntry(other.m_entries[i])) {
+                    new (NotNull, std::addressof(m_entries[m_entriesLength])) ValueType(other.m_entries[i]);
+                    insertIntoFreshBuckets(m_entriesLength);
+                    ++m_entriesLength;
+                    ++m_liveCount;
+                }
+            }
+        }
+    }
+
+    OrderedHashTable(OrderedHashTable&& other) noexcept
+        : m_buckets(std::exchange(other.m_buckets, nullptr))
+        , m_entries(std::exchange(other.m_entries, nullptr))
+        , m_bucketCount(std::exchange(other.m_bucketCount, 0))
+        , m_entriesCapacity(std::exchange(other.m_entriesCapacity, 0))
+        , m_entriesLength(std::exchange(other.m_entriesLength, 0))
+        , m_liveCount(std::exchange(other.m_liveCount, 0))
+    {
+    }
+
+    OrderedHashTable& operator=(const OrderedHashTable& other)
+    {
+        if (this != &other) {
+            OrderedHashTable tmp(other);
+            swap(tmp);
+        }
+        return *this;
+    }
+
+    OrderedHashTable& operator=(OrderedHashTable&& other) noexcept
+    {
+        OrderedHashTable tmp(WTF::move(other));
+        swap(tmp);
+        return *this;
+    }
+
+    ~OrderedHashTable()
+    {
+        deallocateAll();
+    }
+
+    void swap(OrderedHashTable& other)
+    {
+        std::swap(m_buckets, other.m_buckets);
+        std::swap(m_entries, other.m_entries);
+        std::swap(m_bucketCount, other.m_bucketCount);
+        std::swap(m_entriesCapacity, other.m_entriesCapacity);
+        std::swap(m_entriesLength, other.m_entriesLength);
+        std::swap(m_liveCount, other.m_liveCount);
+    }
+
+    unsigned size() const { return m_liveCount; }
+    unsigned capacity() const { return m_entriesCapacity; }
+    bool isEmpty() const { return !m_liveCount; }
+
+    iterator begin() LIFETIME_BOUND
+    {
+        return iterator(this, 0);
+    }
+
+    iterator end() LIFETIME_BOUND
+    {
+        return iterator(this, m_entriesLength);
+    }
+
+    const_iterator begin() const LIFETIME_BOUND
+    {
+        return const_iterator(this, 0);
+    }
+
+    const_iterator end() const LIFETIME_BOUND
+    {
+        return const_iterator(this, m_entriesLength);
+    }
+
+    reverse_iterator rbegin() LIFETIME_BOUND
+    {
+        return reverse_iterator(this, m_entriesLength);
+    }
+
+    reverse_iterator rend() LIFETIME_BOUND
+    {
+        return reverse_iterator(this, 0);
+    }
+
+    const_reverse_iterator rbegin() const LIFETIME_BOUND
+    {
+        return const_reverse_iterator(this, m_entriesLength);
+    }
+
+    const_reverse_iterator rend() const LIFETIME_BOUND
+    {
+        return const_reverse_iterator(this, 0);
+    }
+
+    ValueType* lookup(const KeyType& key)
+    {
+        if (!m_buckets)
+            return nullptr;
+        uint32_t mask = m_bucketCount - 1;
+        uint32_t probeCount = 0;
+        uint32_t i = HashFunctions::hash(key) & mask;
+        while (true) {
+            uint32_t index = m_buckets[i];
+            if (index == emptyBucket)
+                return nullptr;
+            if (!isDeletedEntry(m_entries[index]) && HashFunctions::equal(Extractor::extract(m_entries[index]), key))
+                return &m_entries[index];
+            ++probeCount;
+            i = (i + probeCount) & mask;
+        }
+    }
+
+    const ValueType* lookup(const KeyType& key) const
+    {
+        return const_cast<OrderedHashTable*>(this)->lookup(key);
+    }
+
+    template<typename HashTranslator, typename T>
+    ValueType* lookup(const T& key)
+    {
+        if (!m_buckets)
+            return nullptr;
+        uint32_t mask = m_bucketCount - 1;
+        uint32_t probeCount = 0;
+        uint32_t i = HashTranslator::hash(key) & mask;
+        while (true) {
+            uint32_t index = m_buckets[i];
+            if (index == emptyBucket)
+                return nullptr;
+            if (!isDeletedEntry(m_entries[index]) && HashTranslator::equal(Extractor::extract(m_entries[index]), key))
+                return &m_entries[index];
+            ++probeCount;
+            i = (i + probeCount) & mask;
+        }
+    }
+
+    template<typename HashTranslator, typename T>
+    const ValueType* lookup(const T& key) const
+    {
+        return const_cast<OrderedHashTable*>(this)->template lookup<HashTranslator>(key);
+    }
+
+    iterator find(const KeyType& key) LIFETIME_BOUND
+    {
+        if (!m_buckets)
+            return end();
+        uint32_t mask = m_bucketCount - 1;
+        uint32_t probeCount = 0;
+        uint32_t i = HashFunctions::hash(key) & mask;
+        while (true) {
+            uint32_t index = m_buckets[i];
+            if (index == emptyBucket)
+                return end();
+            if (!isDeletedEntry(m_entries[index]) && HashFunctions::equal(Extractor::extract(m_entries[index]), key))
+                return iterator(this, index);
+            ++probeCount;
+            i = (i + probeCount) & mask;
+        }
+    }
+
+    const_iterator find(const KeyType& key) const LIFETIME_BOUND
+    {
+        if (!m_buckets)
+            return end();
+        uint32_t mask = m_bucketCount - 1;
+        uint32_t probeCount = 0;
+        uint32_t i = HashFunctions::hash(key) & mask;
+        while (true) {
+            uint32_t index = m_buckets[i];
+            if (index == emptyBucket)
+                return end();
+            if (!isDeletedEntry(m_entries[index]) && HashFunctions::equal(Extractor::extract(m_entries[index]), key))
+                return const_iterator(this, index);
+            ++probeCount;
+            i = (i + probeCount) & mask;
+        }
+    }
+
+    template<typename HashTranslator, typename T>
+    iterator find(const T& key) LIFETIME_BOUND
+    {
+        if (!m_buckets)
+            return end();
+        uint32_t mask = m_bucketCount - 1;
+        uint32_t probeCount = 0;
+        uint32_t i = HashTranslator::hash(key) & mask;
+        while (true) {
+            uint32_t index = m_buckets[i];
+            if (index == emptyBucket)
+                return end();
+            if (!isDeletedEntry(m_entries[index]) && HashTranslator::equal(Extractor::extract(m_entries[index]), key))
+                return iterator(this, index);
+            ++probeCount;
+            i = (i + probeCount) & mask;
+        }
+    }
+
+    template<typename HashTranslator, typename T>
+    const_iterator find(const T& key) const LIFETIME_BOUND
+    {
+        return const_cast<OrderedHashTable*>(this)->template find<HashTranslator>(key);
+    }
+
+    bool contains(const KeyType& key) const
+    {
+        return lookup(key) != nullptr;
+    }
+
+    template<typename HashTranslator, typename T>
+    bool contains(const T& key) const
+    {
+        return const_cast<OrderedHashTable*>(this)->template lookup<HashTranslator>(key) != nullptr;
+    }
+
+    AddResult add(const KeyType& key, NOESCAPE const auto& valueFunctor)
+    {
+        return internalAdd(key, valueFunctor);
+    }
+
+    AddResult add(KeyType&& key, NOESCAPE const auto& valueFunctor)
+    {
+        return internalAdd(std::forward<KeyType>(key), valueFunctor);
+    }
+
+    template<typename HashTranslator, typename K>
+    AddResult add(K&& key, NOESCAPE const auto& valueFunctor)
+    {
+        if (!m_buckets) {
+            initializeBuckets(initialBucketCount);
+            allocateEntries(entriesCapacityFromBucketCount(initialBucketCount));
+        }
+
+        uint32_t hash = HashTranslator::hash(key);
+        uint32_t mask = m_bucketCount - 1;
+        uint32_t probeCount = 0;
+        uint32_t i = hash & mask;
+        uint32_t insertSlot = UINT32_MAX;
+
+        while (true) {
+            uint32_t index = m_buckets[i];
+            if (index == emptyBucket) {
+                if (insertSlot == UINT32_MAX)
+                    insertSlot = i;
+                break;
+            }
+            if (isDeletedEntry(m_entries[index])) {
+                if (insertSlot == UINT32_MAX)
+                    insertSlot = i;
+            } else if (HashTranslator::equal(Extractor::extract(m_entries[index]), key))
+                return { iterator(this, index), false };
+            ++probeCount;
+            i = (i + probeCount) & mask;
+        }
+
+        if (m_entriesLength == m_entriesCapacity) {
+            rehashForAdd();
+            insertSlot = probeForEmpty(hash);
+        }
+
+        uint32_t newIndex = m_entriesLength;
+        HashTranslator::translate(m_entries[newIndex], std::forward<K>(key), valueFunctor);
+        m_buckets[insertSlot] = newIndex;
+        auto result = AddResult { iterator(this, newIndex), true };
+        ++m_entriesLength;
+        ++m_liveCount;
+        return result;
+    }
+
+    void remove(iterator it)
+    {
+        ASSERT(it.m_table == this);
+        ASSERT(it.m_index < m_entriesLength);
+        removeEntryAtIndex(it.m_index);
+    }
+
+    void remove(const_iterator it)
+    {
+        ASSERT(it.m_table == this);
+        ASSERT(it.m_index < m_entriesLength);
+        removeEntryAtIndex(it.m_index);
+    }
+
+    void remove(const KeyType& key)
+    {
+        auto it = find(key);
+        if (it != end())
+            remove(it);
+    }
+
+    bool removeIf(NOESCAPE const auto& functor)
+    {
+        // Defer shrinkIfNeeded until after the loop. Shrinking reallocates m_entries
+        // and resets m_entriesLength, which would invalidate iteration.
+        bool changed = false;
+        for (uint32_t i = 0; i < m_entriesLength; ++i) {
+            if (!isDeletedEntry(m_entries[i]) && functor(m_entries[i])) {
+                hashTraitsDeleteBucket<Traits>(m_entries[i]);
+                --m_liveCount;
+                changed = true;
+            }
+        }
+        if (changed)
+            shrinkIfNeeded();
+        return changed;
+    }
+
+    void clear()
+    {
+        deallocateAll();
+        m_buckets = nullptr;
+        m_entries = nullptr;
+        m_bucketCount = 0;
+        m_entriesCapacity = 0;
+        m_entriesLength = 0;
+        m_liveCount = 0;
+    }
+
+    void reserveInitialCapacity(unsigned keyCount)
+    {
+        ASSERT(isEmpty());
+        if (!keyCount)
+            return;
+        uint32_t newBucketCount = bucketCountForKeyCount(keyCount);
+        if (newBucketCount > m_bucketCount) {
+            deallocateAll();
+            m_buckets = nullptr;
+            m_entries = nullptr;
+            initializeBuckets(newBucketCount);
+            allocateEntries(entriesCapacityFromBucketCount(newBucketCount));
+        }
+    }
+
+    // Internal accessors used by iterators
+    ValueType* entries() { return m_entries; }
+    const ValueType* entries() const { return m_entries; }
+    uint32_t entriesLength() const { return m_entriesLength; }
+
+    bool isDeletedEntry(const ValueType& value) const
+    {
+        return KeyTraits::isDeletedValue(Extractor::extract(value));
+    }
+
+private:
+    static constexpr uint32_t emptyBucket = UINT32_MAX;
+    static constexpr unsigned initialBucketCount = 8;
+
+    static constexpr uint32_t entriesCapacityFromBucketCount(uint32_t bucketCount)
+    {
+        // Load factor 3/4: entries array is 3/4 of bucket array. Leaves room for
+        // empty slots so probing terminates quickly.
+        return (bucketCount * 3) / 4;
+    }
+
+    static constexpr uint32_t bucketCountForKeyCount(uint32_t keyCount)
+    {
+        uint32_t bucketCount = initialBucketCount;
+        while (entriesCapacityFromBucketCount(bucketCount) < keyCount)
+            bucketCount <<= 1;
+        return bucketCount;
+    }
+
+    // Assumes no key equals the one being inserted and no deleted slots appear
+    // in the probe path — valid immediately after initializeBuckets() or rehash().
+    void insertIntoFreshBuckets(uint32_t entryIndex)
+    {
+        uint32_t insertSlot = probeForEmpty(HashFunctions::hash(Extractor::extract(m_entries[entryIndex])));
+        m_buckets[insertSlot] = entryIndex;
+    }
+
+    uint32_t probeForEmpty(uint32_t hash) const
+    {
+        uint32_t mask = m_bucketCount - 1;
+        uint32_t probeCount = 0;
+        uint32_t i = hash & mask;
+        while (m_buckets[i] != emptyBucket) {
+            ++probeCount;
+            i = (i + probeCount) & mask;
+        }
+        return i;
+    }
+
+    void initializeBuckets(uint32_t count)
+    {
+        m_bucketCount = count;
+        m_buckets = static_cast<uint32_t*>(Malloc::malloc(count * sizeof(uint32_t)));
+        std::fill_n(m_buckets, count, emptyBucket);
+    }
+
+    void allocateEntries(uint32_t cap)
+    {
+        m_entriesCapacity = cap;
+        m_entries = static_cast<ValueType*>(Malloc::malloc(cap * sizeof(ValueType)));
+    }
+
+    void deallocateAll()
+    {
+        if (m_entries) {
+            for (uint32_t i = 0; i < m_entriesLength; ++i) {
+                if (!isDeletedEntry(m_entries[i]))
+                    m_entries[i].~ValueType();
+            }
+            Malloc::free(m_entries);
+        }
+        if (m_buckets)
+            Malloc::free(m_buckets);
+    }
+
+    template<typename K>
+    AddResult internalAdd(K&& key, NOESCAPE const auto& valueFunctor)
+    {
+        if (!m_buckets) {
+            initializeBuckets(initialBucketCount);
+            allocateEntries(entriesCapacityFromBucketCount(initialBucketCount));
+        }
+
+        uint32_t hash = HashFunctions::hash(key);
+        uint32_t mask = m_bucketCount - 1;
+        uint32_t probeCount = 0;
+        uint32_t i = hash & mask;
+        uint32_t insertSlot = UINT32_MAX;
+
+        while (true) {
+            uint32_t index = m_buckets[i];
+            if (index == emptyBucket) {
+                if (insertSlot == UINT32_MAX)
+                    insertSlot = i;
+                break;
+            }
+            if (isDeletedEntry(m_entries[index])) {
+                if (insertSlot == UINT32_MAX)
+                    insertSlot = i;
+            } else if (HashFunctions::equal(Extractor::extract(m_entries[index]), key))
+                return { iterator(this, index), false };
+            ++probeCount;
+            i = (i + probeCount) & mask;
+        }
+
+        if (m_entriesLength == m_entriesCapacity) {
+            rehashForAdd();
+            insertSlot = probeForEmpty(hash);
+        }
+
+        uint32_t newIndex = m_entriesLength;
+        new (NotNull, std::addressof(m_entries[newIndex])) ValueType(valueFunctor());
+        m_buckets[insertSlot] = newIndex;
+        auto result = AddResult { iterator(this, newIndex), true };
+        ++m_entriesLength;
+        ++m_liveCount;
+        return result;
+    }
+
+    void removeEntryAtIndex(uint32_t index)
+    {
+        ASSERT(index < m_entriesLength);
+        ASSERT(!isDeletedEntry(m_entries[index]));
+
+        // The bucket slot keeps pointing at this entry; probes skip it via
+        // isDeletedEntry, so no second probe is needed here.
+        hashTraitsDeleteBucket<Traits>(m_entries[index]);
+
+        --m_liveCount;
+
+        shrinkIfNeeded();
+    }
+
+    void rehashForAdd()
+    {
+        // Entries array is full. Grow if mostly live, otherwise compact in place.
+        if (m_liveCount >= m_entriesCapacity * 3 / 4)
+            rehash(m_bucketCount << 1);
+        else
+            compactInPlace();
+    }
+
+    void shrinkIfNeeded()
+    {
+        if (m_bucketCount <= initialBucketCount)
+            return;
+        if (m_liveCount >= m_entriesLength / 4)
+            return;
+        rehash(std::max<uint32_t>(m_bucketCount >> 1, initialBucketCount));
+    }
+
+    void compactInPlace()
+    {
+        uint32_t writeIndex = 0;
+        for (uint32_t readIndex = 0; readIndex < m_entriesLength; ++readIndex) {
+            if (isDeletedEntry(m_entries[readIndex]))
+                continue;
+            if (readIndex != writeIndex) {
+                new (NotNull, std::addressof(m_entries[writeIndex])) ValueType(WTF::move(m_entries[readIndex]));
+                m_entries[readIndex].~ValueType();
+            }
+            ++writeIndex;
+        }
+        m_entriesLength = writeIndex;
+        m_liveCount = writeIndex;
+
+        std::fill_n(m_buckets, m_bucketCount, emptyBucket);
+        for (uint32_t i = 0; i < m_entriesLength; ++i)
+            insertIntoFreshBuckets(i);
+    }
+
+    void rehash(uint32_t newBucketCount)
+    {
+        uint32_t* oldBuckets = m_buckets;
+        ValueType* oldEntries = m_entries;
+        uint32_t oldLength = m_entriesLength;
+
+        uint32_t newCapacity = entriesCapacityFromBucketCount(newBucketCount);
+
+        initializeBuckets(newBucketCount);
+        allocateEntries(newCapacity);
+
+        m_entriesLength = 0;
+        m_liveCount = 0;
+
+        for (uint32_t i = 0; i < oldLength; ++i) {
+            if (!isDeletedEntry(oldEntries[i])) {
+                new (NotNull, std::addressof(m_entries[m_entriesLength])) ValueType(WTF::move(oldEntries[i]));
+                oldEntries[i].~ValueType();
+                insertIntoFreshBuckets(m_entriesLength);
+                ++m_entriesLength;
+                ++m_liveCount;
+            }
+        }
+
+        Malloc::free(oldEntries);
+        Malloc::free(oldBuckets);
+    }
+
+    uint32_t* m_buckets { nullptr };
+    ValueType* m_entries { nullptr };
+    uint32_t m_bucketCount { 0 };
+    uint32_t m_entriesCapacity { 0 };
+    uint32_t m_entriesLength { 0 };
+    uint32_t m_liveCount { 0 };
+};
+
+template<typename TableType, typename ValueType>
+class OrderedHashTableIterator {
+    using iterator_category = std::forward_iterator_tag;
+    using value_type = ValueType;
+    using difference_type = ptrdiff_t;
+    using pointer = ValueType*;
+    using reference = ValueType&;
+
+public:
+    OrderedHashTableIterator() = default;
+
+    ValueType* get() const
+    {
+        ASSERT(m_table);
+        ASSERT(m_index < m_table->entriesLength());
+        return &m_table->entries()[m_index];
+    }
+
+    ValueType& operator*() const { return *get(); }
+    ValueType* operator->() const { return get(); }
+
+    OrderedHashTableIterator& operator++()
+    {
+        ASSERT(m_table);
+        ASSERT(m_index < m_table->entriesLength());
+        ++m_index;
+        skipDeleted();
+        return *this;
+    }
+
+    friend bool operator==(const OrderedHashTableIterator& a, const OrderedHashTableIterator& b)
+    {
+        return a.m_table == b.m_table && a.m_index == b.m_index;
+    }
+
+private:
+    friend TableType;
+    template<typename, typename> friend class OrderedHashTableConstIterator;
+    // Give OrderedHashMap/OrderedHashSet access to m_index for remove(iterator)
+    template<typename, typename, typename, typename, typename, typename, typename> friend class OrderedHashTable;
+
+    OrderedHashTableIterator(TableType* table, uint32_t index)
+        : m_table(table)
+        , m_index(index)
+    {
+        skipDeleted();
+    }
+
+    void skipDeleted()
+    {
+        while (m_index < m_table->entriesLength() && m_table->isDeletedEntry(m_table->entries()[m_index]))
+            ++m_index;
+    }
+
+    TableType* m_table { nullptr };
+    uint32_t m_index { 0 };
+};
+
+template<typename TableType, typename ValueType>
+class OrderedHashTableConstIterator {
+    using iterator_category = std::forward_iterator_tag;
+    using value_type = ValueType;
+    using difference_type = ptrdiff_t;
+    using pointer = const ValueType*;
+    using reference = const ValueType&;
+
+public:
+    OrderedHashTableConstIterator() = default;
+
+    OrderedHashTableConstIterator(const OrderedHashTableIterator<std::remove_const_t<TableType>, ValueType>& other)
+        : m_table(other.m_table)
+        , m_index(other.m_index)
+    {
+    }
+
+    const ValueType* get() const
+    {
+        ASSERT(m_table);
+        ASSERT(m_index < m_table->entriesLength());
+        return &m_table->entries()[m_index];
+    }
+
+    const ValueType& operator*() const { return *get(); }
+    const ValueType* operator->() const { return get(); }
+
+    OrderedHashTableConstIterator& operator++()
+    {
+        ASSERT(m_table);
+        ASSERT(m_index < m_table->entriesLength());
+        ++m_index;
+        skipDeleted();
+        return *this;
+    }
+
+    friend bool operator==(const OrderedHashTableConstIterator& a, const OrderedHashTableConstIterator& b)
+    {
+        return a.m_table == b.m_table && a.m_index == b.m_index;
+    }
+
+private:
+    friend TableType;
+    template<typename, typename, typename, typename, typename, typename, typename> friend class OrderedHashTable;
+
+    OrderedHashTableConstIterator(const TableType* table, uint32_t index)
+        : m_table(table)
+        , m_index(index)
+    {
+        skipDeleted();
+    }
+
+    void skipDeleted()
+    {
+        while (m_index < m_table->entriesLength() && m_table->isDeletedEntry(m_table->entries()[m_index]))
+            ++m_index;
+    }
+
+    const TableType* m_table { nullptr };
+    uint32_t m_index { 0 };
+};
+
+template<typename TableType, typename ValueType>
+class OrderedHashTableReverseIterator {
+    using iterator_category = std::forward_iterator_tag;
+    using value_type = ValueType;
+    using difference_type = ptrdiff_t;
+    using pointer = ValueType*;
+    using reference = ValueType&;
+
+public:
+    OrderedHashTableReverseIterator() = default;
+
+    ValueType* get() const
+    {
+        ASSERT(m_table);
+        ASSERT(m_index > 0);
+        ASSERT(m_index <= m_table->entriesLength());
+        return &m_table->entries()[m_index - 1];
+    }
+
+    ValueType& operator*() const { return *get(); }
+    ValueType* operator->() const { return get(); }
+
+    OrderedHashTableReverseIterator& operator++()
+    {
+        ASSERT(m_table);
+        ASSERT(m_index > 0);
+        --m_index;
+        skipDeleted();
+        return *this;
+    }
+
+    friend bool operator==(const OrderedHashTableReverseIterator& a, const OrderedHashTableReverseIterator& b)
+    {
+        return a.m_table == b.m_table && a.m_index == b.m_index;
+    }
+
+private:
+    friend TableType;
+    template<typename, typename> friend class OrderedHashTableConstReverseIterator;
+
+    OrderedHashTableReverseIterator(TableType* table, uint32_t index)
+        : m_table(table)
+        , m_index(index)
+    {
+        skipDeleted();
+    }
+
+    void skipDeleted()
+    {
+        while (m_index > 0 && m_table->isDeletedEntry(m_table->entries()[m_index - 1]))
+            --m_index;
+    }
+
+    TableType* m_table { nullptr };
+    uint32_t m_index { 0 };
+};
+
+template<typename TableType, typename ValueType>
+class OrderedHashTableConstReverseIterator {
+    using iterator_category = std::forward_iterator_tag;
+    using value_type = ValueType;
+    using difference_type = ptrdiff_t;
+    using pointer = const ValueType*;
+    using reference = const ValueType&;
+
+public:
+    OrderedHashTableConstReverseIterator() = default;
+
+    OrderedHashTableConstReverseIterator(const OrderedHashTableReverseIterator<std::remove_const_t<TableType>, ValueType>& other)
+        : m_table(other.m_table)
+        , m_index(other.m_index)
+    {
+    }
+
+    const ValueType* get() const
+    {
+        ASSERT(m_table);
+        ASSERT(m_index > 0);
+        ASSERT(m_index <= m_table->entriesLength());
+        return &m_table->entries()[m_index - 1];
+    }
+
+    const ValueType& operator*() const { return *get(); }
+    const ValueType* operator->() const { return get(); }
+
+    OrderedHashTableConstReverseIterator& operator++()
+    {
+        ASSERT(m_table);
+        ASSERT(m_index > 0);
+        --m_index;
+        skipDeleted();
+        return *this;
+    }
+
+    friend bool operator==(const OrderedHashTableConstReverseIterator& a, const OrderedHashTableConstReverseIterator& b)
+    {
+        return a.m_table == b.m_table && a.m_index == b.m_index;
+    }
+
+private:
+    friend TableType;
+
+    OrderedHashTableConstReverseIterator(const TableType* table, uint32_t index)
+        : m_table(table)
+        , m_index(index)
+    {
+        skipDeleted();
+    }
+
+    void skipDeleted()
+    {
+        while (m_index > 0 && m_table->isDeletedEntry(m_table->entries()[m_index - 1]))
+            --m_index;
+    }
+
+    const TableType* m_table { nullptr };
+    uint32_t m_index { 0 };
+};
+
+} // namespace WTF
+
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Tools/TestWebKitAPI/CMakeLists.txt
+++ b/Tools/TestWebKitAPI/CMakeLists.txt
@@ -89,6 +89,8 @@ set(TestWTF_SOURCES
     Tests/WTF/NeverDestroyed.cpp
     Tests/WTF/OptionCountedSet.cpp
     Tests/WTF/OptionSet.cpp
+    Tests/WTF/OrderedHashMap.cpp
+    Tests/WTF/OrderedHashSet.cpp
     Tests/WTF/Packed.cpp
     Tests/WTF/PackedRef.cpp
     Tests/WTF/PackedRefPtr.cpp

--- a/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
+++ b/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
@@ -1219,6 +1219,8 @@
 				WTF/Observer.cpp,
 				WTF/OptionCountedSet.cpp,
 				WTF/OptionSet.cpp,
+				WTF/OrderedHashMap.cpp,
+				WTF/OrderedHashSet.cpp,
 				WTF/Packed.cpp,
 				WTF/PackedRef.cpp,
 				WTF/PackedRefPtr.cpp,

--- a/Tools/TestWebKitAPI/Tests/WTF/OrderedHashMap.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/OrderedHashMap.cpp
@@ -1,0 +1,754 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include <wtf/OrderedHashMap.h>
+
+#include "Helpers/Test.h"
+#include "MoveOnly.h"
+#include <string>
+#include <wtf/Ref.h>
+#include <wtf/RefCounted.h>
+#include <wtf/RefPtr.h>
+#include <wtf/text/MakeString.h>
+#include <wtf/text/StringHash.h>
+#include <wtf/text/WTFString.h>
+
+namespace TestWebKitAPI {
+
+TEST(WTF_OrderedHashMap, EmptyMap)
+{
+    OrderedHashMap<int, int> map;
+    EXPECT_TRUE(map.isEmpty());
+    EXPECT_EQ(0u, map.size());
+    EXPECT_TRUE(map.begin() == map.end());
+}
+
+TEST(WTF_OrderedHashMap, BasicAddAndFind)
+{
+    OrderedHashMap<int, int> map;
+    auto result = map.add(1, 100);
+    EXPECT_TRUE(result.isNewEntry);
+    EXPECT_EQ(1, result.iterator->key);
+    EXPECT_EQ(100, result.iterator->value);
+    EXPECT_EQ(1u, map.size());
+
+    auto result2 = map.add(1, 200);
+    EXPECT_FALSE(result2.isNewEntry);
+    EXPECT_EQ(100, result2.iterator->value); // Original value preserved
+    EXPECT_EQ(1u, map.size());
+}
+
+TEST(WTF_OrderedHashMap, Set)
+{
+    OrderedHashMap<int, int> map;
+    map.set(1, 100);
+    EXPECT_EQ(100, map.get(1));
+
+    map.set(1, 200);
+    EXPECT_EQ(200, map.get(1)); // Value updated
+    EXPECT_EQ(1u, map.size()); // Size unchanged
+}
+
+TEST(WTF_OrderedHashMap, Ensure)
+{
+    OrderedHashMap<int, int> map;
+    auto result1 = map.ensure(1, [] {
+        return 100;
+    });
+    EXPECT_TRUE(result1.isNewEntry);
+    EXPECT_EQ(100, result1.iterator->value);
+
+    auto result2 = map.ensure(1, [] {
+        return 200;
+    });
+    EXPECT_FALSE(result2.isNewEntry);
+    EXPECT_EQ(100, result2.iterator->value); // Functor not called
+}
+
+TEST(WTF_OrderedHashMap, Contains)
+{
+    OrderedHashMap<int, int> map;
+    map.add(1, 100);
+    map.add(2, 200);
+
+    EXPECT_TRUE(map.contains(1));
+    EXPECT_TRUE(map.contains(2));
+    EXPECT_FALSE(map.contains(3));
+}
+
+TEST(WTF_OrderedHashMap, Get)
+{
+    OrderedHashMap<int, int> map;
+    map.add(1, 100);
+    EXPECT_EQ(100, map.get(1));
+    EXPECT_EQ(0, map.get(999)); // Default for missing key
+}
+
+TEST(WTF_OrderedHashMap, GetOptional)
+{
+    OrderedHashMap<int, int> map;
+    map.add(1, 100);
+    auto result = map.getOptional(1);
+    EXPECT_TRUE(result.has_value());
+    EXPECT_EQ(100, *result);
+
+    auto missing = map.getOptional(999);
+    EXPECT_FALSE(missing.has_value());
+}
+
+TEST(WTF_OrderedHashMap, InsertionOrderPreserved)
+{
+    OrderedHashMap<int, int> map;
+    map.add(3, 300);
+    map.add(1, 100);
+    map.add(4, 400);
+    map.add(1, 999); // Duplicate, should not change order
+    map.add(5, 500);
+    map.add(2, 200);
+
+    Vector<int> keys;
+    for (auto& pair : map)
+        keys.append(pair.key);
+
+    EXPECT_EQ(5u, keys.size());
+    EXPECT_EQ(3, keys[0]);
+    EXPECT_EQ(1, keys[1]);
+    EXPECT_EQ(4, keys[2]);
+    EXPECT_EQ(5, keys[3]);
+    EXPECT_EQ(2, keys[4]);
+}
+
+TEST(WTF_OrderedHashMap, InsertionOrderPreservedAfterDeletion)
+{
+    OrderedHashMap<int, int> map;
+    map.add(1, 100);
+    map.add(2, 200);
+    map.add(3, 300);
+    map.add(4, 400);
+    map.add(5, 500);
+
+    map.remove(3);
+
+    Vector<int> keys;
+    for (auto& pair : map)
+        keys.append(pair.key);
+
+    EXPECT_EQ(4u, keys.size());
+    EXPECT_EQ(1, keys[0]);
+    EXPECT_EQ(2, keys[1]);
+    EXPECT_EQ(4, keys[2]);
+    EXPECT_EQ(5, keys[3]);
+}
+
+TEST(WTF_OrderedHashMap, SetDoesNotChangeOrder)
+{
+    OrderedHashMap<int, int> map;
+    map.add(1, 100);
+    map.add(2, 200);
+    map.add(3, 300);
+
+    map.set(2, 999);
+
+    Vector<int> keys;
+    for (auto& pair : map)
+        keys.append(pair.key);
+
+    EXPECT_EQ(3u, keys.size());
+    EXPECT_EQ(1, keys[0]);
+    EXPECT_EQ(2, keys[1]); // Same position
+    EXPECT_EQ(3, keys[2]);
+    EXPECT_EQ(999, map.get(2)); // Value updated
+}
+
+TEST(WTF_OrderedHashMap, RemoveByKey)
+{
+    OrderedHashMap<int, int> map;
+    map.add(1, 100);
+    map.add(2, 200);
+
+    EXPECT_TRUE(map.remove(1));
+    EXPECT_FALSE(map.contains(1));
+    EXPECT_EQ(1u, map.size());
+    EXPECT_FALSE(map.remove(999)); // Non-existent key
+}
+
+TEST(WTF_OrderedHashMap, RemoveByIterator)
+{
+    OrderedHashMap<int, int> map;
+    map.add(1, 100);
+    map.add(2, 200);
+
+    auto it = map.find(1);
+    EXPECT_TRUE(map.remove(it));
+    EXPECT_FALSE(map.contains(1));
+    EXPECT_EQ(1u, map.size());
+}
+
+TEST(WTF_OrderedHashMap, Take)
+{
+    OrderedHashMap<int, int> map;
+    map.add(1, 100);
+    map.add(2, 200);
+
+    auto value = map.take(1);
+    EXPECT_EQ(100, value);
+    EXPECT_FALSE(map.contains(1));
+    EXPECT_EQ(1u, map.size());
+
+    auto missing = map.take(999);
+    EXPECT_EQ(0, missing); // Default for missing
+}
+
+TEST(WTF_OrderedHashMap, TakeOptional)
+{
+    OrderedHashMap<int, int> map;
+    map.add(1, 100);
+
+    auto result = map.takeOptional(1);
+    EXPECT_TRUE(result.has_value());
+    EXPECT_EQ(100, *result);
+    EXPECT_FALSE(map.contains(1));
+
+    auto missing = map.takeOptional(999);
+    EXPECT_FALSE(missing.has_value());
+}
+
+TEST(WTF_OrderedHashMap, TakeFirst)
+{
+    OrderedHashMap<int, int> map;
+    map.add(3, 300);
+    map.add(1, 100);
+    map.add(2, 200);
+
+    auto value = map.takeFirst();
+    EXPECT_EQ(300, value); // First in insertion order
+    EXPECT_EQ(2u, map.size());
+}
+
+TEST(WTF_OrderedHashMap, Clear)
+{
+    OrderedHashMap<int, int> map;
+    map.add(1, 100);
+    map.add(2, 200);
+    map.clear();
+
+    EXPECT_TRUE(map.isEmpty());
+    EXPECT_EQ(0u, map.size());
+    EXPECT_TRUE(map.begin() == map.end());
+}
+
+TEST(WTF_OrderedHashMap, Swap)
+{
+    OrderedHashMap<int, int> map1;
+    map1.add(1, 100);
+    map1.add(2, 200);
+
+    OrderedHashMap<int, int> map2;
+    map2.add(3, 300);
+
+    map1.swap(map2);
+
+    EXPECT_EQ(1u, map1.size());
+    EXPECT_TRUE(map1.contains(3));
+    EXPECT_EQ(2u, map2.size());
+    EXPECT_TRUE(map2.contains(1));
+    EXPECT_TRUE(map2.contains(2));
+}
+
+TEST(WTF_OrderedHashMap, CopyConstruction)
+{
+    OrderedHashMap<int, int> map1;
+    map1.add(1, 100);
+    map1.add(2, 200);
+    map1.add(3, 300);
+
+    OrderedHashMap<int, int> map2(map1);
+
+    EXPECT_EQ(3u, map2.size());
+
+    // Check insertion order is preserved in copy
+    Vector<int> keys;
+    for (auto& pair : map2)
+        keys.append(pair.key);
+
+    EXPECT_EQ(1, keys[0]);
+    EXPECT_EQ(2, keys[1]);
+    EXPECT_EQ(3, keys[2]);
+}
+
+TEST(WTF_OrderedHashMap, MoveConstruction)
+{
+    OrderedHashMap<int, int> map1;
+    map1.add(1, 100);
+    map1.add(2, 200);
+
+    OrderedHashMap<int, int> map2(WTF::move(map1));
+
+    EXPECT_EQ(2u, map2.size());
+    EXPECT_TRUE(map2.contains(1));
+    EXPECT_TRUE(map2.contains(2));
+    EXPECT_TRUE(map1.isEmpty());
+}
+
+TEST(WTF_OrderedHashMap, CopyAssignment)
+{
+    OrderedHashMap<int, int> map1;
+    map1.add(1, 100);
+    map1.add(2, 200);
+
+    OrderedHashMap<int, int> map2;
+    map2.add(9, 900);
+    map2 = map1;
+
+    EXPECT_EQ(2u, map2.size());
+    EXPECT_TRUE(map2.contains(1));
+    EXPECT_TRUE(map2.contains(2));
+    EXPECT_FALSE(map2.contains(9));
+}
+
+TEST(WTF_OrderedHashMap, MoveAssignment)
+{
+    OrderedHashMap<int, int> map1;
+    map1.add(1, 100);
+
+    OrderedHashMap<int, int> map2;
+    map2.add(9, 900);
+    map2 = WTF::move(map1);
+
+    EXPECT_EQ(1u, map2.size());
+    EXPECT_TRUE(map2.contains(1));
+    EXPECT_TRUE(map1.isEmpty());
+}
+
+TEST(WTF_OrderedHashMap, KeysIteration)
+{
+    OrderedHashMap<int, int> map;
+    map.add(3, 300);
+    map.add(1, 100);
+    map.add(2, 200);
+
+    Vector<int> keys;
+    for (auto& key : map.keys())
+        keys.append(key);
+
+    EXPECT_EQ(3u, keys.size());
+    EXPECT_EQ(3, keys[0]);
+    EXPECT_EQ(1, keys[1]);
+    EXPECT_EQ(2, keys[2]);
+}
+
+TEST(WTF_OrderedHashMap, ValuesIteration)
+{
+    OrderedHashMap<int, int> map;
+    map.add(3, 300);
+    map.add(1, 100);
+    map.add(2, 200);
+
+    Vector<int> values;
+    for (auto& value : map.values())
+        values.append(value);
+
+    EXPECT_EQ(3u, values.size());
+    EXPECT_EQ(300, values[0]);
+    EXPECT_EQ(100, values[1]);
+    EXPECT_EQ(200, values[2]);
+}
+
+TEST(WTF_OrderedHashMap, RehashPreservesOrder)
+{
+    OrderedHashMap<int, int> map;
+    // Insert enough entries to trigger rehashing
+    Vector<int> expectedOrder;
+    for (int i = 0; i < 100; ++i) {
+        map.add(i, i * 10);
+        expectedOrder.append(i);
+    }
+
+    Vector<int> actualOrder;
+    for (auto& pair : map)
+        actualOrder.append(pair.key);
+
+    EXPECT_EQ(expectedOrder, actualOrder);
+}
+
+TEST(WTF_OrderedHashMap, DeleteAndReinsert)
+{
+    OrderedHashMap<int, int> map;
+    map.add(1, 100);
+    map.add(2, 200);
+    map.add(3, 300);
+
+    map.remove(2);
+    map.add(2, 250); // Re-add goes at end
+
+    Vector<int> keys;
+    for (auto& pair : map)
+        keys.append(pair.key);
+
+    EXPECT_EQ(3u, keys.size());
+    EXPECT_EQ(1, keys[0]);
+    EXPECT_EQ(3, keys[1]);
+    EXPECT_EQ(2, keys[2]); // Re-inserted at end
+    EXPECT_EQ(250, map.get(2));
+}
+
+TEST(WTF_OrderedHashMap, ManyDeletesAndInserts)
+{
+    OrderedHashMap<int, int> map;
+    for (int i = 0; i < 50; ++i)
+        map.add(i, i);
+
+    // Delete even numbers
+    for (int i = 0; i < 50; i += 2)
+        map.remove(i);
+
+    EXPECT_EQ(25u, map.size());
+
+    // Check remaining are in order
+    Vector<int> keys;
+    for (auto& pair : map)
+        keys.append(pair.key);
+
+    for (int i = 0; i < 25; ++i)
+        EXPECT_EQ(i * 2 + 1, keys[i]);
+}
+
+TEST(WTF_OrderedHashMap, StringKeys)
+{
+    OrderedHashMap<String, int> map;
+    map.add("banana"_s, 2);
+    map.add("apple"_s, 1);
+    map.add("cherry"_s, 3);
+
+    Vector<String> keys;
+    for (auto& pair : map)
+        keys.append(pair.key);
+
+    EXPECT_EQ(3u, keys.size());
+    EXPECT_STREQ("banana", keys[0].utf8().data());
+    EXPECT_STREQ("apple", keys[1].utf8().data());
+    EXPECT_STREQ("cherry", keys[2].utf8().data());
+}
+
+TEST(WTF_OrderedHashMap, InitializerList)
+{
+    OrderedHashMap<int, int> map {
+        { 3, 300 },
+        { 1, 100 },
+        { 2, 200 }
+    };
+
+    EXPECT_EQ(3u, map.size());
+
+    Vector<int> keys;
+    for (auto& pair : map)
+        keys.append(pair.key);
+
+    EXPECT_EQ(3, keys[0]);
+    EXPECT_EQ(1, keys[1]);
+    EXPECT_EQ(2, keys[2]);
+}
+
+TEST(WTF_OrderedHashMap, ReserveCapacity)
+{
+    OrderedHashMap<int, int> map;
+    map.reserveInitialCapacity(100);
+
+    for (int i = 0; i < 100; ++i)
+        map.add(i, i);
+
+    EXPECT_EQ(100u, map.size());
+
+    Vector<int> keys;
+    for (auto& pair : map)
+        keys.append(pair.key);
+
+    for (int i = 0; i < 100; ++i)
+        EXPECT_EQ(i, keys[i]);
+}
+
+TEST(WTF_OrderedHashMap, ConstIteration)
+{
+    OrderedHashMap<int, int> map;
+    map.add(1, 100);
+    map.add(2, 200);
+
+    const auto& constMap = map;
+    Vector<int> keys;
+    for (auto& pair : constMap)
+        keys.append(pair.key);
+
+    EXPECT_EQ(2u, keys.size());
+    EXPECT_EQ(1, keys[0]);
+    EXPECT_EQ(2, keys[1]);
+}
+
+TEST(WTF_OrderedHashMap, FindReturnsCorrectIterator)
+{
+    OrderedHashMap<int, int> map;
+    map.add(1, 100);
+    map.add(2, 200);
+    map.add(3, 300);
+
+    auto it = map.find(2);
+    EXPECT_TRUE(it != map.end());
+    EXPECT_EQ(2, it->key);
+    EXPECT_EQ(200, it->value);
+
+    auto missing = map.find(999);
+    EXPECT_TRUE(missing == map.end());
+}
+
+TEST(WTF_OrderedHashMap, IteratorComparison)
+{
+    OrderedHashMap<int, int> map;
+    map.add(1, 100);
+
+    EXPECT_TRUE(map.begin() != map.end());
+    EXPECT_FALSE(map.begin() == map.end());
+
+    OrderedHashMap<int, int>::const_iterator constBegin = map.begin();
+    EXPECT_TRUE(constBegin == map.begin());
+    EXPECT_TRUE(constBegin != map.end());
+}
+
+TEST(WTF_OrderedHashMap, CompactInPlacePreservesOrderAndCapacity)
+{
+    // Fills the initial entries array (capacity=6, bucketCount=8), deletes most,
+    // then adds to trigger rehashForAdd on a table that cannot shrink below
+    // initialBucketCount — forcing the compactInPlace branch.
+    OrderedHashMap<int, int> map;
+    for (int i = 0; i < 6; ++i)
+        map.add(i, i * 10);
+    unsigned initialCapacity = map.capacity();
+
+    map.remove(1);
+    map.remove(2);
+    map.remove(3);
+    map.remove(4);
+    EXPECT_EQ(2u, map.size());
+    EXPECT_EQ(initialCapacity, map.capacity());
+
+    map.add(100, 1000);
+    EXPECT_EQ(3u, map.size());
+    EXPECT_EQ(initialCapacity, map.capacity()); // Reused the same allocation.
+
+    Vector<int> keys;
+    Vector<int> values;
+    for (auto& pair : map) {
+        keys.append(pair.key);
+        values.append(pair.value);
+    }
+    EXPECT_EQ(3u, keys.size());
+    EXPECT_EQ(0, keys[0]);
+    EXPECT_EQ(5, keys[1]);
+    EXPECT_EQ(100, keys[2]);
+    EXPECT_EQ(0, values[0]);
+    EXPECT_EQ(50, values[1]);
+    EXPECT_EQ(1000, values[2]);
+
+    EXPECT_EQ(0, map.get(0));
+    EXPECT_EQ(50, map.get(5));
+    EXPECT_EQ(1000, map.get(100));
+    EXPECT_FALSE(map.contains(1));
+    EXPECT_FALSE(map.contains(4));
+}
+
+TEST(WTF_OrderedHashMap, CompactInPlaceOnLargerTable)
+{
+    OrderedHashMap<int, int> map;
+    map.reserveInitialCapacity(12);
+    unsigned reservedCapacity = map.capacity();
+    EXPECT_GE(reservedCapacity, 12u);
+
+    for (int i = 0; i < 12; ++i)
+        map.add(i, i * 10);
+    EXPECT_EQ(12u, map.size());
+    EXPECT_EQ(reservedCapacity, map.capacity());
+
+    // Keep liveCount at 3 so add hits compactInPlace (not shrink, not grow).
+    for (int i = 0; i < 9; ++i)
+        map.remove(i);
+    EXPECT_EQ(3u, map.size());
+    EXPECT_EQ(reservedCapacity, map.capacity());
+
+    map.add(100, 1000);
+    EXPECT_EQ(4u, map.size());
+    EXPECT_EQ(reservedCapacity, map.capacity());
+
+    Vector<int> keys;
+    for (auto& pair : map)
+        keys.append(pair.key);
+    EXPECT_EQ(4u, keys.size());
+    EXPECT_EQ(9, keys[0]);
+    EXPECT_EQ(10, keys[1]);
+    EXPECT_EQ(11, keys[2]);
+    EXPECT_EQ(100, keys[3]);
+
+    EXPECT_EQ(90, map.get(9));
+    EXPECT_EQ(100, map.get(10));
+    EXPECT_EQ(110, map.get(11));
+    EXPECT_EQ(1000, map.get(100));
+}
+
+TEST(WTF_OrderedHashMap, CompactInPlaceWithStringValues)
+{
+    // Non-trivial value type exercises move/destroy paths inside compactInPlace.
+    OrderedHashMap<int, String> map;
+    for (int i = 0; i < 6; ++i)
+        map.add(i, makeString("v"_s, i));
+    unsigned initialCapacity = map.capacity();
+
+    map.remove(1);
+    map.remove(2);
+    map.remove(3);
+    map.remove(4);
+
+    map.add(100, "new"_s);
+    EXPECT_EQ(initialCapacity, map.capacity());
+    EXPECT_EQ(3u, map.size());
+
+    Vector<int> keys;
+    Vector<String> values;
+    for (auto& pair : map) {
+        keys.append(pair.key);
+        values.append(pair.value);
+    }
+    EXPECT_EQ(3u, keys.size());
+    EXPECT_EQ(0, keys[0]);
+    EXPECT_EQ(5, keys[1]);
+    EXPECT_EQ(100, keys[2]);
+    EXPECT_EQ("v0"_s, values[0]);
+    EXPECT_EQ("v5"_s, values[1]);
+    EXPECT_EQ("new"_s, values[2]);
+
+    EXPECT_EQ("v0"_s, map.get(0));
+    EXPECT_EQ("v5"_s, map.get(5));
+    EXPECT_EQ("new"_s, map.get(100));
+}
+
+TEST(WTF_OrderedHashMap, RemoveIfAcrossShrinkThreshold)
+{
+    // Fill past initialBucketCount so shrinkIfNeeded() can actually rehash, then
+    // removeIf enough entries to cross the 1/4 shrink threshold. Prior to the fix
+    // that deferred shrink, this would rehash mid-iteration and skip entries.
+    OrderedHashMap<int, int> map;
+    for (int i = 0; i < 64; ++i)
+        map.add(i, i * 10);
+    EXPECT_EQ(64u, map.size());
+
+    bool changed = map.removeIf([](auto& entry) {
+        return entry.key >= 8;
+    });
+    EXPECT_TRUE(changed);
+    EXPECT_EQ(8u, map.size());
+
+    Vector<int> keys;
+    Vector<int> values;
+    for (auto& entry : map) {
+        keys.append(entry.key);
+        values.append(entry.value);
+    }
+    EXPECT_EQ(8u, keys.size());
+    for (unsigned i = 0; i < keys.size(); ++i) {
+        EXPECT_EQ(static_cast<int>(i), keys[i]);
+        EXPECT_EQ(static_cast<int>(i) * 10, values[i]);
+    }
+
+    for (int i = 0; i < 8; ++i) {
+        EXPECT_TRUE(map.contains(i));
+        EXPECT_EQ(i * 10, map.get(i));
+    }
+    for (int i = 8; i < 64; ++i)
+        EXPECT_FALSE(map.contains(i));
+}
+
+TEST(WTF_OrderedHashMap, MoveOnlyValue)
+{
+    OrderedHashMap<int, MoveOnly> map;
+    auto addResult = map.add(1, MoveOnly(100));
+    EXPECT_TRUE(addResult.isNewEntry);
+    EXPECT_EQ(100u, addResult.iterator->value.value());
+
+    map.set(2, MoveOnly(200));
+    map.add(3, MoveOnly(300));
+    EXPECT_EQ(3u, map.size());
+    EXPECT_EQ(100u, map.find(1)->value.value());
+    EXPECT_EQ(200u, map.find(2)->value.value());
+    EXPECT_EQ(300u, map.find(3)->value.value());
+
+    auto ensured = map.ensure(4, [] { return MoveOnly(400); });
+    EXPECT_TRUE(ensured.isNewEntry);
+    EXPECT_EQ(400u, ensured.iterator->value.value());
+
+    auto taken = map.take(2);
+    EXPECT_EQ(200u, taken.value());
+    EXPECT_EQ(3u, map.size());
+    EXPECT_FALSE(map.contains(2));
+
+    // Insertion order should still be 1, 3, 4 after removing 2.
+    Vector<int> keysInOrder;
+    for (auto& entry : map)
+        keysInOrder.append(entry.key);
+    EXPECT_EQ(3u, keysInOrder.size());
+    EXPECT_EQ(1, keysInOrder[0]);
+    EXPECT_EQ(3, keysInOrder[1]);
+    EXPECT_EQ(4, keysInOrder[2]);
+}
+
+TEST(WTF_OrderedHashMap, MoveOnlyValueRehash)
+{
+    // Force enough additions to trigger rehash with move-only values, exercising
+    // the move construction in the rehash path.
+    OrderedHashMap<int, MoveOnly> map;
+    for (unsigned i = 0; i < 64; ++i)
+        map.add(i, MoveOnly(i * 7));
+    EXPECT_EQ(64u, map.size());
+    for (unsigned i = 0; i < 64; ++i)
+        EXPECT_EQ(i * 7, map.find(i)->value.value());
+}
+
+TEST(WTF_OrderedHashMap, HashTranslatorFindContainsGet)
+{
+    OrderedHashMap<String, unsigned> map;
+    map.add("alpha"_s, 1u);
+    map.add("beta"_s, 2u);
+    map.add("gamma"_s, 3u);
+
+    auto it = map.find<StringViewHashTranslator>(StringView { "beta"_s });
+    EXPECT_TRUE(it != map.end());
+    EXPECT_EQ(2u, it->value);
+
+    EXPECT_TRUE(map.contains<StringViewHashTranslator>(StringView { "alpha"_s }));
+    EXPECT_TRUE(map.contains<StringViewHashTranslator>(StringView { "gamma"_s }));
+    EXPECT_FALSE(map.contains<StringViewHashTranslator>(StringView { "delta"_s }));
+
+    EXPECT_EQ(1u, map.get<StringViewHashTranslator>(StringView { "alpha"_s }));
+    EXPECT_EQ(3u, map.get<StringViewHashTranslator>(StringView { "gamma"_s }));
+    EXPECT_EQ(0u, map.get<StringViewHashTranslator>(StringView { "missing"_s }));
+}
+
+} // namespace TestWebKitAPI

--- a/Tools/TestWebKitAPI/Tests/WTF/OrderedHashSet.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/OrderedHashSet.cpp
@@ -1,0 +1,654 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include <wtf/OrderedHashSet.h>
+
+#include "Helpers/Test.h"
+#include "MoveOnly.h"
+#include <wtf/text/StringHash.h>
+#include <wtf/text/WTFString.h>
+
+namespace TestWebKitAPI {
+
+TEST(WTF_OrderedHashSet, EmptySet)
+{
+    OrderedHashSet<int> set;
+    EXPECT_TRUE(set.isEmpty());
+    EXPECT_EQ(0u, set.size());
+    EXPECT_TRUE(set.begin() == set.end());
+}
+
+TEST(WTF_OrderedHashSet, BasicAddAndContains)
+{
+    OrderedHashSet<int> set;
+    auto result = set.add(1);
+    EXPECT_TRUE(result.isNewEntry);
+    EXPECT_EQ(1u, set.size());
+
+    auto result2 = set.add(1);
+    EXPECT_FALSE(result2.isNewEntry);
+    EXPECT_EQ(1u, set.size());
+
+    EXPECT_TRUE(set.contains(1));
+    EXPECT_FALSE(set.contains(2));
+}
+
+TEST(WTF_OrderedHashSet, InsertionOrderPreserved)
+{
+    OrderedHashSet<int> set;
+    set.add(5);
+    set.add(3);
+    set.add(1);
+    set.add(4);
+    set.add(2);
+
+    Vector<int> values;
+    for (auto& v : set)
+        values.append(v);
+
+    EXPECT_EQ(5u, values.size());
+    EXPECT_EQ(5, values[0]);
+    EXPECT_EQ(3, values[1]);
+    EXPECT_EQ(1, values[2]);
+    EXPECT_EQ(4, values[3]);
+    EXPECT_EQ(2, values[4]);
+}
+
+TEST(WTF_OrderedHashSet, InsertionOrderPreservedAfterDeletion)
+{
+    OrderedHashSet<int> set;
+    set.add(1);
+    set.add(2);
+    set.add(3);
+    set.add(4);
+    set.add(5);
+
+    set.remove(3);
+
+    Vector<int> values;
+    for (auto& v : set)
+        values.append(v);
+
+    EXPECT_EQ(4u, values.size());
+    EXPECT_EQ(1, values[0]);
+    EXPECT_EQ(2, values[1]);
+    EXPECT_EQ(4, values[2]);
+    EXPECT_EQ(5, values[3]);
+}
+
+TEST(WTF_OrderedHashSet, Remove)
+{
+    OrderedHashSet<int> set;
+    set.add(1);
+    set.add(2);
+    set.add(3);
+
+    EXPECT_TRUE(set.remove(2));
+    EXPECT_FALSE(set.contains(2));
+    EXPECT_EQ(2u, set.size());
+    EXPECT_FALSE(set.remove(999));
+}
+
+TEST(WTF_OrderedHashSet, RemoveByIterator)
+{
+    OrderedHashSet<int> set;
+    set.add(1);
+    set.add(2);
+    set.add(3);
+
+    auto it = set.find(2);
+    EXPECT_TRUE(set.remove(it));
+    EXPECT_FALSE(set.contains(2));
+    EXPECT_EQ(2u, set.size());
+}
+
+TEST(WTF_OrderedHashSet, Take)
+{
+    OrderedHashSet<int> set;
+    set.add(1);
+    set.add(2);
+    set.add(3);
+
+    auto value = set.take(2);
+    EXPECT_EQ(2, value);
+    EXPECT_FALSE(set.contains(2));
+    EXPECT_EQ(2u, set.size());
+
+    auto missing = set.take(999);
+    EXPECT_EQ(0, missing); // Default for missing
+}
+
+TEST(WTF_OrderedHashSet, TakeAny)
+{
+    OrderedHashSet<int> set;
+    set.add(5);
+    set.add(3);
+    set.add(1);
+
+    auto value = set.takeAny();
+    EXPECT_EQ(5, value); // First in insertion order
+    EXPECT_EQ(2u, set.size());
+}
+
+TEST(WTF_OrderedHashSet, Clear)
+{
+    OrderedHashSet<int> set;
+    set.add(1);
+    set.add(2);
+    set.clear();
+
+    EXPECT_TRUE(set.isEmpty());
+    EXPECT_EQ(0u, set.size());
+    EXPECT_TRUE(set.begin() == set.end());
+}
+
+TEST(WTF_OrderedHashSet, Swap)
+{
+    OrderedHashSet<int> set1;
+    set1.add(1);
+    set1.add(2);
+
+    OrderedHashSet<int> set2;
+    set2.add(3);
+
+    set1.swap(set2);
+
+    EXPECT_EQ(1u, set1.size());
+    EXPECT_TRUE(set1.contains(3));
+    EXPECT_EQ(2u, set2.size());
+    EXPECT_TRUE(set2.contains(1));
+    EXPECT_TRUE(set2.contains(2));
+}
+
+TEST(WTF_OrderedHashSet, CopyConstruction)
+{
+    OrderedHashSet<int> set1;
+    set1.add(3);
+    set1.add(1);
+    set1.add(2);
+
+    OrderedHashSet<int> set2(set1);
+
+    EXPECT_EQ(3u, set2.size());
+
+    Vector<int> values;
+    for (auto& v : set2)
+        values.append(v);
+
+    EXPECT_EQ(3, values[0]);
+    EXPECT_EQ(1, values[1]);
+    EXPECT_EQ(2, values[2]);
+}
+
+TEST(WTF_OrderedHashSet, MoveConstruction)
+{
+    OrderedHashSet<int> set1;
+    set1.add(1);
+    set1.add(2);
+
+    OrderedHashSet<int> set2(WTF::move(set1));
+
+    EXPECT_EQ(2u, set2.size());
+    EXPECT_TRUE(set2.contains(1));
+    EXPECT_TRUE(set2.contains(2));
+    EXPECT_TRUE(set1.isEmpty());
+}
+
+TEST(WTF_OrderedHashSet, CopyAssignment)
+{
+    OrderedHashSet<int> set1;
+    set1.add(1);
+    set1.add(2);
+
+    OrderedHashSet<int> set2;
+    set2.add(9);
+    set2 = set1;
+
+    EXPECT_EQ(2u, set2.size());
+    EXPECT_TRUE(set2.contains(1));
+    EXPECT_TRUE(set2.contains(2));
+    EXPECT_FALSE(set2.contains(9));
+}
+
+TEST(WTF_OrderedHashSet, MoveAssignment)
+{
+    OrderedHashSet<int> set1;
+    set1.add(1);
+
+    OrderedHashSet<int> set2;
+    set2.add(9);
+    set2 = WTF::move(set1);
+
+    EXPECT_EQ(1u, set2.size());
+    EXPECT_TRUE(set2.contains(1));
+    EXPECT_TRUE(set1.isEmpty());
+}
+
+TEST(WTF_OrderedHashSet, RehashPreservesOrder)
+{
+    OrderedHashSet<int> set;
+    Vector<int> expectedOrder;
+    for (int i = 0; i < 100; ++i) {
+        set.add(i);
+        expectedOrder.append(i);
+    }
+
+    Vector<int> actualOrder;
+    for (auto& v : set)
+        actualOrder.append(v);
+
+    EXPECT_EQ(expectedOrder, actualOrder);
+}
+
+TEST(WTF_OrderedHashSet, DeleteAndReinsert)
+{
+    OrderedHashSet<int> set;
+    set.add(1);
+    set.add(2);
+    set.add(3);
+
+    set.remove(2);
+    set.add(2); // Re-add goes at end
+
+    Vector<int> values;
+    for (auto& v : set)
+        values.append(v);
+
+    EXPECT_EQ(3u, values.size());
+    EXPECT_EQ(1, values[0]);
+    EXPECT_EQ(3, values[1]);
+    EXPECT_EQ(2, values[2]); // Re-inserted at end
+}
+
+TEST(WTF_OrderedHashSet, ManyDeletesAndInserts)
+{
+    OrderedHashSet<int> set;
+    for (int i = 0; i < 50; ++i)
+        set.add(i);
+
+    for (int i = 0; i < 50; i += 2)
+        set.remove(i);
+
+    EXPECT_EQ(25u, set.size());
+
+    Vector<int> values;
+    for (auto& v : set)
+        values.append(v);
+
+    for (int i = 0; i < 25; ++i)
+        EXPECT_EQ(i * 2 + 1, values[i]);
+}
+
+TEST(WTF_OrderedHashSet, StringValues)
+{
+    OrderedHashSet<String> set;
+    set.add("banana"_s);
+    set.add("apple"_s);
+    set.add("cherry"_s);
+
+    Vector<String> values;
+    for (auto& v : set)
+        values.append(v);
+
+    EXPECT_EQ(3u, values.size());
+    EXPECT_STREQ("banana", values[0].utf8().data());
+    EXPECT_STREQ("apple", values[1].utf8().data());
+    EXPECT_STREQ("cherry", values[2].utf8().data());
+}
+
+TEST(WTF_OrderedHashSet, InitializerList)
+{
+    OrderedHashSet<int> set { 5, 3, 1, 4, 2 };
+
+    EXPECT_EQ(5u, set.size());
+
+    Vector<int> values;
+    for (auto& v : set)
+        values.append(v);
+
+    EXPECT_EQ(5, values[0]);
+    EXPECT_EQ(3, values[1]);
+    EXPECT_EQ(1, values[2]);
+    EXPECT_EQ(4, values[3]);
+    EXPECT_EQ(2, values[4]);
+}
+
+TEST(WTF_OrderedHashSet, AddAll)
+{
+    OrderedHashSet<int> set;
+    set.add(1);
+
+    Vector<int> toAdd { 2, 3, 4 };
+    set.addAll(toAdd);
+
+    EXPECT_EQ(4u, set.size());
+
+    Vector<int> values;
+    for (auto& v : set)
+        values.append(v);
+
+    EXPECT_EQ(1, values[0]);
+    EXPECT_EQ(2, values[1]);
+    EXPECT_EQ(3, values[2]);
+    EXPECT_EQ(4, values[3]);
+}
+
+TEST(WTF_OrderedHashSet, Find)
+{
+    OrderedHashSet<int> set;
+    set.add(1);
+    set.add(2);
+    set.add(3);
+
+    auto it = set.find(2);
+    EXPECT_TRUE(it != set.end());
+    EXPECT_EQ(2, *it);
+
+    auto missing = set.find(999);
+    EXPECT_TRUE(missing == set.end());
+}
+
+TEST(WTF_OrderedHashSet, ReserveCapacity)
+{
+    OrderedHashSet<int> set;
+    set.reserveInitialCapacity(100);
+
+    for (int i = 0; i < 100; ++i)
+        set.add(i);
+
+    EXPECT_EQ(100u, set.size());
+
+    Vector<int> values;
+    for (auto& v : set)
+        values.append(v);
+
+    for (int i = 0; i < 100; ++i)
+        EXPECT_EQ(i, values[i]);
+}
+
+TEST(WTF_OrderedHashSet, StressTest)
+{
+    OrderedHashSet<int> set;
+    // Insert 1000 elements
+    for (int i = 0; i < 1000; ++i)
+        set.add(i);
+
+    EXPECT_EQ(1000u, set.size());
+
+    // Remove every 3rd element
+    for (int i = 0; i < 1000; i += 3)
+        set.remove(i);
+
+    // Verify remaining elements are in insertion order
+    Vector<int> remaining;
+    for (auto& v : set)
+        remaining.append(v);
+
+    int expectedIdx = 0;
+    for (int i = 0; i < 1000; ++i) {
+        if (i % 3) {
+            EXPECT_EQ(i, remaining[expectedIdx]);
+            ++expectedIdx;
+        }
+    }
+
+    EXPECT_EQ(static_cast<unsigned>(expectedIdx), set.size());
+}
+
+TEST(WTF_OrderedHashSet, CompactInPlacePreservesOrderAndCapacity)
+{
+    // With initialBucketCount=8, entriesCapacity starts at 6 and the table
+    // does not shrink below initialBucketCount, so compactInPlace is the only
+    // rehash path triggered here.
+    OrderedHashSet<int> set;
+    for (int i = 0; i < 6; ++i)
+        set.add(i);
+    unsigned initialCapacity = set.capacity();
+
+    set.remove(1);
+    set.remove(2);
+    set.remove(3);
+    set.remove(4);
+    EXPECT_EQ(2u, set.size());
+    EXPECT_EQ(initialCapacity, set.capacity());
+
+    // Adding now triggers rehashForAdd. liveCount (2) < 3/4 * capacity (6),
+    // so compactInPlace runs and reuses both the entries and buckets allocations.
+    set.add(100);
+    EXPECT_EQ(3u, set.size());
+    EXPECT_EQ(initialCapacity, set.capacity());
+
+    Vector<int> values;
+    for (auto& v : set)
+        values.append(v);
+    EXPECT_EQ(3u, values.size());
+    EXPECT_EQ(0, values[0]);
+    EXPECT_EQ(5, values[1]);
+    EXPECT_EQ(100, values[2]);
+
+    EXPECT_TRUE(set.contains(0));
+    EXPECT_TRUE(set.contains(5));
+    EXPECT_TRUE(set.contains(100));
+    EXPECT_FALSE(set.contains(1));
+    EXPECT_FALSE(set.contains(4));
+}
+
+TEST(WTF_OrderedHashSet, CompactInPlaceOnLargerTable)
+{
+    // Force a larger table so we can verify compactInPlace works beyond the
+    // initial capacity without triggering a grow or shrink rehash.
+    OrderedHashSet<int> set;
+    set.reserveInitialCapacity(12);
+    unsigned reservedCapacity = set.capacity();
+    EXPECT_GE(reservedCapacity, 12u);
+
+    for (int i = 0; i < 12; ++i)
+        set.add(i);
+    EXPECT_EQ(12u, set.size());
+    EXPECT_EQ(reservedCapacity, set.capacity());
+
+    // shrinkIfNeeded fires when liveCount < entriesLength / 4 (= 3). Keep liveCount
+    // at 3 so the subsequent add takes the compactInPlace branch, not shrink.
+    for (int i = 0; i < 9; ++i)
+        set.remove(i);
+    EXPECT_EQ(3u, set.size());
+    EXPECT_EQ(reservedCapacity, set.capacity());
+
+    set.add(100);
+    EXPECT_EQ(4u, set.size());
+    EXPECT_EQ(reservedCapacity, set.capacity());
+
+    Vector<int> values;
+    for (auto& v : set)
+        values.append(v);
+    EXPECT_EQ(4u, values.size());
+    EXPECT_EQ(9, values[0]);
+    EXPECT_EQ(10, values[1]);
+    EXPECT_EQ(11, values[2]);
+    EXPECT_EQ(100, values[3]);
+}
+
+TEST(WTF_OrderedHashSet, CompactInPlaceWithStrings)
+{
+    // Non-trivial value type exercises move/destroy paths inside compactInPlace.
+    OrderedHashSet<String> set;
+    set.add("zero"_s);
+    set.add("one"_s);
+    set.add("two"_s);
+    set.add("three"_s);
+    set.add("four"_s);
+    set.add("five"_s);
+    unsigned initialCapacity = set.capacity();
+
+    set.remove("one"_s);
+    set.remove("two"_s);
+    set.remove("three"_s);
+    set.remove("four"_s);
+
+    set.add("new"_s);
+    EXPECT_EQ(initialCapacity, set.capacity());
+    EXPECT_EQ(3u, set.size());
+
+    Vector<String> values;
+    for (auto& v : set)
+        values.append(v);
+    EXPECT_EQ(3u, values.size());
+    EXPECT_EQ("zero"_s, values[0]);
+    EXPECT_EQ("five"_s, values[1]);
+    EXPECT_EQ("new"_s, values[2]);
+
+    EXPECT_TRUE(set.contains("zero"_s));
+    EXPECT_TRUE(set.contains("five"_s));
+    EXPECT_TRUE(set.contains("new"_s));
+    EXPECT_FALSE(set.contains("one"_s));
+    EXPECT_FALSE(set.contains("four"_s));
+}
+
+TEST(WTF_OrderedHashSet, CompactInPlaceRepeatedCycles)
+{
+    // Many cycles of "delete most, refill to capacity" keep hitting the compactInPlace
+    // branch. Verify the table remains consistent across all of them.
+    OrderedHashSet<int> set;
+    set.reserveInitialCapacity(12);
+    unsigned capacity = set.capacity();
+
+    for (int i = 0; i < 12; ++i)
+        set.add(i);
+
+    int nextValue = 100;
+    for (int cycle = 0; cycle < 20; ++cycle) {
+        Vector<int> snapshot;
+        for (auto& v : set)
+            snapshot.append(v);
+        // Remove down to 3 live entries (just above the shrink threshold).
+        for (unsigned i = 0; i < snapshot.size() && set.size() > 3; ++i)
+            set.remove(snapshot[i]);
+        EXPECT_EQ(3u, set.size());
+
+        // Refilling will trigger compactInPlace on the first add past capacity.
+        while (set.size() < 12)
+            set.add(nextValue++);
+        EXPECT_EQ(12u, set.size());
+        EXPECT_EQ(capacity, set.capacity()); // No growth happened.
+
+        // All values must round-trip via contains.
+        Vector<int> live;
+        for (auto& v : set)
+            live.append(v);
+        for (int v : live)
+            EXPECT_TRUE(set.contains(v));
+    }
+}
+
+TEST(WTF_OrderedHashSet, RemoveIfAcrossShrinkThreshold)
+{
+    // Fill past initialBucketCount so shrinkIfNeeded() can actually rehash, then
+    // removeIf enough entries to cross the 1/4 shrink threshold. Prior to the fix
+    // that deferred shrink, this would rehash mid-iteration and skip entries.
+    OrderedHashSet<int> set;
+    for (int i = 0; i < 64; ++i)
+        set.add(i);
+    EXPECT_EQ(64u, set.size());
+
+    bool changed = set.removeIf([](int value) {
+        return value >= 8;
+    });
+    EXPECT_TRUE(changed);
+    EXPECT_EQ(8u, set.size());
+
+    Vector<int> remaining;
+    for (int v : set)
+        remaining.append(v);
+    EXPECT_EQ(8u, remaining.size());
+    for (unsigned i = 0; i < remaining.size(); ++i)
+        EXPECT_EQ(static_cast<int>(i), remaining[i]);
+
+    for (int i = 0; i < 8; ++i)
+        EXPECT_TRUE(set.contains(i));
+    for (int i = 8; i < 64; ++i)
+        EXPECT_FALSE(set.contains(i));
+}
+
+TEST(WTF_OrderedHashSet, MoveOnlyValue)
+{
+    OrderedHashSet<MoveOnly> set;
+    auto addResult = set.add(MoveOnly(1));
+    EXPECT_TRUE(addResult.isNewEntry);
+    EXPECT_EQ(1u, addResult.iterator->value());
+
+    set.add(MoveOnly(2));
+    set.add(MoveOnly(3));
+    EXPECT_EQ(3u, set.size());
+    EXPECT_TRUE(set.contains(MoveOnly(1)));
+    EXPECT_TRUE(set.contains(MoveOnly(2)));
+    EXPECT_TRUE(set.contains(MoveOnly(3)));
+
+    auto duplicate = set.add(MoveOnly(2));
+    EXPECT_FALSE(duplicate.isNewEntry);
+    EXPECT_EQ(3u, set.size());
+
+    auto taken = set.take(MoveOnly(2));
+    EXPECT_EQ(2u, taken.value());
+    EXPECT_FALSE(set.contains(MoveOnly(2)));
+
+    Vector<unsigned> remainingInOrder;
+    for (auto& v : set)
+        remainingInOrder.append(v.value());
+    EXPECT_EQ(2u, remainingInOrder.size());
+    EXPECT_EQ(1u, remainingInOrder[0]);
+    EXPECT_EQ(3u, remainingInOrder[1]);
+}
+
+TEST(WTF_OrderedHashSet, MoveOnlyValueRehash)
+{
+    OrderedHashSet<MoveOnly> set;
+    for (unsigned i = 0; i < 64; ++i)
+        set.add(MoveOnly(i));
+    EXPECT_EQ(64u, set.size());
+    for (unsigned i = 0; i < 64; ++i)
+        EXPECT_TRUE(set.contains(MoveOnly(i)));
+}
+
+TEST(WTF_OrderedHashSet, HashTranslatorFindContains)
+{
+    OrderedHashSet<String> set;
+    set.add("alpha"_s);
+    set.add("beta"_s);
+    set.add("gamma"_s);
+
+    auto it = set.find<StringViewHashTranslator>(StringView { "beta"_s });
+    EXPECT_TRUE(it != set.end());
+    EXPECT_EQ("beta"_s, *it);
+
+    EXPECT_TRUE(set.contains<StringViewHashTranslator>(StringView { "alpha"_s }));
+    EXPECT_TRUE(set.contains<StringViewHashTranslator>(StringView { "gamma"_s }));
+    EXPECT_FALSE(set.contains<StringViewHashTranslator>(StringView { "delta"_s }));
+
+    auto missing = set.find<StringViewHashTranslator>(StringView { "delta"_s });
+    EXPECT_TRUE(missing == set.end());
+}
+
+} // namespace TestWebKitAPI


### PR DESCRIPTION
#### a45c69df953869aaf54b5f253e4254b90e8bee6e
<pre>
[WTF] Add OrderedHashTable
<a href="https://bugs.webkit.org/show_bug.cgi?id=314476">https://bugs.webkit.org/show_bug.cgi?id=314476</a>
<a href="https://rdar.apple.com/176650881">rdar://176650881</a>

Reviewed by Yijia Huang.

Through RapidHash work (which changes the hash code, thus changes the
ordering of HashTable entries), we found many code which is wrongly
relying on HashTable&apos;s entries&apos; ordering. This revealed that we have
many use cases,

1. We want to preserve insertion ordering of HashSet by paying some
   memory cost.
2. But we do not want to make it dramatically slower.

Currently, canonical solution for this is using ListHashSet. But this
is dramatically slower compared to the normal HashMap since it is
effectively a linked-list. This is costly in terms of memory and it is
slow. This offers another benefit, &quot;you can remove entries while
iterating&quot;, but in many cases, we do not need that characteristics.

This patch adds OrderedHashMap / OrderedHashSet. Basically this is
similar to JSC&apos;s PropertyTable implementation. We maintain hashtable for
indice and entries buffer, and entries buffer is maintaining insertion
ordering.

Tests: Tools/TestWebKitAPI/Tests/WTF/OrderedHashMap.cpp
       Tools/TestWebKitAPI/Tests/WTF/OrderedHashSet.cpp

* Source/JavaScriptCore/runtime/AbstractModuleRecord.h:
* Source/WTF/WTF.xcodeproj/project.pbxproj:
* Source/WTF/wtf/CMakeLists.txt:
* Source/WTF/wtf/Forward.h:
* Source/WTF/wtf/OrderedHashMap.h: Added.
(WTF::OrderedHashTableConstIteratorAdapter::OrderedHashTableConstIteratorAdapter):
(WTF::OrderedHashTableConstIteratorAdapter::get const):
(WTF::OrderedHashTableConstIteratorAdapter::operator* const):
(WTF::OrderedHashTableConstIteratorAdapter::operator-&gt; const):
(WTF::OrderedHashTableConstIteratorAdapter::operator++):
(WTF::OrderedHashTableConstIteratorAdapter::keys):
(WTF::OrderedHashTableConstIteratorAdapter::values):
(WTF::OrderedHashTableIteratorAdapter::OrderedHashTableIteratorAdapter):
(WTF::OrderedHashTableIteratorAdapter::get const):
(WTF::OrderedHashTableIteratorAdapter::operator* const):
(WTF::OrderedHashTableIteratorAdapter::operator-&gt; const):
(WTF::OrderedHashTableIteratorAdapter::operator++):
(WTF::OrderedHashTableIteratorAdapter::operator OrderedHashTableConstIteratorAdapter&lt;HashTableType, KeyType, MappedType&gt; const):
(WTF::OrderedHashTableIteratorAdapter::keys):
(WTF::OrderedHashTableIteratorAdapter::values):
(WTF::operator==):
(WTF::OrderedHashTableConstKeysIterator::OrderedHashTableConstKeysIterator):
(WTF::OrderedHashTableConstKeysIterator::get const):
(WTF::OrderedHashTableConstKeysIterator::operator* const):
(WTF::OrderedHashTableConstKeysIterator::operator-&gt; const):
(WTF::OrderedHashTableConstKeysIterator::operator++):
(WTF::OrderedHashTableKeysIterator::OrderedHashTableKeysIterator):
(WTF::OrderedHashTableKeysIterator::get const):
(WTF::OrderedHashTableKeysIterator::operator* const):
(WTF::OrderedHashTableKeysIterator::operator-&gt; const):
(WTF::OrderedHashTableKeysIterator::operator++):
(WTF::OrderedHashTableKeysIterator::operator OrderedHashTableConstKeysIterator&lt;HashTableType, KeyType, MappedType&gt; const):
(WTF::OrderedHashTableConstValuesIterator::OrderedHashTableConstValuesIterator):
(WTF::OrderedHashTableConstValuesIterator::get const):
(WTF::OrderedHashTableConstValuesIterator::operator* const):
(WTF::OrderedHashTableConstValuesIterator::operator-&gt; const):
(WTF::OrderedHashTableConstValuesIterator::operator++):
(WTF::OrderedHashTableValuesIterator::OrderedHashTableValuesIterator):
(WTF::OrderedHashTableValuesIterator::get const):
(WTF::OrderedHashTableValuesIterator::operator* const):
(WTF::OrderedHashTableValuesIterator::operator-&gt; const):
(WTF::OrderedHashTableValuesIterator::operator++):
(WTF::OrderedHashTableValuesIterator::operator OrderedHashTableConstValuesIterator&lt;HashTableType, KeyType, MappedType&gt; const):
* Source/WTF/wtf/OrderedHashSet.h: Added.
* Source/WTF/wtf/OrderedHashTable.h: Added.
(WTF::OrderedHashTableIterator::get const):
(WTF::OrderedHashTableIterator::operator* const):
(WTF::OrderedHashTableIterator::operator-&gt; const):
(WTF::OrderedHashTableIterator::operator++):
(WTF::OrderedHashTableIterator::operator==):
(WTF::OrderedHashTableIterator::OrderedHashTableIterator):
(WTF::OrderedHashTableIterator::skipDeleted):
(WTF::OrderedHashTableConstIterator::OrderedHashTableConstIterator):
(WTF::OrderedHashTableConstIterator::get const):
(WTF::OrderedHashTableConstIterator::operator* const):
(WTF::OrderedHashTableConstIterator::operator-&gt; const):
(WTF::OrderedHashTableConstIterator::operator++):
(WTF::OrderedHashTableConstIterator::operator==):
(WTF::OrderedHashTableConstIterator::skipDeleted):
(WTF::OrderedHashTableReverseIterator::get const):
(WTF::OrderedHashTableReverseIterator::operator* const):
(WTF::OrderedHashTableReverseIterator::operator-&gt; const):
(WTF::OrderedHashTableReverseIterator::operator++):
(WTF::OrderedHashTableReverseIterator::operator==):
(WTF::OrderedHashTableReverseIterator::OrderedHashTableReverseIterator):
(WTF::OrderedHashTableReverseIterator::skipDeleted):
(WTF::OrderedHashTableConstReverseIterator::OrderedHashTableConstReverseIterator):
(WTF::OrderedHashTableConstReverseIterator::get const):
(WTF::OrderedHashTableConstReverseIterator::operator* const):
(WTF::OrderedHashTableConstReverseIterator::operator-&gt; const):
(WTF::OrderedHashTableConstReverseIterator::operator++):
(WTF::OrderedHashTableConstReverseIterator::operator==):
(WTF::OrderedHashTableConstReverseIterator::skipDeleted):
* Tools/TestWebKitAPI/CMakeLists.txt:
* Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj:
* Tools/TestWebKitAPI/Tests/WTF/OrderedHashMap.cpp: Added.
(TestWebKitAPI::TEST(WTF_OrderedHashMap, EmptyMap)):
(TestWebKitAPI::TEST(WTF_OrderedHashMap, BasicAddAndFind)):
(TestWebKitAPI::TEST(WTF_OrderedHashMap, Set)):
(TestWebKitAPI::TEST(WTF_OrderedHashMap, Ensure)):
(TestWebKitAPI::TEST(WTF_OrderedHashMap, Contains)):
(TestWebKitAPI::TEST(WTF_OrderedHashMap, Get)):
(TestWebKitAPI::TEST(WTF_OrderedHashMap, GetOptional)):
(TestWebKitAPI::TEST(WTF_OrderedHashMap, InsertionOrderPreserved)):
(TestWebKitAPI::TEST(WTF_OrderedHashMap, InsertionOrderPreservedAfterDeletion)):
(TestWebKitAPI::TEST(WTF_OrderedHashMap, SetDoesNotChangeOrder)):
(TestWebKitAPI::TEST(WTF_OrderedHashMap, RemoveByKey)):
(TestWebKitAPI::TEST(WTF_OrderedHashMap, RemoveByIterator)):
(TestWebKitAPI::TEST(WTF_OrderedHashMap, Take)):
(TestWebKitAPI::TEST(WTF_OrderedHashMap, TakeOptional)):
(TestWebKitAPI::TEST(WTF_OrderedHashMap, TakeFirst)):
(TestWebKitAPI::TEST(WTF_OrderedHashMap, Clear)):
(TestWebKitAPI::TEST(WTF_OrderedHashMap, Swap)):
(TestWebKitAPI::TEST(WTF_OrderedHashMap, CopyConstruction)):
(TestWebKitAPI::TEST(WTF_OrderedHashMap, MoveConstruction)):
(TestWebKitAPI::TEST(WTF_OrderedHashMap, CopyAssignment)):
(TestWebKitAPI::TEST(WTF_OrderedHashMap, MoveAssignment)):
(TestWebKitAPI::TEST(WTF_OrderedHashMap, KeysIteration)):
(TestWebKitAPI::TEST(WTF_OrderedHashMap, ValuesIteration)):
(TestWebKitAPI::TEST(WTF_OrderedHashMap, RehashPreservesOrder)):
(TestWebKitAPI::TEST(WTF_OrderedHashMap, DeleteAndReinsert)):
(TestWebKitAPI::TEST(WTF_OrderedHashMap, ManyDeletesAndInserts)):
(TestWebKitAPI::TEST(WTF_OrderedHashMap, StringKeys)):
(TestWebKitAPI::TEST(WTF_OrderedHashMap, InitializerList)):
(TestWebKitAPI::TEST(WTF_OrderedHashMap, ReserveCapacity)):
(TestWebKitAPI::TEST(WTF_OrderedHashMap, ConstIteration)):
(TestWebKitAPI::TEST(WTF_OrderedHashMap, FindReturnsCorrectIterator)):
(TestWebKitAPI::TEST(WTF_OrderedHashMap, IteratorComparison)):
(TestWebKitAPI::TEST(WTF_OrderedHashMap, CompactInPlacePreservesOrderAndCapacity)):
(TestWebKitAPI::TEST(WTF_OrderedHashMap, CompactInPlaceOnLargerTable)):
(TestWebKitAPI::TEST(WTF_OrderedHashMap, CompactInPlaceWithStringValues)):
(TestWebKitAPI::TEST(WTF_OrderedHashMap, RemoveIfAcrossShrinkThreshold)):
* Tools/TestWebKitAPI/Tests/WTF/OrderedHashSet.cpp: Added.
(TestWebKitAPI::TEST(WTF_OrderedHashSet, EmptySet)):
(TestWebKitAPI::TEST(WTF_OrderedHashSet, BasicAddAndContains)):
(TestWebKitAPI::TEST(WTF_OrderedHashSet, InsertionOrderPreserved)):
(TestWebKitAPI::TEST(WTF_OrderedHashSet, InsertionOrderPreservedAfterDeletion)):
(TestWebKitAPI::TEST(WTF_OrderedHashSet, Remove)):
(TestWebKitAPI::TEST(WTF_OrderedHashSet, RemoveByIterator)):
(TestWebKitAPI::TEST(WTF_OrderedHashSet, Take)):
(TestWebKitAPI::TEST(WTF_OrderedHashSet, TakeAny)):
(TestWebKitAPI::TEST(WTF_OrderedHashSet, Clear)):
(TestWebKitAPI::TEST(WTF_OrderedHashSet, Swap)):
(TestWebKitAPI::TEST(WTF_OrderedHashSet, CopyConstruction)):
(TestWebKitAPI::TEST(WTF_OrderedHashSet, MoveConstruction)):
(TestWebKitAPI::TEST(WTF_OrderedHashSet, CopyAssignment)):
(TestWebKitAPI::TEST(WTF_OrderedHashSet, MoveAssignment)):
(TestWebKitAPI::TEST(WTF_OrderedHashSet, RehashPreservesOrder)):
(TestWebKitAPI::TEST(WTF_OrderedHashSet, DeleteAndReinsert)):
(TestWebKitAPI::TEST(WTF_OrderedHashSet, ManyDeletesAndInserts)):
(TestWebKitAPI::TEST(WTF_OrderedHashSet, StringValues)):
(TestWebKitAPI::TEST(WTF_OrderedHashSet, InitializerList)):
(TestWebKitAPI::TEST(WTF_OrderedHashSet, AddAll)):
(TestWebKitAPI::TEST(WTF_OrderedHashSet, Find)):
(TestWebKitAPI::TEST(WTF_OrderedHashSet, ReserveCapacity)):
(TestWebKitAPI::TEST(WTF_OrderedHashSet, StressTest)):
(TestWebKitAPI::TEST(WTF_OrderedHashSet, CompactInPlacePreservesOrderAndCapacity)):
(TestWebKitAPI::TEST(WTF_OrderedHashSet, CompactInPlaceOnLargerTable)):
(TestWebKitAPI::TEST(WTF_OrderedHashSet, CompactInPlaceWithStrings)):
(TestWebKitAPI::TEST(WTF_OrderedHashSet, CompactInPlaceRepeatedCycles)):
(TestWebKitAPI::TEST(WTF_OrderedHashSet, RemoveIfAcrossShrinkThreshold)):

Canonical link: <a href="https://commits.webkit.org/313036@main">https://commits.webkit.org/313036@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7d2faaaaaa29c8cb6101cdb8bc254c83beda15d6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/161866 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/35340 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/28443 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/170769 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/118237 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/cce07582-9f94-487a-9a8b-bc4227aea9f2) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/163735 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/35442 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/35342 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/125603 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/88505 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/cd734514-01aa-4cf2-bca9-e0703411b8f1) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/164825 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/27920 "Passed tests") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/145398 "Found 1 new API test failure: TestWebKitAPI.WKWebExtensionAPIAction.ClearTabSpecificActionPropertiesOnNavigation (failure)") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/106199 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/a19c4748-c218-4f6d-aa4d-62678561c5b2) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/26969 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/25479 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/18490 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/153925 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/136662 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/23153 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/173258 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/22704 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/20345 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/24794 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/133896 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/35014 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/29565 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/133901 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/34998 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/144948 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/97091 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/24587 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/28432 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/21771 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/194265 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/34508 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/101989 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/50064 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/34009 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/34251 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/34157 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->