### PR TITLE
[WTF] Add ThreadSafeLazyUniquePtr

### DIFF
--- a/Source/JavaScriptCore/wasm/WasmTypeDefinition.cpp
+++ b/Source/JavaScriptCore/wasm/WasmTypeDefinition.cpp
@@ -1080,62 +1080,53 @@ void RTT::ensureArgumINTBytecode(const CallInformation& callCC) const
 {
     ASSERT(kind() == RTTKind::Function);
 
-    if (m_argumINTBytecode) [[likely]]
-        return;
-
-    auto numArgs = argumentCount();
-
     constexpr static int NUM_ARGUMINT_GPRS = 8;
     constexpr static int NUM_ARGUMINT_FPRS = 8;
 
     ASSERT_UNUSED(NUM_ARGUMINT_GPRS, wasmCallingConvention().jsrArgs.size() <= NUM_ARGUMINT_GPRS);
     ASSERT_UNUSED(NUM_ARGUMINT_FPRS, wasmCallingConvention().fprArgs.size() <= NUM_ARGUMINT_FPRS);
 
-    // Build outside the lock; race losers drop their candidate.
-    auto candidate = IPIntSharedBytecode::createWithSizeFromGenerator(numArgs + 1,
-        [&](size_t index) -> uint8_t {
-            if (index == numArgs)
-                return static_cast<uint8_t>(IPInt::ArgumINTBytecode::End);
+    m_argumINTBytecode.ensure([&] {
+        auto numArgs = argumentCount();
+        auto candidate = IPIntSharedBytecode::createWithSizeFromGenerator(numArgs + 1,
+            [&](size_t index) -> uint8_t {
+                if (index == numArgs)
+                    return static_cast<uint8_t>(IPInt::ArgumINTBytecode::End);
 
-            const ArgumentLocation& argLoc = callCC.params[index];
-            const ValueLocation& loc = argLoc.location;
+                const ArgumentLocation& argLoc = callCC.params[index];
+                const ValueLocation& loc = argLoc.location;
 
-            if (loc.isGPR()) {
+                if (loc.isGPR()) {
 #if USE(JSVALUE64)
-                ASSERT_UNUSED(NUM_ARGUMINT_GPRS, GPRInfo::toArgumentIndex(loc.jsr().gpr()) < NUM_ARGUMINT_GPRS);
-                return static_cast<uint8_t>(IPInt::ArgumINTBytecode::ArgGPR) + GPRInfo::toArgumentIndex(loc.jsr().gpr());
+                    ASSERT_UNUSED(NUM_ARGUMINT_GPRS, GPRInfo::toArgumentIndex(loc.jsr().gpr()) < NUM_ARGUMINT_GPRS);
+                    return static_cast<uint8_t>(IPInt::ArgumINTBytecode::ArgGPR) + GPRInfo::toArgumentIndex(loc.jsr().gpr());
 #elif USE(JSVALUE32_64)
-                ASSERT_UNUSED(NUM_ARGUMINT_GPRS, GPRInfo::toArgumentIndex(loc.jsr().payloadGPR()) < NUM_ARGUMINT_GPRS);
-                ASSERT_UNUSED(NUM_ARGUMINT_GPRS, GPRInfo::toArgumentIndex(loc.jsr().tagGPR()) < NUM_ARGUMINT_GPRS);
-                return static_cast<uint8_t>(IPInt::ArgumINTBytecode::ArgGPR) + GPRInfo::toArgumentIndex(loc.jsr().gpr(WhichValueWord::PayloadWord)) / 2;
+                    ASSERT_UNUSED(NUM_ARGUMINT_GPRS, GPRInfo::toArgumentIndex(loc.jsr().payloadGPR()) < NUM_ARGUMINT_GPRS);
+                    ASSERT_UNUSED(NUM_ARGUMINT_GPRS, GPRInfo::toArgumentIndex(loc.jsr().tagGPR()) < NUM_ARGUMINT_GPRS);
+                    return static_cast<uint8_t>(IPInt::ArgumINTBytecode::ArgGPR) + GPRInfo::toArgumentIndex(loc.jsr().gpr(WhichValueWord::PayloadWord)) / 2;
 #endif
-            }
+                }
 
-            if (loc.isFPR()) {
-                ASSERT_UNUSED(NUM_ARGUMINT_FPRS, FPRInfo::toArgumentIndex(loc.fpr()) < NUM_ARGUMINT_FPRS);
-                return static_cast<uint8_t>(IPInt::ArgumINTBytecode::ArgFPR) + FPRInfo::toArgumentIndex(loc.fpr());
-            }
+                if (loc.isFPR()) {
+                    ASSERT_UNUSED(NUM_ARGUMINT_FPRS, FPRInfo::toArgumentIndex(loc.fpr()) < NUM_ARGUMINT_FPRS);
+                    return static_cast<uint8_t>(IPInt::ArgumINTBytecode::ArgFPR) + FPRInfo::toArgumentIndex(loc.fpr());
+                }
 
-            RELEASE_ASSERT(loc.isStack());
-            switch (argLoc.width) {
-            case Width::Width64:
-                return static_cast<uint8_t>(IPInt::ArgumINTBytecode::Stack);
-            case Width::Width128:
-                return static_cast<uint8_t>(IPInt::ArgumINTBytecode::StackVector);
-            default:
-                RELEASE_ASSERT_NOT_REACHED("No argumINT bytecode for result width");
-            }
-        });
+                RELEASE_ASSERT(loc.isStack());
+                switch (argLoc.width) {
+                case Width::Width64:
+                    return static_cast<uint8_t>(IPInt::ArgumINTBytecode::Stack);
+                case Width::Width128:
+                    return static_cast<uint8_t>(IPInt::ArgumINTBytecode::StackVector);
+                default:
+                    RELEASE_ASSERT_NOT_REACHED("No argumINT bytecode for result width");
+                }
+            });
 
-    ASSERT(candidate->size() == numArgs + 1u);
-    ASSERT(candidate->last() == static_cast<uint8_t>(IPInt::ArgumINTBytecode::End));
-
-    Locker locker { m_ipintBytecodeLock };
-    if (m_argumINTBytecode)
-        return;
-
-    WTF::storeStoreFence();
-    m_argumINTBytecode = candidate.moveToUniquePtr();
+        ASSERT(candidate->size() == numArgs + 1u);
+        ASSERT(candidate->last() == static_cast<uint8_t>(IPInt::ArgumINTBytecode::End));
+        return candidate;
+    });
 }
 
 void RTT::ensureUINTBytecode(const CallInformation& returnCC) const
