### PR TITLE
[GStreamer] Disable Ogg for playback when running the layout tests

### DIFF
--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -2424,6 +2424,8 @@ fast/table/table-display-types-vertical.html [ Failure ]
 # Media-related bugs
 #////////////////////////////////////////////////////////////////////////////////////////
 
+media/media-can-play-ogg.html [ Failure ]
+
 media/audioSession [ Skip ]
 
 webkit.org/b/292839 media/media-fullscreen-not-in-document.html [ Timeout ]

--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/html/semantics/embedded-content/media-elements/mime-types/canPlayType-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/html/semantics/embedded-content/media-elements/mime-types/canPlayType-expected.txt
@@ -7,9 +7,9 @@ PASS audio/mp4 (optional)
 PASS audio/mp4; codecs="mp4a.40.2" (optional)
 PASS audio/mp4 with bogus codec
 PASS audio/mp4 with and without codecs
-PASS audio/ogg (optional)
-PASS audio/ogg; codecs="opus" (optional)
-PASS audio/ogg; codecs="vorbis" (optional)
+NOTRUN audio/ogg (optional) audio/ogg
+NOTRUN audio/ogg; codecs="opus" (optional) audio/ogg
+NOTRUN audio/ogg; codecs="vorbis" (optional) audio/ogg
 PASS audio/ogg with bogus codec
 PASS audio/ogg with and without codecs
 PASS audio/wav (optional)
@@ -40,12 +40,12 @@ PASS video/mp4 codecs subset
 PASS video/mp4 codecs order
 PASS video/mp4 with bogus codec
 PASS video/mp4 with and without codecs
-PASS video/ogg (optional)
-PASS video/ogg; codecs="opus" (optional)
-PASS video/ogg; codecs="vorbis" (optional)
-PASS video/ogg; codecs="theora" (optional)
-PASS video/ogg codecs subset
-PASS video/ogg codecs order
+NOTRUN video/ogg (optional) video/ogg
+NOTRUN video/ogg; codecs="opus" (optional) video/ogg
+NOTRUN video/ogg; codecs="vorbis" (optional) video/ogg
+NOTRUN video/ogg; codecs="theora" (optional) video/ogg
+NOTRUN video/ogg codecs subset video/ogg
+NOTRUN video/ogg codecs order video/ogg
 PASS video/ogg with bogus codec
 PASS video/ogg with and without codecs
 PASS video/webm (optional)

--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/update-the-source-set-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/update-the-source-set-expected.txt
@@ -62,7 +62,7 @@ PASS <picture><source srcset="data:,b" type="text/html"><img src="data:,a" data-
 PASS <picture><source srcset="data:,b" type="text/plain"><img src="data:,a" data-expect="data:,a"></picture>
 PASS <picture><source srcset="data:,b" type="text/css"><img src="data:,a" data-expect="data:,a"></picture>
 FAIL <picture><source srcset="data:,b" type="video/mp4"><img src="data:,a" data-expect="data:,a"></picture> assert_equals: expected "data:,a" but got "data:,b"
-FAIL <picture><source srcset="data:,b" type="video/ogg"><img src="data:,a" data-expect="data:,a"></picture> assert_equals: expected "data:,a" but got "data:,b"
+PASS <picture><source srcset="data:,b" type="video/ogg"><img src="data:,a" data-expect="data:,a"></picture>
 FAIL <picture><source srcset="data:,b" type="video/webm"><img src="data:,a" data-expect="data:,a"></picture> assert_equals: expected "data:,a" but got "data:,b"
 PASS <picture><source srcset="data:,b" type="unknown/unknown"><img src="data:,a" data-expect="data:,a"></picture>
 PASS <picture><source srcset="data:,b" type="application/octet-stream"><img src="data:,a" data-expect="data:,a"></picture>

--- a/LayoutTests/platform/glib/media/W3C/audio/canPlayType/canPlayType_supported_but_no_codecs_parameter_1-expected.txt
+++ b/LayoutTests/platform/glib/media/W3C/audio/canPlayType/canPlayType_supported_but_no_codecs_parameter_1-expected.txt
@@ -1,0 +1,10 @@
+audio.canPlayType() - supported format w/o codecs parameter
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+
+TEST COMPLETE
+spec reference
+
+

