### PR TITLE
[MathML Core] Operator Dictionary: U+2202 ∂ Prefix should be (3, 0) not (2, 1)

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -2178,8 +2178,6 @@ imported/w3c/web-platform-tests/mathml/relations/css-styling/transform.html [ Im
 
 imported/w3c/web-platform-tests/mathml/presentation-markup/operators/mo-lspace-rspace-2.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/mathml/presentation-markup/operators/mo-movablelimits-and-embellished-operator.html [ ImageOnlyFailure ]
-imported/w3c/web-platform-tests/mathml/presentation-markup/operators/op-dict-8.html [ ImageOnlyFailure ]
-imported/w3c/web-platform-tests/mathml/presentation-markup/operators/op-dict-9.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/mathml/presentation-markup/operators/painting-stretchy-operator-001.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/mathml/presentation-markup/scripts/underover-stretchy-002.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/mathml/relations/css-styling/display-with-overflow.html [ ImageOnlyFailure ]

--- a/Source/WebCore/mathml/MathMLOperatorDictionary.cpp
+++ b/Source/WebCore/mathml/MathMLOperatorDictionary.cpp
@@ -277,7 +277,7 @@ static constexpr std::array<Entry, dictionarySize> dictionary {
     Entry { 0x21FF, Infix, 5, 5, Stretchy | Accent }, // LEFT RIGHT OPEN-HEADED ARROW
     Entry { 0x2200, Prefix, 2, 1, 0 }, // FOR ALL
     Entry { 0x2201, Infix, 1, 2, 0 }, // COMPLEMENT
-    Entry { 0x2202, Prefix, 2, 1, 0 }, // PARTIAL DIFFERENTIAL
+    Entry { 0x2202, Prefix, 3, 0, 0 }, // PARTIAL DIFFERENTIAL
     Entry { 0x2203, Prefix, 2, 1, 0 }, // THERE EXISTS
     Entry { 0x2204, Prefix, 2, 1, 0 }, // THERE DOES NOT EXIST
     Entry { 0x2206, Infix, 3, 3, 0 }, // INCREMENT


### PR DESCRIPTION
#### 655d927313ed37f53d0dafeee104d47acdc7142a
<pre>
[MathML Core] Operator Dictionary: U+2202 ∂ Prefix should be (3, 0) not (2, 1)
<a href="https://bugs.webkit.org/show_bug.cgi?id=314486">https://bugs.webkit.org/show_bug.cgi?id=314486</a>
<a href="https://rdar.apple.com/176693587">rdar://176693587</a>

Reviewed by Frédéric Wang Nélar.

This patch aligns WebKit with Gecko/ Firefox and Blink / Chromium.

Per the MathML Core operator dictionary [1], PARTIAL DIFFERENTIAL (U+2202)
as Prefix is lspace=3, rspace=0 (in 18ths of em). WebKit still ships the
MathML 3 values (2, 1), which is what op-dict-9-notref.html pins as the
&quot;older MathML specification&quot; rendering. As a result
op-dict-8.html fails (our spacing doesn&apos;t match MathML Core) and
op-dict-9.html fails (our spacing does match what the mismatch reftest
explicitly rejects).

[1] <a href="https://www.w3.org/TR/mathml-core/#operator-dictionary-human">https://www.w3.org/TR/mathml-core/#operator-dictionary-human</a>

* LayoutTests/TestExpectations: Progressions
* Source/WebCore/mathml/MathMLOperatorDictionary.cpp:

Canonical link: <a href="https://commits.webkit.org/312997@main">https://commits.webkit.org/312997@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9cb49c123b743ad125c0f8bcb60ca1a09d577169

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/161606 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/35080 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/28183 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/170509 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/117977 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/b2769aac-51b0-4615-acc2-7e3a750c5cef) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/163475 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/35181 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/35081 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/125382 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/88306 "1 flakes 1 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/14ad3cba-b2d0-4bab-8abc-f8a1984d58bc) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/164565 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/27682 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/145163 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/105978 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/ebaf6254-6f8d-4a8f-8583-ad2e0db88deb) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/26731 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/25240 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/18230 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/136425 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/22919 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/172997 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/20038 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/24560 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/133672 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/34754 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/29335 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/133677 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36141 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/34738 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/144714 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/96687 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/28204 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/21534 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/34248 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/101693 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/33748 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/33991 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/33897 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->