@@ -1148,70 +1139,63 @@ void RTT::ensureUINTBytecode(const CallInformation& returnCC) const
     ASSERT_UNUSED(NUM_UINT_GPRS, wasmCallingConvention().jsrArgs.size() <= NUM_UINT_GPRS);
     ASSERT_UNUSED(NUM_UINT_FPRS, wasmCallingConvention().fprArgs.size() <= NUM_UINT_FPRS);
 
-    if (m_uINTBytecode) [[likely]]
-        return;
+    m_uINTBytecode.ensure([&] {
+        // Offset past the last stack-typed return, in signature order.
+        uint32_t topOfReturnStackFPOffset = 0;
+        for (const auto& argLoc : returnCC.results) {
+            if (argLoc.location.isStack())
+                topOfReturnStackFPOffset = argLoc.location.offsetFromFP() + bytesForWidth(argLoc.width);
+        }
 
-    // Offset past the last stack-typed return, in signature order.
-    uint32_t topOfReturnStackFPOffset = 0;
-    for (const auto& argLoc : returnCC.results) {
-        if (argLoc.location.isStack())
-            topOfReturnStackFPOffset = argLoc.location.offsetFromFP() + bytesForWidth(argLoc.width);
-    }
+        auto encode = [&](unsigned index) -> uint8_t {
+            const ArgumentLocation& argLoc = returnCC.results[index];
+            const ValueLocation& loc = argLoc.location;
 
-    auto encode = [&](unsigned index) -> uint8_t {
-        const ArgumentLocation& argLoc = returnCC.results[index];
-        const ValueLocation& loc = argLoc.location;
-
-        if (loc.isGPR()) {
+            if (loc.isGPR()) {
 #if USE(JSVALUE64)
-            ASSERT_UNUSED(NUM_UINT_GPRS, GPRInfo::toArgumentIndex(loc.jsr().gpr()) < NUM_UINT_GPRS);
-            return static_cast<uint8_t>(IPInt::UINTBytecode::RetGPR) + GPRInfo::toArgumentIndex(loc.jsr().gpr());
+                ASSERT_UNUSED(NUM_UINT_GPRS, GPRInfo::toArgumentIndex(loc.jsr().gpr()) < NUM_UINT_GPRS);
+                return static_cast<uint8_t>(IPInt::UINTBytecode::RetGPR) + GPRInfo::toArgumentIndex(loc.jsr().gpr());
 #elif USE(JSVALUE32_64)
-            ASSERT_UNUSED(NUM_UINT_GPRS, GPRInfo::toArgumentIndex(loc.jsr().payloadGPR()) < NUM_UINT_GPRS);
-            ASSERT_UNUSED(NUM_UINT_GPRS, GPRInfo::toArgumentIndex(loc.jsr().tagGPR()) < NUM_UINT_GPRS);
-            return static_cast<uint8_t>(IPInt::UINTBytecode::RetGPR) + GPRInfo::toArgumentIndex(loc.jsr().gpr(WhichValueWord::PayloadWord));
+                ASSERT_UNUSED(NUM_UINT_GPRS, GPRInfo::toArgumentIndex(loc.jsr().payloadGPR()) < NUM_UINT_GPRS);
+                ASSERT_UNUSED(NUM_UINT_GPRS, GPRInfo::toArgumentIndex(loc.jsr().tagGPR()) < NUM_UINT_GPRS);
+                return static_cast<uint8_t>(IPInt::UINTBytecode::RetGPR) + GPRInfo::toArgumentIndex(loc.jsr().gpr(WhichValueWord::PayloadWord));
 #endif
-        }
+            }
 
-        if (loc.isFPR()) {
-            ASSERT_UNUSED(NUM_UINT_FPRS, FPRInfo::toArgumentIndex(loc.fpr()) < NUM_UINT_FPRS);
-            return static_cast<uint8_t>(IPInt::UINTBytecode::RetFPR) + FPRInfo::toArgumentIndex(loc.fpr());
-        }
+            if (loc.isFPR()) {
+                ASSERT_UNUSED(NUM_UINT_FPRS, FPRInfo::toArgumentIndex(loc.fpr()) < NUM_UINT_FPRS);
+                return static_cast<uint8_t>(IPInt::UINTBytecode::RetFPR) + FPRInfo::toArgumentIndex(loc.fpr());
+            }
 
-        RELEASE_ASSERT(loc.isStack());
-        switch (argLoc.width) {
-        case Width::Width64:
-            return static_cast<uint8_t>(IPInt::UINTBytecode::Stack);
-        case Width::Width128:
-            return static_cast<uint8_t>(IPInt::UINTBytecode::StackVector);
-        default:
-            RELEASE_ASSERT_NOT_REACHED("No uINT bytecode for result width");
-        }
-    };
+            RELEASE_ASSERT(loc.isStack());
+            switch (argLoc.width) {
+            case Width::Width64:
+                return static_cast<uint8_t>(IPInt::UINTBytecode::Stack);
+            case Width::Width128:
+                return static_cast<uint8_t>(IPInt::UINTBytecode::StackVector);
+            default:
+                RELEASE_ASSERT_NOT_REACHED("No uINT bytecode for result width");
+            }
+        };
 
-    // Layout: [topOfReturnStackFPOffset : u32][encode(last)..encode(first)][End].
-    // Results are consumed in reverse by the uINT dispatcher, so emit in reverse.
-    unsigned size = returnCC.results.size();
-    auto headerBytes = std::bit_cast<std::array<uint8_t, sizeof(uint32_t)>>(topOfReturnStackFPOffset);
-    auto candidate = IPIntSharedBytecode::createWithSizeFromGenerator(sizeof(uint32_t) + size + 1,
-        [&](size_t index) -> uint8_t {
-            if (index < sizeof(uint32_t))
-                return headerBytes[index];
-            size_t i = index - sizeof(uint32_t);
-            if (i == size)
-                return static_cast<uint8_t>(IPInt::UINTBytecode::End);
-            return encode(size - 1 - i);
-        });
+        // Layout: [topOfReturnStackFPOffset : u32][encode(last)..encode(first)][End].
+        // Results are consumed in reverse by the uINT dispatcher, so emit in reverse.
+        unsigned size = returnCC.results.size();
+        auto headerBytes = std::bit_cast<std::array<uint8_t, sizeof(uint32_t)>>(topOfReturnStackFPOffset);
+        auto candidate = IPIntSharedBytecode::createWithSizeFromGenerator(sizeof(uint32_t) + size + 1,
+            [&](size_t index) -> uint8_t {
+                if (index < sizeof(uint32_t))
+                    return headerBytes[index];
+                size_t i = index - sizeof(uint32_t);
+                if (i == size)
+                    return static_cast<uint8_t>(IPInt::UINTBytecode::End);
+                return encode(size - 1 - i);
+            });
 
-    ASSERT(candidate->size() == sizeof(uint32_t) + size + 1u);
-    ASSERT(candidate->last() == static_cast<uint8_t>(IPInt::UINTBytecode::End));
-
-    Locker locker { m_ipintBytecodeLock };
-    if (m_uINTBytecode)
-        return;
-
-    WTF::storeStoreFence();
-    m_uINTBytecode = candidate.moveToUniquePtr();
+        ASSERT(candidate->size() == sizeof(uint32_t) + size + 1u);
+        ASSERT(candidate->last() == static_cast<uint8_t>(IPInt::UINTBytecode::End));
+        return candidate;
+    });
 }
 
 template<bool isTailCall>