--- a/LayoutTests/platform/glib/media/W3C/video/canPlayType/canPlayType_codecs_order_2-expected.txt
+++ b/LayoutTests/platform/glib/media/W3C/video/canPlayType/canPlayType_codecs_order_2-expected.txt
@@ -1,0 +1,12 @@
+video.canPlayType() - codecs parameter order
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS "" is ""
+
+TEST COMPLETE
+spec reference
+
+
+

--- a/LayoutTests/platform/glib/media/W3C/video/canPlayType/canPlayType_supported_but_no_codecs_parameter_2-expected.txt
+++ b/LayoutTests/platform/glib/media/W3C/video/canPlayType/canPlayType_supported_but_no_codecs_parameter_2-expected.txt
@@ -1,0 +1,11 @@
+video.canPlayType() - supported format w/o codecs parameter
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+
+TEST COMPLETE
+spec reference
+
+
+

--- a/LayoutTests/platform/glib/media/W3C/video/canPlayType/canPlayType_two_implies_one_3-expected.txt
+++ b/LayoutTests/platform/glib/media/W3C/video/canPlayType/canPlayType_two_implies_one_3-expected.txt
@@ -1,0 +1,11 @@
+video.canPlayType() - codecs parameter logic
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+
+TEST COMPLETE
+spec reference
+
+
+

--- a/LayoutTests/platform/glib/media/W3C/video/canPlayType/canPlayType_two_implies_one_4-expected.txt
+++ b/LayoutTests/platform/glib/media/W3C/video/canPlayType/canPlayType_two_implies_one_4-expected.txt
@@ -1,0 +1,11 @@
+video.canPlayType() - codecs parameter logic
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+
+TEST COMPLETE
+spec reference
+
+
+

--- a/LayoutTests/platform/glib/media/W3C/video/canPlayType/canPlayType_two_implies_one_5-expected.txt
+++ b/LayoutTests/platform/glib/media/W3C/video/canPlayType/canPlayType_two_implies_one_5-expected.txt
@@ -1,0 +1,12 @@
+video.canPlayType() - codecs parameter logic
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+FAIL "probably" should be . Was probably.
+
+TEST COMPLETE
+spec reference
+
+
+

--- a/LayoutTests/platform/glib/media/W3C/video/canPlayType/canPlayType_two_implies_one_6-expected.txt
+++ b/LayoutTests/platform/glib/media/W3C/video/canPlayType/canPlayType_two_implies_one_6-expected.txt
@@ -1,0 +1,12 @@
+video.canPlayType() - codecs parameter logic
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+FAIL "probably" should be . Was probably.
+
+TEST COMPLETE
+spec reference
+
+
+

