### PR TITLE
Retire decidePolicyForSpeechRecognitionPermissionRequest WKPageUIClient callback slot

### DIFF
--- a/Source/WebKit/UIProcess/API/C/WKPageUIClient.h
+++ b/Source/WebKit/UIProcess/API/C/WKPageUIClient.h
@@ -144,7 +144,6 @@ typedef void (*WKPageDidResignInputElementStrongPasswordAppearanceCallback)(WKPa
 typedef bool (*WKPageShouldAllowDeviceOrientationAndMotionAccessCallback)(WKPageRef page, WKSecurityOriginRef securityOrigin, WKFrameInfoRef frame, const void *clientInfo);
 
 typedef void (*WKPageRunWebAuthenticationPanelCallback)(void);
-typedef void (*WKPageDecidePolicyForSpeechRecognitionPermissionRequestCallback)(WKPageRef page, WKSecurityOriginRef topOrigin, WKSpeechRecognitionPermissionCallbackRef callback);
 
 typedef void (*WKPageDecidePolicyForMediaKeySystemPermissionRequestCallback)(WKPageRef page, WKSecurityOriginRef topOrigin, WKStringRef keySystem, WKMediaKeySystemPermissionCallbackRef callback);
 typedef void (*WKQueryPermissionCallback)(WKStringRef permissionName, WKSecurityOriginRef topOrigin, WKQueryPermissionResultCallbackRef callback);
@@ -1475,7 +1474,7 @@ typedef struct WKPageUIClientV15 {
     WKPageRunWebAuthenticationPanelCallback                             runWebAuthenticationPanel;
 
     // Version 15.
-    WKPageDecidePolicyForSpeechRecognitionPermissionRequestCallback     decidePolicyForSpeechRecognitionPermissionRequest;
+    void*                                                               unused8; // Used to be decidePolicyForSpeechRecognitionPermissionRequest.
     
 } WKPageUIClientV15;
 
@@ -1586,7 +1585,7 @@ typedef struct WKPageUIClientV16 {
     WKPageRunWebAuthenticationPanelCallback                             runWebAuthenticationPanel;
 
     // Version 15.
-    WKPageDecidePolicyForSpeechRecognitionPermissionRequestCallback     decidePolicyForSpeechRecognitionPermissionRequest;
+    void*                                                               unused8; // Used to be decidePolicyForSpeechRecognitionPermissionRequest.
 
     // Version 16.
     WKPageDecidePolicyForMediaKeySystemPermissionRequestCallback        decidePolicyForMediaKeySystemPermissionRequest;
@@ -1700,7 +1699,7 @@ typedef struct WKPageUIClientV17 {
     WKPageRunWebAuthenticationPanelCallback                             runWebAuthenticationPanel;
 
     // Version 15.
-    WKPageDecidePolicyForSpeechRecognitionPermissionRequestCallback     decidePolicyForSpeechRecognitionPermissionRequest;
+    void*                                                               unused8; // Used to be decidePolicyForSpeechRecognitionPermissionRequest.
 
     // Version 16.
     WKPageDecidePolicyForMediaKeySystemPermissionRequestCallback        decidePolicyForMediaKeySystemPermissionRequest;
@@ -1814,7 +1813,7 @@ typedef struct WKPageUIClientV18 {
     WKPageRunWebAuthenticationPanelCallback                             runWebAuthenticationPanel;
 
     // Version 15.
-    WKPageDecidePolicyForSpeechRecognitionPermissionRequestCallback     decidePolicyForSpeechRecognitionPermissionRequest;
+    void*                                                               unused8; // Used to be decidePolicyForSpeechRecognitionPermissionRequest.
 
     // Version 16.
     WKPageDecidePolicyForMediaKeySystemPermissionRequestCallback        decidePolicyForMediaKeySystemPermissionRequest;
@@ -1930,7 +1929,7 @@ typedef struct WKPageUIClientV19 {
     WKPageRunWebAuthenticationPanelCallback                             runWebAuthenticationPanel;
 
     // Version 15.
-    WKPageDecidePolicyForSpeechRecognitionPermissionRequestCallback     decidePolicyForSpeechRecognitionPermissionRequest;
+    void*                                                               unused8; // Used to be decidePolicyForSpeechRecognitionPermissionRequest.
 
     // Version 16.
     WKPageDecidePolicyForMediaKeySystemPermissionRequestCallback        decidePolicyForMediaKeySystemPermissionRequest;


### PR DESCRIPTION
#### 48fd62d2c1b64a247faf434989c68f1b8db76190
<pre>
Retire decidePolicyForSpeechRecognitionPermissionRequest WKPageUIClient callback slot
<a href="https://bugs.webkit.org/show_bug.cgi?id=314494">https://bugs.webkit.org/show_bug.cgi?id=314494</a>
<a href="https://rdar.apple.com/176709259">rdar://176709259</a>

Reviewed by Alex Christensen.

Following 297219@main, the WKSpeechRecognitionPermissionCallback C API has no
callers and no bridge code inside WebKit reads the
decidePolicyForSpeechRecognitionPermissionRequest field from WKPageUIClientV15
through V19. Rename the field to `void* unused8` so the struct layout, and
thus the binary ABI for clients still compiled against these versions,
is preserved, and drop the now-orphan
WKPageDecidePolicyForSpeechRecognitionPermissionRequestCallback typedef.

This intentionally breaks source compatibility for any holdout filling the
field by name, documenting that the slot is retired, and clears the way for
a follow-up that deletes the remaining dead code.

* Source/WebKit/UIProcess/API/C/WKPageUIClient.h:

Canonical link: <a href="https://commits.webkit.org/313459@main">https://commits.webkit.org/313459@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4890ec05c66a81f458dfe7b5b922e6661307d7fa

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/161645 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/35119 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/28222 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/170548 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/118016 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/ac9851fe-1f8a-4260-bc68-ae3b83d683f6) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/35220 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/35120 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/125406 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/88332 "1 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/577a094d-3c8c-4cc0-bc93-c984b8971990) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/164604 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/27711 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/145194 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/106002 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/bc40ffc0-236b-4c3f-891e-bd209517cd0e) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/26760 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/25271 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/18269 "Built successfully") | | 
| [⏳ 🛠 🧪 jsc-x86-64 ](https://ews-build.webkit.org/#/builders/JSC-Tests-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/136453 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/173036 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/20077 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/24591 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/133698 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/34793 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/29365 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/133703 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36398 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/34777 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/144745 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/96745 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/28235 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/21565 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/34287 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/101732 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/33787 "Built successfully") | [⏳ 🧪 mac-site-isolation ](https://ews-build.webkit.org/#/builders/macOS-Sequoia-Release-Site-Isolation-Tests-EWS "Waiting in queue, processing has not started yet") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/34030 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/33936 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->