@@ -1351,68 +1335,52 @@ void RTT::ensureCallBytecode() const
 {
     ASSERT(kind() == RTTKind::Function);
 
-    if (m_callBytecode) [[likely]]
-        return;
+    m_callBytecode.ensure([&] {
+        // Build [arg bytecode][Call][CallReturnMetadata][result bytecode][End] -- the same
+        // layout the generator used to emit inline into m_metadata. MC walks the whole
+        // thing during one call: arg dispatch leaves MC at CallReturnMetadata (inside the
+        // buffer), and ret dispatch continues from there.
+        auto callConvention = wasmCallingConvention().callInformationFor(*this, CallRole::Caller);
+        Vector<uint8_t, 16> bytes = buildCallArgumentBytecode</* isTailCall */ false>(callConvention);
 
-    // Build [arg bytecode][Call][CallReturnMetadata][result bytecode][End] -- the same
-    // layout the generator used to emit inline into m_metadata. MC walks the whole
-    // thing during one call: arg dispatch leaves MC at CallReturnMetadata (inside the
-    // buffer), and ret dispatch continues from there.
-    auto callConvention = wasmCallingConvention().callInformationFor(*this, CallRole::Caller);
-    Vector<uint8_t, 16> bytes = buildCallArgumentBytecode</* isTailCall */ false>(callConvention);
+        Checked<uint32_t> frameSize = WTF::roundUpToMultipleOf<stackAlignmentBytes()>(callConvention.headerAndArgumentStackSizeInBytes);
+        IPInt::CallReturnMetadata returnMeta {
+            .stackFrameSize = frameSize,
+            .firstStackResultSPOffset = 0,
+        };
 
-    Checked<uint32_t> frameSize = WTF::roundUpToMultipleOf<stackAlignmentBytes()>(callConvention.headerAndArgumentStackSizeInBytes);
-    IPInt::CallReturnMetadata returnMeta {
-        .stackFrameSize = frameSize,
-        .firstStackResultSPOffset = 0,
-    };
+        Vector<uint8_t, 16> resultBytes;
+        Checked<uint32_t> firstStackResultSPOffset = buildCallResultBytecode(resultBytes, callConvention);
+        returnMeta.firstStackResultSPOffset = firstStackResultSPOffset;
 
-    Vector<uint8_t, 16> resultBytes;
-    Checked<uint32_t> firstStackResultSPOffset = buildCallResultBytecode(resultBytes, callConvention);
-    returnMeta.firstStackResultSPOffset = firstStackResultSPOffset;
+        auto toSpan = [&](auto& value) {
+            auto start = std::bit_cast<const uint8_t*>(&value);
+            return std::span { start, start + sizeof(value) };
+        };
+        bytes.append(toSpan(returnMeta));
+        bytes.append(resultBytes.span());
 
-    auto toSpan = [&](auto& value) {
-        auto start = std::bit_cast<const uint8_t*>(&value);
-        return std::span { start, start + sizeof(value) };
-    };
-    bytes.append(toSpan(returnMeta));
-    bytes.append(resultBytes.span());
-
-    auto candidate = IPIntSharedBytecode::createFromVector(WTF::move(bytes));
-
-    Locker locker { m_ipintBytecodeLock };
-    if (m_callBytecode)
-        return;
-
-    WTF::storeStoreFence();
-    m_callBytecode = candidate.moveToUniquePtr();
+        return IPIntSharedBytecode::createFromVector(WTF::move(bytes));
+    });
 }
 
 void RTT::ensureTailCallBytecode() const
 {
     ASSERT(kind() == RTTKind::Function);
 
-    if (m_tailCallBytecode) [[likely]]
-        return;
+    m_tailCallBytecode.ensure([&] {
+        // [arg bytecode][TailCall terminator][stackArgumentsAndResultsInBytes (u32)].
+        // The trailing u32 is read by .ipint_perform_tail_call via `loadi [MC]`
+        // after mINT dispatch hits TailCall, so MC naturally lands on it.
+        auto callConvention = wasmCallingConvention().callInformationFor(*this, CallRole::Caller);
+        auto bytes = buildCallArgumentBytecode</* isTailCall */ true>(callConvention);
 
-    // [arg bytecode][TailCall terminator][stackArgumentsAndResultsInBytes (u32)].
-    // The trailing u32 is read by .ipint_perform_tail_call via `loadi [MC]`
-    // after mINT dispatch hits TailCall, so MC naturally lands on it.
-    auto callConvention = wasmCallingConvention().callInformationFor(*this, CallRole::Caller);
-    auto bytes = buildCallArgumentBytecode</* isTailCall */ true>(callConvention);
+        uint32_t stackArgumentsAndResultsInBytes = roundUpToMultipleOf<stackAlignmentBytes()>(callConvention.headerAndArgumentStackSizeInBytes) - callConvention.headerIncludingThisSizeInBytes;
+        ASSERT(!(stackArgumentsAndResultsInBytes % 16));
+        bytes.append(std::span { std::bit_cast<const uint8_t*>(&stackArgumentsAndResultsInBytes), sizeof(stackArgumentsAndResultsInBytes) });
 
-    uint32_t stackArgumentsAndResultsInBytes = roundUpToMultipleOf<stackAlignmentBytes()>(callConvention.headerAndArgumentStackSizeInBytes) - callConvention.headerIncludingThisSizeInBytes;
-    ASSERT(!(stackArgumentsAndResultsInBytes % 16));
-    bytes.append(std::span { std::bit_cast<const uint8_t*>(&stackArgumentsAndResultsInBytes), sizeof(stackArgumentsAndResultsInBytes) });
-
-    auto candidate = IPIntSharedBytecode::createFromVector(WTF::move(bytes));
-
-    Locker locker { m_ipintBytecodeLock };
-    if (m_tailCallBytecode)
-        return;
-
-    WTF::storeStoreFence();
-    m_tailCallBytecode = candidate.moveToUniquePtr();
+        return IPIntSharedBytecode::createFromVector(WTF::move(bytes));
+    });
 }
 
 } } // namespace JSC::Wasm

