### PR TITLE
HTMLPreloadScanner does not preload <image> tag

### DIFF
--- a/LayoutTests/fast/preloader/image-with-incorrect-tag-expected.txt
+++ b/LayoutTests/fast/preloader/image-with-incorrect-tag-expected.txt
@@ -1,4 +1,4 @@
 This test requires DumpRenderTree to see the log of what resources are loaded.
 
-    <image src=resources/image1.png>
+    <imagex src=resources/image1.png>
 

--- a/LayoutTests/fast/preloader/image-with-incorrect-tag.html
+++ b/LayoutTests/fast/preloader/image-with-incorrect-tag.html
@@ -8,4 +8,4 @@
     This test requires DumpRenderTree to see the log of what resources are loaded.
     <script src=resources/non-existant.js></script>
     <script>document.write("<plaintext>");</script>
-    <image src=resources/image1.png>
+    <imagex src=resources/image1.png>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/syntax/speculative-parsing/generated/document-write/image-src.tentative.sub-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/syntax/speculative-parsing/generated/document-write/image-src.tentative.sub-expected.txt
@@ -1,7 +1,8 @@
 
     <!-- speculative case in document.write -->
-    <image src="/html/syntax/speculative-parsing/resources/stash.py?action=put&amp;uuid=43ceaad4-6cc8-4561-afbd-fc621abccb40&amp;encodingcheck=&Gbreve;">
+    <image src="/html/syntax/speculative-parsing/resources/stash.py?action=put&amp;uuid=958d24b5-114f-44d7-867f-7b6ed7a64d46&amp;encodingcheck=&Gbreve;">
 
 
-FAIL Speculative parsing, document.write(): image-src Unhandled rejection: assert_not_equals: speculative case did not fetch got disallowed value ""
+
+PASS Speculative parsing, document.write(): image-src
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/syntax/speculative-parsing/generated/page-load/image-src.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/syntax/speculative-parsing/generated/page-load/image-src.tentative-expected.txt
@@ -1,4 +1,4 @@
 
 
-FAIL Speculative parsing, page load: image-src Unhandled rejection: assert_not_equals: speculative case did not fetch got disallowed value ""
+PASS Speculative parsing, page load: image-src
 