--- a/Source/WebCore/platform/graphics/gstreamer/GStreamerRegistryScanner.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/GStreamerRegistryScanner.cpp
@@ -671,7 +671,9 @@ void GStreamerRegistryScanner::initializeDecoders(const GStreamerRegistryScanner
 
     fillMimeTypeSetFromCapsMapping(factories, mapping);
 
-    if (factories.hasElementForMediaType(ElementFactories::Type::Demuxer, "application/ogg"_s)) {
+    auto value = CStringView::unsafeFromUTF8(g_getenv("WEBKIT_GST_CAN_PLAY_OGG"));
+    bool isOggAllowed = value.isEmpty() ? true : (WTF::equalLettersIgnoringASCIICase(value.span(), "true"_s) || WTF::equalLettersIgnoringASCIICase(value.span(), "1"_s));
+    if (isOggAllowed && factories.hasElementForMediaType(ElementFactories::Type::Demuxer, "application/ogg"_s)) {
         m_decoderMimeTypeSet.add("application/ogg"_s);
 
         if (vorbisSupported) {

--- a/Tools/Scripts/webkitpy/port/glib.py
+++ b/Tools/Scripts/webkitpy/port/glib.py
@@ -144,6 +144,10 @@ class GLibPort(Port):
             # disable color output, making -stderr files more human-readable.
             environment['GST_DEBUG_NO_COLOR'] = '1'
 
+        # Disable the Ogg container support for playback. The WPT and WebKit media tests will
+        # fallback to mp4, nowadays likely the most common container used for playback on the Web.
+        environment['WEBKIT_GST_CAN_PLAY_OGG'] = '0'
+
         environment['WEBKIT_GST_ALLOW_PLAYBACK_OF_INVISIBLE_VIDEOS'] = '1'
         environment['WEBKIT_GST_WEBRTC_FORCE_EARLY_VIDEO_DECODING'] = '1'
 

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKPage/glib/TestUIClient.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKPage/glib/TestUIClient.cpp
@@ -854,7 +854,7 @@ static void testWebViewMouseTarget(UIClientTest* test, gconstpointer)
         " <img style='position:absolute; left:1; top:10' src='0xdeadbeef' width=5 height=5></img>"
         " <a style='position:absolute; left:1; top:20' href='http://www.webkitgtk.org/logo' title='WebKitGTK Logo'><img src='0xdeadbeef' width=5 height=5></img></a>"
         " <input style='position:absolute; left:1; top:30' size='10'></input>"
-        " <video style='position:absolute; left:1; top:100' width='300' height='300' controls='controls' preload='none'><source src='movie.ogg' type='video/ogg' /></video>"
+        " <video style='position:absolute; left:1; top:100' width='300' height='300' controls='controls' preload='none'><source src='movie.mp4' type='video/mp4' /></video>"
         " <p style='position:absolute; left:1; top:120' id='text_to_select'>Lorem ipsum.</p>"
         "</body></html>";
 
@@ -915,7 +915,7 @@ static void testWebViewMouseTarget(UIClientTest* test, gconstpointer)
     g_assert_false(webkit_hit_test_result_context_is_editable(hitTestResult));
     g_assert_false(webkit_hit_test_result_context_is_scrollbar(hitTestResult));
     g_assert_false(webkit_hit_test_result_context_is_selection(hitTestResult));
-    g_assert_cmpstr(webkit_hit_test_result_get_media_uri(hitTestResult), ==, "file:///movie.ogg");
+    g_assert_cmpstr(webkit_hit_test_result_get_media_uri(hitTestResult), ==, "file:///movie.mp4");
     g_assert_cmpuint(test->m_mouseTargetModifiers, ==, 0);
 
     // Mover over input.


### PR DESCRIPTION
#### 1f07720c2fcbbc0d5120929ed2b8aeb7363b5b91
<pre>
[GStreamer] Disable Ogg for playback when running the layout tests
<a href="https://bugs.webkit.org/show_bug.cgi?id=314484">https://bugs.webkit.org/show_bug.cgi?id=314484</a>

Reviewed by NOBODY (OOPS!).

Disable the Ogg container support for playback. The WPT and WebKit media tests will fallback to mp4,
nowadays likely the most common container used for playback on the Web.

* LayoutTests/platform/glib/TestExpectations:
* LayoutTests/platform/glib/imported/w3c/web-platform-tests/html/semantics/embedded-content/media-elements/mime-types/canPlayType-expected.txt:
* LayoutTests/platform/glib/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/update-the-source-set-expected.txt:
* LayoutTests/platform/glib/media/W3C/audio/canPlayType/canPlayType_supported_but_no_codecs_parameter_1-expected.txt: Added.
* LayoutTests/platform/glib/media/W3C/video/canPlayType/canPlayType_codecs_order_2-expected.txt: Added.
* LayoutTests/platform/glib/media/W3C/video/canPlayType/canPlayType_supported_but_no_codecs_parameter_2-expected.txt: Added.
* LayoutTests/platform/glib/media/W3C/video/canPlayType/canPlayType_two_implies_one_3-expected.txt: Added.
* LayoutTests/platform/glib/media/W3C/video/canPlayType/canPlayType_two_implies_one_4-expected.txt: Added.
* LayoutTests/platform/glib/media/W3C/video/canPlayType/canPlayType_two_implies_one_5-expected.txt: Added.
* LayoutTests/platform/glib/media/W3C/video/canPlayType/canPlayType_two_implies_one_6-expected.txt: Added.
* Source/WebCore/platform/graphics/gstreamer/GStreamerRegistryScanner.cpp:
(WebCore::GStreamerRegistryScanner::initializeDecoders):
* Tools/Scripts/webkitpy/port/glib.py:
(GLibPort.setup_environ_for_server):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1f07720c2fcbbc0d5120929ed2b8aeb7363b5b91

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/161698 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/35172 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/28275 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/170601 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/118069 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/163567 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/35273 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/35173 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/125451 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/88374 "1 flakes 3 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/164657 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/27760 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/145241 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/106047 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/161018 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/26809 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/25319 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/18322 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/136502 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/22996 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/173089 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/20130 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/24637 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/133743 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/34846 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/29411 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/133748 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/34830 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/144791 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/96836 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/28282 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/21611 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/34340 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/101785 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/33840 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/34083 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/33989 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->