--- a/Source/JavaScriptCore/wasm/WasmTypeDefinition.h
+++ b/Source/JavaScriptCore/wasm/WasmTypeDefinition.h
@@ -46,6 +46,7 @@
 #include <wtf/ReferenceWrapperVector.h>
 #include <wtf/StdLibExtras.h>
 #include <wtf/TZoneMalloc.h>
+#include <wtf/ThreadSafeLazyUniquePtr.h>
 #include <wtf/ThreadSafeRefCounted.h>
 #include <wtf/Vector.h>
 
@@ -867,8 +868,8 @@ public:
     CodePtr<JSEntryPtrTag> jsToWasmICEntrypoint() const;
 #endif
 
-    // Function-kind only. Lazy-install under m_ipintBytecodeLock; buffer is
-    // immutable once published.
+    // Function-kind only. Lazy-installed via a CAS in ThreadSafeLazyUniquePtr;
+    // buffer is immutable once published.
     void ensureArgumINTBytecode(const CallInformation&) const;
     void ensureUINTBytecode(const CallInformation&) const;
 
@@ -1030,11 +1031,10 @@ private:
     mutable RefPtr<JSToWasmICCallee> m_jsToWasmICCallee;
     mutable Lock m_jitCodeLock;
 #endif
-    mutable Lock m_ipintBytecodeLock;
-    mutable std::unique_ptr<const IPIntSharedBytecode> m_argumINTBytecode;
-    mutable std::unique_ptr<const IPIntSharedBytecode> m_uINTBytecode;
-    mutable std::unique_ptr<const IPIntSharedBytecode> m_callBytecode;
-    mutable std::unique_ptr<const IPIntSharedBytecode> m_tailCallBytecode;
+    mutable ThreadSafeLazyUniquePtr<const IPIntSharedBytecode> m_argumINTBytecode;
+    mutable ThreadSafeLazyUniquePtr<const IPIntSharedBytecode> m_uINTBytecode;
+    mutable ThreadSafeLazyUniquePtr<const IPIntSharedBytecode> m_callBytecode;
+    mutable ThreadSafeLazyUniquePtr<const IPIntSharedBytecode> m_tailCallBytecode;
     Variant<RTTFunctionPayload, RTTStructPayload, RTTArrayPayload> m_payload;
 };
 