--- a/Source/WebCore/html/parser/HTMLPreloadScanner.cpp
+++ b/Source/WebCore/html/parser/HTMLPreloadScanner.cpp
@@ -63,6 +63,7 @@ TokenPreloadScanner::TagId TokenPreloadScanner::tagIdFor(const HTMLToken::DataVe
 {
     static constexpr SortedArrayMap map { std::to_array<std::pair<PackedASCIILiteral<uint64_t>, TokenPreloadScanner::TagId>>({
         { "base"_s, TagId::Base },
+        { "image"_s, TagId::Img },
         { "img"_s, TagId::Img },
         { "input"_s, TagId::Input },
         { "link"_s, TagId::Link },
@@ -539,6 +540,16 @@ void TokenPreloadScanner::scan(const HTMLToken& token, Vector<std::unique_ptr<Pr
         // Don't speculatively preload scripts inside SVG.
         if (m_foreignContentCount && tagId == TagId::Script)
             return;
+
+        // <image> is rewritten to <img> by the HTML parser only in HTML content; inside SVG
+        // foreign content it is the SVG image element (which uses href/xlink:href, not src),
+        // so it must not be preloaded as if it were an HTML <img>. (A literal <img> breaks
+        // out of foreign content per HTML parsing rules, so handling it as Img is fine.)
+        if (m_foreignContentCount && tagId == TagId::Img) {
+            static constexpr auto imageAsUTF16 = std::to_array<char16_t>({ 'i', 'm', 'a', 'g', 'e' });
+            if (equalSpans(token.name().span(), std::span { imageAsUTF16 }))
+                return;
+        }
 
         StartTagScanner scanner(document, tagId, m_deviceScaleFactor);
         scanner.processAttributes(token.attributes(), m_pictureSourceState);


### PR DESCRIPTION
#### 9687c6cc96cf8b5696f78b0645ce948974ce531b
<pre>
HTMLPreloadScanner does not preload &lt;image&gt; tag
<a href="https://bugs.webkit.org/show_bug.cgi?id=314497">https://bugs.webkit.org/show_bug.cgi?id=314497</a>
<a href="https://rdar.apple.com/176712749">rdar://176712749</a>

Reviewed by Chris Dumez.

This patch aligns WebKit with Gecko / Firefox.

Per the HTML parsing spec [1]:

  &quot;An image start tag token is handled by the tree builder, but it
  is not in this list because it is not an element; it gets turned
  into an img element.&quot;

And in the &quot;in body&quot; insertion mode [2]:

  &quot;A start tag whose tag name is &apos;image&apos;:
    Parse error. Change the token&apos;s tag name to &apos;img&apos; and reprocess
    it. (Don&apos;t ask.)&quot;

That is, the tree builder rewrites &lt;image&gt; to &lt;img&gt; and reprocesses
it. The speculative preload scanner did not perform this aliasing,
so &lt;image src=&quot;...&quot;&gt; was bucketed as TagId::Unknown and produced no
preload, even though the document parser then materializes a real
&lt;img&gt; element that fetches the resource.

Teach tagIdFor() to map &quot;image&quot; to TagId::Img. Because &lt;image&gt; is
not in the HTML &quot;break out of foreign content&quot; list (while &lt;img&gt;
is), inside SVG foreign content &lt;image&gt; stays as the SVG image
element, which uses href/xlink:href rather than src. Guard scan()
so the preload is skipped in that case to avoid regressing
svg-image-src.tentative.

[1] <a href="https://html.spec.whatwg.org/multipage/parsing.html#special">https://html.spec.whatwg.org/multipage/parsing.html#special</a>
[2] <a href="https://html.spec.whatwg.org/multipage/parsing.html#parsing-main-inbody">https://html.spec.whatwg.org/multipage/parsing.html#parsing-main-inbody</a>

* LayoutTests/imported/w3c/web-platform-tests/html/syntax/speculative-parsing/generated/document-write/image-src.tentative.sub-expected.txt: Progression
* LayoutTests/imported/w3c/web-platform-tests/html/syntax/speculative-parsing/generated/page-load/image-src.tentative-expected.txt: Ditto
* Source/WebCore/html/parser/HTMLPreloadScanner.cpp:
(WebCore::TokenPreloadScanner::tagIdFor):
(WebCore::TokenPreloadScanner::scan):

Replace &lt;image&gt; with &lt;imagex&gt; so the test actually uses an unknown tag.
&lt;image&gt; is a legacy alias the HTML parser (and now the preload scanner)
rewrites to &lt;img&gt;, which defeats the test&apos;s purpose: confirming the
nested-template preload fix does not preload an unrecognized tag.

* LayoutTests/fast/preloader/image-with-incorrect-tag-expected.txt: Updated.
* LayoutTests/fast/preloader/image-with-incorrect-tag.html: Updated.

Canonical link: <a href="https://commits.webkit.org/312984@main">https://commits.webkit.org/312984@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/040555b2b43944b0a495f593721b3540a3a425f7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/161750 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/35224 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/28327 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/170653 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/118121 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/ac37a8ad-e396-4591-8a76-ad2d8f7738aa) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/163619 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/35325 "Build is in progress. Recent messages:OS: Tahoe (26.2), Xcode: 26.2; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (warnings)") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/35225 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/125496 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/88416 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/3809206a-44e9-4cf0-adc6-a7f36f18533f) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/164709 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/27806 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/145287 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/106092 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/280c3cf0-73ea-4e64-87de-7da86741bab5) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/26855 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/25368 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/18374 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/136548 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/23042 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/173142 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/20182 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/24683 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/133790 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/34898 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/29457 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/133795 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36134 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/34882 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/144837 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/96915 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/28332 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/21659 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/34392 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/101837 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/33892 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/34135 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/34041 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->