--- a/Source/WTF/WTF.xcodeproj/project.pbxproj
+++ b/Source/WTF/WTF.xcodeproj/project.pbxproj
@@ -907,6 +907,7 @@
 		E3260E982DA0E508003FC93F /* StructDump.h in Headers */ = {isa = PBXBuildFile; fileRef = E3260E972DA0E508003FC93F /* StructDump.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		E32AB5012B5CE35D00B9FAAE /* LazyRef.h in Headers */ = {isa = PBXBuildFile; fileRef = E32AB4FF2B5CE35D00B9FAAE /* LazyRef.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		E32AB5022B5CE35D00B9FAAE /* LazyUniqueRef.h in Headers */ = {isa = PBXBuildFile; fileRef = E32AB5002B5CE35D00B9FAAE /* LazyUniqueRef.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		82722C867A8346EB9034D804 /* ThreadSafeLazyUniquePtr.h in Headers */ = {isa = PBXBuildFile; fileRef = 96C342C5B2894529B448A3CD /* ThreadSafeLazyUniquePtr.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		E32B4F3D2E0C698F00BDA4FD /* XTSPI.h in Headers */ = {isa = PBXBuildFile; fileRef = E32B4F3C2E0C698F00BDA4FD /* XTSPI.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		E336674A2722551100259122 /* Int128.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E33667492722550900259122 /* Int128.cpp */; };
 		E336BD2F2BAB8A0400E8471C /* CharacterProperties.h in Headers */ = {isa = PBXBuildFile; fileRef = E336BD2E2BAB8A0400E8471C /* CharacterProperties.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -1993,6 +1994,7 @@
 		E3260E972DA0E508003FC93F /* StructDump.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; lineEnding = 0; path = StructDump.h; sourceTree = "<group>"; };
 		E32AB4FF2B5CE35D00B9FAAE /* LazyRef.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = LazyRef.h; sourceTree = "<group>"; };
 		E32AB5002B5CE35D00B9FAAE /* LazyUniqueRef.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = LazyUniqueRef.h; sourceTree = "<group>"; };
+		96C342C5B2894529B448A3CD /* ThreadSafeLazyUniquePtr.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ThreadSafeLazyUniquePtr.h; sourceTree = "<group>"; };
 		E32B4F3C2E0C698F00BDA4FD /* XTSPI.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = XTSPI.h; sourceTree = "<group>"; };
 		E33667492722550900259122 /* Int128.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = Int128.cpp; sourceTree = "<group>"; };
 		E336BD2E2BAB8A0400E8471C /* CharacterProperties.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CharacterProperties.h; sourceTree = "<group>"; };
@@ -2798,6 +2800,7 @@
 				A8A47335151A825B004123FF /* ThreadingPrimitives.h */,
 				5311BD5B1EA822F900525281 /* ThreadMessage.cpp */,
 				5311BD591EA81A9600525281 /* ThreadMessage.h */,
+				96C342C5B2894529B448A3CD /* ThreadSafeLazyUniquePtr.h */,
 				A8A4733E151A825B004123FF /* ThreadSafeRefCounted.h */,
 				E3427B2E2D1636A200919862 /* ThreadSafeRefCountedWithSuppressingSaferCPPChecking.h */,
 				7B2739DC2624DAAA0040F182 /* ThreadSafetyAnalysis.h */,
@@ -3975,6 +3978,7 @@
 				463CCFC12B251D79009AB04E /* ThreadingEnums.h in Headers */,
 				DD3DC8E227A4BF8E007E5B61 /* ThreadingPrimitives.h in Headers */,
 				DD3DC92227A4BF8E007E5B61 /* ThreadMessage.h in Headers */,
+				82722C867A8346EB9034D804 /* ThreadSafeLazyUniquePtr.h in Headers */,
 				DD3DC96927A4BF8E007E5B61 /* ThreadSafeRefCounted.h in Headers */,
 				E3427B2F2D1636A200919862 /* ThreadSafeRefCountedWithSuppressingSaferCPPChecking.h in Headers */,
 				DD3DC97C27A4BF8E007E5B61 /* ThreadSafetyAnalysis.h in Headers */,

--- a/Source/WTF/wtf/CMakeLists.txt
+++ b/Source/WTF/wtf/CMakeLists.txt
@@ -360,6 +360,7 @@ set(WTF_PUBLIC_HEADERS
     ThreadAssertions.h
     ThreadGroup.h
     ThreadMessage.h
+    ThreadSafeLazyUniquePtr.h
     ThreadSafetyAnalysis.h
     ThreadSafeRefCounted.h
     ThreadSafeRefCountedWithSuppressingSaferCPPChecking.h

--- a/Source/WTF/wtf/ThreadSafeLazyUniquePtr.h
+++ b/Source/WTF/wtf/ThreadSafeLazyUniquePtr.h
@@ -1,0 +1,86 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <memory>
+#include <wtf/Atomics.h>
+#include <wtf/Noncopyable.h>
+#include <wtf/Nonmovable.h>
+#include <wtf/UniqueRef.h>
+
+namespace WTF {
+
+// ThreadSafeLazyUniquePtr<T> is a unique-ownership pointer that is lazily installed
+// once, atomically, via a compare-and-swap — no lock required. If multiple
+// threads race to install, only the first install wins and the losers delete
+// their candidate and observe the winner.
+template<typename T>
+class ThreadSafeLazyUniquePtr final {
+    WTF_MAKE_NONCOPYABLE(ThreadSafeLazyUniquePtr);
+    WTF_MAKE_NONMOVABLE(ThreadSafeLazyUniquePtr);
+public:
+    ThreadSafeLazyUniquePtr() = default;
+
+    ~ThreadSafeLazyUniquePtr()
+    {
+        delete m_pointer.load(std::memory_order_relaxed);
+    }
+
+    // In general there is no need to fence in func the compareExchangeStrong will ensure any stores
+    // to initialize the value will happen before the new pointer becomes visible.
+    template<typename Func>
+    T& ensure(NOESCAPE const Func& func) const
+    {
+        T* oldValue = m_pointer.load(std::memory_order_relaxed);
+        if (oldValue) [[likely]] {
+            // On all sensible CPUs, we get an implicit dependency-based load-load barrier when
+            // loading this.
+            return *oldValue;
+        }
+
+        T* newValue = toRawOwned(func());
+        if (T* actual = m_pointer.compareExchangeStrong(nullptr, newValue, std::memory_order_release, std::memory_order_relaxed)) {
+            delete newValue;
+            return *actual;
+        }
+        return *newValue;
+    }
+
+    T* get() const { return m_pointer.load(std::memory_order_relaxed); }
+    explicit operator bool() const { return !!get(); }
+
+private:
+    static T* toRawOwned(std::unique_ptr<T>&& ptr) { return ptr.release(); }
+    static T* toRawOwned(UniqueRef<T>&& ref) { return ref.moveToUniquePtr().release(); }
+
+    mutable Atomic<T*> m_pointer { nullptr };
+};
+
+static_assert(sizeof(ThreadSafeLazyUniquePtr<int>) == sizeof(int*));
+
+} // namespace WTF
+
+using WTF::ThreadSafeLazyUniquePtr;


### PR DESCRIPTION
#### 1661ae2e3ef420aa495e0eb0c6c52c116ff9a94f
<pre>
[WTF] Add ThreadSafeLazyUniquePtr
<a href="https://bugs.webkit.org/show_bug.cgi?id=314487">https://bugs.webkit.org/show_bug.cgi?id=314487</a>
<a href="https://rdar.apple.com/176696158">rdar://176696158</a>

Reviewed by Keith Miller.

Point of this class is adding handy class which uses the pattern,

    if (oldValue)
        return oldValue;

    newValue = factory();
    if (oldValue = Strong-CAS-with-release(oldValue, nullptr, newValue)) {
        destroy newValue;
        return oldValue;
    }
    return newValue;

This removes necessity of locking to publish a new value to the other
thread. We speculatively create a new value and attempt to publish it,
if it failed, we use the already published one. But otherwise, we
install a newly created one. This is ownership wrapped version of
Atomics.h&apos;s ensurePointer.

This is something similar to standard C++&apos;s
`std::atomic&lt;std::shared_ptr&lt;T&gt;&gt;`. But it does not offer
`std::atomic&lt;std::unique_ptr&lt;T&gt;&gt;`, so this is why this class exists.

We use this class for IPIntSharedBytecode in RTT. We also remove
storeStoreFence() since now we use &quot;release&quot; to publish a value via strong-CAS.

* Source/JavaScriptCore/wasm/WasmTypeDefinition.cpp:
(JSC::Wasm::RTT::ensureArgumINTBytecode const):
(JSC::Wasm::RTT::ensureUINTBytecode const):
(JSC::Wasm::RTT::ensureCallBytecode const):
(JSC::Wasm::RTT::ensureTailCallBytecode const):
* Source/JavaScriptCore/wasm/WasmTypeDefinition.h:
* Source/WTF/WTF.xcodeproj/project.pbxproj:
* Source/WTF/wtf/CMakeLists.txt:
* Source/WTF/wtf/ThreadSafeLazyUniquePtr.h: Added.

Canonical link: <a href="https://commits.webkit.org/313019@main">https://commits.webkit.org/313019@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bf3fa09f98de5069ee3584c425fad1fff504bb79

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/161877 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/35351 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/28454 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/170780 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/118248 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/587421d6-981a-4efc-b2f4-fae14e65a04e) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/35453 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/35353 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/125600 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/118248 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/5ebece6f-5eab-429e-965e-d6cb29f36240) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/164836 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/27917 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/145396 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/106196 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/50bbcbd0-c31c-4424-aab6-f9e8c3d19e26) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/26966 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/25481 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk3-libwebrtc~~](https://ews-build.webkit.org/#/builders/173/builds/18501 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/153936 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/136659 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/167/builds/23151 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/173269 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/22715 "Built successfully and passed tests") | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/20356 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/24792 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/133900 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/35025 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/29567 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/133905 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/35009 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/144946 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/97103 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/24583 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/164/builds/28433 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/21769 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/194276 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/34519 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/102000 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/50066 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/34020 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/34262 "Built successfully") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/34168 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->